### PR TITLE
Update MapLibre plugin dependencies

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.3",
+    "maplibre-gl-geoagent": "^0.5.4",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.3",
+        "maplibre-gl-geoagent": "^0.5.4",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
@@ -17623,9 +17623,9 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.3.tgz",
-      "integrity": "sha512-VELcdADtGb5qDoPqwxos1w0k99dpp3igzq3wl5hTOb1cOfaxEwy2Qw7ONAao3XwUJtoZcTYqPZO/2eSPEkUwYg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.4.tgz",
+      "integrity": "sha512-xk9EzoLc2lMExqmKJRhQlK/Yvs509G9dfUESOCh9NU8L5PMVWkKLMgiHKJOmku+srvlQvrB1I4vq5LbDIyCorQ==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -23807,7 +23807,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.5.3",
+        "maplibre-gl-geoagent": "^0.5.4",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.5.3",
+    "maplibre-gl-geoagent": "^0.5.4",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-nasa-earthdata": "^0.1.4",


### PR DESCRIPTION
## Summary
- update maplibre-gl-geoagent from 0.5.3 to 0.5.4 in the desktop app and plugins package
- refresh package-lock.json for the updated package
- verified all direct maplibre-gl-* dependencies match the npm latest dist-tag

## Tests
- pre-commit run --files apps/geolibre-desktop/package.json packages/plugins/package.json package-lock.json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a map-related dependency to a newer patch version in the desktop app and plugins package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->