### PR TITLE
feat(add-data): Add CAD (DXF/DWG) Layer source with layer picker and CRS

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { AddDataShellProvider } from "./add-data/context";
 import { KIND_I18N_KEY } from "./add-data/constants";
 import { ArcGISSource } from "./add-data/sources/ArcGISSource";
+import { CadSource } from "./add-data/sources/CadSource";
 import { DeckVizSource } from "./add-data/sources/DeckVizSource";
 import { DelimitedTextSource } from "./add-data/sources/DelimitedTextSource";
 import { GeoRssSource } from "./add-data/sources/GeoRssSource";
@@ -65,6 +66,8 @@ function renderSource(
       return <GeoRssSource />;
     case "delimited-text":
       return <DelimitedTextSource />;
+    case "cad":
+      return <CadSource />;
     case "photos":
       return <PhotosSource />;
     case "mbtiles":

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -22,6 +22,7 @@ export type KindI18nKey =
   | "gpx"
   | "georss"
   | "delimitedText"
+  | "cad"
   | "photos"
   | "mbtiles"
   | "arcgis"
@@ -42,6 +43,7 @@ export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
   gpx: "gpx",
   georss: "georss",
   "delimited-text": "delimitedText",
+  cad: "cad",
   photos: "photos",
   mbtiles: "mbtiles",
   arcgis: "arcgis",
@@ -97,6 +99,20 @@ export const MAX_SAVED_POSTGRES_CONNECTIONS = 10;
 // service-library.ts). Bumping the key would orphan a user's saved services.
 export const SERVICE_LIBRARY_STORAGE_KEY = "geolibre.serviceLibrary";
 export const MAX_SAVED_SERVICES = 200;
+// A short list of common coordinate systems offered as quick presets in the Add
+// CAD Layer dialog (CAD files carry no CRS of their own, so the user names one).
+// The labels are CRS proper names and stay untranslated; selecting one fills the
+// free-text EPSG field, which remains the source of truth.
+export const CAD_CRS_PRESETS: readonly { label: string; value: string }[] = [
+  { label: "WGS 84 (EPSG:4326)", value: "EPSG:4326" },
+  { label: "Web Mercator (EPSG:3857)", value: "EPSG:3857" },
+  { label: "NAD83 (EPSG:4269)", value: "EPSG:4269" },
+  { label: "NAD83 / UTM zone 15N (EPSG:26915)", value: "EPSG:26915" },
+  { label: "NAD83 / Conus Albers (EPSG:5070)", value: "EPSG:5070" },
+  { label: "British National Grid (EPSG:27700)", value: "EPSG:27700" },
+  { label: "ETRS89 / UTM zone 32N (EPSG:25832)", value: "EPSG:25832" },
+];
+
 export const DELIMITED_TEXT_DELIMITERS: Record<
   Exclude<DelimitedTextDelimiter, "custom">,
   string

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -113,6 +113,33 @@ export const CAD_CRS_PRESETS: readonly { label: string; value: string }[] = [
   { label: "ETRS89 / UTM zone 32N (EPSG:25832)", value: "EPSG:25832" },
 ];
 
+// Sample CAD drawings offered in the Add CAD Layer dialog's "Load sample data"
+// dropdown. Each is a recognizable dataset written in a known CRS (CAD carries
+// none), so selecting one fetches the file and pre-fills the matching EPSG; a
+// blank `crs` loads the drawing as-is (already lon/lat). Hosted on Source
+// Cooperative alongside the other GeoLibre samples.
+export const CAD_SAMPLES: readonly {
+  label: string;
+  url: string;
+  crs: string;
+}[] = [
+  {
+    label: "US states (Albers, EPSG:5070)",
+    url: "https://data.source.coop/giswqs/opengeos/us_states_albers_5070.dxf",
+    crs: "EPSG:5070",
+  },
+  {
+    label: "NYC boroughs (State Plane, EPSG:2263)",
+    url: "https://data.source.coop/giswqs/opengeos/nyc_boroughs_stateplane_2263.dxf",
+    crs: "EPSG:2263",
+  },
+  {
+    label: "World populated places (WGS84)",
+    url: "https://data.source.coop/giswqs/opengeos/ne_populated_places_wgs84.dxf",
+    crs: "",
+  },
+];
+
 export const DELIMITED_TEXT_DELIMITERS: Record<
   Exclude<DelimitedTextDelimiter, "custom">,
   string

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { FileUp, Layers } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type CadLayerInfo,
@@ -46,10 +46,17 @@ function normalizeCrs(raw: string): string {
   return value.toUpperCase();
 }
 
-/** True when DuckDB rejected the layer's geometry (mixed / Geometry Collection). */
+/**
+ * True when DuckDB rejected the layer's geometry (a mixed / Geometry Collection
+ * layer it cannot decode to WKB). Matches the known DuckDB 1.5.x wording plus
+ * close variants so a minor message change does not silently leak the raw error;
+ * the caller also logs the original for DevTools.
+ */
 function isUnsupportedGeometryError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /unsupported geometry type/i.test(message);
+  return /unsupported geometry|unknown geometry|geometry collection|geometry type in wkb/i.test(
+    message,
+  );
 }
 
 /**
@@ -66,9 +73,14 @@ export function CadSource() {
     null,
   );
   const [layers, setLayers] = useState<CadLayerInfo[]>([]);
-  const [selectedLayer, setSelectedLayer] = useState("");
+  // `null` = nothing chosen yet; "" is a real selection (an unnamed OGR layer,
+  // which ST_Read reads as the first layer), so the two must stay distinct.
+  const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
   const [crs, setCrs] = useState("");
   const [isReadingLayers, setIsReadingLayers] = useState(false);
+  // Bumped on every file pick / sample load so a slow probe that resolves after
+  // a newer one cannot overwrite the newer file's layers (stale-result guard).
+  const loadSeq = useRef(0);
 
   // `registerFileBuffer` transfers the bytes to the DuckDB worker, which
   // detaches the backing ArrayBuffer. The file is read twice (the layer probe,
@@ -83,51 +95,65 @@ export function CadSource() {
   // Shared by the file picker and the sample loader: stash the bytes, default
   // the layer name, then read the CAD layer list up front so the picker is
   // populated before the user submits (DXF has a single `entities` layer; DWG
-  // is multi-layer).
-  const applyCadBytes = async (path: string, data: ArrayBuffer) => {
+  // is multi-layer). `requestId` is captured by the caller; a probe that the
+  // user has since superseded bails out before touching state. The caller owns
+  // the `isReadingLayers` flag (so the fetch in `handleSelectSample` is covered
+  // too) — this helper never toggles it.
+  const applyCadBytes = async (
+    requestId: number,
+    path: string,
+    data: ArrayBuffer,
+  ) => {
     const file: SelectedCadFile = { path, data };
     setSelectedFile(file);
     setLayers([]);
-    setSelectedLayer("");
+    setSelectedLayer(null);
     source.setLayerName((current) =>
       current.trim() && current !== defaultName
         ? current
         : layerNameFromPath(path, defaultName),
     );
 
-    setIsReadingLayers(true);
-    try {
-      const cadLayers = await readCadLayers(buildVectorFile(file));
-      if (cadLayers.length === 0) {
-        throw new Error(t("addData.cad.errorNoLayers"));
-      }
-      setLayers(cadLayers);
-      setSelectedLayer(cadLayers[0].name);
-    } finally {
-      setIsReadingLayers(false);
+    const cadLayers = await readCadLayers(buildVectorFile(file));
+    if (requestId !== loadSeq.current) return; // superseded by a newer load
+    if (cadLayers.length === 0) {
+      throw new Error(t("addData.cad.errorNoLayers"));
     }
+    setLayers(cadLayers);
+    setSelectedLayer(cadLayers[0].name);
   };
 
   const handleChooseFile = async () => {
     source.setError(null);
-    try {
-      const result = await openLocalDataFileWithFallback({
-        filters: [
-          { name: t("addData.cad.fileFilter"), extensions: ["dxf", "dwg"] },
-        ],
-        accept: ".dxf,.dwg",
-        readBinary: true,
-      });
-      if (!result) return;
-      if (!result.data) throw new Error(t("addData.cad.readError"));
-      await applyCadBytes(result.path, result.data);
-    } catch (err) {
+    const result = await openLocalDataFileWithFallback({
+      filters: [
+        { name: t("addData.cad.fileFilter"), extensions: ["dxf", "dwg"] },
+      ],
+      accept: ".dxf,.dwg",
+      readBinary: true,
+    }).catch((err: unknown) => {
       source.setError(errorMessage(err, t("addData.cad.readError")));
+      return null;
+    });
+    if (!result) return;
+
+    const requestId = ++loadSeq.current;
+    setIsReadingLayers(true);
+    try {
+      if (!result.data) throw new Error(t("addData.cad.readError"));
+      await applyCadBytes(requestId, result.path, result.data);
+    } catch (err) {
+      if (requestId === loadSeq.current) {
+        source.setError(errorMessage(err, t("addData.cad.readError")));
+      }
+    } finally {
+      if (requestId === loadSeq.current) setIsReadingLayers(false);
     }
   };
 
   const handleSelectSample = async (sample: (typeof CAD_SAMPLES)[number]) => {
     source.setError(null);
+    const requestId = ++loadSeq.current;
     setIsReadingLayers(true); // cover the fetch too, not just the layer read
     try {
       const response = await fetch(sample.url);
@@ -137,18 +163,27 @@ export function CadSource() {
         );
       }
       const data = await response.arrayBuffer();
+      if (requestId !== loadSeq.current) return; // a newer load started
       setCrs(sample.crs);
-      await applyCadBytes(sample.url.split("/").pop() || "sample.dxf", data);
+      // Parse the path off the URL so a query string/fragment can't leak into
+      // the filename (and thus the extension detection).
+      const filename =
+        new URL(sample.url).pathname.split("/").pop() || "sample.dxf";
+      await applyCadBytes(requestId, filename, data);
     } catch (err) {
-      source.setError(errorMessage(err, t("addData.cad.readError")));
+      if (requestId === loadSeq.current) {
+        source.setError(errorMessage(err, t("addData.cad.readError")));
+      }
     } finally {
-      setIsReadingLayers(false);
+      if (requestId === loadSeq.current) setIsReadingLayers(false);
     }
   };
 
   const handleSubmit = source.runSubmit(async () => {
     if (!selectedFile) throw new Error(t("addData.cad.errorChooseFile"));
-    if (!selectedLayer) throw new Error(t("addData.cad.errorNoLayer"));
+    // `selectedLayer === ""` is a valid choice (unnamed layer); only `null`
+    // means nothing has been picked.
+    if (selectedLayer === null) throw new Error(t("addData.cad.errorNoLayer"));
 
     const name = source.layerName.trim() || defaultName;
     const overrideSourceCrs = normalizeCrs(crs);
@@ -161,6 +196,8 @@ export function CadSource() {
       );
     } catch (err) {
       if (isUnsupportedGeometryError(err)) {
+        // Keep the raw cause in DevTools while showing the friendly message.
+        console.warn("[GeoLibre] CAD layer geometry could not be decoded", err);
         throw new Error(t("addData.cad.errorUnsupportedGeometry"));
       }
       throw err;
@@ -198,12 +235,17 @@ export function CadSource() {
         source.isSubmitting ||
         isReadingLayers ||
         !selectedFile ||
-        !selectedLayer
+        selectedLayer === null
       }
     >
       <div className="space-y-3">
         <div className="flex flex-wrap items-center gap-2">
-          <Button type="button" variant="outline" onClick={handleChooseFile}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleChooseFile}
+            disabled={isReadingLayers || source.isSubmitting}
+          >
             <FileUp className="mr-2 h-3.5 w-3.5" />
             {t("addData.common.chooseFile")}
           </Button>
@@ -221,7 +263,7 @@ export function CadSource() {
           </Label>
           <Select
             id="cad-layer"
-            value={selectedLayer}
+            value={selectedLayer ?? ""}
             disabled={isReadingLayers || layers.length === 0}
             onChange={(event) => setSelectedLayer(event.target.value)}
           >

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
@@ -1,0 +1,249 @@
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import { FileUp, Layers } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  type CadLayerInfo,
+  type DuckDbVectorFile,
+  loadDuckDbVectorFile,
+  readCadLayers,
+} from "../../../../lib/duckdb-vector-loader";
+import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
+import { CAD_CRS_PRESETS } from "../constants";
+import {
+  createBaseLayer,
+  errorMessage,
+  fileNameFromPath,
+  layerNameFromPath,
+} from "../helpers";
+import { AddDataSourceForm, useAddDataSource } from "../shared";
+
+interface SelectedCadFile {
+  path: string;
+  data: ArrayBuffer;
+}
+
+/** The file extension (lowercased, no dot) of a path, or "" when it has none. */
+function extensionFromPath(path: string): string {
+  const match = /\.([^.\\/]+)$/.exec(fileNameFromPath(path));
+  return match ? match[1].toLowerCase() : "";
+}
+
+/**
+ * Normalize a user-entered CRS into the `AUTHORITY:CODE` form `ST_Transform`
+ * expects: a bare number becomes `EPSG:<n>`, an `epsg:4326` is upper-cased, and
+ * an already-qualified `ESRI:102100` passes through. A blank stays blank (load
+ * the drawing as-is, i.e. assume it is already in lon/lat).
+ */
+function normalizeCrs(raw: string): string {
+  const value = raw.trim();
+  if (!value) return "";
+  if (/^\d+$/.test(value)) return `EPSG:${value}`;
+  return value.toUpperCase();
+}
+
+/** True when DuckDB rejected the layer's geometry (mixed / Geometry Collection). */
+function isUnsupportedGeometryError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /unsupported geometry type/i.test(message);
+}
+
+/**
+ * Add Data source for AutoCAD DXF/DWG drawings. CAD files carry no coordinate
+ * reference system and are usually multi-layer, so this dialog lets the user
+ * pick which OGR layer to load and declare its source CRS; the geometry is read
+ * with DuckDB-WASM's GDAL `CAD`/`DXF` driver and reprojected to WGS84.
+ */
+export function CadSource() {
+  const { t } = useTranslation();
+  const [defaultName] = useState(() => t("addData.cad.defaultName"));
+  const source = useAddDataSource(defaultName);
+  const [selectedFile, setSelectedFile] = useState<SelectedCadFile | null>(
+    null,
+  );
+  const [layers, setLayers] = useState<CadLayerInfo[]>([]);
+  const [selectedLayer, setSelectedLayer] = useState("");
+  const [crs, setCrs] = useState("");
+  const [isReadingLayers, setIsReadingLayers] = useState(false);
+
+  // `registerFileBuffer` transfers the bytes to the DuckDB worker, which
+  // detaches the backing ArrayBuffer. The file is read twice (the layer probe,
+  // then the load), so hand DuckDB a fresh copy each time (`slice(0)`) and keep
+  // the original intact for the next call.
+  const buildVectorFile = (file: SelectedCadFile): DuckDbVectorFile => ({
+    name: fileNameFromPath(file.path),
+    extension: extensionFromPath(file.path),
+    data: new Uint8Array(file.data.slice(0)),
+  });
+
+  const handleChooseFile = async () => {
+    source.setError(null);
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [
+          { name: t("addData.cad.fileFilter"), extensions: ["dxf", "dwg"] },
+        ],
+        accept: ".dxf,.dwg",
+        readBinary: true,
+      });
+      if (!result) return;
+      if (!result.data) throw new Error(t("addData.cad.readError"));
+      const file: SelectedCadFile = { path: result.path, data: result.data };
+      setSelectedFile(file);
+      setLayers([]);
+      setSelectedLayer("");
+      source.setLayerName((current) =>
+        current.trim() && current !== defaultName
+          ? current
+          : layerNameFromPath(result.path, defaultName),
+      );
+
+      // Read the CAD layer list up front so the picker is populated before the
+      // user submits (DXF has a single `entities` layer; DWG is multi-layer).
+      setIsReadingLayers(true);
+      try {
+        const cadLayers = await readCadLayers(buildVectorFile(file));
+        if (cadLayers.length === 0) {
+          throw new Error(t("addData.cad.errorNoLayers"));
+        }
+        setLayers(cadLayers);
+        setSelectedLayer(cadLayers[0].name);
+      } finally {
+        setIsReadingLayers(false);
+      }
+    } catch (err) {
+      source.setError(errorMessage(err, t("addData.cad.readError")));
+    }
+  };
+
+  const handleSubmit = source.runSubmit(async () => {
+    if (!selectedFile) throw new Error(t("addData.cad.errorChooseFile"));
+    if (!selectedLayer) throw new Error(t("addData.cad.errorNoLayer"));
+
+    const name = source.layerName.trim() || defaultName;
+    const overrideSourceCrs = normalizeCrs(crs);
+
+    let featureCollection;
+    try {
+      featureCollection = await loadDuckDbVectorFile(
+        buildVectorFile(selectedFile),
+        { layer: selectedLayer, overrideSourceCrs },
+      );
+    } catch (err) {
+      if (isUnsupportedGeometryError(err)) {
+        throw new Error(t("addData.cad.errorUnsupportedGeometry"));
+      }
+      throw err;
+    }
+
+    source.addAndClose(
+      {
+        ...createBaseLayer(
+          name,
+          "geojson",
+          { type: "geojson" },
+          {
+            sourceKind: "cad",
+            cadLayer: selectedLayer,
+            sourceCrs: overrideSourceCrs || null,
+            featureCount: featureCollection.features.length,
+          },
+        ),
+        geojson: featureCollection,
+        sourcePath: selectedFile.path,
+      },
+      { fit: true },
+    );
+  });
+
+  return (
+    <AddDataSourceForm
+      layerName={source.layerName}
+      onLayerNameChange={source.setLayerName}
+      beforeLayerId={source.beforeLayerId}
+      onBeforeLayerIdChange={source.setBeforeLayerId}
+      onSubmit={handleSubmit}
+      error={source.error}
+      submitDisabled={
+        source.isSubmitting ||
+        isReadingLayers ||
+        !selectedFile ||
+        !selectedLayer
+      }
+    >
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" variant="outline" onClick={handleChooseFile}>
+            <FileUp className="mr-2 h-3.5 w-3.5" />
+            {t("addData.common.chooseFile")}
+          </Button>
+          <span className="min-w-0 truncate text-xs text-muted-foreground">
+            {selectedFile
+              ? fileNameFromPath(selectedFile.path)
+              : t("addData.common.noFileSelected")}
+          </span>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="cad-layer">
+            <Layers className="mr-1 inline h-3.5 w-3.5 align-text-bottom" />
+            {t("addData.cad.layer")}
+          </Label>
+          <Select
+            id="cad-layer"
+            value={selectedLayer}
+            disabled={isReadingLayers || layers.length === 0}
+            onChange={(event) => setSelectedLayer(event.target.value)}
+          >
+            {layers.length === 0 ? (
+              <option value="">
+                {isReadingLayers
+                  ? t("addData.cad.readingLayers")
+                  : t("addData.cad.layerPlaceholder")}
+              </option>
+            ) : (
+              layers.map((layer) => (
+                <option key={layer.name} value={layer.name}>
+                  {t("addData.cad.layerOption", {
+                    name: layer.name || "(unnamed)",
+                    type: layer.geometryType || "?",
+                    count: layer.featureCount,
+                  })}
+                </option>
+              ))
+            )}
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="cad-crs">{t("addData.cad.crs")}</Label>
+          <Input
+            id="cad-crs"
+            placeholder={t("addData.cad.crsPlaceholder")}
+            value={crs}
+            onChange={(event) => setCrs(event.target.value)}
+          />
+          <Select
+            aria-label={t("addData.cad.crsPresetLabel")}
+            value=""
+            onChange={(event) => {
+              if (event.target.value) setCrs(event.target.value);
+            }}
+          >
+            <option value="" disabled>
+              {t("addData.cad.crsPresetLabel")}
+            </option>
+            {CAD_CRS_PRESETS.map((preset) => (
+              <option key={preset.value} value={preset.value}>
+                {preset.label}
+              </option>
+            ))}
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {t("addData.cad.crsHelp")}
+          </p>
+        </div>
+      </div>
+    </AddDataSourceForm>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
@@ -9,14 +9,18 @@ import {
   readCadLayers,
 } from "../../../../lib/duckdb-vector-loader";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
-import { CAD_CRS_PRESETS } from "../constants";
+import { CAD_CRS_PRESETS, CAD_SAMPLES } from "../constants";
 import {
   createBaseLayer,
   errorMessage,
   fileNameFromPath,
   layerNameFromPath,
 } from "../helpers";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import {
+  AddDataSourceForm,
+  SampleDataSelect,
+  useAddDataSource,
+} from "../shared";
 
 interface SelectedCadFile {
   path: string;
@@ -76,6 +80,34 @@ export function CadSource() {
     data: new Uint8Array(file.data.slice(0)),
   });
 
+  // Shared by the file picker and the sample loader: stash the bytes, default
+  // the layer name, then read the CAD layer list up front so the picker is
+  // populated before the user submits (DXF has a single `entities` layer; DWG
+  // is multi-layer).
+  const applyCadBytes = async (path: string, data: ArrayBuffer) => {
+    const file: SelectedCadFile = { path, data };
+    setSelectedFile(file);
+    setLayers([]);
+    setSelectedLayer("");
+    source.setLayerName((current) =>
+      current.trim() && current !== defaultName
+        ? current
+        : layerNameFromPath(path, defaultName),
+    );
+
+    setIsReadingLayers(true);
+    try {
+      const cadLayers = await readCadLayers(buildVectorFile(file));
+      if (cadLayers.length === 0) {
+        throw new Error(t("addData.cad.errorNoLayers"));
+      }
+      setLayers(cadLayers);
+      setSelectedLayer(cadLayers[0].name);
+    } finally {
+      setIsReadingLayers(false);
+    }
+  };
+
   const handleChooseFile = async () => {
     source.setError(null);
     try {
@@ -88,31 +120,29 @@ export function CadSource() {
       });
       if (!result) return;
       if (!result.data) throw new Error(t("addData.cad.readError"));
-      const file: SelectedCadFile = { path: result.path, data: result.data };
-      setSelectedFile(file);
-      setLayers([]);
-      setSelectedLayer("");
-      source.setLayerName((current) =>
-        current.trim() && current !== defaultName
-          ? current
-          : layerNameFromPath(result.path, defaultName),
-      );
-
-      // Read the CAD layer list up front so the picker is populated before the
-      // user submits (DXF has a single `entities` layer; DWG is multi-layer).
-      setIsReadingLayers(true);
-      try {
-        const cadLayers = await readCadLayers(buildVectorFile(file));
-        if (cadLayers.length === 0) {
-          throw new Error(t("addData.cad.errorNoLayers"));
-        }
-        setLayers(cadLayers);
-        setSelectedLayer(cadLayers[0].name);
-      } finally {
-        setIsReadingLayers(false);
-      }
+      await applyCadBytes(result.path, result.data);
     } catch (err) {
       source.setError(errorMessage(err, t("addData.cad.readError")));
+    }
+  };
+
+  const handleSelectSample = async (sample: (typeof CAD_SAMPLES)[number]) => {
+    source.setError(null);
+    setIsReadingLayers(true); // cover the fetch too, not just the layer read
+    try {
+      const response = await fetch(sample.url);
+      if (!response.ok) {
+        throw new Error(
+          t("addData.common.requestFailed", { status: response.status }),
+        );
+      }
+      const data = await response.arrayBuffer();
+      setCrs(sample.crs);
+      await applyCadBytes(sample.url.split("/").pop() || "sample.dxf", data);
+    } catch (err) {
+      source.setError(errorMessage(err, t("addData.cad.readError")));
+    } finally {
+      setIsReadingLayers(false);
     }
   };
 
@@ -243,6 +273,14 @@ export function CadSource() {
             {t("addData.cad.crsHelp")}
           </p>
         </div>
+
+        <SampleDataSelect
+          samples={CAD_SAMPLES.map((sample) => ({
+            label: sample.label,
+            value: sample,
+          }))}
+          onSelect={handleSelectSample}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -10,6 +10,7 @@ export type AddDataKind =
   | "gpx"
   | "georss"
   | "delimited-text"
+  | "cad"
   | "photos"
   | "mbtiles"
   | "arcgis"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -59,6 +59,7 @@ export function AddDataMenu({
     vector: { onSelect: addLayer.vector },
     raster: { onSelect: addLayer.raster },
     "delimited-text": { onSelect: () => onSetAddDataKind("delimited-text") },
+    cad: { onSelect: () => onSetAddDataKind("cad") },
     photos: { onSelect: () => onSetAddDataKind("photos") },
     gpx: { onSelect: () => onSetAddDataKind("gpx") },
     mbtiles: { onSelect: () => onSetAddDataKind("mbtiles") },

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -104,6 +104,7 @@ export const ADD_DATA_KIND_COMMANDS: Array<{
   titleKey: ParseKeys;
 }> = [
   { kind: "delimited-text", titleKey: "toolbar.layerType.delimitedText" },
+  { kind: "cad", titleKey: "toolbar.item.cadLayer" },
   { kind: "gpx", titleKey: "toolbar.layerType.gpx" },
   { kind: "mbtiles", titleKey: "toolbar.layerType.mbtiles" },
   { kind: "xyz", titleKey: "toolbar.layerType.xyz" },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -126,6 +126,10 @@
         "label": "Add Delimited Text Layer",
         "description": "Add a delimited text file or URL as a point layer using longitude and latitude fields."
       },
+      "cad": {
+        "label": "Add CAD (DXF/DWG) Layer",
+        "description": "Add an AutoCAD DXF or DWG drawing as a vector layer, choosing which layer to load and the coordinate reference system to project it from."
+      },
       "photos": {
         "label": "Add Geotagged Photos",
         "description": "Import JPEG/HEIC photos as a point layer, placing each one from its EXIF GPS location."
@@ -282,6 +286,23 @@
       "url": "GeoRSS URL",
       "file": "GeoRSS file",
       "urlPlaceholder": "https://example.com/feed.atom"
+    },
+    "cad": {
+      "defaultName": "CAD Layer",
+      "fileFilter": "CAD (DXF/DWG)",
+      "layer": "CAD layer",
+      "layerPlaceholder": "Choose a CAD file first",
+      "readingLayers": "Reading layers...",
+      "layerOption": "{{name}} ({{type}}, {{count}} features)",
+      "crs": "Source CRS",
+      "crsPlaceholder": "e.g. EPSG:26915",
+      "crsPresetLabel": "Common coordinate systems...",
+      "crsHelp": "Leave blank if the drawing is already in longitude/latitude (WGS84). Otherwise enter the EPSG code of the drawing's coordinate system to reproject it.",
+      "readError": "Could not read this CAD file.",
+      "errorNoLayers": "No layers were found in this CAD file.",
+      "errorChooseFile": "Choose a CAD (DXF/DWG) file first.",
+      "errorNoLayer": "Select a CAD layer to load.",
+      "errorUnsupportedGeometry": "This CAD layer contains mixed or collection geometry that cannot be displayed. Try another layer."
     },
     "delimitedText": {
       "defaultName": "Delimited Text Layer",
@@ -1475,6 +1496,7 @@
       "sectionDatabases": "Databases",
       "georeferencing": "Georeferencing",
       "vectorLayer": "Vector Layer",
+      "cadLayer": "CAD (DXF/DWG) Layer",
       "rasterLayer": "Raster Layer",
       "osmPbfLayer": "OSM PBF Layer",
       "stacLayer": "STAC Layer",

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
@@ -43,6 +43,10 @@ export interface DuckDbVectorLoadOptions {
    * several layers) by passing its name to `ST_Read(..., layer=...)`. When
    * omitted, `ST_Read` reads the first layer, matching its default. Ignored for
    * Parquet sources, which have no layer concept.
+   *
+   * Note: this selects which geometry is read, not which layer's CRS is
+   * discovered — `readSourceCrs` always inspects the first layer. Callers that
+   * need a non-first layer's CRS must supply {@link overrideSourceCrs}.
    */
   layer?: string;
   /**

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
@@ -38,6 +38,21 @@ export interface DuckDbVectorLoadOptions {
    * single-pass (the extra `COUNT(*)` is only run when a guard is attached).
    */
   onLargeDataset?: (dataset: LargeVectorDataset) => boolean | Promise<boolean>;
+  /**
+   * Read a specific OGR layer from a multi-layer source (e.g. a CAD DWG with
+   * several layers) by passing its name to `ST_Read(..., layer=...)`. When
+   * omitted, `ST_Read` reads the first layer, matching its default. Ignored for
+   * Parquet sources, which have no layer concept.
+   */
+  layer?: string;
+  /**
+   * Treat the source geometry as this CRS (an `AUTHORITY:CODE` string such as
+   * `EPSG:26915`) and reproject it to WGS84, overriding any CRS read from the
+   * file. Used for formats that carry no CRS metadata of their own (CAD
+   * DXF/DWG), where the user supplies the coordinate system. A blank value
+   * falls back to the file's own CRS.
+   */
+  overrideSourceCrs?: string;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -204,12 +204,19 @@ async function registerVectorFileBuffers(
   }
 }
 
-function sourceSql(fileName: string, extension: string): string {
+function sourceSql(
+  fileName: string,
+  extension: string,
+  layer?: string,
+): string {
   const quotedName = quoteSqlString(fileName);
   if (isParquetExtension(extension)) {
     return `SELECT * FROM read_parquet(${quotedName})`;
   }
-  return `SELECT * FROM ST_Read(${quotedName})`;
+  // A named layer targets one OGR layer in a multi-layer source (CAD DWG); the
+  // default (no layer=) reads the first layer.
+  const layerArg = layer ? `, layer=${quoteSqlString(layer)}` : "";
+  return `SELECT * FROM ST_Read(${quotedName}${layerArg})`;
 }
 
 /**
@@ -408,7 +415,7 @@ export async function loadDuckDbVectorFile(
       parquetWarmUp(connection, file.extension, file.name),
     );
 
-    const sql = sourceSql(file.name, file.extension);
+    const sql = sourceSql(file.name, file.extension, options.layer);
     const description = rowsFromResult(
       await connection.query(`DESCRIBE ${sql}`),
     );
@@ -426,7 +433,11 @@ export async function loadDuckDbVectorFile(
       await confirmLargeDataset({ name: file.name, featureCount }, options.onLargeDataset);
     }
 
-    const sourceCrs = await readSourceCrs(connection, file);
+    // A caller-supplied CRS (CAD DXF/DWG, which carry none of their own) wins
+    // over the file's metadata; a blank override falls back to the file's CRS.
+    const sourceCrs =
+      options.overrideSourceCrs?.trim() ||
+      (await readSourceCrs(connection, file));
     const geometryJsonSql = geometryGeoJsonSql(
       geometryExpr(detected),
       sourceCrs,
@@ -439,6 +450,60 @@ export async function loadDuckDbVectorFile(
     // Features may carry a null geometry; the app's layer model treats them as
     // a regular FeatureCollection and the map ignores null geometries.
     return toFeatureCollection(rowsFromResult(result)) as FeatureCollection;
+  } finally {
+    await connection.close();
+  }
+}
+
+/** One OGR layer in a multi-layer source, as reported by `ST_Read_Meta`. */
+export interface CadLayerInfo {
+  /** The OGR layer name, passed to `ST_Read(..., layer=...)` to read it. */
+  name: string;
+  /** Feature count GDAL reports for the layer. */
+  featureCount: number;
+  /** The layer's first geometry field type (e.g. `Line String`), or "". */
+  geometryType: string;
+}
+
+/**
+ * List the OGR layers in a CAD (DXF/DWG) file via `ST_Read_Meta`, so the Add CAD
+ * Layer dialog can let the user choose which one to load. DXF exposes a single
+ * `entities` layer; DWG drawings are usually multi-layer. The reported layers
+ * include ones whose geometry `ST_Read` cannot decode (e.g. Geometry
+ * Collection); the load surfaces that per-layer rather than hiding the layer
+ * here, since the count and type are still useful context.
+ *
+ * @param file The CAD file (bytes + name + extension) to inspect.
+ * @returns One {@link CadLayerInfo} per layer, in the file's layer order.
+ */
+export async function readCadLayers(
+  file: DuckDbVectorFile,
+): Promise<CadLayerInfo[]> {
+  const db = await getDatabase();
+  const connection = await db.connect();
+  try {
+    await registerVectorFileBuffers(db, file);
+    await ensureSpatialExtension(connection);
+    const rows = rowsFromResult(
+      await connection.query(
+        `SELECT
+           l.name AS name,
+           l.feature_count AS feature_count,
+           l.geometry_fields[1].type AS geom_type
+         FROM (
+           SELECT UNNEST(layers) AS l
+           FROM ST_Read_Meta(${quoteSqlString(file.name)})
+         )`,
+      ),
+    );
+    return rows.map((row) => ({
+      name: String(row.name ?? ""),
+      featureCount:
+        typeof row.feature_count === "bigint"
+          ? Number(row.feature_count)
+          : Number(row.feature_count ?? 0),
+      geometryType: typeof row.geom_type === "string" ? row.geom_type : "",
+    }));
   } finally {
     await connection.close();
   }

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -250,9 +250,13 @@ function parquetWarmUp(
 function crsSql(fileName: string): string {
   return `
     SELECT
-      -- Always reads the first layer's first geometry field. This matches
-      -- ST_Read's default (no layer= argument) but would be wrong for
-      -- multi-layer or multi-geometry-column files if layer selection is added.
+      -- Always reads the FIRST layer's first geometry field, regardless of the
+      -- loader's \`layer\` option: that option selects which geometry ST_Read
+      -- materializes, not which layer CRS is discovered here. The two formats
+      -- that use a non-first layer (CAD DXF/DWG) carry no embedded CRS, so this
+      -- returns null for them anyway and the user-supplied \`overrideSourceCrs\`
+      -- drives reprojection instead. A future multi-layer format that DOES embed
+      -- per-layer CRS would need this query to look the chosen layer up by name.
       layers[1].geometry_fields[1].crs.auth_name AS auth_name,
       layers[1].geometry_fields[1].crs.auth_code AS auth_code
     FROM ST_Read_Meta(${quoteSqlString(fileName)})
@@ -505,6 +509,12 @@ export async function readCadLayers(
       geometryType: typeof row.geom_type === "string" ? row.geom_type : "",
     }));
   } finally {
+    // Release the probe's file buffer so the worker does not hold a second copy
+    // while the subsequent loadDuckDbVectorFile re-registers the same name.
+    await dropFilesIfPresent(db, [
+      file.name,
+      ...(file.siblingFiles?.map((sibling) => sibling.name) ?? []),
+    ]);
     await connection.close();
   }
 }

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -86,6 +86,7 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   { id: "vector", section: "files", labelKey: "toolbar.item.vectorLayer", tier: "basic" },
   { id: "raster", section: "files", labelKey: "toolbar.item.rasterLayer", tier: "basic" },
   { id: "delimited-text", section: "files", labelKey: "toolbar.layerType.delimitedText", tier: "basic" },
+  { id: "cad", section: "files", labelKey: "toolbar.item.cadLayer", tier: "intermediate" },
   { id: "photos", section: "files", labelKey: "toolbar.layerType.photos", tier: "intermediate" },
   { id: "gpx", section: "files", labelKey: "toolbar.layerType.gpx", tier: "intermediate" },
   { id: "mbtiles", section: "files", labelKey: "toolbar.layerType.mbtiles", tier: "basic" },


### PR DESCRIPTION
## Summary

Adds a dedicated **CAD (DXF/DWG) Layer** entry to the Add Data menu for loading AutoCAD DXF and DWG drawings, with the coordinate-system support these formats need.

CAD files carry **no CRS** of their own and are usually **multi-layer**, which the generic Add Vector Layer path does not handle. This new source addresses both:

- **Layer picker** - lists the file's OGR layers (name, geometry type, feature count) via a new `readCadLayers()` helper over `ST_Read_Meta`, and lets the user choose which one to load.
- **Source CRS** - a free-text EPSG field (`EPSG:26915` or a bare `26915`) plus a dropdown of common presets (WGS 84, Web Mercator, NAD83/UTM, British National Grid, ...). The geometry is reprojected to WGS84 with `ST_Transform`; leaving it blank loads the drawing as-is (assumes lon/lat).
- **Graceful errors** - a layer whose geometry DuckDB cannot decode (e.g. a Geometry Collection) surfaces a friendly "try another layer" message instead of a raw WKB error.

Loading goes through DuckDB-WASM's GDAL `CAD`/`DXF` driver, which the bundled build already ships.

## Implementation

- `duckdb-vector-loader.ts`: new `readCadLayers()` + `CadLayerInfo`; `sourceSql()` accepts a `layer` argument (`ST_Read(..., layer=...)`); `loadDuckDbVectorFile` honours `overrideSourceCrs`.
- `duckdb-vector-guard.ts`: `DuckDbVectorLoadOptions` gains `layer` and `overrideSourceCrs`.
- `CadSource.tsx`: the new dialog body (file picker, layer select, CRS field + presets).
- Wiring: `AddDataKind`/`KIND_I18N_KEY`/`DATA_SOURCE_CATALOG`/`AddDataMenu`/`ADD_DATA_KIND_COMMANDS`/`AddDataDialog`, plus en.json strings.

CAD layers embed their GeoJSON in the project (like the Delimited Text file mode), so they restore from the embedded data rather than re-reading the path (which would drop the chosen layer and CRS).

## Verification

Drove the real app with Playwright + real data:

- Menu item appears; dialog opens; DXF/DWG file picker works.
- **CRS round-trip:** built a DXF whose coordinates are EPSG:3857 meters from known WGS84 cities (SF/LA/NYC), loaded it via the dialog with `CRS = EPSG:3857`, and the resulting layer coordinates matched the original lon/lat **exactly** (`[-122.4194, 37.7749]`, `[-118.2437, 34.0522]`, `[-74.006, 40.7128]`).
- **Multi-layer DWG:** real AutoCAD 2000 DWG enumerated both layers (`0` = 2 LineStrings, `Tavolo 1` = 4 Geometry Collection); layer `0` loaded; the Geometry Collection layer surfaced the friendly error.
- `npm run test:frontend` (1664 passing), eslint clean, and the app type-checks clean (the only `tsc` errors are pre-existing, in untouched `map-controller.ts`/`maplibre-basemap-control.ts` from the upstream maplibre-gl package mismatch).

> Note: in this dev environment the map canvas shows "Map failed to render" due to that same pre-existing `refreshStyleEditor` upstream mismatch; it is unrelated to this change (layers still load into the store).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding CAD drawings (DXF/DWG) as a new data source.
  * Users can choose a CAD file or sample, view available layers, and optionally set/override CRS.
  * Added CAD-specific UI flows, toolbar/menu entries, and new localized text.
  * Introduced automatic layer probing for CAD imports to preselect a layer.

* **Bug Fixes**
  * Improved CAD import error handling with clearer messaging for unsupported geometries and missing/empty layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->