### PR TITLE
fix: numerical angle input for the GeoEditor Rotate tool

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.9.1",
+    "maplibre-gl-geo-editor": "^0.10.0",
     "maplibre-gl-geoagent": "^0.5.4",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.9.1",
+        "maplibre-gl-geo-editor": "^0.10.0",
         "maplibre-gl-geoagent": "^0.5.4",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
@@ -16277,9 +16277,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.9.1.tgz",
-      "integrity": "sha512-YSoBMejy9+j5kRw3HON6P9s//d7WUPz9pC0+7Jo5bgOtJoSS8Kv31EVy8ud5nwCoH5Ie4eyFs9O1pjbtZWrZlQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.0.tgz",
+      "integrity": "sha512-9C+XdG1viXVEnjviFByOeNwsKb6ZAhn2JjWaACW6xPooPqKfD/oXAARgx1Ljyo3v4TPC+Jtf6mVjlbTZ9pBVEg==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -21135,7 +21135,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.9.1",
+        "maplibre-gl-geo-editor": "^0.10.0",
         "maplibre-gl-geoagent": "^0.5.4",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.9.1",
+    "maplibre-gl-geo-editor": "^0.10.0",
     "maplibre-gl-geoagent": "^0.5.4",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -119,7 +119,7 @@ const GEOMAN_EDIT_SYNC_EVENTS = [
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
   name: "GeoEditor",
-  version: "0.8.0",
+  version: "0.9.0",
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
     appApi = app;


### PR DESCRIPTION
## Summary

Fixes #892.

The GeoEditor **Rotate** tool was drag-only (via Geoman), which makes it impossible to align features to an exact bearing or repeat the same rotation across features. This bumps `maplibre-gl-geo-editor` to `^0.10.0`, which adds **precise numerical rotation**:

- While the **Rotate** tool is active, **double-click** (or **right-click**) a feature to open a small popup near the cursor.
- Type an exact **angle in degrees** (e.g. `45`, `90`, `-12.5`).
- Choose a **pivot**: the feature **centroid** (default) or a specific **vertex**.
- **Apply** / **Enter** commits the rotation (recorded in undo/redo history); **Cancel** / **Escape** dismisses it.

The drag-based rotate behavior is unchanged; this is an added precise option.

## Changes

- `maplibre-gl-geo-editor` `^0.9.1` → `^0.10.0` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json`, plus `package-lock.json`.

The implementation lives upstream in opengeos/maplibre-gl-geo-editor#36 (released as v0.10.0).

## Verification

- `npm run build` passes; `pre-commit run --files <changed>` passes (including the npm-build hook).
- The feature was verified end to end in a real browser against the GeoEditor control + Geoman + rotate code path: enabling Rotate then double-click/right-click a polygon opens the popup; typing an angle and Apply/Enter rotates by the exact amount around the centroid (centroid preserved); a vertex pivot keeps that vertex fixed; Escape cancels; Undo restores the geometry.
- The popup reuses the same styling as the existing feature-properties popup (white MapLibre popup content), so it reads consistently in both light and dark themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the embedded map editing library to the latest minor version in both the desktop app and plugin package for improved compatibility.
  * Bumped the map editor plugin’s displayed version accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->