### PR TITLE
docs: simplify Homebrew install (official cask merged)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,9 @@ jobs:
     name: Update Homebrew cask
     needs: build
     runs-on: ubuntu-latest
+    # The primary cask is in the official homebrew/homebrew-cask repo, which
+    # BrewTestBot auto-bumps via livecheck. This job only updates the self-hosted
+    # tap (opengeos/homebrew-geolibre), kept as a fallback.
     # Serialise tap pushes so two close releases can't race on a non-fast-forward.
     concurrency:
       group: homebrew-tap-update

--- a/README.md
+++ b/README.md
@@ -99,19 +99,17 @@ Prebuilt desktop installers for Linux, Windows, and macOS are published on the
 can install the signed, auto-updating build from the
 [Microsoft Store](https://apps.microsoft.com/detail/9nwt67rv531x), or the
 unsigned GitHub Release build via `winget install OpenGeos.GeoLibre`. On macOS
-you can install and update with Homebrew:
+you can install and update with Homebrew — GeoLibre is in the official
+[Homebrew Cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/g/geolibre.rb)
+repository, so no tap is required:
 
 ```bash
-brew tap opengeos/geolibre
-brew trust --cask opengeos/geolibre/geolibre
 brew install --cask geolibre
 ```
 
-`brew trust` is a one-time approval for the non-official tap (skip it on
-Homebrew older than 5.1). The macOS app is signed with an Apple Developer ID
-certificate and notarized by Apple, so it launches normally with no quarantine
-workaround. See [Downloads](docs/downloads.md) for details and the manual
-install steps.
+The macOS app is signed with an Apple Developer ID certificate and notarized by
+Apple, so it launches normally with no quarantine workaround. See
+[Downloads](docs/downloads.md) for details and the manual install steps.
 
 To build from source instead:
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -73,21 +73,13 @@ xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 
 ### Homebrew (recommended)
 
-GeoLibre is available as a [Homebrew Cask](https://docs.brew.sh/Cask-Cookbook)
-from a self-hosted tap:
+GeoLibre is available as an official
+[Homebrew Cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/g/geolibre.rb),
+so no tap or trust step is needed — just install:
 
 ```bash
-brew tap opengeos/geolibre
-brew trust --cask opengeos/geolibre/geolibre
 brew install --cask geolibre
 ```
-
-The `brew trust` step is a one-time approval. Homebrew refuses to load casks
-from non-official taps until you trust them; this is enforced when
-`HOMEBREW_REQUIRE_TAP_TRUST=1` is set and becomes the default in a future
-Homebrew release. `brew trust opengeos/geolibre` trusts the whole tap instead of
-just this cask. The command exists in Homebrew 5.1 and later; on older versions
-skip it.
 
 The macOS DMGs are signed with an Apple Developer ID certificate and notarized
 by Apple, so Gatekeeper allows the app to launch normally with no quarantine
@@ -95,6 +87,12 @@ workaround. Upgrade later with:
 
 ```bash
 brew upgrade --cask geolibre
+```
+
+To remove it:
+
+```bash
+brew uninstall --cask geolibre
 ```
 
 ### Manual installation

--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -3,9 +3,13 @@
 # Render the Homebrew cask for the GeoLibre desktop app.
 #
 # The macOS DMGs are signed with an Apple Developer ID certificate and notarized
-# by Apple, so they install and launch without a quarantine workaround. The cask
-# is distributed from a self-hosted tap because it has not been submitted to the
-# official homebrew/cask repository.
+# by Apple, so they install and launch without a quarantine workaround.
+#
+# GeoLibre is now published in the official homebrew/homebrew-cask repository
+# (Casks/g/geolibre.rb), which is what users install via `brew install --cask
+# geolibre`. This script renders the cask for the self-hosted tap
+# (opengeos/homebrew-geolibre), which is kept as a fallback and updated by the
+# release workflow. See scripts/render-official-cask.sh for the official cask.
 #
 # Usage:
 #   VERSION=1.2.0 \

--- a/scripts/render-official-cask.sh
+++ b/scripts/render-official-cask.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 #
-# Render the cask for submission to the official homebrew/homebrew-cask repo.
+# Render the cask for the official homebrew/homebrew-cask repo.
 #
-# Unlike scripts/render-homebrew-cask.sh (which renders the self-hosted-tap cask
-# consumed by the release workflow), this emits the cask intended for the
-# official repository as Casks/g/geolibre.rb. It uses the `arch` helper and a
-# `livecheck` block so Homebrew's BrewTestBot can auto-bump the version on each
-# new GitHub release.
+# GeoLibre is published in the official repository as Casks/g/geolibre.rb, where
+# Homebrew's BrewTestBot auto-bumps the version on each new GitHub release via
+# the `livecheck` block below. Use this script to regenerate that cask (e.g. when
+# editing metadata or re-submitting). Unlike scripts/render-homebrew-cask.sh
+# (which renders the self-hosted-tap fallback consumed by the release workflow),
+# this emits the official cask and uses the `arch` helper.
 #
 # The official tap rejects unsigned/non-notarized apps, so this is only valid
 # for Developer ID signed and notarized DMGs (v1.4.1 and later).


### PR DESCRIPTION
GeoLibre is now in the official [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/g/geolibre.rb) repo (v1.8.0), so installation no longer needs a custom tap or `brew trust`.

## Changes
- **README.md** / **docs/downloads.md** — install is now just `brew install --cask geolibre`; dropped the `brew tap` + `brew trust` steps and their explanation. Added an uninstall snippet to the downloads doc.
- **scripts/render-homebrew-cask.sh** / **scripts/render-official-cask.sh** — refreshed stale header comments that said the cask "has not been submitted to the official homebrew/cask repository."
- **.github/workflows/release.yml** — added a comment clarifying that the official cask is BrewTestBot-maintained and the `homebrew` job only updates the self-hosted tap.

## Kept as fallback
The self-hosted tap (`opengeos/homebrew-geolibre`) and its release-workflow job are **kept** as a fallback — only the docs and comments changed, no automation was removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified macOS Homebrew install steps to a single `brew install --cask geolibre` command.
  * Clarified that the app is signed and notarized, and added a pointer to manual install instructions.
  * Updated Homebrew installation docs with a removal command for uninstalling the cask.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->