### PR TITLE
fix(storymap): hide faded point outlines and render plugin basemaps in HTML export

### DIFF
--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -322,10 +322,24 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     setExportError(null);
     if (chapters.length === 0) return;
     try {
+      // URL-backed GeoJSON layers (remote GeoJSON, in-browser Parquet/Shapefile
+      // conversion) keep their features only in the live MapLibre source, not in
+      // the store record, so read them back so the export inlines the same data
+      // the map shows instead of dropping the layer (#936).
+      const controller = mapControllerRef.current;
+      const layersForExport = controller
+        ? await Promise.all(
+            layers.map(async (layer) => {
+              if (layer.type !== "geojson" || layer.geojson) return layer;
+              const geojson = await controller.getLayerGeoJson(layer.id);
+              return geojson ? { ...layer, geojson } : layer;
+            }),
+          )
+        : layers;
       const html = buildStoryMapHtml({
         storymap: story,
         basemapStyleUrl,
-        layers,
+        layers: layersForExport,
         projection,
       });
       const slug =
@@ -355,7 +369,15 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
         error instanceof Error ? error.message : String(error),
       );
     }
-  }, [basemapStyleUrl, chapters.length, layers, projection, story, t]);
+  }, [
+    basemapStyleUrl,
+    chapters.length,
+    layers,
+    mapControllerRef,
+    projection,
+    story,
+    t,
+  ]);
 
   const handleExportData = useCallback(
     async (format: "json" | "csv") => {

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -98,8 +98,11 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     if (!isReferenced && !layer.visible) continue;
     // Inline GeoJSON layers and raster tile layers (the latter covers basemaps
     // added through the Basemaps plugin, which are raster layers rather than a
-    // style URL, #936). Layers iterate in store order, which is bottom-to-top,
-    // so a basemap raster (lower in the array) is added before the overlays.
+    // style URL, #936). Layers iterate in store order; the store array is
+    // bottom-to-top, and `map.addLayer` appends each layer above the previous,
+    // so the export reproduces whatever stacking the user set in the app
+    // (the Basemaps plugin inserts basemaps at the bottom, so they end up under
+    // the overlays here too).
     const built = buildInlineLayer(layer);
     if (!built) continue;
     inlineLayers.push({
@@ -253,7 +256,20 @@ function buildInlineLayer(
   if (rasterSource) {
     return {
       source: rasterSource,
-      layerSpec: { type: "raster", paint: { "raster-opacity": 1 } },
+      // Mirror the live app's rasterPaint so raster color adjustments
+      // (brightness/saturation/contrast/hue) survive the export. raster-opacity
+      // is the seed the opacity loop later scales by the layer opacity.
+      layerSpec: {
+        type: "raster",
+        paint: {
+          "raster-opacity": 1,
+          "raster-brightness-min": styleValue(layer.style, "rasterBrightnessMin"),
+          "raster-brightness-max": styleValue(layer.style, "rasterBrightnessMax"),
+          "raster-saturation": styleValue(layer.style, "rasterSaturation"),
+          "raster-contrast": styleValue(layer.style, "rasterContrast"),
+          "raster-hue-rotate": styleValue(layer.style, "rasterHueRotate"),
+        },
+      },
     };
   }
   return null;
@@ -294,6 +310,18 @@ function buildRasterTileSource(
   if (layer.source.scheme === "tms") source.scheme = "tms";
   if (typeof layer.source.attribution === "string") {
     source.attribution = layer.source.attribution;
+  }
+  // Carry the source's coverage extent so the export, like the live map, stops
+  // requesting tiles outside a bounded tile service.
+  if (
+    Array.isArray(layer.source.bounds) &&
+    layer.source.bounds.length === 4 &&
+    layer.source.bounds.every(
+      (value): value is number =>
+        typeof value === "number" && Number.isFinite(value),
+    )
+  ) {
+    source.bounds = layer.source.bounds;
   }
   return source;
 }

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -26,13 +26,34 @@ export interface StoryMapExportOptions {
 
 interface InlineLayerExport {
   id: string;
-  geojson: FeatureCollection;
+  /** MapLibre source spec (a GeoJSON source, or a raster tile source). */
+  source: Record<string, unknown>;
   layerSpec: Record<string, unknown>;
   /** GeoLibre layer-level opacity, combined with the style's per-geometry one. */
   layerOpacity: number;
   /** Whether a chapter fades this layer in (so it starts hidden). */
   fadesIn: boolean;
 }
+
+/**
+ * Minimal blank MapLibre style used when the project has no basemap style URL.
+ *
+ * Basemaps added through the Basemaps plugin are raster *layers* (inlined
+ * below), not a style URL, so the project's `basemapStyleUrl` is empty. Passing
+ * an empty string to MapLibre yields a blank page (#936); a valid blank style
+ * lets the inlined raster basemap and overlays render on top.
+ */
+const BLANK_EXPORT_STYLE: Record<string, unknown> = {
+  version: 8,
+  sources: {},
+  layers: [
+    {
+      id: "background",
+      type: "background",
+      paint: { "background-color": "#ffffff" },
+    },
+  ],
+};
 
 /**
  * Build a self-contained MapLibre storytelling HTML document for a story map.
@@ -73,15 +94,18 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
 
   const inlineLayers: InlineLayerExport[] = [];
   for (const layer of layers) {
-    if (layer.type !== "geojson" || !layer.geojson) continue;
     const isReferenced = referenced.has(layer.id);
     if (!isReferenced && !layer.visible) continue;
-    const layerSpec = buildLayerSpec(layer);
-    if (!layerSpec) continue;
+    // Inline GeoJSON layers and raster tile layers (the latter covers basemaps
+    // added through the Basemaps plugin, which are raster layers rather than a
+    // style URL, #936). Layers iterate in store order, which is bottom-to-top,
+    // so a basemap raster (lower in the array) is added before the overlays.
+    const built = buildInlineLayer(layer);
+    if (!built) continue;
     inlineLayers.push({
       id: layer.id,
-      geojson: layer.geojson,
-      layerSpec,
+      source: built.source,
+      layerSpec: built.layerSpec,
       // Hidden layers export fully transparent so the export matches what
       // GeoLibre renders (the opacity slider value alone ignores visibility).
       layerOpacity: layer.visible ? layer.opacity : 0,
@@ -106,7 +130,10 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       }));
 
   const config = {
-    style: basemapStyleUrl,
+    // Fall back to a blank style when the project carries no basemap style URL
+    // (e.g. the basemap is a Basemaps-plugin raster layer, inlined above), so
+    // MapLibre renders instead of showing a blank page (#936).
+    style: basemapStyleUrl || BLANK_EXPORT_STYLE,
     projection,
     showMarkers: storymap.showMarkers,
     markerColor: storymap.markerColor,
@@ -147,11 +174,11 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     .map((entry) => {
       const sourceId = `${entry.id}-source`;
       const paint = { ...(entry.layerSpec.paint as Record<string, unknown>) };
-      // Seed the opacity paint property: 0 when a chapter fades the layer in,
-      // otherwise the style's per-geometry opacity scaled by the layer opacity
-      // so the export matches what GeoLibre renders.
-      const opacityProp = opacityProperty(entry.layerSpec.type as string);
-      if (opacityProp) {
+      // Seed every opacity paint property the layer type fades: 0 when a chapter
+      // fades the layer in, otherwise the style's per-property opacity scaled by
+      // the layer opacity so the export matches what GeoLibre renders. Circles
+      // carry both fill and stroke opacity so a faded point hides fully (#934).
+      for (const opacityProp of opacityProperties(entry.layerSpec.type as string)) {
         const styleOpacity =
           typeof paint[opacityProp] === "number"
             ? (paint[opacityProp] as number)
@@ -166,7 +193,7 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
         source: sourceId,
         paint,
       };
-      return `    map.addSource(${jsonForScript(sourceId)}, { type: 'geojson', data: ${jsonForScript(entry.geojson)} });
+      return `    map.addSource(${jsonForScript(sourceId)}, ${jsonForScript(entry.source)});
     map.addLayer(${jsonForScript(spec)});`;
     })
     .join("\n");
@@ -187,19 +214,88 @@ function jsonForScript(value: unknown, space?: number): string {
     .replace(/<!--/g, "<\\!--");
 }
 
-function opacityProperty(type: string): string | null {
+function opacityProperties(type: string): string[] {
   switch (type) {
     case "fill":
-      return "fill-opacity";
+      return ["fill-opacity"];
     case "line":
-      return "line-opacity";
+      return ["line-opacity"];
     case "circle":
-      return "circle-opacity";
+      return ["circle-opacity", "circle-stroke-opacity"];
     case "fill-extrusion":
-      return "fill-extrusion-opacity";
+      return ["fill-extrusion-opacity"];
+    case "raster":
+      return ["raster-opacity"];
     default:
-      return null;
+      return [];
   }
+}
+
+/**
+ * Build the MapLibre source and layer spec for a layer the export inlines.
+ *
+ * Handles in-memory GeoJSON layers and raster tile layers (XYZ basemaps and
+ * services). Returns `null` for layer types the export cannot reproduce
+ * stand-alone (e.g. PMTiles or MBTiles that need GeoLibre's own protocols).
+ */
+function buildInlineLayer(
+  layer: GeoLibreLayer,
+): { source: Record<string, unknown>; layerSpec: Record<string, unknown> } | null {
+  if (layer.type === "geojson" && layer.geojson) {
+    const layerSpec = buildLayerSpec(layer);
+    if (!layerSpec) return null;
+    return {
+      source: { type: "geojson", data: layer.geojson },
+      layerSpec,
+    };
+  }
+  const rasterSource = buildRasterTileSource(layer);
+  if (rasterSource) {
+    return {
+      source: rasterSource,
+      layerSpec: { type: "raster", paint: { "raster-opacity": 1 } },
+    };
+  }
+  return null;
+}
+
+/**
+ * Build a MapLibre raster tile source from a raster/XYZ/WMS/WMTS layer, or
+ * `null` when the layer carries no tile URL template. Mirrors the live app's
+ * external raster tile sync so basemaps and tile services render in the export.
+ */
+function buildRasterTileSource(
+  layer: GeoLibreLayer,
+): Record<string, unknown> | null {
+  if (
+    layer.type !== "raster" &&
+    layer.type !== "xyz" &&
+    layer.type !== "wms" &&
+    layer.type !== "wmts"
+  ) {
+    return null;
+  }
+  const tiles = Array.isArray(layer.source.tiles)
+    ? layer.source.tiles.filter((tile): tile is string => typeof tile === "string")
+    : [];
+  if (tiles.length === 0) return null;
+  const source: Record<string, unknown> = {
+    type: "raster",
+    tiles,
+    tileSize:
+      typeof layer.source.tileSize === "number" ? layer.source.tileSize : 256,
+  };
+  if (typeof layer.source.minzoom === "number") {
+    source.minzoom = layer.source.minzoom;
+  }
+  if (typeof layer.source.maxzoom === "number") {
+    source.maxzoom = layer.source.maxzoom;
+  }
+  if (layer.source.scheme === "tms") source.scheme = "tms";
+  if (typeof layer.source.attribution === "string") {
+    source.attribution = layer.source.attribution;
+  }
+  return source;
 }
 
 /** Pick the dominant (most common) geometry kind for the MapLibre layer type. */
@@ -377,7 +473,7 @@ function renderTemplate(
         var layerTypes = {
             'fill': ['fill-opacity'],
             'line': ['line-opacity'],
-            'circle': ['circle-opacity'],
+            'circle': ['circle-opacity', 'circle-stroke-opacity'],
             'symbol': ['icon-opacity', 'text-opacity'],
             'raster': ['raster-opacity'],
             'fill-extrusion': ['fill-extrusion-opacity'],

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -60,7 +60,10 @@ const NON_BASEMAP_STYLE_LAYER_IDS = [
 ];
 const OPACITY_PAINT_PROPERTIES: Record<string, string[]> = {
   background: ["background-opacity"],
-  circle: ["circle-opacity"],
+  // A point's outline fades with its fill so story playback can fully hide a
+  // circle layer; without the stroke property a faded-out point still renders
+  // as a hollow ring (#934).
+  circle: ["circle-opacity", "circle-stroke-opacity"],
   fill: ["fill-opacity"],
   "fill-extrusion": ["fill-extrusion-opacity"],
   heatmap: ["heatmap-opacity"],
@@ -363,6 +366,44 @@ export class MapController {
 
   getMap(): maplibregl.Map | null {
     return this.map;
+  }
+
+  /**
+   * Resolve a layer's rendered GeoJSON from its live MapLibre source.
+   *
+   * The store only keeps inline GeoJSON for layers added from in-memory data;
+   * URL-backed layers (remote GeoJSON, or Parquet/Shapefile converted in the
+   * browser) keep their features only in the MapLibre source. Reading the
+   * source lets callers such as the story-map HTML export inline those features
+   * even when the layer record carries no `geojson`, so the export renders the
+   * same data as the live map (#936).
+   *
+   * @param layerId GeoLibre store layer id.
+   * @returns The source's FeatureCollection, or null when it has none.
+   */
+  async getLayerGeoJson(layerId: string): Promise<FeatureCollection | null> {
+    if (!this.map) return null;
+    const map = this.map;
+    for (const nativeId of this.getNativeLayerIdsByLayerId(layerId)) {
+      const styleLayer = map.getLayer(nativeId);
+      const sourceId =
+        styleLayer && "source" in styleLayer
+          ? (styleLayer as { source?: unknown }).source
+          : undefined;
+      if (typeof sourceId !== "string") continue;
+      const source = map.getSource(sourceId);
+      if (source?.type !== "geojson") continue;
+      try {
+        const data = await (source as maplibregl.GeoJSONSource).getData();
+        if (data && typeof data === "object" && "features" in data) {
+          return data as FeatureCollection;
+        }
+      } catch {
+        // A source still loading (or a URL that failed) has no usable data;
+        // fall through so the export simply omits this layer's features.
+      }
+    }
+    return null;
   }
 
   /**

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -395,9 +395,11 @@ export class MapController {
       if (source?.type !== "geojson") continue;
       try {
         const data = await (source as maplibregl.GeoJSONSource).getData();
-        // A URL-backed source that has not finished loading resolves to the raw
-        // URL string rather than a FeatureCollection; the `"features"` guard
-        // skips it so the export omits the layer instead of embedding a bare URL.
+        // `getData()` returns the source's original data spec: the inline
+        // FeatureCollection for sources set via setData (in-browser-converted
+        // layers), or the raw URL string for URL-backed sources. The `"features"`
+        // guard skips the string case so the export omits such a layer rather
+        // than embedding a bare URL.
         if (data && typeof data === "object" && "features" in data) {
           return data as FeatureCollection;
         }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -395,6 +395,9 @@ export class MapController {
       if (source?.type !== "geojson") continue;
       try {
         const data = await (source as maplibregl.GeoJSONSource).getData();
+        // A URL-backed source that has not finished loading resolves to the raw
+        // URL string rather than a FeatureCollection; the `"features"` guard
+        // skips it so the export omits the layer instead of embedding a bare URL.
         if (data && typeof data === "object" && "features" in data) {
           return data as FeatureCollection;
         }

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -103,6 +103,13 @@ export function circlePaint(style: LayerStyle, opacity: number) {
     ),
     "circle-stroke-color": styleValue(style, "strokeColor"),
     "circle-stroke-width": styleValue(style, "strokeWidth"),
+    // Fade the outline with the layer opacity (and let it be set explicitly)
+    // so story playback can fully hide a point instead of leaving a hollow
+    // ring, and so the stroke is restored when playback ends (#934).
+    "circle-stroke-opacity": scaleByOpacity(
+      simpleStyleNumberValue(style, "stroke-opacity", 1),
+      opacity,
+    ),
   };
 }
 
@@ -150,6 +157,12 @@ export function clusterCirclePaint(style: LayerStyle, opacity: number) {
     "circle-opacity": styleValue(style, "fillOpacity") * opacity,
     "circle-stroke-color": styleValue(style, "strokeColor"),
     "circle-stroke-width": styleValue(style, "strokeWidth"),
+    // Keep the cluster outline in step with its fill so the layer opacity (and
+    // story fades) hide the whole bubble, mirroring {@link circlePaint} (#934).
+    "circle-stroke-opacity": scaleByOpacity(
+      simpleStyleNumberValue(style, "stroke-opacity", 1),
+      opacity,
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

Two related Story Map bugs, both reproduced with the reporter's project (`stoty_map_rendering_bug.json`).

### #934 - Hidden points render as hollow rings
A chapter that fades a point layer to opacity 0 still showed the points as outline-only rings. Story playback only drove `circle-opacity` (the fill); `circle-stroke-opacity` was never touched and defaulted to 1, so a stroked point kept a fully opaque ring.

- Fade `circle-stroke-opacity` alongside `circle-opacity` during playback.
- Set `circle-stroke-opacity` as a managed paint property in `circlePaint`/`clusterCirclePaint` so it scales with layer opacity and is restored when playback ends.

### #936 - Basemap (and points) blank in the HTML export
Basemaps added through the Basemaps plugin are raster **layers**, not a style URL, so the project's empty `basemapStyleUrl` was passed to MapLibre verbatim (blank page) and the raster layer was never inlined.

- Fall back to a blank style object when there is no basemap style URL.
- Inline raster tile layers (XYZ/WMS/WMTS basemaps and services) into the export.
- Read URL-backed GeoJSON layers (remote GeoJSON, in-browser Parquet/Shapefile conversion) back from the live MapLibre source so the export inlines the same features the map shows, instead of dropping the layer.
- The exported runtime fades `circle-stroke-opacity` too, mirroring the #934 fix.

## Verification
Reproduced and verified in the real web app with Playwright using the reporter's project:

- **#934 in-app:** drove the real `MapController.setStoryLayerOpacity` - a stroked point layer faded to 0 now zeroes both `circle-opacity` and `circle-stroke-opacity`; the red rings disappear (before: rings remained).
- **#936 export:** the exported HTML previously rendered a blank page. It now renders the NASA GIBS Blue Marble basemap; chapter 1 shows the basemap with points hidden, chapter 2 fades the ~9k points in. Both basemap and points render, matching the in-app view.
- `npm run test:frontend` (1657 passing) and `npm run build` are green; `pre-commit` (eslint + npm build) passes.

Fixes #934
Fixes #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story map exports now include the actual GeoJSON data for URL-based layers.
  * Exported story maps can now inline raster/tile basemaps more reliably, including when no standard basemap style URL is available.
* **Bug Fixes**
  * Fixed story playback opacity fading so `circle` layers update both fill opacity and stroke opacity (including for point and cluster outlines), preventing hollow-ring rendering.
  * Improved exported map rendering to avoid blank pages in certain basemap configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->