### PR TITLE
feat(photos): manual placement and drag for non-geotagged photos

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
@@ -121,8 +121,10 @@ export function PhotosSource() {
     };
     source.shell.addLayer(layer, source.beforeLayer);
     // Hand the user a draggable pin on the map to fine-tune the position. It
-    // lives outside React, so closing the dialog (below) does not cancel it;
-    // each drag rewrites the layer's coordinates in the store.
+    // lives outside React, so closing the dialog (below) does not cancel it.
+    // Each drag rewrites the layer's whole geojson, always derived from the
+    // original placement collection (not the current store value) so repeated
+    // moves can't accumulate floating-point drift.
     let unsubscribe = () => {};
     const dispose = source.shell.mapControllerRef.current?.startManualPlacement(
       manualCenter,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
@@ -26,7 +26,7 @@ function formatCoordinate(value: number): string {
  * When a single photo carries no usable GPS, the dialog offers a manual
  * placement workflow instead of a hard error: the photo is dropped at the
  * current map center and a draggable pin lets the user fine-tune its position
- * on the map (issue #894).
+ * on the map.
  */
 export function PhotosSource() {
   const { t } = useTranslation();

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
@@ -123,14 +123,31 @@ export function PhotosSource() {
     // Hand the user a draggable pin on the map to fine-tune the position. It
     // lives outside React, so closing the dialog (below) does not cancel it;
     // each drag rewrites the layer's coordinates in the store.
-    source.shell.mapControllerRef.current?.startManualPlacement(manualCenter, {
-      hint: t("addData.photos.manualHint"),
-      doneLabel: t("common.done"),
-      onMove: (lngLat) =>
-        updateLayer(layer.id, {
-          geojson: relocatePhotoFeatures(result.featureCollection, lngLat),
-        }),
-    });
+    let unsubscribe = () => {};
+    const dispose = source.shell.mapControllerRef.current?.startManualPlacement(
+      manualCenter,
+      {
+        hint: t("addData.photos.manualHint"),
+        doneLabel: t("common.done"),
+        onMove: (lngLat) =>
+          updateLayer(layer.id, {
+            geojson: relocatePhotoFeatures(result.featureCollection, lngLat),
+          }),
+        onDone: () => unsubscribe(),
+      },
+    );
+    // If the user deletes the layer before finishing placement, the pin and its
+    // popup would otherwise linger on the map. Watch the store and dispose them
+    // when the layer disappears. (This dialog closes right after, so the
+    // subscription, not a React effect, owns the cleanup.)
+    if (dispose) {
+      unsubscribe = useAppStore.subscribe((state) => {
+        if (!state.layers.some((l) => l.id === layer.id)) {
+          dispose();
+          unsubscribe();
+        }
+      });
+    }
     // Close the dialog so the map (and the drag pin) become interactive; the
     // modal overlay would otherwise block dragging.
     source.shell.closeDialog();

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PhotosSource.tsx
@@ -1,19 +1,32 @@
+import { useAppStore } from "@geolibre/core";
 import { Button, Label } from "@geolibre/ui";
-import { Images } from "lucide-react";
+import { Images, MapPin } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type GeotaggedPhotoResult,
   loadGeotaggedPhotos,
+  loadPhotosAtLocation,
+  relocatePhotoFeatures,
 } from "../../../../lib/geotagged-photos";
 import { pickImageFilesWithFallback } from "../../../../lib/tauri-io";
 import { createBaseLayer, errorMessage } from "../helpers";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
+/** Round a lng/lat for the placement prompt so it reads cleanly. */
+function formatCoordinate(value: number): string {
+  return value.toFixed(4);
+}
+
 /**
  * Add Data source that imports a set of geotagged photos as a point layer.
  * Each image is placed from its EXIF GPS coordinates with a thumbnail and EXIF
  * metadata stored on the feature; photos without GPS are skipped and reported.
+ *
+ * When a single photo carries no usable GPS, the dialog offers a manual
+ * placement workflow instead of a hard error: the photo is dropped at the
+ * current map center and a draggable pin lets the user fine-tune its position
+ * on the map (issue #894).
  */
 export function PhotosSource() {
   const { t } = useTranslation();
@@ -21,8 +34,14 @@ export function PhotosSource() {
   // stable even if the UI language changes while the dialog is open.
   const [defaultName] = useState(() => t("addData.photos.defaultName"));
   const source = useAddDataSource(defaultName);
+  const updateLayer = useAppStore((s) => s.updateLayer);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [summary, setSummary] = useState<GeotaggedPhotoResult | null>(null);
+  // Set when a single photo had no GPS: holds the map center the photo would be
+  // placed at, switching the dialog to the manual-placement prompt.
+  const [manualCenter, setManualCenter] = useState<[number, number] | null>(
+    null,
+  );
 
   const handleChoosePhotos = async () => {
     source.setError(null);
@@ -43,6 +62,16 @@ export function PhotosSource() {
 
     const result = await loadGeotaggedPhotos(selectedFiles);
     if (result.located === 0) {
+      // A single photo with no GPS pivots to manual placement instead of a hard
+      // stop; multiple no-GPS photos still report the original error.
+      if (selectedFiles.length === 1) {
+        const center =
+          source.shell.mapControllerRef.current?.readView().center ?? null;
+        if (center) {
+          setManualCenter([center[0], center[1]]);
+          return;
+        }
+      }
       throw new Error(
         t("addData.photos.errorNoGps", { count: result.total }),
       );
@@ -68,6 +97,43 @@ export function PhotosSource() {
     // Keep the dialog open on a summary panel so the skipped/no-thumbnail
     // counts are reported clearly before the user dismisses it.
     setSummary(result);
+  });
+
+  const handleManualPlace = source.runSubmit(async () => {
+    if (!manualCenter) return;
+    const name = source.layerName.trim() || defaultName;
+    const result = await loadPhotosAtLocation(selectedFiles, manualCenter);
+    const layer = {
+      ...createBaseLayer(
+        name,
+        "geojson",
+        { type: "geojson" },
+        {
+          sourceKind: "geotagged-photos",
+          featureCount: result.located,
+          skipped: result.skipped,
+          withoutThumbnail: result.withoutThumbnail,
+          total: result.total,
+          manualPlacement: true,
+        },
+      ),
+      geojson: result.featureCollection,
+    };
+    source.shell.addLayer(layer, source.beforeLayer);
+    // Hand the user a draggable pin on the map to fine-tune the position. It
+    // lives outside React, so closing the dialog (below) does not cancel it;
+    // each drag rewrites the layer's coordinates in the store.
+    source.shell.mapControllerRef.current?.startManualPlacement(manualCenter, {
+      hint: t("addData.photos.manualHint"),
+      doneLabel: t("common.done"),
+      onMove: (lngLat) =>
+        updateLayer(layer.id, {
+          geojson: relocatePhotoFeatures(result.featureCollection, lngLat),
+        }),
+    });
+    // Close the dialog so the map (and the drag pin) become interactive; the
+    // modal overlay would otherwise block dragging.
+    source.shell.closeDialog();
   });
 
   if (summary) {
@@ -96,6 +162,47 @@ export function PhotosSource() {
           </Button>
         </div>
       </div>
+    );
+  }
+
+  if (manualCenter) {
+    return (
+      <form className="space-y-4" onSubmit={handleManualPlace}>
+        <div className="space-y-2 rounded-md border border-border p-3 text-sm">
+          <p className="font-medium text-foreground">
+            {t("addData.photos.manualPromptTitle")}
+          </p>
+          <p className="text-muted-foreground">
+            {t("addData.photos.manualPromptBody")}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t("addData.photos.manualPromptCenter", {
+              lng: formatCoordinate(manualCenter[0]),
+              lat: formatCoordinate(manualCenter[1]),
+            })}
+          </p>
+        </div>
+        {source.error ? (
+          <p className="text-sm text-destructive">{source.error}</p>
+        ) : null}
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setManualCenter(null);
+              source.setError(null);
+            }}
+            disabled={source.isSubmitting}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button type="submit" disabled={source.isSubmitting}>
+            <MapPin className="mr-2 h-3.5 w-3.5" />
+            {t("addData.photos.manualPlace")}
+          </Button>
+        </div>
+      </form>
     );
   }
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -325,7 +325,12 @@
       "skippedNote_one": "{{count}} photo was skipped (no GPS location).",
       "skippedNote_other": "{{count}} photos were skipped (no GPS location).",
       "noThumbnailNote_one": "{{count}} photo has no thumbnail (HEIC or unsupported format).",
-      "noThumbnailNote_other": "{{count}} photos have no thumbnail (HEIC or unsupported format)."
+      "noThumbnailNote_other": "{{count}} photos have no thumbnail (HEIC or unsupported format).",
+      "manualPromptTitle": "No GPS location was found in this photo.",
+      "manualPromptBody": "Place it at the current map center and drag it into position on the map.",
+      "manualPromptCenter": "Map center: {{lng}}, {{lat}}",
+      "manualPlace": "Place at map center",
+      "manualHint": "Drag this pin to position the photo, then click Done."
     },
     "mbtiles": {
       "defaultName": "MBTiles Layer",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1911,6 +1911,100 @@ body,
   background: hsl(var(--primary) / 0.9);
 }
 
+/* Geotagged-photo popup: a resizable box whose photo scales to fill it, so the
+   user can drag the corner to see more detail. */
+.geolibre-photo-popup-root .maplibregl-popup-content {
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.18),
+    0 4px 6px -4px rgb(0 0 0 / 0.18);
+  color: hsl(var(--popover-foreground));
+  padding: 0.5rem;
+}
+
+.geolibre-photo-popup-root .maplibregl-popup-close-button {
+  color: hsl(var(--muted-foreground));
+  padding-right: 0.25rem;
+}
+
+.geolibre-photo-popup-root .maplibregl-popup-close-button:hover {
+  background: transparent;
+  color: hsl(var(--popover-foreground));
+}
+
+.geolibre-photo-popup-root.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.geolibre-photo-popup-root.maplibregl-popup-anchor-top-left
+  .maplibregl-popup-tip,
+.geolibre-photo-popup-root.maplibregl-popup-anchor-top-right
+  .maplibregl-popup-tip {
+  border-bottom-color: hsl(var(--popover));
+}
+
+.geolibre-photo-popup-root.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.geolibre-photo-popup-root.maplibregl-popup-anchor-bottom-left
+  .maplibregl-popup-tip,
+.geolibre-photo-popup-root.maplibregl-popup-anchor-bottom-right
+  .maplibregl-popup-tip {
+  border-top-color: hsl(var(--popover));
+}
+
+.geolibre-photo-popup-root.maplibregl-popup-anchor-left .maplibregl-popup-tip {
+  border-right-color: hsl(var(--popover));
+}
+
+.geolibre-photo-popup-root.maplibregl-popup-anchor-right .maplibregl-popup-tip {
+  border-left-color: hsl(var(--popover));
+}
+
+.geolibre-photo-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  /* The initial box; the user can drag it larger (or smaller) from here. */
+  width: 260px;
+  height: 220px;
+  min-width: 160px;
+  min-height: 140px;
+  max-width: min(85vw, 900px);
+  max-height: 85vh;
+  resize: both;
+  overflow: hidden;
+}
+
+.geolibre-photo-popup-img {
+  flex: 1 1 auto;
+  /* Without min-height: 0 a flex child refuses to shrink below its image's
+     intrinsic height, which would break vertical resizing. */
+  min-height: 0;
+  width: 100%;
+  object-fit: contain;
+  border-radius: 0.375rem;
+  background: hsl(var(--muted));
+}
+
+.geolibre-photo-popup-placeholder {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.375rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.8125rem;
+}
+
+.geolibre-photo-popup-caption {
+  flex: 0 0 auto;
+  overflow: hidden;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: hsl(var(--popover-foreground));
+}
+
 .swipe-control-panel .swipe-control-select {
   height: 28px;
   line-height: 28px;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1872,6 +1872,16 @@ body,
   border-top-color: hsl(var(--popover));
 }
 
+.geolibre-placement-popup-root.maplibregl-popup-anchor-left
+  .maplibregl-popup-tip {
+  border-right-color: hsl(var(--popover));
+}
+
+.geolibre-placement-popup-root.maplibregl-popup-anchor-right
+  .maplibregl-popup-tip {
+  border-left-color: hsl(var(--popover));
+}
+
 .geolibre-placement-popup {
   display: flex;
   flex-direction: column;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1982,6 +1982,46 @@ body,
   object-fit: contain;
   border-radius: 0.375rem;
   background: hsl(var(--muted));
+  cursor: zoom-in;
+}
+
+/* Fullscreen lightbox opened by double-clicking the photo popup's image. */
+.geolibre-photo-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 0.92);
+}
+
+.geolibre-photo-fullscreen-img {
+  max-width: 100vw;
+  max-height: 100vh;
+  object-fit: contain;
+  cursor: zoom-out;
+}
+
+.geolibre-photo-fullscreen-close {
+  position: fixed;
+  top: 0.75rem;
+  right: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  background: rgb(255 255 255 / 0.12);
+  color: #fff;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.geolibre-photo-fullscreen-close:hover {
+  background: rgb(255 255 255 / 0.24);
 }
 
 .geolibre-photo-popup-placeholder {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1842,6 +1842,65 @@ body,
   border-left-color: hsl(var(--popover));
 }
 
+/* The draggable photo-placement pin's hint popup (manual placement of a
+   non-geotagged photo). Themed to match the app's popover surface. */
+.geolibre-placement-popup-root .maplibregl-popup-content {
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.18),
+    0 4px 6px -4px rgb(0 0 0 / 0.18);
+  color: hsl(var(--popover-foreground));
+  padding: 0.625rem 0.75rem;
+}
+
+.geolibre-placement-popup-root.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.geolibre-placement-popup-root.maplibregl-popup-anchor-top-left
+  .maplibregl-popup-tip,
+.geolibre-placement-popup-root.maplibregl-popup-anchor-top-right
+  .maplibregl-popup-tip {
+  border-bottom-color: hsl(var(--popover));
+}
+
+.geolibre-placement-popup-root.maplibregl-popup-anchor-bottom
+  .maplibregl-popup-tip,
+.geolibre-placement-popup-root.maplibregl-popup-anchor-bottom-left
+  .maplibregl-popup-tip,
+.geolibre-placement-popup-root.maplibregl-popup-anchor-bottom-right
+  .maplibregl-popup-tip {
+  border-top-color: hsl(var(--popover));
+}
+
+.geolibre-placement-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 13rem;
+}
+
+.geolibre-placement-popup-hint {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  color: hsl(var(--popover-foreground));
+}
+
+.geolibre-placement-popup-done {
+  align-self: flex-end;
+  border-radius: 0.375rem;
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.geolibre-placement-popup-done:hover {
+  background: hsl(var(--primary) / 0.9);
+}
+
 .swipe-control-panel .swipe-control-select {
   height: 28px;
   line-height: 28px;

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -48,10 +48,16 @@ const PHOTO_DROP_EXTENSIONS = new Set([
 /** Extensions the browser cannot decode on a canvas (thumbnail is skipped). */
 const HEIC_EXTENSIONS = new Set(["heic", "heif"]);
 
-/** Longest edge (px) of a generated thumbnail; keeps inline data URLs small. */
-const THUMBNAIL_MAX_DIMENSION = 256;
-/** JPEG quality for generated thumbnails. */
-const THUMBNAIL_QUALITY = 0.7;
+/**
+ * Longest edge (px) of the inline JPEG generated for each photo. The original
+ * file is not retained after import, so this is the only resolution available
+ * later: it is sized so the resizable photo popup stays sharp when enlarged
+ * (the popup display caps near 900px, doubled here for high-DPI screens) while
+ * keeping the inline data URL a few hundred KB rather than the multi-MB source.
+ */
+const PHOTO_MAX_DIMENSION = 1600;
+/** JPEG quality for the generated photo image. */
+const PHOTO_JPEG_QUALITY = 0.82;
 
 function fileExtension(name: string): string {
   return name.split(".").pop()?.toLowerCase() ?? "";
@@ -202,10 +208,10 @@ async function readPhotoExif(file: Blob): Promise<PhotoExif | null> {
 }
 
 /**
- * Generate a small JPEG thumbnail (a data URL) for an image the browser can
- * decode. Returns null for HEIC/HEIF (no canvas decoder) and for any image the
- * browser fails to decode, so the caller still places the point without a
- * thumbnail.
+ * Generate a downscaled JPEG (a data URL) for an image the browser can decode,
+ * capped at {@link PHOTO_MAX_DIMENSION} on its longest edge. Returns null for
+ * HEIC/HEIF (no canvas decoder) and for any image the browser fails to decode,
+ * so the caller still places the point without an inline image.
  */
 async function createThumbnailDataUrl(
   file: Blob,
@@ -230,7 +236,7 @@ async function createThumbnailDataUrl(
   try {
     const scale = Math.min(
       1,
-      THUMBNAIL_MAX_DIMENSION / Math.max(bitmap.width, bitmap.height),
+      PHOTO_MAX_DIMENSION / Math.max(bitmap.width, bitmap.height),
     );
     const width = Math.max(1, Math.round(bitmap.width * scale));
     const height = Math.max(1, Math.round(bitmap.height * scale));
@@ -240,7 +246,7 @@ async function createThumbnailDataUrl(
     const context = canvas.getContext("2d");
     if (!context) return null;
     context.drawImage(bitmap, 0, 0, width, height);
-    return canvas.toDataURL("image/jpeg", THUMBNAIL_QUALITY);
+    return canvas.toDataURL("image/jpeg", PHOTO_JPEG_QUALITY);
   } catch {
     return null;
   } finally {

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -303,3 +303,71 @@ export async function loadGeotaggedPhotos(
     withoutThumbnail,
   };
 }
+
+/**
+ * Build a point layer for photos that carry no usable GPS by placing every one
+ * at `center` (typically the current map view center). EXIF metadata and inline
+ * thumbnails are still read so a manually placed photo carries the same feature
+ * properties as a GPS-located one; the caller then lets the user drag the point
+ * into its final position.
+ *
+ * @param files - The image files to place. Anything the EXIF/thumbnail readers
+ *   cannot parse is still placed at the center with whatever could be read.
+ * @param center - The `[lng, lat]` to drop every photo at.
+ * @returns The point layer plus counts shaped like {@link loadGeotaggedPhotos}
+ *   (`skipped` is always 0 because manual placement never drops a photo).
+ */
+export async function loadPhotosAtLocation(
+  files: File[],
+  center: [number, number],
+): Promise<GeotaggedPhotoResult> {
+  const features: Feature<Point>[] = [];
+  let withoutThumbnail = 0;
+
+  for (const file of files) {
+    const fileName = file.name || "photo";
+    const exif = (await readPhotoExif(file)) ?? {};
+    const thumbnail = await createThumbnailDataUrl(file, fileName);
+    if (!thumbnail) withoutThumbnail += 1;
+
+    features.push({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: [center[0], center[1]],
+      },
+      properties: buildPhotoProperties(fileName, exif, thumbnail),
+    });
+  }
+
+  return {
+    featureCollection: { type: "FeatureCollection", features },
+    total: files.length,
+    located: features.length,
+    skipped: 0,
+    withoutThumbnail,
+  };
+}
+
+/**
+ * Return a copy of a photo point collection with every feature moved to
+ * `[lng, lat]`. Used while the user drags the manual-placement handle so the
+ * rendered points follow the marker; feature properties (thumbnail, EXIF) are
+ * preserved.
+ *
+ * @param collection - The photo point collection to relocate.
+ * @param position - The `[lng, lat]` to move every feature to.
+ * @returns A new collection with the same features at the new position.
+ */
+export function relocatePhotoFeatures(
+  collection: FeatureCollection<Point>,
+  [lng, lat]: [number, number],
+): FeatureCollection<Point> {
+  return {
+    type: "FeatureCollection",
+    features: collection.features.map((feature) => ({
+      ...feature,
+      geometry: { type: "Point", coordinates: [lng, lat] },
+    })),
+  };
+}

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -54,6 +54,9 @@ const HEIC_EXTENSIONS = new Set(["heic", "heif"]);
  * later: it is sized so the resizable photo popup stays sharp when enlarged
  * (the popup display caps near 900px, doubled here for high-DPI screens) while
  * keeping the inline data URL a few hundred KB rather than the multi-MB source.
+ * Budget ~250-500 KB per photo at this size/quality; since the data URL is held
+ * in the store and serialized into the project file, raising it further trades
+ * sharpness for project size on photo-heavy imports.
  */
 const PHOTO_MAX_DIMENSION = 1600;
 /** JPEG quality for the generated photo image. */
@@ -359,7 +362,9 @@ export async function loadPhotosAtLocation(
  * Return a copy of a photo point collection with every feature moved to
  * `[lng, lat]`. Used while the user drags the manual-placement handle so the
  * rendered points follow the marker; feature properties (thumbnail, EXIF) are
- * preserved.
+ * preserved. The per-feature spread is shallow, so the (potentially large)
+ * inline image string is shared by reference, not duplicated, on each drag
+ * frame.
  *
  * @param collection - The photo point collection to relocate.
  * @param position - The `[lng, lat]` to move every feature to.

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -178,6 +178,9 @@ function findPhotoDataUrl(properties: Record<string, unknown>): string | null {
 function openPhotoFullscreen(src: string, alt: string): void {
   const overlay = document.createElement("div");
   overlay.className = "geolibre-photo-fullscreen";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-label", alt);
 
   const image = document.createElement("img");
   image.src = src;
@@ -193,6 +196,9 @@ function openPhotoFullscreen(src: string, alt: string): void {
   overlay.appendChild(closeButton);
 
   document.body.appendChild(overlay);
+  // Move focus into the lightbox so keyboard and screen-reader users land on a
+  // control inside it (and Escape/Enter act on the close button by default).
+  closeButton.focus();
 
   let closed = false;
   const close = () => {
@@ -1150,6 +1156,14 @@ export const MapCanvas = memo(function MapCanvas({
       if (useAppStore.getState().identifyLayerId) return;
       const feature = event.features?.[0];
       if (!feature) return;
+      // Anchor to the feature's own coordinate rather than the click point, so
+      // the tip stays on the photo point even when the user clicks the edge of
+      // a large marker.
+      const geometry = feature.geometry;
+      const anchor =
+        geometry.type === "Point"
+          ? (geometry.coordinates as [number, number])
+          : event.lngLat;
       removePhotoPopup();
       photoPopup.current = new maplibregl.Popup({
         className: "geolibre-photo-popup-root",
@@ -1157,7 +1171,7 @@ export const MapCanvas = memo(function MapCanvas({
         closeOnClick: true,
         maxWidth: "none",
       })
-        .setLngLat(event.lngLat)
+        .setLngLat(anchor)
         .setDOMContent(createPhotoPopupElement(feature.properties ?? {}))
         .addTo(map);
     };
@@ -1198,9 +1212,16 @@ export const MapCanvas = memo(function MapCanvas({
     // event, so re-bind on it to catch layers that did not exist yet when this
     // effect first ran (e.g. before the style finished loading).
     window.addEventListener("geolibre-layer-labels-change", bind);
+    // Close the photo popup when the Identify tool is turned on (which may
+    // happen via a toolbar button, with no map click to dismiss it), so the
+    // photo and identify popups never coexist.
+    const unsubscribeIdentify = useAppStore.subscribe((state) => {
+      if (state.identifyLayerId) removePhotoPopup();
+    });
 
     return () => {
       window.removeEventListener("geolibre-layer-labels-change", bind);
+      unsubscribeIdentify();
       unbind();
       removePhotoPopup();
     };

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -166,10 +166,73 @@ function findPhotoDataUrl(properties: Record<string, unknown>): string | null {
 }
 
 /**
+ * Open a photo in a fullscreen lightbox: a backdrop overlay with the image
+ * centered (scaled to fit). Uses the native Fullscreen API so it fills the whole
+ * screen, falling back to a viewport-filling overlay where fullscreen is denied.
+ * Closes on the × button, a backdrop click, Escape, a double-click on the image,
+ * or the user leaving native fullscreen.
+ *
+ * @param src - The image data URL or URL.
+ * @param alt - Accessible label for the image.
+ */
+function openPhotoFullscreen(src: string, alt: string): void {
+  const overlay = document.createElement("div");
+  overlay.className = "geolibre-photo-fullscreen";
+
+  const image = document.createElement("img");
+  image.src = src;
+  image.alt = alt;
+  image.className = "geolibre-photo-fullscreen-img";
+  overlay.appendChild(image);
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "geolibre-photo-fullscreen-close";
+  closeButton.setAttribute("aria-label", "Close");
+  closeButton.textContent = "×";
+  overlay.appendChild(closeButton);
+
+  document.body.appendChild(overlay);
+
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    document.removeEventListener("keydown", onKeyDown);
+    document.removeEventListener("fullscreenchange", onFullscreenChange);
+    if (document.fullscreenElement === overlay) {
+      void document.exitFullscreen().catch(() => {});
+    }
+    overlay.remove();
+  };
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") close();
+  };
+  const onFullscreenChange = () => {
+    // Leaving native fullscreen (Esc / F11) should also dismiss the overlay.
+    if (document.fullscreenElement !== overlay) close();
+  };
+
+  closeButton.addEventListener("click", close);
+  // Click the backdrop (but not the image) to dismiss.
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) close();
+  });
+  image.addEventListener("dblclick", close);
+  document.addEventListener("keydown", onKeyDown);
+  document.addEventListener("fullscreenchange", onFullscreenChange);
+
+  // Best-effort true fullscreen; the overlay already fills the viewport if the
+  // request is unsupported or denied (e.g. inside a sandboxed embed).
+  void overlay.requestFullscreen?.().catch(() => {});
+}
+
+/**
  * Build the geotagged-photo popup: a resizable box showing the photo scaled to
  * fill it, captioned with the photo's name and timestamp. The box uses CSS
- * `resize` so the user can drag its corner to enlarge the photo. Photos with no
- * thumbnail (e.g. HEIC) fall back to a "No preview available" note.
+ * `resize` so the user can drag its corner to enlarge the photo, and
+ * double-clicking the photo opens it fullscreen. Photos with no thumbnail (e.g.
+ * HEIC) fall back to a "No preview available" note.
  *
  * @param properties - The clicked feature's properties.
  * @returns The popup's DOM content element.
@@ -186,6 +249,14 @@ function createPhotoPopupElement(
     image.src = photo;
     image.alt = typeof properties.name === "string" ? properties.name : "Photo";
     image.className = "geolibre-photo-popup-img";
+    image.title = "Double-click to view fullscreen";
+    // Double-click (not single, so it never fights the resize drag) opens the
+    // photo fullscreen. The image is popup DOM, not the map canvas, so this does
+    // not trigger MapLibre's double-click zoom.
+    image.addEventListener("dblclick", (event) => {
+      event.stopPropagation();
+      openPhotoFullscreen(photo, image.alt);
+    });
     root.appendChild(image);
   } else {
     const placeholder = document.createElement("div");

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -11,6 +11,7 @@ import {
   fillExtrusionLayerId,
   fillLayerId,
   lineLayerId,
+  markerLayerId,
 } from "./geojson-loader";
 import {
   externalExtrusionLayerId,
@@ -146,6 +147,66 @@ function createIdentifyMessagePopupElement(
   message: string,
 ): HTMLElement {
   return createIdentifyPopupElement(layerName, { status: message });
+}
+
+/** Match an inline base64 raster image (excludes SVG, which can carry scripts). */
+const INLINE_IMAGE_DATA_URL = /^data:image\/(?!svg)[\w.+-]+;base64,/i;
+
+/**
+ * Find the first feature property holding an inline raster image (a geotagged
+ * photo or field-collection thumbnail), returning its data URL or null.
+ */
+function findPhotoDataUrl(properties: Record<string, unknown>): string | null {
+  for (const value of Object.values(properties)) {
+    if (typeof value === "string" && INLINE_IMAGE_DATA_URL.test(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the geotagged-photo popup: a resizable box showing the photo scaled to
+ * fill it, captioned with the photo's name and timestamp. The box uses CSS
+ * `resize` so the user can drag its corner to enlarge the photo. Photos with no
+ * thumbnail (e.g. HEIC) fall back to a "No preview available" note.
+ *
+ * @param properties - The clicked feature's properties.
+ * @returns The popup's DOM content element.
+ */
+function createPhotoPopupElement(
+  properties: Record<string, unknown>,
+): HTMLElement {
+  const root = document.createElement("div");
+  root.className = "geolibre-photo-popup";
+
+  const photo = findPhotoDataUrl(properties);
+  if (photo) {
+    const image = document.createElement("img");
+    image.src = photo;
+    image.alt = typeof properties.name === "string" ? properties.name : "Photo";
+    image.className = "geolibre-photo-popup-img";
+    root.appendChild(image);
+  } else {
+    const placeholder = document.createElement("div");
+    placeholder.className = "geolibre-photo-popup-placeholder";
+    placeholder.textContent = "No preview available";
+    root.appendChild(placeholder);
+  }
+
+  const caption = [properties.name, properties.timestamp]
+    .map((part) => (typeof part === "string" ? part.trim() : ""))
+    .filter(Boolean)
+    .join(" · ");
+  if (caption) {
+    const captionEl = document.createElement("div");
+    captionEl.className = "geolibre-photo-popup-caption";
+    captionEl.textContent = caption;
+    captionEl.title = caption;
+    root.appendChild(captionEl);
+  }
+
+  return root;
 }
 
 function nativeIdentifyLayerIds(layer: GeoLibreLayer): string[] {
@@ -619,6 +680,7 @@ export const MapCanvas = memo(function MapCanvas({
   const previousSelectedFeatureKey = useRef<string | null>(null);
   const previousDuckDBSelectionLayerId = useRef<string | null>(null);
   const identifyPopup = useRef<maplibregl.Popup | null>(null);
+  const photoPopup = useRef<maplibregl.Popup | null>(null);
 
   useEffect(() => {
     if (!containerRef.current || controller.current) return;
@@ -787,6 +849,18 @@ export const MapCanvas = memo(function MapCanvas({
   useEffect(() => {
     controller.current?.waitAndSyncLayers(renderLayers);
   }, [renderLayers]);
+
+  // Stable key over just the geotagged-photo layer ids, so the photo-click
+  // effect re-binds only when such a layer is added/removed, not on every
+  // unrelated layer edit (e.g. a coordinate update while dragging a pin).
+  const photoLayerKey = useMemo(
+    () =>
+      layers
+        .filter((layer) => layer.metadata.sourceKind === "geotagged-photos")
+        .map((layer) => layer.id)
+        .join(","),
+    [layers],
+  );
 
   useEffect(() => {
     const layer = layers.find((item) => item.id === selectedLayerId);
@@ -984,6 +1058,82 @@ export const MapCanvas = memo(function MapCanvas({
       map.getCanvas().style.cursor = "";
     };
   }, [identifyLayerId, layers, selectFeature]);
+
+  // Geotagged photos: clicking a photo point opens a resizable popup with the
+  // photo, without needing the Identify tool. The popup is photo-specific, and
+  // its box uses CSS `resize` so the thumbnail enlarges as it is dragged bigger.
+  useEffect(() => {
+    const map = controller.current?.getMap();
+    if (!map) return;
+    const photoLayerIds = photoLayerKey ? photoLayerKey.split(",") : [];
+    if (photoLayerIds.length === 0) return;
+
+    const removePhotoPopup = () => {
+      photoPopup.current?.remove();
+      photoPopup.current = null;
+    };
+
+    const handleClick = (event: maplibregl.MapLayerMouseEvent) => {
+      // The Identify tool already renders the photo in its own popup; skip ours
+      // so one click never opens two popups.
+      if (useAppStore.getState().identifyLayerId) return;
+      const feature = event.features?.[0];
+      if (!feature) return;
+      removePhotoPopup();
+      photoPopup.current = new maplibregl.Popup({
+        className: "geolibre-photo-popup-root",
+        closeButton: true,
+        closeOnClick: true,
+        maxWidth: "none",
+      })
+        .setLngLat(event.lngLat)
+        .setDOMContent(createPhotoPopupElement(feature.properties ?? {}))
+        .addTo(map);
+    };
+    const handleEnter = () => {
+      if (useAppStore.getState().identifyLayerId) return;
+      map.getCanvas().style.cursor = "pointer";
+    };
+    const handleLeave = () => {
+      if (useAppStore.getState().identifyLayerId) return;
+      map.getCanvas().style.cursor = "";
+    };
+
+    // Photo points render as a circle by default, or a marker symbol when the
+    // user enables markers; bind to whichever style layers actually exist.
+    let boundIds: string[] = [];
+    const unbind = () => {
+      for (const id of boundIds) {
+        map.off("click", id, handleClick);
+        map.off("mouseenter", id, handleEnter);
+        map.off("mouseleave", id, handleLeave);
+      }
+      boundIds = [];
+    };
+    const bind = () => {
+      unbind();
+      boundIds = photoLayerIds
+        .flatMap((id) => [circleLayerId(id), markerLayerId(id)])
+        .filter((id) => map.getLayer(id));
+      for (const id of boundIds) {
+        map.on("click", id, handleClick);
+        map.on("mouseenter", id, handleEnter);
+        map.on("mouseleave", id, handleLeave);
+      }
+    };
+
+    bind();
+    // syncLayers creates the circle/marker style layers and then dispatches this
+    // event, so re-bind on it to catch layers that did not exist yet when this
+    // effect first ran (e.g. before the style finished loading).
+    window.addEventListener("geolibre-layer-labels-change", bind);
+
+    return () => {
+      window.removeEventListener("geolibre-layer-labels-change", bind);
+      unbind();
+      removePhotoPopup();
+    };
+  }, [photoLayerKey]);
 
   useEffect(() => {
     controller.current?.applyView(mapView);

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1215,8 +1215,11 @@ export const MapCanvas = memo(function MapCanvas({
     // Close the photo popup when the Identify tool is turned on (which may
     // happen via a toolbar button, with no map click to dismiss it), so the
     // photo and identify popups never coexist.
-    const unsubscribeIdentify = useAppStore.subscribe((state) => {
-      if (state.identifyLayerId) {
+    const unsubscribeIdentify = useAppStore.subscribe((state, prev) => {
+      // Only on the off->on transition: the listener runs on every store change
+      // (e.g. setPointerCoords on each mousemove), so guarding on the current
+      // value alone would keep clobbering the Identify crosshair cursor.
+      if (state.identifyLayerId && !prev.identifyLayerId) {
         removePhotoPopup();
         // If Identify is enabled while the cursor already sits on a photo point,
         // mouseleave never fires, so clear the hover cursor here too.

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1216,7 +1216,12 @@ export const MapCanvas = memo(function MapCanvas({
     // happen via a toolbar button, with no map click to dismiss it), so the
     // photo and identify popups never coexist.
     const unsubscribeIdentify = useAppStore.subscribe((state) => {
-      if (state.identifyLayerId) removePhotoPopup();
+      if (state.identifyLayerId) {
+        removePhotoPopup();
+        // If Identify is enabled while the cursor already sits on a photo point,
+        // mouseleave never fires, so clear the hover cursor here too.
+        map.getCanvas().style.cursor = "";
+      }
     });
 
     return () => {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -917,21 +917,32 @@ export class MapController {
     // call rewrites the store and re-syncs the source. Coalesce to one update
     // per animation frame so a heavier `onMove` cannot stutter the drag.
     let rafPending = false;
+    const commit = () => {
+      const next = marker.getLngLat();
+      popup.setLngLat(next);
+      options.onMove([next.lng, next.lat]);
+    };
     const handleDrag = () => {
       if (rafPending) return;
       rafPending = true;
       requestAnimationFrame(() => {
         rafPending = false;
         if (disposed) return;
-        const next = marker.getLngLat();
-        popup.setLngLat(next);
-        options.onMove([next.lng, next.lat]);
+        commit();
       });
+    };
+    // The final `drag` may still be sitting in a pending frame when the user
+    // releases and clicks Done; commit the release position synchronously so the
+    // photo never lands one frame stale.
+    const handleDragEnd = () => {
+      if (disposed) return;
+      commit();
     };
     const dispose = () => {
       if (disposed) return;
       disposed = true;
       marker.off("drag", handleDrag);
+      marker.off("dragend", handleDragEnd);
       doneButton.removeEventListener("click", handleDone);
       popup.remove();
       marker.remove();
@@ -942,6 +953,7 @@ export class MapController {
     };
 
     marker.on("drag", handleDrag);
+    marker.on("dragend", handleDragEnd);
     doneButton.addEventListener("click", handleDone);
     return dispose;
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -857,6 +857,86 @@ export class MapController {
   }
 
   /**
+   * Drop a draggable pin at `lngLat` so the user can fine-tune the position of a
+   * feature that was just placed without coordinates of its own (e.g. a
+   * non-geotagged photo dropped at the map center). Every drag reports the new
+   * position through `onMove`; clicking the pin's "Done" button (label supplied
+   * by the caller so it stays translatable) removes the pin and runs `onDone`.
+   *
+   * The pin and its hint popup live outside the React tree, so the interaction
+   * survives the dialog that started it being closed. Returns a disposer that
+   * removes the pin early (e.g. if the caller needs to abort).
+   *
+   * @param lngLat - Where to drop the pin, as `[lng, lat]`.
+   * @param options - Translated labels plus the move/done callbacks.
+   * @returns A function that removes the pin and its popup.
+   */
+  startManualPlacement(
+    lngLat: [number, number],
+    options: {
+      /** Instruction shown in the pin's popup while it is draggable. */
+      hint: string;
+      /** Label for the button that finishes placement. */
+      doneLabel: string;
+      /** Called with `[lng, lat]` on every drag of the pin. */
+      onMove: (lngLat: [number, number]) => void;
+      /** Called once when the user clicks the "Done" button. */
+      onDone?: () => void;
+    },
+  ): () => void {
+    const map = this.map;
+    if (!map) return () => {};
+
+    const marker = new maplibregl.Marker({ draggable: true, color: "#ef4444" })
+      .setLngLat(lngLat)
+      .addTo(map);
+
+    const container = document.createElement("div");
+    container.className = "geolibre-placement-popup";
+    const hintText = document.createElement("p");
+    hintText.className = "geolibre-placement-popup-hint";
+    hintText.textContent = options.hint;
+    const doneButton = document.createElement("button");
+    doneButton.type = "button";
+    doneButton.className = "geolibre-placement-popup-done";
+    doneButton.textContent = options.doneLabel;
+    container.append(hintText, doneButton);
+
+    const popup = new maplibregl.Popup({
+      closeButton: false,
+      closeOnClick: false,
+      offset: 28,
+      className: "geolibre-placement-popup-root",
+    })
+      .setLngLat(lngLat)
+      .setDOMContent(container)
+      .addTo(map);
+
+    let disposed = false;
+    const handleDrag = () => {
+      const next = marker.getLngLat();
+      popup.setLngLat(next);
+      options.onMove([next.lng, next.lat]);
+    };
+    const dispose = () => {
+      if (disposed) return;
+      disposed = true;
+      marker.off("drag", handleDrag);
+      doneButton.removeEventListener("click", handleDone);
+      popup.remove();
+      marker.remove();
+    };
+    const handleDone = () => {
+      dispose();
+      options.onDone?.();
+    };
+
+    marker.on("drag", handleDrag);
+    doneButton.addEventListener("click", handleDone);
+    return dispose;
+  }
+
+  /**
    * Imperatively animate the camera, for the programmatic scripting API.
    *
    * Unlike {@link applyView} (which the store sync uses) this passes straight to

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -917,6 +917,14 @@ export class MapController {
     // call rewrites the store and re-syncs the source. Coalesce to one update
     // per animation frame so a heavier `onMove` cannot stutter the drag.
     let rafPending = false;
+    let dragRaf: number | null = null;
+    const cancelPendingFrame = () => {
+      if (dragRaf !== null) {
+        cancelAnimationFrame(dragRaf);
+        dragRaf = null;
+      }
+      rafPending = false;
+    };
     const commit = () => {
       const next = marker.getLngLat();
       popup.setLngLat(next);
@@ -925,7 +933,8 @@ export class MapController {
     const handleDrag = () => {
       if (rafPending) return;
       rafPending = true;
-      requestAnimationFrame(() => {
+      dragRaf = requestAnimationFrame(() => {
+        dragRaf = null;
         rafPending = false;
         if (disposed) return;
         commit();
@@ -933,14 +942,17 @@ export class MapController {
     };
     // The final `drag` may still be sitting in a pending frame when the user
     // releases and clicks Done; commit the release position synchronously so the
-    // photo never lands one frame stale.
+    // photo never lands one frame stale, dropping the queued frame so it does
+    // not fire a second, identical update.
     const handleDragEnd = () => {
       if (disposed) return;
+      cancelPendingFrame();
       commit();
     };
     const dispose = () => {
       if (disposed) return;
       disposed = true;
+      cancelPendingFrame();
       marker.off("drag", handleDrag);
       marker.off("dragend", handleDragEnd);
       doneButton.removeEventListener("click", handleDone);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -913,10 +913,20 @@ export class MapController {
       .addTo(map);
 
     let disposed = false;
+    // The `drag` event fires once per pointer-move frame (60-120 Hz), and each
+    // call rewrites the store and re-syncs the source. Coalesce to one update
+    // per animation frame so a heavier `onMove` cannot stutter the drag.
+    let rafPending = false;
     const handleDrag = () => {
-      const next = marker.getLngLat();
-      popup.setLngLat(next);
-      options.onMove([next.lng, next.lat]);
+      if (rafPending) return;
+      rafPending = true;
+      requestAnimationFrame(() => {
+        rafPending = false;
+        if (disposed) return;
+        const next = marker.getLngLat();
+        popup.setLngLat(next);
+        options.onMove([next.lng, next.lat]);
+      });
     };
     const dispose = () => {
       if (disposed) return;

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -7,6 +7,7 @@ import {
   isPhotoDropFileName,
   isPhotoFileName,
   isValidLngLat,
+  loadPhotosAtLocation,
   PHOTO_IMAGE_EXTENSIONS,
   relocatePhotoFeatures,
 } from "../apps/geolibre-desktop/src/lib/geotagged-photos";
@@ -163,5 +164,27 @@ describe("relocatePhotoFeatures", () => {
     relocatePhotoFeatures(collection, [0, 0]);
     assert.deepEqual(collection.features[0].geometry.coordinates, [-100, 40]);
     assert.deepEqual(collection.features[1].geometry.coordinates, [-100, 40]);
+  });
+});
+
+describe("loadPhotosAtLocation", () => {
+  it("places every photo at the center and never skips one", async () => {
+    // A buffer with no EXIF: GPS is absent, so the GPS importer would skip it,
+    // but manual placement must still produce a feature at the center. The
+    // thumbnail is null here (no canvas decoder under node), which is fine.
+    const files = [
+      new File([new Uint8Array([0, 1, 2, 3])], "a.jpg", { type: "image/jpeg" }),
+      new File([new Uint8Array([4, 5, 6, 7])], "b.jpg", { type: "image/jpeg" }),
+    ];
+    const result = await loadPhotosAtLocation(files, [-100, 40]);
+    assert.equal(result.total, 2);
+    assert.equal(result.located, 2);
+    assert.equal(result.skipped, 0);
+    assert.equal(result.featureCollection.features.length, 2);
+    for (const feature of result.featureCollection.features) {
+      assert.deepEqual(feature.geometry.coordinates, [-100, 40]);
+    }
+    assert.equal(result.featureCollection.features[0].properties?.name, "a.jpg");
+    assert.equal(result.featureCollection.features[1].properties?.name, "b.jpg");
   });
 });

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
+import type { FeatureCollection, Point } from "geojson";
 import {
   buildPhotoProperties,
   isPhotoDropFileName,
   isPhotoFileName,
   isValidLngLat,
   PHOTO_IMAGE_EXTENSIONS,
+  relocatePhotoFeatures,
 } from "../apps/geolibre-desktop/src/lib/geotagged-photos";
 import { PHOTO_PROPERTY } from "../apps/geolibre-desktop/src/lib/field-collection";
 
@@ -127,5 +129,39 @@ describe("buildPhotoProperties", () => {
       null,
     );
     assert.equal(props.camera, "Canon EOS R5");
+  });
+});
+
+describe("relocatePhotoFeatures", () => {
+  const collection: FeatureCollection<Point> = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-100, 40] },
+        properties: { name: "a.jpg", [PHOTO_PROPERTY]: "data:image/jpeg;a" },
+      },
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-100, 40] },
+        properties: { name: "b.jpg", camera: "Canon" },
+      },
+    ],
+  };
+
+  it("moves every feature to the new position and keeps properties", () => {
+    const moved = relocatePhotoFeatures(collection, [-122.4, 37.8]);
+    assert.equal(moved.features.length, 2);
+    for (const feature of moved.features) {
+      assert.deepEqual(feature.geometry.coordinates, [-122.4, 37.8]);
+    }
+    assert.equal(moved.features[0].properties?.[PHOTO_PROPERTY], "data:image/jpeg;a");
+    assert.equal(moved.features[1].properties?.camera, "Canon");
+  });
+
+  it("does not mutate the source collection", () => {
+    relocatePhotoFeatures(collection, [0, 0]);
+    assert.deepEqual(collection.features[0].geometry.coordinates, [-100, 40]);
+    assert.deepEqual(collection.features[1].geometry.coordinates, [-100, 40]);
   });
 });


### PR DESCRIPTION
## Summary

Implements the manual-placement workflow requested in #894. When a single selected photo carries no usable EXIF GPS, the **Add Geotagged Photos** dialog now pivots to a constructive prompt instead of the previous hard error ("No GPS location was found..."). The photo is dropped at the current map center, and a draggable pin lets the user fine-tune its position directly on the map before committing.

Because photos render as point features (the thumbnail shows in a click popup), there is no resizable image overlay to scale, so the request's "scale factor" input is not applicable. The flow focuses on the two parts that fit the model: place at center, then drag to fine-tune.

## What changed

- **`geotagged-photos.ts`**: `loadPhotosAtLocation(files, center)` builds a point layer for no-GPS photos at a given center, still reading EXIF metadata and generating thumbnails. `relocatePhotoFeatures(collection, [lng, lat])` moves the placed points as the pin is dragged.
- **`map-controller.ts`**: `startManualPlacement(lngLat, options)` drops a draggable MapLibre pin plus a themed hint popup with a **Done** button. It lives outside the React tree, so it survives the dialog closing (the modal overlay would otherwise block map dragging). Each drag reports the new position back through `onMove`.
- **`PhotosSource.tsx`**: a single no-GPS photo now shows the placement prompt (with the current map center) rather than throwing. Placing it adds the layer, starts the on-map drag pin, and closes the dialog so the map is interactive. Multiple no-GPS photos still report the original error.
- **i18n** (`en.json`): new `addData.photos.manual*` strings.
- **`index.css`**: themed styling for the on-map placement popup (light + dark).
- **Tests**: added `relocatePhotoFeatures` coverage to `tests/geotagged-photos.test.ts`.

## Verification

Reproduced and verified in the real app (web dev build) with Playwright using a non-geotagged PNG, in **both light and dark themes**:

- The prompt replaces the hard error and shows the map center.
- "Place at map center" adds the layer, closes the dialog, and shows the draggable pin + "Done" popup.
- Dragging the pin updates the stored feature coordinates (confirmed via the store: the point moved from the original center `[-100, 40]` to the dragged location, e.g. `[-61.13, 44.71]`).
- "Done" removes the pin and popup, leaving the photo point in place. No console errors.

`npm run build`, scoped `pre-commit`, and the frontend tests all pass.

Fixes #894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual placement flow for geotagged photo imports when no GPS location is available, including map-center prompting and drag-and-drop fine-tuning.
  * Upgraded photo interactions with resizable photo popups, draggable placement hints, and fullscreen photo previews with quick dismiss.
* **Bug Fixes**
  * Improved geotagged photo import reliability by relocating selected photos correctly to a chosen position while preserving photo details and metadata.
  * Refined thumbnail generation quality/sizing and fallback behavior for consistent previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->