### PR TITLE
feat(map): exclude plugin-internal style layers from the layer control

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -260,6 +260,11 @@ export class MapController {
   private logoControl: maplibregl.LogoControl | null = null;
   private layerControl: LayerControl | null = null;
   private layerControlSignature = "";
+  // Debounce timer for refreshing the layer control on style changes, so a
+  // plugin adding/removing native style layers (e.g. ones flagged
+  // `metadata["geolibre:internal"]`) updates the control's exclusion list.
+  private layerControlStyleRefreshTimer: ReturnType<typeof setTimeout> | null =
+    null;
   // True while pushing store paint back into the layer control's open style
   // editor, so onLayerStyleChange callbacks during that refresh are ignored
   // (reentrancy guard against a sync loop). See syncLayerControlState.
@@ -347,6 +352,17 @@ export class MapController {
     this.map.on("style.load", handleStyleReady);
     this.map.once("load", handleStyleReady);
     this.map.once("idle", () => this.enforceProjection());
+    // Plugins can add native style layers directly (outside the layer store);
+    // refresh the layer control on style changes so internal-flagged layers are
+    // excluded reactively. Debounced because styledata fires frequently, and
+    // refreshLayerControl no-ops when the computed signature is unchanged.
+    this.map.on("styledata", () => {
+      if (this.layerControlStyleRefreshTimer !== null) return;
+      this.layerControlStyleRefreshTimer = setTimeout(() => {
+        this.layerControlStyleRefreshTimer = null;
+        this.refreshLayerControl(this.syncedLayers);
+      }, 200);
+    });
     // Add the fullscreen toggle first so it anchors the top of the top-right
     // control cluster, matching the universal placement users expect (issue
     // #512). MapLibre stacks controls in insertion order within a corner.
@@ -1474,9 +1490,21 @@ export class MapController {
     const nativeStyleLayerIds = layers.flatMap((layer) =>
       this.getCandidateStyleLayers(layer).map(({ id }) => id),
     );
+    // Hide style layers a plugin marks as internal chrome (e.g. selection
+    // footprints, draw/highlight helpers) so they don't clutter the control.
+    const internalStyleLayerIds = (this.map?.getStyle()?.layers ?? [])
+      .filter((styleLayer) =>
+        Boolean(
+          (styleLayer.metadata as Record<string, unknown> | undefined)?.[
+            "geolibre:internal"
+          ],
+        ),
+      )
+      .map((styleLayer) => styleLayer.id);
     const excludeLayers = [
       ...LAYER_CONTROL_EXCLUDED_LAYERS,
       ...nativeStyleLayerIds,
+      ...internalStyleLayerIds,
     ];
     const controllableLayers = layers.filter(
       (layer) =>

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -354,10 +354,15 @@ export class MapController {
     this.map.once("idle", () => this.enforceProjection());
     // Plugins can add native style layers directly (outside the layer store);
     // refresh the layer control on style changes so internal-flagged layers are
-    // excluded reactively. Debounced because styledata fires frequently, and
-    // refreshLayerControl no-ops when the computed signature is unchanged.
+    // excluded reactively. Debounced (trailing edge) because styledata fires
+    // frequently, and refreshLayerControl no-ops when the computed signature is
+    // unchanged. Resetting the timer on each event waits until the burst of
+    // style updates quiets so the control never rebuilds against a half-built
+    // style.
     this.map.on("styledata", () => {
-      if (this.layerControlStyleRefreshTimer !== null) return;
+      if (this.layerControlStyleRefreshTimer !== null) {
+        clearTimeout(this.layerControlStyleRefreshTimer);
+      }
       this.layerControlStyleRefreshTimer = setTimeout(() => {
         this.layerControlStyleRefreshTimer = null;
         this.refreshLayerControl(this.syncedLayers);
@@ -680,6 +685,10 @@ export class MapController {
     this.removeAttributionControl();
     this.removeLogoControl();
     this.removeLayerControl();
+    if (this.layerControlStyleRefreshTimer !== null) {
+      clearTimeout(this.layerControlStyleRefreshTimer);
+      this.layerControlStyleRefreshTimer = null;
+    }
     this.map?.remove();
     this.map = null;
     this.styleReady = false;
@@ -1500,12 +1509,18 @@ export class MapController {
           ],
         ),
       )
-      .map((styleLayer) => styleLayer.id);
-    const excludeLayers = [
-      ...LAYER_CONTROL_EXCLUDED_LAYERS,
-      ...nativeStyleLayerIds,
-      ...internalStyleLayerIds,
-    ];
+      .map((styleLayer) => styleLayer.id)
+      // Sort so a plugin reordering an already-hidden internal layer (which
+      // shuffles live style order) doesn't change the exclusion signature and
+      // force an unnecessary control rebuild.
+      .sort();
+    const excludeLayers = Array.from(
+      new Set([
+        ...LAYER_CONTROL_EXCLUDED_LAYERS,
+        ...nativeStyleLayerIds,
+        ...internalStyleLayerIds,
+      ]),
+    );
     const controllableLayers = layers.filter(
       (layer) =>
         this.getNativeLayerIds(layer).length > 0 ||


### PR DESCRIPTION
## Summary
Lets plugins keep internal chrome out of the on-map Layer Control. The control now excludes style layers whose `metadata["geolibre:internal"]` is set, and refreshes on `styledata` (debounced) so the exclusion applies reactively when a plugin adds/removes such layers.

## Motivation
External map-control plugins add native style layers for selection/overlay chrome (e.g. the Vantor Open Data plugin's footprint, draw-bbox, and highlight layers). These previously appeared as separate entries in the Layer Control, cluttering it. Plugins can now tag those layers internal and they are hidden from the control while still rendering on the map. (Their actual data layers — e.g. COGs added via `addCogLayer` — still appear as normal store layers.)

## Test plan
- [x] With the Vantor Open Data plugin active: searching renders footprints on the map but they no longer appear in the Layer Control; the visualized COG still appears as a managed layer.
- [x] `eslint` clean on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layer control updates so changes to the map style refresh more smoothly without repeated flicker or excessive updates.
  * Hidden internal map styling layers from the layer control, reducing clutter and preventing unintended visibility of system-managed layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->