### PR TITLE
fix(3d-tiles): panel fills form content on resize (#923)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -57,7 +57,7 @@
     "jspdf": "^4.2.1",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.5.3",
+    "maplibre-gl-3d-tiles": "^0.5.4",
     "maplibre-gl-basemap-control": "^0.9.0",
     "maplibre-gl-components": "^0.25.3",
     "maplibre-gl-duckdb": "^0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "jspdf": "^4.2.1",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.5.3",
+        "maplibre-gl-3d-tiles": "^0.5.4",
         "maplibre-gl-basemap-control": "^0.9.0",
         "maplibre-gl-components": "^0.25.3",
         "maplibre-gl-duckdb": "^0.2.3",
@@ -17303,9 +17303,9 @@
       }
     },
     "node_modules/maplibre-gl-3d-tiles": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.3.tgz",
-      "integrity": "sha512-I5bZerqhQnLzvB9XiIDt0KF9+BfPfWvVWgCidyAlR3ufroJfhVb1MfJSJLKwUr5t+PKNSLfH513xs5YrMNB5cw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.4.tgz",
+      "integrity": "sha512-uo79jaIvvWQ+xoMYstd+QlvMuH2Siv18LeKVg9IjIjyNY6Wub0FOGgnTpz827N7UPIb2BrggHHpR8VFuf6W7/A==",
       "license": "MIT",
       "dependencies": {
         "3d-tiles-renderer": "^0.4.27",
@@ -23798,7 +23798,7 @@
         "geotiff": "^3.0.5",
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.5.3",
+        "maplibre-gl-3d-tiles": "^0.5.4",
         "maplibre-gl-basemap-control": "^0.9.0",
         "maplibre-gl-components": "^0.25.3",
         "maplibre-gl-duckdb": "^0.2.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
     "geotiff": "^3.0.5",
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.5.3",
+    "maplibre-gl-3d-tiles": "^0.5.4",
     "maplibre-gl-basemap-control": "^0.9.0",
     "maplibre-gl-components": "^0.25.3",
     "maplibre-gl-duckdb": "^0.2.3",


### PR DESCRIPTION
Fixes #923.

## Problem

In the **Add 3D Tiles Layer** panel, dragging the corner resize handle expanded the panel frame but the form did not reflow, so the extra space became a band of empty whitespace at the bottom and the Request headers textarea never grew to use it. The panel was also capped at a fixed `720px`, so on a tall viewport the content could spill into a scrollbar even when there was room to show every field at once.

## Root cause

The panel lives in the upstream `maplibre-gl-3d-tiles` package, so the fix is there: opengeos/maplibre-gl-3d-tiles#16 (released as **v0.5.4**).

- The content area is now a flex column and the form fills it; the Request headers field is flagged growable so it absorbs the panel's spare vertical height and its textarea enlarges, instead of pooling whitespace below the form.
- The panel is capped to the full room between its anchor and the opposite map edge instead of a fixed `720px`, so a tall viewport shows all fields in one view and a scrollbar appears only as a fallback.

## GeoLibre change

Bump `maplibre-gl-3d-tiles` `^0.5.3` -> `^0.5.4` in `apps/geolibre-desktop` and `packages/plugins`, plus the lockfile.

## Verification

Drove the real web app with Playwright on the clean published 0.5.4, in **both light and dark themes**:

- **Initial render** (1500x1080): panel sizes to content (~623px), `max-height` resolves to the available map room (~954px) instead of 720px, no whitespace, no scrollbar.
- **After resizing** the panel to ~931px tall: the form fills the content area (whitespace 0, no scrollbar) and the Request headers textarea grows from ~50px to ~373px.

`npm run build` and pre-commit both pass.