### PR TITLE
Fix GeoParquet files with base64 WKB geometry

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -78,7 +78,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.8.1",
+    "maplibre-gl-vector": "^0.8.4",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
+++ b/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
@@ -30,6 +30,9 @@ struct NativeVectorOptions {
 struct DetectedGeometry {
     column: String,
     is_wkb: bool,
+    is_base64_wkb: bool,
+    requires_base64_wkb_validation: bool,
+    base64_wkb_candidates: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -157,7 +160,7 @@ fn load_native_vector_file_blocking(
     let conn = open_native_duckdb()?;
     let sql = source_sql(&options);
     let columns = describe_source_columns(&conn, &sql)?;
-    let detected = detect_geometry_column(&columns)?;
+    let detected = detect_geometry_column(&conn, &sql, &columns)?;
     let property_columns: Vec<String> = columns
         .iter()
         .filter(|column| column.name != detected.column)
@@ -286,8 +289,34 @@ fn describe_source_columns(conn: &Connection, sql: &str) -> Result<Vec<Described
     Ok(columns)
 }
 
-fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometry, String> {
+fn detect_geometry_column(
+    conn: &Connection,
+    source_sql: &str,
+    columns: &[DescribedColumn],
+) -> Result<DetectedGeometry, String> {
+    let detected = detect_geometry_column_from_schema(columns)?;
+    if !detected.requires_base64_wkb_validation {
+        return Ok(detected);
+    }
+    for column in &detected.base64_wkb_candidates {
+        if has_valid_base64_wkb_values(conn, source_sql, column)? {
+            return Ok(DetectedGeometry {
+                column: column.clone(),
+                is_wkb: detected.is_wkb,
+                is_base64_wkb: detected.is_base64_wkb,
+                requires_base64_wkb_validation: false,
+                base64_wkb_candidates: Vec::new(),
+            });
+        }
+    }
+    Err("DuckDB did not find a geometry column in this file.".to_string())
+}
+
+fn detect_geometry_column_from_schema(
+    columns: &[DescribedColumn],
+) -> Result<DetectedGeometry, String> {
     let mut wkb_candidate: Option<(usize, String)> = None;
+    let mut base64_wkb_candidates: Vec<(usize, String)> = Vec::new();
     for column in columns {
         if column
             .column_type
@@ -297,19 +326,24 @@ fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometr
             return Ok(DetectedGeometry {
                 column: column.name.clone(),
                 is_wkb: false,
+                is_base64_wkb: false,
+                requires_base64_wkb_validation: false,
+                base64_wkb_candidates: Vec::new(),
             });
         }
         let lower_name = column.name.to_ascii_lowercase();
         let upper_type = column.column_type.to_ascii_uppercase();
-        if (upper_type.starts_with("BLOB")
+        if !WKB_GEOMETRY_COLUMN_NAMES.contains(&lower_name.as_str()) {
+            continue;
+        }
+        let rank = WKB_GEOMETRY_COLUMN_NAMES
+            .iter()
+            .position(|candidate| *candidate == lower_name.as_str())
+            .unwrap_or(WKB_GEOMETRY_COLUMN_NAMES.len());
+        if upper_type.starts_with("BLOB")
             || upper_type.starts_with("BINARY")
-            || upper_type.starts_with("VARBINARY"))
-            && WKB_GEOMETRY_COLUMN_NAMES.contains(&lower_name.as_str())
+            || upper_type.starts_with("VARBINARY")
         {
-            let rank = WKB_GEOMETRY_COLUMN_NAMES
-                .iter()
-                .position(|candidate| *candidate == lower_name.as_str())
-                .unwrap_or(WKB_GEOMETRY_COLUMN_NAMES.len());
             if wkb_candidate
                 .as_ref()
                 .map(|(current_rank, _)| rank < *current_rank)
@@ -317,6 +351,11 @@ fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometr
             {
                 wkb_candidate = Some((rank, column.name.clone()));
             }
+        } else if upper_type.starts_with("VARCHAR")
+            || upper_type.starts_with("TEXT")
+            || upper_type.starts_with("STRING")
+        {
+            base64_wkb_candidates.push((rank, column.name.clone()));
         }
     }
 
@@ -324,10 +363,47 @@ fn detect_geometry_column(columns: &[DescribedColumn]) -> Result<DetectedGeometr
         return Ok(DetectedGeometry {
             column,
             is_wkb: true,
+            is_base64_wkb: false,
+            requires_base64_wkb_validation: false,
+            base64_wkb_candidates: Vec::new(),
+        });
+    }
+    base64_wkb_candidates.sort_by_key(|(rank, _)| *rank);
+    if let Some((_, column)) = base64_wkb_candidates.first() {
+        return Ok(DetectedGeometry {
+            column: column.clone(),
+            is_wkb: true,
+            is_base64_wkb: true,
+            requires_base64_wkb_validation: true,
+            base64_wkb_candidates: base64_wkb_candidates
+                .into_iter()
+                .map(|(_, column)| column)
+                .collect(),
         });
     }
 
     Err("DuckDB did not find a geometry column in this file.".to_string())
+}
+
+fn has_valid_base64_wkb_values(
+    conn: &Connection,
+    source_sql: &str,
+    column: &str,
+) -> Result<bool, String> {
+    let column_sql = quote_identifier(column);
+    let sample_column = quote_identifier("__geolibre_base64_wkb_sample");
+    let probe_sql = format!(
+        "SELECT count(*) AS sample_count, \
+         count(TRY(ST_GeomFromWKB(from_base64({sample_column})))) AS valid_count \
+         FROM (SELECT {column_sql} AS {sample_column} FROM ({source_sql}) AS data \
+         WHERE {column_sql} IS NOT NULL LIMIT 20) AS sample"
+    );
+    let (sample_count, valid_count): (i64, i64) = conn
+        .query_row(&probe_sql, [], |row| Ok((row.get(0)?, row.get(1)?)))
+        .map_err(|error| format!("Could not validate base64 WKB geometry values: {error}"))?;
+    // Require every sampled non-null value to decode as WKB so a user attribute
+    // named "geometry" or "wkb" is not promoted based on a partial match.
+    Ok(sample_count > 0 && sample_count == valid_count)
 }
 
 fn read_source_crs(conn: &Connection, options: &NativeVectorOptions) -> Option<String> {
@@ -404,9 +480,18 @@ fn crs_auth_code(crs: &serde_json::Value) -> Option<String> {
 }
 
 fn geometry_expr(detected: &DetectedGeometry) -> String {
+    assert!(
+        !detected.requires_base64_wkb_validation,
+        "base64 WKB geometry must be value-validated before SQL generation"
+    );
     let column = quote_identifier(&detected.column);
     if detected.is_wkb {
-        format!("ST_GeomFromWKB({column})")
+        let wkb = if detected.is_base64_wkb {
+            format!("from_base64({column})")
+        } else {
+            column
+        };
+        format!("ST_GeomFromWKB({wkb})")
     } else {
         column
     }
@@ -610,6 +695,51 @@ mod tests {
         .expect("write GeoParquet fixture");
     }
 
+    fn create_base64_wkb_parquet(path: &str) {
+        let conn = Connection::open_in_memory().expect("open DuckDB");
+        conn.execute_batch(&format!(
+            "
+            CREATE TABLE places AS
+            SELECT
+              1 AS id,
+              'Luxembourg' AS name,
+              'AQMAAAABAAAABQAAAFCW6nIMPRdA3PVYDQjGSECxTV13Nj0XQHRYwfoLxkhA4MiF5+M8F0BWd0PCEcZIQPjdWB27PBdAIePTAA7GSEBQlupyDD0XQNz1WA0IxkhA' AS geometry;
+            COPY places TO {} (FORMAT PARQUET);
+            ",
+            quote_sql_string(path)
+        ))
+        .expect("write base64 WKB Parquet fixture");
+    }
+
+    fn create_plain_string_geometry_parquet(path: &str) {
+        let conn = Connection::open_in_memory().expect("open DuckDB");
+        conn.execute_batch(&format!(
+            "
+            CREATE TABLE places AS
+            SELECT 1 AS id, 'not WKB' AS geometry;
+            COPY places TO {} (FORMAT PARQUET);
+            ",
+            quote_sql_string(path)
+        ))
+        .expect("write plain string geometry fixture");
+    }
+
+    fn create_ranked_base64_wkb_candidates_parquet(path: &str) {
+        let conn = Connection::open_in_memory().expect("open DuckDB");
+        conn.execute_batch(&format!(
+            "
+            CREATE TABLE places AS
+            SELECT
+              1 AS id,
+              'not WKB' AS geometry,
+              'AQMAAAABAAAABQAAAFCW6nIMPRdA3PVYDQjGSECxTV13Nj0XQHRYwfoLxkhA4MiF5+M8F0BWd0PCEcZIQPjdWB27PBdAIePTAA7GSEBQlupyDD0XQNz1WA0IxkhA' AS wkb;
+            COPY places TO {} (FORMAT PARQUET);
+            ",
+            quote_sql_string(path)
+        ))
+        .expect("write ranked base64 WKB candidate fixture");
+    }
+
     fn install_spatial_extension_for_tests(conn: &Connection) -> Result<(), String> {
         conn.execute_batch("INSTALL spatial; LOAD spatial;")
             .map_err(|error| format!("Could not install/load DuckDB spatial extension: {error}"))
@@ -634,6 +764,62 @@ mod tests {
         assert_eq!(features[0]["geometry"]["type"], "Point");
         assert_eq!(features[0]["geometry"]["coordinates"][0], -122.4194);
         assert_eq!(features[0]["geometry"]["coordinates"][1], 37.7749);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn native_loader_reads_base64_wkb_geometry_column() {
+        let path = temp_geoparquet_path();
+        create_base64_wkb_parquet(&path);
+
+        let options = native_options(path.clone(), None, None).expect("native options");
+        let collection = load_native_vector_file_blocking(options).expect("load vector file");
+        let features = collection["features"].as_array().expect("features array");
+        assert_eq!(features.len(), 1);
+        assert_eq!(features[0]["properties"]["id"], 1);
+        assert_eq!(features[0]["properties"]["name"], "Luxembourg");
+        assert_eq!(features[0]["geometry"]["type"], "Polygon");
+        assert_eq!(
+            features[0]["geometry"]["coordinates"][0][0][0],
+            5.809617801254333
+        );
+        assert_eq!(
+            features[0]["geometry"]["coordinates"][0][0][1],
+            49.54712073177117
+        );
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn native_loader_rejects_plain_string_geometry_column() {
+        let path = temp_geoparquet_path();
+        create_plain_string_geometry_parquet(&path);
+
+        let options = native_options(path.clone(), None, None).expect("native options");
+        let error = load_native_vector_file_blocking(options).expect_err("reject plain string");
+        assert!(error.contains("DuckDB did not find a geometry column"));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn native_loader_tries_ranked_base64_wkb_candidates() {
+        let path = temp_geoparquet_path();
+        create_ranked_base64_wkb_candidates_parquet(&path);
+
+        let options = native_options(path.clone(), None, None).expect("native options");
+        let collection = load_native_vector_file_blocking(options).expect("load vector file");
+        let features = collection["features"].as_array().expect("features array");
+        assert_eq!(features.len(), 1);
+        assert_eq!(features[0]["properties"]["id"], 1);
+        assert_eq!(features[0]["properties"]["geometry"], "not WKB");
+        assert_eq!(features[0]["geometry"]["type"], "Polygon");
+        assert_eq!(
+            features[0]["geometry"]["coordinates"][0][0][0],
+            5.809617801254333
+        );
 
         let _ = std::fs::remove_file(path);
     }
@@ -669,7 +855,7 @@ mod tests {
 
     #[test]
     fn wkb_detection_uses_preferred_column_name() {
-        let detected = detect_geometry_column(&[
+        let detected = detect_geometry_column_from_schema(&[
             DescribedColumn {
                 name: "wkb".to_string(),
                 column_type: "BLOB".to_string(),
@@ -682,6 +868,28 @@ mod tests {
         .expect("detect WKB geometry");
         assert_eq!(detected.column, "geometry");
         assert!(detected.is_wkb);
+        assert!(!detected.is_base64_wkb);
+        assert!(!detected.requires_base64_wkb_validation);
+    }
+
+    #[test]
+    fn wkb_detection_marks_base64_string_geometry_candidates() {
+        let detected = detect_geometry_column_from_schema(&[
+            DescribedColumn {
+                name: "id".to_string(),
+                column_type: "BIGINT".to_string(),
+            },
+            DescribedColumn {
+                name: "geometry".to_string(),
+                column_type: "VARCHAR".to_string(),
+            },
+        ])
+        .expect("detect base64 WKB geometry");
+        assert_eq!(detected.column, "geometry");
+        assert!(detected.is_wkb);
+        assert!(detected.is_base64_wkb);
+        assert!(detected.requires_base64_wkb_validation);
+        assert_eq!(detected.base64_wkb_candidates, vec!["geometry".to_string()]);
     }
 
     #[test]

--- a/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
@@ -38,8 +38,14 @@ export function isGeometryColumnType(columnType: unknown): boolean {
 
 export interface DetectedGeometry {
   column: string;
-  /** True when the column is a raw WKB blob that needs ST_GeomFromWKB. */
+  /** True when the column stores WKB that needs ST_GeomFromWKB. */
   isWkb: boolean;
+  /** True when a WKB value is stored as a base64 string. */
+  isBase64Wkb?: boolean;
+  /** True when schema detection found a string WKB candidate that still needs a value probe. */
+  requiresBase64WkbValidation?: boolean;
+  /** Ranked string WKB candidates to value-probe before SQL generation. */
+  base64WkbCandidates?: string[];
 }
 
 /**
@@ -60,21 +66,57 @@ export function detectGeometryColumn(
   if (typeof native === "string") {
     return { column: native, isWkb: false };
   }
-  // Require the WKB candidate to be a binary/blob type. Matching on name alone
-  // would route a same-named non-binary column (e.g. a VARCHAR "geometry")
-  // through ST_GeomFromWKB and surface an opaque DuckDB error instead of the
-  // clear "no geometry column" message callers expect.
-  const wkb = description.find(
+  const rankedWkbCandidates = description
+    .filter(
+      (row): row is Record<string, unknown> & { column_name: string } =>
+        typeof row.column_name === "string" &&
+        WKB_GEOMETRY_COLUMN_NAMES.has(row.column_name.toLowerCase()),
+    )
+    .sort(
+      (a, b) =>
+        wkbColumnRank(a.column_name) - wkbColumnRank(b.column_name),
+    );
+
+  // Prefer binary/blob WKB candidates because DuckDB reads canonical WKB as
+  // binary data. String WKB candidates are intentionally a later fallback and
+  // must be value-probed by the loader before being decoded: they may be base64
+  // geometry, but WKB-style names are still user-authored attributes in some
+  // loose Parquet files.
+  const wkb = rankedWkbCandidates.find(
     (row) =>
-      typeof row.column_name === "string" &&
       typeof row.column_type === "string" &&
-      /^(BLOB|BINARY|VARBINARY)/i.test(row.column_type) &&
-      WKB_GEOMETRY_COLUMN_NAMES.has(row.column_name.toLowerCase()),
+      /^(BLOB|BINARY|VARBINARY)/i.test(row.column_type),
   )?.column_name;
   if (typeof wkb === "string") {
     return { column: wkb, isWkb: true };
   }
+
+  const base64WkbCandidates = rankedWkbCandidates
+    .filter(
+      (row) =>
+        typeof row.column_type === "string" &&
+        /^(VARCHAR|TEXT|STRING)/i.test(row.column_type),
+    )
+    .map((row) => row.column_name);
+  if (base64WkbCandidates.length > 0) {
+    return {
+      column: base64WkbCandidates[0],
+      isWkb: true,
+      isBase64Wkb: true,
+      requiresBase64WkbValidation: true,
+      base64WkbCandidates,
+    };
+  }
   return null;
+}
+
+function wkbColumnRank(name: string): number {
+  let rank = 0;
+  for (const candidate of WKB_GEOMETRY_COLUMN_NAMES) {
+    if (candidate === name.toLowerCase()) return rank;
+    rank += 1;
+  }
+  return WKB_GEOMETRY_COLUMN_NAMES.size;
 }
 
 /**
@@ -82,8 +124,15 @@ export function detectGeometryColumn(
  * column is referenced directly; a raw WKB blob is decoded with ST_GeomFromWKB.
  */
 export function geometryExpr(detected: DetectedGeometry): string {
+  if (detected.requiresBase64WkbValidation) {
+    throw new Error(
+      "Base64 WKB geometry candidates must be validated before SQL generation.",
+    );
+  }
   const column = quoteIdentifier(detected.column);
-  return detected.isWkb ? `ST_GeomFromWKB(${column})` : column;
+  if (!detected.isWkb) return column;
+  const wkb = detected.isBase64Wkb ? `from_base64(${column})` : column;
+  return `ST_GeomFromWKB(${wkb})`;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -280,6 +280,7 @@ async function readSourceCrs(
 
 function toFeatureCollection(
   rows: Record<string, unknown>[],
+  geometryColumn?: string,
 ): FeatureCollection<Geometry | null> {
   const features = rows.map((row) => {
     const rawGeometry = row[GEOMETRY_JSON_COLUMN];
@@ -292,7 +293,13 @@ function toFeatureCollection(
     const properties: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(row)) {
-      if (key === GEOMETRY_JSON_COLUMN || value instanceof Uint8Array) continue;
+      if (
+        key === GEOMETRY_JSON_COLUMN ||
+        key === geometryColumn ||
+        value instanceof Uint8Array
+      ) {
+        continue;
+      }
       properties[key] = normalizePropertyValue(value);
     }
 
@@ -325,6 +332,56 @@ function normalizePropertyValue(value: unknown): unknown {
     );
   }
   return value;
+}
+
+async function validateDetectedGeometry(
+  connection: duckdb.AsyncDuckDBConnection,
+  source: string,
+  detected: ReturnType<typeof detectGeometryColumn>,
+): Promise<NonNullable<ReturnType<typeof detectGeometryColumn>> | null> {
+  if (!detected) return null;
+  if (!detected.requiresBase64WkbValidation) return detected;
+  const candidates = detected.base64WkbCandidates ?? [];
+  for (const column of candidates) {
+    if (await hasValidBase64WkbValues(connection, source, column)) {
+      const {
+        requiresBase64WkbValidation: _validated,
+        base64WkbCandidates: _candidates,
+        ...validated
+      } = detected;
+      return { ...validated, column };
+    }
+  }
+  return null;
+}
+
+async function hasValidBase64WkbValues(
+  connection: duckdb.AsyncDuckDBConnection,
+  source: string,
+  column: string,
+): Promise<boolean> {
+  const columnSql = quoteIdentifier(column);
+  const sampleColumn = quoteIdentifier("__geolibre_base64_wkb_sample");
+  const rows = rowsFromResult(
+    await connection.query(
+      `SELECT count(*) AS sample_count, count(TRY(ST_GeomFromWKB(from_base64(${sampleColumn})))) AS valid_count ` +
+        `FROM (SELECT ${columnSql} AS ${sampleColumn} FROM (${source}) AS data ` +
+        `WHERE ${columnSql} IS NOT NULL LIMIT 20) AS sample`,
+    ),
+  );
+  const row = rows[0] ?? {};
+  const sampleCount = numberFromCount(row.sample_count);
+  const validCount = numberFromCount(row.valid_count);
+  // Require every sampled non-null value to decode as WKB so a user attribute
+  // named "geometry" or "wkb" is not promoted based on a partial match.
+  return sampleCount > 0 && sampleCount === validCount;
+}
+
+function numberFromCount(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") return Number(value);
+  return 0;
 }
 
 /**
@@ -410,7 +467,11 @@ export async function loadDuckDbVectorFile(
     const description = rowsFromResult(
       await connection.query(`DESCRIBE ${sql}`),
     );
-    const detected = detectGeometryColumn(description);
+    const detected = await validateDetectedGeometry(
+      connection,
+      sql,
+      detectGeometryColumn(description),
+    );
 
     if (!detected) {
       throw new Error("DuckDB did not find a geometry column in this file.");
@@ -440,7 +501,10 @@ export async function loadDuckDbVectorFile(
     );
     // Features may carry a null geometry; the app's layer model treats them as
     // a regular FeatureCollection and the map ignores null geometries.
-    return toFeatureCollection(rowsFromResult(result)) as FeatureCollection;
+    return toFeatureCollection(
+      rowsFromResult(result),
+      detected.column,
+    ) as FeatureCollection;
   } finally {
     await connection.close();
   }
@@ -566,7 +630,11 @@ export async function reprojectFeatureCollectionToWgs84(
     const description = rowsFromResult(
       await connection.query(`DESCRIBE ${sql}`),
     );
-    const detected = detectGeometryColumn(description);
+    const detected = await validateDetectedGeometry(
+      connection,
+      sql,
+      detectGeometryColumn(description),
+    );
     if (!detected) {
       // No geometry to reproject; hand back the stripped collection untouched.
       return stripped as FeatureCollection;
@@ -580,7 +648,10 @@ export async function reprojectFeatureCollectionToWgs84(
         GEOMETRY_JSON_COLUMN,
       )} FROM (${sql}) AS data`,
     );
-    return toFeatureCollection(rowsFromResult(result)) as FeatureCollection;
+    return toFeatureCollection(
+      rowsFromResult(result),
+      detected.column,
+    ) as FeatureCollection;
   } finally {
     await connection.close();
     await dropFilesIfPresent(db, [sourceFile]);
@@ -702,16 +773,21 @@ export async function convertDuckDbVectorToGeoParquet(
       const description = rowsFromResult(
         await connection.query(`DESCRIBE ${sql}`),
       );
-      const detected = detectGeometryColumn(description);
+      const detected = await validateDetectedGeometry(
+        connection,
+        sql,
+        detectGeometryColumn(description),
+      );
       if (!detected) {
         throw new Error("DuckDB did not find a geometry column in this file.");
       }
       geometryColumn = detected.column;
       const geometrySql = quoteIdentifier(geometryColumn);
-      // Plain Parquet files may carry geometry as a WKB blob; rebuild it as a
-      // GEOMETRY column so ST_Hilbert and the GeoParquet writer can use it.
+      // Plain Parquet files may carry geometry as WKB bytes or base64 WKB;
+      // rebuild it as a GEOMETRY column so ST_Hilbert and the GeoParquet writer
+      // can use it.
       source = detected.isWkb
-        ? `SELECT * REPLACE (ST_GeomFromWKB(${geometrySql}) AS ${geometrySql}) FROM (${sql}) AS data`
+        ? `SELECT * REPLACE (${geometryExpr(detected)} AS ${geometrySql}) FROM (${sql}) AS data`
         : sql;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.8.1",
+        "maplibre-gl-vector": "^0.8.4",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17964,9 +17964,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.1.tgz",
-      "integrity": "sha512-l9dkCdtkbYcldyPtOcV4Ae6zdT9GD9HS4i8gCGLyIgJ4SMvNV0HmPS3DFKZ65MzZNUGsQgpHJ8Y1hrcMEe35gQ==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.4.tgz",
+      "integrity": "sha512-E1VtxIlpq5270USTNLETIxPeSFocfj+27RA84GYCOd2Am9ySmWQv0DkSaIPBGxpBQ9MELvpNx144vUk8Atc+CQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -23819,7 +23819,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.8.1",
+        "maplibre-gl-vector": "^0.8.4",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.8.1",
+    "maplibre-gl-vector": "^0.8.4",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/tests/duckdb-geometry.test.ts
+++ b/tests/duckdb-geometry.test.ts
@@ -82,10 +82,38 @@ describe("detectGeometryColumn", () => {
     });
   });
 
-  it("ignores a WKB-named column that is not a binary type", () => {
+  it("falls back to a base64 string WKB column (issue #984)", () => {
     const detected = detectGeometryColumn([
       describeRow("id", "BIGINT"),
       describeRow("geometry", "VARCHAR"),
+    ]);
+    assert.deepEqual(detected, {
+      column: "geometry",
+      isWkb: true,
+      isBase64Wkb: true,
+      requiresBase64WkbValidation: true,
+      base64WkbCandidates: ["geometry"],
+    });
+  });
+
+  it("ranks multiple base64 string WKB candidates by well-known name", () => {
+    const detected = detectGeometryColumn([
+      describeRow("wkb", "VARCHAR"),
+      describeRow("geometry", "VARCHAR"),
+    ]);
+    assert.deepEqual(detected, {
+      column: "geometry",
+      isWkb: true,
+      isBase64Wkb: true,
+      requiresBase64WkbValidation: true,
+      base64WkbCandidates: ["geometry", "wkb"],
+    });
+  });
+
+  it("ignores a WKB-named column that is neither binary nor string", () => {
+    const detected = detectGeometryColumn([
+      describeRow("id", "BIGINT"),
+      describeRow("geometry", "INTEGER"),
     ]);
     assert.equal(detected, null);
   });
@@ -108,6 +136,26 @@ describe("geometryExpr", () => {
     assert.equal(
       geometryExpr({ column: "geometry_wkb", isWkb: true }),
       'ST_GeomFromWKB("geometry_wkb")',
+    );
+  });
+
+  it("decodes a base64 WKB string with from_base64", () => {
+    assert.equal(
+      geometryExpr({ column: "geometry", isWkb: true, isBase64Wkb: true }),
+      'ST_GeomFromWKB(from_base64("geometry"))',
+    );
+  });
+
+  it("rejects unvalidated base64 WKB candidates", () => {
+    assert.throws(
+      () =>
+        geometryExpr({
+          column: "geometry",
+          isWkb: true,
+          isBase64Wkb: true,
+          requiresBase64WkbValidation: true,
+        }),
+      /must be validated/,
     );
   });
 


### PR DESCRIPTION
## Summary
- bump maplibre-gl-vector to 0.8.4, which validates and decodes base64 WKB GeoParquet geometry columns
- add GeoLibre-side support for base64 WKB geometry in DuckDB WASM and native DuckDB loaders
- probe ranked base64 WKB candidates in order so a non-geometry `geometry` string attribute does not hide a valid `wkb` column
- avoid leaking raw geometry columns into feature properties and reject plain string geometry columns that fail the WKB probe
- cover the detector and native loader with regression tests

Fixes #984

Upstream: https://github.com/opengeos/maplibre-gl-vector/pull/35
Release: https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.8.4

## Tests
- npm run test:frontend -- tests/duckdb-geometry.test.ts
- cargo test --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml --features native-duckdb native_loader
- pre-commit run --files apps/geolibre-desktop/package.json apps/geolibre-desktop/src-tauri/src/native_duckdb.rs apps/geolibre-desktop/src/lib/duckdb-geometry.ts apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts package-lock.json packages/plugins/package.json tests/duckdb-geometry.test.ts

## Browser verification
- Loaded /tmp/geolibre-issue-984-base64-wkb.geoparquet through Add Data > GeoParquet Layer in light mode with maplibre-gl-vector 0.8.4; layer appeared, map zoomed to BBox 5.7869, 49.4570, 6.1499, 49.7148, diagnostics stayed 0
- Repeated the same fixture in dark mode; layer appeared, map zoomed to the same bounds, diagnostics stayed 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vector layers with geometry stored as base64-encoded WKB, making more files load correctly.
  * Fixed geometry fields from being duplicated into layer properties.
  * Better distinguishes valid geometry columns from plain text or unsupported column types.

* **Chores**
  * Updated the MapLibre vector dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->