### PR TITLE
feat(colorbar): stack-order fix, stacking direction, and resizable panel (#884)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -59,7 +59,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.9.0",
-    "maplibre-gl-components": "^0.25.2",
+    "maplibre-gl-components": "^0.25.3",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -59,7 +59,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.9.0",
-    "maplibre-gl-components": "^0.25.1",
+    "maplibre-gl-components": "^0.25.2",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.9.0",
-        "maplibre-gl-components": "^0.25.1",
+        "maplibre-gl-components": "^0.25.2",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -188,9 +188,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.1.tgz",
-      "integrity": "sha512-witQScF0CnzkOyqMzpZ8MBH6GS4di31X0Fby6uQO7kId+zC9FF2X+1zhY4jIGIkJERamahASAzRC/NfYyDVGqA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.2.tgz",
+      "integrity": "sha512-S4c28/Kp9WyzqT+o2VPSsM6HL53V6PzSb6HSpuWCGI0ApYHldzbKkpuiMUJliZ24K2GdMGhuPH1f8altixuvoA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -23800,7 +23800,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.9.0",
-        "maplibre-gl-components": "^0.25.1",
+        "maplibre-gl-components": "^0.25.2",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -23839,9 +23839,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.1.tgz",
-      "integrity": "sha512-witQScF0CnzkOyqMzpZ8MBH6GS4di31X0Fby6uQO7kId+zC9FF2X+1zhY4jIGIkJERamahASAzRC/NfYyDVGqA==",
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.2.tgz",
+      "integrity": "sha512-S4c28/Kp9WyzqT+o2VPSsM6HL53V6PzSb6HSpuWCGI0ApYHldzbKkpuiMUJliZ24K2GdMGhuPH1f8altixuvoA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.9.0",
-        "maplibre-gl-components": "^0.25.2",
+        "maplibre-gl-components": "^0.25.3",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -188,9 +188,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.2.tgz",
-      "integrity": "sha512-S4c28/Kp9WyzqT+o2VPSsM6HL53V6PzSb6HSpuWCGI0ApYHldzbKkpuiMUJliZ24K2GdMGhuPH1f8altixuvoA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.3.tgz",
+      "integrity": "sha512-2pC2NUwu/7QCqJvBq52XKV+/5IPkEBUPasH7e3vfiyv3uwDldagvBq5EkBfLdgCUdmetnlZU2qCjVbWGzGzR4w==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -23800,7 +23800,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.9.0",
-        "maplibre-gl-components": "^0.25.2",
+        "maplibre-gl-components": "^0.25.3",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -23839,9 +23839,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.2.tgz",
-      "integrity": "sha512-S4c28/Kp9WyzqT+o2VPSsM6HL53V6PzSb6HSpuWCGI0ApYHldzbKkpuiMUJliZ24K2GdMGhuPH1f8altixuvoA==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.3.tgz",
+      "integrity": "sha512-2pC2NUwu/7QCqJvBq52XKV+/5IPkEBUPasH7e3vfiyv3uwDldagvBq5EkBfLdgCUdmetnlZU2qCjVbWGzGzR4w==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.9.0",
-    "maplibre-gl-components": "^0.25.1",
+    "maplibre-gl-components": "^0.25.2",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.9.0",
-    "maplibre-gl-components": "^0.25.2",
+    "maplibre-gl-components": "^0.25.3",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1432,7 +1432,7 @@ function normalizeComponentsProjectState(
   };
 }
 
-function normalizeColorbarState(
+export function normalizeColorbarState(
   state: unknown
 ): ComponentColorbarGuiState | undefined {
   if (!state || typeof state !== "object") return undefined;

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1432,6 +1432,7 @@ function normalizeComponentsProjectState(
   };
 }
 
+/** @internal Exported only so the project-state normalizer can be unit-tested. */
 export function normalizeColorbarState(
   state: unknown
 ): ComponentColorbarGuiState | undefined {

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -814,6 +814,7 @@ interface ComponentColorbarGuiState extends ComponentColorbarGuiEntryState {
   hasColorbar: boolean;
   selectedColorbarIndex: number;
   colorbars: ComponentColorbarGuiEntryState[];
+  stackOrientation: "horizontal" | "vertical";
 }
 
 interface ComponentLegendItem {
@@ -1452,6 +1453,8 @@ function normalizeColorbarState(
     hasColorbar: colorbars.length > 0,
     selectedColorbarIndex,
     colorbars,
+    stackOrientation:
+      candidate.stackOrientation === "horizontal" ? "horizontal" : "vertical",
   };
 }
 

--- a/tests/colorbar-state-normalization.test.ts
+++ b/tests/colorbar-state-normalization.test.ts
@@ -2,9 +2,6 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { normalizeColorbarState } from "../packages/plugins/src/plugins/maplibre-components.ts";
 
-// Guards the colorbar `stackOrientation` flag in saved project state:
-// horizontal persists on reopen, and missing/unknown values fall back to
-// vertical for backward compatibility with older projects.
 describe("normalizeColorbarState stackOrientation", () => {
   it("keeps a horizontal stack orientation", () => {
     const normalized = normalizeColorbarState({
@@ -13,6 +10,12 @@ describe("normalizeColorbarState stackOrientation", () => {
       stackOrientation: "horizontal",
     });
     assert.equal(normalized?.stackOrientation, "horizontal");
+  });
+
+  it("returns undefined for null/undefined/non-object input", () => {
+    assert.equal(normalizeColorbarState(null), undefined);
+    assert.equal(normalizeColorbarState(undefined), undefined);
+    assert.equal(normalizeColorbarState("nope"), undefined);
   });
 
   it("defaults missing stack orientation to vertical (backward compat)", () => {

--- a/tests/colorbar-state-normalization.test.ts
+++ b/tests/colorbar-state-normalization.test.ts
@@ -2,13 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { normalizeColorbarState } from "../packages/plugins/src/plugins/maplibre-components.ts";
 
-/**
- * The colorbar plugin persists a `stackOrientation` flag (vertical vs
- * horizontal stacking) in the saved project state. These tests guard the
- * normalization path that runs on both live control snapshots and deserialized
- * project JSON, so a user's horizontal choice round-trips on reopen and old
- * projects without the field fall back to the previous (vertical) behavior.
- */
+// Guards the colorbar `stackOrientation` flag in saved project state:
+// horizontal persists on reopen, and missing/unknown values fall back to
+// vertical for backward compatibility with older projects.
 describe("normalizeColorbarState stackOrientation", () => {
   it("keeps a horizontal stack orientation", () => {
     const normalized = normalizeColorbarState({
@@ -33,6 +29,15 @@ describe("normalizeColorbarState stackOrientation", () => {
     assert.equal(normalized?.stackOrientation, "vertical");
   });
 
+  it("preserves an explicit vertical stack orientation", () => {
+    const normalized = normalizeColorbarState({
+      visible: true,
+      colorbars: [],
+      stackOrientation: "vertical",
+    });
+    assert.equal(normalized?.stackOrientation, "vertical");
+  });
+
   it("round-trips a horizontal choice through a second normalization", () => {
     const once = normalizeColorbarState({
       visible: true,
@@ -40,7 +45,7 @@ describe("normalizeColorbarState stackOrientation", () => {
         {
           mode: "named",
           colormap: "viridis",
-          customColors: "",
+          customColors: "#440154, #31688e, #21918c, #90d743, #fde725",
           vmin: 0,
           vmax: 100,
           label: "Depth",

--- a/tests/colorbar-state-normalization.test.ts
+++ b/tests/colorbar-state-normalization.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { normalizeColorbarState } from "../packages/plugins/src/plugins/maplibre-components.ts";
+
+/**
+ * The colorbar plugin persists a `stackOrientation` flag (vertical vs
+ * horizontal stacking) in the saved project state. These tests guard the
+ * normalization path that runs on both live control snapshots and deserialized
+ * project JSON, so a user's horizontal choice round-trips on reopen and old
+ * projects without the field fall back to the previous (vertical) behavior.
+ */
+describe("normalizeColorbarState stackOrientation", () => {
+  it("keeps a horizontal stack orientation", () => {
+    const normalized = normalizeColorbarState({
+      visible: true,
+      colorbars: [],
+      stackOrientation: "horizontal",
+    });
+    assert.equal(normalized?.stackOrientation, "horizontal");
+  });
+
+  it("defaults missing stack orientation to vertical (backward compat)", () => {
+    const normalized = normalizeColorbarState({ visible: true, colorbars: [] });
+    assert.equal(normalized?.stackOrientation, "vertical");
+  });
+
+  it("coerces an unknown stack orientation to vertical", () => {
+    const normalized = normalizeColorbarState({
+      visible: true,
+      colorbars: [],
+      stackOrientation: "diagonal",
+    });
+    assert.equal(normalized?.stackOrientation, "vertical");
+  });
+
+  it("round-trips a horizontal choice through a second normalization", () => {
+    const once = normalizeColorbarState({
+      visible: true,
+      colorbars: [
+        {
+          mode: "named",
+          colormap: "viridis",
+          customColors: "",
+          vmin: 0,
+          vmax: 100,
+          label: "Depth",
+          units: "",
+          orientation: "vertical",
+          colorbarPosition: "bottom-right",
+        },
+      ],
+      stackOrientation: "horizontal",
+    });
+    const twice = normalizeColorbarState(once);
+    assert.equal(twice?.stackOrientation, "horizontal");
+    assert.deepEqual(twice, once);
+  });
+});


### PR DESCRIPTION
## Summary

Colorbar plugin improvements from #884, plus a resizable config panel:

- **Issue 2 (bug): colorbars jumped position on update.** When several colorbars shared a corner, **Update Selected Colorbar** moved the edited one to the top of the stack (the control removed and re-added it, and MapLibre inserts bottom-corner controls at the front). Fixed: colorbars sharing a corner are grouped into one control and re-render in place in stable order.
- **Issue 3 (feature): stacking direction.** Choose to stack multiple colorbars **vertically** (default) or **horizontally**, via a new **Stack multiple colorbars** dropdown. Independent of a single bar's orientation.
- **Resizable panel.** The colorbar config panel now resizes from two bottom-corner grips (matching the HTML and data panels); drag either grip to grow it toward the map interior.

Issue 1 (separate Name vs Label field) was scoped by the reporter to a later release and is not included.

## How

All three live in the upstream `maplibre-gl-components` package:
- opengeos/maplibre-gl-components#116 (stacking) released as **v0.25.2**
- opengeos/maplibre-gl-components#117 (resizable panel) released as **v0.25.3**

This PR bumps `maplibre-gl-components` to `^0.25.3` in `apps/geolibre-desktop` and `packages/plugins`, and mirrors the new `stackOrientation` field in the saved colorbar project state so a horizontal choice round-trips on reopen.

## Testing

- `npm run build` and scoped `pre-commit run --files ...` (incl. the npm-build hook) pass; added `tests/colorbar-state-normalization.test.ts` for the stackOrientation round-trip.
- Upstream suites: 215 tests pass, with regression tests for grouped stacking, the stacking toggle, and the resize grips.
- Verified in the running app with Playwright (light + dark): update keeps stack order; horizontal lays colorbars side by side; dragging a bottom grip grows the panel in both width and height. No console errors.

Fixes #884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color bar orientation handling: an explicit **“horizontal”** setting is preserved; missing or invalid values now reliably fall back to **“vertical”** and remain stable across repeated normalization.
* **Tests**
  * Added Node test coverage for `stackOrientation` normalization, including backward-compatible defaults, invalid-value coercion, and idempotency.
* **Chores**
  * Updated the shared map rendering component dependency in both the desktop and plugin packages to `^0.25.3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->