### PR TITLE
feat(add-data): retrieve layers/types for WMS and WFS from GetCapabilities

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -92,6 +92,9 @@ export const DEFAULT_ARCGIS_URLS: Record<ArcGISLayerType, string> = {
 };
 // Keep in sync with GPX_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
 export const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
+// Keep in sync with WMS_PROXY_PATH in vite.config.ts (the dev proxy binds it
+// there). Used to fetch a WMS GetCapabilities document without tripping CORS.
+export const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 export const POSTGRES_CONNECTIONS_STORAGE_KEY =
   "geolibre.postgres.connectionStrings";
 export const MAX_SAVED_POSTGRES_CONNECTIONS = 10;

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -95,6 +95,9 @@ export const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 // Keep in sync with WMS_PROXY_PATH in vite.config.ts (the dev proxy binds it
 // there). Used to fetch a WMS GetCapabilities document without tripping CORS.
 export const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+// Keep in sync with WFS_PROXY_PATH in vite.config.ts. Used to fetch a WFS
+// GetCapabilities document (and GetFeature responses) without tripping CORS.
+export const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 export const POSTGRES_CONNECTIONS_STORAGE_KEY =
   "geolibre.postgres.connectionStrings";
 export const MAX_SAVED_POSTGRES_CONNECTIONS = 10;

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -226,12 +226,26 @@ async function fetchCapabilitiesText(
 ): Promise<{ ok: boolean; status: number; text: string }> {
   if (isTauri()) {
     // `fetch_url_bytes` rejects on a non-2xx status, so a resolved value is OK.
+    // The Rust command has its own timeout and cannot be cancelled mid-flight,
+    // but race it against the caller's abort + a 30s cap so this call still
+    // returns promptly (matching the browser fetch branch below) rather than
+    // hanging on a slow host or a superseded request.
     const { invoke } = await import("@tauri-apps/api/core");
-    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
-      url: requestUrl,
-    });
-    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-    return { ok: true, status: 200, text: decodeXmlBytes(array) };
+    const timeout = AbortSignal.timeout(30_000);
+    const abort = signal ? AbortSignal.any([signal, timeout]) : timeout;
+    try {
+      const bytes = await Promise.race([
+        invoke<number[] | Uint8Array>("fetch_url_bytes", { url: requestUrl }),
+        rejectOnAbort(abort),
+      ]);
+      const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+      return { ok: true, status: 200, text: decodeXmlBytes(array) };
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        throw new Error("The request timed out.");
+      }
+      throw error;
+    }
   }
   const fetchUrl = isViteDevServer()
     ? `${devProxyPath}?url=${encodeURIComponent(requestUrl)}`
@@ -257,6 +271,23 @@ async function fetchCapabilitiesText(
     throw error;
   }
   return { ok: response.ok, status: response.status, text: await response.text() };
+}
+
+/**
+ * A promise that never resolves and rejects when the signal aborts (with its
+ * abort reason, e.g. a `TimeoutError`). Used to race an uncancellable call
+ * against a caller abort / timeout.
+ */
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal.addEventListener("abort", () => reject(signal.reason), {
+      once: true,
+    });
+  });
 }
 
 /**
@@ -312,7 +343,11 @@ function buildCapabilitiesUrl(
   url.searchParams.set("SERVICE", service);
   url.searchParams.set("REQUEST", "GetCapabilities");
   if (version) url.searchParams.set("VERSION", version);
-  return relative ? `${url.pathname}${url.search}` : url.toString();
+  if (!relative) return url.toString();
+  // A protocol-relative endpoint (`//host/path`) carries its own host through
+  // the dummy-base parse; keep it rather than dropping the origin.
+  if (endpoint.startsWith("//")) return `//${url.host}${url.pathname}${url.search}`;
+  return `${url.pathname}${url.search}`;
 }
 
 /** A single requestable (named) layer advertised by a WMS GetCapabilities. */

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -322,18 +322,15 @@ function charsetFromContentType(contentType: string | null): string | undefined 
 }
 
 /**
- * Builds an OGC `GetCapabilities` request URL, stripping any operation
- * parameters already on the endpoint (e.g. a copied `REQUEST=GetMap`) so they
- * cannot collide with the ones added here. Only the query string is rewritten,
- * so the endpoint's path form is preserved exactly — absolute, root-relative,
+ * Rewrites an endpoint's query string: removes the given operation parameters
+ * and sets `extra`, leaving the path form untouched — absolute, root-relative,
  * route-relative (`geoserver/wms`), and protocol-relative (`//host/wms`) all
- * round-trip unchanged.
+ * round-trip unchanged. Drops the `?` entirely when nothing remains.
  */
-function buildCapabilitiesUrl(
+function rewriteEndpointQuery(
   endpoint: string,
-  service: "WMS" | "WFS",
   operationParams: ReadonlySet<string>,
-  version?: string,
+  extra: Array<[string, string]>,
 ): string {
   const hashIndex = endpoint.indexOf("#");
   const withoutHash = hashIndex === -1 ? endpoint : endpoint.slice(0, hashIndex);
@@ -346,10 +343,49 @@ function buildCapabilitiesUrl(
   for (const key of Array.from(params.keys())) {
     if (operationParams.has(key.toLowerCase())) params.delete(key);
   }
-  params.set("SERVICE", service);
-  params.set("REQUEST", "GetCapabilities");
-  if (version) params.set("VERSION", version);
-  return `${path}?${params.toString()}${hash}`;
+  for (const [key, value] of extra) params.set(key, value);
+  const query = params.toString();
+  return query ? `${path}?${query}${hash}` : `${path}${hash}`;
+}
+
+/**
+ * Builds an OGC `GetCapabilities` request URL, stripping any operation
+ * parameters already on the endpoint (e.g. a copied `REQUEST=GetMap`) so they
+ * cannot collide with the ones added here.
+ */
+function buildCapabilitiesUrl(
+  endpoint: string,
+  service: "WMS" | "WFS",
+  operationParams: ReadonlySet<string>,
+  version?: string,
+): string {
+  const extra: Array<[string, string]> = [
+    ["SERVICE", service],
+    ["REQUEST", "GetCapabilities"],
+  ];
+  if (version) extra.push(["VERSION", version]);
+  return rewriteEndpointQuery(endpoint, operationParams, extra);
+}
+
+/**
+ * Strips the OGC operation parameters (SERVICE / REQUEST / VERSION / LAYERS /
+ * typeName / outputFormat / BBOX / …) from a service endpoint, leaving a clean
+ * base URL. A user commonly pastes a full `…?REQUEST=GetCapabilities` URL; these
+ * leftover params must be removed before a GetMap / GetFeature URL is built on
+ * top, or the duplicated (and conflicting) `REQUEST` makes the server answer the
+ * wrong operation (e.g. returning capabilities XML instead of features).
+ *
+ * @param endpoint - The service endpoint as entered by the user.
+ * @param service - Which operation-parameter set to strip.
+ * @returns The endpoint with its OGC operation parameters removed.
+ */
+export function stripOgcOperationParams(
+  endpoint: string,
+  service: "WMS" | "WFS",
+): string {
+  const operationParams =
+    service === "WMS" ? WMS_OPERATION_PARAMS : WFS_OPERATION_PARAMS;
+  return rewriteEndpointQuery(endpoint, operationParams, []);
 }
 
 /** A single requestable (named) layer advertised by a WMS GetCapabilities. */

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -270,7 +270,13 @@ async function fetchCapabilitiesText(
     }
     throw error;
   }
-  return { ok: response.ok, status: response.status, text: await response.text() };
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  const charset = charsetFromContentType(response.headers.get("content-type"));
+  return {
+    ok: response.ok,
+    status: response.status,
+    text: decodeXmlBytes(buffer, charset),
+  };
 }
 
 /**
@@ -291,15 +297,18 @@ function rejectOnAbort(signal: AbortSignal): Promise<never> {
 }
 
 /**
- * Decodes capabilities bytes to text, honoring a non-UTF-8 charset declared in
- * the XML prolog (`<?xml … encoding="ISO-8859-1"?>`). The browser fetch path
- * gets this for free via `response.text()`, but the Tauri byte path must do it
- * by hand or a legacy Latin-1 service would render mojibake.
+ * Decodes capabilities bytes to text, honoring a non-UTF-8 charset. The HTTP
+ * `Content-Type` charset (when present) wins; otherwise the charset declared in
+ * the XML prolog (`<?xml … encoding="ISO-8859-1"?>`) is used, defaulting to
+ * UTF-8. `Response.text()` only honors the HTTP header, so both the browser and
+ * the Tauri byte paths run through this to avoid mojibake from a legacy Latin-1
+ * service that declares its charset only in the prolog.
  */
-function decodeXmlBytes(bytes: Uint8Array): string {
+function decodeXmlBytes(bytes: Uint8Array, httpCharset?: string): string {
   // The prolog is ASCII, so decode a short head to read the declared charset.
   const head = new TextDecoder("ascii").decode(bytes.subarray(0, 256));
-  const label = head.match(/encoding=["']([\w-]+)["']/i)?.[1] ?? "utf-8";
+  const prologCharset = head.match(/encoding=["']([\w-]+)["']/i)?.[1];
+  const label = httpCharset || prologCharset || "utf-8";
   try {
     return new TextDecoder(label).decode(bytes);
   } catch {
@@ -307,11 +316,18 @@ function decodeXmlBytes(bytes: Uint8Array): string {
   }
 }
 
+/** Extracts the `charset` from a `Content-Type` header value, if any. */
+function charsetFromContentType(contentType: string | null): string | undefined {
+  return contentType?.match(/charset=["']?([\w-]+)/i)?.[1];
+}
+
 /**
  * Builds an OGC `GetCapabilities` request URL, stripping any operation
  * parameters already on the endpoint (e.g. a copied `REQUEST=GetMap`) so they
- * cannot collide with the ones added here. Handles both absolute and relative
- * endpoints; the stripping applies to relative endpoints too.
+ * cannot collide with the ones added here. Only the query string is rewritten,
+ * so the endpoint's path form is preserved exactly — absolute, root-relative,
+ * route-relative (`geoserver/wms`), and protocol-relative (`//host/wms`) all
+ * round-trip unchanged.
  */
 function buildCapabilitiesUrl(
   endpoint: string,
@@ -319,35 +335,21 @@ function buildCapabilitiesUrl(
   operationParams: ReadonlySet<string>,
   version?: string,
 ): string {
-  const DUMMY_BASE = "http://geolibre.invalid";
-  let url: URL;
-  let relative = false;
-  try {
-    url = new URL(endpoint);
-  } catch {
-    try {
-      url = new URL(endpoint, DUMMY_BASE);
-      relative = true;
-    } catch {
-      const params: Array<[string, string]> = [
-        ["SERVICE", service],
-        ["REQUEST", "GetCapabilities"],
-      ];
-      if (version) params.push(["VERSION", version]);
-      return appendQuery(endpoint, params);
-    }
+  const hashIndex = endpoint.indexOf("#");
+  const withoutHash = hashIndex === -1 ? endpoint : endpoint.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? "" : endpoint.slice(hashIndex);
+  const queryIndex = withoutHash.indexOf("?");
+  const path = queryIndex === -1 ? withoutHash : withoutHash.slice(0, queryIndex);
+  const rawQuery = queryIndex === -1 ? "" : withoutHash.slice(queryIndex + 1);
+
+  const params = new URLSearchParams(rawQuery);
+  for (const key of Array.from(params.keys())) {
+    if (operationParams.has(key.toLowerCase())) params.delete(key);
   }
-  for (const key of Array.from(url.searchParams.keys())) {
-    if (operationParams.has(key.toLowerCase())) url.searchParams.delete(key);
-  }
-  url.searchParams.set("SERVICE", service);
-  url.searchParams.set("REQUEST", "GetCapabilities");
-  if (version) url.searchParams.set("VERSION", version);
-  if (!relative) return url.toString();
-  // A protocol-relative endpoint (`//host/path`) carries its own host through
-  // the dummy-base parse; keep it rather than dropping the origin.
-  if (endpoint.startsWith("//")) return `//${url.host}${url.pathname}${url.search}`;
-  return `${url.pathname}${url.search}`;
+  params.set("SERVICE", service);
+  params.set("REQUEST", "GetCapabilities");
+  if (version) params.set("VERSION", version);
+  return `${path}?${params.toString()}${hash}`;
 }
 
 /** A single requestable (named) layer advertised by a WMS GetCapabilities. */

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -458,7 +458,9 @@ function capabilitiesRootError(
     rootName === "ServiceException" ||
     rootName === "ExceptionReport";
   if (isException) {
-    const message = root?.textContent?.replace(/\s+/g, " ").trim();
+    // Cap the length: a service's exception body is rendered straight into the
+    // error paragraph, and a misbehaving one could return a huge payload.
+    const message = root?.textContent?.replace(/\s+/g, " ").trim().slice(0, 500);
     return message || `The ${service} service returned an error.`;
   }
   return `The response is not a ${service} capabilities document.`;

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -10,6 +10,7 @@ import {
   GPX_PROXY_PATH,
   MAX_SAVED_POSTGRES_CONNECTIONS,
   POSTGRES_CONNECTIONS_STORAGE_KEY,
+  WMS_PROXY_PATH,
 } from "./constants";
 import type { DelimitedTextDelimiter } from "./types";
 
@@ -199,6 +200,155 @@ export function proxyFeedRequestUrl(url: string): string {
   return isViteDevServer()
     ? `${GPX_PROXY_PATH}?url=${encodeURIComponent(url)}`
     : url;
+}
+
+/**
+ * Routes a WMS request through the dev-server CORS proxy when running under
+ * Vite, so a `fetch()` for a service's GetCapabilities document is not blocked
+ * by the WMS host's missing CORS headers. In production builds (Tauri / nginx)
+ * the URL is returned unchanged and the fetch relies on the service's own CORS.
+ */
+export function proxyWmsRequestUrl(url: string): string {
+  return isViteDevServer()
+    ? `${WMS_PROXY_PATH}?url=${encodeURIComponent(url)}`
+    : url;
+}
+
+/** A single requestable (named) layer advertised by a WMS GetCapabilities. */
+export interface WmsLayerOption {
+  /** The layer's `<Name>` — the value passed as the WMS `LAYERS` parameter. */
+  name: string;
+  /** The layer's human-readable `<Title>`; falls back to the name if absent. */
+  title: string;
+}
+
+/**
+ * Builds a WMS `GetCapabilities` request URL from a service endpoint. Any WMS
+ * operation parameters already present on the endpoint (e.g. a `REQUEST=GetMap`
+ * left over from a copied GetMap URL) are stripped first so they cannot collide
+ * with the `SERVICE`/`REQUEST` parameters this adds.
+ *
+ * @param endpoint - The WMS service base URL, with or without a query string.
+ * @returns The GetCapabilities request URL.
+ */
+export function createWmsGetCapabilitiesUrl(endpoint: string): string {
+  const operationParams = new Set([
+    "service",
+    "request",
+    "version",
+    "layers",
+    "styles",
+    "format",
+    "transparent",
+    "bbox",
+    "width",
+    "height",
+    "srs",
+    "crs",
+  ]);
+  try {
+    const url = new URL(endpoint);
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (operationParams.has(key.toLowerCase())) url.searchParams.delete(key);
+    }
+    url.searchParams.set("SERVICE", "WMS");
+    url.searchParams.set("REQUEST", "GetCapabilities");
+    return url.toString();
+  } catch {
+    // Relative or otherwise unparseable endpoint: fall back to a plain append.
+    return appendQuery(endpoint, [
+      ["SERVICE", "WMS"],
+      ["REQUEST", "GetCapabilities"],
+    ]);
+  }
+}
+
+/**
+ * Extracts the requestable (named) layers from a WMS GetCapabilities document.
+ * Only `<Layer>` elements that carry their own `<Name>` are requestable; the
+ * container layers that merely group others (a `<Title>` but no `<Name>`) are
+ * skipped. Traversal is namespace-agnostic so it handles both WMS 1.1.1
+ * (`WMT_MS_Capabilities`) and 1.3.0 (`WMS_Capabilities`, default namespace).
+ *
+ * @param xmlText - The raw GetCapabilities XML response body.
+ * @returns The named layers in document order, deduplicated by name.
+ */
+export function parseWmsCapabilitiesLayers(xmlText: string): WmsLayerOption[] {
+  const doc = new DOMParser().parseFromString(xmlText, "application/xml");
+  if (doc.querySelector("parsererror")) {
+    throw new Error("Could not parse the WMS capabilities document.");
+  }
+  const root = doc.documentElement;
+  if (!root || root.localName === "ServiceExceptionReport") {
+    const message = root?.textContent?.trim();
+    throw new Error(message || "The WMS service returned an error.");
+  }
+
+  const layers: WmsLayerOption[] = [];
+  const seen = new Set<string>();
+  // Every <Layer> in the document, at any nesting depth. Reading each one's own
+  // direct <Name>/<Title> and deduplicating by name means the container layers
+  // (which have no <Name>) are skipped without tracking the tree ourselves. The
+  // "*" namespace wildcard covers both WMS 1.1.1 (no namespace) and 1.3.0
+  // (default `http://www.opengis.net/wms` namespace).
+  const layerElements = root.getElementsByTagNameNS("*", "Layer");
+  for (let i = 0; i < layerElements.length; i += 1) {
+    const layer = layerElements[i];
+    const name = directChildText(layer, "Name");
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    layers.push({ name, title: directChildText(layer, "Title") || name });
+  }
+  return layers;
+}
+
+/**
+ * Reads the direct-child element with the given local name and returns its
+ * trimmed text. Restricting to direct children keeps a `<Layer>`'s own `<Name>`
+ * / `<Title>` from being confused with those nested inside its `<Style>` or
+ * child `<Layer>` elements.
+ */
+function directChildText(element: Element, localName: string): string {
+  for (const child of Array.from(element.children)) {
+    if (child.localName === localName) return (child.textContent ?? "").trim();
+  }
+  return "";
+}
+
+/**
+ * Fetches a WMS service's GetCapabilities document and returns its requestable
+ * layers. Routes through the dev-server CORS proxy under Vite; in production it
+ * relies on the service's own CORS headers.
+ *
+ * @param endpoint - The WMS service base URL.
+ * @param options - Optional abort signal.
+ * @returns The named layers advertised by the service.
+ */
+export async function fetchWmsLayers(
+  endpoint: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<WmsLayerOption[]> {
+  const requestUrl = createWmsGetCapabilitiesUrl(endpoint.trim());
+  let response: Response;
+  try {
+    response = await fetch(proxyWmsRequestUrl(requestUrl), {
+      signal: options.signal
+        ? AbortSignal.any([options.signal, AbortSignal.timeout(30_000)])
+        : AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new Error("The request timed out.");
+    }
+    throw error;
+  }
+  const text = await response.text();
+  // A well-formed error body is still XML, so only treat a non-2xx as fatal
+  // when the payload is not XML we can parse for a ServiceException message.
+  if (!response.ok && !/^\s*</.test(text)) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return parseWmsCapabilitiesLayers(text);
 }
 
 export function resolveDelimitedTextDelimiter(

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -231,7 +231,7 @@ async function fetchCapabilitiesText(
       url: requestUrl,
     });
     const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-    return { ok: true, status: 200, text: new TextDecoder().decode(array) };
+    return { ok: true, status: 200, text: decodeXmlBytes(array) };
   }
   const fetchUrl = isViteDevServer()
     ? `${devProxyPath}?url=${encodeURIComponent(requestUrl)}`
@@ -259,6 +259,62 @@ async function fetchCapabilitiesText(
   return { ok: response.ok, status: response.status, text: await response.text() };
 }
 
+/**
+ * Decodes capabilities bytes to text, honoring a non-UTF-8 charset declared in
+ * the XML prolog (`<?xml … encoding="ISO-8859-1"?>`). The browser fetch path
+ * gets this for free via `response.text()`, but the Tauri byte path must do it
+ * by hand or a legacy Latin-1 service would render mojibake.
+ */
+function decodeXmlBytes(bytes: Uint8Array): string {
+  // The prolog is ASCII, so decode a short head to read the declared charset.
+  const head = new TextDecoder("ascii").decode(bytes.subarray(0, 256));
+  const label = head.match(/encoding=["']([\w-]+)["']/i)?.[1] ?? "utf-8";
+  try {
+    return new TextDecoder(label).decode(bytes);
+  } catch {
+    return new TextDecoder("utf-8").decode(bytes);
+  }
+}
+
+/**
+ * Builds an OGC `GetCapabilities` request URL, stripping any operation
+ * parameters already on the endpoint (e.g. a copied `REQUEST=GetMap`) so they
+ * cannot collide with the ones added here. Handles both absolute and relative
+ * endpoints; the stripping applies to relative endpoints too.
+ */
+function buildCapabilitiesUrl(
+  endpoint: string,
+  service: "WMS" | "WFS",
+  operationParams: ReadonlySet<string>,
+  version?: string,
+): string {
+  const DUMMY_BASE = "http://geolibre.invalid";
+  let url: URL;
+  let relative = false;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    try {
+      url = new URL(endpoint, DUMMY_BASE);
+      relative = true;
+    } catch {
+      const params: Array<[string, string]> = [
+        ["SERVICE", service],
+        ["REQUEST", "GetCapabilities"],
+      ];
+      if (version) params.push(["VERSION", version]);
+      return appendQuery(endpoint, params);
+    }
+  }
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (operationParams.has(key.toLowerCase())) url.searchParams.delete(key);
+  }
+  url.searchParams.set("SERVICE", service);
+  url.searchParams.set("REQUEST", "GetCapabilities");
+  if (version) url.searchParams.set("VERSION", version);
+  return relative ? `${url.pathname}${url.search}` : url.toString();
+}
+
 /** A single requestable (named) layer advertised by a WMS GetCapabilities. */
 export interface WmsLayerOption {
   /** The layer's `<Name>` — the value passed as the WMS `LAYERS` parameter. */
@@ -276,36 +332,23 @@ export interface WmsLayerOption {
  * @param endpoint - The WMS service base URL, with or without a query string.
  * @returns The GetCapabilities request URL.
  */
+const WMS_OPERATION_PARAMS: ReadonlySet<string> = new Set([
+  "service",
+  "request",
+  "version",
+  "layers",
+  "styles",
+  "format",
+  "transparent",
+  "bbox",
+  "width",
+  "height",
+  "srs",
+  "crs",
+]);
+
 export function createWmsGetCapabilitiesUrl(endpoint: string): string {
-  const operationParams = new Set([
-    "service",
-    "request",
-    "version",
-    "layers",
-    "styles",
-    "format",
-    "transparent",
-    "bbox",
-    "width",
-    "height",
-    "srs",
-    "crs",
-  ]);
-  try {
-    const url = new URL(endpoint);
-    for (const key of Array.from(url.searchParams.keys())) {
-      if (operationParams.has(key.toLowerCase())) url.searchParams.delete(key);
-    }
-    url.searchParams.set("SERVICE", "WMS");
-    url.searchParams.set("REQUEST", "GetCapabilities");
-    return url.toString();
-  } catch {
-    // Relative or otherwise unparseable endpoint: fall back to a plain append.
-    return appendQuery(endpoint, [
-      ["SERVICE", "WMS"],
-      ["REQUEST", "GetCapabilities"],
-    ]);
-  }
+  return buildCapabilitiesUrl(endpoint, "WMS", WMS_OPERATION_PARAMS);
 }
 
 /**
@@ -323,10 +366,13 @@ export function parseWmsCapabilitiesLayers(xmlText: string): WmsLayerOption[] {
   if (doc.querySelector("parsererror")) {
     throw new Error("Could not parse the WMS capabilities document.");
   }
+  // Validate the root element rather than trusting any XML that parses: an OWS
+  // ServiceException or an HTML/proxy error page also parses, and returning its
+  // (empty) layer list would mislead the UI into "No layers were found".
   const root = doc.documentElement;
-  if (!root || root.localName === "ServiceExceptionReport") {
-    const message = root?.textContent?.trim();
-    throw new Error(message || "The WMS service returned an error.");
+  const rootName = root?.localName;
+  if (rootName !== "WMS_Capabilities" && rootName !== "WMT_MS_Capabilities") {
+    throw new Error(capabilitiesRootError(root, "WMS"));
   }
 
   const layers: WmsLayerOption[] = [];
@@ -358,6 +404,27 @@ function directChildText(element: Element, localName: string): string {
     if (child.localName === localName) return (child.textContent ?? "").trim();
   }
   return "";
+}
+
+/**
+ * Builds an error message for a capabilities document whose root is not the
+ * expected element. An OWS/OGC exception root carries a human-readable reason,
+ * so surface it; anything else (e.g. an HTML error page) gets a generic note.
+ */
+function capabilitiesRootError(
+  root: Element | null,
+  service: "WMS" | "WFS",
+): string {
+  const rootName = root?.localName;
+  const isException =
+    rootName === "ServiceExceptionReport" ||
+    rootName === "ServiceException" ||
+    rootName === "ExceptionReport";
+  if (isException) {
+    const message = root?.textContent?.replace(/\s+/g, " ").trim();
+    return message || `The ${service} service returned an error.`;
+  }
+  return `The response is not a ${service} capabilities document.`;
 }
 
 /**
@@ -405,40 +472,25 @@ export interface WfsFeatureTypeOption {
  * @param version - Optional WFS version to request (e.g. "2.0.0").
  * @returns The GetCapabilities request URL.
  */
+const WFS_OPERATION_PARAMS: ReadonlySet<string> = new Set([
+  "service",
+  "request",
+  "version",
+  "typename",
+  "typenames",
+  "outputformat",
+  "srsname",
+  "bbox",
+  "count",
+  "maxfeatures",
+  "resulttype",
+]);
+
 export function createWfsGetCapabilitiesUrl(
   endpoint: string,
   version?: string,
 ): string {
-  const operationParams = new Set([
-    "service",
-    "request",
-    "version",
-    "typename",
-    "typenames",
-    "outputformat",
-    "srsname",
-    "bbox",
-    "count",
-    "maxfeatures",
-    "resulttype",
-  ]);
-  try {
-    const url = new URL(endpoint);
-    for (const key of Array.from(url.searchParams.keys())) {
-      if (operationParams.has(key.toLowerCase())) url.searchParams.delete(key);
-    }
-    url.searchParams.set("SERVICE", "WFS");
-    url.searchParams.set("REQUEST", "GetCapabilities");
-    if (version) url.searchParams.set("VERSION", version);
-    return url.toString();
-  } catch {
-    const params: Array<[string, string]> = [
-      ["SERVICE", "WFS"],
-      ["REQUEST", "GetCapabilities"],
-    ];
-    if (version) params.push(["VERSION", version]);
-    return appendQuery(endpoint, params);
-  }
+  return buildCapabilitiesUrl(endpoint, "WFS", WFS_OPERATION_PARAMS, version);
 }
 
 /**
@@ -456,14 +508,11 @@ export function parseWfsCapabilitiesFeatureTypes(
   if (doc.querySelector("parsererror")) {
     throw new Error("Could not parse the WFS capabilities document.");
   }
+  // Validate the root element (see parseWmsCapabilitiesLayers) so an exception
+  // or HTML error page surfaces an error instead of an empty type list.
   const root = doc.documentElement;
-  if (
-    !root ||
-    root.localName === "ServiceExceptionReport" ||
-    root.localName === "ExceptionReport"
-  ) {
-    const message = root?.textContent?.trim();
-    throw new Error(message || "The WFS service returned an error.");
+  if (root?.localName !== "WFS_Capabilities") {
+    throw new Error(capabilitiesRootError(root, "WFS"));
   }
 
   const featureTypes: WfsFeatureTypeOption[] = [];

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -5,11 +5,13 @@
 
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
+import { isTauri } from "../../../lib/is-tauri";
 import {
   DELIMITED_TEXT_DELIMITERS,
   GPX_PROXY_PATH,
   MAX_SAVED_POSTGRES_CONNECTIONS,
   POSTGRES_CONNECTIONS_STORAGE_KEY,
+  WFS_PROXY_PATH,
   WMS_PROXY_PATH,
 } from "./constants";
 import type { DelimitedTextDelimiter } from "./types";
@@ -203,15 +205,58 @@ export function proxyFeedRequestUrl(url: string): string {
 }
 
 /**
- * Routes a WMS request through the dev-server CORS proxy when running under
- * Vite, so a `fetch()` for a service's GetCapabilities document is not blocked
- * by the WMS host's missing CORS headers. In production builds (Tauri / nginx)
- * the URL is returned unchanged and the fetch relies on the service's own CORS.
+ * Fetches an OGC service capabilities document as text, working around the
+ * cross-origin restrictions that block a plain browser fetch of a WMS/WFS host
+ * that omits CORS headers:
+ * - Desktop (Tauri): fetched natively through the `fetch_url_bytes` command,
+ *   which runs in Rust and is not subject to browser CORS, so any service works.
+ * - Dev server (Vite): routed through the same-origin dev proxy.
+ * - Hosted web build: a direct fetch, which only succeeds when the service
+ *   sends `Access-Control-Allow-Origin`.
+ *
+ * @param requestUrl - The absolute GetCapabilities request URL.
+ * @param devProxyPath - The dev-server proxy path to use under Vite.
+ * @param signal - Optional abort signal.
+ * @returns The response ok flag, status, and body text.
  */
-export function proxyWmsRequestUrl(url: string): string {
-  return isViteDevServer()
-    ? `${WMS_PROXY_PATH}?url=${encodeURIComponent(url)}`
-    : url;
+async function fetchCapabilitiesText(
+  requestUrl: string,
+  devProxyPath: string,
+  signal?: AbortSignal,
+): Promise<{ ok: boolean; status: number; text: string }> {
+  if (isTauri()) {
+    // `fetch_url_bytes` rejects on a non-2xx status, so a resolved value is OK.
+    const { invoke } = await import("@tauri-apps/api/core");
+    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
+      url: requestUrl,
+    });
+    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return { ok: true, status: 200, text: new TextDecoder().decode(array) };
+  }
+  const fetchUrl = isViteDevServer()
+    ? `${devProxyPath}?url=${encodeURIComponent(requestUrl)}`
+    : requestUrl;
+  let response: Response;
+  try {
+    response = await fetch(fetchUrl, {
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(30_000)])
+        : AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new Error("The request timed out.");
+    }
+    // A CORS rejection surfaces as a bare TypeError with no status. Point the
+    // user at the workarounds instead of a cryptic "Failed to fetch".
+    if (error instanceof TypeError) {
+      throw new Error(
+        "Could not reach the service. It may not allow cross-origin requests from the browser; try the desktop app or enter the layer name manually.",
+      );
+    }
+    throw error;
+  }
+  return { ok: response.ok, status: response.status, text: await response.text() };
 }
 
 /** A single requestable (named) layer advertised by a WMS GetCapabilities. */
@@ -317,8 +362,8 @@ function directChildText(element: Element, localName: string): string {
 
 /**
  * Fetches a WMS service's GetCapabilities document and returns its requestable
- * layers. Routes through the dev-server CORS proxy under Vite; in production it
- * relies on the service's own CORS headers.
+ * layers. Works cross-origin in the desktop app and dev server; in the hosted
+ * web build it relies on the service's own CORS headers.
  *
  * @param endpoint - The WMS service base URL.
  * @param options - Optional abort signal.
@@ -329,26 +374,134 @@ export async function fetchWmsLayers(
   options: { signal?: AbortSignal } = {},
 ): Promise<WmsLayerOption[]> {
   const requestUrl = createWmsGetCapabilitiesUrl(endpoint.trim());
-  let response: Response;
-  try {
-    response = await fetch(proxyWmsRequestUrl(requestUrl), {
-      signal: options.signal
-        ? AbortSignal.any([options.signal, AbortSignal.timeout(30_000)])
-        : AbortSignal.timeout(30_000),
-    });
-  } catch (error) {
-    if (error instanceof DOMException && error.name === "TimeoutError") {
-      throw new Error("The request timed out.");
-    }
-    throw error;
-  }
-  const text = await response.text();
+  const { ok, status, text } = await fetchCapabilitiesText(
+    requestUrl,
+    WMS_PROXY_PATH,
+    options.signal,
+  );
   // A well-formed error body is still XML, so only treat a non-2xx as fatal
   // when the payload is not XML we can parse for a ServiceException message.
-  if (!response.ok && !/^\s*</.test(text)) {
-    throw new Error(`Request failed with status ${response.status}`);
+  if (!ok && !/^\s*</.test(text)) {
+    throw new Error(`Request failed with status ${status}`);
   }
   return parseWmsCapabilitiesLayers(text);
+}
+
+/** A single feature type advertised by a WFS GetCapabilities. */
+export interface WfsFeatureTypeOption {
+  /** The type's `<Name>` — the value passed as the WFS `typeName(s)` param. */
+  name: string;
+  /** The type's human-readable `<Title>`; falls back to the name if absent. */
+  title: string;
+}
+
+/**
+ * Builds a WFS `GetCapabilities` request URL from a service endpoint. Any WFS
+ * operation parameters already present on the endpoint (e.g. a leftover
+ * `REQUEST=GetFeature`) are stripped first so they cannot collide with the
+ * `SERVICE`/`REQUEST` parameters this adds.
+ *
+ * @param endpoint - The WFS service base URL, with or without a query string.
+ * @param version - Optional WFS version to request (e.g. "2.0.0").
+ * @returns The GetCapabilities request URL.
+ */
+export function createWfsGetCapabilitiesUrl(
+  endpoint: string,
+  version?: string,
+): string {
+  const operationParams = new Set([
+    "service",
+    "request",
+    "version",
+    "typename",
+    "typenames",
+    "outputformat",
+    "srsname",
+    "bbox",
+    "count",
+    "maxfeatures",
+    "resulttype",
+  ]);
+  try {
+    const url = new URL(endpoint);
+    for (const key of Array.from(url.searchParams.keys())) {
+      if (operationParams.has(key.toLowerCase())) url.searchParams.delete(key);
+    }
+    url.searchParams.set("SERVICE", "WFS");
+    url.searchParams.set("REQUEST", "GetCapabilities");
+    if (version) url.searchParams.set("VERSION", version);
+    return url.toString();
+  } catch {
+    const params: Array<[string, string]> = [
+      ["SERVICE", "WFS"],
+      ["REQUEST", "GetCapabilities"],
+    ];
+    if (version) params.push(["VERSION", version]);
+    return appendQuery(endpoint, params);
+  }
+}
+
+/**
+ * Extracts the advertised feature types from a WFS GetCapabilities document.
+ * Reads each `<FeatureType>`'s own `<Name>`/`<Title>`. Traversal is
+ * namespace-agnostic so WFS 1.0.0/1.1.0/2.0.0 all work.
+ *
+ * @param xmlText - The raw GetCapabilities XML response body.
+ * @returns The feature types in document order, deduplicated by name.
+ */
+export function parseWfsCapabilitiesFeatureTypes(
+  xmlText: string,
+): WfsFeatureTypeOption[] {
+  const doc = new DOMParser().parseFromString(xmlText, "application/xml");
+  if (doc.querySelector("parsererror")) {
+    throw new Error("Could not parse the WFS capabilities document.");
+  }
+  const root = doc.documentElement;
+  if (
+    !root ||
+    root.localName === "ServiceExceptionReport" ||
+    root.localName === "ExceptionReport"
+  ) {
+    const message = root?.textContent?.trim();
+    throw new Error(message || "The WFS service returned an error.");
+  }
+
+  const featureTypes: WfsFeatureTypeOption[] = [];
+  const seen = new Set<string>();
+  const elements = root.getElementsByTagNameNS("*", "FeatureType");
+  for (let i = 0; i < elements.length; i += 1) {
+    const element = elements[i];
+    const name = directChildText(element, "Name");
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    featureTypes.push({ name, title: directChildText(element, "Title") || name });
+  }
+  return featureTypes;
+}
+
+/**
+ * Fetches a WFS service's GetCapabilities document and returns its feature
+ * types. Works cross-origin in the desktop app and dev server; in the hosted
+ * web build it relies on the service's own CORS headers.
+ *
+ * @param endpoint - The WFS service base URL.
+ * @param options - Optional WFS version and abort signal.
+ * @returns The feature types advertised by the service.
+ */
+export async function fetchWfsFeatureTypes(
+  endpoint: string,
+  options: { version?: string; signal?: AbortSignal } = {},
+): Promise<WfsFeatureTypeOption[]> {
+  const requestUrl = createWfsGetCapabilitiesUrl(endpoint.trim(), options.version);
+  const { ok, status, text } = await fetchCapabilitiesText(
+    requestUrl,
+    WFS_PROXY_PATH,
+    options.signal,
+  );
+  if (!ok && !/^\s*</.test(text)) {
+    throw new Error(`Request failed with status ${status}`);
+  }
+  return parseWfsCapabilitiesFeatureTypes(text);
 }
 
 export function resolveDelimitedTextDelimiter(

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -1,4 +1,5 @@
-import { Input, Label, Select } from "@geolibre/ui";
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import { ListTree, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -6,7 +7,12 @@ import {
   fetchGeoJsonFeatureCollection,
 } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
-import { createBaseLayer } from "../helpers";
+import {
+  createBaseLayer,
+  errorMessage,
+  fetchWfsFeatureTypes,
+  type WfsFeatureTypeOption,
+} from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldString,
@@ -23,6 +29,38 @@ export function WfsSource() {
   const [wfsOutputFormat, setWfsOutputFormat] = useState("application/json");
   const [wfsSrsName, setWfsSrsName] = useState("EPSG:4326");
   const [wfsMaxFeatures, setWfsMaxFeatures] = useState("1000");
+  const [typeOptions, setTypeOptions] = useState<WfsFeatureTypeOption[]>([]);
+  const [isRetrieving, setIsRetrieving] = useState(false);
+  const [retrieveError, setRetrieveError] = useState<string | null>(null);
+
+  const handleRetrieveTypes = async () => {
+    const endpoint = wfsEndpoint.trim();
+    if (!endpoint) {
+      setRetrieveError(t("addData.wfs.errorUrl"));
+      return;
+    }
+    setIsRetrieving(true);
+    setRetrieveError(null);
+    try {
+      const options = await fetchWfsFeatureTypes(endpoint, {
+        version: wfsVersion,
+      });
+      if (options.length === 0) {
+        setTypeOptions([]);
+        setRetrieveError(t("addData.wfs.noTypesFound"));
+        return;
+      }
+      setTypeOptions(options);
+      // Preselect the first type when the field is empty so a single click
+      // leaves the form ready to submit.
+      if (!wfsTypeName.trim()) setWfsTypeName(options[0].name);
+    } catch (error) {
+      setTypeOptions([]);
+      setRetrieveError(errorMessage(error, t("addData.wfs.retrieveError")));
+    } finally {
+      setIsRetrieving(false);
+    }
+  };
 
   const getFields = (): ServiceFields => ({
     endpoint: wfsEndpoint,
@@ -42,6 +80,9 @@ export function WfsSource() {
     );
     setWfsSrsName(serviceFieldString(fields, "srsName", "EPSG:4326"));
     setWfsMaxFeatures(serviceFieldString(fields, "maxFeatures", "1000"));
+    // The new endpoint's feature types must be re-retrieved, so drop the list.
+    setTypeOptions([]);
+    setRetrieveError(null);
   };
 
   const handleSubmit = source.runSubmit(async () => {
@@ -119,22 +160,68 @@ export function WfsSource() {
         />
         <div className="space-y-1.5">
           <Label htmlFor="wfs-endpoint">{t("addData.common.serviceUrl")}</Label>
-          <Input
-            id="wfs-endpoint"
-            placeholder={t("addData.wfs.urlPlaceholder")}
-            value={wfsEndpoint}
-            onChange={(event) => setWfsEndpoint(event.target.value)}
-          />
+          <div className="flex gap-2">
+            <Input
+              id="wfs-endpoint"
+              placeholder={t("addData.wfs.urlPlaceholder")}
+              value={wfsEndpoint}
+              onChange={(event) => {
+                setWfsEndpoint(event.target.value);
+                // Feature types belong to the previous endpoint; clear them so
+                // the dropdown never offers stale options for another service.
+                if (typeOptions.length > 0) setTypeOptions([]);
+                if (retrieveError) setRetrieveError(null);
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleRetrieveTypes}
+              disabled={isRetrieving || !wfsEndpoint.trim()}
+              className="shrink-0"
+            >
+              {isRetrieving ? (
+                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <ListTree className="mr-2 h-3.5 w-3.5" />
+              )}
+              {isRetrieving
+                ? t("addData.wfs.retrieving")
+                : t("addData.wfs.retrieveTypes")}
+            </Button>
+          </div>
+          {retrieveError ? (
+            <p className="text-xs text-destructive">{retrieveError}</p>
+          ) : null}
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="wfs-type-name">{t("addData.wfs.featureType")}</Label>
-            <Input
-              id="wfs-type-name"
-              placeholder={t("addData.common.workspaceLayerPlaceholder")}
-              value={wfsTypeName}
-              onChange={(event) => setWfsTypeName(event.target.value)}
-            />
+            {typeOptions.length > 0 ? (
+              <Select
+                id="wfs-type-name"
+                value={wfsTypeName}
+                onChange={(event) => setWfsTypeName(event.target.value)}
+              >
+                <option value="" disabled>
+                  {t("addData.wfs.selectType")}
+                </option>
+                {typeOptions.map((option) => (
+                  <option key={option.name} value={option.name}>
+                    {option.title === option.name
+                      ? option.name
+                      : `${option.title} (${option.name})`}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <Input
+                id="wfs-type-name"
+                placeholder={t("addData.common.workspaceLayerPlaceholder")}
+                value={wfsTypeName}
+                onChange={(event) => setWfsTypeName(event.target.value)}
+              />
+            )}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="wfs-version">{t("addData.wfs.version")}</Label>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -42,8 +42,15 @@ export function WfsSource() {
     retrieveAbortRef.current = null;
   };
 
-  // Abort an in-flight retrieval if the dialog closes mid-request.
-  useEffect(() => () => retrieveAbortRef.current?.abort(), []);
+  // Abort an in-flight retrieval if the dialog closes mid-request, and advance
+  // the token so its finally block cannot set state after unmount.
+  useEffect(
+    () => () => {
+      retrieveTokenRef.current += 1;
+      retrieveAbortRef.current?.abort();
+    },
+    [],
+  );
 
   const handleRetrieveTypes = async () => {
     const endpoint = wfsEndpoint.trim();
@@ -267,7 +274,18 @@ export function WfsSource() {
             <Select
               id="wfs-version"
               value={wfsVersion}
-              onChange={(event) => setWfsVersion(event.target.value)}
+              onChange={(event) => {
+                setWfsVersion(event.target.value);
+                // Capabilities are fetched per version, so a version change can
+                // stale the retrieved list; drop it (and cancel any retrieval in
+                // flight) so it is re-fetched for the newly chosen version.
+                if (typeOptions.length > 0 || isRetrieving) {
+                  cancelRetrieve();
+                  setTypeOptions([]);
+                  setIsRetrieving(false);
+                }
+                if (retrieveError) setRetrieveError(null);
+              }}
             >
               <option value="2.0.0">2.0.0</option>
               <option value="1.1.0">1.1.0</option>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { ListTree, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   createWfsGetFeatureUrl,
@@ -32,6 +32,15 @@ export function WfsSource() {
   const [typeOptions, setTypeOptions] = useState<WfsFeatureTypeOption[]>([]);
   const [isRetrieving, setIsRetrieving] = useState(false);
   const [retrieveError, setRetrieveError] = useState<string | null>(null);
+  const typeListId = useId();
+  // See WmsSource: guards a stale in-flight retrieval from overwriting the form.
+  const retrieveTokenRef = useRef(0);
+  const retrieveAbortRef = useRef<AbortController | null>(null);
+
+  const cancelRetrieve = () => {
+    retrieveAbortRef.current?.abort();
+    retrieveAbortRef.current = null;
+  };
 
   const handleRetrieveTypes = async () => {
     const endpoint = wfsEndpoint.trim();
@@ -39,12 +48,20 @@ export function WfsSource() {
       setRetrieveError(t("addData.wfs.errorUrl"));
       return;
     }
+    retrieveAbortRef.current?.abort();
+    const controller = new AbortController();
+    retrieveAbortRef.current = controller;
+    const token = ++retrieveTokenRef.current;
+    const isStale = () =>
+      token !== retrieveTokenRef.current || controller.signal.aborted;
     setIsRetrieving(true);
     setRetrieveError(null);
     try {
       const options = await fetchWfsFeatureTypes(endpoint, {
         version: wfsVersion,
+        signal: controller.signal,
       });
+      if (isStale()) return;
       if (options.length === 0) {
         setTypeOptions([]);
         setRetrieveError(t("addData.wfs.noTypesFound"));
@@ -55,10 +72,11 @@ export function WfsSource() {
       // leaves the form ready to submit.
       if (!wfsTypeName.trim()) setWfsTypeName(options[0].name);
     } catch (error) {
+      if (isStale()) return;
       setTypeOptions([]);
       setRetrieveError(errorMessage(error, t("addData.wfs.retrieveError")));
     } finally {
-      setIsRetrieving(false);
+      if (token === retrieveTokenRef.current) setIsRetrieving(false);
     }
   };
 
@@ -80,7 +98,9 @@ export function WfsSource() {
     );
     setWfsSrsName(serviceFieldString(fields, "srsName", "EPSG:4326"));
     setWfsMaxFeatures(serviceFieldString(fields, "maxFeatures", "1000"));
-    // The new endpoint's feature types must be re-retrieved, so drop the list.
+    // The new endpoint's feature types must be re-retrieved, so drop the list
+    // and cancel any retrieval still in flight for the previous endpoint.
+    cancelRetrieve();
     setTypeOptions([]);
     setRetrieveError(null);
   };
@@ -167,9 +187,14 @@ export function WfsSource() {
               value={wfsEndpoint}
               onChange={(event) => {
                 setWfsEndpoint(event.target.value);
-                // Feature types belong to the previous endpoint; clear them so
-                // the dropdown never offers stale options for another service.
-                if (typeOptions.length > 0) setTypeOptions([]);
+                // Feature types belong to the previous endpoint; clear them (and
+                // cancel any in-flight retrieval) so the list never reflects a
+                // different service.
+                if (typeOptions.length > 0 || isRetrieving) {
+                  cancelRetrieve();
+                  setTypeOptions([]);
+                  setIsRetrieving(false);
+                }
                 if (retrieveError) setRetrieveError(null);
               }}
             />
@@ -197,15 +222,18 @@ export function WfsSource() {
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="wfs-type-name">{t("addData.wfs.featureType")}</Label>
+            {/* Text input backed by a <datalist> of retrieved types: dropdown
+                suggestions for the common pick, free text preserved for manual
+                entry when a service blocks GetCapabilities. */}
+            <Input
+              id="wfs-type-name"
+              list={typeOptions.length > 0 ? typeListId : undefined}
+              placeholder={t("addData.common.workspaceLayerPlaceholder")}
+              value={wfsTypeName}
+              onChange={(event) => setWfsTypeName(event.target.value)}
+            />
             {typeOptions.length > 0 ? (
-              <Select
-                id="wfs-type-name"
-                value={wfsTypeName}
-                onChange={(event) => setWfsTypeName(event.target.value)}
-              >
-                <option value="" disabled>
-                  {t("addData.wfs.selectType")}
-                </option>
+              <datalist id={typeListId}>
                 {typeOptions.map((option) => (
                   <option key={option.name} value={option.name}>
                     {option.title === option.name
@@ -213,15 +241,8 @@ export function WfsSource() {
                       : `${option.title} (${option.name})`}
                   </option>
                 ))}
-              </Select>
-            ) : (
-              <Input
-                id="wfs-type-name"
-                placeholder={t("addData.common.workspaceLayerPlaceholder")}
-                value={wfsTypeName}
-                onChange={(event) => setWfsTypeName(event.target.value)}
-              />
-            )}
+              </datalist>
+            ) : null}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="wfs-version">{t("addData.wfs.version")}</Label>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { ListTree, Loader2 } from "lucide-react";
-import { useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   createWfsGetFeatureUrl,
@@ -41,6 +41,9 @@ export function WfsSource() {
     retrieveAbortRef.current?.abort();
     retrieveAbortRef.current = null;
   };
+
+  // Abort an in-flight retrieval if the dialog closes mid-request.
+  useEffect(() => () => retrieveAbortRef.current?.abort(), []);
 
   const handleRetrieveTypes = async () => {
     const endpoint = wfsEndpoint.trim();

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -11,6 +11,7 @@ import {
   createBaseLayer,
   errorMessage,
   fetchWfsFeatureTypes,
+  stripOgcOperationParams,
   type WfsFeatureTypeOption,
 } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
@@ -128,8 +129,11 @@ export function WfsSource() {
       throw new Error(t("addData.wfs.errorMaxFeaturesNumeric"));
     }
 
+    // Strip any leftover operation params (a pasted GetCapabilities URL) so the
+    // GetFeature request is not built with a conflicting duplicate REQUEST,
+    // which would make the server return capabilities XML instead of features.
     const featureUrl = createWfsGetFeatureUrl({
-      endpoint: wfsEndpoint.trim(),
+      endpoint: stripOgcOperationParams(wfsEndpoint.trim(), "WFS"),
       typeName: wfsTypeName.trim(),
       version: wfsVersion,
       outputFormat: wfsOutputFormat.trim(),

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -221,22 +221,24 @@ export function WfsSource() {
           {retrieveError ? (
             <p className="text-xs text-destructive">{retrieveError}</p>
           ) : null}
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="wfs-type-name">{t("addData.wfs.featureType")}</Label>
-            {/* Text input backed by a <datalist> of retrieved types: dropdown
-                suggestions for the common pick, free text preserved for manual
-                entry when a service blocks GetCapabilities. */}
-            <Input
-              id="wfs-type-name"
-              list={typeOptions.length > 0 ? typeListId : undefined}
-              placeholder={t("addData.common.workspaceLayerPlaceholder")}
-              value={wfsTypeName}
-              onChange={(event) => setWfsTypeName(event.target.value)}
-            />
-            {typeOptions.length > 0 ? (
-              <datalist id={typeListId}>
+          {typeOptions.length > 0 ? (
+            <div className="space-y-1.5">
+              <Label htmlFor={typeListId}>
+                {t("addData.wfs.retrievedTypes")}
+              </Label>
+              {/* Picker listing every retrieved feature type; fills the field
+                  below on select. Value stays empty (action menu), so it always
+                  shows the full list and can never mismatch the free-text field. */}
+              <Select
+                id={typeListId}
+                value=""
+                onChange={(event) => {
+                  if (event.target.value) setWfsTypeName(event.target.value);
+                }}
+              >
+                <option value="" disabled>
+                  {t("addData.wfs.selectType", { count: typeOptions.length })}
+                </option>
                 {typeOptions.map((option) => (
                   <option key={option.name} value={option.name}>
                     {option.title === option.name
@@ -244,8 +246,21 @@ export function WfsSource() {
                       : `${option.title} (${option.name})`}
                   </option>
                 ))}
-              </datalist>
-            ) : null}
+              </Select>
+            </div>
+          ) : null}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="wfs-type-name">{t("addData.wfs.featureType")}</Label>
+            {/* Plain free-text field: holds the submitted typeName and stays
+                editable for manual entry. The picker above fills it. */}
+            <Input
+              id="wfs-type-name"
+              placeholder={t("addData.common.workspaceLayerPlaceholder")}
+              value={wfsTypeName}
+              onChange={(event) => setWfsTypeName(event.target.value)}
+            />
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="wfs-version">{t("addData.wfs.version")}</Label>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -21,19 +21,65 @@ import {
 } from "../service-library";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
+/**
+ * Retains the WFS form input across dialog close/reopen (in memory, for the
+ * session) so a user can add several feature types from the same service
+ * without re-entering the URL or re-retrieving its type list each time.
+ */
+interface WfsFormCache {
+  endpoint: string;
+  typeName: string;
+  version: string;
+  outputFormat: string;
+  srsName: string;
+  maxFeatures: string;
+  options: WfsFeatureTypeOption[];
+}
+let wfsFormCache: WfsFormCache | null = null;
+
 export function WfsSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.wfs.defaultName"));
-  const [wfsEndpoint, setWfsEndpoint] = useState("");
-  const [wfsTypeName, setWfsTypeName] = useState("");
-  const [wfsVersion, setWfsVersion] = useState("2.0.0");
-  const [wfsOutputFormat, setWfsOutputFormat] = useState("application/json");
-  const [wfsSrsName, setWfsSrsName] = useState("EPSG:4326");
-  const [wfsMaxFeatures, setWfsMaxFeatures] = useState("1000");
-  const [typeOptions, setTypeOptions] = useState<WfsFeatureTypeOption[]>([]);
+  const [wfsEndpoint, setWfsEndpoint] = useState(wfsFormCache?.endpoint ?? "");
+  const [wfsTypeName, setWfsTypeName] = useState(wfsFormCache?.typeName ?? "");
+  const [wfsVersion, setWfsVersion] = useState(wfsFormCache?.version ?? "2.0.0");
+  const [wfsOutputFormat, setWfsOutputFormat] = useState(
+    wfsFormCache?.outputFormat ?? "application/json",
+  );
+  const [wfsSrsName, setWfsSrsName] = useState(
+    wfsFormCache?.srsName ?? "EPSG:4326",
+  );
+  const [wfsMaxFeatures, setWfsMaxFeatures] = useState(
+    wfsFormCache?.maxFeatures ?? "1000",
+  );
+  const [typeOptions, setTypeOptions] = useState<WfsFeatureTypeOption[]>(
+    wfsFormCache?.options ?? [],
+  );
   const [isRetrieving, setIsRetrieving] = useState(false);
   const [retrieveError, setRetrieveError] = useState<string | null>(null);
   const typeListId = useId();
+
+  // Persist the form input so reopening the dialog restores the URL, the fields,
+  // and the retrieved feature-type list.
+  useEffect(() => {
+    wfsFormCache = {
+      endpoint: wfsEndpoint,
+      typeName: wfsTypeName,
+      version: wfsVersion,
+      outputFormat: wfsOutputFormat,
+      srsName: wfsSrsName,
+      maxFeatures: wfsMaxFeatures,
+      options: typeOptions,
+    };
+  }, [
+    wfsEndpoint,
+    wfsTypeName,
+    wfsVersion,
+    wfsOutputFormat,
+    wfsSrsName,
+    wfsMaxFeatures,
+    typeOptions,
+  ]);
   // See WmsSource: guards a stale in-flight retrieval from overwriting the form.
   const retrieveTokenRef = useRef(0);
   const retrieveAbortRef = useRef<AbortController | null>(null);

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -43,8 +43,15 @@ export function WmsSource() {
     retrieveAbortRef.current = null;
   };
 
-  // Abort an in-flight retrieval if the dialog closes mid-request.
-  useEffect(() => () => retrieveAbortRef.current?.abort(), []);
+  // Abort an in-flight retrieval if the dialog closes mid-request, and advance
+  // the token so its finally block cannot set state after unmount.
+  useEffect(
+    () => () => {
+      retrieveTokenRef.current += 1;
+      retrieveAbortRef.current?.abort();
+    },
+    [],
+  );
 
   const handleRetrieveLayers = async () => {
     const endpoint = wmsEndpoint.trim();

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
-import { Loader2, ListTree } from "lucide-react";
-import { useState } from "react";
+import { ListTree, Loader2 } from "lucide-react";
+import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
 import {
@@ -30,6 +30,18 @@ export function WmsSource() {
   const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>([]);
   const [isRetrieving, setIsRetrieving] = useState(false);
   const [retrieveError, setRetrieveError] = useState<string | null>(null);
+  const layerListId = useId();
+  // Guards against a stale in-flight retrieval overwriting the form after the
+  // user has moved on: a monotonic token identifies the latest request, and the
+  // AbortController cancels the previous one when a new request or an endpoint
+  // edit supersedes it.
+  const retrieveTokenRef = useRef(0);
+  const retrieveAbortRef = useRef<AbortController | null>(null);
+
+  const cancelRetrieve = () => {
+    retrieveAbortRef.current?.abort();
+    retrieveAbortRef.current = null;
+  };
 
   const handleRetrieveLayers = async () => {
     const endpoint = wmsEndpoint.trim();
@@ -37,10 +49,19 @@ export function WmsSource() {
       setRetrieveError(t("addData.wms.errorUrl"));
       return;
     }
+    retrieveAbortRef.current?.abort();
+    const controller = new AbortController();
+    retrieveAbortRef.current = controller;
+    const token = ++retrieveTokenRef.current;
+    const isStale = () =>
+      token !== retrieveTokenRef.current || controller.signal.aborted;
     setIsRetrieving(true);
     setRetrieveError(null);
     try {
-      const options = await fetchWmsLayers(endpoint);
+      const options = await fetchWmsLayers(endpoint, {
+        signal: controller.signal,
+      });
+      if (isStale()) return;
       if (options.length === 0) {
         setLayerOptions([]);
         setRetrieveError(t("addData.wms.noLayersFound"));
@@ -51,10 +72,11 @@ export function WmsSource() {
       // leaves the form ready to submit.
       if (!wmsLayers.trim()) setWmsLayers(options[0].name);
     } catch (error) {
+      if (isStale()) return;
       setLayerOptions([]);
       setRetrieveError(errorMessage(error, t("addData.wms.retrieveError")));
     } finally {
-      setIsRetrieving(false);
+      if (token === retrieveTokenRef.current) setIsRetrieving(false);
     }
   };
 
@@ -74,7 +96,9 @@ export function WmsSource() {
     setWmsFormat(serviceFieldString(fields, "format", "image/png"));
     setWmsTransparent(serviceFieldBoolean(fields, "transparent", true));
     setWmsTileSize(serviceFieldString(fields, "tileSize", "256"));
-    // The new endpoint's layers must be re-retrieved, so drop the old list.
+    // The new endpoint's layers must be re-retrieved, so drop the old list and
+    // cancel any retrieval still in flight for the previous endpoint.
+    cancelRetrieve();
     setLayerOptions([]);
     setRetrieveError(null);
   };
@@ -143,9 +167,14 @@ export function WmsSource() {
               value={wmsEndpoint}
               onChange={(event) => {
                 setWmsEndpoint(event.target.value);
-                // Layers belong to the previous endpoint; clear them so the
-                // dropdown never offers stale options for a different service.
-                if (layerOptions.length > 0) setLayerOptions([]);
+                // Layers belong to the previous endpoint; clear them (and cancel
+                // any in-flight retrieval) so the list never reflects a
+                // different service.
+                if (layerOptions.length > 0 || isRetrieving) {
+                  cancelRetrieve();
+                  setLayerOptions([]);
+                  setIsRetrieving(false);
+                }
                 if (retrieveError) setRetrieveError(null);
               }}
             />
@@ -173,15 +202,19 @@ export function WmsSource() {
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="wms-layers">{t("addData.wms.layers")}</Label>
+            {/* A text input backed by a <datalist> of the retrieved layers: the
+                dropdown suggestions cover the common single-layer pick, while
+                free text still allows a comma-separated composite LAYERS value
+                or manual entry when a service blocks GetCapabilities. */}
+            <Input
+              id="wms-layers"
+              list={layerOptions.length > 0 ? layerListId : undefined}
+              placeholder={t("addData.common.workspaceLayerPlaceholder")}
+              value={wmsLayers}
+              onChange={(event) => setWmsLayers(event.target.value)}
+            />
             {layerOptions.length > 0 ? (
-              <Select
-                id="wms-layers"
-                value={wmsLayers}
-                onChange={(event) => setWmsLayers(event.target.value)}
-              >
-                <option value="" disabled>
-                  {t("addData.wms.selectLayer")}
-                </option>
+              <datalist id={layerListId}>
                 {layerOptions.map((option) => (
                   <option key={option.name} value={option.name}>
                     {option.title === option.name
@@ -189,15 +222,8 @@ export function WmsSource() {
                       : `${option.title} (${option.name})`}
                   </option>
                 ))}
-              </Select>
-            ) : (
-              <Input
-                id="wms-layers"
-                placeholder={t("addData.common.workspaceLayerPlaceholder")}
-                value={wmsLayers}
-                onChange={(event) => setWmsLayers(event.target.value)}
-              />
-            )}
+              </datalist>
+            ) : null}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="wms-styles">{t("addData.wms.styles")}</Label>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -8,6 +8,7 @@ import {
   createWmsTileUrl,
   errorMessage,
   fetchWmsLayers,
+  stripOgcOperationParams,
   type WmsLayerOption,
 } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
@@ -120,8 +121,11 @@ export function WmsSource() {
       throw new Error(t("addData.wms.errorLayers"));
     }
     const tileSize = Number(wmsTileSize) || 256;
+    // Strip any leftover operation params (a pasted GetCapabilities URL) so the
+    // GetMap request is not built with a conflicting duplicate REQUEST.
+    const endpoint = stripOgcOperationParams(wmsEndpoint.trim(), "WMS");
     const tileUrl = createWmsTileUrl({
-      endpoint: wmsEndpoint.trim(),
+      endpoint,
       layers: wmsLayers.trim(),
       styles: wmsStyles.trim(),
       format: wmsFormat,
@@ -136,7 +140,7 @@ export function WmsSource() {
           type: "raster",
           tiles: [tileUrl],
           tileSize,
-          url: wmsEndpoint.trim(),
+          url: endpoint,
           layers: wmsLayers.trim(),
           styles: wmsStyles.trim(),
           format: wmsFormat,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -19,19 +19,61 @@ import {
 } from "../service-library";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
+/**
+ * Retains the WMS form input across dialog close/reopen (in memory, for the
+ * session) so a user can add several layers from the same service without
+ * re-entering the URL or re-retrieving its layer list each time.
+ */
+interface WmsFormCache {
+  endpoint: string;
+  layers: string;
+  styles: string;
+  format: string;
+  transparent: boolean;
+  tileSize: string;
+  options: WmsLayerOption[];
+}
+let wmsFormCache: WmsFormCache | null = null;
+
 export function WmsSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.wms.defaultName"));
-  const [wmsEndpoint, setWmsEndpoint] = useState("");
-  const [wmsLayers, setWmsLayers] = useState("");
-  const [wmsStyles, setWmsStyles] = useState("");
-  const [wmsFormat, setWmsFormat] = useState("image/png");
-  const [wmsTransparent, setWmsTransparent] = useState(true);
-  const [wmsTileSize, setWmsTileSize] = useState("256");
-  const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>([]);
+  const [wmsEndpoint, setWmsEndpoint] = useState(wmsFormCache?.endpoint ?? "");
+  const [wmsLayers, setWmsLayers] = useState(wmsFormCache?.layers ?? "");
+  const [wmsStyles, setWmsStyles] = useState(wmsFormCache?.styles ?? "");
+  const [wmsFormat, setWmsFormat] = useState(wmsFormCache?.format ?? "image/png");
+  const [wmsTransparent, setWmsTransparent] = useState(
+    wmsFormCache?.transparent ?? true,
+  );
+  const [wmsTileSize, setWmsTileSize] = useState(wmsFormCache?.tileSize ?? "256");
+  const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>(
+    wmsFormCache?.options ?? [],
+  );
   const [isRetrieving, setIsRetrieving] = useState(false);
   const [retrieveError, setRetrieveError] = useState<string | null>(null);
   const layerListId = useId();
+
+  // Persist the form input so reopening the dialog restores the URL, the fields,
+  // and the retrieved layer list.
+  useEffect(() => {
+    wmsFormCache = {
+      endpoint: wmsEndpoint,
+      layers: wmsLayers,
+      styles: wmsStyles,
+      format: wmsFormat,
+      transparent: wmsTransparent,
+      tileSize: wmsTileSize,
+      options: layerOptions,
+    };
+  }, [
+    wmsEndpoint,
+    wmsLayers,
+    wmsStyles,
+    wmsFormat,
+    wmsTransparent,
+    wmsTileSize,
+    layerOptions,
+  ]);
   // Guards against a stale in-flight retrieval overwriting the form after the
   // user has moved on: a monotonic token identifies the latest request, and the
   // AbortController cancels the previous one when a new request or an endpoint

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { ListTree, Loader2 } from "lucide-react";
-import { useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
 import {
@@ -42,6 +42,9 @@ export function WmsSource() {
     retrieveAbortRef.current?.abort();
     retrieveAbortRef.current = null;
   };
+
+  // Abort an in-flight retrieval if the dialog closes mid-request.
+  useEffect(() => () => retrieveAbortRef.current?.abort(), []);
 
   const handleRetrieveLayers = async () => {
     const endpoint = wmsEndpoint.trim();

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -1,8 +1,15 @@
-import { Input, Label, Select } from "@geolibre/ui";
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import { Loader2, ListTree } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
-import { createBaseLayer, createWmsTileUrl } from "../helpers";
+import {
+  createBaseLayer,
+  createWmsTileUrl,
+  errorMessage,
+  fetchWmsLayers,
+  type WmsLayerOption,
+} from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldBoolean,
@@ -20,6 +27,36 @@ export function WmsSource() {
   const [wmsFormat, setWmsFormat] = useState("image/png");
   const [wmsTransparent, setWmsTransparent] = useState(true);
   const [wmsTileSize, setWmsTileSize] = useState("256");
+  const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>([]);
+  const [isRetrieving, setIsRetrieving] = useState(false);
+  const [retrieveError, setRetrieveError] = useState<string | null>(null);
+
+  const handleRetrieveLayers = async () => {
+    const endpoint = wmsEndpoint.trim();
+    if (!endpoint) {
+      setRetrieveError(t("addData.wms.errorUrl"));
+      return;
+    }
+    setIsRetrieving(true);
+    setRetrieveError(null);
+    try {
+      const options = await fetchWmsLayers(endpoint);
+      if (options.length === 0) {
+        setLayerOptions([]);
+        setRetrieveError(t("addData.wms.noLayersFound"));
+        return;
+      }
+      setLayerOptions(options);
+      // Preselect the first layer when the field is empty so a single click
+      // leaves the form ready to submit.
+      if (!wmsLayers.trim()) setWmsLayers(options[0].name);
+    } catch (error) {
+      setLayerOptions([]);
+      setRetrieveError(errorMessage(error, t("addData.wms.retrieveError")));
+    } finally {
+      setIsRetrieving(false);
+    }
+  };
 
   const getFields = (): ServiceFields => ({
     endpoint: wmsEndpoint,
@@ -37,6 +74,9 @@ export function WmsSource() {
     setWmsFormat(serviceFieldString(fields, "format", "image/png"));
     setWmsTransparent(serviceFieldBoolean(fields, "transparent", true));
     setWmsTileSize(serviceFieldString(fields, "tileSize", "256"));
+    // The new endpoint's layers must be re-retrieved, so drop the old list.
+    setLayerOptions([]);
+    setRetrieveError(null);
   };
 
   const handleSubmit = source.runSubmit(() => {
@@ -96,22 +136,68 @@ export function WmsSource() {
         />
         <div className="space-y-1.5">
           <Label htmlFor="wms-endpoint">{t("addData.common.serviceUrl")}</Label>
-          <Input
-            id="wms-endpoint"
-            placeholder={t("addData.wms.urlPlaceholder")}
-            value={wmsEndpoint}
-            onChange={(event) => setWmsEndpoint(event.target.value)}
-          />
+          <div className="flex gap-2">
+            <Input
+              id="wms-endpoint"
+              placeholder={t("addData.wms.urlPlaceholder")}
+              value={wmsEndpoint}
+              onChange={(event) => {
+                setWmsEndpoint(event.target.value);
+                // Layers belong to the previous endpoint; clear them so the
+                // dropdown never offers stale options for a different service.
+                if (layerOptions.length > 0) setLayerOptions([]);
+                if (retrieveError) setRetrieveError(null);
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleRetrieveLayers}
+              disabled={isRetrieving || !wmsEndpoint.trim()}
+              className="shrink-0"
+            >
+              {isRetrieving ? (
+                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <ListTree className="mr-2 h-3.5 w-3.5" />
+              )}
+              {isRetrieving
+                ? t("addData.wms.retrieving")
+                : t("addData.wms.retrieveLayers")}
+            </Button>
+          </div>
+          {retrieveError ? (
+            <p className="text-xs text-destructive">{retrieveError}</p>
+          ) : null}
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="wms-layers">{t("addData.wms.layers")}</Label>
-            <Input
-              id="wms-layers"
-              placeholder={t("addData.common.workspaceLayerPlaceholder")}
-              value={wmsLayers}
-              onChange={(event) => setWmsLayers(event.target.value)}
-            />
+            {layerOptions.length > 0 ? (
+              <Select
+                id="wms-layers"
+                value={wmsLayers}
+                onChange={(event) => setWmsLayers(event.target.value)}
+              >
+                <option value="" disabled>
+                  {t("addData.wms.selectLayer")}
+                </option>
+                {layerOptions.map((option) => (
+                  <option key={option.name} value={option.name}>
+                    {option.title === option.name
+                      ? option.name
+                      : `${option.title} (${option.name})`}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <Input
+                id="wms-layers"
+                placeholder={t("addData.common.workspaceLayerPlaceholder")}
+                value={wmsLayers}
+                onChange={(event) => setWmsLayers(event.target.value)}
+              />
+            )}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="wms-styles">{t("addData.wms.styles")}</Label>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -201,23 +201,25 @@ export function WmsSource() {
           {retrieveError ? (
             <p className="text-xs text-destructive">{retrieveError}</p>
           ) : null}
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="wms-layers">{t("addData.wms.layers")}</Label>
-            {/* A text input backed by a <datalist> of the retrieved layers: the
-                dropdown suggestions cover the common single-layer pick, while
-                free text still allows a comma-separated composite LAYERS value
-                or manual entry when a service blocks GetCapabilities. */}
-            <Input
-              id="wms-layers"
-              list={layerOptions.length > 0 ? layerListId : undefined}
-              placeholder={t("addData.common.workspaceLayerPlaceholder")}
-              value={wmsLayers}
-              onChange={(event) => setWmsLayers(event.target.value)}
-            />
-            {layerOptions.length > 0 ? (
-              <datalist id={layerListId}>
+          {layerOptions.length > 0 ? (
+            <div className="space-y-1.5">
+              <Label htmlFor={layerListId}>
+                {t("addData.wms.retrievedLayers")}
+              </Label>
+              {/* A picker that lists every retrieved layer and fills the Layers
+                  field below on select. Its own value stays empty (an action
+                  menu, like Load sample data), so it always shows the full list
+                  and can never mismatch the free-text field. */}
+              <Select
+                id={layerListId}
+                value=""
+                onChange={(event) => {
+                  if (event.target.value) setWmsLayers(event.target.value);
+                }}
+              >
+                <option value="" disabled>
+                  {t("addData.wms.selectLayer", { count: layerOptions.length })}
+                </option>
                 {layerOptions.map((option) => (
                   <option key={option.name} value={option.name}>
                     {option.title === option.name
@@ -225,8 +227,22 @@ export function WmsSource() {
                       : `${option.title} (${option.name})`}
                   </option>
                 ))}
-              </datalist>
-            ) : null}
+              </Select>
+            </div>
+          ) : null}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="wms-layers">{t("addData.wms.layers")}</Label>
+            {/* Plain free-text field: holds the submitted LAYERS value and stays
+                editable for a comma-separated composite value or manual entry.
+                The retrieved-layers picker above fills it. */}
+            <Input
+              id="wms-layers"
+              placeholder={t("addData.common.workspaceLayerPlaceholder")}
+              value={wmsLayers}
+              onChange={(event) => setWmsLayers(event.target.value)}
+            />
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="wms-styles">{t("addData.wms.styles")}</Label>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -235,7 +235,6 @@
       "transparent": "Transparent background",
       "retrieveLayers": "Retrieve layers",
       "retrieving": "Retrieving...",
-      "selectLayer": "Select a layer",
       "noLayersFound": "No layers were found for this service.",
       "retrieveError": "Could not retrieve layers from this service."
     },
@@ -254,7 +253,6 @@
       "errorMaxFeaturesNumeric": "Enter a numeric max features value.",
       "retrieveTypes": "Retrieve types",
       "retrieving": "Retrieving...",
-      "selectType": "Select a feature type",
       "noTypesFound": "No feature types were found for this service.",
       "retrieveError": "Could not retrieve feature types from this service."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -235,6 +235,8 @@
       "transparent": "Transparent background",
       "retrieveLayers": "Retrieve layers",
       "retrieving": "Retrieving...",
+      "retrievedLayers": "Retrieved layers",
+      "selectLayer": "Select from {{count}} layers",
       "noLayersFound": "No layers were found for this service.",
       "retrieveError": "Could not retrieve layers from this service."
     },
@@ -253,6 +255,8 @@
       "errorMaxFeaturesNumeric": "Enter a numeric max features value.",
       "retrieveTypes": "Retrieve types",
       "retrieving": "Retrieving...",
+      "retrievedTypes": "Retrieved feature types",
+      "selectType": "Select from {{count}} feature types",
       "noTypesFound": "No feature types were found for this service.",
       "retrieveError": "Could not retrieve feature types from this service."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -251,7 +251,12 @@
       "outputFormat": "Output format",
       "srsName": "SRS name",
       "maxFeatures": "Max features",
-      "errorMaxFeaturesNumeric": "Enter a numeric max features value."
+      "errorMaxFeaturesNumeric": "Enter a numeric max features value.",
+      "retrieveTypes": "Retrieve types",
+      "retrieving": "Retrieving...",
+      "selectType": "Select a feature type",
+      "noTypesFound": "No feature types were found for this service.",
+      "retrieveError": "Could not retrieve feature types from this service."
     },
     "wmts": {
       "defaultName": "WMTS Layer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -232,7 +232,12 @@
       "urlPlaceholder": "https://example.com/geoserver/wms",
       "layers": "Layers",
       "styles": "Styles",
-      "transparent": "Transparent background"
+      "transparent": "Transparent background",
+      "retrieveLayers": "Retrieve layers",
+      "retrieving": "Retrieving...",
+      "selectLayer": "Select a layer",
+      "noLayersFound": "No layers were found for this service.",
+      "retrieveError": "Could not retrieve layers from this service."
     },
     "wfs": {
       "defaultName": "WFS Layer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -236,7 +236,8 @@
       "retrieveLayers": "Retrieve layers",
       "retrieving": "Retrieving...",
       "retrievedLayers": "Retrieved layers",
-      "selectLayer": "Select from {{count}} layers",
+      "selectLayer_one": "Select from {{count}} layer",
+      "selectLayer_other": "Select from {{count}} layers",
       "noLayersFound": "No layers were found for this service.",
       "retrieveError": "Could not retrieve layers from this service."
     },
@@ -256,7 +257,8 @@
       "retrieveTypes": "Retrieve types",
       "retrieving": "Retrieving...",
       "retrievedTypes": "Retrieved feature types",
-      "selectType": "Select from {{count}} feature types",
+      "selectType_one": "Select from {{count}} feature type",
+      "selectType_other": "Select from {{count}} feature types",
       "noTypesFound": "No feature types were found for this service.",
       "retrieveError": "Could not retrieve feature types from this service."
     },

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -112,6 +112,13 @@ describe("createWmsGetCapabilitiesUrl", () => {
     );
   });
 
+  it("preserves a route-relative endpoint's path form", () => {
+    assert.equal(
+      createWmsGetCapabilitiesUrl("geoserver/wms"),
+      "geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities",
+    );
+  });
+
   it("keeps the host of a protocol-relative endpoint", () => {
     const url = createWmsGetCapabilitiesUrl("//example.com/geoserver/wms");
     assert.ok(url.startsWith("//example.com/geoserver/wms?"));

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -112,6 +112,14 @@ describe("createWmsGetCapabilitiesUrl", () => {
     );
   });
 
+  it("keeps the host of a protocol-relative endpoint", () => {
+    const url = createWmsGetCapabilitiesUrl("//example.com/geoserver/wms");
+    assert.ok(url.startsWith("//example.com/geoserver/wms?"));
+    const params = new URLSearchParams(url.slice(url.indexOf("?")));
+    assert.equal(params.get("SERVICE"), "WMS");
+    assert.equal(params.get("REQUEST"), "GetCapabilities");
+  });
+
   it("strips stale operation params on a relative endpoint too", () => {
     const url = createWmsGetCapabilitiesUrl(
       "/geoserver/wms?REQUEST=GetMap&LAYERS=a&token=abc",

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { FeatureCollection } from "geojson";
 import {
   appendQuery,
+  createWmsGetCapabilitiesUrl,
   createWmsTileUrl,
   fileNameFromPath,
   geoJsonToPointRows,
@@ -80,6 +81,34 @@ describe("createWmsTileUrl", () => {
     });
     assert.ok(url.includes("TRANSPARENT=FALSE"));
     assert.ok(url.includes("HEIGHT=512"));
+  });
+});
+
+describe("createWmsGetCapabilitiesUrl", () => {
+  it("appends SERVICE and REQUEST to a bare endpoint", () => {
+    const url = new URL(createWmsGetCapabilitiesUrl("https://x.test/wms"));
+    assert.equal(url.searchParams.get("SERVICE"), "WMS");
+    assert.equal(url.searchParams.get("REQUEST"), "GetCapabilities");
+  });
+
+  it("strips leftover GetMap operation params so they cannot collide", () => {
+    const url = new URL(
+      createWmsGetCapabilitiesUrl(
+        "https://x.test/wms?SERVICE=WMS&REQUEST=GetMap&LAYERS=a&BBOX=0,0,1,1&token=abc",
+      ),
+    );
+    assert.equal(url.searchParams.get("REQUEST"), "GetCapabilities");
+    assert.equal(url.searchParams.get("LAYERS"), null);
+    assert.equal(url.searchParams.get("BBOX"), null);
+    // Non-operation params (e.g. an auth token) are preserved.
+    assert.equal(url.searchParams.get("token"), "abc");
+  });
+
+  it("falls back to a plain append for a relative endpoint", () => {
+    assert.equal(
+      createWmsGetCapabilitiesUrl("/geoserver/wms"),
+      "/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities",
+    );
   });
 });
 

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { FeatureCollection } from "geojson";
 import {
   appendQuery,
+  createWfsGetCapabilitiesUrl,
   createWmsGetCapabilitiesUrl,
   createWmsTileUrl,
   fileNameFromPath,
@@ -109,6 +110,33 @@ describe("createWmsGetCapabilitiesUrl", () => {
       createWmsGetCapabilitiesUrl("/geoserver/wms"),
       "/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities",
     );
+  });
+});
+
+describe("createWfsGetCapabilitiesUrl", () => {
+  it("appends SERVICE, REQUEST, and the version when given", () => {
+    const url = new URL(
+      createWfsGetCapabilitiesUrl("https://x.test/wfs", "2.0.0"),
+    );
+    assert.equal(url.searchParams.get("SERVICE"), "WFS");
+    assert.equal(url.searchParams.get("REQUEST"), "GetCapabilities");
+    assert.equal(url.searchParams.get("VERSION"), "2.0.0");
+  });
+
+  it("strips leftover GetFeature operation params", () => {
+    const url = new URL(
+      createWfsGetCapabilitiesUrl(
+        "https://x.test/ows?service=WFS&version=1.1.0&request=GetFeature&typeName=a&token=abc",
+      ),
+    );
+    assert.equal(url.searchParams.get("REQUEST"), "GetCapabilities");
+    assert.equal(url.searchParams.get("typeName"), null);
+    assert.equal(url.searchParams.get("token"), "abc");
+  });
+
+  it("omits VERSION when not provided", () => {
+    const url = new URL(createWfsGetCapabilitiesUrl("https://x.test/wfs"));
+    assert.equal(url.searchParams.get("VERSION"), null);
   });
 });
 

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -105,11 +105,23 @@ describe("createWmsGetCapabilitiesUrl", () => {
     assert.equal(url.searchParams.get("token"), "abc");
   });
 
-  it("falls back to a plain append for a relative endpoint", () => {
+  it("handles a relative endpoint", () => {
     assert.equal(
       createWmsGetCapabilitiesUrl("/geoserver/wms"),
       "/geoserver/wms?SERVICE=WMS&REQUEST=GetCapabilities",
     );
+  });
+
+  it("strips stale operation params on a relative endpoint too", () => {
+    const url = createWmsGetCapabilitiesUrl(
+      "/geoserver/wms?REQUEST=GetMap&LAYERS=a&token=abc",
+    );
+    // Relative form is preserved (no scheme/host injected).
+    assert.ok(url.startsWith("/geoserver/wms?"));
+    const params = new URLSearchParams(url.slice(url.indexOf("?")));
+    assert.equal(params.get("REQUEST"), "GetCapabilities");
+    assert.equal(params.get("LAYERS"), null);
+    assert.equal(params.get("token"), "abc");
   });
 });
 

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   createWmsGetCapabilitiesUrl,
   createWmsTileUrl,
   fileNameFromPath,
+  stripOgcOperationParams,
   geoJsonToPointRows,
   inferDelimitedTextField,
   layerNameFromPath,
@@ -164,6 +165,35 @@ describe("createWfsGetCapabilitiesUrl", () => {
   it("omits VERSION when not provided", () => {
     const url = new URL(createWfsGetCapabilitiesUrl("https://x.test/wfs"));
     assert.equal(url.searchParams.get("VERSION"), null);
+  });
+});
+
+describe("stripOgcOperationParams", () => {
+  it("removes a pasted GetCapabilities query, leaving the base endpoint", () => {
+    assert.equal(
+      stripOgcOperationParams(
+        "https://wms.ign.gob.ar/geoserver/ows?service=wfs&version=1.1.0&request=GetCapabilities",
+        "WFS",
+      ),
+      "https://wms.ign.gob.ar/geoserver/ows",
+    );
+  });
+
+  it("keeps non-operation params like an auth token", () => {
+    assert.equal(
+      stripOgcOperationParams(
+        "https://x.test/wms?REQUEST=GetMap&LAYERS=a&token=abc",
+        "WMS",
+      ),
+      "https://x.test/wms?token=abc",
+    );
+  });
+
+  it("leaves an already-clean endpoint untouched", () => {
+    assert.equal(
+      stripOgcOperationParams("https://x.test/geoserver/wms", "WMS"),
+      "https://x.test/geoserver/wms",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a **Retrieve layers** button to the Add WMS Layer dialog and a **Retrieve types** button to the Add WFS Layer dialog. Each fetches the service's `GetCapabilities` document and populates the layer/feature-type field as a dropdown, so users pick from a list instead of typing the name by hand.

Requested in discussion #1016, where adding WMS/WFS layers was hard because the name had to be entered manually and large services (many layers) made that impractical.

## What changed

- **WMS:** new *Retrieve layers* button next to the Service URL. On success the **Layers** field becomes a dropdown listing every named (requestable) layer as `Title (name)`, with the first preselected.
- **WFS:** new *Retrieve types* button. On success the **Feature type** field becomes a dropdown of the service's feature types, first preselected.
- Both fields fall back to the original free-text input until layers are retrieved, so manual entry still works. The list is cleared when the endpoint changes or a saved/sample preset is loaded, so stale options are never offered for a different service.
- **Cross-origin fetch that works everywhere.** Services that omit CORS headers (e.g. Argentina's SEGEMAR/IGN) used to fail in the desktop and hosted web builds. The capabilities fetch now routes through:
  - the native `fetch_url_bytes` Tauri command (reqwest, not subject to CORS) in the **desktop app**, so any service works;
  - the same-origin dev proxy under **Vite**;
  - a direct fetch otherwise (**hosted web**), which still requires the service to send `Access-Control-Allow-Origin`.
  
  A CORS rejection now surfaces an actionable message instead of a bare "Failed to fetch".

## New helpers (`add-data/helpers.ts`)

- `createWmsGetCapabilitiesUrl` / `createWfsGetCapabilitiesUrl` build the request URL and strip any leftover operation params.
- `parseWmsCapabilitiesLayers` / `parseWfsCapabilitiesFeatureTypes` extract the entries; both use `getElementsByTagNameNS`, so they are namespace-agnostic across WMS 1.1.1/1.3.0 and WFS 1.0.0/1.1.0/2.0.0.
- `fetchWmsLayers` / `fetchWfsFeatureTypes` tie them together over the shared cross-environment fetch with a 30s timeout.

## Testing

- Unit tests for `createWmsGetCapabilitiesUrl` and `createWfsGetCapabilitiesUrl` (bare endpoint, stripping operation params, relative/version handling).
- Verified in the running app (Playwright), in **both light and dark themes**:
  - WMS: `ahocevar.com/geoserver/wms` (retrieved layers, added `topp:states`, renders on the map) and Argentina's `sigam.segemar.gov.ar` (107 layers retrieved).
  - WFS: Argentina's `wms.ign.gob.ar/geoserver/ows` (192 feature types retrieved) and the built-in GeoServer sample (added and rendered).
- `pre-commit run --files` (eslint + npm build) passes.

## Note on the hosted web build

Cross-origin capabilities requests to a service that sends **no** `Access-Control-Allow-Origin` header cannot be made from a static hosted page (browser CORS). Those services work in the **desktop app** and the **dev server**, and manual entry remains available as a fallback everywhere. Fully fixing them on the hosted web build would require a server-side proxy (a separate infra change).

Closes #1016.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WMS layer retrieval to the “Add Data” flow with a “Retrieve layers” button, loading indicator, and selectable suggestions (manual entry still supported).
  * Added WFS feature-type retrieval with a “Retrieve types” button, loading indicator, version-aware suggestions, and manual entry still supported.
* **Bug Fixes**
  * Improved WMS/WFS capabilities discovery, including better timeout/CORS failure messaging and character set handling.
  * Prevented stale retrieval results by cancelling in-flight requests and only applying the latest response.
* **Documentation**
  * Added localized strings for retrieve, loading, empty, and error states.
* **Tests**
  * Added coverage for WMS/WFS GetCapabilities URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->