### PR TITLE
fix(geo-editor): dead first click when switching between draw tools (#889)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.10.0",
+    "maplibre-gl-geo-editor": "^0.10.1",
     "maplibre-gl-geoagent": "^0.5.4",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.10.0",
+        "maplibre-gl-geo-editor": "^0.10.1",
         "maplibre-gl-geoagent": "^0.5.4",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
@@ -16277,9 +16277,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.0.tgz",
-      "integrity": "sha512-9C+XdG1viXVEnjviFByOeNwsKb6ZAhn2JjWaACW6xPooPqKfD/oXAARgx1Ljyo3v4TPC+Jtf6mVjlbTZ9pBVEg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.1.tgz",
+      "integrity": "sha512-jLliz+m2P0xxX12yjXYfpoQc+vR58nEs+vZJA43Z1DWwZagjC2NR5oQZNJ2Otcifzx8ZVbedvEuNy50242E3Rw==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -21135,7 +21135,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.10.0",
+        "maplibre-gl-geo-editor": "^0.10.1",
         "maplibre-gl-geoagent": "^0.5.4",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.10.0",
+    "maplibre-gl-geo-editor": "^0.10.1",
     "maplibre-gl-geoagent": "^0.5.4",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-splat": "^0.2.8",


### PR DESCRIPTION
## Summary

Fixes #889. When switching directly from one GeoEditor draw tool to another
(e.g. Marker -> Circle), the first click on the map canvas was unresponsive: the
newly selected tool only started drawing on the second click ("dead click").

## Root cause

The bug lives in the `maplibre-gl-geo-editor` package's Geoman wrapper.
`enableDrawMode()` called `geoman.enableDraw()` **synchronously** while the
previous tool's `geoman.disableAllModes()` teardown was still in flight (that
call is asynchronous). The in-flight teardown then landed on top of the freshly
enabled draw mode and swallowed its first canvas click.

## Fix

Bumps `maplibre-gl-geo-editor` `0.10.0 -> 0.10.1`, which sequences the newly
selected tool's activation after the previous tool's teardown promise settles,
guarded by a monotonic request token so fast reselects (e.g. `circle -> line ->
circle`) can't let a stale request win. Freehand is sequenced the same way.

- Upstream PR: https://github.com/opengeos/maplibre-gl-geo-editor/pull/37
- Upstream release: https://github.com/opengeos/maplibre-gl-geo-editor/releases/tag/v0.10.1

## Verification

The reported symptom is Safari/macOS-specific and timing-dependent; it does not
reproduce on Chromium/Linux (confirmed by the reporter and locally), so this was
verified by the upstream package's unit tests (which cover the deferred enable,
the reselect race, and freehand sequencing) plus root-cause analysis, rather
than a live Safari repro. The fix is browser-agnostic: it removes the sync/async
race regardless of which browser's event timing exposes it. `npm run build`
passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled editor dependency to a newer patch version across desktop and plugin packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->