### PR TITLE
fix(geocoding): route desktop geocoding through native HTTP to bypass CORS

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -48,6 +48,7 @@
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
+    "@tauri-apps/plugin-http": "^2.5.2",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "apache-arrow": "^17.0.0",
     "dompurify": "^3.4.10",

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -805,8 +805,37 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -832,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -845,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -994,6 +1023,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1270,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1637,6 +1690,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-http",
  "tauri-plugin-opener",
  "zip 2.4.2",
 ]
@@ -1830,6 +1884,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2048,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2019,9 +2093,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2530,6 +2606,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3250,6 +3332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,6 +3355,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -3511,9 +3609,13 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -3522,6 +3624,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4266,6 +4369,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,7 +4410,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -4521,6 +4645,30 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-http"
+version = "2.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
+dependencies = [
+ "bytes",
+ "cookie_store",
+ "data-url",
+ "http",
+ "regex",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+ "urlpattern",
 ]
 
 [[package]]
@@ -4784,7 +4932,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5629,6 +5789,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 duckdb = { version = "1.10504.0", features = ["bundled", "parquet"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -19,11 +19,14 @@
       ]
     },
     {
-      "comment": "Geocoding (place search / reverse geocode) is routed through the native HTTP client so it bypasses the WebView's CORS — public Nominatim's CDN intermittently omits the CORS header on cached responses, which the WebView rejects as 'Search failed'. Also lets us send a User-Agent as Nominatim's policy requires.",
+      "comment": "Geocoding (place search / reverse geocode) is routed through the native HTTP client so it bypasses the WebView's CORS — public Nominatim's CDN intermittently omits the CORS header on cached responses, which the WebView rejects as 'Search failed'. Also lets us send a User-Agent as Nominatim's policy requires. Scoped to the built-in geocoder provider hosts only (keep in sync with the GEOCODING_PROVIDERS registry / lib/geocoding-fetch.ts); custom/self-hosted endpoints fall back to the browser fetch.",
       "identifier": "http:default",
       "allow": [
-        { "url": "http://*" },
-        { "url": "https://*" }
+        { "url": "https://nominatim.openstreetmap.org/*" },
+        { "url": "https://api.geocode.earth/*" },
+        { "url": "https://geocode.arcgis.com/*" },
+        { "url": "https://api.mapbox.com/*" },
+        { "url": "https://maps.googleapis.com/*" }
       ]
     }
   ]

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -17,6 +17,14 @@
         { "url": "http://*" },
         { "url": "https://*" }
       ]
+    },
+    {
+      "comment": "Geocoding (place search / reverse geocode) is routed through the native HTTP client so it bypasses the WebView's CORS — public Nominatim's CDN intermittently omits the CORS header on cached responses, which the WebView rejects as 'Search failed'. Also lets us send a User-Agent as Nominatim's policy requires.",
+      "identifier": "http:default",
+      "allow": [
+        { "url": "http://*" },
+        { "url": "https://*" }
+      ]
     }
   ]
 }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -182,6 +182,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
         .manage(EarthEngineOAuthState::default())
         .manage(MartinServerState {

--- a/apps/geolibre-desktop/src/lib/geocoding-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/geocoding-fetch.ts
@@ -1,0 +1,33 @@
+import { setGeocodingFetch } from "@geolibre/core";
+
+/**
+ * Identify the app to geocoding services. Nominatim's usage policy requires a
+ * User-Agent (or Referer) naming the application; the WebView's browser `fetch`
+ * cannot set that header, but Tauri's native HTTP client can.
+ */
+const GEOCODER_USER_AGENT =
+  "GeoLibre-Desktop (+https://github.com/opengeos/GeoLibre)";
+
+/**
+ * Route geocoding requests through Tauri's native HTTP client instead of the
+ * WebView's `fetch`.
+ *
+ * This bypasses browser CORS enforcement: public Nominatim's CDN intermittently
+ * drops the `Access-Control-Allow-Origin` header on cached responses, which the
+ * WebView then rejects — surfacing to the user as "Search failed. Try again."
+ * (the symptom that failed Microsoft Store certification). The native client is
+ * not bound by CORS and can also send a proper User-Agent, as Nominatim's usage
+ * policy requires.
+ *
+ * Loaded lazily and only in the desktop build so the web/embedded bundles never
+ * pull in `@tauri-apps/plugin-http`.
+ */
+export async function installNativeGeocodingFetch(): Promise<void> {
+  const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+  const nativeFetch: typeof globalThis.fetch = (input, init) => {
+    const headers = new Headers(init?.headers);
+    headers.set("User-Agent", GEOCODER_USER_AGENT);
+    return tauriFetch(input, { ...init, headers });
+  };
+  setGeocodingFetch(nativeFetch);
+}

--- a/apps/geolibre-desktop/src/lib/geocoding-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/geocoding-fetch.ts
@@ -1,4 +1,4 @@
-import { setGeocodingFetch } from "@geolibre/core";
+import { GEOCODING_PROVIDERS, setGeocodingFetch } from "@geolibre/core";
 
 /**
  * Identify the app to geocoding services. Nominatim's usage policy requires a
@@ -9,15 +9,54 @@ const GEOCODER_USER_AGENT =
   "GeoLibre-Desktop (+https://github.com/opengeos/GeoLibre)";
 
 /**
- * Route geocoding requests through Tauri's native HTTP client instead of the
- * WebView's `fetch`.
+ * Hosts of the built-in geocoding providers' default endpoints. Only these are
+ * routed through the native HTTP client; any other host (a project-configured
+ * custom or self-hosted endpoint) keeps the browser `fetch` — unchanged from
+ * before this bypass existed. This bounds the native, CORS-exempt client to the
+ * exact hosts that need it, and it stays in sync with the provider registry in
+ * `@geolibre/core`. The Tauri capability scope (`src-tauri/capabilities/
+ * default.json`, `http:default`) must list the same hosts.
+ */
+const NATIVE_FETCH_HOSTS = new Set(
+  GEOCODING_PROVIDERS.flatMap((provider) =>
+    [provider.defaultForwardEndpoint, provider.defaultReverseEndpoint].flatMap(
+      (endpoint) => {
+        try {
+          return [new URL(endpoint).host];
+        } catch {
+          return [];
+        }
+      },
+    ),
+  ),
+);
+
+/** The request URL's host, or null when it cannot be parsed. */
+function requestHost(input: RequestInfo | URL): string | null {
+  try {
+    const href =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    return new URL(href).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Route geocoding requests to the built-in providers through Tauri's native
+ * HTTP client instead of the WebView's `fetch`.
  *
  * This bypasses browser CORS enforcement: public Nominatim's CDN intermittently
  * drops the `Access-Control-Allow-Origin` header on cached responses, which the
  * WebView then rejects — surfacing to the user as "Search failed. Try again."
  * (the symptom that failed Microsoft Store certification). The native client is
  * not bound by CORS and can also send a proper User-Agent, as Nominatim's usage
- * policy requires.
+ * policy requires. Requests to any other host fall back to the browser `fetch`,
+ * so the native client stays scoped to the known provider hosts.
  *
  * Loaded lazily and only in the desktop build so the web/embedded bundles never
  * pull in `@tauri-apps/plugin-http`.
@@ -25,6 +64,12 @@ const GEOCODER_USER_AGENT =
 export async function installNativeGeocodingFetch(): Promise<void> {
   const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
   const nativeFetch: typeof globalThis.fetch = (input, init) => {
+    const host = requestHost(input);
+    if (!host || !NATIVE_FETCH_HOSTS.has(host)) {
+      // Custom/self-hosted endpoint: keep the browser fetch (its behavior is
+      // unchanged by this fix, and it is outside the native capability scope).
+      return fetch(input, init);
+    }
     const headers = new Headers(init?.headers);
     headers.set("User-Agent", GEOCODER_USER_AGENT);
     return tauriFetch(input, { ...init, headers });

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -51,9 +51,14 @@ installDiagnosticsCapture();
 // which the WebView rejects as "Search failed. Try again." Lazy + desktop-only
 // so the web/embedded bundles never import the Tauri HTTP plugin.
 if (isTauri()) {
-  void import("./lib/geocoding-fetch").then(({ installNativeGeocodingFetch }) =>
-    installNativeGeocodingFetch(),
-  );
+  void import("./lib/geocoding-fetch")
+    .then(({ installNativeGeocodingFetch }) => installNativeGeocodingFetch())
+    .catch((error: unknown) => {
+      // If the install fails, geocoding stays on the browser fetch (the
+      // CORS-buggy path this fixes), so surface it rather than let it become a
+      // silent unhandled rejection.
+      console.error("[GeoLibre] Failed to install native geocoding fetch", error);
+    });
 }
 // Recover from chunks orphaned by a web redeploy (stale lazy import → 404). A
 // no-op in the desktop build, whose chunks are bundled locally.

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -41,9 +41,20 @@ import { I18nextProvider } from "react-i18next";
 // paint is already in the right language.
 import i18n from "./i18n";
 import { installDiagnosticsCapture } from "./lib/diagnostics";
+import { isTauri } from "./lib/is-tauri";
 import { installStaleChunkReload } from "./lib/stale-chunk-reload";
 
 installDiagnosticsCapture();
+// In the desktop build, route geocoding (place search / reverse geocode)
+// through Tauri's native HTTP client so it bypasses WebView CORS: public
+// Nominatim's CDN intermittently omits the CORS header on cached responses,
+// which the WebView rejects as "Search failed. Try again." Lazy + desktop-only
+// so the web/embedded bundles never import the Tauri HTTP plugin.
+if (isTauri()) {
+  void import("./lib/geocoding-fetch").then(({ installNativeGeocodingFetch }) =>
+    installNativeGeocodingFetch(),
+  );
+}
 // Recover from chunks orphaned by a web redeploy (stale lazy import → 404). A
 // no-op in the desktop build, whose chunks are bundled locally.
 installStaleChunkReload();

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
+        "@tauri-apps/plugin-http": "^2.5.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "apache-arrow": "^17.0.0",
         "dompurify": "^3.4.10",
@@ -8403,6 +8404,15 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz",
       "integrity": "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-http": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-http/-/plugin-http-2.5.9.tgz",
+      "integrity": "sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"

--- a/packages/core/src/geocoding.ts
+++ b/packages/core/src/geocoding.ts
@@ -25,7 +25,9 @@ import { getRuntimeEnvironment } from "./runtime-env";
  *
  * Browser fetch cannot set `User-Agent`/`Referer`, so the app is identified to
  * Nominatim via the optional `email` query parameter plus the automatically
- * sent `Referer`. See docs/user-guide/data-integrations.md#geocoding.
+ * sent `Referer`. The desktop build overrides this with a native (Tauri) fetch
+ * via {@link setGeocodingFetch} — see the note there. See
+ * docs/user-guide/data-integrations.md#geocoding.
  */
 
 export const DEFAULT_FORWARD_GEOCODE_ENDPOINT =
@@ -805,6 +807,40 @@ export function csvRowsToGeocodeRequests(
 }
 
 /**
+ * The fetch implementation used by {@link geocodeForward}/{@link geocodeReverse}.
+ * Null means "use the global browser `fetch`" (the default for the web and
+ * embedded builds).
+ */
+let geocodingFetch: typeof globalThis.fetch | null = null;
+
+/**
+ * Override the fetch used for geocoding requests, or pass null to restore the
+ * global browser `fetch`.
+ *
+ * The desktop shell sets this to Tauri's native HTTP fetch so geocoding requests
+ * are made from the Rust side, which:
+ *   - bypasses the WebView's CORS enforcement. Public Nominatim's CDN
+ *     intermittently omits the `Access-Control-Allow-Origin` header on cached
+ *     responses, which the browser then rejects — surfacing to the user as
+ *     "Search failed. Try again." (the symptom that failed Microsoft Store
+ *     certification); and
+ *   - can send a `User-Agent` identifying the app, as Nominatim's usage policy
+ *     requires (browser fetch cannot set that header).
+ *
+ * Safe to call multiple times; only the most recent implementation is used.
+ */
+export function setGeocodingFetch(
+  fetchImpl: typeof globalThis.fetch | null,
+): void {
+  geocodingFetch = fetchImpl;
+}
+
+/** The active geocoding fetch: the injected override, else the global fetch. */
+function geocodeFetch(): typeof globalThis.fetch {
+  return geocodingFetch ?? fetch;
+}
+
+/**
  * Forward-geocode a single query through the configured provider, returning
  * normalized matches.
  */
@@ -818,7 +854,7 @@ export async function geocodeForward(
     email: config.email,
     limit: options.limit,
   });
-  const response = await fetch(url, {
+  const response = await geocodeFetch()(url, {
     signal: options.signal,
     headers: { Accept: "application/json" },
   });
@@ -844,7 +880,7 @@ export async function geocodeReverse(
     email: config.email,
     zoom: options.zoom,
   });
-  const response = await fetch(url, {
+  const response = await geocodeFetch()(url, {
     signal: options.signal,
     headers: { Accept: "application/json" },
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export {
   csvRowsToGeocodeRequests,
   geocodeForward,
   geocodeReverse,
+  setGeocodingFetch,
   type GeocoderConfig,
   type GeocodingProvider,
   type GeocodingProviderId,

--- a/tests/geocoding.test.ts
+++ b/tests/geocoding.test.ts
@@ -5,11 +5,14 @@ import {
   buildReverseGeocodeUrl,
   csvRowsToGeocodeRequests,
   geocodeMatchToFeature,
+  geocodeForward,
   geocoderMinIntervalMs,
   geocoderNeedsApiKey,
+  geocodeReverse,
   GEOCODING_PROVIDERS,
   getGeocodingProvider,
   nextDelayMs,
+  setGeocodingFetch,
   nominatimResultToFeature,
   nominatimReverseResultToDisplay,
   normalizeGeocodingProviderId,
@@ -501,5 +504,70 @@ describe("geocodeMatchToFeature", () => {
       geocodeMatchToFeature({ lat: NaN, lon: 0, displayName: "", score: null }),
       null,
     );
+  });
+});
+
+describe("setGeocodingFetch", () => {
+  const NOMINATIM: GeocoderConfig = {
+    providerId: "nominatim",
+    forwardEndpoint: PUBLIC_FORWARD,
+    reverseEndpoint: PUBLIC_REVERSE,
+  };
+
+  it("routes forward geocoding through the injected fetch", async () => {
+    const seen: string[] = [];
+    const fake: typeof globalThis.fetch = (input) => {
+      seen.push(String(input));
+      return Promise.resolve(
+        new Response(JSON.stringify([{ lat: "48.85", lon: "2.35", display_name: "Paris" }]), {
+          status: 200,
+        }),
+      );
+    };
+    setGeocodingFetch(fake);
+    try {
+      const matches = await geocodeForward("Paris", { config: NOMINATIM });
+      assert.equal(matches.length, 1);
+      assert.equal(matches[0]?.displayName, "Paris");
+      assert.equal(seen.length, 1);
+      assert.ok(seen[0]?.startsWith(PUBLIC_FORWARD));
+    } finally {
+      setGeocodingFetch(null);
+    }
+  });
+
+  it("routes reverse geocoding through the injected fetch", async () => {
+    const seen: string[] = [];
+    const fake: typeof globalThis.fetch = (input) => {
+      seen.push(String(input));
+      return Promise.resolve(
+        new Response(JSON.stringify({ display_name: "Paris, France", address: {} }), {
+          status: 200,
+        }),
+      );
+    };
+    setGeocodingFetch(fake);
+    try {
+      const result = await geocodeReverse(2.35, 48.85, { config: NOMINATIM });
+      assert.equal(result?.displayName, "Paris, France");
+      assert.equal(seen.length, 1);
+      assert.ok(seen[0]?.startsWith(PUBLIC_REVERSE));
+    } finally {
+      setGeocodingFetch(null);
+    }
+  });
+
+  it("propagates a non-ok response from the injected fetch as an error", async () => {
+    setGeocodingFetch(() =>
+      Promise.resolve(new Response("nope", { status: 429 })),
+    );
+    try {
+      await assert.rejects(
+        () => geocodeForward("Paris", { config: NOMINATIM }),
+        /HTTP 429/,
+      );
+    } finally {
+      setGeocodingFetch(null);
+    }
   });
 });


### PR DESCRIPTION
Place search failed intermittently in the packaged desktop app with "Search failed. Try again." — the failure that blocked Microsoft Store certification (10.1.2.10 Functionality).

Root cause is not the Tauri CSP (connect-src already allows https:). The geocoder uses the WebView's browser fetch against public Nominatim, whose Varnish CDN intermittently omits the Access-Control-Allow-Origin header on cached responses. The OPTIONS preflight always returns it, but a cached GET does not, so the WebView rejects the response and fetch throws — surfacing as "Search failed". Common place names are more likely cached, so the failure is intermittent and reproduced by the store reviewer.

Fix: add a pluggable fetch to the shared geocoding client (setGeocodingFetch). The desktop shell injects Tauri's native HTTP plugin fetch, which runs from Rust and is not bound by browser CORS, and sets a User-Agent identifying the app as Nominatim's usage policy requires (browser fetch cannot set that header). Web/embedded builds are unchanged — they keep the global browser fetch and never import the Tauri HTTP plugin.

- packages/core: setGeocodingFetch override + tests
- desktop: tauri-plugin-http (Cargo + capability scope), native fetch wrapper, wired at startup behind isTauri()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop geocoding now routes built-in provider requests through the native HTTP client for more reliable address lookups.
  * Added an API to override the geocoding request transport (with automatic fallback for non-allowed hosts).

* **Bug Fixes**
  * Mitigates browser security/CORS-related geocoding failures by avoiding WebView fetch for built-in providers.
  * Sends the required User-Agent and restricts HTTP access to known geocoder endpoints.

* **Tests**
  * Added coverage for geocoding transport override behavior and HTTP error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->