### PR TITLE
fix(wms): honor WMS 1.3.0 in GetMap requests for 1.3.0-only servers

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -69,11 +69,14 @@ export function appendQuery(
 
 /**
  * Normalizes a WMS version to one of the two protocol variants the GetMap
- * builder emits: anything in the 1.3 line is "1.3.0", everything else (or an
- * unset value) falls back to "1.1.1".
+ * builder emits: anything in the 1.3 line is "1.3.0", everything else (an
+ * unset value, or a non-string from an untyped JS plugin) falls back to
+ * "1.1.1".
  */
-export function normalizeWmsVersion(version: string | null | undefined): string {
-  return version?.trim().startsWith("1.3") ? "1.3.0" : "1.1.1";
+export function normalizeWmsVersion(version: unknown): string {
+  return typeof version === "string" && version.trim().startsWith("1.3")
+    ? "1.3.0"
+    : "1.1.1";
 }
 
 export function createWmsTileUrl(options: {

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -68,7 +68,7 @@ export function appendQuery(
 }
 
 /**
- * Normalizes a WMS version to the one of the two protocol variants the GetMap
+ * Normalizes a WMS version to one of the two protocol variants the GetMap
  * builder emits: anything in the 1.3 line is "1.3.0", everything else (or an
  * unset value) falls back to "1.1.1".
  */
@@ -514,11 +514,6 @@ export function parseWmsCapabilities(xmlText: string): WmsCapabilities {
   return { layers, version: root.getAttribute("version") };
 }
 
-/** Backward-compatible wrapper over {@link parseWmsCapabilities}. */
-export function parseWmsCapabilitiesLayers(xmlText: string): WmsLayerOption[] {
-  return parseWmsCapabilities(xmlText).layers;
-}
-
 /**
  * Reads the direct-child element with the given local name and returns its
  * trimmed text. Restricting to direct children keeps a `<Layer>`'s own `<Name>`
@@ -637,7 +632,7 @@ export function parseWfsCapabilitiesFeatureTypes(
   if (doc.querySelector("parsererror")) {
     throw new Error("Could not parse the WFS capabilities document.");
   }
-  // Validate the root element (see parseWmsCapabilitiesLayers) so an exception
+  // Validate the root element (see parseWmsCapabilities) so an exception
   // or HTML error page surfaces an error instead of an empty type list.
   const root = doc.documentElement;
   if (root?.localName !== "WFS_Capabilities") {

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -121,7 +121,10 @@ export function wmsVersionFromEndpoint(endpoint: string): string | null {
   } catch {
     return null;
   }
-  if (!/^1\.[013]/.test(value)) return null;
+  // Recognize any 1.x value so detection agrees with normalizeWmsVersion's
+  // bucketing (e.g. a rare VERSION=1.2.0 lands in the 1.1.1 bucket rather
+  // than being silently ignored).
+  if (!/^1\.\d/.test(value)) return null;
   return normalizeWmsVersion(value);
 }
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -67,6 +67,15 @@ export function appendQuery(
   return `${endpoint}${separator}${query}`;
 }
 
+/**
+ * Normalizes a WMS version to the one of the two protocol variants the GetMap
+ * builder emits: anything in the 1.3 line is "1.3.0", everything else (or an
+ * unset value) falls back to "1.1.1".
+ */
+export function normalizeWmsVersion(version: string | null | undefined): string {
+  return version?.trim().startsWith("1.3") ? "1.3.0" : "1.1.1";
+}
+
 export function createWmsTileUrl(options: {
   endpoint: string;
   layers: string;
@@ -74,20 +83,46 @@ export function createWmsTileUrl(options: {
   format: string;
   transparent: boolean;
   tileSize: number;
+  /** WMS protocol version, "1.1.1" (default) or "1.3.0". */
+  version?: string;
 }): string {
+  // WMS 1.3.0 renames the SRS parameter to CRS; a 1.3.0-only server (e.g. the
+  // IGN Géoplateforme raster endpoint) rejects a 1.1.1 request outright with
+  // VersionNegotiationFailed. EPSG:3857 keeps easting/northing axis order in
+  // both versions, so the BBOX template is unchanged.
+  const version = normalizeWmsVersion(options.version);
   return appendQuery(options.endpoint, [
     ["SERVICE", "WMS"],
     ["REQUEST", "GetMap"],
-    ["VERSION", "1.1.1"],
+    ["VERSION", version],
     ["LAYERS", options.layers],
     ["STYLES", options.styles],
     ["FORMAT", options.format],
     ["TRANSPARENT", options.transparent ? "TRUE" : "FALSE"],
-    ["SRS", "EPSG:3857"],
+    [version === "1.3.0" ? "CRS" : "SRS", "EPSG:3857"],
     ["BBOX", "{bbox-epsg-3857}"],
     ["WIDTH", String(options.tileSize)],
     ["HEIGHT", String(options.tileSize)],
   ]);
+}
+
+/**
+ * Reads the WMS version from a `VERSION` query parameter the user left on a
+ * pasted service URL, so the Add Data form can preselect it before the
+ * parameter is stripped from the endpoint. Returns null when the URL carries
+ * no recognizable version.
+ */
+export function wmsVersionFromEndpoint(endpoint: string): string | null {
+  const match = /[?&]version=([^&#]+)/i.exec(endpoint);
+  if (!match) return null;
+  let value: string;
+  try {
+    value = decodeURIComponent(match[1]).trim();
+  } catch {
+    return null;
+  }
+  if (!/^1\.[013]/.test(value)) return null;
+  return normalizeWmsVersion(value);
 }
 
 export function parseRequiredNumber(value: string, label: string): number {
@@ -424,17 +459,30 @@ export function createWmsGetCapabilitiesUrl(endpoint: string): string {
   return buildCapabilitiesUrl(endpoint, "WMS", WMS_OPERATION_PARAMS);
 }
 
+/** The parts of a WMS GetCapabilities document the Add Data dialog uses. */
+export interface WmsCapabilities {
+  /** The named layers in document order, deduplicated by name. */
+  layers: WmsLayerOption[];
+  /**
+   * The service's negotiated WMS version (the root element's `version`
+   * attribute), or null when the document does not carry one. A 1.3.0-only
+   * server reports it here, letting the form switch the GetMap version.
+   */
+  version: string | null;
+}
+
 /**
- * Extracts the requestable (named) layers from a WMS GetCapabilities document.
- * Only `<Layer>` elements that carry their own `<Name>` are requestable; the
- * container layers that merely group others (a `<Title>` but no `<Name>`) are
- * skipped. Traversal is namespace-agnostic so it handles both WMS 1.1.1
- * (`WMT_MS_Capabilities`) and 1.3.0 (`WMS_Capabilities`, default namespace).
+ * Extracts the requestable (named) layers and the negotiated version from a
+ * WMS GetCapabilities document. Only `<Layer>` elements that carry their own
+ * `<Name>` are requestable; the container layers that merely group others (a
+ * `<Title>` but no `<Name>`) are skipped. Traversal is namespace-agnostic so
+ * it handles both WMS 1.1.1 (`WMT_MS_Capabilities`) and 1.3.0
+ * (`WMS_Capabilities`, default namespace).
  *
  * @param xmlText - The raw GetCapabilities XML response body.
- * @returns The named layers in document order, deduplicated by name.
+ * @returns The named layers plus the document's version attribute.
  */
-export function parseWmsCapabilitiesLayers(xmlText: string): WmsLayerOption[] {
+export function parseWmsCapabilities(xmlText: string): WmsCapabilities {
   const doc = new DOMParser().parseFromString(xmlText, "application/xml");
   if (doc.querySelector("parsererror")) {
     throw new Error("Could not parse the WMS capabilities document.");
@@ -463,7 +511,12 @@ export function parseWmsCapabilitiesLayers(xmlText: string): WmsLayerOption[] {
     seen.add(name);
     layers.push({ name, title: directChildText(layer, "Title") || name });
   }
-  return layers;
+  return { layers, version: root.getAttribute("version") };
+}
+
+/** Backward-compatible wrapper over {@link parseWmsCapabilities}. */
+export function parseWmsCapabilitiesLayers(xmlText: string): WmsLayerOption[] {
+  return parseWmsCapabilities(xmlText).layers;
 }
 
 /**
@@ -504,17 +557,18 @@ function capabilitiesRootError(
 
 /**
  * Fetches a WMS service's GetCapabilities document and returns its requestable
- * layers. Works cross-origin in the desktop app and dev server; in the hosted
- * web build it relies on the service's own CORS headers.
+ * layers plus the negotiated version. Works cross-origin in the desktop app
+ * and dev server; in the hosted web build it relies on the service's own CORS
+ * headers.
  *
  * @param endpoint - The WMS service base URL.
  * @param options - Optional abort signal.
- * @returns The named layers advertised by the service.
+ * @returns The named layers and version advertised by the service.
  */
-export async function fetchWmsLayers(
+export async function fetchWmsCapabilities(
   endpoint: string,
   options: { signal?: AbortSignal } = {},
-): Promise<WmsLayerOption[]> {
+): Promise<WmsCapabilities> {
   const requestUrl = createWmsGetCapabilitiesUrl(endpoint.trim());
   const { ok, status, text } = await fetchCapabilitiesText(
     requestUrl,
@@ -526,7 +580,7 @@ export async function fetchWmsLayers(
   if (!ok && !/^\s*</.test(text)) {
     throw new Error(`Request failed with status ${status}`);
   }
-  return parseWmsCapabilitiesLayers(text);
+  return parseWmsCapabilities(text);
 }
 
 /** A single feature type advertised by a WFS GetCapabilities. */

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -51,8 +51,9 @@ export function WmsSource() {
   );
   const [wmsTileSize, setWmsTileSize] = useState(wmsFormCache?.tileSize ?? "256");
   const [wmsVersion, setWmsVersion] = useState(wmsFormCache?.version ?? "1.1.1");
-  // True once the user picks a version in the selector; auto-detection (from a
-  // pasted URL or the capabilities response) must not override that choice.
+  // True while the version has an explicit source — the selector, a pasted
+  // URL's VERSION parameter, or a saved service entry. Capabilities
+  // auto-detection only fills the version in when no explicit source exists.
   // Mirrored in a ref so the async retrieve handler reads the value current at
   // response time, not the one captured when the button was clicked.
   const [versionTouched, setVersionTouched] = useState(
@@ -184,17 +185,12 @@ export function WmsSource() {
     // A saved service predating the version field falls back to the endpoint's
     // own VERSION parameter (if any) rather than silently resetting to 1.1.1.
     // Normalize whatever was stored so a hand-edited value (e.g. "1.3") still
-    // matches the selector's option pair.
-    setWmsVersion(
-      normalizeWmsVersion(
-        serviceFieldString(
-          fields,
-          "version",
-          wmsVersionFromEndpoint(endpoint) ?? "1.1.1",
-        ),
-      ),
-    );
-    markVersionTouched(false);
+    // matches the selector's option pair. Either source is an explicit prior
+    // choice, so capabilities auto-detection must not override it later.
+    const savedVersion = serviceFieldString(fields, "version");
+    const detectedVersion = wmsVersionFromEndpoint(endpoint);
+    setWmsVersion(normalizeWmsVersion(savedVersion || detectedVersion || "1.1.1"));
+    markVersionTouched(Boolean(savedVersion || detectedVersion));
     // The new endpoint's layers must be re-retrieved, so drop the old list and
     // cancel any retrieval still in flight for the previous endpoint.
     cancelRetrieve();
@@ -276,20 +272,21 @@ export function WmsSource() {
                 setWmsEndpoint(value);
                 // A pasted URL often carries the service's VERSION (stripped
                 // before the GetMap is built); adopt it so a 1.3.0-only server
-                // works without a manual version change. Only act when the
-                // detected version actually changed, and only drop a manual
-                // version choice when the service itself (origin + path)
-                // changed — fixing an unrelated typo in the same URL must not
-                // clobber the user's selection.
+                // works without a manual version change, and treat it as an
+                // explicit source that capabilities auto-detection must not
+                // override. Only act when the detected version actually
+                // changed, and only drop the explicit choice when the service
+                // itself (origin + path) changed — fixing an unrelated typo in
+                // the same URL must not clobber the selection.
                 const detected = wmsVersionFromEndpoint(value);
                 if (detected && detected !== wmsVersionFromEndpoint(previous)) {
                   setWmsVersion(detected);
-                  markVersionTouched(false);
+                  markVersionTouched(true);
                 } else if (
                   value.trim().split(/[?#]/)[0] !==
                   previous.trim().split(/[?#]/)[0]
                 ) {
-                  markVersionTouched(false);
+                  markVersionTouched(detected != null);
                 }
                 // Layers belong to the previous endpoint; clear them (and cancel
                 // any in-flight retrieval) so the list never reflects a

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -34,6 +34,7 @@ interface WmsFormCache {
   transparent: boolean;
   tileSize: string;
   version: string;
+  versionTouched: boolean;
   options: WmsLayerOption[];
 }
 let wmsFormCache: WmsFormCache | null = null;
@@ -50,6 +51,11 @@ export function WmsSource() {
   );
   const [wmsTileSize, setWmsTileSize] = useState(wmsFormCache?.tileSize ?? "256");
   const [wmsVersion, setWmsVersion] = useState(wmsFormCache?.version ?? "1.1.1");
+  // True once the user picks a version in the selector; auto-detection (from a
+  // pasted URL or the capabilities response) must not override that choice.
+  const [versionTouched, setVersionTouched] = useState(
+    wmsFormCache?.versionTouched ?? false,
+  );
   const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>(
     wmsFormCache?.options ?? [],
   );
@@ -68,6 +74,7 @@ export function WmsSource() {
       transparent: wmsTransparent,
       tileSize: wmsTileSize,
       version: wmsVersion,
+      versionTouched,
       options: layerOptions,
     };
   }, [
@@ -78,6 +85,7 @@ export function WmsSource() {
     wmsTransparent,
     wmsTileSize,
     wmsVersion,
+    versionTouched,
     layerOptions,
   ]);
   // Guards against a stale in-flight retrieval overwriting the form after the
@@ -128,8 +136,10 @@ export function WmsSource() {
       }
       setLayerOptions(options);
       // Adopt the service's negotiated version so a 1.3.0-only server (e.g.
-      // the IGN Géoplateforme raster endpoint) gets a GetMap it accepts.
-      if (version) setWmsVersion(normalizeWmsVersion(version));
+      // the IGN Géoplateforme raster endpoint) gets a GetMap it accepts —
+      // unless the user already picked a version explicitly, since a server
+      // can negotiate GetCapabilities and GetMap differently.
+      if (version && !versionTouched) setWmsVersion(normalizeWmsVersion(version));
       // Preselect the first layer when the field is empty so a single click
       // leaves the form ready to submit.
       if (!wmsLayers.trim()) setWmsLayers(options[0].name);
@@ -162,13 +172,18 @@ export function WmsSource() {
     setWmsTileSize(serviceFieldString(fields, "tileSize", "256"));
     // A saved service predating the version field falls back to the endpoint's
     // own VERSION parameter (if any) rather than silently resetting to 1.1.1.
+    // Normalize whatever was stored so a hand-edited value (e.g. "1.3") still
+    // matches the selector's option pair.
     setWmsVersion(
-      serviceFieldString(
-        fields,
-        "version",
-        wmsVersionFromEndpoint(endpoint) ?? "1.1.1",
+      normalizeWmsVersion(
+        serviceFieldString(
+          fields,
+          "version",
+          wmsVersionFromEndpoint(endpoint) ?? "1.1.1",
+        ),
       ),
     );
+    setVersionTouched(false);
     // The new endpoint's layers must be re-retrieved, so drop the old list and
     // cancel any retrieval still in flight for the previous endpoint.
     cancelRetrieve();
@@ -248,9 +263,11 @@ export function WmsSource() {
                 setWmsEndpoint(event.target.value);
                 // A pasted URL often carries the service's VERSION (stripped
                 // before the GetMap is built); adopt it so a 1.3.0-only server
-                // works without a manual version change.
+                // works without a manual version change. A new endpoint is a
+                // new service, so it also clears any manual version choice.
                 const detected = wmsVersionFromEndpoint(event.target.value);
                 if (detected) setWmsVersion(detected);
+                setVersionTouched(false);
                 // Layers belong to the previous endpoint; clear them (and cancel
                 // any in-flight retrieval) so the list never reflects a
                 // different service.
@@ -358,7 +375,10 @@ export function WmsSource() {
             <Select
               id="wms-version"
               value={wmsVersion}
-              onChange={(event) => setWmsVersion(event.target.value)}
+              onChange={(event) => {
+                setWmsVersion(event.target.value);
+                setVersionTouched(true);
+              }}
             >
               <option value="1.1.1">1.1.1</option>
               <option value="1.3.0">1.3.0</option>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -53,9 +53,16 @@ export function WmsSource() {
   const [wmsVersion, setWmsVersion] = useState(wmsFormCache?.version ?? "1.1.1");
   // True once the user picks a version in the selector; auto-detection (from a
   // pasted URL or the capabilities response) must not override that choice.
+  // Mirrored in a ref so the async retrieve handler reads the value current at
+  // response time, not the one captured when the button was clicked.
   const [versionTouched, setVersionTouched] = useState(
     wmsFormCache?.versionTouched ?? false,
   );
+  const versionTouchedRef = useRef(versionTouched);
+  const markVersionTouched = (touched: boolean) => {
+    versionTouchedRef.current = touched;
+    setVersionTouched(touched);
+  };
   const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>(
     wmsFormCache?.options ?? [],
   );
@@ -138,8 +145,12 @@ export function WmsSource() {
       // Adopt the service's negotiated version so a 1.3.0-only server (e.g.
       // the IGN Géoplateforme raster endpoint) gets a GetMap it accepts —
       // unless the user already picked a version explicitly, since a server
-      // can negotiate GetCapabilities and GetMap differently.
-      if (version && !versionTouched) setWmsVersion(normalizeWmsVersion(version));
+      // can negotiate GetCapabilities and GetMap differently. Read the ref,
+      // not the state: the user may have touched the selector while this
+      // request was in flight.
+      if (version && !versionTouchedRef.current) {
+        setWmsVersion(normalizeWmsVersion(version));
+      }
       // Preselect the first layer when the field is empty so a single click
       // leaves the form ready to submit.
       if (!wmsLayers.trim()) setWmsLayers(options[0].name);
@@ -183,7 +194,7 @@ export function WmsSource() {
         ),
       ),
     );
-    setVersionTouched(false);
+    markVersionTouched(false);
     // The new endpoint's layers must be re-retrieved, so drop the old list and
     // cancel any retrieval still in flight for the previous endpoint.
     cancelRetrieve();
@@ -260,14 +271,26 @@ export function WmsSource() {
               placeholder={t("addData.wms.urlPlaceholder")}
               value={wmsEndpoint}
               onChange={(event) => {
-                setWmsEndpoint(event.target.value);
+                const value = event.target.value;
+                const previous = wmsEndpoint;
+                setWmsEndpoint(value);
                 // A pasted URL often carries the service's VERSION (stripped
                 // before the GetMap is built); adopt it so a 1.3.0-only server
-                // works without a manual version change. A new endpoint is a
-                // new service, so it also clears any manual version choice.
-                const detected = wmsVersionFromEndpoint(event.target.value);
-                if (detected) setWmsVersion(detected);
-                setVersionTouched(false);
+                // works without a manual version change. Only act when the
+                // detected version actually changed, and only drop a manual
+                // version choice when the service itself (origin + path)
+                // changed — fixing an unrelated typo in the same URL must not
+                // clobber the user's selection.
+                const detected = wmsVersionFromEndpoint(value);
+                if (detected && detected !== wmsVersionFromEndpoint(previous)) {
+                  setWmsVersion(detected);
+                  markVersionTouched(false);
+                } else if (
+                  value.trim().split(/[?#]/)[0] !==
+                  previous.trim().split(/[?#]/)[0]
+                ) {
+                  markVersionTouched(false);
+                }
                 // Layers belong to the previous endpoint; clear them (and cancel
                 // any in-flight retrieval) so the list never reflects a
                 // different service.
@@ -377,7 +400,7 @@ export function WmsSource() {
               value={wmsVersion}
               onChange={(event) => {
                 setWmsVersion(event.target.value);
-                setVersionTouched(true);
+                markVersionTouched(true);
               }}
             >
               <option value="1.1.1">1.1.1</option>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -171,7 +171,9 @@ export function WmsSource() {
     format: wmsFormat,
     transparent: wmsTransparent,
     tileSize: wmsTileSize,
-    version: wmsVersion,
+    // Only persist the version when it has an explicit source; an untouched
+    // default stays eligible for URL/capabilities auto-detection on reload.
+    ...(versionTouched ? { version: wmsVersion } : {}),
   });
 
   const applyFields = (fields: ServiceFields) => {
@@ -274,19 +276,25 @@ export function WmsSource() {
                 // before the GetMap is built); adopt it so a 1.3.0-only server
                 // works without a manual version change, and treat it as an
                 // explicit source that capabilities auto-detection must not
-                // override. Only act when the detected version actually
-                // changed, and only drop the explicit choice when the service
-                // itself (origin + path) changed — fixing an unrelated typo in
-                // the same URL must not clobber the selection.
+                // override. A different service (origin + path changed) always
+                // re-derives the version from its own URL — or the default —
+                // so a choice made for the previous service cannot leak onto
+                // it. Within the same service, only an actual change to the
+                // URL's declared VERSION is adopted; fixing an unrelated typo
+                // must not clobber a manual selection.
                 const detected = wmsVersionFromEndpoint(value);
-                if (detected && detected !== wmsVersionFromEndpoint(previous)) {
+                const serviceChanged =
+                  value.trim().split(/[?#]/)[0] !==
+                  previous.trim().split(/[?#]/)[0];
+                if (serviceChanged) {
+                  setWmsVersion(detected ?? "1.1.1");
+                  markVersionTouched(detected != null);
+                } else if (
+                  detected &&
+                  detected !== wmsVersionFromEndpoint(previous)
+                ) {
                   setWmsVersion(detected);
                   markVersionTouched(true);
-                } else if (
-                  value.trim().split(/[?#]/)[0] !==
-                  previous.trim().split(/[?#]/)[0]
-                ) {
-                  markVersionTouched(detected != null);
                 }
                 // Layers belong to the previous endpoint; clear them (and cancel
                 // any in-flight retrieval) so the list never reflects a

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -7,8 +7,10 @@ import {
   createBaseLayer,
   createWmsTileUrl,
   errorMessage,
-  fetchWmsLayers,
+  fetchWmsCapabilities,
+  normalizeWmsVersion,
   stripOgcOperationParams,
+  wmsVersionFromEndpoint,
   type WmsLayerOption,
 } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
@@ -31,6 +33,7 @@ interface WmsFormCache {
   format: string;
   transparent: boolean;
   tileSize: string;
+  version: string;
   options: WmsLayerOption[];
 }
 let wmsFormCache: WmsFormCache | null = null;
@@ -46,6 +49,7 @@ export function WmsSource() {
     wmsFormCache?.transparent ?? true,
   );
   const [wmsTileSize, setWmsTileSize] = useState(wmsFormCache?.tileSize ?? "256");
+  const [wmsVersion, setWmsVersion] = useState(wmsFormCache?.version ?? "1.1.1");
   const [layerOptions, setLayerOptions] = useState<WmsLayerOption[]>(
     wmsFormCache?.options ?? [],
   );
@@ -63,6 +67,7 @@ export function WmsSource() {
       format: wmsFormat,
       transparent: wmsTransparent,
       tileSize: wmsTileSize,
+      version: wmsVersion,
       options: layerOptions,
     };
   }, [
@@ -72,6 +77,7 @@ export function WmsSource() {
     wmsFormat,
     wmsTransparent,
     wmsTileSize,
+    wmsVersion,
     layerOptions,
   ]);
   // Guards against a stale in-flight retrieval overwriting the form after the
@@ -111,7 +117,7 @@ export function WmsSource() {
     setIsRetrieving(true);
     setRetrieveError(null);
     try {
-      const options = await fetchWmsLayers(endpoint, {
+      const { layers: options, version } = await fetchWmsCapabilities(endpoint, {
         signal: controller.signal,
       });
       if (isStale()) return;
@@ -121,6 +127,9 @@ export function WmsSource() {
         return;
       }
       setLayerOptions(options);
+      // Adopt the service's negotiated version so a 1.3.0-only server (e.g.
+      // the IGN Géoplateforme raster endpoint) gets a GetMap it accepts.
+      if (version) setWmsVersion(normalizeWmsVersion(version));
       // Preselect the first layer when the field is empty so a single click
       // leaves the form ready to submit.
       if (!wmsLayers.trim()) setWmsLayers(options[0].name);
@@ -140,15 +149,26 @@ export function WmsSource() {
     format: wmsFormat,
     transparent: wmsTransparent,
     tileSize: wmsTileSize,
+    version: wmsVersion,
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setWmsEndpoint(serviceFieldString(fields, "endpoint"));
+    const endpoint = serviceFieldString(fields, "endpoint");
+    setWmsEndpoint(endpoint);
     setWmsLayers(serviceFieldString(fields, "layers"));
     setWmsStyles(serviceFieldString(fields, "styles"));
     setWmsFormat(serviceFieldString(fields, "format", "image/png"));
     setWmsTransparent(serviceFieldBoolean(fields, "transparent", true));
     setWmsTileSize(serviceFieldString(fields, "tileSize", "256"));
+    // A saved service predating the version field falls back to the endpoint's
+    // own VERSION parameter (if any) rather than silently resetting to 1.1.1.
+    setWmsVersion(
+      serviceFieldString(
+        fields,
+        "version",
+        wmsVersionFromEndpoint(endpoint) ?? "1.1.1",
+      ),
+    );
     // The new endpoint's layers must be re-retrieved, so drop the old list and
     // cancel any retrieval still in flight for the previous endpoint.
     cancelRetrieve();
@@ -166,6 +186,7 @@ export function WmsSource() {
     // Strip any leftover operation params (a pasted GetCapabilities URL) so the
     // GetMap request is not built with a conflicting duplicate REQUEST.
     const endpoint = stripOgcOperationParams(wmsEndpoint.trim(), "WMS");
+    const version = normalizeWmsVersion(wmsVersion);
     const tileUrl = createWmsTileUrl({
       endpoint,
       layers: wmsLayers.trim(),
@@ -173,6 +194,7 @@ export function WmsSource() {
       format: wmsFormat,
       transparent: wmsTransparent,
       tileSize,
+      version,
     });
     source.addAndClose(
       createBaseLayer(
@@ -187,6 +209,7 @@ export function WmsSource() {
           styles: wmsStyles.trim(),
           format: wmsFormat,
           transparent: wmsTransparent,
+          version,
         },
         { service: "wms" },
       ),
@@ -223,6 +246,11 @@ export function WmsSource() {
               value={wmsEndpoint}
               onChange={(event) => {
                 setWmsEndpoint(event.target.value);
+                // A pasted URL often carries the service's VERSION (stripped
+                // before the GetMap is built); adopt it so a 1.3.0-only server
+                // works without a manual version change.
+                const detected = wmsVersionFromEndpoint(event.target.value);
+                if (detected) setWmsVersion(detected);
                 // Layers belong to the previous endpoint; clear them (and cancel
                 // any in-flight retrieval) so the list never reflects a
                 // different service.
@@ -324,6 +352,17 @@ export function WmsSource() {
               value={wmsTileSize}
               onChange={(event) => setWmsTileSize(event.target.value)}
             />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="wms-version">{t("addData.wms.version")}</Label>
+            <Select
+              id="wms-version"
+              value={wmsVersion}
+              onChange={(event) => setWmsVersion(event.target.value)}
+            >
+              <option value="1.1.1">1.1.1</option>
+              <option value="1.3.0">1.3.0</option>
+            </Select>
           </div>
         </div>
         <label className="flex items-center gap-2 text-sm">

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -687,6 +687,14 @@ export function createAppAPI(
       const resolvedFormat = format ?? "image/png";
       const resolvedTransparent = transparent ?? true;
       const resolvedVersion = normalizeWmsVersion(version);
+      // Mirror setMapProjection's unrecognized-value warning so a typo'd
+      // version from an untyped JS plugin is visible instead of silently
+      // coerced.
+      if (version !== undefined && version !== resolvedVersion) {
+        console.warn(
+          `[GeoLibre] addWmsLayer: unsupported WMS version "${String(version)}"; using "${resolvedVersion}".`,
+        );
+      }
       const tileUrl = createWmsTileUrl({
         endpoint: url,
         layers,

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -72,7 +72,10 @@ import {
 } from "../lib/external-plugins";
 import { appendDiagnostic } from "../lib/diagnostics";
 import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
-import { createWmsTileUrl } from "../components/layout/add-data/helpers";
+import {
+  createWmsTileUrl,
+  normalizeWmsVersion,
+} from "../components/layout/add-data/helpers";
 import { createExternalNativeStoreLayer } from "../lib/external-native-layer";
 import { mergeStringLists } from "../lib/string-lists";
 import {
@@ -664,6 +667,7 @@ export function createAppAPI(
         styles,
         format,
         transparent,
+        version,
         ...tileOptions
       } = options;
       // TypeScript enforces these, but an untyped JS plugin can pass "" — an
@@ -682,6 +686,7 @@ export function createAppAPI(
       const resolvedStyles = styles ?? "";
       const resolvedFormat = format ?? "image/png";
       const resolvedTransparent = transparent ?? true;
+      const resolvedVersion = normalizeWmsVersion(version);
       const tileUrl = createWmsTileUrl({
         endpoint: url,
         layers,
@@ -689,6 +694,7 @@ export function createAppAPI(
         format: resolvedFormat,
         transparent: resolvedTransparent,
         tileSize,
+        version: resolvedVersion,
       });
       return store.addTileLayer(
         name,
@@ -703,6 +709,7 @@ export function createAppAPI(
             styles: resolvedStyles,
             format: resolvedFormat,
             transparent: resolvedTransparent,
+            version: resolvedVersion,
           },
           ...tileOptions,
         },

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -689,8 +689,12 @@ export function createAppAPI(
       const resolvedVersion = normalizeWmsVersion(version);
       // Mirror setMapProjection's unrecognized-value warning so a typo'd
       // version from an untyped JS plugin is visible instead of silently
-      // coerced.
-      if (version !== undefined && version !== resolvedVersion) {
+      // coerced. Valid shorthand in a recognized 1.x family (e.g. "1.3") is
+      // not warned about — it normalizes cleanly.
+      if (
+        version !== undefined &&
+        (typeof version !== "string" || !/^1\.\d/.test(version.trim()))
+      ) {
         console.warn(
           `[GeoLibre] addWmsLayer: unsupported WMS version "${String(version)}"; using "${resolvedVersion}".`,
         );

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -251,7 +251,8 @@
       "selectLayer_one": "Select from {{count}} layer",
       "selectLayer_other": "Select from {{count}} layers",
       "noLayersFound": "No layers were found for this service.",
-      "retrieveError": "Could not retrieve layers from this service."
+      "retrieveError": "Could not retrieve layers from this service.",
+      "version": "WMS version"
     },
     "wfs": {
       "defaultName": "WFS Layer",

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -292,6 +292,7 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
   styles?: string;
   format?: string; // default "image/png"
   transparent?: boolean; // default true
+  version?: string; // "1.1.1" (default) or "1.3.0" (sends CRS instead of SRS)
 }
 
 export interface GeoLibreCogLayerOptions {

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -80,6 +80,11 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
   format?: string;
   /** Request transparent tiles (default true). */
   transparent?: boolean;
+  /**
+   * WMS protocol version: `"1.1.1"` (default) or `"1.3.0"`. Version 1.3.0
+   * sends `CRS` instead of `SRS`; some servers accept only one version.
+   */
+  version?: string;
 }
 
 /**

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1356,7 +1356,7 @@ class Map(anywidget.AnyWidget):
         image_format: str = "image/png",
         transparent: bool = True,
         tile_size: int = 256,
-        version: str = "1.1.1",
+        version: str | None = "1.1.1",
         **style: Any,
     ) -> str:
         """Add a WMS layer rendered as tiled raster (a WMS GetMap request).

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1356,6 +1356,7 @@ class Map(anywidget.AnyWidget):
         image_format: str = "image/png",
         transparent: bool = True,
         tile_size: int = 256,
+        version: str = "1.1.1",
         **style: Any,
     ) -> str:
         """Add a WMS layer rendered as tiled raster (a WMS GetMap request).
@@ -1368,6 +1369,9 @@ class Map(anywidget.AnyWidget):
             image_format: WMS image format (e.g. ``"image/png"``).
             transparent: Whether to request transparent tiles.
             tile_size: Tile size in pixels.
+            version: WMS protocol version, ``"1.1.1"`` (default) or
+                ``"1.3.0"``. Version 1.3.0 sends ``CRS`` instead of ``SRS``;
+                some servers accept only one version.
             **style: Style overrides.
 
         Returns:
@@ -1382,6 +1386,7 @@ class Map(anywidget.AnyWidget):
                 image_format=image_format,
                 transparent=transparent,
                 tile_size=tile_size,
+                version=version,
                 **style,
             )
         )

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -376,7 +376,7 @@ def wms_layer(
     image_format: str = "image/png",
     transparent: bool = True,
     tile_size: int = 256,
-    version: str = "1.1.1",
+    version: str | None = "1.1.1",
     **style: Any,
 ) -> dict[str, Any]:
     """Build a WMS layer rendered as tiled raster (a WMS GetMap request).
@@ -396,7 +396,7 @@ def wms_layer(
         version: WMS protocol version, ``"1.1.1"`` (default) or ``"1.3.0"``.
             Version 1.3.0 sends ``CRS`` instead of ``SRS``; some servers accept
             only one version. EPSG:3857 keeps its axis order in both, so the
-            BBOX template is unchanged.
+            BBOX template is unchanged. None falls back to ``"1.1.1"``.
         **style: Style overrides merged into the default layer style.
 
     Returns:

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -352,6 +352,18 @@ def _append_query(endpoint: str, params: list[tuple[str, str]]) -> str:
     return f"{base}{separator}{query}{sep}{fragment}"
 
 
+def _normalize_wms_version(version: str) -> str:
+    """Normalize a WMS version to the "1.1.1"/"1.3.0" pair the builder emits.
+
+    Args:
+        version: The requested WMS protocol version.
+
+    Returns:
+        ``"1.3.0"`` for any version in the 1.3 line, ``"1.1.1"`` otherwise.
+    """
+    return "1.3.0" if version.strip().startswith("1.3") else "1.1.1"
+
+
 def wms_layer(
     name: str,
     endpoint: str,
@@ -361,6 +373,7 @@ def wms_layer(
     image_format: str = "image/png",
     transparent: bool = True,
     tile_size: int = 256,
+    version: str = "1.1.1",
     **style: Any,
 ) -> dict[str, Any]:
     """Build a WMS layer rendered as tiled raster (a WMS GetMap request).
@@ -377,22 +390,27 @@ def wms_layer(
         image_format: WMS image format (e.g. ``"image/png"``).
         transparent: Whether to request transparent tiles.
         tile_size: Tile size in pixels.
+        version: WMS protocol version, ``"1.1.1"`` (default) or ``"1.3.0"``.
+            Version 1.3.0 sends ``CRS`` instead of ``SRS``; some servers accept
+            only one version. EPSG:3857 keeps its axis order in both, so the
+            BBOX template is unchanged.
         **style: Style overrides merged into the default layer style.
 
     Returns:
         A layer dict for the project's ``layers`` array.
     """
+    wms_version = _normalize_wms_version(version)
     tile_url = _append_query(
         endpoint,
         [
             ("SERVICE", "WMS"),
             ("REQUEST", "GetMap"),
-            ("VERSION", "1.1.1"),
+            ("VERSION", wms_version),
             ("LAYERS", layers),
             ("STYLES", styles),
             ("FORMAT", image_format),
             ("TRANSPARENT", "TRUE" if transparent else "FALSE"),
-            ("SRS", "EPSG:3857"),
+            ("CRS" if wms_version == "1.3.0" else "SRS", "EPSG:3857"),
             ("BBOX", "{bbox-epsg-3857}"),
             ("WIDTH", str(tile_size)),
             ("HEIGHT", str(tile_size)),
@@ -408,6 +426,7 @@ def wms_layer(
         "styles": styles,
         "format": image_format,
         "transparent": transparent,
+        "version": wms_version,
     }
     layer["metadata"] = {"service": "wms"}
     return layer

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -352,15 +352,18 @@ def _append_query(endpoint: str, params: list[tuple[str, str]]) -> str:
     return f"{base}{separator}{query}{sep}{fragment}"
 
 
-def _normalize_wms_version(version: str) -> str:
+def _normalize_wms_version(version: str | None) -> str:
     """Normalize a WMS version to the "1.1.1"/"1.3.0" pair the builder emits.
 
     Args:
-        version: The requested WMS protocol version.
+        version: The requested WMS protocol version, or None.
 
     Returns:
-        ``"1.3.0"`` for any version in the 1.3 line, ``"1.1.1"`` otherwise.
+        ``"1.3.0"`` for any version in the 1.3 line, ``"1.1.1"`` otherwise
+        (including None or a non-string value).
     """
+    if not isinstance(version, str):
+        return "1.1.1"
     return "1.3.0" if version.strip().startswith("1.3") else "1.1.1"
 
 

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -129,6 +129,10 @@ def test_wms_layer_version_defaults_to_1_1_1():
     assert project.wms_layer("x", "https://e/wms", "a", version="2.0")[
         "source"
     ]["version"] == "1.1.1"
+    # A None from an untyped caller must not raise.
+    assert project.wms_layer("x", "https://e/wms", "a", version=None)[
+        "source"
+    ]["version"] == "1.1.1"
 
 
 def test_wms_layer_transparent_false():

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -106,6 +106,31 @@ def test_wms_layer_shape_and_url():
     assert "WIDTH=256" in tile
 
 
+def test_wms_layer_version_1_3_0_uses_crs():
+    # A 1.3.0-only server (e.g. the IGN Géoplateforme raster endpoint) rejects
+    # a 1.1.1 GetMap, so the version must be honored and SRS renamed to CRS.
+    layer = project.wms_layer("x", "https://e/wms", "a", version="1.3.0")
+    tile = layer["source"]["tiles"][0]
+    assert "VERSION=1.3.0" in tile
+    assert "CRS=EPSG%3A3857" in tile
+    assert "SRS=" not in tile
+    assert "BBOX={bbox-epsg-3857}" in tile
+    assert layer["source"]["version"] == "1.3.0"
+
+
+def test_wms_layer_version_defaults_to_1_1_1():
+    layer = project.wms_layer("x", "https://e/wms", "a")
+    tile = layer["source"]["tiles"][0]
+    assert "VERSION=1.1.1" in tile
+    assert "SRS=EPSG%3A3857" in tile
+    assert "CRS=" not in tile
+    assert layer["source"]["version"] == "1.1.1"
+    # An unrecognized version falls back rather than emitting a bad request.
+    assert project.wms_layer("x", "https://e/wms", "a", version="2.0")[
+        "source"
+    ]["version"] == "1.1.1"
+
+
 def test_wms_layer_transparent_false():
     layer = project.wms_layer(
         "x", "https://e/wms", "a", transparent=False, tile_size=512

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -129,6 +129,9 @@ describe("normalizeWmsVersion", () => {
     assert.equal(normalizeWmsVersion("1.3.0"), "1.3.0");
     assert.equal(normalizeWmsVersion("1.3"), "1.3.0");
     assert.equal(normalizeWmsVersion("garbage"), "1.1.1");
+    // An untyped JS plugin can pass a non-string; it must not throw.
+    assert.equal(normalizeWmsVersion(1.3), "1.1.1");
+    assert.equal(normalizeWmsVersion({}), "1.1.1");
   });
 });
 

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -143,6 +143,8 @@ describe("wmsVersionFromEndpoint", () => {
       "1.1.1",
     );
     assert.equal(wmsVersionFromEndpoint("https://x.test/wms?VERSION=1.0.0"), "1.1.1");
+    // Any 1.x value is bucketed the same way normalizeWmsVersion buckets it.
+    assert.equal(wmsVersionFromEndpoint("https://x.test/wms?VERSION=1.2.0"), "1.1.1");
   });
 
   it("returns null when no usable version is present", () => {

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -7,7 +7,9 @@ import {
   createWmsGetCapabilitiesUrl,
   createWmsTileUrl,
   fileNameFromPath,
+  normalizeWmsVersion,
   stripOgcOperationParams,
+  wmsVersionFromEndpoint,
   geoJsonToPointRows,
   inferDelimitedTextField,
   layerNameFromPath,
@@ -83,6 +85,71 @@ describe("createWmsTileUrl", () => {
     });
     assert.ok(url.includes("TRANSPARENT=FALSE"));
     assert.ok(url.includes("HEIGHT=512"));
+  });
+
+  it("defaults to WMS 1.1.1 with an SRS parameter", () => {
+    const url = createWmsTileUrl({
+      endpoint: "https://x.test/wms",
+      layers: "a",
+      styles: "",
+      format: "image/png",
+      transparent: true,
+      tileSize: 256,
+    });
+    assert.ok(url.includes("VERSION=1.1.1"));
+    assert.ok(url.includes("SRS=EPSG%3A3857"));
+    assert.ok(!url.includes("CRS="));
+  });
+
+  it("switches to CRS for a WMS 1.3.0 request", () => {
+    // A 1.3.0-only server (e.g. the IGN Géoplateforme raster endpoint) rejects
+    // a 1.1.1 GetMap with VersionNegotiationFailed, so the version must be
+    // honored and the SRS parameter renamed to CRS.
+    const url = createWmsTileUrl({
+      endpoint: "https://x.test/wms",
+      layers: "a",
+      styles: "",
+      format: "image/png",
+      transparent: true,
+      tileSize: 256,
+      version: "1.3.0",
+    });
+    assert.ok(url.includes("VERSION=1.3.0"));
+    assert.ok(url.includes("CRS=EPSG%3A3857"));
+    assert.ok(!url.includes("SRS="));
+    assert.ok(url.includes("BBOX={bbox-epsg-3857}"));
+  });
+});
+
+describe("normalizeWmsVersion", () => {
+  it("collapses versions to the 1.1.1/1.3.0 pair", () => {
+    assert.equal(normalizeWmsVersion(undefined), "1.1.1");
+    assert.equal(normalizeWmsVersion(null), "1.1.1");
+    assert.equal(normalizeWmsVersion("1.1.1"), "1.1.1");
+    assert.equal(normalizeWmsVersion("1.3.0"), "1.3.0");
+    assert.equal(normalizeWmsVersion("1.3"), "1.3.0");
+    assert.equal(normalizeWmsVersion("garbage"), "1.1.1");
+  });
+});
+
+describe("wmsVersionFromEndpoint", () => {
+  it("reads the VERSION parameter from a pasted service URL", () => {
+    assert.equal(
+      wmsVersionFromEndpoint("https://data.geopf.fr/wms-r?VERSION=1.3.0"),
+      "1.3.0",
+    );
+    assert.equal(
+      wmsVersionFromEndpoint("https://x.test/wms?version=1.1.1&foo=1"),
+      "1.1.1",
+    );
+    assert.equal(wmsVersionFromEndpoint("https://x.test/wms?VERSION=1.0.0"), "1.1.1");
+  });
+
+  it("returns null when no usable version is present", () => {
+    assert.equal(wmsVersionFromEndpoint("https://x.test/wms"), null);
+    assert.equal(wmsVersionFromEndpoint("https://x.test/wms?VERSION=abc"), null);
+    // An undecodable value must not throw.
+    assert.equal(wmsVersionFromEndpoint("https://x.test/wms?VERSION=%E0%A4%A"), null);
   });
 });
 


### PR DESCRIPTION
## Summary

Adding a WMS layer from a server that only speaks WMS 1.3.0 rendered nothing: the Add WMS dialog always built GetMap tile URLs with `VERSION=1.1.1&SRS=EPSG:3857`, and a 1.3.0-only server such as the IGN Geoplateforme raster endpoint (`https://data.geopf.fr/wms-r`) rejects every tile with HTTP 400 `VersionNegotiationFailed`. The vector endpoint (`wms-v/ows`) tolerates 1.1.1, which is why it appeared to work while `wms-r` did not.

Reported in discussion: https://github.com/opengeos/GeoLibre/discussions/1075

## Changes

- `createWmsTileUrl` accepts a `version` and sends `CRS` instead of `SRS` for 1.3.0. EPSG:3857 keeps its axis order in both versions, so the `{bbox-epsg-3857}` template is unchanged.
- The Add WMS dialog gains a **WMS version** selector (1.1.1 default / 1.3.0). It is auto-set from a pasted URL's `VERSION` parameter (previously silently stripped) and from the negotiated version in the GetCapabilities response when using Retrieve layers.
- The version is persisted on the layer source, so project round-trips and WMS GetFeatureInfo identify (which already honored `source.version`) use it consistently.
- The plugin `addWmsLayer` API (`GeoLibreWmsLayerOptions.version`) and the Python `Map.add_wms(version=...)` API accept the same optional version, keeping the three GetMap builders in sync.

## Verification

- Reproduced pre-fix in the running app: the geopf `wms-r` layer produced HTTP 400 on every GetMap tile and a blank layer.
- Post-fix, verified in the running web app in both light and dark themes: `GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2` from `https://data.geopf.fr/wms-r?VERSION=1.3.0` renders (version auto-detected from the pasted URL), with zero console errors; toggling the layer off/on confirms the imagery comes from the WMS layer.
- Regression-checked the 1.1.1 path with the built-in USGS NAIP sample: still defaults to 1.1.1 and adds cleanly.
- New unit tests: `createWmsTileUrl` 1.3.0/default behavior, `normalizeWmsVersion`, `wmsVersionFromEndpoint` (frontend); `wms_layer` version handling (Python). Full frontend suite (1844 tests), Python suite (155 passed), `npm run build`, eslint, and pre-commit all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WMS version selection in the layer add flow, including detecting version from pasted/previous endpoints and persisting user choice.
  * Updated WMS capabilities loading to read the server’s capabilities version and apply it when appropriate.
  * Extended WMS layer APIs to accept an explicit `version` (supports both 1.1.1 and 1.3.0).
* **Bug Fixes**
  * Improved GetMap tile URL generation by using the correct axis parameter naming per selected/negotiated version.
* **Tests**
  * Added/expanded unit tests for version normalization, endpoint extraction, and correct URL/source parameters for 1.1.1 vs 1.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->