### PR TITLE
Fix globe popup occlusion

### DIFF
--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -1,0 +1,118 @@
+import type maplibregl from "maplibre-gl";
+
+export const GLOBE_POPUP_OCCLUDED_CLASS = "geolibre-globe-popup-occluded";
+
+const PATCHED_POPUP_MARKER = "__geolibreGlobePopupOcclusionPatched";
+const DEFAULT_OCCLUDED_OPACITY = 0;
+
+type PopupConstructor = new (
+  options?: maplibregl.PopupOptions,
+) => maplibregl.Popup;
+
+type PatchablePopupConstructor = PopupConstructor & {
+  [PATCHED_POPUP_MARKER]?: true;
+};
+
+interface PatchableMapLibre {
+  Popup: PatchablePopupConstructor;
+}
+
+interface PopupInternals {
+  _container?: HTMLElement;
+  _map?: {
+    transform?: {
+      isLocationOccluded?: (lngLat: unknown) => boolean;
+    };
+  };
+  _updateOpacity?: () => void;
+  getLngLat: () => unknown;
+  options?: {
+    locationOccludedOpacity?: number | string;
+  };
+}
+
+interface InteractiveStyles {
+  pointerEvents: string;
+  visibility: string;
+}
+
+const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
+
+function shouldSuppressInteraction(popup: PopupInternals): boolean {
+  const opacity = popup.options?.locationOccludedOpacity;
+  return opacity === DEFAULT_OCCLUDED_OPACITY || opacity === "0";
+}
+
+function restoreInteractiveStyles(container: HTMLElement): void {
+  const previous = hiddenPopupStyles.get(container);
+  if (!previous) return;
+  container.style.pointerEvents = previous.pointerEvents;
+  container.style.visibility = previous.visibility;
+  hiddenPopupStyles.delete(container);
+}
+
+function setPopupOccluded(container: HTMLElement, occluded: boolean): void {
+  container.classList.toggle(GLOBE_POPUP_OCCLUDED_CLASS, occluded);
+
+  if (!occluded) {
+    restoreInteractiveStyles(container);
+    return;
+  }
+
+  if (!hiddenPopupStyles.has(container)) {
+    hiddenPopupStyles.set(container, {
+      pointerEvents: container.style.pointerEvents,
+      visibility: container.style.visibility,
+    });
+  }
+  container.style.pointerEvents = "none";
+  container.style.visibility = "hidden";
+}
+
+export function syncPopupGlobeOcclusion(popup: maplibregl.Popup): boolean {
+  const popupInternals = popup as unknown as PopupInternals;
+  const container = popupInternals._container;
+  const isLocationOccluded =
+    popupInternals._map?.transform?.isLocationOccluded;
+
+  if (
+    !container ||
+    !isLocationOccluded ||
+    !shouldSuppressInteraction(popupInternals)
+  ) {
+    if (container) setPopupOccluded(container, false);
+    return false;
+  }
+
+  const occluded = Boolean(isLocationOccluded(popupInternals.getLngLat()));
+  setPopupOccluded(container, occluded);
+  return occluded;
+}
+
+export function installGlobePopupOcclusion(
+  maplibre: typeof maplibregl,
+): void {
+  const api = maplibre as unknown as PatchableMapLibre;
+  const OriginalPopup = api.Popup;
+  if (OriginalPopup[PATCHED_POPUP_MARKER]) return;
+
+  class GeoLibrePopup extends OriginalPopup {
+    constructor(options: maplibregl.PopupOptions = {}) {
+      super({
+        ...options,
+        locationOccludedOpacity:
+          options.locationOccludedOpacity ?? DEFAULT_OCCLUDED_OPACITY,
+      });
+
+      const popup = this as unknown as PopupInternals;
+      const updateOpacity = popup._updateOpacity;
+      popup._updateOpacity = () => {
+        updateOpacity?.call(this);
+        syncPopupGlobeOcclusion(this);
+      };
+    }
+  }
+
+  GeoLibrePopup[PATCHED_POPUP_MARKER] = true;
+  api.Popup = GeoLibrePopup;
+}

--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -1,5 +1,6 @@
 import type maplibregl from "maplibre-gl";
 
+/** JS-observable marker for occluded popups; visual hiding is applied inline. */
 export const GLOBE_POPUP_OCCLUDED_CLASS = "geolibre-globe-popup-occluded";
 
 const PATCHED_POPUP_MARKER = "__geolibreGlobePopupOcclusionPatched";
@@ -40,6 +41,7 @@ const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
 
 function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
+  // MapLibre accepts CSS opacity strings too; treat an explicit "0" like 0.
   return opacity === DEFAULT_OCCLUDED_OPACITY || opacity === "0";
 }
 
@@ -72,20 +74,23 @@ function setPopupOccluded(container: HTMLElement, occluded: boolean): void {
 export function syncPopupGlobeOcclusion(popup: maplibregl.Popup): boolean {
   const popupInternals = popup as unknown as PopupInternals;
   const container = popupInternals._container;
-  const isLocationOccluded =
-    popupInternals._map?.transform?.isLocationOccluded;
+  const opacity = popupInternals.options?.locationOccludedOpacity;
+  const transform = popupInternals._map?.transform;
+  const isLocationOccluded = transform?.isLocationOccluded;
 
-  if (
-    !container ||
-    !isLocationOccluded ||
-    !shouldSuppressInteraction(popupInternals)
-  ) {
+  if (!container || opacity === undefined) {
     if (container) setPopupOccluded(container, false);
     return false;
   }
 
-  const occluded = Boolean(isLocationOccluded(popupInternals.getLngLat()));
-  setPopupOccluded(container, occluded);
+  const lngLat = popupInternals.getLngLat();
+  const occluded =
+    Boolean(lngLat) && Boolean(isLocationOccluded?.call(transform, lngLat));
+  container.style.opacity = occluded ? `${opacity}` : "";
+  setPopupOccluded(
+    container,
+    occluded && shouldSuppressInteraction(popupInternals),
+  );
   return occluded;
 }
 
@@ -104,10 +109,7 @@ export function installGlobePopupOcclusion(
           options.locationOccludedOpacity ?? DEFAULT_OCCLUDED_OPACITY,
       });
 
-      const popup = this as unknown as PopupInternals;
-      const updateOpacity = popup._updateOpacity;
-      popup._updateOpacity = () => {
-        updateOpacity?.call(this);
+      (this as unknown as PopupInternals)._updateOpacity = () => {
         syncPopupGlobeOcclusion(this);
       };
     }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -42,8 +42,6 @@ import {
 import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
 import { ResetBearingControl } from "./reset-bearing-control";
 
-installGlobePopupOcclusion(maplibregl);
-
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
 };
@@ -763,6 +761,7 @@ export class MapController {
 
   syncLayers(layers: GeoLibreLayer[]): void {
     if (!this.isStyleReady() || !this.map) return;
+    installGlobePopupOcclusion(maplibregl);
     const map = this.map;
 
     const nextIds = layers.map((l) => l.id);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -39,7 +39,10 @@ import {
   syncLayer,
   vectorTileStyleLayerIds,
 } from "./layer-sync";
+import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
 import { ResetBearingControl } from "./reset-bearing-control";
+
+installGlobePopupOcclusion(maplibregl);
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type maplibregl from "maplibre-gl";
+import {
+  GLOBE_POPUP_OCCLUDED_CLASS,
+  installGlobePopupOcclusion,
+} from "../packages/map/src/globe-popup-occlusion";
+
+interface FakeContainer {
+  classList: DOMTokenList;
+  style: {
+    opacity: string;
+    pointerEvents: string;
+    visibility: string;
+  };
+}
+
+function createClassList(): DOMTokenList {
+  const classes = new Set<string>();
+  return {
+    add: (...tokens: string[]) => {
+      for (const token of tokens) classes.add(token);
+    },
+    remove: (...tokens: string[]) => {
+      for (const token of tokens) classes.delete(token);
+    },
+    contains: (token: string) => classes.has(token),
+    toggle: (token: string, force?: boolean) => {
+      const next = force ?? !classes.has(token);
+      if (next) classes.add(token);
+      else classes.delete(token);
+      return next;
+    },
+  } as unknown as DOMTokenList;
+}
+
+function createContainer(): HTMLElement {
+  const container: FakeContainer = {
+    classList: createClassList(),
+    style: {
+      opacity: "",
+      pointerEvents: "auto",
+      visibility: "visible",
+    },
+  };
+  return container as unknown as HTMLElement;
+}
+
+function createMaplibreStub(): typeof maplibregl {
+  class FakePopup {
+    _container = createContainer();
+    _map = {
+      transform: {
+        isLocationOccluded: () => false,
+      },
+    };
+    _updateOpacity: () => void;
+    options: maplibregl.PopupOptions;
+
+    constructor(options: maplibregl.PopupOptions = {}) {
+      this.options = options;
+      this._updateOpacity = () => {
+        if (this.options.locationOccludedOpacity === undefined) return;
+        if (this._map.transform.isLocationOccluded()) {
+          this._container.style.opacity = `${this.options.locationOccludedOpacity}`;
+        } else {
+          this._container.style.opacity = "";
+        }
+      };
+    }
+
+    getLngLat() {
+      return { lng: 0, lat: 0 };
+    }
+  }
+
+  return {
+    Popup: FakePopup,
+  } as unknown as typeof maplibregl;
+}
+
+describe("installGlobePopupOcclusion", () => {
+  it("defaults popups to hidden globe occlusion and restores interaction", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = new maplibre.Popup() as maplibregl.Popup & {
+      _container: HTMLElement;
+      _map: { transform: { isLocationOccluded: () => boolean } };
+      _updateOpacity: () => void;
+      options: maplibregl.PopupOptions;
+    };
+    assert.equal(popup.options.locationOccludedOpacity, 0);
+
+    popup._map.transform.isLocationOccluded = () => true;
+    popup._updateOpacity();
+
+    assert.equal(popup._container.style.opacity, "0");
+    assert.equal(popup._container.style.pointerEvents, "none");
+    assert.equal(popup._container.style.visibility, "hidden");
+    assert.equal(
+      popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+      true,
+    );
+
+    popup._map.transform.isLocationOccluded = () => false;
+    popup._updateOpacity();
+
+    assert.equal(popup._container.style.opacity, "");
+    assert.equal(popup._container.style.pointerEvents, "auto");
+    assert.equal(popup._container.style.visibility, "visible");
+    assert.equal(
+      popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+      false,
+    );
+  });
+
+  it("respects explicit nonzero locationOccludedOpacity values", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = new maplibre.Popup({
+      locationOccludedOpacity: 0.35,
+    }) as maplibregl.Popup & {
+      _container: HTMLElement;
+      _map: { transform: { isLocationOccluded: () => boolean } };
+      _updateOpacity: () => void;
+      options: maplibregl.PopupOptions;
+    };
+
+    popup._map.transform.isLocationOccluded = () => true;
+    popup._updateOpacity();
+
+    assert.equal(popup.options.locationOccludedOpacity, 0.35);
+    assert.equal(popup._container.style.opacity, "0.35");
+    assert.equal(popup._container.style.pointerEvents, "auto");
+    assert.equal(popup._container.style.visibility, "visible");
+    assert.equal(
+      popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+      false,
+    );
+  });
+
+  it("is idempotent", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+    const once = maplibre.Popup;
+    installGlobePopupOcclusion(maplibre);
+
+    assert.equal(maplibre.Popup, once);
+  });
+});

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -51,7 +51,9 @@ function createMaplibreStub(): typeof maplibregl {
     _container = createContainer();
     _map = {
       transform: {
-        isLocationOccluded: () => false,
+        isLocationOccluded(_lngLat?: unknown) {
+          return false;
+        },
       },
     };
     _updateOpacity: () => void;
@@ -133,6 +135,60 @@ describe("installGlobePopupOcclusion", () => {
 
     assert.equal(popup.options.locationOccludedOpacity, 0.35);
     assert.equal(popup._container.style.opacity, "0.35");
+    assert.equal(popup._container.style.pointerEvents, "auto");
+    assert.equal(popup._container.style.visibility, "visible");
+    assert.equal(
+      popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+      false,
+    );
+  });
+
+  it("calls isLocationOccluded with the transform receiver", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = new maplibre.Popup() as maplibregl.Popup & {
+      _container: HTMLElement;
+      _map: {
+        transform: {
+          receiverMarker: string;
+          isLocationOccluded: (lngLat?: unknown) => boolean;
+        };
+      };
+      _updateOpacity: () => void;
+    };
+
+    popup._map.transform = {
+      receiverMarker: "transform",
+      isLocationOccluded(this: { receiverMarker: string }) {
+        return this.receiverMarker === "transform";
+      },
+    };
+    popup._updateOpacity();
+
+    assert.equal(popup._container.style.opacity, "0");
+    assert.equal(popup._container.style.pointerEvents, "none");
+  });
+
+  it("treats a popup with no coordinate as visible", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = new maplibre.Popup() as maplibregl.Popup & {
+      _container: HTMLElement;
+      _map: { transform: { isLocationOccluded: () => boolean } };
+      _updateOpacity: () => void;
+      getLngLat: () => undefined;
+    };
+    let called = false;
+    popup.getLngLat = () => undefined;
+    popup._map.transform.isLocationOccluded = () => {
+      called = true;
+      return true;
+    };
+    popup._updateOpacity();
+
+    assert.equal(called, false);
     assert.equal(popup._container.style.pointerEvents, "auto");
     assert.equal(popup._container.style.visibility, "visible");
     assert.equal(


### PR DESCRIPTION
## Summary
- Default GeoLibre's shared MapLibre Popup constructor to hide popups whose anchor is occluded behind the globe.
- Suppress pointer interaction and visibility while an occluded popup is hidden, then restore its previous inline interaction styles when visible again.
- Add focused tests for default occlusion, style restoration, explicit nonzero opacity values, and idempotent installation.

Fixes #960

## Testing
- node --import tsx --test tests/globe-popup-occlusion.test.ts
- npm run test:frontend
- npm run lint -- --quiet
- npm run build
- pre-commit run --files packages/map/src/map-controller.ts packages/map/src/globe-popup-occlusion.ts tests/globe-popup-occlusion.test.ts
- Playwright, light mode: verified the running app bundle's shared MapLibre Popup defaults to locationOccludedOpacity 0, hides and disables pointer events when occluded, and restores when visible
- Playwright, dark mode: repeated the same runtime popup occlusion check after toggling the app theme

## Notes
MapLibre owns the underlying native Popup occlusion option, but GeoLibre can apply a host-side default for app and plugin popups that use the shared MapLibre module. No upstream package release is needed for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Globe popups now automatically adjust their appearance and interaction when their location is hidden by the globe.
  * Added support for installing this behavior once at app startup.

* **Bug Fixes**
  * Popups now correctly hide, disable interaction, and restore their previous state when they move in and out of occluded areas.
  * The globe popup behavior now respects custom opacity settings while keeping interaction handling consistent.

* **Tests**
  * Added coverage for occlusion handling, style restoration, and repeated installation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->