### PR TITLE
feat(plugins): expose maplibre-gl-raster and projection control to plugins

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -72,7 +72,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.6.4",
+    "maplibre-gl-raster": "^0.7.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -801,6 +801,27 @@ export function createAppAPI(
           }),
         ));
     })(),
+    // Hand external plugins GeoLibre's own maplibre-gl-raster module so they
+    // render COGs on the host's single deck.gl/luma.gl instance. A bundled
+    // second copy throws on luma.gl's "already initialized" guard. Memoized so
+    // repeated calls reuse one resolved module.
+    getMaplibreGlRaster: (() => {
+      let cached: Promise<typeof import("maplibre-gl-raster")> | undefined;
+      return () => (cached ??= import("maplibre-gl-raster"));
+    })(),
+    // Set the persisted projection preference so the host's projection
+    // enforcement keeps it (a raw map.setProjection is reverted on idle).
+    // deck.gl-backed plugins need mercator; globe breaks deck tile traversal.
+    setMapProjection: (projection: "globe" | "mercator") => {
+      const store = useAppStore.getState();
+      const { map } = store.preferences;
+      if (map.projection === projection) return;
+      store.setPreferences({
+        ...store.preferences,
+        map: { ...map, projection },
+      });
+    },
+    getMapProjection: () => useAppStore.getState().preferences.map.projection,
     registerRightPanel,
     unregisterRightPanel,
     openRightPanel,

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -813,6 +813,11 @@ export function createAppAPI(
     // enforcement keeps it (a raw map.setProjection is reverted on idle).
     // deck.gl-backed plugins need mercator; globe breaks deck tile traversal.
     setMapProjection: (projection: "globe" | "mercator") => {
+      // External plugins call through a JS boundary where TypeScript can't
+      // enforce the union, so reject anything else. An invalid value would be
+      // persisted and make enforceProjection throw and reschedule on every idle
+      // forever.
+      if (projection !== "globe" && projection !== "mercator") return;
       const store = useAppStore.getState();
       const { map } = store.preferences;
       if (map.projection === projection) return;

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -807,7 +807,13 @@ export function createAppAPI(
     // repeated calls reuse one resolved module.
     getMaplibreGlRaster: (() => {
       let cached: Promise<typeof import("maplibre-gl-raster")> | undefined;
-      return () => (cached ??= import("maplibre-gl-raster"));
+      return () =>
+        (cached ??= import("maplibre-gl-raster").catch((error) => {
+          // Don't memoize a rejection: a transient chunk-load failure would
+          // otherwise poison getMaplibreGlRaster() for the whole session.
+          cached = undefined;
+          throw error;
+        }));
     })(),
     // Set the persisted projection preference so the host's projection
     // enforcement keeps it (a raw map.setProjection is reverted on idle).
@@ -817,7 +823,12 @@ export function createAppAPI(
       // enforce the union, so reject anything else. An invalid value would be
       // persisted and make enforceProjection throw and reschedule on every idle
       // forever.
-      if (projection !== "globe" && projection !== "mercator") return;
+      if (projection !== "globe" && projection !== "mercator") {
+        console.warn(
+          `[GeoLibre] setMapProjection: ignoring unknown projection "${String(projection)}" (expected "globe" or "mercator").`,
+        );
+        return;
+      }
       const store = useAppStore.getState();
       const { map } = store.preferences;
       if (map.projection === projection) return;
@@ -826,7 +837,10 @@ export function createAppAPI(
         map: { ...map, projection },
       });
     },
-    getMapProjection: () => useAppStore.getState().preferences.map.projection,
+    getMapProjection: () =>
+      // Legacy projects may not carry a projection preference; default to globe
+      // like MapController.enforceProjection so the declared return type holds.
+      useAppStore.getState().preferences.map.projection ?? "globe",
     registerRightPanel,
     unregisterRightPanel,
     openRightPanel,

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.6.4",
+        "maplibre-gl-raster": "^0.7.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",
@@ -16469,9 +16469,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.6.4.tgz",
-      "integrity": "sha512-HA4ITvVSoqemkT0TILwMTsSiMBhWpDWOklHYqkGvggUDmrN9E1+d+UPLDLE4x146nLh3v877IABP45qdd4o43g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.7.0.tgz",
+      "integrity": "sha512-t71Ng1BHoJChJULfxBIn1POZpUDnf8p17mNrhAOlCtsTkiC1sTaCWh8xlXomJEM3zak+t8LkLk2EysCg+lfNgw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21142,7 +21142,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.6.4",
+        "maplibre-gl-raster": "^0.7.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -46,7 +46,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.6.4",
+    "maplibre-gl-raster": "^0.7.0",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -358,6 +358,11 @@ export interface GeoLibreAppAPI {
    * projection enforcement keeps it). deck.gl-backed plugins call this with
    * `"mercator"` because deck.gl's tiled rendering does not support globe view;
    * a raw `map.setProjection` is reverted on the next idle by the host.
+   *
+   * There is no automatic rollback: a plugin that forces a projection on
+   * activate should save the user's choice with {@link getMapProjection} first
+   * and restore it on `deactivate`, otherwise the user is left in the forced
+   * projection after the plugin is turned off.
    */
   setMapProjection?: (projection: "globe" | "mercator") => void;
   /** Current map projection preference. */

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -343,6 +343,26 @@ export interface GeoLibreAppAPI {
    */
   getDeckGL?: () => Promise<GeoLibreDeckGL>;
   /**
+   * Resolve GeoLibre's own `maplibre-gl-raster` module so an external plugin can
+   * render Cloud-Optimized GeoTIFFs through the host's instance instead of
+   * bundling its own. maplibre-gl-raster pulls in deck.gl and luma.gl, which
+   * throw on a second copy (luma.gl: "already initialized"); a bundled plugin
+   * copy therefore fails to activate. GeoLibre already ships maplibre-gl-raster
+   * (the built-in raster layer uses it), so it hands plugins the same instance.
+   * Always present on the GeoLibre desktop and web hosts; typed optional for
+   * forward-compatibility, so plugins should call it with optional chaining.
+   */
+  getMaplibreGlRaster?: () => Promise<typeof import("maplibre-gl-raster")>;
+  /**
+   * Set the map projection preference (persisted in app state, so the host's
+   * projection enforcement keeps it). deck.gl-backed plugins call this with
+   * `"mercator"` because deck.gl's tiled rendering does not support globe view;
+   * a raw `map.setProjection` is reverted on the next idle by the host.
+   */
+  setMapProjection?: (projection: "globe" | "mercator") => void;
+  /** Current map projection preference. */
+  getMapProjection?: () => "globe" | "mercator";
+  /**
    * Register a plugin-owned right-sidebar panel that docks beside the built-in
    * Style panel and behaves like a first-class part of the workspace. Returns
    * an unregister function (call it from `deactivate`). The panel is not shown

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -362,7 +362,16 @@ export interface GeoLibreAppAPI {
    * There is no automatic rollback: a plugin that forces a projection on
    * activate should save the user's choice with {@link getMapProjection} first
    * and restore it on `deactivate`, otherwise the user is left in the forced
-   * projection after the plugin is turned off.
+   * projection after the plugin is turned off. Fall back when the getter is
+   * absent on an older host so `deactivate` never passes `undefined` (the
+   * runtime guard ignores it, stranding the user in the forced projection):
+   *
+   * ```ts
+   * const saved = app.getMapProjection?.() ?? "globe";
+   * app.setMapProjection?.("mercator");
+   * // on deactivate:
+   * app.setMapProjection?.(saved);
+   * ```
    */
   setMapProjection?: (projection: "globe" | "mercator") => void;
   /** Current map projection preference. */


### PR DESCRIPTION
## Summary
Two new plugin app-API capabilities so external (deck.gl-backed) plugins render on the host's single deck.gl/luma.gl instance instead of bundling their own:

- `getMaplibreGlRaster()` - hands plugins GeoLibre's `maplibre-gl-raster` module (the same one the built-in raster layer uses). A plugin bundling its own copy ships a second deck.gl/luma.gl, which trips luma.gl's "already initialized" guard so the plugin fails to activate.
- `setMapProjection()` / `getMapProjection()` - set/read the persisted projection preference. deck.gl tile rendering does not support globe view; a raw `map.setProjection` is reverted on the next idle by `enforceProjection`, so plugins need to set the preference (as the USGS LiDAR plugin already does internally).

Also bumps `maplibre-gl-raster` to `^0.7.0` for its headless `LayerManager` export.

## Motivation
Enables external plugins like Vantor Open Data (COG viewer) to render Cloud-Optimized GeoTIFFs in GeoLibre. Without these, such a plugin loads but cannot activate (luma.gl conflict) and cannot render tiles (globe view).

## Test plan
- [x] Loaded an external deck.gl-backed plugin (maplibre-gl-vantor) that calls `getMaplibreGlRaster()` and `setMapProjection('mercator')`.
- [x] Plugin activates with no "multiple versions" / "already initialized" errors.
- [x] Adding a COG flips the map to mercator and renders the raster.
- [x] `eslint` clean on changed files (no new warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for switching and reading the map projection between globe and mercator.
  * Improved plugin compatibility by sharing the app’s raster map integration, helping avoid rendering conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->