### PR TITLE
Update raster plugin for issue 969

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -72,7 +72,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.6.3",
+    "maplibre-gl-raster": "^0.6.4",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.6.3",
+        "maplibre-gl-raster": "^0.6.4",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",
@@ -17780,9 +17780,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.6.3.tgz",
-      "integrity": "sha512-KsXWj7HlgsfBKTsdSyhqxFYgGuC5nS+4qJX4fBcc5RnFwA+6QtDCVxQbcMspCbHQbVz6MV62nUj5YEJAMQqyzw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.6.4.tgz",
+      "integrity": "sha512-HA4ITvVSoqemkT0TILwMTsSiMBhWpDWOklHYqkGvggUDmrN9E1+d+UPLDLE4x146nLh3v877IABP45qdd4o43g==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -23813,7 +23813,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.6.3",
+        "maplibre-gl-raster": "^0.6.4",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -46,7 +46,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.6.3",
+    "maplibre-gl-raster": "^0.6.4",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",


### PR DESCRIPTION
## Summary
- bump maplibre-gl-raster to 0.6.4 in GeoLibre desktop and plugins packages
- consume the upstream fix that loads raster samples immediately, places sample loading after direct inputs, and adds rendering-engine help

Fixes #969

Upstream: https://github.com/opengeos/maplibre-gl-raster/pull/27
Release: https://github.com/opengeos/maplibre-gl-raster/releases/tag/v0.6.4

## Tests
- Browser verification in GeoLibre: light theme with maplibre-gl-raster (GPU), Land cover sample loaded
- Browser verification in GeoLibre: dark theme with cog-tiler-wasm (WASM), Elevation DEM sample loaded
- npm run build
- pre-commit run --files apps/geolibre-desktop/package.json packages/plugins/package.json package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a mapping-related dependency in the desktop app and plugins to the latest patch version, which may improve stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->