### PR TITLE
fix(zarr): live colormap/clim for NetCDF/Zarr layers (maplibre-gl-components 0.25.4)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
     "maplibre-gl-basemap-control": "^0.10.0",
-    "maplibre-gl-components": "^0.25.3",
+    "maplibre-gl-components": "^0.25.4",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
         "maplibre-gl-basemap-control": "^0.10.0",
-        "maplibre-gl-components": "^0.25.3",
+        "maplibre-gl-components": "^0.25.4",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -188,9 +188,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.3.tgz",
-      "integrity": "sha512-2pC2NUwu/7QCqJvBq52XKV+/5IPkEBUPasH7e3vfiyv3uwDldagvBq5EkBfLdgCUdmetnlZU2qCjVbWGzGzR4w==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.4.tgz",
+      "integrity": "sha512-qZZJ7wLYtg7d40mJRmC8lhMPr/NZxLuVq8oplke7RwguSgLiB3n12piy04pTKgd7x3y2D5c4gG2bQBOIU+P53A==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -21129,7 +21129,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
         "maplibre-gl-basemap-control": "^0.10.0",
-        "maplibre-gl-components": "^0.25.3",
+        "maplibre-gl-components": "^0.25.4",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -21168,9 +21168,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.3.tgz",
-      "integrity": "sha512-2pC2NUwu/7QCqJvBq52XKV+/5IPkEBUPasH7e3vfiyv3uwDldagvBq5EkBfLdgCUdmetnlZU2qCjVbWGzGzR4w==",
+      "version": "0.25.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.4.tgz",
+      "integrity": "sha512-qZZJ7wLYtg7d40mJRmC8lhMPr/NZxLuVq8oplke7RwguSgLiB3n12piy04pTKgd7x3y2D5c4gG2bQBOIU+P53A==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
     "maplibre-gl-basemap-control": "^0.10.0",
-    "maplibre-gl-components": "^0.25.3",
+    "maplibre-gl-components": "^0.25.4",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",


### PR DESCRIPTION
## Summary

Bumps `maplibre-gl-components` to **0.25.4**, which fixes live restyling of Zarr / Cloud-Optimized NetCDF layers.

Previously, changing the **colormap** or **Clim Min/Max** in the Zarr layer panel only updated the internal state and the colormap preview swatch — it never restyled the already-added layers. Only opacity was wired to update live. So the controls appeared to do nothing, and re-adding the layer to apply them fails for store-backed layers (Cloud-Optimized NetCDF, whose kerchunk store the panel's "Add Layer" button does not re-provide).

Upstream fix: **opengeos/maplibre-gl-components#118** (released as v0.25.4). It adds `_updateColormap()`/`_updateClim()` (mirroring the existing `_updateOpacity()`) that call the carbonplan `ZarrLayer`'s `setColormap()`/`setClim()` on every live layer, keep the per-layer props in sync, and trigger a repaint. It also preserves a valid clim value of `0`.

## Changes

- `maplibre-gl-components`: `^0.25.3` → `^0.25.4` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json` (+ `package-lock.json`).

## Testing

Verified in the real app with the published 0.25.4: loaded the Cloud-Optimized NetCDF sample, then changed the colormap (blue → magma) and Clim Max in the Zarr panel — the layer now restyles **live** with no console errors. `npm run build` and pre-commit pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a map rendering component to the latest patch release in the desktop app and plugin package.
  * This includes general compatibility and stability improvements from the dependency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->