### PR TITLE
fix(layers): friendlier empty-state hint for the Beginner profile

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -339,9 +339,8 @@ export function LayerPanel({
   hideOwnRail = false,
 }: LayerPanelProps) {
   const { t } = useTranslation();
-  // Beginners get a friendlier empty-state hint pointing at basemaps (the
-  // easiest first layer) as well as the Add Data menu; other profiles keep the
-  // concise message so the panel stays uncluttered on small screens (#881).
+  // Beginners get an empty-state hint that also points at basemaps (the easiest
+  // first layer); other profiles keep the concise one-liner (#881).
   const isBeginnerProfile = useDesktopSettingsStore(
     (s) => activeInterfaceProfile(s.desktopSettings.uiProfile) === "beginner",
   );

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -339,8 +339,7 @@ export function LayerPanel({
   hideOwnRail = false,
 }: LayerPanelProps) {
   const { t } = useTranslation();
-  // Beginners get an empty-state hint that also points at basemaps (the easiest
-  // first layer); other profiles keep the concise one-liner (#881).
+  // Beginners also get a basemap hint in the empty state; others keep the one-liner (#881).
   const isBeginnerProfile = useDesktopSettingsStore(
     (s) => activeInterfaceProfile(s.desktopSettings.uiProfile) === "beginner",
   );

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -339,7 +339,6 @@ export function LayerPanel({
   hideOwnRail = false,
 }: LayerPanelProps) {
   const { t } = useTranslation();
-  // Beginners also get a basemap hint in the empty state; others keep the one-liner (#881).
   const isBeginnerProfile = useDesktopSettingsStore(
     (s) => activeInterfaceProfile(s.desktopSettings.uiProfile) === "beginner",
   );

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -29,6 +29,8 @@ import type { MapController } from "@geolibre/map";
 import { isPlaceholderLayer, placeholderMessage } from "@geolibre/map";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
+import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
+import { activeInterfaceProfile } from "../../lib/ui-profile";
 import {
   Button,
   Dialog,
@@ -337,6 +339,12 @@ export function LayerPanel({
   hideOwnRail = false,
 }: LayerPanelProps) {
   const { t } = useTranslation();
+  // Beginners get a friendlier empty-state hint pointing at basemaps (the
+  // easiest first layer) as well as the Add Data menu; other profiles keep the
+  // concise message so the panel stays uncluttered on small screens (#881).
+  const isBeginnerProfile = useDesktopSettingsStore(
+    (s) => activeInterfaceProfile(s.desktopSettings.uiProfile) === "beginner",
+  );
   const layers = useAppStore((s) => s.layers);
   const layerGroups = useAppStore((s) => s.layerGroups);
   const addLayerGroup = useAppStore((s) => s.addLayerGroup);
@@ -1426,7 +1434,9 @@ export function LayerPanel({
         <div className="space-y-1 p-2">
           {layers.length === 0 && (
             <p className="px-2 py-4 text-xs text-muted-foreground">
-              No data layers. Add data from the toolbar.
+              {isBeginnerProfile
+                ? t("layers.emptyBeginner")
+                : t("layers.empty")}
             </p>
           )}
           {emptyGroups.map((group) => (

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2204,7 +2204,9 @@
     "newGroupFromLayer": "New group from layer",
     "moveToGroup": "Move to group",
     "removeFromGroup": "Remove from group",
-    "hiddenByGroup": "Hidden because its group is not visible"
+    "hiddenByGroup": "Hidden because its group is not visible",
+    "empty": "No data layers. Add data from the toolbar.",
+    "emptyBeginner": "No layers yet. Add basemaps via Plugins → Basemaps, or your own data via the Add Data menu."
   },
   "rasterSymbology": {
     "colorRampLabel": "Color ramp",


### PR DESCRIPTION
## Summary

Issue #881 asked for friendlier onboarding copy in the empty Layers panel. The current message — "No data layers. Add data from the toolbar." — points new users straight at the advanced data-import path and never hints that the Basemaps plugin opens a whole library of instantly usable layers.

Per discussion in the issue (keep the main screen uncluttered on mobile, but still help absolute beginners), this scopes the richer hint to the **Beginner** interface profile only:

- **Beginner profile:** "No layers yet. Add basemaps via Plugins → Basemaps, or your own data via the Add Data menu."
- **Intermediate / Advanced / default profiles:** keep the concise "No data layers. Add data from the toolbar." so the panel stays compact on small screens.

Both strings are now routed through `t()` (`layers.empty` / `layers.emptyBeginner`) instead of being hardcoded, so they are translatable.

## Implementation

- `LayerPanel` reads the active interface profile via `activeInterfaceProfile(uiProfile)` and swaps the empty-state copy when it is `beginner`.
- Added `layers.empty` and `layers.emptyBeginner` to `en.json`.

## Verification

Drove the real web app with Playwright using real profile/theme combinations:

| Profile | Theme | Empty-state text |
|---|---|---|
| Beginner | light | New basemaps hint ✅ |
| Beginner | dark | New basemaps hint ✅ |
| Advanced (default) | light | Concise one-liner ✅ |
| Advanced (default) | dark | Concise one-liner ✅ |

The referenced menu labels (Plugins → Basemaps, Add Data) match the real UI strings.

Fixes #881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a beginner-specific empty-state message for the Layers panel when no layers are available.
  * Kept the existing general empty-state message for other profiles, adjusting the text based on the active interface profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->