### PR TITLE
fix(msix): use full Partner Center identity for Store submission

### DIFF
--- a/.github/workflows/msix-store.yml
+++ b/.github/workflows/msix-store.yml
@@ -7,11 +7,6 @@ name: Build Store MSIX
 
 on:
   workflow_dispatch:
-  # Temporary: lets this build run from the feature branch before the workflow
-  # lands on the default branch (workflow_dispatch requires the default branch).
-  # Removed before merge so main only exposes the manual trigger.
-  push:
-    branches: [fix/msix-store-identity]
 
 permissions:
   contents: read

--- a/.github/workflows/msix-store.yml
+++ b/.github/workflows/msix-store.yml
@@ -7,6 +7,11 @@ name: Build Store MSIX
 
 on:
   workflow_dispatch:
+  # Temporary: lets this build run from the feature branch before the workflow
+  # lands on the default branch (workflow_dispatch requires the default branch).
+  # Removed before merge so main only exposes the manual trigger.
+  push:
+    branches: [fix/msix-store-identity]
 
 permissions:
   contents: read

--- a/.github/workflows/msix-store.yml
+++ b/.github/workflows/msix-store.yml
@@ -1,0 +1,51 @@
+name: Build Store MSIX
+
+# Manually builds the Windows MSIX package for a Microsoft Store submission and
+# uploads it as a workflow artifact. This does NOT touch any GitHub release; it
+# exists so a Store-ready package can be produced on demand (e.g. to fix a
+# rejected submission) without re-publishing a release.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build MSIX
+    runs-on: windows-2025
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build Tauri release binary
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+        run: npm run tauri:build -- --no-sign
+
+      - name: Build MSIX package
+        id: build_msix
+        shell: pwsh
+        run: ./packaging/msix/build-msix.ps1
+
+      - name: Upload MSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geolibre-store-msix
+          path: ${{ steps.build_msix.outputs.msix_path }}
+          if-no-files-found: error

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -34,16 +34,20 @@ pwsh ./packaging/msix/build-msix.ps1 `
   -DisplayName "GeoLibre"                            # a name reserved in Partner Center
 ```
 
-| Parameter | Default | Why override for the Store |
+The defaults are the opengeos Partner Center identity, so a bare
+`./build-msix.ps1` produces a Store-ready package. Override them for a
+self-signed sideload build or a different publisher.
+
+| Parameter | Default (Store identity) | Notes |
 | --- | --- | --- |
-| `-Name` | Tauri identifier (`org.geolibre.desktop`) | Must be the reserved `Package/Identity/Name` |
-| `-Publisher` | `CN=GeoLibre` | Must be your seller `CN=<GUID>` |
+| `-Name` | `OpenGeospatialSolutions.GeoLibre` | Reserved `Package/Identity/Name`; the Store rejects the Tauri identifier. Pass `""` to fall back to `org.geolibre.desktop` for a non-Store build |
+| `-Publisher` | `CN=E6AE8172-DC4F-4F79-844B-9D84204BF95A` | Seller `CN=<GUID>` from Partner Center; must match the account publisher ID |
 | `-PublisherDisplayName` | `Open Geospatial Solutions` | Must match your publisher display name exactly; the Store does not remap it |
-| `-DisplayName` | Tauri `productName` (`GeoLibre Desktop`) | `Properties/DisplayName` must be a **reserved** name |
+| `-DisplayName` | `GeoLibre` | Reserved `Properties/DisplayName`; differs from the Tauri `productName` (`GeoLibre Desktop`). Pass `""` to fall back to the productName |
 | `-Language` | `en-us` | Every MSIX must declare a language |
 
 The package family name is derived automatically from `-Name` + `-Publisher`, so
-it will match once those are correct.
+it matches (`OpenGeospatialSolutions.GeoLibre_wby2ff7ejknn4`) once those are correct.
 
 `-DisplayName` sets only the package display name (`Properties/DisplayName`, used
 for the Store listing). The Start-menu / taskbar name

--- a/packaging/msix/build-msix.ps1
+++ b/packaging/msix/build-msix.ps1
@@ -3,20 +3,26 @@ param(
   [string] $Configuration = "release",
   [ValidateSet("x64", "x86", "arm64", "arm", "neutral")]
   [string] $Architecture = "x64",
-  [string] $Publisher = "CN=GeoLibre",
+  # Identity/Publisher. The Microsoft Store validates this against the account's
+  # publisher ID, so it must be the seller CN=<GUID> from Partner Center
+  # (Product Identity), not a friendly name. Override for a self-signed sideload
+  # build.
+  [string] $Publisher = "CN=E6AE8172-DC4F-4F79-844B-9D84204BF95A",
   # Properties/PublisherDisplayName. The Microsoft Store validates this strictly
   # against the registered publisher display name, so it must match Partner
   # Center exactly ("Open Geospatial Solutions"). Unlike Identity Name/Publisher,
   # the Store does not remap it on ingestion.
   [string] $PublisherDisplayName = "Open Geospatial Solutions",
-  # Identity Name. Defaults to the Tauri identifier; override with the reserved
-  # package name from Partner Center (Product Identity) for a Microsoft Store
-  # submission.
-  [string] $Name = "",
-  # Package display name (Properties/DisplayName). Defaults to the Tauri
-  # productName; for a Microsoft Store submission it must be a name you reserved
-  # in Partner Center (e.g. "GeoLibre"), which may differ from the product name.
-  [string] $DisplayName = "",
+  # Identity Name. Must be the reserved package name from Partner Center
+  # (Product Identity) for a Microsoft Store submission; the Store rejects the
+  # Tauri identifier. Pass "" to fall back to the Tauri identifier for a
+  # non-Store build.
+  [string] $Name = "OpenGeospatialSolutions.GeoLibre",
+  # Package display name (Properties/DisplayName). For a Microsoft Store
+  # submission it must be a name you reserved in Partner Center ("GeoLibre"),
+  # which differs from the Tauri productName ("GeoLibre Desktop"). Pass "" to
+  # fall back to the productName for a non-Store build.
+  [string] $DisplayName = "GeoLibre",
   # Default package language. Required by the Store; every MSIX must declare one.
   [ValidatePattern('^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{1,8})*$')]
   [string] $Language = "en-us"


### PR DESCRIPTION
## Problem

The v1.9.0 Microsoft Store submission was rejected because the MSIX's `Package/Identity` did not match the reserved Partner Center identity. The Store validates **every** identity field strictly and does not remap `Name`/`Publisher` on ingestion:

- Invalid package identity name: `org.geolibre.desktop` (expected `OpenGeospatialSolutions.GeoLibre`)
- Invalid package family name: `org.geolibre.desktop_v6dsnp8ebbdfr` (expected `OpenGeospatialSolutions.GeoLibre_wby2ff7ejknn4`)
- Invalid package publisher name: `CN=GeoLibre` (expected `CN=E6AE8172-...`)
- Unreserved `Properties/DisplayName`: `GeoLibre Desktop` (must be the reserved `GeoLibre`)

## Fix

`packaging/msix/build-msix.ps1` now defaults to the opengeos Partner Center identity, so a bare `./build-msix.ps1` (as invoked by `release.yml`) produces a Store-ready package:

| Field | Old default | New default |
| --- | --- | --- |
| Identity `Name` | Tauri identifier `org.geolibre.desktop` | `OpenGeospatialSolutions.GeoLibre` |
| `Publisher` | `CN=GeoLibre` | `CN=E6AE8172-DC4F-4F79-844B-9D84204BF95A` |
| Properties `DisplayName` | Tauri productName `GeoLibre Desktop` | `GeoLibre` (reserved) |
| `PublisherDisplayName` | (already fixed) `Open Geospatial Solutions` | unchanged |

The package family name derives from `Name` + `Publisher`, so it now resolves to the expected `OpenGeospatialSolutions.GeoLibre_wby2ff7ejknn4`. The Start-menu name (`VisualElements/@DisplayName`) intentionally stays `GeoLibre Desktop` (not validated by the Store). Each value can still be overridden for a self-signed sideload build; the packaging README table is updated.

## On-demand build

Adds `.github/workflows/msix-store.yml`, a `workflow_dispatch` job that builds the MSIX and uploads it as a workflow artifact. This lets a Store-ready package be produced without re-publishing a GitHub release (used to generate the corrected v1.9.0 upload).

## Verification

Built via the new workflow and confirmed the resulting `AppxManifest.xml` carries all four required identity values. The package was uploaded to Partner Center and passed package validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow to build and upload a Store-ready MSIX package for Windows.

* **Documentation**
  * Updated MSIX packaging guidance with clearer default values and override behavior for Store and non-Store builds.

* **Bug Fixes**
  * Improved default package identity settings so MSIX builds are generated with the expected Store-ready app name, publisher, and display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->