### PR TITLE
fix(basemap): apply resolved provider style URL and recover from failed basemaps

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.9.0",
+    "maplibre-gl-basemap-control": "^0.10.0",
     "maplibre-gl-components": "^0.25.3",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.9.0",
+        "maplibre-gl-basemap-control": "^0.10.0",
         "maplibre-gl-components": "^0.25.3",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17378,9 +17378,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.9.0.tgz",
-      "integrity": "sha512-C5XRc+IVFrXP1AGEHu0JWYDho8sScgFVs4H6RyonT7ORywlb3bWnlfAHXHbNnKikcM3CCMdtvTDhTJ+txDr3zQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.10.0.tgz",
+      "integrity": "sha512-feTSjYTOZd/touyOTz6VYHUvk2La2WhPTARBOfspv45LoJ6F9DmK7mqITMwVqfv1kDqH8mOBUSYOUFezcSms0Q==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23799,7 +23799,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.9.0",
+        "maplibre-gl-basemap-control": "^0.10.0",
         "maplibre-gl-components": "^0.25.3",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.9.0",
+    "maplibre-gl-basemap-control": "^0.10.0",
     "maplibre-gl-components": "^0.25.3",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -102,6 +102,15 @@ let basemapControl: BasemapControl | null = null;
 // GeoLibre layer ids of registered raster basemaps, keyed by basemap id. In
 // multiple mode several raster basemaps can be registered at once.
 const registeredRasterLayers = new Map<string, string>();
+// The most recent style-basemap swap and the background style URL it replaced,
+// so a failed provider style (e.g. an Amazon Location basemap with an invalid
+// API key) can roll the background back instead of leaving a blank map. The
+// control restores the previous basemap itself when that was one of its own
+// style basemaps, but it cannot know GeoLibre's background style when the
+// previous basemap was a stacked raster, so GeoLibre keeps this fallback. See
+// opengeos/GeoLibre#913.
+let styleChangeFallback: { attemptedUrl: string; previousUrl: string } | null =
+  null;
 
 export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-basemap-control",
@@ -115,6 +124,9 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
       });
       basemapControl.on("basemapremove", (event) => {
         handleBasemapRemove(app, event);
+      });
+      basemapControl.on("error", (event) => {
+        handleBasemapError(app, event);
       });
       addRuntimeEnvListener();
     }
@@ -249,8 +261,46 @@ function handleBasemapChange(
   // before touching the layer manager, so an unrecognized future source type
   // does not evict the raster overlays without replacing the style.
   if (source.type !== "style" && source.type !== "vector-style") return;
+  // Provider style basemaps (Amazon Location, MapTiler, Mapbox, ...) carry a
+  // templated source.url with `{api-key}`/`{aws-region}` placeholders that the
+  // control substitutes from the user's credentials. Apply the resolved URL the
+  // control reports rather than the raw template, which would otherwise reach
+  // MapLibre unsubstituted and fail to load, blanking the map. Plain style
+  // basemaps have no placeholders and report no resolvedStyleUrl, so fall back
+  // to source.url. See opengeos/GeoLibre#913.
+  const styleUrl = event.resolvedStyleUrl ?? source.url;
+  // Remember the background to roll back to if this style fails to load, but not
+  // for the control's own rollback event (which carries `restored`), so a failed
+  // swap's fallback survives the rollback that follows it.
+  if (!event.restored) {
+    styleChangeFallback = {
+      attemptedUrl: styleUrl,
+      previousUrl: app.getActiveBasemap(),
+    };
+  }
   unregisterAllRasterBasemaps(app);
-  app.setBasemap(source.url);
+  app.setBasemap(styleUrl);
+}
+
+// Roll the background style back when a provider style basemap fails to load
+// (e.g. an invalid API key 403s its tiles). The control restores the previous
+// basemap itself when that was one of its own style basemaps; this backstop
+// covers the case it cannot — when the replaced background was a GeoLibre style
+// the control does not own (the user had a raster basemap stacked on top). Only
+// acts when the failed style is still applied, so it never clobbers a newer
+// successful change. See opengeos/GeoLibre#913.
+function handleBasemapError(
+  app: GeoLibreAppAPI,
+  event: BasemapControlEventPayload,
+): void {
+  if (event.type !== "error") return;
+  const fallback = styleChangeFallback;
+  if (!fallback) return;
+  styleChangeFallback = null;
+  if (app.getActiveBasemap() !== fallback.attemptedUrl) return;
+  if (fallback.previousUrl && fallback.previousUrl !== fallback.attemptedUrl) {
+    app.setBasemap(fallback.previousUrl);
+  }
 }
 
 function handleBasemapRemove(

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -157,6 +157,9 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
     unregisterAllRasterBasemaps(app);
     app.removeMapControl(basemapControl);
     basemapControl = null;
+    // Drop any pending style-failure fallback so a later reactivation cannot
+    // act on it against a fresh control instance.
+    styleChangeFallback = null;
   },
   getMapControlPosition: () => basemapControlPosition,
   setMapControlPosition: (
@@ -251,6 +254,10 @@ function handleBasemapChange(
 ): void {
   // Narrows the BasemapControlEventPayload union so event.basemap is accessible.
   if (event.type !== "basemapchange") return;
+  // Any fresh user selection (a different style, or a raster overlay) supersedes
+  // a pending style-failure fallback, so drop it here before the early returns
+  // below. The control's own rollback carries `restored` and must keep it.
+  if (!event.restored) styleChangeFallback = null;
   const { source } = event.basemap;
   if (source.type === "raster") {
     registerRasterBasemap(app, event.basemap, event);


### PR DESCRIPTION
## Problem

Amazon Location basemaps (and any provider style basemap that needs an API key) were broken. The Basemaps control reports a selected basemap with a templated `source.url` like `https://maps.geo.{aws-region}.amazonaws.com/v2/styles/Standard/descriptor?key={api-key}`. The control substitutes those placeholders and applies the style itself, but GeoLibre re-applied the **raw template** (`event.basemap.source.url`) through the store, overwriting the control's correctly-resolved style with an unsubstituted URL that fails to load.

As a result:
- Even with a valid key, an Amazon basemap could not render (the `{aws-region}` host does not resolve).
- With an invalid key, the map was erased to a blank canvas with no error, and the layer panel was left in a broken state.

Reported in #913.

## Fix

This consumes [`maplibre-gl-basemap-control@0.10.0`](https://github.com/opengeos/maplibre-gl-basemap-control/releases/tag/v0.10.0), which adds:
- `resolvedStyleUrl` on the `basemapchange` event (the fully substituted URL the control applied), and
- automatic recovery: when a provider style fails to load (a failed descriptor, or unauthorized 401/403 tiles for a credentialed provider) the control restores the previous basemap and emits an `error` with the inline credential field re-revealed.

GeoLibre changes:
- Apply `event.resolvedStyleUrl` (falling back to `source.url` for plain style basemaps) instead of the raw template.
- Listen to the control's `error` event and roll the background style back to what it was before the failed swap, covering the case the control cannot restore itself (the previous basemap was a raster the user had stacked on a GeoLibre-owned background). A `restored` flag on the control's rollback event keeps GeoLibre from treating the rollback as a fresh change.

## Verification

Drove the real web app with Playwright using an invalid Amazon key, in **both light and dark themes**:
- The map is restored to the previous basemap (OpenFreeMap) instead of going blank.
- An inline error appears: *"Could not load the "Amazon Standard" basemap (HTTP 403). Check the API key and try again."* with a "Get an Amazon API key" link and the key field accessible for retry.
- Selecting a normal basemap (e.g. OpenStreetMap) afterward works cleanly, with a correct layer panel (resolves the issue's "extra bug").

`npm run build` and the scoped `pre-commit` (eslint + npm build) pass. Upstream ships 84 passing tests covering the resolved-URL and rollback behavior.

Fixes #913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved basemap switching reliability by restoring the last working style when a newly selected provider style fails to load.
  * Reduced the chance of ending up with a blank map after a failed basemap change.
* **Chores**
  * Updated the map basemap control dependency to a newer version to improve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->