### PR TITLE
fix(map): sync layer control style editor with the Style sidebar (#912)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17652,9 +17652,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.3.tgz",
-      "integrity": "sha512-vGEaEEvxx/mY+u+egGFRNLoyxnxWr4UYJTNI5lnQsKREWSAl04nc9GnAX7504Y0H56DHGele1uJJIbqjW5gCuA==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.4.tgz",
+      "integrity": "sha512-MgMeR99rlQyIQNanGCioy/U0ufj4ycmiGhXaSbojH34vw0L/PLdUCiXZeWnTRduoUsKV1eMRwmYTTsVIK1+cXQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23710,7 +23710,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.17.3",
+        "maplibre-gl-layer-control": "^0.17.4",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.17.3",
+    "maplibre-gl-layer-control": "^0.17.4",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -99,53 +99,35 @@ function isCustomControllableLayer(layer: GeoLibreLayer): boolean {
  * style editor into a partial {@link LayerStyle} update for the store, so the
  * floating editor and the right-hand Style sidebar stay in sync (issue #912).
  *
- * Layer-level opacity is handled separately (it lives on the layer record, not
- * its style); see {@link MapController.applyLayerControlStyleChange}. Properties
- * GeoLibre's style model does not track return `null` and are ignored — the
- * control still applies them to the map, they just are not mirrored to the
- * store.
+ * Scope is deliberately limited to the raster color adjustments, which map
+ * one-to-one to {@link LayerStyle} fields. Vector paint is **not** round-tripped
+ * here: GeoLibre renders vector layers through an expression-based style model
+ * (opacities are scaled by the layer opacity, and width/radius/colors become
+ * `interpolate`/`case` expressions under proportional sizing, the meters width
+ * unit, a data-driven `vectorStyleMode`, or simplestyle). The value the control
+ * reads back is the *rendered* paint, so storing it verbatim would corrupt
+ * those configurations. The control still applies vector edits to the map; the
+ * sidebar Style panel remains the canonical editor for vector symbology.
+ * Layer-level opacity is handled separately — see
+ * {@link MapController.applyLayerControlStyleChange}.
  */
 export function layerControlPaintToStyle(
   property: string,
   value: unknown,
 ): Partial<LayerStyle> | null {
-  const num = typeof value === "number" ? value : null;
-  const hex = typeof value === "string" ? value : null;
+  if (typeof value !== "number") return null;
 
   switch (property) {
-    // Raster color adjustments (the primary #912 case: basemap/raster sliders).
     case "raster-brightness-min":
-      return num === null ? null : { rasterBrightnessMin: num };
+      return { rasterBrightnessMin: value };
     case "raster-brightness-max":
-      return num === null ? null : { rasterBrightnessMax: num };
+      return { rasterBrightnessMax: value };
     case "raster-saturation":
-      return num === null ? null : { rasterSaturation: num };
+      return { rasterSaturation: value };
     case "raster-contrast":
-      return num === null ? null : { rasterContrast: num };
+      return { rasterContrast: value };
     case "raster-hue-rotate":
-      return num === null ? null : { rasterHueRotate: num };
-    // Common vector paint props, best-effort mapped to the flat single-symbol
-    // style fields. Layers using a data-driven vectorStyleMode override these,
-    // matching how the sidebar already behaves.
-    case "fill-color":
-    case "circle-color":
-      return hex === null ? null : { fillColor: hex };
-    // Both fill-opacity and circle-opacity derive from fillOpacity in
-    // syncLayer (fillPaint/circlePaint), so they round-trip through that field.
-    case "fill-opacity":
-    case "circle-opacity":
-      return num === null ? null : { fillOpacity: num };
-    case "line-color":
-    case "fill-outline-color":
-    case "circle-stroke-color":
-      return hex === null ? null : { strokeColor: hex };
-    case "line-width":
-    case "circle-stroke-width":
-      return num === null ? null : { strokeWidth: num };
-    case "circle-radius":
-      return num === null ? null : { circleRadius: num };
-    case "text-color":
-      return hex === null ? null : { textColor: hex };
+      return { rasterHueRotate: value };
     default:
       return null;
   }
@@ -274,6 +256,10 @@ export class MapController {
   private logoControl: maplibregl.LogoControl | null = null;
   private layerControl: LayerControl | null = null;
   private layerControlSignature = "";
+  // True while pushing store paint back into the layer control's open style
+  // editor, so onLayerStyleChange callbacks during that refresh are ignored
+  // (reentrancy guard against a sync loop). See syncLayerControlState.
+  private refreshingStyleEditor = false;
   private basemapStyleUrl = DEFAULT_BASEMAP;
   private basemapVisible = true;
   private basemapOpacity = 1;
@@ -1387,29 +1373,39 @@ export class MapController {
     // did, this path would loop forever (sync → refresh → onLayerStyleChange →
     // applyLayerControlStyleChange → setLayerStyle → sync → ...). The upstream
     // library guarantees this by setting input values programmatically, which
-    // does not dispatch an input event.
-    this.layerControl?.refreshStyleEditor();
+    // does not dispatch an input event. The reentrancy guard below is a cheap
+    // defense in case a future upstream version regresses that guarantee.
+    this.refreshingStyleEditor = true;
+    try {
+      this.layerControl?.refreshStyleEditor();
+    } finally {
+      this.refreshingStyleEditor = false;
+    }
   }
 
   /**
    * Mirror a paint property edited via the layer control's per-layer style
    * editor into the store. The per-type opacities that GeoLibre derives
    * directly from the layer-level opacity (raster/line/text/icon) map to
-   * {@link AppState.setLayerOpacity}; everything else maps to
-   * {@link LayerStyle} via {@link layerControlPaintToStyle}. Unmapped
-   * properties are ignored.
+   * {@link AppState.setLayerOpacity}; raster color adjustments map to
+   * {@link LayerStyle} via {@link layerControlPaintToStyle}. Other properties
+   * (vector paint) are ignored — see that helper for why.
    */
   private applyLayerControlStyleChange(
     layerId: string,
     property: string,
     value: unknown,
   ): void {
+    // Ignore callbacks that fire while we are pushing store values back into
+    // the editor; otherwise a misbehaving refresh could create a sync loop.
+    if (this.refreshingStyleEditor) return;
     const store = useAppStore.getState();
     // These paint properties equal the layer-level opacity in syncLayer
     // (rasterPaint/linePaint use it directly; symbol layers set
     // text-opacity/icon-opacity to it), so an edit to them is an edit to the
-    // layer's opacity. circle-opacity is intentionally *not* here: circlePaint
-    // derives it from fillOpacity, so it maps to that style field instead.
+    // layer's opacity and round-trips losslessly. fill-opacity/circle-opacity
+    // are deliberately not here: syncLayer scales them by the layer opacity, so
+    // the rendered value the control reports is not the raw style value.
     if (
       property === "raster-opacity" ||
       property === "line-opacity" ||

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1401,13 +1401,14 @@ export class MapController {
     if (this.refreshingStyleEditor) return;
     const store = useAppStore.getState();
     // These paint properties equal the layer-level opacity in syncLayer
-    // (rasterPaint/linePaint use it directly; symbol layers set
+    // (rasterPaint/heatmapPaint/linePaint use it directly; symbol layers set
     // text-opacity/icon-opacity to it), so an edit to them is an edit to the
     // layer's opacity and round-trips losslessly. fill-opacity/circle-opacity
     // are deliberately not here: syncLayer scales them by the layer opacity, so
     // the rendered value the control reports is not the raw style value.
     if (
       property === "raster-opacity" ||
+      property === "heatmap-opacity" ||
       property === "line-opacity" ||
       property === "text-opacity" ||
       property === "icon-opacity"

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -130,7 +130,10 @@ export function layerControlPaintToStyle(
     case "fill-color":
     case "circle-color":
       return hex === null ? null : { fillColor: hex };
+    // Both fill-opacity and circle-opacity derive from fillOpacity in
+    // syncLayer (fillPaint/circlePaint), so they round-trip through that field.
     case "fill-opacity":
+    case "circle-opacity":
       return num === null ? null : { fillOpacity: num };
     case "line-color":
     case "fill-outline-color":
@@ -1379,14 +1382,22 @@ export class MapController {
     // layer control's open style editor so edits made elsewhere — e.g. the
     // right-hand Style sidebar — are reflected there too (issue #912). No-op
     // when no editor is open; skips the input the user is actively dragging.
+    //
+    // Invariant: refreshStyleEditor() must NOT fire onLayerStyleChange. If it
+    // did, this path would loop forever (sync → refresh → onLayerStyleChange →
+    // applyLayerControlStyleChange → setLayerStyle → sync → ...). The upstream
+    // library guarantees this by setting input values programmatically, which
+    // does not dispatch an input event.
     this.layerControl?.refreshStyleEditor();
   }
 
   /**
    * Mirror a paint property edited via the layer control's per-layer style
-   * editor into the store. {@code raster-opacity} maps to the layer-level
-   * opacity; everything else maps to {@link LayerStyle} via
-   * {@link layerControlPaintToStyle}. Unmapped properties are ignored.
+   * editor into the store. The per-type opacities that GeoLibre derives
+   * directly from the layer-level opacity (raster/line/text/icon) map to
+   * {@link AppState.setLayerOpacity}; everything else maps to
+   * {@link LayerStyle} via {@link layerControlPaintToStyle}. Unmapped
+   * properties are ignored.
    */
   private applyLayerControlStyleChange(
     layerId: string,
@@ -1394,7 +1405,17 @@ export class MapController {
     value: unknown,
   ): void {
     const store = useAppStore.getState();
-    if (property === "raster-opacity") {
+    // These paint properties equal the layer-level opacity in syncLayer
+    // (rasterPaint/linePaint use it directly; symbol layers set
+    // text-opacity/icon-opacity to it), so an edit to them is an edit to the
+    // layer's opacity. circle-opacity is intentionally *not* here: circlePaint
+    // derives it from fillOpacity, so it maps to that style field instead.
+    if (
+      property === "raster-opacity" ||
+      property === "line-opacity" ||
+      property === "text-opacity" ||
+      property === "icon-opacity"
+    ) {
       if (typeof value === "number") store.setLayerOpacity(layerId, value);
       return;
     }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -6,6 +6,7 @@ import {
 } from "@geolibre/core";
 import type {
   GeoLibreLayer,
+  LayerStyle,
   MapPreferences,
   MapProjection,
   MapViewState,
@@ -91,6 +92,60 @@ const EMPTY_HIGHLIGHT: FeatureCollection = {
 
 function isCustomControllableLayer(layer: GeoLibreLayer): boolean {
   return typeof layer.metadata.customLayerType === "string";
+}
+
+/**
+ * Translate a MapLibre paint property edited in the layer control's per-layer
+ * style editor into a partial {@link LayerStyle} update for the store, so the
+ * floating editor and the right-hand Style sidebar stay in sync (issue #912).
+ *
+ * Layer-level opacity is handled separately (it lives on the layer record, not
+ * its style); see {@link MapController.applyLayerControlStyleChange}. Properties
+ * GeoLibre's style model does not track return `null` and are ignored — the
+ * control still applies them to the map, they just are not mirrored to the
+ * store.
+ */
+export function layerControlPaintToStyle(
+  property: string,
+  value: unknown,
+): Partial<LayerStyle> | null {
+  const num = typeof value === "number" ? value : null;
+  const hex = typeof value === "string" ? value : null;
+
+  switch (property) {
+    // Raster color adjustments (the primary #912 case: basemap/raster sliders).
+    case "raster-brightness-min":
+      return num === null ? null : { rasterBrightnessMin: num };
+    case "raster-brightness-max":
+      return num === null ? null : { rasterBrightnessMax: num };
+    case "raster-saturation":
+      return num === null ? null : { rasterSaturation: num };
+    case "raster-contrast":
+      return num === null ? null : { rasterContrast: num };
+    case "raster-hue-rotate":
+      return num === null ? null : { rasterHueRotate: num };
+    // Common vector paint props, best-effort mapped to the flat single-symbol
+    // style fields. Layers using a data-driven vectorStyleMode override these,
+    // matching how the sidebar already behaves.
+    case "fill-color":
+    case "circle-color":
+      return hex === null ? null : { fillColor: hex };
+    case "fill-opacity":
+      return num === null ? null : { fillOpacity: num };
+    case "line-color":
+    case "fill-outline-color":
+    case "circle-stroke-color":
+      return hex === null ? null : { strokeColor: hex };
+    case "line-width":
+    case "circle-stroke-width":
+      return num === null ? null : { strokeWidth: num };
+    case "circle-radius":
+      return num === null ? null : { circleRadius: num };
+    case "text-color":
+      return hex === null ? null : { textColor: hex };
+    default:
+      return null;
+  }
 }
 
 function nativeLayerSuffix(layerId: string): string | undefined {
@@ -1278,6 +1333,12 @@ export class MapController {
       onBackgroundOpacityChange: (opacity) => {
         useAppStore.getState().setBasemapOpacity(opacity);
       },
+      // The per-layer style editor edits MapLibre paint directly; mirror those
+      // edits into the store (the source of truth) so the right-hand Style
+      // sidebar stays in sync and the change survives the next layer sync.
+      onLayerStyleChange: (layerId, property, value) => {
+        this.applyLayerControlStyleChange(layerId, property, value);
+      },
     });
     this.map.addControl(
       this.layerControl,
@@ -1314,6 +1375,31 @@ export class MapController {
   private syncLayerControlState(): void {
     this.syncLayerControlBackgroundState();
     this.syncLayerControlLayerStates(this.syncedLayers);
+    // Push the latest paint (already applied to the map by syncLayer) into the
+    // layer control's open style editor so edits made elsewhere — e.g. the
+    // right-hand Style sidebar — are reflected there too (issue #912). No-op
+    // when no editor is open; skips the input the user is actively dragging.
+    this.layerControl?.refreshStyleEditor();
+  }
+
+  /**
+   * Mirror a paint property edited via the layer control's per-layer style
+   * editor into the store. {@code raster-opacity} maps to the layer-level
+   * opacity; everything else maps to {@link LayerStyle} via
+   * {@link layerControlPaintToStyle}. Unmapped properties are ignored.
+   */
+  private applyLayerControlStyleChange(
+    layerId: string,
+    property: string,
+    value: unknown,
+  ): void {
+    const store = useAppStore.getState();
+    if (property === "raster-opacity") {
+      if (typeof value === "number") store.setLayerOpacity(layerId, value);
+      return;
+    }
+    const styleUpdate = layerControlPaintToStyle(property, value);
+    if (styleUpdate) store.setLayerStyle(layerId, styleUpdate);
   }
 
   private createLayerControlConfig(

--- a/tests/layer-control-style-sync.test.ts
+++ b/tests/layer-control-style-sync.test.ts
@@ -35,11 +35,10 @@ describe("layerControlPaintToStyle", () => {
     assert.deepEqual(layerControlPaintToStyle("fill-opacity", 0.5), {
       fillOpacity: 0.5,
     });
-    assert.deepEqual(layerControlPaintToStyle("line-color", "#0000ff"), {
-      strokeColor: "#0000ff",
-    });
-    assert.deepEqual(layerControlPaintToStyle("line-width", 3), {
-      strokeWidth: 3,
+    // circle-opacity round-trips through fillOpacity (circlePaint derives it
+    // from that field), same as fill-opacity.
+    assert.deepEqual(layerControlPaintToStyle("circle-opacity", 0.4), {
+      fillOpacity: 0.4,
     });
     assert.deepEqual(layerControlPaintToStyle("circle-radius", 8), {
       circleRadius: 8,
@@ -49,13 +48,37 @@ describe("layerControlPaintToStyle", () => {
     });
   });
 
-  it("returns null for raster-opacity (handled as layer-level opacity, not style)", () => {
+  it("maps every strokeColor / strokeWidth alias (switch fall-through)", () => {
+    assert.deepEqual(layerControlPaintToStyle("line-color", "#0000ff"), {
+      strokeColor: "#0000ff",
+    });
+    assert.deepEqual(layerControlPaintToStyle("fill-outline-color", "#0000ff"), {
+      strokeColor: "#0000ff",
+    });
+    assert.deepEqual(
+      layerControlPaintToStyle("circle-stroke-color", "#0000ff"),
+      { strokeColor: "#0000ff" },
+    );
+    assert.deepEqual(layerControlPaintToStyle("line-width", 3), {
+      strokeWidth: 3,
+    });
+    assert.deepEqual(layerControlPaintToStyle("circle-stroke-width", 2), {
+      strokeWidth: 2,
+    });
+  });
+
+  it("returns null for opacities applied as the layer-level opacity", () => {
+    // raster/line/text/icon opacity equal layer.opacity in syncLayer, so they
+    // are routed to setLayerOpacity by applyLayerControlStyleChange rather than
+    // mapped to a LayerStyle field here.
     assert.equal(layerControlPaintToStyle("raster-opacity", 0.6), null);
+    assert.equal(layerControlPaintToStyle("line-opacity", 0.6), null);
+    assert.equal(layerControlPaintToStyle("text-opacity", 0.6), null);
+    assert.equal(layerControlPaintToStyle("icon-opacity", 0.6), null);
   });
 
   it("returns null for properties GeoLibre's style model does not track", () => {
     assert.equal(layerControlPaintToStyle("line-blur", 2), null);
-    assert.equal(layerControlPaintToStyle("icon-opacity", 0.5), null);
     assert.equal(layerControlPaintToStyle("unknown-prop", 1), null);
   });
 

--- a/tests/layer-control-style-sync.test.ts
+++ b/tests/layer-control-style-sync.test.ts
@@ -3,11 +3,13 @@ import { describe, it } from "node:test";
 import { layerControlPaintToStyle } from "../packages/map/src/map-controller";
 
 // The layer control's per-layer style editor edits MapLibre paint properties
-// directly. layerControlPaintToStyle maps those edits back to the store's
-// LayerStyle so the floating editor and the right-hand Style sidebar stay in
-// sync (issue #912).
+// directly. layerControlPaintToStyle maps the raster color adjustments back to
+// the store's LayerStyle so the floating editor and the right-hand Style
+// sidebar stay in sync (issue #912). Vector paint is intentionally not mapped:
+// GeoLibre renders vector layers through an expression-based style model, so
+// the rendered values the control reports would not round-trip losslessly.
 describe("layerControlPaintToStyle", () => {
-  it("maps the raster color adjustments (the primary #912 case)", () => {
+  it("maps the raster color adjustments (the #912 case)", () => {
     assert.deepEqual(layerControlPaintToStyle("raster-brightness-min", -0.3), {
       rasterBrightnessMin: -0.3,
     });
@@ -25,67 +27,30 @@ describe("layerControlPaintToStyle", () => {
     });
   });
 
-  it("maps common vector paint properties to the flat style fields", () => {
-    assert.deepEqual(layerControlPaintToStyle("fill-color", "#ff0000"), {
-      fillColor: "#ff0000",
-    });
-    assert.deepEqual(layerControlPaintToStyle("circle-color", "#00ff00"), {
-      fillColor: "#00ff00",
-    });
-    assert.deepEqual(layerControlPaintToStyle("fill-opacity", 0.5), {
-      fillOpacity: 0.5,
-    });
-    // circle-opacity round-trips through fillOpacity (circlePaint derives it
-    // from that field), same as fill-opacity.
-    assert.deepEqual(layerControlPaintToStyle("circle-opacity", 0.4), {
-      fillOpacity: 0.4,
-    });
-    assert.deepEqual(layerControlPaintToStyle("circle-radius", 8), {
-      circleRadius: 8,
-    });
-    assert.deepEqual(layerControlPaintToStyle("text-color", "#222222"), {
-      textColor: "#222222",
-    });
-  });
-
-  it("maps every strokeColor / strokeWidth alias (switch fall-through)", () => {
-    assert.deepEqual(layerControlPaintToStyle("line-color", "#0000ff"), {
-      strokeColor: "#0000ff",
-    });
-    assert.deepEqual(layerControlPaintToStyle("fill-outline-color", "#0000ff"), {
-      strokeColor: "#0000ff",
-    });
-    assert.deepEqual(
-      layerControlPaintToStyle("circle-stroke-color", "#0000ff"),
-      { strokeColor: "#0000ff" },
-    );
-    assert.deepEqual(layerControlPaintToStyle("line-width", 3), {
-      strokeWidth: 3,
-    });
-    assert.deepEqual(layerControlPaintToStyle("circle-stroke-width", 2), {
-      strokeWidth: 2,
-    });
-  });
-
-  it("returns null for opacities applied as the layer-level opacity", () => {
-    // raster/line/text/icon opacity equal layer.opacity in syncLayer, so they
-    // are routed to setLayerOpacity by applyLayerControlStyleChange rather than
-    // mapped to a LayerStyle field here.
+  it("returns null for raster-opacity (handled as layer-level opacity, not style)", () => {
     assert.equal(layerControlPaintToStyle("raster-opacity", 0.6), null);
-    assert.equal(layerControlPaintToStyle("line-opacity", 0.6), null);
-    assert.equal(layerControlPaintToStyle("text-opacity", 0.6), null);
-    assert.equal(layerControlPaintToStyle("icon-opacity", 0.6), null);
   });
 
-  it("returns null for properties GeoLibre's style model does not track", () => {
-    assert.equal(layerControlPaintToStyle("line-blur", 2), null);
+  it("returns null for vector paint (not round-tripped into the expression-based model)", () => {
+    // Colors, widths/radii, and fill/circle opacity all depend on the layer's
+    // style mode (vectorStyleMode, proportional sizing, meters width unit,
+    // simplestyle, opacity scaling), so the rendered value is not the raw style
+    // value. These are left to the sidebar Style panel.
+    assert.equal(layerControlPaintToStyle("fill-color", "#ff0000"), null);
+    assert.equal(layerControlPaintToStyle("line-color", "#0000ff"), null);
+    assert.equal(layerControlPaintToStyle("circle-color", "#00ff00"), null);
+    assert.equal(layerControlPaintToStyle("fill-opacity", 0.5), null);
+    assert.equal(layerControlPaintToStyle("circle-opacity", 0.4), null);
+    assert.equal(layerControlPaintToStyle("line-width", 3), null);
+    assert.equal(layerControlPaintToStyle("circle-radius", 8), null);
+    assert.equal(layerControlPaintToStyle("text-color", "#222222"), null);
+  });
+
+  it("returns null for unknown properties and non-numeric values", () => {
     assert.equal(layerControlPaintToStyle("unknown-prop", 1), null);
-  });
-
-  it("ignores values of the wrong type for a property", () => {
-    // A numeric property given a string, or a color given a number, is dropped
-    // rather than written through with a bad value.
+    assert.equal(layerControlPaintToStyle("line-blur", 2), null);
+    // A raster slider property given a non-number is dropped rather than
+    // written through with a bad value.
     assert.equal(layerControlPaintToStyle("raster-brightness-max", "0.4"), null);
-    assert.equal(layerControlPaintToStyle("fill-color", 1), null);
   });
 });

--- a/tests/layer-control-style-sync.test.ts
+++ b/tests/layer-control-style-sync.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { layerControlPaintToStyle } from "../packages/map/src/map-controller";
+
+// The layer control's per-layer style editor edits MapLibre paint properties
+// directly. layerControlPaintToStyle maps those edits back to the store's
+// LayerStyle so the floating editor and the right-hand Style sidebar stay in
+// sync (issue #912).
+describe("layerControlPaintToStyle", () => {
+  it("maps the raster color adjustments (the primary #912 case)", () => {
+    assert.deepEqual(layerControlPaintToStyle("raster-brightness-min", -0.3), {
+      rasterBrightnessMin: -0.3,
+    });
+    assert.deepEqual(layerControlPaintToStyle("raster-brightness-max", 0.4), {
+      rasterBrightnessMax: 0.4,
+    });
+    assert.deepEqual(layerControlPaintToStyle("raster-saturation", 0.5), {
+      rasterSaturation: 0.5,
+    });
+    assert.deepEqual(layerControlPaintToStyle("raster-contrast", -0.2), {
+      rasterContrast: -0.2,
+    });
+    assert.deepEqual(layerControlPaintToStyle("raster-hue-rotate", 120), {
+      rasterHueRotate: 120,
+    });
+  });
+
+  it("maps common vector paint properties to the flat style fields", () => {
+    assert.deepEqual(layerControlPaintToStyle("fill-color", "#ff0000"), {
+      fillColor: "#ff0000",
+    });
+    assert.deepEqual(layerControlPaintToStyle("circle-color", "#00ff00"), {
+      fillColor: "#00ff00",
+    });
+    assert.deepEqual(layerControlPaintToStyle("fill-opacity", 0.5), {
+      fillOpacity: 0.5,
+    });
+    assert.deepEqual(layerControlPaintToStyle("line-color", "#0000ff"), {
+      strokeColor: "#0000ff",
+    });
+    assert.deepEqual(layerControlPaintToStyle("line-width", 3), {
+      strokeWidth: 3,
+    });
+    assert.deepEqual(layerControlPaintToStyle("circle-radius", 8), {
+      circleRadius: 8,
+    });
+    assert.deepEqual(layerControlPaintToStyle("text-color", "#222222"), {
+      textColor: "#222222",
+    });
+  });
+
+  it("returns null for raster-opacity (handled as layer-level opacity, not style)", () => {
+    assert.equal(layerControlPaintToStyle("raster-opacity", 0.6), null);
+  });
+
+  it("returns null for properties GeoLibre's style model does not track", () => {
+    assert.equal(layerControlPaintToStyle("line-blur", 2), null);
+    assert.equal(layerControlPaintToStyle("icon-opacity", 0.5), null);
+    assert.equal(layerControlPaintToStyle("unknown-prop", 1), null);
+  });
+
+  it("ignores values of the wrong type for a property", () => {
+    // A numeric property given a string, or a color given a number, is dropped
+    // rather than written through with a bad value.
+    assert.equal(layerControlPaintToStyle("raster-brightness-max", "0.4"), null);
+    assert.equal(layerControlPaintToStyle("fill-color", 1), null);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #912. The on-map layer control's per-layer "Edit Style" panel edited
MapLibre paint properties directly and never told the store, so changes made in
the floating editor (raster brightness, saturation, contrast, hue, opacity, ...)
did **not** reflect in the right-hand Style sidebar, and sidebar edits did not
update an already-open floating editor. Because every layer sync re-derives
paint from the store, a floating edit was also liable to be overwritten on the
next sync.

## What changed

- Bumps **`maplibre-gl-layer-control` to `^0.17.4`** (opengeos/maplibre-gl-layer-control#62,
  released as v0.17.4), which adds an `onLayerStyleChange` callback and a
  `refreshStyleEditor()` method, gives the editor's action buttons a neutral
  palette, and relabels them **"Reset Style"** / **"Remove Layer"**.
- Wires `onLayerStyleChange` into the store:
  - The per-type opacities that equal the layer-level opacity in `syncLayer`
    (`raster-opacity`, `line-opacity`, `text-opacity`, `icon-opacity`) map to
    `setLayerOpacity`.
  - The raster color adjustments map to `LayerStyle` via `layerControlPaintToStyle`.
  - **Vector paint is intentionally not round-tripped.** GeoLibre renders vector
    layers through an expression-based style model (opacities scaled by the
    layer opacity; width/radius/colors become `interpolate`/`case` expressions
    under proportional sizing, the meters width unit, a data-driven
    `vectorStyleMode`, or simplestyle), so the rendered value the control reports
    would not map back losslessly. The sidebar Style panel remains the canonical
    vector editor.
- After each layer sync, calls `refreshStyleEditor()` so an open floating editor
  reflects edits made elsewhere (e.g. the sidebar). It skips the actively
  dragged input, and a `refreshingStyleEditor` reentrancy guard drops any
  callback that fires during the refresh, so the sync→refresh path can't loop.

Net effect: the **raster** floating editor and the Style sidebar stay in sync in
both directions, layer opacity stays consistent across the floating editor / the
sidebar / the left layer list, and edits persist instead of being reverted.

### A note on the issue's other points

- **Auto-close on sidebar slider drag** (point 2) is already prevented: the
  control is only torn down and rebuilt on a structural signature change, which
  excludes opacity/visibility/style edits. Verified the floating editor stays
  open through sidebar and floating style edits.
- **Neutral buttons / clearer labels** (points 3 and 4) come from the upstream
  0.17.4 bump.
- Per maintainer guidance on the issue, the redundant on-map layer control is
  kept (no mutual-exclusion with the panels); this PR makes the states
  consistent.

## Tests

- `tests/layer-control-style-sync.test.ts` covers `layerControlPaintToStyle`
  (raster mappings; raster-opacity and vector paint return null; unknown /
  non-numeric values dropped).
- Upstream adds `tests/layerStyleChange.test.ts` for the callback and
  `refreshStyleEditor`.

## Verification

Drove the real app (Playwright) with a USGS imagery XYZ raster layer:

- Floating Brightness Max / Saturation edits update the sidebar live, and vice
  versa.
- Opacity stays in sync across the floating editor, the Style sidebar, and the
  left layer list.
- **Reset Style** resets both panels and the editor stays open.
- Buttons render neutral and read "Reset Style" / "Remove Layer" / "Close".
- Confirmed in both light and dark themes; no console errors.

`npm run build`, the related frontend tests, and `pre-commit` on the changed
files all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded layer style syncing so edits in the paint editor reliably update the app’s layer style settings.
  * Added additional paint-to-style mappings for raster brightness/saturation/contrast/hue-rotate.

* **Bug Fixes**
  * Prevented the style editor UI from drifting during layer synchronization.
  * Improved opacity edit handling by applying opacity changes to the correct layer controls.

* **Tests**
  * Added coverage for paint-to-style mapping, including unknown and non-numeric inputs.

* **Chores**
  * Updated a map-related dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->