### PR TITLE
Fix Deck.gl example data flow

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -58,6 +58,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   });
   const [deckVizStatus, setDeckVizStatus] = useState<string | null>(null);
   const [isLoadingDeckViz, setIsLoadingDeckViz] = useState(false);
+  const [closeAfterDeckVizAdd, setCloseAfterDeckVizAdd] = useState(true);
   // Scenegraph (glTF 3D model) layer-specific inputs.
   const [deckVizModelUrl, setDeckVizModelUrl] = useState(startSg?.modelUrl ?? "");
   const [deckVizModelMode, setDeckVizModelMode] = useState<"single" | "data">(
@@ -177,7 +178,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   };
 
   // Validates format/role completeness, then writes the deck-viz store layer
-  // and fits the map. Shared by the "Use example data" and submit paths.
+  // and fits the map.
   const finalizeDeckVizLayer = (params: {
     parsed: DeckVizParsedInput;
     mapping: DeckVizFieldMapping;
@@ -257,33 +258,21 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     } else if (bounds) {
       source.shell.mapControllerRef.current?.fitBounds(bounds);
     }
-    source.shell.closeDialog();
+    if (closeAfterDeckVizAdd) {
+      source.shell.closeDialog();
+    }
   };
 
-  const handleUseDeckVizExample = async () => {
+  const handleUseDeckVizExample = () => {
     const def = getDeckVizLayerDef(deckVizKind);
     if (!def) return;
     source.setError(null);
     setDeckVizStatus(null);
-    setIsLoadingDeckViz(true);
-    try {
-      const response = await fetch(def.example.url);
-      if (!response.ok) {
-        throw new Error(t("addData.common.requestFailed", { status: response.status }));
-      }
-      const parsed = detectAndParseDeckVizInput(await response.text());
-      finalizeDeckVizLayer({
-        parsed,
-        mapping: def.example.fieldMapping,
-        style: { ...DEFAULT_DECK_VIZ_STYLE, ...(def.example.style ?? {}) },
-        sourcePath: def.example.url,
-        scenegraph: def.example.scenegraph,
-      });
-    } catch (err) {
-      source.setError(errorMessage(err, t("addData.deckViz.errorExample")));
-    } finally {
-      setIsLoadingDeckViz(false);
-    }
+    setDeckVizMode("url");
+    setDeckVizUrl(def.example.url);
+    setDeckVizSourcePath("");
+    setDeckVizParsed(null);
+    setDeckVizMapping({});
   };
 
   const handleRetrieveDeckVizColumns = async () => {
@@ -742,6 +731,15 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
             ) : null}
           </div>
         ) : null}
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={closeAfterDeckVizAdd}
+            onChange={(event) => setCloseAfterDeckVizAdd(event.target.checked)}
+          />
+          {t("addData.deckViz.closeAfterAdd")}
+        </label>
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -444,6 +444,7 @@
       "loadData": "Load data",
       "selectRole": "— select —",
       "roleNone": "(none)",
+      "closeAfterAdd": "Close dialog after adding layer",
       "color": "Color",
       "pointSize": "Point size",
       "cellSize": "Cell size",


### PR DESCRIPTION
## Summary
- Change Deck.gl example data to populate the Data URL field without fetching, adding a layer, closing the dialog, or moving the map
- Keep Load data and Add layer as explicit user actions
- Add a Deck.gl dialog checkbox to control whether the dialog closes after adding a layer

Fixes #971

## Verification
- Reproduced issue #971 in the dev app before the fix
- Verified in light theme that Use example data keeps the dialog open, fills the Data URL, keeps Add layer disabled, and does not add a layer or fit the map
- Verified Load data then Add layer creates and fits the Scatterplot layer when close-after-add is checked
- Verified in dark theme that unchecking close-after-add keeps the dialog open after adding another Scatterplot layer and the Add Data toolbar remains available
- npm run build -w geolibre-desktop -- --mode development
- npx eslint apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
- conda run -n geo pre-commit run --files apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx apps/geolibre-desktop/src/i18n/locales/en.json