### PR TITLE
fix(usgs-lidar): disambiguate Clear labels and lock Search Map Extent while drawing

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -77,7 +77,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
-    "maplibre-gl-usgs-lidar": "^0.11.0",
+    "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.8.4",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
-        "maplibre-gl-usgs-lidar": "^0.11.0",
+        "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.8.4",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
@@ -17940,9 +17940,9 @@
       }
     },
     "node_modules/maplibre-gl-usgs-lidar": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.0.tgz",
-      "integrity": "sha512-LQZts31VsYawlXPprazKBQcO1DrbWvA3T7uV57LE+XCo/+28aIiNWWOZvq+Zyt3jNTG9dRoTKIUFLFLJNgEtMA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.1.tgz",
+      "integrity": "sha512-5xNKH6pDQwhHQyl4EO6axyF6knypR+7WZiVjVqP6WM8YxY9ULQVu+l/NitaMqf5qNK+lse4+4DAi/yzgD9MvxA==",
       "license": "MIT",
       "dependencies": {
         "maplibre-gl-layer-control": ">=0.14.1",
@@ -23818,7 +23818,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
-        "maplibre-gl-usgs-lidar": "^0.11.0",
+        "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.8.4",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -50,7 +50,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
-    "maplibre-gl-usgs-lidar": "^0.11.0",
+    "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.8.4",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",

--- a/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
+++ b/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
@@ -138,7 +138,7 @@ const mountUsgsLidarControl = (app: GeoLibreAppAPI): boolean => {
 export const maplibreUsgsLidarPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-usgs-lidar",
   name: "USGS LiDAR",
-  version: "0.11.0",
+  version: "0.11.1",
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
 


### PR DESCRIPTION
## Summary

Fixes #999. The USGS LiDAR plugin panel had two UX issues reported against the web version:

1. **Ambiguous "Clear" labels.** Three stacked actions all read `Clear` / `Clear All`, making it unclear which scope a click discards.
2. **Conflicting search controls.** With a custom bounding box drawn, `Search Map Extent` stayed enabled, so the map-extent and drawn-area search scopes could both be submitted.

Both live in the upstream `maplibre-gl-usgs-lidar` control, so the fix shipped there first and this PR consumes the release.

## Changes

- Bump `maplibre-gl-usgs-lidar` `^0.11.0` → `^0.11.1` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json` (+ `package-lock.json`), and the plugin wrapper's `version` metadata.

The new release:
- Renames the three reset actions to **Clear Drawn Area**, **Clear Selection**, and **Remove All Loaded Layers**.
- Disables **Search Map Extent** while a drawn bounding box is active (tooltip: "Clear the drawn area to search by map extent"); it re-enables automatically when the area is cleared.

## Upstream

- PR: https://github.com/opengeos/maplibre-gl-usgs-lidar/pull/40 (merged)
- Release: https://github.com/opengeos/maplibre-gl-usgs-lidar/releases/tag/v0.11.1 (published to npm)

## Verification

Verified in the real app (dev server) with the **published 0.11.1**, in both light and dark themes: the three labels are now distinct, and drawing a rectangle disables `Search Map Extent` and shows `Clear Drawn Area`; clearing it re-enables the button. `npm run build` and pre-commit pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the USGS LiDAR mapping package to a newer patch version across the desktop app and plugins.
  * Bumped the related plugin version to keep package metadata in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->