### PR TITLE
Update vector sample loading workflow

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -78,7 +78,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.8.0",
+    "maplibre-gl-vector": "^0.8.1",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.8.0",
+        "maplibre-gl-vector": "^0.8.1",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17964,9 +17964,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.0.tgz",
-      "integrity": "sha512-2YRSCPrq2scveyvqCOchojflTGRqHchg314350+ZSua8e6p6v4sIjSJGybby/rHAT7Vklory+05FREzmg8K4Gw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.1.tgz",
+      "integrity": "sha512-l9dkCdtkbYcldyPtOcV4Ae6zdT9GD9HS4i8gCGLyIgJ4SMvNV0HmPS3DFKZ65MzZNUGsQgpHJ8Y1hrcMEe35gQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -23819,7 +23819,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.8.0",
+        "maplibre-gl-vector": "^0.8.1",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.8.0",
+    "maplibre-gl-vector": "^0.8.1",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"


### PR DESCRIPTION
## Summary
- bump maplibre-gl-vector to 0.8.1
- consume the upstream fix that makes Add Vector Layer sample picks fill the URL field without auto-loading data
- keep loading under the explicit Load button workflow

## Upstream
- opengeos/maplibre-gl-vector#32
- https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.8.1

## Verification
- npm run build
- pre-commit run --files apps/geolibre-desktop/package.json packages/plugins/package.json package-lock.json
- Playwright in light and dark themes with the US cities sample: sample pick filled the URL and left the vector panel at zero layers; clicking Load then added the vector layer

Fixes #970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a mapping-related dependency in the desktop app and plugin package to the latest patch version. This includes minor stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->