### PR TITLE
feat(raster): populate Legend from a paletted raster's color table

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -407,14 +407,14 @@ export function RasterSymbologySection({
       setLegendStatus("error");
       return;
     }
-    // Supersede any prior read, then guard every resolution against a layer
-    // switch (or this read being aborted) so a stale result can't overwrite the
-    // new layer's status.
+    // Supersede any prior read. The layer-switch guard is the abort itself: the
+    // [layer.id] effect's cleanup aborts this controller, so a resolution after
+    // a switch is skipped via signal.aborted (this closure's `layer` binding
+    // can't change, so comparing ids here would be dead code).
     legendAbortRef.current?.abort();
     const controller = new AbortController();
     legendAbortRef.current = controller;
-    const requestedLayerId = layer.id;
-    const stale = () => controller.signal.aborted || requestedLayerId !== layer.id;
+    const stale = () => controller.signal.aborted;
     setLegendStatus("pending");
     try {
       const entries = await getPaletteLegend(
@@ -439,6 +439,8 @@ export function RasterSymbologySection({
           // Dock the on-map legend opposite the editor panel (top-left) so the
           // two don't overlap.
           legendPosition: "bottom-right",
+          // Skip the mutation entirely if this call was superseded mid-flight.
+          signal: controller.signal,
         },
       );
       if (stale()) return;

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -12,9 +12,10 @@ import {
   type RasterSymbology,
   colormapColors,
   computeRasterBreaks,
-  extractPaletteLegend,
+  getPaletteLegend,
   getRasterBandStats,
   openLegendPanelWithItems,
+  type PaletteLegendEntry,
   savedRasterSymbology,
   warmColormapColors,
 } from "@geolibre/plugins";
@@ -182,6 +183,12 @@ export function RasterSymbologySection({
   // user has since switched away from.
   const legendAbortRef = useRef<AbortController | null>(null);
 
+  // The embedded palette's class colors, loaded (and cached) for palette
+  // rasters so the color-ramp preview shows the real colors instead of the gray
+  // fallback the "palette" sentinel resolves to.
+  const [paletteEntries, setPaletteEntries] =
+    useState<PaletteLegendEntry[] | null>(null);
+
   // Clear the action state when the selected layer changes (like `stats`
   // above), and cancel any in-flight palette read so a late resolution never
   // attributes its outcome to the newly-selected layer.
@@ -204,6 +211,34 @@ export function RasterSymbologySection({
     typeof layer.metadata?.localBytesUrl === "string"
       ? layer.metadata.localBytesUrl
       : null;
+  // Source URL used by both the palette read and the legend action: the
+  // control's URL for a remote COG, or the session blob for a file-backed one.
+  const rasterUrl =
+    (typeof layer.source?.url === "string" ? layer.source.url : null) ??
+    localBytesUrl;
+  // A single-band raster rendered through its embedded color table.
+  const isPaletteRaster =
+    state.mode === "single" && state.colormap === "palette";
+
+  // Load the embedded palette colors for a palette raster (cached per layer),
+  // so the ramp preview reflects the actual classes. Cleared first on a layer
+  // switch so a stale preview isn't shown.
+  useEffect(() => {
+    setPaletteEntries(null);
+    if (!isPaletteRaster || !rasterUrl) return;
+    let cancelled = false;
+    void getPaletteLegend(layer.id, rasterUrl)
+      .then((entries) => {
+        if (!cancelled) setPaletteEntries(entries);
+      })
+      .catch(() => {
+        // A failed palette read just leaves the preview on its gray fallback.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [layer.id, isPaletteRaster, rasterUrl]);
+
   useEffect(() => {
     setStats(null);
     let cancelled = false;
@@ -368,10 +403,7 @@ export function RasterSymbologySection({
   // for the user to rename). Resolves the source the same way stats do: the
   // control's URL, or the session blob for a file-backed raster.
   async function createLegendFromPalette(): Promise<void> {
-    const sourceUrl =
-      typeof layer.source?.url === "string" ? layer.source.url : null;
-    const url = sourceUrl ?? localBytesUrl;
-    if (!url) {
+    if (!rasterUrl) {
       setLegendStatus("error");
       return;
     }
@@ -385,7 +417,11 @@ export function RasterSymbologySection({
     const stale = () => controller.signal.aborted || requestedLayerId !== layer.id;
     setLegendStatus("pending");
     try {
-      const entries = await extractPaletteLegend(url, controller.signal);
+      const entries = await getPaletteLegend(
+        layer.id,
+        rasterUrl,
+        controller.signal,
+      );
       if (stale()) return;
       if (!entries || entries.length === 0) {
         setLegendStatus("empty");
@@ -400,6 +436,9 @@ export function RasterSymbologySection({
             color: entry.color,
             shape: "square" as const,
           })),
+          // Dock the on-map legend opposite the editor panel (top-left) so the
+          // two don't overlap.
+          legendPosition: "bottom-right",
         },
       );
       if (stale()) return;
@@ -412,8 +451,7 @@ export function RasterSymbologySection({
 
   // The image palette only feeds a legend in single-band palette mode; other
   // colormaps are continuous and have no per-value classes to enumerate.
-  const canCreateLegend =
-    state.mode === "single" && state.colormap === "palette";
+  const canCreateLegend = isPaletteRaster;
 
   const paletteLegendControl = canCreateLegend ? (
     <div className="space-y-1">
@@ -572,13 +610,22 @@ export function RasterSymbologySection({
   // control's "palette" default); surface it so the picker reflects what is
   // actually rendered instead of silently showing the first.
   if (!isCustom && !COLORMAP_OPTIONS.some((o) => o.name === ramp)) {
+    // The "palette" sentinel isn't a real ramp: label it clearly and preview it
+    // with the embedded palette's own class colors (once loaded) rather than the
+    // misleading gray fallback the name would otherwise resolve to.
+    const isImagePalette = ramp === "palette";
+    const paletteColors =
+      paletteEntries?.map((entry) => entry.color) ?? [];
     rampOptions.push({
       value: ramp,
-      label: ramp,
+      label: isImagePalette ? t("rasterSymbology.imagePalette") : ramp,
       // rampColors only warms names in SORTED_COLORMAPS, so for an
       // out-of-catalog ramp rampColors[ramp] is always undefined; rampPreview
       // (seeded by the previewRamp effect above) is the real source here.
-      colors: rampColors[ramp] ?? rampPreview,
+      colors:
+        isImagePalette && paletteColors.length > 0
+          ? paletteColors
+          : (rampColors[ramp] ?? rampPreview),
     });
   }
   for (const colormap of SORTED_COLORMAPS) {

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -12,11 +12,15 @@ import {
   type RasterSymbology,
   colormapColors,
   computeRasterBreaks,
+  extractPaletteLegend,
   getRasterBandStats,
+  openLegendPanelWithItems,
   savedRasterSymbology,
   warmColormapColors,
 } from "@geolibre/plugins";
+import type { MapController } from "@geolibre/map";
 import {
+  Button,
   type ColorRampOption,
   ColorRampSelect,
   Input,
@@ -26,8 +30,9 @@ import {
   Textarea,
 } from "@geolibre/ui";
 import { COLORMAP_OPTIONS } from "maplibre-gl-raster";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { createAppAPI } from "../../hooks/usePlugins";
 
 type RasterStateRecord = {
   mode: "single" | "rgb";
@@ -147,8 +152,16 @@ function rangeFromBreaks(breaks: number[]): [number, number][] {
  * render injection).
  *
  * @param props.layer - The selected raster store layer.
+ * @param props.mapControllerRef - Live map controller, used to open and
+ *   populate the Legend control from the raster's embedded palette.
  */
-export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
+export function RasterSymbologySection({
+  layer,
+  mapControllerRef,
+}: {
+  layer: GeoLibreLayer;
+  mapControllerRef: RefObject<MapController | null>;
+}) {
   const { t } = useTranslation();
   const updateLayer = useAppStore((s) => s.updateLayer);
   const state = readRasterState(layer);
@@ -159,6 +172,12 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
 
   const [stats, setStats] = useState<RasterBandStats | null>(null);
   const lastStatsRef = useRef<RasterBandStats | null>(null);
+
+  // Status of the "Create legend from palette" action: idle, in-flight, or a
+  // message key (empty palette / read error) shown beneath the button.
+  const [legendStatus, setLegendStatus] = useState<
+    "idle" | "pending" | "empty" | "error"
+  >("idle");
 
   // Fetch band statistics lazily once the user is classifying (equal-interval
   // and quantile both need a data range / histogram). Aborts implicitly via
@@ -329,6 +348,79 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
       },
     });
   }
+
+  // Reads the raster's embedded color table and opens the Legend control with
+  // one item per pixel value present in the data (labelled with the bare value
+  // for the user to rename). Resolves the source the same way stats do: the
+  // control's URL, or the session blob for a file-backed raster.
+  async function createLegendFromPalette(): Promise<void> {
+    const sourceUrl =
+      typeof layer.source?.url === "string" ? layer.source.url : null;
+    const url = sourceUrl ?? localBytesUrl;
+    if (!url) {
+      setLegendStatus("error");
+      return;
+    }
+    setLegendStatus("pending");
+    try {
+      const entries = await extractPaletteLegend(url);
+      if (!entries || entries.length === 0) {
+        setLegendStatus("empty");
+        return;
+      }
+      const opened = await openLegendPanelWithItems(
+        createAppAPI(mapControllerRef),
+        {
+          title: layer.name,
+          items: entries.map((entry) => ({
+            label: String(entry.value),
+            color: entry.color,
+            shape: "square" as const,
+          })),
+        },
+      );
+      setLegendStatus(opened ? "idle" : "error");
+    } catch {
+      setLegendStatus("error");
+    }
+  }
+
+  // The image palette only feeds a legend in single-band palette mode; other
+  // colormaps are continuous and have no per-value classes to enumerate.
+  const canCreateLegend =
+    state.mode === "single" && state.colormap === "palette";
+
+  const paletteLegendControl = canCreateLegend ? (
+    <div className="space-y-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        disabled={legendStatus === "pending"}
+        onClick={() => void createLegendFromPalette()}
+      >
+        {legendStatus === "pending"
+          ? t("rasterSymbology.createLegendPending")
+          : t("rasterSymbology.createLegend")}
+      </Button>
+      {legendStatus === "empty" && (
+        <p className="text-[10px] text-muted-foreground">
+          {t("rasterSymbology.createLegendEmpty")}
+        </p>
+      )}
+      {legendStatus === "error" && (
+        <p className="text-[10px] text-destructive">
+          {t("rasterSymbology.createLegendError")}
+        </p>
+      )}
+      {legendStatus !== "empty" && legendStatus !== "error" && (
+        <p className="text-[10px] text-muted-foreground">
+          {t("rasterSymbology.createLegendHint")}
+        </p>
+      )}
+    </div>
+  ) : null;
 
   // --- Mode ---
   const modeControl = (
@@ -548,6 +640,8 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
         />
         {t("rasterSymbology.reverseRamp")}
       </label>
+
+      {paletteLegendControl}
 
       <label className="flex items-center gap-2 text-xs">
         <input

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -178,6 +178,20 @@ export function RasterSymbologySection({
   const [legendStatus, setLegendStatus] = useState<
     "idle" | "pending" | "empty" | "error"
   >("idle");
+  // Aborts an in-flight palette read so its result can't land on a layer the
+  // user has since switched away from.
+  const legendAbortRef = useRef<AbortController | null>(null);
+
+  // Clear the action state when the selected layer changes (like `stats`
+  // above), and cancel any in-flight palette read so a late resolution never
+  // attributes its outcome to the newly-selected layer.
+  useEffect(() => {
+    setLegendStatus("idle");
+    return () => {
+      legendAbortRef.current?.abort();
+      legendAbortRef.current = null;
+    };
+  }, [layer.id]);
 
   // Fetch band statistics lazily once the user is classifying (equal-interval
   // and quantile both need a data range / histogram). Aborts implicitly via
@@ -361,9 +375,18 @@ export function RasterSymbologySection({
       setLegendStatus("error");
       return;
     }
+    // Supersede any prior read, then guard every resolution against a layer
+    // switch (or this read being aborted) so a stale result can't overwrite the
+    // new layer's status.
+    legendAbortRef.current?.abort();
+    const controller = new AbortController();
+    legendAbortRef.current = controller;
+    const requestedLayerId = layer.id;
+    const stale = () => controller.signal.aborted || requestedLayerId !== layer.id;
     setLegendStatus("pending");
     try {
-      const entries = await extractPaletteLegend(url);
+      const entries = await extractPaletteLegend(url, controller.signal);
+      if (stale()) return;
       if (!entries || entries.length === 0) {
         setLegendStatus("empty");
         return;
@@ -379,8 +402,10 @@ export function RasterSymbologySection({
           })),
         },
       );
+      if (stale()) return;
       setLegendStatus(opened ? "idle" : "error");
     } catch {
+      if (stale()) return;
       setLegendStatus("error");
     }
   }

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3096,7 +3096,10 @@ export function StylePanel({
               </>
             )}
             {layer.metadata.sourceKind === RASTER_SOURCE_KIND && (
-              <RasterSymbologySection layer={layer} />
+              <RasterSymbologySection
+                layer={layer}
+                mapControllerRef={mapControllerRef}
+              />
             )}
             <Separator />
             <Button

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2364,6 +2364,7 @@
     "customColors": "Custom colors",
     "customColorsValid": "{{count}} colors, low to high. Use Reverse to flip.",
     "customColorsHint": "Enter at least two hex codes, separated by commas or spaces.",
+    "imagePalette": "Image palette",
     "createLegend": "Create legend from palette",
     "createLegendHint": "Adds a legend with one item per pixel value, using the raster's palette colors. Rename items to class names afterward.",
     "createLegendPending": "Reading palette…",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2363,7 +2363,12 @@
     "customRamp": "Custom…",
     "customColors": "Custom colors",
     "customColorsValid": "{{count}} colors, low to high. Use Reverse to flip.",
-    "customColorsHint": "Enter at least two hex codes, separated by commas or spaces."
+    "customColorsHint": "Enter at least two hex codes, separated by commas or spaces.",
+    "createLegend": "Create legend from palette",
+    "createLegendHint": "Adds a legend with one item per pixel value, using the raster's palette colors. Rename items to class names afterward.",
+    "createLegendPending": "Reading palette…",
+    "createLegendEmpty": "No palette colors found for this raster.",
+    "createLegendError": "Could not read the raster palette."
   },
   "raster": {
     "cogConvertConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Convert it to a Cloud-Optimized GeoTIFF now and load that?",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -177,6 +177,8 @@ export {
   getRasterBandStats,
 } from "./plugins/raster-symbology-texture";
 export {
+  disposeAllPaletteLegends,
+  disposePaletteLegend,
   extractPaletteLegend,
   getPaletteLegend,
   type PaletteLegendEntry,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -178,6 +178,7 @@ export {
 } from "./plugins/raster-symbology-texture";
 export {
   extractPaletteLegend,
+  getPaletteLegend,
   type PaletteLegendEntry,
 } from "./plugins/raster-palette";
 export { colormapColors, warmColormapColors } from "./plugins/colormap-colors";

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -85,6 +85,7 @@ export {
   openColorbarPanel,
   openHtmlPanel,
   openLegendPanel,
+  openLegendPanelWithItems,
   openLidarLayerPanel,
   restoreLidarLayers,
   openMeasurePanel,
@@ -175,6 +176,10 @@ export {
   RASTER_SOURCE_KIND,
   getRasterBandStats,
 } from "./plugins/raster-symbology-texture";
+export {
+  extractPaletteLegend,
+  type PaletteLegendEntry,
+} from "./plugins/raster-palette";
 export { colormapColors, warmColormapColors } from "./plugins/colormap-colors";
 export {
   closeVectorLayerPanel,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1818,6 +1818,68 @@ export function openLegendPanel(app: GeoLibreAppAPI): void {
   void openStandaloneLegendControl(app);
 }
 
+/**
+ * Opens the Legend control (creating and mounting it if needed) and fills the
+ * currently-selected legend entry with the given title and items, replacing
+ * whatever it held (the default placeholder entry on first open). Used to
+ * populate a legend from a paletted raster's color table.
+ *
+ * @param app - The live app API used to mount the control.
+ * @param options.title - Legend title (typically the raster layer name).
+ * @param options.items - Legend items (color swatch + label) to show.
+ * @returns Whether the control was opened and populated.
+ */
+export async function openLegendPanelWithItems(
+  app: GeoLibreAppAPI,
+  options: { title: string; items: ComponentLegendItem[] },
+): Promise<boolean> {
+  const opened = await openStandaloneLegendControl(app);
+  if (!opened) return false;
+  // openStandaloneLegendControl shows/expands on a 0ms timer; defer past it so
+  // the state we set is not clobbered by that deferred show, and so getState()
+  // reflects the freshly-created control.
+  return await new Promise<boolean>((resolve) => {
+    setTimeout(() => {
+      if (!legendControl) {
+        resolve(false);
+        return;
+      }
+      const control = legendControl as RestorableLegendGuiControl;
+      const current = legendControl.getState() as unknown as ComponentLegendGuiState;
+      const index =
+        Number.isInteger(current.selectedLegendIndex) &&
+        current.selectedLegendIndex >= 0
+          ? current.selectedLegendIndex
+          : 0;
+      const entry: ComponentLegendGuiEntryState = {
+        title: options.title,
+        items: options.items,
+        legendPosition: current.legendPosition ?? "bottom-left",
+      };
+      // Mirror the replacement onto both the top-level fields and the selected
+      // slot of the `legends` array so the control's single- and multi-legend
+      // views stay consistent (matches how project restore round-trips state).
+      const legends =
+        Array.isArray(current.legends) && current.legends.length > 0
+          ? current.legends.map((existing, i) => (i === index ? entry : existing))
+          : [entry];
+      restoreGuiControlState(control, {
+        ...current,
+        title: entry.title,
+        items: entry.items,
+        legendPosition: entry.legendPosition,
+        hasLegend: true,
+        selectedLegendIndex: index,
+        legends,
+      });
+      control.expand();
+      control.show();
+      setLegendPanelVisible(true);
+      resolve(true);
+    }, 0);
+  });
+}
+
 export function closeLegendPanel(app: GeoLibreAppAPI): void {
   teardownLegendControl(app);
 }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1844,38 +1844,50 @@ export async function openLegendPanelWithItems(
         resolve(false);
         return;
       }
-      const control = legendControl as RestorableLegendGuiControl;
-      const current = legendControl.getState() as unknown as ComponentLegendGuiState;
-      const index =
-        Number.isInteger(current.selectedLegendIndex) &&
-        current.selectedLegendIndex >= 0
-          ? current.selectedLegendIndex
-          : 0;
-      const entry: ComponentLegendGuiEntryState = {
-        title: options.title,
-        items: options.items,
-        legendPosition: current.legendPosition ?? "bottom-left",
-      };
-      // Mirror the replacement onto both the top-level fields and the selected
-      // slot of the `legends` array so the control's single- and multi-legend
-      // views stay consistent (matches how project restore round-trips state).
-      const legends =
-        Array.isArray(current.legends) && current.legends.length > 0
-          ? current.legends.map((existing, i) => (i === index ? entry : existing))
-          : [entry];
-      restoreGuiControlState(control, {
-        ...current,
-        title: entry.title,
-        items: entry.items,
-        legendPosition: entry.legendPosition,
-        hasLegend: true,
-        selectedLegendIndex: index,
-        legends,
-      });
-      control.expand();
-      control.show();
-      setLegendPanelVisible(true);
-      resolve(true);
+      // Guard the whole mutation: if the vendor control throws in getState /
+      // setState / expand / show, resolve(false) instead of leaving the promise
+      // (and the caller's "pending" UI) hanging forever.
+      try {
+        const control = legendControl as RestorableLegendGuiControl;
+        const current =
+          legendControl.getState() as unknown as ComponentLegendGuiState;
+        const entry: ComponentLegendGuiEntryState = {
+          title: options.title,
+          items: options.items,
+          legendPosition: current.legendPosition ?? "bottom-left",
+        };
+        // Mirror the replacement onto both the top-level fields and the selected
+        // slot of the `legends` array so the control's single- and multi-legend
+        // views stay consistent (matches how project restore round-trips state).
+        // `selectedIndex` clamps a stale index into range so the written-back
+        // `selectedLegendIndex` can never point past the array it indexes.
+        const baseLegends =
+          Array.isArray(current.legends) && current.legends.length > 0
+            ? current.legends
+            : [entry];
+        const index = Math.max(
+          0,
+          selectedIndex(current.selectedLegendIndex, baseLegends.length),
+        );
+        const legends = baseLegends.map((existing, i) =>
+          i === index ? entry : existing,
+        );
+        restoreGuiControlState(control, {
+          ...current,
+          title: entry.title,
+          items: entry.items,
+          legendPosition: entry.legendPosition,
+          hasLegend: true,
+          selectedLegendIndex: index,
+          legends,
+        });
+        control.expand();
+        control.show();
+        setLegendPanelVisible(true);
+        resolve(true);
+      } catch {
+        resolve(false);
+      }
     }, 0);
   });
 }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -971,10 +971,18 @@ function constrainGuiPanelToViewport(panelSelector: string): void {
     const panel = document.querySelector<HTMLElement>(panelSelector);
     if (!panel) return;
     const rect = panel.getBoundingClientRect();
-    const mapBottom =
-      panel.closest<HTMLElement>(".maplibregl-map")?.getBoundingClientRect()
-        .bottom ?? window.innerHeight;
-    const key = `${Math.round(rect.top)}:${Math.round(mapBottom)}`;
+    const mapRect = panel
+      .closest<HTMLElement>(".maplibregl-map")
+      ?.getBoundingClientRect();
+    // apply() constrains width as well as height, so the settle key tracks both
+    // axes: the panel's top-left corner and the map's bottom-right edge. A shift
+    // on either axis re-caps.
+    const key = [
+      Math.round(rect.top),
+      Math.round(rect.left),
+      Math.round(mapRect?.bottom ?? window.innerHeight),
+      Math.round(mapRect?.right ?? window.innerWidth),
+    ].join(":");
     if (key !== previousKey) {
       previousKey = key;
       apply();
@@ -1875,6 +1883,9 @@ export function openLegendPanel(app: GeoLibreAppAPI): void {
  *   Defaults to the control's current position (or bottom-left). The editor
  *   panel itself always docks top-left, so pass a right/other corner to keep
  *   the on-map legend from overlapping it.
+ * @param options.signal - Abort signal checked just before the mutation. If the
+ *   caller supersedes this call (e.g. the user switches layers) the shared
+ *   Legend control is left untouched, not populated with stale data.
  * @returns Whether the control was opened and populated.
  */
 export async function openLegendPanelWithItems(
@@ -1883,6 +1894,7 @@ export async function openLegendPanelWithItems(
     title: string;
     items: ComponentLegendItem[];
     legendPosition?: GeoLibreMapControlPosition;
+    signal?: AbortSignal;
   },
 ): Promise<boolean> {
   const opened = await openStandaloneLegendControl(app);
@@ -1893,6 +1905,14 @@ export async function openLegendPanelWithItems(
   return await new Promise<boolean>((resolve) => {
     setTimeout(() => {
       if (!legendControl) {
+        resolve(false);
+        return;
+      }
+      // A superseded call (the caller aborted after switching away) must not
+      // populate the shared control with the previous layer's data. Checked
+      // here, inside the deferred timer, because that is the first point after
+      // the caller could have aborted.
+      if (options.signal?.aborted) {
         resolve(false);
         return;
       }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -180,6 +180,10 @@ const SPLATTING_SAMPLE_URL =
   "https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 const GUI_PANEL_VIEWPORT_MARGIN = 16;
+// Poll interval / cap for re-measuring a just-expanded GUI panel while its
+// layout settles (see constrainGuiPanelToViewport).
+const GUI_PANEL_SETTLE_INTERVAL_MS = 100;
+const GUI_PANEL_SETTLE_MAX_TICKS = 20;
 
 const COMPONENT_CONTROL_NAMES = [
   "spinGlobe",
@@ -915,9 +919,7 @@ const DEFAULT_HTML_GUI_ENTRY: ComponentHtmlGuiEntryState = {
 };
 
 function constrainGuiPanelToViewport(panelSelector: string): void {
-  // Defer measurement until after the expanded panel has been laid out so
-  // getBoundingClientRect() reflects the fully expanded dimensions.
-  requestAnimationFrame(() => {
+  const apply = () => {
     const panel = document.querySelector<HTMLElement>(panelSelector);
     if (!panel) return;
 
@@ -927,20 +929,62 @@ function constrainGuiPanelToViewport(panelSelector: string): void {
     panel.style.maxWidth = "";
 
     const rect = panel.getBoundingClientRect();
+    // Constrain to the map container, not the window: the status bar is a
+    // sibling below the map, so the map's bottom edge already excludes it.
+    // Measuring against window.innerHeight would let a tall panel (e.g. a
+    // many-class legend) run under the status bar. Fall back to the window if
+    // the panel isn't inside a map for some reason.
+    const mapEl = panel.closest<HTMLElement>(".maplibregl-map");
+    const mapRect = mapEl?.getBoundingClientRect();
+    const viewportBottom = mapRect ? mapRect.bottom : window.innerHeight;
+    const viewportRight = mapRect ? mapRect.right : window.innerWidth;
+
     const availableHeight = Math.floor(
-      window.innerHeight - rect.top - GUI_PANEL_VIEWPORT_MARGIN
+      viewportBottom - rect.top - GUI_PANEL_VIEWPORT_MARGIN
     );
-    if (availableHeight > 160 && rect.bottom > window.innerHeight) {
+    if (availableHeight > 160 && rect.bottom > viewportBottom) {
       panel.style.maxHeight = `${availableHeight}px`;
     }
 
     const availableWidth = Math.floor(
-      window.innerWidth - rect.left - GUI_PANEL_VIEWPORT_MARGIN
+      viewportRight - rect.left - GUI_PANEL_VIEWPORT_MARGIN
     );
-    if (availableWidth > 220 && rect.right > window.innerWidth) {
+    if (availableWidth > 220 && rect.right > viewportRight) {
       panel.style.maxWidth = `${availableWidth}px`;
     }
-  });
+  };
+
+  // Opening + populating + expanding a control in the same tick (as the "Create
+  // legend from palette" flow does) leaves both the map container's bottom and
+  // the panel's own top offset shifting for a few hundred ms -- the map sits at
+  // the full window height and the panel starts higher until the status bar row
+  // and control stack claim their space, sometimes plateauing at an
+  // intermediate value before the final one. Measuring only on the first frame
+  // would cap the panel too tall and let it slip under the status bar. Poll the
+  // input geometry (panel top + map bottom) over a bounded window and re-cap
+  // each time it actually changes, so the last change -- the real settle --
+  // lands the cap on the final layout. Applying only on change keeps it from
+  // flickering the scroll position while idle.
+  let previousKey = "";
+  let ticks = 0;
+  const settle = () => {
+    const panel = document.querySelector<HTMLElement>(panelSelector);
+    if (!panel) return;
+    const rect = panel.getBoundingClientRect();
+    const mapBottom =
+      panel.closest<HTMLElement>(".maplibregl-map")?.getBoundingClientRect()
+        .bottom ?? window.innerHeight;
+    const key = `${Math.round(rect.top)}:${Math.round(mapBottom)}`;
+    if (key !== previousKey) {
+      previousKey = key;
+      apply();
+    }
+    ticks += 1;
+    if (ticks < GUI_PANEL_SETTLE_MAX_TICKS) {
+      setTimeout(settle, GUI_PANEL_SETTLE_INTERVAL_MS);
+    }
+  };
+  requestAnimationFrame(settle);
 }
 
 export interface CogRasterLayerOptions {
@@ -1827,11 +1871,19 @@ export function openLegendPanel(app: GeoLibreAppAPI): void {
  * @param app - The live app API used to mount the control.
  * @param options.title - Legend title (typically the raster layer name).
  * @param options.items - Legend items (color swatch + label) to show.
+ * @param options.legendPosition - Map corner for the rendered on-map legend.
+ *   Defaults to the control's current position (or bottom-left). The editor
+ *   panel itself always docks top-left, so pass a right/other corner to keep
+ *   the on-map legend from overlapping it.
  * @returns Whether the control was opened and populated.
  */
 export async function openLegendPanelWithItems(
   app: GeoLibreAppAPI,
-  options: { title: string; items: ComponentLegendItem[] },
+  options: {
+    title: string;
+    items: ComponentLegendItem[];
+    legendPosition?: GeoLibreMapControlPosition;
+  },
 ): Promise<boolean> {
   const opened = await openStandaloneLegendControl(app);
   if (!opened) return false;
@@ -1854,7 +1906,8 @@ export async function openLegendPanelWithItems(
         const entry: ComponentLegendGuiEntryState = {
           title: options.title,
           items: options.items,
-          legendPosition: current.legendPosition ?? "bottom-left",
+          legendPosition:
+            options.legendPosition ?? current.legendPosition ?? "bottom-left",
         };
         // Mirror the replacement onto both the top-level fields and the selected
         // slot of the `legends` array so the control's single- and multi-legend
@@ -1884,6 +1937,14 @@ export async function openLegendPanelWithItems(
         control.expand();
         control.show();
         setLegendPanelVisible(true);
+        // The control was already expanded by openStandaloneLegendControl, so
+        // the expand() above is a no-op and its "expand" handler (which fits the
+        // panel to the viewport) never re-fires for this now-taller, populated
+        // panel. Run the constraint directly so a many-class legend doesn't
+        // overflow under the status bar.
+        constrainGuiPanelToViewport(
+          ".geolibre-legend-control .legend-gui-panel",
+        );
         resolve(true);
       } catch {
         resolve(false);

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -20,6 +20,10 @@ import {
   disposeAllRasterClassification,
   disposeRasterClassification,
 } from "./raster-symbology-texture";
+import {
+  disposeAllPaletteLegends,
+  disposePaletteLegend,
+} from "./raster-palette";
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
@@ -509,6 +513,7 @@ function createRasterControl(
   control.on("rasterremove", (event) => {
     if (!event.layerId) return;
     disposeRasterClassification(event.layerId);
+    disposePaletteLegend(event.layerId);
   });
   // A striped (non-tiled) GeoTIFF cannot be streamed as tiles, so the upstream
   // fails the layer with a "not tiled" error. Offer the registered host handler
@@ -716,6 +721,7 @@ function patchRasterControlOnRemove(
     }
     unwireRasterStoreSync();
     disposeAllRasterClassification();
+    disposeAllPaletteLegends();
     // A control torn down mid-restore must not leave its successor
     // permanently suppressing store sync events.
     resetRasterStoreSyncSuspension();

--- a/packages/plugins/src/plugins/raster-palette.ts
+++ b/packages/plugins/src/plugins/raster-palette.ts
@@ -1,0 +1,139 @@
+import { loadGeoTIFF } from "maplibre-gl-raster";
+
+/**
+ * One legend entry derived from a paletted raster: the raw pixel value and the
+ * hex color the embedded color table assigns it. The label is intentionally the
+ * bare value so the user can rename it to a class name (e.g. "Tree cover").
+ */
+export type PaletteLegendEntry = {
+  /** The raw (stored) pixel value this palette entry colors. */
+  value: number;
+  /** The entry's color as a `#rrggbb` hex string. */
+  color: string;
+};
+
+/**
+ * A raster resolution level (the full image or an overview) reduced to the
+ * tile-read surface this module needs. Mirrors the shape of `@developmentseed/
+ * geotiff`'s `GeoTIFF` / `Overview` without importing the (transitive) package.
+ */
+type RasterLevel = {
+  tileCount: { x: number; y: number };
+  fetchTile: (
+    x: number,
+    y: number,
+    options?: { signal?: AbortSignal },
+  ) => Promise<{ array: TileArray }>;
+};
+
+/** Decoded tile data, either pixel-interleaved or one array per band. */
+type TileArray = {
+  width: number;
+  height: number;
+  /** Non-zero = valid pixel, 0 = nodata; null when the image carries no mask. */
+  mask: Uint8Array | null;
+  /** Samples per pixel. */
+  count: number;
+} & (
+  | { layout: "pixel-interleaved"; data: ArrayLike<number> }
+  | { layout: "band-separate"; bands: ArrayLike<number>[] }
+);
+
+/** The loaded GeoTIFF reduced to the members this module reads. */
+type LoadedTiff = RasterLevel & {
+  cachedTags?: { colorMap?: ArrayLike<number>; nodata?: number | null };
+  nodata: number | null;
+  overviews: RasterLevel[];
+};
+
+/**
+ * Backstop on how many tiles the value scan reads. A categorical COG's coarsest
+ * overview is only a handful of tiles, so this never trips in practice; it just
+ * bounds the work for an oddly-tiled or non-pyramided raster.
+ */
+const MAX_SCAN_TILES = 512;
+
+/** Two-digit lowercase hex for a 0-255 channel. */
+function hex2(value: number): string {
+  return Math.max(0, Math.min(255, value)).toString(16).padStart(2, "0");
+}
+
+/** First-band values of a decoded tile, regardless of interleave layout. */
+function firstBandValues(array: TileArray): ArrayLike<number> {
+  if (array.layout === "band-separate") return array.bands[0];
+  if (array.count <= 1) return array.data;
+  // Pixel-interleaved with multiple bands: band 0 sits at stride `count`.
+  const pixels = array.width * array.height;
+  const out = new Float64Array(pixels);
+  for (let i = 0; i < pixels; i++) out[i] = array.data[i * array.count];
+  return out;
+}
+
+/**
+ * Reads a paletted raster's embedded color table and returns a legend entry for
+ * every pixel value that actually occurs in the data (nodata excluded), each
+ * paired with the color the palette assigns it.
+ *
+ * Filler entries a color table leaves at a placeholder color are skipped by
+ * construction: only values present in the raster are returned, so a land-cover
+ * palette with 256 slots but 8 real classes yields exactly those 8. Present
+ * values are read from the coarsest overview, which — for the nearest-neighbor
+ * overviews categorical COGs ship with — preserves the class set.
+ *
+ * @param url - A URL (remote COG or session blob) for the GeoTIFF to inspect.
+ * @param signal - Optional abort signal for the tile reads.
+ * @returns Sorted legend entries, an empty array when the raster has a color
+ *   table but no non-nodata pixels, or `null` when it carries no color table.
+ */
+export async function extractPaletteLegend(
+  url: string,
+  signal?: AbortSignal,
+): Promise<PaletteLegendEntry[] | null> {
+  const tiff = (await loadGeoTIFF(url)) as unknown as LoadedTiff;
+  const cmap = tiff.cachedTags?.colorMap;
+  if (!cmap || cmap.length < 3) return null;
+
+  // The ColorMap tag stores 16-bit R, then G, then B, each `entries` long.
+  const entries = Math.floor(cmap.length / 3);
+  const colorFor = (value: number): string | null => {
+    if (!Number.isInteger(value) || value < 0 || value >= entries) return null;
+    const r = Number(cmap[value]) >> 8;
+    const g = Number(cmap[entries + value]) >> 8;
+    const b = Number(cmap[2 * entries + value]) >> 8;
+    return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+  };
+
+  const nodata = tiff.cachedTags?.nodata ?? tiff.nodata ?? null;
+  // The coarsest overview is the cheapest full-coverage read; fall back to the
+  // full-resolution image for a raster with no overview pyramid.
+  const level: RasterLevel =
+    tiff.overviews.length > 0
+      ? tiff.overviews[tiff.overviews.length - 1]
+      : tiff;
+
+  const present = new Set<number>();
+  let tilesRead = 0;
+  outer: for (let ty = 0; ty < level.tileCount.y; ty++) {
+    for (let tx = 0; tx < level.tileCount.x; tx++) {
+      if (signal?.aborted) return null;
+      if (tilesRead >= MAX_SCAN_TILES) break outer;
+      const { array } = await level.fetchTile(tx, ty, { signal });
+      const values = firstBandValues(array);
+      const { mask } = array;
+      for (let i = 0; i < values.length; i++) {
+        if (mask && mask[i] === 0) continue;
+        const value = values[i];
+        if (nodata !== null && value === nodata) continue;
+        present.add(value);
+      }
+      tilesRead++;
+    }
+  }
+
+  const legend: PaletteLegendEntry[] = [];
+  for (const value of [...present].sort((a, b) => a - b)) {
+    const color = colorFor(value);
+    if (color) legend.push({ value, color });
+  }
+  return legend;
+}

--- a/packages/plugins/src/plugins/raster-palette.ts
+++ b/packages/plugins/src/plugins/raster-palette.ts
@@ -81,7 +81,8 @@ function firstBandValues(array: TileArray): ArrayLike<number> {
  * overviews categorical COGs ship with — preserves the class set.
  *
  * @param url - A URL (remote COG or session blob) for the GeoTIFF to inspect.
- * @param signal - Optional abort signal for the tile reads.
+ * @param signal - Optional abort signal for the tile reads; an abort rejects the
+ *   returned promise (it never resolves to `null`).
  * @returns Sorted legend entries, an empty array when the raster has a color
  *   table but no non-nodata pixels, or `null` when it carries no color table.
  */
@@ -112,11 +113,18 @@ export async function extractPaletteLegend(
       : tiff;
 
   const present = new Set<number>();
+  const totalTiles = level.tileCount.x * level.tileCount.y;
   let tilesRead = 0;
+  let truncated = false;
   outer: for (let ty = 0; ty < level.tileCount.y; ty++) {
     for (let tx = 0; tx < level.tileCount.x; tx++) {
-      if (signal?.aborted) return null;
-      if (tilesRead >= MAX_SCAN_TILES) break outer;
+      // Abort surfaces as a thrown error (the standard AbortSignal contract) so
+      // it is never confused with the `null` "no color table" return.
+      signal?.throwIfAborted();
+      if (tilesRead >= MAX_SCAN_TILES) {
+        truncated = true;
+        break outer;
+      }
       const { array } = await level.fetchTile(tx, ty, { signal });
       const values = firstBandValues(array);
       const { mask } = array;
@@ -128,6 +136,15 @@ export async function extractPaletteLegend(
       }
       tilesRead++;
     }
+  }
+  if (truncated) {
+    // Don't silently ship a partial class set: a raster with no overview
+    // pyramid (so the full image is scanned) could exceed the cap and drop
+    // rare classes. Warn so an incomplete legend is at least traceable.
+    console.warn(
+      `[GeoLibre] Palette legend scan capped at ${MAX_SCAN_TILES}/${totalTiles} tiles; ` +
+        "the legend may omit rare classes.",
+    );
   }
 
   const legend: PaletteLegendEntry[] = [];

--- a/packages/plugins/src/plugins/raster-palette.ts
+++ b/packages/plugins/src/plugins/raster-palette.ts
@@ -91,8 +91,36 @@ export async function extractPaletteLegend(
   signal?: AbortSignal,
 ): Promise<PaletteLegendEntry[] | null> {
   const tiff = (await loadGeoTIFF(url)) as unknown as LoadedTiff;
+  return await buildPaletteLegend(tiff, signal);
+}
+
+/**
+ * The color-table decode + present-value scan behind {@link extractPaletteLegend},
+ * split out from the `loadGeoTIFF` fetch so the parsing is unit-testable with a
+ * synthetic tiff. Not part of the package's public API.
+ *
+ * @param tiff - A loaded GeoTIFF (maplibre-gl-raster's internal shape).
+ * @param signal - Optional abort signal for the tile reads.
+ * @returns See {@link extractPaletteLegend}.
+ * @internal
+ */
+export async function buildPaletteLegend(
+  tiff: LoadedTiff,
+  signal?: AbortSignal,
+): Promise<PaletteLegendEntry[] | null> {
   const cmap = tiff.cachedTags?.colorMap;
   if (!cmap || cmap.length < 3) return null;
+
+  // The reads below reach into maplibre-gl-raster's internal GeoTIFF shape via a
+  // structural cast (see LoadedTiff). Guard the fields the scan needs so a
+  // future upstream rename fails loudly here instead of silently yielding an
+  // empty legend.
+  if (!Array.isArray(tiff.overviews) || typeof tiff.fetchTile !== "function") {
+    throw new Error(
+      "maplibre-gl-raster loadGeoTIFF returned an unexpected shape; " +
+        "the palette reader needs updating for this version.",
+    );
+  }
 
   // The ColorMap tag stores 16-bit R, then G, then B, each `entries` long.
   const entries = Math.floor(cmap.length / 3);
@@ -158,8 +186,12 @@ export async function extractPaletteLegend(
 // One palette read per layer is enough (a layer id maps to a fixed source), so
 // cache the result. Both the symbology panel's ramp preview and the
 // "Create legend from palette" action share it, and a band/re-render doesn't
-// re-scan the file.
-const legendCache = new Map<string, PaletteLegendEntry[]>();
+// re-scan the file. The in-flight promise is cached too, so concurrent callers
+// (preview effect + button) join one read instead of racing two scans.
+const legendCache = new Map<
+  string,
+  PaletteLegendEntry[] | Promise<PaletteLegendEntry[] | null>
+>();
 
 /**
  * Cached wrapper around {@link extractPaletteLegend}, keyed by layer id, so the
@@ -177,8 +209,34 @@ export async function getPaletteLegend(
   signal?: AbortSignal,
 ): Promise<PaletteLegendEntry[] | null> {
   const cached = legendCache.get(layerId);
-  if (cached) return cached;
-  const entries = await extractPaletteLegend(url, signal);
-  if (entries) legendCache.set(layerId, entries);
-  return entries;
+  if (cached) return await cached;
+  const read = extractPaletteLegend(url, signal)
+    .then((entries) => {
+      // Replace the in-flight promise with the resolved entries; drop the cache
+      // slot when there is no palette so a later attempt can retry.
+      if (entries) legendCache.set(layerId, entries);
+      else legendCache.delete(layerId);
+      return entries;
+    })
+    .catch((error) => {
+      legendCache.delete(layerId);
+      throw error;
+    });
+  legendCache.set(layerId, read);
+  return await read;
+}
+
+/**
+ * Drops a single layer's cached palette (on raster removal), mirroring
+ * {@link disposeRasterClassification}.
+ *
+ * @param layerId - The layer id to evict.
+ */
+export function disposePaletteLegend(layerId: string): void {
+  legendCache.delete(layerId);
+}
+
+/** Drops every cached palette (on raster control teardown). */
+export function disposeAllPaletteLegends(): void {
+  legendCache.clear();
 }

--- a/packages/plugins/src/plugins/raster-palette.ts
+++ b/packages/plugins/src/plugins/raster-palette.ts
@@ -154,3 +154,31 @@ export async function extractPaletteLegend(
   }
   return legend;
 }
+
+// One palette read per layer is enough (a layer id maps to a fixed source), so
+// cache the result. Both the symbology panel's ramp preview and the
+// "Create legend from palette" action share it, and a band/re-render doesn't
+// re-scan the file.
+const legendCache = new Map<string, PaletteLegendEntry[]>();
+
+/**
+ * Cached wrapper around {@link extractPaletteLegend}, keyed by layer id, so the
+ * palette is read from the file only once per layer.
+ *
+ * @param layerId - The store layer id, used as the cache key.
+ * @param url - A URL (remote COG or session blob) for the GeoTIFF.
+ * @param signal - Optional abort signal, forwarded on a cache miss.
+ * @returns The cached or freshly-read legend entries, or `null` when the raster
+ *   carries no color table.
+ */
+export async function getPaletteLegend(
+  layerId: string,
+  url: string,
+  signal?: AbortSignal,
+): Promise<PaletteLegendEntry[] | null> {
+  const cached = legendCache.get(layerId);
+  if (cached) return cached;
+  const entries = await extractPaletteLegend(url, signal);
+  if (entries) legendCache.set(layerId, entries);
+  return entries;
+}

--- a/tests/raster-palette.test.ts
+++ b/tests/raster-palette.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildPaletteLegend,
+  type PaletteLegendEntry,
+} from "../packages/plugins/src/plugins/raster-palette";
+
+// The color table stores 8-bit channels scaled to 16-bit (GDAL writes value *
+// 257, so value >> 8 recovers the 8-bit channel). Build a 256-entry RGB table
+// from a value -> [r, g, b] map the same way.
+function colorMap(colors: Record<number, [number, number, number]>): Uint16Array {
+  const n = 256;
+  const cmap = new Uint16Array(n * 3);
+  for (const [value, [r, g, b]] of Object.entries(colors)) {
+    const v = Number(value);
+    cmap[v] = r * 257;
+    cmap[n + v] = g * 257;
+    cmap[2 * n + v] = b * 257;
+  }
+  return cmap;
+}
+
+type TileArray =
+  | {
+      layout: "band-separate";
+      bands: ArrayLike<number>[];
+      width: number;
+      height: number;
+      mask: Uint8Array | null;
+      count: number;
+    }
+  | {
+      layout: "pixel-interleaved";
+      data: ArrayLike<number>;
+      width: number;
+      height: number;
+      mask: Uint8Array | null;
+      count: number;
+    };
+
+// Minimal stand-in for maplibre-gl-raster's loaded GeoTIFF: one overview level
+// whose single tile decodes to the given array. buildPaletteLegend only reads
+// cachedTags, nodata, overviews, tileCount and fetchTile off it.
+function fakeTiff(options: {
+  colorMap?: Uint16Array;
+  nodata?: number | null;
+  tile?: TileArray;
+}) {
+  const level = {
+    tileCount: { x: 1, y: 1 },
+    fetchTile: async () => ({ array: options.tile }),
+  };
+  return {
+    cachedTags:
+      options.colorMap !== undefined
+        ? { colorMap: options.colorMap, nodata: options.nodata ?? null }
+        : { nodata: options.nodata ?? null },
+    nodata: options.nodata ?? null,
+    overviews: [level],
+    tileCount: { x: 1, y: 1 },
+    fetchTile: async () => ({ array: options.tile }),
+  } as unknown as Parameters<typeof buildPaletteLegend>[0];
+}
+
+async function legendOf(
+  tiff: Parameters<typeof buildPaletteLegend>[0],
+): Promise<PaletteLegendEntry[] | null> {
+  return await buildPaletteLegend(tiff);
+}
+
+describe("buildPaletteLegend", () => {
+  it("returns null when the raster carries no color table", async () => {
+    const tiff = fakeTiff({
+      tile: {
+        layout: "band-separate",
+        bands: [new Uint8Array([10, 20])],
+        width: 2,
+        height: 1,
+        mask: null,
+        count: 1,
+      },
+    });
+    assert.equal(await legendOf(tiff), null);
+  });
+
+  it("decodes 16-bit color-table entries to hex and lists only present values", async () => {
+    const tiff = fakeTiff({
+      colorMap: colorMap({
+        10: [0, 100, 0],
+        20: [255, 187, 34],
+        30: [255, 255, 76], // in the table but never occurs in the data
+      }),
+      nodata: 0,
+      tile: {
+        layout: "band-separate",
+        bands: [new Uint8Array([0, 20, 10, 10, 0])],
+        width: 5,
+        height: 1,
+        mask: null,
+        count: 1,
+      },
+    });
+    assert.deepEqual(await legendOf(tiff), [
+      { value: 10, color: "#006400" },
+      { value: 20, color: "#ffbb22" },
+    ]);
+  });
+
+  it("excludes the nodata value and mask-flagged pixels", async () => {
+    const tiff = fakeTiff({
+      colorMap: colorMap({ 10: [1, 2, 3], 20: [4, 5, 6], 30: [7, 8, 9] }),
+      nodata: 0,
+      tile: {
+        layout: "band-separate",
+        // 30 sits under a 0 mask entry, 0 is nodata; only 10 and 20 survive.
+        bands: [new Uint8Array([0, 10, 20, 30])],
+        width: 4,
+        height: 1,
+        mask: new Uint8Array([1, 1, 1, 0]),
+        count: 1,
+      },
+    });
+    assert.deepEqual(await legendOf(tiff), [
+      { value: 10, color: "#010203" },
+      { value: 20, color: "#040506" },
+    ]);
+  });
+
+  it("reads band 0 from a pixel-interleaved tile with multiple bands", async () => {
+    const tiff = fakeTiff({
+      colorMap: colorMap({ 10: [10, 10, 10], 20: [20, 20, 20] }),
+      nodata: 0,
+      tile: {
+        layout: "pixel-interleaved",
+        // stride 2: band-0 values are 10, 20 (the 99s are band 1 and ignored).
+        data: new Uint8Array([10, 99, 20, 99]),
+        width: 2,
+        height: 1,
+        mask: null,
+        count: 2,
+      },
+    });
+    assert.deepEqual(await legendOf(tiff), [
+      { value: 10, color: "#0a0a0a" },
+      { value: 20, color: "#141414" },
+    ]);
+  });
+
+  it("returns an empty legend when only nodata pixels are present", async () => {
+    const tiff = fakeTiff({
+      colorMap: colorMap({ 10: [1, 1, 1] }),
+      nodata: 0,
+      tile: {
+        layout: "band-separate",
+        bands: [new Uint8Array([0, 0, 0])],
+        width: 3,
+        height: 1,
+        mask: null,
+        count: 1,
+      },
+    });
+    assert.deepEqual(await legendOf(tiff), []);
+  });
+
+  it("throws when the loaded object lacks the expected tiff shape", async () => {
+    const broken = {
+      cachedTags: { colorMap: colorMap({ 10: [1, 1, 1] }) },
+      nodata: 0,
+      // no overviews / fetchTile
+    } as unknown as Parameters<typeof buildPaletteLegend>[0];
+    await assert.rejects(() => buildPaletteLegend(broken), /unexpected shape/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the feature requested in #1014: automatically populate the map Legend from a paletted (categorical) raster's embedded color table, such as ESA WorldCover land cover data.

The raster symbology panel now shows a **Create legend from palette** button when a single-band raster is rendered with its embedded image palette (colormap `palette`). Clicking it:

1. Reads the GeoTIFF's embedded color table and the pixel values actually present in the data.
2. Opens the **Controls -> Legend** control populated with one item per class, colored from the palette and labelled with the raw pixel value.

The labels are plain values so the user can rename them to class names afterward (e.g. `10` -> `Tree cover`), matching the request in the issue.

## How it works

Palette extraction is fully client-side (no backend, no upstream package change):

- Reuses the existing `loadGeoTIFF` loader to read `cachedTags.colorMap` (the embedded 16-bit RGB color table).
- Scans the coarsest overview for the set of pixel values present, so filler entries and classes not in the data are excluded. Only the classes that actually occur are listed.
- Populates the existing `LegendGuiControl` via its state, reusing the same round-trip the project save/load path uses.

## Verification

Verified in the running app with the ESA WorldCover sample from the issue. The generated legend contained exactly the 8 classes present in the data (10, 20, 30, 40, 50, 60, 80, 90), each with the exact palette color from the GeoTIFF color table (checked against `gdalinfo`):

| Value | Legend color | GDAL color table |
| --- | --- | --- |
| 10 | #006400 | 0,100,0 |
| 20 | #ffbb22 | 255,187,34 |
| 30 | #ffff4c | 255,255,76 |
| 40 | #f096ff | 240,150,255 |
| 50 | #fa0000 | 250,0,0 |
| 60 | #b4b4b4 | 180,180,180 |
| 80 | #0064c8 | 0,100,200 |
| 90 | #0096a0 | 0,150,160 |

Nodata (0), the opaque-black filler entries, and palette classes absent from the data (70, 95, 100) were correctly excluded. New UI strings are translatable via `t()` and added to `en.json`. `npm run typecheck` and pre-commit (eslint + npm build) pass.

Fixes #1014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Create legend from palette” action for single-band palette rasters, generating legend entries from the raster’s embedded palette.
  * Opens the Legend panel pre-filled with the extracted palette entries.
* **UI Improvements**
  * Added status feedback for palette reading (pending, empty, error) and an explanatory hint after creation.
  * Updated the color-ramp palette option to use extracted palette colors.
* **Bug Fixes**
  * Improved Legend panel viewport sizing and ensured palette legend resources are cleaned up when raster layers are removed.
* **Localization**
  * Added English strings for the new palette-to-legend action and its status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->