### PR TITLE
fix(graticule): release focus when pressing Enter in numeric inputs

### DIFF
--- a/packages/plugins/src/plugins/maplibre-graticule.ts
+++ b/packages/plugins/src/plugins/maplibre-graticule.ts
@@ -671,8 +671,9 @@ function buildPanelBody(container: HTMLElement): void {
       const v = Number(el.value);
       if (Number.isFinite(v)) set(v);
     });
-    // Pressing Enter commits the value (via the change event above) and then
-    // releases focus, so map navigation hotkeys are not trapped in the field.
+    // Pressing Enter releases focus; the resulting blur fires the change event
+    // above, which commits the value, so map navigation hotkeys are no longer
+    // trapped in the field.
     el.addEventListener("keydown", (e) => {
       if (e.key === "Enter") el.blur();
     });

--- a/packages/plugins/src/plugins/maplibre-graticule.ts
+++ b/packages/plugins/src/plugins/maplibre-graticule.ts
@@ -671,6 +671,11 @@ function buildPanelBody(container: HTMLElement): void {
       const v = Number(el.value);
       if (Number.isFinite(v)) set(v);
     });
+    // Pressing Enter commits the value (via the change event above) and then
+    // releases focus, so map navigation hotkeys are not trapped in the field.
+    el.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") el.blur();
+    });
     controls.push(() => {
       el.value = String(get());
     });


### PR DESCRIPTION
## Summary

Fixes #932 (Issue 2, the valid one).

In the Gridlines panel, pressing Enter inside a numeric input (Interval, Line width, Line opacity, Label size) correctly applied the value to the map, but left the text cursor inside the field. The trapped keyboard focus blocked standard map navigation hotkeys and left the input susceptible to accidental keystrokes.

This adds an `Enter` keydown handler to the panel's `number()` input helper that blurs the input after the existing `change` listener commits the value, returning focus to the canvas.

Issue 1 from the report (disable the Interval field in Auto mode) was determined to be invalid: even in auto spacing mode the interval still bounds the smallest grid spacing, so the field must stay active.

## Verification

Drove the real web app with Playwright:
- Set values and pressed Enter on the Interval, Line width, and Label size inputs.
- Confirmed the value is applied and `document.activeElement` becomes `BODY` (focus released) afterward.
- Verified in both light and dark themes (the fix is focus-behavior only and theme-independent).
- `tests/graticule.test.ts` and the pre-commit npm-build hook pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing **Enter** in numeric graticule settings fields now commits the value and exits the field, improving keyboard navigation.
  * Map navigation shortcuts are less likely to be blocked while a numeric input is focused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->