### PR TITLE
fix(storymap): export globe + 3D extrusion, scroll/exit/resize fixes, name prompt

### DIFF
--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -36,6 +36,7 @@ import {
   type HandoutChapter,
 } from "../../lib/storymap-pdf";
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
+import { promptDownloadNameIfNeeded } from "../../hooks/useFileNamePrompt";
 
 interface StoryMapHandoutDialogProps {
   open: boolean;
@@ -245,6 +246,15 @@ export function StoryMapHandoutDialog({
       return;
     }
 
+    // Ask for the file name up front (browsers without a native save picker
+    // would otherwise auto-download a fixed name) so a cancel skips the slow
+    // capture entirely (#921).
+    const defaultName = await promptDownloadNameIfNeeded(
+      `${slugify(title || story.title)}-handout.pdf`,
+      ["pdf"],
+    );
+    if (defaultName === null) return;
+
     const original = mapControllerRef.current?.readView();
     abortRef.current = false;
     setGenerating(true);
@@ -282,7 +292,7 @@ export function StoryMapHandoutDialog({
         footer,
       });
       const saved = await saveBinaryFileWithFallback(bytes, {
-        defaultName: `${slugify(title || story.title)}-handout.pdf`,
+        defaultName,
         filters: [{ name: t("storymap.handout.pdfFile"), extensions: ["pdf"] }],
         browserTypes: [
           {

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -61,6 +61,7 @@ import {
   Upload,
 } from "lucide-react";
 import { saveTextFileWithFallback } from "../../lib/tauri-io";
+import { promptDownloadNameIfNeeded } from "../../hooks/useFileNamePrompt";
 import { buildStoryMapHtml } from "../../lib/storymap-export";
 import { StoryMapHandoutDialog } from "./StoryMapHandoutDialog";
 
@@ -91,6 +92,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   const storymap = useAppStore((s) => s.storymap);
   const layers = useAppStore((s) => s.layers);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
+  const projection = useAppStore((s) => s.preferences.map.projection);
 
   const setStorymap = useAppStore((s) => s.setStorymap);
   const updateSettings = useAppStore((s) => s.updateStorymapSettings);
@@ -105,20 +107,26 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importFormatRef = useRef<"json" | "csv">("json");
 
-  // Explicit dialog size once the user drags the bottom-right grip (null = the
-  // default responsive size). The dialog element is read for its live size.
+  // Explicit dialog size/position once the user drags the bottom-right grip
+  // (null = the default centred responsive size). The dialog element is read
+  // for its live geometry. `left`/`top` pin the dialog to its current top-left
+  // corner so resizing grows only the bottom-right corner.
   const dialogRef = useRef<HTMLDivElement>(null);
   const [dialogSize, setDialogSize] = useState<{
     width: number;
     height: number;
+    left: number;
+    top: number;
   } | null>(null);
   // Tears down an in-progress resize drag (removes the window listeners and
   // cancels the pending RAF) so it can't leak if the dialog unmounts mid-drag.
   const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   // Resize the whole dialog from its bottom-right grip. The dialog is centred
-  // via a -50% transform, so the right/bottom edges move by half the size
-  // change; growing by 2x the pointer delta keeps the grip under the cursor.
+  // via a -50% transform by default; on the first drag we pin it to its current
+  // top-left corner (style overrides the transform) so the bottom-right corner
+  // tracks the cursor 1:1, like a normal window resize. The previous "grow from
+  // the centre at 2x the delta" made the whole dialog jump outward (#918).
   const startDialogResize = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       event.preventDefault();
@@ -131,7 +139,9 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
       const startY = event.clientY;
       const startW = rect.width;
       const startH = rect.height;
-      let next = { width: startW, height: startH };
+      const left = rect.left;
+      const top = rect.top;
+      let next = { width: startW, height: startH, left, top };
       let frame: number | null = null;
       const prevCursor = document.body.style.cursor;
       const prevSelect = document.body.style.userSelect;
@@ -140,13 +150,15 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
 
       const onMove = (e: PointerEvent) => {
         next = {
+          left,
+          top,
           width: Math.max(
             360,
-            Math.min(window.innerWidth - 16, startW + (e.clientX - startX) * 2),
+            Math.min(window.innerWidth - left - 8, startW + (e.clientX - startX)),
           ),
           height: Math.max(
             320,
-            Math.min(window.innerHeight - 16, startH + (e.clientY - startY) * 2),
+            Math.min(window.innerHeight - top - 8, startH + (e.clientY - startY)),
           ),
         };
         if (frame !== null) return;
@@ -270,7 +282,9 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   const handlePresent = useCallback(() => {
     if (chapters.length === 0) return;
     setOpen(false);
-    setPresenting(true);
+    // Presenting from the editor: exiting the presentation should bring the
+    // editor back rather than dropping to the bare map (#918).
+    setPresenting(true, true);
   }, [chapters.length, setOpen, setPresenting]);
 
   const handleExport = useCallback(async () => {
@@ -281,14 +295,21 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
         storymap: story,
         basemapStyleUrl,
         layers,
+        projection,
       });
       const slug =
         (story.title || "story-map")
           .toLowerCase()
           .replace(/[^a-z0-9]+/g, "-")
           .replace(/^-+|-+$/g, "") || "story-map";
+      // Let the user name the file before it downloads in browsers without a
+      // native save picker, instead of always saving "<slug>.html" (#921).
+      const defaultName = await promptDownloadNameIfNeeded(`${slug}.html`, [
+        "html",
+      ]);
+      if (defaultName === null) return;
       await saveTextFileWithFallback(html, {
-        defaultName: `${slug}.html`,
+        defaultName,
         filters: [{ name: t("storymap.htmlFile"), extensions: ["html"] }],
         browserTypes: [
           {
@@ -303,7 +324,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
         error instanceof Error ? error.message : String(error),
       );
     }
-  }, [basemapStyleUrl, chapters.length, layers, story, t]);
+  }, [basemapStyleUrl, chapters.length, layers, projection, story, t]);
 
   const handleExportData = useCallback(
     async (format: "json" | "csv") => {
@@ -320,8 +341,13 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
             ? serializeStoryMapJson(story)
             : serializeStoryMapCsv(story);
         const mimeType = format === "json" ? "application/json" : "text/csv";
+        const defaultName = await promptDownloadNameIfNeeded(
+          `${slug}.${format}`,
+          [format],
+        );
+        if (defaultName === null) return;
         await saveTextFileWithFallback(content, {
-          defaultName: `${slug}.${format}`,
+          defaultName,
           filters: [{ name: format.toUpperCase(), extensions: [format] }],
           browserTypes: [
             {
@@ -377,12 +403,25 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
         ref={dialogRef}
-        className="flex max-h-[88vh] w-[min(92vw,46rem)] flex-col gap-0 p-0"
+        // A definite height (not just max-height) is what lets the inner
+        // ScrollArea size and scroll: under max-height alone the viewport's
+        // percentage height never resolves, so the body overflowed and the
+        // footer was clipped until the user manually resized (#918). max-w-none
+        // lets the dialog reach its intended width instead of the dialog
+        // primitive's default max-w-lg.
+        className="flex h-[88vh] w-[min(92vw,46rem)] max-w-none flex-col gap-0 p-0"
         style={
           dialogSize
             ? {
+                left: dialogSize.left,
+                top: dialogSize.top,
                 width: dialogSize.width,
                 height: dialogSize.height,
+                // The dialog primitive centres itself with the CSS `translate`
+                // property (not `transform`), so cancel that to pin the
+                // top-left corner we measured (#918).
+                translate: "none",
+                transform: "none",
                 maxWidth: "none",
                 maxHeight: "none",
               }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -202,8 +202,10 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     const clampToViewport = () =>
       setDialogSize((prev) => {
         if (!prev) return prev;
-        const width = Math.min(prev.width, window.innerWidth - 16);
-        const height = Math.min(prev.height, window.innerHeight - 16);
+        // Keep the same minimum dimensions the drag handler enforces so a tiny
+        // window can't shrink the dialog below a usable size.
+        const width = Math.max(360, Math.min(prev.width, window.innerWidth - 16));
+        const height = Math.max(320, Math.min(prev.height, window.innerHeight - 16));
         const left = Math.max(8, Math.min(prev.left, window.innerWidth - width - 8));
         const top = Math.max(8, Math.min(prev.top, window.innerHeight - height - 8));
         if (

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -191,6 +191,35 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   // Tear down an in-progress resize drag if the dialog unmounts mid-drag.
   useEffect(() => () => resizeCleanupRef.current?.(), []);
 
+  // A dragged size pins the dialog to an absolute top-left, which the browser
+  // window can later shrink past, leaving the dialog clipped and ungrabbable.
+  // Re-clamp the stored geometry into the viewport whenever the window resizes
+  // (#918 review). Keyed on whether a custom size exists so the listener isn't
+  // re-subscribed on every drag frame; the functional update reads the latest.
+  const hasCustomSize = dialogSize !== null;
+  useEffect(() => {
+    if (!hasCustomSize) return;
+    const clampToViewport = () =>
+      setDialogSize((prev) => {
+        if (!prev) return prev;
+        const width = Math.min(prev.width, window.innerWidth - 16);
+        const height = Math.min(prev.height, window.innerHeight - 16);
+        const left = Math.max(8, Math.min(prev.left, window.innerWidth - width - 8));
+        const top = Math.max(8, Math.min(prev.top, window.innerHeight - height - 8));
+        if (
+          width === prev.width &&
+          height === prev.height &&
+          left === prev.left &&
+          top === prev.top
+        ) {
+          return prev;
+        }
+        return { width, height, left, top };
+      });
+    window.addEventListener("resize", clampToViewport);
+    return () => window.removeEventListener("resize", clampToViewport);
+  }, [hasCustomSize]);
+
   const story: StoryMap = storymap ?? DEFAULT_STORY_MAP;
   const chapters = story.chapters;
   // Reset has something to clear when the story carries chapters or any
@@ -284,7 +313,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     setOpen(false);
     // Presenting from the editor: exiting the presentation should bring the
     // editor back rather than dropping to the bare map (#918).
-    setPresenting(true, true);
+    setPresenting(true, /* returnToEditor */ true);
   }, [chapters.length, setOpen, setPresenting]);
 
   const handleExport = useCallback(async () => {

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -48,7 +48,17 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const { t } = useTranslation();
   const presenting = useAppStore((s) => s.ui.storymapPresenting);
   const setPresenting = useAppStore((s) => s.setStorymapPresenting);
+  const setPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
   const storymap = useAppStore((s) => s.storymap);
+
+  // Exit the presentation, reopening the editor when it was launched from there
+  // so the user lands back in the editor instead of the bare map (#918). Reads
+  // the flag before clearing it via setPresenting(false).
+  const exitPresentation = useCallback(() => {
+    const reopenEditor = useAppStore.getState().ui.storymapReturnToEditor;
+    setPresenting(false);
+    if (reopenEditor) setPanelOpen(true);
+  }, [setPanelOpen, setPresenting]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const insetRef = useRef<HTMLDivElement>(null);
@@ -359,11 +369,11 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   useEffect(() => {
     if (!presenting) return;
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setPresenting(false);
+      if (event.key === "Escape") exitPresentation();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [presenting, setPresenting]);
+  }, [presenting, exitPresentation]);
 
   // A presentation with no chapters has nothing to show; close it.
   useEffect(() => {
@@ -392,7 +402,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
           variant="secondary"
           size="sm"
           className="shadow-md"
-          onClick={() => setPresenting(false)}
+          onClick={exitPresentation}
         >
           <X className="mr-1 h-4 w-4" />
           {t("storymap.exitPresentation")}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -375,10 +375,11 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     return () => window.removeEventListener("keydown", onKey);
   }, [presenting, exitPresentation]);
 
-  // A presentation with no chapters has nothing to show; close it.
+  // A presentation with no chapters has nothing to show; close it (routing
+  // through exitPresentation so it still honors the return-to-editor intent).
   useEffect(() => {
-    if (presenting && chapters.length === 0) setPresenting(false);
-  }, [presenting, chapters.length, setPresenting]);
+    if (presenting && chapters.length === 0) exitPresentation();
+  }, [presenting, chapters.length, exitPresentation]);
 
   if (!presenting || chapters.length === 0) return null;
 

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -82,8 +82,10 @@ export function ensureFileExtension(
   if (extensions.some((e) => lower.endsWith(`.${e.toLowerCase()}`))) {
     return name;
   }
-  // Strip any trailing dots first so "my-story." doesn't become a double dot.
-  return `${name.replace(/\.+$/, "")}.${ext}`;
+  // Strip any trailing dots first so "my-story." doesn't become a double dot;
+  // fall back to "download" when the name was only dots (e.g. "." / "..") so we
+  // never produce a hidden, extension-only file like ".html".
+  return `${name.replace(/\.+$/, "") || "download"}.${ext}`;
 }
 
 /**

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { browserSaveFallsBackToDownload } from "../lib/tauri-io";
 
 /**
  * Options describing a single file-name prompt request.
@@ -66,3 +67,50 @@ export const useFileNamePrompt = create<FileNamePromptState>((set, get) => ({
     resolve?.(null);
   },
 }));
+
+/**
+ * Append the first allowed extension to a user-entered file name when it lacks
+ * one, so a name like "my-story" becomes "my-story.html".
+ */
+export function ensureFileExtension(
+  name: string,
+  extensions: string[],
+): string {
+  const ext = extensions[0];
+  if (!ext) return name;
+  const lower = name.toLowerCase();
+  if (extensions.some((e) => lower.endsWith(`.${e.toLowerCase()}`))) {
+    return name;
+  }
+  // Strip any trailing dots first so "my-story." doesn't become a double dot.
+  return `${name.replace(/\.+$/, "")}.${ext}`;
+}
+
+/**
+ * Prompt for a download file name when the browser would otherwise save under a
+ * fixed default. Tauri and Chromium offer a name in their native save dialog,
+ * so this returns {@link defaultName} unchanged there; only Firefox/Safari
+ * (which auto-download) open the name prompt. The pre-filled value is the base
+ * name without its extension, which is re-applied (and path-illegal characters
+ * are stripped) once the user confirms.
+ *
+ * @param defaultName Suggested file name, including its extension.
+ * @param extensions Allowed extensions; the first is appended when missing.
+ * @returns The name to pass as `defaultName`, or null if the user cancelled.
+ */
+export async function promptDownloadNameIfNeeded(
+  defaultName: string,
+  extensions: string[],
+): Promise<string | null> {
+  if (!browserSaveFallsBackToDownload()) return defaultName;
+  const base = defaultName.replace(/\.[^./\\]+$/, "");
+  const chosen = await useFileNamePrompt.getState().prompt({ defaultName: base });
+  if (chosen === null) return null;
+  const sanitized = chosen
+    .trim()
+    // Replace characters illegal in common filesystems (path separators, the
+    // null byte, etc.) so a pasted name cannot smuggle in a path.
+    // eslint-disable-next-line no-control-regex
+    .replace(/[/\\:*?"<>|\x00]/g, "_");
+  return ensureFileExtension(sanitized, extensions);
+}

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -79,8 +79,12 @@ export function ensureFileExtension(
   const ext = extensions[0];
   if (!ext) return name;
   const lower = name.toLowerCase();
-  if (extensions.some((e) => lower.endsWith(`.${e.toLowerCase()}`))) {
-    return name;
+  const present = extensions.find((e) => lower.endsWith(`.${e.toLowerCase()}`));
+  if (present) {
+    // Already ends in an allowed extension; keep it, but guard a base-less name
+    // like ".html" (a hidden dotfile) by giving it a "download" stem.
+    const base = name.slice(0, -(present.length + 1)).replace(/\.+$/, "");
+    return base ? name : `download${name.slice(-(present.length + 1))}`;
   }
   // Strip any trailing dots first so "my-story." doesn't become a double dot;
   // fall back to "download" when the name was only dots (e.g. "." / "..") so we

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -112,11 +112,12 @@ export async function promptDownloadNameIfNeeded(
   const base = defaultName.replace(/\.[^./\\]+$/, "");
   const chosen = await useFileNamePrompt.getState().prompt({ defaultName: base });
   if (chosen === null) return null;
+  // `chosen` is already trimmed by the prompt's submit handler.
   const sanitized = chosen
-    .trim()
-    // Replace characters illegal in common filesystems (path separators, the
-    // null byte, etc.) so a pasted name cannot smuggle in a path.
+    // Replace characters illegal in common filesystems (path separators and the
+    // C0 control range plus DEL, incl. the null byte) so a pasted name cannot
+    // smuggle in a path or control character.
     // eslint-disable-next-line no-control-regex
-    .replace(/[/\\:*?"<>|\x00]/g, "_");
+    .replace(/[/\\:*?"<>|\x00-\x1f\x7f]/g, "_");
   return ensureFileExtension(sanitized, extensions);
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -82,22 +82,7 @@ import {
   saveTextFileWithFallback,
 } from "../lib/tauri-io";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
-import { useFileNamePrompt } from "./useFileNamePrompt";
-
-/**
- * Append the first allowed extension to a user-entered file name when it lacks
- * one, so a name like "my-bookmarks" becomes "my-bookmarks.json".
- */
-function ensureFileExtension(name: string, extensions: string[]): string {
-  const ext = extensions[0];
-  if (!ext) return name;
-  const lower = name.toLowerCase();
-  if (extensions.some((e) => lower.endsWith(`.${e.toLowerCase()}`))) {
-    return name;
-  }
-  // Strip any trailing dots first so "my-bookmarks." doesn't become a double dot.
-  return `${name.replace(/\.+$/, "")}.${ext}`;
-}
+import { ensureFileExtension, useFileNamePrompt } from "./useFileNamePrompt";
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -535,7 +535,11 @@ function renderTemplate(
         map.on('load', function () {
             // Match the in-app projection (globe by default) so the exported
             // story does not silently fall back to 2D Mercator (#917).
-            try { map.setProjection({ type: config.projection || 'globe' }); } catch (e) { console.error('[GeoLibre] projection failed', e); }
+            try {
+                map.setProjection({ type: config.projection || 'globe' });
+            } catch (e) {
+                console.error('[GeoLibre] projection failed', e);
+            }
 ${inlineLayerScript}
 
             scroller.setup({ step: '.step', offset: 0.5 })

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -1,7 +1,10 @@
 import type { FeatureCollection, Geometry } from "geojson";
 import {
+  extrusionColorValue,
+  extrusionHeightValue,
   styleValue,
   type GeoLibreLayer,
+  type MapProjection,
   type StoryMap,
 } from "@geolibre/core";
 import { sanitizeStoryHtml } from "./sanitize-html";
@@ -13,6 +16,12 @@ export interface StoryMapExportOptions {
   basemapStyleUrl: string;
   /** Project layers; only in-memory GeoJSON layers are inlined into the export. */
   layers: GeoLibreLayer[];
+  /**
+   * Map projection the exported page renders in. Mirrors the in-app projection
+   * so a globe story stays a globe (and not 2D Mercator) once exported (#917).
+   * Defaults to globe when omitted, matching the app default.
+   */
+  projection?: MapProjection;
 }
 
 interface InlineLayerExport {
@@ -37,7 +46,7 @@ interface InlineLayerExport {
  * @returns A complete HTML document as a string.
  */
 export function buildStoryMapHtml(options: StoryMapExportOptions): string {
-  const { storymap, basemapStyleUrl, layers } = options;
+  const { storymap, basemapStyleUrl, layers, projection = "globe" } = options;
 
   // The template reads chapters[0] for the initial camera, so an empty story
   // cannot produce a working page. Callers gate this behind a chapter count,
@@ -98,6 +107,7 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
 
   const config = {
     style: basemapStyleUrl,
+    projection,
     showMarkers: storymap.showMarkers,
     markerColor: storymap.markerColor,
     inset: storymap.inset,
@@ -244,6 +254,22 @@ function buildLayerSpec(
   if (!kind) return null;
 
   if (kind === "polygon") {
+    // Extruded polygons export as a 3D fill-extrusion (mirroring the in-app
+    // render) so the story keeps its extruded look instead of flattening to a
+    // 2D fill (#917). The opacity is seeded here and scaled by the layer
+    // opacity later, just like the flat-fill path.
+    if (layer.style.extrusionEnabled) {
+      return {
+        type: "fill-extrusion",
+        paint: {
+          "fill-extrusion-color": extrusionColorValue(layer.style),
+          "fill-extrusion-opacity": styleValue(layer.style, "extrusionOpacity"),
+          "fill-extrusion-height": extrusionHeightValue(layer.style),
+          "fill-extrusion-base": styleValue(layer.style, "extrusionBase"),
+          "fill-extrusion-vertical-gradient": true,
+        },
+      };
+    }
     return {
       type: "fill",
       paint: {
@@ -507,6 +533,9 @@ function renderTemplate(
         var cameraToken = 0;
 
         map.on('load', function () {
+            // Match the in-app projection (globe by default) so the exported
+            // story does not silently fall back to 2D Mercator (#917).
+            try { map.setProjection({ type: config.projection || 'globe' }); } catch (e) { console.error('[GeoLibre] projection failed', e); }
 ${inlineLayerScript}
 
             scroller.setup({ step: '.step', offset: 0.5 })

--- a/e2e/storymap.spec.ts
+++ b/e2e/storymap.spec.ts
@@ -96,3 +96,66 @@ test("persists a story map across save and reopen", async ({ page }) => {
     dialog.locator('input:not([type="file"])').first(),
   ).toHaveValue("A Tour of Five Cities");
 });
+
+/**
+ * #917: the exported HTML must render in the same projection as the app (globe
+ * by default), not 2D Mercator. #921: with no native save picker, exporting
+ * must prompt for a file name first instead of auto-downloading a default.
+ */
+test("exports the story as a globe HTML page after a name prompt", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    delete (window as unknown as Record<string, unknown>).showSaveFilePicker;
+  });
+
+  await waitForMap(page);
+
+  const dialog = await openStoryMapPanel(page);
+  await dialog.getByRole("button", { name: "Load sample story" }).click();
+  await expect(
+    dialog.getByRole("heading", { name: "Chapters (5)" }),
+  ).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await dialog.getByRole("button", { name: "Export HTML" }).click();
+
+  // No native save picker, so a name prompt appears first (#921). Confirm it.
+  const prompt = page.getByRole("dialog").filter({ hasText: "Save file as" });
+  await expect(prompt).toBeVisible();
+  await prompt.getByRole("button", { name: "Save", exact: true }).click();
+
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  const html = Buffer.concat(chunks).toString("utf8");
+
+  // The exported page must carry and apply the globe projection (#917).
+  expect(html).toMatch(/"projection":\s*"globe"/);
+  expect(html).toMatch(/setProjection\(\{ type: config\.projection/);
+});
+
+/**
+ * #918: exiting a presentation that was launched from the editor must return to
+ * the editor, not drop the user onto the bare map.
+ */
+test("returns to the editor after exiting a presentation", async ({ page }) => {
+  await waitForMap(page);
+
+  const dialog = await openStoryMapPanel(page);
+  await dialog.getByRole("button", { name: "Load sample story" }).click();
+  await expect(
+    dialog.getByRole("heading", { name: "Chapters (5)" }),
+  ).toBeVisible();
+
+  // Enter the presentation; the editor dialog closes.
+  await dialog.getByRole("button", { name: "Present" }).click();
+  await expect(page.getByRole("dialog")).toBeHidden();
+
+  // Exit the presentation; the editor must reopen (#918).
+  await page.getByRole("button", { name: "Exit" }).click();
+  await expect(
+    page.getByRole("dialog").getByRole("heading", { name: "Story Map" }),
+  ).toBeVisible();
+});

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -198,6 +198,10 @@ export interface AppState {
     dashboardOpen: boolean;
     storymapPanelOpen: boolean;
     storymapPresenting: boolean;
+    // True when the active presentation was launched from the editor, so exiting
+    // it reopens the Story Map editor instead of dropping to the bare map
+    // (#918). Auto-presented projects (opened for viewing) leave this false.
+    storymapReturnToEditor: boolean;
     // Id of the chapter currently being composed on the live map. When set, the
     // Story Map dialog is hidden so the user can pan/zoom/tilt the real map and
     // save the resulting camera back into this chapter (issue #775).
@@ -279,7 +283,10 @@ export interface AppState {
   setAttributeTableOpen: (open: boolean) => void;
   setDashboardOpen: (open: boolean) => void;
   setStorymapPanelOpen: (open: boolean) => void;
-  setStorymapPresenting: (presenting: boolean) => void;
+  setStorymapPresenting: (
+    presenting: boolean,
+    returnToEditor?: boolean,
+  ) => void;
   setStorymapComposing: (chapterId: string | null) => void;
   setModelBuilderOpen: (open: boolean) => void;
   setCollaborateDialogOpen: (open: boolean) => void;
@@ -591,6 +598,7 @@ export const useAppStore = create<AppState>()(
         dashboardOpen: false,
         storymapPanelOpen: false,
         storymapPresenting: false,
+        storymapReturnToEditor: false,
         storymapComposingId: null,
         modelBuilderOpen: false,
         zoomToSelectedFeature: false,
@@ -798,8 +806,16 @@ export const useAppStore = create<AppState>()(
             ...(open ? { storymapComposingId: null } : {}),
           },
         })),
-      setStorymapPresenting: (presenting) =>
-        set((s) => ({ ui: { ...s.ui, storymapPresenting: presenting } })),
+      setStorymapPresenting: (presenting, returnToEditor = false) =>
+        set((s) => ({
+          ui: {
+            ...s.ui,
+            storymapPresenting: presenting,
+            // Track whether exiting should reopen the editor; only meaningful
+            // while presenting, so it clears once the presentation ends (#918).
+            storymapReturnToEditor: presenting ? returnToEditor : false,
+          },
+        })),
       setStorymapComposing: (chapterId) =>
         set((s) => ({ ui: { ...s.ui, storymapComposingId: chapterId } })),
       setModelBuilderOpen: (open) =>
@@ -1285,6 +1301,7 @@ export const useAppStore = create<AppState>()(
           ui: {
             ...s.ui,
             storymapPresenting: false,
+            storymapReturnToEditor: false,
             storymapPanelOpen: false,
             storymapComposingId: null,
           },
@@ -1313,6 +1330,9 @@ export const useAppStore = create<AppState>()(
           ui: {
             ...s.ui,
             storymapPresenting: presentStory,
+            // A bundled story auto-presents for viewing, so exiting it should
+            // not pop open the editor (#918).
+            storymapReturnToEditor: false,
             storymapPanelOpen: false,
             storymapComposingId: null,
           },


### PR DESCRIPTION
Fixes #917
Fixes #918
Fixes #921

All three reports are about the Story Map feature. This PR fixes them together.

## #917 — Export keeps 2D and drops 3D extrusion
The exported HTML never carried the projection, so it always rendered in 2D Mercator even when the app was in globe mode, and extruded polygons were serialized as flat 2D fills.

- Serialize the project's map projection into the exported page and apply it with `map.setProjection(...)` (defaults to globe).
- Export extruded polygon layers as `fill-extrusion` (color, height, base, opacity, vertical gradient) instead of a flat `fill`, mirroring the in-app render.

## #918 — Story Map usability
- **Scroll / sizing:** the editor only had a `max-height`, so the inner scroll viewport's percentage height never resolved; the body overflowed and the footer buttons were clipped until the user manually dragged the resize grip. The dialog now uses a definite height (so it scrolls out of the box) and reaches its intended width.
- **Erratic resize:** the resize grip grew the dialog symmetrically from its centre at 2x the pointer delta, which read as a sudden jump. The dialog is now pinned to its top-left corner on resize so the bottom-right grip resizes it 1:1, like a normal window.
- **Exit returns to editor:** exiting a presentation that was launched from the editor reopens the editor instead of dropping to the bare map. Projects that auto-present on load (opened for viewing) still exit to the map.

## #921 — Filename prompt before export
HTML, data, and PDF exports auto-downloaded a fixed default name in browsers without the File System Access save picker (Firefox/Safari). They now prompt for a file name first (reusing the existing app-wide name prompt). Tauri and Chromium are unchanged since their native save dialogs already let the user name the file.

## Verification
Verified in the real app with Playwright in both light and dark themes:
- Exported a story with a 3D-extruded buildings layer and confirmed the rendered HTML uses `projection: "globe"` and a `fill-extrusion` layer with the data-driven height.
- Confirmed the editor scrolls without manual resizing and the footer is visible; resize keeps the top-left fixed with 1:1 growth.
- Confirmed exiting a presentation reopens the editor.
- Confirmed the filename prompt appears (with `showSaveFilePicker` removed) before the HTML export downloads.

Added e2e coverage for the globe HTML export + name prompt and the exit-to-editor flow; `npm run test:frontend`, the storymap e2e spec, the production build, and `pre-commit` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story map HTML export now uses the selected projection and prompts for a save filename (when applicable).
  * Polygon layers can export 3D extrusion styling when extrusion is enabled.
* **Bug Fixes**
  * Canceling a filename prompt now reliably aborts the corresponding export (HTML/JSON/CSV).
  * Exiting presentation now consistently returns to the Story Map editor.
  * Story map export/editor dialog resizing is more stable and preserves window position.
* **Tests**
  * Added end-to-end coverage for HTML export (projection settings + filename prompt) and presentation exit navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->