### PR TITLE
fix(desktop): drop in-app updater from the Microsoft Store build

### DIFF
--- a/.github/workflows/msix-store.yml
+++ b/.github/workflows/msix-store.yml
@@ -36,6 +36,10 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+          # Strip the in-app "Check for updates" flow from this Store-only build
+          # so the package updates solely through the Store (Microsoft policy
+          # 10.2.5). Set only here — the release.yml installers keep the updater.
+          GEOLIBRE_STORE_BUILD: "1"
         run: npm run tauri:build -- --no-sign
 
       - name: Build MSIX package

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -102,8 +102,9 @@ export function AboutDialog({
   );
 
   const handleCheckForUpdates = async () => {
-    // Belt-and-braces: the Store build hides every trigger for this flow, but
-    // never reach out to GitHub even if one slips through (policy 10.2.5).
+    // Belt-and-braces: the Store build hides every trigger for this flow; this
+    // guard ensures it never reaches out to GitHub even if one slips through
+    // (policy 10.2.5).
     if (IS_STORE_BUILD) return;
     abortRef.current?.abort();
     const controller = new AbortController();

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -16,6 +16,7 @@ import {
   APP_VERSION,
   compareVersions,
   fetchLatestRelease,
+  IS_STORE_BUILD,
   UPDATE_URL,
   UpdateCheckError,
 } from "../../lib/updates";
@@ -101,6 +102,9 @@ export function AboutDialog({
   );
 
   const handleCheckForUpdates = async () => {
+    // Belt-and-braces: the Store build hides every trigger for this flow, but
+    // never reach out to GitHub even if one slips through (policy 10.2.5).
+    if (IS_STORE_BUILD) return;
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -188,103 +192,109 @@ export function AboutDialog({
             <span className="text-muted-foreground">{t("about.version")}</span>
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
           </div>
-          <Button
-            className="w-full justify-between"
-            disabled={updateStatus === "checking"}
-            onClick={() => void handleCheckForUpdates()}
-            type="button"
-            variant="outline"
-          >
-            <span className="inline-flex items-center gap-2">
-              <RefreshCw
-                className={`h-3.5 w-3.5 ${
-                  updateStatus === "checking" ? "animate-spin" : ""
-                }`}
-              />
-              {updateStatus === "checking"
-                ? t("about.checking")
-                : updateStatus === "error"
-                  ? t("about.tryAgain")
-                  : t("about.checkForUpdates")}
-            </span>
-          </Button>
-          {updateStatus !== "idle" && updateStatus !== "checking" ? (
-            <div className="rounded-md border bg-muted/30 px-3 py-2">
-              {updateStatus === "current" ? (
-                <div className="flex items-center gap-2 text-foreground">
-                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
-                  <span>
-                    {latestVersion
-                      ? t("about.upToDate", { version: latestVersion })
-                      : t("about.upToDateNoVersion")}
-                  </span>
-                </div>
-              ) : null}
-              {updateStatus === "available" ? (
-                <div className="space-y-3">
-                  <div className="font-medium text-foreground">
-                    {t("updates.available.title", {
-                      version: latestVersion ?? t("updates.available.fallback"),
-                    })}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {t("updates.available.summary", {
-                      current: `v${APP_VERSION}`,
-                    })}
-                  </div>
-                  <div className="space-y-1.5">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      {t("updates.changelogTitle")}
-                    </div>
-                    <ReleaseNotes notes={latestNotes} />
-                  </div>
-                  <div className="space-y-1.5">
-                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      {t("updates.stepsTitle")}
-                    </div>
-                    <UpdateInstructions />
-                  </div>
-                  <Button
-                    className="w-full justify-between"
-                    onClick={() => void openExternalLink(latestUrl)}
-                    type="button"
-                    variant="default"
-                  >
-                    <span>{t("updates.download")}</span>
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              ) : null}
-              {updateStatus === "error" ? (
-                <div className="space-y-2">
-                  <div className="text-foreground">
-                    {t("updates.error.message")}
-                  </div>
-                  {updateError ? (
-                    <div className="text-xs text-muted-foreground">
-                      {updateError}
+          {/* The Microsoft Store build omits the entire in-app update flow
+              so the app updates only through the Store (policy 10.2.5). */}
+          {!IS_STORE_BUILD && (
+            <>
+              <Button
+                className="w-full justify-between"
+                disabled={updateStatus === "checking"}
+                onClick={() => void handleCheckForUpdates()}
+                type="button"
+                variant="outline"
+              >
+                <span className="inline-flex items-center gap-2">
+                  <RefreshCw
+                    className={`h-3.5 w-3.5 ${
+                      updateStatus === "checking" ? "animate-spin" : ""
+                    }`}
+                  />
+                  {updateStatus === "checking"
+                    ? t("about.checking")
+                    : updateStatus === "error"
+                      ? t("about.tryAgain")
+                      : t("about.checkForUpdates")}
+                </span>
+              </Button>
+              {updateStatus !== "idle" && updateStatus !== "checking" ? (
+                <div className="rounded-md border bg-muted/30 px-3 py-2">
+                  {updateStatus === "current" ? (
+                    <div className="flex items-center gap-2 text-foreground">
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                      <span>
+                        {latestVersion
+                          ? t("about.upToDate", { version: latestVersion })
+                          : t("about.upToDateNoVersion")}
+                      </span>
                     </div>
                   ) : null}
-                  {/* Group the hint with its button and divide it from the error
-                      message above so the two muted lines do not read as one. */}
-                  <div className="space-y-1.5 border-t pt-2">
-                    <div className="text-xs text-muted-foreground">
-                      {t("updates.error.viewDownloadsHint")}
+                  {updateStatus === "available" ? (
+                    <div className="space-y-3">
+                      <div className="font-medium text-foreground">
+                        {t("updates.available.title", {
+                          version: latestVersion ?? t("updates.available.fallback"),
+                        })}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {t("updates.available.summary", {
+                          current: `v${APP_VERSION}`,
+                        })}
+                      </div>
+                      <div className="space-y-1.5">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {t("updates.changelogTitle")}
+                        </div>
+                        <ReleaseNotes notes={latestNotes} />
+                      </div>
+                      <div className="space-y-1.5">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          {t("updates.stepsTitle")}
+                        </div>
+                        <UpdateInstructions />
+                      </div>
+                      <Button
+                        className="w-full justify-between"
+                        onClick={() => void openExternalLink(latestUrl)}
+                        type="button"
+                        variant="default"
+                      >
+                        <span>{t("updates.download")}</span>
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Button>
                     </div>
-                    <Button
-                      className="w-full justify-between"
-                      onClick={() => void openExternalLink(UPDATE_URL)}
-                      type="button"
-                      variant="outline"
-                    >
-                      <span>{t("updates.error.viewDownloads")}</span>
-                      <ExternalLink className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
+                  ) : null}
+                  {updateStatus === "error" ? (
+                    <div className="space-y-2">
+                      <div className="text-foreground">
+                        {t("updates.error.message")}
+                      </div>
+                      {updateError ? (
+                        <div className="text-xs text-muted-foreground">
+                          {updateError}
+                        </div>
+                      ) : null}
+                      {/* Group the hint with its button and divide it from the error
+                          message above so the two muted lines do not read as one. */}
+                      <div className="space-y-1.5 border-t pt-2">
+                        <div className="text-xs text-muted-foreground">
+                          {t("updates.error.viewDownloadsHint")}
+                        </div>
+                        <Button
+                          className="w-full justify-between"
+                          onClick={() => void openExternalLink(UPDATE_URL)}
+                          type="button"
+                          variant="outline"
+                        >
+                          <span>{t("updates.error.viewDownloads")}</span>
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
-            </div>
-          ) : null}
+            </>
+          )}
           <div className="space-y-2 border-t pt-3">
             <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               {t("about.generalSectionTitle")}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1315,7 +1315,10 @@ export function SettingsDialog({
               {t("settings.menu.environmentVariables")}
             </DropdownMenuItem>
           )}
-          {isTauri() && (
+          {/* Share the same gate as the in-dialog nav/pane so the Store build
+              (and the web build) hide this shortcut too — otherwise it would
+              open the dialog on a fallback section. */}
+          {isSectionVisible("updates") && (
             <DropdownMenuItem
               onSelect={() => {
                 setSection("updates");

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -85,7 +85,7 @@ import {
   normalizeHexColor,
   type ThemeScheme,
 } from "../../lib/theme-schemes";
-import type { UpdateNotificationLevel } from "../../lib/updates";
+import { IS_STORE_BUILD, type UpdateNotificationLevel } from "../../lib/updates";
 import {
   DATA_SOURCE_CATALOG,
   DATA_SOURCE_SECTION_LABEL_KEYS,
@@ -410,6 +410,9 @@ export function SettingsDialog({
     // Automated update checks run in the desktop build only, so the section is
     // hidden on the web where its controls would be inert.
     if (id === "updates" && !isTauri()) return false;
+    // The Microsoft Store build has no in-app update flow to configure (policy
+    // 10.2.5), so its settings section is dropped entirely.
+    if (id === "updates" && IS_STORE_BUILD) return false;
     const gate = SECTION_GATE[id];
     return gate ? showSettingsItem(gate) : true;
   };

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -90,6 +90,7 @@ import { KeyboardShortcutsDialog } from "../command/KeyboardShortcutsDialog";
 import { useGlobalShortcuts } from "../../hooks/useGlobalShortcuts";
 import { useViewportHistory } from "../../hooks/useViewportHistory";
 import type { Command } from "../../lib/commands";
+import { IS_STORE_BUILD } from "../../lib/updates";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AddNetcdfDialog } from "./AddNetcdfDialog";
 import { AboutDialog } from "./AboutDialog";
@@ -820,16 +821,22 @@ export function TopToolbar({
       icon: MessageSquare,
       run: () => void openExternalLink(FEEDBACK_URL),
     },
-    {
-      id: "help.updates",
-      title: t("toolbar.command.checkForUpdates"),
-      group: t("toolbar.commandGroup.help"),
-      icon: RefreshCw,
-      run: () => {
-        setAboutOpen(true);
-        setCheckForUpdatesRequest((value) => value + 1);
-      },
-    },
+    // The Microsoft Store build omits the "Check for updates" command so the app
+    // updates only through the Store (policy 10.2.5).
+    ...(IS_STORE_BUILD
+      ? []
+      : [
+          {
+            id: "help.updates",
+            title: t("toolbar.command.checkForUpdates"),
+            group: t("toolbar.commandGroup.help"),
+            icon: RefreshCw,
+            run: () => {
+              setAboutOpen(true);
+              setCheckForUpdatesRequest((value) => value + 1);
+            },
+          },
+        ]),
     {
       id: "help.about",
       title: t("toolbar.command.about"),

--- a/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import { IS_STORE_BUILD } from "../../../lib/updates";
 import { isMenuItemVisible } from "../../../lib/ui-profile";
 import {
   FEEDBACK_URL,
@@ -51,7 +52,12 @@ export function HelpMenu({
 }: HelpMenuProps) {
   const { t } = useTranslation();
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
-  const show = (id: string) => isMenuItemVisible(uiProfile, id);
+  // The Microsoft Store build strips the "Check for updates" item entirely so the
+  // app only updates through the Store (policy 10.2.5); other builds keep it.
+  const show = (id: string) =>
+    id === "help.checkForUpdates" && IS_STORE_BUILD
+      ? false
+      : isMenuItemVisible(uiProfile, id);
 
   return (
     <DropdownMenu>

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -7,6 +7,7 @@ import {
 import {
   APP_VERSION,
   fetchLatestRelease,
+  IS_STORE_BUILD,
   meetsNotificationLevel,
   releaseSeverity,
   UpdateCheckError,
@@ -89,6 +90,10 @@ export function useStartupUpdateCheck() {
     // Automated startup checks are a desktop-only feature; the web build
     // refreshes to the latest version on reload and needs no prompt.
     if (!isTauri()) return;
+
+    // The Microsoft Store build must update only through the Store (policy
+    // 10.2.5), so it never reaches out to GitHub to check for a newer release.
+    if (IS_STORE_BUILD) return;
 
     const settings =
       useDesktopSettingsStore.getState().desktopSettings.updates;

--- a/apps/geolibre-desktop/src/lib/updates.ts
+++ b/apps/geolibre-desktop/src/lib/updates.ts
@@ -21,6 +21,19 @@ export const APP_VERSION: string =
   typeof __GEOLIBRE_VERSION__ !== "undefined" ? __GEOLIBRE_VERSION__ : "0.0.0";
 
 /**
+ * True in the Microsoft Store MSIX build, where the entire in-app update flow is
+ * removed so the app updates only through the Store (Microsoft policy 10.2.5
+ * rejects a Store app that updates itself outside the Store). Guarded the same
+ * way as {@link APP_VERSION} so the pure helpers here stay importable in a plain
+ * Node test (where the define is absent) without throwing a ReferenceError.
+ * Injected by vite.config.ts; set only by the Store build (msix-store.yml).
+ */
+export const IS_STORE_BUILD: boolean =
+  typeof __GEOLIBRE_STORE_BUILD__ !== "undefined"
+    ? __GEOLIBRE_STORE_BUILD__
+    : false;
+
+/**
  * How a newer release differs from the running version. Used to filter startup
  * notifications by the user's chosen granularity (see {@link UpdateNotificationLevel}).
  */

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -3,6 +3,11 @@
 
 declare const __GEOLIBRE_VERSION__: string;
 
+// True only in the Microsoft Store MSIX build (GEOLIBRE_STORE_BUILD=1), where the
+// in-app update checker is removed so the app updates solely through the Store
+// (Microsoft policy 10.2.5). false in every other build. See vite.config.ts.
+declare const __GEOLIBRE_STORE_BUILD__: boolean;
+
 // jsDelivr URLs for the PGlite engine and its PostGIS extension, injected by
 // vite.config.ts. Only the embed (Jupyter wheel) build reads them, from
 // pglite-loader.cdn.ts; web/desktop builds bundle PGlite and never reference

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -88,6 +88,15 @@ const PGLITE_CDN = process.env.GEOLIBRE_PGLITE_CDN !== "0";
 const IS_EMBED = process.env.GEOLIBRE_EMBED === "1";
 const PWA_DISABLED = IS_TAURI_BUILD || IS_EMBED;
 
+// Microsoft Store MSIX build. Strips the in-app "Check for updates" flow (Help
+// menu, command palette, About dialog, and the automated startup check) so the
+// Store package updates only through the Store — Microsoft policy 10.2.5 rejects
+// a Store app that updates itself outside the Store. Set ONLY by the dedicated
+// Store build path (.github/workflows/msix-store.yml); every other build (the
+// GitHub .exe/winget installer, the sideload MSIX, portable, macOS, Linux, web,
+// and the Jupyter embed) leaves it unset, so their update checker is untouched.
+const IS_STORE_BUILD = process.env.GEOLIBRE_STORE_BUILD === "1";
+
 const pgliteCdnRequire = createRequire(import.meta.url);
 // The ESM entry of a package's manifest. Prefer the `module` field and the
 // `import` condition of `exports` (both point at the ESM build); never fall back
@@ -821,6 +830,7 @@ export default defineConfig({
   clearScreen: false,
   define: {
     __GEOLIBRE_VERSION__: JSON.stringify(APP_VERSION),
+    __GEOLIBRE_STORE_BUILD__: JSON.stringify(IS_STORE_BUILD),
     __PGLITE_CDN_URL__: JSON.stringify(PGLITE_CDN_URL),
     __PGLITE_POSTGIS_CDN_URL__: JSON.stringify(PGLITE_POSTGIS_CDN_URL),
     __CEREUS_WASM_CDN_URL__: JSON.stringify(CEREUS_WASM_CDN_URL),

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -22,6 +22,24 @@ npm run msix:build
 
 ## Build for the Microsoft Store
 
+> [!IMPORTANT]
+> The Store rejects apps that update themselves outside the Store (policy
+> 10.2.5). The in-app "Check for updates" flow (Help menu, command palette, About
+> dialog, and the automated startup check) is compiled **out** of the frontend
+> only when the `GEOLIBRE_STORE_BUILD=1` environment variable is set during the
+> Tauri build. `build-msix.ps1` repackages the *already-built* binary, so this
+> variable must be exported before `npm run tauri:build`, not passed to this
+> script. The [`msix-store.yml`](../../.github/workflows/msix-store.yml) workflow
+> sets it automatically; when building a Store package locally, set it yourself:
+>
+> ```powershell
+> $env:GEOLIBRE_STORE_BUILD = "1"
+> npm run tauri:build -- --no-sign
+> ```
+>
+> Leave it unset for the winget / sideload MSIX (`release.yml`) — those keep the
+> updater and are never submitted to the Store.
+
 The Store validates the package identity against the values reserved for the app
 in Partner Center (**Product management -> Product Identity**). Pass them as
 parameters; the Store-required fields differ from the defaults:


### PR DESCRIPTION
## Problem

The Microsoft Store rejected our submission under **policy 10.2.5 — Security · Installing and Updating Store Apps**:

> The product updates outside the Store. Please ensure that the product and in-app products are updated only through the Store and resubmit.
> Location where update is found: **Help → Check for Updates → Download update**

GeoLibre's update flow is a custom GitHub-release checker (`lib/updates.ts`) that queries `api.github.com/.../releases/latest` and surfaces a "Download update" link. It also runs an automated startup check. All of this must be absent from the Store package.

## The constraint

One `tauri build` produces every Windows artifact — the GitHub `.exe`/winget installer, the sideload MSIX, and the portable zip all share the same compiled frontend (`build-msix.ps1` just repackages the binary). So the updater can't be stripped at the packaging step, and stripping it from the shared build would also kill it in the GitHub `.exe` and every other OS.

The clean seam is the dedicated **`msix-store.yml`** workflow, whose only output is the Store MSIX.

## Approach

Add a compile-time flag `GEOLIBRE_STORE_BUILD`, following the repo's existing `GEOLIBRE_*` env-flag convention:

- `vite.config.ts` injects it as the `__GEOLIBRE_STORE_BUILD__` define; `lib/updates.ts` exposes it as `IS_STORE_BUILD` (guarded for Node tests, like `APP_VERSION`).
- Every update surface is gated on it:
  - Help menu "Check for Updates" item (`HelpMenu.tsx`)
  - Command-palette entry (`TopToolbar.tsx`)
  - About dialog update section + handler (`AboutDialog.tsx`)
  - Automated startup check (`useStartupUpdateCheck.ts`)
  - Updates settings section (`SettingsDialog.tsx`)
- `msix-store.yml` sets `GEOLIBRE_STORE_BUILD: "1"`; `packaging/msix/README.md` documents the requirement for local Store builds.

Because the flag folds to a literal `true` in the Store build, esbuild tree-shakes the GitHub-checking code out entirely — it isn't just hidden.

## What is **not** affected

The flag is unset everywhere except `msix-store.yml`. macOS, Linux, web, the Jupyter embed, the GitHub Windows `.exe`, winget, portable, and the sideload MSIX all keep the full update checker.

## Verification

- `tsc -b` — no new errors
- `eslint` — clean
- `tests/updates.test.ts` — 16/16 pass
- `pre-commit` (`eslint` + full `npm build`) — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microsoft Store builds now use a Store-only update flow, removing the in-app “Check for updates” options and related update prompts.

* **Bug Fixes**
  * Prevented update checks from running in Microsoft Store builds, avoiding unnecessary network calls and update-related UI in that version of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->