### PR TITLE
fix(sql): self-heal a failed DuckDB build instead of caching the rejection

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -56,7 +56,18 @@ export interface DuckDbVectorFile {
 }
 
 export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
-  dbPromise ??= createDatabase();
+  if (!dbPromise) {
+    // Clear the memo if the build rejects (identity-guarded so a concurrent
+    // rebuild is not clobbered): a transient WASM-bundle fetch failure must not
+    // leave a rejected promise cached forever, breaking every later call.
+    const building: Promise<duckdb.AsyncDuckDB> = createDatabase().catch(
+      (error) => {
+        if (dbPromise === building) dbPromise = null;
+        throw error;
+      },
+    );
+    dbPromise = building;
+  }
   return dbPromise;
 }
 
@@ -70,7 +81,18 @@ let sqlDbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
 
 /** The DuckDB instance dedicated to the SQL Workspace. */
 export function getSqlDatabase(): Promise<duckdb.AsyncDuckDB> {
-  sqlDbPromise ??= createDatabase();
+  if (!sqlDbPromise) {
+    // Same self-heal as getDatabase: clear the memo (identity-guarded against a
+    // concurrent resetSqlDatabase) if the build rejects, so a failed build is
+    // retried rather than cached as a permanently-rejected promise.
+    const building: Promise<duckdb.AsyncDuckDB> = createDatabase().catch(
+      (error) => {
+        if (sqlDbPromise === building) sqlDbPromise = null;
+        throw error;
+      },
+    );
+    sqlDbPromise = building;
+  }
   return sqlDbPromise;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1042. During its review, the Claude bot flagged that a failed DuckDB build is cached as a permanently-rejected promise — the same "broken until reload" class of bug #1042 fixes, from a different trigger.

`getDatabase` / `getSqlDatabase` memoize `createDatabase()` with `??=`. If the **first** build rejects (a transient failure fetching the WASM bundle or the spatial extension), the rejected promise is cached forever: `??=` never reassigns it, so every later call re-throws the same rejection and DuckDB is unusable until a full page reload.

## Fix

Clear the memo when the build rejects, so the next call retries the build. The clear is identity-guarded (`if (dbPromise === building)`) so a concurrent rebuild — e.g. `resetSqlDatabase` swapping in a fresh instance — is not clobbered.

## Testing

`npm run typecheck`, the `tests/duckdb-*` / `tests/spatial-extension-config` suites, and `pre-commit run --files` (eslint + npm build) pass. The change is on the failure path only; the happy path is unchanged.
