### PR TITLE
fix: load GeoPackages via Add Vector Layer without hanging

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -78,7 +78,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.8.4",
+    "maplibre-gl-vector": "^0.8.5",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.8.4",
+        "maplibre-gl-vector": "^0.8.5",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -16653,9 +16653,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.4.tgz",
-      "integrity": "sha512-E1VtxIlpq5270USTNLETIxPeSFocfj+27RA84GYCOd2Am9ySmWQv0DkSaIPBGxpBQ9MELvpNx144vUk8Atc+CQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.5.tgz",
+      "integrity": "sha512-bf0Ic4inn5Q3xi8OWaCZ0E5hulUDDPrjV757uPJq2Ye9IYT8BqQ0mwFadFZqrxE/ld+dInP7WLwdiierYYLo8A==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21148,7 +21148,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.8.4",
+        "maplibre-gl-vector": "^0.8.5",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.8.4",
+    "maplibre-gl-vector": "^0.8.5",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"


### PR DESCRIPTION
## Problem

Loading a GeoPackage through **Add Data → Add Vector Layer → Click to browse → Load** gets stuck on **"Converting … to GeoJSON"** forever (#1013). Drag-and-dropping the same `.gpkg` works fine.

The two paths convert differently:
- **Drag-and-drop** uses GeoLibre's own sql.js GeoPackage reader (`gpkg-reader.ts`), which bypasses GDAL.
- The **Add Vector Layer panel** is the upstream `maplibre-gl-vector` control, which converted the file itself via DuckDB-WASM `ST_Read`. GDAL's GeoPackage driver, on the single-threaded DuckDB-WASM build a browser loads, hangs indefinitely probing for `-journal`/`-wal` sidecar files (or crashes with `thread constructor failed`). Repairing `gpkg_ogr_contents` does not fix it.

## Fix

Bump `maplibre-gl-vector` to **0.8.5**, which now reads GeoPackages with **sql.js** (decoding the WKB geometry blobs directly) and reprojects through DuckDB's GeoJSON reader, bypassing GDAL entirely. `listLayers` for multi-layer GeoPackages was moved off `ST_Read_Meta` too. See opengeos/maplibre-gl-vector#36 / v0.8.5.

This PR is just the version bump in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json` (plus the lockfile).

## Verification

Verified in the web dev build by loading a 39-feature `POLYGON` GeoPackage in `EPSG:32643` (`landcover_change_smoothed.gpkg`) via Add Vector Layer in **both light and dark themes**: it now loads as 39 features, reprojects to the correct location near Bengaluru, and renders, with zero GDAL `-journal`/`-wal` probing in the console. `pre-commit run --files` (incl. the full npm build) passes.

Fixes #1013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s map rendering dependency to a newer patch version, which may improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->