### PR TITLE
docs: rename Live Demo to Launch GeoLibre Web; make Getting Started user-focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoLibre
 
-[![live demo](https://img.shields.io/badge/Live-demo-green.svg)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 [![GeoLibre shared project](https://img.shields.io/badge/GeoLibre-share-green.svg)](https://share.geolibre.app)
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -3,7 +3,7 @@
 GeoLibre desktop installers are published from GitHub Releases.
 
 [View releases](https://github.com/opengeos/GeoLibre/releases){ .md-button .md-button--primary }
-[Open live demo](https://viewer.geolibre.app/){ .md-button }
+[Launch GeoLibre Web](https://viewer.geolibre.app/){ .md-button }
 
 ## Release assets
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,12 @@ The [`geolibre`](python.md) Python package embeds the full GeoLibre app in a Jup
 pip install geolibre
 ```
 
+Or install it from conda-forge:
+
+```bash
+conda install -c conda-forge geolibre
+```
+
 See the [Python Package](python.md) reference to get started.
 
 ### On Android

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,20 +15,58 @@
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
-GeoLibre is a free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. It runs everywhere you do, in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all while keeping your data local and private. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS.
+GeoLibre is a free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. It runs everywhere you do, in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all while keeping your data local and private.
+
+This page helps you start using GeoLibre. If you want to contribute to GeoLibre or run it from source, jump to [Run from source](#run-from-source) below or read the [Contributing](contributing.md) guide.
+
+## Use GeoLibre
+
+Pick whichever fits how you work. The same app ships in every form, so projects and `.geolibre.json` files move between them.
+
+### On the web
+
+GeoLibre Web is the full app running in your browser, with nothing to install. It keeps your data local and private, processing everything client-side in your browser session.
+
+[Launch GeoLibre Web](https://viewer.geolibre.app/){ .md-button .md-button--primary }
+
+You can load browser-selected vector data supported by DuckDB-WASM Spatial, drag GeoTIFF/COG rasters onto the map, add URL-based services and datasets (XYZ, WMS, GeoJSON, vector tiles, COG, ArcGIS, FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats), style layers, and test plugins. Desktop-only file dialogs, local MBTiles, local raster file reads, and project save/open need the desktop app.
+
+### On the desktop
+
+The desktop app adds local filesystem dialogs, local MBTiles, local raster file reads, and project save/open. Installers are available for Windows, macOS, and Linux, including the Microsoft Store, Homebrew, winget, the AUR, COPR, and Flatpak.
+
+[Download the desktop app](downloads.md){ .md-button .md-button--primary }
+
+### In Jupyter
+
+The [`geolibre`](python.md) Python package embeds the full GeoLibre app in a Jupyter notebook and drives the map through an expanded leafmap-style API that syncs both ways, so UI edits read back from Python.
+
+```bash
+pip install geolibre
+```
+
+See the [Python Package](python.md) reference to get started.
+
+### On Android
+
+GeoLibre ships as a native Android app built from the same codebase, with a responsive touch layout for phones. See [Android](android.md) for install details.
 
 ## Video tutorials
 
 - [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 - [Geoprocessing in the Browser: 700+ Free GIS Tools in GeoLibre, Zero Install](https://youtu.be/W32bIQO_nG8)
 
-## Prerequisites
+## Run from source
+
+This section is for contributors and developers who want to clone GeoLibre and run it locally. Most users do not need it. For the full development workflow, project layout, and quality gate, see the [Contributing](contributing.md) guide. GeoLibre is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS.
+
+### Prerequisites
 
 - Node.js 22 or newer
 - Rust toolchain for desktop builds
 - Linux desktop build dependencies from the Tauri v2 prerequisites
 
-## Install
+### Install
 
 ```bash
 git clone https://github.com/opengeos/GeoLibre.git
@@ -38,7 +76,7 @@ npm install
 
 Bun users can run `bun install`. The root `trustedDependencies` list allows the known install scripts for `core-js`, `@google/genai`, and `protobufjs`.
 
-## Update
+### Update
 
 To update an existing source checkout to the latest version, pull the changes, reinstall dependencies (in case `package.json` changed), and rebuild:
 
@@ -50,7 +88,7 @@ npm install            # or: bun install
 
 If you run a production build, rebuild afterwards with `npm run build` (web) or `npm run tauri:build` (desktop). If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), the `git pull` and `npm install` above are enough — just restart the dev server to pick up the changes.
 
-## Run the browser UI
+### Run the browser UI
 
 ```bash
 npm run dev
@@ -60,7 +98,7 @@ Open `http://localhost:5173`. The map and browser vector import support local ve
 
 Desktop filesystem dialogs, local MBTiles, local raster file reads, project save/open, and other filesystem operations require Tauri.
 
-## Run with Docker
+### Run with Docker
 
 The repository includes a Dockerfile for the browser version of GeoLibre. It builds the Vite app and serves the production files with nginx:
 
@@ -86,13 +124,13 @@ docker build --build-arg GEOLIBRE_APP_BASE=/geolibre/ -t geolibre .
 
 The container always serves the app from its root path. The build argument only sets the URL prefix that the app expects, so subpath deployments also require a reverse proxy in front of the container that strips the prefix before forwarding requests (for example, nginx `proxy_pass http://geolibre/;` with a trailing slash).
 
-## Run the desktop app
+### Run the desktop app
 
 ```bash
 npm run tauri:dev
 ```
 
-## Build
+### Build
 
 ```bash
 npm run build

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-[![live demo](https://img.shields.io/badge/Live-demo-green.svg)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 [![GeoLibre shared project](https://img.shields.io/badge/GeoLibre-share-green.svg)](https://share.geolibre.app)
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ hide:
       work, project files, styling, plugins, and modern geospatial workflows.
     </p>
     <div class="hero__actions">
-      <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Open live demo</a>
+      <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Launch GeoLibre Web</a>
       <a class="md-button" href="getting-started/">Get started</a>
       <a class="md-button" href="user-guide/interface/">User guide</a>
       <a class="md-button" href="downloads/">Download app</a>
@@ -118,12 +118,12 @@ New to GeoLibre? Start with the [User Guide](user-guide/interface.md) for a feat
 [Read the User Guide](user-guide/interface.md){ .md-button .md-button--primary }
 [Browse the Tutorials](tutorials/index.md){ .md-button }
 
-## Try it in the browser
+## GeoLibre on the web
 
-The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, adding URL-based layers, styling layers, and testing plugins. Desktop-only file dialogs, local MBTiles, local raster reads, and filesystem save/open operations still require the installed Tauri app.
+GeoLibre Web is the full browser version of the GeoLibre app, ready to use with nothing to install. It is great for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, adding URL-based layers, styling layers, and testing plugins. Desktop-only file dialogs, local MBTiles, local raster reads, and filesystem save/open operations still require the installed Tauri app.
 
 !!! note "Hosted on GitHub Pages, private by design"
-    The live demo is a static site deployed on GitHub Pages and runs entirely in your browser. It has no analytics and no server account, and the data you load is processed client-side in your browser session. Data leaves your browser only when you choose to add a remote URL or explicitly share a project.
+    GeoLibre Web is a static site deployed on GitHub Pages and runs entirely in your browser. It has no analytics and no server account, and the data you load is processed client-side in your browser session. Data leaves your browser only when you choose to add a remote URL or explicitly share a project.
 
 Open a project by passing a public `.geolibre.json` URL with the `url` query parameter:
 
@@ -153,7 +153,7 @@ https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geol
 
 Other parameters control the toolbar, panels, and theme. See [Embedding & Sharing](user-guide/embedding.md) for the full parameter reference and `<iframe>` examples.
 
-[Open the live demo](https://viewer.geolibre.app/){ .md-button .md-button--primary }
+[Launch GeoLibre Web](https://viewer.geolibre.app/){ .md-button .md-button--primary }
 [Embedding & Sharing](user-guide/embedding.md){ .md-button }
 
 ## Project status

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Downloads: downloads.md
-  - Live Demo: /demo/
+  - Launch GeoLibre Web: /demo/
   - User Guide:
       - Interface Overview: user-guide/interface.md
       - Projects: user-guide/projects.md


### PR DESCRIPTION
Addresses discussion #919.

## Changes

### Rename "Live Demo" to "Launch GeoLibre Web"
The hosted web viewer is the main entry point for most users, so the "Live Demo" label undersold it as not production-ready. Renamed the navigation link and the call-to-action buttons:

- `mkdocs.yml`: nav item `Live Demo` -> `Launch GeoLibre Web`
- `docs/index.md`: hero button and the "Try it in the browser" button -> `Launch GeoLibre Web`; reworded that section to "GeoLibre on the web" and to describe it as the full browser app rather than a demo
- `docs/downloads.md`: `Open live demo` button -> `Launch GeoLibre Web`

The conventional shields.io badges (README and Getting Started) are left as-is.

### Make Getting Started user-focused
The Getting Started page was entirely developer-oriented. It now leads with a "Use GeoLibre" section (web, desktop, Jupyter, Android) and moves the clone/install/run-locally instructions into a clearly labelled "Run from source" section for contributors, with a pointer to the Contributing guide.

## Verification
- `zensical build --strict` passes with no issues (links and nav anchors resolve, including the new `#run-from-source` anchor)
- `pre-commit run --files` passes on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the web launch call-to-action to **“Launch GeoLibre Web”** across the site, badges, and navigation.
  * Updated the getting started guide to provide clearer, dedicated sections for web, desktop, Jupyter, and Android usage.
  * Refreshed run-from-source section structure and heading levels to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->