### PR TITLE
fix(pyodide-console): load pyodide.asm.js via blob so a self-hosted mirror works under CSP

### DIFF
--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-config.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-config.ts
@@ -32,3 +32,21 @@ export function getPyodideIndexUrl(
   const url = override || DEFAULT_INDEX_URL;
   return url.endsWith("/") ? url : `${url}/`;
 }
+
+/**
+ * Whether `indexURL` is the built-in jsDelivr CDN default (rather than a custom
+ * `VITE_PYODIDE_INDEX_URL` mirror).
+ *
+ * The default CDN origin is whitelisted in the app's `script-src` CSP, so
+ * consumers can take Pyodide's normal load path for it and reserve the
+ * fetch-then-blob workaround for non-whitelisted mirrors.
+ *
+ * Args:
+ *   indexURL: A resolved indexURL, e.g. from `getPyodideIndexUrl()`.
+ *
+ * Returns:
+ *   True when `indexURL` is the default CDN URL.
+ */
+export function isDefaultPyodideIndexUrl(indexURL: string): boolean {
+  return indexURL === DEFAULT_INDEX_URL;
+}

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -212,7 +212,7 @@ function loadPyodideScript(indexURL: string): Promise<void> {
     await injectScript(
       `${indexURL}pyodide.asm.js`,
       () => typeof window._createPyodideModule === "function",
-      "globalThis._createPyodideModule",
+      "window._createPyodideModule",
     );
   })().catch((error) => {
     scriptPromise = null;

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -74,6 +74,11 @@ function emitProgress(phase: string): void {
   for (const listener of progressListeners) listener(phase);
 }
 
+// Both this script memo and the runtimePromise singleton below are intentionally
+// not keyed on indexURL: `getPyodideIndexUrl()` is stable for the app's lifetime,
+// so the console always resolves the same URL. Runtime mirror-switching is out of
+// scope; supporting it would mean rebuilding the whole runtime, not just rekeying
+// this promise.
 let scriptPromise: Promise<void> | null = null;
 
 // Generous bound on each runtime-script fetch. Large enough for the multi-MB

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -99,13 +99,17 @@ async function injectScript(
   label: string,
 ): Promise<void> {
   if (isReady()) return;
-  let source: string;
+  // Read as an ArrayBuffer rather than text: pyodide.asm.js is the multi-MB
+  // Emscripten runtime, and decoding it to a (UTF-16) JS string before copying
+  // it into the Blob would roughly triple its peak memory footprint. The Blob
+  // is fed straight to a <script src>, so the raw bytes are all we need.
+  let source: ArrayBuffer;
   try {
     const response = await fetch(scriptUrl);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    source = await response.text();
+    source = await response.arrayBuffer();
   } catch (cause) {
     throw new Error(
       `Failed to load the Pyodide runtime script from ${scriptUrl}.`,
@@ -169,6 +173,11 @@ function loadPyodideScript(indexURL: string): Promise<void> {
       () => typeof window.loadPyodide === "function",
       "window.loadPyodide",
     );
+    // Pyodide 0.27.x's loadPyodide() does a dynamic import() of pyodide.asm.js
+    // only when globalThis._createPyodideModule is not already a function, so
+    // pre-defining it via the blob path short-circuits that CSP-blocked import.
+    // This hinges on an Emscripten/Pyodide internal: re-verify it still holds
+    // whenever PYODIDE_VERSION in pyodide-config.ts is bumped.
     await injectScript(
       `${indexURL}pyodide.asm.js`,
       () => typeof window._createPyodideModule === "function",

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -1,6 +1,6 @@
 import type { MapController } from "@geolibre/map";
 import consoleApiSource from "./console_api.py?raw";
-import { getPyodideIndexUrl } from "./pyodide-config";
+import { getPyodideIndexUrl, isDefaultPyodideIndexUrl } from "./pyodide-config";
 import {
   createScriptingHandlers,
   type ScriptingDeps,
@@ -76,6 +76,10 @@ function emitProgress(phase: string): void {
 
 let scriptPromise: Promise<void> | null = null;
 
+// Generous bound on each runtime-script fetch. Large enough for the multi-MB
+// pyodide.asm.js over a slow link, small enough to escape a dead mirror.
+const SCRIPT_FETCH_TIMEOUT_MS = 60_000;
+
 /**
  * Fetch a Pyodide runtime script and run it via a `blob:` URL, then confirm it
  * defined the global it is supposed to.
@@ -104,8 +108,15 @@ async function injectScript(
   // it into the Blob would roughly triple its peak memory footprint. The Blob
   // is fed straight to a <script src>, so the raw bytes are all we need.
   let source: ArrayBuffer;
+  // Bound the fetch so a hung or misconfigured mirror surfaces an error (and
+  // the caller's memo reset enables a retry) instead of an infinite spinner.
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    SCRIPT_FETCH_TIMEOUT_MS,
+  );
   try {
-    const response = await fetch(scriptUrl);
+    const response = await fetch(scriptUrl, { signal: controller.signal });
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
@@ -115,6 +126,8 @@ async function injectScript(
       `Failed to load the Pyodide runtime script from ${scriptUrl}.`,
       { cause },
     );
+  } finally {
+    clearTimeout(timeout);
   }
   const blobUrl = URL.createObjectURL(
     new Blob([source], { type: "text/javascript" }),
@@ -123,25 +136,29 @@ async function injectScript(
     await new Promise<void>((resolve, reject) => {
       const script = document.createElement("script");
       script.src = blobUrl;
+      // The script's globals persist once it has executed, so the element is
+      // dead weight afterwards; remove it on every path to keep the DOM clean
+      // (and so a retry never leaves orphan <script> tags).
       script.onload = () => {
+        script.remove();
         if (isReady()) {
           resolve();
           return;
         }
-        script.remove();
         reject(
           new Error(
             `Pyodide script loaded but ${label} is not defined; the content at ${scriptUrl} may be incorrect.`,
           ),
         );
       };
-      // The caller's `.catch` owns resetting the memo on failure; remove the
-      // dead element so a retry doesn't leave orphan <script> tags.
+      // `onerror` fires when the browser fails to load the blob resource, not
+      // when the executed script throws (those reach window.onerror); word the
+      // message as a load failure accordingly.
       script.onerror = () => {
         script.remove();
         reject(
           new Error(
-            `Failed to execute the Pyodide runtime script from ${scriptUrl}.`,
+            `Failed to load the injected Pyodide runtime script from ${scriptUrl}.`,
           ),
         );
       };
@@ -156,15 +173,17 @@ async function injectScript(
  * Load Pyodide's two entry scripts once so the runtime can initialize from any
  * `indexURL`, including a self-hosted mirror, under Tauri's CSP.
  *
- * `pyodide.js` defines `window.loadPyodide`. We then also pre-inject
- * `pyodide.asm.js` (which defines `globalThis._createPyodideModule`) because
- * `loadPyodide()` otherwise dynamically `import()`s that file from `indexURL`,
- * and that import is blocked by `script-src` for a non-whitelisted mirror.
- * Pyodide skips the import when `_createPyodideModule` is already a function, so
- * the pre-injected blob short-circuits it. Both scripts are reached via the same
- * fetch-then-blob path (see `injectScript`). Pyodide's remaining assets (wasm,
- * lockfile, wheels) load via `fetch`, allowed by `connect-src`, so passing
- * `indexURL` to `loadPyodide({ indexURL })` resolves them unchanged.
+ * `pyodide.js` defines `window.loadPyodide`. For a custom mirror we then also
+ * pre-inject `pyodide.asm.js` (which defines `globalThis._createPyodideModule`)
+ * because `loadPyodide()` otherwise dynamically `import()`s that file from
+ * `indexURL`, and that import is blocked by `script-src` for a non-whitelisted
+ * mirror. Pyodide skips the import when `_createPyodideModule` is already a
+ * function, so the pre-injected blob short-circuits it. The default jsDelivr CDN
+ * is already in `script-src`, so we skip the asm.js pre-injection there and let
+ * Pyodide's own (cache-aware, streaming) import run, keeping the common path
+ * unchanged. Pyodide's remaining assets (wasm, lockfile, wheels) load via
+ * `fetch`, allowed by `connect-src`, so passing `indexURL` to
+ * `loadPyodide({ indexURL })` resolves them unchanged.
  */
 function loadPyodideScript(indexURL: string): Promise<void> {
   scriptPromise ??= (async () => {
@@ -173,11 +192,13 @@ function loadPyodideScript(indexURL: string): Promise<void> {
       () => typeof window.loadPyodide === "function",
       "window.loadPyodide",
     );
-    // Pyodide 0.27.x's loadPyodide() does a dynamic import() of pyodide.asm.js
-    // only when globalThis._createPyodideModule is not already a function, so
-    // pre-defining it via the blob path short-circuits that CSP-blocked import.
-    // This hinges on an Emscripten/Pyodide internal: re-verify it still holds
-    // whenever PYODIDE_VERSION in pyodide-config.ts is bumped.
+    if (isDefaultPyodideIndexUrl(indexURL)) return;
+    // Custom mirror only. Pyodide 0.27.x's loadPyodide() does a dynamic
+    // import() of pyodide.asm.js solely when globalThis._createPyodideModule is
+    // not already a function, so pre-defining it via the blob path
+    // short-circuits that CSP-blocked import. This hinges on an
+    // Emscripten/Pyodide internal: re-verify it still holds whenever
+    // PYODIDE_VERSION in pyodide-config.ts is bumped.
     await injectScript(
       `${indexURL}pyodide.asm.js`,
       () => typeof window._createPyodideModule === "function",

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -122,6 +122,10 @@ async function injectScript(
   );
   try {
     const response = await fetch(scriptUrl, { signal: controller.signal });
+    // The timeout only guards against a dead/unresponsive mirror, which is
+    // disproven the moment headers arrive. Clear it here so a slow but live
+    // mirror isn't aborted partway through the multi-MB asm.js body download.
+    clearTimeout(timeout);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
@@ -132,6 +136,7 @@ async function injectScript(
       { cause },
     );
   } finally {
+    // Idempotent; covers a fetch that rejects before the clear above.
     clearTimeout(timeout);
   }
   const blobUrl = URL.createObjectURL(

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -42,6 +42,10 @@ type LoadPyodide = (options: { indexURL: string }) => Promise<PyodideAPI>;
 declare global {
   interface Window {
     loadPyodide?: LoadPyodide;
+    // Emscripten factory exposed by pyodide.asm.js. loadPyodide() dynamically
+    // `import()`s pyodide.asm.js only when this is not already a function, so
+    // pre-injecting the script (below) lets us skip that CSP-blocked import.
+    _createPyodideModule?: unknown;
   }
 }
 
@@ -73,74 +77,103 @@ function emitProgress(phase: string): void {
 let scriptPromise: Promise<void> | null = null;
 
 /**
- * Load `pyodide.js` once so `window.loadPyodide` is available.
+ * Fetch a Pyodide runtime script and run it via a `blob:` URL, then confirm it
+ * defined the global it is supposed to.
  *
- * We `fetch()` the script and inject it via a `blob:` URL instead of pointing a
- * `<script src>` straight at `indexURL`. Tauri's `script-src` CSP only allows
- * the jsDelivr CDN origins, so a custom `VITE_PYODIDE_INDEX_URL` mirror would be
- * blocked as a direct script source — but `connect-src` permits `https:`
+ * Tauri's `script-src` CSP only allows the jsDelivr CDN origins, so a custom
+ * `VITE_PYODIDE_INDEX_URL` mirror cannot be reached as a direct `<script src>`
+ * nor by Pyodide's own dynamic `import()` — but `connect-src` permits `https:`
  * fetches and `script-src` permits `blob:`, so fetch-then-blob reaches any
  * mirror. The vector-tools worker sidesteps the same CSP via `importScripts`;
- * this is the main-thread equivalent, mirroring `external-plugins.ts`. Pyodide's
- * own asset resolution is unaffected because `indexURL` is passed explicitly to
- * `loadPyodide({ indexURL })`.
+ * this is the main-thread equivalent, mirroring `external-plugins.ts`.
+ *
+ * @param scriptUrl - The absolute URL of the script to load.
+ * @param isReady - Predicate that returns true once the script's global is
+ *   present; used to reject a 200 HTML error page or corrupted payload (which
+ *   `onload` does not catch) so the `.catch` memo reset enables a clean retry.
+ * @param label - Human-readable name of the global, for the diagnostic message.
+ */
+async function injectScript(
+  scriptUrl: string,
+  isReady: () => boolean,
+  label: string,
+): Promise<void> {
+  if (isReady()) return;
+  let source: string;
+  try {
+    const response = await fetch(scriptUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    source = await response.text();
+  } catch (cause) {
+    throw new Error(
+      `Failed to load the Pyodide runtime script from ${scriptUrl}.`,
+      { cause },
+    );
+  }
+  const blobUrl = URL.createObjectURL(
+    new Blob([source], { type: "text/javascript" }),
+  );
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = blobUrl;
+      script.onload = () => {
+        if (isReady()) {
+          resolve();
+          return;
+        }
+        script.remove();
+        reject(
+          new Error(
+            `Pyodide script loaded but ${label} is not defined; the content at ${scriptUrl} may be incorrect.`,
+          ),
+        );
+      };
+      // The caller's `.catch` owns resetting the memo on failure; remove the
+      // dead element so a retry doesn't leave orphan <script> tags.
+      script.onerror = () => {
+        script.remove();
+        reject(
+          new Error(
+            `Failed to execute the Pyodide runtime script from ${scriptUrl}.`,
+          ),
+        );
+      };
+      document.head.appendChild(script);
+    });
+  } finally {
+    URL.revokeObjectURL(blobUrl);
+  }
+}
+
+/**
+ * Load Pyodide's two entry scripts once so the runtime can initialize from any
+ * `indexURL`, including a self-hosted mirror, under Tauri's CSP.
+ *
+ * `pyodide.js` defines `window.loadPyodide`. We then also pre-inject
+ * `pyodide.asm.js` (which defines `globalThis._createPyodideModule`) because
+ * `loadPyodide()` otherwise dynamically `import()`s that file from `indexURL`,
+ * and that import is blocked by `script-src` for a non-whitelisted mirror.
+ * Pyodide skips the import when `_createPyodideModule` is already a function, so
+ * the pre-injected blob short-circuits it. Both scripts are reached via the same
+ * fetch-then-blob path (see `injectScript`). Pyodide's remaining assets (wasm,
+ * lockfile, wheels) load via `fetch`, allowed by `connect-src`, so passing
+ * `indexURL` to `loadPyodide({ indexURL })` resolves them unchanged.
  */
 function loadPyodideScript(indexURL: string): Promise<void> {
   scriptPromise ??= (async () => {
-    if (window.loadPyodide) return;
-    const scriptUrl = `${indexURL}pyodide.js`;
-    let source: string;
-    try {
-      const response = await fetch(scriptUrl);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      source = await response.text();
-    } catch (cause) {
-      throw new Error(
-        `Failed to load the Pyodide runtime script from ${scriptUrl}.`,
-        { cause },
-      );
-    }
-    const blobUrl = URL.createObjectURL(
-      new Blob([source], { type: "text/javascript" }),
+    await injectScript(
+      `${indexURL}pyodide.js`,
+      () => typeof window.loadPyodide === "function",
+      "window.loadPyodide",
     );
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const script = document.createElement("script");
-        script.src = blobUrl;
-        // `onload` fires when the blob script is parsed and executed, which does
-        // not guarantee it actually exposed `window.loadPyodide` — a mirror can
-        // return a 200 with an HTML error page or corrupted JS. Verify the global
-        // here so a bad payload rejects (and the `.catch` clears the memo for a
-        // re-fetch) instead of resolving and wedging every later retry.
-        script.onload = () => {
-          if (window.loadPyodide) {
-            resolve();
-            return;
-          }
-          script.remove();
-          reject(
-            new Error(
-              `Pyodide script loaded but window.loadPyodide is not defined; the content at ${scriptUrl} may be incorrect.`,
-            ),
-          );
-        };
-        // The shared `.catch` below owns resetting scriptPromise on failure;
-        // remove the dead element so a retry doesn't leave orphan <script> tags.
-        script.onerror = () => {
-          script.remove();
-          reject(
-            new Error(
-              `Failed to execute the Pyodide runtime script from ${scriptUrl}.`,
-            ),
-          );
-        };
-        document.head.appendChild(script);
-      });
-    } finally {
-      URL.revokeObjectURL(blobUrl);
-    }
+    await injectScript(
+      `${indexURL}pyodide.asm.js`,
+      () => typeof window._createPyodideModule === "function",
+      "globalThis._createPyodideModule",
+    );
   })().catch((error) => {
     scriptPromise = null;
     throw error;

--- a/tests/pyodide-config.test.ts
+++ b/tests/pyodide-config.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   PYODIDE_VERSION,
   getPyodideIndexUrl,
+  isDefaultPyodideIndexUrl,
 } from "../apps/geolibre-desktop/src/lib/pyodide/pyodide-config";
 
 describe("getPyodideIndexUrl", () => {
@@ -39,6 +40,35 @@ describe("getPyodideIndexUrl", () => {
     assert.equal(
       getPyodideIndexUrl({ VITE_PYODIDE_INDEX_URL: "   " }),
       `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`,
+    );
+  });
+});
+
+describe("isDefaultPyodideIndexUrl", () => {
+  // This branch decides whether the Python Console pre-injects pyodide.asm.js to
+  // dodge the CSP-blocked dynamic import (only needed for a non-whitelisted
+  // mirror); the default CDN keeps Pyodide's own import.
+  it("returns true for the resolved default CDN URL", () => {
+    assert.equal(isDefaultPyodideIndexUrl(getPyodideIndexUrl({})), true);
+  });
+
+  it("returns false for a custom mirror URL", () => {
+    assert.equal(
+      isDefaultPyodideIndexUrl(
+        getPyodideIndexUrl({ VITE_PYODIDE_INDEX_URL: "https://mirror.test/pyodide/" }),
+      ),
+      false,
+    );
+  });
+
+  it("returns false for the default CDN URL without a trailing slash", () => {
+    // Guard the exact-match contract: callers must pass a resolved (normalized)
+    // indexURL, as getPyodideIndexUrl always appends the trailing slash.
+    assert.equal(
+      isDefaultPyodideIndexUrl(
+        `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full`,
+      ),
+      false,
     );
   });
 });

--- a/tests/pyodide-config.test.ts
+++ b/tests/pyodide-config.test.ts
@@ -61,7 +61,7 @@ describe("isDefaultPyodideIndexUrl", () => {
     );
   });
 
-  it("returns false for the default CDN URL without a trailing slash", () => {
+  it("returns false for an unnormalized CDN URL (caller must pass getPyodideIndexUrl output)", () => {
     // Guard the exact-match contract: callers must pass a resolved (normalized)
     // indexURL, as getPyodideIndexUrl always appends the trailing slash.
     assert.equal(
@@ -70,5 +70,17 @@ describe("isDefaultPyodideIndexUrl", () => {
       ),
       false,
     );
+  });
+});
+
+describe("Pyodide version pin", () => {
+  it("flags a version bump for re-verifying the asm.js mirror workaround", () => {
+    // Tripwire: the Python Console's custom-mirror path (pyodide-console.ts)
+    // relies on loadPyodide() skipping its dynamic import() of pyodide.asm.js
+    // when globalThis._createPyodideModule is already defined — an Emscripten
+    // internal that is not part of Pyodide's public API. When bumping
+    // PYODIDE_VERSION, re-verify that short-circuit still holds against a
+    // self-hosted mirror under the Tauri CSP, then update this expected value.
+    assert.equal(PYODIDE_VERSION, "0.27.7");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #997. The desktop Python Console failed to honor a self-hosted `VITE_PYODIDE_INDEX_URL` mirror: the console showed `Failed to fetch dynamically imported module: <mirror>/pyodide.asm.js`.

PR #421 already fetch+blob-injects `pyodide.js` so `window.loadPyodide` is reachable from any `indexURL`. But `loadPyodide()` then does a dynamic `import()` of `pyodide.asm.js` from the same `indexURL`. Tauri's `script-src` CSP only whitelists the jsDelivr CDN origins, and a mirror origin cannot be allowlisted at build time, so that import is blocked. The vector-tools worker avoids this because `importScripts` inside a Web Worker bypasses the main-thread CSP.

## Fix

`loadPyodide()` only `import()`s `pyodide.asm.js` when `globalThis._createPyodideModule` is not already a function. Pre-injecting that script through the same fetch-then-blob path used for `pyodide.js` (`connect-src` permits the `https:`/`localhost` fetch, `script-src` permits `blob:`) defines the global up front, so `loadPyodide` short-circuits the CSP-blocked import. Pyodide's remaining assets (wasm, lockfile, wheels) already load via `fetch`, allowed by `connect-src`, so passing `indexURL` to `loadPyodide({ indexURL })` resolves them unchanged.

The existing single-script loader is generalized into `injectScript()` and run for both entry scripts. No CSP changes; no new worker.

## Verification

Served the production web build under the exact production Tauri CSP (copied from `src-tauri/tauri.conf.json`) and pointed the runtime at a self-hosted pyodide mirror on a `localhost` port that is in `connect-src` but deliberately not in `script-src`:

- Control: a raw `import('<mirror>/pyodide.asm.js')` is blocked with `Failed to fetch dynamically imported module`, reproducing the report and confirming the mirror origin is genuinely outside `script-src`.
- After the fix: the Python Console initializes and runs Python (`print(40 + 2)` -> `42`). Network trace shows `pyodide.asm.js` arriving as a `fetch` (the blob path), not as a blocked script import.
- Confirmed in both light and dark themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Pyodide startup by loading the required runtime scripts more reliably before initialization.

* **Bug Fixes**
  * Added checks to fail fast when a script load returns an error page or when the expected runtime global is missing.
  * Enhanced resilience against browser security constraints affecting script-based initialization.

* **Chores**
  * Updated browser type declarations to include the additional Pyodide runtime global.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->