### PR TITLE
fix(raster): offer convert-to-COG for striped GeoTIFFs loaded from a URL

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -793,6 +793,25 @@ export function DesktopShell({
           window.alert(t("raster.rasterDownloadFailed", { name }));
           return;
         }
+        // A URL can answer 200 with non-GeoTIFF content (an auth/login or error
+        // page), which downloads fine but is not convertible. Check the TIFF
+        // magic bytes ("II*\0" little-endian or "MM\0*" big-endian) up front so
+        // that surfaces as a clear "not a GeoTIFF" message instead of the
+        // misleading "could not convert" one the parser would otherwise trigger.
+        const isTiff =
+          bytes.length >= 4 &&
+          ((bytes[0] === 0x49 &&
+            bytes[1] === 0x49 &&
+            bytes[2] === 0x2a &&
+            bytes[3] === 0x00) ||
+            (bytes[0] === 0x4d &&
+              bytes[1] === 0x4d &&
+              bytes[2] === 0x00 &&
+              bytes[3] === 0x2a));
+        if (!isTiff) {
+          window.alert(t("raster.rasterNotGeotiff", { name }));
+          return;
+        }
         if (!bytesAreRemote) {
           // Local file: pick the prompt by size now that the header is cheap to
           // read, then confirm once. (A remote source already confirmed above.)

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -781,10 +781,12 @@ export function DesktopShell({
         ) {
           return;
         }
-        // Read the source bytes in their own try so a network/timeout failure
-        // (only reachable for a remote URL) reports a download problem rather
-        // than the misleading "could not convert" message below, which assumes a
-        // conversion was attempted.
+        // Read the source bytes in their own try so a failure to obtain them
+        // (only reachable for a remote URL: a network/timeout error, or a
+        // RangeError when the downloaded file is too large to allocate as an
+        // ArrayBuffer) reports a download problem rather than the misleading
+        // "could not convert" message below, which assumes a conversion was
+        // attempted. The rasterDownloadFailed string names both causes.
         let bytes: Uint8Array;
         try {
           bytes = await readBytes();

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -767,20 +767,44 @@ export function DesktopShell({
   // and hands us the bytes; the conversion and the prompt live here because this
   // layer has i18n and the client-side converter. See opengeos/GeoLibre#789.
   useEffect(() => {
-    setNonTiledRasterHandler(async ({ name, readBytes, dismiss }) => {
+    setNonTiledRasterHandler(async ({ name, bytesAreRemote, readBytes, dismiss }) => {
       try {
+        // For a remote source readBytes() streams the whole file over the
+        // network, so confirm up front before that download starts. A local
+        // file resolves instantly, so it keeps the single post-read prompt
+        // below (which can also surface the large-raster warning). See #916.
+        if (
+          bytesAreRemote &&
+          !window.confirm(t("raster.cogConvertConfirm", { name }))
+        ) {
+          return;
+        }
         const bytes = await readBytes();
         const info = await readGeoTiffInfo(bytes);
         const samples = info.width * info.height * Math.max(info.bands, 1);
-        const message =
-          samples > LARGE_RASTER_SAMPLE_LIMIT
-            ? t("raster.cogConvertLargeConfirm", {
+        if (samples > LARGE_RASTER_SAMPLE_LIMIT) {
+          // Big enough that conversion may be slow or memory-heavy; warn now
+          // that the dimensions are known, even if a remote source already
+          // confirmed the download above.
+          if (
+            !window.confirm(
+              t("raster.cogConvertLargeConfirm", {
                 name,
                 width: info.width,
                 height: info.height,
-              })
-            : t("raster.cogConvertConfirm", { name });
-        if (!window.confirm(message)) return;
+              }),
+            )
+          ) {
+            return;
+          }
+        } else if (
+          !bytesAreRemote &&
+          !window.confirm(t("raster.cogConvertConfirm", { name }))
+        ) {
+          // Local file, not large: the original single convert prompt. A remote
+          // source already confirmed before the download, so do not prompt twice.
+          return;
+        }
         const cog = await convertGeoTiffToCog(bytes);
         // The cast is required: TS types Uint8Array as Uint8Array<ArrayBufferLike>,
         // which is not directly assignable to BlobPart's ArrayBufferView.

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -28,7 +28,7 @@ import {
   startLayerGeometryEdit,
   subscribeGeometryEdit,
 } from "@geolibre/plugins";
-import { convertGeoTiffToCog, readGeoTiffInfo } from "@geolibre/processing";
+import { convertGeoTiffToCog, isTiff, readGeoTiffInfo } from "@geolibre/processing";
 import {
   type CSSProperties,
   type DragEvent,
@@ -796,21 +796,12 @@ export function DesktopShell({
           return;
         }
         // A URL can answer 200 with non-GeoTIFF content (an auth/login or error
-        // page), which downloads fine but is not convertible. Check the TIFF
-        // magic bytes ("II*\0" little-endian or "MM\0*" big-endian) up front so
-        // that surfaces as a clear "not a GeoTIFF" message instead of the
-        // misleading "could not convert" one the parser would otherwise trigger.
-        const isTiff =
-          bytes.length >= 4 &&
-          ((bytes[0] === 0x49 &&
-            bytes[1] === 0x49 &&
-            bytes[2] === 0x2a &&
-            bytes[3] === 0x00) ||
-            (bytes[0] === 0x4d &&
-              bytes[1] === 0x4d &&
-              bytes[2] === 0x00 &&
-              bytes[3] === 0x2a));
-        if (!isTiff) {
+        // page), which downloads fine but is not convertible. Sniff the TIFF
+        // signature up front so that surfaces as a clear "not a GeoTIFF" message
+        // instead of the misleading "could not convert" one the parser would
+        // otherwise trigger. isTiff accepts BigTIFF too, matching the wasm
+        // reader/converter, so a valid >4 GiB raster is not wrongly rejected.
+        if (!isTiff(bytes)) {
           window.alert(t("raster.rasterNotGeotiff", { name }));
           return;
         }

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -770,12 +770,14 @@ export function DesktopShell({
     setNonTiledRasterHandler(async ({ name, bytesAreRemote, readBytes, dismiss }) => {
       try {
         // For a remote source readBytes() streams the whole file over the
-        // network, so confirm up front before that download starts. A local
-        // file resolves instantly, so it keeps the single post-read prompt
-        // below (which can also surface the large-raster warning). See #916.
+        // network, so confirm up front before that download starts -- with a
+        // message that names the download, since that cost is the part unique to
+        // the remote path. A local file resolves instantly, so it keeps the
+        // single post-read prompt below (which can also surface the large-raster
+        // warning). See #916.
         if (
           bytesAreRemote &&
-          !window.confirm(t("raster.cogConvertConfirm", { name }))
+          !window.confirm(t("raster.cogConvertRemoteConfirm", { name }))
         ) {
           return;
         }

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -782,17 +782,23 @@ export function DesktopShell({
           return;
         }
         // Read the source bytes in their own try so a failure to obtain them
-        // (only reachable for a remote URL: a network/timeout error, or a
-        // RangeError when the downloaded file is too large to allocate as an
-        // ArrayBuffer) reports a download problem rather than the misleading
-        // "could not convert" message below, which assumes a conversion was
-        // attempted. The rasterDownloadFailed string names both causes.
+        // reports a read/download problem rather than the misleading "could not
+        // convert" message below, which assumes a conversion was attempted. For
+        // a remote URL this is a network/timeout error or a RangeError when the
+        // download is too large to allocate (rasterDownloadFailed names both);
+        // for a local file it is the rare case of the blob URL being revoked
+        // (e.g. the layer removed) before the read, so fall back to the generic
+        // convert-failed message rather than the server-oriented download one.
         let bytes: Uint8Array;
         try {
           bytes = await readBytes();
         } catch (error) {
-          console.error("[GeoLibre] Failed to download raster for conversion", error);
-          window.alert(t("raster.rasterDownloadFailed", { name }));
+          console.error("[GeoLibre] Failed to read raster for conversion", error);
+          window.alert(
+            bytesAreRemote
+              ? t("raster.rasterDownloadFailed", { name })
+              : t("raster.cogConvertFailed", { name }),
+          );
           return;
         }
         // A URL can answer 200 with non-GeoTIFF content (an auth/login or error

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -779,7 +779,18 @@ export function DesktopShell({
         ) {
           return;
         }
-        const bytes = await readBytes();
+        // Read the source bytes in their own try so a network/timeout failure
+        // (only reachable for a remote URL) reports a download problem rather
+        // than the misleading "could not convert" message below, which assumes a
+        // conversion was attempted.
+        let bytes: Uint8Array;
+        try {
+          bytes = await readBytes();
+        } catch (error) {
+          console.error("[GeoLibre] Failed to download raster for conversion", error);
+          window.alert(t("raster.rasterDownloadFailed", { name }));
+          return;
+        }
         const info = await readGeoTiffInfo(bytes);
         const samples = info.width * info.height * Math.max(info.bands, 1);
         if (samples > LARGE_RASTER_SAMPLE_LIMIT) {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -769,12 +769,12 @@ export function DesktopShell({
   useEffect(() => {
     setNonTiledRasterHandler(async ({ name, bytesAreRemote, readBytes, dismiss }) => {
       try {
-        // For a remote source readBytes() streams the whole file over the
-        // network, so confirm up front before that download starts -- with a
-        // message that names the download, since that cost is the part unique to
-        // the remote path. A local file resolves instantly, so it keeps the
-        // single post-read prompt below (which can also surface the large-raster
-        // warning). See #916.
+        // A remote source gets a single up-front prompt that names the download:
+        // its size is unknown until it has been fetched, so prompting again after
+        // the download (with dimensions) would just risk discarding a large file
+        // the user already agreed to download. A local file resolves instantly,
+        // so it defers to the post-read prompt below, which can pick the
+        // large-raster warning now that the dimensions are cheap to read. See #916.
         if (
           bytesAreRemote &&
           !window.confirm(t("raster.cogConvertRemoteConfirm", { name }))
@@ -793,30 +793,20 @@ export function DesktopShell({
           window.alert(t("raster.rasterDownloadFailed", { name }));
           return;
         }
-        const info = await readGeoTiffInfo(bytes);
-        const samples = info.width * info.height * Math.max(info.bands, 1);
-        if (samples > LARGE_RASTER_SAMPLE_LIMIT) {
-          // Big enough that conversion may be slow or memory-heavy; warn now
-          // that the dimensions are known, even if a remote source already
-          // confirmed the download above.
-          if (
-            !window.confirm(
-              t("raster.cogConvertLargeConfirm", {
-                name,
-                width: info.width,
-                height: info.height,
-              }),
-            )
-          ) {
-            return;
-          }
-        } else if (
-          !bytesAreRemote &&
-          !window.confirm(t("raster.cogConvertConfirm", { name }))
-        ) {
-          // Local file, not large: the original single convert prompt. A remote
-          // source already confirmed before the download, so do not prompt twice.
-          return;
+        if (!bytesAreRemote) {
+          // Local file: pick the prompt by size now that the header is cheap to
+          // read, then confirm once. (A remote source already confirmed above.)
+          const info = await readGeoTiffInfo(bytes);
+          const samples = info.width * info.height * Math.max(info.bands, 1);
+          const message =
+            samples > LARGE_RASTER_SAMPLE_LIMIT
+              ? t("raster.cogConvertLargeConfirm", {
+                  name,
+                  width: info.width,
+                  height: info.height,
+                })
+              : t("raster.cogConvertConfirm", { name });
+          if (!window.confirm(message)) return;
         }
         const cog = await convertGeoTiffToCog(bytes);
         // The cast is required: TS types Uint8Array as Uint8Array<ArrayBufferLike>,

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -761,11 +761,11 @@ export function DesktopShell({
     }
   }, []);
 
-  // When a local GeoTIFF fails to load because it is striped (not a tiled COG),
-  // offer to convert it to a COG in the browser and load the result. The raster
-  // plugin detects the case and hands us the bytes; the conversion and the
-  // prompt live here because this layer has i18n and the client-side converter.
-  // See opengeos/GeoLibre#789.
+  // When a GeoTIFF fails to load because it is striped (not a tiled COG), offer
+  // to convert it to a COG in the browser and load the result. Works for both a
+  // local file and a remote URL (issue #916). The raster plugin detects the case
+  // and hands us the bytes; the conversion and the prompt live here because this
+  // layer has i18n and the client-side converter. See opengeos/GeoLibre#789.
   useEffect(() => {
     setNonTiledRasterHandler(async ({ name, readBytes, dismiss }) => {
       try {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2291,10 +2291,10 @@
   },
   "raster": {
     "cogConvertConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Convert it to a Cloud-Optimized GeoTIFF now and load that?",
-    "cogConvertRemoteConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Displaying it means downloading the full file and converting it to a Cloud-Optimized GeoTIFF in the browser. Proceed?",
+    "cogConvertRemoteConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Displaying it means downloading the full file and converting it to a Cloud-Optimized GeoTIFF in the browser, which can be slow and memory-intensive for large files. Proceed?",
     "cogConvertLargeConfirm": "\"{{name}}\" is a large {{width}}×{{height}} GeoTIFF that is not a Cloud-Optimized GeoTIFF. Converting it in the browser may be slow and memory-intensive. Convert and load it anyway?",
     "cogConvertFailed": "Could not convert \"{{name}}\" to a Cloud-Optimized GeoTIFF. Try converting it with gdal_translate or rio cogeo, then load the result.",
-    "rasterDownloadFailed": "Could not download \"{{name}}\". The server may be slow, unreachable, or blocking cross-origin requests. Check the URL and try again.",
+    "rasterDownloadFailed": "Could not download \"{{name}}\". The server may be slow, unreachable, or blocking cross-origin requests, or the file may be too large to hold in memory. Check the URL and try again.",
     "rasterNotGeotiff": "\"{{name}}\" did not return a GeoTIFF. The server may have sent an error or login page instead. Check the URL and try again."
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2291,6 +2291,7 @@
   },
   "raster": {
     "cogConvertConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Convert it to a Cloud-Optimized GeoTIFF now and load that?",
+    "cogConvertRemoteConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Displaying it means downloading the full file and converting it to a Cloud-Optimized GeoTIFF in the browser. Proceed?",
     "cogConvertLargeConfirm": "\"{{name}}\" is a large {{width}}×{{height}} GeoTIFF that is not a Cloud-Optimized GeoTIFF. Converting it in the browser may be slow and memory-intensive. Convert and load it anyway?",
     "cogConvertFailed": "Could not convert \"{{name}}\" to a Cloud-Optimized GeoTIFF. Try converting it with gdal_translate or rio cogeo, then load the result.",
     "rasterDownloadFailed": "Could not download \"{{name}}\". The server may be slow, unreachable, or blocking cross-origin requests. Check the URL and try again."

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2294,6 +2294,7 @@
     "cogConvertRemoteConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Displaying it means downloading the full file and converting it to a Cloud-Optimized GeoTIFF in the browser. Proceed?",
     "cogConvertLargeConfirm": "\"{{name}}\" is a large {{width}}×{{height}} GeoTIFF that is not a Cloud-Optimized GeoTIFF. Converting it in the browser may be slow and memory-intensive. Convert and load it anyway?",
     "cogConvertFailed": "Could not convert \"{{name}}\" to a Cloud-Optimized GeoTIFF. Try converting it with gdal_translate or rio cogeo, then load the result.",
-    "rasterDownloadFailed": "Could not download \"{{name}}\". The server may be slow, unreachable, or blocking cross-origin requests. Check the URL and try again."
+    "rasterDownloadFailed": "Could not download \"{{name}}\". The server may be slow, unreachable, or blocking cross-origin requests. Check the URL and try again.",
+    "rasterNotGeotiff": "\"{{name}}\" did not return a GeoTIFF. The server may have sent an error or login page instead. Check the URL and try again."
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2292,6 +2292,7 @@
   "raster": {
     "cogConvertConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Convert it to a Cloud-Optimized GeoTIFF now and load that?",
     "cogConvertLargeConfirm": "\"{{name}}\" is a large {{width}}×{{height}} GeoTIFF that is not a Cloud-Optimized GeoTIFF. Converting it in the browser may be slow and memory-intensive. Convert and load it anyway?",
-    "cogConvertFailed": "Could not convert \"{{name}}\" to a Cloud-Optimized GeoTIFF. Try converting it with gdal_translate or rio cogeo, then load the result."
+    "cogConvertFailed": "Could not convert \"{{name}}\" to a Cloud-Optimized GeoTIFF. Try converting it with gdal_translate or rio cogeo, then load the result.",
+    "rasterDownloadFailed": "Could not download \"{{name}}\". The server may be slow, unreachable, or blocking cross-origin requests. Check the URL and try again."
   }
 }

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -102,19 +102,21 @@ let restorePanelExpandTimeout: number | null = null;
 let rasterControlInterleaved = true;
 
 /**
- * Details of a local raster that the panel could not render because it is a
- * striped (non-tiled) GeoTIFF rather than a tiled COG. Passed to a host handler
- * registered via {@link setNonTiledRasterHandler}, which can offer to convert it
- * to a COG (the conversion + UI live in the app layer, which has i18n and the
- * client-side converter; this framework-agnostic package only detects the case).
+ * Details of a raster that the panel could not render because it is a striped
+ * (non-tiled) GeoTIFF rather than a tiled COG. Covers both a local file and a
+ * remote URL. Passed to a host handler registered via
+ * {@link setNonTiledRasterHandler}, which can offer to convert it to a COG (the
+ * conversion + UI live in the app layer, which has i18n and the client-side
+ * converter; this framework-agnostic package only detects the case).
  */
 export interface NonTiledRasterRequest {
   /** The failed layer's id. */
   layerId: string;
   /** The failed layer's display name (used for the converted layer too). */
   name: string;
-  /** Reads the original uploaded bytes. Must be awaited before {@link dismiss},
-   * which revokes the underlying blob URL. */
+  /** Reads the original bytes (a local file from its blob URL, or a remote URL
+   * fetched whole). Must be awaited before {@link dismiss}, which revokes a
+   * local file's blob URL. */
   readBytes: () => Promise<Uint8Array>;
   /** Removes the failed layer from the map and the store. */
   dismiss: () => void;
@@ -130,9 +132,10 @@ let nonTiledRasterHandler: NonTiledRasterHandler | null = null;
 const nonTiledInFlight = new Set<string>();
 
 /**
- * Register (or clear, with `null`) a handler invoked when a local GeoTIFF fails
- * to load because it is striped rather than tiled. The app uses this to offer an
- * in-browser convert-to-COG flow. Only one handler is active at a time.
+ * Register (or clear, with `null`) a handler invoked when a GeoTIFF (local file
+ * or remote URL) fails to load because it is striped rather than tiled. The app
+ * uses this to offer an in-browser convert-to-COG flow. Only one handler is
+ * active at a time.
  *
  * @param handler - The handler, or `null` to unregister.
  */
@@ -503,12 +506,15 @@ function createRasterControl(
     const layerId = event.layerId;
     if (nonTiledInFlight.has(layerId)) return;
     const info = control.getRaster(layerId);
-    // Only local files can be re-read and converted in the browser; remote
-    // non-tiled URLs keep the plain error.
-    if (!info || !isNonTiledRasterError(info.error) || info.source.kind !== "file") {
-      return;
-    }
-    const objectUrl = info.source.objectUrl;
+    if (!info || !isNonTiledRasterError(info.error)) return;
+    // Re-read the original bytes so the host can convert them to a COG: a local
+    // file from its blob URL, a remote URL by fetching it whole. The remote
+    // fetch only works when the server allows CORS, which it must have already
+    // to get this far (the panel range-fetched the header to detect "not
+    // tiled"); a CORS-less host would have failed earlier with a fetch error.
+    // See opengeos/GeoLibre#916.
+    const bytesUrl =
+      info.source.kind === "file" ? info.source.objectUrl : info.source.url;
     const handler = nonTiledRasterHandler;
     nonTiledInFlight.add(layerId);
     // Invoke inside the promise chain so even a synchronous throw from the
@@ -521,7 +527,7 @@ function createRasterControl(
           layerId,
           name: info.name,
           readBytes: async () => {
-            const response = await fetch(objectUrl);
+            const response = await fetch(bytesUrl);
             if (!response.ok) {
               throw new Error(
                 `Failed to read raster bytes: ${response.status}`,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -139,6 +139,9 @@ const nonTiledInFlight = new Set<string>();
 // server surfaces a clear conversion failure instead of hanging the handler
 // until the browser's (often minutes-long) global network timeout. A local
 // file's blob URL resolves instantly, so the bound only ever bites remote URLs.
+// Tuning knob: generous for the small striped GeoTIFFs this targets, but a very
+// large file on a slow link could hit it (the host then shows a download error);
+// raise it if that becomes common.
 const NON_TILED_FETCH_TIMEOUT_MS = 60_000;
 
 /**

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -114,6 +114,11 @@ export interface NonTiledRasterRequest {
   layerId: string;
   /** The failed layer's display name (used for the converted layer too). */
   name: string;
+  /** Whether {@link readBytes} streams a full file over the network (a remote
+   * URL source) rather than resolving instantly from a local blob URL. The host
+   * uses this to confirm with the user *before* a potentially large download
+   * starts, instead of after. */
+  bytesAreRemote: boolean;
   /** Reads the original bytes (a local file from its blob URL, or a remote URL
    * fetched whole). Must be awaited before {@link dismiss}, which revokes a
    * local file's blob URL. */
@@ -528,6 +533,9 @@ function createRasterControl(
           ? info.source.url
           : undefined;
     if (!bytesUrl) return;
+    // A remote URL streams the whole file over the network when read; a local
+    // file's blob URL resolves instantly. The host confirms before the download.
+    const bytesAreRemote = info.source.kind === "url";
     const handler = nonTiledRasterHandler;
     nonTiledInFlight.add(layerId);
     // Invoke inside the promise chain so even a synchronous throw from the
@@ -539,6 +547,7 @@ function createRasterControl(
         handler({
           layerId,
           name: info.name,
+          bytesAreRemote,
           readBytes: async () => {
             const response = await fetch(bytesUrl, {
               signal: AbortSignal.timeout(NON_TILED_FETCH_TIMEOUT_MS),

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -130,6 +130,11 @@ let nonTiledRasterHandler: NonTiledRasterHandler | null = null;
 // Layer ids currently being handled, so a repeated 'error' event for the same
 // failed layer does not prompt twice.
 const nonTiledInFlight = new Set<string>();
+// Cap the whole-file fetch of a remote striped GeoTIFF so a slow or stalled
+// server surfaces a clear conversion failure instead of hanging the handler
+// until the browser's (often minutes-long) global network timeout. A local
+// file's blob URL resolves instantly, so the bound only ever bites remote URLs.
+const NON_TILED_FETCH_TIMEOUT_MS = 60_000;
 
 /**
  * Register (or clear, with `null`) a handler invoked when a GeoTIFF (local file
@@ -512,9 +517,17 @@ function createRasterControl(
     // fetch only works when the server allows CORS, which it must have already
     // to get this far (the panel range-fetched the header to detect "not
     // tiled"); a CORS-less host would have failed earlier with a fetch error.
-    // See opengeos/GeoLibre#916.
+    // See opengeos/GeoLibre#916. The explicit per-kind check (rather than a
+    // file/else ternary) means a future source kind without a fetchable URL
+    // bails here instead of silently passing fetch(undefined), which would
+    // request the current page.
     const bytesUrl =
-      info.source.kind === "file" ? info.source.objectUrl : info.source.url;
+      info.source.kind === "file"
+        ? info.source.objectUrl
+        : info.source.kind === "url"
+          ? info.source.url
+          : undefined;
+    if (!bytesUrl) return;
     const handler = nonTiledRasterHandler;
     nonTiledInFlight.add(layerId);
     // Invoke inside the promise chain so even a synchronous throw from the
@@ -527,7 +540,9 @@ function createRasterControl(
           layerId,
           name: info.name,
           readBytes: async () => {
-            const response = await fetch(bytesUrl);
+            const response = await fetch(bytesUrl, {
+              signal: AbortSignal.timeout(NON_TILED_FETCH_TIMEOUT_MS),
+            });
             if (!response.ok) {
               throw new Error(
                 `Failed to read raster bytes: ${response.status}`,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -518,14 +518,16 @@ function createRasterControl(
     const info = control.getRaster(layerId);
     if (!info || !isNonTiledRasterError(info.error)) return;
     // Re-read the original bytes so the host can convert them to a COG: a local
-    // file from its blob URL, a remote URL by fetching it whole. The remote
-    // fetch only works when the server allows CORS, which it must have already
-    // to get this far (the panel range-fetched the header to detect "not
-    // tiled"); a CORS-less host would have failed earlier with a fetch error.
-    // See opengeos/GeoLibre#916. The explicit per-kind check (rather than a
-    // file/else ternary) means a future source kind without a fetchable URL
-    // bails here instead of silently passing fetch(undefined), which would
-    // request the current page.
+    // file from its blob URL, a remote URL by fetching it whole. In the browser
+    // the remote fetch needs the server to allow CORS, which it normally has
+    // already (the panel range-fetched the header to detect "not tiled"); the
+    // Tauri build can patch the header read to go through Tauri commands, so a
+    // non-CORS URL can still reach here and the fetch below then fails -- it
+    // degrades safely to the host's download-failed message, not a crash. See
+    // opengeos/GeoLibre#916. The explicit per-kind check (rather than a file/else
+    // ternary) means a future source kind without a fetchable URL bails here
+    // instead of silently passing fetch(undefined), which would request the
+    // current page.
     const bytesUrl =
       info.source.kind === "file"
         ? info.source.objectUrl

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -551,9 +551,14 @@ function createRasterControl(
           name: info.name,
           bytesAreRemote,
           readBytes: async () => {
-            const response = await fetch(bytesUrl, {
-              signal: AbortSignal.timeout(NON_TILED_FETCH_TIMEOUT_MS),
-            });
+            // Only bound the remote download; a local blob URL resolves from
+            // memory in microseconds, so a timeout timer there is pure overhead.
+            const response = await fetch(
+              bytesUrl,
+              bytesAreRemote
+                ? { signal: AbortSignal.timeout(NON_TILED_FETCH_TIMEOUT_MS) }
+                : undefined,
+            );
             if (!response.ok) {
               throw new Error(
                 `Failed to read raster bytes: ${response.status}`,

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -141,6 +141,7 @@ export {
   listWhiteboxWasmTools,
   listGeolibreWasmTools,
   outputBaseName,
+  isTiff,
 } from "./wasm-client";
 export {
   initCogWasm,

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -166,10 +166,18 @@ function isFeatureCollection(value: unknown): value is FeatureCollection {
   );
 }
 
-// TIFF magic: "II" (little-endian) or "MM" (big-endian) followed by the version
-// number in the byte-order's own endianness - 42 (0x2a) for classic TIFF or 43
-// (0x2b) for BigTIFF (rasters larger than 4 GiB).
-function isTiff(b: Uint8Array): boolean {
+/**
+ * Whether bytes start with the TIFF signature: "II" (little-endian) or "MM"
+ * (big-endian) followed by the version number in the byte order's own
+ * endianness -- 42 (0x2a) for classic TIFF or 43 (0x2b) for BigTIFF (rasters
+ * larger than 4 GiB). A cheap header-only sniff used to reject non-GeoTIFF
+ * content (e.g. an HTML error or login page served with a 200) before handing
+ * the bytes to the wasm reader.
+ *
+ * @param b - The candidate file bytes (only the first four are inspected).
+ * @returns `true` if the bytes look like a TIFF/BigTIFF.
+ */
+export function isTiff(b: Uint8Array): boolean {
   if (b.length < 4) return false;
   const le = b[0] === 0x49 && b[1] === 0x49;
   const be = b[0] === 0x4d && b[1] === 0x4d;


### PR DESCRIPTION
## Problem

Small, simple GeoTIFFs (plain striped, not internally tiled, the kind desktop
GIS tools export) cannot be displayed by the raster panel because
`maplibre-gl-raster` streams tiles and requires an internally tiled COG. For
**local files** GeoLibre already detects the "striped, not tiled" failure and
offers an in-browser convert-to-COG flow (#789), but that handler bailed for any
non-`file` source, so a striped GeoTIFF loaded from a **URL** was left with the
plain error and no recovery path.

Reported in #916 for `https://data.meteo.tech/goes/RR/RR_20260626_12_24h.tif`
(a 5.8 MB, single-band, striped EPSG:4326 GeoTIFF).

## Fix

Extend the existing non-tiled raster handler to remote URL sources: read the
original bytes from the source URL (fetching it whole) instead of only from a
local file's blob URL, then run the same client-side convert-to-COG + reload
flow. No new UI, no Python sidecar, no upstream change.

The remote fetch relies on the host allowing CORS, which it must already to get
this far (the panel range-fetches the GeoTIFF header to detect the striped
case), so a CORS-less host fails earlier with a fetch error rather than reaching
this branch.

## Verification

Drove the real web app with Playwright using the exact dataset from the issue:

- Before: loading the URL shows `Failed to load: This GeoTIFF is striped, not
  tiled ...` with no recovery.
- After: the convert-to-COG prompt appears; accepting it converts in-browser and
  the raster renders on the map (layer shows the `cog` badge, no failure, 0
  console errors).
- Verified the rendered raster in both light and dark themes.

Fixes #916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery and GeoTIFF-to-COG conversion for striped (non-tiled) rasters, working reliably for both local files and remote URLs.
  * Adjusted confirmation flow for remote sources to prevent double prompts while still warning on large rasters when needed.
  * Enhanced non-tiled error handling: download failures now stop with a dedicated error alert, and failed layers are dismissed only after a successful replacement.
  * Added a timeout for remote whole-file fetching to avoid stalled conversions on slow/unreachable servers.
  * Introduced a new user-facing “raster download failed” error message with retry guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->