### PR TITLE
fix(plugins): gate project-supplied plugin URLs behind an explicit trust prompt

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -75,6 +75,7 @@ import {
   createAppAPI,
   getPluginManager,
   useExternalPluginsReady,
+  useProjectPluginTrust,
   useSwipeSplitViewExclusivity,
 } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
@@ -122,6 +123,7 @@ import { StoryMapPanel } from "../storymap/StoryMapPanel";
 import { StoryMapPresenter } from "../storymap/StoryMapPresenter";
 import { DiagnosticsDialog } from "./DiagnosticsDialog";
 import { FileNamePromptDialog } from "./FileNamePromptDialog";
+import { ProjectPluginTrustDialog } from "./ProjectPluginTrustDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
 import type { LayoutOptions } from "../../hooks/useLayoutOptions";
@@ -543,6 +545,9 @@ export function DesktopShell({
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const diagnostics = useDiagnosticsSnapshot();
   const externalPluginsReady = useExternalPluginsReady(mapControllerRef);
+  // Gate plugin URLs carried inside an opened project behind an explicit trust
+  // decision before any of their code is fetched or imported (#1062).
+  const projectPluginTrust = useProjectPluginTrust();
   // Keep Layer Swipe and split view mutually exclusive (#844): entering a
   // multi-pane grid turns the swipe slider off.
   useSwipeSplitViewExclusivity(mapControllerRef);
@@ -1886,6 +1891,9 @@ export function DesktopShell({
       {/* Mounted in the always-rendered shell (not the toolbar) so the bookmark
           export name prompt works even when the toolbar is hidden (`?maponly`). */}
       <FileNamePromptDialog />
+      {/* Trust prompt for plugin URLs carried by an opened project (#1062);
+          inert unless the project references an untrusted plugin URL. */}
+      <ProjectPluginTrustDialog trust={projectPluginTrust} />
       <Suspense fallback={null}>
         <ProcessingDialog
           mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/layout/ProjectPluginTrustDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectPluginTrustDialog.tsx
@@ -6,7 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@geolibre/ui";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { ProjectPluginTrustState } from "../../hooks/usePlugins";
 
@@ -30,12 +30,17 @@ export function ProjectPluginTrustDialog({
 
   // Trusting/dismissing empties pendingUrls synchronously, before the dialog's
   // exit animation finishes. Keep the last non-empty list so the URLs stay
-  // rendered through the close transition instead of flashing blank.
+  // rendered through the close transition instead of flashing blank. Recorded in
+  // an effect rather than the render body so we never write a ref while
+  // rendering.
   const lastPendingUrls = useRef<string[]>([]);
-  if (trust.pendingUrls.length > 0) {
-    lastPendingUrls.current = trust.pendingUrls;
-  }
-  const urls = trust.pendingUrls.length > 0 ? trust.pendingUrls : lastPendingUrls.current;
+  useEffect(() => {
+    if (trust.pendingUrls.length > 0) {
+      lastPendingUrls.current = trust.pendingUrls;
+    }
+  }, [trust.pendingUrls]);
+  const urls =
+    trust.pendingUrls.length > 0 ? trust.pendingUrls : lastPendingUrls.current;
 
   return (
     <Dialog

--- a/apps/geolibre-desktop/src/components/layout/ProjectPluginTrustDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectPluginTrustDialog.tsx
@@ -1,0 +1,88 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useRef } from "react";
+import { useTranslation } from "react-i18next";
+import type { ProjectPluginTrustState } from "../../hooks/usePlugins";
+
+interface ProjectPluginTrustDialogProps {
+  trust: ProjectPluginTrustState;
+}
+
+/**
+ * Prompts the user before an opened project's plugin manifest URLs are fetched
+ * and executed (#1062). A `.geolibre.json` is opened as data and can carry
+ * `plugins.manifestUrls` that would otherwise run third-party code in the
+ * privileged app context. This dialog lists the untrusted URLs (with their
+ * origin highlighted) and requires an explicit decision: trust and load, or
+ * dismiss without loading. It is a no-op when the project references only
+ * already-installed or bundled plugins.
+ */
+export function ProjectPluginTrustDialog({
+  trust,
+}: ProjectPluginTrustDialogProps) {
+  const { t } = useTranslation();
+
+  // Trusting/dismissing empties pendingUrls synchronously, before the dialog's
+  // exit animation finishes. Keep the last non-empty list so the URLs stay
+  // rendered through the close transition instead of flashing blank.
+  const lastPendingUrls = useRef<string[]>([]);
+  if (trust.pendingUrls.length > 0) {
+    lastPendingUrls.current = trust.pendingUrls;
+  }
+  const urls = trust.pendingUrls.length > 0 ? trust.pendingUrls : lastPendingUrls.current;
+
+  return (
+    <Dialog
+      open={trust.pendingUrls.length > 0}
+      onOpenChange={(open: boolean) => {
+        // Closing via Escape / overlay click is treated as "don't load".
+        if (!open) trust.dismiss();
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("managePlugins.trust.title")}</DialogTitle>
+          <DialogDescription>
+            {t("managePlugins.trust.description", { count: urls.length })}
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="max-h-48 space-y-2 overflow-y-auto rounded-md border border-border bg-muted/40 p-3">
+          {urls.map((url) => (
+            <li key={url} className="text-sm break-all">
+              <span className="font-medium">{originOf(url)}</span>
+              <span className="block text-xs text-muted-foreground">{url}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-destructive">{t("managePlugins.trust.warning")}</p>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => trust.dismiss()}>
+            {t("managePlugins.trust.dismissButton")}
+          </Button>
+          <Button onClick={() => trust.trust()}>
+            {t("managePlugins.trust.trustButton")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * The scheme + host of a plugin URL, shown as the prominent origin line. Falls
+ * back to the raw string for anything `URL` cannot parse (the loader would
+ * reject it anyway).
+ */
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return url;
+  }
+}

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -57,7 +57,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readDir, readFile } from "@tauri-apps/plugin-fs";
 import type { RefObject } from "react";
-import { useEffect, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { bundledPluginManifestPaths } from "virtual:bundled-plugins";
 import {
   installWebPluginArchive,
@@ -71,6 +71,7 @@ import {
   type InstalledWebPlugin,
 } from "../lib/external-plugins";
 import { appendDiagnostic } from "../lib/diagnostics";
+import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
 import { createWmsTileUrl } from "../components/layout/add-data/helpers";
 import { createExternalNativeStoreLayer } from "../lib/external-native-layer";
 import { mergeStringLists } from "../lib/string-lists";
@@ -206,15 +207,9 @@ export async function installPluginArchive(
   // so the forced re-scan re-registers the updated version under the same id.
   unloadFilesystemPlugin(manager, pluginId, app);
   const desktopSettings = useDesktopSettingsStore.getState().desktopSettings;
-  const projectManifestUrls =
-    useAppStore.getState().projectPlugins?.manifestUrls ??
-    EMPTY_PLUGIN_MANIFEST_URLS;
-  await ensureExternalPluginsLoadedWithSettings(
-    desktopSettings,
-    projectManifestUrls,
-    app,
-    { force: true },
-  );
+  await ensureExternalPluginsLoadedWithSettings(desktopSettings, app, {
+    force: true,
+  });
   return pluginId;
 }
 
@@ -363,19 +358,21 @@ export function useExternalPluginsReady(
   const desktopSettings = useDesktopSettingsStore(
     (state) => state.desktopSettings,
   );
-  const projectPluginManifestUrls = useAppStore(
-    (state) => state.projectPlugins?.manifestUrls ?? EMPTY_PLUGIN_MANIFEST_URLS,
-  );
 
   useEffect(() => {
     // mapControllerRef is a stable ref object, so it is intentionally not a
     // dependency; createAppAPI dereferences .current lazily.
+    //
+    // Project-supplied plugin URLs are intentionally NOT loaded here: the scan
+    // only ever fetches/imports the user's installed URLs (desktop settings) and
+    // the bundled drop-ins. Untrusted project URLs are surfaced by
+    // useProjectPluginTrust and only reach this scan after the user trusts them
+    // (which adds them to desktopSettings and re-runs this effect). See #1062.
     void ensureExternalPluginsLoadedWithSettings(
       desktopSettings,
-      projectPluginManifestUrls,
       createAppAPI(mapControllerRef),
     );
-  }, [desktopSettings, projectPluginManifestUrls]);
+  }, [desktopSettings]);
 
   return useSyncExternalStore(
     (listener) => {
@@ -385,6 +382,81 @@ export function useExternalPluginsReady(
     () => externalPluginsLoaded,
     () => externalPluginsLoaded,
   );
+}
+
+export interface ProjectPluginTrustState {
+  /**
+   * Project-supplied plugin manifest URLs awaiting the user's trust decision.
+   * Empty when the opened project references no untrusted plugins (its URLs are
+   * already installed or bundled), which is the common case for a user's own
+   * saved projects.
+   */
+  pendingUrls: string[];
+  /**
+   * Trust every pending URL: add it to the persisted desktop settings so it is
+   * installed like any marketplace/manual plugin. This re-runs the external
+   * plugin scan (via useExternalPluginsReady's settings dependency), which is
+   * what actually fetches and imports the now-trusted plugins.
+   */
+  trust: () => void;
+  /** Dismiss the prompt for this session without loading or persisting anything. */
+  dismiss: () => void;
+}
+
+/**
+ * Gate the plugin manifest URLs carried inside an opened project behind an
+ * explicit user trust decision (#1062).
+ *
+ * When a project is opened, its `plugins.manifestUrls` are compared against the
+ * user's installed URLs and the bundled drop-ins. Any URL that is neither is
+ * "untrusted" and is surfaced here so the shell can show a trust prompt before
+ * the plugin's code is ever fetched or imported. Trusting persists the URLs to
+ * desktop settings (which loads them); dismissing loads nothing and persists
+ * nothing. A per-session dismissed set keeps a declined URL from re-prompting
+ * on every render or when another project references the same URL.
+ */
+export function useProjectPluginTrust(): ProjectPluginTrustState {
+  const projectManifestUrls = useAppStore(
+    (state) => state.projectPlugins?.manifestUrls ?? EMPTY_PLUGIN_MANIFEST_URLS,
+  );
+  const trustedManifestUrls = useDesktopSettingsStore(
+    (state) => state.desktopSettings.pluginManifestUrls,
+  );
+  const [dismissedUrls, setDismissedUrls] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const pendingUrls = useMemo(() => {
+    const { untrusted } = partitionProjectPluginManifestUrls(
+      projectManifestUrls,
+      trustedManifestUrls,
+      bundledPluginManifestUrls(),
+    );
+    return untrusted.filter((url) => !dismissedUrls.has(url));
+  }, [projectManifestUrls, trustedManifestUrls, dismissedUrls]);
+
+  const trust = useCallback(() => {
+    if (pendingUrls.length === 0) return;
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    useDesktopSettingsStore.getState().setDesktopSettings({
+      ...current,
+      pluginManifestUrls: mergeStringLists(
+        current.pluginManifestUrls,
+        pendingUrls,
+      ),
+    });
+  }, [pendingUrls]);
+
+  const dismiss = useCallback(() => {
+    if (pendingUrls.length === 0) return;
+    setDismissedUrls((previous) => {
+      const next = new Set(previous);
+      for (const url of pendingUrls) next.add(url);
+      return next;
+    });
+  }, [pendingUrls]);
+
+  return { pendingUrls, trust, dismiss };
 }
 
 /**
@@ -427,7 +499,7 @@ export function useSwipeSplitViewExclusivity(
 // load time rather than stored in Settings, so a baked-in plugin always loads
 // and cannot be removed by the user. The URL loader skips the scheme allow-list
 // applied to user/project URLs, so the desktop tauri:// origin is accepted.
-function bundledPluginManifestUrls(): string[] {
+export function bundledPluginManifestUrls(): string[] {
   if (typeof window === "undefined") return [];
   // Resolve against a base that always ends in "/" so a non-trailing-slash
   // BASE_URL (e.g. "/geolibre") cannot mangle the path into "/geolibreplugins".
@@ -443,14 +515,17 @@ function ensureExternalPluginsLoadedWithSettings(
   desktopSettings: ReturnType<
     typeof useDesktopSettingsStore.getState
   >["desktopSettings"],
-  projectPluginManifestUrls: string[],
   app: ReturnType<typeof createAppAPI>,
   options?: { force?: boolean },
 ): Promise<void> {
+  // Only the user's installed URLs (desktop settings) and the bundled drop-ins
+  // are auto-loaded. Project-supplied URLs are deliberately excluded here so
+  // opening a project never fetches or imports third-party plugin code; they
+  // reach this scan only after the user trusts them, at which point they are in
+  // desktopSettings.pluginManifestUrls (see useProjectPluginTrust / #1062).
   const pluginManifestUrls = mergeStringLists(
     bundledPluginManifestUrls(),
     desktopSettings.pluginManifestUrls,
-    projectPluginManifestUrls,
   );
   const loadKey = JSON.stringify({
     additionalPluginDirectories: desktopSettings.additionalPluginDirectories,

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -63,7 +63,15 @@
   },
   "managePlugins": {
     "failed": "Failed",
-    "failedToLoad": "Failed to load: {{message}}"
+    "failedToLoad": "Failed to load: {{message}}",
+    "trust": {
+      "title": "Load plugins from this project?",
+      "description_one": "This project wants to load 1 external plugin from a URL you have not installed. Plugins run code with full access to the app.",
+      "description_other": "This project wants to load {{count}} external plugins from URLs you have not installed. Plugins run code with full access to the app.",
+      "warning": "Only load plugins from sources you trust. Loaded plugins run with the same privileges as GeoLibre itself.",
+      "trustButton": "Trust and load",
+      "dismissButton": "Don't load"
+    }
   },
   "viewState": {
     "panelTitle": "Info"

--- a/apps/geolibre-desktop/src/lib/plugin-trust.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-trust.ts
@@ -1,0 +1,64 @@
+// Trust gating for plugin manifest URLs carried inside a project file.
+//
+// A `.geolibre.json` project is opened as data and can come from anyone (a
+// shared file, a URL, a gallery card). It can carry `plugins.manifestUrls`,
+// each of which the app would otherwise fetch and dynamically `import()` as a
+// JavaScript module in the privileged renderer context (with access to the
+// Tauri APIs on desktop). Executing that code on open, with no user decision,
+// lets a shared project silently extend the app's trusted codebase (#1062).
+//
+// So project-supplied URLs never auto-load. Only URLs the user has already
+// explicitly installed (their desktop settings) or that ship baked into the
+// build (bundled drop-ins) are trusted to load automatically; every other
+// project URL is held back until the user approves it in a trust prompt.
+
+import { isAllowedPluginManifestUrl } from "@geolibre/core";
+import { normalizeStringList } from "./string-lists";
+
+export interface PartitionedProjectPluginUrls {
+  /** Project URLs already trusted (installed in settings or bundled). */
+  trusted: string[];
+  /** Project URLs that must not load until the user approves them. */
+  untrusted: string[];
+}
+
+/**
+ * Split the plugin manifest URLs carried by a project into the already-trusted
+ * subset and the untrusted subset.
+ *
+ * A URL is trusted only when the user has previously installed it (it is in
+ * `trustedManifestUrls`, i.e. the desktop settings list) or it ships with the
+ * build (`bundledManifestUrls`). Everything else is untrusted and must not be
+ * fetched or imported until the user makes an explicit trust decision.
+ *
+ * URLs that fail the scheme allow-list (`isAllowedPluginManifestUrl`) can never
+ * load, so they are dropped from both lists — matching the filter applied when
+ * the project file is parsed (`normalizeProjectPlugins`).
+ *
+ * @param projectManifestUrls - `plugins.manifestUrls` from the opened project.
+ * @param trustedManifestUrls - The user's installed plugin URLs (desktop settings).
+ * @param bundledManifestUrls - URLs for plugins baked into the build.
+ * @returns The trusted and untrusted partitions, de-duplicated and trimmed.
+ */
+export function partitionProjectPluginManifestUrls(
+  projectManifestUrls: readonly string[],
+  trustedManifestUrls: readonly string[],
+  bundledManifestUrls: readonly string[],
+): PartitionedProjectPluginUrls {
+  const trustedSet = new Set(
+    normalizeStringList([...trustedManifestUrls, ...bundledManifestUrls]),
+  );
+  const trusted: string[] = [];
+  const untrusted: string[] = [];
+  for (const url of normalizeStringList(projectManifestUrls)) {
+    // A disallowed scheme (non-HTTPS, non-loopback) can never load; drop it
+    // rather than surfacing it in a trust prompt the user could never satisfy.
+    if (!isAllowedPluginManifestUrl(url)) continue;
+    if (trustedSet.has(url)) {
+      trusted.push(url);
+    } else {
+      untrusted.push(url);
+    }
+  }
+  return { trusted, untrusted };
+}

--- a/tests/plugin-trust.test.ts
+++ b/tests/plugin-trust.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { partitionProjectPluginManifestUrls } from "../apps/geolibre-desktop/src/lib/plugin-trust";
+
+// Security regression coverage for #1062: a `.geolibre.json` project is opened
+// as data, so its plugin manifest URLs must never be fetched or imported until
+// the user makes an explicit trust decision. The load path only ever scans the
+// TRUSTED set (installed settings URLs + bundled drop-ins), so verifying that a
+// project's URLs are partitioned as "untrusted" proves the auto-loader never
+// sees them.
+describe("partitionProjectPluginManifestUrls", () => {
+  it("treats a project URL not in settings or bundled as untrusted", () => {
+    const { trusted, untrusted } = partitionProjectPluginManifestUrls(
+      ["https://evil.example.com/plugin.json"],
+      [],
+      [],
+    );
+    assert.deepEqual(untrusted, ["https://evil.example.com/plugin.json"]);
+    assert.deepEqual(trusted, []);
+  });
+
+  it("trusts a project URL the user has already installed in settings", () => {
+    const url = "https://plugins.example.com/plugin.json";
+    const { trusted, untrusted } = partitionProjectPluginManifestUrls(
+      [url],
+      [url],
+      [],
+    );
+    assert.deepEqual(trusted, [url]);
+    assert.deepEqual(untrusted, []);
+  });
+
+  it("trusts a project URL that ships as a bundled drop-in", () => {
+    const url = "https://geolibre.app/plugins/demo/plugin.json";
+    const { trusted, untrusted } = partitionProjectPluginManifestUrls(
+      [url],
+      [],
+      [url],
+    );
+    assert.deepEqual(trusted, [url]);
+    assert.deepEqual(untrusted, []);
+  });
+
+  it("splits a mix of trusted and untrusted project URLs", () => {
+    const installed = "https://plugins.example.com/installed/plugin.json";
+    const unknown = "https://third-party.example.com/plugin.json";
+    const { trusted, untrusted } = partitionProjectPluginManifestUrls(
+      [installed, unknown],
+      [installed],
+      [],
+    );
+    assert.deepEqual(trusted, [installed]);
+    assert.deepEqual(untrusted, [unknown]);
+  });
+
+  it("drops disallowed schemes so they never reach the trust prompt", () => {
+    // Non-HTTPS, non-loopback URLs can never load, so they must not surface as
+    // untrusted (a prompt the user could approve but that would still fail).
+    const { trusted, untrusted } = partitionProjectPluginManifestUrls(
+      [
+        "http://evil.example.com/plugin.json",
+        "ftp://evil.example.com/plugin.json",
+        "javascript:alert(1)",
+      ],
+      [],
+      [],
+    );
+    assert.deepEqual(trusted, []);
+    assert.deepEqual(untrusted, []);
+  });
+
+  it("allows an http loopback URL for local plugin development", () => {
+    const url = "http://localhost:8000/plugin.json";
+    const { untrusted } = partitionProjectPluginManifestUrls([url], [], []);
+    assert.deepEqual(untrusted, [url]);
+  });
+
+  it("de-duplicates and trims project URLs", () => {
+    const url = "https://plugins.example.com/plugin.json";
+    const { untrusted } = partitionProjectPluginManifestUrls(
+      [url, `  ${url}  `, url],
+      [],
+      [],
+    );
+    assert.deepEqual(untrusted, [url]);
+  });
+
+  it("matches a trusted settings URL that carries surrounding whitespace", () => {
+    const url = "https://plugins.example.com/plugin.json";
+    const { trusted, untrusted } = partitionProjectPluginManifestUrls(
+      [url],
+      [`  ${url}  `],
+      [],
+    );
+    assert.deepEqual(trusted, [url]);
+    assert.deepEqual(untrusted, []);
+  });
+});


### PR DESCRIPTION
## Summary

Closes a P0 security-hardening gap: a `.geolibre.json` project is opened as data, yet it could carry `plugins.manifestUrls` that were merged into the active plugin source list and then fetched and dynamically `import()`ed as JavaScript modules in the privileged renderer context. Opening a shared project therefore silently extended the app's trusted codebase, which is especially dangerous on the desktop build where renderer code can reach the Tauri APIs and local sidecar workflows.

Fixes #1062

## What changed

- **Project-supplied plugin URLs never auto-load.** The external plugin scan (`ensureExternalPluginsLoadedWithSettings`) now only fetches/imports the user's installed URLs (desktop settings) and the bundled drop-ins. Project URLs are excluded from the merge entirely.
- **New trust gate.** `partitionProjectPluginManifestUrls` (`lib/plugin-trust.ts`) splits a project's URLs into already-trusted (installed or bundled) and untrusted. `useProjectPluginTrust` surfaces the untrusted set, and `ProjectPluginTrustDialog` prompts the user before any code is fetched or imported, showing each URL's origin and warning that plugins run with the app's privileges.
- **Explicit, persisted trust.** "Trust and load" installs the URLs into desktop settings (the same store used by Manage Plugins), which re-runs the existing loader so the now-trusted plugins load. "Don't load" (and Escape/overlay dismiss) loads nothing and persists nothing.
- Disallowed schemes (non-HTTPS, non-loopback) are dropped rather than surfaced in a prompt the user could never satisfy, matching the existing project-parse filter.

## Acceptance criteria

- [x] Opening an untrusted project never fetches or imports a project-supplied plugin URL before user confirmation.
- [x] Trusted/installed plugin URLs continue to work (they are in desktop settings, so no prompt).
- [x] Project files cannot silently add persistent plugin sources to global settings; only "Trust and load" persists.
- [x] Tests cover loading a project with an unknown plugin manifest URL (`tests/plugin-trust.test.ts`).

## Verification

Unit tests (`tests/plugin-trust.test.ts`, 8 cases) plus a real-app run driven with Playwright against a minimal external plugin served over loopback and a crafted project referencing it:

- Opening the project fetched only the project JSON, not the plugin manifest/entry; the plugin's module never evaluated and the trust dialog appeared.
- "Trust and load" then fetched `plugin.json` + `plugin.js`, executed the plugin, and persisted the URL to settings.
- "Don't load" dismissed with nothing fetched, executed, or persisted.
- Verified in both light and dark themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a project plugin trust prompt when opening projects that reference external plugin URLs.
  * Users can review untrusted plugin origins and choose to trust or dismiss them.

* **Bug Fixes**
  * Updated plugin loading to only auto-load trusted and bundled plugins, while keeping unsafe manifest URLs out of the prompt.
  * Improved the trust dialog behavior to avoid empty/flash states during closing transitions.

* **Documentation**
  * Expanded the English UI text for the new trust prompt (including pluralized descriptions and action labels).

* **Tests**
  * Added coverage for trust partitioning, URL normalization/deduping, scheme filtering, and localhost allowance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->