### PR TITLE
Show video layer metadata in layer info

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -70,8 +70,8 @@ export const DEFAULT_DELIMITED_TEXT_URL =
   "https://data.source.coop/giswqs/opengeos/us_cities.csv";
 export const DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD = "latitude";
 export const DEFAULT_DELIMITED_TEXT_LONGITUDE_FIELD = "longitude";
-// MapLibre's "Add a video" sample (a drone clip over San Francisco), pre-filled
-// so the dialog works out of the box. The corners are [lng, lat] pairs.
+// MapLibre's georeferenced video sample, pre-filled so the dialog works out of
+// the box. The corners are [lng, lat] pairs.
 export const DEFAULT_VIDEO_MP4_URL =
   "https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4";
 export const DEFAULT_VIDEO_WEBM_URL =

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
@@ -82,7 +82,12 @@ export function VideoSource() {
       { type: "video", urls, coordinates },
       // Persist the corner bbox so "Zoom to layer" works — a video source
       // exposes no bounds for fitLayer to fall back on.
-      { sourceKind: "video-url", bounds },
+      {
+        sourceKind: "video-url",
+        sourceUrl: primary,
+        ...(webm ? { fallbackSourceUrl: webm } : {}),
+        bounds,
+      },
     );
     source.shell.addLayer(layer, source.beforeLayer);
     // Skip the fit for a degenerate (zero-area) bbox, which would otherwise

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -179,6 +179,34 @@ function layerTypeLabel(
   return layer.type;
 }
 
+function sourceUrlsFromLayer(layer: GeoLibreLayer): string[] {
+  if (layer.type !== "video" || !Array.isArray(layer.source.urls)) {
+    return [];
+  }
+  return layer.source.urls.filter(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0,
+  );
+}
+
+function layerMetadataPayload(layer: GeoLibreLayer): Record<string, unknown> {
+  const videoSourceUrls = sourceUrlsFromLayer(layer);
+  return {
+    layerName: layer.name,
+    layerType: layer.type,
+    ...layer.metadata,
+    ...(videoSourceUrls.length > 0
+      ? {
+          sourceUrl: videoSourceUrls[0],
+          ...(videoSourceUrls[1]
+            ? { fallbackSourceUrl: videoSourceUrls[1] }
+            : {}),
+        }
+      : {}),
+    sourcePath: layer.sourcePath,
+  };
+}
+
 interface LayerOpacitySliderProps {
   label: string;
   ariaLabel: string;
@@ -2312,14 +2340,7 @@ export function LayerPanel({
           <ScrollArea className="max-h-80">
             <pre className="whitespace-pre-wrap break-all text-xs">
               {metadataLayer &&
-                JSON.stringify(
-                  {
-                    ...metadataLayer.metadata,
-                    sourcePath: metadataLayer.sourcePath,
-                  },
-                  null,
-                  2,
-                )}
+                JSON.stringify(layerMetadataPayload(metadataLayer), null, 2)}
             </pre>
           </ScrollArea>
         </DialogContent>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -192,9 +192,9 @@ function sourceUrlsFromLayer(layer: GeoLibreLayer): string[] {
 function layerMetadataPayload(layer: GeoLibreLayer): Record<string, unknown> {
   const videoSourceUrls = sourceUrlsFromLayer(layer);
   return {
+    ...layer.metadata,
     layerName: layer.name,
     layerType: layer.type,
-    ...layer.metadata,
     ...(videoSourceUrls.length > 0
       ? {
           sourceUrl: videoSourceUrls[0],

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -392,7 +392,7 @@
     },
     "video": {
       "defaultName": "Video Layer",
-      "sampleLabel": "Drone over San Francisco",
+      "sampleLabel": "Coastal waves near San Francisco",
       "errorUrl": "Enter a video URL.",
       "errorHttps": "Video URLs must start with https://.",
       "cornerTopLeft": "top-left",


### PR DESCRIPTION
## Summary
- show layer name and type in the layer metadata dialog
- expose video source URLs in the metadata dialog, including legacy video layers that only store URLs on the MapLibre source
- rename the built-in video sample to better match the coastal wave footage

Fixes #972

## Verification
- Added the built-in video sample and opened its metadata dialog in light theme
- Reopened the same metadata dialog in dark theme
- npm run build
- pre-commit run --files apps/geolibre-desktop/src/components/layout/add-data/constants.ts apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx apps/geolibre-desktop/src/components/panels/LayerPanel.tsx apps/geolibre-desktop/src/i18n/locales/en.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced video layer handling to retain and use the primary video URL, and automatically apply a fallback URL when available.
  * Layer “Metadata” now presents more complete details for video layers, including layer name/type and associated source URL fields.
* **Bug Fixes**
  * Video layer rendering now receives the correct source and fallback information for improved reliability.
* **Style**
  * Updated the English label for the video layer sample to better match the displayed content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->