### PR TITLE
feat(style): add transparent fill/outline option to color picker

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2756,6 +2756,9 @@ export function StylePanel({
             id="fillColor"
             value={style.fillColor}
             onChange={(fillColor) => setLayerStyle(layer.id, { fillColor })}
+            allowTransparent
+            transparentLabel={t("style.symbology.transparent")}
+            transparentSwatchLabel={t("style.symbology.transparentSwatch")}
           />
         </div>
       ) : null}
@@ -2765,6 +2768,9 @@ export function StylePanel({
           id="strokeColor"
           value={style.strokeColor}
           onChange={(strokeColor) => setLayerStyle(layer.id, { strokeColor })}
+          allowTransparent
+          transparentLabel={t("style.symbology.transparent")}
+          transparentSwatchLabel={t("style.symbology.transparentSwatch")}
         />
       </div>
       <NumericStyleInput

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3002,8 +3002,10 @@ export function StylePanel({
             <PanelRightClose className="h-4 w-4" />
           </Button>
         </div>
-        <ScrollArea className="flex-1 p-3">
-          <div className="space-y-4">
+        <ScrollArea className="flex-1">
+          {/* Padding on the inner content with extra right clearance so the
+              overlay scrollbar never covers a control's right edge. */}
+          <div className="space-y-4 p-3 pr-5">
             {beforeIdControl}
             {zoomRangeControls}
             <RasterStyleSlider
@@ -3179,8 +3181,11 @@ export function StylePanel({
           <PanelRightClose className="h-4 w-4" />
         </Button>
       </div>
-      <ScrollArea className="flex-1 p-3">
-        <div className="space-y-4">
+      <ScrollArea className="flex-1">
+        {/* Padding lives on the inner content (not the ScrollArea root) with
+            extra right clearance so the overlay scrollbar never covers the
+            right edge of a control (e.g. the "Transparent" label). */}
+        <div className="space-y-4 p-3 pr-5">
           {beforeIdControl}
           {zoomRangeControls}
           {hasExtrusionControls && (

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2757,6 +2757,7 @@ export function StylePanel({
             value={style.fillColor}
             onChange={(fillColor) => setLayerStyle(layer.id, { fillColor })}
             allowTransparent
+            fallbackColor={DEFAULT_LAYER_STYLE.fillColor}
             transparentLabel={t("style.symbology.transparent")}
             transparentSwatchLabel={t("style.symbology.transparentSwatch")}
           />
@@ -2769,6 +2770,7 @@ export function StylePanel({
           value={style.strokeColor}
           onChange={(strokeColor) => setLayerStyle(layer.id, { strokeColor })}
           allowTransparent
+          fallbackColor={DEFAULT_LAYER_STYLE.strokeColor}
           transparentLabel={t("style.symbology.transparent")}
           transparentSwatchLabel={t("style.symbology.transparentSwatch")}
         />

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2214,7 +2214,9 @@
         "vertical": "Vertical lines",
         "dots": "Dots",
         "svg": "Custom SVG"
-      }
+      },
+      "transparent": "Transparent",
+      "transparentSwatch": "No color (transparent). Click to choose a color."
     }
   },
   "layers": {

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -86,6 +86,12 @@ export interface ColorFieldProps
    * Unchecking (or picking a color from the still-clickable swatch/eyedropper)
    * restores an opaque value. Use for fill/outline colors where an invisible
    * value is meaningful.
+   *
+   * Note: the checkbox is the reliable way to clear transparency. Picking from
+   * the native swatch also clears it, except in the edge case where the user
+   * re-selects the exact remembered color — `<input type="color">` fires no
+   * `change` event when the value is unchanged, so the transparent state would
+   * persist. The checkbox covers that case.
    */
   allowTransparent?: boolean;
   /** Label for the transparent checkbox. Pass a `t()` value from app call-sites. */
@@ -139,16 +145,18 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
     // Remember the last opaque color so unchecking "Transparent" can restore it
     // rather than snapping to an arbitrary default. Seed it from the prop at
     // mount so a layer that is opaque on first render is captured immediately;
-    // a layer saved as `transparent` has no prior opaque color to remember, so
-    // it falls back to `fallbackColor` until the user picks one.
+    // a layer with no prior opaque color (mounted transparent, or empty) falls
+    // back to `fallbackColor` until the user picks one. The guard keys off the
+    // value itself (not the `transparent` flag, which also depends on
+    // `allowTransparent`) so the ref can never hold the transparent sentinel.
     const lastOpaqueRef = React.useRef(
-      transparent || !value ? fallbackColor : value,
+      isTransparentColor(value) || !value ? fallbackColor : value,
     );
     // Keep the remembered color current via an effect rather than a render-time
     // ref write, so a discarded/replayed concurrent render can't double-apply.
     React.useEffect(() => {
-      if (!transparent && value) lastOpaqueRef.current = value;
-    }, [transparent, value]);
+      if (value && !isTransparentColor(value)) lastOpaqueRef.current = value;
+    }, [value]);
     // Feature-detect after mount so the rendered output stays deterministic
     // across environments that prerender the build.
     const [supportsEyeDropper, setSupportsEyeDropper] = React.useState(false);

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -44,9 +44,15 @@ export interface ColorFieldProps
     React.InputHTMLAttributes<HTMLInputElement>,
     "type" | "value" | "onChange"
   > {
-  /** The current color as a `#rrggbb` hex string. */
+  /**
+   * The current color as a `#rrggbb` hex string, or `TRANSPARENT_COLOR` when
+   * the transparent toggle is on (only possible with `allowTransparent`).
+   */
   value: string;
-  /** Called with the new `#rrggbb` hex string from the swatch or eyedropper. */
+  /**
+   * Called with the new `#rrggbb` hex string from the swatch or eyedropper, or
+   * `TRANSPARENT_COLOR` when the transparent toggle is checked.
+   */
   onChange: (hex: string) => void;
   /**
    * Called once after a screen-eyedropper pick commits a color. Callers using a
@@ -110,6 +116,13 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
       allowTransparent = false,
       transparentLabel = "Transparent",
       transparentSwatchLabel = "No color (transparent). Click to choose a color.",
+      // `title`/`name`/`form` are pulled out so they can be applied
+      // conditionally below: `title` must win over a forwarded value while
+      // transparent, and a `name`d color input would otherwise submit the
+      // remembered opaque hex instead of the transparent sentinel.
+      title,
+      name,
+      form,
       ...props
     },
     ref,
@@ -123,7 +136,11 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
     const lastOpaqueRef = React.useRef(
       transparent || !value ? "#000000" : value,
     );
-    if (!transparent && value) lastOpaqueRef.current = value;
+    // Keep the remembered color current via an effect rather than a render-time
+    // ref write, so a discarded/replayed concurrent render can't double-apply.
+    React.useEffect(() => {
+      if (!transparent && value) lastOpaqueRef.current = value;
+    }, [transparent, value]);
     // Feature-detect after mount so the rendered output stays deterministic
     // across environments that prerender the build.
     const [supportsEyeDropper, setSupportsEyeDropper] = React.useState(false);
@@ -185,20 +202,35 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
             supportsEyeDropper && fill && "flex-1",
           )}
         >
+          {/* While transparent, the visible color input is left unnamed and a
+              hidden input carries `name`/`form` so a form submits the
+              transparent sentinel rather than the remembered opaque hex. */}
+          {transparent && name ? (
+            <input
+              type="hidden"
+              name={name}
+              form={form}
+              value={TRANSPARENT_COLOR}
+            />
+          ) : null}
           <Input
             ref={ref}
             type="color"
+            name={transparent ? undefined : name}
+            form={form}
             value={transparent ? lastOpaqueRef.current : value}
             disabled={disabled}
-            title={transparent ? transparentSwatchLabel : props.title}
+            title={transparent ? transparentSwatchLabel : title}
             onChange={(event) => onChange(event.target.value)}
-            className={cn(fill && "w-full", className)}
+            // `peer` so the overlay (which covers the input's own
+            // focus-visible border) can re-expose the focus ring below.
+            className={cn("peer", fill && "w-full", className)}
             {...props}
           />
           {transparent ? (
             <span
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 overflow-hidden rounded-md border border-input"
+              className="pointer-events-none absolute inset-0 overflow-hidden rounded-md border border-input peer-focus-visible:border-2 peer-focus-visible:border-ring"
               style={{
                 backgroundColor: "hsl(var(--background))",
                 backgroundImage:

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -76,14 +76,15 @@ export interface ColorFieldProps
   /**
    * When true, a "Transparent" checkbox is shown after the swatch (QGIS-style
    * "no color"). Checking it calls `onChange(TRANSPARENT_COLOR)`; the swatch is
-   * replaced by a checkerboard with a red slash. Unchecking restores the last
-   * opaque color the field held. Use for fill/outline colors where an invisible
+   * overlaid with a checkerboard + red slash that reads as "no color".
+   * Unchecking (or picking a color from the still-clickable swatch/eyedropper)
+   * restores an opaque value. Use for fill/outline colors where an invisible
    * value is meaningful.
    */
   allowTransparent?: boolean;
   /** Label for the transparent checkbox. Pass a `t()` value from app call-sites. */
   transparentLabel?: string;
-  /** Accessible label for the checkerboard "no color" swatch. */
+  /** Tooltip shown on the swatch while transparent. Pass a `t()` value. */
   transparentSwatchLabel?: string;
 }
 
@@ -115,8 +116,13 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
   ) => {
     const transparent = allowTransparent && isTransparentColor(value);
     // Remember the last opaque color so unchecking "Transparent" can restore it
-    // rather than snapping to an arbitrary default.
-    const lastOpaqueRef = React.useRef("#000000");
+    // rather than snapping to an arbitrary default. Seed it from the prop at
+    // mount so a layer that is opaque on first render is captured immediately;
+    // a layer saved as `transparent` has no prior opaque color to remember, so
+    // it falls back to black until the user picks one.
+    const lastOpaqueRef = React.useRef(
+      transparent || !value ? "#000000" : value,
+    );
     if (!transparent && value) lastOpaqueRef.current = value;
     // Feature-detect after mount so the rendered output stays deterministic
     // across environments that prerender the build.
@@ -165,50 +171,53 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
 
     return (
       <div className={cn("flex items-center gap-2", !fill && "inline-flex")}>
-        {transparent ? (
-          // Replace the native swatch (which can only show #rrggbb) with a
-          // checkerboard + red slash that reads as "no color". Clicking it
-          // restores the last opaque color so the user can pick again.
-          <button
-            type="button"
-            onClick={() => setTransparent(false)}
-            disabled={disabled}
-            aria-label={transparentSwatchLabel}
-            title={transparentSwatchLabel}
-            className={cn(
-              "relative h-9 overflow-hidden rounded-md border border-input shadow-xs transition-colors focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-              fill ? "flex-1" : "w-14",
-              className,
-            )}
-            style={{
-              backgroundImage:
-                "linear-gradient(45deg, #c4c4c4 25%, transparent 25%), linear-gradient(-45deg, #c4c4c4 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #c4c4c4 75%), linear-gradient(-45deg, transparent 75%, #c4c4c4 75%)",
-              backgroundSize: "8px 8px",
-              backgroundPosition: "0 0, 0 4px, 4px -4px, -4px 0",
-              backgroundColor: "#ffffff",
-            }}
-          >
-            <span
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-0"
-              style={{
-                background:
-                  "linear-gradient(to top right, transparent calc(50% - 1px), #ef4444 calc(50% - 1px), #ef4444 calc(50% + 1px), transparent calc(50% + 1px))",
-              }}
-            />
-          </button>
-        ) : (
+        {/* The native swatch stays mounted even while transparent so the
+            forwarded ref, `id`, and the rest of `...props` (the StylePanel
+            `Label htmlFor` target, ARIA wiring, etc.) always point at a usable
+            control. When transparent it shows the remembered opaque color under
+            a decorative checkerboard + red slash that reads as "no color";
+            since the overlay is pointer-events-none, clicking the swatch (or
+            the eyedropper) still opens the picker and commits a hex, which
+            clears the transparent state. */}
+        <div
+          className={cn(
+            "relative inline-flex",
+            supportsEyeDropper && fill && "flex-1",
+          )}
+        >
           <Input
             ref={ref}
             type="color"
-            value={value}
+            value={transparent ? lastOpaqueRef.current : value}
             disabled={disabled}
+            title={transparent ? transparentSwatchLabel : props.title}
             onChange={(event) => onChange(event.target.value)}
-            className={cn(supportsEyeDropper && fill && "flex-1", className)}
+            className={cn(fill && "w-full", className)}
             {...props}
           />
-        )}
-        {supportsEyeDropper && !transparent ? (
+          {transparent ? (
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 overflow-hidden rounded-md border border-input"
+              style={{
+                backgroundColor: "hsl(var(--background))",
+                backgroundImage:
+                  "linear-gradient(45deg, hsl(var(--muted-foreground) / 0.35) 25%, transparent 25%), linear-gradient(-45deg, hsl(var(--muted-foreground) / 0.35) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, hsl(var(--muted-foreground) / 0.35) 75%), linear-gradient(-45deg, transparent 75%, hsl(var(--muted-foreground) / 0.35) 75%)",
+                backgroundSize: "8px 8px",
+                backgroundPosition: "0 0, 0 4px, 4px -4px, -4px 0",
+              }}
+            >
+              <span
+                className="absolute inset-0"
+                style={{
+                  background:
+                    "linear-gradient(to top right, transparent calc(50% - 1px), #ef4444 calc(50% - 1px), #ef4444 calc(50% + 1px), transparent calc(50% + 1px))",
+                }}
+              />
+            </span>
+          ) : null}
+        </div>
+        {supportsEyeDropper ? (
           <button
             type="button"
             onClick={pickFromScreen}

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -92,6 +92,13 @@ export interface ColorFieldProps
   transparentLabel?: string;
   /** Tooltip shown on the swatch while transparent. Pass a `t()` value. */
   transparentSwatchLabel?: string;
+  /**
+   * Opaque color restored when the user clears transparency on a field that was
+   * already `TRANSPARENT_COLOR` at mount (no prior opaque color to remember).
+   * Defaults to black; call-sites should pass the domain default (e.g. the
+   * layer style's default fill/stroke color) for a more meaningful restore.
+   */
+  fallbackColor?: string;
 }
 
 /**
@@ -116,6 +123,7 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
       allowTransparent = false,
       transparentLabel = "Transparent",
       transparentSwatchLabel = "No color (transparent). Click to choose a color.",
+      fallbackColor = "#000000",
       // `title`/`name`/`form` are pulled out so they can be applied
       // conditionally below: `title` must win over a forwarded value while
       // transparent, and a `name`d color input would otherwise submit the
@@ -132,9 +140,9 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
     // rather than snapping to an arbitrary default. Seed it from the prop at
     // mount so a layer that is opaque on first render is captured immediately;
     // a layer saved as `transparent` has no prior opaque color to remember, so
-    // it falls back to black until the user picks one.
+    // it falls back to `fallbackColor` until the user picks one.
     const lastOpaqueRef = React.useRef(
-      transparent || !value ? "#000000" : value,
+      transparent || !value ? fallbackColor : value,
     );
     // Keep the remembered color current via an effect rather than a render-time
     // ref write, so a discarded/replayed concurrent render can't double-apply.
@@ -210,6 +218,7 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
               type="hidden"
               name={name}
               form={form}
+              disabled={disabled}
               value={TRANSPARENT_COLOR}
             />
           ) : null}
@@ -221,6 +230,10 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
             value={transparent ? lastOpaqueRef.current : value}
             disabled={disabled}
             title={transparent ? transparentSwatchLabel : title}
+            // The swatch shows the remembered opaque color while transparent, so
+            // give assistive tech an accessible name that conveys the "no color"
+            // state instead of letting it announce that opaque value.
+            aria-label={transparent ? transparentSwatchLabel : undefined}
             onChange={(event) => onChange(event.target.value)}
             // `peer` so the overlay (which covers the input's own
             // focus-visible border) can re-expose the focus ring below.

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -3,6 +3,19 @@ import { Pipette } from "lucide-react";
 import { cn } from "../lib/utils";
 import { Input } from "./input";
 
+/**
+ * The sentinel value a {@link ColorField} stores when its transparent toggle is
+ * on. It is the CSS/MapLibre `transparent` keyword, so it flows straight through
+ * to paint properties (an invisible fill/outline) and round-trips through the
+ * project format as a plain string.
+ */
+export const TRANSPARENT_COLOR = "transparent";
+
+/** Whether a color value is the {@link TRANSPARENT_COLOR} sentinel. */
+export function isTransparentColor(value: string): boolean {
+  return value.trim().toLowerCase() === TRANSPARENT_COLOR;
+}
+
 // The EyeDropper API is not yet part of TypeScript's DOM lib, so declare the
 // minimal surface we use. Unlike the native color input's built-in eyedropper
 // (whose magnifier can render *behind* the picker popup in some browsers), the
@@ -60,6 +73,18 @@ export interface ColorFieldProps
   className?: string;
   /** Classes sizing the eyedropper button; match the swatch for compact rows. */
   buttonClassName?: string;
+  /**
+   * When true, a "Transparent" checkbox is shown after the swatch (QGIS-style
+   * "no color"). Checking it calls `onChange(TRANSPARENT_COLOR)`; the swatch is
+   * replaced by a checkerboard with a red slash. Unchecking restores the last
+   * opaque color the field held. Use for fill/outline colors where an invisible
+   * value is meaningful.
+   */
+  allowTransparent?: boolean;
+  /** Label for the transparent checkbox. Pass a `t()` value from app call-sites. */
+  transparentLabel?: string;
+  /** Accessible label for the checkerboard "no color" swatch. */
+  transparentSwatchLabel?: string;
 }
 
 /**
@@ -81,10 +106,18 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
       eyedropperLabel = "Pick a color from the screen",
       fill = true,
       buttonClassName = "h-9 w-9",
+      allowTransparent = false,
+      transparentLabel = "Transparent",
+      transparentSwatchLabel = "No color (transparent). Click to choose a color.",
       ...props
     },
     ref,
   ) => {
+    const transparent = allowTransparent && isTransparentColor(value);
+    // Remember the last opaque color so unchecking "Transparent" can restore it
+    // rather than snapping to an arbitrary default.
+    const lastOpaqueRef = React.useRef("#000000");
+    if (!transparent && value) lastOpaqueRef.current = value;
     // Feature-detect after mount so the rendered output stays deterministic
     // across environments that prerender the build.
     const [supportsEyeDropper, setSupportsEyeDropper] = React.useState(false);
@@ -122,18 +155,60 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
       }
     }, [onChange, onCommit]);
 
+    const setTransparent = React.useCallback(
+      (next: boolean) => {
+        onChange(next ? TRANSPARENT_COLOR : lastOpaqueRef.current);
+        onCommit?.();
+      },
+      [onChange, onCommit],
+    );
+
     return (
       <div className={cn("flex items-center gap-2", !fill && "inline-flex")}>
-        <Input
-          ref={ref}
-          type="color"
-          value={value}
-          disabled={disabled}
-          onChange={(event) => onChange(event.target.value)}
-          className={cn(supportsEyeDropper && fill && "flex-1", className)}
-          {...props}
-        />
-        {supportsEyeDropper ? (
+        {transparent ? (
+          // Replace the native swatch (which can only show #rrggbb) with a
+          // checkerboard + red slash that reads as "no color". Clicking it
+          // restores the last opaque color so the user can pick again.
+          <button
+            type="button"
+            onClick={() => setTransparent(false)}
+            disabled={disabled}
+            aria-label={transparentSwatchLabel}
+            title={transparentSwatchLabel}
+            className={cn(
+              "relative h-9 overflow-hidden rounded-md border border-input shadow-xs transition-colors focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+              fill ? "flex-1" : "w-14",
+              className,
+            )}
+            style={{
+              backgroundImage:
+                "linear-gradient(45deg, #c4c4c4 25%, transparent 25%), linear-gradient(-45deg, #c4c4c4 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #c4c4c4 75%), linear-gradient(-45deg, transparent 75%, #c4c4c4 75%)",
+              backgroundSize: "8px 8px",
+              backgroundPosition: "0 0, 0 4px, 4px -4px, -4px 0",
+              backgroundColor: "#ffffff",
+            }}
+          >
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0"
+              style={{
+                background:
+                  "linear-gradient(to top right, transparent calc(50% - 1px), #ef4444 calc(50% - 1px), #ef4444 calc(50% + 1px), transparent calc(50% + 1px))",
+              }}
+            />
+          </button>
+        ) : (
+          <Input
+            ref={ref}
+            type="color"
+            value={value}
+            disabled={disabled}
+            onChange={(event) => onChange(event.target.value)}
+            className={cn(supportsEyeDropper && fill && "flex-1", className)}
+            {...props}
+          />
+        )}
+        {supportsEyeDropper && !transparent ? (
           <button
             type="button"
             onClick={pickFromScreen}
@@ -147,6 +222,18 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
           >
             <Pipette className="h-4 w-4" aria-hidden="true" />
           </button>
+        ) : null}
+        {allowTransparent ? (
+          <label className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs text-muted-foreground select-none">
+            <input
+              type="checkbox"
+              checked={transparent}
+              disabled={disabled}
+              onChange={(event) => setTransparent(event.target.checked)}
+              className="h-3.5 w-3.5 cursor-pointer accent-primary disabled:cursor-not-allowed"
+            />
+            {transparentLabel}
+          </label>
         ) : null}
       </div>
     );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,12 @@
 export { cn } from "./lib/utils";
 export { Button, type ButtonProps } from "./components/button";
 export { Input } from "./components/input";
-export { ColorField, type ColorFieldProps } from "./components/color-field";
+export {
+  ColorField,
+  type ColorFieldProps,
+  TRANSPARENT_COLOR,
+  isTransparentColor,
+} from "./components/color-field";
 export {
   ColorRampSelect,
   type ColorRampSelectProps,

--- a/tests/color-field-transparent.test.ts
+++ b/tests/color-field-transparent.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { TRANSPARENT_COLOR, isTransparentColor } from "@geolibre/ui";
+
+// The ColorField component itself is DOM-bound and cannot run in the
+// node --test environment, but its transparent-value contract is pure: the
+// store carries the `transparent` keyword and `isTransparentColor` is what
+// every consumer (paint mapping, the swatch toggle) keys off of.
+describe("isTransparentColor", () => {
+  it("matches the TRANSPARENT_COLOR sentinel", () => {
+    assert.equal(isTransparentColor(TRANSPARENT_COLOR), true);
+  });
+
+  it("is case-insensitive and ignores surrounding whitespace", () => {
+    assert.equal(isTransparentColor("  Transparent "), true);
+    assert.equal(isTransparentColor("TRANSPARENT"), true);
+  });
+
+  it("rejects opaque hex colors and empty values", () => {
+    assert.equal(isTransparentColor("#3b82f6"), false);
+    assert.equal(isTransparentColor("#000000"), false);
+    assert.equal(isTransparentColor(""), false);
+    // Not the CSS keyword, just a substring — must not match.
+    assert.equal(isTransparentColor("semitransparent"), false);
+  });
+});

--- a/tests/vector-symbology.test.ts
+++ b/tests/vector-symbology.test.ts
@@ -103,6 +103,43 @@ describe("vectorColorExpression rule-based mode", () => {
   });
 });
 
+describe("vectorColorExpression with a transparent fallback", () => {
+  it("single mode: passes 'transparent' through as a flat color", () => {
+    assert.equal(
+      vectorColorExpression(style({ vectorStyleMode: "single" }), "transparent"),
+      "transparent",
+    );
+  });
+
+  it("categorized mode: uses 'transparent' as the match fallback", () => {
+    const result = vectorColorExpression(
+      style({
+        vectorStyleMode: "categorized",
+        vectorStyleProperty: "TYPE",
+        vectorStyleStops: [{ value: "park", color: "#00ff00" }],
+      }),
+      "transparent",
+    );
+    assert.deepEqual(result, [
+      "match",
+      ["to-string", ["get", "TYPE"]],
+      "park",
+      "#00ff00",
+      "transparent",
+    ]);
+  });
+
+  it("rule-based mode: uses 'transparent' as the else fallback", () => {
+    assert.equal(
+      vectorColorExpression(
+        style({ vectorStyleMode: "rule-based", vectorRules: [] }),
+        "transparent",
+      ),
+      "transparent",
+    );
+  });
+});
+
 describe("circleRadiusValue proportional sizing", () => {
   it("returns the constant radius when disabled", () => {
     assert.equal(circleRadiusValue(style({ circleRadius: 7 })), 7);


### PR DESCRIPTION
## Summary

Adds a "Transparent" option to the color picker for a layer's **Fill color** and **Outline color**, similar to QGIS. Previously the only way to hide a fill or stroke was to drop its opacity to 0, which is unintuitive and clumsy.

Fixes #935

## What changed

- **`@geolibre/ui` `ColorField`** gains an opt-in `allowTransparent` prop. When enabled, a `Transparent` checkbox is shown after the swatch:
  - Checking it calls `onChange(TRANSPARENT_COLOR)`, where `TRANSPARENT_COLOR` is the CSS/MapLibre `transparent` keyword. This flows straight through to the paint properties as an invisible fill/outline and round-trips through the `.geolibre.json` project format as a plain string.
  - The native swatch (which can only show `#rrggbb`) is replaced by a checkerboard with a red diagonal slash, reading as "no color".
  - Unchecking restores the last opaque color the field held, so the user can pick again.
  - Exposes `TRANSPARENT_COLOR` and `isTransparentColor()` helpers.
- **Style panel** wires `allowTransparent` into the Fill color and Outline color fields, with translated labels (`style.symbology.transparent`, `style.symbology.transparentSwatch`).

No new style fields or migrations: transparency is represented purely as the existing `fillColor` / `strokeColor` string being `transparent`, which MapLibre renders as an invisible fill/outline (and which point/circle layers honor too via the shared color values).

## Verification

Drove the real web app with Playwright using the bundled **Countries** polygon sample, in **both light and dark themes**:

- Toggling **Fill** transparent removes the polygon fill while the outline remains; the swatch shows the checkerboard "no color" indicator.
- Toggling **Outline** transparent removes the borders while the fill remains.
- Unchecking restores the previous color (`#3388ff`).
- No console errors.

Also: `npm run build`, `npm run test:frontend` (1657 pass), and `pre-commit` (eslint + npm build) all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional transparent/no-color support to the color picker, including a transparent toggle and a visual transparent swatch overlay.
  * Transparent selections now preserve the last solid color and correctly submit the “transparent” value.
  * Updated vector style controls to show localized “Transparent” labels for both fill and outline.
* **Bug Fixes**
  * Improved transparent fill/outline handling so the UI renders the correct color state and restores the previous solid value when transparency is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->