### PR TITLE
fix(new-project): prompt to save unsaved changes before the new-project form (#990)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -23,7 +23,13 @@ import {
   Label,
 } from "@geolibre/ui";
 import type { FormEvent } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 const DEFAULT_BASEMAP_ID = "liberty";
@@ -124,8 +130,9 @@ export function NewProjectDialog({
   // matching standard desktop and web GIS conventions. With no unsaved changes,
   // go straight to the configuration form. Read the dirty flag once on open
   // (not as a reactive dep) so "Do not save" doesn't re-trigger the prompt while
-  // the project is still dirty.
-  useEffect(() => {
+  // the project is still dirty. useLayoutEffect (not useEffect) commits this
+  // before paint, so a dirty open never flashes the config form first.
+  useLayoutEffect(() => {
     if (open) setShowSavePrompt(useAppStore.getState().isDirty);
   }, [open]);
   const selectedPreset = useMemo<PresetBasemap | undefined>(
@@ -187,7 +194,8 @@ export function NewProjectDialog({
   const handleCreate = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // Any unsaved changes were already resolved by the save prompt shown when
-    // the dialog opened, so creating here is safe.
+    // the dialog opened, so creating here is safe. createProject() still guards
+    // on canCreate internally, so the removed call-site check is not a regression.
     createProject();
   };
 
@@ -211,10 +219,9 @@ export function NewProjectDialog({
         {showSavePrompt ? (
           <>
             <DialogHeader>
-              <DialogTitle>Save current project?</DialogTitle>
+              <DialogTitle>{t("newProject.savePromptTitle")}</DialogTitle>
               <DialogDescription>
-                The current project has unsaved changes. Save them before
-                creating a new project?
+                {t("newProject.savePromptDescription")}
               </DialogDescription>
             </DialogHeader>
             <div className="flex justify-end gap-2">
@@ -224,7 +231,7 @@ export function NewProjectDialog({
                 disabled={isSaving}
                 onClick={() => handleOpenChange(false)}
               >
-                Cancel
+                {t("common.cancel")}
               </Button>
               <Button
                 type="button"
@@ -232,14 +239,14 @@ export function NewProjectDialog({
                 disabled={isSaving}
                 onClick={() => setShowSavePrompt(false)}
               >
-                Do not save
+                {t("newProject.doNotSave")}
               </Button>
               <Button
                 type="button"
                 disabled={isSaving}
                 onClick={handleSaveThenContinue}
               >
-                {isSaving ? "Saving..." : "Save"}
+                {isSaving ? t("newProject.saving") : t("common.save")}
               </Button>
             </div>
           </>

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -88,7 +88,6 @@ export function NewProjectDialog({
 }: NewProjectDialogProps) {
   const { t } = useTranslation();
   const newProject = useAppStore((s) => s.newProject);
-  const isDirty = useAppStore((s) => s.isDirty);
   const [selectedBasemapId, setSelectedBasemapId] =
     useState<BasemapChoice>(DEFAULT_BASEMAP_ID);
   const [projectName, setProjectName] = useState(DEFAULT_PROJECT_NAME);
@@ -120,6 +119,15 @@ export function NewProjectDialog({
   useEffect(() => {
     if (isCustomSelected) customUrlRef.current?.focus();
   }, [isCustomSelected]);
+  // Prioritize data preservation: when the dialog opens with unsaved changes,
+  // ask to save the current project before showing the new-project form (#990),
+  // matching standard desktop and web GIS conventions. With no unsaved changes,
+  // go straight to the configuration form. Read the dirty flag once on open
+  // (not as a reactive dep) so "Do not save" doesn't re-trigger the prompt while
+  // the project is still dirty.
+  useEffect(() => {
+    if (open) setShowSavePrompt(useAppStore.getState().isDirty);
+  }, [open]);
   const selectedPreset = useMemo<PresetBasemap | undefined>(
     () =>
       [...OPENFREEMAP_BASEMAPS, ...protomapsPresets].find(
@@ -178,21 +186,18 @@ export function NewProjectDialog({
 
   const handleCreate = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!canCreate) return;
-
-    if (isDirty) {
-      setShowSavePrompt(true);
-      return;
-    }
-
+    // Any unsaved changes were already resolved by the save prompt shown when
+    // the dialog opened, so creating here is safe.
     createProject();
   };
 
-  const handleSaveThenCreate = async () => {
+  const handleSaveThenContinue = async () => {
     setIsSaving(true);
     try {
       const saved = await onSaveCurrentProject();
-      if (saved) createProject();
+      // Advance to the configuration form only once the current project is
+      // safely saved; a cancelled or failed save keeps the prompt up.
+      if (saved) setShowSavePrompt(false);
     } catch (error) {
       console.error("Failed to save project", error);
     } finally {
@@ -217,7 +222,7 @@ export function NewProjectDialog({
                 type="button"
                 variant="outline"
                 disabled={isSaving}
-                onClick={() => setShowSavePrompt(false)}
+                onClick={() => handleOpenChange(false)}
               >
                 Cancel
               </Button>
@@ -225,14 +230,14 @@ export function NewProjectDialog({
                 type="button"
                 variant="secondary"
                 disabled={isSaving}
-                onClick={createProject}
+                onClick={() => setShowSavePrompt(false)}
               >
                 Do not save
               </Button>
               <Button
                 type="button"
                 disabled={isSaving}
-                onClick={handleSaveThenCreate}
+                onClick={handleSaveThenContinue}
               >
                 {isSaving ? "Saving..." : "Save"}
               </Button>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -79,7 +79,11 @@
     "sectionOpenFreeMap": "OpenFreeMap",
     "sectionProtomaps": "Protomaps",
     "sectionOther": "Other",
-    "customUrlButton": "Custom URL"
+    "customUrlButton": "Custom URL",
+    "savePromptTitle": "Save current project?",
+    "savePromptDescription": "The current project has unsaved changes. Save them before creating a new project?",
+    "doNotSave": "Do not save",
+    "saving": "Saving..."
   },
   "basemapPicker": {
     "title": "Change basemap",


### PR DESCRIPTION
## Summary

Fixes #990.

Creating a new project while the active project had unsaved changes showed the dialogs out of order: GeoLibre opened the new-project configuration wizard first (project name + basemap), and only after the user clicked **Create** did it ask **"Save current project?"**. Users had to pick a name and basemap with no idea whether their current work would be preserved.

This reverses the sequence to match standard desktop and web GIS conventions:

1. User chooses **Project → New...** with unsaved changes.
2. The **"Save current project?"** prompt appears immediately (Cancel / Do not save / Save).
   - **Cancel** aborts the whole action and keeps the current project intact.
   - **Do not save** advances to the configuration form.
   - **Save** saves the current project, then advances to the configuration form (a cancelled or failed save keeps the prompt up).
3. The new-project configuration form is shown, then **Create** loads the new project.

When there are no unsaved changes, the configuration form opens directly, unchanged from before.

## Implementation

All in `NewProjectDialog.tsx`: the save prompt is now driven on dialog open from the dirty flag (read once, not reactively, so "Do not save" doesn't re-trigger it) instead of being deferred until Create.

## Verification

Verified in the real app with Playwright against a dirty project (background basemap hidden), in **both light and dark themes**:

- Dirty + New -> "Save current project?" prompt shows first.
- Do not save -> configuration form -> Create -> new project loads.
- Cancel -> dialog closes, current work preserved.
- No unsaved changes + New -> configuration form opens directly (no prompt).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the new project flow so unsaved changes are checked when opening the dialog, reducing surprise prompts during creation.
  * Updated the save prompt actions so “Do not save” only closes the prompt, while “Save” keeps the prompt open if saving fails or is canceled.
  * New project creation now continues directly after unsaved changes are handled, making the flow more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->