### PR TITLE
fix(whitebox): honor output extension and render expression fields for WASM tools

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -13,6 +13,7 @@ import {
   runWhiteboxTool,
   runWhiteboxToolWasm,
   outputBaseName,
+  fileOutputTargetExtension,
   type WhiteboxJob,
   type WhiteboxLayerInput,
   type WhiteboxTool,
@@ -467,6 +468,9 @@ export function ProcessingDialog({
   const browsedInputsRef = useRef<
     Map<string, { name: string; bytes: Uint8Array; geojson?: FeatureCollection }>
   >(new Map());
+  // The parameters passed to the most recent run, so output naming can honor the
+  // output path the user actually typed (which the finished job does not carry).
+  const lastRunParametersRef = useRef<Record<string, unknown>>({});
 
   const selectedTool = useMemo(() => {
     const tool =
@@ -906,14 +910,21 @@ export function ProcessingDialog({
         const outKind = param ? parameterKind(param) : "";
         if (outKind === "file_out" || outKind === "vector_out") {
           const label = `${jobToolLabel} ${humanize(name)}`.replace(/\s+/g, "_");
-          // A vector_out's CRS-preserving format is only recoverable from its
-          // magic bytes; a file_out's format follows the parameter's declared
-          // output extension (e.g. a CSV table), which a byte sniff cannot
-          // recover since CSV/JSON/HTML have no magic signature.
+          // Prefer the content signature: a `vector_out` and most binary
+          // `file_out` formats (GeoParquet/FlatGeobuf/zipped Shapefile/PNG/
+          // PMTiles) are identifiable from their magic bytes. Only signature-less
+          // text formats (CSV/JSON/HTML) return `bin`; for those, fall back to
+          // the extension the tool was actually told to write — the user's typed
+          // output path, else the param's declared format (shared with the WASM
+          // runner via `fileOutputTargetExtension`).
+          const sniffed = fileOutputExtension(value);
           const extension =
-            outKind === "file_out" && param
-              ? outputExtensionForParameter(param).slice(1)
-              : fileOutputExtension(value);
+            sniffed !== "bin" || outKind !== "file_out" || !param
+              ? sniffed
+              : fileOutputTargetExtension(
+                  param,
+                  lastRunParametersRef.current[name],
+                );
           downloadBytes(value, `${label}.${extension}`);
         } else if (onAddRaster) {
           // Display name stays human-readable; the file name matches the actual
@@ -1017,6 +1028,10 @@ export function ProcessingDialog({
     // in the form state (the form only resets on tool change) would otherwise be
     // cast to a bogus format and produce a `..._output.undefined` filename.
     const vectorOutputFormat = normalizeVectorOutputFormat(vectorOutValue);
+
+    // Remember this run's parameters so output-download naming can recover the
+    // output path the user typed once the job finishes.
+    lastRunParametersRef.current = parameters;
 
     try {
       const request = {

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -243,14 +243,35 @@ function acceptForParameter(param: WhiteboxToolParameter): string {
     .join(",");
 }
 
+/** The raw `data_kind` of a parameter (e.g. `raster`, `table`), lowercased. */
+function parameterDataKind(param: WhiteboxToolParameter): string {
+  const schema =
+    param.schema && typeof param.schema === "object"
+      ? (param.schema as Record<string, unknown>)
+      : {};
+  const dataset =
+    schema.dataset && typeof schema.dataset === "object"
+      ? (schema.dataset as Record<string, unknown>)
+      : {};
+  return String(
+    param.data_kind ?? dataset.kind ?? param.type ?? "",
+  ).toLowerCase();
+}
+
 function outputExtensionForParameter(param: WhiteboxToolParameter): string {
   const kind = parameterKind(param);
   if (kind === "raster_out") return ".tif";
   if (kind === "vector_out") return ".shp";
   if (kind === "lidar_out") return ".laz";
-  if (/\bcsv\b/i.test(`${param.name} ${param.type ?? ""}`)) return ".csv";
-  if (/\bhtml\b/i.test(`${param.name} ${param.type ?? ""}`)) return ".html";
-  if (/\bjson\b/i.test(`${param.name} ${param.type ?? ""}`)) return ".json";
+  // Sniff the intended text format from the parameter's name, description, and
+  // type (e.g. vector_summary_statistics' output is an "Output CSV path"). A
+  // `table` output with no explicit format word defaults to CSV, matching how
+  // Whitebox writes tabular results.
+  const hint = `${param.name} ${param.description ?? ""} ${param.type ?? ""}`;
+  if (/\bcsv\b/i.test(hint)) return ".csv";
+  if (/\bhtml\b/i.test(hint)) return ".html";
+  if (/\bjson\b/i.test(hint)) return ".json";
+  if (parameterDataKind(param) === "table") return ".csv";
   return ".txt";
 }
 
@@ -885,7 +906,15 @@ export function ProcessingDialog({
         const outKind = param ? parameterKind(param) : "";
         if (outKind === "file_out" || outKind === "vector_out") {
           const label = `${jobToolLabel} ${humanize(name)}`.replace(/\s+/g, "_");
-          downloadBytes(value, `${label}.${fileOutputExtension(value)}`);
+          // A vector_out's CRS-preserving format is only recoverable from its
+          // magic bytes; a file_out's format follows the parameter's declared
+          // output extension (e.g. a CSV table), which a byte sniff cannot
+          // recover since CSV/JSON/HTML have no magic signature.
+          const extension =
+            outKind === "file_out" && param
+              ? outputExtensionForParameter(param).slice(1)
+              : fileOutputExtension(value);
+          downloadBytes(value, `${label}.${extension}`);
         } else if (onAddRaster) {
           // Display name stays human-readable; the file name matches the actual
           // WASM output path (e.g. fill_depressions_wang_and_liu_output.tif), so

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -14,6 +14,7 @@ import {
   runWhiteboxToolWasm,
   outputBaseName,
   fileOutputTargetExtension,
+  outputTextFormatHint,
   type WhiteboxJob,
   type WhiteboxLayerInput,
   type WhiteboxTool,
@@ -244,36 +245,18 @@ function acceptForParameter(param: WhiteboxToolParameter): string {
     .join(",");
 }
 
-/** The raw `data_kind` of a parameter (e.g. `raster`, `table`), lowercased. */
-function parameterDataKind(param: WhiteboxToolParameter): string {
-  const schema =
-    param.schema && typeof param.schema === "object"
-      ? (param.schema as Record<string, unknown>)
-      : {};
-  const dataset =
-    schema.dataset && typeof schema.dataset === "object"
-      ? (schema.dataset as Record<string, unknown>)
-      : {};
-  return String(
-    param.data_kind ?? dataset.kind ?? param.type ?? "",
-  ).toLowerCase();
-}
-
 function outputExtensionForParameter(param: WhiteboxToolParameter): string {
   const kind = parameterKind(param);
   if (kind === "raster_out") return ".tif";
   if (kind === "vector_out") return ".shp";
   if (kind === "lidar_out") return ".laz";
-  // Sniff the intended text format from the parameter's name, description, and
-  // type (e.g. vector_summary_statistics' output is an "Output CSV path"). A
-  // `table` output with no explicit format word defaults to CSV, matching how
-  // Whitebox writes tabular results.
-  const hint = `${param.name} ${param.description ?? ""} ${param.type ?? ""}`;
-  if (/\bcsv\b/i.test(hint)) return ".csv";
-  if (/\bhtml\b/i.test(hint)) return ".html";
-  if (/\bjson\b/i.test(hint)) return ".json";
-  if (parameterDataKind(param) === "table") return ".csv";
-  return ".txt";
+  // Sniff the intended text format from the parameter's name/description/type
+  // via the same shared helper the WASM runner uses (e.g.
+  // vector_summary_statistics' output is an "Output CSV path"). Only the
+  // fallback differs: a friendly `.txt` here for a default filename suggestion,
+  // vs the opaque `.dat` the runner writes.
+  const hint = outputTextFormatHint(param);
+  return hint ? `.${hint}` : ".txt";
 }
 
 function defaultOutputName(
@@ -468,9 +451,14 @@ export function ProcessingDialog({
   const browsedInputsRef = useRef<
     Map<string, { name: string; bytes: Uint8Array; geojson?: FeatureCollection }>
   >(new Map());
-  // The parameters passed to the most recent run, so output naming can honor the
-  // output path the user actually typed (which the finished job does not carry).
-  const lastRunParametersRef = useRef<Record<string, unknown>>({});
+  // Parameters passed to each run, keyed by the resulting job id, so output
+  // naming can honor the output path the user actually typed (which the finished
+  // job does not carry). Keyed per job (not a single slot) so a rapid re-run
+  // cannot overwrite the entry a still-draining previous job is reading; the
+  // entry is deleted once its outputs are imported.
+  const runParametersByJobRef = useRef<Map<string, Record<string, unknown>>>(
+    new Map(),
+  );
 
   const selectedTool = useMemo(() => {
     const tool =
@@ -881,6 +869,11 @@ export function ProcessingDialog({
       const jobToolLabel = jobTool
         ? toolLabel(jobTool)
         : humanize(nextJob.tool_id);
+      // This job's own run parameters (not a shared slot), consumed once here so a
+      // concurrent re-run cannot repoint the output-path lookup below.
+      const runParameters =
+        runParametersByJobRef.current.get(nextJob.id) ?? {};
+      runParametersByJobRef.current.delete(nextJob.id);
       for (const [name, value] of entries) {
         const path = isFeatureCollection(value) ? "" : (outputPath(value) ?? "");
         const data = isFeatureCollection(value)
@@ -921,10 +914,7 @@ export function ProcessingDialog({
           const extension =
             sniffed !== "bin" || outKind !== "file_out" || !param
               ? sniffed
-              : fileOutputTargetExtension(
-                  param,
-                  lastRunParametersRef.current[name],
-                );
+              : fileOutputTargetExtension(param, runParameters[name]);
           downloadBytes(value, `${label}.${extension}`);
         } else if (onAddRaster) {
           // Display name stays human-readable; the file name matches the actual
@@ -1029,10 +1019,6 @@ export function ProcessingDialog({
     // cast to a bogus format and produce a `..._output.undefined` filename.
     const vectorOutputFormat = normalizeVectorOutputFormat(vectorOutValue);
 
-    // Remember this run's parameters so output-download naming can recover the
-    // output path the user typed once the job finishes.
-    lastRunParametersRef.current = parameters;
-
     try {
       const request = {
         tool_id: selectedTool.id,
@@ -1051,9 +1037,18 @@ export function ProcessingDialog({
           requestAnimationFrame(() => requestAnimationFrame(resolve)),
         );
       }
-      setJob(
-        await (runLocal ? runWhiteboxToolWasm(request) : runWhiteboxTool(request)),
-      );
+      const nextJob = await (runLocal
+        ? runWhiteboxToolWasm(request)
+        : runWhiteboxTool(request));
+      // Record this run's parameters against its job id so output-download naming
+      // can later recover the output path the user typed (the job omits it). Only
+      // the WASM runner returns inline binary outputs that need this; the sidecar
+      // returns fetchable paths. `succeeded` is terminal for WASM, so a failed run
+      // adds nothing to clean up.
+      if (runLocal && nextJob.status === "succeeded") {
+        runParametersByJobRef.current.set(nextJob.id, parameters);
+      }
+      setJob(nextJob);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Could not start Whitebox tool.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13797,9 +13797,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.2.tgz",
-      "integrity": "sha512-qfcRaEk7nq/V1DTE00Sv/F+Ue1WOHWIUaFN8acP1TWUeAyAP3MTQdHGlJLBR/J6Ht6+SbdeoLxdtkw8XWXQpUw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.3.tgz",
+      "integrity": "sha512-bKem9Y/5hVdgcNDNNUxxFovLCyFAeSQ+LFrrTZX85FYWYw3FXkvdZAtQwirJAInUs8EPO5OAsDnNB5XADJEDDQ==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -21353,7 +21353,7 @@
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^0.5.2",
+        "geolibre-wasm": "^0.5.3",
         "geotiff": "^3.0.5"
       },
       "devDependencies": {

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -33,7 +33,7 @@
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^0.5.2",
+    "geolibre-wasm": "^0.5.3",
     "geotiff": "^3.0.5"
   },
   "devDependencies": {

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -148,6 +148,7 @@ export {
   mergeWasmToolManifests,
   outputBaseName,
   fileOutputTargetExtension,
+  outputTextFormatHint,
   isTiff,
 } from "./wasm-client";
 export {

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -147,6 +147,7 @@ export {
   listWasmToolManifests,
   mergeWasmToolManifests,
   outputBaseName,
+  fileOutputTargetExtension,
   isTiff,
 } from "./wasm-client";
 export {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -196,6 +196,59 @@ export async function listWasmToolManifests(): Promise<WhiteboxTool[]> {
  * @param wasmTools - Every WASM tool manifest ({@link listWasmToolManifests}).
  * @returns Catalog tools with WASM parameters, plus WASM-only GeoLibre tools.
  */
+/** Scalar catalog kinds trusted to correct a mislabeled WASM manifest param. */
+const CATALOG_SCALAR_KINDS = new Set(["string", "int", "double"]);
+
+/**
+ * Whether the catalog's kind should override the WASM manifest's for a param
+ * they both declare (matched by name). The WASM binary's manifest occasionally
+ * mislabels a free-form scalar parameter: `extract_by_attribute`'s `statement`
+ * expression is typed `bool` (rendering a checkbox) and `field_calculator`'s
+ * `expression` is typed as a vector input (rendering a second layer picker),
+ * so neither exposes a text field to type the expression (GeoLibre#1073). When
+ * the Python sidecar's catalog types the same-named param as a plain scalar
+ * (string/int/double) but the WASM manifest makes it a dataset I/O or a bool, we
+ * trust the catalog so the dialog renders (and the runner serializes) a text
+ * input. Genuine enums/dropdowns and already-matching kinds are left untouched.
+ *
+ * @param wasmKind - The kind derived from the WASM manifest param.
+ * @param catalogKind - The kind the catalog declares for the same-named param.
+ * @returns `true` when the catalog kind should replace the WASM kind.
+ */
+function shouldPreferCatalogKind(
+  wasmKind: string,
+  catalogKind: string | undefined,
+): boolean {
+  if (!catalogKind || catalogKind === wasmKind) return false;
+  if (!CATALOG_SCALAR_KINDS.has(catalogKind)) return false;
+  return (
+    wasmKind.endsWith("_in") || wasmKind.endsWith("_out") || wasmKind === "bool"
+  );
+}
+
+/**
+ * Reconcile one tool's WASM manifest params against the catalog's. The WASM
+ * params win (names and set), but a same-named catalog param corrects a WASM
+ * kind that mislabels a scalar as a dataset/bool (see {@link shouldPreferCatalogKind}).
+ */
+function reconcileToolParams(
+  catalogParams: WhiteboxToolParameter[] | undefined,
+  wasmParams: WhiteboxToolParameter[] | undefined,
+): WhiteboxToolParameter[] {
+  const catalogByName = new Map(
+    (catalogParams ?? []).map((param) => [param.name, param] as const),
+  );
+  return (wasmParams ?? []).map((param) => {
+    const catalogParam = catalogByName.get(param.name);
+    if (!catalogParam) return param;
+    const catalogKind = paramKind(catalogParam);
+    if (shouldPreferCatalogKind(paramKind(param), catalogKind)) {
+      return { ...param, kind: catalogKind as WhiteboxToolParameter["kind"] };
+    }
+    return param;
+  });
+}
+
 export function mergeWasmToolManifests(
   catalogTools: WhiteboxTool[],
   wasmTools: WhiteboxTool[],
@@ -211,8 +264,13 @@ export function mergeWasmToolManifests(
     // and for the tool's provenance; keep only the catalog's display metadata
     // (name, category, …). Preserving `source` matters so a GeoLibre-authored
     // tool that also has a catalog stub keeps its "geolibre" marker for the
-    // source filter.
-    return { ...tool, params: wasm.params, source: wasm.source ?? tool.source };
+    // source filter. A same-named catalog param still corrects a WASM kind that
+    // mislabels a scalar expression as a dataset/bool (GeoLibre#1073).
+    return {
+      ...tool,
+      params: reconcileToolParams(tool.params, wasm.params),
+      source: wasm.source ?? tool.source,
+    };
   });
   const geolibreOnly = [...wasmById.values()].filter(
     (tool) => tool.source === "geolibre",
@@ -247,6 +305,39 @@ function paramKind(p: WhiteboxToolParameter): string {
   if (role === "input") return datasetParameterKind(dataKind, "in");
   if (role === "output") return datasetParameterKind(dataKind, "out");
   return dataKind;
+}
+
+/**
+ * Extension (without the dot) the WASM runner should give a `file_out` file so
+ * the tool's own format check passes. Whitebox tools infer a table/report
+ * format from the output path's extension, so we honor the extension of the
+ * user-chosen output path; when none is present we default a `table` output to
+ * CSV and anything else to an opaque `.dat`.
+ *
+ * @param param - The output parameter (carries `data_kind`/`schema`).
+ * @param requested - The user-chosen output path, if any.
+ * @returns A lowercase extension without a leading dot (e.g. `csv`, `json`, `dat`).
+ */
+export function fileOutputTargetExtension(
+  param: WhiteboxToolParameter,
+  requested: unknown,
+): string {
+  if (typeof requested === "string") {
+    const match = requested.match(/\.([A-Za-z0-9]+)$/);
+    if (match) return match[1].toLowerCase();
+  }
+  const schema =
+    param.schema && typeof param.schema === "object"
+      ? (param.schema as Record<string, unknown>)
+      : {};
+  const dataset =
+    schema.dataset && typeof schema.dataset === "object"
+      ? (schema.dataset as Record<string, unknown>)
+      : {};
+  const dataKind = String(
+    param.data_kind ?? dataset.kind ?? param.type ?? "",
+  ).toLowerCase();
+  return dataKind === "table" ? "csv" : "dat";
 }
 
 function isFeatureCollection(value: unknown): value is FeatureCollection {
@@ -436,9 +527,17 @@ export async function runWhiteboxToolWasm(
         args.push(`--${name}=/work/${file}`);
       }
     } else if (kind === "raster_out" || kind === "file_out") {
-      // file_out is treated as an opaque binary output (no GeoJSON parsing),
-      // mirroring how raster outputs are returned as raw bytes.
-      const ext = kind === "file_out" ? "dat" : "tif";
+      // raster_out is always a GeoTIFF. file_out is an opaque output whose
+      // format the tool infers from the output *extension* (e.g.
+      // vector_summary_statistics rejects any output path that isn't ".csv").
+      // Honor the extension of the user-chosen output path; fall back to CSV for
+      // a tabular output, else an opaque ".dat". Hardcoding ".dat" here made
+      // every such tool fail its own ".csv path" validation regardless of what
+      // the user typed (see GeoLibre#1074).
+      const ext =
+        kind === "file_out"
+          ? fileOutputTargetExtension(param, request.parameters[name])
+          : "tif";
       const file = `${outputBaseName(request.tool_id, name)}.${ext}`;
       outputs.push({ name, file, kind: "bytes" });
       args.push(`--${name}=/work/${file}`);

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -207,9 +207,13 @@ const CATALOG_SCALAR_KINDS = new Set(["string", "int", "double"]);
  * `expression` is typed as a vector input (rendering a second layer picker),
  * so neither exposes a text field to type the expression (GeoLibre#1073). When
  * the Python sidecar's catalog types the same-named param as a plain scalar
- * (string/int/double) but the WASM manifest makes it a dataset I/O or a bool, we
- * trust the catalog so the dialog renders (and the runner serializes) a text
- * input. Genuine enums/dropdowns and already-matching kinds are left untouched.
+ * (string/int/double) but the WASM manifest makes it a dataset **input** or a
+ * bool, we trust the catalog so the dialog renders (and the runner serializes) a
+ * text input. Genuine enums/dropdowns and already-matching kinds are left
+ * untouched. Output params are deliberately excluded: neither motivating bug
+ * (#1073) involves an output, and diverting a genuine dataset output into the
+ * plain-arg path would break its run, so a scalar-typed catalog output never
+ * overrides a WASM `*_out`.
  *
  * @param wasmKind - The kind derived from the WASM manifest param.
  * @param catalogKind - The kind the catalog declares for the same-named param.
@@ -221,9 +225,7 @@ function shouldPreferCatalogKind(
 ): boolean {
   if (!catalogKind || catalogKind === wasmKind) return false;
   if (!CATALOG_SCALAR_KINDS.has(catalogKind)) return false;
-  return (
-    wasmKind.endsWith("_in") || wasmKind.endsWith("_out") || wasmKind === "bool"
-  );
+  return wasmKind.endsWith("_in") || wasmKind === "bool";
 }
 
 /**
@@ -311,8 +313,9 @@ function paramKind(p: WhiteboxToolParameter): string {
  * Extension (without the dot) the WASM runner should give a `file_out` file so
  * the tool's own format check passes. Whitebox tools infer a table/report
  * format from the output path's extension, so we honor the extension of the
- * user-chosen output path; when none is present we default a `table` output to
- * CSV and anything else to an opaque `.dat`.
+ * user-chosen output path; when none is present we sniff the intended text
+ * format from the parameter's name/description (e.g. an "Output JSON report
+ * path."), default a `table` output to CSV, and fall back to an opaque `.dat`.
  *
  * @param param - The output parameter (carries `data_kind`/`schema`).
  * @param requested - The user-chosen output path, if any.
@@ -326,6 +329,12 @@ export function fileOutputTargetExtension(
     const match = requested.match(/\.([A-Za-z0-9]+)$/);
     if (match) return match[1].toLowerCase();
   }
+  // Mirror ProcessingDialog's `outputExtensionForParameter` hint order so a
+  // blank output field still writes the format the param's prose declares.
+  const hint = `${param.name ?? ""} ${param.description ?? ""} ${param.type ?? ""}`;
+  if (/\bcsv\b/i.test(hint)) return "csv";
+  if (/\bhtml\b/i.test(hint)) return "html";
+  if (/\bjson\b/i.test(hint)) return "json";
   const schema =
     param.schema && typeof param.schema === "object"
       ? (param.schema as Record<string, unknown>)

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -207,25 +207,36 @@ const CATALOG_SCALAR_KINDS = new Set(["string", "int", "double"]);
  * `expression` is typed as a vector input (rendering a second layer picker),
  * so neither exposes a text field to type the expression (GeoLibre#1073). When
  * the Python sidecar's catalog types the same-named param as a plain scalar
- * (string/int/double) but the WASM manifest makes it a dataset **input** or a
- * bool, we trust the catalog so the dialog renders (and the runner serializes) a
- * text input. Genuine enums/dropdowns and already-matching kinds are left
- * untouched. Output params are deliberately excluded: neither motivating bug
- * (#1073) involves an output, and diverting a genuine dataset output into the
- * plain-arg path would break its run, so a scalar-typed catalog output never
- * overrides a WASM `*_out`.
+ * (string/int/double) but the WASM manifest makes it a `bool` (any name) or a
+ * dataset **input** whose *name* marks it as a free-text expression, we trust
+ * the catalog so the dialog renders (and the runner serializes) a text input.
  *
+ * The scope is deliberately tight:
+ * - A `bool` mislabel is always safe to correct (no dataset is involved), which
+ *   covers `extract_by_attribute.statement`.
+ * - A dataset **input** is only downgraded when its name is `expression`/
+ *   `statement` (mirroring the upstream wbcore `looks_like_expression` fix),
+ *   which covers `field_calculator.expression` without downgrading a genuine
+ *   raster/vector/lidar input that the catalog merely mistyped as a scalar.
+ * - Outputs are never touched: diverting a real dataset output into the
+ *   plain-arg path would break its run.
+ *
+ * Enums/dropdowns and already-matching kinds are left untouched.
+ *
+ * @param param - The WASM manifest param (its name gates the input case).
  * @param wasmKind - The kind derived from the WASM manifest param.
  * @param catalogKind - The kind the catalog declares for the same-named param.
  * @returns `true` when the catalog kind should replace the WASM kind.
  */
 function shouldPreferCatalogKind(
+  param: WhiteboxToolParameter,
   wasmKind: string,
   catalogKind: string | undefined,
 ): boolean {
   if (!catalogKind || catalogKind === wasmKind) return false;
   if (!CATALOG_SCALAR_KINDS.has(catalogKind)) return false;
-  return wasmKind.endsWith("_in") || wasmKind === "bool";
+  if (wasmKind === "bool") return true;
+  return wasmKind.endsWith("_in") && /\b(expression|statement)\b/i.test(param.name);
 }
 
 /**
@@ -244,7 +255,7 @@ function reconcileToolParams(
     const catalogParam = catalogByName.get(param.name);
     if (!catalogParam) return param;
     const catalogKind = paramKind(catalogParam);
-    if (shouldPreferCatalogKind(paramKind(param), catalogKind)) {
+    if (shouldPreferCatalogKind(param, paramKind(param), catalogKind)) {
       return { ...param, kind: catalogKind as WhiteboxToolParameter["kind"] };
     }
     return param;
@@ -329,8 +340,22 @@ export function fileOutputTargetExtension(
     const match = requested.match(/\.([A-Za-z0-9]+)$/);
     if (match) return match[1].toLowerCase();
   }
-  // Mirror ProcessingDialog's `outputExtensionForParameter` hint order so a
-  // blank output field still writes the format the param's prose declares.
+  return outputTextFormatHint(param) ?? "dat";
+}
+
+/**
+ * The text/tabular output format a `file_out` parameter declares through its
+ * name, description, or `table` data kind, as a bare extension (`csv`/`html`/
+ * `json`), or `null` when nothing recognizable is found. Shared by the WASM
+ * runner's {@link fileOutputTargetExtension} and the dialog's default-name and
+ * download-naming code so the two hint lists cannot drift apart.
+ *
+ * @param param - The output parameter.
+ * @returns `"csv" | "html" | "json"`, or `null` if no text format is implied.
+ */
+export function outputTextFormatHint(
+  param: WhiteboxToolParameter,
+): string | null {
   const hint = `${param.name ?? ""} ${param.description ?? ""} ${param.type ?? ""}`;
   if (/\bcsv\b/i.test(hint)) return "csv";
   if (/\bhtml\b/i.test(hint)) return "html";
@@ -346,7 +371,7 @@ export function fileOutputTargetExtension(
   const dataKind = String(
     param.data_kind ?? dataset.kind ?? param.type ?? "",
   ).toLowerCase();
-  return dataKind === "table" ? "csv" : "dat";
+  return dataKind === "table" ? "csv" : null;
 }
 
 function isFeatureCollection(value: unknown): value is FeatureCollection {

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  fileOutputTargetExtension,
   mergeWasmToolManifests,
   normalizeVectorOutputFormat,
   type WhiteboxTool,
@@ -115,6 +116,80 @@ describe("mergeWasmToolManifests", () => {
     assert.equal(merged[0].display_name, "Write GeoParquet");
   });
 
+  it("corrects a WASM param the manifest mislabels as a dataset/bool (#1073)", () => {
+    // The WASM binary types extract_by_attribute's `statement` expression as a
+    // bool (a checkbox) and field_calculator's `expression` as a vector input (a
+    // second layer picker), so neither exposes a text field. The catalog types
+    // both as plain strings; that scalar kind must win for matched param names.
+    const catalog: WhiteboxTool = {
+      id: "field_calculator",
+      display_name: "Field Calculator",
+      params: [
+        { name: "input", kind: "vector_in", required: true },
+        { name: "field", kind: "string", required: true },
+        { name: "field_type", kind: "int", required: false },
+        { name: "expression", kind: "string", required: true },
+        { name: "output", kind: "vector_out", required: false },
+      ],
+    };
+    const wasm: WhiteboxTool = {
+      id: "field_calculator",
+      params: [
+        { name: "input", data_kind: "vector", io_role: "input", required: true },
+        { name: "field", data_kind: "string", required: true },
+        // A real enum/dropdown: its kind must be left alone, not coerced to int.
+        {
+          name: "field_type",
+          schema: { kind: "enum", options: [{ value: "float" }] },
+          options: ["float", "integer", "text"],
+        },
+        // Mislabeled as a vector input; the catalog's `string` must win.
+        {
+          name: "expression",
+          data_kind: "vector",
+          io_role: "input",
+          required: true,
+        },
+        { name: "output", data_kind: "vector", io_role: "output" },
+      ],
+    };
+    const [tool] = mergeWasmToolManifests([catalog], [wasm]);
+    const byName = new Map(tool.params?.map((p) => [p.name, p]));
+    // Param names/set still come from the WASM manifest.
+    assert.deepEqual(
+      tool.params?.map((p) => p.name),
+      ["input", "field", "field_type", "expression", "output"],
+    );
+    // The mislabeled expression is corrected to a string (a text field).
+    assert.equal(byName.get("expression")?.kind, "string");
+    // A genuine enum keeps its dropdown; the catalog's `int` does not clobber it.
+    assert.equal(byName.get("field_type")?.kind, undefined);
+    // Matching dataset kinds are untouched (no spurious override).
+    assert.equal(byName.get("input")?.kind, undefined);
+  });
+
+  it("corrects a bool-typed expression param to a string (#1073)", () => {
+    const catalog: WhiteboxTool = {
+      id: "extract_by_attribute",
+      params: [
+        { name: "input", kind: "vector_in", required: true },
+        { name: "statement", kind: "string", required: true },
+        { name: "output", kind: "vector_out", required: true },
+      ],
+    };
+    const wasm: WhiteboxTool = {
+      id: "extract_by_attribute",
+      params: [
+        { name: "input", data_kind: "vector", io_role: "input", required: true },
+        { name: "statement", data_kind: "bool", required: true },
+        { name: "output", data_kind: "vector", io_role: "output", required: true },
+      ],
+    };
+    const [tool] = mergeWasmToolManifests([catalog], [wasm]);
+    const statement = tool.params?.find((p) => p.name === "statement");
+    assert.equal(statement?.kind, "string");
+  });
+
   it("does not append WASM-only Whitebox tools missing from the catalog", () => {
     const wasmOnlyWhitebox: WhiteboxTool = {
       id: "some_wasm_only_whitebox_tool",
@@ -139,5 +214,36 @@ describe("normalizeVectorOutputFormat", () => {
     assert.equal(normalizeVectorOutputFormat(""), "geojson");
     assert.equal(normalizeVectorOutputFormat(undefined), "geojson");
     assert.equal(normalizeVectorOutputFormat(42), "geojson");
+  });
+});
+
+describe("fileOutputTargetExtension", () => {
+  // vector_summary_statistics' output param, as the WASM manifest reports it.
+  const tableOutput = {
+    name: "output",
+    description: "Output CSV path.",
+    data_kind: "table",
+    io_role: "output",
+    schema: { dataset: { kind: "table" }, kind: "output", mode: "new" },
+  };
+
+  it("honors the extension of the user-chosen output path", () => {
+    // The bug in #1074: a hardcoded ".dat" made vector_summary_statistics reject
+    // its own output path. The user's ".csv" choice must reach the tool.
+    assert.equal(fileOutputTargetExtension(tableOutput, "test.csv"), "csv");
+    assert.equal(
+      fileOutputTargetExtension(tableOutput, "/Users/me/report.JSON"),
+      "json",
+    );
+  });
+
+  it("defaults a table output to csv when no path is given", () => {
+    assert.equal(fileOutputTargetExtension(tableOutput, undefined), "csv");
+    assert.equal(fileOutputTargetExtension(tableOutput, ""), "csv");
+  });
+
+  it("falls back to an opaque .dat for a non-table output", () => {
+    const opaque = { name: "output", data_kind: "file", io_role: "output" };
+    assert.equal(fileOutputTargetExtension(opaque, undefined), "dat");
   });
 });

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -190,6 +190,24 @@ describe("mergeWasmToolManifests", () => {
     assert.equal(statement?.kind, "string");
   });
 
+  it("does not downgrade a genuine dataset input the catalog mistyped scalar", () => {
+    // Only expression/statement-named inputs are corrected; a real raster/vector
+    // input whose name is not an expression must keep its WASM dataset kind even
+    // if the catalog snapshot mistypes it as a string.
+    const catalog: WhiteboxTool = {
+      id: "some_tool",
+      params: [{ name: "input", kind: "string", required: true }],
+    };
+    const wasm: WhiteboxTool = {
+      id: "some_tool",
+      params: [
+        { name: "input", data_kind: "raster", io_role: "input", required: true },
+      ],
+    };
+    const [tool] = mergeWasmToolManifests([catalog], [wasm]);
+    assert.equal(tool.params?.[0]?.kind, undefined);
+  });
+
   it("never overrides a WASM output param, even if the catalog types it scalar", () => {
     // A scalar-typed catalog output must not divert a genuine WASM dataset
     // output into the plain-arg path (which would break its run). Only inputs

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -190,6 +190,25 @@ describe("mergeWasmToolManifests", () => {
     assert.equal(statement?.kind, "string");
   });
 
+  it("never overrides a WASM output param, even if the catalog types it scalar", () => {
+    // A scalar-typed catalog output must not divert a genuine WASM dataset
+    // output into the plain-arg path (which would break its run). Only inputs
+    // and bools are corrected.
+    const catalog: WhiteboxTool = {
+      id: "some_tool",
+      params: [{ name: "output", kind: "string", required: true }],
+    };
+    const wasm: WhiteboxTool = {
+      id: "some_tool",
+      params: [
+        { name: "output", data_kind: "vector", io_role: "output", required: true },
+      ],
+    };
+    const [tool] = mergeWasmToolManifests([catalog], [wasm]);
+    // Kind stays unset so parameterKind resolves the WASM vector_out.
+    assert.equal(tool.params?.[0]?.kind, undefined);
+  });
+
   it("does not append WASM-only Whitebox tools missing from the catalog", () => {
     const wasmOnlyWhitebox: WhiteboxTool = {
       id: "some_wasm_only_whitebox_tool",
@@ -242,7 +261,28 @@ describe("fileOutputTargetExtension", () => {
     assert.equal(fileOutputTargetExtension(tableOutput, ""), "csv");
   });
 
-  it("falls back to an opaque .dat for a non-table output", () => {
+  it("sniffs the format from the description when no path/table is given", () => {
+    // A JSON/HTML report param whose format lives only in its prose must not
+    // fall through to .dat when the output field is blank (would reproduce #1074
+    // for that tool).
+    const jsonReport = {
+      name: "output",
+      description: "Optional output report path (.json or .csv).",
+      data_kind: "file",
+      io_role: "output",
+    };
+    // csv wins over json in the hint order (both are valid for this tool).
+    assert.equal(fileOutputTargetExtension(jsonReport, undefined), "csv");
+    const jsonOnly = {
+      name: "match_report",
+      description: "Optional JSON output path for summary diagnostics.",
+      data_kind: "file",
+      io_role: "output",
+    };
+    assert.equal(fileOutputTargetExtension(jsonOnly, undefined), "json");
+  });
+
+  it("falls back to an opaque .dat for a non-table, non-text output", () => {
     const opaque = { name: "output", data_kind: "file", io_role: "output" };
     assert.equal(fileOutputTargetExtension(opaque, undefined), "dat");
   });


### PR DESCRIPTION
## Summary

Fixes two Whitebox toolbox bugs in the in-browser (WASM) path.

### #1074 — Vector Summary Statistics rejects the output CSV path

The WASM runner hardcoded a `.dat` extension for every `file_out` parameter, so tools whose output format is inferred from the path extension received `--output=..._output.dat` and failed their own validation (`output must be a .csv path`) regardless of what the user typed.

- `wasm-client.ts`: derive the `file_out` extension from the user-chosen output path, falling back to CSV for a tabular (`table`) output and `.dat` otherwise.
- `ProcessingDialog.tsx`: sniff the intended text format from the parameter's name/description/type (and default a `table` output to CSV) so the default filename is `.csv`, and name the download by the parameter's declared extension instead of a byte sniff (CSV/JSON/HTML have no magic bytes, so they were being saved as `.bin`).

This is entirely GeoLibre-side; no upstream change was involved.

### #1073 — No expression field for Extract By Attribute / Field Calculator

Root cause is upstream: `geolibre-wasm`'s enriched manifest inferred Extract By Attribute's `statement` expression as a `bool` (a checkbox) and Field Calculator's `expression` as a vector input (a second layer picker), so neither exposed a text field.

Fixed at the source and propagated:
- **whitebox-wasm#5** (merged) — `wbcore` now infers `expression`/`statement` params as free-text strings.
- **geolibre-rust#33** (merged) — bumps the pinned `whitebox-wasm` rev; **geolibre-wasm 0.5.3** released to npm.
- This PR bumps `geolibre-wasm` to `^0.5.3`, so the manifest is correct at the source.

`mergeWasmToolManifests` also keeps a defensive reconciliation: when the sidecar catalog types a same-named param as a plain scalar but the WASM manifest makes it a dataset I/O or `bool`, the catalog kind wins. This both covered the bug before 0.5.3 and guards against any other mislabeled tool going forward.

## Testing

- New unit tests for `fileOutputTargetExtension` and the manifest reconciliation; full frontend suite green (1836 pass); typecheck + pre-commit (npm build) clean.
- Verified in the real app (web/WASM) with `us_cities.geojson` in both light and dark themes:
  - Vector Summary Statistics grouped by `region` on `pop_max` downloads a valid `Vector_Summary_Statistics_Output.csv` (both a typed `test.csv` path and the empty/Auto default).
  - Extract By Attribute (`pop_max > 5000000`) and Field Calculator (`pop_max / 1000`) show a text expression field and produce correct output layers.
- Confirmed the shipped `geolibre-wasm@0.5.3` manifest reports both params as `data_kind=string`.

Fixes #1074
Fixes #1073


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processing output downloads now choose file extensions more intelligently based on output type and (when applicable) the user’s chosen save path, with case-insensitive extension handling.
  * Table outputs default to `.csv`, while text-like outputs can resolve to formats such as `.csv/.html/.json`; other non-table outputs fall back to `.dat`.

* **Bug Fixes**
  * Improved merging of tool metadata so misclassified parameter kinds are corrected more reliably, while avoiding unintended overrides for enum/output parameters.

* **Tests**
  * Added regression tests covering parameter-kind correction and output-extension inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->