### PR TITLE
fix(desktop): only disable WebKitGTK DMABUF renderer on old WebKitGTK

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-opener",
+ "webkit2gtk-sys",
  "zip 2.4.2",
 ]
 

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -45,3 +45,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # OS CSPRNG for the per-launch Jupyter token (already an indirect dep).
 getrandom = "0.2"
+
+# Runtime WebKitGTK version check (already an indirect dep via tauri/wry).
+[target."cfg(target_os = \"linux\")".dependencies]
+webkit2gtk-sys = "2"

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2506,11 +2506,24 @@ fn create_oauth_popup_window(
 
 #[cfg(target_os = "linux")]
 fn configure_linux_webkit() {
-    // WebKitGTK's DMABUF renderer can fail to allocate GBM buffers on some
-    // Linux graphics stacks, leaving the Tauri window blank. Only set the
-    // default when unset so an explicit user/distributor value wins.
+    // WebKitGTK's DMABUF renderer could fail to allocate GBM buffers on older
+    // graphics stacks, leaving the Tauri window blank, so it used to be
+    // disabled here unconditionally. Disabling it also forces a slow readback
+    // compositing path that visibly drops MapLibre pan/zoom FPS, and the
+    // allocation bugs are fixed in current WebKitGTK, so keep the workaround
+    // only for versions older than 2.48. An explicit user/distributor value
+    // always wins (per WebKit semantics, "0" keeps DMABUF on and any other
+    // value disables it). Only set the default when unset.
     if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        let webkit_version = unsafe {
+            (
+                webkit2gtk_sys::webkit_get_major_version(),
+                webkit2gtk_sys::webkit_get_minor_version(),
+            )
+        };
+        if webkit_version < (2, 48) {
+            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        }
     }
     // Prefer portal-backed native dialogs on Linux. This avoids GTK/GIO file
     // metadata warnings that can appear around file and folder pickers.


### PR DESCRIPTION
## Summary
- The Linux desktop app has forced `WEBKIT_DISABLE_DMABUF_RENDERER=1` since #10 to work around blank windows caused by GBM buffer allocation failures. That failure class is fixed in modern WebKitGTK, and disabling DMABUF forces a slow readback compositing path: benchmarking the built app in a WebKitGTK 2.52 view showed continuous map panning at ~46 FPS with the renderer disabled vs ~60 FPS enabled, matching the 25-30 FPS lag reported when zooming/panning at low zoom on Linux (macOS/Windows use different webviews and are unaffected).
- Gate the workaround to WebKitGTK < 2.48 using the runtime version from `webkit2gtk-sys` (already an indirect dependency via tauri/wry), so old graphics stacks keep the blank-window fix while current ones get the fast path.
- An explicit user/distributor value still wins in both directions: WebKit treats `"0"` as DMABUF enabled and any other value as disabled, and the default is only applied when the variable is unset.

## Test plan
- [x] `npm run check:rust` and `cargo fmt --check` pass.
- [x] Launched the debug build on Linux (WebKitGTK 2.52, Wayland, Intel/Mesa): window renders normally (no blank window) and WebKit child processes no longer inherit `WEBKIT_DISABLE_DMABUF_RENDERER`.
- [x] Measured drag-pan FPS of the built app in a WebKitGTK harness with synthesized mouse drags and WebGL draw-call counting: ~46 FPS with DMABUF disabled vs ~60 FPS enabled.
- [ ] Manual pan/zoom in the desktop app on Linux to confirm smoothness.
- [ ] Confirm macOS and Windows builds are unaffected (Linux-only code path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux app startup compatibility by only applying a WebKitGTK rendering fallback on older versions.
  - This helps newer Linux systems use the default renderer when supported, while keeping older systems stable.
  - Added a Linux-specific runtime check to better match the installed WebKitGTK version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->