### PR TITLE
fix(processing): reproject_vector (and other WASM tools) fail with wrong parameter names

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -610,10 +610,10 @@ export function ProcessingDialog({
         setError(
           catalogError instanceof Error
             ? catalogError.message
-            : "Could not load Whitebox catalog snapshot.",
+            : t("processing.whitebox.catalogSnapshotError"),
         );
       } else if (nextTools.length === 0) {
-        setError("Could not load Whitebox catalog snapshot.");
+        setError(t("processing.whitebox.catalogSnapshotError"));
       }
       setLoadingTools(false);
       return;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -602,12 +602,18 @@ export function ProcessingDialog({
           ? current
           : nextTools[0]?.id ?? "",
       );
-      if (nextTools.length === 0) {
+      // Surface a catalog-fetch failure even when the WASM manifests still yield
+      // a few GeoLibre-authored tools: otherwise the user silently loses the
+      // ~700 Whitebox catalog tools with no explanation (a regression vs the
+      // sidecar path, which always reported the error).
+      if (catalogError) {
         setError(
           catalogError instanceof Error
             ? catalogError.message
             : "Could not load Whitebox catalog snapshot.",
         );
+      } else if (nextTools.length === 0) {
+        setError("Could not load Whitebox catalog snapshot.");
       }
       setLoadingTools(false);
       return;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -7,7 +7,8 @@ import {
   fetchRemoteWhiteboxCatalogSnapshot,
   fetchWhiteboxStatus,
   fetchWhiteboxTools,
-  listGeolibreWasmTools,
+  listWasmToolManifests,
+  mergeWasmToolManifests,
   runWhiteboxTool,
   runWhiteboxToolWasm,
   outputBaseName,
@@ -566,36 +567,47 @@ export function ProcessingDialog({
 
     // In WASM mode the tools run in-browser, so skip the Python sidecar probe
     // entirely (on the web build that request 404s to the SPA index.html, which
-    // is the "Unexpected token '<'" JSON error). Just load the catalog for the
-    // parameter UI.
+    // is the "Unexpected token '<'" JSON error). Load the catalog for the tool
+    // list + display metadata, then let the WASM binary's own manifests be
+    // authoritative for parameters: the local tools can expose a different
+    // parameter set than the sidecar (e.g. reproject_vector validates `epsg`,
+    // not the catalog's `dst_epsg`, #1047), and they add the GeoLibre-authored
+    // tools (write_geoparquet, delineate_depressions, …) absent from the catalog.
     if (runLocal) {
-      await applyRemoteCatalogSnapshot(
-        t("processing.whitebox.runningLocally"),
-        false,
-      );
-      // The GeoLibre-authored tools (write_geoparquet, delineate_depressions, …)
-      // aren't in the Whitebox catalog snapshot, so append them from the WASM
-      // binary's own manifests. WASM-only: they have no Python sidecar
-      // equivalent, hence only in the runLocal branch.
+      setRuntimeAvailable(false);
+      setRuntimeMessage(t("processing.whitebox.runningLocally"));
+      let catalogTools: WhiteboxTool[] = [];
+      let catalogError: unknown = null;
       try {
-        const geolibreTools = await listGeolibreWasmTools();
-        if (geolibreTools.length > 0) {
-          setTools((current) => {
-            // On an id collision, prefer the GeoLibre manifest (it carries the
-            // richer param schemas) over a catalog stub.
-            const geolibreIds = new Set(geolibreTools.map((tool) => tool.id));
-            return [
-              ...current.filter((tool) => !geolibreIds.has(tool.id)),
-              ...geolibreTools,
-            ];
-          });
-          // Select the first GeoLibre tool if the snapshot was empty (otherwise
-          // applyRemoteCatalogSnapshot already picked a selection).
-          setSelectedToolId((current) => current || geolibreTools[0].id);
-        }
+        // Hide locked ("pro"-tier) tools: they cannot run, so omit them from the
+        // catalog entirely rather than show them as disabled rows.
+        catalogTools = (await fetchRemoteWhiteboxCatalogSnapshot()).filter(
+          (tool) => !tool.locked,
+        );
       } catch (err) {
-        // Non-fatal: the catalog tools still load if the WASM enumeration fails.
-        console.warn("[GeoLibre] Could not enumerate WASM GeoLibre tools:", err);
+        catalogError = err;
+      }
+      let wasmTools: WhiteboxTool[] = [];
+      try {
+        wasmTools = await listWasmToolManifests();
+      } catch (err) {
+        // Non-fatal: the catalog tools still load if the WASM enumeration fails
+        // (they just keep the catalog's parameter names).
+        console.warn("[GeoLibre] Could not enumerate WASM tool manifests:", err);
+      }
+      const nextTools = mergeWasmToolManifests(catalogTools, wasmTools);
+      setTools(nextTools);
+      setSelectedToolId((current) =>
+        nextTools.some((tool) => tool.id === current)
+          ? current
+          : nextTools[0]?.id ?? "",
+      );
+      if (nextTools.length === 0) {
+        setError(
+          catalogError instanceof Error
+            ? catalogError.message
+            : "Could not load Whitebox catalog snapshot.",
+        );
       }
       setLoadingTools(false);
       return;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -9,10 +9,10 @@ import {
   fetchWhiteboxTools,
   listWasmToolManifests,
   mergeWasmToolManifests,
+  normalizeVectorOutputFormat,
   runWhiteboxTool,
   runWhiteboxToolWasm,
   outputBaseName,
-  type VectorOutputFormat,
   type WhiteboxJob,
   type WhiteboxLayerInput,
   type WhiteboxTool,
@@ -605,6 +605,12 @@ export function ProcessingDialog({
           wasmError,
         );
       }
+      if (catalogError) {
+        console.warn(
+          "[GeoLibre] Could not load Whitebox catalog snapshot:",
+          catalogError,
+        );
+      }
       const nextTools = mergeWasmToolManifests(catalogTools, wasmTools);
       setTools(nextTools);
       setSelectedToolId((current) =>
@@ -626,7 +632,10 @@ export function ProcessingDialog({
             ? catalogError.message
             : t("processing.whitebox.catalogSnapshotError"),
         );
-      } else if (nextTools.length === 0) {
+      } else if (catalogTools.length === 0 || nextTools.length === 0) {
+        // The catalog can also resolve to an empty list (a malformed/empty
+        // snapshot doesn't throw), which silently drops the ~700 Whitebox tools
+        // even when a few GeoLibre-authored WASM tools keep `nextTools` non-empty.
         setError(t("processing.whitebox.catalogSnapshotError"));
       }
       setLoadingTools(false);
@@ -947,10 +956,10 @@ export function ProcessingDialog({
         )
       : undefined;
     const vectorOutValue = vectorOut ? values[vectorOut.name] : undefined;
-    const vectorOutputFormat: VectorOutputFormat =
-      typeof vectorOutValue === "string" && vectorOutValue
-        ? (vectorOutValue as VectorOutputFormat)
-        : "geojson";
+    // Validate against the known formats: a stale sidecar-mode output path left
+    // in the form state (the form only resets on tool change) would otherwise be
+    // cast to a bogus format and produce a `..._output.undefined` filename.
+    const vectorOutputFormat = normalizeVectorOutputFormat(vectorOutValue);
 
     try {
       const request = {
@@ -1402,11 +1411,12 @@ function ParameterField({
       ) : kind === "vector_out" && runLocal ? (
         // In WASM mode a vector output is either a WGS84 map layer (GeoJSON) or a
         // downloaded file in a CRS-preserving format that keeps a reprojection's
-        // target CRS (which the map, being EPSG:4326, cannot show).
+        // target CRS (which the map, being EPSG:4326, cannot show). Normalize the
+        // value so a stale sidecar-mode output path doesn't leak into the Select.
         <div className="grid gap-1.5">
           <Select
             id={`whitebox-${param.name}`}
-            value={valueText || "geojson"}
+            value={normalizeVectorOutputFormat(valueText)}
             onChange={(event) => onChange(event.target.value)}
           >
             <option value="geojson">
@@ -1422,7 +1432,7 @@ function ParameterField({
               {t("processing.whitebox.output.shapefile")}
             </option>
           </Select>
-          {valueText && valueText !== "geojson" && (
+          {normalizeVectorOutputFormat(valueText) !== "geojson" && (
             <p className="text-xs text-muted-foreground">
               {t("processing.whitebox.output.projectedHint")}
             </p>

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -576,24 +576,30 @@ export function ProcessingDialog({
     if (runLocal) {
       setRuntimeAvailable(false);
       setRuntimeMessage(t("processing.whitebox.runningLocally"));
-      let catalogTools: WhiteboxTool[] = [];
-      let catalogError: unknown = null;
-      try {
-        // Hide locked ("pro"-tier) tools: they cannot run, so omit them from the
-        // catalog entirely rather than show them as disabled rows.
-        catalogTools = (await fetchRemoteWhiteboxCatalogSnapshot()).filter(
-          (tool) => !tool.locked,
+      // The catalog snapshot (HTTP/bundled asset) and the WASM manifest
+      // enumeration (loads + queries the WASM module) are independent, so fetch
+      // them concurrently rather than serially.
+      const [catalogResult, wasmResult] = await Promise.allSettled([
+        fetchRemoteWhiteboxCatalogSnapshot(),
+        listWasmToolManifests(),
+      ]);
+      // Hide locked ("pro"-tier) tools: they cannot run, so omit them from the
+      // catalog entirely rather than show them as disabled rows.
+      const catalogTools =
+        catalogResult.status === "fulfilled"
+          ? catalogResult.value.filter((tool) => !tool.locked)
+          : [];
+      const catalogError =
+        catalogResult.status === "rejected" ? catalogResult.reason : null;
+      const wasmTools =
+        wasmResult.status === "fulfilled" ? wasmResult.value : [];
+      const wasmError =
+        wasmResult.status === "rejected" ? wasmResult.reason : null;
+      if (wasmError) {
+        console.warn(
+          "[GeoLibre] Could not enumerate WASM tool manifests:",
+          wasmError,
         );
-      } catch (err) {
-        catalogError = err;
-      }
-      let wasmTools: WhiteboxTool[] = [];
-      try {
-        wasmTools = await listWasmToolManifests();
-      } catch (err) {
-        // Non-fatal: the catalog tools still load if the WASM enumeration fails
-        // (they just keep the catalog's parameter names).
-        console.warn("[GeoLibre] Could not enumerate WASM tool manifests:", err);
       }
       const nextTools = mergeWasmToolManifests(catalogTools, wasmTools);
       setTools(nextTools);
@@ -602,11 +608,15 @@ export function ProcessingDialog({
           ? current
           : nextTools[0]?.id ?? "",
       );
-      // Surface a catalog-fetch failure even when the WASM manifests still yield
-      // a few GeoLibre-authored tools: otherwise the user silently loses the
-      // ~700 Whitebox catalog tools with no explanation (a regression vs the
-      // sidecar path, which always reported the error).
-      if (catalogError) {
+      // In local mode the WASM runner is what actually executes tools, so its
+      // failure is the most important to report: without it every tool keeps the
+      // catalog's parameter names and would fail on run (exactly #1047). Failing
+      // that, surface a catalog-fetch failure even when the WASM manifests still
+      // yielded a few GeoLibre-authored tools, so the user is not silently left
+      // without the ~700 Whitebox catalog tools.
+      if (wasmError) {
+        setError(t("processing.whitebox.localRunnerError"));
+      } else if (catalogError) {
         setError(
           catalogError instanceof Error
             ? catalogError.message

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -12,6 +12,7 @@ import {
   runWhiteboxTool,
   runWhiteboxToolWasm,
   outputBaseName,
+  type VectorOutputFormat,
   type WhiteboxJob,
   type WhiteboxLayerInput,
   type WhiteboxTool,
@@ -138,14 +139,17 @@ function isOutputParameter(param: WhiteboxToolParameter): boolean {
 }
 
 /**
- * Best-effort extension for a `file_out` blob, sniffed from its magic bytes.
- * Covers the formats GeoLibre `file_out` tools emit today (GeoParquet, PNG,
- * PMTiles); a genuinely opaque output falls back to `.bin`. Extend the sniff
- * here if a future tool writes a recognizable text format.
+ * Best-effort extension for a binary tool output, sniffed from its magic bytes.
+ * Covers the formats GeoLibre `file_out` and (CRS-preserving) `vector_out` tools
+ * emit today (GeoParquet, FlatGeobuf, zipped Shapefile, PNG, PMTiles); a
+ * genuinely opaque output falls back to `.bin`. Extend the sniff here if a
+ * future tool writes a recognizable format.
  */
 function fileOutputExtension(bytes: Uint8Array): string {
   const matches = (sig: number[]) => sig.every((b, i) => bytes[i] === b);
   if (matches([0x50, 0x41, 0x52, 0x31])) return "parquet"; // "PAR1"
+  if (matches([0x66, 0x67, 0x62, 0x03])) return "fgb"; // FlatGeobuf "fgb\x03"
+  if (matches([0x50, 0x4b, 0x03, 0x04])) return "zip"; // Shapefile bundle "PK\x03\x04"
   if (matches([0x89, 0x50, 0x4e, 0x47])) return "png";
   // "PMTiles"
   if (matches([0x50, 0x4d, 0x54, 0x69, 0x6c, 0x65, 0x73])) return "pmtiles";
@@ -834,12 +838,15 @@ export function ProcessingDialog({
 
       // Binary outputs come back from the WASM runner inline. Raster (COG) bytes
       // become a new raster layer; a `file_out` (e.g. write_geoparquet .parquet,
-      // a rendered .png, a .pmtiles) is not a GeoTIFF, so download it instead of
-      // handing it to the raster loader.
+      // a rendered .png, a .pmtiles) or a CRS-preserving `vector_out`
+      // (GeoParquet/FlatGeobuf/zipped Shapefile, chosen to keep a reprojection's
+      // target CRS) is not a GeoTIFF, so download it instead of handing it to the
+      // raster loader.
       for (const [name, value] of Object.entries(nextJob.outputs)) {
         if (!(value instanceof Uint8Array)) continue;
         const param = jobTool?.params?.find((item) => item.name === name);
-        if (param && parameterKind(param) === "file_out") {
+        const outKind = param ? parameterKind(param) : "";
+        if (outKind === "file_out" || outKind === "vector_out") {
           const label = `${jobToolLabel} ${humanize(name)}`.replace(/\s+/g, "_");
           downloadBytes(value, `${label}.${fileOutputExtension(value)}`);
         } else if (onAddRaster) {
@@ -931,6 +938,20 @@ export function ProcessingDialog({
       }
     }
 
+    // In WASM mode a vector_out param carries the chosen output format (its value
+    // is otherwise unused by the runner). A CRS-preserving format keeps a
+    // reprojection's target CRS and comes back as a downloadable file.
+    const vectorOut = runLocal
+      ? (selectedTool.params ?? []).find(
+          (item) => parameterKind(item) === "vector_out",
+        )
+      : undefined;
+    const vectorOutValue = vectorOut ? values[vectorOut.name] : undefined;
+    const vectorOutputFormat: VectorOutputFormat =
+      typeof vectorOutValue === "string" && vectorOutValue
+        ? (vectorOutValue as VectorOutputFormat)
+        : "geojson";
+
     try {
       const request = {
         tool_id: selectedTool.id,
@@ -939,6 +960,7 @@ export function ProcessingDialog({
         layer_inputs: layerInputs,
         include_pro: false,
         tier: "open",
+        vector_output_format: vectorOutputFormat,
       };
       // The local WASM runner executes synchronously on the main thread, so yield
       // twice to the browser first: this lets React commit and paint the Run
@@ -1222,6 +1244,7 @@ export function ProcessingDialog({
                       param={param}
                       layers={layers}
                       toolId={selectedTool.id}
+                      runLocal={runLocal}
                       value={values[param.name]}
                       onChange={(value) => updateValue(param.name, value)}
                       onPickFile={(fileName, bytes) =>
@@ -1313,6 +1336,7 @@ interface ParameterFieldProps {
   onChange: (value: unknown) => void;
   onPickFile?: (fileName: string, bytes: Uint8Array) => void;
   toolId: string;
+  runLocal: boolean;
   value: unknown;
 }
 
@@ -1322,8 +1346,10 @@ function ParameterField({
   onChange,
   onPickFile,
   toolId,
+  runLocal,
   value,
 }: ParameterFieldProps) {
+  const { t } = useTranslation();
   const kind = parameterKind(param);
   const availableLayers = layers.filter((layer) =>
     canUseLayerForParameter(layer, param),
@@ -1373,6 +1399,35 @@ function ParameterField({
           onChange={onChange}
           onPickFile={onPickFile}
         />
+      ) : kind === "vector_out" && runLocal ? (
+        // In WASM mode a vector output is either a WGS84 map layer (GeoJSON) or a
+        // downloaded file in a CRS-preserving format that keeps a reprojection's
+        // target CRS (which the map, being EPSG:4326, cannot show).
+        <div className="grid gap-1.5">
+          <Select
+            id={`whitebox-${param.name}`}
+            value={valueText || "geojson"}
+            onChange={(event) => onChange(event.target.value)}
+          >
+            <option value="geojson">
+              {t("processing.whitebox.output.geojson")}
+            </option>
+            <option value="geoparquet">
+              {t("processing.whitebox.output.geoparquet")}
+            </option>
+            <option value="flatgeobuf">
+              {t("processing.whitebox.output.flatgeobuf")}
+            </option>
+            <option value="shapefile">
+              {t("processing.whitebox.output.shapefile")}
+            </option>
+          </Select>
+          {valueText && valueText !== "geojson" && (
+            <p className="text-xs text-muted-foreground">
+              {t("processing.whitebox.output.projectedHint")}
+            </p>
+          )}
+        </div>
       ) : isPathParameter(param) ? (
         <PathPickerInput
           id={`whitebox-${param.name}`}

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -595,6 +595,13 @@ export function ProcessingDialog({
           : [];
       const catalogError =
         catalogResult.status === "rejected" ? catalogResult.reason : null;
+      // A snapshot that resolves to an empty list (malformed/empty JSON that
+      // doesn't throw) silently drops the ~700 Whitebox tools. Detect it from
+      // the raw result, not `catalogTools`, so a fetch that returned only locked
+      // tools isn't mistaken for a load failure.
+      const catalogEmpty =
+        catalogResult.status === "fulfilled" &&
+        catalogResult.value.length === 0;
       const wasmTools =
         wasmResult.status === "fulfilled" ? wasmResult.value : [];
       const wasmError =
@@ -632,10 +639,7 @@ export function ProcessingDialog({
             ? catalogError.message
             : t("processing.whitebox.catalogSnapshotError"),
         );
-      } else if (catalogTools.length === 0 || nextTools.length === 0) {
-        // The catalog can also resolve to an empty list (a malformed/empty
-        // snapshot doesn't throw), which silently drops the ~700 Whitebox tools
-        // even when a few GeoLibre-authored WASM tools keep `nextTools` non-empty.
+      } else if (catalogEmpty || nextTools.length === 0) {
         setError(t("processing.whitebox.catalogSnapshotError"));
       }
       setLoadingTools(false);
@@ -787,6 +791,30 @@ export function ProcessingDialog({
     // previously browsed file's bytes for this parameter.
     browsedInputsRef.current.delete(name);
     setValues((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleRunLocalChange = (nextRunLocal: boolean) => {
+    setRunLocal(nextRunLocal);
+    // A `vector_out` param holds an output-format string in WASM mode but a
+    // free-text path in sidecar mode, and the form only resets on tool change.
+    // Turning WASM mode off would otherwise leave a format like "geoparquet" as
+    // the sidecar output path, so reset any such param to its default.
+    if (nextRunLocal || !selectedTool) return;
+    const defaults = createDefaultValues(selectedTool);
+    setValues((prev) => {
+      const next = { ...prev };
+      for (const param of selectedTool.params ?? []) {
+        const current = prev[param.name];
+        if (
+          parameterKind(param) === "vector_out" &&
+          typeof current === "string" &&
+          normalizeVectorOutputFormat(current) === current
+        ) {
+          next[param.name] = defaults[param.name];
+        }
+      }
+      return next;
+    });
   };
 
   // Stash a browsed input file's bytes and show its name in the field. Used by
@@ -1203,7 +1231,7 @@ export function ProcessingDialog({
                     type="checkbox"
                     data-testid="whitebox-run-local"
                     checked={runLocal}
-                    onChange={(e) => setRunLocal(e.target.checked)}
+                    onChange={(e) => handleRunLocalChange(e.target.checked)}
                   />
                   {t("processing.whitebox.runLocal")}
                 </label>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2109,6 +2109,7 @@
       "runLocal": "Run locally (WASM)",
       "runLocalHint": "Run locally in WebAssembly (no Python sidecar)",
       "runningLocally": "Running locally with WebAssembly. No sidecar required.",
+      "catalogSnapshotError": "Could not load Whitebox catalog snapshot.",
       "filterBySource": "Filter by source",
       "allSources": "All sources",
       "geolibreTools": "GeoLibre tools",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2111,6 +2111,13 @@
       "runningLocally": "Running locally with WebAssembly. No sidecar required.",
       "catalogSnapshotError": "Could not load Whitebox catalog snapshot.",
       "localRunnerError": "Could not load the local (WASM) tool runner. Turn off \"Run locally (WASM)\" to use the sidecar.",
+      "output": {
+        "geojson": "GeoJSON (add to map)",
+        "geoparquet": "GeoParquet (download, keeps CRS)",
+        "flatgeobuf": "FlatGeobuf (download, keeps CRS)",
+        "shapefile": "Shapefile (download, keeps CRS)",
+        "projectedHint": "Saved to your downloads in the target CRS. The map only displays EPSG:4326, so a projected result is not added as a layer."
+      },
       "filterBySource": "Filter by source",
       "allSources": "All sources",
       "geolibreTools": "GeoLibre tools",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2110,6 +2110,7 @@
       "runLocalHint": "Run locally in WebAssembly (no Python sidecar)",
       "runningLocally": "Running locally with WebAssembly. No sidecar required.",
       "catalogSnapshotError": "Could not load Whitebox catalog snapshot.",
+      "localRunnerError": "Could not load the local (WASM) tool runner. Turn off \"Run locally (WASM)\" to use the sidecar.",
       "filterBySource": "Filter by source",
       "allSources": "All sources",
       "geolibreTools": "GeoLibre tools",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2110,7 +2110,7 @@
       "runLocalHint": "Run locally in WebAssembly (no Python sidecar)",
       "runningLocally": "Running locally with WebAssembly. No sidecar required.",
       "catalogSnapshotError": "Could not load Whitebox catalog snapshot.",
-      "localRunnerError": "Could not load the local (WASM) tool runner. Turn off \"Run locally (WASM)\" to use the sidecar.",
+      "localRunnerError": "Could not load the local (WASM) tool runner. Refresh and try again, or use the sidecar if it is available.",
       "output": {
         "geojson": "GeoJSON (add to map)",
         "geoparquet": "GeoParquet (download, keeps CRS)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21293,6 +21293,7 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
+        "fflate": "^0.8.3",
         "geolibre-wasm": "^0.5.2",
         "geotiff": "^3.0.5"
       },
@@ -21300,6 +21301,12 @@
         "@types/geojson": "^7946.0.16",
         "typescript": "^6.0.3"
       }
+    },
+    "packages/processing/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "packages/ui": {
       "name": "@geolibre/ui",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13763,9 +13763,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.1.tgz",
-      "integrity": "sha512-HkvSSw99ZoR8/J/b6AIsDxK7RToaHnNCeMB7PW+SbwLQdXdWfpZgij+0yfDYLEfQ9MWf521iNl29RQXxVhLKRQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.2.tgz",
+      "integrity": "sha512-qfcRaEk7nq/V1DTE00Sv/F+Ue1WOHWIUaFN8acP1TWUeAyAP3MTQdHGlJLBR/J6Ht6+SbdeoLxdtkw8XWXQpUw==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -21293,7 +21293,7 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geolibre-wasm": "^0.5.1",
+        "geolibre-wasm": "^0.5.2",
         "geotiff": "^3.0.5"
       },
       "devDependencies": {

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -32,7 +32,7 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
-    "geolibre-wasm": "^0.5.1",
+    "geolibre-wasm": "^0.5.2",
     "geotiff": "^3.0.5"
   },
   "devDependencies": {

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -32,6 +32,7 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
+    "fflate": "^0.8.3",
     "geolibre-wasm": "^0.5.2",
     "geotiff": "^3.0.5"
   },

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -107,6 +107,8 @@ export {
   fetchVectorStatus,
   runWhiteboxTool,
   WHITEBOX_CATALOG_URL,
+  VECTOR_OUTPUT_FORMATS,
+  normalizeVectorOutputFormat,
   type ConversionJob,
   type ConversionStatus,
   type CsvToGeoParquetRequest,

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -142,6 +142,8 @@ export {
   whiteboxWasmAvailable,
   listWhiteboxWasmTools,
   listGeolibreWasmTools,
+  listWasmToolManifests,
+  mergeWasmToolManifests,
   outputBaseName,
   isTiff,
 } from "./wasm-client";

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -141,7 +141,6 @@ export {
   runWhiteboxToolWasm,
   whiteboxWasmAvailable,
   listWhiteboxWasmTools,
-  listGeolibreWasmTools,
   listWasmToolManifests,
   mergeWasmToolManifests,
   outputBaseName,

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -127,6 +127,7 @@ export {
   type VectorToPmtilesRequest,
   type VectorToShapefileRequest,
   type VectorToVectorRequest,
+  type VectorOutputFormat,
   type VectorStatus,
   type VectorToolRequest,
   type VectorToolResult,

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -145,6 +145,34 @@ export type VectorOutputFormat =
   | "flatgeobuf"
   | "shapefile";
 
+/** Every valid {@link VectorOutputFormat}, for validating untrusted values. */
+export const VECTOR_OUTPUT_FORMATS: readonly VectorOutputFormat[] = [
+  "geojson",
+  "geoparquet",
+  "flatgeobuf",
+  "shapefile",
+];
+
+/**
+ * Coerce an arbitrary value to a {@link VectorOutputFormat}, falling back to
+ * `"geojson"`. Guards against a stale `vector_out` value: in sidecar mode the
+ * param holds a free-text output path, which persists in the form state after
+ * toggling "Run locally (WASM)" (the form only resets on tool change). Without
+ * this, that path string would be force-cast to a format and produce a broken
+ * output filename such as `..._output.undefined`.
+ *
+ * @param value - An arbitrary value that may or may not be a known format.
+ * @returns The value if it is a known format, otherwise `"geojson"`.
+ */
+export function normalizeVectorOutputFormat(
+  value: unknown,
+): VectorOutputFormat {
+  return typeof value === "string" &&
+    (VECTOR_OUTPUT_FORMATS as readonly string[]).includes(value)
+    ? (value as VectorOutputFormat)
+    : "geojson";
+}
+
 export interface RunWhiteboxToolRequest {
   tool_id: string;
   parameters: Record<string, unknown>;

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -131,6 +131,20 @@ export interface WhiteboxLayerInput {
   bytes?: Uint8Array;
 }
 
+/**
+ * Output format for the in-browser WASM runner's `vector_out` parameters.
+ * `"geojson"` (the default) is reprojected to WGS84 (RFC 7946) and returned as a
+ * `FeatureCollection` for a map layer; the other formats preserve the tool's
+ * target-CRS coordinates and CRS metadata and are returned as bytes to download
+ * (a reprojection result would otherwise lose its projection, since GeoLibre and
+ * MapLibre only render EPSG:4326). Ignored by the Python sidecar.
+ */
+export type VectorOutputFormat =
+  | "geojson"
+  | "geoparquet"
+  | "flatgeobuf"
+  | "shapefile";
+
 export interface RunWhiteboxToolRequest {
   tool_id: string;
   parameters: Record<string, unknown>;
@@ -138,6 +152,8 @@ export interface RunWhiteboxToolRequest {
   layer_inputs?: Record<string, WhiteboxLayerInput>;
   include_pro?: boolean;
   tier?: string;
+  /** WASM runner only: format for `vector_out` outputs (default `"geojson"`). */
+  vector_output_format?: VectorOutputFormat;
 }
 
 interface WhiteboxCatalogResponse {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -8,10 +8,50 @@
 import type { FeatureCollection } from "geojson";
 import type {
   RunWhiteboxToolRequest,
+  VectorOutputFormat,
   WhiteboxJob,
   WhiteboxTool,
   WhiteboxToolParameter,
 } from "./sidecar-client";
+
+/**
+ * File extension the WASM tool writes for each CRS-preserving vector output
+ * format. Selecting one of these (instead of the default GeoJSON) keeps the
+ * tool's target-CRS coordinates, which the GeoJSON writer would otherwise
+ * reproject back to WGS84 for RFC 7946 compliance.
+ */
+const VECTOR_OUTPUT_EXTENSION: Record<
+  Exclude<VectorOutputFormat, "geojson">,
+  string
+> = {
+  geoparquet: "parquet",
+  flatgeobuf: "fgb",
+  shapefile: "shp",
+};
+
+/**
+ * Bundle a Shapefile the WASM tool wrote (`.shp` plus its `.shx`/`.dbf`/`.prj`/
+ * `.cpg` sidecars) into a single zip, since a Shapefile is inherently multi-file.
+ * Returns `null` when the main `.shp` is missing (a failed/partial write).
+ *
+ * @param shpFile - The `.shp` filename in the WASM output map.
+ * @param files - Every file the tool wrote, keyed by name.
+ * @returns The zip bytes, or `null` if there is no `.shp` to bundle.
+ */
+async function zipShapefileSidecars(
+  shpFile: string,
+  files: Record<string, Uint8Array>,
+): Promise<Uint8Array | null> {
+  const base = shpFile.replace(/\.shp$/i, "");
+  const members: Record<string, Uint8Array> = {};
+  for (const ext of ["shp", "shx", "dbf", "prj", "cpg"]) {
+    const member = files[`${base}.${ext}`];
+    if (member) members[`${base}.${ext}`] = member;
+  }
+  if (!members[`${base}.shp`]) return null;
+  const { zipSync } = await import("fflate");
+  return zipSync(members);
+}
 
 interface ToolRunResult {
   exitCode: number;
@@ -316,7 +356,17 @@ export async function runWhiteboxToolWasm(
   const encoder = new TextEncoder();
   const input: Record<string, Uint8Array> = {};
   const args: string[] = [];
-  const outputs: { name: string; file: string; raster: boolean }[] = [];
+  // How each output file is turned into a job output: "geojson" is parsed into a
+  // FeatureCollection (a map layer); "bytes" is returned raw (a raster COG, a
+  // file_out blob, or a CRS-preserving vector file to download); "shapefile" is
+  // zipped with its sidecars first.
+  const outputs: {
+    name: string;
+    file: string;
+    kind: "geojson" | "bytes" | "shapefile";
+  }[] = [];
+  const vectorFormat: VectorOutputFormat =
+    request.vector_output_format ?? "geojson";
 
   for (const param of request.tool?.params ?? []) {
     const kind = paramKind(param);
@@ -359,15 +409,28 @@ export async function runWhiteboxToolWasm(
       input[file] = bytes;
       args.push(`--${name}=/work/${file}`);
     } else if (kind === "vector_out") {
-      const file = `${outputBaseName(request.tool_id, name)}.geojson`;
-      outputs.push({ name, file, raster: false });
-      args.push(`--${name}=/work/${file}`);
+      const base = outputBaseName(request.tool_id, name);
+      // GeoJSON is reprojected to WGS84 on write (a map layer); the other formats
+      // keep the tool's target CRS and are returned as bytes to download.
+      if (vectorFormat === "geojson") {
+        const file = `${base}.geojson`;
+        outputs.push({ name, file, kind: "geojson" });
+        args.push(`--${name}=/work/${file}`);
+      } else {
+        const file = `${base}.${VECTOR_OUTPUT_EXTENSION[vectorFormat]}`;
+        outputs.push({
+          name,
+          file,
+          kind: vectorFormat === "shapefile" ? "shapefile" : "bytes",
+        });
+        args.push(`--${name}=/work/${file}`);
+      }
     } else if (kind === "raster_out" || kind === "file_out") {
       // file_out is treated as an opaque binary output (no GeoJSON parsing),
       // mirroring how raster outputs are returned as raw bytes.
       const ext = kind === "file_out" ? "dat" : "tif";
       const file = `${outputBaseName(request.tool_id, name)}.${ext}`;
-      outputs.push({ name, file, raster: true });
+      outputs.push({ name, file, kind: "bytes" });
       args.push(`--${name}=/work/${file}`);
     } else {
       const value = request.parameters[name];
@@ -390,9 +453,14 @@ export async function runWhiteboxToolWasm(
 
   const out: Record<string, unknown> = {};
   for (const entry of outputs) {
+    if (entry.kind === "shapefile") {
+      const zipped = await zipShapefileSidecars(entry.file, files);
+      if (zipped) out[entry.name] = zipped;
+      continue;
+    }
     const bytes = files[entry.file];
     if (!bytes) continue;
-    if (entry.raster) {
+    if (entry.kind === "bytes") {
       out[entry.name] = bytes;
       continue;
     }

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -144,8 +144,13 @@ export async function listWasmToolManifests(): Promise<WhiteboxTool[]> {
  * the toolbox can only discover them from the binary's own manifests.
  */
 export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
-  const tools = await listWasmToolManifests();
-  return tools.filter((tool) => tool.source === "geolibre");
+  const { listManifests } = await loadToolsModule();
+  const manifests = await listManifests();
+  // Filter by source *before* mapping so we don't allocate a WhiteboxTool for
+  // every one of the ~700 Whitebox manifests just to discard them.
+  return manifests
+    .filter((manifest) => manifest.source?.toLowerCase() === "geolibre")
+    .map(manifestToWhiteboxTool);
 }
 
 /**
@@ -171,14 +176,13 @@ export function mergeWasmToolManifests(
   const wasmById = new Map(wasmTools.map((tool) => [tool.id, tool] as const));
   const merged = catalogTools.map((tool) => {
     const wasm = wasmById.get(tool.id);
+    // Defensive fallback: a tool the WASM binary reports with no params (a
+    // malformed/empty manifest, or a rare zero-parameter tool) keeps the
+    // catalog's params rather than being blanked to an unusable empty form.
     if (!wasm?.params?.length) return tool;
     // Consume the match so only WASM-only tools remain to be appended below.
     wasmById.delete(tool.id);
-    return {
-      ...tool,
-      params: wasm.params,
-      return_type: wasm.return_type ?? tool.return_type,
-    };
+    return { ...tool, params: wasm.params };
   });
   const geolibreOnly = [...wasmById.values()].filter(
     (tool) => tool.source === "geolibre",

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -6,6 +6,7 @@
 // algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB memory and
 // single-threaded execution (use the sidecar for very large data).
 import type { FeatureCollection } from "geojson";
+import { normalizeVectorOutputFormat } from "./sidecar-client";
 import type {
   RunWhiteboxToolRequest,
   VectorOutputFormat,
@@ -32,23 +33,26 @@ const VECTOR_OUTPUT_EXTENSION: Record<
 /**
  * Bundle a Shapefile the WASM tool wrote (`.shp` plus its `.shx`/`.dbf`/`.prj`/
  * `.cpg` sidecars) into a single zip, since a Shapefile is inherently multi-file.
- * Returns `null` when the main `.shp` is missing (a failed/partial write).
+ * Returns `null` when any of the core members (`.shp`/`.shx`/`.dbf`) is missing:
+ * most GIS clients reject a Shapefile that lacks them, so an incomplete bundle
+ * is treated like a failed/partial write rather than shipped as a valid output.
  *
  * @param shpFile - The `.shp` filename in the WASM output map.
  * @param files - Every file the tool wrote, keyed by name.
- * @returns The zip bytes, or `null` if there is no `.shp` to bundle.
+ * @returns The zip bytes, or `null` if the core `.shp`/`.shx`/`.dbf` are incomplete.
  */
 async function zipShapefileSidecars(
   shpFile: string,
   files: Record<string, Uint8Array>,
 ): Promise<Uint8Array | null> {
   const base = shpFile.replace(/\.shp$/i, "");
+  const required = ["shp", "shx", "dbf"] as const;
   const members: Record<string, Uint8Array> = {};
-  for (const ext of ["shp", "shx", "dbf", "prj", "cpg"]) {
+  for (const ext of [...required, "prj", "cpg"]) {
     const member = files[`${base}.${ext}`];
     if (member) members[`${base}.${ext}`] = member;
   }
-  if (!members[`${base}.shp`]) return null;
+  if (required.some((ext) => !members[`${base}.${ext}`])) return null;
   const { zipSync } = await import("fflate");
   return zipSync(members);
 }
@@ -365,8 +369,13 @@ export async function runWhiteboxToolWasm(
     file: string;
     kind: "geojson" | "bytes" | "shapefile";
   }[] = [];
-  const vectorFormat: VectorOutputFormat =
-    request.vector_output_format ?? "geojson";
+  // Defensive: validate the requested format so a bad value (e.g. a stale
+  // output path from switching sidecar/WASM modes) degrades to GeoJSON instead
+  // of indexing VECTOR_OUTPUT_EXTENSION to `undefined` and writing a
+  // `..._output.undefined` file the tool can't format.
+  const vectorFormat: VectorOutputFormat = normalizeVectorOutputFormat(
+    request.vector_output_format,
+  );
 
   for (const param of request.tool?.params ?? []) {
     const kind = paramKind(param);

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -176,12 +176,14 @@ export function mergeWasmToolManifests(
   const wasmById = new Map(wasmTools.map((tool) => [tool.id, tool] as const));
   const merged = catalogTools.map((tool) => {
     const wasm = wasmById.get(tool.id);
+    if (!wasm) return tool;
+    // Consume the match regardless of what follows, so a WASM-only-appended
+    // tool (below) can never duplicate a catalog tool's id.
+    wasmById.delete(tool.id);
     // Defensive fallback: a tool the WASM binary reports with no params (a
     // malformed/empty manifest, or a rare zero-parameter tool) keeps the
     // catalog's params rather than being blanked to an unusable empty form.
-    if (!wasm?.params?.length) return tool;
-    // Consume the match so only WASM-only tools remain to be appended below.
-    wasmById.delete(tool.id);
+    if (!wasm.params?.length) return tool;
     return { ...tool, params: wasm.params };
   });
   const geolibreOnly = [...wasmById.values()].filter(

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -84,49 +84,106 @@ export async function listWhiteboxWasmTools(): Promise<string[]> {
 }
 
 /**
+ * Map one WASM tool manifest to the {@link WhiteboxTool} shape the Processing
+ * toolbox renders. Each manifest param already carries `io_role`/`data_kind`/
+ * `schema`, which the dialog's `parameterKind` reads directly; we additionally
+ * flatten an enum schema's choices to `options` so the param renders as a
+ * dropdown. `source` is preserved only for GeoLibre-authored tools, matching how
+ * the Whitebox catalog snapshot leaves Whitebox tools' `source` unset.
+ */
+function manifestToWhiteboxTool(manifest: ToolManifest): WhiteboxTool {
+  return {
+    id: manifest.id,
+    display_name: manifest.display_name,
+    summary: manifest.summary,
+    category: manifest.category,
+    license_tier: manifest.license_tier,
+    source:
+      manifest.source?.toLowerCase() === "geolibre" ? "geolibre" : undefined,
+    params: (manifest.params ?? []).map((param) => {
+      const mapped: WhiteboxToolParameter = {
+        name: param.name,
+        description: param.description,
+        required: param.required,
+        io_role: param.io_role,
+        data_kind: param.data_kind,
+        schema: param.schema,
+      };
+      if (param.schema?.kind === "enum" && Array.isArray(param.schema.options)) {
+        // Coerce to strings (not filter to strings): an enum with numeric or
+        // boolean values would otherwise drop to an empty list and render as a
+        // plain text input instead of a dropdown.
+        mapped.options = param.schema.options
+          .map((option) => option?.value)
+          .filter((value) => value != null)
+          .map(String);
+      }
+      return mapped;
+    }),
+  };
+}
+
+/**
+ * Every WASM tool manifest mapped to {@link WhiteboxTool}. In local (WASM) mode
+ * the binary is the source of truth for parameter names and shapes, which can
+ * diverge from the Python sidecar's catalog for the same tool id (e.g.
+ * `reproject_vector` takes `epsg`, not the catalog's `dst_epsg`). Use
+ * {@link mergeWasmToolManifests} to reconcile these against the catalog.
+ */
+export async function listWasmToolManifests(): Promise<WhiteboxTool[]> {
+  const { listManifests } = await loadToolsModule();
+  const manifests = await listManifests();
+  return manifests.map(manifestToWhiteboxTool);
+}
+
+/**
  * The GeoLibre-authored tools (`source: "geolibre"`) the WASM runner adds on top
  * of the Whitebox suite — e.g. `write_geoparquet`, `delineate_depressions` —
  * mapped to {@link WhiteboxTool} so the Processing toolbox can list and run them
  * alongside the catalog tools. These aren't in the Whitebox catalog snapshot, so
  * the toolbox can only discover them from the binary's own manifests.
- *
- * Each manifest param already carries `io_role`/`data_kind`/`schema`, which the
- * dialog's `parameterKind` reads directly; we additionally flatten an enum
- * schema's choices to `options` so the param renders as a dropdown.
  */
 export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
-  const { listManifests } = await loadToolsModule();
-  const manifests = await listManifests();
-  return manifests
-    .filter((manifest) => manifest.source?.toLowerCase() === "geolibre")
-    .map((manifest) => ({
-      id: manifest.id,
-      display_name: manifest.display_name,
-      summary: manifest.summary,
-      category: manifest.category,
-      license_tier: manifest.license_tier,
-      source: "geolibre",
-      params: (manifest.params ?? []).map((param) => {
-        const mapped: WhiteboxToolParameter = {
-          name: param.name,
-          description: param.description,
-          required: param.required,
-          io_role: param.io_role,
-          data_kind: param.data_kind,
-          schema: param.schema,
-        };
-        if (param.schema?.kind === "enum" && Array.isArray(param.schema.options)) {
-          // Coerce to strings (not filter to strings): an enum with numeric or
-          // boolean values would otherwise drop to an empty list and render as a
-          // plain text input instead of a dropdown.
-          mapped.options = param.schema.options
-            .map((option) => option?.value)
-            .filter((value) => value != null)
-            .map(String);
-        }
-        return mapped;
-      }),
-    }));
+  const tools = await listWasmToolManifests();
+  return tools.filter((tool) => tool.source === "geolibre");
+}
+
+/**
+ * Reconcile the Whitebox catalog snapshot with the WASM binary's own manifests
+ * for local (WASM) mode. The catalog supplies the tool list, display names, and
+ * categories; the WASM manifest is authoritative for each tool's parameters,
+ * because the binary can expose a different parameter set than the Python
+ * sidecar (e.g. `reproject_vector` validates `epsg`, whereas the catalog names
+ * the parameter `dst_epsg`, causing a "parameter 'epsg' is required" failure).
+ *
+ * Every catalog tool that the WASM binary also implements keeps its catalog
+ * metadata but takes the manifest's parameters; the GeoLibre-authored tools that
+ * never appear in the catalog are appended.
+ *
+ * @param catalogTools - Tools from the Whitebox catalog snapshot.
+ * @param wasmTools - Every WASM tool manifest ({@link listWasmToolManifests}).
+ * @returns Catalog tools with WASM parameters, plus WASM-only GeoLibre tools.
+ */
+export function mergeWasmToolManifests(
+  catalogTools: WhiteboxTool[],
+  wasmTools: WhiteboxTool[],
+): WhiteboxTool[] {
+  const wasmById = new Map(wasmTools.map((tool) => [tool.id, tool] as const));
+  const merged = catalogTools.map((tool) => {
+    const wasm = wasmById.get(tool.id);
+    if (!wasm?.params?.length) return tool;
+    // Consume the match so only WASM-only tools remain to be appended below.
+    wasmById.delete(tool.id);
+    return {
+      ...tool,
+      params: wasm.params,
+      return_type: wasm.return_type ?? tool.return_type,
+    };
+  });
+  const geolibreOnly = [...wasmById.values()].filter(
+    (tool) => tool.source === "geolibre",
+  );
+  return [...merged, ...geolibreOnly];
 }
 
 function datasetParameterKind(dataKind: string, suffix: "in" | "out"): string {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -372,7 +372,8 @@ export async function runWhiteboxToolWasm(
   // Defensive: validate the requested format so a bad value (e.g. a stale
   // output path from switching sidecar/WASM modes) degrades to GeoJSON instead
   // of indexing VECTOR_OUTPUT_EXTENSION to `undefined` and writing a
-  // `..._output.undefined` file the tool can't format.
+  // `..._output.undefined` file the tool can't format. One format applies to
+  // every `vector_out` param; no current tool exposes more than one.
   const vectorFormat: VectorOutputFormat = normalizeVectorOutputFormat(
     request.vector_output_format,
   );
@@ -464,7 +465,16 @@ export async function runWhiteboxToolWasm(
   for (const entry of outputs) {
     if (entry.kind === "shapefile") {
       const zipped = await zipShapefileSidecars(entry.file, files);
-      if (zipped) out[entry.name] = zipped;
+      if (zipped) {
+        out[entry.name] = zipped;
+      } else {
+        // The tool reported success but the Shapefile is incomplete (a core
+        // .shp/.shx/.dbf member is missing). Note it in the job messages so the
+        // user isn't left with a silently empty output.
+        stdout.push(
+          `Warning: "${entry.name}" produced an incomplete Shapefile (missing .shp/.shx/.dbf); no output written.`,
+        );
+      }
       continue;
     }
     const bytes = files[entry.file];

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -137,23 +137,6 @@ export async function listWasmToolManifests(): Promise<WhiteboxTool[]> {
 }
 
 /**
- * The GeoLibre-authored tools (`source: "geolibre"`) the WASM runner adds on top
- * of the Whitebox suite — e.g. `write_geoparquet`, `delineate_depressions` —
- * mapped to {@link WhiteboxTool} so the Processing toolbox can list and run them
- * alongside the catalog tools. These aren't in the Whitebox catalog snapshot, so
- * the toolbox can only discover them from the binary's own manifests.
- */
-export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
-  const { listManifests } = await loadToolsModule();
-  const manifests = await listManifests();
-  // Filter by source *before* mapping so we don't allocate a WhiteboxTool for
-  // every one of the ~700 Whitebox manifests just to discard them.
-  return manifests
-    .filter((manifest) => manifest.source?.toLowerCase() === "geolibre")
-    .map(manifestToWhiteboxTool);
-}
-
-/**
  * Reconcile the Whitebox catalog snapshot with the WASM binary's own manifests
  * for local (WASM) mode. The catalog supplies the tool list, display names, and
  * categories; the WASM manifest is authoritative for each tool's parameters,
@@ -177,14 +160,15 @@ export function mergeWasmToolManifests(
   const merged = catalogTools.map((tool) => {
     const wasm = wasmById.get(tool.id);
     if (!wasm) return tool;
-    // Consume the match regardless of what follows, so a WASM-only-appended
-    // tool (below) can never duplicate a catalog tool's id.
+    // Consume the match so a WASM-only-appended tool (below) can never duplicate
+    // a catalog tool's id.
     wasmById.delete(tool.id);
-    // Defensive fallback: a tool the WASM binary reports with no params (a
-    // malformed/empty manifest, or a rare zero-parameter tool) keeps the
-    // catalog's params rather than being blanked to an unusable empty form.
-    if (!wasm.params?.length) return tool;
-    return { ...tool, params: wasm.params };
+    // The WASM binary is authoritative for the parameters (even an empty set)
+    // and for the tool's provenance; keep only the catalog's display metadata
+    // (name, category, …). Preserving `source` matters so a GeoLibre-authored
+    // tool that also has a catalog stub keeps its "geolibre" marker for the
+    // source filter.
+    return { ...tool, params: wasm.params, source: wasm.source ?? tool.source };
   });
   const geolibreOnly = [...wasmById.values()].filter(
     (tool) => tool.source === "geolibre",

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -82,30 +82,36 @@ describe("mergeWasmToolManifests", () => {
     );
   });
 
-  it("does not duplicate a catalog tool when its WASM match has empty params", () => {
-    // A GeoLibre-authored tool that also has a catalog stub but whose WASM
-    // manifest reports no params must be consumed (kept once, catalog params),
-    // never appended a second time via the GeoLibre-only leftovers.
+  it("consumes a matched GeoLibre tool once and preserves its source", () => {
+    // A GeoLibre-authored tool that also has a catalog stub must be merged once
+    // (never appended a second time via the GeoLibre-only leftovers), take the
+    // WASM manifest's params, and keep its "geolibre" source so the source
+    // filter still recognises it.
     const catalogStub: WhiteboxTool = {
       id: "write_geoparquet",
       display_name: "Write GeoParquet",
       params: [{ name: "input", kind: "vector_in", required: true }],
     };
-    const wasmEmptyParams: WhiteboxTool = {
+    const wasmTool: WhiteboxTool = {
       id: "write_geoparquet",
       source: "geolibre",
-      params: [],
+      params: [
+        { name: "input", data_kind: "vector", io_role: "input" },
+        { name: "compression", data_kind: "string" },
+      ],
     };
-    const merged = mergeWasmToolManifests([catalogStub], [wasmEmptyParams]);
+    const merged = mergeWasmToolManifests([catalogStub], [wasmTool]);
     assert.equal(
       merged.filter((tool) => tool.id === "write_geoparquet").length,
       1,
     );
-    // Falls back to the catalog params since the WASM manifest had none.
     assert.deepEqual(
       merged[0].params?.map((param) => param.name),
-      ["input"],
+      ["input", "compression"],
     );
+    assert.equal(merged[0].source, "geolibre");
+    // Catalog display metadata is retained.
+    assert.equal(merged[0].display_name, "Write GeoParquet");
   });
 
   it("does not append WASM-only Whitebox tools missing from the catalog", () => {

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   mergeWasmToolManifests,
+  normalizeVectorOutputFormat,
   type WhiteboxTool,
 } from "@geolibre/processing";
 
@@ -121,5 +122,22 @@ describe("mergeWasmToolManifests", () => {
     };
     const merged = mergeWasmToolManifests([], [wasmOnlyWhitebox]);
     assert.equal(merged.length, 0);
+  });
+});
+
+describe("normalizeVectorOutputFormat", () => {
+  it("passes through the known formats", () => {
+    for (const format of ["geojson", "geoparquet", "flatgeobuf", "shapefile"]) {
+      assert.equal(normalizeVectorOutputFormat(format), format);
+    }
+  });
+
+  it("falls back to geojson for a stale output path or bad value", () => {
+    // A leftover sidecar-mode path (or any non-format string/undefined) must not
+    // be treated as a format, else the WASM runner writes `..._output.undefined`.
+    assert.equal(normalizeVectorOutputFormat("/Users/me/output.shp"), "geojson");
+    assert.equal(normalizeVectorOutputFormat(""), "geojson");
+    assert.equal(normalizeVectorOutputFormat(undefined), "geojson");
+    assert.equal(normalizeVectorOutputFormat(42), "geojson");
   });
 });

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  mergeWasmToolManifests,
+  type WhiteboxTool,
+} from "@geolibre/processing";
+
+// The Whitebox catalog snapshot (from the Python sidecar) names reproject_vector's
+// destination-CRS parameter `dst_epsg` and carries sidecar-only extras. The WASM
+// binary's own manifest for the same tool validates `epsg` instead, so building
+// CLI args from the catalog fails with "parameter 'epsg' is required" (#1047).
+const catalogReprojectVector: WhiteboxTool = {
+  id: "reproject_vector",
+  display_name: "Reproject Vector",
+  category: "Projection and Georeferencing",
+  params: [
+    { name: "input", kind: "vector_in", required: true },
+    { name: "dst_epsg", kind: "int", required: true },
+    { name: "output", kind: "file_out", required: true },
+    { name: "failure_policy", kind: "string", required: false },
+    { name: "antimeridian_policy", kind: "string", required: false },
+  ],
+};
+
+const wasmReprojectVector: WhiteboxTool = {
+  id: "reproject_vector",
+  display_name: "Reproject Vector",
+  category: "Vector",
+  params: [
+    { name: "input", data_kind: "vector", io_role: "input", required: true },
+    { name: "epsg", data_kind: "number", required: true },
+    { name: "output", data_kind: "vector", io_role: "output", required: true },
+  ],
+};
+
+const geolibreOnlyTool: WhiteboxTool = {
+  id: "write_geoparquet",
+  display_name: "Write GeoParquet",
+  source: "geolibre",
+  params: [{ name: "input", data_kind: "vector", io_role: "input" }],
+};
+
+describe("mergeWasmToolManifests", () => {
+  it("replaces a catalog tool's params with the WASM manifest's", () => {
+    const merged = mergeWasmToolManifests(
+      [catalogReprojectVector],
+      [wasmReprojectVector],
+    );
+    const tool = merged.find((item) => item.id === "reproject_vector");
+    assert.ok(tool, "reproject_vector should still be present");
+    // The WASM binary's parameter names win, so args are built as `--epsg=...`.
+    assert.deepEqual(
+      tool.params?.map((param) => param.name),
+      ["input", "epsg", "output"],
+    );
+    // Catalog display metadata is preserved (only params are overridden).
+    assert.equal(tool.category, "Projection and Georeferencing");
+  });
+
+  it("keeps catalog params when the WASM binary lacks the tool", () => {
+    const merged = mergeWasmToolManifests([catalogReprojectVector], []);
+    const tool = merged.find((item) => item.id === "reproject_vector");
+    assert.deepEqual(
+      tool?.params?.map((param) => param.name),
+      ["input", "dst_epsg", "output", "failure_policy", "antimeridian_policy"],
+    );
+  });
+
+  it("appends GeoLibre-authored tools absent from the catalog", () => {
+    const merged = mergeWasmToolManifests(
+      [catalogReprojectVector],
+      [wasmReprojectVector, geolibreOnlyTool],
+    );
+    assert.ok(
+      merged.some((tool) => tool.id === "write_geoparquet"),
+      "GeoLibre-only tool should be appended",
+    );
+    // The WASM whitebox match is consumed, not duplicated as a WASM-only entry.
+    assert.equal(
+      merged.filter((tool) => tool.id === "reproject_vector").length,
+      1,
+    );
+  });
+
+  it("does not append WASM-only Whitebox tools missing from the catalog", () => {
+    const wasmOnlyWhitebox: WhiteboxTool = {
+      id: "some_wasm_only_whitebox_tool",
+      params: [{ name: "input", data_kind: "raster", io_role: "input" }],
+    };
+    const merged = mergeWasmToolManifests([], [wasmOnlyWhitebox]);
+    assert.equal(merged.length, 0);
+  });
+});

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -82,6 +82,32 @@ describe("mergeWasmToolManifests", () => {
     );
   });
 
+  it("does not duplicate a catalog tool when its WASM match has empty params", () => {
+    // A GeoLibre-authored tool that also has a catalog stub but whose WASM
+    // manifest reports no params must be consumed (kept once, catalog params),
+    // never appended a second time via the GeoLibre-only leftovers.
+    const catalogStub: WhiteboxTool = {
+      id: "write_geoparquet",
+      display_name: "Write GeoParquet",
+      params: [{ name: "input", kind: "vector_in", required: true }],
+    };
+    const wasmEmptyParams: WhiteboxTool = {
+      id: "write_geoparquet",
+      source: "geolibre",
+      params: [],
+    };
+    const merged = mergeWasmToolManifests([catalogStub], [wasmEmptyParams]);
+    assert.equal(
+      merged.filter((tool) => tool.id === "write_geoparquet").length,
+      1,
+    );
+    // Falls back to the catalog params since the WASM manifest had none.
+    assert.deepEqual(
+      merged[0].params?.map((param) => param.name),
+      ["input"],
+    );
+  });
+
   it("does not append WASM-only Whitebox tools missing from the catalog", () => {
     const wasmOnlyWhitebox: WhiteboxTool = {
       id: "some_wasm_only_whitebox_tool",


### PR DESCRIPTION
Fixes #1047.

## Problem

In the Whitebox toolbox with **Run locally (WASM)** enabled, running **Reproject Vector** failed with:

```
failed: validation error: parameter 'epsg' is required
```

even though the form showed a filled **Dst Epsg** field.

## Root cause

The toolbox built each tool's parameter form from the Python sidecar's **catalog snapshot**, whose parameter names can diverge from the in-browser **WASM binary** for the same tool id. For `reproject_vector` the catalog names the destination-CRS parameter `dst_epsg` (plus sidecar-only extras like `failure_policy`, `antimeridian_policy`), but the WASM tool validates a parameter named `epsg`. So GeoLibre passed `--dst_epsg=…` and the WASM binary rejected it.

## Fix

In local (WASM) mode, reconcile the two sources: the catalog still supplies the tool list, display names, and categories, but the **WASM binary's own manifests are now authoritative for each tool's parameters** (`mergeWasmToolManifests`). This corrects `reproject_vector` and any other tool whose WASM parameter set differs from the sidecar catalog, and still appends the GeoLibre-authored tools that never appear in the catalog.

Beneath the parameter mismatch there was a second, upstream bug: the WASM `reproject_vector` could not derive a source CRS from a plain GeoJSON layer (GeoJSON is EPSG:4326 by RFC 7946) and failed with `layer_to_epsg requires source CRS metadata`. That is fixed upstream and shipped in **geolibre-wasm 0.5.2**, which this PR bumps to:

- opengeos/whitebox-wasm#4 — default the GeoJSON reader's source CRS to EPSG:4326
- opengeos/geolibre-rust#32 — rebuild + release `geolibre-wasm` 0.5.2

## Verification

Drove the real app in the browser (dev build) on the `us_cities` sample GeoJSON layer, in **both light and dark themes**:

- Reproject Vector now shows the correct WASM params (**Input vector layer**, **Destination EPSG code**, **Output vector path**) instead of the catalog's `dst_epsg` / `failure_policy` / `antimeridian_policy`.
- Running it to **EPSG:7844** (the reporter's value) succeeds, writes `reproject_vector_output.geojson`, and adds the output layer to the map. No console errors.

Also added a unit test for `mergeWasmToolManifests`; full frontend suite (1740 tests) passes, eslint + npm build pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vector output format support for in-browser runs (GeoJSON, GeoParquet, FlatGeobuf, Shapefile) with a new selector and normalized request handling.
  * Local tool availability now combines the remote catalog with in-browser tool metadata for more consistent parameter definitions.
* **Bug Fixes**
  * Improved downloads for binary vector results, including CRS-preserving vector outputs and zipped Shapefile bundles.
  * Expanded downloadable binary format detection and enhanced handling when tool listings fail.
* **Tests**
  * Added coverage for merging catalog vs in-browser tool definitions and output-format normalization.
* **Chores**
  * Updated the in-browser processing dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->