### PR TITLE
docs: add Troubleshooting page for browser/Safari cache issues

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting
+
+This page collects fixes for common problems when running GeoLibre Web in a browser. Most display glitches after an update come down to a stale browser cache, so start there.
+
+## Stale browser cache
+
+GeoLibre Web is a single-page app that browsers cache aggressively. After a new version ships, an outdated cached copy can leave you with display errors, missing or non-responsive controls, plugins that appear not to load, or stale data. The fix is to clear the cache and reload so the browser fetches the latest build.
+
+Try these in order:
+
+- **Hard refresh** the page to bypass the cache once:
+    - **Windows / Linux**: `Ctrl + Shift + R` (Chrome, Edge, Firefox).
+    - **macOS Chrome / Edge / Firefox**: `Cmd + Shift + R`.
+    - **macOS Safari**: `Cmd + Option + R`.
+- **Open the app in a private / incognito window** to confirm the problem is cache related. If it works there, the cache is the cause.
+- **Clear the cached files** for the GeoLibre site if a hard refresh is not enough, then reload.
+
+!!! note "Safari users"
+    Safari caches web GIS apps aggressively, so it is the most common source of these issues. To empty Safari's cache, choose **Develop → Empty Caches** (`Cmd + Option + E`), or **Safari → Clear History**, then reload the page. If the **Develop** menu is hidden, enable it in **Safari → Settings → Advanced → Show features for web developers**.
+
+A fresh page load against the latest build resolves the large majority of "the app looks broken after updating" reports.
+
+## Plugins do not appear to activate
+
+If a plugin's **Activate** action seems to do nothing, first rule out the stale-cache cause above with a hard refresh or a private window. Once you are on the latest build, an active plugin shows a checkmark next to its entry in the **Plugins** menu, and map controls (when the plugin provides one) appear at the configured corner of the map.
+
+## Desktop-only features in the browser
+
+Some capabilities require the desktop app and are unavailable in the browser build: local filesystem dialogs, local MBTiles, local raster file reads, and project save/open. If one of these is missing, you are likely running GeoLibre Web rather than the desktop app. See [Getting Started](../getting-started.md) for how the web, desktop, and Jupyter builds differ.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Settings & Preferences: user-guide/settings.md
       - Story Maps: user-guide/storymaps.md
       - Embedding & Sharing: user-guide/embedding.md
+      - Troubleshooting: user-guide/troubleshooting.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Your First Map: tutorials/first-map.md


### PR DESCRIPTION
## Summary

Adds a **Troubleshooting** page to the User Guide and wires it into the docs nav.

The page documents the most common cause of "the app looks broken after updating" reports: a stale browser cache. It covers hard refresh (per OS/browser), confirming with a private window, and clearing cached files, with a dedicated note for Safari users (Develop → Empty Caches / `Cmd + Option + E`, or Clear History) since Safari caches web GIS apps most aggressively.

This is the documentation update requested in #931. The feature-request portion of that issue (plugin-activation visual feedback) is intentionally out of scope here.

## Changes

- New `docs/user-guide/troubleshooting.md` with sections on stale browser cache, plugins that appear not to activate, and desktop-only features in the browser.
- `mkdocs.yml`: add the page to the User Guide nav.

Fixes #931