### PR TITLE
ci: harden Claude Code workflow trigger and token permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,53 +11,53 @@ on:
     types: [submitted]
 
 jobs:
-  claude:
-    # Only run for an explicit @claude mention AND only when the author is a
-    # trusted user (repo owner, org member, or invited collaborator). This keeps
-    # a first-time or external contributor from triggering a write-capable agent
-    # run by commenting `@claude` on a public issue or PR.
+  # First-line gate: only proceed on an explicit @claude mention, and resolve
+  # the invoking user's REAL repository permission level before any token is
+  # granted. `author_association == 'COLLABORATOR'` is not sufficient on its
+  # own -- read-only and triage-only collaborators also report COLLABORATOR, so
+  # gating on the enum alone would let a non-push user invoke the agent. This
+  # job runs with a read-only token and emits `trusted=true` only for users who
+  # can already push (write / maintain / admin roles).
+  check-access:
     if: |
-      (
-        github.event_name == 'issue_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '@claude') &&
-        (
-          github.event.review.author_association == 'OWNER' ||
-          github.event.review.author_association == 'MEMBER' ||
-          github.event.review.author_association == 'COLLABORATOR'
-        )
-      ) ||
-      (
-        github.event_name == 'issues' &&
-        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
-        (
-          github.event.issue.author_association == 'OWNER' ||
-          github.event.issue.author_association == 'MEMBER' ||
-          github.event.issue.author_association == 'COLLABORATOR'
-        )
-      )
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      trusted: ${{ steps.check.outputs.trusted }}
+    steps:
+      - name: Resolve actor permission level
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          role=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name' 2>/dev/null || echo none)
+          echo "Actor ${ACTOR} resolved to role: ${role}"
+          case "${role}" in
+            admin | maintain | write) echo "trusted=true" >> "${GITHUB_OUTPUT}" ;;
+            *) echo "trusted=false" >> "${GITHUB_OUTPUT}" ;;
+          esac
+
+  claude:
+    needs: check-access
+    if: needs.check-access.outputs.trusted == 'true'
     runs-on: ubuntu-latest
     # Least-privilege token. Each scope maps to a concrete operation the agent
-    # performs, and the whole job only runs after the trusted-author gate above.
-    # `id-token: write` is intentionally omitted: this workflow authenticates
-    # with an OAuth token and has no OIDC use case.
+    # performs, and this job only runs after check-access confirms the invoking
+    # user already has push access. `id-token: write` is intentionally omitted:
+    # this workflow authenticates with an OAuth token and has no OIDC use case.
+    #
+    # Residual risk: this gate controls WHO can invoke the agent, not WHAT it
+    # reads. A trusted maintainer invoking @claude on an issue/PR authored by an
+    # untrusted user still exposes the agent to attacker-controlled text (the
+    # diff or issue body) and thus to prompt injection while it holds a
+    # write-capable token. Review the target before invoking on untrusted input.
     permissions:
       contents: write # commit and push changes on a branch when asked to edit code
       pull-requests: write # open/update PRs and post review replies

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,12 +37,23 @@ jobs:
           REPO: ${{ github.repository }}
           ACTOR: ${{ github.actor }}
         run: |
-          role=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name' 2>/dev/null || echo none)
-          echo "Actor ${ACTOR} resolved to role: ${role}"
-          case "${role}" in
-            admin | maintain | write) echo "trusted=true" >> "${GITHUB_OUTPUT}" ;;
-            *) echo "trusted=false" >> "${GITHUB_OUTPUT}" ;;
-          esac
+          if role=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.role_name' 2>err.log); then
+            echo "Actor ${ACTOR} resolved to role: ${role}"
+            case "${role}" in
+              admin | maintain | write) echo "trusted=true" >> "${GITHUB_OUTPUT}" ;;
+              *) echo "trusted=false" >> "${GITHUB_OUTPUT}" ;;
+            esac
+          elif grep -q 'HTTP 404' err.log; then
+            # 404 = the actor is not a collaborator with any role: not trusted.
+            echo "Actor ${ACTOR} is not a repository collaborator; marking untrusted."
+            echo "trusted=false" >> "${GITHUB_OUTPUT}"
+          else
+            # Any other failure (auth, rate limit, network) must not be silently
+            # downgraded to "untrusted" -- surface it and fail the job instead.
+            echo "::error::Permission lookup for ${ACTOR} failed:"
+            cat err.log
+            exit 1
+          fi
 
   claude:
     needs: check-access

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,8 +25,11 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    # This job only calls the REST API (via gh) and never checks out or reads
+    # repository content, so it needs no repository scopes. The
+    # collaborators/permission endpoint requires only metadata:read, which the
+    # GITHUB_TOKEN always retains even with an empty permissions block.
+    permissions: {}
     outputs:
       trusted: ${{ steps.check.outputs.trusted }}
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,18 +12,57 @@ on:
 
 jobs:
   claude:
+    # Only run for an explicit @claude mention AND only when the author is a
+    # trusted user (repo owner, org member, or invited collaborator). This keeps
+    # a first-time or external contributor from triggering a write-capable agent
+    # run by commenting `@claude` on a public issue or PR.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (
+          github.event.review.author_association == 'OWNER' ||
+          github.event.review.author_association == 'MEMBER' ||
+          github.event.review.author_association == 'COLLABORATOR'
+        )
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (
+          github.event.issue.author_association == 'OWNER' ||
+          github.event.issue.author_association == 'MEMBER' ||
+          github.event.issue.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
+    # Least-privilege token. Each scope maps to a concrete operation the agent
+    # performs, and the whole job only runs after the trusted-author gate above.
+    # `id-token: write` is intentionally omitted: this workflow authenticates
+    # with an OAuth token and has no OIDC use case.
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write # commit and push changes on a branch when asked to edit code
+      pull-requests: write # open/update PRs and post review replies
+      issues: write # post replies on the triggering issue
+      actions: read # read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes #1061.

## Problem

The `Claude Code` workflow (`.github/workflows/claude.yml`) could be triggered from any public issue or PR comment containing `@claude`, while the job ran with broad write permissions (`contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`). Combined with comment-based triggering and an agent that acts on natural-language instructions, that made the workflow a sensitive repo-level control plane reachable by untrusted users.

## Changes

- **Trusted-author gate.** The job now only runs when the `@claude` mention comes from a user whose `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, applied across all four trigger events (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`). A first-time or external contributor can no longer start a write-capable run by commenting `@claude`.
- **Removed `id-token: write`.** This workflow authenticates with an OAuth token and has no OIDC use case, so the OIDC token permission is dropped.
- **Documented remaining scopes.** Each retained permission is annotated with the concrete operation it enables. `contents: write` is kept so trusted maintainers can still have the agent commit code, now guarded by the author gate as the mitigating control; `pull-requests`/`issues: write` back the agent's replies; `actions: read` reads CI results.

## Acceptance criteria

- [x] A first-time or external contributor cannot trigger a write-capable agent run by commenting `@claude`.
- [x] `id-token: write` removed.
- [x] Remaining write permissions documented against the operations they enable. (`contents: write` retained deliberately behind the trust gate rather than removed, to preserve maintainer code-edit use; happy to drop it to read-only if preferred.)

## Verification

YAML validated with a parser; confirmed the resolved `permissions` map is `{contents: write, pull-requests: write, issues: write, actions: read}` with no `id-token` key, and the `if:` expression parses. No app runtime surface to exercise (CI config only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated assistant triggering by adding an explicit mention–based access check that verifies collaborator permission before the assistant runs.
  * Tightened workflow security by limiting granted permissions and updating authentication to rely solely on an OAuth token (no OIDC/id-token usage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->