### PR TITLE
feat(issues): add GitHub issue forms and triage labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Report unexpected behavior or a possible flaw in GeoLibre.
+title: "[Bug]: "
+labels: ["unconfirmed possible issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a problem. Please fill out the sections below so we can reproduce and confirm the issue.
+
+        Reports start as **unconfirmed possible issue**. Once a maintainer reproduces the problem, it is promoted to **bug**.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the [existing issues](https://github.com/opengeos/GeoLibre/issues) and did not find a duplicate.
+          required: true
+        - label: This is a bug report, not a usage question (questions belong in [Discussions](https://github.com/opengeos/GeoLibre/discussions)).
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the unexpected behavior.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Tell us how to reproduce the behavior, step by step.
+      placeholder: |
+        1. Open '...'
+        2. Add data '...'
+        3. Click on '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+  - type: input
+    id: app
+    attributes:
+      label: How are you running GeoLibre?
+      description: Web app, desktop app, or Jupyter, plus the version if you know it.
+      placeholder: Desktop app v0.x.y / Web (https://geolibre.app) / Jupyter
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system and browser
+      description: e.g. Windows 11 + Chrome 126, macOS 14 + Safari, Ubuntu 24.04.
+    validations:
+      required: false
+  - type: textarea
+    id: data
+    attributes:
+      label: Sample data
+      description: If the bug is tied to a specific dataset, share a small sample or a link so we can reproduce it.
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or logs
+      description: Add screenshots, screen recordings, or console output if they help explain the problem.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/opengeos/GeoLibre/discussions/new?category=q-a
+    about: Have a "how do I do X?" question? Please ask in Discussions (Q&A) to keep the issue tracker focused on bugs and feature requests.
+  - name: Ideas and general discussion
+    url: https://github.com/opengeos/GeoLibre/discussions
+    about: Share early-stage ideas, show your work, or chat with the community in Discussions.
+  - name: Documentation
+    url: https://geolibre.app
+    about: Browse the docs and guides before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for helping make GeoLibre better. Please describe what you would like and why it matters.
 
-        The scope you pick below helps maintainers triage. It maps to the **enhancement (small)**, **enhancement (medium)**, and **wishlist** labels.
+        This form labels the issue **enhancement**. The scope you pick below is informational: a maintainer will read your selection and add the matching **enhancement (small)**, **enhancement (medium)**, or **wishlist** label during triage.
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest a new feature, enhancement, or UX improvement for GeoLibre.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping make GeoLibre better. Please describe what you would like and why it matters.
+
+        The scope you pick below helps maintainers triage. It maps to the **enhancement (small)**, **enhancement (medium)**, and **wishlist** labels.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched the [existing issues](https://github.com/opengeos/GeoLibre/issues) and did not find a duplicate request.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow, pain point, or limitation that motivates this request.
+      placeholder: When working with ..., it is hard to ... because ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you would like to see. Mockups or examples are welcome.
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Estimated scope
+      description: Your best guess at the size. A maintainer will confirm and apply the matching label.
+      options:
+        - "Small: a minor tweak, small UI change, or text adjustment"
+        - "Medium: a broader feature that is feasible in a reasonable timeframe"
+        - "Wishlist: a larger or longer-term idea"
+        - "Not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you currently use, or other approaches you thought about.
+    validations:
+      required: false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,47 @@
+# Source of truth for this repository's issue/PR labels.
+# Synced to GitHub by .github/workflows/labels.yml on push to main.
+# The sync is additive (delete-other-labels is off), so labels not listed
+# here are left untouched.
+
+- name: bug
+  color: "d73a4a"
+  description: Something isn't working
+- name: unconfirmed possible issue
+  color: "fef2c0"
+  description: Reported behavior not yet reproduced or confirmed as a bug
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or request
+- name: enhancement (small)
+  color: "c5f0f5"
+  description: Minor feature, small UI tweak, or text adjustment
+- name: enhancement (medium)
+  color: "76d3dd"
+  description: Broader feature, feasible within a reasonable timeframe
+- name: wishlist
+  color: "4a0aca"
+  description: Feature requests that require significant efforts
+- name: question
+  color: "d876e3"
+  description: Further information is requested
+- name: waiting on user feedback
+  color: "fbca04"
+  description: Progress depends on the reporter (e.g. sample data or verification)
+- name: documentation
+  color: "0075ca"
+  description: Improvements or additions to documentation
+- name: duplicate
+  color: "cfd3d7"
+  description: This issue or pull request already exists
+- name: good first issue
+  color: "7057ff"
+  description: Good for newcomers
+- name: help wanted
+  color: "008672"
+  description: Extra attention is needed
+- name: invalid
+  color: "e4e669"
+  description: This doesn't seem right
+- name: wontfix
+  color: "ffffff"
+  description: This will not be worked on

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,27 @@
+name: Sync labels
+
+# Keeps the repository's labels in sync with .github/labels.yml so they are
+# version-controlled and recreated automatically if deleted. The sync is
+# additive: existing labels not listed in the manifest are left untouched.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Implements the labeling and issue-intake framework proposed in #896. Adds structured **GitHub Issue Forms** so incoming reports self-label and stay organized, and creates the proposed triage labels.

### Issue Forms (`.github/ISSUE_TEMPLATE/`)

- **`bug_report.yml`** — guided fields (what happened, steps, expected, environment, sample data, screenshots). Auto-applies **`unconfirmed possible issue`** so reports enter a triage state and are promoted to **`bug`** only after a maintainer reproduces them.
- **`feature_request.yml`** — problem/proposal fields plus a **scope dropdown** (small / medium / wishlist / not sure) that maps to the sized enhancement labels. Auto-applies **`enhancement`**.
- **`config.yml`** — disables blank issues and routes usage questions to **Discussions → Q&A**, plus links to Ideas/General and the docs. This keeps "how do I do X?" out of the issue tracker, as discussed in the thread.

### New labels (created on the repo)

- `waiting on user feedback` — progress depends on the reporter
- `unconfirmed possible issue` — reported but not yet reproduced/confirmed
- `enhancement (small)` — minor tweak / small UI / text change
- `enhancement (medium)` — broader but feasible feature

Existing `question`, `bug`, `wishlist`, and `duplicate` labels already cover the rest of the proposal.

## Notes

- Bug reports intentionally land as `unconfirmed possible issue` rather than `bug`, matching the proposal's triage-before-confirm philosophy.
- GitHub Issue Forms cannot conditionally apply labels from a dropdown, so the feature form applies `enhancement` and a maintainer promotes it to the matching sized label after reading the selected scope.

Closes #896
