### PR TITLE
Show external plugin load failures

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -34,10 +34,12 @@ import {
 } from "react";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
 import {
+  getExternalPluginLoadIssues,
   getPluginManager,
   installPluginArchive,
   installPluginArchiveFromFile,
   listPluginArchivesFromFile,
+  subscribeToExternalPluginLoads,
   uninstallPluginArchiveFromFile,
   upgradeExternalPlugin,
 } from "../../hooks/usePlugins";
@@ -190,6 +192,11 @@ export function ManagePluginsDialog({
     }
     return versions;
   }, [managerVersion]);
+  const externalLoadIssues = useSyncExternalStore(
+    subscribeToExternalPluginLoads,
+    getExternalPluginLoadIssues,
+    getExternalPluginLoadIssues,
+  );
 
   const installedSet = useMemo(
     () => new Set(desktopSettings.pluginManifestUrls.map((url) => url.trim())),
@@ -584,6 +591,7 @@ export function ManagePluginsDialog({
                     );
                     const updateAvailable = isUpgradeable(entry);
                     const loadPending = isLoadPending(entry);
+                    const loadIssue = externalLoadIssues.get(entry.manifestUrl);
                     return (
                       <div
                         key={entry.id}
@@ -646,6 +654,11 @@ export function ManagePluginsDialog({
                               {actionError.message}
                             </p>
                           ) : null}
+                          {installed && loadIssue ? (
+                            <p className="text-[11px] text-destructive">
+                              Failed to load: {loadIssue}
+                            </p>
+                          ) : null}
                         </div>
                         <div className="flex shrink-0 items-center gap-1.5">
                           {!installed ? (
@@ -706,7 +719,12 @@ export function ManagePluginsDialog({
                                   Update
                                 </Button>
                               ) : null}
-                              {loadPending ? (
+                              {loadIssue ? (
+                                <span className="flex items-center gap-1 text-xs text-destructive">
+                                  <AlertTriangle className="h-3.5 w-3.5" />
+                                  Failed
+                                </span>
+                              ) : loadPending ? (
                                 <span className="flex items-center gap-1 text-xs text-muted-foreground">
                                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                                   Loading…

--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -32,6 +32,7 @@ import {
   useSyncExternalStore,
   type RefObject,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
 import {
   getExternalPluginLoadIssues,
@@ -93,6 +94,7 @@ export function ManagePluginsDialog({
   onOpenChange,
   mapControllerRef,
 }: ManagePluginsDialogProps) {
+  const { t } = useTranslation();
   const desktopSettings = useDesktopSettingsStore((s) => s.desktopSettings);
   const setDesktopSettings = useDesktopSettingsStore(
     (s) => s.setDesktopSettings,
@@ -656,7 +658,9 @@ export function ManagePluginsDialog({
                           ) : null}
                           {installed && loadIssue ? (
                             <p className="text-[11px] text-destructive">
-                              Failed to load: {loadIssue}
+                              {t("managePlugins.failedToLoad", {
+                                message: loadIssue,
+                              })}
                             </p>
                           ) : null}
                         </div>
@@ -722,7 +726,7 @@ export function ManagePluginsDialog({
                               {loadIssue ? (
                                 <span className="flex items-center gap-1 text-xs text-destructive">
                                   <AlertTriangle className="h-3.5 w-3.5" />
-                                  Failed
+                                  {t("managePlugins.failed")}
                                 </span>
                               ) : loadPending ? (
                                 <span className="flex items-center gap-1 text-xs text-muted-foreground">

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -501,7 +501,10 @@ function ensureExternalPluginsLoadedWithSettings(
     })
     .then((result) => {
       externalPluginLoadIssues = new Map(
-        result.issues.map((issue) => [issue.archiveName, issue.message]),
+        result.issues.map((issue) => [
+          issue.sourceUrl ?? issue.archiveName,
+          issue.message,
+        ]),
       );
       notifyExternalPluginsListeners();
       if (result.loadedPluginIds.length) {

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -149,11 +149,23 @@ manager.registerAll([
 let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;
 let externalPluginsLoadKey: string | null = null;
+let externalPluginLoadIssues = new Map<string, string>();
 const externalPluginsListeners = new Set<() => void>();
 const EMPTY_PLUGIN_MANIFEST_URLS: string[] = [];
 
 export function getPluginManager(): PluginManager {
   return manager;
+}
+
+export function getExternalPluginLoadIssues(): ReadonlyMap<string, string> {
+  return externalPluginLoadIssues;
+}
+
+export function subscribeToExternalPluginLoads(
+  listener: () => void,
+): () => void {
+  externalPluginsListeners.add(listener);
+  return () => externalPluginsListeners.delete(listener);
 }
 
 // Upgrade an installed external plugin in place by re-fetching its manifest URL
@@ -457,6 +469,7 @@ function ensureExternalPluginsLoadedWithSettings(
     return externalPluginsLoadPromise;
   }
 
+  externalPluginLoadIssues = new Map();
   setExternalPluginsLoaded(false);
   externalPluginsLoadKey = loadKey;
   // Serialize scans: loadExternalPlugins reads and writes module-level state
@@ -484,6 +497,9 @@ function ensureExternalPluginsLoadedWithSettings(
       );
     })
     .then((result) => {
+      externalPluginLoadIssues = new Map(
+        result.issues.map((issue) => [issue.archiveName, issue.message]),
+      );
       if (result.loadedPluginIds.length) {
         console.info(
           `Loaded external GeoLibre plugins from ${result.pluginSources.join(

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -164,6 +164,8 @@ export function getExternalPluginLoadIssues(): ReadonlyMap<string, string> {
 export function subscribeToExternalPluginLoads(
   listener: () => void,
 ): () => void {
+  // Shares the ready-state listener set so marketplace rows update for both
+  // successful loads and per-plugin load issues.
   externalPluginsListeners.add(listener);
   return () => externalPluginsListeners.delete(listener);
 }
@@ -470,6 +472,7 @@ function ensureExternalPluginsLoadedWithSettings(
   }
 
   externalPluginLoadIssues = new Map();
+  notifyExternalPluginsListeners();
   setExternalPluginsLoaded(false);
   externalPluginsLoadKey = loadKey;
   // Serialize scans: loadExternalPlugins reads and writes module-level state
@@ -500,6 +503,7 @@ function ensureExternalPluginsLoadedWithSettings(
       externalPluginLoadIssues = new Map(
         result.issues.map((issue) => [issue.archiveName, issue.message]),
       );
+      notifyExternalPluginsListeners();
       if (result.loadedPluginIds.length) {
         console.info(
           `Loaded external GeoLibre plugins from ${result.pluginSources.join(
@@ -924,6 +928,10 @@ function isTauriRuntime(): boolean {
 function setExternalPluginsLoaded(loaded: boolean): void {
   if (externalPluginsLoaded === loaded) return;
   externalPluginsLoaded = loaded;
+  notifyExternalPluginsListeners();
+}
+
+function notifyExternalPluginsListeners(): void {
   for (const listener of externalPluginsListeners) listener();
 }
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -61,6 +61,10 @@
     "newFolder": "New Folder",
     "defaultFolderName": "Folder"
   },
+  "managePlugins": {
+    "failed": "Failed",
+    "failedToLoad": "Failed to load: {{message}}"
+  },
   "viewState": {
     "panelTitle": "Info"
   },

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -37,6 +37,7 @@ interface ExternalPluginBundleLoadResult {
 
 export interface ExternalPluginLoadIssue {
   archiveName: string;
+  sourceUrl?: string;
   message: string;
 }
 
@@ -109,6 +110,7 @@ export async function loadExternalPlugins(
         if (loadedFrom !== bundle.archiveName) {
           issues.push({
             archiveName: bundle.archiveName,
+            sourceUrl: bundle.sourceUrl,
             message: `Plugin id '${bundle.manifest.id}' is already loaded from '${loadedFrom}'. Restart GeoLibre to load this copy.`,
           });
         }
@@ -117,6 +119,7 @@ export async function loadExternalPlugins(
       if (registeredPluginIds.has(bundle.manifest.id)) {
         issues.push({
           archiveName: bundle.archiveName,
+          sourceUrl: bundle.sourceUrl,
           message: `Plugin id '${bundle.manifest.id}' is already registered.`,
         });
         continue;
@@ -136,6 +139,7 @@ export async function loadExternalPlugins(
     } catch (error) {
       issues.push({
         archiveName: bundle.archiveName,
+        sourceUrl: bundle.sourceUrl,
         message:
           error instanceof Error
             ? error.message
@@ -190,6 +194,7 @@ async function loadPluginUrlBundles(
     } else {
       issues.push({
         archiveName: manifestUrls[index],
+        sourceUrl: manifestUrls[index],
         message:
           result.reason instanceof Error
             ? result.reason.message
@@ -241,6 +246,7 @@ async function loadPluginUrlBundle(
 
   return {
     archiveName: manifestUrl,
+    sourceUrl: manifestUrl,
     manifest,
     entrySource,
     styleSource,

--- a/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
@@ -9,6 +9,7 @@ import { unzip } from "fflate";
 
 export interface ExternalPluginBundle {
   archiveName: string;
+  sourceUrl?: string;
   manifest: GeoLibreExternalPluginManifest;
   entrySource: string;
   styleSource?: string | null;


### PR DESCRIPTION
## Summary
- retain the latest external plugin load issue by source URL
- expose those issues to Manage Plugins through the existing external plugin load subscription
- show Failed / Failed to load with the loader error instead of an indefinite Loading state when a URL plugin is installed but not registered

## Verification
- npm run lint (passes with existing warnings)
- npm run build -w geolibre-desktop
- browser smoke test: installed live NASA OPERA 0.2.5 from plugins.geolibre.app and verified the row shows Installed, not Loading or Failed

## Notes
The NASA OPERA registry bundle was also hotfixed to 0.2.5 and reduced below 5 MiB. This app-side change prevents future plugin load failures from appearing as a stuck installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin management now clearly shows when an installed plugin fails to load.
  * Failed plugins now display a visible “Failed” indicator and a translated error message in the details view.
  * Load failure states update automatically after external plugin loading completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->