### PR TITLE
Add Google Photorealistic 3D Tiles support

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -18,7 +18,8 @@ name: Cloudflare preview
 #   CLOUDFLARE_API_TOKEN   - needs the "Cloudflare Pages: Edit" permission
 #   CLOUDFLARE_ACCOUNT_ID
 # Optional (baked into the client bundle, same as pages.yml):
-#   VITE_GEE_OAUTH_CLIENT_ID, VITE_PROTOMAPS_API_KEY
+#   VITE_GEE_OAUTH_CLIENT_ID, VITE_PROTOMAPS_API_KEY,
+#   VITE_GOOGLE_MAPS_API_KEY or GOOGLE_MAPS_API_KEY
 
 on:
   pull_request:
@@ -78,6 +79,8 @@ jobs:
           GEOLIBRE_APP_BASE: ./
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
+          VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
 
       - name: Build documentation

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,6 +61,11 @@ jobs:
           # dialog can offer Protomaps basemaps. When unset, those options are
           # hidden (see getProtomapsStyleUrl in @geolibre/core).
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
+          # Google Photorealistic 3D Tiles and Google Street View use the same
+          # Maps key. Prefer the Vite-prefixed secret name, but also pass the
+          # bare name below so vite.config.ts can expose local/CI test setups.
+          VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           # Public relay URL (baked into the client bundle), not a secret. Lights
           # up live collaboration; requires the workers/collab relay to be
           # deployed (see docs/collaboration.md).

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1610,6 +1610,11 @@ body,
   box-shadow: 0 0 0 2px hsl(var(--ring) / 0.16) !important;
 }
 
+.geolibre-3d-tiles-panel .geolibre-google-tiles-key-toggle {
+  align-self: flex-start;
+  margin-top: 6px;
+}
+
 .geolibre-3d-tiles-panel .three-d-tiles-checkbox input,
 .geolibre-3d-tiles-panel .three-d-tiles-list-actions input[type="checkbox"],
 .geolibre-3d-tiles-panel .three-d-tiles-opacity {

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -24,6 +24,21 @@ const APP_VERSION = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf8"),
 ).version as string;
 
+// Vite resolves `mode` from the `--mode` CLI flag (defaulting to `development`
+// for `vite`/`vite dev` and `production` for `vite build`). This shim runs at
+// module load, before `defineConfig` receives the resolved mode, so read
+// `--mode` from argv directly and fall back to NODE_ENV (which Vite's CLI sets
+// from the command). This lets `loadEnv` pick up mode-specific files such as
+// `.env.staging.local` under `vite build --mode staging`, not just NODE_ENV.
+function resolveViteMode(): string {
+  const argv = process.argv;
+  const inline = argv.find((arg) => arg.startsWith("--mode="));
+  if (inline) return inline.slice("--mode=".length);
+  const flagIndex = argv.findIndex((arg) => arg === "--mode" || arg === "-m");
+  if (flagIndex !== -1 && argv[flagIndex + 1]) return argv[flagIndex + 1];
+  return process.env.NODE_ENV || "development";
+}
+
 // Vite only exposes `VITE_`-prefixed vars to the client, so the Google Maps key
 // is surfaced as `VITE_GOOGLE_MAPS_API_KEY`. Accept a bare `GOOGLE_MAPS_API_KEY`
 // too (handy for local shell/CI testing) and copy it into the prefixed name.
@@ -31,11 +46,7 @@ const APP_VERSION = JSON.parse(
 // so a key placed in `apps/geolibre-desktop/.env.local` also works, not just a
 // real shell env var (process.env alone would miss the file).
 const CONFIG_DIR = path.dirname(fileURLToPath(import.meta.url));
-const FILE_ENV = loadEnv(
-  process.env.NODE_ENV || "development",
-  CONFIG_DIR,
-  "",
-);
+const FILE_ENV = loadEnv(resolveViteMode(), CONFIG_DIR, "");
 if (!process.env.VITE_GOOGLE_MAPS_API_KEY) {
   const googleMapsApiKey =
     process.env.GOOGLE_MAPS_API_KEY ||

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -8,7 +8,8 @@ import type {
   RollupOptions,
   WarningHandlerWithDefault,
 } from "rollup";
-import { defineConfig, type Plugin } from "vite";
+import { fileURLToPath } from "node:url";
+import { defineConfig, loadEnv, type Plugin } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { bundledPlugins } from "./vite-plugins/bundled-plugins";
 import { copyRtlText } from "./vite-plugins/copy-rtl-text";
@@ -23,8 +24,26 @@ const APP_VERSION = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf8"),
 ).version as string;
 
-if (!process.env.VITE_GOOGLE_MAPS_API_KEY && process.env.GOOGLE_MAPS_API_KEY) {
-  process.env.VITE_GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+// Vite only exposes `VITE_`-prefixed vars to the client, so the Google Maps key
+// is surfaced as `VITE_GOOGLE_MAPS_API_KEY`. Accept a bare `GOOGLE_MAPS_API_KEY`
+// too (handy for local shell/CI testing) and copy it into the prefixed name.
+// `loadEnv(mode, dir, "")` reads the app's `.env*` files with no prefix filter,
+// so a key placed in `apps/geolibre-desktop/.env.local` also works, not just a
+// real shell env var (process.env alone would miss the file).
+const CONFIG_DIR = path.dirname(fileURLToPath(import.meta.url));
+const FILE_ENV = loadEnv(
+  process.env.NODE_ENV || "development",
+  CONFIG_DIR,
+  "",
+);
+if (!process.env.VITE_GOOGLE_MAPS_API_KEY) {
+  const googleMapsApiKey =
+    process.env.GOOGLE_MAPS_API_KEY ||
+    FILE_ENV.VITE_GOOGLE_MAPS_API_KEY ||
+    FILE_ENV.GOOGLE_MAPS_API_KEY;
+  if (googleMapsApiKey) {
+    process.env.VITE_GOOGLE_MAPS_API_KEY = googleMapsApiKey;
+  }
 }
 
 // Tauri sets TAURI_ENV_* env vars while running its beforeBuildCommand

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -23,6 +23,10 @@ const APP_VERSION = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf8"),
 ).version as string;
 
+if (!process.env.VITE_GOOGLE_MAPS_API_KEY && process.env.GOOGLE_MAPS_API_KEY) {
+  process.env.VITE_GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+}
+
 // Tauri sets TAURI_ENV_* env vars while running its beforeBuildCommand
 // (`npm run build`), so their presence flags a desktop build. Used below to drop
 // the service worker from the desktop bundle.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,14 +158,14 @@ Where to find the output:
 
 ## Optional imagery credentials
 
-The Street View plugin can use Google Street View and Mapillary imagery. Create `apps/geolibre-desktop/.env.local` and set one or both provider credentials:
+The Street View plugin can use Google Street View and Mapillary imagery. The 3D Tiles panel can also load Google Photorealistic 3D Tiles with the same Google Maps key. Create `apps/geolibre-desktop/.env.local` and set one or both provider credentials:
 
 ```env
 VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 VITE_MAPILLARY_ACCESS_TOKEN=your_mapillary_access_token
 ```
 
-For Google Street View, enable the Maps Embed API for the key in Google Cloud. For Mapillary, create an app in the Mapillary developer dashboard and use its client access token.
+For Google Street View, enable the Maps Embed API for the key in Google Cloud. For Google Photorealistic 3D Tiles, enable the Map Tiles API. For local shell testing, `GOOGLE_MAPS_API_KEY` is also accepted by the desktop Vite build. For Mapillary, create an app in the Mapillary developer dashboard and use its client access token.
 
 Restart `npm run dev` or `npm run tauri:dev` after changing environment variables.
 
@@ -195,7 +195,7 @@ VITE_TOMTOM_API_KEY=your_tomtom_api_key             # TomTom Traffic Flow
 VITE_HERE_API_KEY=your_here_api_key                 # HERE Traffic Flow
 ```
 
-Google Traffic reuses the same `VITE_GOOGLE_MAPS_API_KEY` as Street View; enable the **Map Tiles API** for that key in Google Cloud. A newly entered key takes effect immediately, without reopening the project. Until a provider's key is set, its overlay reports a missing-key error instead of loading tiles.
+Google Traffic and Google Photorealistic 3D Tiles reuse the same `VITE_GOOGLE_MAPS_API_KEY` as Street View; enable the **Map Tiles API** for that key in Google Cloud. A newly entered key takes effect immediately, without reopening the project. Until a provider's key is set, its overlay reports a missing-key error instead of loading tiles.
 
 ## Optional Amazon Location styles
 

--- a/docs/user-guide/adding-data.md
+++ b/docs/user-guide/adding-data.md
@@ -42,7 +42,7 @@ Vector files are reprojected to EPSG:4326 on load. In the browser, vector import
 | --- | --- |
 | **LiDAR Layer** | Point-cloud visualization, rendered with deck.gl. |
 | **Splatting Layer** | Gaussian splat scenes. |
-| **3D Tiles Layer** | OGC 3D Tiles, restored when reopening a project. |
+| **3D Tiles Layer** | OGC 3D Tiles, restored when reopening a project. Includes a Google Photorealistic 3D Tiles sample that reads `VITE_GOOGLE_MAPS_API_KEY` or `GOOGLE_MAPS_API_KEY` from the runtime environment. |
 
 ## Databases
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -36,7 +36,7 @@ Panels also auto-hide on small screens for a responsive layout.
 - **Environment variables**: named key-value pairs (for example, API keys for Earth Engine, Street View, and other integrations). You can enable or disable individual variables, and secret values are masked. Variable names must start with a letter or underscore and contain only letters, numbers, and underscores.
 
 !!! tip "Where credentials go"
-    Provider credentials for integrations like Earth Engine, Street View, or other keyed services belong here. See [Data Integrations](data-integrations.md) and [Getting Started](../getting-started.md#optional-imagery-credentials).
+    Provider credentials for integrations like Earth Engine, Street View, Google Photorealistic 3D Tiles, or other keyed services belong here. See [Data Integrations](data-integrations.md) and [Getting Started](../getting-started.md#optional-imagery-credentials).
 
 !!! tip "Protomaps basemaps"
     To use the [Protomaps](https://protomaps.com) basemaps in the **New map** dialog, add an environment variable named `VITE_PROTOMAPS_API_KEY` with your own Protomaps API key. The Protomaps options appear in the dialog as soon as the key is enabled — no restart needed. When no key is set, the Protomaps section is hidden. See [Getting Started](../getting-started.md#optional-basemap-credentials) for setting the key at build time for a self-hosted deployment.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export {
   type ReverseGeocodeDisplay,
 } from "./geocoding";
 export {
+  getGoogleMapsApiKey,
   getProtomapsApiKey,
   getProtomapsStyleUrl,
   getRuntimeEnvironment,

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -73,9 +73,13 @@ export function getProtomapsApiKey(
 /**
  * Resolves the Google Maps API key from the runtime environment.
  *
- * GeoLibre's browser-facing builds normally use `VITE_GOOGLE_MAPS_API_KEY`,
- * while local desktop development may expose `GOOGLE_MAPS_API_KEY` directly
- * through Vite's envPrefix allowlist.
+ * GeoLibre's browser-facing builds normally use `VITE_GOOGLE_MAPS_API_KEY`.
+ * The bare `GOOGLE_MAPS_API_KEY` fallback is reached two ways: (1) the desktop
+ * Vite config copies it to `VITE_GOOGLE_MAPS_API_KEY` at build time for local
+ * shell testing (`vite.config.ts`'s `envPrefix` does not include the bare
+ * name), and (2) a project's own runtime environment variables
+ * (`window.__GEOLIBRE_RUNTIME_ENV__`), which are not subject to Vite's
+ * envPrefix allowlist at all.
  *
  * @param env - Environment record (defaults to the runtime environment);
  *   injectable for testing.

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -71,6 +71,27 @@ export function getProtomapsApiKey(
 }
 
 /**
+ * Resolves the Google Maps API key from the runtime environment.
+ *
+ * GeoLibre's browser-facing builds normally use `VITE_GOOGLE_MAPS_API_KEY`,
+ * while local desktop development may expose `GOOGLE_MAPS_API_KEY` directly
+ * through Vite's envPrefix allowlist.
+ *
+ * @param env - Environment record (defaults to the runtime environment);
+ *   injectable for testing.
+ * @returns The trimmed API key, or undefined when unset.
+ */
+export function getGoogleMapsApiKey(
+  env?: Record<string, string | undefined>,
+): string | undefined {
+  const runtimeEnv = env ?? getRuntimeEnvironment();
+  const trimmed =
+    runtimeEnv.VITE_GOOGLE_MAPS_API_KEY?.trim() ||
+    runtimeEnv.GOOGLE_MAPS_API_KEY?.trim();
+  return trimmed || undefined;
+}
+
+/**
  * Builds a full Protomaps v5 style URL for a flavor, injecting the API key.
  *
  * @param flavor - The Protomaps flavor name (e.g. `light`, `dark`, `white`,

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -82,18 +82,32 @@ let googleTilesBoundMap: unknown;
 let ensureGoogleTilesOverlayInFlight: Promise<void> | null = null;
 let googleTilesMountRetryScheduled = false;
 let googleTilesMountRetries = 0;
+// Latches once the bounded mount retry gives up, so the warning logs once
+// rather than on every subsequent store-driven render.
+let googleTilesMountGaveUp = false;
 let googleTilesPreviousProjection: "globe" | "mercator" | null = null;
 let googleAltitudeOffsetTile3DLayerClass: DeckTile3DLayerClass | null = null;
+// Runtime-env listener owned by the Google overlay lifecycle, so a project with
+// only Google layers (which never creates the native ThreeDTilesControl) still
+// picks up an API-key change without reopening the project.
+let googleTilesRuntimeEnvUnsubscribe: (() => void) | null = null;
 // The last rendered Google-layer signature, used to skip rebuilding deck layers
 // when an unrelated layer mutation fires the store subscription.
 let lastGoogleTilesLayerSignature: string | null = null;
+const googleTilesApiKeysByLayerId = new Map<string, string>();
+const googleTilesApiKeysByPanel = new WeakMap<HTMLElement, string>();
 // ~1s at 60fps: bound the mount retry so a map that never initializes cannot
 // spin requestAnimationFrame forever.
 const GOOGLE_TILES_MAX_MOUNT_RETRIES = 60;
 
 type ThreeDTilesLayerInstance = InstanceType<typeof ThreeDTilesLayer>;
 
-type RenderableDeckLayer = Layer & {
+// Structural shape of the deck.gl Tile3DLayer instances we subclass. It is
+// intentionally NOT `Layer & …`: the abstract `Layer` base declares abstract
+// members (e.g. initializeState) that a class expression extending this
+// constructor would otherwise be required to implement, even though the real
+// runtime base (deck.gl's Tile3DLayer) already provides them.
+type RenderableDeckLayer = {
   props: Record<string, unknown>;
   renderLayers(): unknown;
 };
@@ -619,14 +633,6 @@ function installGooglePhotorealisticTilesPanelHandlers(
   const urlInput = getThreeDTilesUrlInput(panel);
   urlInput?.addEventListener("input", applyDefaults);
   urlInput?.addEventListener("change", applyDefaults);
-  panel.addEventListener("input", (event) => {
-    if (
-      event.target instanceof HTMLInputElement &&
-      event.target.getAttribute("aria-label") === "Altitude offset"
-    ) {
-      updateGooglePhotorealisticTilesAltitudeOffset(control, panel);
-    }
-  });
   // Intercept the submit on the panel (an ancestor of the form) during the
   // capture phase so this runs before maplibre-gl-3d-tiles' own form-level
   // submit listener. A capture listener on the form target itself would not:
@@ -665,29 +671,6 @@ function installGooglePhotorealisticTilesPanelHandlers(
   applyDefaults();
 }
 
-function updateGooglePhotorealisticTilesAltitudeOffset(
-  control: ThreeDTilesControl,
-  panel: HTMLElement,
-): void {
-  if (!isGooglePhotorealisticTilesetUrl(getThreeDTilesUrlInput(panel)?.value)) {
-    return;
-  }
-  const altitudeInput = panel.querySelector<HTMLInputElement>(
-    'input[aria-label="Altitude offset"]',
-  );
-  const altitudeOffset = numberInputValue(
-    altitudeInput?.value,
-    numberValue(control.getState().altitudeOffset, 0),
-  );
-  const store = useAppStore.getState();
-  for (const layer of store.layers.filter(isGooglePhotorealisticTilesLayer)) {
-    store.updateLayer(layer.id, {
-      source: { ...layer.source, altitudeOffset },
-      metadata: { ...layer.metadata, altitudeOffset },
-    });
-  }
-}
-
 function applyGooglePhotorealisticTilesPanelDefaults(
   control: ThreeDTilesControl,
 ): void {
@@ -709,7 +692,9 @@ function applyGooglePhotorealisticTilesPanelDefaults(
           parseThreeDTilesRequestHeaders(headersInput.value),
         ),
       );
+      headersInput.placeholder = "";
     }
+    googleTilesApiKeysByPanel.delete(panel);
     panel.dataset.geolibreGoogleMapsApiKeyVisible = "false";
     // Re-arm the one-shot altitude default so it applies again if the user
     // returns to a Google URL.
@@ -754,9 +739,13 @@ function applyGooglePhotorealisticTilesPanelDefaults(
   );
   if (!headersInput) return;
 
+  headersInput.placeholder = `${GOOGLE_MAPS_API_KEY_HEADER}: <your Google Maps API key>`;
+  const rawHeaders = parseThreeDTilesRequestHeaders(headersInput.value);
+  const panelApiKey = rememberGoogleMapsApiKeyFromHeaders(panel, rawHeaders);
   const headers = resolveThreeDTilesRequestHeaders(
     GOOGLE_PHOTOREALISTIC_TILES_URL,
-    parseThreeDTilesRequestHeaders(headersInput.value),
+    rawHeaders,
+    panelApiKey,
   );
   installGooglePhotorealisticHeadersToggle(panel, headersInput);
   headersInput.value = serializeGooglePhotorealisticPanelRequestHeaders(
@@ -798,9 +787,12 @@ function installGooglePhotorealisticHeadersToggle(
       : "false";
     updateGooglePhotorealisticHeadersToggle(toggle, visible);
 
+    const rawHeaders = parseThreeDTilesRequestHeaders(headersInput.value);
+    const panelApiKey = rememberGoogleMapsApiKeyFromHeaders(panel, rawHeaders);
     const headers = resolveThreeDTilesRequestHeaders(
       GOOGLE_PHOTOREALISTIC_TILES_URL,
-      parseThreeDTilesRequestHeaders(headersInput.value),
+      rawHeaders,
+      panelApiKey,
     );
     headersInput.value = serializeGooglePhotorealisticPanelRequestHeaders(
       headers,
@@ -858,13 +850,19 @@ async function addGooglePhotorealisticTilesFromPanel(
     panel
       .querySelector<HTMLInputElement>('input[aria-label="Layer name"]')
       ?.value.trim() || GOOGLE_PHOTOREALISTIC_TILES_LABEL;
+  const rawHeaders = parseThreeDTilesRequestHeaders(
+    panel.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Request headers"]',
+    )?.value ?? "",
+  );
+  const manualGoogleMapsApiKey = rememberGoogleMapsApiKeyFromHeaders(
+    panel,
+    rawHeaders,
+  );
   const headers = resolveThreeDTilesRequestHeaders(
     GOOGLE_PHOTOREALISTIC_TILES_URL,
-    parseThreeDTilesRequestHeaders(
-      panel.querySelector<HTMLTextAreaElement>(
-        'textarea[aria-label="Request headers"]',
-      )?.value ?? "",
-    ),
+    rawHeaders,
+    manualGoogleMapsApiKey,
   );
   const flyToOnLoad =
     panel.querySelector<HTMLInputElement>(
@@ -886,6 +884,7 @@ async function addGooglePhotorealisticTilesFromPanel(
     opacity,
     visible,
     requestHeaders: headers,
+    googleMapsApiKey: manualGoogleMapsApiKey,
     flyTo: flyToOnLoad,
     map: control.getMap(),
   });
@@ -909,12 +908,16 @@ function addGooglePhotorealisticTilesLayer(
     opacity: number;
     visible: boolean;
     requestHeaders?: Record<string, string>;
+    googleMapsApiKey?: string;
     flyTo: boolean;
     map?: ReturnType<ThreeDTilesControl["getMap"]>;
   },
 ): string {
   const id = `${GOOGLE_PHOTOREALISTIC_LAYER_ID_PREFIX}-${crypto.randomUUID()}`;
   const deckLayerId = `${id}-deck`;
+  if (options.googleMapsApiKey) {
+    googleTilesApiKeysByLayerId.set(id, options.googleMapsApiKey);
+  }
 
   useAppStore.getState().addLayer({
     id,
@@ -972,8 +975,20 @@ function updateGooglePhotorealisticTilesPanelList(
   }
 
   const googleList = ensureGooglePhotorealisticTilesPanelList(panel);
-  googleList.replaceChildren();
   googleList.hidden = googleLayers.length === 0;
+
+  // Only rebuild the DOM when the SET of Google layers changes. This runs on
+  // every store mutation anywhere in the app, and an unconditional
+  // replaceChildren() would detach and recreate the per-layer opacity <input>
+  // mid-drag (dropping pointer capture and truncating the gesture). The slider
+  // and visibility checkbox already reflect their own live state, and the map
+  // is updated by renderGooglePhotorealisticTilesLayers, so skipping the
+  // rebuild when the ids are unchanged is safe.
+  const idSignature = googleLayers.map((layer) => layer.id).join("|");
+  if (googleList.dataset.geolibreGoogleListIds === idSignature) return;
+  googleList.dataset.geolibreGoogleListIds = idSignature;
+
+  googleList.replaceChildren();
   if (googleLayers.length === 0) return;
 
   for (const layer of googleLayers) {
@@ -1124,7 +1139,14 @@ function forceGooglePhotorealisticMercatorProjection(
   mapOverride?: ReturnType<ThreeDTilesControl["getMap"]>,
 ): void {
   if (googleTilesPreviousProjection === null) {
-    googleTilesPreviousProjection = app.getMapProjection?.() ?? null;
+    // Only remember a projection worth restoring to. Never capture "mercator":
+    // it may be a value WE forced and persisted into the project file, so a
+    // reopened Google-only project would otherwise capture the forced mercator
+    // as the "previous" and leave the map stuck in mercator after the last
+    // Google layer is removed. Capturing only "globe" restores correctly
+    // within a session and never auto-restores a forced value across reloads.
+    const current = app.getMapProjection?.() ?? null;
+    googleTilesPreviousProjection = current === "globe" ? "globe" : null;
   }
   app.setMapProjection?.("mercator");
   ensureMercatorProjection(mapOverride ?? app.getMap?.());
@@ -1191,12 +1213,48 @@ async function runEnsureGooglePhotorealisticTilesOverlay(
   // A fresh overlay instance holds no layers and no prior mount attempts.
   lastGoogleTilesLayerSignature = null;
   googleTilesMountRetries = 0;
+  googleTilesMountGaveUp = false;
+  addGoogleTilesRuntimeEnvListener();
   googleTilesStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     if (state.layers !== previous.layers) {
+      const currentGoogleLayerIds = new Set(
+        state.layers
+          .filter(isGooglePhotorealisticTilesLayer)
+          .map(({ id }) => id),
+      );
+      for (const layer of previous.layers) {
+        if (
+          isGooglePhotorealisticTilesLayer(layer) &&
+          !currentGoogleLayerIds.has(layer.id)
+        ) {
+          googleTilesApiKeysByLayerId.delete(layer.id);
+        }
+      }
       renderGooglePhotorealisticTilesLayers();
     }
   });
   renderGooglePhotorealisticTilesLayers();
+}
+
+function addGoogleTilesRuntimeEnvListener(): void {
+  if (googleTilesRuntimeEnvUnsubscribe || typeof window === "undefined") return;
+
+  // A newly entered API key does not change any persisted layer record, so the
+  // render signature would be unchanged; reset it to force a rebuild that
+  // threads the new key into the deck.gl Tile3DLayer. Registered here (not only
+  // in createThreeDTilesControl) so Google-only projects, which never open the
+  // native 3D Tiles panel, still react to a key change.
+  const handleRuntimeEnvChange = () => {
+    lastGoogleTilesLayerSignature = null;
+    renderGooglePhotorealisticTilesLayers();
+  };
+  window.addEventListener("geolibre:runtime-env-change", handleRuntimeEnvChange);
+  googleTilesRuntimeEnvUnsubscribe = () => {
+    window.removeEventListener(
+      "geolibre:runtime-env-change",
+      handleRuntimeEnvChange,
+    );
+  };
 }
 
 function renderGooglePhotorealisticTilesLayers(): void {
@@ -1223,6 +1281,7 @@ function renderGooglePhotorealisticTilesLayers(): void {
     }
     lastGoogleTilesLayerSignature = null;
     googleTilesMountRetries = 0;
+    googleTilesMountGaveUp = false;
     restoreGooglePhotorealisticPreviousProjection();
     return;
   }
@@ -1240,6 +1299,11 @@ function renderGooglePhotorealisticTilesLayers(): void {
     }
     googleTilesOverlayMounted = true;
     googleTilesMountRetries = 0;
+    googleTilesMountGaveUp = false;
+    // The successful mount can happen on a later async retry, after the map
+    // becomes ready; record the map it actually bound to so a subsequent
+    // ensure() call does not see a stale null and needlessly tear down/refetch.
+    googleTilesBoundMap = googleTilesApp.getMap?.() ?? null;
     // A fresh mount starts with no layers, so force the setProps below.
     lastGoogleTilesLayerSignature = null;
   }
@@ -1264,11 +1328,15 @@ function renderGooglePhotorealisticTilesLayers(): void {
 function scheduleGoogleTilesMountRetry(): void {
   if (
     googleTilesMountRetryScheduled ||
+    googleTilesMountGaveUp ||
     typeof requestAnimationFrame === "undefined"
   ) {
     return;
   }
   if (googleTilesMountRetries >= GOOGLE_TILES_MAX_MOUNT_RETRIES) {
+    // Latch so this warns once, not on every subsequent store-driven render.
+    // A later inline addMapControl attempt can still recover and clear this.
+    googleTilesMountGaveUp = true;
     console.warn(
       "[GeoLibre] Gave up mounting the Google 3D Tiles overlay after repeated addMapControl failures.",
     );
@@ -1287,8 +1355,17 @@ function googleTilesLayerSignature(layers: GeoLibreLayer[]): string {
     .map((layer) => {
       const headers = stringRecordValue(layer.source.requestHeaders);
       const altitudeOffset = numberValue(layer.source.altitudeOffset, 0);
-      const headerKeys = headers ? Object.keys(headers).sort().join(",") : "";
-      return `${layer.id}:${layer.visible ? 1 : 0}:${layer.opacity}:${altitudeOffset}:${headerKeys}`;
+      // Sign both header names AND values: a changed custom header value must
+      // produce a new signature so the Tile3DLayer rebuilds rather than reusing
+      // stale request headers.
+      const headerEntries = headers
+        ? JSON.stringify(
+            Object.entries(headers).sort(([left], [right]) =>
+              left.localeCompare(right),
+            ),
+          )
+        : "";
+      return `${layer.id}:${layer.visible ? 1 : 0}:${layer.opacity}:${altitudeOffset}:${headerEntries}`;
     })
     .join("|");
 }
@@ -1301,6 +1378,7 @@ function buildGooglePhotorealisticTilesDeckLayer(
   const requestHeaders = resolveThreeDTilesRequestHeaders(
     GOOGLE_PHOTOREALISTIC_TILES_URL,
     stringRecordValue(layer.source.requestHeaders),
+    googleTilesApiKeysByLayerId.get(layer.id),
   );
 
   const Tile3DLayer = getGoogleAltitudeOffsetTile3DLayerClass();
@@ -1319,7 +1397,7 @@ function buildGooglePhotorealisticTilesDeckLayer(
     opacity: layer.opacity,
     pickable: false,
     operation: "draw",
-  }) as Layer;
+  }) as unknown as Layer;
 }
 
 function getGoogleAltitudeOffsetTile3DLayerClass(): DeckTile3DLayerClass {
@@ -1598,7 +1676,9 @@ function numberValue(value: unknown, fallback: number): number {
 }
 
 function numberInputValue(value: unknown, fallback: number): number {
-  if (typeof value !== "string") return fallback;
+  // Number("") is 0 (finite), so guard the empty/whitespace case explicitly:
+  // a blank field must fall back, not silently resolve to 0.
+  if (typeof value !== "string" || value.trim() === "") return fallback;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
 }
@@ -1642,11 +1722,15 @@ function stringRecordValue(
 function resolveThreeDTilesRequestHeaders(
   url: string,
   headers: Record<string, string> | undefined,
+  googleMapsApiKey?: string,
 ): Record<string, string> | undefined {
   if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
 
   const nonGoogleHeaders = stripGoogleMapsApiKeyHeader(headers);
-  const apiKey = getGoogleMapsApiKey();
+  const apiKey =
+    googleMapsApiKeyHeaderValue(headers) ??
+    googleMapsApiKey ??
+    getGoogleMapsApiKey();
   if (!apiKey) return nonEmptyRecord(nonGoogleHeaders);
   return {
     ...(nonGoogleHeaders ?? {}),
@@ -1670,6 +1754,34 @@ function stripGoogleMapsApiKeyHeader(
     ([name]) => name.toLowerCase() !== GOOGLE_MAPS_API_KEY_HEADER.toLowerCase(),
   );
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function googleMapsApiKeyHeaderValue(
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  if (!headers) return undefined;
+  const entry = Object.entries(headers).find(
+    ([name]) => name.toLowerCase() === GOOGLE_MAPS_API_KEY_HEADER.toLowerCase(),
+  );
+  const value = entry?.[1].trim();
+  if (!value || googleMapsApiKeyIsMask(value)) return undefined;
+  return value;
+}
+
+function rememberGoogleMapsApiKeyFromHeaders(
+  panel: HTMLElement,
+  headers: Record<string, string> | undefined,
+): string | undefined {
+  const apiKey = googleMapsApiKeyHeaderValue(headers);
+  if (apiKey) {
+    googleTilesApiKeysByPanel.set(panel, apiKey);
+    return apiKey;
+  }
+  return googleTilesApiKeysByPanel.get(panel);
+}
+
+function googleMapsApiKeyIsMask(value: string): boolean {
+  return /^\*+$/.test(value.trim());
 }
 
 function isGooglePhotorealisticTilesetUrl(url: string): boolean {

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -1,8 +1,11 @@
 import {
   DEFAULT_LAYER_STYLE,
+  getGoogleMapsApiKey,
   type GeoLibreLayer,
   useAppStore,
 } from "@geolibre/core";
+import type { Layer } from "@deck.gl/core";
+import type { MapboxOverlay } from "@deck.gl/mapbox";
 import {
   DEFAULT_TILESET_URL,
   ThreeDTilesControl,
@@ -12,7 +15,12 @@ import {
   type ThreeDTilesControlOptions,
   type ThreeDTilesItemState,
 } from "maplibre-gl-3d-tiles";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+import type {
+  GeoLibreAppAPI,
+  GeoLibreDeckGL,
+  GeoLibreMapControlPosition,
+} from "../types";
+import { ensureMercatorProjection } from "./map-projection-utils";
 
 const threeDTilesControlPosition: GeoLibreMapControlPosition = "top-left";
 const THREE_D_TILES_LAYER_ID = "geolibre-3d-tiles";
@@ -22,6 +30,22 @@ const THREE_D_TILES_LAYER_ID = "geolibre-3d-tiles";
 const THREE_VERSION = "0.184.0";
 const DEFAULT_DRACO_DECODER_PATH = `https://unpkg.com/three@${THREE_VERSION}/examples/jsm/libs/draco/`;
 const DEFAULT_KTX2_TRANSCODER_PATH = `https://unpkg.com/three@${THREE_VERSION}/examples/jsm/libs/basis/`;
+const GOOGLE_PHOTOREALISTIC_TILES_URL =
+  "https://tile.googleapis.com/v1/3dtiles/root.json";
+const GOOGLE_PHOTOREALISTIC_TILES_LABEL =
+  "Google Photorealistic 3D Tiles";
+const GOOGLE_MAPS_API_KEY_HEADER = "X-GOOG-API-KEY";
+const GOOGLE_MAPS_API_KEY_MASK = "********";
+const GOOGLE_PHOTOREALISTIC_SOURCE_KIND =
+  "google-photorealistic-3d-tiles";
+const GOOGLE_PHOTOREALISTIC_LAYER_ID_PREFIX =
+  "geolibre-google-photorealistic-3d-tiles";
+const GOOGLE_PHOTOREALISTIC_INITIAL_VIEW = {
+  center: [14.42, 50.089] as [number, number],
+  zoom: 16,
+  bearing: 90,
+  pitch: 60,
+};
 
 const THREE_D_TILES_OPTIONS = {
   className: "geolibre-3d-tiles-control",
@@ -32,7 +56,13 @@ const THREE_D_TILES_OPTIONS = {
   title: "Add 3D Tiles Layer",
   // Empty input; the sample tileset is the explicit, opt-in way to load one.
   tilesetUrl: "",
-  sampleData: [{ label: "AGI HQ", url: DEFAULT_TILESET_URL }],
+  sampleData: [
+    { label: "AGI HQ", url: DEFAULT_TILESET_URL },
+    {
+      label: GOOGLE_PHOTOREALISTIC_TILES_LABEL,
+      url: GOOGLE_PHOTOREALISTIC_TILES_URL,
+    },
+  ],
 } satisfies ThreeDTilesControlOptions;
 
 let threeDTilesControl: ThreeDTilesControl | null = null;
@@ -40,6 +70,16 @@ let threeDTilesControlMounted = false;
 let threeDTilesPanelPinned = false;
 let threeDTilesStoreUnsubscribe: (() => void) | null = null;
 let threeDTilesStoreSyncSuspended = 0;
+let threeDTilesRuntimeEnvUnsubscribe: (() => void) | null = null;
+let activeThreeDTilesApp: GeoLibreAppAPI | null = null;
+
+let googleTilesOverlay: MapboxOverlay | null = null;
+let googleTilesOverlayMounted = false;
+let googleTilesStoreUnsubscribe: (() => void) | null = null;
+let googleTilesDeckGL: GeoLibreDeckGL | null = null;
+let googleTilesApp: GeoLibreAppAPI | null = null;
+let googleTilesBoundMap: unknown;
+let ensureGoogleTilesOverlayInFlight: Promise<void> | null = null;
 
 type ThreeDTilesLayerInstance = InstanceType<typeof ThreeDTilesLayer>;
 
@@ -64,6 +104,8 @@ export function closeThreeDTilesLayerPanel(app: GeoLibreAppAPI): void {
 }
 
 export function restoreThreeDTilesLayers(app: GeoLibreAppAPI): void {
+  restoreGooglePhotorealisticTilesLayers(app);
+
   const layers = useAppStore
     .getState()
     .layers.filter(isThreeDTilesControlLayer);
@@ -114,6 +156,7 @@ function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
 function ensureThreeDTilesControl(
   app: GeoLibreAppAPI,
 ): ThreeDTilesControl | null {
+  activeThreeDTilesApp = app;
   threeDTilesControl ??= createThreeDTilesControl();
 
   if (!threeDTilesControlMounted) {
@@ -123,6 +166,7 @@ function ensureThreeDTilesControl(
     );
     if (!added) {
       resetThreeDTilesControl(threeDTilesControl);
+      if (activeThreeDTilesApp === app) activeThreeDTilesApp = null;
       return null;
     }
     threeDTilesControlMounted = true;
@@ -145,7 +189,12 @@ function createThreeDTilesControl(): ThreeDTilesControl {
 
   control.on("statechange", syncHandler);
   patchThreeDTilesControlOnRemove(control);
+  addThreeDTilesRuntimeEnvListener(control);
   threeDTilesStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (state.layers !== previous.layers) {
+      updateGooglePhotorealisticTilesPanelList(control);
+    }
+
     const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
 
     for (const layer of previous.layers) {
@@ -250,7 +299,10 @@ function restoreThreeDTilesMapLayer(
   const layerName = layer.name || layerNameFromUrl(url, id);
   const beforeId = validThreeDTilesBeforeId(control, layer.beforeId);
   const altitudeOffset = numberValue(layer.source.altitudeOffset, 0);
-  const requestHeaders = stringRecordValue(layer.source.requestHeaders);
+  const requestHeaders = resolveThreeDTilesRequestHeaders(
+    url,
+    stringRecordValue(layer.source.requestHeaders),
+  );
   const existingTilesets = control
     .getState()
     .tilesets.filter((tileset) => tileset.id !== id);
@@ -389,11 +441,13 @@ function createThreeDTilesStoreLayer(
       sourceId: tileset.id,
       type: "3d-tiles",
       url: tileset.tilesetUrl,
-      // Persisted so a saved project reloads an authenticated tileset; this
-      // means any credential in a header is stored in the project file.
-      // JSON.stringify drops the key when undefined, so a header-less tileset
-      // is not written to the project file.
-      requestHeaders: tileset.requestHeaders,
+      // Non-Google authenticated tilesets still persist their headers. Google
+      // Photorealistic 3D Tiles resolves its API key from runtime env instead,
+      // so shared projects do not carry the key in plain text.
+      requestHeaders: persistedThreeDTilesRequestHeaders(
+        tileset.tilesetUrl,
+        tileset.requestHeaders,
+      ),
     },
     visible: tileset.visible,
     opacity,
@@ -457,9 +511,12 @@ function resetThreeDTilesControl(control: ThreeDTilesControl | null): void {
 
   threeDTilesStoreUnsubscribe?.();
   threeDTilesStoreUnsubscribe = null;
+  threeDTilesRuntimeEnvUnsubscribe?.();
+  threeDTilesRuntimeEnvUnsubscribe = null;
   threeDTilesPanelPinned = false;
   threeDTilesControlMounted = false;
   threeDTilesControl = null;
+  activeThreeDTilesApp = null;
   // Clear the suspension counter so a control torn down mid-hydration cannot
   // leave its successor permanently suppressing store sync events.
   threeDTilesStoreSyncSuspended = 0;
@@ -469,7 +526,8 @@ function isThreeDTilesControlLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "3d-tiles" &&
     layer.metadata.sourceKind === "3d-tiles-url" &&
-    layer.metadata.externalNativeLayer === true
+    layer.metadata.externalNativeLayer === true &&
+    !isGooglePhotorealisticTilesetLayerUrl(layer)
   );
 }
 
@@ -498,8 +556,552 @@ function installThreeDTilesPanelHandlers(
   if (panel) {
     panel.classList.add("geolibre-3d-tiles-panel");
     installThreeDTilesCloseHandler(control, panel);
+    if (control) {
+      installGooglePhotorealisticTilesPanelHandlers(control, panel);
+      updateGooglePhotorealisticTilesPanelList(control);
+    }
   }
   installThreeDTilesToggleHandler(control);
+}
+
+function addThreeDTilesRuntimeEnvListener(control: ThreeDTilesControl): void {
+  if (threeDTilesRuntimeEnvUnsubscribe || typeof window === "undefined") return;
+
+  const handleRuntimeEnvChange = () => {
+    applyGooglePhotorealisticTilesPanelDefaults(control);
+    renderGooglePhotorealisticTilesLayers();
+  };
+
+  window.addEventListener(
+    "geolibre:runtime-env-change",
+    handleRuntimeEnvChange,
+  );
+  threeDTilesRuntimeEnvUnsubscribe = () => {
+    window.removeEventListener(
+      "geolibre:runtime-env-change",
+      handleRuntimeEnvChange,
+    );
+  };
+}
+
+function installGooglePhotorealisticTilesPanelHandlers(
+  control: ThreeDTilesControl,
+  panel: HTMLElement,
+): void {
+  if (panel.dataset.geolibreGoogleTilesHandler === "true") return;
+  panel.dataset.geolibreGoogleTilesHandler = "true";
+
+  const applyDefaults = () =>
+    applyGooglePhotorealisticTilesPanelDefaults(control);
+  const deferApplyDefaults = () => window.setTimeout(applyDefaults, 0);
+  const urlInput = getThreeDTilesUrlInput(panel);
+  urlInput?.addEventListener("input", applyDefaults);
+  urlInput?.addEventListener("change", applyDefaults);
+  panel
+    .querySelector<HTMLFormElement>(".three-d-tiles-form")
+    ?.addEventListener(
+      "submit",
+      (event) => {
+        applyDefaults();
+        if (!isGooglePhotorealisticTilesetUrl(urlInput?.value ?? "")) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        void addGooglePhotorealisticTilesFromPanel(control, panel);
+      },
+      { capture: true },
+    );
+  panel.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const option = target.closest<HTMLButtonElement>(
+      ".three-d-tiles-sample-option",
+    );
+    if (option?.title === GOOGLE_PHOTOREALISTIC_TILES_URL) {
+      deferApplyDefaults();
+    }
+  });
+
+  applyDefaults();
+}
+
+function applyGooglePhotorealisticTilesPanelDefaults(
+  control: ThreeDTilesControl,
+): void {
+  const panel = getThreeDTilesPanel(control);
+  if (!panel) return;
+
+  const urlInput = getThreeDTilesUrlInput(panel);
+  if (!urlInput || !isGooglePhotorealisticTilesetUrl(urlInput.value)) {
+    setGooglePhotorealisticHeadersToggleVisible(panel, false);
+    return;
+  }
+
+  const layerNameInput = panel.querySelector<HTMLInputElement>(
+    'input[aria-label="Layer name"]',
+  );
+  if (
+    layerNameInput &&
+    (!layerNameInput.value.trim() ||
+      layerNameInput.value.trim() === "3D Tiles" ||
+      layerNameInput.value.trim() ===
+        layerNameFromUrl(GOOGLE_PHOTOREALISTIC_TILES_URL, "3D Tiles"))
+  ) {
+    layerNameInput.value = GOOGLE_PHOTOREALISTIC_TILES_LABEL;
+  }
+
+  const altitudeInput = panel.querySelector<HTMLInputElement>(
+    'input[aria-label="Altitude offset"]',
+  );
+  if (
+    altitudeInput &&
+    (!altitudeInput.value.trim() || Number(altitudeInput.value) === -300)
+  ) {
+    altitudeInput.value = "0";
+  }
+
+  const headersInput = panel.querySelector<HTMLTextAreaElement>(
+    'textarea[aria-label="Request headers"]',
+  );
+  if (!headersInput) return;
+
+  const headers = resolveThreeDTilesRequestHeaders(
+    GOOGLE_PHOTOREALISTIC_TILES_URL,
+    parseThreeDTilesRequestHeaders(headersInput.value),
+  );
+  installGooglePhotorealisticHeadersToggle(panel, headersInput);
+  headersInput.value = serializeGooglePhotorealisticPanelRequestHeaders(
+    headers,
+    panel.dataset.geolibreGoogleMapsApiKeyVisible === "true",
+  );
+  setGooglePhotorealisticHeadersToggleVisible(
+    panel,
+    Boolean(headers?.[GOOGLE_MAPS_API_KEY_HEADER]),
+  );
+}
+
+function getThreeDTilesUrlInput(panel: HTMLElement): HTMLInputElement | null {
+  return panel.querySelector<HTMLInputElement>('input[aria-label="Tileset URL"]');
+}
+
+function installGooglePhotorealisticHeadersToggle(
+  panel: HTMLElement,
+  headersInput: HTMLTextAreaElement,
+): void {
+  if (panel.querySelector(".geolibre-google-tiles-key-toggle")) return;
+
+  panel.dataset.geolibreGoogleMapsApiKeyVisible = "false";
+
+  const toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.className =
+    "geolibre-google-tiles-key-toggle three-d-tiles-small-button";
+  toggle.textContent = "Show key";
+  toggle.setAttribute("aria-label", "Show Google Maps API key");
+  toggle.setAttribute("aria-pressed", "false");
+  toggle.hidden = true;
+
+  toggle.addEventListener("click", () => {
+    const visible =
+      panel.dataset.geolibreGoogleMapsApiKeyVisible !== "true";
+    panel.dataset.geolibreGoogleMapsApiKeyVisible = visible
+      ? "true"
+      : "false";
+    updateGooglePhotorealisticHeadersToggle(toggle, visible);
+
+    const headers = resolveThreeDTilesRequestHeaders(
+      GOOGLE_PHOTOREALISTIC_TILES_URL,
+      parseThreeDTilesRequestHeaders(headersInput.value),
+    );
+    headersInput.value = serializeGooglePhotorealisticPanelRequestHeaders(
+      headers,
+      visible,
+    );
+  });
+
+  headersInput.insertAdjacentElement("afterend", toggle);
+}
+
+function setGooglePhotorealisticHeadersToggleVisible(
+  panel: HTMLElement,
+  visible: boolean,
+): void {
+  const toggle = panel.querySelector<HTMLButtonElement>(
+    ".geolibre-google-tiles-key-toggle",
+  );
+  if (toggle) toggle.hidden = !visible;
+}
+
+function updateGooglePhotorealisticHeadersToggle(
+  toggle: HTMLButtonElement,
+  visible: boolean,
+): void {
+  toggle.textContent = visible ? "Hide key" : "Show key";
+  toggle.setAttribute(
+    "aria-label",
+    visible ? "Hide Google Maps API key" : "Show Google Maps API key",
+  );
+  toggle.setAttribute("aria-pressed", visible ? "true" : "false");
+}
+
+async function addGooglePhotorealisticTilesFromPanel(
+  control: ThreeDTilesControl,
+  panel: HTMLElement,
+): Promise<void> {
+  const app = activeThreeDTilesApp;
+  if (!app) return;
+
+  const name =
+    panel
+      .querySelector<HTMLInputElement>('input[aria-label="Layer name"]')
+      ?.value.trim() || GOOGLE_PHOTOREALISTIC_TILES_LABEL;
+  const headers = resolveThreeDTilesRequestHeaders(
+    GOOGLE_PHOTOREALISTIC_TILES_URL,
+    parseThreeDTilesRequestHeaders(
+      panel.querySelector<HTMLTextAreaElement>(
+        'textarea[aria-label="Request headers"]',
+      )?.value ?? "",
+    ),
+  );
+  const flyToOnLoad =
+    panel.querySelector<HTMLInputElement>(
+      'input[aria-label="Fly to tileset after load"]',
+    )?.checked ?? true;
+  const visible =
+    panel.querySelector<HTMLInputElement>('input[aria-label="Visible on load"]')
+      ?.checked ?? true;
+  const opacity = numberValue(control.getState().opacity, 1);
+
+  addGooglePhotorealisticTilesLayer(app, {
+    name,
+    opacity,
+    visible,
+    requestHeaders: headers,
+    flyTo: flyToOnLoad,
+  });
+  control.collapse();
+  updateGooglePhotorealisticTilesPanelList(control);
+}
+
+function restoreGooglePhotorealisticTilesLayers(app: GeoLibreAppAPI): void {
+  if (
+    useAppStore.getState().layers.some(isGooglePhotorealisticTilesLayer)
+  ) {
+    void ensureGooglePhotorealisticTilesOverlay(app);
+  }
+}
+
+function addGooglePhotorealisticTilesLayer(
+  app: GeoLibreAppAPI,
+  options: {
+    name: string;
+    opacity: number;
+    visible: boolean;
+    requestHeaders?: Record<string, string>;
+    flyTo: boolean;
+  },
+): string {
+  const id = `${GOOGLE_PHOTOREALISTIC_LAYER_ID_PREFIX}-${crypto.randomUUID()}`;
+  const deckLayerId = `${id}-deck`;
+
+  useAppStore.getState().addLayer({
+    id,
+    name: options.name,
+    type: "3d-tiles",
+    source: {
+      sourceId: id,
+      type: GOOGLE_PHOTOREALISTIC_SOURCE_KIND,
+      url: GOOGLE_PHOTOREALISTIC_TILES_URL,
+      // Keep non-Google custom headers, but never persist the API key header.
+      requestHeaders: persistedThreeDTilesRequestHeaders(
+        GOOGLE_PHOTOREALISTIC_TILES_URL,
+        options.requestHeaders,
+      ),
+    },
+    visible: options.visible,
+    opacity: options.opacity,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      customLayerType: GOOGLE_PHOTOREALISTIC_SOURCE_KIND,
+      externalDeckLayer: true,
+      externalNativeLayer: true,
+      identifiable: false,
+      nativeLayerIds: [deckLayerId],
+      sourceId: id,
+      sourceKind: GOOGLE_PHOTOREALISTIC_SOURCE_KIND,
+      bounds: [-180, -85, 180, 85],
+    },
+    sourcePath: GOOGLE_PHOTOREALISTIC_TILES_URL,
+  });
+
+  void ensureGooglePhotorealisticTilesOverlay(app);
+  if (options.flyTo) flyToGooglePhotorealisticTiles(app);
+  return id;
+}
+
+function updateGooglePhotorealisticTilesPanelList(
+  control: ThreeDTilesControl | null,
+): void {
+  const panel = getThreeDTilesPanel(control);
+  if (!panel) return;
+
+  const nativeTilesetCount = control?.getState().tilesets.length ?? 0;
+  const googleLayers = useAppStore
+    .getState()
+    .layers.filter(isGooglePhotorealisticTilesLayer);
+  const nativeStatus = panel.querySelector<HTMLElement>(
+    ".three-d-tiles-status",
+  );
+  if (nativeStatus) {
+    nativeStatus.hidden =
+      nativeTilesetCount === 0 && googleLayers.length > 0;
+  }
+
+  const googleList = ensureGooglePhotorealisticTilesPanelList(panel);
+  googleList.replaceChildren();
+  googleList.hidden = googleLayers.length === 0;
+  if (googleLayers.length === 0) return;
+
+  for (const layer of googleLayers) {
+    googleList.appendChild(createGooglePhotorealisticTilesPanelListItem(layer));
+  }
+}
+
+function ensureGooglePhotorealisticTilesPanelList(
+  panel: HTMLElement,
+): HTMLElement {
+  const existing = panel.querySelector<HTMLElement>(
+    ".geolibre-google-tiles-list",
+  );
+  if (existing) return existing;
+
+  const googleList = document.createElement("div");
+  googleList.className = "geolibre-google-tiles-list three-d-tiles-list";
+  googleList.hidden = true;
+
+  const nativeList = panel.querySelector<HTMLElement>(".three-d-tiles-list");
+  if (nativeList) {
+    nativeList.insertAdjacentElement("afterend", googleList);
+  } else {
+    panel.appendChild(googleList);
+  }
+
+  return googleList;
+}
+
+function createGooglePhotorealisticTilesPanelListItem(
+  layer: GeoLibreLayer,
+): HTMLElement {
+  const item = document.createElement("div");
+  item.className =
+    "geolibre-google-tiles-list-item three-d-tiles-list-item active";
+
+  const meta = document.createElement("div");
+  meta.className = "three-d-tiles-list-meta";
+
+  const title = document.createElement("button");
+  title.className = "three-d-tiles-list-title";
+  title.type = "button";
+  title.textContent = layer.name || GOOGLE_PHOTOREALISTIC_TILES_LABEL;
+  title.addEventListener("click", () => {
+    if (googleTilesApp) flyToGooglePhotorealisticTiles(googleTilesApp);
+  });
+
+  const url = document.createElement("span");
+  url.className = "three-d-tiles-list-url";
+  url.textContent = GOOGLE_PHOTOREALISTIC_TILES_URL;
+
+  const status = document.createElement("span");
+  status.className = "three-d-tiles-list-status";
+  status.dataset.status = "loaded";
+  status.textContent = "loaded";
+
+  meta.appendChild(title);
+  meta.appendChild(url);
+  meta.appendChild(status);
+
+  const actions = document.createElement("div");
+  actions.className = "three-d-tiles-list-actions";
+
+  const visible = document.createElement("input");
+  visible.type = "checkbox";
+  visible.checked = layer.visible;
+  visible.setAttribute(
+    "aria-label",
+    `Toggle ${layer.name || GOOGLE_PHOTOREALISTIC_TILES_LABEL}`,
+  );
+  visible.addEventListener("change", () => {
+    useAppStore.getState().updateLayer(layer.id, { visible: visible.checked });
+  });
+
+  const opacity = document.createElement("input");
+  opacity.className = "three-d-tiles-opacity";
+  opacity.type = "range";
+  opacity.min = "0";
+  opacity.max = "1";
+  opacity.step = "0.05";
+  opacity.value = String(layer.opacity);
+  opacity.setAttribute(
+    "aria-label",
+    `Opacity for ${layer.name || GOOGLE_PHOTOREALISTIC_TILES_LABEL}`,
+  );
+  opacity.addEventListener("input", () => {
+    const nextOpacity = Number(opacity.value);
+    if (Number.isFinite(nextOpacity)) {
+      useAppStore.getState().updateLayer(layer.id, { opacity: nextOpacity });
+    }
+  });
+
+  const flyTo = createGooglePhotorealisticTilesPanelSmallButton("Fly");
+  flyTo.addEventListener("click", () => {
+    if (googleTilesApp) flyToGooglePhotorealisticTiles(googleTilesApp);
+  });
+
+  const remove = createGooglePhotorealisticTilesPanelSmallButton("Remove");
+  remove.addEventListener("click", () => {
+    useAppStore.getState().removeLayer(layer.id);
+  });
+
+  actions.appendChild(visible);
+  actions.appendChild(opacity);
+  actions.appendChild(flyTo);
+  actions.appendChild(remove);
+
+  item.appendChild(meta);
+  item.appendChild(actions);
+  return item;
+}
+
+function createGooglePhotorealisticTilesPanelSmallButton(
+  label: string,
+): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.className = "three-d-tiles-small-button";
+  button.type = "button";
+  button.textContent = label;
+  return button;
+}
+
+function flyToGooglePhotorealisticTiles(app: GeoLibreAppAPI): void {
+  const map = app.getMap?.();
+  if (!map) return;
+  ensureMercatorProjection(map);
+  map.flyTo({
+    ...GOOGLE_PHOTOREALISTIC_INITIAL_VIEW,
+    essential: true,
+  });
+}
+
+function isGooglePhotorealisticTilesLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "3d-tiles" &&
+    (layer.metadata.sourceKind === GOOGLE_PHOTOREALISTIC_SOURCE_KIND ||
+      isGooglePhotorealisticTilesetLayerUrl(layer))
+  );
+}
+
+function ensureGooglePhotorealisticTilesOverlay(
+  app: GeoLibreAppAPI,
+): Promise<void> {
+  if (ensureGoogleTilesOverlayInFlight) return ensureGoogleTilesOverlayInFlight;
+  ensureGoogleTilesOverlayInFlight = runEnsureGooglePhotorealisticTilesOverlay(
+    app,
+  ).finally(() => {
+    ensureGoogleTilesOverlayInFlight = null;
+  });
+  return ensureGoogleTilesOverlayInFlight;
+}
+
+async function runEnsureGooglePhotorealisticTilesOverlay(
+  app: GeoLibreAppAPI,
+): Promise<void> {
+  googleTilesApp = app;
+  if (!app.getDeckGL) return;
+  googleTilesDeckGL ??= await app.getDeckGL();
+
+  const map = app.getMap?.() ?? null;
+  if (googleTilesOverlay && googleTilesBoundMap === map) {
+    renderGooglePhotorealisticTilesLayers();
+    return;
+  }
+
+  if (googleTilesOverlay && googleTilesOverlayMounted) {
+    app.removeMapControl(googleTilesOverlay);
+  }
+  googleTilesBoundMap = map;
+  googleTilesOverlay = new googleTilesDeckGL.mapbox.MapboxOverlay({
+    interleaved: false,
+    layers: [],
+  });
+  googleTilesOverlayMounted = false;
+  googleTilesStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (state.layers !== previous.layers) {
+      renderGooglePhotorealisticTilesLayers();
+    }
+  });
+  renderGooglePhotorealisticTilesLayers();
+}
+
+function renderGooglePhotorealisticTilesLayers(): void {
+  if (!googleTilesOverlay || !googleTilesDeckGL || !googleTilesApp) return;
+
+  const layers = useAppStore
+    .getState()
+    .layers.filter(isGooglePhotorealisticTilesLayer);
+  if (layers.length > 0) {
+    ensureMercatorProjection(googleTilesApp.getMap?.());
+  }
+
+  if (!googleTilesOverlayMounted) {
+    if (layers.length === 0) return;
+    if (!googleTilesApp.addMapControl(googleTilesOverlay, "top-left")) return;
+    googleTilesOverlayMounted = true;
+  }
+
+  const deckLayers = layers
+    .filter((layer) => layer.visible)
+    .map((layer) => buildGooglePhotorealisticTilesDeckLayer(layer))
+    .filter((layer): layer is Layer => layer !== null)
+    .reverse();
+
+  googleTilesOverlay.setProps({ layers: deckLayers });
+}
+
+function buildGooglePhotorealisticTilesDeckLayer(
+  layer: GeoLibreLayer,
+): Layer | null {
+  if (!googleTilesDeckGL) return null;
+  const requestHeaders = resolveThreeDTilesRequestHeaders(
+    GOOGLE_PHOTOREALISTIC_TILES_URL,
+    stringRecordValue(layer.source.requestHeaders),
+  );
+
+  return new googleTilesDeckGL.geoLayers.Tile3DLayer({
+    id: googlePhotorealisticTilesDeckLayerId(layer),
+    data: GOOGLE_PHOTOREALISTIC_TILES_URL,
+    loadOptions: {
+      fetch: requestHeaders ? { headers: requestHeaders } : undefined,
+      tileset: {
+        maximumScreenSpaceError: 20,
+        maximumMemoryUsage: 512,
+        memoryAdjustedScreenSpaceError: true,
+      },
+    },
+    opacity: layer.opacity,
+    pickable: false,
+    operation: "terrain+draw",
+  }) as Layer;
+}
+
+function googlePhotorealisticTilesDeckLayerId(layer: GeoLibreLayer): string {
+  const nativeLayerIds = layer.metadata.nativeLayerIds;
+  if (Array.isArray(nativeLayerIds)) {
+    const deckLayerId = nativeLayerIds.find(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    );
+    if (deckLayerId) return deckLayerId;
+  }
+  return `${layer.id}-deck`;
 }
 
 function getThreeDTilesPanel(
@@ -712,6 +1314,104 @@ function stringRecordValue(
       entry[0].trim() !== "" && typeof entry[1] === "string",
   );
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function resolveThreeDTilesRequestHeaders(
+  url: string,
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
+
+  const nonGoogleHeaders = stripGoogleMapsApiKeyHeader(headers);
+  const apiKey = getGoogleMapsApiKey();
+  if (!apiKey) return nonEmptyRecord(nonGoogleHeaders);
+  return {
+    ...(nonGoogleHeaders ?? {}),
+    [GOOGLE_MAPS_API_KEY_HEADER]: apiKey,
+  };
+}
+
+function persistedThreeDTilesRequestHeaders(
+  url: string,
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
+  return nonEmptyRecord(stripGoogleMapsApiKeyHeader(headers));
+}
+
+function stripGoogleMapsApiKeyHeader(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const entries = Object.entries(headers).filter(
+    ([name]) => name.toLowerCase() !== GOOGLE_MAPS_API_KEY_HEADER.toLowerCase(),
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function isGooglePhotorealisticTilesetUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === "tile.googleapis.com" &&
+      parsed.pathname === "/v1/3dtiles/root.json"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isGooglePhotorealisticTilesetLayerUrl(layer: GeoLibreLayer): boolean {
+  const url = stringValue(layer.source.url) ?? layer.sourcePath;
+  return url ? isGooglePhotorealisticTilesetUrl(url) : false;
+}
+
+function parseThreeDTilesRequestHeaders(
+  text: string,
+): Record<string, string> | undefined {
+  const headers: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const name = line.slice(0, separator).trim();
+    if (!name) continue;
+    headers[name] = line.slice(separator + 1).trim();
+  }
+  return nonEmptyRecord(headers);
+}
+
+function serializeThreeDTilesRequestHeaders(
+  headers: Record<string, string> | undefined,
+): string {
+  if (!headers) return "";
+  return Object.entries(headers)
+    .map(([name, value]) => `${name}: ${value}`)
+    .join("\n");
+}
+
+function serializeGooglePhotorealisticPanelRequestHeaders(
+  headers: Record<string, string> | undefined,
+  showApiKey: boolean,
+): string {
+  if (!headers) return "";
+  if (showApiKey) return serializeThreeDTilesRequestHeaders(headers);
+
+  return serializeThreeDTilesRequestHeaders(
+    Object.fromEntries(
+      Object.entries(headers).map(([name, value]) => [
+        name,
+        name.toLowerCase() === GOOGLE_MAPS_API_KEY_HEADER.toLowerCase()
+          ? GOOGLE_MAPS_API_KEY_MASK
+          : value,
+      ]),
+    ),
+  );
+}
+
+function nonEmptyRecord(
+  value: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  return value && Object.keys(value).length > 0 ? value : undefined;
 }
 
 function recordsEqual(

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -80,8 +80,26 @@ let googleTilesDeckGL: GeoLibreDeckGL | null = null;
 let googleTilesApp: GeoLibreAppAPI | null = null;
 let googleTilesBoundMap: unknown;
 let ensureGoogleTilesOverlayInFlight: Promise<void> | null = null;
+let googleTilesMountRetryScheduled = false;
+let googleTilesMountRetries = 0;
+let googleTilesPreviousProjection: "globe" | "mercator" | null = null;
+let googleAltitudeOffsetTile3DLayerClass: DeckTile3DLayerClass | null = null;
+// The last rendered Google-layer signature, used to skip rebuilding deck layers
+// when an unrelated layer mutation fires the store subscription.
+let lastGoogleTilesLayerSignature: string | null = null;
+// ~1s at 60fps: bound the mount retry so a map that never initializes cannot
+// spin requestAnimationFrame forever.
+const GOOGLE_TILES_MAX_MOUNT_RETRIES = 60;
 
 type ThreeDTilesLayerInstance = InstanceType<typeof ThreeDTilesLayer>;
+
+type RenderableDeckLayer = Layer & {
+  props: Record<string, unknown>;
+  renderLayers(): unknown;
+};
+type DeckTile3DLayerClass = new (
+  props: Record<string, unknown>,
+) => RenderableDeckLayer;
 
 interface ThreeDTilesControlInternals {
   _layers?: Map<string, ThreeDTilesLayerInstance>;
@@ -569,6 +587,10 @@ function addThreeDTilesRuntimeEnvListener(control: ThreeDTilesControl): void {
 
   const handleRuntimeEnvChange = () => {
     applyGooglePhotorealisticTilesPanelDefaults(control);
+    // The resolved API key may have changed, but the persisted layer records
+    // (which never carry the key) have not, so the render signature would be
+    // unchanged. Force a rebuild so the new key reaches the deck.gl layer.
+    lastGoogleTilesLayerSignature = null;
     renderGooglePhotorealisticTilesLayers();
   };
 
@@ -597,19 +619,38 @@ function installGooglePhotorealisticTilesPanelHandlers(
   const urlInput = getThreeDTilesUrlInput(panel);
   urlInput?.addEventListener("input", applyDefaults);
   urlInput?.addEventListener("change", applyDefaults);
-  panel
-    .querySelector<HTMLFormElement>(".three-d-tiles-form")
-    ?.addEventListener(
-      "submit",
-      (event) => {
-        applyDefaults();
-        if (!isGooglePhotorealisticTilesetUrl(urlInput?.value ?? "")) return;
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        void addGooglePhotorealisticTilesFromPanel(control, panel);
-      },
-      { capture: true },
-    );
+  panel.addEventListener("input", (event) => {
+    if (
+      event.target instanceof HTMLInputElement &&
+      event.target.getAttribute("aria-label") === "Altitude offset"
+    ) {
+      updateGooglePhotorealisticTilesAltitudeOffset(control, panel);
+    }
+  });
+  // Intercept the submit on the panel (an ancestor of the form) during the
+  // capture phase so this runs before maplibre-gl-3d-tiles' own form-level
+  // submit listener. A capture listener on the form target itself would not:
+  // per the DOM spec, listeners on the same target fire in registration order
+  // regardless of the capture flag, and the library registers its submit
+  // listener first (at panel construction, before this lazy install). Capturing
+  // on the ancestor also covers both Load-button clicks and Enter submission.
+  panel.addEventListener(
+    "submit",
+    (event) => {
+      if (
+        !(event.target instanceof HTMLElement) ||
+        !event.target.classList.contains("three-d-tiles-form")
+      ) {
+        return;
+      }
+      applyDefaults();
+      if (!isGooglePhotorealisticTilesetUrl(urlInput?.value ?? "")) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      void addGooglePhotorealisticTilesFromPanel(control, panel);
+    },
+    { capture: true },
+  );
   panel.addEventListener("click", (event) => {
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
@@ -624,6 +665,29 @@ function installGooglePhotorealisticTilesPanelHandlers(
   applyDefaults();
 }
 
+function updateGooglePhotorealisticTilesAltitudeOffset(
+  control: ThreeDTilesControl,
+  panel: HTMLElement,
+): void {
+  if (!isGooglePhotorealisticTilesetUrl(getThreeDTilesUrlInput(panel)?.value)) {
+    return;
+  }
+  const altitudeInput = panel.querySelector<HTMLInputElement>(
+    'input[aria-label="Altitude offset"]',
+  );
+  const altitudeOffset = numberInputValue(
+    altitudeInput?.value,
+    numberValue(control.getState().altitudeOffset, 0),
+  );
+  const store = useAppStore.getState();
+  for (const layer of store.layers.filter(isGooglePhotorealisticTilesLayer)) {
+    store.updateLayer(layer.id, {
+      source: { ...layer.source, altitudeOffset },
+      metadata: { ...layer.metadata, altitudeOffset },
+    });
+  }
+}
+
 function applyGooglePhotorealisticTilesPanelDefaults(
   control: ThreeDTilesControl,
 ): void {
@@ -632,6 +696,24 @@ function applyGooglePhotorealisticTilesPanelDefaults(
 
   const urlInput = getThreeDTilesUrlInput(panel);
   if (!urlInput || !isGooglePhotorealisticTilesetUrl(urlInput.value)) {
+    // Switched away from the Google tileset: drop the masked X-GOOG-API-KEY the
+    // Google flow injected so the native 3D Tiles submit path does not send or
+    // persist a bogus custom header (which would cause avoidable CORS/preflight
+    // failures on the non-Google source).
+    const headersInput = panel.querySelector<HTMLTextAreaElement>(
+      'textarea[aria-label="Request headers"]',
+    );
+    if (headersInput) {
+      headersInput.value = serializeThreeDTilesRequestHeaders(
+        stripGoogleMapsApiKeyHeader(
+          parseThreeDTilesRequestHeaders(headersInput.value),
+        ),
+      );
+    }
+    panel.dataset.geolibreGoogleMapsApiKeyVisible = "false";
+    // Re-arm the one-shot altitude default so it applies again if the user
+    // returns to a Google URL.
+    delete panel.dataset.geolibreGoogleAltitudeApplied;
     setGooglePhotorealisticHeadersToggleVisible(panel, false);
     return;
   }
@@ -652,11 +734,19 @@ function applyGooglePhotorealisticTilesPanelDefaults(
   const altitudeInput = panel.querySelector<HTMLInputElement>(
     'input[aria-label="Altitude offset"]',
   );
+  // Google photorealistic tiles are anchored to the WGS84 ellipsoid, so the
+  // native control's -300 default offset is wrong for them. Apply a 0 default
+  // once, the first time the URL becomes a Google tileset, then leave the field
+  // alone. This defaults pass runs on every URL input/change, so overwriting
+  // unconditionally would silently reset a value the user deliberately typed
+  // (including -300, which is indistinguishable from the native default).
   if (
     altitudeInput &&
+    panel.dataset.geolibreGoogleAltitudeApplied !== "true" &&
     (!altitudeInput.value.trim() || Number(altitudeInput.value) === -300)
   ) {
     altitudeInput.value = "0";
+    panel.dataset.geolibreGoogleAltitudeApplied = "true";
   }
 
   const headersInput = panel.querySelector<HTMLTextAreaElement>(
@@ -718,7 +808,10 @@ function installGooglePhotorealisticHeadersToggle(
     );
   });
 
-  headersInput.insertAdjacentElement("afterend", toggle);
+  headersInput
+    .closest(".three-d-tiles-field")
+    ?.insertAdjacentElement("afterend", toggle) ??
+    headersInput.insertAdjacentElement("afterend", toggle);
 }
 
 function setGooglePhotorealisticHeadersToggleVisible(
@@ -750,6 +843,17 @@ async function addGooglePhotorealisticTilesFromPanel(
   const app = activeThreeDTilesApp;
   if (!app) return;
 
+  // The submitted URL is only used to detect that this is the Google tileset;
+  // the layer always loads the canonical root URL and takes its key from the
+  // env / X-GOOG-API-KEY header. Warn if the user embedded a `key=` query
+  // parameter (as Google's docs often show), which is silently ignored here.
+  const submittedUrl = getThreeDTilesUrlInput(panel)?.value.trim();
+  if (submittedUrl && urlHasKeyQueryParam(submittedUrl)) {
+    console.warn(
+      "[GeoLibre] Ignoring the `key` query parameter in the Google Photorealistic 3D Tiles URL; the API key is taken from VITE_GOOGLE_MAPS_API_KEY (or the X-GOOG-API-KEY request header) instead.",
+    );
+  }
+
   const name =
     panel
       .querySelector<HTMLInputElement>('input[aria-label="Layer name"]')
@@ -770,13 +874,20 @@ async function addGooglePhotorealisticTilesFromPanel(
     panel.querySelector<HTMLInputElement>('input[aria-label="Visible on load"]')
       ?.checked ?? true;
   const opacity = numberValue(control.getState().opacity, 1);
+  const altitudeOffset = numberInputValue(
+    panel.querySelector<HTMLInputElement>('input[aria-label="Altitude offset"]')
+      ?.value,
+    numberValue(control.getState().altitudeOffset, 0),
+  );
 
   addGooglePhotorealisticTilesLayer(app, {
     name,
+    altitudeOffset,
     opacity,
     visible,
     requestHeaders: headers,
     flyTo: flyToOnLoad,
+    map: control.getMap(),
   });
   control.collapse();
   updateGooglePhotorealisticTilesPanelList(control);
@@ -794,10 +905,12 @@ function addGooglePhotorealisticTilesLayer(
   app: GeoLibreAppAPI,
   options: {
     name: string;
+    altitudeOffset: number;
     opacity: number;
     visible: boolean;
     requestHeaders?: Record<string, string>;
     flyTo: boolean;
+    map?: ReturnType<ThreeDTilesControl["getMap"]>;
   },
 ): string {
   const id = `${GOOGLE_PHOTOREALISTIC_LAYER_ID_PREFIX}-${crypto.randomUUID()}`;
@@ -811,6 +924,7 @@ function addGooglePhotorealisticTilesLayer(
       sourceId: id,
       type: GOOGLE_PHOTOREALISTIC_SOURCE_KIND,
       url: GOOGLE_PHOTOREALISTIC_TILES_URL,
+      altitudeOffset: options.altitudeOffset,
       // Keep non-Google custom headers, but never persist the API key header.
       requestHeaders: persistedThreeDTilesRequestHeaders(
         GOOGLE_PHOTOREALISTIC_TILES_URL,
@@ -829,12 +943,13 @@ function addGooglePhotorealisticTilesLayer(
       sourceId: id,
       sourceKind: GOOGLE_PHOTOREALISTIC_SOURCE_KIND,
       bounds: [-180, -85, 180, 85],
+      altitudeOffset: options.altitudeOffset,
     },
     sourcePath: GOOGLE_PHOTOREALISTIC_TILES_URL,
   });
 
   void ensureGooglePhotorealisticTilesOverlay(app);
-  if (options.flyTo) flyToGooglePhotorealisticTiles(app);
+  if (options.flyTo) flyToGooglePhotorealisticTiles(app, options.map);
   return id;
 }
 
@@ -981,14 +1096,44 @@ function createGooglePhotorealisticTilesPanelSmallButton(
   return button;
 }
 
-function flyToGooglePhotorealisticTiles(app: GeoLibreAppAPI): void {
-  const map = app.getMap?.();
-  if (!map) return;
-  ensureMercatorProjection(map);
+function flyToGooglePhotorealisticTiles(
+  app: GeoLibreAppAPI,
+  mapOverride?: ReturnType<ThreeDTilesControl["getMap"]>,
+): void {
+  forceGooglePhotorealisticMercatorProjection(app, mapOverride);
+  useAppStore.getState().setMapView(
+    {
+      ...GOOGLE_PHOTOREALISTIC_INITIAL_VIEW,
+      bbox: undefined,
+    },
+    false,
+  );
+  const map = mapOverride ?? app.getMap?.();
+  if (!map) {
+    app.fitBounds?.([14.35, 50.05, 14.49, 50.12]);
+    return;
+  }
   map.flyTo({
     ...GOOGLE_PHOTOREALISTIC_INITIAL_VIEW,
     essential: true,
   });
+}
+
+function forceGooglePhotorealisticMercatorProjection(
+  app: GeoLibreAppAPI,
+  mapOverride?: ReturnType<ThreeDTilesControl["getMap"]>,
+): void {
+  if (googleTilesPreviousProjection === null) {
+    googleTilesPreviousProjection = app.getMapProjection?.() ?? null;
+  }
+  app.setMapProjection?.("mercator");
+  ensureMercatorProjection(mapOverride ?? app.getMap?.());
+}
+
+function restoreGooglePhotorealisticPreviousProjection(): void {
+  if (!googleTilesApp || googleTilesPreviousProjection === null) return;
+  googleTilesApp.setMapProjection?.(googleTilesPreviousProjection);
+  googleTilesPreviousProjection = null;
 }
 
 function isGooglePhotorealisticTilesLayer(layer: GeoLibreLayer): boolean {
@@ -1025,14 +1170,27 @@ async function runEnsureGooglePhotorealisticTilesOverlay(
   }
 
   if (googleTilesOverlay && googleTilesOverlayMounted) {
-    app.removeMapControl(googleTilesOverlay);
+    // The previously bound map may already be torn down (style reload / project
+    // open), in which case removeMapControl can throw. Guard it like the other
+    // overlays in this repo so a stale-map cleanup does not break the rebind.
+    try {
+      app.removeMapControl(googleTilesOverlay);
+    } catch (error) {
+      console.warn(
+        "[GeoLibre] Failed to detach the Google 3D Tiles overlay from the previous map",
+        error,
+      );
+    }
   }
   googleTilesBoundMap = map;
   googleTilesOverlay = new googleTilesDeckGL.mapbox.MapboxOverlay({
-    interleaved: false,
+    interleaved: true,
     layers: [],
   });
   googleTilesOverlayMounted = false;
+  // A fresh overlay instance holds no layers and no prior mount attempts.
+  lastGoogleTilesLayerSignature = null;
+  googleTilesMountRetries = 0;
   googleTilesStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     if (state.layers !== previous.layers) {
       renderGooglePhotorealisticTilesLayers();
@@ -1047,15 +1205,52 @@ function renderGooglePhotorealisticTilesLayers(): void {
   const layers = useAppStore
     .getState()
     .layers.filter(isGooglePhotorealisticTilesLayer);
-  if (layers.length > 0) {
-    ensureMercatorProjection(googleTilesApp.getMap?.());
+
+  // Tear the overlay back down once the last Google tileset is gone, mirroring
+  // the lazy mount below, so an empty deck.gl overlay is not left attached to
+  // the map for the rest of the session.
+  if (layers.length === 0) {
+    if (googleTilesOverlayMounted) {
+      try {
+        googleTilesApp.removeMapControl(googleTilesOverlay);
+      } catch (error) {
+        console.warn(
+          "[GeoLibre] Failed to remove the empty Google 3D Tiles overlay",
+          error,
+        );
+      }
+      googleTilesOverlayMounted = false;
+    }
+    lastGoogleTilesLayerSignature = null;
+    googleTilesMountRetries = 0;
+    restoreGooglePhotorealisticPreviousProjection();
+    return;
   }
 
+  forceGooglePhotorealisticMercatorProjection(googleTilesApp);
+
   if (!googleTilesOverlayMounted) {
-    if (layers.length === 0) return;
-    if (!googleTilesApp.addMapControl(googleTilesOverlay, "top-left")) return;
+    if (!googleTilesApp.addMapControl(googleTilesOverlay, "top-left")) {
+      // The map may still be initializing (e.g. during project restore). The
+      // store subscription only fires on layer-set changes, so schedule a
+      // bounded retry on the next animation frame rather than leaving the tiles
+      // permanently unmounted.
+      scheduleGoogleTilesMountRetry();
+      return;
+    }
     googleTilesOverlayMounted = true;
+    googleTilesMountRetries = 0;
+    // A fresh mount starts with no layers, so force the setProps below.
+    lastGoogleTilesLayerSignature = null;
   }
+
+  // The store subscription fires on ANY layer-set change, not just Google ones.
+  // Rebuilding hands deck.gl new loadOptions/fetch object references each time,
+  // which can trigger a needless tileset re-fetch, so skip when nothing about
+  // the Google layers themselves changed.
+  const signature = googleTilesLayerSignature(layers);
+  if (signature === lastGoogleTilesLayerSignature) return;
+  lastGoogleTilesLayerSignature = signature;
 
   const deckLayers = layers
     .filter((layer) => layer.visible)
@@ -1066,18 +1261,53 @@ function renderGooglePhotorealisticTilesLayers(): void {
   googleTilesOverlay.setProps({ layers: deckLayers });
 }
 
+function scheduleGoogleTilesMountRetry(): void {
+  if (
+    googleTilesMountRetryScheduled ||
+    typeof requestAnimationFrame === "undefined"
+  ) {
+    return;
+  }
+  if (googleTilesMountRetries >= GOOGLE_TILES_MAX_MOUNT_RETRIES) {
+    console.warn(
+      "[GeoLibre] Gave up mounting the Google 3D Tiles overlay after repeated addMapControl failures.",
+    );
+    return;
+  }
+  googleTilesMountRetries += 1;
+  googleTilesMountRetryScheduled = true;
+  requestAnimationFrame(() => {
+    googleTilesMountRetryScheduled = false;
+    renderGooglePhotorealisticTilesLayers();
+  });
+}
+
+function googleTilesLayerSignature(layers: GeoLibreLayer[]): string {
+  return layers
+    .map((layer) => {
+      const headers = stringRecordValue(layer.source.requestHeaders);
+      const altitudeOffset = numberValue(layer.source.altitudeOffset, 0);
+      const headerKeys = headers ? Object.keys(headers).sort().join(",") : "";
+      return `${layer.id}:${layer.visible ? 1 : 0}:${layer.opacity}:${altitudeOffset}:${headerKeys}`;
+    })
+    .join("|");
+}
+
 function buildGooglePhotorealisticTilesDeckLayer(
   layer: GeoLibreLayer,
 ): Layer | null {
   if (!googleTilesDeckGL) return null;
+  const altitudeOffset = numberValue(layer.source.altitudeOffset, 0);
   const requestHeaders = resolveThreeDTilesRequestHeaders(
     GOOGLE_PHOTOREALISTIC_TILES_URL,
     stringRecordValue(layer.source.requestHeaders),
   );
 
-  return new googleTilesDeckGL.geoLayers.Tile3DLayer({
+  const Tile3DLayer = getGoogleAltitudeOffsetTile3DLayerClass();
+  return new Tile3DLayer({
     id: googlePhotorealisticTilesDeckLayerId(layer),
     data: GOOGLE_PHOTOREALISTIC_TILES_URL,
+    altitudeOffset,
     loadOptions: {
       fetch: requestHeaders ? { headers: requestHeaders } : undefined,
       tileset: {
@@ -1088,8 +1318,95 @@ function buildGooglePhotorealisticTilesDeckLayer(
     },
     opacity: layer.opacity,
     pickable: false,
-    operation: "terrain+draw",
+    operation: "draw",
   }) as Layer;
+}
+
+function getGoogleAltitudeOffsetTile3DLayerClass(): DeckTile3DLayerClass {
+  if (googleAltitudeOffsetTile3DLayerClass) {
+    return googleAltitudeOffsetTile3DLayerClass;
+  }
+  if (!googleTilesDeckGL) {
+    throw new Error("deck.gl modules are not loaded");
+  }
+
+  const BaseLayer = googleTilesDeckGL.geoLayers
+    .Tile3DLayer as unknown as DeckTile3DLayerClass;
+  googleAltitudeOffsetTile3DLayerClass = class extends BaseLayer {
+    static componentName = "GoogleAltitudeOffsetTile3DLayer";
+
+    renderLayers(): unknown {
+      const altitudeOffset = numberValue(this.props.altitudeOffset, 0);
+      return offsetGooglePhotorealisticTileLayers(
+        super.renderLayers(),
+        altitudeOffset,
+      );
+    }
+  };
+  return googleAltitudeOffsetTile3DLayerClass;
+}
+
+function offsetGooglePhotorealisticTileLayers(
+  layers: unknown,
+  altitudeOffset: number,
+): unknown {
+  if (!Number.isFinite(altitudeOffset) || altitudeOffset === 0) {
+    return layers;
+  }
+  if (Array.isArray(layers)) {
+    return layers.map((layer) =>
+      offsetGooglePhotorealisticTileLayers(layer, altitudeOffset),
+    );
+  }
+  if (!isDeckLayerInstance(layers)) return layers;
+
+  return layers.clone({
+    modelMatrix: translatedModelMatrix(
+      matrix16Value(layers.props.modelMatrix),
+      altitudeOffset,
+    ),
+  });
+}
+
+function translatedModelMatrix(
+  modelMatrix: number[] | null,
+  altitudeOffset: number,
+): number[] {
+  const source = modelMatrix ?? [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  ];
+  const translated = [...source];
+  translated[12] = source[12] + source[8] * altitudeOffset;
+  translated[13] = source[13] + source[9] * altitudeOffset;
+  translated[14] = source[14] + source[10] * altitudeOffset;
+  translated[15] = source[15] + source[11] * altitudeOffset;
+  return translated;
+}
+
+function matrix16Value(value: unknown): number[] | null {
+  if (!isArrayLike(value)) return null;
+  const values = Array.from(value);
+  if (
+    values.length === 16 &&
+    values.every((entry): entry is number => typeof entry === "number")
+  ) {
+    return values;
+  }
+  return null;
+}
+
+function isDeckLayerInstance(value: unknown): value is Layer & {
+  props: Record<string, unknown>;
+  clone(props: Record<string, unknown>): Layer;
+} {
+  return (
+    isRecord(value) &&
+    isRecord(value.props) &&
+    typeof value.clone === "function"
+  );
 }
 
 function googlePhotorealisticTilesDeckLayerId(layer: GeoLibreLayer): string {
@@ -1280,6 +1597,12 @@ function numberValue(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) ? value : fallback;
 }
 
+function numberInputValue(value: unknown, fallback: number): number {
+  if (typeof value !== "string") return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 function optionalNumberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? value
@@ -1366,6 +1689,14 @@ function isGooglePhotorealisticTilesetLayerUrl(layer: GeoLibreLayer): boolean {
   return url ? isGooglePhotorealisticTilesetUrl(url) : false;
 }
 
+function urlHasKeyQueryParam(url: string): boolean {
+  try {
+    return new URL(url).searchParams.has("key");
+  } catch {
+    return false;
+  }
+}
+
 function parseThreeDTilesRequestHeaders(
   text: string,
 ): Record<string, string> | undefined {
@@ -1441,6 +1772,15 @@ function valuesEqual(left: unknown, right: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isArrayLike(value: unknown): value is ArrayLike<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "length" in value &&
+    typeof value.length === "number"
+  );
 }
 
 function layerNameFromUrl(url: string, fallback: string): string {

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from "@geolibre/core";
+import { getGoogleMapsApiKey, useAppStore } from "@geolibre/core";
 import {
   BasemapControl,
   type BasemapChangeEvent,
@@ -44,7 +44,7 @@ function getTrafficOverlayCredentials(): {
 } {
   const env = getRuntimeEnvironment();
   return {
-    googleMapsApiKey: env.VITE_GOOGLE_MAPS_API_KEY?.trim() || "",
+    googleMapsApiKey: getGoogleMapsApiKey(env) || "",
     tomtomApiKey: env.VITE_TOMTOM_API_KEY?.trim() || "",
     hereApiKey: env.VITE_HERE_API_KEY?.trim() || "",
   };

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -1,3 +1,4 @@
+import { getGoogleMapsApiKey } from "@geolibre/core";
 import {
   StreetViewControl,
   type StreetViewControlOptions,
@@ -29,7 +30,7 @@ function getStreetViewCredentials(): Pick<
   "defaultProvider" | "googleApiKey" | "mapillaryAccessToken"
 > {
   const env = getRuntimeEnvironment();
-  const googleApiKey = env.VITE_GOOGLE_MAPS_API_KEY?.trim() || undefined;
+  const googleApiKey = getGoogleMapsApiKey(env);
   const mapillaryAccessToken =
     env.VITE_MAPILLARY_ACCESS_TOKEN?.trim() || undefined;
 

--- a/tests/google-maps-api-key.test.ts
+++ b/tests/google-maps-api-key.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getGoogleMapsApiKey } from "@geolibre/core";
+
+describe("getGoogleMapsApiKey", () => {
+  it("returns undefined when env is missing or empty", () => {
+    assert.equal(getGoogleMapsApiKey({}), undefined);
+    assert.equal(getGoogleMapsApiKey({ VITE_GOOGLE_MAPS_API_KEY: "" }), undefined);
+    assert.equal(
+      getGoogleMapsApiKey({ VITE_GOOGLE_MAPS_API_KEY: "   " }),
+      undefined,
+    );
+    assert.equal(getGoogleMapsApiKey({ GOOGLE_MAPS_API_KEY: "  " }), undefined);
+  });
+
+  it("returns the trimmed VITE_ key when set", () => {
+    assert.equal(
+      getGoogleMapsApiKey({ VITE_GOOGLE_MAPS_API_KEY: "  abc123  " }),
+      "abc123",
+    );
+  });
+
+  it("falls back to the bare GOOGLE_MAPS_API_KEY", () => {
+    assert.equal(
+      getGoogleMapsApiKey({ GOOGLE_MAPS_API_KEY: "  bare-key  " }),
+      "bare-key",
+    );
+  });
+
+  it("prefers VITE_GOOGLE_MAPS_API_KEY over the bare name", () => {
+    assert.equal(
+      getGoogleMapsApiKey({
+        VITE_GOOGLE_MAPS_API_KEY: "prefixed",
+        GOOGLE_MAPS_API_KEY: "bare",
+      }),
+      "prefixed",
+    );
+  });
+
+  it("falls back to the bare name when the VITE_ value is blank", () => {
+    assert.equal(
+      getGoogleMapsApiKey({
+        VITE_GOOGLE_MAPS_API_KEY: "   ",
+        GOOGLE_MAPS_API_KEY: "bare",
+      }),
+      "bare",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Google Photorealistic 3D Tiles as a 3D Tiles sample backed by deck.gl Tile3DLayer
- resolve Google Maps API keys from VITE_GOOGLE_MAPS_API_KEY or GOOGLE_MAPS_API_KEY
- mask the Google API key in the 3D Tiles request headers panel by default
- show Google tiles in the 3D Tiles panel list with visibility, opacity, fly-to, and remove controls
- document Google Photorealistic 3D Tiles configuration

## Validation
- npm run build
- pre-commit run --all-files
- browser smoke test for Google sample selection, masked headers, tileset add, and panel list behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added **Google Photorealistic 3D Tiles** support in the desktop app, including layer creation/restoration and a panel UI with a **show/hide API key** toggle.
  * Improved Google Tiles rendering for the MapLibre 3D Tiles experience with runtime header handling.

* **Bug Fixes**
  * Prevented Google API keys from being stored in project state while still using them at runtime.
  * Improved missing-credential behavior with clear missing-key errors.

* **Documentation**
  * Expanded setup and environment-variable guidance for Google/traffic overlays and the relevant integrations.

* **Tests**
  * Added coverage for Google Maps API key resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="1546" height="998" alt="image" src="https://github.com/user-attachments/assets/6788d2a5-495a-405b-bba9-45fe5a9ec2da" />
