### PR TITLE
Add directions route metrics

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -12,6 +12,7 @@ import {
 import type { MapController } from "@geolibre/map";
 import { Clock, MapPin, Navigation, Route, Trash2, Undo2, X } from "lucide-react";
 import { type RefObject, useSyncExternalStore } from "react";
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Button } from "@geolibre/ui";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
@@ -20,23 +21,44 @@ interface MapModeBannerProps {
   mapControllerRef: RefObject<MapController | null>;
 }
 
-function formatDistance(meters: number, locale: string): string {
+function formatDistance(
+  meters: number,
+  locale: string,
+  t: TFunction,
+): string {
   if (meters >= 1000) {
-    return `${new Intl.NumberFormat(locale, {
+    const value = new Intl.NumberFormat(locale, {
       maximumFractionDigits: meters >= 10000 ? 0 : 1,
-    }).format(meters / 1000)} km`;
+    }).format(meters / 1000);
+    return t("map.directionsMode.distanceKilometers", { value });
   }
-  return `${new Intl.NumberFormat(locale, {
+  const value = new Intl.NumberFormat(locale, {
     maximumFractionDigits: 0,
-  }).format(meters)} m`;
+  }).format(meters);
+  return t("map.directionsMode.distanceMeters", { value });
 }
 
-function formatDuration(seconds: number): string {
+function formatDuration(
+  seconds: number,
+  locale: string,
+  t: TFunction,
+): string {
   const minutes = Math.max(1, Math.round(seconds / 60));
-  if (minutes < 60) return `${minutes} min`;
+  if (minutes < 60) {
+    const value = new Intl.NumberFormat(locale).format(minutes);
+    return t("map.directionsMode.durationMinutes", { value });
+  }
   const hours = Math.floor(minutes / 60);
   const remainder = minutes % 60;
-  return remainder > 0 ? `${hours} hr ${remainder} min` : `${hours} hr`;
+  const formattedHours = new Intl.NumberFormat(locale).format(hours);
+  if (remainder > 0) {
+    const formattedMinutes = new Intl.NumberFormat(locale).format(remainder);
+    return t("map.directionsMode.durationHoursMinutes", {
+      hours: formattedHours,
+      minutes: formattedMinutes,
+    });
+  }
+  return t("map.directionsMode.durationHours", { value: formattedHours });
 }
 
 /**
@@ -140,6 +162,7 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
                         {formatDistance(
                           routeMetrics.totalDistanceMeters,
                           i18n.language,
+                          t,
                         )}
                       </p>
                     </div>
@@ -149,7 +172,11 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
                         {t("map.directionsMode.estimatedTime")}
                       </div>
                       <p className="truncate text-sm font-semibold">
-                        {formatDuration(routeMetrics.totalDurationSeconds)}
+                        {formatDuration(
+                          routeMetrics.totalDurationSeconds,
+                          i18n.language,
+                          t,
+                        )}
                       </p>
                     </div>
                   </div>
@@ -166,9 +193,17 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
                             })}
                           </span>
                           <span className="shrink-0 tabular-nums">
-                            {formatDistance(leg.distanceMeters, i18n.language)}
+                            {formatDistance(
+                              leg.distanceMeters,
+                              i18n.language,
+                              t,
+                            )}
                             {" / "}
-                            {formatDuration(leg.durationSeconds)}
+                            {formatDuration(
+                              leg.durationSeconds,
+                              i18n.language,
+                              t,
+                            )}
                           </span>
                         </div>
                       ))}

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -1,14 +1,16 @@
 import {
   clearDirectionsWaypoints,
+  getDirectionsRouteMetrics,
   DIRECTIONS_PLUGIN_ID,
   getDirectionsWaypointCount,
   isDirectionsRemovalInFlight,
+  isDirectionsRouteLoading,
   removeLastDirectionsWaypoint,
   REVERSE_GEOCODE_PLUGIN_ID,
   subscribeDirectionsState,
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
-import { MapPin, Navigation, Trash2, Undo2, X } from "lucide-react";
+import { Clock, MapPin, Navigation, Route, Trash2, Undo2, X } from "lucide-react";
 import { type RefObject, useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@geolibre/ui";
@@ -16,6 +18,25 @@ import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 
 interface MapModeBannerProps {
   mapControllerRef: RefObject<MapController | null>;
+}
+
+function formatDistance(meters: number, locale: string): string {
+  if (meters >= 1000) {
+    return `${new Intl.NumberFormat(locale, {
+      maximumFractionDigits: meters >= 10000 ? 0 : 1,
+    }).format(meters / 1000)} km`;
+  }
+  return `${new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 0,
+  }).format(meters)} m`;
+}
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.max(1, Math.round(seconds / 60));
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder > 0 ? `${hours} hr ${remainder} min` : `${hours} hr`;
 }
 
 /**
@@ -31,7 +52,7 @@ interface MapModeBannerProps {
  * automatically as waypoints change, so no manual "calculate" action is needed.
  */
 export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
-  const { t } = useTranslation();
+  const { i18n, t } = useTranslation();
   const { isActive, toggle } = usePluginRegistry();
 
   // Live waypoint count, so the remove/clear actions can disable themselves
@@ -47,6 +68,16 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
     subscribeDirectionsState,
     isDirectionsRemovalInFlight,
     isDirectionsRemovalInFlight,
+  );
+  const routeMetrics = useSyncExternalStore(
+    subscribeDirectionsState,
+    getDirectionsRouteMetrics,
+    getDirectionsRouteMetrics,
+  );
+  const routeLoading = useSyncExternalStore(
+    subscribeDirectionsState,
+    isDirectionsRouteLoading,
+    isDirectionsRouteLoading,
   );
 
   const directionsActive = isActive(DIRECTIONS_PLUGIN_ID);
@@ -88,6 +119,70 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
           <span className="sr-only" aria-live="polite">
             {t("map.directionsMode.waypointCount", { count: waypointCount })}
           </span>
+          {waypointCount >= 2 ? (
+            <div
+              className="rounded-md border bg-muted/30 p-2"
+              data-testid="directions-route-metrics"
+            >
+              {routeLoading && !routeMetrics ? (
+                <p className="text-xs text-muted-foreground">
+                  {t("map.directionsMode.calculating")}
+                </p>
+              ) : routeMetrics ? (
+                <div className="space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                        <Route className="h-3 w-3" aria-hidden="true" />
+                        {t("map.directionsMode.totalDistance")}
+                      </div>
+                      <p className="truncate text-sm font-semibold">
+                        {formatDistance(
+                          routeMetrics.totalDistanceMeters,
+                          i18n.language,
+                        )}
+                      </p>
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                        <Clock className="h-3 w-3" aria-hidden="true" />
+                        {t("map.directionsMode.estimatedTime")}
+                      </div>
+                      <p className="truncate text-sm font-semibold">
+                        {formatDuration(routeMetrics.totalDurationSeconds)}
+                      </p>
+                    </div>
+                  </div>
+                  {routeMetrics.legs.length > 1 ? (
+                    <div className="max-h-20 space-y-1 overflow-auto border-t pt-2 text-xs text-muted-foreground">
+                      {routeMetrics.legs.map((leg, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between gap-3"
+                        >
+                          <span>
+                            {t("map.directionsMode.segment", {
+                              index: index + 1,
+                            })}
+                          </span>
+                          <span className="shrink-0 tabular-nums">
+                            {formatDistance(leg.distanceMeters, i18n.language)}
+                            {" / "}
+                            {formatDuration(leg.durationSeconds)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  {t("map.directionsMode.metricsUnavailable")}
+                </p>
+              )}
+            </div>
+          ) : null}
+
           <div className="flex flex-wrap items-center justify-end gap-2">
             <Button
               type="button"

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -43,6 +43,9 @@ function formatDuration(
   locale: string,
   t: TFunction,
 ): string {
+  if (seconds < 30) {
+    return t("map.directionsMode.durationLessThanMinute");
+  }
   const minutes = Math.max(1, Math.round(seconds / 60));
   if (minutes < 60) {
     const value = new Intl.NumberFormat(locale).format(minutes);
@@ -144,9 +147,11 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
           {waypointCount >= 2 ? (
             <div
               className="rounded-md border bg-muted/30 p-2"
+              aria-live="polite"
+              aria-atomic="true"
               data-testid="directions-route-metrics"
             >
-              {routeLoading && !routeMetrics ? (
+              {routeLoading ? (
                 <p className="text-xs text-muted-foreground">
                   {t("map.directionsMode.calculating")}
                 </p>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -943,6 +943,11 @@
       "estimatedTime": "Estimated time",
       "segment": "Segment {{index}}",
       "metricsUnavailable": "Route metrics unavailable",
+      "distanceKilometers": "{{value}} km",
+      "distanceMeters": "{{value}} m",
+      "durationMinutes": "{{value}} min",
+      "durationHours": "{{value}} hr",
+      "durationHoursMinutes": "{{hours}} hr {{minutes}} min",
       "waypointCount_zero": "No waypoints placed yet",
       "waypointCount_one": "{{count}} waypoint placed",
       "waypointCount_other": "{{count}} waypoints placed"

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -938,6 +938,11 @@
       "removeLast": "Remove last",
       "clear": "Clear",
       "exit": "Exit",
+      "calculating": "Calculating route...",
+      "totalDistance": "Distance",
+      "estimatedTime": "Estimated time",
+      "segment": "Segment {{index}}",
+      "metricsUnavailable": "Route metrics unavailable",
       "waypointCount_zero": "No waypoints placed yet",
       "waypointCount_one": "{{count}} waypoint placed",
       "waypointCount_other": "{{count}} waypoints placed"

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -945,6 +945,7 @@
       "metricsUnavailable": "Route metrics unavailable",
       "distanceKilometers": "{{value}} km",
       "distanceMeters": "{{value}} m",
+      "durationLessThanMinute": "< 1 min",
       "durationMinutes": "{{value}} min",
       "durationHours": "{{value}} hr",
       "durationHoursMinutes": "{{hours}} hr {{minutes}} min",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -188,9 +188,13 @@ export {
 // the tests import the sync helpers from the module paths directly.
 export {
   clearDirectionsWaypoints,
+  type DirectionsRouteLegMetric,
+  type DirectionsRouteMetrics,
   DIRECTIONS_PLUGIN_ID,
+  getDirectionsRouteMetrics,
   getDirectionsWaypointCount,
   isDirectionsRemovalInFlight,
+  isDirectionsRouteLoading,
   maplibreDirectionsPlugin,
   removeLastDirectionsWaypoint,
   restoreDirections,

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -1,4 +1,5 @@
 import type MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
+import type { MapLibreGlDirectionsRoutingData } from "@maplibre/maplibre-gl-directions";
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 
@@ -37,6 +38,31 @@ let loadToken = 0;
 // plugin stays the single owner of the directions instance.
 type DirectionsStateListener = () => void;
 const directionsStateListeners = new Set<DirectionsStateListener>();
+
+export interface DirectionsRouteLegMetric {
+  distanceMeters: number;
+  durationSeconds: number;
+}
+
+export interface DirectionsRouteMetrics {
+  totalDistanceMeters: number;
+  totalDurationSeconds: number;
+  legs: DirectionsRouteLegMetric[];
+}
+
+interface OsrmRouteLeg {
+  distance?: unknown;
+  duration?: unknown;
+}
+
+interface OsrmRoute {
+  distance?: unknown;
+  duration?: unknown;
+  legs?: OsrmRouteLeg[];
+}
+
+let routeMetrics: DirectionsRouteMetrics | null = null;
+let routeLoading = false;
 
 // True while a removeLastDirectionsWaypoint() call is mid route-refetch. Exposed
 // so the banner can disable its "remove last" button until the async call
@@ -83,6 +109,25 @@ export function subscribeDirectionsState(
  */
 export function getDirectionsWaypointCount(): number {
   return directions ? directions.waypoints.length : 0;
+}
+
+/**
+ * The latest metrics returned by the active directions session.
+ *
+ * @returns Distance/time metrics for the selected route, or null while no
+ * route has been calculated.
+ */
+export function getDirectionsRouteMetrics(): DirectionsRouteMetrics | null {
+  return routeMetrics;
+}
+
+/**
+ * Whether the current directions session is waiting on a route response.
+ *
+ * @returns True while OSRM is calculating a route.
+ */
+export function isDirectionsRouteLoading(): boolean {
+  return routeLoading;
 }
 
 /**
@@ -160,6 +205,62 @@ export function clearDirectionsWaypoints(): void {
   // Clearing supersedes any in-flight removal: drop the flag so the post-clear
   // state is consistent (the aborted removal's .finally re-runs this harmlessly).
   removalInFlight = false;
+  routeLoading = false;
+  routeMetrics = null;
+  notifyDirectionsState();
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function extractRouteMetrics(
+  event: { data: MapLibreGlDirectionsRoutingData },
+): DirectionsRouteMetrics | null {
+  const route = event.data.directions?.routes[0] as OsrmRoute | undefined;
+  if (!route) return null;
+
+  const legs =
+    route.legs
+      ?.map((leg) => {
+        const distanceMeters = toFiniteNumber(leg.distance);
+        const durationSeconds = toFiniteNumber(leg.duration);
+        if (distanceMeters == null || durationSeconds == null) return null;
+        return { distanceMeters, durationSeconds };
+      })
+      .filter((leg): leg is DirectionsRouteLegMetric => leg != null) ?? [];
+
+  const totalDistanceMeters =
+    toFiniteNumber(route.distance) ??
+    legs.reduce((sum, leg) => sum + leg.distanceMeters, 0);
+  const totalDurationSeconds =
+    toFiniteNumber(route.duration) ??
+    legs.reduce((sum, leg) => sum + leg.durationSeconds, 0);
+
+  if (totalDistanceMeters <= 0 && totalDurationSeconds <= 0) return null;
+  return { totalDistanceMeters, totalDurationSeconds, legs };
+}
+
+function handleDirectionsFetchStart(): void {
+  routeLoading = true;
+  routeMetrics = null;
+  notifyDirectionsState();
+}
+
+function handleDirectionsFetchEnd(event: {
+  data: MapLibreGlDirectionsRoutingData;
+}): void {
+  routeLoading = false;
+  routeMetrics = extractRouteMetrics(event);
+  notifyDirectionsState();
+}
+
+function handleDirectionsWaypointChange(): void {
+  const count = getDirectionsWaypointCount();
+  if (count < 2) {
+    routeLoading = false;
+    routeMetrics = null;
+  }
   notifyDirectionsState();
 }
 
@@ -184,9 +285,11 @@ function attach(app: GeoLibreAppAPI): void {
       // Mirror the live waypoint count to any subscribed UI (the mode banner).
       // These events fire after the change is drawn, so the waypoints getter
       // already reflects the new state when notifyDirectionsState reads it.
-      directions.on("addwaypoint", notifyDirectionsState);
-      directions.on("removewaypoint", notifyDirectionsState);
-      directions.on("setwaypoints", notifyDirectionsState);
+      directions.on("addwaypoint", handleDirectionsWaypointChange);
+      directions.on("removewaypoint", handleDirectionsWaypointChange);
+      directions.on("setwaypoints", handleDirectionsWaypointChange);
+      directions.on("fetchroutesstart", handleDirectionsFetchStart);
+      directions.on("fetchroutesend", handleDirectionsFetchEnd);
       loadingControl = new LoadingIndicatorControl(directions);
       app.addMapControl(loadingControl, "top-right");
       // The instance now exists; nudge subscribers so a banner that mounted
@@ -210,15 +313,19 @@ function teardown(app: GeoLibreAppAPI): void {
   }
   // Detach our listeners before destroy() so teardown is self-contained and
   // does not rely on the library's destroy() also tearing down its emitter.
-  directions?.off("addwaypoint", notifyDirectionsState);
-  directions?.off("removewaypoint", notifyDirectionsState);
-  directions?.off("setwaypoints", notifyDirectionsState);
+  directions?.off("addwaypoint", handleDirectionsWaypointChange);
+  directions?.off("removewaypoint", handleDirectionsWaypointChange);
+  directions?.off("setwaypoints", handleDirectionsWaypointChange);
+  directions?.off("fetchroutesstart", handleDirectionsFetchStart);
+  directions?.off("fetchroutesend", handleDirectionsFetchEnd);
   directions?.destroy();
   directions = null;
   directionsMap = null;
   // A removal can't be pending once the instance is gone; clear the flag so a
   // teardown mid-refetch doesn't leave the next session's button disabled.
   removalInFlight = false;
+  routeLoading = false;
+  routeMetrics = null;
   // Reset the count subscribers see to 0 now the session is gone.
   notifyDirectionsState();
 }

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -214,30 +214,44 @@ function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function extractRouteMetrics(
-  event: { data: MapLibreGlDirectionsRoutingData },
+export function extractDirectionsRouteMetrics(
+  directions: MapLibreGlDirectionsRoutingData["directions"],
 ): DirectionsRouteMetrics | null {
-  const route = event.data.directions?.routes[0] as OsrmRoute | undefined;
+  const route = directions?.routes[0] as OsrmRoute | undefined;
   if (!route) return null;
 
-  const legs =
-    route.legs
-      ?.map((leg) => {
-        const distanceMeters = toFiniteNumber(leg.distance);
-        const durationSeconds = toFiniteNumber(leg.duration);
-        if (distanceMeters == null || durationSeconds == null) return null;
-        return { distanceMeters, durationSeconds };
-      })
-      .filter((leg): leg is DirectionsRouteLegMetric => leg != null) ?? [];
+  const rawLegs = route.legs ?? [];
+  const legs = rawLegs
+    .map((leg) => {
+      const distanceMeters = toFiniteNumber(leg.distance);
+      const durationSeconds = toFiniteNumber(leg.duration);
+      if (distanceMeters == null || durationSeconds == null) return null;
+      return { distanceMeters, durationSeconds };
+    })
+    .filter((leg): leg is DirectionsRouteLegMetric => leg != null);
 
+  const routeDistanceMeters = toFiniteNumber(route.distance);
+  const routeDurationSeconds = toFiniteNumber(route.duration);
+  const canUseLegTotals = rawLegs.length > 0 && legs.length === rawLegs.length;
   const totalDistanceMeters =
-    toFiniteNumber(route.distance) ??
-    legs.reduce((sum, leg) => sum + leg.distanceMeters, 0);
+    routeDistanceMeters ??
+    (canUseLegTotals
+      ? legs.reduce((sum, leg) => sum + leg.distanceMeters, 0)
+      : null);
   const totalDurationSeconds =
-    toFiniteNumber(route.duration) ??
-    legs.reduce((sum, leg) => sum + leg.durationSeconds, 0);
+    routeDurationSeconds ??
+    (canUseLegTotals
+      ? legs.reduce((sum, leg) => sum + leg.durationSeconds, 0)
+      : null);
 
-  if (totalDistanceMeters <= 0 && totalDurationSeconds <= 0) return null;
+  if (
+    totalDistanceMeters == null ||
+    totalDurationSeconds == null ||
+    totalDistanceMeters <= 0 ||
+    totalDurationSeconds <= 0
+  ) {
+    return null;
+  }
   return { totalDistanceMeters, totalDurationSeconds, legs };
 }
 
@@ -251,7 +265,7 @@ function handleDirectionsFetchEnd(event: {
   data: MapLibreGlDirectionsRoutingData;
 }): void {
   routeLoading = false;
-  routeMetrics = extractRouteMetrics(event);
+  routeMetrics = extractDirectionsRouteMetrics(event.data.directions);
   notifyDirectionsState();
 }
 

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -63,6 +63,8 @@ interface OsrmRoute {
 
 let routeMetrics: DirectionsRouteMetrics | null = null;
 let routeLoading = false;
+let routeLoadingFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+const ROUTE_LOADING_FALLBACK_MS = 60_000;
 
 // True while a removeLastDirectionsWaypoint() call is mid route-refetch. Exposed
 // so the banner can disable its "remove last" button until the async call
@@ -205,6 +207,7 @@ export function clearDirectionsWaypoints(): void {
   // Clearing supersedes any in-flight removal: drop the flag so the post-clear
   // state is consistent (the aborted removal's .finally re-runs this harmlessly).
   removalInFlight = false;
+  clearRouteLoadingFallback();
   routeLoading = false;
   routeMetrics = null;
   notifyDirectionsState();
@@ -212,6 +215,12 @@ export function clearDirectionsWaypoints(): void {
 
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function clearRouteLoadingFallback(): void {
+  if (routeLoadingFallbackTimer == null) return;
+  clearTimeout(routeLoadingFallbackTimer);
+  routeLoadingFallbackTimer = null;
 }
 
 export function extractDirectionsRouteMetrics(
@@ -256,14 +265,22 @@ export function extractDirectionsRouteMetrics(
 }
 
 function handleDirectionsFetchStart(): void {
+  clearRouteLoadingFallback();
   routeLoading = true;
   routeMetrics = null;
+  routeLoadingFallbackTimer = setTimeout(() => {
+    routeLoadingFallbackTimer = null;
+    if (!routeLoading) return;
+    routeLoading = false;
+    notifyDirectionsState();
+  }, ROUTE_LOADING_FALLBACK_MS);
   notifyDirectionsState();
 }
 
 function handleDirectionsFetchEnd(event: {
   data: MapLibreGlDirectionsRoutingData;
 }): void {
+  clearRouteLoadingFallback();
   routeLoading = false;
   routeMetrics = extractDirectionsRouteMetrics(event.data.directions);
   notifyDirectionsState();
@@ -272,6 +289,7 @@ function handleDirectionsFetchEnd(event: {
 function handleDirectionsWaypointChange(): void {
   const count = getDirectionsWaypointCount();
   if (count < 2) {
+    clearRouteLoadingFallback();
     routeLoading = false;
     routeMetrics = null;
   }
@@ -338,6 +356,7 @@ function teardown(app: GeoLibreAppAPI): void {
   // A removal can't be pending once the instance is gone; clear the flag so a
   // teardown mid-refetch doesn't leave the next session's button disabled.
   removalInFlight = false;
+  clearRouteLoadingFallback();
   routeLoading = false;
   routeMetrics = null;
   // Reset the count subscribers see to 0 now the session is gone.

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -3,8 +3,10 @@ import { describe, it } from "node:test";
 import {
   clearDirectionsWaypoints,
   DIRECTIONS_PLUGIN_ID,
+  getDirectionsRouteMetrics,
   getDirectionsWaypointCount,
   isDirectionsRemovalInFlight,
+  isDirectionsRouteLoading,
   maplibreDirectionsPlugin,
   removeLastDirectionsWaypoint,
   subscribeDirectionsState,
@@ -29,12 +31,19 @@ describe("directions control surface (inactive)", () => {
     assert.equal(getDirectionsWaypointCount(), 0);
   });
 
+  it("reports no route metrics when the tool is inactive", () => {
+    assert.equal(getDirectionsRouteMetrics(), null);
+    assert.equal(isDirectionsRouteLoading(), false);
+  });
+
   it("treats remove-last and clear as no-ops when inactive", () => {
     assert.doesNotThrow(() => removeLastDirectionsWaypoint());
     assert.doesNotThrow(() => clearDirectionsWaypoints());
     assert.equal(getDirectionsWaypointCount(), 0);
     // A no-op removal must not leave the in-flight flag stuck on.
     assert.equal(isDirectionsRemovalInFlight(), false);
+    assert.equal(getDirectionsRouteMetrics(), null);
+    assert.equal(isDirectionsRouteLoading(), false);
   });
 
   it("returns an idempotent unsubscribe from subscribeDirectionsState", () => {

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -136,7 +136,7 @@ describe("directions route metrics extraction", () => {
   });
 
   it("rejects degenerate zero route totals", () => {
-    const metrics = extractDirectionsRouteMetrics({
+    const zeroDistance = extractDirectionsRouteMetrics({
       code: "Ok",
       routes: [
         {
@@ -149,6 +149,20 @@ describe("directions route metrics extraction", () => {
       waypoints: [],
     } as DirectionsResponse);
 
-    assert.equal(metrics, null);
+    const zeroDuration = extractDirectionsRouteMetrics({
+      code: "Ok",
+      routes: [
+        {
+          distance: 30,
+          duration: 0,
+          geometry: "",
+          legs: [{ distance: 30, duration: 0 }],
+        },
+      ],
+      waypoints: [],
+    } as DirectionsResponse);
+
+    assert.equal(zeroDistance, null);
+    assert.equal(zeroDuration, null);
   });
 });

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   clearDirectionsWaypoints,
   DIRECTIONS_PLUGIN_ID,
+  extractDirectionsRouteMetrics,
   getDirectionsRouteMetrics,
   getDirectionsWaypointCount,
   isDirectionsRemovalInFlight,
@@ -11,6 +12,8 @@ import {
   removeLastDirectionsWaypoint,
   subscribeDirectionsState,
 } from "../packages/plugins/src/plugins/maplibre-directions";
+
+type DirectionsResponse = Parameters<typeof extractDirectionsRouteMetrics>[0];
 
 describe("maplibreDirectionsPlugin", () => {
   it("is a Controls toggle that is off by default", () => {
@@ -58,5 +61,94 @@ describe("directions control surface (inactive)", () => {
       unsubscribe();
       unsubscribe();
     });
+  });
+});
+
+describe("directions route metrics extraction", () => {
+  it("reads route totals and leg metrics from an OSRM response", () => {
+    const metrics = extractDirectionsRouteMetrics({
+      code: "Ok",
+      routes: [
+        {
+          distance: 1234,
+          duration: 456,
+          geometry: "",
+          legs: [
+            { distance: 1000, duration: 300 },
+            { distance: 234, duration: 156 },
+          ],
+        },
+      ],
+      waypoints: [],
+    } as DirectionsResponse);
+
+    assert.deepEqual(metrics, {
+      totalDistanceMeters: 1234,
+      totalDurationSeconds: 456,
+      legs: [
+        { distanceMeters: 1000, durationSeconds: 300 },
+        { distanceMeters: 234, durationSeconds: 156 },
+      ],
+    });
+  });
+
+  it("falls back to complete leg totals when route totals are absent", () => {
+    const metrics = extractDirectionsRouteMetrics({
+      code: "Ok",
+      routes: [
+        {
+          geometry: "",
+          legs: [
+            { distance: 1000, duration: 300 },
+            { distance: 500, duration: 120 },
+          ],
+        },
+      ],
+      waypoints: [],
+    } as DirectionsResponse);
+
+    assert.deepEqual(metrics, {
+      totalDistanceMeters: 1500,
+      totalDurationSeconds: 420,
+      legs: [
+        { distanceMeters: 1000, durationSeconds: 300 },
+        { distanceMeters: 500, durationSeconds: 120 },
+      ],
+    });
+  });
+
+  it("rejects incomplete leg fallback totals", () => {
+    const metrics = extractDirectionsRouteMetrics({
+      code: "Ok",
+      routes: [
+        {
+          geometry: "",
+          legs: [
+            { distance: 1000, duration: 300 },
+            { distance: 500 },
+          ],
+        },
+      ],
+      waypoints: [],
+    } as DirectionsResponse);
+
+    assert.equal(metrics, null);
+  });
+
+  it("rejects degenerate zero route totals", () => {
+    const metrics = extractDirectionsRouteMetrics({
+      code: "Ok",
+      routes: [
+        {
+          distance: 0,
+          duration: 30,
+          geometry: "",
+          legs: [{ distance: 0, duration: 30 }],
+        },
+      ],
+      waypoints: [],
+    } as DirectionsResponse);
+
+    assert.equal(metrics, null);
   });
 });


### PR DESCRIPTION
## Summary
- show OSRM route distance and estimated travel time in the Directions mode banner
- expose Directions route metrics through the plugin state subscription
- add inactive-state coverage for the new metrics getters

## Notes
- The existing Directions endpoint is the public OSRM demo route API, which supports route distance and duration but not avoid-zone/city constraints in this setup.

Fixes #968

## Tests
- npm run build -w geolibre-desktop
- node --import tsx --test tests/directions.test.ts
- node --import tsx --test tests/i18n-catalogs.test.ts
- pre-commit run --files packages/plugins/src/plugins/maplibre-directions.ts packages/plugins/src/index.ts apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx apps/geolibre-desktop/src/i18n/locales/en.json tests/directions.test.ts

## Verification
- Verified in the dev app with Directions active using two map waypoints. The banner displayed total distance and estimated time in light mode.
- Toggled dark mode with the active route and confirmed the metrics remained visible.