### PR TITLE
feat(desktop): bundle signed DuckDB spatial extension for offline native loads

### DIFF
--- a/apps/geolibre-desktop/src-tauri/resources/duckdb/.gitignore
+++ b/apps/geolibre-desktop/src-tauri/resources/duckdb/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -200,11 +200,78 @@ pub fn run() {
             poll_earth_engine_oauth
         ])
         .setup(|app| {
+            point_native_duckdb_at_bundled_spatial_extension(app.handle());
             create_main_window(app)?;
             Ok(())
         })
         .run(tauri::generate_context!())
         .expect("error while running GeoLibre Desktop");
+}
+
+/// Environment variable the native DuckDB loader reads to find a local spatial
+/// extension to `LOAD` (see `native_duckdb::trusted_spatial_extension_path`).
+const DUCKDB_SPATIAL_EXTENSION_ENV: &str = "GEOLIBRE_DUCKDB_SPATIAL_EXTENSION_PATH";
+
+/// Per-platform resource subpath of the bundled DuckDB spatial extension,
+/// populated by `scripts/fetch-duckdb-spatial.mjs` and shipped via the
+/// `resources/duckdb/**/*` entry in `tauri.conf.json`. Returns `None` on
+/// platforms we do not fetch a binary for, where the loader falls back to a
+/// runtime `LOAD spatial`.
+fn bundled_spatial_extension_subpath() -> Option<&'static str> {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        Some("resources/duckdb/osx_arm64/spatial.duckdb_extension")
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        Some("resources/duckdb/osx_amd64/spatial.duckdb_extension")
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        Some("resources/duckdb/windows_amd64/spatial.duckdb_extension")
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        Some("resources/duckdb/linux_amd64/spatial.duckdb_extension")
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        Some("resources/duckdb/linux_arm64/spatial.duckdb_extension")
+    }
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+    )))]
+    {
+        None
+    }
+}
+
+/// Point the native DuckDB loader at the spatial extension bundled with the app
+/// so packaged, offline desktop builds can `LOAD` a signed extension without a
+/// network install. A pre-set environment variable wins, so developers and CI
+/// can override the bundled binary. When no binary is bundled for this platform
+/// (for example in `tauri dev` before `fetch:duckdb-spatial` has run), the loader
+/// falls back to a runtime `LOAD spatial`.
+fn point_native_duckdb_at_bundled_spatial_extension(app: &tauri::AppHandle) {
+    if env::var_os(DUCKDB_SPATIAL_EXTENSION_ENV).is_some() {
+        return;
+    }
+    let Some(subpath) = bundled_spatial_extension_subpath() else {
+        return;
+    };
+    let Ok(path) = app
+        .path()
+        .resolve(subpath, tauri::path::BaseDirectory::Resource)
+    else {
+        return;
+    };
+    if path.is_file() {
+        env::set_var(DUCKDB_SPATIAL_EXTENSION_ENV, path);
+    }
 }
 
 #[tauri::command]
@@ -2490,8 +2557,28 @@ fn configure_linux_webkit() {}
 
 #[cfg(test)]
 mod tests {
-    use super::{find_zip_manifest_path, is_allowed_local_vector_path, plugin_archive_file_name};
+    use super::{
+        bundled_spatial_extension_subpath, find_zip_manifest_path, is_allowed_local_vector_path,
+        plugin_archive_file_name,
+    };
     use std::io::{Cursor, Write};
+
+    #[test]
+    fn bundled_spatial_extension_subpath_matches_fetch_layout() {
+        // On every platform we fetch a binary for, the subpath must live under
+        // resources/duckdb and name the spatial extension file the loader LOADs.
+        // scripts/fetch-duckdb-spatial.mjs writes exactly this layout.
+        if let Some(subpath) = bundled_spatial_extension_subpath() {
+            assert!(
+                subpath.starts_with("resources/duckdb/"),
+                "subpath {subpath} must be under resources/duckdb/"
+            );
+            assert!(
+                subpath.ends_with("/spatial.duckdb_extension"),
+                "subpath {subpath} must name the spatial extension file"
+            );
+        }
+    }
 
     #[test]
     fn allows_absolute_vector_paths() {

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": ["../../../backend/geolibre_server"],
+    "resources": ["../../../backend/geolibre_server", "resources/duckdb/**/*"],
     "icon": [
       "icons/icon.png",
       "icons/32x32.png",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "npm run build -w geolibre-desktop",
     "build:jupyterlite": "node scripts/build-jupyterlite.mjs",
     "build:embed": "node scripts/build-embed.mjs",
+    "fetch:duckdb-spatial": "node scripts/fetch-duckdb-spatial.mjs",
     "typecheck": "npm run build",
     "lint": "eslint apps packages workers tests",
     "test": "npm run test:frontend",

--- a/scripts/duckdb-spatial-checksums.json
+++ b/scripts/duckdb-spatial-checksums.json
@@ -1,0 +1,10 @@
+{
+  "version": "v1.5.4",
+  "sha256": {
+    "osx_arm64": "575c609c1eb0b45be5d4000792528579746233c5d57d3fa83aa825d11740a1ec",
+    "osx_amd64": "df5af2359bd4be3f347ba3a843fd440f4db653dadd8eb31fe6c16a67abbb1bc8",
+    "windows_amd64": "9952e232a1dcb400ea4da0d1e6d91f34ae525e116233868e7906187d3d58133c",
+    "linux_amd64": "819a0fa94d2e8257371bb4d97f32c47586b42c85e24bab1bcbf8712a88b8ccfa",
+    "linux_arm64": "af2547875834496f3112261631cc8d8c96ae67912edab6b4e3d5f4f7545e547a"
+  }
+}

--- a/scripts/duckdb-target.mjs
+++ b/scripts/duckdb-target.mjs
@@ -1,0 +1,13 @@
+// Shared parser for the build target triple so the tauri-build wrapper and the
+// DuckDB fetch helper agree on the flag forms. `tauri build` accepts the split
+// (`--target <triple>`, `-t <triple>`) and joined (`--target=<triple>`,
+// `-t=<triple>`) forms, so a single source of truth keeps them from drifting.
+export function parseTargetTripleArg(args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--target" || arg === "-t") return args[i + 1] ?? "";
+    if (arg.startsWith("--target=")) return arg.slice("--target=".length);
+    if (arg.startsWith("-t=")) return arg.slice("-t=".length);
+  }
+  return "";
+}

--- a/scripts/fetch-duckdb-spatial.mjs
+++ b/scripts/fetch-duckdb-spatial.mjs
@@ -1,0 +1,89 @@
+// Downloads and gunzips the DuckDB spatial extension (v1.5.4) for every target
+// platform into the Tauri resources tree. Run before `tauri:build`.
+//
+// Security: the extension is native code that gets loaded into the desktop app
+// and bundled into release installers, so it must be fetched over HTTPS and
+// verified against a checked-in SHA-256 manifest (scripts/duckdb-spatial-checksums.json).
+// The download is gunzipped to a temp file, hashed, and only moved into the
+// resources tree when the hash matches the pinned value. A mismatch fails the
+// build (and never leaves a partial or untrusted file in place). On first run
+// for a new version, run with GEOLIBRE_WRITE_CHECKSUMS=1 to record the pinned
+// hashes, then review and commit the manifest.
+import { createWriteStream } from "node:fs";
+import { mkdir, rm, readFile, writeFile, rename } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createGunzip } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+
+const DUCKDB_VERSION = "v1.5.4";
+const PLATFORMS = ["osx_arm64", "osx_amd64", "windows_amd64", "linux_amd64", "linux_arm64"];
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outBase = join(root, "apps/geolibre-desktop/src-tauri/resources/duckdb");
+const manifestPath = join(root, "scripts/duckdb-spatial-checksums.json");
+const writeChecksums = process.env.GEOLIBRE_WRITE_CHECKSUMS === "1";
+
+async function sha256File(path) {
+  const hash = createHash("sha256");
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
+}
+
+async function loadManifest() {
+  try {
+    const raw = await readFile(manifestPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return parsed.version === DUCKDB_VERSION ? parsed.sha256 ?? {} : {};
+  } catch {
+    return {};
+  }
+}
+
+const expected = await loadManifest();
+const recorded = {};
+
+for (const platform of PLATFORMS) {
+  const url = `https://extensions.duckdb.org/${DUCKDB_VERSION}/${platform}/spatial.duckdb_extension.gz`;
+  const outDir = join(outBase, platform);
+  const outFile = join(outDir, "spatial.duckdb_extension");
+  const tmpFile = `${outFile}.tmp`;
+  await mkdir(outDir, { recursive: true });
+  process.stdout.write(`Fetching ${platform} ... `);
+  const res = await fetch(url);
+  if (!res.ok) {
+    await rm(tmpFile, { force: true });
+    throw new Error(`Failed ${platform}: HTTP ${res.status} from ${url}`);
+  }
+  await pipeline(res.body, createGunzip(), createWriteStream(tmpFile));
+
+  const digest = await sha256File(tmpFile);
+  const pinned = expected[platform];
+  if (pinned && pinned !== digest) {
+    await rm(tmpFile, { force: true });
+    throw new Error(
+      `Checksum mismatch for ${platform}.\n  expected ${pinned}\n  got      ${digest}\n` +
+        `Refusing to bundle an unverified native extension. If the upstream artifact ` +
+        `legitimately changed, re-pin with GEOLIBRE_WRITE_CHECKSUMS=1 and review the diff.`,
+    );
+  }
+  if (!pinned && !writeChecksums) {
+    await rm(tmpFile, { force: true });
+    throw new Error(
+      `No pinned checksum for ${platform} (DuckDB ${DUCKDB_VERSION}). ` +
+        `Re-run with GEOLIBRE_WRITE_CHECKSUMS=1 to record it, then commit ` +
+        `scripts/duckdb-spatial-checksums.json.`,
+    );
+  }
+  recorded[platform] = digest;
+  await rename(tmpFile, outFile);
+  console.log(pinned ? "done (verified)" : `done (recorded ${digest.slice(0, 12)}...)`);
+}
+
+if (writeChecksums) {
+  const manifest = { version: DUCKDB_VERSION, sha256: recorded };
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`Wrote ${manifestPath}. Review and commit it.`);
+}
+console.log("All spatial extensions fetched.");

--- a/scripts/fetch-duckdb-spatial.mjs
+++ b/scripts/fetch-duckdb-spatial.mjs
@@ -65,8 +65,9 @@ const HOST_TO_PLATFORM = {
 function parseTargetTriple(argv) {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === "--target" && argv[i + 1]) return argv[i + 1];
+    if ((arg === "--target" || arg === "-t") && argv[i + 1]) return argv[i + 1];
     if (arg.startsWith("--target=")) return arg.slice("--target=".length);
+    if (arg.startsWith("-t=")) return arg.slice("-t=".length);
   }
   return (
     process.env.GEOLIBRE_DUCKDB_TARGET || process.env.CARGO_BUILD_TARGET || ""

--- a/scripts/fetch-duckdb-spatial.mjs
+++ b/scripts/fetch-duckdb-spatial.mjs
@@ -122,7 +122,13 @@ async function loadManifest() {
     // and re-pinning an unverified extension from the network.
     throw error;
   }
-  const parsed = JSON.parse(raw);
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    // A corrupt manifest must fail loudly, not be re-pinned from the network.
+    throw new Error(`${manifestPath} contains invalid JSON: ${error.message}`);
+  }
   return parsed.version === DUCKDB_VERSION ? parsed.sha256 ?? {} : {};
 }
 
@@ -133,11 +139,39 @@ async function fetchPlatform(platform, expected, recorded) {
   const tmpFile = `${outFile}.tmp`;
   await mkdir(outDir, { recursive: true });
   process.stdout.write(`Fetching ${platform} ... `);
-  let res;
+  // The abort signal bounds the whole download, including the streaming body,
+  // so a stalled CDN fails fast rather than hanging the build. Any failure
+  // along the way removes the temp file so an unverified artifact never lingers.
   try {
-    res = await fetch(url, {
+    const res = await fetch(url, {
       signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
     });
+    if (!res.ok) {
+      throw new Error(`Failed ${platform}: HTTP ${res.status} from ${url}`);
+    }
+    await pipeline(res.body, createGunzip(), createWriteStream(tmpFile));
+
+    const digest = await sha256File(tmpFile);
+    const pinned = expected[platform];
+    if (pinned && pinned !== digest) {
+      throw new Error(
+        `Checksum mismatch for ${platform}.\n  expected ${pinned}\n  got      ${digest}\n` +
+          `Refusing to bundle an unverified native extension. If the upstream artifact ` +
+          `legitimately changed, re-pin with GEOLIBRE_WRITE_CHECKSUMS=1 and review the diff.`
+      );
+    }
+    if (!pinned && !writeChecksums) {
+      throw new Error(
+        `No pinned checksum for ${platform} (DuckDB ${DUCKDB_VERSION}). ` +
+          `Re-run with GEOLIBRE_WRITE_CHECKSUMS=1 to record it, then commit ` +
+          `scripts/duckdb-spatial-checksums.json.`
+      );
+    }
+    recorded[platform] = digest;
+    await rename(tmpFile, outFile);
+    console.log(
+      pinned ? "done (verified)" : `done (recorded ${digest.slice(0, 12)}...)`
+    );
   } catch (error) {
     await rm(tmpFile, { force: true });
     if (error?.name === "TimeoutError") {
@@ -147,35 +181,6 @@ async function fetchPlatform(platform, expected, recorded) {
     }
     throw error;
   }
-  if (!res.ok) {
-    await rm(tmpFile, { force: true });
-    throw new Error(`Failed ${platform}: HTTP ${res.status} from ${url}`);
-  }
-  await pipeline(res.body, createGunzip(), createWriteStream(tmpFile));
-
-  const digest = await sha256File(tmpFile);
-  const pinned = expected[platform];
-  if (pinned && pinned !== digest) {
-    await rm(tmpFile, { force: true });
-    throw new Error(
-      `Checksum mismatch for ${platform}.\n  expected ${pinned}\n  got      ${digest}\n` +
-        `Refusing to bundle an unverified native extension. If the upstream artifact ` +
-        `legitimately changed, re-pin with GEOLIBRE_WRITE_CHECKSUMS=1 and review the diff.`
-    );
-  }
-  if (!pinned && !writeChecksums) {
-    await rm(tmpFile, { force: true });
-    throw new Error(
-      `No pinned checksum for ${platform} (DuckDB ${DUCKDB_VERSION}). ` +
-        `Re-run with GEOLIBRE_WRITE_CHECKSUMS=1 to record it, then commit ` +
-        `scripts/duckdb-spatial-checksums.json.`
-    );
-  }
-  recorded[platform] = digest;
-  await rename(tmpFile, outFile);
-  console.log(
-    pinned ? "done (verified)" : `done (recorded ${digest.slice(0, 12)}...)`
-  );
 }
 
 // Removes platform directories we are not bundling so `resources/duckdb/**/*`

--- a/scripts/fetch-duckdb-spatial.mjs
+++ b/scripts/fetch-duckdb-spatial.mjs
@@ -25,6 +25,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createGunzip } from "node:zlib";
 import { pipeline } from "node:stream/promises";
+import { parseTargetTripleArg } from "./duckdb-target.mjs";
 
 const DUCKDB_VERSION = "v1.5.4";
 const PLATFORMS = [
@@ -63,14 +64,11 @@ const HOST_TO_PLATFORM = {
 };
 
 function parseTargetTriple(argv) {
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if ((arg === "--target" || arg === "-t") && argv[i + 1]) return argv[i + 1];
-    if (arg.startsWith("--target=")) return arg.slice("--target=".length);
-    if (arg.startsWith("-t=")) return arg.slice("-t=".length);
-  }
   return (
-    process.env.GEOLIBRE_DUCKDB_TARGET || process.env.CARGO_BUILD_TARGET || ""
+    parseTargetTripleArg(argv) ||
+    process.env.GEOLIBRE_DUCKDB_TARGET ||
+    process.env.CARGO_BUILD_TARGET ||
+    ""
   );
 }
 
@@ -153,7 +151,9 @@ async function fetchPlatform(platform, expected, recorded) {
 
     const digest = await sha256File(tmpFile);
     const pinned = expected[platform];
-    if (pinned && pinned !== digest) {
+    // In re-pin mode a changed digest is recorded (the committed manifest diff
+    // is the human review gate); otherwise a mismatch aborts the build.
+    if (pinned && pinned !== digest && !writeChecksums) {
       throw new Error(
         `Checksum mismatch for ${platform}.\n  expected ${pinned}\n  got      ${digest}\n` +
           `Refusing to bundle an unverified native extension. If the upstream artifact ` +
@@ -170,7 +170,9 @@ async function fetchPlatform(platform, expected, recorded) {
     recorded[platform] = digest;
     await rename(tmpFile, outFile);
     console.log(
-      pinned ? "done (verified)" : `done (recorded ${digest.slice(0, 12)}...)`
+      pinned === digest
+        ? "done (verified)"
+        : `done (recorded ${digest.slice(0, 12)}...)`
     );
   } catch (error) {
     await rm(tmpFile, { force: true });

--- a/scripts/fetch-duckdb-spatial.mjs
+++ b/scripts/fetch-duckdb-spatial.mjs
@@ -1,5 +1,13 @@
-// Downloads and gunzips the DuckDB spatial extension (v1.5.4) for every target
-// platform into the Tauri resources tree. Run before `tauri:build`.
+// Downloads and gunzips the DuckDB spatial extension (v1.5.4) into the Tauri
+// resources tree. Run before `tauri:build`.
+//
+// By default this fetches only the artifact for the active build target (the
+// host platform, or a Rust target triple passed via `--target`/`CARGO_BUILD_TARGET`/
+// `GEOLIBRE_DUCKDB_TARGET`), since `bundled_spatial_extension_subpath()` in
+// src/lib.rs loads exactly one per-platform file at runtime. Sibling platform
+// directories are pruned so `resources/duckdb/**/*` cannot leak other targets'
+// binaries into an installer. Pass GEOLIBRE_WRITE_CHECKSUMS=1 to fetch every
+// platform and re-pin the manifest (see below).
 //
 // Security: the extension is native code that gets loaded into the desktop app
 // and bundled into release installers, so it must be fetched over HTTPS and
@@ -8,7 +16,7 @@
 // resources tree when the hash matches the pinned value. A mismatch fails the
 // build (and never leaves a partial or untrusted file in place). On first run
 // for a new version, run with GEOLIBRE_WRITE_CHECKSUMS=1 to record the pinned
-// hashes, then review and commit the manifest.
+// hashes for every platform, then review and commit the manifest.
 import { createWriteStream } from "node:fs";
 import { mkdir, rm, readFile, writeFile, rename } from "node:fs/promises";
 import { createHash } from "node:crypto";
@@ -19,11 +27,81 @@ import { createGunzip } from "node:zlib";
 import { pipeline } from "node:stream/promises";
 
 const DUCKDB_VERSION = "v1.5.4";
-const PLATFORMS = ["osx_arm64", "osx_amd64", "windows_amd64", "linux_amd64", "linux_arm64"];
+const PLATFORMS = [
+  "osx_arm64",
+  "osx_amd64",
+  "windows_amd64",
+  "linux_amd64",
+  "linux_arm64",
+];
+// Fail fast if the CDN stalls so the build never hangs indefinitely.
+const DOWNLOAD_TIMEOUT_MS = 60_000;
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const outBase = join(root, "apps/geolibre-desktop/src-tauri/resources/duckdb");
 const manifestPath = join(root, "scripts/duckdb-spatial-checksums.json");
 const writeChecksums = process.env.GEOLIBRE_WRITE_CHECKSUMS === "1";
+
+// Maps the Rust target triples we build for to DuckDB's platform identifiers.
+const TRIPLE_TO_PLATFORM = {
+  "aarch64-apple-darwin": "osx_arm64",
+  "x86_64-apple-darwin": "osx_amd64",
+  "x86_64-pc-windows-msvc": "windows_amd64",
+  "x86_64-pc-windows-gnu": "windows_amd64",
+  "x86_64-unknown-linux-gnu": "linux_amd64",
+  "x86_64-unknown-linux-musl": "linux_amd64",
+  "aarch64-unknown-linux-gnu": "linux_arm64",
+  "aarch64-unknown-linux-musl": "linux_arm64",
+};
+
+// Falls back to the host when no explicit target triple is supplied.
+const HOST_TO_PLATFORM = {
+  "darwin:arm64": "osx_arm64",
+  "darwin:x64": "osx_amd64",
+  "win32:x64": "windows_amd64",
+  "linux:x64": "linux_amd64",
+  "linux:arm64": "linux_arm64",
+};
+
+function parseTargetTriple(argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--target" && argv[i + 1]) return argv[i + 1];
+    if (arg.startsWith("--target=")) return arg.slice("--target=".length);
+  }
+  return (
+    process.env.GEOLIBRE_DUCKDB_TARGET || process.env.CARGO_BUILD_TARGET || ""
+  );
+}
+
+function resolveActivePlatforms() {
+  const triple = parseTargetTriple(process.argv.slice(2)).trim();
+  if (triple) {
+    // A universal macOS binary carries both arch slices, each resolving its own
+    // per-arch subpath at runtime, so it needs both DuckDB artifacts.
+    if (triple === "universal-apple-darwin") {
+      return ["osx_arm64", "osx_amd64"];
+    }
+    const platform = TRIPLE_TO_PLATFORM[triple];
+    if (!platform) {
+      throw new Error(
+        `Unsupported DuckDB target triple "${triple}". Known triples: ` +
+          `${Object.keys(TRIPLE_TO_PLATFORM).join(
+            ", "
+          )}, universal-apple-darwin.`
+      );
+    }
+    return [platform];
+  }
+  const hostKey = `${process.platform}:${process.arch}`;
+  const platform = HOST_TO_PLATFORM[hostKey];
+  if (!platform) {
+    throw new Error(
+      `Unsupported host platform "${hostKey}" for the DuckDB spatial extension. ` +
+        `Pass --target <rust-triple> to select one of: ${PLATFORMS.join(", ")}.`
+    );
+  }
+  return [platform];
+}
 
 async function sha256File(path) {
   const hash = createHash("sha256");
@@ -32,26 +110,42 @@ async function sha256File(path) {
 }
 
 async function loadManifest() {
+  let raw;
   try {
-    const raw = await readFile(manifestPath, "utf8");
-    const parsed = JSON.parse(raw);
-    return parsed.version === DUCKDB_VERSION ? parsed.sha256 ?? {} : {};
-  } catch {
-    return {};
+    raw = await readFile(manifestPath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {};
+    }
+    // Surface I/O failures instead of silently treating them as "no manifest"
+    // and re-pinning an unverified extension from the network.
+    throw error;
   }
+  const parsed = JSON.parse(raw);
+  return parsed.version === DUCKDB_VERSION ? parsed.sha256 ?? {} : {};
 }
 
-const expected = await loadManifest();
-const recorded = {};
-
-for (const platform of PLATFORMS) {
+async function fetchPlatform(platform, expected, recorded) {
   const url = `https://extensions.duckdb.org/${DUCKDB_VERSION}/${platform}/spatial.duckdb_extension.gz`;
   const outDir = join(outBase, platform);
   const outFile = join(outDir, "spatial.duckdb_extension");
   const tmpFile = `${outFile}.tmp`;
   await mkdir(outDir, { recursive: true });
   process.stdout.write(`Fetching ${platform} ... `);
-  const res = await fetch(url);
+  let res;
+  try {
+    res = await fetch(url, {
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+  } catch (error) {
+    await rm(tmpFile, { force: true });
+    if (error?.name === "TimeoutError") {
+      throw new Error(
+        `Timed out after ${DOWNLOAD_TIMEOUT_MS}ms fetching ${url}`
+      );
+    }
+    throw error;
+  }
   if (!res.ok) {
     await rm(tmpFile, { force: true });
     throw new Error(`Failed ${platform}: HTTP ${res.status} from ${url}`);
@@ -65,7 +159,7 @@ for (const platform of PLATFORMS) {
     throw new Error(
       `Checksum mismatch for ${platform}.\n  expected ${pinned}\n  got      ${digest}\n` +
         `Refusing to bundle an unverified native extension. If the upstream artifact ` +
-        `legitimately changed, re-pin with GEOLIBRE_WRITE_CHECKSUMS=1 and review the diff.`,
+        `legitimately changed, re-pin with GEOLIBRE_WRITE_CHECKSUMS=1 and review the diff.`
     );
   }
   if (!pinned && !writeChecksums) {
@@ -73,12 +167,39 @@ for (const platform of PLATFORMS) {
     throw new Error(
       `No pinned checksum for ${platform} (DuckDB ${DUCKDB_VERSION}). ` +
         `Re-run with GEOLIBRE_WRITE_CHECKSUMS=1 to record it, then commit ` +
-        `scripts/duckdb-spatial-checksums.json.`,
+        `scripts/duckdb-spatial-checksums.json.`
     );
   }
   recorded[platform] = digest;
   await rename(tmpFile, outFile);
-  console.log(pinned ? "done (verified)" : `done (recorded ${digest.slice(0, 12)}...)`);
+  console.log(
+    pinned ? "done (verified)" : `done (recorded ${digest.slice(0, 12)}...)`
+  );
+}
+
+// Removes platform directories we are not bundling so `resources/duckdb/**/*`
+// never carries another target's native binary into an installer.
+async function pruneOtherPlatforms(keep) {
+  await Promise.all(
+    PLATFORMS.filter((platform) => !keep.includes(platform)).map((platform) =>
+      rm(join(outBase, platform), { recursive: true, force: true })
+    )
+  );
+}
+
+const expected = await loadManifest();
+const recorded = {};
+
+// Re-pinning records the full manifest, so it needs every platform. A normal
+// build only ships the active target, so fetch (and keep) just that one.
+const platforms = writeChecksums ? PLATFORMS : resolveActivePlatforms();
+
+for (const platform of platforms) {
+  await fetchPlatform(platform, expected, recorded);
+}
+
+if (!writeChecksums) {
+  await pruneOtherPlatforms(platforms);
 }
 
 if (writeChecksums) {
@@ -86,4 +207,8 @@ if (writeChecksums) {
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
   console.log(`Wrote ${manifestPath}. Review and commit it.`);
 }
-console.log("All spatial extensions fetched.");
+console.log(
+  writeChecksums
+    ? "All spatial extensions fetched."
+    : `Spatial extension fetched for ${platforms.join(", ")}.`
+);

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -6,13 +6,18 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const userArgs = process.argv.slice(2);
 
-// Forward an explicit `--target <triple>` (cross-build) to the fetch helper so
-// it pulls the matching DuckDB artifact rather than the host's.
+// Forward an explicit cross-build target to the fetch helper so it pulls the
+// matching DuckDB artifact rather than the host's. Tauri accepts both the split
+// form (`--target <triple>`) and the joined form (`--target=<triple>`).
 const targetIndex = userArgs.indexOf("--target");
-const targetArgs =
+const targetEqualsArg = userArgs.find((arg) => arg.startsWith("--target="));
+const targetTriple =
   targetIndex !== -1 && userArgs[targetIndex + 1]
-    ? ["--target", userArgs[targetIndex + 1]]
-    : [];
+    ? userArgs[targetIndex + 1]
+    : targetEqualsArg
+    ? targetEqualsArg.slice("--target=".length)
+    : "";
+const targetArgs = targetTriple ? ["--target", targetTriple] : [];
 
 // Fetch and verify the DuckDB spatial extension into the Tauri resources tree
 // before bundling, so packaged desktop builds ship a signed extension the native

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -1,25 +1,15 @@
 import { spawnSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseTargetTripleArg } from "./duckdb-target.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const userArgs = process.argv.slice(2);
 
 // Forward an explicit cross-build target to the fetch helper so it pulls the
-// matching DuckDB artifact rather than the host's. `tauri build` accepts the
-// split (`--target <triple>`, `-t <triple>`) and joined (`--target=<triple>`,
-// `-t=<triple>`) forms, so handle all of them.
-function extractTargetTriple(args) {
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === "--target" || arg === "-t") return args[i + 1] || "";
-    if (arg.startsWith("--target=")) return arg.slice("--target=".length);
-    if (arg.startsWith("-t=")) return arg.slice("-t=".length);
-  }
-  return "";
-}
-const targetTriple = extractTargetTriple(userArgs);
+// matching DuckDB artifact rather than the host's.
+const targetTriple = parseTargetTripleArg(userArgs);
 const targetArgs = targetTriple ? ["--target", targetTriple] : [];
 
 // Fetch and verify the DuckDB spatial extension into the Tauri resources tree

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -4,22 +4,30 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+const userArgs = process.argv.slice(2);
+
+// Forward an explicit `--target <triple>` (cross-build) to the fetch helper so
+// it pulls the matching DuckDB artifact rather than the host's.
+const targetIndex = userArgs.indexOf("--target");
+const targetArgs =
+  targetIndex !== -1 && userArgs[targetIndex + 1]
+    ? ["--target", userArgs[targetIndex + 1]]
+    : [];
+
 // Fetch and verify the DuckDB spatial extension into the Tauri resources tree
 // before bundling, so packaged desktop builds ship a signed extension the native
 // DuckDB loader can read offline. A checksum mismatch aborts the build here.
 const fetched = spawnSync(
-  "node",
-  [resolve(repoRoot, "scripts/fetch-duckdb-spatial.mjs")],
+  process.execPath,
+  [resolve(repoRoot, "scripts/fetch-duckdb-spatial.mjs"), ...targetArgs],
   {
     cwd: repoRoot,
     stdio: "inherit",
-  },
+  }
 );
 if (fetched.status !== 0) {
   process.exit(fetched.status ?? 1);
 }
-
-const userArgs = process.argv.slice(2);
 const buildArgs =
   userArgs.length === 0 && process.platform === "linux"
     ? ["--bundles", "deb,rpm"]
@@ -32,7 +40,7 @@ const result = spawnSync(
     cwd: repoRoot,
     shell: process.platform === "win32",
     stdio: "inherit",
-  },
+  }
 );
 
 process.exit(result.status ?? 1);

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -3,6 +3,22 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Fetch and verify the DuckDB spatial extension into the Tauri resources tree
+// before bundling, so packaged desktop builds ship a signed extension the native
+// DuckDB loader can read offline. A checksum mismatch aborts the build here.
+const fetched = spawnSync(
+  "node",
+  [resolve(repoRoot, "scripts/fetch-duckdb-spatial.mjs")],
+  {
+    cwd: repoRoot,
+    stdio: "inherit",
+  },
+);
+if (fetched.status !== 0) {
+  process.exit(fetched.status ?? 1);
+}
+
 const userArgs = process.argv.slice(2);
 const buildArgs =
   userArgs.length === 0 && process.platform === "linux"

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -7,16 +7,19 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const userArgs = process.argv.slice(2);
 
 // Forward an explicit cross-build target to the fetch helper so it pulls the
-// matching DuckDB artifact rather than the host's. Tauri accepts both the split
-// form (`--target <triple>`) and the joined form (`--target=<triple>`).
-const targetIndex = userArgs.indexOf("--target");
-const targetEqualsArg = userArgs.find((arg) => arg.startsWith("--target="));
-const targetTriple =
-  targetIndex !== -1 && userArgs[targetIndex + 1]
-    ? userArgs[targetIndex + 1]
-    : targetEqualsArg
-    ? targetEqualsArg.slice("--target=".length)
-    : "";
+// matching DuckDB artifact rather than the host's. `tauri build` accepts the
+// split (`--target <triple>`, `-t <triple>`) and joined (`--target=<triple>`,
+// `-t=<triple>`) forms, so handle all of them.
+function extractTargetTriple(args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--target" || arg === "-t") return args[i + 1] || "";
+    if (arg.startsWith("--target=")) return arg.slice("--target=".length);
+    if (arg.startsWith("-t=")) return arg.slice("-t=".length);
+  }
+  return "";
+}
+const targetTriple = extractTargetTriple(userArgs);
 const targetArgs = targetTriple ? ["--target", targetTriple] : [];
 
 // Fetch and verify the DuckDB spatial extension into the Tauri resources tree


### PR DESCRIPTION
## Summary

Follow-up to #963. The native DuckDB vector loader added there loads the spatial extension with a bare `LOAD spatial`, which needs a network install or a machine-local extension. Packaged, offline desktop builds had no signed extension to load.

This bundles a per-platform, SHA-256 verified spatial extension and points the loader at it through the `GEOLIBRE_DUCKDB_SPATIAL_EXTENSION_PATH` seam #963 already reads, so the bundled extension loads signed without `allow_unsigned_extensions`. The native engine in `native_duckdb.rs` is untouched.

## What changed

- `scripts/fetch-duckdb-spatial.mjs` fetches each per-platform spatial extension over HTTPS and verifies its SHA-256 against `scripts/duckdb-spatial-checksums.json`, aborting the build on a mismatch. Bootstrap a new DuckDB version with `GEOLIBRE_WRITE_CHECKSUMS=1`.
- `scripts/tauri-build.mjs` runs the fetch before bundling, so release builds always ship a verified extension.
- `tauri.conf.json` bundles `resources/duckdb/**/*`. The binaries stay gitignored, only the `.gitignore` is tracked.
- `lib.rs` `setup` resolves the bundled per-platform extension and sets `GEOLIBRE_DUCKDB_SPATIAL_EXTENSION_PATH` when it is unset, falling back to a runtime `LOAD spatial` in `tauri dev` before `fetch:duckdb-spatial` has run. A pre-set env var still wins, so CI and developers can override.

## Why this is safe

The bundled extensions come from the official `extensions.duckdb.org` and are signed by DuckDB, so they load through #963's signed `LOAD` path with no `allow_unsigned_extensions`. The checksum manifest pins each artifact, so a tampered or swapped binary fails the build rather than shipping.

## Test plan

- [x] `cargo test --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml --lib` (16 passing, includes #963's `native_loader_reads_real_geoparquet_as_geojson` and the new `bundled_spatial_extension_subpath_matches_fetch_layout`)
- [x] `cargo fmt --check` clean
- [x] Verified the bundled signed extension `LOAD`s without `allow_unsigned_extensions` and runs spatial functions (throwaway test, since removed)
- [x] `npm run fetch:duckdb-spatial` verifies all 5 platforms against the committed manifest
- [x] `npm run tauri:build` succeeds and the packaged app loads a local vector file via drag and drop using the native path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled the DuckDB spatial native extension with the desktop app, automatically using the correct platform build.
  * Added a build-time download/verification step that fetches, unpacks, and packages the extension.
* **Bug Fixes**
  * Improved startup reliability by loading the bundled extension when available, with a safe fallback otherwise.
* **Tests**
  * Added tests to confirm the correct platform-to-bundled filename selection.
* **Chores**
  * Updated the build to fetch before bundling, refreshed pinned checksums (v1.5.4), expanded packaged resources, and adjusted DuckDB artifact ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->