### PR TITLE
fix(settings): editable hex input for the custom accent color

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1712,7 +1712,6 @@ export function SettingsDialog({
                             wrapping label drives (#911). */}
                         <input
                           type="text"
-                          inputMode="text"
                           spellCheck={false}
                           autoComplete="off"
                           className="ml-auto w-24 rounded border bg-transparent px-2 py-1 text-right font-mono text-xs uppercase text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive aria-[invalid=true]:text-destructive"
@@ -1726,8 +1725,10 @@ export function SettingsDialog({
                           onBlur={commitCustomColorDraft}
                           onKeyDown={(event) => {
                             if (event.key === "Enter") {
+                              // Blur is the single commit path; the resulting
+                              // onBlur applies/reverts the draft, so don't also
+                              // commit here and double-write the same value.
                               event.preventDefault();
-                              commitCustomColorDraft();
                               event.currentTarget.blur();
                             }
                           }}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1723,6 +1723,10 @@ export function SettingsDialog({
                             customColorDraft ??
                             desktopSettings.theme.customColor
                           }
+                          // The field already holds a full `#rrggbb` at the
+                          // maxLength cap, so select all on focus to let the user
+                          // type a replacement instead of silently dropping keys.
+                          onFocus={(event) => event.target.select()}
                           onChange={(event) =>
                             setCustomColorDraft(event.target.value)
                           }

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -809,8 +809,17 @@ export function SettingsDialog({
   // mirrors the saved color. On commit a valid 3- or 6-digit hex applies and an
   // invalid one is discarded, so the field reverts to the last valid color (#911).
   const [customColorDraft, setCustomColorDraft] = useState<string | null>(null);
+  // Set just before the Escape-triggered blur so the imminent blur discards the
+  // draft instead of committing it: the dialog still closes (its own Escape
+  // handler), but the typed value is cancelled rather than applied on the way out.
+  const skipCustomColorCommitRef = useRef(false);
 
   const commitCustomColorDraft = () => {
+    if (skipCustomColorCommitRef.current) {
+      skipCustomColorCommitRef.current = false;
+      setCustomColorDraft(null);
+      return;
+    }
     if (customColorDraft === null) return;
     const normalized = normalizeHexColor(customColorDraft);
     if (normalized) updateSavedThemeCustomColor(normalized);
@@ -1714,10 +1723,11 @@ export function SettingsDialog({
                           type="text"
                           spellCheck={false}
                           autoComplete="off"
-                          // `#rrggbb` is the longest value this accepts, so cap
-                          // the field rather than let a huge paste sit there
-                          // visually clobbered until blur reverts it.
-                          maxLength={7}
+                          // `#rrggbb` is the longest value this accepts; the
+                          // extra slot lets a paste with one stray leading/
+                          // trailing space survive intact for normalizeHexColor
+                          // to trim, while still capping a runaway paste.
+                          maxLength={8}
                           className="ml-auto w-24 rounded border bg-transparent px-2 py-1 text-right font-mono text-xs uppercase text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive aria-[invalid=true]:text-destructive"
                           value={
                             customColorDraft ??
@@ -1737,6 +1747,12 @@ export function SettingsDialog({
                               // onBlur applies/reverts the draft, so don't also
                               // commit here and double-write the same value.
                               event.preventDefault();
+                              event.currentTarget.blur();
+                            } else if (event.key === "Escape") {
+                              // Cancel the edit: flag the commit to skip, then
+                              // blur so the value is dropped, not applied. The
+                              // dialog's own Escape handling still closes it.
+                              skipCustomColorCommitRef.current = true;
                               event.currentTarget.blur();
                             }
                           }}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -80,7 +80,11 @@ import {
 import { useLanguage } from "../../hooks/useLanguage";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/is-tauri";
-import { THEME_SCHEMES, type ThemeScheme } from "../../lib/theme-schemes";
+import {
+  THEME_SCHEMES,
+  normalizeHexColor,
+  type ThemeScheme,
+} from "../../lib/theme-schemes";
 import type { UpdateNotificationLevel } from "../../lib/updates";
 import {
   DATA_SOURCE_CATALOG,
@@ -469,6 +473,9 @@ export function SettingsDialog({
       // focus RAF fires, a leftover target would otherwise fire on a later
       // open that never asked for it.
       setPendingFocus(null);
+      // Discard any uncommitted hex text so a half-typed/invalid value never
+      // resurfaces on the next open (the swatch already shows the saved color).
+      setCustomColorDraft(null);
       return;
     }
     const seededPreferences = clonePreferences(
@@ -795,6 +802,19 @@ export function SettingsDialog({
       ...current,
       theme: { ...current.theme, scheme: "custom", customColor },
     });
+  };
+
+  // In-progress text for the inline hex field next to the swatch. While the user
+  // is typing or pasting a code it holds the raw string; `null` means the field
+  // mirrors the saved color. On commit a valid 3- or 6-digit hex applies and an
+  // invalid one is discarded, so the field reverts to the last valid color (#911).
+  const [customColorDraft, setCustomColorDraft] = useState<string | null>(null);
+
+  const commitCustomColorDraft = () => {
+    if (customColorDraft === null) return;
+    const normalized = normalizeHexColor(customColorDraft);
+    if (normalized) updateSavedThemeCustomColor(normalized);
+    setCustomColorDraft(null);
   };
 
   const updateDraftUpdateSettings = (patch: Partial<UpdateSettings>) => {
@@ -1685,9 +1705,38 @@ export function SettingsDialog({
                           aria-label={t("settings.appearance.customColor")}
                         />
                         <span>{t("settings.appearance.customColor")}</span>
-                        <code className="ml-auto text-xs uppercase text-muted-foreground">
-                          {desktopSettings.theme.customColor}
-                        </code>
+                        {/* Inline hex entry so power users can type or paste an
+                            exact code instead of only dragging the native picker.
+                            The text input is interactive content, so a click lands
+                            here and focuses it rather than reopening the picker the
+                            wrapping label drives (#911). */}
+                        <input
+                          type="text"
+                          inputMode="text"
+                          spellCheck={false}
+                          autoComplete="off"
+                          className="ml-auto w-24 rounded border bg-transparent px-2 py-1 text-right font-mono text-xs uppercase text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive aria-[invalid=true]:text-destructive"
+                          value={
+                            customColorDraft ??
+                            desktopSettings.theme.customColor
+                          }
+                          onChange={(event) =>
+                            setCustomColorDraft(event.target.value)
+                          }
+                          onBlur={commitCustomColorDraft}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              event.preventDefault();
+                              commitCustomColorDraft();
+                              event.currentTarget.blur();
+                            }
+                          }}
+                          aria-label={t("settings.appearance.customColorHex")}
+                          aria-invalid={
+                            customColorDraft !== null &&
+                            normalizeHexColor(customColorDraft) === null
+                          }
+                        />
                       </label>
                     ) : null}
                   </div>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1714,6 +1714,10 @@ export function SettingsDialog({
                           type="text"
                           spellCheck={false}
                           autoComplete="off"
+                          // `#rrggbb` is the longest value this accepts, so cap
+                          // the field rather than let a huge paste sit there
+                          // visually clobbered until blur reverts it.
+                          maxLength={7}
                           className="ml-auto w-24 rounded border bg-transparent px-2 py-1 text-right font-mono text-xs uppercase text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive aria-[invalid=true]:text-destructive"
                           value={
                             customColorDraft ??
@@ -1735,6 +1739,7 @@ export function SettingsDialog({
                           aria-label={t("settings.appearance.customColorHex")}
                           aria-invalid={
                             customColorDraft !== null &&
+                            customColorDraft.trim() !== "" &&
                             normalizeHexColor(customColorDraft) === null
                           }
                         />

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -474,7 +474,10 @@ export function SettingsDialog({
       // open that never asked for it.
       setPendingFocus(null);
       // Discard any uncommitted hex text so a half-typed/invalid value never
-      // resurfaces on the next open (the swatch already shows the saved color).
+      // resurfaces on the next open (the swatch already shows the saved color),
+      // and clear the Escape skip flag so a leftover true can't swallow the
+      // first edit of the next session.
+      skipCustomColorCommitRef.current = false;
       setCustomColorDraft(null);
       return;
     }
@@ -1757,10 +1760,14 @@ export function SettingsDialog({
                             }
                           }}
                           aria-label={t("settings.appearance.customColorHex")}
+                          // `|| undefined` omits the attribute entirely when
+                          // valid; a literal aria-invalid="false" makes some
+                          // screen readers announce "invalid: false" on focus.
                           aria-invalid={
-                            customColorDraft !== null &&
-                            customColorDraft.trim() !== "" &&
-                            normalizeHexColor(customColorDraft) === null
+                            (customColorDraft !== null &&
+                              customColorDraft.trim() !== "" &&
+                              normalizeHexColor(customColorDraft) === null) ||
+                            undefined
                           }
                         />
                       </label>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1726,22 +1726,24 @@ export function SettingsDialog({
                           type="text"
                           spellCheck={false}
                           autoComplete="off"
-                          // `#rrggbb` is the longest value this accepts; the
-                          // extra slot lets a paste with one stray leading/
-                          // trailing space survive intact for normalizeHexColor
-                          // to trim, while still capping a runaway paste.
-                          maxLength={8}
                           className="ml-auto w-24 rounded border bg-transparent px-2 py-1 text-right font-mono text-xs uppercase text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive aria-[invalid=true]:text-destructive"
                           value={
                             customColorDraft ??
                             desktopSettings.theme.customColor
                           }
-                          // The field already holds a full `#rrggbb` at the
-                          // maxLength cap, so select all on focus to let the user
-                          // type a replacement instead of silently dropping keys.
+                          // The field already holds a full `#rrggbb`, so select
+                          // all on focus to let the user type a replacement.
                           onFocus={(event) => event.target.select()}
+                          // Drop whitespace and cap to the longest valid form
+                          // (`#rrggbb`) as the draft is stored, so a padded or
+                          // oversized paste is sanitized in place instead of
+                          // sitting clobbered; this also bounds a runaway paste
+                          // without a brittle maxLength that has to guess how
+                          // much surrounding whitespace to allow.
                           onChange={(event) =>
-                            setCustomColorDraft(event.target.value)
+                            setCustomColorDraft(
+                              event.target.value.replace(/\s/g, "").slice(0, 7),
+                            )
                           }
                           onBlur={commitCustomColorDraft}
                           onKeyDown={(event) => {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1064,6 +1064,7 @@
       "accentColor": "Accent color",
       "custom": "Custom",
       "customColor": "Custom color",
+      "customColorHex": "Custom color hex code",
       "scheme": {
         "blue": "Blue",
         "violet": "Violet",

--- a/apps/geolibre-desktop/src/lib/theme-schemes.ts
+++ b/apps/geolibre-desktop/src/lib/theme-schemes.ts
@@ -111,6 +111,18 @@ function expandHex(hex: string): string {
 }
 
 /**
+ * Normalize free-form hex input to a canonical `#rrggbb` lowercase string, or
+ * `null` when it is not a valid 3- or 6-digit hex. A leading `#` is optional, so
+ * the Appearance pane can accept typed or pasted codes like `D58400` (#911).
+ */
+export function normalizeHexColor(value: string): string | null {
+  const trimmed = value.trim();
+  const candidate = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+  if (!isHexColor(candidate)) return null;
+  return `#${expandHex(candidate)}`;
+}
+
+/**
  * Convert a hex color to the bare HSL channels (`"H S% L%"`) the design tokens
  * expect. Returns null for invalid input.
  *

--- a/tests/theme-normalize-hex.test.ts
+++ b/tests/theme-normalize-hex.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { normalizeHexColor } from "../apps/geolibre-desktop/src/lib/theme-schemes";
+
+describe("normalizeHexColor", () => {
+  it("accepts 6-digit hex with or without a leading #", () => {
+    assert.equal(normalizeHexColor("#D58400"), "#d58400");
+    assert.equal(normalizeHexColor("D58400"), "#d58400");
+  });
+
+  it("expands 3-digit shorthand to its six lowercase digits", () => {
+    assert.equal(normalizeHexColor("#0f0"), "#00ff00");
+    assert.equal(normalizeHexColor("abc"), "#aabbcc");
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    assert.equal(normalizeHexColor("  #3B82F6  "), "#3b82f6");
+  });
+
+  it("returns null for anything that is not a valid 3- or 6-digit hex", () => {
+    for (const bad of ["", "#", "nothex", "#12", "#12345", "#1234567", "ggg"]) {
+      assert.equal(normalizeHexColor(bad), null, `expected null for ${bad}`);
+    }
+  });
+});

--- a/tests/theme-normalize-hex.test.ts
+++ b/tests/theme-normalize-hex.test.ts
@@ -11,6 +11,9 @@ describe("normalizeHexColor", () => {
   it("expands 3-digit shorthand to its six lowercase digits", () => {
     assert.equal(normalizeHexColor("#0f0"), "#00ff00");
     assert.equal(normalizeHexColor("abc"), "#aabbcc");
+    // Uppercase, no leading # — exercises both the case-insensitive match and
+    // the lowercasing of the expanded result.
+    assert.equal(normalizeHexColor("ABC"), "#aabbcc");
   });
 
   it("tolerates surrounding whitespace", () => {
@@ -18,7 +21,18 @@ describe("normalizeHexColor", () => {
   });
 
   it("returns null for anything that is not a valid 3- or 6-digit hex", () => {
-    for (const bad of ["", "#", "nothex", "#12", "#12345", "#1234567", "ggg"]) {
+    // `#1234` is the CSS Color 4 RGBA shorthand — valid in CSS, but this app
+    // only renders 3- or 6-digit hex, so it must be rejected here.
+    for (const bad of [
+      "",
+      "#",
+      "nothex",
+      "#12",
+      "#1234",
+      "#12345",
+      "#1234567",
+      "ggg",
+    ]) {
       assert.equal(normalizeHexColor(bad), null, `expected null for ${bad}`);
     }
   });

--- a/tests/theme-normalize-hex.test.ts
+++ b/tests/theme-normalize-hex.test.ts
@@ -18,6 +18,8 @@ describe("normalizeHexColor", () => {
 
   it("tolerates surrounding whitespace", () => {
     assert.equal(normalizeHexColor("  #3B82F6  "), "#3b82f6");
+    // No leading # exercises the branch that prepends one after trimming.
+    assert.equal(normalizeHexColor("  D58400  "), "#d58400");
   });
 
   it("returns null for anything that is not a valid 3- or 6-digit hex", () => {

--- a/tests/theme-normalize-hex.test.ts
+++ b/tests/theme-normalize-hex.test.ts
@@ -25,6 +25,7 @@ describe("normalizeHexColor", () => {
     // only renders 3- or 6-digit hex, so it must be rejected here.
     for (const bad of [
       "",
+      "   ",
       "#",
       "nothex",
       "#12",


### PR DESCRIPTION
## Summary

Fixes #911. The **Appearance → Custom color** row wrapped the color swatch and a read-only hex code (`<code>`) inside a single `<label>`, so clicking the hex code forwarded the click to the native color picker and made it impossible to type or paste an exact value.

This replaces the read-only code with an inline text input so power users can enter a precise hex value:

- Click the hex code to focus the text field (no longer pops the picker); the swatch and the row background still open the native picker as before.
- Commits on **Enter** or **blur**.
- Accepts a **3- or 6-digit** hex, **with or without** a leading `#` (e.g. `D58400`, `0f0`); the value is normalized to canonical `#rrggbb`.
- Invalid input gracefully **reverts to the last valid color** and the field shows `aria-invalid` feedback (destructive border/text).
- Keyboard accessible via Tab.
- An uncommitted draft is discarded when the dialog closes, so a half-typed value never resurfaces on the next open.

A small `normalizeHexColor` helper was added to `theme-schemes.ts` (reusing the existing hex regex and expansion) with unit tests.

## Verification

Drove the real web app with Playwright and confirmed in **both light and dark themes**:

- Typing `f97316` (no `#`) → applied as `#f97316`, swatch synced.
- Typing `#0f0` → expanded to `#00ff00`.
- Typing `nothex` / `bogus` → reverted to the last valid color, dialog stayed open, field flagged invalid.
- Clicking the hex code focused the text input (`type="text"`), not the picker.

Also added `tests/theme-normalize-hex.test.ts`, ran the frontend i18n catalog test, full build/typecheck, and pre-commit (all green).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now edit the Appearance “Custom” accent color using a direct hex input with inline validation.
  * Hex input is normalized automatically (supports 3- and 6-digit formats, optional `#`, trimming whitespace).

* **Bug Fixes**
  * Partially typed or invalid hex values are discarded when the dialog is closed or when you cancel with Escape.
  * Changes are committed reliably when you press Enter or when the field loses focus.

* **Tests**
  * Added automated coverage for hex normalization, including valid/invalid and whitespace cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->