### PR TITLE
fix(desktop): shrink default DuckDB build

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,14 @@ npm run build
 npm run tauri:build
 ```
 
+The default desktop build keeps the Linux binary small and uses DuckDB-WASM for
+DuckDB-backed browser features. To build a larger desktop binary with the native
+`duckdb-rs` vector loader enabled, run:
+
+```bash
+npm run tauri:build:native-duckdb
+```
+
 Where to find the output:
 
 - **Web build** — static files in `apps/geolibre-desktop/dist/`. Serve this directory with any static web server (or the Docker image above).

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "node ../../scripts/tauri-build.mjs"
+    "tauri:build": "node ../../scripts/tauri-build.mjs",
+    "tauri:build:native-duckdb": "node ../../scripts/tauri-build.mjs --native-duckdb"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2021"
 name = "geolibre_desktop_lib"
 crate-type = ["lib", "cdylib", "staticlib"]
 
+[features]
+default = []
+native-duckdb = ["dep:duckdb"]
+
 # Optimize the release binary for size. The frontend assets dominate the binary,
 # but these still trim the Rust code: LTO + a single codegen unit let the linker
 # drop dead code across crates, `strip` removes symbols/debuginfo, `opt-level="s"`
@@ -29,7 +33,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
-duckdb = { version = "1.10504.0", features = ["bundled", "parquet"] }
+duckdb = { version = "1.10504.0", features = ["bundled", "parquet"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 flate2 = "1"

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1,5 +1,25 @@
 mod earth_engine_oauth;
+#[cfg(feature = "native-duckdb")]
 mod native_duckdb;
+#[cfg(not(feature = "native-duckdb"))]
+mod native_duckdb {
+    #[tauri::command]
+    pub async fn count_native_vector_file_features(
+        _path: String,
+        _layer: Option<String>,
+    ) -> Result<usize, String> {
+        Err("Native DuckDB is not enabled in this build.".to_string())
+    }
+
+    #[tauri::command]
+    pub async fn load_native_vector_file(
+        _path: String,
+        _layer: Option<String>,
+        _override_source_crs: Option<String>,
+    ) -> Result<serde_json::Value, String> {
+        Err("Native DuckDB is not enabled in this build.".to_string())
+    }
+}
 
 use earth_engine_oauth::{
     poll_earth_engine_oauth, start_earth_engine_oauth, EarthEngineOAuthState,

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -1,8 +1,4 @@
 import * as duckdb from "@duckdb/duckdb-wasm";
-import duckdbWasmEh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
-import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
-import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
-import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import {
   detectGeometryColumn,
@@ -19,6 +15,7 @@ import {
 } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { isLikelyGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";
+import { selectDuckDbBundle } from "./duckdb-wasm-bundles";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 // Re-exported for existing importers (sql-workspace, duckdb-processing, etc.)
@@ -43,17 +40,6 @@ const EXPORT_GEOJSON_EXTENSION = "geojson";
 const EXPORT_GEOPARQUET_EXTENSION = "parquet";
 
 const FEATURE_COUNT_COLUMN = "__geolibre_feature_count";
-
-const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
-  mvp: {
-    mainModule: duckdbWasmMvp,
-    mainWorker: mvpWorker,
-  },
-  eh: {
-    mainModule: duckdbWasmEh,
-    mainWorker: ehWorker,
-  },
-};
 
 let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
 
@@ -158,7 +144,7 @@ export async function ensureH3Extension(
 }
 
 async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
-  const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
+  const bundle = await selectDuckDbBundle();
   const worker = new Worker(bundle.mainWorker!, { type: "module" });
   const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
   const db = new duckdb.AsyncDuckDB(logger, worker);

--- a/apps/geolibre-desktop/src/lib/duckdb-wasm-bundles.tauri.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-wasm-bundles.tauri.ts
@@ -1,0 +1,11 @@
+import type * as duckdb from "@duckdb/duckdb-wasm";
+import duckdbWasmEh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
+import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
+
+export async function selectDuckDbBundle(): Promise<duckdb.DuckDBBundle> {
+  return {
+    mainModule: duckdbWasmEh,
+    mainWorker: ehWorker,
+    pthreadWorker: null,
+  };
+}

--- a/apps/geolibre-desktop/src/lib/duckdb-wasm-bundles.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-wasm-bundles.ts
@@ -1,0 +1,20 @@
+import * as duckdb from "@duckdb/duckdb-wasm";
+import duckdbWasmEh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
+import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
+import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
+import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
+
+const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
+  mvp: {
+    mainModule: duckdbWasmMvp,
+    mainWorker: mvpWorker,
+  },
+  eh: {
+    mainModule: duckdbWasmEh,
+    mainWorker: ehWorker,
+  },
+};
+
+export function selectDuckDbBundle(): Promise<duckdb.DuckDBBundle> {
+  return duckdb.selectBundle(MANUAL_BUNDLES);
+}

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -469,6 +469,38 @@ function cereusCdnLoaderPlugin(): Plugin {
   };
 }
 
+function duckdbWasmBundlesPlugin(): Plugin {
+  const modulePath = path.resolve(
+    __dirname,
+    IS_TAURI_BUILD
+      ? "src/lib/duckdb-wasm-bundles.tauri.ts"
+      : "src/lib/duckdb-wasm-bundles.ts",
+  );
+  return {
+    name: "geolibre-duckdb-wasm-bundles",
+    enforce: "pre",
+    resolveId(source) {
+      return /(?:^|\/)duckdb-wasm-bundles(?:\.ts)?$/.test(source)
+        ? modulePath
+        : null;
+    },
+  };
+}
+
+function removeJupyterLiteFromTauriDistPlugin(): Plugin {
+  return {
+    name: "geolibre-remove-jupyterlite-from-tauri-dist",
+    apply: "build",
+    closeBundle() {
+      if (!IS_TAURI_BUILD) return;
+      rmSync(path.resolve(__dirname, "dist/jupyterlite"), {
+        recursive: true,
+        force: true,
+      });
+    },
+  };
+}
+
 function projectUrlQueryPlugin(): Plugin {
   return {
     name: "geolibre-project-url-query",
@@ -728,6 +760,7 @@ export default defineConfig({
   plugins: [
     ...(PGLITE_CDN ? [pgliteCdnLoaderPlugin()] : []),
     ...(CEREUS_CDN ? [cereusCdnLoaderPlugin()] : []),
+    duckdbWasmBundlesPlugin(),
     stripDuckDbWorkerSourcemapPlugin(),
     projectUrlQueryPlugin(),
     bundledPlugins(path.resolve(__dirname, "public/plugins")),
@@ -744,6 +777,7 @@ export default defineConfig({
     react(),
     wmsProxyPlugin(),
     selectiveJsMinifyPlugin(),
+    removeJupyterLiteFromTauriDistPlugin(),
     ...pwaPlugin(),
   ],
   clearScreen: false,

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -181,4 +181,8 @@ npm install
 npm run tauri:build
 ```
 
+The default desktop build keeps the Linux binary small and uses DuckDB-WASM for
+DuckDB-backed browser features. To build a larger desktop binary with the native
+`duckdb-rs` vector loader enabled, run `npm run tauri:build:native-duckdb`.
+
 Desktop builds require the Rust toolchain and Tauri platform prerequisites.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,6 +143,14 @@ npm run build
 npm run tauri:build
 ```
 
+The default desktop build keeps the Linux binary small and uses DuckDB-WASM for
+DuckDB-backed browser features. To build a larger desktop binary with the native
+`duckdb-rs` vector loader enabled, run:
+
+```bash
+npm run tauri:build:native-duckdb
+```
+
 Where to find the output:
 
 - **Web build** — static files in `apps/geolibre-desktop/dist/`. Serve this directory with any static web server (or the Docker image above).

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tauri": "npm run tauri -w geolibre-desktop",
     "tauri:dev": "npm run tauri dev -w geolibre-desktop",
     "tauri:build": "node scripts/tauri-build.mjs",
+    "tauri:build:native-duckdb": "node scripts/tauri-build.mjs --native-duckdb",
     "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/msix/build-msix.ps1",
     "portable:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/portable/build-portable.ps1"
   },

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -4,10 +4,16 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const userArgs = process.argv.slice(2);
+const nativeDuckDb = userArgs.includes("--native-duckdb");
+const tauriArgs = userArgs.filter((arg) => arg !== "--native-duckdb");
 const buildArgs =
-  userArgs.length === 0 && process.platform === "linux"
+  tauriArgs.length === 0 && process.platform === "linux"
     ? ["--bundles", "deb,rpm"]
-    : userArgs;
+    : tauriArgs;
+
+if (nativeDuckDb) {
+  buildArgs.push("--features", "native-duckdb");
+}
 
 const result = spawnSync(
   "npm",


### PR DESCRIPTION
## Summary
- make native duckdb-rs optional behind a native-duckdb Cargo feature
- add npm run tauri:build:native-duckdb for larger native DuckDB desktop builds
- keep Tauri DuckDB-WASM to one EH engine and remove generated JupyterLite from desktop dist before embedding
- document native DuckDB build instructions

## Validation
- cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml
- cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml --features native-duckdb
- node --check scripts/tauri-build.mjs
- npm run tauri:build

## Size check
- default Linux binary: 28M
- default .deb/.rpm: 24M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional native desktop build path that can be enabled with a new build command.
  * Desktop builds now clearly support two modes: a smaller default build and a larger native-enabled build.

* **Documentation**
  * Updated build and getting-started guides with the new native build command and build-size notes.

* **Bug Fixes**
  * Desktop builds now handle missing native database support more gracefully, avoiding hard failures when the feature is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->