### PR TITLE
fix(planetary): restore saved raster layers

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -19,6 +19,7 @@ import {
   REVERSE_GEOCODE_PLUGIN_ID,
   restoreEffects,
   restoreLidarLayers,
+  restorePlanetaryComputerLayers,
   restoreRasterLayers,
   restoreThreeDTilesLayers,
   restoreVectorLayers,
@@ -862,6 +863,7 @@ export function DesktopShell({
     );
     restoreThreeDTilesLayers(appAPI);
     restoreRasterLayers(appAPI);
+    restorePlanetaryComputerLayers(appAPI);
     restoreVectorLayers(appAPI);
     // Re-stream saved LiDAR (COPC) point clouds. A `lidar-url` layer restores
     // into the store as inert metadata; the point cloud is loaded by the LiDAR

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -135,6 +135,7 @@ export {
 export {
   closePlanetaryComputerPanel,
   openPlanetaryComputerPanel,
+  restorePlanetaryComputerLayers,
 } from "./plugins/maplibre-planetary-computer";
 export {
   closeEarthEnginePanel,

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -339,13 +339,16 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
     if (restoreToken !== planetaryComputerRestoreToken) return;
 
     let restoredCount = 0;
-    const failedLayerNames: string[] = [];
+    const failedLayers: PlanetaryComputerFailedRestore[] = [];
     for (const [index, result] of results.entries()) {
       const layer = layersToRestore[index];
       if (result.status === "fulfilled") {
         if (result.value) restoredCount += 1;
       } else {
-        failedLayerNames.push(layer?.name ?? "unknown");
+        failedLayers.push({
+          id: layer?.id ?? "",
+          name: layer?.name ?? "unknown",
+        });
         console.error(
           `[GeoLibre] Failed to restore Planetary Computer layer "${
             layer?.name ?? "unknown"
@@ -355,20 +358,26 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
       }
     }
 
+    if (failedLayers.length > 0) {
+      removeFailedPlanetaryComputerStoreLayers(control, failedLayers);
+    }
+
     if (restoredCount > 0) {
-      if (failedLayerNames.length > 0) {
+      if (failedLayers.length > 0) {
         console.warn(
           "[GeoLibre] Some Planetary Computer layers could not be restored " +
-            `and will be removed from the layer list: ${failedLayerNames.join(
-              ", "
-            )}`
+            `and were removed from the layer list: ${failedLayers
+              .map((layer) => layer.name)
+              .join(", ")}`
         );
       }
       emitPlanetaryComputerRestore(control);
-    } else if (layersToRestore.length > 0) {
+    } else if (failedLayers.length > 0) {
       console.warn(
         "[GeoLibre] No Planetary Computer layers could be restored; " +
-          "the saved layers will remain in the panel but will not render."
+          `the saved layers were removed from the layer list: ${failedLayers
+            .map((layer) => layer.name)
+            .join(", ")}`
       );
     }
   })().catch((error) => {
@@ -427,6 +436,7 @@ async function restorePlanetaryComputerLayer(
   );
   if (!currentLayer) return false;
   registerRestoredPlanetaryComputerLayer(control, currentLayer, {
+    collectionId,
     item,
     type: "item",
   });
@@ -437,7 +447,7 @@ function registerRestoredPlanetaryComputerLayer(
   control: PlanetaryComputerControl,
   layer: GeoLibreLayer,
   source:
-    | { item: STACItem; type: "item" }
+    | { collectionId: string; item: STACItem; type: "item" }
     | { collection: STACCollection; type: "collection" | "mosaic" }
 ): void {
   const map = control.getMap();
@@ -449,16 +459,16 @@ function registerRestoredPlanetaryComputerLayer(
     stringArrayMetadata(layer, "assets") || renderParams.assets || [];
   const savedBounds = numberArrayMetadata(layer, "bounds");
   const tileParams = assets.length ? { ...renderParams, assets } : renderParams;
+  const internals = requiredPlanetaryComputerRestoreInternals(control);
 
   if (map.getLayer(layer.id)) map.removeLayer(layer.id);
   if (map.getSource(sourceId)) map.removeSource(sourceId);
 
   if (source.type === "item") {
-    const collectionId = source.item.collection || "";
     map.addSource(sourceId, {
       type: "raster",
       url: getPlanetaryComputerTilerClient().getItemTileJSONUrl(
-        collectionId,
+        source.item.collection || source.collectionId,
         source.item.id,
         tileParams
       ),
@@ -477,7 +487,8 @@ function registerRestoredPlanetaryComputerLayer(
       ],
       tileSize: tileParams.tile_size || 256,
       bounds:
-        savedBounds ?? boundsTuple(source.collection.extent.spatial.bbox[0]),
+        savedBounds ??
+        boundsTuple(source.collection.extent?.spatial?.bbox?.[0]),
       attribution: "Microsoft Planetary Computer",
     });
   }
@@ -512,21 +523,27 @@ function registerRestoredPlanetaryComputerLayer(
     showControls: false,
   };
 
-  const internals = control as unknown as PlanetaryComputerControlInternals;
-  if (internals._layerManager?.layers) {
-    internals._layerManager.layers.set(layer.id, activeLayer);
-  } else {
-    console.warn(
-      "[GeoLibre] Planetary Computer _layerManager.layers not found; " +
-        "layer manager may be out of sync after restore. " +
-        "Re-verify against maplibre-gl-planetary-computer internals."
-    );
+  internals.layerManagerLayers.set(layer.id, activeLayer);
+  if (!internals.activeLayers.some((current) => current.id === layer.id)) {
+    internals.activeLayers.push(activeLayer);
   }
-  if (
-    internals._state?.activeLayers &&
-    !internals._state.activeLayers.some((current) => current.id === layer.id)
-  ) {
-    internals._state.activeLayers.push(activeLayer);
+}
+
+function removeFailedPlanetaryComputerStoreLayers(
+  control: PlanetaryComputerControl,
+  failedLayers: PlanetaryComputerFailedRestore[]
+): void {
+  const activeLayerIds = new Set(
+    control.getState().activeLayers.map((layer) => layer.id)
+  );
+  for (const failedLayer of failedLayers) {
+    if (!failedLayer.id || activeLayerIds.has(failedLayer.id)) continue;
+    const storeLayer = useAppStore
+      .getState()
+      .layers.find((layer) => layer.id === failedLayer.id);
+    if (storeLayer && isPlanetaryComputerLayer(storeLayer)) {
+      useAppStore.getState().removeLayer(failedLayer.id);
+    }
   }
 }
 
@@ -591,8 +608,18 @@ function renderedLayerIds(layer: GeoLibreLayer): string[] {
 function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
   // Private API verified against maplibre-gl-planetary-computer 0.3.0. These
   // calls are needed so the upstream panel and GeoLibre store see restored
-  // layers that were re-registered with saved IDs.
+  // layers that were re-registered with saved IDs. In 0.3.0, _emit constructs
+  // PlanetaryComputerEventData from _state.activeLayers synchronously, which is
+  // why one "layer:add" emit is enough to reconcile all restored layers.
   const internals = control as unknown as PlanetaryComputerControlInternals;
+  if (!internals._emit) {
+    console.warn(
+      "[GeoLibre] Planetary Computer _emit not found; " +
+        "the restored panel state may not refresh. " +
+        "Re-verify against maplibre-gl-planetary-computer internals."
+    );
+    return;
+  }
   internals._emit?.("layer:add");
   internals._emit?.("statechange");
   internals._renderContent?.();
@@ -689,14 +716,40 @@ type PlanetaryComputerLayerManagerInternals = {
 };
 
 // Mirrors private maplibre-gl-planetary-computer 0.3.0 internals used only by
-// the restore path. Keep all access guarded so dependency drift degrades with a
-// warning/no-op instead of crashing project open.
+// the restore path. Missing required internals make the affected layer restore
+// fail before any map mutation, so dependency drift does not corrupt control
+// state.
 type PlanetaryComputerControlInternals = {
   _layerManager?: PlanetaryComputerLayerManagerInternals;
   _state?: { activeLayers: ActiveLayer[] };
   _emit?: (event: "layer:add" | "statechange") => void;
   _renderContent?: () => void;
 };
+
+type PlanetaryComputerRestoreInternals = {
+  activeLayers: ActiveLayer[];
+  layerManagerLayers: Map<string, ActiveLayer>;
+};
+
+type PlanetaryComputerFailedRestore = {
+  id: string;
+  name: string;
+};
+
+function requiredPlanetaryComputerRestoreInternals(
+  control: PlanetaryComputerControl
+): PlanetaryComputerRestoreInternals {
+  const internals = control as unknown as PlanetaryComputerControlInternals;
+  const layerManagerLayers = internals._layerManager?.layers;
+  const activeLayers = internals._state?.activeLayers;
+  if (!layerManagerLayers || !activeLayers) {
+    throw new Error(
+      "Planetary Computer restore internals are unavailable; " +
+        "re-verify against maplibre-gl-planetary-computer internals."
+    );
+  }
+  return { activeLayers, layerManagerLayers };
+}
 
 function stringMetadata(layer: GeoLibreLayer, key: string): string | undefined {
   const value = layer.metadata[key];

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -64,7 +64,9 @@ export function closePlanetaryComputerPanel(app: GeoLibreAppAPI): void {
 async function openStandalonePlanetaryComputerControl(
   app: GeoLibreAppAPI
 ): Promise<boolean> {
-  const control = await ensurePlanetaryComputerControl(app);
+  const control = await ensurePlanetaryComputerControl(app, {
+    hiddenOnMount: false,
+  });
   if (!control) return false;
 
   setTimeout(() => {
@@ -119,7 +121,8 @@ function getPlanetaryComputerConstructors(): Promise<{
 }
 
 async function ensurePlanetaryComputerControl(
-  app: GeoLibreAppAPI
+  app: GeoLibreAppAPI,
+  options: { hiddenOnMount?: boolean } = {}
 ): Promise<PlanetaryComputerControl | null> {
   // Unlike the deck.gl-based plugins (GeoParquet, DuckDB), no
   // ensureMercatorProjection call is needed: the control adds native
@@ -141,7 +144,9 @@ async function ensurePlanetaryComputerControl(
       return null;
     }
     planetaryComputerControlMounted = true;
-    hidePlanetaryComputerControl(planetaryComputerControl);
+    if (options.hiddenOnMount ?? true) {
+      hidePlanetaryComputerControl(planetaryComputerControl);
+    }
     wirePlanetaryComputerCloseButton(planetaryComputerControl);
   }
 
@@ -331,12 +336,16 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
         restorePlanetaryComputerLayer(control, layer, restoreToken)
       )
     );
+    if (restoreToken !== planetaryComputerRestoreToken) return;
+
     let restoredCount = 0;
+    const failedLayerNames: string[] = [];
     for (const [index, result] of results.entries()) {
       const layer = layersToRestore[index];
       if (result.status === "fulfilled") {
         if (result.value) restoredCount += 1;
       } else {
+        failedLayerNames.push(layer?.name ?? "unknown");
         console.error(
           `[GeoLibre] Failed to restore Planetary Computer layer "${
             layer?.name ?? "unknown"
@@ -347,11 +356,16 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
     }
 
     if (restoredCount > 0) {
+      if (failedLayerNames.length > 0) {
+        console.warn(
+          "[GeoLibre] Some Planetary Computer layers could not be restored " +
+            `and will be removed from the layer list: ${failedLayerNames.join(
+              ", "
+            )}`
+        );
+      }
       emitPlanetaryComputerRestore(control);
-    } else if (
-      layersToRestore.length > 0 &&
-      restoreToken === planetaryComputerRestoreToken
-    ) {
+    } else if (layersToRestore.length > 0) {
       console.warn(
         "[GeoLibre] No Planetary Computer layers could be restored; " +
           "the saved layers will remain in the panel but will not render."
@@ -499,7 +513,15 @@ function registerRestoredPlanetaryComputerLayer(
   };
 
   const internals = control as unknown as PlanetaryComputerControlInternals;
-  internals._layerManager?.layers?.set(layer.id, activeLayer);
+  if (internals._layerManager?.layers) {
+    internals._layerManager.layers.set(layer.id, activeLayer);
+  } else {
+    console.warn(
+      "[GeoLibre] Planetary Computer _layerManager.layers not found; " +
+        "layer manager may be out of sync after restore. " +
+        "Re-verify against maplibre-gl-planetary-computer internals."
+    );
+  }
   if (
     internals._state?.activeLayers &&
     !internals._state.activeLayers.some((current) => current.id === layer.id)
@@ -567,6 +589,9 @@ function renderedLayerIds(layer: GeoLibreLayer): string[] {
 }
 
 function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
+  // Private API verified against maplibre-gl-planetary-computer 0.3.0. These
+  // calls are needed so the upstream panel and GeoLibre store see restored
+  // layers that were re-registered with saved IDs.
   const internals = control as unknown as PlanetaryComputerControlInternals;
   internals._emit?.("layer:add");
   internals._emit?.("statechange");
@@ -663,6 +688,9 @@ type PlanetaryComputerLayerManagerInternals = {
   layers?: Map<string, ActiveLayer>;
 };
 
+// Mirrors private maplibre-gl-planetary-computer 0.3.0 internals used only by
+// the restore path. Keep all access guarded so dependency drift degrades with a
+// warning/no-op instead of crashing project open.
 type PlanetaryComputerControlInternals = {
   _layerManager?: PlanetaryComputerLayerManagerInternals;
   _state?: { activeLayers: ActiveLayer[] };

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -49,6 +49,7 @@ let planetaryComputerTilerClient: TiTilerClient | null = null;
 let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
 let planetaryComputerRestoreToken = 0;
 let planetaryComputerRestorePreservedLayerIds = new Set<string>();
+let planetaryComputerStoreSyncSuspended = 0;
 
 export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePlanetaryComputerControl(app);
@@ -182,7 +183,10 @@ function createPlanetaryComputerControl(
 
         const currentLayer = currentById.get(layer.id);
         if (!currentLayer) {
-          planetaryComputerControl?.removeLayer(layer.id);
+          planetaryComputerRestorePreservedLayerIds.delete(layer.id);
+          runWithPlanetaryComputerStoreSyncSuspended(() => {
+            planetaryComputerControl?.removeLayer(layer.id);
+          });
           continue;
         }
 
@@ -207,6 +211,8 @@ function createPlanetaryComputerControl(
 function syncPlanetaryComputerLayersToStore(
   event: PlanetaryComputerEventData
 ): void {
+  if (planetaryComputerStoreSyncSuspended > 0) return;
+
   const store = useAppStore.getState();
   const activeLayers = event.state.activeLayers;
   const activeLayerIds = new Set(activeLayers.map((layer) => layer.id));
@@ -217,11 +223,13 @@ function syncPlanetaryComputerLayersToStore(
       !activeLayerIds.has(storeLayer.id) &&
       !planetaryComputerRestorePreservedLayerIds.has(storeLayer.id)
     ) {
+      planetaryComputerRestorePreservedLayerIds.delete(storeLayer.id);
       store.removeLayer(storeLayer.id);
     }
   }
 
   for (const activeLayer of activeLayers) {
+    planetaryComputerRestorePreservedLayerIds.delete(activeLayer.id);
     const layer = createPlanetaryComputerStoreLayer(activeLayer);
     const existing = useAppStore
       .getState()
@@ -312,11 +320,13 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
       .layers.filter(isPlanetaryComputerLayer);
     const storeLayerIds = new Set(storeLayers.map((layer) => layer.id));
 
-    for (const activeLayer of [...control.getState().activeLayers]) {
-      if (!storeLayerIds.has(activeLayer.id)) {
-        control.removeLayer(activeLayer.id);
+    runWithPlanetaryComputerStoreSyncSuspended(() => {
+      for (const activeLayer of [...control.getState().activeLayers]) {
+        if (!storeLayerIds.has(activeLayer.id)) {
+          control.removeLayer(activeLayer.id);
+        }
       }
-    }
+    });
 
     const activeLayerIds = new Set(
       control.getState().activeLayers.map((layer) => layer.id)
@@ -340,15 +350,14 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
         restorePlanetaryComputerLayer(control, layer, restoreToken)
       )
     );
-    if (restoreToken !== planetaryComputerRestoreToken) return;
 
-    let restoredCount = 0;
+    const restoredLayerIds = new Set<string>();
     const invalidLayers: PlanetaryComputerRestoreFailure[] = [];
     const transientFailures: PlanetaryComputerRestoreFailure[] = [];
     for (const [index, result] of results.entries()) {
       const layer = layersToRestore[index];
       if (result.status === "fulfilled") {
-        if (result.value) restoredCount += 1;
+        if (result.value) restoredLayerIds.add(result.value);
       } else {
         const failure = {
           id: layer?.id ?? "",
@@ -368,6 +377,15 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
       }
     }
 
+    if (restoreToken !== planetaryComputerRestoreToken) {
+      rollbackSupersededPlanetaryComputerRestore(
+        control,
+        layersToRestore,
+        restoredLayerIds
+      );
+      return;
+    }
+
     if (invalidLayers.length > 0) {
       removeInvalidPlanetaryComputerStoreLayers(control, invalidLayers);
       console.warn(
@@ -379,6 +397,11 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
     }
 
     if (transientFailures.length > 0) {
+      for (const transientFailure of transientFailures) {
+        if (transientFailure.id) {
+          planetaryComputerRestorePreservedLayerIds.add(transientFailure.id);
+        }
+      }
       console.warn(
         "[GeoLibre] Some Planetary Computer layers could not be restored " +
           `and were kept in the layer list: ${transientFailures
@@ -387,11 +410,8 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
       );
     }
 
-    if (restoredCount > 0) {
-      emitPlanetaryComputerRestore(
-        control,
-        new Set(transientFailures.map((layer) => layer.id).filter(Boolean))
-      );
+    if (restoredLayerIds.size > 0) {
+      emitPlanetaryComputerRestore(control);
     }
   })().catch((error) => {
     console.error(
@@ -405,7 +425,7 @@ async function restorePlanetaryComputerLayer(
   control: PlanetaryComputerControl,
   layer: GeoLibreLayer,
   restoreToken: number
-): Promise<boolean> {
+): Promise<string | null> {
   const collectionId = stringMetadata(layer, "stacCollectionId");
   const layerType = stringMetadata(layer, "planetaryComputerLayerType");
   if (!collectionId) {
@@ -423,12 +443,12 @@ async function restorePlanetaryComputerLayer(
       layer,
       restoreToken
     );
-    if (!currentLayer) return false;
+    if (!currentLayer) return null;
     registerRestoredPlanetaryComputerLayer(control, currentLayer, {
       collection,
       type: layerType,
     });
-    return true;
+    return currentLayer.id;
   }
 
   const itemId = stringMetadata(layer, "stacItemId");
@@ -447,13 +467,13 @@ async function restorePlanetaryComputerLayer(
     layer,
     restoreToken
   );
-  if (!currentLayer) return false;
+  if (!currentLayer) return null;
   registerRestoredPlanetaryComputerLayer(control, currentLayer, {
     collectionId,
     item,
     type: "item",
   });
-  return true;
+  return currentLayer.id;
 }
 
 function registerRestoredPlanetaryComputerLayer(
@@ -551,6 +571,7 @@ function removeInvalidPlanetaryComputerStoreLayers(
   );
   for (const invalidLayer of invalidLayers) {
     if (!invalidLayer.id || activeLayerIds.has(invalidLayer.id)) continue;
+    planetaryComputerRestorePreservedLayerIds.delete(invalidLayer.id);
     const storeLayer = useAppStore
       .getState()
       .layers.find((layer) => layer.id === invalidLayer.id);
@@ -558,6 +579,38 @@ function removeInvalidPlanetaryComputerStoreLayers(
       useAppStore.getState().removeLayer(invalidLayer.id);
     }
   }
+}
+
+function rollbackSupersededPlanetaryComputerRestore(
+  control: PlanetaryComputerControl,
+  layersToRestore: GeoLibreLayer[],
+  restoredLayerIds: Set<string>
+): void {
+  if (restoredLayerIds.size === 0) return;
+
+  const restoredLayersById = new Map(
+    layersToRestore.map((layer) => [layer.id, layer])
+  );
+  let keptRestoredLayer = false;
+
+  runWithPlanetaryComputerStoreSyncSuspended(() => {
+    for (const restoredLayerId of restoredLayerIds) {
+      const restoredLayer = restoredLayersById.get(restoredLayerId);
+      if (
+        restoredLayer &&
+        currentStoreLayerMatchesPlanetaryComputerRestore(restoredLayer)
+      ) {
+        keptRestoredLayer = true;
+        continue;
+      }
+
+      control.removeLayer(restoredLayerId);
+    }
+
+    if (keptRestoredLayer) {
+      emitPlanetaryComputerRestore(control);
+    }
+  });
 }
 
 function currentRestorablePlanetaryComputerLayer(
@@ -576,18 +629,47 @@ function currentRestorablePlanetaryComputerLayer(
     .getState()
     .layers.find((candidate) => candidate.id === layer.id);
   if (!currentLayer || !isPlanetaryComputerLayer(currentLayer)) return null;
-  if (
-    stringMetadata(currentLayer, "stacCollectionId") !==
-      stringMetadata(layer, "stacCollectionId") ||
-    stringMetadata(currentLayer, "stacItemId") !==
-      stringMetadata(layer, "stacItemId") ||
-    stringMetadata(currentLayer, "planetaryComputerLayerType") !==
-      stringMetadata(layer, "planetaryComputerLayerType")
-  ) {
+  if (!hasSamePlanetaryComputerRestoreSource(currentLayer, layer)) {
     return null;
   }
 
   return currentLayer;
+}
+
+function currentStoreLayerMatchesPlanetaryComputerRestore(
+  restoredLayer: GeoLibreLayer
+): boolean {
+  const currentLayer = useAppStore
+    .getState()
+    .layers.find((candidate) => candidate.id === restoredLayer.id);
+  return (
+    !!currentLayer &&
+    isPlanetaryComputerLayer(currentLayer) &&
+    hasSamePlanetaryComputerRestoreSource(currentLayer, restoredLayer)
+  );
+}
+
+function hasSamePlanetaryComputerRestoreSource(
+  currentLayer: GeoLibreLayer,
+  restoredLayer: GeoLibreLayer
+): boolean {
+  return (
+    stringMetadata(currentLayer, "stacCollectionId") ===
+      stringMetadata(restoredLayer, "stacCollectionId") &&
+    stringMetadata(currentLayer, "stacItemId") ===
+      stringMetadata(restoredLayer, "stacItemId") &&
+    stringMetadata(currentLayer, "planetaryComputerLayerType") ===
+      stringMetadata(restoredLayer, "planetaryComputerLayerType")
+  );
+}
+
+function runWithPlanetaryComputerStoreSyncSuspended<T>(callback: () => T): T {
+  planetaryComputerStoreSyncSuspended += 1;
+  try {
+    return callback();
+  } finally {
+    planetaryComputerStoreSyncSuspended -= 1;
+  }
 }
 
 function nextRenderedStoreLayerId(
@@ -618,10 +700,7 @@ function renderedLayerIds(layer: GeoLibreLayer): string[] {
   return [...nativeLayerIds, layer.id];
 }
 
-function emitPlanetaryComputerRestore(
-  control: PlanetaryComputerControl,
-  preservedLayerIds = new Set<string>()
-): void {
+function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
   // Private API verified against maplibre-gl-planetary-computer 0.3.0. These
   // calls are needed so the upstream panel and GeoLibre store see restored
   // layers that were re-registered with saved IDs. In 0.3.0, _emit constructs
@@ -636,15 +715,9 @@ function emitPlanetaryComputerRestore(
     );
     return;
   }
-  const previousPreservedLayerIds = planetaryComputerRestorePreservedLayerIds;
-  planetaryComputerRestorePreservedLayerIds = preservedLayerIds;
-  try {
-    internals._emit("layer:add");
-    internals._emit("statechange");
-    internals._renderContent?.();
-  } finally {
-    planetaryComputerRestorePreservedLayerIds = previousPreservedLayerIds;
-  }
+  internals._emit("layer:add");
+  internals._emit("statechange");
+  internals._renderContent?.();
 }
 
 function getPlanetaryComputerStacClient(): STACClient {

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -47,6 +47,7 @@ let planetaryComputerConstructors: {
 let planetaryComputerStacClient: STACClient | null = null;
 let planetaryComputerTilerClient: TiTilerClient | null = null;
 let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
+let planetaryComputerRestoreToken = 0;
 
 export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePlanetaryComputerControl(app);
@@ -61,7 +62,7 @@ export function closePlanetaryComputerPanel(app: GeoLibreAppAPI): void {
 }
 
 async function openStandalonePlanetaryComputerControl(
-  app: GeoLibreAppAPI,
+  app: GeoLibreAppAPI
 ): Promise<boolean> {
   const control = await ensurePlanetaryComputerControl(app);
   if (!control) return false;
@@ -80,7 +81,7 @@ async function openStandalonePlanetaryComputerControl(
 // leave the icon on the map); only a direct click on the X button hides the
 // whole control until it is reopened from the Processing menu.
 function wirePlanetaryComputerCloseButton(
-  control: PlanetaryComputerControl | null,
+  control: PlanetaryComputerControl | null
 ): void {
   const closeButton = control
     ?.getPanelElement()
@@ -90,7 +91,7 @@ function wirePlanetaryComputerCloseButton(
   }
   closeButton.dataset.geolibreCloseWired = "true";
   closeButton.addEventListener("click", () =>
-    hidePlanetaryComputerControl(control),
+    hidePlanetaryComputerControl(control)
   );
 }
 
@@ -118,7 +119,7 @@ function getPlanetaryComputerConstructors(): Promise<{
 }
 
 async function ensurePlanetaryComputerControl(
-  app: GeoLibreAppAPI,
+  app: GeoLibreAppAPI
 ): Promise<PlanetaryComputerControl | null> {
   // Unlike the deck.gl-based plugins (GeoParquet, DuckDB), no
   // ensureMercatorProjection call is needed: the control adds native
@@ -127,13 +128,13 @@ async function ensurePlanetaryComputerControl(
     await getPlanetaryComputerConstructors();
 
   planetaryComputerControl ??= createPlanetaryComputerControl(
-    PlanetaryComputerControlClass,
+    PlanetaryComputerControlClass
   );
 
   if (!planetaryComputerControlMounted) {
     const added = app.addMapControl(
       planetaryComputerControl,
-      planetaryComputerControlPosition,
+      planetaryComputerControlPosition
     );
     if (!added) {
       resetPlanetaryComputerControl(planetaryComputerControl);
@@ -148,7 +149,7 @@ async function ensurePlanetaryComputerControl(
 }
 
 function createPlanetaryComputerControl(
-  PlanetaryComputerControlClass: PlanetaryComputerControlConstructor,
+  PlanetaryComputerControlClass: PlanetaryComputerControlConstructor
 ): PlanetaryComputerControl {
   const control = new PlanetaryComputerControlClass(PLANETARY_COMPUTER_OPTIONS);
   patchPlanetaryComputerControlOnRemove(control);
@@ -167,7 +168,7 @@ function createPlanetaryComputerControl(
   planetaryComputerStoreUnsubscribe ??= useAppStore.subscribe(
     (state, previous) => {
       const currentById = new Map(
-        state.layers.map((layer) => [layer.id, layer]),
+        state.layers.map((layer) => [layer.id, layer])
       );
 
       for (const layer of previous.layers) {
@@ -191,14 +192,14 @@ function createPlanetaryComputerControl(
           });
         }
       }
-    },
+    }
   );
 
   return control;
 }
 
 function syncPlanetaryComputerLayersToStore(
-  event: PlanetaryComputerEventData,
+  event: PlanetaryComputerEventData
 ): void {
   const store = useAppStore.getState();
   const activeLayers = event.state.activeLayers;
@@ -238,7 +239,7 @@ function syncPlanetaryComputerLayersToStore(
 }
 
 function createPlanetaryComputerStoreLayer(
-  activeLayer: ActiveLayer,
+  activeLayer: ActiveLayer
 ): GeoLibreLayer {
   const bbox =
     activeLayer.item?.bbox ??
@@ -292,26 +293,27 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
     .layers.some(isPlanetaryComputerLayer);
   if (!hasPlanetaryComputerLayers && !planetaryComputerControl) return;
 
+  const restoreToken = ++planetaryComputerRestoreToken;
   void (async () => {
     const control = await ensurePlanetaryComputerControl(app);
-    if (!control) return;
+    if (!control || restoreToken !== planetaryComputerRestoreToken) return;
 
     const storeLayers = useAppStore
       .getState()
       .layers.filter(isPlanetaryComputerLayer);
     const storeLayerIds = new Set(storeLayers.map((layer) => layer.id));
 
-    for (const activeLayer of control.getState().activeLayers) {
+    for (const activeLayer of [...control.getState().activeLayers]) {
       if (!storeLayerIds.has(activeLayer.id)) {
         control.removeLayer(activeLayer.id);
       }
     }
 
     const activeLayerIds = new Set(
-      control.getState().activeLayers.map((layer) => layer.id),
+      control.getState().activeLayers.map((layer) => layer.id)
     );
 
-    let restoredCount = 0;
+    const layersToRestore: GeoLibreLayer[] = [];
     for (const layer of storeLayers) {
       if (activeLayerIds.has(layer.id)) {
         control.updateLayer(layer.id, {
@@ -321,24 +323,44 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
         continue;
       }
 
-      try {
-        await restorePlanetaryComputerLayer(control, layer);
-        restoredCount += 1;
-      } catch (error) {
+      layersToRestore.push(layer);
+    }
+
+    const results = await Promise.allSettled(
+      layersToRestore.map((layer) =>
+        restorePlanetaryComputerLayer(control, layer, restoreToken)
+      )
+    );
+    let restoredCount = 0;
+    for (const [index, result] of results.entries()) {
+      const layer = layersToRestore[index];
+      if (result.status === "fulfilled") {
+        if (result.value) restoredCount += 1;
+      } else {
         console.error(
-          `[GeoLibre] Failed to restore Planetary Computer layer "${layer.name}"`,
-          error,
+          `[GeoLibre] Failed to restore Planetary Computer layer "${
+            layer?.name ?? "unknown"
+          }"`,
+          result.reason
         );
       }
     }
 
     if (restoredCount > 0) {
       emitPlanetaryComputerRestore(control);
+    } else if (
+      layersToRestore.length > 0 &&
+      restoreToken === planetaryComputerRestoreToken
+    ) {
+      console.warn(
+        "[GeoLibre] No Planetary Computer layers could be restored; " +
+          "the saved layers will remain in the panel but will not render."
+      );
     }
   })().catch((error) => {
     console.error(
       "[GeoLibre] Failed to restore Planetary Computer layers",
-      error,
+      error
     );
   });
 }
@@ -346,41 +368,55 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
 async function restorePlanetaryComputerLayer(
   control: PlanetaryComputerControl,
   layer: GeoLibreLayer,
-): Promise<void> {
+  restoreToken: number
+): Promise<boolean> {
   const collectionId = stringMetadata(layer, "stacCollectionId");
   const layerType = stringMetadata(layer, "planetaryComputerLayerType");
   if (!collectionId) {
     throw new Error(
-      "Saved Planetary Computer layer is missing a collection id.",
+      "Saved Planetary Computer layer is missing a collection id."
     );
   }
 
   if (layerType === "collection" || layerType === "mosaic") {
     const collection = await getPlanetaryComputerStacClient().getCollection(
-      collectionId,
+      collectionId
     );
-    registerRestoredPlanetaryComputerLayer(control, layer, {
+    const currentLayer = currentRestorablePlanetaryComputerLayer(
+      control,
+      layer,
+      restoreToken
+    );
+    if (!currentLayer) return false;
+    registerRestoredPlanetaryComputerLayer(control, currentLayer, {
       collection,
       type: layerType,
     });
-    return;
+    return true;
   }
 
   const itemId = stringMetadata(layer, "stacItemId");
   if (!itemId) {
     throw new Error(
-      "Saved Planetary Computer item layer is missing an item id.",
+      "Saved Planetary Computer item layer is missing an item id."
     );
   }
 
   const item = await getPlanetaryComputerStacClient().getItem(
     collectionId,
-    itemId,
+    itemId
   );
-  registerRestoredPlanetaryComputerLayer(control, layer, {
+  const currentLayer = currentRestorablePlanetaryComputerLayer(
+    control,
+    layer,
+    restoreToken
+  );
+  if (!currentLayer) return false;
+  registerRestoredPlanetaryComputerLayer(control, currentLayer, {
     item,
     type: "item",
   });
+  return true;
 }
 
 function registerRestoredPlanetaryComputerLayer(
@@ -388,7 +424,7 @@ function registerRestoredPlanetaryComputerLayer(
   layer: GeoLibreLayer,
   source:
     | { item: STACItem; type: "item" }
-    | { collection: STACCollection; type: "collection" | "mosaic" },
+    | { collection: STACCollection; type: "collection" | "mosaic" }
 ): void {
   const map = control.getMap();
   if (!map) throw new Error("Planetary Computer control is not attached.");
@@ -410,7 +446,7 @@ function registerRestoredPlanetaryComputerLayer(
       url: getPlanetaryComputerTilerClient().getItemTileJSONUrl(
         collectionId,
         source.item.id,
-        tileParams,
+        tileParams
       ),
       tileSize: tileParams.tile_size || 256,
       bounds: boundsTuple(source.item.bbox),
@@ -422,7 +458,7 @@ function registerRestoredPlanetaryComputerLayer(
       tiles: [
         getPlanetaryComputerTilerClient().getCollectionTileUrl(
           source.collection.id,
-          tileParams,
+          tileParams
         ),
       ],
       tileSize: tileParams.tile_size || 256,
@@ -432,17 +468,20 @@ function registerRestoredPlanetaryComputerLayer(
     });
   }
 
-  map.addLayer({
-    id: layer.id,
-    type: "raster",
-    source: sourceId,
-    layout: {
-      visibility: layer.visible ? "visible" : "none",
+  map.addLayer(
+    {
+      id: layer.id,
+      type: "raster",
+      source: sourceId,
+      layout: {
+        visibility: layer.visible ? "visible" : "none",
+      },
+      paint: {
+        "raster-opacity": layer.opacity,
+      },
     },
-    paint: {
-      "raster-opacity": layer.opacity,
-    },
-  });
+    nextRenderedStoreLayerId(map, layer.id)
+  );
 
   const activeLayer: ActiveLayer = {
     id: layer.id,
@@ -462,10 +501,69 @@ function registerRestoredPlanetaryComputerLayer(
   const internals = control as unknown as PlanetaryComputerControlInternals;
   internals._layerManager?.layers?.set(layer.id, activeLayer);
   if (
+    internals._state?.activeLayers &&
     !internals._state.activeLayers.some((current) => current.id === layer.id)
   ) {
     internals._state.activeLayers.push(activeLayer);
   }
+}
+
+function currentRestorablePlanetaryComputerLayer(
+  control: PlanetaryComputerControl,
+  layer: GeoLibreLayer,
+  restoreToken: number
+): GeoLibreLayer | null {
+  if (
+    restoreToken !== planetaryComputerRestoreToken ||
+    control !== planetaryComputerControl
+  ) {
+    return null;
+  }
+
+  const currentLayer = useAppStore
+    .getState()
+    .layers.find((candidate) => candidate.id === layer.id);
+  if (!currentLayer || !isPlanetaryComputerLayer(currentLayer)) return null;
+  if (
+    stringMetadata(currentLayer, "stacCollectionId") !==
+      stringMetadata(layer, "stacCollectionId") ||
+    stringMetadata(currentLayer, "stacItemId") !==
+      stringMetadata(layer, "stacItemId") ||
+    stringMetadata(currentLayer, "planetaryComputerLayerType") !==
+      stringMetadata(layer, "planetaryComputerLayerType")
+  ) {
+    return null;
+  }
+
+  return currentLayer;
+}
+
+function nextRenderedStoreLayerId(
+  map: NonNullable<ReturnType<PlanetaryComputerControl["getMap"]>>,
+  layerId: string
+): string | undefined {
+  const layers = useAppStore.getState().layers;
+  const layerIndex = layers.findIndex((layer) => layer.id === layerId);
+  if (layerIndex < 0) return undefined;
+
+  for (const candidate of layers.slice(layerIndex + 1)) {
+    for (const renderedId of renderedLayerIds(candidate)) {
+      if (renderedId !== layerId && map.getLayer(renderedId)) {
+        return renderedId;
+      }
+    }
+  }
+  return undefined;
+}
+
+function renderedLayerIds(layer: GeoLibreLayer): string[] {
+  const nativeLayerIds = Array.isArray(layer.metadata.nativeLayerIds)
+    ? layer.metadata.nativeLayerIds.filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0
+      )
+    : [];
+  return [...nativeLayerIds, layer.id];
 }
 
 function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
@@ -512,7 +610,7 @@ function planetaryComputerLayerName(activeLayer: ActiveLayer): string {
 }
 
 function patchPlanetaryComputerControlOnRemove(
-  control: PlanetaryComputerControl,
+  control: PlanetaryComputerControl
 ): void {
   const originalOnRemove = control.onRemove.bind(control);
   control.onRemove = () => {
@@ -522,7 +620,7 @@ function patchPlanetaryComputerControlOnRemove(
 }
 
 function resetPlanetaryComputerControl(
-  control: PlanetaryComputerControl | null,
+  control: PlanetaryComputerControl | null
 ): void {
   if (planetaryComputerControl !== control) return;
 
@@ -536,7 +634,7 @@ function resetPlanetaryComputerControl(
 }
 
 function hidePlanetaryComputerControl(
-  control: PlanetaryComputerControl | null,
+  control: PlanetaryComputerControl | null
 ): void {
   const container = control?.getContainer();
   const panel = control?.getPanelElement();
@@ -545,7 +643,7 @@ function hidePlanetaryComputerControl(
 }
 
 function showPlanetaryComputerControl(
-  control: PlanetaryComputerControl | null,
+  control: PlanetaryComputerControl | null
 ): void {
   const container = control?.getContainer();
   const panel = control?.getPanelElement();
@@ -567,7 +665,7 @@ type PlanetaryComputerLayerManagerInternals = {
 
 type PlanetaryComputerControlInternals = {
   _layerManager?: PlanetaryComputerLayerManagerInternals;
-  _state: { activeLayers: ActiveLayer[] };
+  _state?: { activeLayers: ActiveLayer[] };
   _emit?: (event: "layer:add" | "statechange") => void;
   _renderContent?: () => void;
 };
@@ -579,7 +677,7 @@ function stringMetadata(layer: GeoLibreLayer, key: string): string | undefined {
 
 function stringArrayMetadata(
   layer: GeoLibreLayer,
-  key: string,
+  key: string
 ): string[] | undefined {
   const value = layer.metadata[key];
   return Array.isArray(value) &&
@@ -590,7 +688,7 @@ function stringArrayMetadata(
 
 function numberArrayMetadata(
   layer: GeoLibreLayer,
-  key: string,
+  key: string
 ): [number, number, number, number] | undefined {
   const value = layer.metadata[key];
   return boundsTuple(value);
@@ -604,7 +702,7 @@ function tileParamsMetadata(layer: GeoLibreLayer, key: string): TileParams {
 }
 
 function boundsTuple(
-  value: unknown,
+  value: unknown
 ): [number, number, number, number] | undefined {
   return Array.isArray(value) &&
     value.length === 4 &&

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -48,6 +48,7 @@ let planetaryComputerStacClient: STACClient | null = null;
 let planetaryComputerTilerClient: TiTilerClient | null = null;
 let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
 let planetaryComputerRestoreToken = 0;
+let planetaryComputerRestorePreservedLayerIds = new Set<string>();
 
 export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePlanetaryComputerControl(app);
@@ -212,7 +213,10 @@ function syncPlanetaryComputerLayersToStore(
 
   for (const storeLayer of store.layers) {
     if (!isPlanetaryComputerLayer(storeLayer)) continue;
-    if (!activeLayerIds.has(storeLayer.id)) {
+    if (
+      !activeLayerIds.has(storeLayer.id) &&
+      !planetaryComputerRestorePreservedLayerIds.has(storeLayer.id)
+    ) {
       store.removeLayer(storeLayer.id);
     }
   }
@@ -339,16 +343,22 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
     if (restoreToken !== planetaryComputerRestoreToken) return;
 
     let restoredCount = 0;
-    const failedLayers: PlanetaryComputerFailedRestore[] = [];
+    const invalidLayers: PlanetaryComputerRestoreFailure[] = [];
+    const transientFailures: PlanetaryComputerRestoreFailure[] = [];
     for (const [index, result] of results.entries()) {
       const layer = layersToRestore[index];
       if (result.status === "fulfilled") {
         if (result.value) restoredCount += 1;
       } else {
-        failedLayers.push({
+        const failure = {
           id: layer?.id ?? "",
           name: layer?.name ?? "unknown",
-        });
+        };
+        if (isInvalidPlanetaryComputerLayerMetadataError(result.reason)) {
+          invalidLayers.push(failure);
+        } else {
+          transientFailures.push(failure);
+        }
         console.error(
           `[GeoLibre] Failed to restore Planetary Computer layer "${
             layer?.name ?? "unknown"
@@ -358,26 +368,29 @@ export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
       }
     }
 
-    if (failedLayers.length > 0) {
-      removeFailedPlanetaryComputerStoreLayers(control, failedLayers);
+    if (invalidLayers.length > 0) {
+      removeInvalidPlanetaryComputerStoreLayers(control, invalidLayers);
+      console.warn(
+        "[GeoLibre] Some Planetary Computer layers had invalid saved " +
+          `metadata and were removed from the layer list: ${invalidLayers
+            .map((layer) => layer.name)
+            .join(", ")}`
+      );
+    }
+
+    if (transientFailures.length > 0) {
+      console.warn(
+        "[GeoLibre] Some Planetary Computer layers could not be restored " +
+          `and were kept in the layer list: ${transientFailures
+            .map((layer) => layer.name)
+            .join(", ")}`
+      );
     }
 
     if (restoredCount > 0) {
-      if (failedLayers.length > 0) {
-        console.warn(
-          "[GeoLibre] Some Planetary Computer layers could not be restored " +
-            `and were removed from the layer list: ${failedLayers
-              .map((layer) => layer.name)
-              .join(", ")}`
-        );
-      }
-      emitPlanetaryComputerRestore(control);
-    } else if (failedLayers.length > 0) {
-      console.warn(
-        "[GeoLibre] No Planetary Computer layers could be restored; " +
-          `the saved layers were removed from the layer list: ${failedLayers
-            .map((layer) => layer.name)
-            .join(", ")}`
+      emitPlanetaryComputerRestore(
+        control,
+        new Set(transientFailures.map((layer) => layer.id).filter(Boolean))
       );
     }
   })().catch((error) => {
@@ -396,7 +409,7 @@ async function restorePlanetaryComputerLayer(
   const collectionId = stringMetadata(layer, "stacCollectionId");
   const layerType = stringMetadata(layer, "planetaryComputerLayerType");
   if (!collectionId) {
-    throw new Error(
+    throw new InvalidPlanetaryComputerLayerMetadataError(
       "Saved Planetary Computer layer is missing a collection id."
     );
   }
@@ -420,7 +433,7 @@ async function restorePlanetaryComputerLayer(
 
   const itemId = stringMetadata(layer, "stacItemId");
   if (!itemId) {
-    throw new Error(
+    throw new InvalidPlanetaryComputerLayerMetadataError(
       "Saved Planetary Computer item layer is missing an item id."
     );
   }
@@ -529,20 +542,20 @@ function registerRestoredPlanetaryComputerLayer(
   }
 }
 
-function removeFailedPlanetaryComputerStoreLayers(
+function removeInvalidPlanetaryComputerStoreLayers(
   control: PlanetaryComputerControl,
-  failedLayers: PlanetaryComputerFailedRestore[]
+  invalidLayers: PlanetaryComputerRestoreFailure[]
 ): void {
   const activeLayerIds = new Set(
     control.getState().activeLayers.map((layer) => layer.id)
   );
-  for (const failedLayer of failedLayers) {
-    if (!failedLayer.id || activeLayerIds.has(failedLayer.id)) continue;
+  for (const invalidLayer of invalidLayers) {
+    if (!invalidLayer.id || activeLayerIds.has(invalidLayer.id)) continue;
     const storeLayer = useAppStore
       .getState()
-      .layers.find((layer) => layer.id === failedLayer.id);
+      .layers.find((layer) => layer.id === invalidLayer.id);
     if (storeLayer && isPlanetaryComputerLayer(storeLayer)) {
-      useAppStore.getState().removeLayer(failedLayer.id);
+      useAppStore.getState().removeLayer(invalidLayer.id);
     }
   }
 }
@@ -605,7 +618,10 @@ function renderedLayerIds(layer: GeoLibreLayer): string[] {
   return [...nativeLayerIds, layer.id];
 }
 
-function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
+function emitPlanetaryComputerRestore(
+  control: PlanetaryComputerControl,
+  preservedLayerIds = new Set<string>()
+): void {
   // Private API verified against maplibre-gl-planetary-computer 0.3.0. These
   // calls are needed so the upstream panel and GeoLibre store see restored
   // layers that were re-registered with saved IDs. In 0.3.0, _emit constructs
@@ -620,9 +636,15 @@ function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
     );
     return;
   }
-  internals._emit?.("layer:add");
-  internals._emit?.("statechange");
-  internals._renderContent?.();
+  const previousPreservedLayerIds = planetaryComputerRestorePreservedLayerIds;
+  planetaryComputerRestorePreservedLayerIds = preservedLayerIds;
+  try {
+    internals._emit("layer:add");
+    internals._emit("statechange");
+    internals._renderContent?.();
+  } finally {
+    planetaryComputerRestorePreservedLayerIds = previousPreservedLayerIds;
+  }
 }
 
 function getPlanetaryComputerStacClient(): STACClient {
@@ -731,10 +753,21 @@ type PlanetaryComputerRestoreInternals = {
   layerManagerLayers: Map<string, ActiveLayer>;
 };
 
-type PlanetaryComputerFailedRestore = {
+type PlanetaryComputerRestoreFailure = {
   id: string;
   name: string;
 };
+
+class InvalidPlanetaryComputerLayerMetadataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidPlanetaryComputerLayerMetadataError";
+  }
+}
+
+function isInvalidPlanetaryComputerLayerMetadataError(error: unknown): boolean {
+  return error instanceof InvalidPlanetaryComputerLayerMetadataError;
+}
 
 function requiredPlanetaryComputerRestoreInternals(
   control: PlanetaryComputerControl

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -8,11 +8,20 @@ import type {
   PlanetaryComputerControl,
   PlanetaryComputerEventData,
   PlanetaryComputerOptions,
+  STACClient,
+  STACCollection,
+  STACItem,
+  TiTilerClient,
+  TileParams,
 } from "maplibre-gl-planetary-computer";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
 
 type PlanetaryComputerControlConstructor =
-  (typeof import("maplibre-gl-planetary-computer"))["PlanetaryComputerControl"];
+  typeof import("maplibre-gl-planetary-computer")["PlanetaryComputerControl"];
+type STACClientConstructor =
+  typeof import("maplibre-gl-planetary-computer")["STACClient"];
+type TiTilerClientConstructor =
+  typeof import("maplibre-gl-planetary-computer")["TiTilerClient"];
 
 const planetaryComputerControlPosition: GeoLibreMapControlPosition = "top-left";
 
@@ -27,7 +36,16 @@ let planetaryComputerControl: PlanetaryComputerControl | null = null;
 let planetaryComputerControlMounted = false;
 let planetaryComputerConstructorsPromise: Promise<{
   PlanetaryComputerControl: PlanetaryComputerControlConstructor;
+  STACClient: STACClientConstructor;
+  TiTilerClient: TiTilerClientConstructor;
 }> | null = null;
+let planetaryComputerConstructors: {
+  PlanetaryComputerControl: PlanetaryComputerControlConstructor;
+  STACClient: STACClientConstructor;
+  TiTilerClient: TiTilerClientConstructor;
+} | null = null;
+let planetaryComputerStacClient: STACClient | null = null;
+let planetaryComputerTilerClient: TiTilerClient | null = null;
 let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
 
 export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
@@ -45,32 +63,13 @@ export function closePlanetaryComputerPanel(app: GeoLibreAppAPI): void {
 async function openStandalonePlanetaryComputerControl(
   app: GeoLibreAppAPI,
 ): Promise<boolean> {
-  // Unlike the deck.gl-based plugins (GeoParquet, DuckDB), no
-  // ensureMercatorProjection call is needed: the control adds native
-  // MapLibre raster layers, which render correctly on the globe projection.
-  const { PlanetaryComputerControl: PlanetaryComputerControlClass } =
-    await getPlanetaryComputerConstructors();
-
-  planetaryComputerControl ??= createPlanetaryComputerControl(
-    PlanetaryComputerControlClass,
-  );
-
-  if (!planetaryComputerControlMounted) {
-    const added = app.addMapControl(
-      planetaryComputerControl,
-      planetaryComputerControlPosition,
-    );
-    if (!added) {
-      resetPlanetaryComputerControl(planetaryComputerControl);
-      return false;
-    }
-    planetaryComputerControlMounted = true;
-  }
+  const control = await ensurePlanetaryComputerControl(app);
+  if (!control) return false;
 
   setTimeout(() => {
-    showPlanetaryComputerControl(planetaryComputerControl);
-    planetaryComputerControl?.expand();
-    wirePlanetaryComputerCloseButton(planetaryComputerControl);
+    showPlanetaryComputerControl(control);
+    control.expand();
+    wirePlanetaryComputerCloseButton(control);
   }, 0);
   return true;
 }
@@ -97,14 +96,55 @@ function wirePlanetaryComputerCloseButton(
 
 function getPlanetaryComputerConstructors(): Promise<{
   PlanetaryComputerControl: PlanetaryComputerControlConstructor;
+  STACClient: STACClientConstructor;
+  TiTilerClient: TiTilerClientConstructor;
 }> {
-  planetaryComputerConstructorsPromise ??=
-    import("maplibre-gl-planetary-computer").then(
-      ({ PlanetaryComputerControl: PlanetaryComputerControlClass }) => ({
-        PlanetaryComputerControl: PlanetaryComputerControlClass,
-      }),
-    );
+  planetaryComputerConstructorsPromise ??= import(
+    "maplibre-gl-planetary-computer"
+  ).then((module) => {
+    const {
+      PlanetaryComputerControl: PlanetaryComputerControlClass,
+      STACClient: STACClientClass,
+      TiTilerClient: TiTilerClientClass,
+    } = module;
+    planetaryComputerConstructors = {
+      PlanetaryComputerControl: PlanetaryComputerControlClass,
+      STACClient: STACClientClass,
+      TiTilerClient: TiTilerClientClass,
+    };
+    return planetaryComputerConstructors;
+  });
   return planetaryComputerConstructorsPromise;
+}
+
+async function ensurePlanetaryComputerControl(
+  app: GeoLibreAppAPI,
+): Promise<PlanetaryComputerControl | null> {
+  // Unlike the deck.gl-based plugins (GeoParquet, DuckDB), no
+  // ensureMercatorProjection call is needed: the control adds native
+  // MapLibre raster layers, which render correctly on the globe projection.
+  const { PlanetaryComputerControl: PlanetaryComputerControlClass } =
+    await getPlanetaryComputerConstructors();
+
+  planetaryComputerControl ??= createPlanetaryComputerControl(
+    PlanetaryComputerControlClass,
+  );
+
+  if (!planetaryComputerControlMounted) {
+    const added = app.addMapControl(
+      planetaryComputerControl,
+      planetaryComputerControlPosition,
+    );
+    if (!added) {
+      resetPlanetaryComputerControl(planetaryComputerControl);
+      return null;
+    }
+    planetaryComputerControlMounted = true;
+    hidePlanetaryComputerControl(planetaryComputerControl);
+    wirePlanetaryComputerCloseButton(planetaryComputerControl);
+  }
+
+  return planetaryComputerControl;
 }
 
 function createPlanetaryComputerControl(
@@ -238,6 +278,231 @@ function createPlanetaryComputerStoreLayer(
   };
 }
 
+/**
+ * Replays saved Planetary Computer raster layers into the upstream control.
+ * The upstream addItemLayer/addCollectionLayer methods generate fresh IDs, so
+ * project restore has to recreate the native MapLibre layers with the saved
+ * GeoLibre IDs and register them with the control's runtime layer manager.
+ *
+ * @param app - The GeoLibre app API.
+ */
+export function restorePlanetaryComputerLayers(app: GeoLibreAppAPI): void {
+  const hasPlanetaryComputerLayers = useAppStore
+    .getState()
+    .layers.some(isPlanetaryComputerLayer);
+  if (!hasPlanetaryComputerLayers && !planetaryComputerControl) return;
+
+  void (async () => {
+    const control = await ensurePlanetaryComputerControl(app);
+    if (!control) return;
+
+    const storeLayers = useAppStore
+      .getState()
+      .layers.filter(isPlanetaryComputerLayer);
+    const storeLayerIds = new Set(storeLayers.map((layer) => layer.id));
+
+    for (const activeLayer of control.getState().activeLayers) {
+      if (!storeLayerIds.has(activeLayer.id)) {
+        control.removeLayer(activeLayer.id);
+      }
+    }
+
+    const activeLayerIds = new Set(
+      control.getState().activeLayers.map((layer) => layer.id),
+    );
+
+    let restoredCount = 0;
+    for (const layer of storeLayers) {
+      if (activeLayerIds.has(layer.id)) {
+        control.updateLayer(layer.id, {
+          opacity: layer.opacity,
+          visible: layer.visible,
+        });
+        continue;
+      }
+
+      try {
+        await restorePlanetaryComputerLayer(control, layer);
+        restoredCount += 1;
+      } catch (error) {
+        console.error(
+          `[GeoLibre] Failed to restore Planetary Computer layer "${layer.name}"`,
+          error,
+        );
+      }
+    }
+
+    if (restoredCount > 0) {
+      emitPlanetaryComputerRestore(control);
+    }
+  })().catch((error) => {
+    console.error(
+      "[GeoLibre] Failed to restore Planetary Computer layers",
+      error,
+    );
+  });
+}
+
+async function restorePlanetaryComputerLayer(
+  control: PlanetaryComputerControl,
+  layer: GeoLibreLayer,
+): Promise<void> {
+  const collectionId = stringMetadata(layer, "stacCollectionId");
+  const layerType = stringMetadata(layer, "planetaryComputerLayerType");
+  if (!collectionId) {
+    throw new Error(
+      "Saved Planetary Computer layer is missing a collection id.",
+    );
+  }
+
+  if (layerType === "collection" || layerType === "mosaic") {
+    const collection = await getPlanetaryComputerStacClient().getCollection(
+      collectionId,
+    );
+    registerRestoredPlanetaryComputerLayer(control, layer, {
+      collection,
+      type: layerType,
+    });
+    return;
+  }
+
+  const itemId = stringMetadata(layer, "stacItemId");
+  if (!itemId) {
+    throw new Error(
+      "Saved Planetary Computer item layer is missing an item id.",
+    );
+  }
+
+  const item = await getPlanetaryComputerStacClient().getItem(
+    collectionId,
+    itemId,
+  );
+  registerRestoredPlanetaryComputerLayer(control, layer, {
+    item,
+    type: "item",
+  });
+}
+
+function registerRestoredPlanetaryComputerLayer(
+  control: PlanetaryComputerControl,
+  layer: GeoLibreLayer,
+  source:
+    | { item: STACItem; type: "item" }
+    | { collection: STACCollection; type: "collection" | "mosaic" },
+): void {
+  const map = control.getMap();
+  if (!map) throw new Error("Planetary Computer control is not attached.");
+
+  const sourceId = stringMetadata(layer, "sourceId") || `${layer.id}-source`;
+  const renderParams = tileParamsMetadata(layer, "renderParams");
+  const assets =
+    stringArrayMetadata(layer, "assets") || renderParams.assets || [];
+  const savedBounds = numberArrayMetadata(layer, "bounds");
+  const tileParams = assets.length ? { ...renderParams, assets } : renderParams;
+
+  if (map.getLayer(layer.id)) map.removeLayer(layer.id);
+  if (map.getSource(sourceId)) map.removeSource(sourceId);
+
+  if (source.type === "item") {
+    const collectionId = source.item.collection || "";
+    map.addSource(sourceId, {
+      type: "raster",
+      url: getPlanetaryComputerTilerClient().getItemTileJSONUrl(
+        collectionId,
+        source.item.id,
+        tileParams,
+      ),
+      tileSize: tileParams.tile_size || 256,
+      bounds: boundsTuple(source.item.bbox),
+      attribution: "Microsoft Planetary Computer",
+    });
+  } else {
+    map.addSource(sourceId, {
+      type: "raster",
+      tiles: [
+        getPlanetaryComputerTilerClient().getCollectionTileUrl(
+          source.collection.id,
+          tileParams,
+        ),
+      ],
+      tileSize: tileParams.tile_size || 256,
+      bounds:
+        savedBounds ?? boundsTuple(source.collection.extent.spatial.bbox[0]),
+      attribution: "Microsoft Planetary Computer",
+    });
+  }
+
+  map.addLayer({
+    id: layer.id,
+    type: "raster",
+    source: sourceId,
+    layout: {
+      visibility: layer.visible ? "visible" : "none",
+    },
+    paint: {
+      "raster-opacity": layer.opacity,
+    },
+  });
+
+  const activeLayer: ActiveLayer = {
+    id: layer.id,
+    type: source.type,
+    sourceId,
+    ...(source.type === "item"
+      ? { item: source.item, collection: undefined }
+      : { collection: source.collection }),
+    visible: layer.visible,
+    opacity: layer.opacity,
+    assets,
+    renderParams: tileParams,
+    presetName: stringMetadata(layer, "presetName"),
+    showControls: false,
+  };
+
+  const internals = control as unknown as PlanetaryComputerControlInternals;
+  internals._layerManager?.layers?.set(layer.id, activeLayer);
+  if (
+    !internals._state.activeLayers.some((current) => current.id === layer.id)
+  ) {
+    internals._state.activeLayers.push(activeLayer);
+  }
+}
+
+function emitPlanetaryComputerRestore(control: PlanetaryComputerControl): void {
+  const internals = control as unknown as PlanetaryComputerControlInternals;
+  internals._emit?.("layer:add");
+  internals._emit?.("statechange");
+  internals._renderContent?.();
+}
+
+function getPlanetaryComputerStacClient(): STACClient {
+  if (!planetaryComputerStacClient) {
+    const { STACClient: STACClientClass } =
+      getResolvedPlanetaryComputerConstructors();
+    planetaryComputerStacClient = new STACClientClass();
+  }
+  return planetaryComputerStacClient;
+}
+
+function getPlanetaryComputerTilerClient(): TiTilerClient {
+  if (!planetaryComputerTilerClient) {
+    const { TiTilerClient: TiTilerClientClass } =
+      getResolvedPlanetaryComputerConstructors();
+    planetaryComputerTilerClient = new TiTilerClientClass();
+  }
+  return planetaryComputerTilerClient;
+}
+
+function getResolvedPlanetaryComputerConstructors(): {
+  STACClient: STACClientConstructor;
+  TiTilerClient: TiTilerClientConstructor;
+} {
+  if (!planetaryComputerConstructors) {
+    throw new Error("Planetary Computer constructors are not loaded.");
+  }
+  return planetaryComputerConstructors;
+}
+
 function planetaryComputerLayerName(activeLayer: ActiveLayer): string {
   if (activeLayer.item) return activeLayer.item.id;
   if (activeLayer.collection) {
@@ -294,4 +559,56 @@ function isPlanetaryComputerLayer(layer: GeoLibreLayer): boolean {
     layer.metadata.sourceKind === "planetary-computer-raster" &&
     layer.metadata.externalNativeLayer === true
   );
+}
+
+type PlanetaryComputerLayerManagerInternals = {
+  layers?: Map<string, ActiveLayer>;
+};
+
+type PlanetaryComputerControlInternals = {
+  _layerManager?: PlanetaryComputerLayerManagerInternals;
+  _state: { activeLayers: ActiveLayer[] };
+  _emit?: (event: "layer:add" | "statechange") => void;
+  _renderContent?: () => void;
+};
+
+function stringMetadata(layer: GeoLibreLayer, key: string): string | undefined {
+  const value = layer.metadata[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function stringArrayMetadata(
+  layer: GeoLibreLayer,
+  key: string,
+): string[] | undefined {
+  const value = layer.metadata[key];
+  return Array.isArray(value) &&
+    value.every((entry) => typeof entry === "string")
+    ? value
+    : undefined;
+}
+
+function numberArrayMetadata(
+  layer: GeoLibreLayer,
+  key: string,
+): [number, number, number, number] | undefined {
+  const value = layer.metadata[key];
+  return boundsTuple(value);
+}
+
+function tileParamsMetadata(layer: GeoLibreLayer, key: string): TileParams {
+  const value = layer.metadata[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as TileParams)
+    : {};
+}
+
+function boundsTuple(
+  value: unknown,
+): [number, number, number, number] | undefined {
+  return Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((entry) => typeof entry === "number")
+    ? (value as [number, number, number, number])
+    : undefined;
 }


### PR DESCRIPTION
## Summary
- restore saved Microsoft Planetary Computer raster layers when a project reopens
- preserve saved GeoLibre layer ids and store order while registering restored layers with the upstream control
- wire the restore into the app project-load sequence

Fixes #965

## Verification
- Loaded the issue project with two Copernicus DEM Planetary Computer rasters in the web app
- Confirmed STAC item, TileJSON, and raster tile requests returned 200 for both DEM tiles
- Checked light and dark themes with Diagnostics: 0 and no console errors
- Ran npm run build -w geolibre-desktop
- Ran pre-commit run --files apps/geolibre-desktop/src/components/layout/DesktopShell.tsx packages/plugins/src/index.ts packages/plugins/src/plugins/maplibre-planetary-computer.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Planetary Computer raster layers are now fully restored automatically when reopening a saved project, including correct tile/render configuration and bounds.
  * The “restore layers” capability is exported for reuse by other parts of the app.

* **Bug Fixes**
  * Restored layers reliably return to the saved visibility and opacity settings.
  * Layers no longer present in the saved project are removed during restore.

* **Improvements**
  * The Planetary Computer panel lifecycle is refined to keep map layer state consistent during restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->