### PR TITLE
fix(geoagent): custom provider, model loading, and commit-based key save

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.0",
+    "maplibre-gl-geoagent": "^0.5.1",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.4.4",
+    "maplibre-gl-geoagent": "^0.5.0",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.1",
+    "maplibre-gl-geoagent": "^0.5.2",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.2",
+    "maplibre-gl-geoagent": "^0.5.3",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.0",
+        "maplibre-gl-geoagent": "^0.5.1",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
@@ -17623,9 +17623,9 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.0.tgz",
-      "integrity": "sha512-puy3U5SPnLVLxgyI7lgKpVfZeOKolj6WCf9bWSQeMdVAh3bFCyKEMVbPALP+qztU8jctLzgnq3wLbJZxOEh8ow==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.1.tgz",
+      "integrity": "sha512-Uezv/EMYUJP7E4yu7gn6NqKeeaXqanDQIEAjdWN6sKv/7JgwUsNkqK9yA769e5+qQd/XQAT100eIV8EJwLr/jA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -23807,7 +23807,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.0",
+        "maplibre-gl-geoagent": "^0.5.1",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.1",
+        "maplibre-gl-geoagent": "^0.5.2",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
@@ -17623,9 +17623,9 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.1.tgz",
-      "integrity": "sha512-Uezv/EMYUJP7E4yu7gn6NqKeeaXqanDQIEAjdWN6sKv/7JgwUsNkqK9yA769e5+qQd/XQAT100eIV8EJwLr/jA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.2.tgz",
+      "integrity": "sha512-ubNriAqYHNKzw6TItGYysS3S8qS55GuDj2QnDqlqXzToN/4bji3JciGnWh77l20M5yRVRkBmTwzIPjI2i74gOg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -23807,7 +23807,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.1",
+        "maplibre-gl-geoagent": "^0.5.2",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.2",
+        "maplibre-gl-geoagent": "^0.5.3",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
@@ -17623,9 +17623,9 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.2.tgz",
-      "integrity": "sha512-ubNriAqYHNKzw6TItGYysS3S8qS55GuDj2QnDqlqXzToN/4bji3JciGnWh77l20M5yRVRkBmTwzIPjI2i74gOg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.3.tgz",
+      "integrity": "sha512-VELcdADtGb5qDoPqwxos1w0k99dpp3igzq3wl5hTOb1cOfaxEwy2Qw7ONAao3XwUJtoZcTYqPZO/2eSPEkUwYg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -23807,7 +23807,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.2",
+        "maplibre-gl-geoagent": "^0.5.3",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.4.4",
+        "maplibre-gl-geoagent": "^0.5.0",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
@@ -17623,9 +17623,9 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.4.4.tgz",
-      "integrity": "sha512-CGZxZO6lcais5Edmojy22eJ/WAA6LFUw8BV8VuchAdBW+l+NWF1RWRpWYvzWMPkXCNH8NbmhX3FsTfnhhcxaVw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.0.tgz",
+      "integrity": "sha512-puy3U5SPnLVLxgyI7lgKpVfZeOKolj6WCf9bWSQeMdVAh3bFCyKEMVbPALP+qztU8jctLzgnq3wLbJZxOEh8ow==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -23807,7 +23807,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.4.4",
+        "maplibre-gl-geoagent": "^0.5.0",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.1",
+    "maplibre-gl-geoagent": "^0.5.2",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.4.4",
+    "maplibre-gl-geoagent": "^0.5.0",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.0",
+    "maplibre-gl-geoagent": "^0.5.1",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.2",
+    "maplibre-gl-geoagent": "^0.5.3",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -7,7 +7,7 @@ import type { FeatureCollection } from "geojson";
 
 /**
  * Mirrors the private `Overlay` record kept by MapLibreAgentTools in
- * maplibre-gl-geoagent (verified against v0.4.2). The tools instance exposes
+ * maplibre-gl-geoagent (verified against v0.5.0). The tools instance exposes
  * these through its `overlays` Map; re-verify the shape when bumping the
  * dependency.
  */

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -8,8 +8,9 @@ import type { FeatureCollection } from "geojson";
 /**
  * Mirrors the private `Overlay` record kept by MapLibreAgentTools in
  * maplibre-gl-geoagent (verified against v0.5.0). The tools instance exposes
- * these through its `overlays` Map; re-verify the shape when bumping the
- * dependency.
+ * these through its `overlays` Map; re-verify the shape — especially the
+ * `kind` union, since a new value falls through to the raster branch in
+ * `createGeoAgentStoreLayer` with no type error — when bumping the dependency.
  */
 export type GeoAgentOverlayRecord = {
   kind: "geojson" | "raster" | "basemap" | "marker" | "native" | "gee";

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -114,10 +114,10 @@ describe("syncGeoAgentOverlaysToStore", () => {
   });
 
   it("maps raster and basemap overlays to raster store layers", () => {
-    // raster, basemap, and gee share the single raster-tile branch in
-    // createGeoAgentStoreLayer. Pin that here so a future `kind` added to the
-    // union that should NOT be a raster layer fails visibly instead of silently
-    // falling through to this branch.
+    // raster and basemap share the single raster-tile branch in
+    // createGeoAgentStoreLayer (gee is covered by the Earth Engine test above).
+    // Pin that here so a future `kind` added to the union that should NOT be a
+    // raster layer fails visibly instead of silently falling through.
     for (const kind of ["raster", "basemap"] as const) {
       const layer = createGeoAgentStoreLayer({
         kind,

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -113,6 +113,33 @@ describe("syncGeoAgentOverlaysToStore", () => {
     assert.deepEqual(layer.metadata.nativeLayerIds, ["ndvi"]);
   });
 
+  it("maps raster and basemap overlays to raster store layers", () => {
+    // raster, basemap, and gee share the single raster-tile branch in
+    // createGeoAgentStoreLayer. Pin that here so a future `kind` added to the
+    // union that should NOT be a raster layer fails visibly instead of silently
+    // falling through to this branch.
+    for (const kind of ["raster", "basemap"] as const) {
+      const layer = createGeoAgentStoreLayer({
+        kind,
+        name: `Overlay ${kind}`,
+        sourceIds: [`${kind}-source`],
+        layerIds: [kind],
+        url: `https://tiles.example.com/${kind}/{z}/{x}/{y}.png`,
+        attribution: "Example",
+      });
+
+      assert.equal(layer.type, "raster");
+      assert.equal(layer.opacity, 1);
+      assert.equal(layer.metadata.identifiable, false);
+      assert.equal(layer.metadata.tileType, "raster");
+      assert.equal(layer.metadata.geoAgentOverlayKind, kind);
+      assert.equal(
+        layer.metadata.tileUrl,
+        `https://tiles.example.com/${kind}/{z}/{x}/{y}.png`,
+      );
+    }
+  });
+
   it("removes store layers whose overlays are gone, leaving others alone", () => {
     useAppStore.getState().addLayer(otherStoreLayer());
     syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay(), geeOverlay()));

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -106,6 +106,8 @@ describe("syncGeoAgentOverlaysToStore", () => {
     assert.equal(layer.type, "raster");
     assert.equal(layer.opacity, 1);
     assert.equal(layer.metadata.identifiable, false);
+    assert.equal(layer.metadata.tileType, "raster");
+    assert.equal(layer.metadata.geoAgentOverlayKind, "gee");
     assert.equal(
       layer.metadata.tileUrl,
       "https://earthengine.googleapis.com/tiles/{z}/{x}/{y}",


### PR DESCRIPTION
## Summary

Addresses two GeoAgent beta-test reports by bumping `maplibre-gl-geoagent` to `^0.5.0` (published from opengeos/maplibre-gl-geoagent#24, release v0.5.0).

### #937 — premature "Ready" badge / no save confirmation
- The API key is written to storage only when the user **commits** it (Enter or blur), not on every keystroke. Typing a single character no longer flips the status badge to "Ready" (it stays "Setup required").
- Committing shows an inline **"API key saved."** confirmation (auto-hides after 5s) and a **"Press Enter to save"** hint while the field has uncommitted edits.

### #939 — provider/model rigidity and premature prompt input
- New **"OpenAI-Compatible (Custom)"** provider with an **API base URL** field, so local LLM servers and private OpenAI-compatible endpoints work.
- New **"Load models"** button + model dropdown. Committing a key (or clicking the button) calls the provider's model-list endpoint, which both verifies the key and populates the dropdown (OpenAI, OpenAI-compatible, Anthropic, Google, Bedrock).
- Verification gating: an invalid key (HTTP 401/403) marks "Invalid API key" and keeps the prompt locked; a network/CORS/unsupported failure leaves the key usable but unverified so a provider that blocks browser model listing never blocks the user. Relative/non-http(s) base URLs are rejected so the key cannot leak to the app origin.
- The **prompt textarea** (not just the Send button) is now disabled until the agent is configured and the key is not known-invalid.

## Verification
- `npm run build` and `pre-commit run --files <changed>` pass.
- Verified end-to-end in the running app (light + dark themes) with the published `maplibre-gl-geoagent@0.5.0`: typing one character keeps "Setup required" with the prompt disabled; committing a bad OpenAI key shows "Verifying…" then "Invalid API key" with the prompt locked; the custom provider pointed at a live OpenAI-compatible endpoint loaded 340 models and unlocked the prompt once a model was selected.

Fixes #937
Fixes #939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the GeoAgent/maplibre integration dependency to `^0.5.3` in both the desktop and plugin packages.
* **Documentation**
  * Refreshed the GeoAgent overlay “tools” guidance to match the updated dependency and added a reminder to re-check overlay kind mappings.
* **Tests**
  * Expanded GeoAgent overlay synchronization tests to validate additional raster-layer metadata (including tile and overlay-kind details), including coverage for both raster and basemap overlays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->