### PR TITLE
fix(vector): load desktop files with native DuckDB

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -10,11 +10,24 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -69,6 +82,175 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +301,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -150,7 +332,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -176,7 +358,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -220,6 +402,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -277,6 +468,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +508,30 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -342,6 +569,28 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -432,12 +681,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -503,12 +760,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -593,6 +881,34 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -862,6 +1178,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
+name = "duckdb"
+version = "1.10504.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1363,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1084,6 +1419,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1283,6 +1624,8 @@ dependencies = [
 name = "geolibre-desktop"
 version = "1.8.0"
 dependencies = [
+ "chrono",
+ "duckdb",
  "flate2",
  "getrandom 0.2.17",
  "reqwest 0.12.28",
@@ -1295,7 +1638,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -1487,10 +1830,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1498,7 +1856,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -1523,6 +1881,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1937,6 +2304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2365,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2461,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10504.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip 6.0.0",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2486,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2055,6 +2512,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2194,10 +2657,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2206,6 +2697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2651,7 +3143,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2758,6 +3250,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +3307,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2843,13 +3355,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2859,7 +3398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2945,6 +3493,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -3059,6 +3616,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3067,9 +3653,26 @@ dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3089,6 +3692,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3096,7 +3712,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3212,6 +3828,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
@@ -3446,6 +4068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,6 +4186,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,6 +4230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3678,6 +4328,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3998,7 +4654,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4081,6 +4737,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4446,6 +5111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,6 +5267,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -5423,6 +6095,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,7 +6131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5498,7 +6179,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
@@ -5633,6 +6314,26 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
+duckdb = { version = "1.10504.0", features = ["bundled", "parquet"] }
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 flate2 = "1"
 tar = "0.4"

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod earth_engine_oauth;
+mod native_duckdb;
 
 use earth_engine_oauth::{
     poll_earth_engine_oauth, start_earth_engine_oauth, EarthEngineOAuthState,
@@ -176,9 +177,11 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             close_oauth_popups,
+            native_duckdb::count_native_vector_file_features,
             ensure_martin_binary,
             fetch_url_bytes,
             install_external_plugin_archive,
+            native_duckdb::load_native_vector_file,
             load_external_plugin_bundles,
             read_admin_profile,
             read_local_file,
@@ -250,7 +253,7 @@ const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
 /// byte-oriented rather than `std::path` based so they behave identically for the
 /// Windows-style paths a project may carry regardless of the host the binary
 /// runs on.
-fn is_allowed_local_vector_path(path: &str) -> bool {
+pub(crate) fn is_allowed_local_vector_path(path: &str) -> bool {
     let bytes = path.as_bytes();
     let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
 

--- a/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
+++ b/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
@@ -201,8 +201,8 @@ fn ensure_spatial_extension(conn: &Connection) -> Result<(), String> {
         return Ok(());
     }
 
-    conn.execute_batch("INSTALL spatial; LOAD spatial;")
-        .map_err(|error| format!("Could not install/load DuckDB spatial extension: {error}"))
+    conn.execute_batch("LOAD spatial;")
+        .map_err(|error| format!("Could not load DuckDB spatial extension: {error}"))
 }
 
 fn trusted_spatial_extension_path() -> Result<Option<String>, String> {
@@ -579,7 +579,7 @@ mod tests {
 
     fn create_real_geoparquet(path: &str) {
         let conn = Connection::open_in_memory().expect("open DuckDB");
-        ensure_spatial_extension(&conn).expect("load spatial");
+        install_spatial_extension_for_tests(&conn).expect("load spatial");
         conn.execute_batch(&format!(
             "
             CREATE TABLE places AS
@@ -591,6 +591,11 @@ mod tests {
             quote_sql_string(path)
         ))
         .expect("write GeoParquet fixture");
+    }
+
+    fn install_spatial_extension_for_tests(conn: &Connection) -> Result<(), String> {
+        conn.execute_batch("INSTALL spatial; LOAD spatial;")
+            .map_err(|error| format!("Could not install/load DuckDB spatial extension: {error}"))
     }
 
     #[test]

--- a/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
+++ b/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
@@ -1,0 +1,537 @@
+use chrono::{Duration, NaiveDate, NaiveTime, SecondsFormat, TimeZone, Utc};
+use duckdb::{
+    types::{TimeUnit, Value, ValueRef},
+    Connection, Row,
+};
+use serde_json::{json, Map};
+use std::path::Path;
+
+const GEOMETRY_JSON_COLUMN: &str = "__geolibre_geometry_geojson";
+const FEATURE_COUNT_COLUMN: &str = "__geolibre_feature_count";
+const TARGET_CRS: &str = "EPSG:4326";
+const WKB_GEOMETRY_COLUMN_NAMES: [&str; 6] = [
+    "geometry",
+    "geom",
+    "wkb_geometry",
+    "geometry_wkb",
+    "geom_wkb",
+    "wkb",
+];
+
+#[derive(Clone)]
+struct NativeVectorOptions {
+    path: String,
+    extension: String,
+    layer: Option<String>,
+    override_source_crs: Option<String>,
+    spatial_extension_path: Option<String>,
+}
+
+#[derive(Debug)]
+struct DetectedGeometry {
+    column: String,
+    is_wkb: bool,
+}
+
+#[derive(Debug)]
+struct DescribedColumn {
+    name: String,
+    column_type: String,
+}
+
+#[tauri::command]
+pub async fn count_native_vector_file_features(
+    path: String,
+    layer: Option<String>,
+    spatial_extension_path: Option<String>,
+) -> Result<usize, String> {
+    let options = native_options(path, layer, None, spatial_extension_path)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        count_native_vector_file_features_blocking(options)
+    })
+    .await
+    .map_err(|error| format!("Native DuckDB count task failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn load_native_vector_file(
+    path: String,
+    layer: Option<String>,
+    override_source_crs: Option<String>,
+    spatial_extension_path: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let options = native_options(path, layer, override_source_crs, spatial_extension_path)?;
+    tauri::async_runtime::spawn_blocking(move || load_native_vector_file_blocking(options))
+        .await
+        .map_err(|error| format!("Native DuckDB load task failed: {error}"))?
+}
+
+fn native_options(
+    path: String,
+    layer: Option<String>,
+    override_source_crs: Option<String>,
+    spatial_extension_path: Option<String>,
+) -> Result<NativeVectorOptions, String> {
+    if !crate::is_allowed_local_vector_path(&path) {
+        return Err(format!(
+            "Refusing to read \"{path}\": not an absolute local vector file path"
+        ));
+    }
+    Ok(NativeVectorOptions {
+        extension: vector_extension(&path),
+        path,
+        layer: blank_to_none(layer),
+        override_source_crs: blank_to_none(override_source_crs),
+        spatial_extension_path: blank_to_none(spatial_extension_path),
+    })
+}
+
+fn blank_to_none(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn vector_extension(path: &str) -> String {
+    let name = Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path)
+        .to_ascii_lowercase();
+    if name.ends_with(".geoparquet") {
+        "geoparquet".to_string()
+    } else {
+        Path::new(&name)
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .unwrap_or("")
+            .to_string()
+    }
+}
+
+fn count_native_vector_file_features_blocking(
+    options: NativeVectorOptions,
+) -> Result<usize, String> {
+    let conn = open_native_duckdb(&options)?;
+    let sql = source_sql(&options);
+    let count_sql = format!(
+        "SELECT count(*) AS {} FROM ({sql}) AS data",
+        quote_identifier(FEATURE_COUNT_COLUMN)
+    );
+    conn.query_row(&count_sql, [], |row| row.get::<_, i64>(0))
+        .map(|count| count.max(0) as usize)
+        .map_err(|error| format!("Could not count vector features with native DuckDB: {error}"))
+}
+
+fn load_native_vector_file_blocking(
+    options: NativeVectorOptions,
+) -> Result<serde_json::Value, String> {
+    let conn = open_native_duckdb(&options)?;
+    let sql = source_sql(&options);
+    let columns = describe_source_columns(&conn, &sql)?;
+    let detected = detect_geometry_column(&columns)?;
+    let property_columns: Vec<String> = columns
+        .iter()
+        .filter(|column| column.name != detected.column)
+        .map(|column| column.name.clone())
+        .collect();
+    let source_crs = match options.override_source_crs.clone() {
+        Some(crs) => Some(crs),
+        None => read_source_crs(&conn, &options),
+    };
+    let geometry_json_sql = geometry_geojson_sql(&geometry_expr(&detected), source_crs.as_deref());
+    let mut select_columns: Vec<String> = property_columns
+        .iter()
+        .map(|column| quote_identifier(column))
+        .collect();
+    select_columns.push(format!(
+        "{geometry_json_sql} AS {}",
+        quote_identifier(GEOMETRY_JSON_COLUMN)
+    ));
+    let load_sql = format!("SELECT {} FROM ({sql}) AS data", select_columns.join(", "));
+
+    let mut stmt = conn
+        .prepare(&load_sql)
+        .map_err(|error| format!("Could not prepare native DuckDB vector query: {error}"))?;
+    let mut column_names = property_columns;
+    column_names.push(GEOMETRY_JSON_COLUMN.to_string());
+    let mut rows = stmt
+        .query([])
+        .map_err(|error| format!("Could not read vector rows with native DuckDB: {error}"))?;
+    let mut features = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| format!("Could not read vector row with native DuckDB: {error}"))?
+    {
+        features.push(row_to_feature(row, &column_names)?);
+    }
+    Ok(json!({
+        "type": "FeatureCollection",
+        "features": features,
+    }))
+}
+
+fn open_native_duckdb(options: &NativeVectorOptions) -> Result<Connection, String> {
+    let conn = Connection::open_in_memory()
+        .map_err(|error| format!("Could not open native DuckDB: {error}"))?;
+    let _ = conn.execute_batch("LOAD parquet;");
+    ensure_spatial_extension(&conn, options.spatial_extension_path.as_deref())?;
+    Ok(conn)
+}
+
+fn ensure_spatial_extension(
+    conn: &Connection,
+    spatial_extension_path: Option<&str>,
+) -> Result<(), String> {
+    if let Some(path) = spatial_extension_path {
+        conn.execute_batch(&format!(
+            "LOAD {}",
+            quote_sql_string(&path.replace('\\', "/"))
+        ))
+        .map_err(|error| {
+            format!("Could not load DuckDB spatial extension from \"{path}\": {error}")
+        })?;
+        return Ok(());
+    }
+
+    conn.execute_batch("INSTALL spatial; LOAD spatial;")
+        .map_err(|error| format!("Could not install/load DuckDB spatial extension: {error}"))
+}
+
+fn is_parquet_extension(extension: &str) -> bool {
+    extension == "parquet" || extension == "geoparquet"
+}
+
+fn source_sql(options: &NativeVectorOptions) -> String {
+    let quoted_path = quote_sql_string(&options.path.replace('\\', "/"));
+    if is_parquet_extension(&options.extension) {
+        return format!("SELECT * FROM read_parquet({quoted_path})");
+    }
+    let layer_arg = options
+        .layer
+        .as_ref()
+        .map(|layer| format!(", layer={}", quote_sql_string(layer)))
+        .unwrap_or_default();
+    format!("SELECT * FROM ST_Read({quoted_path}{layer_arg})")
+}
+
+fn describe_source_columns(conn: &Connection, sql: &str) -> Result<Vec<DescribedColumn>, String> {
+    let describe_sql = format!("DESCRIBE {sql}");
+    let mut stmt = conn
+        .prepare(&describe_sql)
+        .map_err(|error| format!("Could not describe vector source with native DuckDB: {error}"))?;
+    let mut rows = stmt
+        .query([])
+        .map_err(|error| format!("Could not inspect vector columns with native DuckDB: {error}"))?;
+    let mut columns = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| format!("Could not read vector column description: {error}"))?
+    {
+        let column_name: String = row
+            .get(0)
+            .map_err(|error| format!("Could not read described column name: {error}"))?;
+        let column_type: String = row
+            .get(1)
+            .map_err(|error| format!("Could not read described column type: {error}"))?;
+        columns.push(DescribedColumn {
+            name: column_name,
+            column_type,
+        });
+    }
+    Ok(columns)
+}
+
+fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometry, String> {
+    let mut wkb_candidate = None;
+    for column in columns {
+        if column
+            .column_type
+            .to_ascii_uppercase()
+            .starts_with("GEOMETRY")
+        {
+            return Ok(DetectedGeometry {
+                column: column.name.clone(),
+                is_wkb: false,
+            });
+        }
+        let lower_name = column.name.to_ascii_lowercase();
+        let upper_type = column.column_type.to_ascii_uppercase();
+        if (upper_type.starts_with("BLOB")
+            || upper_type.starts_with("BINARY")
+            || upper_type.starts_with("VARBINARY"))
+            && WKB_GEOMETRY_COLUMN_NAMES.contains(&lower_name.as_str())
+        {
+            wkb_candidate = Some(column.name.clone());
+        }
+    }
+
+    if let Some(column) = wkb_candidate {
+        return Ok(DetectedGeometry {
+            column,
+            is_wkb: true,
+        });
+    }
+
+    Err("DuckDB did not find a geometry column in this file.".to_string())
+}
+
+fn read_source_crs(conn: &Connection, options: &NativeVectorOptions) -> Option<String> {
+    if is_parquet_extension(&options.extension) {
+        return None;
+    }
+    let meta_sql = format!(
+        "SELECT layers[1].geometry_fields[1].crs.auth_name AS auth_name, \
+         layers[1].geometry_fields[1].crs.auth_code AS auth_code \
+         FROM ST_Read_Meta({})",
+        quote_sql_string(&options.path.replace('\\', "/"))
+    );
+    conn.query_row(&meta_sql, [], |row| {
+        let auth_name: Option<String> = row.get(0)?;
+        let auth_code: Option<String> = row.get(1)?;
+        Ok((auth_name, auth_code))
+    })
+    .ok()
+    .and_then(|(auth_name, auth_code)| {
+        let auth_name = auth_name?.trim().to_ascii_uppercase();
+        let auth_code = auth_code?.trim().to_string();
+        if auth_name.is_empty() || auth_code.is_empty() {
+            None
+        } else {
+            Some(format!("{auth_name}:{auth_code}"))
+        }
+    })
+}
+
+fn geometry_expr(detected: &DetectedGeometry) -> String {
+    let column = quote_identifier(&detected.column);
+    if detected.is_wkb {
+        format!("ST_GeomFromWKB({column})")
+    } else {
+        column
+    }
+}
+
+fn geometry_geojson_sql(geometry_expression: &str, source_crs: Option<&str>) -> String {
+    match source_crs {
+        Some(source_crs) => format!(
+            "ST_AsGeoJSON(ST_Transform({geometry_expression}, {}, {}, true))",
+            quote_sql_string(source_crs),
+            quote_sql_string(TARGET_CRS)
+        ),
+        None => format!("ST_AsGeoJSON({geometry_expression})"),
+    }
+}
+
+fn row_to_feature(row: &Row<'_>, column_names: &[String]) -> Result<serde_json::Value, String> {
+    let mut properties = Map::new();
+    let mut geometry = serde_json::Value::Null;
+
+    for (index, column_name) in column_names.iter().enumerate() {
+        let value = row.get_ref(index).map_err(|error| {
+            format!("Could not read native DuckDB column \"{column_name}\": {error}")
+        })?;
+        if column_name == GEOMETRY_JSON_COLUMN {
+            geometry = match value {
+                ValueRef::Null => serde_json::Value::Null,
+                ValueRef::Text(bytes) => {
+                    let text = std::str::from_utf8(bytes)
+                        .map_err(|error| format!("Geometry GeoJSON was not UTF-8: {error}"))?;
+                    serde_json::from_str(text)
+                        .map_err(|error| format!("Geometry GeoJSON was invalid: {error}"))?
+                }
+                _ => serde_json::Value::Null,
+            };
+            continue;
+        }
+        if matches!(value, ValueRef::Blob(_)) {
+            continue;
+        }
+        properties.insert(column_name.clone(), duckdb_value_to_json(&value.to_owned()));
+    }
+
+    Ok(json!({
+        "type": "Feature",
+        "geometry": geometry,
+        "properties": properties,
+    }))
+}
+
+fn duckdb_value_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Null => serde_json::Value::Null,
+        Value::Boolean(value) => json!(value),
+        Value::TinyInt(value) => json!(value),
+        Value::SmallInt(value) => json!(value),
+        Value::Int(value) => json!(value),
+        Value::BigInt(value) => json_number_or_string_i128(*value as i128),
+        Value::HugeInt(value) => json_number_or_string_i128(*value),
+        Value::UTinyInt(value) => json!(value),
+        Value::USmallInt(value) => json!(value),
+        Value::UInt(value) => json!(value),
+        Value::UBigInt(value) => json_number_or_string_u128(*value as u128),
+        Value::Float(value) => json!(value),
+        Value::Double(value) => json!(value),
+        Value::Decimal(value) => json!(value.to_string()),
+        Value::Timestamp(unit, value) => json!(format_timestamp(*unit, *value)),
+        Value::Text(value) => json!(value),
+        Value::Blob(_) => serde_json::Value::Null,
+        Value::Date32(value) => json!(format_date32(*value)),
+        Value::Time64(unit, value) => json!(format_time(*unit, *value)),
+        Value::Interval {
+            months,
+            days,
+            nanos,
+        } => json!(format!("{months} months {days} days {nanos} ns")),
+        Value::List(values) | Value::Array(values) => {
+            serde_json::Value::Array(values.iter().map(duckdb_value_to_json).collect())
+        }
+        Value::Enum(value) => json!(value),
+        Value::Struct(values) => {
+            let mut object = Map::new();
+            for (key, value) in values.iter() {
+                object.insert(key.clone(), duckdb_value_to_json(value));
+            }
+            serde_json::Value::Object(object)
+        }
+        Value::Map(values) => {
+            let mut object = Map::new();
+            for (key, value) in values.iter() {
+                object.insert(value_json_key(key), duckdb_value_to_json(value));
+            }
+            serde_json::Value::Object(object)
+        }
+        Value::Union(value) => duckdb_value_to_json(value),
+    }
+}
+
+fn json_number_or_string_i128(value: i128) -> serde_json::Value {
+    if value >= i64::MIN as i128 && value <= i64::MAX as i128 {
+        json!(value as i64)
+    } else {
+        json!(value.to_string())
+    }
+}
+
+fn json_number_or_string_u128(value: u128) -> serde_json::Value {
+    if value <= u64::MAX as u128 {
+        json!(value as u64)
+    } else {
+        json!(value.to_string())
+    }
+}
+
+fn format_timestamp(unit: TimeUnit, value: i64) -> String {
+    let micros = match unit {
+        TimeUnit::Second => value.saturating_mul(1_000_000),
+        TimeUnit::Millisecond => value.saturating_mul(1_000),
+        TimeUnit::Microsecond => value,
+        TimeUnit::Nanosecond => value / 1_000,
+    };
+    let seconds = micros.div_euclid(1_000_000);
+    let nanos = (micros.rem_euclid(1_000_000) as u32).saturating_mul(1_000);
+    Utc.timestamp_opt(seconds, nanos)
+        .single()
+        .map(|datetime| datetime.to_rfc3339_opts(SecondsFormat::Micros, true))
+        .unwrap_or_else(|| format!("{micros}us since 1970-01-01T00:00:00Z"))
+}
+
+fn format_date32(value: i32) -> String {
+    NaiveDate::from_ymd_opt(1970, 1, 1)
+        .and_then(|epoch| epoch.checked_add_signed(Duration::days(value as i64)))
+        .map(|date| date.to_string())
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn format_time(unit: TimeUnit, value: i64) -> String {
+    let micros = match unit {
+        TimeUnit::Second => value.saturating_mul(1_000_000),
+        TimeUnit::Millisecond => value.saturating_mul(1_000),
+        TimeUnit::Microsecond => value,
+        TimeUnit::Nanosecond => value / 1_000,
+    };
+    let seconds = micros.div_euclid(1_000_000);
+    let nanos = (micros.rem_euclid(1_000_000) as u32).saturating_mul(1_000);
+    NaiveTime::from_num_seconds_from_midnight_opt(seconds as u32, nanos)
+        .map(|time| time.format("%H:%M:%S%.6f").to_string())
+        .unwrap_or_else(|| format!("{micros}us"))
+}
+
+fn value_json_key(value: &Value) -> String {
+    match duckdb_value_to_json(value) {
+        serde_json::Value::String(value) => value,
+        other => other.to_string(),
+    }
+}
+
+fn quote_sql_string(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_geoparquet_path() -> String {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before Unix epoch")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "geolibre-native-duckdb-{suffix}-{}.geoparquet",
+                std::process::id()
+            ))
+            .to_string_lossy()
+            .to_string()
+    }
+
+    fn create_real_geoparquet(path: &str) {
+        let conn = Connection::open_in_memory().expect("open DuckDB");
+        ensure_spatial_extension(&conn, None).expect("load spatial");
+        conn.execute_batch(&format!(
+            "
+            CREATE TABLE places AS
+            SELECT 1 AS id, 'San Francisco' AS name, ST_Point(-122.4194, 37.7749) AS geometry
+            UNION ALL
+            SELECT 2 AS id, 'New York' AS name, ST_Point(-73.9857, 40.7484) AS geometry;
+            COPY places TO {} (FORMAT PARQUET);
+            ",
+            quote_sql_string(path)
+        ))
+        .expect("write GeoParquet fixture");
+    }
+
+    #[test]
+    fn native_loader_reads_real_geoparquet_as_geojson() {
+        let path = temp_geoparquet_path();
+        create_real_geoparquet(&path);
+
+        let options = native_options(path.clone(), None, None, None).expect("native options");
+        let feature_count =
+            count_native_vector_file_features_blocking(options.clone()).expect("count features");
+        assert_eq!(feature_count, 2);
+
+        let collection = load_native_vector_file_blocking(options).expect("load vector file");
+        assert_eq!(collection["type"], "FeatureCollection");
+        let features = collection["features"].as_array().expect("features array");
+        assert_eq!(features.len(), 2);
+        assert_eq!(features[0]["properties"]["id"], 1);
+        assert_eq!(features[0]["properties"]["name"], "San Francisco");
+        assert_eq!(features[0]["geometry"]["type"], "Point");
+        assert_eq!(features[0]["geometry"]["coordinates"][0], -122.4194);
+        assert_eq!(features[0]["geometry"]["coordinates"][1], 37.7749);
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
+++ b/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
@@ -18,13 +18,12 @@ const WKB_GEOMETRY_COLUMN_NAMES: [&str; 6] = [
     "wkb",
 ];
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct NativeVectorOptions {
     path: String,
     extension: String,
     layer: Option<String>,
     override_source_crs: Option<String>,
-    spatial_extension_path: Option<String>,
 }
 
 #[derive(Debug)]
@@ -43,9 +42,8 @@ struct DescribedColumn {
 pub async fn count_native_vector_file_features(
     path: String,
     layer: Option<String>,
-    spatial_extension_path: Option<String>,
 ) -> Result<usize, String> {
-    let options = native_options(path, layer, None, spatial_extension_path)?;
+    let options = native_options(path, layer, None)?;
     tauri::async_runtime::spawn_blocking(move || {
         count_native_vector_file_features_blocking(options)
     })
@@ -58,9 +56,8 @@ pub async fn load_native_vector_file(
     path: String,
     layer: Option<String>,
     override_source_crs: Option<String>,
-    spatial_extension_path: Option<String>,
 ) -> Result<serde_json::Value, String> {
-    let options = native_options(path, layer, override_source_crs, spatial_extension_path)?;
+    let options = native_options(path, layer, override_source_crs)?;
     tauri::async_runtime::spawn_blocking(move || load_native_vector_file_blocking(options))
         .await
         .map_err(|error| format!("Native DuckDB load task failed: {error}"))?
@@ -70,11 +67,15 @@ fn native_options(
     path: String,
     layer: Option<String>,
     override_source_crs: Option<String>,
-    spatial_extension_path: Option<String>,
 ) -> Result<NativeVectorOptions, String> {
     if !crate::is_allowed_local_vector_path(&path) {
         return Err(format!(
             "Refusing to read \"{path}\": not an absolute local vector file path"
+        ));
+    }
+    if has_duckdb_glob_metacharacter(&path) {
+        return Err(format!(
+            "Refusing to read \"{path}\": glob paths are not allowed"
         ));
     }
     Ok(NativeVectorOptions {
@@ -82,7 +83,6 @@ fn native_options(
         path,
         layer: blank_to_none(layer),
         override_source_crs: blank_to_none(override_source_crs),
-        spatial_extension_path: blank_to_none(spatial_extension_path),
     })
 }
 
@@ -114,10 +114,14 @@ fn vector_extension(path: &str) -> String {
     }
 }
 
+fn has_duckdb_glob_metacharacter(path: &str) -> bool {
+    path.contains('*') || path.contains('?') || path.contains('[')
+}
+
 fn count_native_vector_file_features_blocking(
     options: NativeVectorOptions,
 ) -> Result<usize, String> {
-    let conn = open_native_duckdb(&options)?;
+    let conn = open_native_duckdb()?;
     let sql = source_sql(&options);
     let count_sql = format!(
         "SELECT count(*) AS {} FROM ({sql}) AS data",
@@ -131,7 +135,7 @@ fn count_native_vector_file_features_blocking(
 fn load_native_vector_file_blocking(
     options: NativeVectorOptions,
 ) -> Result<serde_json::Value, String> {
-    let conn = open_native_duckdb(&options)?;
+    let conn = open_native_duckdb()?;
     let sql = source_sql(&options);
     let columns = describe_source_columns(&conn, &sql)?;
     let detected = detect_geometry_column(&columns)?;
@@ -176,19 +180,17 @@ fn load_native_vector_file_blocking(
     }))
 }
 
-fn open_native_duckdb(options: &NativeVectorOptions) -> Result<Connection, String> {
+fn open_native_duckdb() -> Result<Connection, String> {
     let conn = Connection::open_in_memory()
         .map_err(|error| format!("Could not open native DuckDB: {error}"))?;
-    let _ = conn.execute_batch("LOAD parquet;");
-    ensure_spatial_extension(&conn, options.spatial_extension_path.as_deref())?;
+    conn.execute_batch("LOAD parquet;")
+        .map_err(|error| format!("Could not load DuckDB parquet extension: {error}"))?;
+    ensure_spatial_extension(&conn)?;
     Ok(conn)
 }
 
-fn ensure_spatial_extension(
-    conn: &Connection,
-    spatial_extension_path: Option<&str>,
-) -> Result<(), String> {
-    if let Some(path) = spatial_extension_path {
+fn ensure_spatial_extension(conn: &Connection) -> Result<(), String> {
+    if let Some(path) = trusted_spatial_extension_path()? {
         conn.execute_batch(&format!(
             "LOAD {}",
             quote_sql_string(&path.replace('\\', "/"))
@@ -201,6 +203,26 @@ fn ensure_spatial_extension(
 
     conn.execute_batch("INSTALL spatial; LOAD spatial;")
         .map_err(|error| format!("Could not install/load DuckDB spatial extension: {error}"))
+}
+
+fn trusted_spatial_extension_path() -> Result<Option<String>, String> {
+    let Some(path) = blank_to_none(std::env::var("GEOLIBRE_DUCKDB_SPATIAL_EXTENSION_PATH").ok())
+    else {
+        return Ok(None);
+    };
+    let canonical = Path::new(&path)
+        .canonicalize()
+        .map_err(|error| format!("Could not resolve DuckDB spatial extension path: {error}"))?;
+    if !canonical.is_file() {
+        return Err(format!(
+            "DuckDB spatial extension path is not a file: {}",
+            canonical.display()
+        ));
+    }
+    canonical
+        .to_str()
+        .map(|path| Some(path.to_string()))
+        .ok_or_else(|| "DuckDB spatial extension path was not valid UTF-8".to_string())
 }
 
 fn is_parquet_extension(extension: &str) -> bool {
@@ -248,7 +270,7 @@ fn describe_source_columns(conn: &Connection, sql: &str) -> Result<Vec<Described
 }
 
 fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometry, String> {
-    let mut wkb_candidate = None;
+    let mut wkb_candidate: Option<(usize, String)> = None;
     for column in columns {
         if column
             .column_type
@@ -267,11 +289,21 @@ fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometr
             || upper_type.starts_with("VARBINARY"))
             && WKB_GEOMETRY_COLUMN_NAMES.contains(&lower_name.as_str())
         {
-            wkb_candidate = Some(column.name.clone());
+            let rank = WKB_GEOMETRY_COLUMN_NAMES
+                .iter()
+                .position(|candidate| *candidate == lower_name.as_str())
+                .unwrap_or(WKB_GEOMETRY_COLUMN_NAMES.len());
+            if wkb_candidate
+                .as_ref()
+                .map(|(current_rank, _)| rank < *current_rank)
+                .unwrap_or(true)
+            {
+                wkb_candidate = Some((rank, column.name.clone()));
+            }
         }
     }
 
-    if let Some(column) = wkb_candidate {
+    if let Some((_, column)) = wkb_candidate {
         return Ok(DetectedGeometry {
             column,
             is_wkb: true,
@@ -283,7 +315,7 @@ fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometr
 
 fn read_source_crs(conn: &Connection, options: &NativeVectorOptions) -> Option<String> {
     if is_parquet_extension(&options.extension) {
-        return None;
+        return read_geoparquet_source_crs(conn, options);
     }
     let meta_sql = format!(
         "SELECT layers[1].geometry_fields[1].crs.auth_name AS auth_name, \
@@ -306,6 +338,52 @@ fn read_source_crs(conn: &Connection, options: &NativeVectorOptions) -> Option<S
             Some(format!("{auth_name}:{auth_code}"))
         }
     })
+}
+
+fn read_geoparquet_source_crs(conn: &Connection, options: &NativeVectorOptions) -> Option<String> {
+    let metadata_sql = format!(
+        "SELECT decode(value) FROM parquet_kv_metadata({}) WHERE decode(key) = 'geo' LIMIT 1",
+        quote_sql_string(&options.path.replace('\\', "/"))
+    );
+    let metadata: String = conn.query_row(&metadata_sql, [], |row| row.get(0)).ok()?;
+    geoparquet_crs_from_metadata(&metadata)
+}
+
+fn geoparquet_crs_from_metadata(metadata: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(metadata).ok()?;
+    let primary_column = value
+        .get("primary_column")
+        .and_then(|value| value.as_str())
+        .unwrap_or("geometry");
+    let crs = value.get("columns")?.get(primary_column)?.get("crs")?;
+    if crs.is_null() {
+        return None;
+    }
+    crs_auth_code(crs)
+}
+
+fn crs_auth_code(crs: &serde_json::Value) -> Option<String> {
+    let id = match crs.get("id")? {
+        serde_json::Value::Array(ids) => ids.last()?,
+        id => id,
+    };
+    let authority = id
+        .get("authority")
+        .or_else(|| id.get("auth_name"))?
+        .as_str()?
+        .trim()
+        .to_ascii_uppercase();
+    let code = id.get("code").or_else(|| id.get("auth_code"))?;
+    let code = match code {
+        serde_json::Value::String(value) => value.trim().to_string(),
+        serde_json::Value::Number(value) => value.to_string(),
+        _ => return None,
+    };
+    if authority.is_empty() || code.is_empty() {
+        None
+    } else {
+        Some(format!("{authority}:{code}"))
+    }
 }
 
 fn geometry_expr(detected: &DetectedGeometry) -> String {
@@ -366,14 +444,14 @@ fn duckdb_value_to_json(value: &Value) -> serde_json::Value {
     match value {
         Value::Null => serde_json::Value::Null,
         Value::Boolean(value) => json!(value),
-        Value::TinyInt(value) => json!(value),
-        Value::SmallInt(value) => json!(value),
-        Value::Int(value) => json!(value),
+        Value::TinyInt(value) => json_number_or_string_i128(*value as i128),
+        Value::SmallInt(value) => json_number_or_string_i128(*value as i128),
+        Value::Int(value) => json_number_or_string_i128(*value as i128),
         Value::BigInt(value) => json_number_or_string_i128(*value as i128),
         Value::HugeInt(value) => json_number_or_string_i128(*value),
-        Value::UTinyInt(value) => json!(value),
-        Value::USmallInt(value) => json!(value),
-        Value::UInt(value) => json!(value),
+        Value::UTinyInt(value) => json_number_or_string_u128(*value as u128),
+        Value::USmallInt(value) => json_number_or_string_u128(*value as u128),
+        Value::UInt(value) => json_number_or_string_u128(*value as u128),
         Value::UBigInt(value) => json_number_or_string_u128(*value as u128),
         Value::Float(value) => json!(value),
         Value::Double(value) => json!(value),
@@ -411,7 +489,9 @@ fn duckdb_value_to_json(value: &Value) -> serde_json::Value {
 }
 
 fn json_number_or_string_i128(value: i128) -> serde_json::Value {
-    if value >= i64::MIN as i128 && value <= i64::MAX as i128 {
+    const MIN_SAFE_INTEGER: i128 = -9_007_199_254_740_991;
+    const MAX_SAFE_INTEGER: i128 = 9_007_199_254_740_991;
+    if (MIN_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value) {
         json!(value as i64)
     } else {
         json!(value.to_string())
@@ -419,7 +499,8 @@ fn json_number_or_string_i128(value: i128) -> serde_json::Value {
 }
 
 fn json_number_or_string_u128(value: u128) -> serde_json::Value {
-    if value <= u64::MAX as u128 {
+    const MAX_SAFE_INTEGER: u128 = 9_007_199_254_740_991;
+    if value <= MAX_SAFE_INTEGER {
         json!(value as u64)
     } else {
         json!(value.to_string())
@@ -457,7 +538,7 @@ fn format_time(unit: TimeUnit, value: i64) -> String {
     };
     let seconds = micros.div_euclid(1_000_000);
     let nanos = (micros.rem_euclid(1_000_000) as u32).saturating_mul(1_000);
-    NaiveTime::from_num_seconds_from_midnight_opt(seconds as u32, nanos)
+    NaiveTime::from_num_seconds_from_midnight_opt(u32::try_from(seconds).unwrap_or(u32::MAX), nanos)
         .map(|time| time.format("%H:%M:%S%.6f").to_string())
         .unwrap_or_else(|| format!("{micros}us"))
 }
@@ -498,7 +579,7 @@ mod tests {
 
     fn create_real_geoparquet(path: &str) {
         let conn = Connection::open_in_memory().expect("open DuckDB");
-        ensure_spatial_extension(&conn, None).expect("load spatial");
+        ensure_spatial_extension(&conn).expect("load spatial");
         conn.execute_batch(&format!(
             "
             CREATE TABLE places AS
@@ -517,7 +598,7 @@ mod tests {
         let path = temp_geoparquet_path();
         create_real_geoparquet(&path);
 
-        let options = native_options(path.clone(), None, None, None).expect("native options");
+        let options = native_options(path.clone(), None, None).expect("native options");
         let feature_count =
             count_native_vector_file_features_blocking(options.clone()).expect("count features");
         assert_eq!(feature_count, 2);
@@ -533,5 +614,75 @@ mod tests {
         assert_eq!(features[0]["geometry"]["coordinates"][1], 37.7749);
 
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn native_options_rejects_duckdb_glob_paths() {
+        let error = native_options("/tmp/*.parquet".to_string(), None, None)
+            .expect_err("glob path should be rejected");
+        assert!(error.contains("glob paths are not allowed"));
+    }
+
+    #[test]
+    fn wkb_detection_uses_preferred_column_name() {
+        let detected = detect_geometry_column(&[
+            DescribedColumn {
+                name: "wkb".to_string(),
+                column_type: "BLOB".to_string(),
+            },
+            DescribedColumn {
+                name: "geometry".to_string(),
+                column_type: "BLOB".to_string(),
+            },
+        ])
+        .expect("detect WKB geometry");
+        assert_eq!(detected.column, "geometry");
+        assert!(detected.is_wkb);
+    }
+
+    #[test]
+    fn integer_json_uses_javascript_safe_range() {
+        assert_eq!(
+            json_number_or_string_i128(9_007_199_254_740_991),
+            json!(9_007_199_254_740_991_i64)
+        );
+        assert_eq!(
+            json_number_or_string_i128(9_007_199_254_740_992),
+            json!("9007199254740992")
+        );
+        assert_eq!(
+            json_number_or_string_u128(9_007_199_254_740_992),
+            json!("9007199254740992")
+        );
+    }
+
+    #[test]
+    fn out_of_range_time_falls_back_to_raw_microseconds() {
+        let micros = (u32::MAX as i64 + 1) * 1_000_000;
+        assert_eq!(
+            format_time(TimeUnit::Microsecond, micros),
+            format!("{micros}us")
+        );
+    }
+
+    #[test]
+    fn geoparquet_crs_reads_primary_column_authority_code() {
+        let metadata = r#"{
+            "version": "1.1.0",
+            "primary_column": "geom",
+            "columns": {
+                "geom": {
+                    "encoding": "WKB",
+                    "crs": {
+                        "type": "ProjectedCRS",
+                        "id": { "authority": "EPSG", "code": 3857 }
+                    }
+                }
+            }
+        }"#;
+        assert_eq!(
+            geoparquet_crs_from_metadata(metadata),
+            Some("EPSG:3857".to_string())
+        );
     }
 }

--- a/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
+++ b/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
@@ -115,7 +115,26 @@ fn vector_extension(path: &str) -> String {
 }
 
 fn has_duckdb_glob_metacharacter(path: &str) -> bool {
-    path.contains('*') || path.contains('?') || path.contains('[')
+    path.contains('*')
+        || path.contains('?')
+        || (has_duckdb_bracket_glob(path) && !Path::new(path).is_file())
+}
+
+fn has_duckdb_bracket_glob(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte != b'[' {
+            continue;
+        }
+        if bytes[index + 1..]
+            .iter()
+            .position(|candidate| *candidate == b']')
+            .is_some_and(|closing_index| closing_index > 0)
+        {
+            return true;
+        }
+    }
+    false
 }
 
 fn count_native_vector_file_features_blocking(
@@ -183,8 +202,6 @@ fn load_native_vector_file_blocking(
 fn open_native_duckdb() -> Result<Connection, String> {
     let conn = Connection::open_in_memory()
         .map_err(|error| format!("Could not open native DuckDB: {error}"))?;
-    conn.execute_batch("LOAD parquet;")
-        .map_err(|error| format!("Could not load DuckDB parquet extension: {error}"))?;
     ensure_spatial_extension(&conn)?;
     Ok(conn)
 }
@@ -626,6 +643,28 @@ mod tests {
         let error = native_options("/tmp/*.parquet".to_string(), None, None)
             .expect_err("glob path should be rejected");
         assert!(error.contains("glob paths are not allowed"));
+
+        let bracket_pattern = format!(
+            "{}/geolibre-native-duckdb-[{}].parquet",
+            std::env::temp_dir().display(),
+            std::process::id()
+        );
+        let error = native_options(bracket_pattern, None, None)
+            .expect_err("bracket glob should be rejected");
+        assert!(error.contains("glob paths are not allowed"));
+    }
+
+    #[test]
+    fn native_options_allows_literal_brackets_in_existing_paths() {
+        let path = format!(
+            "{}/geolibre-native-duckdb-[literal]-{}.parquet",
+            std::env::temp_dir().display(),
+            std::process::id()
+        );
+        std::fs::write(&path, []).expect("create literal bracket file");
+        let options = native_options(path.clone(), None, None).expect("native options");
+        assert_eq!(options.path, path);
+        let _ = std::fs::remove_file(path);
     }
 
     #[test]

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -25,7 +25,10 @@ import {
   parseDelimitedTextLayer,
 } from "./delimited-text";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
-import type { DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
+import {
+  confirmLargeDataset,
+  type DuckDbVectorLoadOptions,
+} from "./duckdb-vector-guard";
 import type { GeotaggedPhotoResult } from "./geotagged-photos";
 import {
   PHOTO_IMAGE_EXTENSIONS,
@@ -35,6 +38,7 @@ import {
 import { parseGpxLayer } from "./gpx";
 import { isTauri } from "./is-tauri";
 import { parseKmlText } from "./kml";
+import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 // Re-exported so existing `import { isTauri } from "./tauri-io"` consumers keep
 // working; the implementation lives in the lightweight ./is-tauri module.
@@ -524,6 +528,73 @@ async function loadDuckDbVector(
   return loadDuckDbVectorFile(file, options);
 }
 
+interface NativeDuckDbVectorInvokeOptions {
+  layer?: string;
+  overrideSourceCrs?: string;
+  spatialExtensionPath?: string;
+}
+
+interface NativeDuckDbVectorAttempt {
+  data: FeatureCollection | null;
+  largeDatasetApproved: boolean;
+}
+
+function nativeDuckDbInvokeOptions(
+  options?: DuckDbVectorLoadOptions,
+): NativeDuckDbVectorInvokeOptions {
+  return {
+    ...(options?.layer?.trim() ? { layer: options.layer.trim() } : {}),
+    ...(options?.overrideSourceCrs?.trim()
+      ? { overrideSourceCrs: options.overrideSourceCrs.trim() }
+      : {}),
+    ...(getSpatialExtensionPath()
+      ? { spatialExtensionPath: getSpatialExtensionPath() }
+      : {}),
+  };
+}
+
+async function tryLoadNativeDuckDbVectorPath(
+  path: string,
+  options?: DuckDbVectorLoadOptions,
+): Promise<NativeDuckDbVectorAttempt> {
+  if (!isTauri()) return { data: null, largeDatasetApproved: false };
+
+  const invokeOptions = nativeDuckDbInvokeOptions(options);
+  let largeDatasetApproved = false;
+  try {
+    if (options?.onLargeDataset) {
+      const featureCount = await invoke<number>(
+        "count_native_vector_file_features",
+        {
+          path,
+          ...invokeOptions,
+        },
+      );
+      await confirmLargeDataset(
+        { name: browserSafeFileName(path), featureCount },
+        options.onLargeDataset,
+      );
+      largeDatasetApproved = true;
+    }
+
+    const value = await invoke<unknown>("load_native_vector_file", {
+      path,
+      ...invokeOptions,
+    });
+    return {
+      data: assertFeatureCollection(value),
+      largeDatasetApproved,
+    };
+  } catch (error) {
+    if (isVectorLoadCancelled(error)) throw error;
+    console.warn(
+      "[GeoLibre] Native DuckDB vector load failed; falling back to DuckDB-WASM.",
+      error,
+    );
+    return { data: null, largeDatasetApproved };
+  }
+}
+
 /**
  * Load one KML entry, preferring the styled in-house reader so embedded
  * symbology survives, and falling back to DuckDB/GDAL for KML the reader does
@@ -688,6 +759,11 @@ export interface PickedVectorFile {
   companionFiles: File[];
   /** Absolute filesystem path the main file was read from. */
   sourcePath: string;
+  /**
+   * GeoJSON materialized by native duckdb-rs for formats that would otherwise
+   * make the Add Vector Layer panel load DuckDB-WASM.
+   */
+  nativeData?: FeatureCollection;
 }
 
 /**
@@ -729,7 +805,12 @@ export async function pickVectorFilesWithSidecars(): Promise<PickedVectorFile[]>
               (sibling) => new File([toArrayBuffer(sibling.data)], sibling.name),
             )
           : [];
-      picked.push({ file, companionFiles, sourcePath: path });
+      picked.push({
+        file,
+        companionFiles,
+        sourcePath: path,
+        nativeData: await tryLoadPickedNativeVectorPath(path),
+      });
     } catch (error) {
       console.warn(`Could not read the selected file "${path}".`, error);
     }
@@ -749,7 +830,11 @@ export async function pickVectorFilesWithSidecars(): Promise<PickedVectorFile[]>
  */
 export async function readVectorFileWithSidecars(
   path: string,
-): Promise<{ file: File; companionFiles: File[] } | null> {
+): Promise<{
+  file: File;
+  companionFiles: File[];
+  nativeData?: FeatureCollection;
+} | null> {
   // Reject `..` segments as well as relative paths: the path comes from a
   // (possibly hand-edited) project file, so a traversal must not reach outside
   // wherever Tauri's filesystem scope allows. The scope is the real boundary;
@@ -771,11 +856,33 @@ export async function readVectorFileWithSidecars(
             (sibling) => new File([toArrayBuffer(sibling.data)], sibling.name),
           )
         : [];
-    return { file, companionFiles };
+    return {
+      file,
+      companionFiles,
+      nativeData: await tryLoadPickedNativeVectorPath(path),
+    };
   } catch (error) {
     console.warn(`Could not read local vector file "${path}".`, error);
     return null;
   }
+}
+
+async function tryLoadPickedNativeVectorPath(
+  path: string,
+): Promise<FeatureCollection | undefined> {
+  const extension = fileExtension(path);
+  if (
+    extension === "geojson" ||
+    extension === "json" ||
+    extension === "kml" ||
+    extension === "kmz" ||
+    extension === "gpx" ||
+    extension === "zip"
+  ) {
+    return undefined;
+  }
+  const result = await tryLoadNativeDuckDbVectorPath(path);
+  return result.data ?? undefined;
 }
 
 export function isAbsoluteLocalPath(path: string): boolean {
@@ -864,6 +971,18 @@ async function loadTauriVectorFile(
     }
   }
 
+  const nativeAttempt = await tryLoadNativeDuckDbVectorPath(path, options);
+  if (nativeAttempt.data) {
+    return {
+      data: nativeAttempt.data,
+      path,
+    };
+  }
+  const wasmOptions =
+    nativeAttempt.largeDatasetApproved && options
+      ? { ...options, onLargeDataset: undefined }
+      : options;
+
   try {
     const siblingFiles =
       extension === "shp" ? await readShapefileSiblings(path) : [];
@@ -875,7 +994,7 @@ async function loadTauriVectorFile(
           data: await readLocalFileBytes(path),
           siblingFiles,
         },
-        options,
+        wasmOptions,
       ),
       path,
     };

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -870,7 +870,12 @@ export async function readVectorFileWithSidecars(
       file,
       companionFiles,
       nativeData: await tryLoadPickedNativeVectorPath(path, {
-        onLargeDataset: () => false,
+        onLargeDataset: ({ name, featureCount }) => {
+          console.warn(
+            `[GeoLibre] Skipping native vector restore for "${name}" because it contains ${featureCount.toLocaleString()} features; re-add the file to confirm loading it as GeoJSON.`,
+          );
+          return false;
+        },
       }),
     };
   } catch (error) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -596,7 +596,10 @@ function confirmPickedNativeVectorDataset({
   featureCount,
 }: LargeVectorDataset): boolean {
   return window.confirm(
-    `${name} contains ${featureCount.toLocaleString()} features. Loading it as GeoJSON may use a lot of memory. Continue?`,
+    i18next.t("toolbar.item.largeVectorDesc", {
+      name,
+      count: featureCount.toLocaleString(),
+    }),
   );
 }
 

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -28,6 +28,7 @@ import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 import {
   confirmLargeDataset,
   type DuckDbVectorLoadOptions,
+  type LargeVectorDataset,
 } from "./duckdb-vector-guard";
 import type { GeotaggedPhotoResult } from "./geotagged-photos";
 import {
@@ -38,7 +39,6 @@ import {
 import { parseGpxLayer } from "./gpx";
 import { isTauri } from "./is-tauri";
 import { parseKmlText } from "./kml";
-import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 // Re-exported so existing `import { isTauri } from "./tauri-io"` consumers keep
 // working; the implementation lives in the lightweight ./is-tauri module.
@@ -531,12 +531,11 @@ async function loadDuckDbVector(
 interface NativeDuckDbVectorInvokeOptions {
   layer?: string;
   overrideSourceCrs?: string;
-  spatialExtensionPath?: string;
 }
 
 interface NativeDuckDbVectorAttempt {
   data: FeatureCollection | null;
-  largeDatasetApproved: boolean;
+  featureCountChecked: boolean;
 }
 
 function nativeDuckDbInvokeOptions(
@@ -547,9 +546,6 @@ function nativeDuckDbInvokeOptions(
     ...(options?.overrideSourceCrs?.trim()
       ? { overrideSourceCrs: options.overrideSourceCrs.trim() }
       : {}),
-    ...(getSpatialExtensionPath()
-      ? { spatialExtensionPath: getSpatialExtensionPath() }
-      : {}),
   };
 }
 
@@ -557,10 +553,10 @@ async function tryLoadNativeDuckDbVectorPath(
   path: string,
   options?: DuckDbVectorLoadOptions,
 ): Promise<NativeDuckDbVectorAttempt> {
-  if (!isTauri()) return { data: null, largeDatasetApproved: false };
+  if (!isTauri()) return { data: null, featureCountChecked: false };
 
   const invokeOptions = nativeDuckDbInvokeOptions(options);
-  let largeDatasetApproved = false;
+  let featureCountChecked = false;
   try {
     if (options?.onLargeDataset) {
       const featureCount = await invoke<number>(
@@ -574,7 +570,7 @@ async function tryLoadNativeDuckDbVectorPath(
         { name: browserSafeFileName(path), featureCount },
         options.onLargeDataset,
       );
-      largeDatasetApproved = true;
+      featureCountChecked = true;
     }
 
     const value = await invoke<unknown>("load_native_vector_file", {
@@ -583,7 +579,7 @@ async function tryLoadNativeDuckDbVectorPath(
     });
     return {
       data: assertFeatureCollection(value),
-      largeDatasetApproved,
+      featureCountChecked,
     };
   } catch (error) {
     if (isVectorLoadCancelled(error)) throw error;
@@ -591,8 +587,17 @@ async function tryLoadNativeDuckDbVectorPath(
       "[GeoLibre] Native DuckDB vector load failed; falling back to DuckDB-WASM.",
       error,
     );
-    return { data: null, largeDatasetApproved };
+    return { data: null, featureCountChecked };
   }
+}
+
+function confirmPickedNativeVectorDataset({
+  name,
+  featureCount,
+}: LargeVectorDataset): boolean {
+  return window.confirm(
+    `${name} contains ${featureCount.toLocaleString()} features. Loading it as GeoJSON may use a lot of memory. Continue?`,
+  );
 }
 
 /**
@@ -809,7 +814,9 @@ export async function pickVectorFilesWithSidecars(): Promise<PickedVectorFile[]>
         file,
         companionFiles,
         sourcePath: path,
-        nativeData: await tryLoadPickedNativeVectorPath(path),
+        nativeData: await tryLoadPickedNativeVectorPath(path, {
+          onLargeDataset: confirmPickedNativeVectorDataset,
+        }),
       });
     } catch (error) {
       console.warn(`Could not read the selected file "${path}".`, error);
@@ -859,7 +866,9 @@ export async function readVectorFileWithSidecars(
     return {
       file,
       companionFiles,
-      nativeData: await tryLoadPickedNativeVectorPath(path),
+      nativeData: await tryLoadPickedNativeVectorPath(path, {
+        onLargeDataset: () => false,
+      }),
     };
   } catch (error) {
     console.warn(`Could not read local vector file "${path}".`, error);
@@ -869,6 +878,7 @@ export async function readVectorFileWithSidecars(
 
 async function tryLoadPickedNativeVectorPath(
   path: string,
+  options: DuckDbVectorLoadOptions,
 ): Promise<FeatureCollection | undefined> {
   const extension = fileExtension(path);
   if (
@@ -881,8 +891,13 @@ async function tryLoadPickedNativeVectorPath(
   ) {
     return undefined;
   }
-  const result = await tryLoadNativeDuckDbVectorPath(path);
-  return result.data ?? undefined;
+  try {
+    const result = await tryLoadNativeDuckDbVectorPath(path, options);
+    return result.data ?? undefined;
+  } catch (error) {
+    if (isVectorLoadCancelled(error)) return undefined;
+    throw error;
+  }
 }
 
 export function isAbsoluteLocalPath(path: string): boolean {
@@ -979,7 +994,7 @@ async function loadTauriVectorFile(
     };
   }
   const wasmOptions =
-    nativeAttempt.largeDatasetApproved && options
+    nativeAttempt.featureCountChecked && options
       ? { ...options, onLargeDataset: undefined }
       : options;
 

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -273,8 +273,13 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
                   useAppStore.getState().removeLayer(layer.id);
                   return undefined;
                 }
-                return replayVectorLayer(control, layer, file.file, {
-                  companionFiles: file.companionFiles,
+                const source = file.nativeData
+                  ? nativeGeoJsonFile(file.file, file.nativeData)
+                  : file.file;
+                return replayVectorLayer(control, layer, source, {
+                  companionFiles: file.nativeData
+                    ? undefined
+                    : file.companionFiles,
                   localPath,
                 });
               })
@@ -729,10 +734,26 @@ export async function addPickedVectorFiles(
   control: VectorDataSink,
   picked: GeoLibrePickedVectorFile[],
 ): Promise<void> {
-  for (const { file, companionFiles, sourcePath } of picked) {
-    await control.addData(file, {
-      ...(companionFiles.length > 0 ? { companionFiles } : {}),
+  for (const { file, companionFiles, sourcePath, nativeData } of picked) {
+    const source = nativeData ? nativeGeoJsonFile(file, nativeData) : file;
+    await control.addData(source, {
+      ...(nativeData ? { name: file.name } : {}),
+      ...(!nativeData && companionFiles.length > 0 ? { companionFiles } : {}),
       ...(sourcePath ? { sourcePath } : {}),
     });
   }
+}
+
+function nativeGeoJsonFile(file: File, data: FeatureCollection): File {
+  return new File([JSON.stringify(data)], `${fileBaseName(file.name)}.geojson`, {
+    type: "application/geo+json",
+  });
+}
+
+function fileBaseName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "vector";
+  const lastSlash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  const fileName = lastSlash >= 0 ? trimmed.slice(lastSlash + 1) : trimmed;
+  return fileName.replace(/\.[^.]+$/, "") || "vector";
 }

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -173,6 +173,12 @@ export interface GeoLibrePickedVectorFile {
    * file when a saved project reopens.
    */
   sourcePath?: string;
+  /**
+   * FeatureCollection materialized by a desktop host's native vector reader.
+   * When present, the Add Vector Layer bridge can load it as GeoJSON while
+   * still persisting {@link sourcePath} for project restore.
+   */
+  nativeData?: FeatureCollection;
 }
 
 export interface GeoLibreAppAPI {
@@ -276,7 +282,11 @@ export interface GeoLibreAppAPI {
    */
   readLocalVectorFile?: (
     path: string,
-  ) => Promise<{ file: File; companionFiles: File[] } | null>;
+  ) => Promise<{
+    file: File;
+    companionFiles: File[];
+    nativeData?: FeatureCollection;
+  } | null>;
   /**
    * Save text content to a file chosen by the user. The host handles the
    * platform specifics (a native save dialog under Tauri, a browser download

--- a/tests/vector-desktop-picker.test.ts
+++ b/tests/vector-desktop-picker.test.ts
@@ -10,17 +10,21 @@ function createSink() {
   const calls: Array<{
     name: string;
     companionFiles?: string[];
+    layerName?: string;
     sourcePath?: string;
+    text?: string;
   }> = [];
   const sink = {
     addData: async (
       source: File,
-      options?: { companionFiles?: File[]; sourcePath?: string },
+      options?: { companionFiles?: File[]; name?: string; sourcePath?: string },
     ) => {
       calls.push({
         name: source.name,
         companionFiles: options?.companionFiles?.map((file) => file.name),
+        layerName: options?.name,
         sourcePath: options?.sourcePath,
+        text: await source.text(),
       });
       return {} as never;
     },
@@ -61,6 +65,35 @@ describe("addPickedVectorFiles", () => {
     assert.equal(calls.length, 2);
     assert.equal(calls[0].companionFiles, undefined);
     assert.equal(calls[1].companionFiles, undefined);
+  });
+
+  it("loads native DuckDB results as GeoJSON while preserving sourcePath", async () => {
+    const { sink, calls } = createSink();
+
+    await addPickedVectorFiles(sink, [
+      {
+        file: new File(["parquet"], "places.parquet"),
+        companionFiles: [new File(["dbf"], "places.dbf")],
+        sourcePath: "/data/places.parquet",
+        nativeData: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              properties: { id: 1 },
+              geometry: { type: "Point", coordinates: [0, 1] },
+            },
+          ],
+        },
+      },
+    ]);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].name, "places.geojson");
+    assert.equal(calls[0].layerName, "places.parquet");
+    assert.equal(calls[0].sourcePath, "/data/places.parquet");
+    assert.equal(calls[0].companionFiles, undefined);
+    assert.match(calls[0].text ?? "", /"FeatureCollection"/);
   });
 
   it("loads nothing when the dialog was cancelled (empty list)", async () => {


### PR DESCRIPTION
## Summary
- Add native duckdb-rs vector loading commands to the Tauri host for local Parquet, GeoParquet, and GDAL-readable vector files.
- Route desktop picker, restore, and drag/drop path-backed vector imports through native DuckDB before falling back to DuckDB-WASM.
- Preserve Add Vector Layer source paths by passing native-loaded data back through the vector control as GeoJSON.

Fixes #962

## Test plan
- [x] cargo test --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml native_loader_reads_real_geoparquet_as_geojson -- --nocapture
- [x] cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml
- [x] node --import tsx --test tests/duckdb-vector-guard.test.ts tests/vector-desktop-picker.test.ts
- [x] pre-commit run --files apps/geolibre-desktop/src-tauri/Cargo.lock apps/geolibre-desktop/src-tauri/Cargo.toml apps/geolibre-desktop/src-tauri/src/lib.rs apps/geolibre-desktop/src-tauri/src/native_duckdb.rs apps/geolibre-desktop/src/lib/tauri-io.ts packages/plugins/src/plugins/maplibre-vector.ts packages/plugins/src/types.ts tests/vector-desktop-picker.test.ts
- [x] npm run tauri:build
- [x] Packaged desktop binary smoke-launched under Xvfb and rendered the app window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop vector-file loading now uses native processing for compatible local files, returning GeoJSON for faster display and smoother project restore.
  * Native-loaded vector data is retained through the pick and restore workflow, preserving geometry and attributes while keeping the original source path.

* **Bug Fixes**
  * Large-dataset confirmation now occurs only once during load.
  * Restores/imports now correctly apply native-loaded GeoJSON and omit companion files when native data is available.

* **Tests**
  * Added coverage for native-loaded GeoJSON being added with the expected filename and layer name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->