### PR TITLE
feat(add-data): support OGC API vector tiles as a remote source

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -19,6 +19,7 @@ import { DelimitedTextSource } from "./add-data/sources/DelimitedTextSource";
 import { GeoRssSource } from "./add-data/sources/GeoRssSource";
 import { GpxSource } from "./add-data/sources/GpxSource";
 import { MbtilesSource } from "./add-data/sources/MbtilesSource";
+import { OgcVectorTilesSource } from "./add-data/sources/OgcVectorTilesSource";
 import { PhotosSource } from "./add-data/sources/PhotosSource";
 import { PostgresSource } from "./add-data/sources/PostgresSource";
 import { VideoSource } from "./add-data/sources/VideoSource";
@@ -60,6 +61,8 @@ function renderSource(
       return <WfsSource />;
     case "wmts":
       return <WmtsSource />;
+    case "ogc-vector-tiles":
+      return <OgcVectorTilesSource />;
     case "gpx":
       return <GpxSource />;
     case "georss":

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -19,6 +19,7 @@ export type KindI18nKey =
   | "wms"
   | "wfs"
   | "wmts"
+  | "ogcVectorTiles"
   | "gpx"
   | "georss"
   | "delimitedText"
@@ -40,6 +41,7 @@ export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
   wms: "wms",
   wfs: "wfs",
   wmts: "wmts",
+  "ogc-vector-tiles": "ogcVectorTiles",
   gpx: "gpx",
   georss: "georss",
   "delimited-text": "delimitedText",
@@ -61,6 +63,13 @@ export const DEFAULT_WFS_ENDPOINT = "https://ahocevar.com/geoserver/wfs";
 export const DEFAULT_WFS_TYPE_NAME = "topp:states";
 export const DEFAULT_WMTS_URL =
   "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/119/{z}/{y}/{x}";
+// PDOK BGT (Dutch large-scale base map) served as OGC API - Tiles vector tiles.
+// The style document carries the source-layer names the TileJSON omits; both
+// are prefilled so the sample works out of the box (zoom into the Netherlands).
+export const DEFAULT_OGC_VECTOR_TILES_URL =
+  "https://api.pdok.nl/lv/bgt/ogc/v1/tiles/WebMercatorQuad?f=tilejson";
+export const DEFAULT_OGC_VECTOR_TILES_STYLE_URL =
+  "https://api.pdok.nl/lv/bgt/ogc/v1/styles/bgt_standaardvisualisatie__webmercatorquad?f=mapbox";
 export const DEFAULT_GPX_URL =
   "https://data.source.coop/giswqs/opengeos/fells_loop.gpx";
 // USGS "Magnitude 2.5+ Earthquakes, Past Day" Atom feed (Simple georss:point).

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcVectorTilesSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcVectorTilesSource.tsx
@@ -1,0 +1,158 @@
+import { Input, Label } from "@geolibre/ui";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { resolveOgcVectorTiles } from "../../../../lib/ogc-vector-tiles";
+import {
+  DEFAULT_OGC_VECTOR_TILES_STYLE_URL,
+  DEFAULT_OGC_VECTOR_TILES_URL,
+} from "../constants";
+import { createBaseLayer } from "../helpers";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
+
+interface OgcSample {
+  tilesUrl: string;
+  styleUrl: string;
+}
+
+/**
+ * Adds an OGC API - Tiles (vector) source as a MapLibre vector layer. The user
+ * supplies a TileJSON metadata URL or a `{z}/{y}/{x}` MVT template, and may add
+ * a Mapbox/MapLibre style URL to discover the tileset's source layers (an OGC
+ * API TileJSON often omits them). Rendering uses GeoLibre's default per-source
+ * layer styling; the style's own paint is not applied.
+ */
+export function OgcVectorTilesSource() {
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.ogcVectorTiles.defaultName"));
+  const [tilesUrl, setTilesUrl] = useState("");
+  const [styleUrl, setStyleUrl] = useState("");
+  const [sourceLayersText, setSourceLayersText] = useState("");
+
+  const applySample = (sample: OgcSample) => {
+    setTilesUrl(sample.tilesUrl);
+    setStyleUrl(sample.styleUrl);
+    setSourceLayersText("");
+  };
+
+  const handleSubmit = source.runSubmit(async () => {
+    if (!tilesUrl.trim() && !styleUrl.trim()) {
+      throw new Error(t("addData.ogcVectorTiles.errorUrl"));
+    }
+    const manualLayers = sourceLayersText
+      .split(",")
+      .map((layer) => layer.trim())
+      .filter(Boolean);
+    const config = await resolveOgcVectorTiles({
+      tilesUrl: tilesUrl.trim(),
+      styleUrl: styleUrl.trim() || undefined,
+      sourceLayers: manualLayers,
+    });
+    if (!config.url && !(config.tiles && config.tiles.length > 0)) {
+      throw new Error(t("addData.ogcVectorTiles.errorNoTiles"));
+    }
+    if (config.sourceLayers.length === 0) {
+      throw new Error(t("addData.ogcVectorTiles.errorNoLayers"));
+    }
+    const name =
+      source.layerName.trim() ||
+      config.name ||
+      t("addData.ogcVectorTiles.defaultName");
+    source.addAndClose(
+      createBaseLayer(
+        name,
+        "vector-tiles",
+        {
+          type: "vector",
+          ...(config.url ? { url: config.url } : {}),
+          ...(config.tiles ? { tiles: config.tiles } : {}),
+          sourceLayer: config.sourceLayers[0],
+          sourceLayers: config.sourceLayers,
+          bounds: config.bounds,
+          minzoom: config.minzoom,
+          maxzoom: config.maxzoom,
+        },
+        {
+          bounds: config.bounds,
+          center: config.center,
+          minzoom: config.minzoom,
+          maxzoom: config.maxzoom,
+          sourceKind: "ogc-vector-tiles",
+          sourceLayers: config.sourceLayers,
+          tilesUrl: tilesUrl.trim() || undefined,
+          styleUrl: styleUrl.trim() || undefined,
+        },
+      ),
+      { fit: Boolean(config.bounds || config.center) },
+    );
+  });
+
+  return (
+    <AddDataSourceForm
+      layerName={source.layerName}
+      onLayerNameChange={source.setLayerName}
+      beforeLayerId={source.beforeLayerId}
+      onBeforeLayerIdChange={source.setBeforeLayerId}
+      onSubmit={handleSubmit}
+      error={source.error}
+      submitDisabled={source.isSubmitting}
+      useServiceIcon
+    >
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="ogc-vt-tiles-url">
+            {t("addData.ogcVectorTiles.tilesUrl")}
+          </Label>
+          <Input
+            id="ogc-vt-tiles-url"
+            placeholder={t("addData.ogcVectorTiles.tilesUrlPlaceholder")}
+            value={tilesUrl}
+            onChange={(event) => setTilesUrl(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("addData.ogcVectorTiles.tilesUrlHint")}
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ogc-vt-style-url">
+            {t("addData.ogcVectorTiles.styleUrl")}
+          </Label>
+          <Input
+            id="ogc-vt-style-url"
+            placeholder={t("addData.ogcVectorTiles.styleUrlPlaceholder")}
+            value={styleUrl}
+            onChange={(event) => setStyleUrl(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("addData.ogcVectorTiles.styleUrlHint")}
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="ogc-vt-source-layers">
+            {t("addData.ogcVectorTiles.sourceLayers")}
+          </Label>
+          <Input
+            id="ogc-vt-source-layers"
+            placeholder={t("addData.ogcVectorTiles.sourceLayersPlaceholder")}
+            value={sourceLayersText}
+            onChange={(event) => setSourceLayersText(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("addData.ogcVectorTiles.sourceLayersHint")}
+          </p>
+        </div>
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.ogcVectorTiles.sampleLabel"),
+              value: {
+                tilesUrl: DEFAULT_OGC_VECTOR_TILES_URL,
+                styleUrl: DEFAULT_OGC_VECTOR_TILES_STYLE_URL,
+              },
+            },
+          ]}
+          onSelect={applySample}
+        />
+      </div>
+    </AddDataSourceForm>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcVectorTilesSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcVectorTilesSource.tsx
@@ -1,5 +1,5 @@
 import { Input, Label } from "@geolibre/ui";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { resolveOgcVectorTiles } from "../../../../lib/ogc-vector-tiles";
 import {
@@ -28,6 +28,16 @@ export function OgcVectorTilesSource() {
   const [styleUrl, setStyleUrl] = useState("");
   const [sourceLayersText, setSourceLayersText] = useState("");
 
+  // Cancel the in-flight metadata/style/collections fetches if the dialog closes
+  // mid-request, so a slow response cannot add the layer after the user leaves.
+  const resolveAbortRef = useRef<AbortController | null>(null);
+  useEffect(
+    () => () => {
+      resolveAbortRef.current?.abort();
+    },
+    [],
+  );
+
   const applySample = (sample: OgcSample) => {
     setTilesUrl(sample.tilesUrl);
     setStyleUrl(sample.styleUrl);
@@ -42,11 +52,17 @@ export function OgcVectorTilesSource() {
       .split(",")
       .map((layer) => layer.trim())
       .filter(Boolean);
+    resolveAbortRef.current?.abort();
+    const controller = new AbortController();
+    resolveAbortRef.current = controller;
     const config = await resolveOgcVectorTiles({
       tilesUrl: tilesUrl.trim(),
       styleUrl: styleUrl.trim() || undefined,
       sourceLayers: manualLayers,
+      signal: controller.signal,
     });
+    // A superseded/cancelled request must not add a layer after the fact.
+    if (controller.signal.aborted) return;
     if (!config.url && !(config.tiles && config.tiles.length > 0)) {
       throw new Error(t("addData.ogcVectorTiles.errorNoTiles"));
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcVectorTilesSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcVectorTilesSource.tsx
@@ -82,7 +82,9 @@ export function OgcVectorTilesSource() {
           styleUrl: styleUrl.trim() || undefined,
         },
       ),
-      { fit: Boolean(config.bounds || config.center) },
+      // fitLayer resolves a vector-tiles layer only from bounds (it never reads
+      // `center` for this type), so only request a fit when bounds are known.
+      { fit: Boolean(config.bounds) },
     );
   });
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -7,6 +7,7 @@ export type AddDataKind =
   | "wms"
   | "wfs"
   | "wmts"
+  | "ogc-vector-tiles"
   | "gpx"
   | "georss"
   | "delimited-text"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -68,6 +68,9 @@ export function AddDataMenu({
     wms: { onSelect: () => onSetAddDataKind("wms") },
     wfs: { onSelect: () => onSetAddDataKind("wfs") },
     wmts: { onSelect: () => onSetAddDataKind("wmts") },
+    "ogc-vector-tiles": {
+      onSelect: () => onSetAddDataKind("ogc-vector-tiles"),
+    },
     arcgis: { onSelect: () => onSetAddDataKind("arcgis") },
     georss: { onSelect: () => onSetAddDataKind("georss") },
     stac: { onSelect: addLayer.stac },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -122,6 +122,10 @@
         "label": "Add WMTS Layer",
         "description": "Add a WMTS tile URL template as a raster layer."
       },
+      "ogcVectorTiles": {
+        "label": "Add OGC Vector Tiles Layer",
+        "description": "Add an OGC API - Tiles (vector) service from a TileJSON or tile template, optionally reading its source layers from a style URL."
+      },
       "gpx": {
         "label": "Add GPX Layer",
         "description": "Add GPX waypoints, routes, and tracks as one or more vector layers."
@@ -267,6 +271,22 @@
       "sampleLabel": "World imagery (Wayback)",
       "errorUrl": "Enter a WMTS tile URL template.",
       "urlPlaceholder": "https://example.com/wmts/{z}/{y}/{x}.png"
+    },
+    "ogcVectorTiles": {
+      "defaultName": "OGC Vector Tiles Layer",
+      "tilesUrl": "Tiles URL",
+      "tilesUrlPlaceholder": "https://example.com/tiles/WebMercatorQuad?f=tilejson",
+      "tilesUrlHint": "A TileJSON metadata URL or a {z}/{y}/{x} MVT tile template.",
+      "styleUrl": "Style URL",
+      "styleUrlPlaceholder": "https://example.com/styles/default?f=mapbox",
+      "styleUrlHint": "Optional Mapbox/MapLibre style JSON. Used to discover the tileset's source layers when the TileJSON omits them.",
+      "sourceLayers": "Source layers",
+      "sourceLayersPlaceholder": "layer_a, layer_b",
+      "sourceLayersHint": "Optional comma-separated source layer names. Overrides the layers found in the TileJSON or style.",
+      "sampleLabel": "PDOK BGT (Netherlands)",
+      "errorUrl": "Enter a tiles URL or a style URL.",
+      "errorNoTiles": "Could not determine the vector tile endpoint. Enter a TileJSON URL, a tile template, or a style URL.",
+      "errorNoLayers": "Could not determine the vector tile source layers. Add a style URL or enter the source layer names."
     },
     "arcgis": {
       "defaultName": "ArcGIS Layer",
@@ -1370,6 +1390,7 @@
       "wms": "WMS Layer",
       "wfs": "WFS Layer",
       "wmts": "WMTS Layer",
+      "ogcVectorTiles": "OGC Vector Tiles Layer",
       "arcgis": "ArcGIS Layer",
       "georss": "GeoRSS Layer",
       "video": "Video Layer",

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -165,25 +165,82 @@ export function tileJsonConfig(
   if (typeof tilejson.maxzoom === "number") config.maxzoom = tilejson.maxzoom;
   const bounds = asBounds(tilejson.bounds);
   if (bounds) config.bounds = bounds;
-  if (Array.isArray(tilejson.center)) {
-    config.center = tilejson.center.filter(
-      (value): value is number => typeof value === "number",
-    );
+  // A TileJSON `center` is `[lng, lat]` or `[lng, lat, zoom]`; reject anything
+  // else so non-finite or malformed values never reach the layer metadata.
+  const center = tilejson.center;
+  if (
+    Array.isArray(center) &&
+    (center.length === 2 || center.length === 3) &&
+    center.every((value) => typeof value === "number" && Number.isFinite(value))
+  ) {
+    config.center = center as number[];
   }
   const sourceLayers = vectorLayerIds(tilejson);
   if (sourceLayers.length > 0) config.sourceLayers = sourceLayers;
   return config;
 }
 
-/** Fetches and parses a remote JSON document, working around cross-origin limits. */
+/** Lowercases `{z}`/`{x}`/`{y}` so MapLibre's case-sensitive tile substitution
+ * works: an uppercase-placeholder template would otherwise be requested
+ * verbatim and silently fail to load. */
+function normalizeTilePlaceholders(url: string): string {
+  return url
+    .replace(/\{z\}/gi, "{z}")
+    .replace(/\{x\}/gi, "{x}")
+    .replace(/\{y\}/gi, "{y}");
+}
+
+/** A promise that rejects when the signal aborts, with its abort reason. Used to
+ * race an uncancellable Tauri invoke against the caller's abort and a timeout. */
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
+}
+
+/** Converts opaque fetch/abort failures into a clear, user-facing Error so the
+ * Add Data dialog surfaces the real cause instead of a generic fallback. */
+function normalizeFetchError(error: unknown): Error {
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return new Error("The request timed out.");
+  }
+  // A CORS/network rejection surfaces as a bare TypeError with no status.
+  if (error instanceof TypeError) {
+    return new Error(
+      "Could not reach the service. It may not allow cross-origin requests from the browser; try the desktop app.",
+    );
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Fetches and parses a remote JSON document, working around cross-origin limits.
+ * The Tauri path uses the Rust `fetch_url_bytes` command (not subject to browser
+ * CORS); the dev server routes through the same-origin proxy; the hosted web
+ * build fetches directly. All paths honor the caller's abort signal and a 30s
+ * timeout so an unresponsive OGC endpoint cannot hang the Add Data form.
+ */
 async function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  const timeout = AbortSignal.timeout(30_000);
+  const abort = signal ? AbortSignal.any([signal, timeout]) : timeout;
   if (isTauri()) {
-    // The Rust `fetch_url_bytes` command is not subject to browser CORS, so any
-    // OGC service works from the desktop app.
+    // `fetch_url_bytes` cannot be cancelled mid-flight, so race it against the
+    // abort/timeout to still return promptly on a slow or hung host.
     const { invoke } = await import("@tauri-apps/api/core");
-    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", { url });
-    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-    return JSON.parse(new TextDecoder().decode(array));
+    try {
+      const bytes = await Promise.race([
+        invoke<number[] | Uint8Array>("fetch_url_bytes", { url }),
+        rejectOnAbort(abort),
+      ]);
+      const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+      return JSON.parse(new TextDecoder().decode(array));
+    } catch (error) {
+      throw normalizeFetchError(error);
+    }
   }
   const isDev = Boolean(
     (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV,
@@ -191,10 +248,12 @@ async function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown>
   const fetchUrl = isDev
     ? `${OGC_PROXY_PATH}?url=${encodeURIComponent(url)}`
     : url;
-  const timeout = AbortSignal.timeout(30_000);
-  const response = await fetch(fetchUrl, {
-    signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
-  });
+  let response: Response;
+  try {
+    response = await fetch(fetchUrl, { signal: abort });
+  } catch (error) {
+    throw normalizeFetchError(error);
+  }
   if (!response.ok) {
     throw new Error(`Request failed with status ${response.status}`);
   }
@@ -225,7 +284,7 @@ export async function resolveOgcVectorTiles(input: {
 
   if (tilesUrl) {
     if (hasTilePlaceholders(tilesUrl)) {
-      config.tiles = [tilesUrl];
+      config.tiles = [normalizeTilePlaceholders(tilesUrl)];
     } else {
       const tilejson = (await fetchOgcJson(
         tilesUrl,
@@ -238,9 +297,13 @@ export async function resolveOgcVectorTiles(input: {
   if (styleUrl) {
     const style = (await fetchOgcJson(styleUrl, input.signal)) as StyleLike;
     const vector = firstVectorSource(style);
-    if (config.sourceLayers.length === 0) {
-      config.sourceLayers = styleSourceLayers(style, vector?.id);
-    }
+    // A provided style is authoritative for the layers it references, so its
+    // source layers take precedence over the TileJSON's `vector_layers` (the
+    // documented manual > style > TileJSON order). An explicit manual list
+    // still wins below. When the style references none, keep what the TileJSON
+    // advertised rather than blanking the layer.
+    const layerNames = styleSourceLayers(style, vector?.id);
+    if (layerNames.length > 0) config.sourceLayers = layerNames;
     if (!config.name && typeof style.name === "string") {
       config.name = style.name;
     }
@@ -249,7 +312,7 @@ export async function resolveOgcVectorTiles(input: {
       if (typeof vector.source.url === "string") {
         config.url = vector.source.url;
       } else {
-        config.tiles = asTiles(vector.source.tiles);
+        config.tiles = asTiles(vector.source.tiles)?.map(normalizeTilePlaceholders);
       }
       if (config.minzoom === undefined && typeof vector.source.minzoom === "number") {
         config.minzoom = vector.source.minzoom;
@@ -265,6 +328,9 @@ export async function resolveOgcVectorTiles(input: {
   if (input.sourceLayers && input.sourceLayers.length > 0) {
     config.sourceLayers = input.sourceLayers;
   }
+  // Defensive: `sourceLayers` is always an array above, but guarantee it so the
+  // dialog can safely read `.length` on the "no source layers" path.
+  if (!Array.isArray(config.sourceLayers)) config.sourceLayers = [];
 
   return config;
 }

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -110,10 +110,13 @@ export function unionCollectionBounds(
       collection as { extent?: { spatial?: { crs?: unknown; bbox?: unknown } } }
     )?.extent?.spatial;
     if (!spatial || !isLonLatCrs(spatial.crs)) continue;
-    // `bbox` is an array of boxes; the first is the overall extent.
+    // `bbox` is an array of boxes; the first is the overall extent. A box that
+    // crosses the antimeridian (west > east) is not handled: the plain min/max
+    // union below would widen it the wrong way, so skip it rather than produce
+    // a bogus world-spanning extent.
     const box = Array.isArray(spatial.bbox) ? spatial.bbox[0] : undefined;
     const bounds = asBounds(box);
-    if (!bounds) continue;
+    if (!bounds || bounds[0] > bounds[2]) continue;
     west = Math.min(west, bounds[0]);
     south = Math.min(south, bounds[1]);
     east = Math.max(east, bounds[2]);
@@ -131,11 +134,15 @@ export function unionCollectionBounds(
  * undefined on any failure so it cannot block adding the layer.
  *
  * @param tilesUrl - A tiles URL or template that contains `/tiles/`.
- * @param signal - An optional abort signal for the request.
+ * @param signal - The abort signal (caller + overall deadline) for the request.
+ * @param callerSignal - The caller's own signal; a caller abort is rethrown so a
+ *   cancelled add-data request cannot still add the layer, while network and
+ *   timeout failures are swallowed (bounds are best-effort).
  */
 async function fetchOgcCollectionsBounds(
   tilesUrl: string,
   signal?: AbortSignal,
+  callerSignal?: AbortSignal,
 ): Promise<[number, number, number, number] | undefined> {
   const withoutQuery = tilesUrl.split("?")[0];
   const marker = "/tiles/";
@@ -154,13 +161,19 @@ async function fetchOgcCollectionsBounds(
       collections?: unknown;
     };
     return unionCollectionBounds(doc?.collections);
-  } catch {
+  } catch (error) {
+    if (callerSignal?.aborted) throw error;
     return undefined;
   }
 }
 
 /**
  * The first `type: "vector"` source in a style document, with its id.
+ *
+ * Heuristic: OGC API styles usually declare a single vector source (the
+ * tileset), so the first one is it. A style that bundles several vector sources
+ * (e.g. a basemap alongside the tileset) cannot be disambiguated here; the
+ * user can then enter the source layers manually to override.
  *
  * @param style - A parsed Mapbox/MapLibre style document.
  * @returns The source and its key, or null when the style has no vector source.
@@ -299,21 +312,22 @@ function normalizeFetchError(error: unknown): Error {
  * Fetches and parses a remote JSON document, working around cross-origin limits.
  * The Tauri path uses the Rust `fetch_url_bytes` command (not subject to browser
  * CORS); the dev server routes through the same-origin proxy; the hosted web
- * build fetches directly. All paths honor the caller's abort signal and a 30s
- * timeout so an unresponsive OGC endpoint cannot hang the Add Data form.
+ * build fetches directly. When the caller passes a `signal` it owns the deadline
+ * (see `resolveOgcVectorTiles`, which shares one across its requests); otherwise
+ * a 30s timeout is applied so an unresponsive endpoint cannot hang forever.
  */
 async function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown> {
-  const timeout = AbortSignal.timeout(30_000);
-  const abort = signal ? AbortSignal.any([signal, timeout]) : timeout;
+  const abort = signal ?? AbortSignal.timeout(30_000);
   if (isTauri()) {
     // `fetch_url_bytes` cannot be cancelled mid-flight, so race it against the
     // abort/timeout to still return promptly on a slow or hung host.
     const { invoke } = await import("@tauri-apps/api/core");
+    const bytesPromise = invoke<number[] | Uint8Array>("fetch_url_bytes", { url });
+    // If the abort/timeout wins the race, the invoke promise is left unobserved;
+    // swallow a later rejection so it does not surface as an unhandled rejection.
+    bytesPromise.catch(() => {});
     try {
-      const bytes = await Promise.race([
-        invoke<number[] | Uint8Array>("fetch_url_bytes", { url }),
-        rejectOnAbort(abort),
-      ]);
+      const bytes = await Promise.race([bytesPromise, rejectOnAbort(abort)]);
       const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
       return JSON.parse(new TextDecoder().decode(array));
     } catch (error) {
@@ -360,20 +374,34 @@ export async function resolveOgcVectorTiles(input: {
   const styleUrl = input.styleUrl?.trim();
   let config: OgcVectorTilesConfig = { sourceLayers: [] };
 
-  if (tilesUrl) {
-    if (hasTilePlaceholders(tilesUrl)) {
-      config.tiles = [normalizeTilePlaceholders(tilesUrl)];
-    } else {
-      const tilejson = (await fetchOgcJson(
-        tilesUrl,
-        input.signal,
-      )) as Record<string, unknown>;
-      config = { ...config, ...tileJsonConfig(tilejson, tilesUrl) };
-    }
+  // One overall deadline shared across every request (the TileJSON, the style,
+  // and the best-effort collections lookup) so a merely-slow host cannot make
+  // the sequential lookups add up to several times the intended 30s.
+  const deadline = AbortSignal.timeout(30_000);
+  const signal = input.signal
+    ? AbortSignal.any([input.signal, deadline])
+    : deadline;
+
+  // The TileJSON and style documents are independent, so fetch them together
+  // rather than back to back (the built-in sample fills in both). A raw tile
+  // template needs no fetch.
+  const isTemplate = tilesUrl !== "" && hasTilePlaceholders(tilesUrl);
+  const [tilejsonDoc, styleDoc] = await Promise.all([
+    tilesUrl && !isTemplate ? fetchOgcJson(tilesUrl, signal) : Promise.resolve(null),
+    styleUrl ? fetchOgcJson(styleUrl, signal) : Promise.resolve(null),
+  ]);
+
+  if (isTemplate) {
+    config.tiles = [normalizeTilePlaceholders(tilesUrl)];
+  } else if (tilejsonDoc) {
+    config = {
+      ...config,
+      ...tileJsonConfig(tilejsonDoc as Record<string, unknown>, tilesUrl),
+    };
   }
 
-  if (styleUrl) {
-    const style = (await fetchOgcJson(styleUrl, input.signal)) as StyleLike;
+  if (styleDoc) {
+    const style = styleDoc as StyleLike;
     const vector = firstVectorSource(style);
     // A provided style is authoritative for the layers it references, so its
     // source layers take precedence over the TileJSON's `vector_layers` (the
@@ -385,13 +413,21 @@ export async function resolveOgcVectorTiles(input: {
     if (!config.name && typeof style.name === "string") {
       config.name = style.name;
     }
-    // Fall back to the style's own vector source when no tiles input was given.
-    if (!config.url && !config.tiles && vector) {
-      if (typeof vector.source.url === "string") {
-        config.url = vector.source.url;
-      } else {
-        config.tiles = asTiles(vector.source.tiles)?.map(normalizeTilePlaceholders);
+    if (vector) {
+      // Fall back to the style's own vector source only when no tiles input was
+      // given...
+      if (!config.url && !config.tiles) {
+        if (typeof vector.source.url === "string") {
+          config.url = vector.source.url;
+        } else {
+          config.tiles = asTiles(vector.source.tiles)?.map(
+            normalizeTilePlaceholders,
+          );
+        }
       }
+      // ...but always fill a missing zoom range / bounds from the style, even
+      // when the tiles came from a raw template that carries none, so MapLibre
+      // does not request tiles outside the levels the endpoint serves.
       if (config.minzoom === undefined && typeof vector.source.minzoom === "number") {
         config.minzoom = vector.source.minzoom;
       }
@@ -412,11 +448,18 @@ export async function resolveOgcVectorTiles(input: {
 
   // An OGC API TileJSON frequently omits `bounds`, which leaves zoom-to-layer
   // with nothing to fit. Fall back to the collections extent so the layer can
-  // still be framed on the map.
+  // still be framed. Only attempt it for a metadata-style URL (no `{z}/{x}/{y}`
+  // placeholders): a raw XYZ template that merely contains `/tiles/` is very
+  // unlikely to be an OGC API service, so probing `/collections` would just be
+  // a wasted request to a third-party host.
   if (!config.bounds) {
     const reference = tilesUrl || config.url || config.tiles?.[0];
-    if (reference && reference.includes("/tiles/")) {
-      config.bounds = await fetchOgcCollectionsBounds(reference, input.signal);
+    if (reference && !hasTilePlaceholders(reference) && reference.includes("/tiles/")) {
+      config.bounds = await fetchOgcCollectionsBounds(
+        reference,
+        signal,
+        input.signal,
+      );
     }
   }
 

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -81,6 +81,84 @@ function asTiles(value: unknown): string[] | undefined {
   return tiles.length > 0 ? tiles : undefined;
 }
 
+/** Whether an OGC `extent.spatial.crs` is lon/lat (CRS84/EPSG:4326). The OGC API
+ * default when the field is absent is CRS84, so undefined counts as lon/lat. */
+function isLonLatCrs(crs: unknown): boolean {
+  if (crs === undefined || crs === null) return true;
+  return typeof crs === "string" && /CRS84|4326/i.test(crs);
+}
+
+/**
+ * The `[west, south, east, north]` union of an OGC API collections list, using
+ * each collection's `extent.spatial.bbox` (only when advertised in lon/lat).
+ *
+ * @param collections - The `collections` array from an OGC API document, or a
+ *   single collection wrapped in an array.
+ * @returns The union bounds, or undefined when none are usable.
+ */
+export function unionCollectionBounds(
+  collections: unknown,
+): [number, number, number, number] | undefined {
+  if (!Array.isArray(collections)) return undefined;
+  let west = Infinity;
+  let south = Infinity;
+  let east = -Infinity;
+  let north = -Infinity;
+  let found = false;
+  for (const collection of collections) {
+    const spatial = (
+      collection as { extent?: { spatial?: { crs?: unknown; bbox?: unknown } } }
+    )?.extent?.spatial;
+    if (!spatial || !isLonLatCrs(spatial.crs)) continue;
+    // `bbox` is an array of boxes; the first is the overall extent.
+    const box = Array.isArray(spatial.bbox) ? spatial.bbox[0] : undefined;
+    const bounds = asBounds(box);
+    if (!bounds) continue;
+    west = Math.min(west, bounds[0]);
+    south = Math.min(south, bounds[1]);
+    east = Math.max(east, bounds[2]);
+    north = Math.max(north, bounds[3]);
+    found = true;
+  }
+  return found ? [west, south, east, north] : undefined;
+}
+
+/**
+ * Best-effort discovery of a tileset's geographic extent from the OGC API
+ * collections metadata, used for zoom-to-layer when the TileJSON advertises no
+ * `bounds`. Derives the API base by stripping the `/tiles/...` suffix from the
+ * tiles URL, then reads the collection(s) extent. Never throws; returns
+ * undefined on any failure so it cannot block adding the layer.
+ *
+ * @param tilesUrl - A tiles URL or template that contains `/tiles/`.
+ * @param signal - An optional abort signal for the request.
+ */
+async function fetchOgcCollectionsBounds(
+  tilesUrl: string,
+  signal?: AbortSignal,
+): Promise<[number, number, number, number] | undefined> {
+  const withoutQuery = tilesUrl.split("?")[0];
+  const marker = "/tiles/";
+  const index = withoutQuery.indexOf(marker);
+  if (index === -1) return undefined;
+  const base = withoutQuery.slice(0, index);
+  try {
+    // Single-collection tileset (.../collections/{id}/tiles/...): the collection
+    // resource itself carries the extent. Otherwise it is a multi-collection
+    // (map) tileset, whose sibling /collections lists every collection.
+    if (/\/collections\/[^/]+$/.test(base)) {
+      const collection = await fetchOgcJson(`${base}?f=json`, signal);
+      return unionCollectionBounds([collection]);
+    }
+    const doc = (await fetchOgcJson(`${base}/collections?f=json`, signal)) as {
+      collections?: unknown;
+    };
+    return unionCollectionBounds(doc?.collections);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * The first `type: "vector"` source in a style document, with its id.
  *
@@ -331,6 +409,16 @@ export async function resolveOgcVectorTiles(input: {
   // Defensive: `sourceLayers` is always an array above, but guarantee it so the
   // dialog can safely read `.length` on the "no source layers" path.
   if (!Array.isArray(config.sourceLayers)) config.sourceLayers = [];
+
+  // An OGC API TileJSON frequently omits `bounds`, which leaves zoom-to-layer
+  // with nothing to fit. Fall back to the collections extent so the layer can
+  // still be framed on the map.
+  if (!config.bounds) {
+    const reference = tilesUrl || config.url || config.tiles?.[0];
+    if (reference && reference.includes("/tiles/")) {
+      config.bounds = await fetchOgcCollectionsBounds(reference, input.signal);
+    }
+  }
 
   return config;
 }

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -1,0 +1,270 @@
+/**
+ * Helpers for adding an OGC API - Tiles (vector) source as a MapLibre vector
+ * layer. The user points at either a TileJSON metadata document or a
+ * `{z}/{y}/{x}` MVT tile template, and optionally a Mapbox/MapLibre style
+ * document that names the tileset's source layers.
+ *
+ * A MapLibre vector source can only be drawn once its `source-layer` names are
+ * known, but an OGC API TileJSON commonly omits `vector_layers`. So the source
+ * layers are resolved in priority order: an explicit manual list, then the
+ * distinct `source-layer` values referenced by the style document, then the
+ * TileJSON's `vector_layers` ids.
+ */
+
+import { isTauri } from "./is-tauri";
+
+/** Dev-server CORS proxy path; kept in sync with GPX_PROXY_PATH in vite.config.ts. */
+const OGC_PROXY_PATH = "/__geolibre_gpx_proxy";
+
+/** The resolved configuration for an OGC API vector tiles layer. */
+export interface OgcVectorTilesConfig {
+  /** A suggested layer name from the tileset/style metadata, if any. */
+  name?: string;
+  /** A TileJSON URL for MapLibre to load the source from. */
+  url?: string;
+  /** Explicit `{z}/{x}/{y}` tile templates, used when no TileJSON URL applies. */
+  tiles?: string[];
+  minzoom?: number;
+  maxzoom?: number;
+  bounds?: [number, number, number, number];
+  center?: number[];
+  /** The vector source layers to draw. */
+  sourceLayers: string[];
+}
+
+interface StyleLike {
+  name?: unknown;
+  sources?: unknown;
+  layers?: unknown;
+}
+
+interface VectorSourceLike {
+  type?: unknown;
+  url?: unknown;
+  tiles?: unknown;
+  minzoom?: unknown;
+  maxzoom?: unknown;
+  bounds?: unknown;
+}
+
+/**
+ * Whether a URL is a directly usable MapLibre tile template (has `{z}`, `{x}`,
+ * and `{y}` placeholders) rather than a TileJSON metadata URL. OGC API
+ * templates that use `{tileMatrix}/{tileRow}/{tileCol}` are not MapLibre
+ * compatible and are treated as metadata URLs (a fetch that then fails clearly).
+ */
+export function hasTilePlaceholders(url: string): boolean {
+  const lower = url.toLowerCase();
+  return (
+    lower.includes("{z}") && lower.includes("{x}") && lower.includes("{y}")
+  );
+}
+
+/** A `[west, south, east, north]` tuple, if `value` looks like one. */
+function asBounds(value: unknown): [number, number, number, number] | undefined {
+  if (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((n) => typeof n === "number" && Number.isFinite(n))
+  ) {
+    return value as [number, number, number, number];
+  }
+  return undefined;
+}
+
+/** Non-empty string tile templates from an unknown `tiles` value. */
+function asTiles(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const tiles = value.filter(
+    (tile): tile is string => typeof tile === "string" && tile.length > 0,
+  );
+  return tiles.length > 0 ? tiles : undefined;
+}
+
+/**
+ * The first `type: "vector"` source in a style document, with its id.
+ *
+ * @param style - A parsed Mapbox/MapLibre style document.
+ * @returns The source and its key, or null when the style has no vector source.
+ */
+export function firstVectorSource(
+  style: StyleLike,
+): { id: string; source: VectorSourceLike } | null {
+  if (!style.sources || typeof style.sources !== "object") return null;
+  for (const [id, source] of Object.entries(
+    style.sources as Record<string, unknown>,
+  )) {
+    if (
+      source &&
+      typeof source === "object" &&
+      (source as VectorSourceLike).type === "vector"
+    ) {
+      return { id, source: source as VectorSourceLike };
+    }
+  }
+  return null;
+}
+
+/**
+ * The distinct, non-empty `source-layer` values referenced by a style's layers,
+ * in first-seen order.
+ *
+ * @param style - A parsed Mapbox/MapLibre style document.
+ * @param sourceId - When given, only layers bound to this source are considered.
+ * @returns The referenced source-layer names.
+ */
+export function styleSourceLayers(style: StyleLike, sourceId?: string): string[] {
+  if (!Array.isArray(style.layers)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const layer of style.layers) {
+    if (!layer || typeof layer !== "object") continue;
+    const entry = layer as { "source-layer"?: unknown; source?: unknown };
+    if (sourceId !== undefined && entry.source !== sourceId) continue;
+    const sourceLayer = entry["source-layer"];
+    if (
+      typeof sourceLayer === "string" &&
+      sourceLayer.length > 0 &&
+      !seen.has(sourceLayer)
+    ) {
+      seen.add(sourceLayer);
+      result.push(sourceLayer);
+    }
+  }
+  return result;
+}
+
+/** The `id` strings from a TileJSON `vector_layers`/`vectorLayers` array. */
+function vectorLayerIds(tilejson: Record<string, unknown>): string[] {
+  const layers = tilejson.vector_layers ?? tilejson.vectorLayers;
+  if (!Array.isArray(layers)) return [];
+  return layers
+    .map((layer) =>
+      layer && typeof layer === "object"
+        ? (layer as { id?: unknown }).id
+        : undefined,
+    )
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+/**
+ * Builds a partial config from a parsed TileJSON document. MapLibre is handed
+ * the TileJSON URL directly (it re-reads `tiles`/zoom), so `url` is set to the
+ * metadata URL rather than the inner tile templates.
+ *
+ * @param tilejson - The parsed TileJSON document.
+ * @param tilejsonUrl - The URL the document was fetched from.
+ */
+export function tileJsonConfig(
+  tilejson: Record<string, unknown>,
+  tilejsonUrl: string,
+): Partial<OgcVectorTilesConfig> {
+  const config: Partial<OgcVectorTilesConfig> = { url: tilejsonUrl };
+  if (typeof tilejson.name === "string") config.name = tilejson.name;
+  if (typeof tilejson.minzoom === "number") config.minzoom = tilejson.minzoom;
+  if (typeof tilejson.maxzoom === "number") config.maxzoom = tilejson.maxzoom;
+  const bounds = asBounds(tilejson.bounds);
+  if (bounds) config.bounds = bounds;
+  if (Array.isArray(tilejson.center)) {
+    config.center = tilejson.center.filter(
+      (value): value is number => typeof value === "number",
+    );
+  }
+  const sourceLayers = vectorLayerIds(tilejson);
+  if (sourceLayers.length > 0) config.sourceLayers = sourceLayers;
+  return config;
+}
+
+/** Fetches and parses a remote JSON document, working around cross-origin limits. */
+async function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  if (isTauri()) {
+    // The Rust `fetch_url_bytes` command is not subject to browser CORS, so any
+    // OGC service works from the desktop app.
+    const { invoke } = await import("@tauri-apps/api/core");
+    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", { url });
+    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return JSON.parse(new TextDecoder().decode(array));
+  }
+  const isDev = Boolean(
+    (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV,
+  );
+  const fetchUrl = isDev
+    ? `${OGC_PROXY_PATH}?url=${encodeURIComponent(url)}`
+    : url;
+  const timeout = AbortSignal.timeout(30_000);
+  const response = await fetch(fetchUrl, {
+    signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Resolves the configuration for an OGC API vector tiles layer from the URLs the
+ * user provided, fetching the TileJSON and/or style document as needed.
+ *
+ * @param input.tilesUrl - A TileJSON metadata URL or a `{z}/{x}/{y}` template.
+ * @param input.styleUrl - An optional Mapbox/MapLibre style URL, used to derive
+ *   the tileset (when `tilesUrl` is blank) and its source layers.
+ * @param input.sourceLayers - An optional manual list of source layers that
+ *   overrides whatever the documents advertise.
+ * @param input.signal - An optional abort signal for the network requests.
+ * @returns The resolved source config to build a `vector-tiles` layer from.
+ */
+export async function resolveOgcVectorTiles(input: {
+  tilesUrl: string;
+  styleUrl?: string;
+  sourceLayers?: string[];
+  signal?: AbortSignal;
+}): Promise<OgcVectorTilesConfig> {
+  const tilesUrl = input.tilesUrl.trim();
+  const styleUrl = input.styleUrl?.trim();
+  let config: OgcVectorTilesConfig = { sourceLayers: [] };
+
+  if (tilesUrl) {
+    if (hasTilePlaceholders(tilesUrl)) {
+      config.tiles = [tilesUrl];
+    } else {
+      const tilejson = (await fetchOgcJson(
+        tilesUrl,
+        input.signal,
+      )) as Record<string, unknown>;
+      config = { ...config, ...tileJsonConfig(tilejson, tilesUrl) };
+    }
+  }
+
+  if (styleUrl) {
+    const style = (await fetchOgcJson(styleUrl, input.signal)) as StyleLike;
+    const vector = firstVectorSource(style);
+    if (config.sourceLayers.length === 0) {
+      config.sourceLayers = styleSourceLayers(style, vector?.id);
+    }
+    if (!config.name && typeof style.name === "string") {
+      config.name = style.name;
+    }
+    // Fall back to the style's own vector source when no tiles input was given.
+    if (!config.url && !config.tiles && vector) {
+      if (typeof vector.source.url === "string") {
+        config.url = vector.source.url;
+      } else {
+        config.tiles = asTiles(vector.source.tiles);
+      }
+      if (config.minzoom === undefined && typeof vector.source.minzoom === "number") {
+        config.minzoom = vector.source.minzoom;
+      }
+      if (config.maxzoom === undefined && typeof vector.source.maxzoom === "number") {
+        config.maxzoom = vector.source.maxzoom;
+      }
+      const bounds = asBounds(vector.source.bounds);
+      if (!config.bounds && bounds) config.bounds = bounds;
+    }
+  }
+
+  if (input.sourceLayers && input.sourceLayers.length > 0) {
+    config.sourceLayers = input.sourceLayers;
+  }
+
+  return config;
+}

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -96,6 +96,7 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   { id: "wms", section: "webServices", labelKey: "toolbar.layerType.wms", tier: "basic" },
   { id: "wfs", section: "webServices", labelKey: "toolbar.layerType.wfs", tier: "intermediate" },
   { id: "wmts", section: "webServices", labelKey: "toolbar.layerType.wmts", tier: "intermediate" },
+  { id: "ogc-vector-tiles", section: "webServices", labelKey: "toolbar.layerType.ogcVectorTiles", tier: "intermediate" },
   { id: "arcgis", section: "webServices", labelKey: "toolbar.layerType.arcgis", tier: "intermediate" },
   { id: "georss", section: "webServices", labelKey: "toolbar.layerType.georss", tier: "intermediate" },
   { id: "stac", section: "webServices", labelKey: "toolbar.item.stacLayer", tier: "advanced" },

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -2187,9 +2187,34 @@ function syncVectorTileLayer(
 ): void {
   const src = sourceId(layer.id);
   const url = layer.source.url as string | undefined;
-  if (!url) return;
+  // OGC API tilesets (and any raw tile template) are added from `tiles` when no
+  // TileJSON URL is available; MapLibre then needs the zoom range up front so it
+  // does not request tiles outside the tileset's advertised levels.
+  const tiles = Array.isArray(layer.source.tiles)
+    ? (layer.source.tiles as unknown[]).filter(
+        (tile): tile is string => typeof tile === "string" && tile.length > 0,
+      )
+    : undefined;
+  if (!url && !(tiles && tiles.length > 0)) return;
   if (!map.getSource(src)) {
-    map.addSource(src, { type: "vector", url });
+    if (url) {
+      map.addSource(src, { type: "vector", url });
+    } else {
+      const bounds = layer.source.bounds;
+      map.addSource(src, {
+        type: "vector",
+        tiles: tiles as string[],
+        ...(typeof layer.source.minzoom === "number"
+          ? { minzoom: layer.source.minzoom }
+          : {}),
+        ...(typeof layer.source.maxzoom === "number"
+          ? { maxzoom: layer.source.maxzoom }
+          : {}),
+        ...(Array.isArray(bounds) && bounds.length === 4
+          ? { bounds: bounds as [number, number, number, number] }
+          : {}),
+      });
+    }
   }
   const visibility = layer.visible ? "visible" : "none";
   const sourceLayers = getVectorTileSourceLayers(layer);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -943,13 +943,38 @@ export class MapController {
       this.getLayerMetadataBounds(layer) ??
       this.getLayerSourceBounds(layer);
     if (!bounds || !this.map) return;
-    this.map.fitBounds(
-      [
-        [bounds[0], bounds[1]],
-        [bounds[2], bounds[3]],
-      ],
-      { padding: 40, duration: 800 },
-    );
+    const box: [[number, number], [number, number]] = [
+      [bounds[0], bounds[1]],
+      [bounds[2], bounds[3]],
+    ];
+    // Tile layers only carry data from their source `minzoom` up (e.g. an OGC
+    // API vector tileset served only at z17). Fitting the whole extent would
+    // land far below that zoom and render nothing, so when the fit is too far
+    // out, fly to the extent center at the layer's minimum render zoom instead.
+    const minRenderZoom = this.getLayerMinRenderZoom(layer);
+    if (minRenderZoom !== null) {
+      const camera = this.map.cameraForBounds(box, { padding: 40 });
+      if (camera?.center && typeof camera.zoom === "number" && camera.zoom < minRenderZoom) {
+        this.map.flyTo({
+          center: camera.center,
+          zoom: minRenderZoom,
+          duration: 800,
+        });
+        return;
+      }
+    }
+    this.map.fitBounds(box, { padding: 40, duration: 800 });
+  }
+
+  /** The layer's minimum render zoom (its tile source `minzoom`), if advertised
+   * — the zoom below which a tile source shows no data. */
+  private getLayerMinRenderZoom(layer: GeoLibreLayer): number | null {
+    for (const value of [layer.source.minzoom, layer.metadata.minzoom]) {
+      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+        return value;
+      }
+    }
+    return null;
   }
 
   fitBounds(bounds: [number, number, number, number]): void {

--- a/tests/ogc-vector-tiles.test.ts
+++ b/tests/ogc-vector-tiles.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  firstVectorSource,
+  hasTilePlaceholders,
+  styleSourceLayers,
+  tileJsonConfig,
+} from "../apps/geolibre-desktop/src/lib/ogc-vector-tiles";
+
+describe("hasTilePlaceholders", () => {
+  it("recognizes a MapLibre {z}/{x}/{y} template", () => {
+    assert.equal(
+      hasTilePlaceholders("https://ex.com/tiles/{z}/{y}/{x}?f=mvt"),
+      true,
+    );
+    assert.equal(hasTilePlaceholders("https://ex.com/{Z}/{X}/{Y}.pbf"), true);
+  });
+
+  it("treats TileJSON and OGC matrix templates as non-templates", () => {
+    assert.equal(
+      hasTilePlaceholders("https://ex.com/tiles/WebMercatorQuad?f=tilejson"),
+      false,
+    );
+    assert.equal(
+      hasTilePlaceholders("https://ex.com/{tileMatrix}/{tileRow}/{tileCol}"),
+      false,
+    );
+  });
+});
+
+describe("firstVectorSource", () => {
+  it("returns the first vector source with its id", () => {
+    const style = {
+      sources: {
+        basemap: { type: "raster", tiles: ["https://ex.com/{z}/{x}/{y}.png"] },
+        bgt: { type: "vector", tiles: ["https://ex.com/{z}/{y}/{x}?f=mvt"] },
+      },
+      layers: [],
+    };
+    const result = firstVectorSource(style);
+    assert.equal(result?.id, "bgt");
+    assert.equal(result?.source.type, "vector");
+  });
+
+  it("returns null when there is no vector source", () => {
+    assert.equal(firstVectorSource({ sources: {}, layers: [] }), null);
+    assert.equal(firstVectorSource({}), null);
+  });
+});
+
+describe("styleSourceLayers", () => {
+  const style = {
+    sources: { bgt: { type: "vector" } },
+    layers: [
+      { id: "a", source: "bgt", "source-layer": "roads" },
+      { id: "b", source: "bgt", "source-layer": "roads" },
+      { id: "c", source: "bgt", "source-layer": "buildings" },
+      { id: "d", source: "other", "source-layer": "elsewhere" },
+      { id: "e", source: "bgt" },
+    ],
+  };
+
+  it("collects distinct source-layer names in first-seen order", () => {
+    assert.deepEqual(styleSourceLayers(style), [
+      "roads",
+      "buildings",
+      "elsewhere",
+    ]);
+  });
+
+  it("filters to a single source when an id is given", () => {
+    assert.deepEqual(styleSourceLayers(style, "bgt"), ["roads", "buildings"]);
+  });
+});
+
+describe("tileJsonConfig", () => {
+  it("hands MapLibre the TileJSON URL and reads zoom/bounds/layers", () => {
+    const config = tileJsonConfig(
+      {
+        name: "Example",
+        minzoom: 5,
+        maxzoom: 14,
+        bounds: [-180, -85, 180, 85],
+        vector_layers: [{ id: "roads" }, { id: "water" }, { bad: true }],
+      },
+      "https://ex.com/tiles?f=tilejson",
+    );
+    assert.equal(config.url, "https://ex.com/tiles?f=tilejson");
+    assert.equal(config.name, "Example");
+    assert.equal(config.minzoom, 5);
+    assert.equal(config.maxzoom, 14);
+    assert.deepEqual(config.bounds, [-180, -85, 180, 85]);
+    assert.deepEqual(config.sourceLayers, ["roads", "water"]);
+  });
+
+  it("omits source layers when the TileJSON advertises none", () => {
+    const config = tileJsonConfig({}, "https://ex.com/tiles?f=tilejson");
+    assert.equal(config.url, "https://ex.com/tiles?f=tilejson");
+    assert.equal(config.sourceLayers, undefined);
+  });
+});

--- a/tests/ogc-vector-tiles.test.ts
+++ b/tests/ogc-vector-tiles.test.ts
@@ -7,6 +7,7 @@ import {
   resolveOgcVectorTiles,
   styleSourceLayers,
   tileJsonConfig,
+  unionCollectionBounds,
 } from "../apps/geolibre-desktop/src/lib/ogc-vector-tiles";
 
 describe("hasTilePlaceholders", () => {
@@ -108,6 +109,28 @@ describe("tileJsonConfig", () => {
     );
     assert.equal(tileJsonConfig({ center: [5, Infinity] }, "u").center, undefined);
     assert.equal(tileJsonConfig({ center: [1, 2, 3, 4] }, "u").center, undefined);
+  });
+});
+
+describe("unionCollectionBounds", () => {
+  it("unions the lon/lat bboxes of an OGC collections list", () => {
+    const collections = [
+      { extent: { spatial: { bbox: [[-1.6, 48, 12.4, 56.1]], crs: "CRS84" } } },
+      { extent: { spatial: { bbox: [[3, 50, 7, 53]] } } }, // crs omitted = CRS84
+    ];
+    assert.deepEqual(unionCollectionBounds(collections), [-1.6, 48, 12.4, 56.1]);
+  });
+
+  it("ignores collections with a non-lon/lat crs or no usable bbox", () => {
+    assert.equal(
+      unionCollectionBounds([
+        { extent: { spatial: { bbox: [[0, 0, 1, 1]], crs: "EPSG:3857" } } },
+        { extent: {} },
+        {},
+      ]),
+      undefined,
+    );
+    assert.equal(unionCollectionBounds(undefined), undefined);
   });
 });
 

--- a/tests/ogc-vector-tiles.test.ts
+++ b/tests/ogc-vector-tiles.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   firstVectorSource,
   hasTilePlaceholders,
+  resolveOgcVectorTiles,
   styleSourceLayers,
   tileJsonConfig,
 } from "../apps/geolibre-desktop/src/lib/ogc-vector-tiles";
@@ -98,5 +99,35 @@ describe("tileJsonConfig", () => {
     const config = tileJsonConfig({}, "https://ex.com/tiles?f=tilejson");
     assert.equal(config.url, "https://ex.com/tiles?f=tilejson");
     assert.equal(config.sourceLayers, undefined);
+  });
+
+  it("keeps only a finite [lng, lat(, zoom)] center", () => {
+    assert.deepEqual(
+      tileJsonConfig({ center: [5, 52, 8] }, "u").center,
+      [5, 52, 8],
+    );
+    assert.equal(tileJsonConfig({ center: [5, Infinity] }, "u").center, undefined);
+    assert.equal(tileJsonConfig({ center: [1, 2, 3, 4] }, "u").center, undefined);
+  });
+});
+
+// The `{z}/{x}/{y}` template path resolves without any network request, so it
+// can be exercised directly.
+describe("resolveOgcVectorTiles (template path)", () => {
+  it("normalizes uppercase placeholders MapLibre would not substitute", async () => {
+    const config = await resolveOgcVectorTiles({
+      tilesUrl: "https://ex.com/{Z}/{Y}/{X}?f=mvt",
+      sourceLayers: ["roads"],
+    });
+    assert.deepEqual(config.tiles, ["https://ex.com/{z}/{y}/{x}?f=mvt"]);
+    assert.deepEqual(config.sourceLayers, ["roads"]);
+  });
+
+  it("always returns sourceLayers as an array", async () => {
+    const config = await resolveOgcVectorTiles({
+      tilesUrl: "https://ex.com/{z}/{x}/{y}",
+    });
+    assert.ok(Array.isArray(config.sourceLayers));
+    assert.equal(config.sourceLayers.length, 0);
   });
 });

--- a/tests/ogc-vector-tiles.test.ts
+++ b/tests/ogc-vector-tiles.test.ts
@@ -154,3 +154,46 @@ describe("resolveOgcVectorTiles (template path)", () => {
     assert.equal(config.sourceLayers.length, 0);
   });
 });
+
+// Exercises the full resolver against a stubbed OGC API: a TileJSON without
+// bounds, then the collections extent used as the fallback.
+describe("resolveOgcVectorTiles (bounds fallback)", () => {
+  it("derives config.bounds from the /collections extent", async () => {
+    const responses: Record<string, unknown> = {
+      "https://ex.com/ogc/v1/tiles/WMQ?f=tilejson": {
+        tilejson: "3.0.0",
+        minzoom: 17,
+        maxzoom: 17,
+        vector_layers: [{ id: "roads" }],
+      },
+      "https://ex.com/ogc/v1/collections?f=json": {
+        collections: [
+          { extent: { spatial: { bbox: [[3, 50, 7, 53]], crs: "CRS84" } } },
+        ],
+      },
+    };
+    const original = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = ((input: string | URL | Request) => {
+      const url = String(input);
+      calls.push(url);
+      const body = responses[url];
+      return Promise.resolve({
+        ok: body !== undefined,
+        status: body !== undefined ? 200 : 404,
+        json: async () => body ?? {},
+      } as Response);
+    }) as typeof fetch;
+    try {
+      const config = await resolveOgcVectorTiles({
+        tilesUrl: "https://ex.com/ogc/v1/tiles/WMQ?f=tilejson",
+      });
+      assert.deepEqual(config.bounds, [3, 50, 7, 53]);
+      assert.deepEqual(config.sourceLayers, ["roads"]);
+      assert.equal(config.minzoom, 17);
+      assert.ok(calls.includes("https://ex.com/ogc/v1/collections?f=json"));
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for **OGC API - Tiles (vector)** as a remote data source, requested in #1049. A new **OGC Vector Tiles Layer** entry appears under **Add Data → Web Services**.

The user provides:
- **Tiles URL** — a TileJSON metadata URL (e.g. `.../tiles/WebMercatorQuad?f=tilejson`) or a direct `{z}/{y}/{x}` MVT tile template.
- **Style URL** (optional) — a Mapbox/MapLibre style JSON. An OGC API TileJSON commonly omits `vector_layers`, so the style is used to discover the tileset's `source-layer` names.
- **Source layers** (optional) — a manual comma-separated list that overrides whatever the documents advertise.

The layer is added as a MapLibre `vector` source and rendered with GeoLibre's default per-source-layer styling (fill/line/circle), the same path already used by PostgreSQL/Martin vector tiles. Full upstream style paint (sprites/glyphs across hundreds of style layers) is out of scope here, matching the issue's note that styling "could be quite complex."

## Changes

- **`lib/ogc-vector-tiles.ts`** (new) — cross-origin JSON fetch (Tauri native / dev proxy / direct) plus pure parsers (`hasTilePlaceholders`, `firstVectorSource`, `styleSourceLayers`, `tileJsonConfig`) and a `resolveOgcVectorTiles` orchestrator.
- **`packages/map/src/layer-sync.ts`** — `syncVectorTileLayer` now adds a vector source from a `tiles[]` template (with `minzoom`/`maxzoom`/`bounds`) when no TileJSON `url` is present.
- **`OgcVectorTilesSource.tsx`** (new) + wiring through the Add Data dialog, menu, `DATA_SOURCE_CATALOG`, and `en.json`.
- Unit tests for the pure parsers (`tests/ogc-vector-tiles.test.ts`).

## Verification

Verified end to end in the real app (browser, `npm run dev`) with the reporter's PDOK BGT dataset:
- Added the layer via the sample preset (TileJSON + style URLs), source layers auto-discovered from the style.
- Flew to Amsterdam at z17+; the BGT buildings/roads/water render correctly.
- Confirmed the dialog and rendering in both **light and dark** themes.

`npm run build`, `npm run lint` (0 errors), and the frontend test suite pass.

Fixes #1049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **OGC Vector Tiles Layer** to the Add Data flow, including a new menu/toolbar option, prefilled OGC endpoints, URL inputs (tiles/style), and optional **source-layer** overrides.

* **Bug Fixes**
  * Improved vector-tile synchronization to create vector sources from available tile templates/tiles when TileJSON URLs are missing, including zoom and bounds when available.
  * Updated layer fitting to avoid zooming below a layer’s minimum render zoom for better camera behavior.

* **Tests**
  * Added automated tests for OGC vector-tile resolution and helper logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->