### PR TITLE
fix(sql): recover the SQL Workspace from a poisoned remote-read state

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-processing.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-processing.ts
@@ -26,7 +26,8 @@ export function createDuckDbCapability(): DuckDbCapability {
       const db = await getDatabase();
       const connection = await db.connect();
       try {
-        if (names.includes("spatial")) await ensureSpatialExtension(connection);
+        if (names.includes("spatial"))
+          await ensureSpatialExtension(db, connection);
         if (names.includes("h3")) await ensureH3Extension(connection);
       } finally {
         await connection.close();

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -74,19 +74,64 @@ export function getSqlDatabase(): Promise<duckdb.AsyncDuckDB> {
   return sqlDbPromise;
 }
 
+// Count of SQL queries currently using each SQL instance, so a poisoned one is
+// terminated only once no query is still on it (see resetSqlDatabase). Instances
+// flagged here are pending teardown once their in-flight count drains to zero.
+const sqlDbInFlight = new WeakMap<duckdb.AsyncDuckDB, number>();
+const sqlDbTerminateWhenIdle = new WeakSet<duckdb.AsyncDuckDB>();
+
+async function terminateSqlDatabase(db: duckdb.AsyncDuckDB): Promise<void> {
+  sqlDbTerminateWhenIdle.delete(db);
+  try {
+    await db.terminate();
+  } catch {
+    // Best-effort teardown: the instance is already being discarded.
+  }
+}
+
+/**
+ * Marks a query as in flight on a SQL instance. Pair every call with a
+ * {@link releaseSqlDatabase} in a `finally` so the count cannot leak.
+ */
+export function acquireSqlDatabase(db: duckdb.AsyncDuckDB): void {
+  sqlDbInFlight.set(db, (sqlDbInFlight.get(db) ?? 0) + 1);
+}
+
+/**
+ * Marks a query as finished on a SQL instance. If the instance was flagged for
+ * teardown by {@link resetSqlDatabase} and this was the last in-flight query, it
+ * is terminated now.
+ */
+export async function releaseSqlDatabase(
+  db: duckdb.AsyncDuckDB,
+): Promise<void> {
+  const next = (sqlDbInFlight.get(db) ?? 1) - 1;
+  if (next > 0) {
+    sqlDbInFlight.set(db, next);
+    return;
+  }
+  sqlDbInFlight.delete(db);
+  if (sqlDbTerminateWhenIdle.has(db)) await terminateSqlDatabase(db);
+}
+
 /**
  * Rebuilds the SQL Workspace's DuckDB instance to recover from a poisoned remote
  * read path — duckdb-wasm 1.33.1-dev45 permanently breaks `read_parquet` over
  * HTTP (failing with "stoi: no conversion") on an instance that ran
  * `LOAD spatial` before its first successful remote Parquet read, and that state
- * cannot be undone in place. The old worker is terminated (safe: nothing else
- * uses this instance) and the next {@link getSqlDatabase} builds a fresh one
- * that re-runs the pre-spatial warm-up.
+ * cannot be undone in place. Stops handing the instance out so the next
+ * {@link getSqlDatabase} builds a fresh one that re-runs the pre-spatial warm-up.
  *
  * `poisoned` scopes the swap: it is a no-op unless that instance is still the
  * current one, so a fresh instance a concurrent caller has already rebuilt is
- * never terminated. The identity is re-checked after the await to close the
+ * never discarded. The identity is re-checked after the await to close the
  * window where another reset ran while this one was suspended.
+ *
+ * The old worker is terminated to free its WASM heap, but only once no query is
+ * still using it: if another SQL query is in flight on the same instance, the
+ * teardown is deferred to {@link releaseSqlDatabase} so that query is not
+ * stranded. Nothing outside the SQL Workspace uses this instance, so the shared
+ * DB's consumers are unaffected either way.
  *
  * @param poisoned - The instance to replace; only reset if it is still current.
  */
@@ -106,10 +151,11 @@ export async function resetSqlDatabase(
   if (current !== poisoned || sqlDbPromise !== previous) return;
   sqlDbPromise = null;
   spatialExtensionByDb.delete(poisoned);
-  try {
-    await poisoned.terminate();
-  } catch {
-    // Best-effort teardown: the instance is already being discarded.
+  // Terminate now if idle; otherwise let the last in-flight query's release do it.
+  if ((sqlDbInFlight.get(poisoned) ?? 0) > 0) {
+    sqlDbTerminateWhenIdle.add(poisoned);
+  } else {
+    await terminateSqlDatabase(poisoned);
   }
 }
 
@@ -175,7 +221,9 @@ export async function ensureSpatialExtension(
   try {
     await promise;
   } catch (error) {
-    spatialExtensionByDb.delete(db);
+    // Only clear the memo if it still points at this failed load: a concurrent
+    // caller may have already installed a retry, which must not be wiped out.
+    if (spatialExtensionByDb.get(db) === promise) spatialExtensionByDb.delete(db);
     throw error;
   }
 }

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -61,9 +61,9 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
 }
 
 /**
- * Discards the memoized DuckDB instance (and its extension load state) so the
- * next {@link getDatabase} builds a fresh one. The old worker is terminated
- * best-effort.
+ * Stops handing out the memoized DuckDB instance (and its extension load state)
+ * so the next {@link getDatabase} builds a fresh one, without terminating the
+ * old worker.
  *
  * This is the recovery path for a WASM instance whose remote HTTP read path has
  * been poisoned — duckdb-wasm 1.33.1-dev45 permanently breaks `read_parquet`
@@ -71,11 +71,14 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
  * `LOAD spatial` before its first successful remote Parquet read, and that state
  * cannot be undone in place. A fresh instance re-runs the pre-spatial warm-up.
  *
- * Because the instance is shared app-wide, `poisoned` scopes the teardown: the
- * reset is a no-op unless the current instance is exactly that poisoned one, so
- * a fresh instance a concurrent caller has already rebuilt is never terminated.
- * A poisoned instance's remote-read path is already broken for every consumer,
- * so replacing it is the correct recovery for all of them.
+ * The instance is shared app-wide, so this deliberately does NOT `terminate()`
+ * it: any consumer with an in-flight query (vector loads, exports, reprojection,
+ * processing) keeps using the old instance uninterrupted, and it is garbage-
+ * collected once no one references it. Only remote reads are poisoned, and only
+ * the SQL Workspace issues those, so the other consumers are unaffected either
+ * way. `poisoned` scopes the swap: it is a no-op unless the current instance is
+ * exactly that poisoned one, so a fresh instance a concurrent caller has already
+ * rebuilt is never discarded.
  *
  * @param poisoned - The instance to replace; only reset if it is still current.
  */
@@ -91,16 +94,11 @@ export async function resetDatabase(
     current = null;
   }
   // Another query may have already rebuilt the DB after this one was poisoned;
-  // do not tear that fresh instance down.
+  // do not discard that fresh instance.
   if (current !== poisoned) return;
   dbPromise = null;
   spatialExtensionPromise = null;
   h3ExtensionPromise = null;
-  try {
-    await poisoned.terminate();
-  } catch {
-    // Best-effort teardown: the instance is already being discarded.
-  }
 }
 
 let spatialExtensionPromise: Promise<void> | null = null;

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -60,6 +60,31 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
   return dbPromise;
 }
 
+/**
+ * Discards the memoized DuckDB instance (and its extension load state) so the
+ * next {@link getDatabase} builds a fresh one. The old worker is terminated
+ * best-effort.
+ *
+ * This is the recovery path for a WASM instance whose remote HTTP read path has
+ * been poisoned — duckdb-wasm 1.33.1-dev45 permanently breaks `read_parquet`
+ * over HTTP (failing with "stoi: no conversion") on an instance that ran
+ * `LOAD spatial` before its first successful remote Parquet read, and that state
+ * cannot be undone in place. A fresh instance re-runs the pre-spatial warm-up.
+ */
+export async function resetDatabase(): Promise<void> {
+  const previous = dbPromise;
+  dbPromise = null;
+  spatialExtensionPromise = null;
+  h3ExtensionPromise = null;
+  if (!previous) return;
+  try {
+    const db = await previous;
+    await db.terminate();
+  } catch {
+    // Best-effort teardown: the instance is already being discarded.
+  }
+}
+
 let spatialExtensionPromise: Promise<void> | null = null;
 
 /**

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -60,32 +60,40 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
   return dbPromise;
 }
 
+// The SQL Workspace runs on its own DuckDB instance, separate from the shared
+// one every other consumer uses. It is the only feature that reads remote
+// Parquet over HTTP, which is the operation duckdb-wasm 1.33.1-dev45 can poison
+// (see resetSqlDatabase). Isolating it means the poison-recovery rebuild can
+// safely terminate and replace the instance without disturbing in-flight vector
+// loads, exports, reprojection, or processing on the shared instance.
+let sqlDbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
+
+/** The DuckDB instance dedicated to the SQL Workspace. */
+export function getSqlDatabase(): Promise<duckdb.AsyncDuckDB> {
+  sqlDbPromise ??= createDatabase();
+  return sqlDbPromise;
+}
+
 /**
- * Stops handing out the memoized DuckDB instance (and its extension load state)
- * so the next {@link getDatabase} builds a fresh one, without terminating the
- * old worker.
- *
- * This is the recovery path for a WASM instance whose remote HTTP read path has
- * been poisoned — duckdb-wasm 1.33.1-dev45 permanently breaks `read_parquet`
- * over HTTP (failing with "stoi: no conversion") on an instance that ran
+ * Rebuilds the SQL Workspace's DuckDB instance to recover from a poisoned remote
+ * read path — duckdb-wasm 1.33.1-dev45 permanently breaks `read_parquet` over
+ * HTTP (failing with "stoi: no conversion") on an instance that ran
  * `LOAD spatial` before its first successful remote Parquet read, and that state
- * cannot be undone in place. A fresh instance re-runs the pre-spatial warm-up.
+ * cannot be undone in place. The old worker is terminated (safe: nothing else
+ * uses this instance) and the next {@link getSqlDatabase} builds a fresh one
+ * that re-runs the pre-spatial warm-up.
  *
- * The instance is shared app-wide, so this deliberately does NOT `terminate()`
- * it: any consumer with an in-flight query (vector loads, exports, reprojection,
- * processing) keeps using the old instance uninterrupted, and it is garbage-
- * collected once no one references it. Only remote reads are poisoned, and only
- * the SQL Workspace issues those, so the other consumers are unaffected either
- * way. `poisoned` scopes the swap: it is a no-op unless the current instance is
- * exactly that poisoned one, so a fresh instance a concurrent caller has already
- * rebuilt is never discarded.
+ * `poisoned` scopes the swap: it is a no-op unless that instance is still the
+ * current one, so a fresh instance a concurrent caller has already rebuilt is
+ * never terminated. The identity is re-checked after the await to close the
+ * window where another reset ran while this one was suspended.
  *
  * @param poisoned - The instance to replace; only reset if it is still current.
  */
-export async function resetDatabase(
+export async function resetSqlDatabase(
   poisoned: duckdb.AsyncDuckDB,
 ): Promise<void> {
-  const previous = dbPromise;
+  const previous = sqlDbPromise;
   if (!previous) return;
   let current: duckdb.AsyncDuckDB | null = null;
   try {
@@ -93,66 +101,81 @@ export async function resetDatabase(
   } catch {
     current = null;
   }
-  // Another query may have already rebuilt the DB after this one was poisoned;
-  // do not discard that fresh instance.
-  if (current !== poisoned) return;
-  dbPromise = null;
-  spatialExtensionPromise = null;
-  h3ExtensionPromise = null;
+  // Another query may have rebuilt the instance while we awaited; only discard
+  // the still-current poisoned one.
+  if (current !== poisoned || sqlDbPromise !== previous) return;
+  sqlDbPromise = null;
+  spatialExtensionByDb.delete(poisoned);
+  try {
+    await poisoned.terminate();
+  } catch {
+    // Best-effort teardown: the instance is already being discarded.
+  }
 }
 
-let spatialExtensionPromise: Promise<void> | null = null;
+// Spatial extension load state, keyed per instance so the shared DB and the SQL
+// Workspace DB each track their own load (and a rebuilt SQL instance starts
+// fresh). Memoized as a promise so concurrent callers share one INSTALL/LOAD.
+const spatialExtensionByDb = new WeakMap<
+  duckdb.AsyncDuckDB,
+  Promise<void>
+>();
 
 /**
  * Install and load the DuckDB spatial extension once per database instance.
- * `getDatabase` returns a memoized singleton, so the extension persists across
- * connections and the redundant INSTALL/LOAD queries are skipped on reuse.
- *
- * The load is memoized as a promise rather than a boolean so concurrent callers
- * (the function is exported and reused) share a single INSTALL/LOAD instead of
- * each racing to run it. On failure the memo is cleared so a later call retries.
+ * Redundant INSTALL/LOAD queries are skipped on reuse; on failure the memo is
+ * cleared so a later call retries.
  *
  * When `VITE_DUCKDB_SPATIAL_EXTENSION_PATH` is set, INSTALL is skipped and
  * the extension is loaded from the provided local path (useful for offline or
  * sandboxed environments where the remote extension repository is unreachable).
+ *
+ * @param db - The instance the extension is loaded on (keys the memo).
+ * @param connection - A connection to that instance to run the load on.
+ * @param beforeLoad - Optional pre-load warm-up (a remote read before LOAD).
  */
 export async function ensureSpatialExtension(
+  db: duckdb.AsyncDuckDB,
   connection: duckdb.AsyncDuckDBConnection,
   beforeLoad?: () => Promise<void>,
 ): Promise<void> {
-  spatialExtensionPromise ??= (async () => {
-    // duckdb-wasm 1.33.1-dev45 breaks read_parquet on any connection that runs
-    // LOAD spatial itself before it has read a Parquet file. `beforeLoad` lets
-    // the caller warm up that path (a pre-spatial read) before any LOAD,
-    // including the custom-path branch below, which is the only thing that
-    // initialises it. Runs before the branch split so a custom extension path
-    // (VITE_DUCKDB_SPATIAL_EXTENSION_PATH) gets the same warm-up.
-    if (beforeLoad) {
-      try {
-        await beforeLoad();
-      } catch (error) {
-        // Warm-up is best-effort; a failure here must not block spatial
-        // loading. Warn (not debug, which DevTools hides by default) so a
-        // genuinely corrupt/mislabelled file surfaces its real cause here
-        // instead of only as a later "stoi: no conversion" on DESCRIBE.
-        console.warn("[GeoLibre] spatial warm-up failed (ignored)", error);
+  let promise = spatialExtensionByDb.get(db);
+  if (!promise) {
+    promise = (async () => {
+      // duckdb-wasm 1.33.1-dev45 breaks read_parquet on any connection that runs
+      // LOAD spatial itself before it has read a Parquet file. `beforeLoad` lets
+      // the caller warm up that path (a pre-spatial read) before any LOAD,
+      // including the custom-path branch below, which is the only thing that
+      // initialises it. Runs before the branch split so a custom extension path
+      // (VITE_DUCKDB_SPATIAL_EXTENSION_PATH) gets the same warm-up.
+      if (beforeLoad) {
+        try {
+          await beforeLoad();
+        } catch (error) {
+          // Warm-up is best-effort; a failure here must not block spatial
+          // loading. Warn (not debug, which DevTools hides by default) so a
+          // genuinely corrupt/mislabelled file surfaces its real cause here
+          // instead of only as a later "stoi: no conversion" on DESCRIBE.
+          console.warn("[GeoLibre] spatial warm-up failed (ignored)", error);
+        }
       }
-    }
 
-    const customPath = getSpatialExtensionPath();
-    if (customPath) {
-      const normalizedPath = customPath.replace(/\\/g, "/");
-      await connection.query(`LOAD ${quoteSqlString(normalizedPath)}`);
-      return;
-    }
+      const customPath = getSpatialExtensionPath();
+      if (customPath) {
+        const normalizedPath = customPath.replace(/\\/g, "/");
+        await connection.query(`LOAD ${quoteSqlString(normalizedPath)}`);
+        return;
+      }
 
-    await connection.query("INSTALL spatial");
-    await connection.query("LOAD spatial");
-  })();
+      await connection.query("INSTALL spatial");
+      await connection.query("LOAD spatial");
+    })();
+    spatialExtensionByDb.set(db, promise);
+  }
   try {
-    await spatialExtensionPromise;
+    await promise;
   } catch (error) {
-    spatialExtensionPromise = null;
+    spatialExtensionByDb.delete(db);
     throw error;
   }
 }
@@ -500,6 +523,7 @@ export async function loadDuckDbVectorFile(
   try {
     await registerVectorFileBuffers(db, file);
     await ensureSpatialExtension(
+      db,
       connection,
       parquetWarmUp(connection, file.extension, file.name),
     );
@@ -579,7 +603,7 @@ export async function readCadLayers(
   const connection = await db.connect();
   try {
     await registerVectorFileBuffers(db, file);
-    await ensureSpatialExtension(connection);
+    await ensureSpatialExtension(db, connection);
     const rows = rowsFromResult(
       await connection.query(
         `SELECT
@@ -665,7 +689,7 @@ export async function reprojectFeatureCollectionToWgs84(
   const sourceFile = `geolibre-reproject-${(reprojectionSeq += 1)}.geojson`;
   try {
     await db.registerFileText(sourceFile, JSON.stringify(fc));
-    await ensureSpatialExtension(connection);
+    await ensureSpatialExtension(db, connection);
 
     const sql = `SELECT * FROM ST_Read(${quoteSqlString(sourceFile)})`;
     const description = rowsFromResult(
@@ -794,6 +818,7 @@ export async function convertDuckDbVectorToGeoParquet(
     // neither affected by the bug; `parquetWarmUp` returns undefined for both,
     // and the `options.csv` guard short-circuits the CSV branch before calling it.
     await ensureSpatialExtension(
+      db,
       connection,
       options.csv ? undefined : parquetWarmUp(connection, file.extension, file.name),
     );
@@ -867,7 +892,7 @@ export async function exportDuckDbGeoParquet(
 
   try {
     await registerGeoJsonExportSource(db, geojson, sourceFile);
-    await ensureSpatialExtension(connection);
+    await ensureSpatialExtension(db, connection);
     await connection.query(
       `COPY (SELECT * FROM ST_Read(${quoteSqlString(
         sourceFile,

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -70,16 +70,34 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
  * over HTTP (failing with "stoi: no conversion") on an instance that ran
  * `LOAD spatial` before its first successful remote Parquet read, and that state
  * cannot be undone in place. A fresh instance re-runs the pre-spatial warm-up.
+ *
+ * Because the instance is shared app-wide, `poisoned` scopes the teardown: the
+ * reset is a no-op unless the current instance is exactly that poisoned one, so
+ * a fresh instance a concurrent caller has already rebuilt is never terminated.
+ * A poisoned instance's remote-read path is already broken for every consumer,
+ * so replacing it is the correct recovery for all of them.
+ *
+ * @param poisoned - The instance to replace; only reset if it is still current.
  */
-export async function resetDatabase(): Promise<void> {
+export async function resetDatabase(
+  poisoned: duckdb.AsyncDuckDB,
+): Promise<void> {
   const previous = dbPromise;
+  if (!previous) return;
+  let current: duckdb.AsyncDuckDB | null = null;
+  try {
+    current = await previous;
+  } catch {
+    current = null;
+  }
+  // Another query may have already rebuilt the DB after this one was poisoned;
+  // do not tear that fresh instance down.
+  if (current !== poisoned) return;
   dbPromise = null;
   spatialExtensionPromise = null;
   h3ExtensionPromise = null;
-  if (!previous) return;
   try {
-    const db = await previous;
-    await db.terminate();
+    await poisoned.terminate();
   } catch {
     // Best-effort teardown: the instance is already being discarded.
   }

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -715,32 +715,45 @@ export async function runSqlQuery(
   // convenient `SELECT * FROM https://…/x.parquet` form runs.
   const rewritten = rewriteBareSources(withCloudUrls);
 
+  // Only a query that actually reads a remote source can hit the poisoned-
+  // instance path, so gate the recovery on a real remote reader call (not an
+  // http URL that merely appears in a string literal or WHERE clause).
+  const hasRemoteReader = statementHasRemoteReader(rewritten);
+
+  const db = await getDatabase();
   try {
-    return await runSqlStatementOnce(rewritten, layers);
+    return await runSqlStatementOnce(rewritten, layers, db);
   } catch (error) {
     // Recover from a poisoned WASM instance: duckdb-wasm 1.33.1-dev45 breaks
     // remote read_parquet with "stoi: no conversion" on an instance that ran
     // LOAD spatial before its first successful remote read (e.g. after an
     // earlier query's warm-up failed). That state cannot be undone in place, so
     // rebuild the instance — which re-runs the pre-spatial warm-up — and retry
-    // once. Only for remote queries, so a genuine local error is not retried.
-    if (isPoisonedRemoteReadError(error, rewritten)) {
-      await resetDatabase();
-      return await runSqlStatementOnce(rewritten, layers);
+    // once. Scope the reset to `db` so a fresh instance is never torn down.
+    if (hasRemoteReader && isStoiConversionError(error)) {
+      await resetDatabase(db);
+      return await runSqlStatementOnce(rewritten, layers, await getDatabase());
     }
     throw error;
   }
 }
 
-/**
- * True when an error is the duckdb-wasm poisoned-instance symptom on a query
- * that reads a remote source: the "stoi: no conversion" failure combined with
- * an HTTP(S) URL in the (already rewritten) statement.
- */
-function isPoisonedRemoteReadError(error: unknown, statement: string): boolean {
+/** True when an error is the duckdb-wasm poisoned-instance "stoi" symptom. */
+function isStoiConversionError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return (
-    /stoi:\s*no conversion/i.test(message) && /https?:\/\//i.test(statement)
+  return /stoi:\s*no conversion/i.test(message);
+}
+
+/**
+ * True when the statement contains a real remote-reader call (a native reader
+ * with an http(s) URL argument). Uses the same literal masking as
+ * {@link registerRemoteSources}, so an http URL inside a string literal or
+ * comment is ignored.
+ */
+function statementHasRemoteReader(statement: string): boolean {
+  const masked = maskSqlLiterals(statement);
+  return [...statement.matchAll(REMOTE_READER_ARG_PATTERN)].some(
+    (match) => masked[match.index ?? 0] !== " ",
   );
 }
 
@@ -752,8 +765,8 @@ function isPoisonedRemoteReadError(error: unknown, statement: string): boolean {
 async function runSqlStatementOnce(
   rewritten: string,
   layers: GeoLibreLayer[],
+  db: AsyncDuckDB,
 ): Promise<SqlQueryResult> {
-  const db = await getDatabase();
   const connection = await db.connect();
   // Per-run prefix so concurrent queries on the shared database do not register
   // or drop one another's VFS files. Populated by registerLayerTables and

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -7,11 +7,11 @@ import {
 } from "@duckdb/duckdb-wasm";
 import {
   ensureSpatialExtension,
-  getDatabase,
+  getSqlDatabase,
   isGeometryColumnType,
   quoteIdentifier,
   quoteSqlString,
-  resetDatabase,
+  resetSqlDatabase,
   rowsFromResult,
 } from "./duckdb-vector-loader";
 import { GDAL_AUTO_FID_COLUMN, stripAutoFidColumn } from "./duckdb-geometry";
@@ -589,14 +589,7 @@ async function registerRemoteSources(
   statement: string,
   registeredFiles: string[],
 ): Promise<{ statement: string; readerCalls: string[] }> {
-  // Match against the masked SQL so a reader call that appears inside a string
-  // literal or comment is ignored: a match whose start is blanked in the mask is
-  // not real code. Match indices are valid against the original string, and the
-  // reader keyword and URL the pattern captures are code (never masked).
-  const masked = maskSqlLiterals(statement);
-  const matches = [...statement.matchAll(REMOTE_READER_ARG_PATTERN)].filter(
-    (match) => masked[match.index ?? 0] !== " ",
-  );
+  const matches = matchRemoteReaderCalls(statement);
 
   // Collect each distinct URL that is a native reader's argument, keeping the
   // first reader function it appears with (used to warm up the HTTP path).
@@ -720,7 +713,7 @@ export async function runSqlQuery(
   // http URL that merely appears in a string literal or WHERE clause).
   const hasRemoteReader = statementHasRemoteReader(rewritten);
 
-  const db = await getDatabase();
+  const db = await getSqlDatabase();
   try {
     return await runSqlStatementOnce(rewritten, layers, db);
   } catch (error) {
@@ -728,11 +721,12 @@ export async function runSqlQuery(
     // remote read_parquet with "stoi: no conversion" on an instance that ran
     // LOAD spatial before its first successful remote read (e.g. after an
     // earlier query's warm-up failed). That state cannot be undone in place, so
-    // rebuild the instance — which re-runs the pre-spatial warm-up — and retry
-    // once. Scope the reset to `db` so a fresh instance is never torn down.
+    // rebuild the SQL Workspace's dedicated instance — which re-runs the
+    // pre-spatial warm-up — and retry once. Scope the reset to `db` so a fresh
+    // instance is never torn down.
     if (hasRemoteReader && isStoiConversionError(error)) {
-      await resetDatabase(db);
-      return await runSqlStatementOnce(rewritten, layers, await getDatabase());
+      await resetSqlDatabase(db);
+      return await runSqlStatementOnce(rewritten, layers, await getSqlDatabase());
     }
     throw error;
   }
@@ -745,16 +739,25 @@ function isStoiConversionError(error: unknown): boolean {
 }
 
 /**
- * True when the statement contains a real remote-reader call (a native reader
- * with an http(s) URL argument). Uses the same literal masking as
- * {@link registerRemoteSources}, so an http URL inside a string literal or
- * comment is ignored.
+ * The native reader calls with an http(s) URL argument in a statement, ignoring
+ * any that appear inside a string literal or comment. Matches against the masked
+ * SQL (a match whose start is blanked in the mask is not real code); the match
+ * indices are valid against the original string, and the reader keyword and URL
+ * the pattern captures are code (never masked).
  */
-function statementHasRemoteReader(statement: string): boolean {
+function matchRemoteReaderCalls(statement: string): RegExpMatchArray[] {
   const masked = maskSqlLiterals(statement);
-  return [...statement.matchAll(REMOTE_READER_ARG_PATTERN)].some(
+  return [...statement.matchAll(REMOTE_READER_ARG_PATTERN)].filter(
     (match) => masked[match.index ?? 0] !== " ",
   );
+}
+
+/**
+ * True when the statement contains a real remote-reader call (a native reader
+ * with an http(s) URL argument), ignoring URLs inside string literals.
+ */
+function statementHasRemoteReader(statement: string): boolean {
+  return matchRemoteReaderCalls(statement).length > 0;
 }
 
 /**
@@ -804,7 +807,7 @@ async function runSqlStatementOnce(
     ) {
       warmups.push(`read_parquet(${quoteSqlString(SAMPLE_DATASET_URL)})`);
     }
-    await ensureSpatialExtension(connection, async () => {
+    await ensureSpatialExtension(db, connection, async () => {
       for (const readerCall of warmups) {
         await connection.query(`SELECT 1 FROM ${readerCall} LIMIT 0`);
       }

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -11,6 +11,7 @@ import {
   isGeometryColumnType,
   quoteIdentifier,
   quoteSqlString,
+  resetDatabase,
   rowsFromResult,
 } from "./duckdb-vector-loader";
 import { GDAL_AUTO_FID_COLUMN, stripAutoFidColumn } from "./duckdb-geometry";
@@ -714,6 +715,44 @@ export async function runSqlQuery(
   // convenient `SELECT * FROM https://…/x.parquet` form runs.
   const rewritten = rewriteBareSources(withCloudUrls);
 
+  try {
+    return await runSqlStatementOnce(rewritten, layers);
+  } catch (error) {
+    // Recover from a poisoned WASM instance: duckdb-wasm 1.33.1-dev45 breaks
+    // remote read_parquet with "stoi: no conversion" on an instance that ran
+    // LOAD spatial before its first successful remote read (e.g. after an
+    // earlier query's warm-up failed). That state cannot be undone in place, so
+    // rebuild the instance — which re-runs the pre-spatial warm-up — and retry
+    // once. Only for remote queries, so a genuine local error is not retried.
+    if (isPoisonedRemoteReadError(error, rewritten)) {
+      await resetDatabase();
+      return await runSqlStatementOnce(rewritten, layers);
+    }
+    throw error;
+  }
+}
+
+/**
+ * True when an error is the duckdb-wasm poisoned-instance symptom on a query
+ * that reads a remote source: the "stoi: no conversion" failure combined with
+ * an HTTP(S) URL in the (already rewritten) statement.
+ */
+function isPoisonedRemoteReadError(error: unknown, statement: string): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /stoi:\s*no conversion/i.test(message) && /https?:\/\//i.test(statement)
+  );
+}
+
+/**
+ * Runs one attempt of a prepared SQL statement against a DuckDB instance. Split
+ * out of {@link runSqlQuery} so it can be retried against a freshly rebuilt
+ * instance when the current one's remote read path is poisoned.
+ */
+async function runSqlStatementOnce(
+  rewritten: string,
+  layers: GeoLibreLayer[],
+): Promise<SqlQueryResult> {
   const db = await getDatabase();
   const connection = await db.connect();
   // Per-run prefix so concurrent queries on the shared database do not register

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -6,11 +6,13 @@ import {
   type AsyncDuckDBConnection,
 } from "@duckdb/duckdb-wasm";
 import {
+  acquireSqlDatabase,
   ensureSpatialExtension,
   getSqlDatabase,
   isGeometryColumnType,
   quoteIdentifier,
   quoteSqlString,
+  releaseSqlDatabase,
   resetSqlDatabase,
   rowsFromResult,
 } from "./duckdb-vector-loader";
@@ -713,20 +715,31 @@ export async function runSqlQuery(
   // http URL that merely appears in a string literal or WHERE clause).
   const hasRemoteReader = statementHasRemoteReader(rewritten);
 
+  // Run one attempt, ref-counting the instance so a poison recovery can defer
+  // terminating it until no query is still using it.
+  const attempt = async (db: AsyncDuckDB): Promise<SqlQueryResult> => {
+    acquireSqlDatabase(db);
+    try {
+      return await runSqlStatementOnce(rewritten, layers, db);
+    } finally {
+      await releaseSqlDatabase(db);
+    }
+  };
+
   const db = await getSqlDatabase();
   try {
-    return await runSqlStatementOnce(rewritten, layers, db);
+    return await attempt(db);
   } catch (error) {
     // Recover from a poisoned WASM instance: duckdb-wasm 1.33.1-dev45 breaks
     // remote read_parquet with "stoi: no conversion" on an instance that ran
     // LOAD spatial before its first successful remote read (e.g. after an
     // earlier query's warm-up failed). That state cannot be undone in place, so
     // rebuild the SQL Workspace's dedicated instance — which re-runs the
-    // pre-spatial warm-up — and retry once. Scope the reset to `db` so a fresh
-    // instance is never torn down.
+    // pre-spatial warm-up — and retry once. `attempt` has already released `db`,
+    // so resetSqlDatabase tears it down now unless another query is still on it.
     if (hasRemoteReader && isStoiConversionError(error)) {
       await resetSqlDatabase(db);
-      return await runSqlStatementOnce(rewritten, layers, await getSqlDatabase());
+      return await attempt(await getSqlDatabase());
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Fixes a regression where a remote query in the SQL Workspace fails with **`Invalid Error: stoi: no conversion`** and stays broken for the rest of the session until a page reload.

```sql
SELECT NAME, CONTINENT, POP_EST, geom
FROM https://data.source.coop/giswqs/opengeos/countries.parquet
LIMIT 100;
```

## Root cause

duckdb-wasm 1.33.1-dev45 permanently breaks remote `read_parquet` over HTTP on a WASM instance that runs `LOAD spatial` **before** its first successful remote Parquet read. `runSqlQuery` guards against this with a pre-spatial HTTP "warm-up" read, but:

- `ensureSpatialExtension` memoizes the spatial load **module-wide**, so the warm-up only runs on the first query of the session, and
- the warm-up is **best-effort** (its failure is caught and ignored), so `LOAD spatial` proceeds anyway.

So a single failed warm-up — an earlier query with a bad/unreachable URL, or a transient network blip — loads spatial un-warmed and poisons the instance. Every later remote read then fails with `stoi: no conversion`, with no recovery until reload. A fresh session works, which is why this reads as "it used to work."

## Fix

- Add `resetDatabase()` (`duckdb-vector-loader.ts`): discards the memoized DuckDB instance and extension load state and terminates the old worker, so the next `getDatabase()` builds a fresh instance that re-runs the pre-spatial warm-up.
- In `runSqlQuery`, split the execution into `runSqlStatementOnce` and retry once through a rebuilt instance when a query hits the poisoned-instance symptom (`isPoisonedRemoteReadError`: `stoi: no conversion` + an HTTP(S) URL in the statement). Non-remote errors and genuinely bad URLs are not retried, so there is no loop.

This keeps local queries working (spatial still loads best-effort) while making remote reads self-heal.

## Testing

- Verified in the running app (Playwright, DuckDB engine):
  - Fresh session: the countries query returns 100 rows.
  - Session poisoned by a prior bad-URL query: the same countries query now **recovers automatically** and returns 100 rows (previously failed until reload).
  - A genuinely bad URL errors cleanly (`IO Error: No files found ...`) with no retry loop.
- `tests/duckdb-*`, `tests/spatial-extension-config`, `tests/sql-completion` pass; `pre-commit run --files` (eslint + npm build) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for SQL queries that load remote (HTTP/HTTPS) data sources, including detection of remote-reader calls and safer handling of transient failures.
  * Added automatic one-time recovery from rare “poisoned” DuckDB-WASM states by resetting the SQL workspace, reloading required capabilities, and retrying the failed query once.
  * Reduced extension-load inconsistencies by ensuring spatial support is initialized per database instance and bound correctly to the active connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->