### PR TITLE
fix: parse 3D tile content on main thread to avoid CDN worker

### DIFF
--- a/packages/plugins/src/plugins/arcgis-i3s-tiles.ts
+++ b/packages/plugins/src/plugins/arcgis-i3s-tiles.ts
@@ -36,6 +36,27 @@ export const THREE_D_TILES_TILESET_LOAD_LIMITS = {
   maximumMemoryUsage: 512,
   memoryAdjustedScreenSpaceError: true,
 } as const;
+
+/**
+ * loaders.gl load options shared by the deck.gl 3D-tiles overlays (this I3S
+ * overlay and the Google Photorealistic one).
+ *
+ * `core.worker: false` parses tile content on the main thread instead of a
+ * loaders.gl worker. By default @loaders.gl fetches its worker scripts (the
+ * i3s-content worker here, draco/basis-texture workers for glTF content) from
+ * the unpkg CDN at runtime, which the Tauri desktop CSP (`worker-src 'self'
+ * blob:`, no unpkg in `script-src`) blocks — so tiles never render in the
+ * packaged app, and it would fail offline too. Disabling workers removes that
+ * external CDN dependency entirely; parsing runs in-process on every platform.
+ * The same restrictive `worker-src` applies to the nginx-served web build, so
+ * this is applied unconditionally rather than gated to Tauri. `worker` must be
+ * nested under `core` — that is the documented loaders.gl option shape; a
+ * top-level `worker` only works via a deprecated backwards-compat alias.
+ */
+export const THREE_D_TILES_DECK_LOAD_OPTIONS = {
+  tileset: THREE_D_TILES_TILESET_LOAD_LIMITS,
+  core: { worker: false },
+} as const;
 // ~1s at 60fps, matching GOOGLE_TILES_MAX_MOUNT_RETRIES so a slow project
 // restore has the same budget to wait for the map before giving up.
 const I3S_MAX_MOUNT_RETRIES = 60;
@@ -345,32 +366,33 @@ function i3sLayerSignature(layers: GeoLibreLayer[]): string {
     .join("|");
 }
 
-function buildArcgisI3sTilesDeckLayer(layer: GeoLibreLayer): Layer | null {
-  if (!i3sDeckGL || !i3sLoader) return null;
+// The deck.gl class + I3SLoader are injectable so a unit test can assert the
+// constructed Tile3DLayer's props (e.g. the CSP-critical loadOptions) without a
+// live map/overlay. Defaults are evaluated per call, so production callers pick
+// up the lazily-populated module globals.
+export function buildArcgisI3sTilesDeckLayer(
+  layer: GeoLibreLayer,
+  deps: { deckGL: GeoLibreDeckGL | null; loader: unknown } = {
+    deckGL: i3sDeckGL,
+    loader: i3sLoader,
+  },
+): Layer | null {
+  const { deckGL, loader } = deps;
+  if (!deckGL || !loader) return null;
   const url = typeof layer.source.url === "string" ? layer.source.url : "";
   if (!url) return null;
 
-  const Tile3DLayer = i3sDeckGL.geoLayers.Tile3DLayer as unknown as new (
+  const Tile3DLayer = deckGL.geoLayers.Tile3DLayer as unknown as new (
     props: Record<string, unknown>,
   ) => Layer;
 
   return new Tile3DLayer({
     id: `${layer.id}-deck`,
     data: url,
-    loader: i3sLoader,
-    // Cap tile detail/memory so a large textured-mesh scene doesn't load with
-    // deck.gl's unbounded defaults (shared with the Google overlay).
-    loadOptions: {
-      tileset: THREE_D_TILES_TILESET_LOAD_LIMITS,
-      // Parse I3S content on the main thread instead of a loaders.gl worker.
-      // By default @loaders.gl/i3s pulls its i3s-content worker from the unpkg
-      // CDN at runtime (https://unpkg.com/@loaders.gl/i3s@x/dist/…-worker.js),
-      // which the Tauri desktop CSP (worker-src 'self' blob:, no unpkg in
-      // script-src) blocks — so tiles never render on the packaged app (and it
-      // would fail offline too). Disabling workers removes that external CDN
-      // dependency entirely; parsing runs in-process on every platform.
-      worker: false,
-    },
+    loader,
+    // Tile detail/memory caps + main-thread parsing, shared with the Google
+    // overlay. See THREE_D_TILES_DECK_LOAD_OPTIONS for why workers are disabled.
+    loadOptions: THREE_D_TILES_DECK_LOAD_OPTIONS,
     opacity: layer.opacity,
     pickable: false,
     operation: "draw",

--- a/packages/plugins/src/plugins/arcgis-i3s-tiles.ts
+++ b/packages/plugins/src/plugins/arcgis-i3s-tiles.ts
@@ -392,7 +392,9 @@ export function buildArcgisI3sTilesDeckLayer(
     loader,
     // Tile detail/memory caps + main-thread parsing, shared with the Google
     // overlay. See THREE_D_TILES_DECK_LOAD_OPTIONS for why workers are disabled.
-    loadOptions: THREE_D_TILES_DECK_LOAD_OPTIONS,
+    // Spread into a fresh object per layer (matching the Google call site) so no
+    // two layers share one loadOptions reference.
+    loadOptions: { ...THREE_D_TILES_DECK_LOAD_OPTIONS },
     opacity: layer.opacity,
     pickable: false,
     operation: "draw",

--- a/packages/plugins/src/plugins/arcgis-i3s-tiles.ts
+++ b/packages/plugins/src/plugins/arcgis-i3s-tiles.ts
@@ -362,6 +362,14 @@ function buildArcgisI3sTilesDeckLayer(layer: GeoLibreLayer): Layer | null {
     // deck.gl's unbounded defaults (shared with the Google overlay).
     loadOptions: {
       tileset: THREE_D_TILES_TILESET_LOAD_LIMITS,
+      // Parse I3S content on the main thread instead of a loaders.gl worker.
+      // By default @loaders.gl/i3s pulls its i3s-content worker from the unpkg
+      // CDN at runtime (https://unpkg.com/@loaders.gl/i3s@x/dist/…-worker.js),
+      // which the Tauri desktop CSP (worker-src 'self' blob:, no unpkg in
+      // script-src) blocks — so tiles never render on the packaged app (and it
+      // would fail offline too). Disabling workers removes that external CDN
+      // dependency entirely; parsing runs in-process on every platform.
+      worker: false,
     },
     opacity: layer.opacity,
     pickable: false,

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -1470,6 +1470,12 @@ function buildGooglePhotorealisticTilesDeckLayer(
     loadOptions: {
       fetch: requestHeaders ? { headers: requestHeaders } : undefined,
       tileset: THREE_D_TILES_TILESET_LOAD_LIMITS,
+      // Decode glTF tile content on the main thread. loaders.gl otherwise
+      // fetches its draco/basis-texture workers from the unpkg CDN at runtime,
+      // which the Tauri desktop CSP blocks (and which breaks offline use); this
+      // keeps parsing in-process on every platform. See the matching note in
+      // arcgis-i3s-tiles.ts.
+      worker: false,
     },
     opacity: layer.opacity,
     pickable: false,

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -29,7 +29,7 @@ import {
   arcgisI3sSceneLayerName,
   isArcgisI3sSceneLayerUrl,
   restoreArcgisI3sTilesLayers,
-  THREE_D_TILES_TILESET_LOAD_LIMITS,
+  THREE_D_TILES_DECK_LOAD_OPTIONS,
 } from "./arcgis-i3s-tiles";
 
 const threeDTilesControlPosition: GeoLibreMapControlPosition = "top-left";
@@ -1467,15 +1467,12 @@ function buildGooglePhotorealisticTilesDeckLayer(
     id: googlePhotorealisticTilesDeckLayerId(layer),
     data: GOOGLE_PHOTOREALISTIC_TILES_URL,
     altitudeOffset,
+    // Tileset caps + main-thread parsing shared with the I3S overlay (see
+    // THREE_D_TILES_DECK_LOAD_OPTIONS for why workers are disabled), plus this
+    // layer's per-request auth headers.
     loadOptions: {
+      ...THREE_D_TILES_DECK_LOAD_OPTIONS,
       fetch: requestHeaders ? { headers: requestHeaders } : undefined,
-      tileset: THREE_D_TILES_TILESET_LOAD_LIMITS,
-      // Decode glTF tile content on the main thread. loaders.gl otherwise
-      // fetches its draco/basis-texture workers from the unpkg CDN at runtime,
-      // which the Tauri desktop CSP blocks (and which breaks offline use); this
-      // keeps parsing in-process on every platform. See the matching note in
-      // arcgis-i3s-tiles.ts.
-      worker: false,
     },
     opacity: layer.opacity,
     pickable: false,

--- a/tests/arcgis-i3s-tiles.test.ts
+++ b/tests/arcgis-i3s-tiles.test.ts
@@ -162,11 +162,13 @@ describe("buildArcgisI3sTilesDeckLayer", () => {
 
   it("passes the shared main-thread load options to the Tile3DLayer", () => {
     // The whole point of the CSP fix: the constructed layer must carry
-    // core.worker === false so parsing never falls back to a CDN worker.
-    assert.equal(build()?.loadOptions, THREE_D_TILES_DECK_LOAD_OPTIONS);
+    // core.worker === false so parsing never falls back to a CDN worker. The
+    // call site spreads the shared constant into a fresh object, so compare by
+    // value rather than reference.
+    const props = build();
+    assert.deepEqual(props?.loadOptions, THREE_D_TILES_DECK_LOAD_OPTIONS);
     assert.equal(
-      (build()?.loadOptions as typeof THREE_D_TILES_DECK_LOAD_OPTIONS).core
-        .worker,
+      (props?.loadOptions as typeof THREE_D_TILES_DECK_LOAD_OPTIONS).core.worker,
       false,
     );
   });

--- a/tests/arcgis-i3s-tiles.test.ts
+++ b/tests/arcgis-i3s-tiles.test.ts
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   arcgisI3sSceneLayerName,
+  buildArcgisI3sTilesDeckLayer,
   i3sTilesetLngLat,
   isArcgisI3sSceneLayerUrl,
   isArcgisI3sTilesLayer,
   persistI3sTilesetCenter,
   ARCGIS_I3S_SOURCE_KIND,
+  THREE_D_TILES_DECK_LOAD_OPTIONS,
 } from "../packages/plugins/src/plugins/arcgis-i3s-tiles";
+import type { GeoLibreDeckGL } from "../packages/plugins/src/types";
 import { useAppStore } from "../packages/core/src/store";
 import type { GeoLibreLayer } from "../packages/core/src/types";
 
@@ -113,6 +116,69 @@ describe("arcgisI3sSceneLayerName", () => {
     assert.equal(
       arcgisI3sSceneLayerName("https://host/rest/services/Bad%ZZName/SceneServer"),
       "Bad%ZZName",
+    );
+  });
+});
+
+describe("THREE_D_TILES_DECK_LOAD_OPTIONS", () => {
+  // Regression guard: @loaders.gl otherwise fetches its parsing workers from the
+  // unpkg CDN at runtime, which the Tauri desktop CSP blocks. Workers must stay
+  // disabled, and `worker` must be nested under `core` (the documented shape; a
+  // top-level `worker` only works via a deprecated backwards-compat alias).
+  it("disables loaders.gl workers via core.worker", () => {
+    assert.equal(THREE_D_TILES_DECK_LOAD_OPTIONS.core.worker, false);
+  });
+});
+
+describe("buildArcgisI3sTilesDeckLayer", () => {
+  const layer = {
+    id: "i3s-1",
+    name: "Scene",
+    type: "3d-tiles",
+    source: {
+      sourceId: "i3s-1",
+      type: ARCGIS_I3S_SOURCE_KIND,
+      url: "https://host/City/SceneServer",
+    },
+    visible: true,
+    opacity: 0.5,
+    style: {},
+    metadata: { sourceKind: ARCGIS_I3S_SOURCE_KIND },
+  } as unknown as GeoLibreLayer;
+
+  function build() {
+    const props: Record<string, unknown>[] = [];
+    class FakeTile3DLayer {
+      constructor(p: Record<string, unknown>) {
+        props.push(p);
+      }
+    }
+    const deckGL = {
+      geoLayers: { Tile3DLayer: FakeTile3DLayer },
+    } as unknown as GeoLibreDeckGL;
+    buildArcgisI3sTilesDeckLayer(layer, { deckGL, loader: {} });
+    return props[0];
+  }
+
+  it("passes the shared main-thread load options to the Tile3DLayer", () => {
+    // The whole point of the CSP fix: the constructed layer must carry
+    // core.worker === false so parsing never falls back to a CDN worker.
+    assert.equal(build()?.loadOptions, THREE_D_TILES_DECK_LOAD_OPTIONS);
+    assert.equal(
+      (build()?.loadOptions as typeof THREE_D_TILES_DECK_LOAD_OPTIONS).core
+        .worker,
+      false,
+    );
+  });
+
+  it("returns null when the deck.gl class or loader is missing", () => {
+    assert.equal(buildArcgisI3sTilesDeckLayer(layer, { deckGL: null, loader: {} }), null);
+    assert.equal(
+      buildArcgisI3sTilesDeckLayer(layer, {
+        deckGL: { geoLayers: { Tile3DLayer: class {} } } as unknown as GeoLibreDeckGL,
+        loader: null,
+      }),
+      null,
     );
   });
 });


### PR DESCRIPTION
## Summary
- ArcGIS I3S 3D tiles fail to render in the Tauri desktop build (reported on Windows) because `@loaders.gl/i3s` fetches its `i3s-content` parsing worker from the unpkg CDN at runtime, which the desktop CSP (`worker-src 'self' blob:`, no unpkg in `script-src`) blocks. This also breaks offline use.
- Pass `worker: false` in the `Tile3DLayer` `loadOptions` so tile content parses in-process, removing the external CDN dependency on every platform.
- Apply the same fix to the Google Photorealistic 3D Tiles layer, whose glTF draco/basis-texture workers load from unpkg the same way and had the identical latent failure.

## Test plan
- [x] `packages/plugins` type-check clean (`tsc --noEmit`)
- [x] `tests/arcgis-i3s-tiles.test.ts` passes (15/15)
- [x] pre-commit (eslint + npm build) passes on the changed files
- [ ] Load an ArcGIS Scene Layer (I3S) in the packaged desktop app on Windows and confirm tiles render with no `importScripts` / worker network error in the console
- [ ] Load Google Photorealistic 3D Tiles in the packaged desktop app and confirm tiles render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of ArcGIS i3s and Google Photorealistic 3D tile loading by disabling background decoding workers, supporting stricter security environments and improving offline consistency.
  * Ensures the safer loading configuration is applied consistently across both 3D tile sources.
* **Tests**
  * Added regression tests to verify the shared 3D tile loading configuration is used and that layer creation behaves correctly when required dependencies aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->