### PR TITLE
fix: exported story basemap + collapse plugin panels on project load

### DIFF
--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -31,8 +31,12 @@ interface InlineLayerExport {
   layerSpec: Record<string, unknown>;
   /** GeoLibre layer-level opacity, combined with the style's per-geometry one. */
   layerOpacity: number;
-  /** Whether a chapter fades this layer in (so it starts hidden). */
-  fadesIn: boolean;
+  /**
+   * Absolute opacity chapter 0 assigns this layer, or undefined when chapter 0
+   * does not touch it (then the natural opacity applies). Mirrors the in-app
+   * presenter's chapter 0 so the first frame is not blank (#950).
+   */
+  chapterZeroOpacity?: number;
 }
 
 /**
@@ -78,18 +82,27 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
 
   // Only inline layers that are actually referenced by a chapter transition or
   // that are visible GeoJSON layers, so the export stays focused on the story.
-  // `referenced` (enter ∪ exit) drives which layers to inline; only layers a
-  // chapter fades *in* should start hidden, so those are tracked separately.
+  // `referenced` (enter ∪ exit) drives which layers to inline.
   const referenced = new Set<string>();
-  const referencedOnEnter = new Set<string>();
   for (const chapter of storymap.chapters) {
     for (const change of chapter.onChapterEnter) {
       referenced.add(change.layerId);
-      referencedOnEnter.add(change.layerId);
     }
     for (const change of chapter.onChapterExit) {
       referenced.add(change.layerId);
     }
+  }
+
+  // A layer's starting opacity must match what the in-app presenter shows on the
+  // first chapter, which applies chapter 0's onChapterEnter on top of the live
+  // (naturally visible) layers via enterChapter(0). So seed each layer from
+  // chapter 0's opacity if it sets one, and otherwise leave it at its natural
+  // opacity. The previous heuristic started *any* layer a later chapter fades in
+  // at opacity 0, which hid a basemap raster that a chapter fades to 1 until the
+  // reader scrolled to it, leaving the map blank on load (#950).
+  const chapterZeroOpacity = new Map<string, number>();
+  for (const change of storymap.chapters[0].onChapterEnter) {
+    chapterZeroOpacity.set(change.layerId, change.opacity);
   }
 
   const inlineLayers: InlineLayerExport[] = [];
@@ -112,9 +125,9 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       // Hidden layers export fully transparent so the export matches what
       // GeoLibre renders (the opacity slider value alone ignores visibility).
       layerOpacity: layer.visible ? layer.opacity : 0,
-      // Layers a chapter fades in start hidden; exit-only and unreferenced
-      // layers keep their natural opacity so they are visible until faded out.
-      fadesIn: referencedOnEnter.has(layer.id),
+      // Absolute opacity chapter 0 sets for this layer, if any. When present it
+      // overrides the natural opacity below so the first frame matches the app.
+      chapterZeroOpacity: chapterZeroOpacity.get(layer.id),
     });
   }
 
@@ -177,8 +190,9 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     .map((entry) => {
       const sourceId = `${entry.id}-source`;
       const paint = { ...(entry.layerSpec.paint as Record<string, unknown>) };
-      // Seed every opacity paint property the layer type fades: 0 when a chapter
-      // fades the layer in, otherwise the style's per-property opacity scaled by
+      // Seed every opacity paint property the layer type fades. When chapter 0
+      // assigns this layer an opacity, start there (matching the in-app first
+      // frame, #950); otherwise use the style's per-property opacity scaled by
       // the layer opacity so the export matches what GeoLibre renders. Circles
       // carry both fill and stroke opacity so a faded point hides fully (#934).
       for (const opacityProp of opacityProperties(entry.layerSpec.type as string)) {
@@ -186,9 +200,10 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
           typeof paint[opacityProp] === "number"
             ? (paint[opacityProp] as number)
             : 1;
-        paint[opacityProp] = entry.fadesIn
-          ? 0
-          : styleOpacity * entry.layerOpacity;
+        paint[opacityProp] =
+          entry.chapterZeroOpacity !== undefined
+            ? entry.chapterZeroOpacity
+            : styleOpacity * entry.layerOpacity;
       }
       const spec = {
         ...entry.layerSpec,

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -193,7 +193,9 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       // Seed every opacity paint property the layer type fades. When chapter 0
       // assigns this layer an opacity, start there (matching the in-app first
       // frame, #950); otherwise use the style's per-property opacity scaled by
-      // the layer opacity so the export matches what GeoLibre renders. Circles
+      // the layer opacity so the export matches what GeoLibre renders. A chapter
+      // 0 opacity wins outright, including over a hidden layer's 0, exactly as
+      // the in-app presenter's setLayerOpacity overwrites the live value. Circles
       // carry both fill and stroke opacity so a faded point hides fully (#934).
       for (const opacityProp of opacityProperties(entry.layerSpec.type as string)) {
         const styleOpacity =

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -363,19 +363,27 @@ export class PluginManager {
     // Plugins pop their control panel open when activated so a user who just
     // enabled one lands in it. On a project restore that is unwanted: a loaded
     // project (e.g. a gallery `?url=` link) would bury the map under every
-    // expanded panel it carries (#952). Collect each control added during the
-    // restore and collapse it immediately (so the first paint is collapsed) and
-    // again on the next tick, after the auto-expand that plugins schedule from
-    // activate() with setTimeout(0) has run.
-    const restoredControls: IControl[] = [];
-    const collapseControl = (control: IControl): void => {
+    // expanded panel it carries (#952). Collapse each control added while
+    // restoring so panels stay closed. This also closes a panel re-added by
+    // setMapControlPosition for an already-active plugin whose saved position
+    // differs, which matches the project-load intent.
+    const collapseRestoredPanel = (control: IControl): void => {
       const collapsible = control as { collapse?: () => void };
       if (typeof collapsible.collapse !== "function") return;
+      // Collapse now so the first paint is collapsed, then again after the
+      // plugin's own auto-expand. Plugins open their panel with a setTimeout(0)
+      // expand from activate(), queued after this control was added, so a single
+      // deferred collapse here would run before that expand and lose; defer twice
+      // so the re-collapse lands after it. Doing this per control (instead of
+      // once after the activate loop) also covers controls a plugin adds
+      // asynchronously while restoring, e.g. behind a dynamic-import mount.
       collapsible.collapse();
-      restoredControls.push(control);
+      setTimeout(() => {
+        setTimeout(() => collapsible.collapse?.(), 0);
+      }, 0);
     };
     const scopeForRestore = (id: string): GeoLibreAppAPI =>
-      scopeAppToPlugin(app, id, { onControlAdded: collapseControl });
+      scopeAppToPlugin(app, id, { onControlAdded: collapseRestoredPanel });
 
     // Deactivate first so plugins that should be inactive tear down their live
     // controls before we touch positions or settings. This keeps the order of
@@ -435,18 +443,6 @@ export class PluginManager {
       // would, so an async mount that later fails (e.g. a stale chunk after a
       // redeploy) must roll back here too, not just from activate().
       this.watchAsyncActivation(id, activated, scopedApp, generation);
-    }
-
-    // Re-collapse after the synchronous restore returns. Plugins schedule their
-    // auto-expand with setTimeout(0) from activate(); this runs after all of
-    // them (it is queued last) so the panels end collapsed even though each one
-    // tried to open itself.
-    if (restoredControls.length > 0) {
-      setTimeout(() => {
-        for (const control of restoredControls) {
-          (control as { collapse?: () => void }).collapse?.();
-        }
-      }, 0);
     }
 
     if (changed) this.notify();

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -1,4 +1,5 @@
 import type { ProjectPluginState } from "@geolibre/core";
+import type { IControl } from "maplibre-gl";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
@@ -359,6 +360,23 @@ export class PluginManager {
     );
     let changed = false;
 
+    // Plugins pop their control panel open when activated so a user who just
+    // enabled one lands in it. On a project restore that is unwanted: a loaded
+    // project (e.g. a gallery `?url=` link) would bury the map under every
+    // expanded panel it carries (#952). Collect each control added during the
+    // restore and collapse it immediately (so the first paint is collapsed) and
+    // again on the next tick, after the auto-expand that plugins schedule from
+    // activate() with setTimeout(0) has run.
+    const restoredControls: IControl[] = [];
+    const collapseControl = (control: IControl): void => {
+      const collapsible = control as { collapse?: () => void };
+      if (typeof collapsible.collapse !== "function") return;
+      collapsible.collapse();
+      restoredControls.push(control);
+    };
+    const scopeForRestore = (id: string): GeoLibreAppAPI =>
+      scopeAppToPlugin(app, id, { onControlAdded: collapseControl });
+
     // Deactivate first so plugins that should be inactive tear down their live
     // controls before we touch positions or settings. This keeps the order of
     // operations from rebuilding a control only to remove it on the next pass.
@@ -377,7 +395,7 @@ export class PluginManager {
     for (const [id, plugin] of this.plugins) {
       // One scoped app per plugin so any menu it (re)registers from
       // setMapControlPosition/applyProjectState is owner-tagged correctly.
-      const scopedApp = scopeAppToPlugin(app, id);
+      const scopedApp = scopeForRestore(id);
       const defaultPosition = this.defaultMapControlPositions.get(id);
       const targetPosition = state?.mapControlPositions[id] ?? defaultPosition;
       if (targetPosition && plugin.setMapControlPosition) {
@@ -407,7 +425,7 @@ export class PluginManager {
       if (this.active.has(id)) continue;
       const plugin = this.plugins.get(id);
       if (!plugin) continue;
-      const scopedApp = scopeAppToPlugin(app, id);
+      const scopedApp = scopeForRestore(id);
       const activated = plugin.activate(scopedApp);
       if (activated === false) continue;
       const generation = this.nextActivationGeneration(id);
@@ -417,6 +435,18 @@ export class PluginManager {
       // would, so an async mount that later fails (e.g. a stale chunk after a
       // redeploy) must roll back here too, not just from activate().
       this.watchAsyncActivation(id, activated, scopedApp, generation);
+    }
+
+    // Re-collapse after the synchronous restore returns. Plugins schedule their
+    // auto-expand with setTimeout(0) from activate(); this runs after all of
+    // them (it is queued last) so the panels end collapsed even though each one
+    // tried to open itself.
+    if (restoredControls.length > 0) {
+      setTimeout(() => {
+        for (const control of restoredControls) {
+          (control as { collapse?: () => void }).collapse?.();
+        }
+      }, 0);
     }
 
     if (changed) this.notify();
@@ -446,26 +476,52 @@ export class PluginManager {
  * lifecycle callback that hands a plugin the app (activate, deactivate,
  * handleUrlParameters, setMapControlPosition, applyProjectState) passes a scoped
  * app, so a menu the plugin (re)registers from any of them is tagged correctly,
- * including one registered asynchronously after the callback returns. Returns
- * the app unchanged when the host exposes no `registerToolbarMenu`.
+ * including one registered asynchronously after the callback returns. With
+ * `onControlAdded` it also intercepts `addMapControl` (used by project restore
+ * to collapse newly added panels, #952). Returns the app unchanged when neither
+ * applies.
  */
+interface ScopeAppOptions {
+  /**
+   * Called with every control a plugin adds through `addMapControl` while the
+   * scope is active. Used during project restore to keep newly added panels
+   * collapsed (#952).
+   */
+  onControlAdded?: (control: IControl) => void;
+}
+
 function scopeAppToPlugin(
   app: GeoLibreAppAPI,
   pluginId: string,
+  options: ScopeAppOptions = {},
 ): GeoLibreAppAPI {
+  const { onControlAdded } = options;
   const register = app.registerToolbarMenu;
-  if (!register) return app;
-  // The public `registerToolbarMenu` is single-arg; the host's concrete impl
-  // accepts an owner id as a second argument (see toolbar-menu-registry). Cast
-  // here so the owner stays a host-side injection that plugins never see.
-  const registerWithOwner = register as (
-    menu: GeoLibreToolbarMenu,
-    ownerPluginId: string,
-  ) => () => void;
-  return {
-    ...app,
-    registerToolbarMenu: (menu) => registerWithOwner(menu, pluginId),
-  };
+  if (!register && !onControlAdded) return app;
+
+  const scoped: GeoLibreAppAPI = { ...app };
+
+  if (register) {
+    // The public `registerToolbarMenu` is single-arg; the host's concrete impl
+    // accepts an owner id as a second argument (see toolbar-menu-registry). Cast
+    // here so the owner stays a host-side injection that plugins never see.
+    const registerWithOwner = register as (
+      menu: GeoLibreToolbarMenu,
+      ownerPluginId: string,
+    ) => () => void;
+    scoped.registerToolbarMenu = (menu) => registerWithOwner(menu, pluginId);
+  }
+
+  if (onControlAdded) {
+    const addMapControl = app.addMapControl;
+    scoped.addMapControl = (control, position) => {
+      const added = addMapControl(control, position);
+      if (added !== false) onControlAdded(control);
+      return added;
+    };
+  }
+
+  return scoped;
 }
 
 // Retaining several recent contexts (rather than only the latest) keeps dedup

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -581,6 +581,13 @@ export interface GeoLibrePlugin {
    * that resolves to `false` (or rejects) when the mount ultimately fails; the
    * host then rolls back the optimistic active state so the Plugins menu does
    * not show a plugin that never came up.
+   *
+   * If a plugin auto-opens its control panel on activation, expand it with a
+   * `setTimeout(() => control.expand(), 0)` (the convention every built-in
+   * control follows). On a project restore the host re-collapses panels one
+   * tick after that expand so a loaded project does not bury the map (#952);
+   * deferring the expand by more than one tick would defeat that and leave the
+   * panel open after restore.
    */
   activate: (app: GeoLibreAppAPI) => boolean | void | Promise<boolean | void>;
   deactivate: (app: GeoLibreAppAPI) => void;

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -802,7 +802,14 @@ describe("PluginManager panel auto-expand on restore", () => {
     });
   }
 
-  const flushTimers = () => new Promise((resolve) => setTimeout(resolve, 0));
+  // Drain several macrotask ticks: the re-collapse is double-deferred so it
+  // lands after the plugin's own setTimeout(0) expand, and an async activation
+  // adds another tick before its control even exists.
+  async function flushTimers(times = 4) {
+    for (let i = 0; i < times; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
 
   it("keeps restored plugin panels collapsed", async () => {
     const manager = new PluginManager();
@@ -829,9 +836,52 @@ describe("PluginManager panel auto-expand on restore", () => {
     );
   });
 
+  it("collapses panels added by an async activation", async () => {
+    const manager = new PluginManager();
+    const control = fakeControl();
+    const addMapControl = () => true;
+    const mockApp = { addMapControl } as unknown as GeoLibreAppAPI;
+
+    // A plugin mounted behind a dynamic import: it adds its control (and
+    // auto-expands) only after activate()'s promise has begun resolving, so the
+    // collapse must follow each control rather than fire once after the loop.
+    manager.register(
+      testPlugin({
+        id: "async-basemaps",
+        activate: (api) =>
+          new Promise<void>((resolve) => {
+            setTimeout(() => {
+              api.addMapControl(control as never);
+              setTimeout(() => control.expand(), 0);
+              resolve();
+            }, 0);
+          }),
+      }),
+    );
+
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: ["async-basemaps"],
+        mapControlPositions: {},
+        settings: {},
+      },
+      mockApp,
+    );
+
+    await flushTimers();
+    assert.equal(
+      control.collapsed,
+      true,
+      "a panel added by an async activation during restore must end collapsed",
+    );
+  });
+
   it("still expands the panel on a user activation", async () => {
     const manager = new PluginManager();
     const control = fakeControl();
+    // Start collapsed so the assertion only passes if activate() really expands.
+    control.collapsed = true;
     const addMapControl = () => true;
     const mockApp = { addMapControl } as unknown as GeoLibreAppAPI;
     manager.register(panelPlugin("basemaps", control));

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -776,3 +776,73 @@ describe("PluginManager toolbar menu scoping", () => {
     assert.deepEqual(seen, ["settings-menu-plugin"]);
   });
 });
+
+describe("PluginManager panel auto-expand on restore", () => {
+  // A control like the Basemaps panel: starts expanded and pops itself open
+  // (with setTimeout(0), the way the real plugins do) when its plugin activates.
+  function fakeControl() {
+    return {
+      collapsed: false,
+      expand() {
+        this.collapsed = false;
+      },
+      collapse() {
+        this.collapsed = true;
+      },
+    };
+  }
+
+  function panelPlugin(id: string, control: ReturnType<typeof fakeControl>) {
+    return testPlugin({
+      id,
+      activate: (api) => {
+        api.addMapControl(control as never);
+        setTimeout(() => control.expand(), 0);
+      },
+    });
+  }
+
+  const flushTimers = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("keeps restored plugin panels collapsed", async () => {
+    const manager = new PluginManager();
+    const control = fakeControl();
+    const addMapControl = () => true;
+    const mockApp = { addMapControl } as unknown as GeoLibreAppAPI;
+    manager.register(panelPlugin("basemaps", control));
+
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: ["basemaps"],
+        mapControlPositions: {},
+        settings: {},
+      },
+      mockApp,
+    );
+
+    await flushTimers();
+    assert.equal(
+      control.collapsed,
+      true,
+      "a project restore must not leave plugin panels expanded over the map",
+    );
+  });
+
+  it("still expands the panel on a user activation", async () => {
+    const manager = new PluginManager();
+    const control = fakeControl();
+    const addMapControl = () => true;
+    const mockApp = { addMapControl } as unknown as GeoLibreAppAPI;
+    manager.register(panelPlugin("basemaps", control));
+
+    manager.activate("basemaps", mockApp);
+
+    await flushTimers();
+    assert.equal(
+      control.collapsed,
+      false,
+      "activating a plugin from the menu should still open its panel",
+    );
+  });
+});

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -877,6 +877,53 @@ describe("PluginManager panel auto-expand on restore", () => {
     );
   });
 
+  it("collapses a panel re-added when a restored position differs", async () => {
+    const manager = new PluginManager();
+    const control = fakeControl();
+    let currentPosition = "top-right";
+    const addMapControl = () => true;
+    const mockApp = { addMapControl } as unknown as GeoLibreAppAPI;
+
+    // A plugin whose saved position differs from the live one: restore calls
+    // setMapControlPosition, which re-adds (and re-expands) the control. That
+    // re-add must go through the restore collapse too, not just activate().
+    manager.register(
+      testPlugin({
+        id: "positioned-plugin",
+        activate: (api) => {
+          api.addMapControl(control as never, "top-right" as never);
+          setTimeout(() => control.expand(), 0);
+        },
+        getMapControlPosition: () => currentPosition as never,
+        setMapControlPosition: (api, position) => {
+          currentPosition = position;
+          api.addMapControl(control as never, position);
+          setTimeout(() => control.expand(), 0);
+        },
+      }),
+    );
+
+    manager.activate("positioned-plugin", mockApp);
+    await flushTimers();
+
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: ["positioned-plugin"],
+        mapControlPositions: { "positioned-plugin": "bottom-left" as never },
+        settings: {},
+      },
+      mockApp,
+    );
+
+    await flushTimers();
+    assert.equal(
+      control.collapsed,
+      true,
+      "a panel re-added by a position change during restore must stay collapsed",
+    );
+  });
+
   it("still expands the panel on a user activation", async () => {
     const manager = new PluginManager();
     const control = fakeControl();


### PR DESCRIPTION
Fixes two bugs that surface when a project is opened from a shared/gallery link.

## #950 - Basemap does not load on exported story map

In a Story Map HTML export, a layer's starting opacity was forced to 0 whenever *any* chapter faded that layer in. The maritime-piracy story fades its NASA GIBS basemap raster to 1 on a later chapter, so the export started the basemap hidden and the map was blank on load until the reader scrolled to that chapter.

The fix seeds each inlined layer's initial opacity from chapter 0's `onChapterEnter` (the same state the in-app presenter shows via `enterChapter(0)`), falling back to the layer's natural opacity. Layers the author hides in chapter 0 still start hidden and fade in later; a basemap chapter 0 never touches stays visible from the first frame, matching the preview.

## #952 - Plugin panels open and block the view on project load

Plugins pop their control panel open when activated (so a user who just enabled one lands in it). On a project restore that buried the map under every expanded panel the project carried (the Basemaps panel in the report).

`restoreProjectState` now collapses every control added during the restore, on the next tick after the plugins' own `setTimeout(0)` auto-expand has run, so panels end collapsed. Activating a plugin from the Plugins menu still opens its panel. The interception is central (in the scoped app's `addMapControl`), so it covers all built-in and external plugins without touching each one.

## Verification

Driven in the real app with Playwright against the reporter's project (`?url=https://share.geolibre.app/spatialthoughts/maritime-piracy.geolibre.json`):

- #952: panels are collapsed on load (dark and light themes) and still expand on manual activation from the Plugins menu.
- #950: exported the story HTML before and after the change; before, the basemap was blank on load and only appeared at chapter 3; after, the basemap renders on the first chapter and stays correct through every chapter, with overlay fades intact.

`npm run build`, the full frontend test suite, and pre-commit all pass. Added `plugin-manager` tests covering collapse-on-restore and expand-on-user-activation. `buildStoryMapHtml` has no unit test (it depends on a DOM via DOMPurify), so #950 was verified end to end in the browser.

Fixes #950
Fixes #952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Story map exports now match the in-app first-chapter visuals more closely by applying consistent layer opacity behavior during export.
  * Restoring projects now reliably collapses plugin control panels, even when panels attempt to auto-expand during restore.
* **Tests**
  * Added automated coverage to verify plugin panels stay collapsed after restore, including scenarios with deferred/asynchronous control expansion.
* **Documentation**
  * Updated plugin `activate` guidance to clarify expected auto-expand timing and restore re-collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->