### PR TITLE
Address globe popup review follow-up

### DIFF
--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -28,7 +28,7 @@ interface PopupInternals {
   _updateOpacity?: () => void;
   getLngLat: () => unknown;
   options?: {
-    locationOccludedOpacity?: number | string;
+    locationOccludedOpacity?: number | string | null;
   };
 }
 
@@ -41,8 +41,7 @@ const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
 
 function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
-  // MapLibre accepts CSS opacity strings too; treat an explicit "0" like 0.
-  return opacity === DEFAULT_OCCLUDED_OPACITY || opacity === "0";
+  return Number(opacity) === DEFAULT_OCCLUDED_OPACITY;
 }
 
 function restoreInteractiveStyles(container: HTMLElement): void {
@@ -78,7 +77,7 @@ export function syncPopupGlobeOcclusion(popup: maplibregl.Popup): boolean {
   const transform = popupInternals._map?.transform;
   const isLocationOccluded = transform?.isLocationOccluded;
 
-  if (!container || opacity === undefined) {
+  if (!container || opacity === undefined || opacity === null) {
     if (container) setPopupOccluded(container, false);
     return false;
   }
@@ -109,7 +108,10 @@ export function installGlobePopupOcclusion(
           options.locationOccludedOpacity ?? DEFAULT_OCCLUDED_OPACITY,
       });
 
-      (this as unknown as PopupInternals)._updateOpacity = () => {
+      const popup = this as unknown as PopupInternals;
+      const updateOpacity = popup._updateOpacity;
+      popup._updateOpacity = () => {
+        if (popup.getLngLat()) updateOpacity?.call(this);
         syncPopupGlobeOcclusion(this);
       };
     }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -331,6 +331,7 @@ export class MapController {
       // Trade-off: adds one extra framebuffer copy per frame on tiled renderers.
       canvasContextAttributes: { preserveDrawingBuffer: true },
     });
+    installGlobePopupOcclusion(maplibregl);
     // The constructor options above already apply the static constraints.
     // The transform constraint is installed by the MapCanvas effect that
     // fires on mount, so calling applyMapPreferences here would only add a
@@ -761,7 +762,6 @@ export class MapController {
 
   syncLayers(layers: GeoLibreLayer[]): void {
     if (!this.isStyleReady() || !this.map) return;
-    installGlobePopupOcclusion(maplibregl);
     const map = this.map;
 
     const nextIds = layers.map((l) => l.id);

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -143,6 +143,26 @@ describe("installGlobePopupOcclusion", () => {
     );
   });
 
+  it("suppresses interaction for zero opacity strings", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = new maplibre.Popup({
+      locationOccludedOpacity: "0.0",
+    }) as maplibregl.Popup & {
+      _container: HTMLElement;
+      _map: { transform: { isLocationOccluded: () => boolean } };
+      _updateOpacity: () => void;
+    };
+
+    popup._map.transform.isLocationOccluded = () => true;
+    popup._updateOpacity();
+
+    assert.equal(popup._container.style.opacity, "0.0");
+    assert.equal(popup._container.style.pointerEvents, "none");
+    assert.equal(popup._container.style.visibility, "hidden");
+  });
+
   it("calls isLocationOccluded with the transform receiver", () => {
     const maplibre = createMaplibreStub();
     installGlobePopupOcclusion(maplibre);


### PR DESCRIPTION
## Summary
- Move the globe popup occlusion installer into `MapController.init()` so it is installed once during map setup instead of during layer sync.
- Preserve MapLibre's native popup opacity updater when a popup has a coordinate, while keeping GeoLibre's guarded occlusion sync for hidden/interactive state.
- Handle CSS-style zero opacity strings and add regression coverage for that case.

Follow-up to #981 after it was merged while the final review comments were being addressed.

## Testing
- node --import tsx --test tests/globe-popup-occlusion.test.ts
- npm run test:frontend
- npm run build
- pre-commit run --files packages/map/src/map-controller.ts packages/map/src/globe-popup-occlusion.ts tests/globe-popup-occlusion.test.ts
- Playwright, light mode: verified the running app bundle defaults shared MapLibre Popup to occlusion opacity 0, hides and disables pointer events while occluded, and restores when visible
- Playwright, dark mode: repeated the same runtime popup occlusion check after toggling the app theme