### PR TITLE
chore: move web viewer to web.geolibre.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoLibre
 
-[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 [![GeoLibre shared project](https://img.shields.io/badge/GeoLibre-share-green.svg)](https://share.geolibre.app)
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)
@@ -20,7 +20,7 @@ A free and open-source, lightweight, cloud-native GIS platform for visualizing, 
 
 GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**. The same workspace runs as a native desktop app, a native Android app, in any modern web browser, and adapts responsively to mobile and small screens.
 
-[![GeoLibre demo showing 3D Tiles rendered on a MapLibre map](https://files.opengeos.org/GeoLibre-demo.webp)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![GeoLibre demo showing 3D Tiles rendered on a MapLibre map](https://files.opengeos.org/GeoLibre-demo.webp)](https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 
 **Video tutorials:**
 
@@ -281,7 +281,7 @@ The browser demo supports URL parameters for iframe-friendly layouts.
 
 Open a project by URL:
 
-<https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json>
+<https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json>
 
 Supported query parameters:
 
@@ -298,13 +298,13 @@ Supported query parameters:
 Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact
 ```
 
 Hide the Layers, Style, and Attribute table panels for map-focused embeds:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
@@ -312,7 +312,7 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 For a fully chrome-free, map-only embed, use `maponly`. It hides the toolbar menu, all panels, and the status bar:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
 ```
 
 ## Python package (Jupyter)

--- a/apps/geolibre-desktop/src/components/layout/NoServiceWorkerBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NoServiceWorkerBanner.tsx
@@ -7,7 +7,7 @@ import { openExternalLink } from "../../lib/open-external";
  * active. Offered as the remediation link when the current build (desktop, or
  * the dev server) has no controlling service worker so downloads can't persist.
  */
-const OFFLINE_WEB_APP_URL = "https://viewer.geolibre.app";
+const OFFLINE_WEB_APP_URL = "https://web.geolibre.app";
 
 interface NoServiceWorkerBannerProps {
   /** The build-specific warning text shown above the web-app link. */

--- a/apps/geolibre-desktop/src/lib/html-export.ts
+++ b/apps/geolibre-desktop/src/lib/html-export.ts
@@ -4,7 +4,7 @@
 import type { GeoLibreProject } from "@geolibre/core";
 
 // Hosted viewer used as the default embed target (matches Python's default).
-export const DEFAULT_VIEWER_BASE_URL = "https://viewer.geolibre.app/";
+export const DEFAULT_VIEWER_BASE_URL = "https://web.geolibre.app/";
 
 // Excludes the structural CSS chars ("{};:") so a width/height can't close the
 // <style> rule and inject CSS; "/" is allowed so calc() divisions pass (extends

--- a/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
+++ b/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
@@ -6,7 +6,7 @@ const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
 /**
  * Whether to suppress the first-launch onboarding wizard because the app is
  * opened as an embed/deep link, where the modal would just cover the map:
- *   - a project deep link (e.g. viewer.geolibre.app `?url=`) opens straight
+ *   - a project deep link (e.g. web.geolibre.app `?url=`) opens straight
  *     into a shared project, or
  *   - an explicit `?welcome=0` (also `false`/`off`/`no`) opts out, for embeds
  *     that don't load a project URL but still want a clean first paint.

--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -1,7 +1,7 @@
 /**
  * Recovery for stale lazy-loaded chunks after a redeploy.
  *
- * On a static host (the GitHub Pages web demo behind viewer.geolibre.app), each
+ * On a static host (the GitHub Pages web demo behind web.geolibre.app), each
  * deployment writes content-hashed JS chunks and deletes the previous build's
  * chunks. Browsers cache hashed assets for hours, so a tab that loaded an
  * earlier build keeps a cached lazy chunk whose dynamic `import()` targets a

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -3,7 +3,7 @@
 GeoLibre desktop installers are published from GitHub Releases.
 
 [View releases](https://github.com/opengeos/GeoLibre/releases){ .md-button .md-button--primary }
-[Launch GeoLibre Web](https://viewer.geolibre.app/){ .md-button }
+[Launch GeoLibre Web](https://web.geolibre.app/){ .md-button }
 
 ## Release assets
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 [![GeoLibre shared project](https://img.shields.io/badge/GeoLibre-share-green.svg)](https://share.geolibre.app)
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)
@@ -27,7 +27,7 @@ Pick whichever fits how you work. The same app ships in every form, so projects 
 
 GeoLibre Web is the full app running in your browser, with nothing to install. It keeps your data local and private, processing everything client-side in your browser session.
 
-[Launch GeoLibre Web](https://viewer.geolibre.app/){ .md-button .md-button--primary }
+[Launch GeoLibre Web](https://web.geolibre.app/){ .md-button .md-button--primary }
 
 You can load browser-selected vector data supported by DuckDB-WASM Spatial, drag GeoTIFF/COG rasters onto the map, add URL-based services and datasets (XYZ, WMS, GeoJSON, vector tiles, COG, ArcGIS, FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats), style layers, and test plugins. Desktop-only file dialogs, local MBTiles, local raster file reads, and project save/open need the desktop app.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ hide:
       work, project files, styling, plugins, and modern geospatial workflows.
     </p>
     <div class="hero__actions">
-      <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Launch GeoLibre Web</a>
+      <a class="md-button md-button--primary" href="https://web.geolibre.app/">Launch GeoLibre Web</a>
       <a class="md-button" href="getting-started/">Get started</a>
       <a class="md-button" href="user-guide/interface/">User guide</a>
       <a class="md-button" href="downloads/">Download app</a>
@@ -129,19 +129,19 @@ GeoLibre Web is the full browser version of the GeoLibre app, ready to use with 
 Open a project by passing a public `.geolibre.json` URL with the `url` query parameter:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json
 ```
 
 For narrow embeds, add `?layout=compact` to the demo URL to use icon-only toolbar buttons and hide project metadata:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact
 ```
 
 For map-focused embeds, add `&panels=none` to hide the Layers, Style, and Attribute table panels:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
@@ -149,12 +149,12 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 For a fully chrome-free, map-only embed, add `&maponly` to hide the toolbar menu, all panels, and the status bar:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
 ```
 
 Other parameters control the toolbar, panels, and theme. See [Embedding & Sharing](user-guide/embedding.md) for the full parameter reference and `<iframe>` examples.
 
-[Launch GeoLibre Web](https://viewer.geolibre.app/){ .md-button .md-button--primary }
+[Launch GeoLibre Web](https://web.geolibre.app/){ .md-button .md-button--primary }
 [Embedding & Sharing](user-guide/embedding.md){ .md-button }
 
 ## Project status

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -264,7 +264,7 @@ Validate URL parameter values before acting on them. Anyone can craft a link to 
 For example:
 
 ```text
-https://viewer.geolibre.app/?url=https://example.com/project.geolibre.json&exampleGeoJson=https://example.com/data.geojson
+https://web.geolibre.app/?url=https://example.com/project.geolibre.json&exampleGeoJson=https://example.com/data.geojson
 ```
 
 A URL parameter activates only an already-registered (installed) plugin that owns it; it never loads a plugin from the URL. For external plugins, include the plugin manifest URL in the project `plugins` state (so the plugin is registered) before relying on its URL handler — the matching parameter then activates and dispatches it even if it is not in the active set.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,7 +63,7 @@
 
 ## v0.8: Viewer, desktop packaging, plugins, and dynamic layers
 
-- [x] Cloudflare Worker viewer served from `viewer.geolibre.app`
+- [x] Cloudflare Worker viewer served from `web.geolibre.app`
 - [x] Browser demo links updated to the production viewer
 - [x] GPX drag-and-drop split into named waypoint, track, and route layers
 - [x] Vector layers reprojected to EPSG:4326 on load

--- a/docs/tutorials/first-map.md
+++ b/docs/tutorials/first-map.md
@@ -1,10 +1,10 @@
 # Your First Map
 
-This tutorial takes you from an empty workspace to a styled map with inspectable data, in a few minutes. You can do all of it in the [live viewer](https://viewer.geolibre.app/).
+This tutorial takes you from an empty workspace to a styled map with inspectable data, in a few minutes. You can do all of it in the [live viewer](https://web.geolibre.app/).
 
 ## 1. Open GeoLibre
 
-Open [viewer.geolibre.app](https://viewer.geolibre.app/), or launch the desktop app. You start with a basemap and an empty [Layers panel](../user-guide/layers.md).
+Open [web.geolibre.app](https://web.geolibre.app/), or launch the desktop app. You start with a basemap and an empty [Layers panel](../user-guide/layers.md).
 
 ## 2. Add a layer
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -4,7 +4,7 @@ These tutorials walk through common GeoLibre workflows end to end. Each one is s
 
 ## Before you start
 
-- You can follow most tutorials in the **live viewer** at [viewer.geolibre.app](https://viewer.geolibre.app/), which is the browser build of GeoLibre. No installation required.
+- You can follow most tutorials in the **live viewer** at [web.geolibre.app](https://web.geolibre.app/), which is the browser build of GeoLibre. No installation required.
 - A few steps need the **desktop app**: opening and saving project files, reading local MBTiles and rasters, and the Python sidecar tools (raster processing, sidecar conversions, and Whitebox). These are called out where they appear. See [Downloads](../downloads.md) to install.
 - The sample dataset used in several tutorials is a public GeoParquet file of world countries: `https://data.source.coop/giswqs/opengeos/countries.parquet`.
 

--- a/docs/tutorials/sharing-embedding.md
+++ b/docs/tutorials/sharing-embedding.md
@@ -27,7 +27,7 @@ The shared file captures the same layers, styles, plugin state, and map view as 
 Anyone can open the shared project in the live viewer by passing it as the `url` parameter:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/you/my-map.geolibre.json
+https://web.geolibre.app/?url=https://share.geolibre.app/you/my-map.geolibre.json
 ```
 
 ## 4. Embed it in a page
@@ -36,7 +36,7 @@ Use an `<iframe>` and the embed parameters to control the chrome. For a clean, m
 
 ```html
 <iframe
-  src="https://viewer.geolibre.app/?url=https://share.geolibre.app/you/my-map.geolibre.json&amp;maponly"
+  src="https://web.geolibre.app/?url=https://share.geolibre.app/you/my-map.geolibre.json&amp;maponly"
   title="GeoLibre map"
   width="100%"
   height="600"

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -4,12 +4,12 @@ GeoLibre's browser build can be embedded in any web page and configured through 
 
 ## The live viewer
 
-The browser build is hosted at `https://viewer.geolibre.app/`. It is a static site deployed on GitHub Pages that runs entirely in your browser: it has no analytics and no server account, and the data you load is processed client-side. Data leaves your browser only when you add a remote URL or explicitly share a project.
+The browser build is hosted at `https://web.geolibre.app/`. It is a static site deployed on GitHub Pages that runs entirely in your browser: it has no analytics and no server account, and the data you load is processed client-side. Data leaves your browser only when you add a remote URL or explicitly share a project.
 
 Open a public project by passing its `.geolibre.json` URL with the `url` parameter:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json
+https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json
 ```
 
 A project URL like this comes from **Project → Share**. See [Projects](projects.md#share).
@@ -34,7 +34,7 @@ A chrome-free `maponly` embed shows only the map, as in this shared 3D Tiles pro
 Parameters combine. For a narrow, chrome-free, dark embed of a shared project:
 
 ```text
-https://viewer.geolibre.app/?url=https://share.geolibre.app/you/project.geolibre.json&maponly&theme=dark
+https://web.geolibre.app/?url=https://share.geolibre.app/you/project.geolibre.json&maponly&theme=dark
 ```
 
 ## Embedding in a page
@@ -43,7 +43,7 @@ Drop the viewer into an `<iframe>`:
 
 ```html
 <iframe
-  src="https://viewer.geolibre.app/?url=https://share.geolibre.app/you/project.geolibre.json&amp;maponly"
+  src="https://web.geolibre.app/?url=https://share.geolibre.app/you/project.geolibre.json&amp;maponly"
   title="GeoLibre map"
   width="100%"
   height="600"

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -773,7 +773,7 @@ class Map(anywidget.AnyWidget):
     # Hosted GeoLibre viewer used as the default to_html() app, so an exported
     # file is portable (loads the app over the network instead of the
     # session-bound localhost bundle).
-    _DEFAULT_HTML_APP_URL = "https://viewer.geolibre.app/"
+    _DEFAULT_HTML_APP_URL = "https://web.geolibre.app/"
 
     def to_html(
         self,

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -19,12 +19,12 @@ describe("buildProjectHtml", () => {
     const html = buildProjectHtml({
       project: PROJECT,
       title: "My Map",
-      appUrl: "https://viewer.geolibre.app/",
+      appUrl: "https://web.geolibre.app/",
     });
     assert.match(html, /<title>My Map<\/title>/);
     assert.match(
       html,
-      /<iframe id="geolibre-frame" src="https:\/\/viewer\.geolibre\.app\/\?embed=1"/,
+      /<iframe id="geolibre-frame" src="https:\/\/web\.geolibre\.app\/\?embed=1"/,
     );
     // The project rides in a JSON <script> block and is replayed over the bridge.
     assert.match(html, /id="geolibre-project"/);
@@ -42,7 +42,7 @@ describe("buildProjectHtml", () => {
 
   it("defaults the app URL to the hosted viewer", () => {
     const html = buildProjectHtml({ project: PROJECT, title: "T" });
-    assert.match(html, /src="https:\/\/viewer\.geolibre\.app\/\?embed=1"/);
+    assert.match(html, /src="https:\/\/web\.geolibre\.app\/\?embed=1"/);
   });
 
   it("escapes '<' in the inlined JSON so a value cannot break out", () => {
@@ -84,16 +84,16 @@ describe("buildProjectHtml", () => {
       appUrl: "javascript:alert(1)",
     });
     assert.ok(!html.includes("javascript:alert(1)"));
-    assert.match(html, /src="https:\/\/viewer\.geolibre\.app\/\?embed=1"/);
+    assert.match(html, /src="https:\/\/web\.geolibre\.app\/\?embed=1"/);
   });
 
   it("does not append embed=1 twice when the app URL already has it", () => {
     const html = buildProjectHtml({
       project: PROJECT,
       title: "T",
-      appUrl: "https://viewer.geolibre.app/?embed=1",
+      appUrl: "https://web.geolibre.app/?embed=1",
     });
-    assert.match(html, /src="https:\/\/viewer\.geolibre\.app\/\?embed=1"/);
+    assert.match(html, /src="https:\/\/web\.geolibre\.app\/\?embed=1"/);
     assert.ok(!html.includes("embed=1&amp;embed=1"));
   });
 

--- a/tests/share-gallery.test.ts
+++ b/tests/share-gallery.test.ts
@@ -28,7 +28,7 @@ function rawProject(overrides: Record<string, unknown> = {}) {
     tags: ["water", "ocean"],
     rawJsonUrl: `${BASE}/giswqs/my-map.geolibre.json`,
     projectUrl: `${BASE}/giswqs/my-map`,
-    viewerUrl: `https://viewer.geolibre.app/?url=${BASE}/giswqs/my-map.geolibre.json`,
+    viewerUrl: `https://web.geolibre.app/?url=${BASE}/giswqs/my-map.geolibre.json`,
     ...overrides,
   };
 }

--- a/tests/share-geolibre.test.ts
+++ b/tests/share-geolibre.test.ts
@@ -14,7 +14,7 @@ const PROJECT_DTO = {
   username: "giswqs",
   slug: "my-map",
   projectUrl: "https://share.geolibre.app/giswqs/my-map",
-  viewerUrl: "https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/my-map.geolibre.json",
+  viewerUrl: "https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/my-map.geolibre.json",
   rawJsonUrl: "https://share.geolibre.app/giswqs/my-map.geolibre.json",
 };
 

--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -1,4 +1,4 @@
-// viewer.geolibre.app
+// web.geolibre.app
 //
 // Serves the GeoLibre web viewer at a clean subdomain by proxying to the build
 // already published at https://geolibre.app/demo (GitHub Pages). We proxy rather
@@ -7,10 +7,10 @@
 // Pages has no such limit, so it stays the origin of record.
 //
 // The viewer build uses relative asset paths, so requests map 1:1:
-//   viewer.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
+//   web.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
 //
 // Origin redirects (e.g. trailing slash) are followed server-side so the public
-// viewer.geolibre.app URL is preserved and geolibre.app/demo is never exposed.
+// web.geolibre.app URL is preserved and geolibre.app/demo is never exposed.
 
 const ORIGIN = "https://geolibre.app/demo";
 
@@ -33,7 +33,7 @@ export default {
 
     // Follow origin redirects (e.g. trailing slash) server-side to preserve the
     // public URL. This assumes geolibre.app/demo never redirects back to
-    // viewer.geolibre.app, which would otherwise make the worker loop on itself.
+    // web.geolibre.app, which would otherwise make the worker loop on itself.
     try {
       return await fetch(target, {
         method: request.method,

--- a/workers/viewer/wrangler.toml
+++ b/workers/viewer/wrangler.toml
@@ -6,5 +6,5 @@ compatibility_date = "2025-03-01"
 # Cloudflare account, the DNS record and TLS certificate are provisioned
 # automatically on the first deploy.
 [[routes]]
-pattern = "viewer.geolibre.app"
+pattern = "web.geolibre.app"
 custom_domain = true


### PR DESCRIPTION
## Summary
- Repoint the web viewer from viewer.geolibre.app to its new hostname web.geolibre.app across the Cloudflare custom-domain route, embed/HTML-export base URLs, docs, and tests.

## Test plan
- [x] node --import tsx --test tests/html-export.test.ts tests/share-geolibre.test.ts tests/share-gallery.test.ts (54 pass)
- [x] pre-commit run on changed files (eslint + npm build pass)
- [ ] Confirm wrangler deploy binds the web.geolibre.app custom domain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated GeoLibre web links and launch buttons across docs and app messaging to use the new `web.geolibre.app` address.
  * Exported HTML and sharing examples now open the hosted web app at the updated URL.

* **Bug Fixes**
  * Fixed outdated links in banners, tutorials, and embedding examples so users are directed to the correct web app location.

* **Documentation**
  * Refreshed setup, sharing, and embedding guides to match the current web app domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->