### PR TITLE
feat(storymap): hide-itinerary toggle, handout subtitle/byline, start/closing slides

### DIFF
--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import maplibregl from "maplibre-gl";
 import { useTranslation } from "react-i18next";
-import type { StoryMap } from "@geolibre/core";
+import type { StoryChapter, StoryMap, StorySlideMode } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   Button,
@@ -37,12 +37,94 @@ import {
 } from "../../lib/storymap-pdf";
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
 import { promptDownloadNameIfNeeded } from "../../hooks/useFileNamePrompt";
+import { STORY_GLOBAL_VIEW } from "../../lib/storymap-constants";
 
 interface StoryMapHandoutDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   story: StoryMap;
   mapControllerRef: RefObject<MapController | null>;
+}
+
+/** A non-`"none"` start/closing slide mode. */
+type SlideMode = Exclude<StorySlideMode, "none">;
+
+const STORY_START_ID = "__story_start__";
+const STORY_END_ID = "__story_end__";
+
+/** One exportable screen: a chapter or an intro/outro slide. */
+type HandoutScreen =
+  | { id: string; kind: "chapter"; chapter: StoryChapter; index: number }
+  | {
+      id: string;
+      kind: "slide";
+      position: "start" | "end";
+      mode: SlideMode;
+    };
+
+/**
+ * Build the ordered list of exportable screens: the optional start slide, the
+ * chapters, then the optional closing slide (#998).
+ */
+function buildScreens(story: StoryMap): HandoutScreen[] {
+  const screens: HandoutScreen[] = [];
+  if (story.startSlide !== "none") {
+    screens.push({
+      id: STORY_START_ID,
+      kind: "slide",
+      position: "start",
+      mode: story.startSlide,
+    });
+  }
+  story.chapters.forEach((chapter, index) =>
+    screens.push({ id: chapter.id, kind: "chapter", chapter, index }),
+  );
+  if (story.endSlide !== "none") {
+    screens.push({
+      id: STORY_END_ID,
+      kind: "slide",
+      position: "end",
+      mode: story.endSlide,
+    });
+  }
+  return screens;
+}
+
+/**
+ * Render a solid-color page-sized canvas for a blank/black slide page, so the
+ * PDF has a real screen rather than an empty page.
+ */
+function solidColorCanvas(color: string): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = 1200;
+  canvas.height = 900;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  return canvas;
+}
+
+/** The solid background a blank/black slide paints, or null for a map view. */
+function slideCoverColor(
+  mode: SlideMode,
+  theme: "light" | "dark",
+): string | null {
+  if (mode === "black") return "#000000";
+  if (mode === "blank") return theme === "light" ? "#fafafa" : "#444444";
+  return null;
+}
+
+/** The camera a global/adjacent slide captures. */
+function slideLocation(
+  screen: Extract<HandoutScreen, { kind: "slide" }>,
+  chapters: StoryChapter[],
+): StoryChapter["location"] {
+  if (screen.mode === "global") return STORY_GLOBAL_VIEW;
+  return screen.position === "start"
+    ? chapters[0].location
+    : chapters[chapters.length - 1].location;
 }
 
 /** Maximum time to wait for the map to settle (tiles loaded) per chapter. */
@@ -186,11 +268,15 @@ export function StoryMapHandoutDialog({
 }: StoryMapHandoutDialogProps) {
   const { t } = useTranslation();
   const chapters = story.chapters;
+  // Chapters plus the optional start/closing slides, in export order.
+  const screens = useMemo(() => buildScreens(story), [story]);
 
   const [selected, setSelected] = useState<Record<string, boolean>>({});
   const [paperSize, setPaperSize] = useState<PaperSizeId>("a4");
   const [orientation, setOrientation] = useState<Orientation>("landscape");
   const [title, setTitle] = useState("");
+  const [subtitle, setSubtitle] = useState("");
+  const [byline, setByline] = useState("");
   const [footer, setFooter] = useState("");
   const [generating, setGenerating] = useState(false);
   const [progress, setProgress] = useState<{ current: number; total: number } | null>(
@@ -203,34 +289,37 @@ export function StoryMapHandoutDialog({
   // the running loop sees the latest value without being re-created.
   const abortRef = useRef(false);
 
-  // Seed the selection (all chapters) and the title/footer from the story each
-  // time the dialog opens, so it reflects the latest story without clobbering
-  // edits made while it is open.
+  // Seed the selection (all screens) and the title/subtitle/byline/footer from
+  // the story each time the dialog opens, so it reflects the latest story
+  // without clobbering edits made while it is open. The subtitle and byline
+  // mirror the main Story Map settings so the export matches the screen (#996).
   useEffect(() => {
     if (!open) return;
-    setSelected(Object.fromEntries(chapters.map((c) => [c.id, true])));
-    // Strip any HTML the story title/footer carry (the sample footer has links)
-    // so the fields show readable text instead of raw markup.
+    setSelected(Object.fromEntries(screens.map((s) => [s.id, true])));
+    // Strip any HTML the story fields carry (the sample footer has links) so the
+    // inputs show readable text instead of raw markup.
     setTitle(singleLine(story.title));
+    setSubtitle(singleLine(story.subtitle));
+    setByline(singleLine(story.byline));
     setFooter(singleLine(story.footer));
     setError(null);
     setNotice(null);
     setProgress(null);
-    // Only re-seed on open; chapters/story are read at that moment.
+    // Only re-seed on open; screens/story are read at that moment.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const selectedCount = useMemo(
-    () => chapters.filter((c) => selected[c.id]).length,
-    [chapters, selected],
+    () => screens.filter((s) => selected[s.id]).length,
+    [screens, selected],
   );
 
-  const allSelected = selectedCount === chapters.length && chapters.length > 0;
+  const allSelected = selectedCount === screens.length && screens.length > 0;
 
   const toggleAll = useCallback(() => {
     const next = !allSelected;
-    setSelected(Object.fromEntries(chapters.map((c) => [c.id, next])));
-  }, [allSelected, chapters]);
+    setSelected(Object.fromEntries(screens.map((s) => [s.id, next])));
+  }, [allSelected, screens]);
 
   const handleGenerate = useCallback(async () => {
     setError(null);
@@ -240,7 +329,7 @@ export function StoryMapHandoutDialog({
       setError(t("storymap.handout.noMap"));
       return;
     }
-    const chosen = chapters.filter((c) => selected[c.id]);
+    const chosen = screens.filter((s) => selected[s.id]);
     if (chosen.length === 0) {
       setError(t("storymap.handout.noneSelected"));
       return;
@@ -262,8 +351,43 @@ export function StoryMapHandoutDialog({
       const captures: HandoutChapter[] = [];
       for (let i = 0; i < chosen.length; i++) {
         if (abortRef.current) break;
-        const chapter = chosen[i];
+        const screen = chosen[i];
         setProgress({ current: i + 1, total: chosen.length });
+
+        if (screen.kind === "slide") {
+          // Blank/black slides need no map capture: paint a solid full-page
+          // color. Global/adjacent slides capture the map at the slide camera
+          // with no title or text overlay (#998).
+          const color = slideCoverColor(screen.mode, story.theme);
+          if (color) {
+            const canvas = solidColorCanvas(color);
+            captures.push({
+              title: "",
+              map: { data: canvas, width: canvas.width, height: canvas.height },
+              fullBleed: true,
+            });
+            continue;
+          }
+          await jumpAndWaitIdle(
+            map,
+            slideLocation(screen, chapters),
+            () => abortRef.current,
+          );
+          if (abortRef.current) break;
+          const slideShot = captureMapImage(map);
+          captures.push({
+            title: "",
+            map: {
+              data: slideShot.image,
+              width: slideShot.width,
+              height: slideShot.height,
+            },
+            fullBleed: true,
+          });
+          continue;
+        }
+
+        const chapter = screen.chapter;
         await jumpAndWaitIdle(map, chapter.location, () => abortRef.current);
         if (abortRef.current) break;
         const shot = captureMapImage(map);
@@ -289,6 +413,8 @@ export function StoryMapHandoutDialog({
         paperSize,
         orientation,
         title,
+        subtitle,
+        byline,
         footer,
       });
       const saved = await saveBinaryFileWithFallback(bytes, {
@@ -320,12 +446,16 @@ export function StoryMapHandoutDialog({
     }
   }, [
     chapters,
+    screens,
     selected,
     paperSize,
     orientation,
     title,
+    subtitle,
+    byline,
     footer,
     story.title,
+    story.theme,
     mapControllerRef,
     onOpenChange,
     t,
@@ -354,7 +484,7 @@ export function StoryMapHandoutDialog({
                 <h3 className="text-sm font-semibold">
                   {t("storymap.handout.screens", {
                     count: selectedCount,
-                    total: chapters.length,
+                    total: screens.length,
                   })}
                 </h3>
                 <Button
@@ -369,29 +499,45 @@ export function StoryMapHandoutDialog({
                 </Button>
               </div>
               <div className="space-y-1 rounded-md border p-2">
-                {chapters.map((chapter, index) => (
-                  <label
-                    key={chapter.id}
-                    className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={selected[chapter.id] ?? false}
-                      onChange={(e) =>
-                        setSelected((prev) => ({
-                          ...prev,
-                          [chapter.id]: e.target.checked,
-                        }))
-                      }
-                    />
-                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted text-xs">
-                      {index + 1}
-                    </span>
-                    <span className="truncate">
-                      {chapter.title || t("storymap.untitledChapter")}
-                    </span>
-                  </label>
-                ))}
+                {screens.map((screen) => {
+                  const isSlide = screen.kind === "slide";
+                  const label = isSlide
+                    ? screen.position === "start"
+                      ? t("storymap.handout.startSlide")
+                      : t("storymap.handout.endSlide")
+                    : screen.chapter.title || t("storymap.untitledChapter");
+                  return (
+                    <label
+                      key={screen.id}
+                      className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected[screen.id] ?? false}
+                        onChange={(e) =>
+                          setSelected((prev) => ({
+                            ...prev,
+                            [screen.id]: e.target.checked,
+                          }))
+                        }
+                      />
+                      <span
+                        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded text-xs ${
+                          isSlide
+                            ? "bg-primary/15 text-primary"
+                            : "bg-muted"
+                        }`}
+                      >
+                        {isSlide
+                          ? screen.position === "start"
+                            ? "▶"
+                            : "■"
+                          : screen.index + 1}
+                      </span>
+                      <span className="truncate">{label}</span>
+                    </label>
+                  );
+                })}
               </div>
             </div>
 
@@ -446,6 +592,28 @@ export function StoryMapHandoutDialog({
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder={t("storymap.handout.documentTitlePlaceholder")}
+              />
+            </Field>
+            <Field
+              label={t("storymap.handout.subtitle")}
+              htmlFor="storymap-handout-subtitle"
+            >
+              <Input
+                id="storymap-handout-subtitle"
+                value={subtitle}
+                onChange={(e) => setSubtitle(e.target.value)}
+                placeholder={t("storymap.handout.subtitlePlaceholder")}
+              />
+            </Field>
+            <Field
+              label={t("storymap.handout.byline")}
+              htmlFor="storymap-handout-byline"
+            >
+              <Input
+                id="storymap-handout-byline"
+                value={byline}
+                onChange={(e) => setByline(e.target.value)}
+                placeholder={t("storymap.handout.bylinePlaceholder")}
               />
             </Field>
             <Field

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -8,7 +8,11 @@ import {
 } from "react";
 import maplibregl from "maplibre-gl";
 import { useTranslation } from "react-i18next";
-import type { StoryChapter, StoryMap, StorySlideMode } from "@geolibre/core";
+import type {
+  StoryActiveSlideMode,
+  StoryChapter,
+  StoryMap,
+} from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   Button,
@@ -49,9 +53,6 @@ interface StoryMapHandoutDialogProps {
   mapControllerRef: RefObject<MapController | null>;
 }
 
-/** A non-`"none"` start/closing slide mode. */
-type SlideMode = Exclude<StorySlideMode, "none">;
-
 const STORY_START_ID = "__story_start__";
 const STORY_END_ID = "__story_end__";
 
@@ -62,7 +63,7 @@ type HandoutScreen =
       id: string;
       kind: "slide";
       position: "start" | "end";
-      mode: SlideMode;
+      mode: StoryActiveSlideMode;
     };
 
 /**

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -42,7 +42,9 @@ import {
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
 import { promptDownloadNameIfNeeded } from "../../hooks/useFileNamePrompt";
 import {
+  STORY_END_STEP_ID,
   STORY_GLOBAL_VIEW,
+  STORY_START_STEP_ID,
   storySlideCoverColor,
 } from "../../lib/storymap-constants";
 
@@ -52,9 +54,6 @@ interface StoryMapHandoutDialogProps {
   story: StoryMap;
   mapControllerRef: RefObject<MapController | null>;
 }
-
-const STORY_START_ID = "__story_start__";
-const STORY_END_ID = "__story_end__";
 
 /** One exportable screen: a chapter or an intro/outro slide. */
 type HandoutScreen =
@@ -74,7 +73,7 @@ function buildScreens(story: StoryMap): HandoutScreen[] {
   const screens: HandoutScreen[] = [];
   if (story.startSlide !== "none") {
     screens.push({
-      id: STORY_START_ID,
+      id: STORY_START_STEP_ID,
       kind: "slide",
       position: "start",
       mode: story.startSlide,
@@ -85,7 +84,7 @@ function buildScreens(story: StoryMap): HandoutScreen[] {
   );
   if (story.endSlide !== "none") {
     screens.push({
-      id: STORY_END_ID,
+      id: STORY_END_STEP_ID,
       kind: "slide",
       position: "end",
       mode: story.endSlide,
@@ -103,10 +102,15 @@ function solidColorCanvas(color: string): HTMLCanvasElement {
   canvas.width = 1200;
   canvas.height = 900;
   const ctx = canvas.getContext("2d");
-  if (ctx) {
-    ctx.fillStyle = color;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // A null context (e.g. the browser hit its canvas-context limit) would leave
+  // the canvas transparent and silently emit a blank slide page; throw instead
+  // so the export's catch surfaces it. solidColorCanvas only runs on a
+  // user-initiated export, so throwing is safe here.
+  if (!ctx) {
+    throw new Error("Could not get a 2D canvas context for the slide page.");
   }
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
   return canvas;
 }
 

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -37,7 +37,10 @@ import {
 } from "../../lib/storymap-pdf";
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
 import { promptDownloadNameIfNeeded } from "../../hooks/useFileNamePrompt";
-import { STORY_GLOBAL_VIEW } from "../../lib/storymap-constants";
+import {
+  STORY_GLOBAL_VIEW,
+  storySlideCoverColor,
+} from "../../lib/storymap-constants";
 
 interface StoryMapHandoutDialogProps {
   open: boolean;
@@ -106,25 +109,17 @@ function solidColorCanvas(color: string): HTMLCanvasElement {
   return canvas;
 }
 
-/** The solid background a blank/black slide paints, or null for a map view. */
-function slideCoverColor(
-  mode: SlideMode,
-  theme: "light" | "dark",
-): string | null {
-  if (mode === "black") return "#000000";
-  if (mode === "blank") return theme === "light" ? "#fafafa" : "#444444";
-  return null;
-}
-
 /** The camera a global/adjacent slide captures. */
 function slideLocation(
   screen: Extract<HandoutScreen, { kind: "slide" }>,
   chapters: StoryChapter[],
 ): StoryChapter["location"] {
   if (screen.mode === "global") return STORY_GLOBAL_VIEW;
-  return screen.position === "start"
-    ? chapters[0].location
-    : chapters[chapters.length - 1].location;
+  // Fall back to the global view when the story has no chapters (an adjacent
+  // slide configured before any chapter exists), so the export never reads an
+  // undefined chapter location.
+  const index = screen.position === "start" ? 0 : chapters.length - 1;
+  return chapters[index]?.location ?? STORY_GLOBAL_VIEW;
 }
 
 /** Maximum time to wait for the map to settle (tiles loaded) per chapter. */
@@ -358,7 +353,7 @@ export function StoryMapHandoutDialog({
           // Blank/black slides need no map capture: paint a solid full-page
           // color. Global/adjacent slides capture the map at the slide camera
           // with no title or text overlay (#998).
-          const color = slideCoverColor(screen.mode, story.theme);
+          const color = storySlideCoverColor(screen.mode, story.theme);
           if (color) {
             const canvas = solidColorCanvas(color);
             captures.push({

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -23,6 +23,7 @@ import {
   type StoryInsetPosition,
   type StoryLayerOpacityChange,
   type StoryMap,
+  type StorySlideMode,
 } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
@@ -768,7 +769,84 @@ function StorySettings({
             </option>
           </Select>
         ) : null}
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={story.hideChapterNav}
+            onChange={(e) => onChange({ hideChapterNav: e.target.checked })}
+          />
+          {t("storymap.field.hideChapterNav")}
+        </label>
       </div>
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+        <SlideControl
+          position="start"
+          label={t("storymap.field.startView")}
+          value={story.startSlide}
+          onChange={(startSlide) => onChange({ startSlide })}
+          t={t}
+        />
+        <SlideControl
+          position="end"
+          label={t("storymap.field.closingSlide")}
+          value={story.endSlide}
+          onChange={(endSlide) => onChange({ endSlide })}
+          t={t}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Checkbox + mode dropdown for a story's start or closing slide (#998).
+ *
+ * Unchecking sets the slide to `"none"`; checking defaults to `"blank"` and
+ * reveals the dropdown so the author can pick the screen treatment. The
+ * "adjacent" mode reads as "preview of the first chapter" at the start and
+ * "hold on the last chapter" at the end, so its label depends on `position`.
+ */
+function SlideControl({
+  position,
+  label,
+  value,
+  onChange,
+  t,
+}: {
+  position: "start" | "end";
+  label: string;
+  value: StorySlideMode;
+  onChange: (mode: StorySlideMode) => void;
+  t: TFn;
+}) {
+  const enabled = value !== "none";
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onChange(e.target.checked ? "blank" : "none")}
+        />
+        {label}
+      </label>
+      {enabled ? (
+        <Select
+          className="w-48"
+          aria-label={label}
+          value={value}
+          onChange={(e) => onChange(e.target.value as StorySlideMode)}
+        >
+          <option value="blank">{t("storymap.slide.blank")}</option>
+          <option value="black">{t("storymap.slide.black")}</option>
+          <option value="global">{t("storymap.slide.global")}</option>
+          <option value="adjacent">
+            {position === "start"
+              ? t("storymap.slide.startAdjacent")
+              : t("storymap.slide.endAdjacent")}
+          </option>
+        </Select>
+      ) : null}
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -342,6 +342,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
         basemapStyleUrl,
         layers: layersForExport,
         projection,
+        navToggleLabel: t("storymap.toggleNav"),
       });
       const slug =
         (story.title || "story-map")

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -3,6 +3,7 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -23,6 +24,7 @@ import { sanitizeStoryHtml } from "../../lib/sanitize-html";
 import {
   STORY_GLOBAL_VIEW,
   STORY_INSET_STYLE_URL,
+  storySlideCoverColor,
 } from "../../lib/storymap-constants";
 
 interface StoryMapPresenterProps {
@@ -68,20 +70,6 @@ function buildPresenterSteps(story: StoryMap): PresenterStep[] {
     });
   }
   return steps;
-}
-
-/**
- * The solid background a blank/black slide paints over the map, or null when the
- * slide keeps the map visible (global/adjacent). Blank matches the panel theme
- * background (`.glsm-light`/`.glsm-dark`).
- */
-function slideCoverColor(
-  mode: PresenterSlideMode,
-  theme: "light" | "dark",
-): string | null {
-  if (mode === "black") return "#000000";
-  if (mode === "blank") return theme === "light" ? "#fafafa" : "#444444";
-  return null;
 }
 
 const ALIGNMENT_CLASS: Record<StoryChapter["alignment"], string> = {
@@ -301,6 +289,28 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const storymapRef = useRef(storymap);
   storymapRef.current = storymap;
 
+  // Initialize nav visibility, the slide cover, and the active-chapter highlight
+  // from the first step *before* the browser paints, so the opening frame never
+  // flashes the previous session's nav (defeating hideChapterNav) or an
+  // uncovered map for a blank/black start slide before the playback effect's
+  // enterStep(0) runs (#998 review). The playback effect re-applies these.
+  useLayoutEffect(() => {
+    if (!hasChapters) return;
+    const story = storymapRef.current;
+    if (!story) return;
+    // Start with the chapter list collapsed when the author chose discoverable
+    // chapters, so the itinerary is not revealed up front (#995).
+    setNavOpen(!story.hideChapterNav);
+    const first = buildPresenterSteps(story)[0];
+    if (first?.kind === "slide") {
+      setActiveChapter(-1);
+      setCoverColor(storySlideCoverColor(first.mode, story.theme));
+    } else {
+      setActiveChapter(0);
+      setCoverColor(null);
+    }
+  }, [hasChapters]);
+
   // Set up scroll observation and the live map side-effects while presenting.
   useEffect(() => {
     if (!hasChapters) return;
@@ -313,11 +323,6 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     // presenting), shadowing the outer memoized `chapters`/`steps` deliberately.
     const chapters = story.chapters;
     const steps = buildPresenterSteps(story);
-
-    // Start with the chapter list collapsed when the author chose discoverable
-    // chapters, so the itinerary is not revealed up front (#995). The toggle
-    // still opens it on demand.
-    setNavOpen(!story.hideChapterNav);
 
     const stepEls = Array.from(
       container.querySelectorAll<HTMLElement>("[data-step-index]"),
@@ -387,11 +392,14 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       // through (exit the one we leave, then enter+exit each skipped chapter in
       // order) so a fast scroll or nav jump reaches the same layer state as
       // stepping one chapter at a time, without firing exits for chapters whose
-      // enter never ran.
-      if (previous >= 0 && previous !== index) {
+      // enter never ran. `previous` is -1 before the first chapter (e.g. jumping
+      // straight from the start slide to chapter N), which replays 0..N-1 so the
+      // skipped chapters' fades still run.
+      if (previous !== index) {
         const dir = previous < index ? 1 : -1;
-        applyEffects(chapters[previous]?.onChapterExit ?? []);
+        if (previous >= 0) applyEffects(chapters[previous]?.onChapterExit ?? []);
         for (let i = previous + dir; i !== index; i += dir) {
+          if (i < 0) continue;
           applyEffects(chapters[i]?.onChapterEnter ?? []);
           applyEffects(chapters[i]?.onChapterExit ?? []);
         }
@@ -400,11 +408,12 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     };
 
     const enterSlide = (step: Extract<PresenterStep, { kind: "slide" }>) => {
-      // A slide is not a chapter, so clear the nav highlight but keep the layer
-      // fades the last chapter set (the closing "hold" slide keeps that state).
-      activeChapterRef.current = -1;
+      // A slide is not a chapter, so clear the nav highlight. Keep
+      // `activeChapterRef` pointing at the last real chapter (it is the replay
+      // anchor): a closing "hold" slide keeps that state, and jumping from a
+      // slide back to a chapter still replays the intermediate chapters' fades.
       setActiveChapter(-1);
-      setCoverColor(slideCoverColor(step.mode, story.theme));
+      setCoverColor(storySlideCoverColor(step.mode, story.theme));
       if (step.mode === "blank" || step.mode === "black") return;
       // Global zooms out to the whole map; "adjacent" previews/holds the
       // neighboring chapter's camera with all text hidden.
@@ -513,6 +522,12 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   // to its scroll-step index by this offset.
   const startOffset =
     storymap && storymap.startSlide !== "none" ? 1 : 0;
+  // A start/closing slide is showing (no chapter highlighted). Slides are
+  // documented as text-free, so the persistent story header/footer hide while
+  // one is active (a blank/black cover already hides them; this also clears the
+  // title/byline/footer for global/adjacent slides). visibility (not display)
+  // keeps their layout so scroll positions and the step observer are unaffected.
+  const slideActive = activeChapter === -1;
 
   return createPortal(
     // The scroll surface captures the wheel so scrolling navigates chapters.
@@ -611,7 +626,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       >
         {storymap &&
         (storymap.title || storymap.subtitle || storymap.byline) ? (
-          <div className={`glsm-header ${themeClass}`}>
+          <div
+            className={`glsm-header ${themeClass}`}
+            style={slideActive ? { visibility: "hidden" } : undefined}
+          >
             {storymap.title ? <h1>{storymap.title}</h1> : null}
             {storymap.subtitle ? <h2>{storymap.subtitle}</h2> : null}
             {storymap.byline ? <p>{storymap.byline}</p> : null}
@@ -696,7 +714,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         </div>
 
         {storymap?.footer ? (
-          <div className={`glsm-footer ${themeClass}`}>
+          <div
+            className={`glsm-footer ${themeClass}`}
+            style={slideActive ? { visibility: "hidden" } : undefined}
+          >
             <p dangerouslySetInnerHTML={{ __html: sanitizeStoryHtml(storymap.footer) }} />
           </div>
         ) : null}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -22,8 +22,10 @@ import { Button, cn } from "@geolibre/ui";
 import { GripVertical, List, X } from "lucide-react";
 import { sanitizeStoryHtml } from "../../lib/sanitize-html";
 import {
+  STORY_END_STEP_ID,
   STORY_GLOBAL_VIEW,
   STORY_INSET_STYLE_URL,
+  STORY_START_STEP_ID,
   storySlideCoverColor,
 } from "../../lib/storymap-constants";
 
@@ -49,7 +51,7 @@ function buildPresenterSteps(story: StoryMap): PresenterStep[] {
   const steps: PresenterStep[] = [];
   if (story.startSlide !== "none") {
     steps.push({
-      key: "__story_start__",
+      key: STORY_START_STEP_ID,
       kind: "slide",
       position: "start",
       mode: story.startSlide,
@@ -60,7 +62,7 @@ function buildPresenterSteps(story: StoryMap): PresenterStep[] {
   );
   if (story.endSlide !== "none") {
     steps.push({
-      key: "__story_end__",
+      key: STORY_END_STEP_ID,
       kind: "slide",
       position: "end",
       mode: story.endSlide,
@@ -499,9 +501,9 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       insetMapRef.current = null;
       activeStepRef.current = -1;
       activeChapterRef.current = -1;
-      // Reset nav highlight, slide cover, and any card drag/resize so the next
-      // presentation starts clean.
-      setActiveChapter(0);
+      // Reset nav highlight (mirroring activeChapterRef = -1), slide cover, and
+      // any card drag/resize so the next presentation starts clean.
+      setActiveChapter(-1);
       setCoverColor(null);
       setCardLayouts({});
       // Undo any direct opacity changes made during playback.

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -10,15 +10,78 @@ import {
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
-import { useAppStore, type StoryChapter } from "@geolibre/core";
+import {
+  useAppStore,
+  type StoryChapter,
+  type StoryMap,
+  type StorySlideMode,
+} from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { Button, cn } from "@geolibre/ui";
 import { GripVertical, List, X } from "lucide-react";
 import { sanitizeStoryHtml } from "../../lib/sanitize-html";
-import { STORY_INSET_STYLE_URL } from "../../lib/storymap-constants";
+import {
+  STORY_GLOBAL_VIEW,
+  STORY_INSET_STYLE_URL,
+} from "../../lib/storymap-constants";
 
 interface StoryMapPresenterProps {
   mapControllerRef: RefObject<MapController | null>;
+}
+
+/** A non-`"none"` start/closing slide mode. */
+type PresenterSlideMode = Exclude<StorySlideMode, "none">;
+
+/** One scroll step in the presentation: a chapter card or an intro/outro slide. */
+type PresenterStep =
+  | { key: string; kind: "chapter"; chapter: StoryChapter; chapterIndex: number }
+  | {
+      key: string;
+      kind: "slide";
+      position: "start" | "end";
+      mode: PresenterSlideMode;
+    };
+
+/**
+ * Expand a story into its ordered scroll steps, inserting the optional start and
+ * closing slides around the chapters (#998).
+ */
+function buildPresenterSteps(story: StoryMap): PresenterStep[] {
+  const steps: PresenterStep[] = [];
+  if (story.startSlide !== "none") {
+    steps.push({
+      key: "__story_start__",
+      kind: "slide",
+      position: "start",
+      mode: story.startSlide,
+    });
+  }
+  story.chapters.forEach((chapter, chapterIndex) =>
+    steps.push({ key: chapter.id, kind: "chapter", chapter, chapterIndex }),
+  );
+  if (story.endSlide !== "none") {
+    steps.push({
+      key: "__story_end__",
+      kind: "slide",
+      position: "end",
+      mode: story.endSlide,
+    });
+  }
+  return steps;
+}
+
+/**
+ * The solid background a blank/black slide paints over the map, or null when the
+ * slide keeps the map visible (global/adjacent). Blank matches the panel theme
+ * background (`.glsm-light`/`.glsm-dark`).
+ */
+function slideCoverColor(
+  mode: PresenterSlideMode,
+  theme: "light" | "dark",
+): string | null {
+  if (mode === "black") return "#000000";
+  if (mode === "blank") return theme === "light" ? "#fafafa" : "#444444";
+  return null;
 }
 
 const ALIGNMENT_CLASS: Record<StoryChapter["alignment"], string> = {
@@ -65,27 +128,40 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const insetMapRef = useRef<maplibregl.Map | null>(null);
   const insetMarkerRef = useRef<maplibregl.Marker | null>(null);
   const markerRef = useRef<maplibregl.Marker | null>(null);
-  const activeIndexRef = useRef<number>(-1);
-  // Mirror of activeIndexRef as state so the navigation pane can highlight the
-  // current chapter.
-  const [activeIndex, setActiveIndex] = useState(0);
+  // Active scroll step (chapters + slides); -1 before the first enter.
+  const activeStepRef = useRef<number>(-1);
+  // Last chapter entered (skipping slides), so layer-fade replay still steps
+  // through chapters in order even when slides sit between them.
+  const activeChapterRef = useRef<number>(-1);
+  // Mirror of the active chapter as state so the navigation pane can highlight
+  // the current chapter (-1 while a start/closing slide is showing).
+  const [activeChapter, setActiveChapter] = useState(0);
+  // Solid color a blank/black slide paints over the map, or null when the map
+  // stays visible.
+  const [coverColor, setCoverColor] = useState<string | null>(null);
   const [navOpen, setNavOpen] = useState(true);
 
   // Memoized so the render path and `hasChapters` get a stable reference.
   const chapters = useMemo(() => storymap?.chapters ?? [], [storymap]);
+  // The ordered scroll steps, recomputed when the story changes (it is frozen
+  // during a presentation, so this is stable while presenting).
+  const steps = useMemo(
+    () => (storymap ? buildPresenterSteps(storymap) : []),
+    [storymap],
+  );
   const hasChapters = presenting && chapters.length > 0;
 
-  // Scroll a chapter into view; the IntersectionObserver then activates it and
+  // Scroll a step into view; the IntersectionObserver then activates it and
   // flies the camera, so clicking the nav reuses the same scroll-driven path.
-  // Holds the playback effect's enterChapter so the nav pane can drive the
-  // camera deterministically rather than waiting on a scroll-triggered observer.
-  const enterChapterRef = useRef<(index: number) => void>(() => {});
+  // Holds the playback effect's enterStep so the nav pane can drive the camera
+  // deterministically rather than waiting on a scroll-triggered observer.
+  const enterStepRef = useRef<(index: number) => void>(() => {});
   // While true, the scroll observer ignores transient intersections caused by a
   // programmatic jump so they can't override the target we just entered.
   const jumpingRef = useRef(false);
-  const goToChapter = useCallback((index: number) => {
+  const goToStep = useCallback((stepIndex: number) => {
     const step = scrollRef.current?.querySelector<HTMLElement>(
-      `[data-chapter-index="${index}"]`,
+      `[data-step-index="${stepIndex}"]`,
     );
     // Center the card, not the step: the step carries a tall bottom padding, so
     // centering it would push the card (and its drag bar) above the viewport.
@@ -94,7 +170,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     target?.scrollIntoView({ block: "center" });
     // Enter the target directly so its camera move always runs, then let the
     // observer take over once the programmatic scroll has settled.
-    enterChapterRef.current(index);
+    enterStepRef.current(stepIndex);
     window.setTimeout(() => {
       jumpingRef.current = false;
     }, 500);
@@ -234,11 +310,17 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     const story = storymapRef.current;
     if (!controller || !map || !container || !story) return;
     // Frozen snapshot for this presentation run (edits are blocked while
-    // presenting), shadowing the outer memoized `chapters` deliberately.
+    // presenting), shadowing the outer memoized `chapters`/`steps` deliberately.
     const chapters = story.chapters;
+    const steps = buildPresenterSteps(story);
 
-    const steps = Array.from(
-      container.querySelectorAll<HTMLElement>("[data-chapter-index]"),
+    // Start with the chapter list collapsed when the author chose discoverable
+    // chapters, so the itinerary is not revealed up front (#995). The toggle
+    // still opens it on demand.
+    setNavOpen(!story.hideChapterNav);
+
+    const stepEls = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-step-index]"),
     );
 
     // Main-map marker, created once and moved per chapter.
@@ -268,17 +350,29 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         .addTo(insetMap);
     }
 
-    const enterChapter = (index: number) => {
-      if (index === activeIndexRef.current) return;
-      const previous = activeIndexRef.current;
-      activeIndexRef.current = index;
-      const chapter = chapters[index];
-      if (!chapter) return;
-      setActiveIndex(index);
+    const applyEffects = (changes: StoryChapter["onChapterEnter"]) => {
+      for (const change of changes) {
+        controller.setStoryLayerOpacity(
+          change.layerId,
+          change.opacity,
+          change.duration,
+        );
+      }
+    };
 
-      steps.forEach((step, i) =>
-        step.classList.toggle("glsm-active", i === index),
-      );
+    const moveCameraTo = (location: StoryChapter["location"]) => {
+      markerRef.current?.setLngLat(location.center);
+      if (insetMapRef.current) {
+        insetMapRef.current.setCenter(location.center);
+        insetMarkerRef.current?.setLngLat(location.center);
+      }
+    };
+
+    const enterChapter = (chapter: StoryChapter, index: number) => {
+      const previous = activeChapterRef.current;
+      activeChapterRef.current = index;
+      setActiveChapter(index);
+      setCoverColor(null);
 
       // Drive the camera through the controller (which handles the optional
       // rotation) rather than mutating the MapLibre instance directly.
@@ -287,22 +381,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         chapter.mapAnimation || "flyTo",
         chapter.rotateAnimation,
       );
-
-      markerRef.current?.setLngLat(chapter.location.center);
-      if (insetMapRef.current) {
-        insetMapRef.current.setCenter(chapter.location.center);
-        insetMarkerRef.current?.setLngLat(chapter.location.center);
-      }
-
-      const applyEffects = (changes: typeof chapter.onChapterEnter) => {
-        for (const change of changes) {
-          controller.setStoryLayerOpacity(
-            change.layerId,
-            change.opacity,
-            change.duration,
-          );
-        }
-      };
+      moveCameraTo(chapter.location);
 
       // Replay the chapters between the old and new position as if scrolled
       // through (exit the one we leave, then enter+exit each skipped chapter in
@@ -310,17 +389,53 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       // stepping one chapter at a time, without firing exits for chapters whose
       // enter never ran.
       if (previous >= 0 && previous !== index) {
-        const step = previous < index ? 1 : -1;
+        const dir = previous < index ? 1 : -1;
         applyEffects(chapters[previous]?.onChapterExit ?? []);
-        for (let i = previous + step; i !== index; i += step) {
+        for (let i = previous + dir; i !== index; i += dir) {
           applyEffects(chapters[i]?.onChapterEnter ?? []);
           applyEffects(chapters[i]?.onChapterExit ?? []);
         }
       }
       applyEffects(chapter.onChapterEnter);
     };
-    // Expose enterChapter so the nav pane can jump directly.
-    enterChapterRef.current = enterChapter;
+
+    const enterSlide = (step: Extract<PresenterStep, { kind: "slide" }>) => {
+      // A slide is not a chapter, so clear the nav highlight but keep the layer
+      // fades the last chapter set (the closing "hold" slide keeps that state).
+      activeChapterRef.current = -1;
+      setActiveChapter(-1);
+      setCoverColor(slideCoverColor(step.mode, story.theme));
+      if (step.mode === "blank" || step.mode === "black") return;
+      // Global zooms out to the whole map; "adjacent" previews/holds the
+      // neighboring chapter's camera with all text hidden.
+      const location =
+        step.mode === "global"
+          ? STORY_GLOBAL_VIEW
+          : step.position === "start"
+            ? chapters[0].location
+            : chapters[chapters.length - 1].location;
+      controller.applyStoryChapterCamera(location, "flyTo", false);
+      moveCameraTo(location);
+    };
+
+    const enterStep = (index: number) => {
+      if (index === activeStepRef.current) return;
+      const step = steps[index];
+      if (!step) return;
+      activeStepRef.current = index;
+
+      stepEls.forEach((el, i) =>
+        el.classList.toggle("glsm-active", i === index),
+      );
+
+      if (step.kind === "chapter") {
+        enterChapter(step.chapter, step.chapterIndex);
+      } else {
+        enterSlide(step);
+      }
+    };
+    // Expose enterStep so the nav pane can jump directly.
+    enterStepRef.current = enterStep;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -330,9 +445,9 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         for (const entry of entries) {
           if (!entry.isIntersecting) continue;
           const index = Number(
-            (entry.target as HTMLElement).dataset.chapterIndex,
+            (entry.target as HTMLElement).dataset.stepIndex,
           );
-          if (Number.isFinite(index)) enterChapter(index);
+          if (Number.isFinite(index)) enterStep(index);
         }
       },
       {
@@ -342,10 +457,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         threshold: 0,
       },
     );
-    for (const step of steps) observer.observe(step);
+    for (const el of stepEls) observer.observe(el);
 
-    // Kick off the first chapter immediately.
-    enterChapter(0);
+    // Kick off the first step immediately.
+    enterStep(0);
 
     return () => {
       observer.disconnect();
@@ -355,10 +470,12 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       insetMarkerRef.current = null;
       insetMapRef.current?.remove();
       insetMapRef.current = null;
-      activeIndexRef.current = -1;
-      // Reset nav highlight and any card drag/resize so the next presentation
-      // starts clean.
-      setActiveIndex(0);
+      activeStepRef.current = -1;
+      activeChapterRef.current = -1;
+      // Reset nav highlight, slide cover, and any card drag/resize so the next
+      // presentation starts clean.
+      setActiveChapter(0);
+      setCoverColor(null);
       setCardLayouts({});
       // Undo any direct opacity changes made during playback.
       controller.restoreLayerStyles();
@@ -392,6 +509,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
 
   const theme = storymap?.theme ?? "dark";
   const themeClass = theme === "light" ? "glsm-light" : "glsm-dark";
+  // Chapters sit after the optional start slide, so a chapter's nav entry maps
+  // to its scroll-step index by this offset.
+  const startOffset =
+    storymap && storymap.startSlide !== "none" ? 1 : 0;
 
   return createPortal(
     // The scroll surface captures the wheel so scrolling navigates chapters.
@@ -429,10 +550,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
             <button
               key={chapter.id}
               type="button"
-              onClick={() => goToChapter(index)}
+              onClick={() => goToStep(index + startOffset)}
               className={cn(
                 "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors",
-                index === activeIndex
+                index === activeChapter
                   ? "bg-primary/15 font-medium text-foreground"
                   : "text-muted-foreground hover:bg-muted",
               )}
@@ -440,7 +561,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
               <span
                 className={cn(
                   "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px]",
-                  index === activeIndex
+                  index === activeChapter
                     ? "bg-primary text-primary-foreground"
                     : "bg-muted text-muted-foreground",
                 )}
@@ -469,6 +590,16 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         </div>
       ) : null}
 
+      {/* Solid cover for a blank/black start or closing slide (#998). Painted
+          over the map (and inset) but below the Exit/nav controls, and
+          pointer-events:none so the wheel still scrolls the story underneath. */}
+      {coverColor ? (
+        <div
+          className="pointer-events-none absolute inset-0 z-[71]"
+          style={{ background: coverColor }}
+        />
+      ) : null}
+
       <StoryMapStyles />
 
       <div
@@ -488,7 +619,19 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         ) : null}
 
         <div className="glsm-features">
-          {chapters.map((chapter, index) => {
+          {steps.map((step, stepIndex) => {
+            // Start/closing slides are empty scroll targets; their visual
+            // treatment (cover or camera) is driven by the playback effect.
+            if (step.kind === "slide") {
+              return (
+                <div
+                  key={step.key}
+                  data-step-index={stepIndex}
+                  className="glsm-step glsm-slide-step"
+                />
+              );
+            }
+            const { chapter } = step;
             const layout = cardLayouts[chapter.id];
             const cardStyle = {
               transform: layout
@@ -500,7 +643,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
             return (
               <div
                 key={chapter.id}
-                data-chapter-index={index}
+                data-step-index={stepIndex}
+                data-chapter-index={step.chapterIndex}
                 className={`glsm-step ${ALIGNMENT_CLASS[chapter.alignment]} ${
                   chapter.hidden ? "glsm-hidden" : ""
                 }`}
@@ -592,6 +736,8 @@ function StoryMapStyles() {
       .glsm-footer p { margin: 0; padding: 0 5%; }
       .glsm-features { padding-top: 10vh; padding-bottom: 45vh; }
       .glsm-hidden { visibility: hidden; }
+      /* Start/closing slides are empty full-height scroll targets (#998). */
+      .glsm-slide-step { min-height: 85vh; padding-bottom: 0; }
       .glsm-centered { width: 50%; margin: 0 auto; }
       .glsm-lefty { width: 33%; margin-left: 5%; }
       .glsm-righty { width: 33%; margin-left: 62%; }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -13,9 +13,9 @@ import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
 import {
   useAppStore,
+  type StoryActiveSlideMode,
   type StoryChapter,
   type StoryMap,
-  type StorySlideMode,
 } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { Button, cn } from "@geolibre/ui";
@@ -31,9 +31,6 @@ interface StoryMapPresenterProps {
   mapControllerRef: RefObject<MapController | null>;
 }
 
-/** A non-`"none"` start/closing slide mode. */
-type PresenterSlideMode = Exclude<StorySlideMode, "none">;
-
 /** One scroll step in the presentation: a chapter card or an intro/outro slide. */
 type PresenterStep =
   | { key: string; kind: "chapter"; chapter: StoryChapter; chapterIndex: number }
@@ -41,7 +38,7 @@ type PresenterStep =
       key: string;
       kind: "slide";
       position: "start" | "end";
-      mode: PresenterSlideMode;
+      mode: StoryActiveSlideMode;
     };
 
 /**
@@ -409,10 +406,11 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       // straight from the start slide to chapter N), which replays 0..N-1 so the
       // skipped chapters' fades still run.
       if (previous !== index) {
+        // Chapter indices are always >= 0: a `previous` of -1 means "before
+        // chapter 0", so the loop starts at i = 0 and only moves toward `index`.
         const dir = previous < index ? 1 : -1;
         if (previous >= 0) applyEffects(chapters[previous]?.onChapterExit ?? []);
         for (let i = previous + dir; i !== index; i += dir) {
-          if (i < 0) continue;
           applyEffects(chapters[i]?.onChapterEnter ?? []);
           applyEffects(chapters[i]?.onChapterExit ?? []);
         }
@@ -434,8 +432,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         step.mode === "global"
           ? STORY_GLOBAL_VIEW
           : step.position === "start"
-            ? chapters[0].location
-            : chapters[chapters.length - 1].location;
+            ? (chapters[0]?.location ?? STORY_GLOBAL_VIEW)
+            : (chapters[chapters.length - 1]?.location ?? STORY_GLOBAL_VIEW);
       controller.applyStoryChapterCamera(location, "flyTo", false);
       // The global overview shows no marker; the adjacent preview keeps the
       // chapter's marker and moves it to that chapter.

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -373,6 +373,17 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       }
     };
 
+    // Hide or show the map (and inset) markers. The "global" overview slide is a
+    // clean world view, so its marker is hidden; chapters and the adjacent
+    // preview keep theirs.
+    const setMarkersVisible = (visible: boolean) => {
+      const value = visible ? "" : "hidden";
+      const marker = markerRef.current?.getElement();
+      if (marker) marker.style.visibility = value;
+      const insetMarker = insetMarkerRef.current?.getElement();
+      if (insetMarker) insetMarker.style.visibility = value;
+    };
+
     const enterChapter = (chapter: StoryChapter, index: number) => {
       const previous = activeChapterRef.current;
       activeChapterRef.current = index;
@@ -386,6 +397,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         chapter.mapAnimation || "flyTo",
         chapter.rotateAnimation,
       );
+      // Re-show the marker in case it was hidden by a preceding global slide.
+      setMarkersVisible(true);
       moveCameraTo(chapter.location);
 
       // Replay the chapters between the old and new position as if scrolled
@@ -424,7 +437,14 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
             ? chapters[0].location
             : chapters[chapters.length - 1].location;
       controller.applyStoryChapterCamera(location, "flyTo", false);
-      moveCameraTo(location);
+      // The global overview shows no marker; the adjacent preview keeps the
+      // chapter's marker and moves it to that chapter.
+      if (step.mode === "global") {
+        setMarkersVisible(false);
+      } else {
+        setMarkersVisible(true);
+        moveCameraTo(location);
+      }
     };
 
     const enterStep = (index: number) => {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2030,7 +2030,7 @@
       "documentTitle": "Document title",
       "documentTitlePlaceholder": "Title shown at the top of each page",
       "subtitle": "Subtitle",
-      "subtitlePlaceholder": "Subtitle shown under the title on the first page",
+      "subtitlePlaceholder": "Subtitle shown under the title on each page",
       "byline": "Byline",
       "bylinePlaceholder": "Author or credit line",
       "footerText": "Footer text",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1979,6 +1979,9 @@
       "showMarkers": "Show markers",
       "markerColor": "Marker color",
       "inset": "Inset minimap",
+      "hideChapterNav": "Hide chapter list",
+      "startView": "Enable start view",
+      "closingSlide": "Enable closing slide",
       "chapterTitle": "Chapter title",
       "description": "Description (HTML allowed)",
       "image": "Image URL",
@@ -2004,6 +2007,13 @@
       "bottomLeft": "Bottom left",
       "bottomRight": "Bottom right"
     },
+    "slide": {
+      "blank": "Empty screen",
+      "black": "Black screen",
+      "global": "Global view",
+      "startAdjacent": "Preview of first chapter",
+      "endAdjacent": "Hold on last chapter"
+    },
     "loadSample": "Load sample story",
     "htmlFile": "HTML",
     "handout": {
@@ -2019,8 +2029,14 @@
       "landscape": "Landscape",
       "documentTitle": "Document title",
       "documentTitlePlaceholder": "Title shown at the top of each page",
+      "subtitle": "Subtitle",
+      "subtitlePlaceholder": "Subtitle shown under the title on the first page",
+      "byline": "Byline",
+      "bylinePlaceholder": "Author or credit line",
       "footerText": "Footer text",
       "footerPlaceholder": "Footer shown at the bottom of each page",
+      "startSlide": "Start slide",
+      "endSlide": "Closing slide",
       "generate": "Generate PDF",
       "stop": "Stop",
       "cancelled": "Export cancelled.",

--- a/apps/geolibre-desktop/src/lib/storymap-constants.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-constants.ts
@@ -1,3 +1,15 @@
 /** Basemap style for the story-map inset minimap (in-app and export). */
 export const STORY_INSET_STYLE_URL =
   "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+/**
+ * Camera used by the `"global"` start/closing slide mode (#998): a zoomed-out,
+ * untilted view of the whole map. Shared by the in-app presenter, the standalone
+ * HTML export, and the PDF handout so all three frame the globe the same way.
+ */
+export const STORY_GLOBAL_VIEW = {
+  center: [0, 20] as [number, number],
+  zoom: 0.6,
+  pitch: 0,
+  bearing: 0,
+};

--- a/apps/geolibre-desktop/src/lib/storymap-constants.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-constants.ts
@@ -1,4 +1,4 @@
-import type { StorySlideMode } from "@geolibre/core";
+import type { StoryActiveSlideMode } from "@geolibre/core";
 
 /** Basemap style for the story-map inset minimap (in-app and export). */
 export const STORY_INSET_STYLE_URL =
@@ -18,7 +18,7 @@ export const STORY_END_STEP_ID = "__story_end__";
  * presenter and the PDF handout so the slide treatment stays consistent (#998).
  */
 export function storySlideCoverColor(
-  mode: StorySlideMode,
+  mode: StoryActiveSlideMode,
   theme: "light" | "dark",
 ): string | null {
   if (mode === "black") return "#000000";

--- a/apps/geolibre-desktop/src/lib/storymap-constants.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-constants.ts
@@ -5,6 +5,13 @@ export const STORY_INSET_STYLE_URL =
   "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
 /**
+ * Synthetic step ids for the optional start/closing slides (#998). Shared by the
+ * presenter, the HTML export template, and the handout so the three stay in sync.
+ */
+export const STORY_START_STEP_ID = "__story_start__";
+export const STORY_END_STEP_ID = "__story_end__";
+
+/**
  * The solid background a blank/black start/closing slide paints over the map, or
  * null when the slide keeps the map visible (global/adjacent). Blank matches the
  * panel theme background (`.glsm-light`/`.glsm-dark`). Shared by the in-app

--- a/apps/geolibre-desktop/src/lib/storymap-constants.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-constants.ts
@@ -1,6 +1,23 @@
+import type { StorySlideMode } from "@geolibre/core";
+
 /** Basemap style for the story-map inset minimap (in-app and export). */
 export const STORY_INSET_STYLE_URL =
   "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+/**
+ * The solid background a blank/black start/closing slide paints over the map, or
+ * null when the slide keeps the map visible (global/adjacent). Blank matches the
+ * panel theme background (`.glsm-light`/`.glsm-dark`). Shared by the in-app
+ * presenter and the PDF handout so the slide treatment stays consistent (#998).
+ */
+export function storySlideCoverColor(
+  mode: StorySlideMode,
+  theme: "light" | "dark",
+): string | null {
+  if (mode === "black") return "#000000";
+  if (mode === "blank") return theme === "light" ? "#fafafa" : "#444444";
+  return null;
+}
 
 /**
  * Camera used by the `"global"` start/closing slide mode (#998): a zoomed-out,

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -764,11 +764,15 @@ ${inlineLayerScript}
                 var bg = slideBg(mode);
                 if (bg) { cover.style.background = bg; cover.style.display = 'block'; return; }
                 cover.style.display = 'none';
+                // The export never ships with zero chapters (buildStoryMapHtml
+                // throws first), but fall back to the global view defensively so
+                // an "adjacent" slide can never read an undefined location.
+                var adjacent = isStart
+                    ? config.chapters[0]
+                    : config.chapters[config.chapters.length - 1];
                 var loc = mode === 'global'
                     ? config.globalView
-                    : (isStart
-                        ? config.chapters[0].location
-                        : config.chapters[config.chapters.length - 1].location);
+                    : ((adjacent && adjacent.location) || config.globalView);
                 map.flyTo(loc);
                 if (config.showMarkers && marker) marker.setLngLat(loc.center);
                 if (insetMap && insetMarker) { insetMap.setCenter(loc.center); insetMarker.setLngLat(loc.center); }

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -757,6 +757,15 @@ ${inlineLayerScript}
             // cover over the map; global zooms out; "adjacent" previews the
             // first chapter (start) or holds the last chapter (end) with the
             // text hidden.
+            // Hide/show the map (and inset) markers. The "global" overview slide
+            // is a clean world view, so its marker is hidden; chapters and the
+            // adjacent preview keep theirs.
+            function setMarkersVisible(visible) {
+                var value = visible ? '' : 'hidden';
+                if (marker) marker.getElement().style.visibility = value;
+                if (insetMarker) insetMarker.getElement().style.visibility = value;
+            }
+
             function enterSlide(mode, isStart) {
                 navItems.forEach(function (it) { it.classList.remove('active'); });
                 map.stop();
@@ -774,8 +783,14 @@ ${inlineLayerScript}
                     ? config.globalView
                     : ((adjacent && adjacent.location) || config.globalView);
                 map.flyTo(loc);
-                if (config.showMarkers && marker) marker.setLngLat(loc.center);
-                if (insetMap && insetMarker) { insetMap.setCenter(loc.center); insetMarker.setLngLat(loc.center); }
+                // Global overview shows no marker; adjacent preview keeps it.
+                if (mode === 'global') {
+                    setMarkersVisible(false);
+                } else {
+                    setMarkersVisible(true);
+                    if (config.showMarkers && marker) marker.setLngLat(loc.center);
+                    if (insetMap && insetMarker) { insetMap.setCenter(loc.center); insetMarker.setLngLat(loc.center); }
+                }
             }
 
             scroller.setup({ step: '.step', offset: 0.5 })
@@ -796,6 +811,8 @@ ${inlineLayerScript}
                     map.stop();
                     var token = ++cameraToken;
                     map[chapter.mapAnimation || 'flyTo'](chapter.location);
+                    // Re-show the marker in case a preceding global slide hid it.
+                    setMarkersVisible(true);
                     if (config.showMarkers && marker) marker.setLngLat(chapter.location.center);
                     if (insetMap && insetMarker) { insetMap.setCenter(chapter.location.center); insetMarker.setLngLat(chapter.location.center); }
                     if (chapter.onChapterEnter.length > 0) chapter.onChapterEnter.forEach(setLayerOpacity);

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -8,7 +8,12 @@ import {
   type StoryMap,
 } from "@geolibre/core";
 import { sanitizeStoryHtml } from "./sanitize-html";
-import { STORY_GLOBAL_VIEW, STORY_INSET_STYLE_URL } from "./storymap-constants";
+import {
+  STORY_END_STEP_ID,
+  STORY_GLOBAL_VIEW,
+  STORY_INSET_STYLE_URL,
+  STORY_START_STEP_ID,
+} from "./storymap-constants";
 
 export interface StoryMapExportOptions {
   storymap: StoryMap;
@@ -176,6 +181,8 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     startSlide: storymap.startSlide,
     endSlide: storymap.endSlide,
     globalView: STORY_GLOBAL_VIEW,
+    startStepId: STORY_START_STEP_ID,
+    endStepId: STORY_END_STEP_ID,
     navToggleLabel,
     title: storymap.title,
     subtitle: storymap.subtitle,
@@ -609,7 +616,7 @@ function renderTemplate(
             s.setAttribute('id', id);
             return s;
         }
-        if (config.startSlide && config.startSlide !== 'none') features.appendChild(makeSlideStep('__story_start__'));
+        if (config.startSlide && config.startSlide !== 'none') features.appendChild(makeSlideStep(config.startStepId));
 
         config.chapters.forEach(function (record, idx) {
             var container = document.createElement('div');
@@ -645,7 +652,7 @@ function renderTemplate(
             container.appendChild(card);
             features.appendChild(container);
         });
-        if (config.endSlide && config.endSlide !== 'none') features.appendChild(makeSlideStep('__story_end__'));
+        if (config.endSlide && config.endSlide !== 'none') features.appendChild(makeSlideStep(config.endStepId));
         story.appendChild(features);
 
         // Navigation pane: list chapters and jump to one on click.
@@ -754,7 +761,7 @@ function renderTemplate(
         // first (redundant) Scrollama enter for it is skipped (#998 review).
         var startSlideInitialized = false;
 
-        map.on('load', function () {
+        map.once('load', function () {
             // Match the in-app projection (globe by default) so the exported
             // story does not silently fall back to 2D Mercator (#917).
             try {
@@ -820,15 +827,15 @@ ${inlineLayerScript}
                 .onStepEnter(function (response) {
                     var id = response.element.id;
                     response.element.classList.add('active');
-                    if (id === '__story_start__' || id === '__story_end__') {
+                    if (id === config.startStepId || id === config.endStepId) {
                         // Skip the redundant first enter for the start slide that
                         // was already initialized synchronously on load, so
                         // global/adjacent modes don't fly the camera twice.
-                        if (id === '__story_start__' && startSlideInitialized) {
+                        if (id === config.startStepId && startSlideInitialized) {
                             startSlideInitialized = false;
                             return;
                         }
-                        enterSlide(id === '__story_start__' ? config.startSlide : config.endSlide, id === '__story_start__');
+                        enterSlide(id === config.startStepId ? config.startSlide : config.endSlide, id === config.startStepId);
                         return;
                     }
                     cover.style.display = 'none';

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -742,6 +742,9 @@ function renderTemplate(
 
         var scroller = scrollama();
         var cameraToken = 0;
+        // Set once the start slide is initialized synchronously on load, so the
+        // first (redundant) Scrollama enter for it is skipped (#998 review).
+        var startSlideInitialized = false;
 
         map.on('load', function () {
             // Match the in-app projection (globe by default) so the exported
@@ -766,10 +769,22 @@ ${inlineLayerScript}
                 if (insetMarker) insetMarker.getElement().style.visibility = value;
             }
 
+            // Hide/show the story title/byline/footer chrome. Slides are
+            // documented as text-free, so the persistent header and footer hide
+            // while one is active, matching the in-app presenter (the blank/black
+            // cover already hides them; this also clears them for global/adjacent).
+            function setChromeHidden(hidden) {
+                var headerEl = document.getElementById('header');
+                var footerEl = document.getElementById('footer');
+                if (headerEl) headerEl.classList.toggle('hidden', hidden);
+                if (footerEl) footerEl.classList.toggle('hidden', hidden);
+            }
+
             function enterSlide(mode, isStart) {
                 navItems.forEach(function (it) { it.classList.remove('active'); });
                 map.stop();
                 ++cameraToken;
+                setChromeHidden(true);
                 var bg = slideBg(mode);
                 if (bg) { cover.style.background = bg; cover.style.display = 'block'; return; }
                 cover.style.display = 'none';
@@ -798,10 +813,18 @@ ${inlineLayerScript}
                     var id = response.element.id;
                     response.element.classList.add('active');
                     if (id === '__story_start__' || id === '__story_end__') {
+                        // Skip the redundant first enter for the start slide that
+                        // was already initialized synchronously on load, so
+                        // global/adjacent modes don't fly the camera twice.
+                        if (id === '__story_start__' && startSlideInitialized) {
+                            startSlideInitialized = false;
+                            return;
+                        }
                         enterSlide(id === '__story_start__' ? config.startSlide : config.endSlide, id === '__story_start__');
                         return;
                     }
                     cover.style.display = 'none';
+                    setChromeHidden(false);
                     var idx = config.chapters.findIndex(function (c) { return c.id === id; });
                     var chapter = config.chapters[idx];
                     if (!chapter) return;
@@ -832,8 +855,14 @@ ${inlineLayerScript}
                 });
 
             // Set the start slide's camera deterministically on load, mirroring
-            // the in-app presenter's first step (#998).
-            if (config.startSlide && config.startSlide !== 'none') enterSlide(config.startSlide, true);
+            // the in-app presenter's first step (#998). This runs synchronously
+            // before Scrollama's first (async) onStepEnter fires for the in-view
+            // start slide, so the flag below skips that redundant second enter
+            // (which would otherwise fly the camera twice for global/adjacent).
+            if (config.startSlide && config.startSlide !== 'none') {
+                enterSlide(config.startSlide, true);
+                startSlideInitialized = true;
+            }
         });
 
         window.addEventListener('resize', scroller.resize);

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -616,7 +616,9 @@ function renderTemplate(
             container.setAttribute('id', record.id);
             container.classList.add('step');
             container.classList.add(alignments[record.alignment] || 'centered');
-            if (idx === 0) container.classList.add('active');
+            // Don't pre-activate chapter 1 when a start slide opens the story, so
+            // its active state isn't shown during the intro slide (#998 review).
+            if (idx === 0 && !(config.startSlide && config.startSlide !== 'none')) container.classList.add('active');
             if (record.hidden) container.classList.add('hidden');
 
             var card = document.createElement('div');
@@ -652,7 +654,7 @@ function renderTemplate(
         nav.className = config.theme;
         config.chapters.forEach(function (record, idx) {
             var item = document.createElement('div');
-            item.className = 'nav-item' + (idx === 0 ? ' active' : '');
+            item.className = 'nav-item' + ((idx === 0 && !(config.startSlide && config.startSlide !== 'none')) ? ' active' : '');
             item.setAttribute('data-id', record.id);
             var num = document.createElement('span'); num.className = 'nav-num'; num.innerText = (idx + 1);
             var t = document.createElement('span'); t.className = 'nav-title'; t.innerText = record.title || ('Chapter ' + (idx + 1));
@@ -689,16 +691,22 @@ function renderTemplate(
             if (mode === 'blank') return config.theme === 'light' ? '#fafafa' : '#444444';
             return null;
         }
-        // Paint the cover up front for a blank/black start slide so the first
-        // frame is the slide, not a flash of the map (#998).
-        if (config.startSlide && config.startSlide !== 'none') {
-            var startBg = slideBg(config.startSlide);
-            if (startBg) { cover.style.background = startBg; cover.style.display = 'block'; }
-        }
 
         var footer = document.createElement('div');
         if (config.footer) { var f = document.createElement('p'); f.innerHTML = config.footer; footer.appendChild(f); }
         if (footer.children.length > 0) { footer.classList.add(config.theme); footer.setAttribute('id', 'footer'); story.appendChild(footer); }
+
+        // Apply the start slide's initial state during DOM construction (before
+        // map load) so a slow style/tile load can't flash the story header/footer
+        // or an uncovered map on a supposedly text-free start slide (#998 review).
+        if (config.startSlide && config.startSlide !== 'none') {
+            var startHeaderEl = document.getElementById('header');
+            if (startHeaderEl) startHeaderEl.classList.add('hidden');
+            var startFooterEl = document.getElementById('footer');
+            if (startFooterEl) startFooterEl.classList.add('hidden');
+            var startBg = slideBg(config.startSlide);
+            if (startBg) { cover.style.background = startBg; cover.style.display = 'block'; }
+        }
 
         // Shape right-to-left scripts (Arabic, Hebrew, Persian, …) correctly so
         // basemap labels are not rendered reversed. Lazy-loaded, so it only

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -22,6 +22,11 @@ export interface StoryMapExportOptions {
    * Defaults to globe when omitted, matching the app default.
    */
   projection?: MapProjection;
+  /**
+   * Localized label for the chapter-list toggle button (title + aria-label).
+   * Defaults to English when omitted so the export still works standalone.
+   */
+  navToggleLabel?: string;
 }
 
 interface InlineLayerExport {
@@ -71,7 +76,13 @@ const BLANK_EXPORT_STYLE: Record<string, unknown> = {
  * @returns A complete HTML document as a string.
  */
 export function buildStoryMapHtml(options: StoryMapExportOptions): string {
-  const { storymap, basemapStyleUrl, layers, projection = "globe" } = options;
+  const {
+    storymap,
+    basemapStyleUrl,
+    layers,
+    projection = "globe",
+    navToggleLabel = "Toggle chapter list",
+  } = options;
 
   // The template reads chapters[0] for the initial camera, so an empty story
   // cannot produce a working page. Callers gate this behind a chapter count,
@@ -165,6 +176,7 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     startSlide: storymap.startSlide,
     endSlide: storymap.endSlide,
     globalView: STORY_GLOBAL_VIEW,
+    navToggleLabel,
     title: storymap.title,
     subtitle: storymap.subtitle,
     byline: storymap.byline,
@@ -511,7 +523,9 @@ function renderTemplate(
         .nav-num { width: 20px; height: 20px; border-radius: 50%; background: rgba(127,127,127,0.3); display: inline-flex; align-items: center; justify-content: center; font-size: 11px; flex-shrink: 0; }
         .nav-item.active .nav-num { background: #3fb1ce; color: #fff; }
         .nav-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } #nav, #nav-toggle { display: none; } }
+        /* Keep the nav toggle reachable on small screens so the chapter list
+           stays discoverable; only cap the pane width to the viewport. */
+        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } #nav { width: auto; max-width: calc(100vw - 24px); } }
         .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan,
         .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan .maplibregl-canvas { touch-action: unset; }
         #inset-map { position: fixed; width: 180px; height: 180px; border: 2px solid rgba(255, 255, 255, 0.8); border-radius: 4px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3); z-index: 10; }
@@ -659,8 +673,8 @@ function renderTemplate(
         navToggle.id = 'nav-toggle';
         navToggle.className = config.theme;
         navToggle.type = 'button';
-        navToggle.title = 'Toggle chapter list';
-        navToggle.setAttribute('aria-label', 'Toggle chapter list');
+        navToggle.title = config.navToggleLabel;
+        navToggle.setAttribute('aria-label', config.navToggleLabel);
         navToggle.textContent = '☰';
         navToggle.addEventListener('click', function () { nav.classList.toggle('hidden-nav'); });
         document.body.appendChild(navToggle);

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -8,7 +8,7 @@ import {
   type StoryMap,
 } from "@geolibre/core";
 import { sanitizeStoryHtml } from "./sanitize-html";
-import { STORY_INSET_STYLE_URL } from "./storymap-constants";
+import { STORY_GLOBAL_VIEW, STORY_INSET_STYLE_URL } from "./storymap-constants";
 
 export interface StoryMapExportOptions {
   storymap: StoryMap;
@@ -159,6 +159,12 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     insetZoom: 1,
     theme: storymap.theme,
     auto: false,
+    // Start the chapter list collapsed and reveal chapters one at a time (#995).
+    hideChapterNav: storymap.hideChapterNav,
+    // Optional intro/outro slides shown before/after the chapters (#998).
+    startSlide: storymap.startSlide,
+    endSlide: storymap.endSlide,
+    globalView: STORY_GLOBAL_VIEW,
     title: storymap.title,
     subtitle: storymap.subtitle,
     byline: storymap.byline,
@@ -477,6 +483,11 @@ function renderTemplate(
         .dark { color: #fafafa; background-color: #444; }
         .step { padding-bottom: 50vh; opacity: 0.25; transition: opacity 0.3s; }
         .step.active { opacity: 0.95; }
+        /* Start/closing slides are empty full-height scroll targets (#998). */
+        .sm-slide-step { min-height: 90vh; padding-bottom: 0; }
+        /* Solid cover painted over the map for a blank/black slide; below the
+           nav, and pointer-events:none so the page still scrolls. */
+        #slide-cover { position: fixed; inset: 0; z-index: 15; display: none; pointer-events: none; }
         .sm-card { position: relative; display: flex; flex-direction: column; max-height: 70vh; line-height: 22px; font-size: 14px; border-radius: 6px; box-shadow: 0 6px 20px rgba(0,0,0,0.25); overflow: hidden; }
         .sm-bar { display: flex; align-items: center; gap: 6px; padding: 7px 10px; cursor: move; user-select: none; touch-action: none; font-weight: 600; font-size: 13px; border-bottom: 1px solid rgba(127,127,127,0.25); }
         .sm-grip { opacity: 0.5; flex-shrink: 0; }
@@ -486,16 +497,21 @@ function renderTemplate(
         .sm-body img { width: 100%; max-height: 38vh; object-fit: cover; border-radius: 2px; }
         .sm-resize { position: absolute; right: 0; bottom: 0; width: 18px; height: 18px; cursor: nwse-resize; touch-action: none; }
         .sm-resize::after { content: ''; position: absolute; right: 4px; bottom: 4px; width: 7px; height: 7px; border-right: 2px solid currentColor; border-bottom: 2px solid currentColor; opacity: 0.5; }
-        #nav { position: fixed; left: 12px; top: 12px; max-height: calc(100vh - 24px); width: 220px; overflow-y: auto; z-index: 20; border-radius: 6px; padding: 6px; box-shadow: 0 4px 16px rgba(0,0,0,0.3); font-size: 13px; }
+        #nav { position: fixed; left: 12px; top: 52px; max-height: calc(100vh - 64px); width: 220px; overflow-y: auto; z-index: 20; border-radius: 6px; padding: 6px; box-shadow: 0 4px 16px rgba(0,0,0,0.3); font-size: 13px; }
         #nav.dark { background: rgba(40,40,40,0.85); color: #fafafa; }
         #nav.light { background: rgba(250,250,250,0.92); color: #444; }
+        #nav.hidden-nav { display: none; }
+        /* Toggle button for the chapter list (#995). */
+        #nav-toggle { position: fixed; left: 12px; top: 12px; z-index: 21; width: 32px; height: 32px; border: none; border-radius: 6px; cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 16px; box-shadow: 0 4px 16px rgba(0,0,0,0.3); }
+        #nav-toggle.dark { background: rgba(40,40,40,0.85); color: #fafafa; }
+        #nav-toggle.light { background: rgba(250,250,250,0.92); color: #444; }
         .nav-item { display: flex; gap: 8px; align-items: center; padding: 7px 9px; border-radius: 4px; cursor: pointer; }
         .nav-item:hover { background: rgba(127,127,127,0.18); }
         .nav-item.active { background: rgba(63,177,206,0.22); font-weight: 600; }
         .nav-num { width: 20px; height: 20px; border-radius: 50%; background: rgba(127,127,127,0.3); display: inline-flex; align-items: center; justify-content: center; font-size: 11px; flex-shrink: 0; }
         .nav-item.active .nav-num { background: #3fb1ce; color: #fff; }
         .nav-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } #nav { display: none; } }
+        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } #nav, #nav-toggle { display: none; } }
         .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan,
         .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan .maplibregl-canvas { touch-action: unset; }
         #inset-map { position: fixed; width: 180px; height: 180px; border: 2px solid rgba(255, 255, 255, 0.8); border-radius: 4px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3); z-index: 10; }
@@ -571,6 +587,16 @@ function renderTemplate(
             });
         }
 
+        // Optional intro/outro slides are empty full-height scroll targets;
+        // their treatment (cover or camera) is applied on enter (#998).
+        function makeSlideStep(id) {
+            var s = document.createElement('div');
+            s.className = 'step sm-slide-step';
+            s.setAttribute('id', id);
+            return s;
+        }
+        if (config.startSlide && config.startSlide !== 'none') features.appendChild(makeSlideStep('__story_start__'));
+
         config.chapters.forEach(function (record, idx) {
             var container = document.createElement('div');
             container.setAttribute('id', record.id);
@@ -603,6 +629,7 @@ function renderTemplate(
             container.appendChild(card);
             features.appendChild(container);
         });
+        if (config.endSlide && config.endSlide !== 'none') features.appendChild(makeSlideStep('__story_end__'));
         story.appendChild(features);
 
         // Navigation pane: list chapters and jump to one on click.
@@ -625,6 +652,35 @@ function renderTemplate(
         });
         document.body.appendChild(nav);
         var navItems = nav.querySelectorAll('.nav-item');
+
+        // Toggle button so the chapter list can be opened/closed; it starts
+        // collapsed for a "discoverable chapters" story (#995).
+        var navToggle = document.createElement('button');
+        navToggle.id = 'nav-toggle';
+        navToggle.className = config.theme;
+        navToggle.type = 'button';
+        navToggle.title = 'Toggle chapter list';
+        navToggle.setAttribute('aria-label', 'Toggle chapter list');
+        navToggle.textContent = '☰';
+        navToggle.addEventListener('click', function () { nav.classList.toggle('hidden-nav'); });
+        document.body.appendChild(navToggle);
+        if (config.hideChapterNav) nav.classList.add('hidden-nav');
+
+        // Solid cover for a blank/black start or closing slide (#998).
+        var cover = document.createElement('div');
+        cover.id = 'slide-cover';
+        document.body.appendChild(cover);
+        function slideBg(mode) {
+            if (mode === 'black') return '#000000';
+            if (mode === 'blank') return config.theme === 'light' ? '#fafafa' : '#444444';
+            return null;
+        }
+        // Paint the cover up front for a blank/black start slide so the first
+        // frame is the slide, not a flash of the map (#998).
+        if (config.startSlide && config.startSlide !== 'none') {
+            var startBg = slideBg(config.startSlide);
+            if (startBg) { cover.style.background = startBg; cover.style.display = 'block'; }
+        }
 
         var footer = document.createElement('div');
         if (config.footer) { var f = document.createElement('p'); f.innerHTML = config.footer; footer.appendChild(f); }
@@ -683,13 +739,40 @@ function renderTemplate(
             }
 ${inlineLayerScript}
 
+            // Drive a start/closing slide (#998): blank/black paint a solid
+            // cover over the map; global zooms out; "adjacent" previews the
+            // first chapter (start) or holds the last chapter (end) with the
+            // text hidden.
+            function enterSlide(mode, isStart) {
+                navItems.forEach(function (it) { it.classList.remove('active'); });
+                map.stop();
+                ++cameraToken;
+                var bg = slideBg(mode);
+                if (bg) { cover.style.background = bg; cover.style.display = 'block'; return; }
+                cover.style.display = 'none';
+                var loc = mode === 'global'
+                    ? config.globalView
+                    : (isStart
+                        ? config.chapters[0].location
+                        : config.chapters[config.chapters.length - 1].location);
+                map.flyTo(loc);
+                if (config.showMarkers && marker) marker.setLngLat(loc.center);
+                if (insetMap && insetMarker) { insetMap.setCenter(loc.center); insetMarker.setLngLat(loc.center); }
+            }
+
             scroller.setup({ step: '.step', offset: 0.5 })
                 .onStepEnter(function (response) {
-                    var idx = config.chapters.findIndex(function (c) { return c.id === response.element.id; });
+                    var id = response.element.id;
+                    response.element.classList.add('active');
+                    if (id === '__story_start__' || id === '__story_end__') {
+                        enterSlide(id === '__story_start__' ? config.startSlide : config.endSlide, id === '__story_start__');
+                        return;
+                    }
+                    cover.style.display = 'none';
+                    var idx = config.chapters.findIndex(function (c) { return c.id === id; });
                     var chapter = config.chapters[idx];
                     if (!chapter) return;
-                    response.element.classList.add('active');
-                    navItems.forEach(function (it) { it.classList.toggle('active', it.getAttribute('data-id') === response.element.id); });
+                    navItems.forEach(function (it) { it.classList.toggle('active', it.getAttribute('data-id') === id); });
                     // Cancel any in-progress move (e.g. a prior chapter's rotation)
                     // and bump the token so its pending moveend handler is ignored.
                     map.stop();
@@ -707,11 +790,15 @@ ${inlineLayerScript}
                     }
                 })
                 .onStepExit(function (response) {
+                    response.element.classList.remove('active');
                     var chapter = config.chapters.find(function (c) { return c.id === response.element.id; });
                     if (!chapter) return;
-                    response.element.classList.remove('active');
                     if (chapter.onChapterExit.length > 0) chapter.onChapterExit.forEach(setLayerOpacity);
                 });
+
+            // Set the start slide's camera deterministically on load, mirroring
+            // the in-app presenter's first step (#998).
+            if (config.startSlide && config.startSlide !== 'none') enterSlide(config.startSlide, true);
         });
 
         window.addEventListener('resize', scroller.resize);

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -684,8 +684,14 @@ function renderTemplate(
         navToggle.type = 'button';
         navToggle.title = config.navToggleLabel;
         navToggle.setAttribute('aria-label', config.navToggleLabel);
+        // aria-pressed mirrors the in-app presenter so assistive tech announces
+        // whether the chapter list is open (#995). It is true when the nav shows.
+        navToggle.setAttribute('aria-pressed', config.hideChapterNav ? 'false' : 'true');
         navToggle.textContent = '☰';
-        navToggle.addEventListener('click', function () { nav.classList.toggle('hidden-nav'); });
+        navToggle.addEventListener('click', function () {
+            var nowHidden = nav.classList.toggle('hidden-nav');
+            navToggle.setAttribute('aria-pressed', nowHidden ? 'false' : 'true');
+        });
         document.body.appendChild(navToggle);
         if (config.hideChapterNav) nav.classList.add('hidden-nav');
 
@@ -727,13 +733,18 @@ function renderTemplate(
             maplibregl.setRTLTextPlugin('https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.4.0/dist/mapbox-gl-rtl-text.js', true).catch(function (e) { console.error('[GeoLibre] RTL plugin failed', e); });
         }
 
+        // For a global start slide, open the map (and inset/markers) at the
+        // global view rather than chapter 0, so a slow style/tile load doesn't
+        // flash chapter 0's view before the load handler flies out (#998 review).
+        var openLocation = config.startSlide === 'global' ? config.globalView : config.chapters[0].location;
+
         var map = new maplibregl.Map({
             container: 'map',
             style: config.style,
-            center: config.chapters[0].location.center,
-            zoom: config.chapters[0].location.zoom,
-            bearing: config.chapters[0].location.bearing,
-            pitch: config.chapters[0].location.pitch,
+            center: openLocation.center,
+            zoom: openLocation.zoom,
+            bearing: openLocation.bearing,
+            pitch: openLocation.pitch,
             interactive: false
         });
 
@@ -743,16 +754,19 @@ function renderTemplate(
             insetContainer.id = 'inset-map';
             insetContainer.classList.add(config.insetPosition || 'bottom-left');
             document.body.appendChild(insetContainer);
-            insetMap = new maplibregl.Map({ container: 'inset-map', style: config.insetStyle, center: config.chapters[0].location.center, zoom: config.insetZoom || 1, interactive: false, attributionControl: false });
+            insetMap = new maplibregl.Map({ container: 'inset-map', style: config.insetStyle, center: openLocation.center, zoom: config.insetZoom || 1, interactive: false, attributionControl: false });
             var markerEl = document.createElement('div');
             markerEl.className = 'inset-marker';
-            insetMarker = new maplibregl.Marker({ element: markerEl }).setLngLat(config.chapters[0].location.center).addTo(insetMap);
+            insetMarker = new maplibregl.Marker({ element: markerEl }).setLngLat(openLocation.center).addTo(insetMap);
+            // The global overview shows no marker; hide it immediately.
+            if (config.startSlide === 'global') insetMarker.getElement().style.visibility = 'hidden';
         }
 
         var marker = null;
         if (config.showMarkers) {
             marker = new maplibregl.Marker({ color: config.markerColor });
-            marker.setLngLat(config.chapters[0].location.center).addTo(map);
+            marker.setLngLat(openLocation.center).addTo(map);
+            if (config.startSlide === 'global') marker.getElement().style.visibility = 'hidden';
         }
 
         var scroller = scrollama();

--- a/apps/geolibre-desktop/src/lib/storymap-pdf.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-pdf.ts
@@ -300,6 +300,9 @@ function drawChapterPage(
 
   if (subtitle) {
     const size = 8.5;
+    // Add the leading gap a title would have provided, so a standalone subtitle
+    // is not flush against the top margin.
+    if (!docTitle) y += 3;
     pdf.setFont("helvetica", "italic");
     pdf.setFontSize(size);
     pdf.setTextColor(140, 140, 140);

--- a/apps/geolibre-desktop/src/lib/storymap-pdf.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-pdf.ts
@@ -379,9 +379,12 @@ function drawChapterPage(
   pdf.setFontSize(footerSize);
   pdf.setTextColor(130, 130, 130);
   if (byline) {
-    // Left-aligned in the footer band, mirroring the right-aligned page number,
-    // and bounded so it cannot run into the centered footer text.
-    const bylineMaxWidth = Math.max(20, widthMm / 2 - MARGIN_MM - PAGE_NUM_SLOT_MM);
+    // Left-aligned in the footer band, occupying the left slot that mirrors the
+    // page-number slot on the right. The centered footer text is kept clear of
+    // both slots (see footerMaxWidth below), so bounding the byline to
+    // PAGE_NUM_SLOT_MM guarantees it never runs into the footer. The first
+    // wrapped line is kept; a very long byline is truncated to this slot.
+    const bylineMaxWidth = Math.max(20, PAGE_NUM_SLOT_MM);
     const [line] = pdf.splitTextToSize(byline, bylineMaxWidth) as string[];
     pdf.text(line, MARGIN_MM, footerY);
   }

--- a/apps/geolibre-desktop/src/lib/storymap-pdf.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-pdf.ts
@@ -36,6 +36,12 @@ export interface HandoutChapter {
   map: HandoutImage;
   /** The chapter's own photo, when it has one and it loaded successfully. */
   photo?: HandoutImage;
+  /**
+   * Draw the map image edge-to-edge as a clean full-page screen with no title,
+   * description, or running header/footer. Used for the start/closing slide
+   * pages (a solid color or a global/preview map view) (#998).
+   */
+  fullBleed?: boolean;
 }
 
 /** Page setup and running text for the handout. */
@@ -44,6 +50,10 @@ export interface HandoutOptions {
   orientation: Orientation;
   /** Document title drawn at the top of every page (omitted when empty). */
   title: string;
+  /** Subtitle drawn under the title on every page (omitted when empty). */
+  subtitle: string;
+  /** Byline drawn at the left of the footer on every page (omitted when empty). */
+  byline: string;
   /** Footer text drawn at the bottom of every page (omitted when empty). */
   footer: string;
 }
@@ -187,6 +197,38 @@ function imageFormat(data: HandoutImage["data"]): "PNG" | "JPEG" {
   return "PNG";
 }
 
+/**
+ * Draw an image edge-to-edge over a box at `(x, y)` of size `boxW x boxH`,
+ * scaling to cover (cropping the overflow) so a full-bleed slide page has no
+ * borders even when the image and page aspect ratios differ. The crop spills
+ * past the page edges, which jsPDF leaves unrendered (clipped to the page box).
+ */
+function drawImageCover(
+  pdf: jsPDF,
+  image: HandoutImage,
+  x: number,
+  y: number,
+  boxW: number,
+  boxH: number,
+): void {
+  const scale =
+    image.width > 0 && image.height > 0
+      ? Math.max(boxW / image.width, boxH / image.height)
+      : 1;
+  const w = image.width > 0 ? image.width * scale : boxW;
+  const h = image.height > 0 ? image.height * scale : boxH;
+  pdf.addImage(
+    image.data,
+    imageFormat(image.data),
+    x + (boxW - w) / 2,
+    y + (boxH - h) / 2,
+    w,
+    h,
+    undefined,
+    "FAST",
+  );
+}
+
 /** Draw an image centered within a box at `(x, y)` of size `boxW x boxH`. */
 function drawImageInBox(
   pdf: jsPDF,
@@ -223,6 +265,13 @@ function drawChapterPage(
   widthMm: number,
   heightMm: number,
 ): void {
+  // A full-bleed slide page is just the captured screen edge-to-edge: no title,
+  // description, or running header/footer (#998).
+  if (chapter.fullBleed) {
+    drawImageCover(pdf, chapter.map, 0, 0, widthMm, heightMm);
+    return;
+  }
+
   const contentWidth = widthMm - MARGIN_MM * 2;
   const footerSize = 9;
   const footerY = heightMm - MARGIN_MM + lineHeightMm(footerSize);
@@ -230,10 +279,12 @@ function drawChapterPage(
   const bottomLimit = heightMm - MARGIN_MM - lineHeightMm(footerSize) - 4;
   let y = MARGIN_MM;
 
-  // The title and footer are running, single-line text; reduce any HTML the
-  // story carried (e.g. the default footer's links) to plain text so the
-  // handout shows readable labels instead of raw markup.
+  // The title/subtitle/byline/footer are running, single-line text; reduce any
+  // HTML the story carried (e.g. the default footer's links) to plain text so
+  // the handout shows readable labels instead of raw markup.
   const docTitle = singleLine(options.title);
+  const subtitle = singleLine(options.subtitle);
+  const byline = singleLine(options.byline);
   const footerText = singleLine(options.footer);
 
   if (docTitle) {
@@ -242,6 +293,17 @@ function drawChapterPage(
     pdf.setFontSize(size);
     pdf.setTextColor(110, 110, 110);
     pdf.text(docTitle, widthMm / 2, y + lineHeightMm(size), {
+      align: "center",
+    });
+    y += lineHeightMm(size) + (subtitle ? 1 : 3);
+  }
+
+  if (subtitle) {
+    const size = 8.5;
+    pdf.setFont("helvetica", "italic");
+    pdf.setFontSize(size);
+    pdf.setTextColor(140, 140, 140);
+    pdf.text(subtitle, widthMm / 2, y + lineHeightMm(size), {
       align: "center",
     });
     y += lineHeightMm(size) + 3;
@@ -316,10 +378,17 @@ function drawChapterPage(
   pdf.setFont("helvetica", "normal");
   pdf.setFontSize(footerSize);
   pdf.setTextColor(130, 130, 130);
+  if (byline) {
+    // Left-aligned in the footer band, mirroring the right-aligned page number,
+    // and bounded so it cannot run into the centered footer text.
+    const bylineMaxWidth = Math.max(20, widthMm / 2 - MARGIN_MM - PAGE_NUM_SLOT_MM);
+    const [line] = pdf.splitTextToSize(byline, bylineMaxWidth) as string[];
+    pdf.text(line, MARGIN_MM, footerY);
+  }
   if (footerText) {
     // Keep the footer centered but bound its width symmetrically so it stays
-    // clear of the right-aligned page number on both sides, even on wide pages
-    // (e.g. Tabloid landscape). Only the first wrapped line is kept.
+    // clear of the byline (left) and the page number (right) on both sides, even
+    // on wide pages (e.g. Tabloid landscape). Only the first wrapped line is kept.
     const footerMaxWidth = Math.max(20, widthMm - 2 * (MARGIN_MM + PAGE_NUM_SLOT_MM));
     // splitTextToSize always returns at least one element for non-empty input,
     // and footerText is non-empty here, so `line` is always a string.

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -34,6 +34,7 @@ import {
   type StoryInsetPosition,
   type StoryLayerOpacityChange,
   type StoryMap,
+  type StorySlideMode,
 } from "./types";
 import {
   DEFAULT_LAYER_GROUP_OPACITY,
@@ -259,6 +260,13 @@ export function normalizeStoryMap(storymap: unknown): StoryMap | null {
     )
       ? (candidate.insetPosition as StoryInsetPosition)
       : DEFAULT_STORY_MAP.insetPosition,
+    hideChapterNav: normalizeBoolean(candidate.hideChapterNav, false),
+    startSlide: STORY_SLIDE_MODES.has(candidate.startSlide as StorySlideMode)
+      ? (candidate.startSlide as StorySlideMode)
+      : DEFAULT_STORY_MAP.startSlide,
+    endSlide: STORY_SLIDE_MODES.has(candidate.endSlide as StorySlideMode)
+      ? (candidate.endSlide as StorySlideMode)
+      : DEFAULT_STORY_MAP.endSlide,
     chapters,
   };
 
@@ -280,7 +288,10 @@ export function storyMapHasContent(story: StoryMap): boolean {
     story.showMarkers !== DEFAULT_STORY_MAP.showMarkers ||
     story.markerColor !== DEFAULT_STORY_MAP.markerColor ||
     story.inset !== DEFAULT_STORY_MAP.inset ||
-    story.insetPosition !== DEFAULT_STORY_MAP.insetPosition
+    story.insetPosition !== DEFAULT_STORY_MAP.insetPosition ||
+    story.hideChapterNav !== DEFAULT_STORY_MAP.hideChapterNav ||
+    story.startSlide !== DEFAULT_STORY_MAP.startSlide ||
+    story.endSlide !== DEFAULT_STORY_MAP.endSlide
   );
 }
 
@@ -302,6 +313,14 @@ const STORY_INSET_POSITIONS = new Set<StoryInsetPosition>([
   "top-right",
   "bottom-left",
   "bottom-right",
+]);
+
+const STORY_SLIDE_MODES = new Set<StorySlideMode>([
+  "none",
+  "blank",
+  "black",
+  "global",
+  "adjacent",
 ]);
 
 function normalizeStoryChapter(chapter: unknown): StoryChapter | null {

--- a/packages/core/src/storymap-sample.ts
+++ b/packages/core/src/storymap-sample.ts
@@ -23,6 +23,9 @@ export function createSampleStoryMap(): StoryMap {
     markerColor: "#3fb1ce",
     inset: true,
     insetPosition: "bottom-left",
+    hideChapterNav: false,
+    startSlide: "none",
+    endSlide: "none",
     chapters: [
       {
         id: "sample-san-francisco",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -871,6 +871,9 @@ export type StoryInsetPosition =
  */
 export type StorySlideMode = "none" | "blank" | "black" | "global" | "adjacent";
 
+/** A start/closing slide that is actually shown (every mode except `"none"`). */
+export type StoryActiveSlideMode = Exclude<StorySlideMode, "none">;
+
 /** Scroll-driven story map authored on top of a GeoLibre project. */
 export interface StoryMap {
   title: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -859,6 +859,18 @@ export type StoryInsetPosition =
   | "bottom-left"
   | "bottom-right";
 
+/**
+ * A non-chapter intro/outro slide shown before the first or after the last
+ * chapter (#998). `"none"` disables it. The remaining modes are:
+ * - `"blank"` a solid screen in the panel theme color,
+ * - `"black"` a solid black screen,
+ * - `"global"` a zoomed-out global view of the map with no text,
+ * - `"adjacent"` the camera of the neighboring chapter (the first chapter for
+ *   the start slide, the last chapter for the closing slide) with all text and
+ *   media hidden, so the presenter can zoom into the full content next.
+ */
+export type StorySlideMode = "none" | "blank" | "black" | "global" | "adjacent";
+
 /** Scroll-driven story map authored on top of a GeoLibre project. */
 export interface StoryMap {
   title: string;
@@ -870,6 +882,16 @@ export interface StoryMap {
   markerColor: string;
   inset: boolean;
   insetPosition: StoryInsetPosition;
+  /**
+   * Start the presentation with the chapter itinerary/navigation panel hidden,
+   * revealing chapters one at a time instead of listing every upcoming location
+   * up front (#995). The presenter still offers a toggle to open the list.
+   */
+  hideChapterNav: boolean;
+  /** Optional intro slide shown before the first chapter (#998). */
+  startSlide: StorySlideMode;
+  /** Optional closing slide shown after the last chapter (#998). */
+  endSlide: StorySlideMode;
   chapters: StoryChapter[];
 }
 
@@ -883,6 +905,9 @@ export const DEFAULT_STORY_MAP: StoryMap = {
   markerColor: "#3fb1ce",
   inset: false,
   insetPosition: "bottom-left",
+  hideChapterNav: false,
+  startSlide: "none",
+  endSlide: "none",
   chapters: [],
 };
 

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -755,6 +755,44 @@ describe("story maps", () => {
     assert.equal(settingsOnly.storymap?.chapters.length, 0);
   });
 
+  it("normalizes hideChapterNav and start/closing slide settings", () => {
+    const base = {
+      version: "0.1.0",
+      name: "Story",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+    };
+    // Valid values round-trip; an invalid slide mode falls back to "none".
+    const project = parseProject(
+      JSON.stringify({
+        ...base,
+        storymap: {
+          hideChapterNav: true,
+          startSlide: "global",
+          endSlide: "warp",
+          chapters: [chapter()],
+        },
+      }),
+    );
+    assert.ok(project.storymap);
+    assert.equal(project.storymap.hideChapterNav, true);
+    assert.equal(project.storymap.startSlide, "global");
+    assert.equal(project.storymap.endSlide, "none");
+
+    // Defaults when omitted.
+    const defaults = parseProject(
+      JSON.stringify({ ...base, storymap: { chapters: [chapter()] } }),
+    );
+    assert.equal(defaults.storymap?.hideChapterNav, false);
+    assert.equal(defaults.storymap?.startSlide, "none");
+    assert.equal(defaults.storymap?.endSlide, "none");
+
+    // A settings-only story is kept when it only sets a non-default slide.
+    const settingsOnly = parseProject(
+      JSON.stringify({ ...base, storymap: { startSlide: "black", chapters: [] } }),
+    );
+    assert.equal(settingsOnly.storymap?.startSlide, "black");
+  });
+
   it("round-trips a story map through the store and back to a project", () => {
     const store = useAppStore.getState();
     store.addStoryChapter(chapter() as never);

--- a/tests/storymap-pdf.test.ts
+++ b/tests/storymap-pdf.test.ts
@@ -4,7 +4,21 @@ import {
   buildStoryMapHandoutPdf,
   htmlToPlainText,
   type HandoutChapter,
+  type HandoutOptions,
 } from "../apps/geolibre-desktop/src/lib/storymap-pdf";
+
+/** Default handout options with empty running text, overridable per test. */
+function opts(overrides: Partial<HandoutOptions> = {}): HandoutOptions {
+  return {
+    paperSize: "a4",
+    orientation: "landscape",
+    title: "",
+    subtitle: "",
+    byline: "",
+    footer: "",
+    ...overrides,
+  };
+}
 
 // A valid 2x2 RGB PNG, enough for jsPDF to embed without a DOM canvas.
 const PNG_2X2 =
@@ -73,12 +87,10 @@ describe("htmlToPlainText", () => {
 
 describe("buildStoryMapHandoutPdf", () => {
   it("produces a valid PDF byte stream", () => {
-    const bytes = buildStoryMapHandoutPdf([chapter()], {
-      paperSize: "a4",
-      orientation: "landscape",
-      title: "My Story",
-      footer: "Footer",
-    });
+    const bytes = buildStoryMapHandoutPdf(
+      [chapter()],
+      opts({ title: "My Story", footer: "Footer" }),
+    );
     assert.ok(bytes instanceof Uint8Array);
     assert.ok(bytes.length > 0);
     // Every PDF starts with the "%PDF" magic header.
@@ -87,15 +99,13 @@ describe("buildStoryMapHandoutPdf", () => {
   });
 
   it("emits one page per chapter", () => {
-    const one = buildStoryMapHandoutPdf([chapter()], {
-      paperSize: "a4",
-      orientation: "portrait",
-      title: "",
-      footer: "",
-    });
+    const one = buildStoryMapHandoutPdf(
+      [chapter()],
+      opts({ orientation: "portrait" }),
+    );
     const three = buildStoryMapHandoutPdf(
       [chapter(), chapter(), chapter()],
-      { paperSize: "letter", orientation: "landscape", title: "T", footer: "F" },
+      opts({ paperSize: "letter", title: "T", footer: "F" }),
     );
     // The "/Count N" entry in the page tree reports the page count.
     const count = (bytes: Uint8Array): number => {
@@ -109,39 +119,55 @@ describe("buildStoryMapHandoutPdf", () => {
 
   it("throws when given no chapters", () => {
     assert.throws(
-      () =>
-        buildStoryMapHandoutPdf([], {
-          paperSize: "a4",
-          orientation: "portrait",
-          title: "",
-          footer: "",
-        }),
+      () => buildStoryMapHandoutPdf([], opts({ orientation: "portrait" })),
       /no chapters/,
     );
   });
 
   it("renders without a title or footer", () => {
-    const bytes = buildStoryMapHandoutPdf([chapter({ description: "" })], {
-      paperSize: "a4",
-      orientation: "portrait",
-      title: "",
-      footer: "",
-    });
+    const bytes = buildStoryMapHandoutPdf(
+      [chapter({ description: "" })],
+      opts({ orientation: "portrait" }),
+    );
     assert.ok(bytes.length > 0);
   });
 
   it("embeds a chapter photo alongside the map when present", () => {
     const withPhoto = buildStoryMapHandoutPdf(
       [chapter({ photo: { data: PNG_2X2, width: 400, height: 300 } })],
-      { paperSize: "a4", orientation: "landscape", title: "T", footer: "F" },
+      opts({ title: "T", footer: "F" }),
     );
-    const withoutPhoto = buildStoryMapHandoutPdf([chapter()], {
-      paperSize: "a4",
-      orientation: "landscape",
-      title: "T",
-      footer: "F",
-    });
+    const withoutPhoto = buildStoryMapHandoutPdf(
+      [chapter()],
+      opts({ title: "T", footer: "F" }),
+    );
     // The photo page embeds a second image, so its byte stream is larger.
     assert.ok(withPhoto.length > withoutPhoto.length);
+  });
+
+  it("renders a subtitle and byline without throwing", () => {
+    const bytes = buildStoryMapHandoutPdf(
+      [chapter()],
+      opts({
+        title: "Title",
+        subtitle: "A subtitle",
+        byline: "By GeoLibre",
+        footer: "Footer",
+      }),
+    );
+    assert.ok(bytes.length > 0);
+  });
+
+  it("renders a full-bleed slide page", () => {
+    // A full-bleed slide (start/closing screen) has no title or description and
+    // still produces a valid one-page document.
+    const bytes = buildStoryMapHandoutPdf(
+      [{ title: "", map: { data: PNG_2X2, width: 1200, height: 900 }, fullBleed: true }],
+      opts(),
+    );
+    assert.ok(bytes.length > 0);
+    const text = Buffer.from(bytes).toString("latin1");
+    const match = text.match(/\/Count (\d+)/);
+    assert.equal(match ? Number(match[1]) : -1, 1);
   });
 });


### PR DESCRIPTION
## Summary

Implements three Story Map beta-test enhancement requests in one PR. All are GeoLibre-side (no upstream package), spanning the authoring panel, the in-app presenter, the standalone HTML export, and the PDF handout.

### #995 — Discoverable chapters
A new **Hide chapter list** setting (next to *Show markers* / *Inset minimap*) starts the presentation with the itinerary/navigation panel collapsed, so upcoming locations are revealed one at a time instead of all up front. The presenter and the exported HTML both honor it and keep a toggle to open the list on demand.

(The earlier "modal dims the map during camera alignment" parts of #995 are already handled by the existing **Compose on map** flow, which closes the dialog and exposes the live map.)

### #996 — Handout subtitle and byline
The PDF Handout Generator now includes **Subtitle** and **Byline** fields, positioned between *Document title* and *Footer text* and pre-filled from the main Story Map settings. They render on every page (subtitle under the title, byline at the left of the footer).

### #998 — Start view and closing slide
Optional **Enable start view** and **Enable closing slide** controls, each with four modes:
- **Empty screen** / **Black screen** — a solid cover over the map
- **Global view** — a zoomed-out globe with no text
- **Preview of first chapter** (start) / **Hold on last chapter** (end) — the adjacent chapter's camera with all text/media hidden

These are wired through the in-app presenter, the standalone HTML export, and the PDF handout (where each enabled slide is selectable as an exported full-bleed page).

## Implementation
- `StoryMap` gains `hideChapterNav`, `startSlide`, `endSlide` (with normalization, defaults, and `storyMapHasContent` coverage).
- Presenter refactored to a unified scroll-step model (chapters + slides) driving the camera, the blank/black cover, and nav state.
- HTML export template mirrors the same slide/cover/nav-toggle behavior.
- Handout dialog builds a screen list (chapters + slides); PDF builder renders subtitle/byline and full-bleed slide pages.

## Testing
- `npm run test:frontend` (1697 pass), plus new cases in `storymap-pdf` and `core-project`.
- `npm run build` and `pre-commit run --files` (eslint + build) pass.
- Verified in the browser with real data (sample story) in both dark and light themes: nav hidden-by-default + toggle, global and blank start slides (dark `#444` and light `#fafafa` covers), and the handout dialog showing pre-filled Subtitle/Byline plus the Start/Closing slide page entries (Screens 7/7).

Fixes #995
Fixes #996
Fixes #998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable story map start/end slides (blank, black, global, and adjacent) plus a hide chapter navigation option.
  * Presenter now uses unified scroll steps for chapters and slides.
  * Story map handout PDFs now support subtitle and byline, including full-bleed slide rendering.
* **Bug Fixes**
  * Improved HTML and PDF export so blank/black slide pages always produce real, renderable output and export progress matches selected screens.
  * Refined stepping/navigation so highlighting and camera transitions behave deterministically.
* **Tests**
  * Added/updated tests for story map normalization and handout PDF options (slides, subtitle/byline, full-bleed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->