### PR TITLE
fix(postgis): follow-ups from the final review round of #1080

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -59,6 +59,12 @@ export function PostgresSource() {
   // string bumps it, so an in-flight listing for the previous string cannot
   // repopulate the dropdown after its results stopped being relevant.
   const listRequestRef = useRef(0);
+  // Latest started editable-connect call. Only its own `finally` may clear
+  // isSubmitting: an older, superseded call settling late must not re-enable
+  // the controls mid-flight of a newer one. Separate from listRequestRef
+  // because input edits bump that token without starting a request (guarding
+  // on it in `finally` would leave isSubmitting stuck true).
+  const connectFlightRef = useRef(0);
 
   // Reset the (shell-owned) Martin connection when the source opens, matching
   // the original dialog: a running server is preserved across reopens only
@@ -75,6 +81,7 @@ export function PostgresSource() {
   // the features are loaded as GeoJSON so edits can be written back.
   const handleConnectEditable = async () => {
     const requestToken = ++listRequestRef.current;
+    const flightId = ++connectFlightRef.current;
     source.setError(null);
     setPostgisStatus(null);
     source.shell.setIsSubmitting(true);
@@ -114,14 +121,13 @@ export function PostgresSource() {
       // several geometry columns appears several times; keep the first entry
       // (the /postgis/read endpoint edits that table's first geometry column)
       // so the select has unique keys.
-      const tables = listed.filter(
-        (table, index) =>
-          listed.findIndex(
-            (candidate) =>
-              candidate.schema === table.schema &&
-              candidate.table === table.table,
-          ) === index,
-      );
+      const seen = new Set<string>();
+      const tables = listed.filter((table) => {
+        const key = postgisTableKey(table);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
       setSavedPostgresConnections(rememberPostgresConnection(connectionString));
       setPostgisConnection(connectionString);
       setPostgisTables(tables);
@@ -141,7 +147,9 @@ export function PostgresSource() {
         setPostgisStatus(null);
       }
     } finally {
-      source.shell.setIsSubmitting(false);
+      if (connectFlightRef.current === flightId) {
+        source.shell.setIsSubmitting(false);
+      }
     }
   };
 

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1078,11 +1078,10 @@ export function LayerPanel({
           // The sidecar reports editor-added fields it could not persist
           // (no matching table column); surface that so the drop is not
           // silent behind a plain success toast.
-          const skippedFieldMessages = result.messages.filter((entry) =>
-            entry.startsWith("Skipped fields"),
-          );
-          if (skippedFieldMessages.length > 0) {
-            message = `${message} ${skippedFieldMessages.join(" ")}`;
+          if (result.skipped_fields?.length) {
+            message = `${message} ${t("layers.saveEditsPostgisSkippedFields", {
+              fields: result.skipped_fields.join(", "),
+            })}`;
           }
         } else {
           const result = await writeVectorToSource({ path, geojson });

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1075,6 +1075,15 @@ export function LayerPanel({
             updated: result.updated,
             deleted: result.deleted,
           });
+          // The sidecar reports editor-added fields it could not persist
+          // (no matching table column); surface that so the drop is not
+          // silent behind a plain success toast.
+          const skippedFieldMessages = result.messages.filter((entry) =>
+            entry.startsWith("Skipped fields"),
+          );
+          if (skippedFieldMessages.length > 0) {
+            message = `${message} ${skippedFieldMessages.join(" ")}`;
+          }
         } else {
           const result = await writeVectorToSource({ path, geojson });
           message = t("layers.saveEditsSuccess", {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2442,6 +2442,7 @@
     "saveEditsError": "Could not save edits to the source file.",
     "saveEditsToPostgis": "Save edits to PostGIS table",
     "saveEditsPostgisSuccess": "Saved to {{table}}: {{inserted}} inserted, {{updated}} updated, {{deleted}} deleted.",
+    "saveEditsPostgisSkippedFields": "Fields without a matching table column were not saved: {{fields}}.",
     "saveEditsPostgisRefreshWarning": "Edits were saved to the table, but refreshing the layer failed. Reload the layer before saving again, or new features may be inserted twice.",
     "saveEditsPostgisNoConnection": "No PostgreSQL connection is available for this layer. Reconnect in Add Data > PostgreSQL, then try again.",
     "typeBasemap": "basemap",

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -707,9 +707,11 @@ def postgis_write(request: PostgisWriteRequest) -> dict[str, Any]:
                     # Compare as text so the (JSON-native) keys match uuid /
                     # numeric / date key columns; both sides render the same
                     # canonical form the /read endpoint serialized. Known edge:
-                    # a timestamp/timestamptz key's Python str() can differ
-                    # from Postgres's ::text rendering, so such exotic keys may
-                    # not match; integer/text/uuid/numeric/date keys all do.
+                    # timestamp/timestamptz and float/real keys' Python str()
+                    # can differ from Postgres's ::text rendering (e.g. '5.0'
+                    # vs '5'), so such exotic keys may not match and their
+                    # deletes no-op (reported in the deleted count);
+                    # integer/text/uuid/numeric/date keys all round-trip.
                     cur.execute(
                         sql.SQL(
                             "DELETE FROM {schema}.{table} WHERE {pk}::text = ANY(%s)"

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -710,7 +710,8 @@ def postgis_write(request: PostgisWriteRequest) -> dict[str, Any]:
                     # timestamp/timestamptz and float/real keys' Python str()
                     # can differ from Postgres's ::text rendering (e.g. '5.0'
                     # vs '5'), so such exotic keys may not match and their
-                    # deletes no-op (reported in the deleted count);
+                    # deletes silently no-op (the deleted count comes out
+                    # lower than the client expects);
                     # integer/text/uuid/numeric/date keys all round-trip.
                     cur.execute(
                         sql.SQL(
@@ -761,4 +762,8 @@ def postgis_write(request: PostgisWriteRequest) -> dict[str, Any]:
         "updated": updated,
         "deleted": deleted,
         "messages": messages,
+        # Structured list of the editor-added fields that had no matching
+        # column, so clients can build their own (translated) warning instead
+        # of parsing the prose in `messages`.
+        "skipped_fields": sorted(skipped),
     }

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -300,6 +300,8 @@ def test_write_reports_skipped_columns(live_table) -> None:
         )
     )
     assert any("added_in_editor" in message for message in result["messages"])
+    # Also exposed structurally so clients can build a translated warning.
+    assert result["skipped_fields"] == ["added_in_editor"]
 
 
 @requires_live_postgis

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -796,6 +796,8 @@ export interface WritePostgisTableResult {
   updated: number;
   deleted: number;
   messages: string[];
+  /** Editor-added fields skipped because no table column matches them. */
+  skipped_fields: string[];
 }
 
 /** Return PostGIS runtime (psycopg) availability in the sidecar. */


### PR DESCRIPTION
Small follow-ups addressing the last review round posted on #1080 just before it merged (the fixes were pushed minutes after the merge, so they moved to this PR):

- **LayerPanel**: the save toast now appends the sidecar's skipped-fields message, so an editor-added attribute with no matching table column is not silently dropped behind a plain success.
- **PostgresSource**: one-pass `Set` dedupe of the spatial-table list (was O(n^2)), and `isSubmitting` is cleared only by the latest started connect call, so a superseded call settling late cannot briefly re-enable the controls mid-flight. A separate flight ref is used deliberately: guarding on the input-edit invalidation token would leave the submitting state stuck when the user edits the field mid-flight without starting a new request.
- **postgis sidecar**: documented the float/real primary-key `::text` comparison edge next to the existing timestamp note.

Verified: full production web build, pre-commit clean; backend suite unaffected (comment-only backend change).

Refs #1080, #1070.