### PR TITLE
Tighten popup zero opacity handling

### DIFF
--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -5,6 +5,7 @@ export const GLOBE_POPUP_OCCLUDED_CLASS = "geolibre-globe-popup-occluded";
 
 const PATCHED_POPUP_MARKER = "__geolibreGlobePopupOcclusionPatched";
 const DEFAULT_OCCLUDED_OPACITY = 0;
+const ZERO_OPACITY_STRING = /^[+-]?(?:0+(?:\.0*)?|\.(?:0+))$/;
 
 type PopupConstructor = new (
   options?: maplibregl.PopupOptions,
@@ -43,12 +44,9 @@ function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
   if (typeof opacity === "string") {
     const trimmedOpacity = opacity.trim();
-    return (
-      trimmedOpacity !== "" &&
-      Number(trimmedOpacity) === DEFAULT_OCCLUDED_OPACITY
-    );
+    return ZERO_OPACITY_STRING.test(trimmedOpacity);
   }
-  // Nullish values are filtered by the caller; use strict comparison for numbers.
+  // Else branch is numeric; strict comparison avoids Number(null) === 0.
   return opacity === DEFAULT_OCCLUDED_OPACITY;
 }
 

--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -41,7 +41,7 @@ const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
 
 function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
-  return Number(opacity) === DEFAULT_OCCLUDED_OPACITY;
+  return opacity !== "" && Number(opacity) === DEFAULT_OCCLUDED_OPACITY;
 }
 
 function restoreInteractiveStyles(container: HTMLElement): void {

--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -42,8 +42,10 @@ const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
 function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
   if (typeof opacity === "string") {
+    const trimmedOpacity = opacity.trim();
     return (
-      opacity.trim() !== "" && Number(opacity) === DEFAULT_OCCLUDED_OPACITY
+      trimmedOpacity !== "" &&
+      Number(trimmedOpacity) === DEFAULT_OCCLUDED_OPACITY
     );
   }
   // Nullish values are filtered by the caller; use strict comparison for numbers.

--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -41,7 +41,12 @@ const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
 
 function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
-  return opacity !== "" && Number(opacity) === DEFAULT_OCCLUDED_OPACITY;
+  if (typeof opacity === "string") {
+    return (
+      opacity.trim() !== "" && Number(opacity) === DEFAULT_OCCLUDED_OPACITY
+    );
+  }
+  return opacity === DEFAULT_OCCLUDED_OPACITY;
 }
 
 function restoreInteractiveStyles(container: HTMLElement): void {

--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -46,7 +46,7 @@ function shouldSuppressInteraction(popup: PopupInternals): boolean {
       opacity.trim() !== "" && Number(opacity) === DEFAULT_OCCLUDED_OPACITY
     );
   }
-  // The caller filters nullish values; the remaining non-string branch is numeric.
+  // Nullish values are filtered by the caller; use strict comparison for numbers.
   return opacity === DEFAULT_OCCLUDED_OPACITY;
 }
 

--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -46,6 +46,7 @@ function shouldSuppressInteraction(popup: PopupInternals): boolean {
       opacity.trim() !== "" && Number(opacity) === DEFAULT_OCCLUDED_OPACITY
     );
   }
+  // The caller filters nullish values; the remaining non-string branch is numeric.
   return opacity === DEFAULT_OCCLUDED_OPACITY;
 }
 

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -169,6 +169,33 @@ describe("installGlobePopupOcclusion", () => {
     });
   }
 
+  for (const opacity of ["", " "]) {
+    it(`does not suppress interaction for blank opacity ${JSON.stringify(
+      opacity,
+    )}`, () => {
+      const maplibre = createMaplibreStub();
+      installGlobePopupOcclusion(maplibre);
+
+      const popup = new maplibre.Popup({
+        locationOccludedOpacity: opacity,
+      }) as maplibregl.Popup & {
+        _container: HTMLElement;
+        _map: { transform: { isLocationOccluded: () => boolean } };
+        _updateOpacity: () => void;
+      };
+
+      popup._map.transform.isLocationOccluded = () => true;
+      popup._updateOpacity();
+
+      assert.equal(popup._container.style.pointerEvents, "auto");
+      assert.equal(popup._container.style.visibility, "visible");
+      assert.equal(
+        popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+        false,
+      );
+    });
+  }
+
   it("calls isLocationOccluded with the transform receiver", () => {
     const maplibre = createMaplibreStub();
     installGlobePopupOcclusion(maplibre);

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -143,7 +143,7 @@ describe("installGlobePopupOcclusion", () => {
     );
   });
 
-  for (const opacity of ["0", "0.0"]) {
+  for (const opacity of ["0", "0.0", " 0 "]) {
     it(`suppresses interaction for zero opacity string ${opacity}`, () => {
       const maplibre = createMaplibreStub();
       installGlobePopupOcclusion(maplibre);
@@ -170,6 +170,7 @@ describe("installGlobePopupOcclusion", () => {
   }
 
   for (const opacity of ["", " "]) {
+    // Browsers reject " " as CSS opacity; the fake container stores it verbatim.
     it(`does not suppress interaction for blank opacity ${JSON.stringify(
       opacity,
     )}`, () => {

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -143,25 +143,31 @@ describe("installGlobePopupOcclusion", () => {
     );
   });
 
-  it("suppresses interaction for zero opacity strings", () => {
-    const maplibre = createMaplibreStub();
-    installGlobePopupOcclusion(maplibre);
+  for (const opacity of ["0", "0.0"]) {
+    it(`suppresses interaction for zero opacity string ${opacity}`, () => {
+      const maplibre = createMaplibreStub();
+      installGlobePopupOcclusion(maplibre);
 
-    const popup = new maplibre.Popup({
-      locationOccludedOpacity: "0.0",
-    }) as maplibregl.Popup & {
-      _container: HTMLElement;
-      _map: { transform: { isLocationOccluded: () => boolean } };
-      _updateOpacity: () => void;
-    };
+      const popup = new maplibre.Popup({
+        locationOccludedOpacity: opacity,
+      }) as maplibregl.Popup & {
+        _container: HTMLElement;
+        _map: { transform: { isLocationOccluded: () => boolean } };
+        _updateOpacity: () => void;
+      };
 
-    popup._map.transform.isLocationOccluded = () => true;
-    popup._updateOpacity();
+      popup._map.transform.isLocationOccluded = () => true;
+      popup._updateOpacity();
 
-    assert.equal(popup._container.style.opacity, "0.0");
-    assert.equal(popup._container.style.pointerEvents, "none");
-    assert.equal(popup._container.style.visibility, "hidden");
-  });
+      assert.equal(popup._container.style.opacity, opacity);
+      assert.equal(popup._container.style.pointerEvents, "none");
+      assert.equal(popup._container.style.visibility, "hidden");
+      assert.equal(
+        popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+        true,
+      );
+    });
+  }
 
   it("calls isLocationOccluded with the transform receiver", () => {
     const maplibre = createMaplibreStub();

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -143,6 +143,7 @@ describe("installGlobePopupOcclusion", () => {
     );
   });
 
+  // Real browsers normalize " 0 " to "0"; the fake container stores it verbatim.
   for (const opacity of ["0", "0.0", " 0 "]) {
     it(`suppresses interaction for zero opacity string ${opacity}`, () => {
       const maplibre = createMaplibreStub();

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -199,6 +199,30 @@ describe("installGlobePopupOcclusion", () => {
     });
   }
 
+  it("does not suppress interaction for non-decimal zero opacity strings", () => {
+    const maplibre = createMaplibreStub();
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = new maplibre.Popup({
+      locationOccludedOpacity: "0e0",
+    }) as maplibregl.Popup & {
+      _container: HTMLElement;
+      _map: { transform: { isLocationOccluded: () => boolean } };
+      _updateOpacity: () => void;
+    };
+
+    popup._map.transform.isLocationOccluded = () => true;
+    popup._updateOpacity();
+
+    assert.equal(popup._container.style.opacity, "0e0");
+    assert.equal(popup._container.style.pointerEvents, "auto");
+    assert.equal(popup._container.style.visibility, "visible");
+    assert.equal(
+      popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS),
+      false,
+    );
+  });
+
   it("calls isLocationOccluded with the transform receiver", () => {
     const maplibre = createMaplibreStub();
     installGlobePopupOcclusion(maplibre);

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -187,6 +187,7 @@ describe("installGlobePopupOcclusion", () => {
       popup._map.transform.isLocationOccluded = () => true;
       popup._updateOpacity();
 
+      assert.equal(popup._container.style.opacity, opacity);
       assert.equal(popup._container.style.pointerEvents, "auto");
       assert.equal(popup._container.style.visibility, "visible");
       assert.equal(


### PR DESCRIPTION
## Summary
- Avoid treating an empty string opacity as zero when deciding whether an occluded popup should suppress interaction.
- Cover both `"0"` and `"0.0"` zero-opacity string values, including the occluded CSS class assertion.

Follow-up to #982, which was merged while this final review nit was being addressed.

## Testing
- node --import tsx --test tests/globe-popup-occlusion.test.ts
- pre-commit run --files packages/map/src/globe-popup-occlusion.ts tests/globe-popup-occlusion.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup interaction handling when occlusion opacity is set with different string formats.
  * Zero-like opacity values such as `0`, `0.0`, and spaced zero strings now correctly hide occluded popups.
  * Blank, whitespace-only, and scientific-notation opacity strings no longer trigger occlusion behavior unexpectedly.
  * Updated popup visibility and pointer interaction states to match the configured opacity more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->