### PR TITLE
Fix OAuth popup new-window panic

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2471,10 +2471,17 @@ fn create_oauth_popup_window(
 ) -> tauri::webview::NewWindowResponse<tauri::Wry> {
     let popup_id = POPUP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let child_app_handle = app_handle.clone();
-    let window = tauri::WebviewWindowBuilder::new(
+    let blank_url: tauri::Url = match "about:blank".parse() {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            eprintln!("OAuth popup: could not parse blank URL: {error}");
+            return tauri::webview::NewWindowResponse::Deny;
+        }
+    };
+    let window = match tauri::WebviewWindowBuilder::new(
         &app_handle,
         format!("oauthPopup{popup_id}"),
-        tauri::WebviewUrl::External("about:blank".parse().expect("valid blank URL")),
+        tauri::WebviewUrl::External(blank_url),
     )
     .window_features(features)
     .title(url.as_str())
@@ -2485,7 +2492,13 @@ fn create_oauth_popup_window(
         let _ = window.set_title(&title);
     })
     .build()
-    .expect("failed to create OAuth popup window");
+    {
+        Ok(window) => window,
+        Err(error) => {
+            eprintln!("OAuth popup: failed to create popup window: {error}");
+            return tauri::webview::NewWindowResponse::Deny;
+        }
+    };
 
     tauri::webview::NewWindowResponse::Create { window }
 }


### PR DESCRIPTION
## Summary
- replace panics in the desktop OAuth popup new-window callback with logged deny responses
- keep successful popup creation returning the Tauri-created child window

Fixes #986

## Testing
- npm run check:rust
- cargo test --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml
- npm run build
- pre-commit run --files apps/geolibre-desktop/src-tauri/src/lib.rs
- Playwright smoke check at http://127.0.0.1:5174/?theme=light and http://127.0.0.1:5174/?theme=dark: app shell rendered with no console errors

Note: the reported SIGABRT is in macOS WebKit's native new-window path, so I could not reproduce that exact abort on this Linux host. A local Tauri dev launch was also blocked because port 5173 is already held by an unrelated maplibre-gl-geoagent Vite process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when opening the OAuth popup window on desktop.
  * If the popup URL cannot be parsed or the window cannot be created, the app now fails gracefully instead of crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->