### PR TITLE
fix(graticule): disable interval input when spacing is Auto

### DIFF
--- a/packages/plugins/src/plugins/maplibre-graticule.ts
+++ b/packages/plugins/src/plugins/maplibre-graticule.ts
@@ -620,7 +620,7 @@ function buildPanelBody(container: HTMLElement): void {
 
   const controls: Array<() => void> = [];
 
-  const addRow = (labelText: string, input: HTMLElement): void => {
+  const addRow = (labelText: string, input: HTMLElement): HTMLElement => {
     const row = document.createElement("label");
     row.style.display = "flex";
     row.style.alignItems = "center";
@@ -631,6 +631,7 @@ function buildPanelBody(container: HTMLElement): void {
     row.appendChild(span);
     row.appendChild(input);
     container.appendChild(row);
+    return row;
   };
 
   const select = (
@@ -659,6 +660,9 @@ function buildPanelBody(container: HTMLElement): void {
     attrs: { min: number; max: number; step: number },
     get: () => number,
     set: (value: number) => void,
+    // Optional predicate; when it returns true the row is grayed out and the
+    // input is disabled (e.g. Interval has no effect while Spacing is Auto).
+    isDisabled?: () => boolean,
   ): void => {
     const el = document.createElement("input");
     el.type = "number";
@@ -677,10 +681,17 @@ function buildPanelBody(container: HTMLElement): void {
     el.addEventListener("keydown", (e) => {
       if (e.key === "Enter") el.blur();
     });
+    const row = addRow(labelText, el);
+    const applyDisabled = (): void => {
+      const disabled = isDisabled?.() ?? false;
+      el.disabled = disabled;
+      row.style.opacity = disabled ? "0.5" : "";
+    };
+    applyDisabled();
     controls.push(() => {
       el.value = String(get());
+      applyDisabled();
     });
-    addRow(labelText, el);
   };
 
   const color = (
@@ -729,6 +740,8 @@ function buildPanelBody(container: HTMLElement): void {
     { min: 0.001, max: 45, step: 0.001 },
     () => settings.spacingDegrees,
     (v) => setGraticuleSettings({ spacingDegrees: v }),
+    // Auto spacing is purely zoom-driven, so the interval has no effect there.
+    () => settings.spacingMode === "auto",
   );
   color(labels.lineColor, () => settings.lineColor, (v) => setGraticuleSettings({ lineColor: v }));
   number(

--- a/packages/plugins/src/plugins/maplibre-graticule.ts
+++ b/packages/plugins/src/plugins/maplibre-graticule.ts
@@ -686,6 +686,10 @@ function buildPanelBody(container: HTMLElement): void {
       const disabled = isDisabled?.() ?? false;
       el.disabled = disabled;
       row.style.opacity = disabled ? "0.5" : "";
+      // The disabled input shows `not-allowed` on its own, but the label text
+      // beside it would otherwise keep the default cursor; set it on the whole
+      // row so hovering anywhere signals the control is inactive.
+      row.style.cursor = disabled ? "not-allowed" : "";
     };
     applyDisabled();
     controls.push(() => {


### PR DESCRIPTION
## Summary

Addresses Issue 1 from the Gridlines plugin beta test report (#932): in **Auto (by zoom)** spacing, the **Interval (°)** input stayed fully active and editable even though `autoStep()` derives the grid step purely from the viewport span and never reads `spacingDegrees`. Editing it appeared to do nothing, which reads as the app being unresponsive.

This grays out (opacity 0.5) and `disabled`s the Interval row whenever Spacing is **Auto**, and re-enables it the moment the user switches to **Fixed interval**. The toggle reuses the panel's existing `syncPanel` pass, so switching the Spacing dropdown updates the disabled state immediately.

Issue 2 from the same report (focus not released on Enter) was already fixed in #945, so this PR covers the remaining item.

## Verification

Drove the real web app with Playwright in both light and dark themes:

- Auto mode: Interval input is `disabled` and its row is grayed (opacity 0.5).
- Switching to Fixed: input re-enables and is editable.
- Switching back to Auto: input disables and grays again.

`tests/graticule.test.ts` passes; `pre-commit` (incl. the npm build hook) is clean.

Fixes #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The interval control in the settings panel now automatically disables and appears greyed out when spacing is set to automatic, preventing confusion about unavailable settings.
  * Disabled numeric controls are now visually reflected more consistently across the settings panel, improving clarity when options are inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->