### PR TITLE
fix(viewer): keep viewer.geolibre.app as a worker route

### DIFF
--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -1,4 +1,4 @@
-// web.geolibre.app
+// web.geolibre.app (and viewer.geolibre.app, the original alias)
 //
 // Serves the GeoLibre web viewer at a clean subdomain by proxying to the build
 // already published at https://geolibre.app/demo (GitHub Pages). We proxy rather
@@ -6,11 +6,12 @@
 // which exceeds Cloudflare's 25 MiB per-asset limit for Workers/Pages. GitHub
 // Pages has no such limit, so it stays the origin of record.
 //
-// The viewer build uses relative asset paths, so requests map 1:1:
-//   web.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
+// Both hostnames route to this worker. The viewer build uses relative asset
+// paths, so requests map 1:1 regardless of which host they arrive on:
+//   {web,viewer}.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
 //
 // Origin redirects (e.g. trailing slash) are followed server-side so the public
-// web.geolibre.app URL is preserved and geolibre.app/demo is never exposed.
+// hostname is preserved and geolibre.app/demo is never exposed.
 
 const ORIGIN = "https://geolibre.app/demo";
 
@@ -32,8 +33,8 @@ export default {
     headers.delete("authorization");
 
     // Follow origin redirects (e.g. trailing slash) server-side to preserve the
-    // public URL. This assumes geolibre.app/demo never redirects back to
-    // web.geolibre.app, which would otherwise make the worker loop on itself.
+    // public URL. This assumes geolibre.app/demo never redirects back to a
+    // viewer host, which would otherwise make the worker loop on itself.
     try {
       return await fetch(target, {
         method: request.method,

--- a/workers/viewer/wrangler.toml
+++ b/workers/viewer/wrangler.toml
@@ -2,9 +2,15 @@ name = "geolibre-viewer"
 main = "src/index.ts"
 compatibility_date = "2025-03-01"
 
-# Binds the custom domain on deploy. Because geolibre.app is managed in this
-# Cloudflare account, the DNS record and TLS certificate are provisioned
-# automatically on the first deploy.
+# Binds the custom domains on deploy. Because geolibre.app is managed in this
+# Cloudflare account, the DNS records and TLS certificates are provisioned
+# automatically on the first deploy. web.geolibre.app is the current hostname;
+# viewer.geolibre.app is the original one, kept as an alias so existing links
+# and embeds keep working.
 [[routes]]
 pattern = "web.geolibre.app"
+custom_domain = true
+
+[[routes]]
+pattern = "viewer.geolibre.app"
 custom_domain = true


### PR DESCRIPTION
## Summary
- Restore viewer.geolibre.app as a Cloudflare custom-domain route on the viewer worker. The earlier rename to web.geolibre.app dropped this route, so deploying unbound the domain and broke existing links and embeds.
- Both hostnames now route to the same worker. web.geolibre.app stays the canonical URL in docs and the app; viewer.geolibre.app is kept as an alias.

## Test plan
- [x] npm run test:worker (worker typecheck passes)
- [x] pre-commit run on changed files (eslint + npm build pass)
- [ ] After deploy, confirm both viewer.geolibre.app and web.geolibre.app serve the viewer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional viewer domain, so both `web.geolibre.app` and `viewer.geolibre.app` now open the same experience.
* **Bug Fixes**
  * Improved routing and redirect handling to better match the expected viewer behavior and avoid redirect issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->