### PR TITLE
fix: exclude Vantor internal helper layers from Layer Swipe

### DIFF
--- a/packages/plugins/src/plugins/internal-layers.ts
+++ b/packages/plugins/src/plugins/internal-layers.ts
@@ -1,0 +1,23 @@
+/**
+ * Glob patterns for plugin "chrome" / internal helper layer ids: drawing and
+ * measure aids, selection / inspect highlight outlines, the USGS lidar coverage
+ * index, and Vantor's internal footprint layers. None of these are user data,
+ * so every control that surfaces a layer list (the Components control grid,
+ * Layer Swipe, ...) hides them to keep the list uncluttered.
+ *
+ * Centralized here so the excluded set stays consistent across controls instead
+ * of drifting per-list. Patterns match the layer ids each plugin uses for its
+ * internal helpers; they are safe to over-include because they only ever match
+ * helper ids, never a user's data layer.
+ */
+export const INTERNAL_HELPER_LAYER_PATTERNS = [
+  "usgs-lidar-*",
+  "lidar-*",
+  "mapbox-gl-draw-*",
+  "gl-draw-*",
+  "gm_*",
+  "inspect-highlight-*",
+  "geolibre-highlight-*",
+  "measure-*",
+  "vantor-*",
+] as const;

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -76,6 +76,7 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
+import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
 import {
   KerchunkReferenceStore,
   loadKerchunkReference,
@@ -221,15 +222,9 @@ const COMPONENTS_OPTIONS = {
   collapsed: false,
   columns: 5,
   defaultControls: COMPONENT_CONTROL_NAMES,
-  excludeLayers: [
-    "usgs-lidar-*",
-    "lidar-*",
-    "mapbox-gl-draw-*",
-    "gl-draw-*",
-    "gm_*",
-    "inspect-highlight-*",
-    "measure-*",
-  ],
+  // Shared with Layer Swipe (and any other layer-list control) so the hidden
+  // "chrome" layer set stays consistent; see INTERNAL_HELPER_LAYER_PATTERNS.
+  excludeLayers: [...INTERNAL_HELPER_LAYER_PATTERNS],
   gap: 2,
   rows: 5,
   showRowColumnControls: true,

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -118,7 +118,17 @@ function getSwipeControlOptions(
     // True only on first activation; restoring saved/project state keeps the user's selection.
     selectVisibleByDefault: previousState === undefined,
     basemapStyle: app.getActiveBasemap(),
-    excludeLayers: ["gl-draw-*", "measure-*", "geolibre-highlight-*"],
+    // Hide plugin chrome layers (drawing/measure helpers, selection footprints,
+    // highlight outlines) so they don't clutter the swipe layer list. The
+    // patterns match the layer ids each plugin uses for its internal helpers;
+    // these globs are re-applied on every live refresh, so layers added after
+    // the control mounts (e.g. Vantor footprints on search) are excluded too.
+    excludeLayers: [
+      "gl-draw-*",
+      "measure-*",
+      "geolibre-highlight-*",
+      "vantor-*",
+    ],
     // List only currently visible layers (plus any already selected), kept in sync live (#843).
     visibleLayersOnly: true,
   };

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -8,6 +8,7 @@ import type {
   GeoLibreMapControlPosition,
   GeoLibrePlugin,
 } from "../types";
+import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
 
 /**
  * Plugin id for the Layer Swipe control. Exported so the app can coordinate it
@@ -119,16 +120,12 @@ function getSwipeControlOptions(
     selectVisibleByDefault: previousState === undefined,
     basemapStyle: app.getActiveBasemap(),
     // Hide plugin chrome layers (drawing/measure helpers, selection footprints,
-    // highlight outlines) so they don't clutter the swipe layer list. The
-    // patterns match the layer ids each plugin uses for its internal helpers;
-    // these globs are re-applied on every live refresh, so layers added after
-    // the control mounts (e.g. Vantor footprints on search) are excluded too.
-    excludeLayers: [
-      "gl-draw-*",
-      "measure-*",
-      "geolibre-highlight-*",
-      "vantor-*",
-    ],
+    // highlight outlines, Vantor footprints) so they don't clutter the swipe
+    // layer list. Shared with the Components control grid via
+    // INTERNAL_HELPER_LAYER_PATTERNS so the excluded set stays consistent. These
+    // globs are re-applied on every live refresh, so layers added after the
+    // control mounts (e.g. Vantor footprints on search) are excluded too.
+    excludeLayers: [...INTERNAL_HELPER_LAYER_PATTERNS],
     // List only currently visible layers (plus any already selected), kept in sync live (#843).
     visibleLayersOnly: true,
   };


### PR DESCRIPTION
## Summary
- The Layer Swipe control listed the Vantor plugin's internal chrome layers (footprint outlines, draw-bbox, highlight helpers) in its layer picker.
- Its exclude list is pattern-based and only covered `gl-draw-*`, `measure-*`, and `geolibre-highlight-*`. Added `vantor-*` so Vantor's helper layers are hidden too.
- The globs are re-applied on every live layer-list refresh, so helpers added after the control mounts (e.g. footprints on search) are excluded as well. Vantor COG layers use their STAC item id (not a `vantor-` prefix), so they remain swipe-able.

## Test plan
- [x] Activate Layer Swipe with the Vantor plugin active and footprints/highlight/draw-bbox layers present: the `vantor-*` helper layers no longer appear in the swipe layer list.
- [x] Vantor COG layers still appear and can be swiped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Layer Swipe control to better exclude internal/generated helper layers, reducing unexpected items appearing in the swipe list.
  * Improved layer filtering consistency across layer-list-style controls so hidden “chrome” helper layers are handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->