### PR TITLE
fix(msix): default PublisherDisplayName to the registered Store name

### DIFF
--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -38,7 +38,7 @@ pwsh ./packaging/msix/build-msix.ps1 `
 | --- | --- | --- |
 | `-Name` | Tauri identifier (`org.geolibre.desktop`) | Must be the reserved `Package/Identity/Name` |
 | `-Publisher` | `CN=GeoLibre` | Must be your seller `CN=<GUID>` |
-| `-PublisherDisplayName` | `GeoLibre` | Must match your publisher display name |
+| `-PublisherDisplayName` | `Open Geospatial Solutions` | Must match your publisher display name exactly; the Store does not remap it |
 | `-DisplayName` | Tauri `productName` (`GeoLibre Desktop`) | `Properties/DisplayName` must be a **reserved** name |
 | `-Language` | `en-us` | Every MSIX must declare a language |
 

--- a/packaging/msix/build-msix.ps1
+++ b/packaging/msix/build-msix.ps1
@@ -4,7 +4,11 @@ param(
   [ValidateSet("x64", "x86", "arm64", "arm", "neutral")]
   [string] $Architecture = "x64",
   [string] $Publisher = "CN=GeoLibre",
-  [string] $PublisherDisplayName = "GeoLibre",
+  # Properties/PublisherDisplayName. The Microsoft Store validates this strictly
+  # against the registered publisher display name, so it must match Partner
+  # Center exactly ("Open Geospatial Solutions"). Unlike Identity Name/Publisher,
+  # the Store does not remap it on ingestion.
+  [string] $PublisherDisplayName = "Open Geospatial Solutions",
   # Identity Name. Defaults to the Tauri identifier; override with the reserved
   # package name from Partner Center (Product Identity) for a Microsoft Store
   # submission.


### PR DESCRIPTION
## Problem

The v1.9.0 Microsoft Store upload failed validation:

> Package acceptance validation error: The PublisherDisplayName element in the app manifest of geolibre-desktop-1.9.0-x64.msix is **GeoLibre**, which doesn't match your publisher display name: **Open Geospatial Solutions**.

The release workflow (`release.yml`) runs `packaging/msix/build-msix.ps1` with no arguments, so the package used the default `PublisherDisplayName = "GeoLibre"`. The Store validates `Properties/PublisherDisplayName` strictly against the registered publisher name and, unlike the `Identity` `Name`/`Publisher` (which it remaps on ingestion), does not rewrite it. That is why this was the only blocking error.

## Fix

- Default `-PublisherDisplayName` to `"Open Geospatial Solutions"` (the registered Partner Center value, already documented in the packaging README).
- Update the packaging README parameter table to match.

The `runFullTrust` warning in the same report is expected for a Tauri desktop app and only needs one-time capability approval in Partner Center; no code change required.

## Note

This corrects future MSIX builds. The already-uploaded v1.9.0 MSIX needs to be rebuilt (re-run the Windows release job, or rebuild locally with the corrected default) to produce an uploadable package.