### PR TITLE
feat: import delimited text (CSV) without coordinates as an attribute table

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -646,27 +646,6 @@ export function resolveDelimitedTextDelimiter(
   return customDelimiter;
 }
 
-export function inferDelimitedTextField(
-  fields: string[],
-  currentField: string,
-  candidates: string[],
-): string {
-  const current = currentField.trim().toLowerCase();
-  const currentMatch = fields.find(
-    (field) => field.trim().toLowerCase() === current,
-  );
-  if (currentMatch) return currentMatch;
-
-  for (const candidate of candidates) {
-    const match = fields.find(
-      (field) => field.trim().toLowerCase() === candidate,
-    );
-    if (match) return match;
-  }
-
-  return fields[0] ?? currentField;
-}
-
 /** Recursively finds the first `[lng, lat]` pair in a GeoJSON coordinate array. */
 function firstCoordinate(coords: unknown): [number, number] | null {
   if (!Array.isArray(coords)) return null;

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -143,14 +143,27 @@ export function DelimitedTextSource() {
       const { text } = await readDelimitedTextSource();
       const fields = parseDelimitedTextFields(text, delimiter);
       setDelimitedTextFields(fields);
-      // Auto-detect the coordinate columns. When none are found, default both
-      // selects to "(None)" so the file imports as a non-spatial attribute
-      // table instead of misparsing an arbitrary column as a coordinate.
+      // Keep a manually chosen column if it still exists in the freshly
+      // retrieved header (e.g. after tweaking the delimiter); otherwise
+      // auto-detect. When neither survives, default to "(None)" so the file
+      // imports as a non-spatial attribute table instead of misparsing an
+      // arbitrary column as a coordinate.
+      const keepIfValid = (current: string): string | undefined => {
+        const normalized = current.trim().toLowerCase();
+        if (!normalized) return undefined;
+        return fields.find((field) => field.trim().toLowerCase() === normalized);
+      };
       const detected = detectCoordinateFields(fields);
-      setDelimitedTextLongitudeField(detected?.longitudeField ?? "");
-      setDelimitedTextLatitudeField(detected?.latitudeField ?? "");
+      const nextLongitude =
+        keepIfValid(delimitedTextLongitudeField) ??
+        detected?.longitudeField ??
+        "";
+      const nextLatitude =
+        keepIfValid(delimitedTextLatitudeField) ?? detected?.latitudeField ?? "";
+      setDelimitedTextLongitudeField(nextLongitude);
+      setDelimitedTextLatitudeField(nextLatitude);
       setDelimitedTextColumnsStatus(
-        detected
+        nextLongitude || nextLatitude
           ? t("addData.delimitedText.retrievedColumns", { count: fields.length })
           : t("addData.delimitedText.retrievedColumnsTable", {
               count: fields.length,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -3,6 +3,7 @@ import { Columns3, FileUp } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  detectCoordinateFields,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "../../../../lib/delimited-text";
@@ -16,7 +17,6 @@ import {
   createBaseLayer,
   errorMessage,
   fileNameFromPath,
-  inferDelimitedTextField,
   layerNameFromPath,
   resolveDelimitedTextDelimiter,
 } from "../helpers";
@@ -143,28 +143,18 @@ export function DelimitedTextSource() {
       const { text } = await readDelimitedTextSource();
       const fields = parseDelimitedTextFields(text, delimiter);
       setDelimitedTextFields(fields);
-      setDelimitedTextLongitudeField((current) =>
-        inferDelimitedTextField(fields, current, [
-          "longitude",
-          "lon",
-          "lng",
-          "long",
-          "x",
-          "xcoord",
-          "x_coord",
-        ]),
-      );
-      setDelimitedTextLatitudeField((current) =>
-        inferDelimitedTextField(fields, current, [
-          "latitude",
-          "lat",
-          "y",
-          "ycoord",
-          "y_coord",
-        ]),
-      );
+      // Auto-detect the coordinate columns. When none are found, default both
+      // selects to "(None)" so the file imports as a non-spatial attribute
+      // table instead of misparsing an arbitrary column as a coordinate.
+      const detected = detectCoordinateFields(fields);
+      setDelimitedTextLongitudeField(detected?.longitudeField ?? "");
+      setDelimitedTextLatitudeField(detected?.latitudeField ?? "");
       setDelimitedTextColumnsStatus(
-        t("addData.delimitedText.retrievedColumns", { count: fields.length }),
+        detected
+          ? t("addData.delimitedText.retrievedColumns", { count: fields.length })
+          : t("addData.delimitedText.retrievedColumnsTable", {
+              count: fields.length,
+            }),
       );
     } catch (err) {
       source.setError(
@@ -204,6 +194,7 @@ export function DelimitedTextSource() {
             delimiter,
             featureCount: result.data.features.length,
             fields: result.fields,
+            isTable: result.isTable,
             latitudeField: delimitedTextLatitudeField.trim(),
             longitudeField: delimitedTextLongitudeField.trim(),
             skippedRows: result.skippedRows,
@@ -214,7 +205,8 @@ export function DelimitedTextSource() {
         geojson: result.data,
         sourcePath,
       },
-      { fit: true },
+      // A non-spatial attribute table has no geometry to fit the map to.
+      { fit: !result.isTable },
     );
   });
 
@@ -389,6 +381,9 @@ export function DelimitedTextSource() {
                 setDelimitedTextLongitudeField(event.target.value)
               }
             >
+              <option value="">
+                {t("addData.delimitedText.noneField")}
+              </option>
               {delimitedTextFieldOptions.map((field) => (
                 <option key={field} value={field}>
                   {field}
@@ -407,6 +402,9 @@ export function DelimitedTextSource() {
                 setDelimitedTextLatitudeField(event.target.value)
               }
             >
+              <option value="">
+                {t("addData.delimitedText.noneField")}
+              </option>
               {delimitedTextFieldOptions.map((field) => (
                 <option key={field} value={field}>
                   {field}
@@ -415,6 +413,9 @@ export function DelimitedTextSource() {
             </Select>
           </div>
         </div>
+        <p className="text-xs text-muted-foreground">
+          {t("addData.delimitedText.tableHint")}
+        </p>
         <SampleDataSelect
           samples={[
             { label: t("addData.delimitedText.sampleLabel"), value: DEFAULT_DELIMITED_TEXT_URL },

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -143,27 +143,34 @@ export function DelimitedTextSource() {
       const { text } = await readDelimitedTextSource();
       const fields = parseDelimitedTextFields(text, delimiter);
       setDelimitedTextFields(fields);
-      // Keep a manually chosen column if it still exists in the freshly
-      // retrieved header (e.g. after tweaking the delimiter); otherwise
-      // auto-detect. When neither survives, default to "(None)" so the file
-      // imports as a non-spatial attribute table instead of misparsing an
-      // arbitrary column as a coordinate.
+      // Resolve the coordinate columns as an all-or-nothing pair so the file is
+      // always in a coherent state (both set = points, both blank = attribute
+      // table), never the mixed state that parseDelimitedTextLayer rejects.
+      // Prefer keeping the current manual choices when both still exist in the
+      // freshly retrieved header (e.g. after tweaking the delimiter); otherwise
+      // auto-detect; otherwise leave both as "(None)" so the file imports as a
+      // non-spatial attribute table instead of misparsing an arbitrary column.
       const keepIfValid = (current: string): string | undefined => {
         const normalized = current.trim().toLowerCase();
         if (!normalized) return undefined;
         return fields.find((field) => field.trim().toLowerCase() === normalized);
       };
+      const keptLongitude = keepIfValid(delimitedTextLongitudeField);
+      const keptLatitude = keepIfValid(delimitedTextLatitudeField);
       const detected = detectCoordinateFields(fields);
-      const nextLongitude =
-        keepIfValid(delimitedTextLongitudeField) ??
-        detected?.longitudeField ??
-        "";
-      const nextLatitude =
-        keepIfValid(delimitedTextLatitudeField) ?? detected?.latitudeField ?? "";
+      let nextLongitude = "";
+      let nextLatitude = "";
+      if (keptLongitude && keptLatitude) {
+        nextLongitude = keptLongitude;
+        nextLatitude = keptLatitude;
+      } else if (detected) {
+        nextLongitude = detected.longitudeField;
+        nextLatitude = detected.latitudeField;
+      }
       setDelimitedTextLongitudeField(nextLongitude);
       setDelimitedTextLatitudeField(nextLatitude);
       setDelimitedTextColumnsStatus(
-        nextLongitude || nextLatitude
+        nextLongitude && nextLatitude
           ? t("addData.delimitedText.retrievedColumns", { count: fields.length })
           : t("addData.delimitedText.retrievedColumnsTable", {
               count: fields.length,

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -144,7 +144,7 @@
       },
       "delimitedText": {
         "label": "Add Delimited Text Layer",
-        "description": "Add a delimited text file or URL as a point layer using longitude and latitude fields."
+        "description": "Add a delimited text file or URL as a point layer using longitude and latitude fields, or as a non-spatial attribute table when no coordinates are available."
       },
       "cad": {
         "label": "Add CAD (DXF/DWG) Layer",
@@ -365,6 +365,8 @@
       "errorDataMissing": "Delimited text data is missing.",
       "retrievedColumns_one": "Retrieved {{count}} column.",
       "retrievedColumns_other": "Retrieved {{count}} columns.",
+      "retrievedColumnsTable_one": "Retrieved {{count}} column. No coordinate columns detected; it will be added as an attribute table.",
+      "retrievedColumnsTable_other": "Retrieved {{count}} columns. No coordinate columns detected; it will be added as an attribute table.",
       "errorRetrieveColumns": "Could not retrieve column names.",
       "url": "Delimited text URL",
       "file": "Delimited text file",
@@ -379,7 +381,9 @@
       "delimiterCustom": "Custom",
       "customDelimiter": "Custom delimiter",
       "longitudeField": "Longitude field",
-      "latitudeField": "Latitude field"
+      "latitudeField": "Latitude field",
+      "noneField": "None (attribute table)",
+      "tableHint": "Leave both coordinate fields as None to add the file as a non-spatial attribute table (for use in an attribute join)."
     },
     "photos": {
       "defaultName": "Photos",

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -87,13 +87,11 @@ export function parseDelimitedTextLayer(
   if (!wantsLatitude && !wantsLongitude) {
     const tableFeatures: Feature<Geometry | null, GeoJsonProperties>[] = rows
       .slice(1)
-      .map((row) => {
-        const properties: GeoJsonProperties = {};
-        fields.forEach((field, index) => {
-          properties[field] = row[index] ?? "";
-        });
-        return { type: "Feature", geometry: null, properties };
-      });
+      .map((row) => ({
+        type: "Feature",
+        geometry: null,
+        properties: buildRowProperties(fields, row),
+      }));
 
     return {
       // GeoJSON Features may legally carry a null geometry; the app's layer
@@ -137,18 +135,13 @@ export function parseDelimitedTextLayer(
       continue;
     }
 
-    const properties: GeoJsonProperties = {};
-    fields.forEach((field, index) => {
-      properties[field] = row[index] ?? "";
-    });
-
     features.push({
       type: "Feature",
       geometry: {
         type: "Point",
         coordinates: [longitude, latitude],
       },
-      properties,
+      properties: buildRowProperties(fields, row),
     });
   }
 
@@ -251,6 +244,23 @@ function parseDelimitedRows(text: string, delimiter: string): string[][] {
   }
 
   return rows;
+}
+
+/**
+ * Builds a feature's properties object by pairing each (de-duplicated) header
+ * name with its raw column value, defaulting to an empty string for short rows.
+ * Shared by the point and attribute-table paths so their property shape cannot
+ * drift apart.
+ */
+function buildRowProperties(
+  fields: string[],
+  row: string[],
+): GeoJsonProperties {
+  const properties: GeoJsonProperties = {};
+  fields.forEach((field, index) => {
+    properties[field] = row[index] ?? "";
+  });
+  return properties;
 }
 
 function uniqueFieldNames(fields: string[]): string[] {

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -27,6 +27,15 @@ export interface DelimitedTextLayerResult {
 export const NO_VALID_COORDINATES_MESSAGE =
   "No rows contained valid longitude and latitude values.";
 
+/**
+ * Thrown by {@link parseDelimitedTextLayer} when exactly one coordinate field is
+ * left blank. Points need both a longitude and a latitude, and an attribute
+ * table needs neither, so a half-specified pair is always a mistake. Exported so
+ * callers can recognize this failure without matching a duplicated literal.
+ */
+export const MIXED_COORDINATE_FIELDS_MESSAGE =
+  "Select both a longitude and a latitude field, or leave both as None to add an attribute table.";
+
 export function parseDelimitedTextFields(
   text: string,
   delimiter: string,
@@ -69,6 +78,12 @@ export function parseDelimitedTextLayer(
   // in an attribute join without inventing coordinates.
   const wantsLatitude = options.latitudeField.trim() !== "";
   const wantsLongitude = options.longitudeField.trim() !== "";
+  // A half-specified coordinate pair (one field chosen, the other left as
+  // "None") can neither build points nor a table, so fail with a clear message
+  // instead of falling through to a raw `field "" was not found` error.
+  if (wantsLatitude !== wantsLongitude) {
+    throw new Error(MIXED_COORDINATE_FIELDS_MESSAGE);
+  }
   if (!wantsLatitude && !wantsLongitude) {
     const tableFeatures: Feature<Geometry | null, GeoJsonProperties>[] = rows
       .slice(1)

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -2,6 +2,7 @@ import type {
   Feature,
   FeatureCollection,
   GeoJsonProperties,
+  Geometry,
   Point,
 } from "geojson";
 
@@ -10,6 +11,12 @@ export interface DelimitedTextLayerResult {
   fields: string[];
   skippedRows: number;
   totalRows: number;
+  /**
+   * True when the layer was built as a non-spatial attribute table (both the
+   * latitude and longitude fields were left blank), so every feature carries a
+   * `null` geometry. Callers use this to skip fitting the map to empty bounds.
+   */
+  isTable: boolean;
 }
 
 /**
@@ -55,6 +62,39 @@ export function parseDelimitedTextLayer(
   }
 
   const fields = uniqueFieldNames(rows[0].map((field) => field.trim()));
+
+  // When both coordinate fields are left blank the file is imported as a
+  // non-spatial attribute table: every row becomes a feature with a null
+  // geometry, so it can back the attribute table and be used as the join layer
+  // in an attribute join without inventing coordinates.
+  const wantsLatitude = options.latitudeField.trim() !== "";
+  const wantsLongitude = options.longitudeField.trim() !== "";
+  if (!wantsLatitude && !wantsLongitude) {
+    const tableFeatures: Feature<Geometry | null, GeoJsonProperties>[] = rows
+      .slice(1)
+      .map((row) => {
+        const properties: GeoJsonProperties = {};
+        fields.forEach((field, index) => {
+          properties[field] = row[index] ?? "";
+        });
+        return { type: "Feature", geometry: null, properties };
+      });
+
+    return {
+      // GeoJSON Features may legally carry a null geometry; the app's layer
+      // model treats these as a regular FeatureCollection (the map ignores
+      // nulls), so the cast to FeatureCollection is safe here.
+      data: {
+        type: "FeatureCollection",
+        features: tableFeatures,
+      } as FeatureCollection,
+      fields,
+      skippedRows: 0,
+      totalRows: rows.length - 1,
+      isTable: true,
+    };
+  }
+
   const latitudeIndex = findFieldIndex(fields, options.latitudeField);
   const longitudeIndex = findFieldIndex(fields, options.longitudeField);
 
@@ -109,6 +149,7 @@ export function parseDelimitedTextLayer(
     fields,
     skippedRows,
     totalRows: rows.length - 1,
+    isTable: false,
   };
 }
 

--- a/packages/map/src/geojson-loader.ts
+++ b/packages/map/src/geojson-loader.ts
@@ -50,6 +50,12 @@ export function getLayerBounds(
 ): [number, number, number, number] | null {
   if (!layer.geojson?.features?.length) return null;
   const box = bbox(layer.geojson);
+  // A collection whose features all carry a null geometry (e.g. a delimited
+  // text file imported as an attribute table, or a non-spatial SQL result)
+  // yields a degenerate ±Infinity box. Report "no bounds" so callers such as
+  // fitLayer/"Zoom to layer" fall back or no-op instead of flying to an
+  // invalid extent.
+  if (!box.every((value) => Number.isFinite(value))) return null;
   return box as [number, number, number, number];
 }
 

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -11,7 +11,6 @@ import {
   stripOgcOperationParams,
   wmsVersionFromEndpoint,
   geoJsonToPointRows,
-  inferDelimitedTextField,
   layerNameFromPath,
   parseOptionalNumber,
   parseRequiredNumber,
@@ -301,22 +300,6 @@ describe("resolveDelimitedTextDelimiter", () => {
     assert.equal(resolveDelimitedTextDelimiter("comma", ""), ",");
     assert.equal(resolveDelimitedTextDelimiter("tab", ""), "\t");
     assert.equal(resolveDelimitedTextDelimiter("custom", "~"), "~");
-  });
-});
-
-describe("inferDelimitedTextField", () => {
-  const fields = ["City", "Longitude", "Latitude"];
-
-  it("keeps the current field when it still exists (case-insensitive)", () => {
-    assert.equal(inferDelimitedTextField(fields, "longitude", []), "Longitude");
-  });
-
-  it("falls back to the first matching candidate, then the first field", () => {
-    assert.equal(
-      inferDelimitedTextField(fields, "missing", ["lat", "latitude"]),
-      "Latitude",
-    );
-    assert.equal(inferDelimitedTextField(fields, "missing", ["nope"]), "City");
   });
 });
 

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -90,6 +90,47 @@ describe("delimited text parsing", () => {
     assert.equal(result.data.features.length, 1);
     assert.deepEqual(result.data.features[0].geometry.coordinates, [4.9, 52.37]);
   });
+
+  it("builds a non-spatial attribute table when both coordinate fields are blank", () => {
+    const result = parseDelimitedTextLayer(
+      [
+        "code;name;chapter",
+        "AVH;Avoine d'hiver;1.1",
+        "BDP;Ble dur de printemps;1.1",
+      ].join("\n"),
+      {
+        delimiter: ";",
+        longitudeField: "",
+        latitudeField: "",
+      },
+    );
+
+    assert.equal(result.isTable, true);
+    assert.equal(result.totalRows, 2);
+    assert.equal(result.skippedRows, 0);
+    assert.equal(result.data.features.length, 2);
+    assert.equal(result.data.features[0].geometry, null);
+    assert.deepEqual(result.data.features[0].properties, {
+      code: "AVH",
+      name: "Avoine d'hiver",
+      chapter: "1.1",
+    });
+    assert.deepEqual(result.fields, ["code", "name", "chapter"]);
+  });
+
+  it("still builds point features (isTable false) when coordinates are provided", () => {
+    const result = parseDelimitedTextLayer(
+      ["name,longitude,latitude", "Raleigh,-78.638,35.779"].join("\n"),
+      {
+        delimiter: ",",
+        longitudeField: "longitude",
+        latitudeField: "latitude",
+      },
+    );
+
+    assert.equal(result.isTable, false);
+    assert.equal(result.data.features.length, 1);
+  });
 });
 
 describe("parseCoordinate", () => {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -118,6 +118,33 @@ describe("delimited text parsing", () => {
     assert.deepEqual(result.fields, ["code", "name", "chapter"]);
   });
 
+  it("rejects a mixed selection where only one coordinate field is blank", () => {
+    assert.throws(
+      () =>
+        parseDelimitedTextLayer(
+          ["name,longitude,latitude", "Raleigh,-78.638,35.779"].join("\n"),
+          {
+            delimiter: ",",
+            longitudeField: "longitude",
+            latitudeField: "",
+          },
+        ),
+      /Select both a longitude and a latitude field/,
+    );
+    assert.throws(
+      () =>
+        parseDelimitedTextLayer(
+          ["name,longitude,latitude", "Raleigh,-78.638,35.779"].join("\n"),
+          {
+            delimiter: ",",
+            longitudeField: "",
+            latitudeField: "latitude",
+          },
+        ),
+      /Select both a longitude and a latitude field/,
+    );
+  });
+
   it("still builds point features (isTable false) when coordinates are provided", () => {
     const result = parseDelimitedTextLayer(
       ["name,longitude,latitude", "Raleigh,-78.638,35.779"].join("\n"),

--- a/tests/layer-bounds.test.ts
+++ b/tests/layer-bounds.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { GeoLibreLayer } from "@geolibre/core";
+import { getLayerBounds } from "../packages/map/src/geojson-loader";
+
+function layerWith(features: GeoLibreLayer["geojson"]): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Test",
+    type: "geojson",
+    visible: true,
+    opacity: 1,
+    source: { type: "geojson", url: "" },
+    metadata: {},
+    geojson: features,
+  } as unknown as GeoLibreLayer;
+}
+
+describe("getLayerBounds", () => {
+  it("returns the bbox for features with real geometry", () => {
+    const bounds = getLayerBounds(
+      layerWith({
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [-78.638, 35.779] },
+            properties: {},
+          },
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [-70, 40] },
+            properties: {},
+          },
+        ],
+      }),
+    );
+
+    assert.deepEqual(bounds, [-78.638, 35.779, -70, 40]);
+  });
+
+  it("returns null for a table layer whose features all have null geometry", () => {
+    const bounds = getLayerBounds(
+      layerWith({
+        type: "FeatureCollection",
+        features: [
+          { type: "Feature", geometry: null, properties: { code: "AVH" } },
+          { type: "Feature", geometry: null, properties: { code: "BDP" } },
+        ],
+      }),
+    );
+
+    assert.equal(bounds, null);
+  });
+
+  it("returns null when there is no geojson", () => {
+    assert.equal(getLayerBounds(layerWith(undefined)), null);
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for importing a delimited text file (CSV/TSV) that has **no latitude/longitude columns** as a non-spatial **attribute table**, so it can be used as the join layer in an attribute join.

Reported in discussion #1076: a user wanted to add a semicolon-delimited CSV with no coordinates (for a later attribute join), but **Add Data > Delimited Text** required lat/lon columns and failed with `No rows contained valid longitude and latitude values`.

## What changed

- **Add Data > Delimited Text** now offers a `None (attribute table)` option for both the Longitude and Latitude fields. When both are left as `None`, the file is imported as a layer of null-geometry features carrying every column as a property (the same shape SQL query results already use). This is a natural join source for **Processing > Vector > Join > Attribute join**.
- **Retrieve columns** auto-detects coordinate columns; when none are found it defaults both selects to `None` and explains the file will be added as an attribute table.
- The map is no longer fit to a table layer (it has no geometry to fit).
- Added parser tests and updated the dialog copy + i18n strings (`en.json`).

## Verification

Drove the real app with Playwright using the reporter's `cultures_2024.csv` (semicolon-delimited, 6 columns, no coordinates), in **both dark and light themes**:

- Retrieve columns reports `Retrieved 6 columns. No coordinate columns detected; it will be added as an attribute table.` and both fields default to `None (attribute table)`.
- The layer adds with **zero console errors** and the attribute table shows all 187 rows / 6 columns correctly.
- `npm run test:frontend` (2022 passing), `npm run build`, and `pre-commit` all pass.

Addresses https://github.com/opengeos/GeoLibre/discussions/1076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delimited text imports can now load as either point layers or non-spatial attribute tables.
  * Added clearer latitude/longitude field prompts, including a “None (attribute table)” option and a hint for coordinate-less imports.

* **Bug Fixes**
  * More reliable coordinate detection and validation (prevents mixed latitude/longitude selection).
  * “Zoom to layer” now runs only for spatial data.
  * Retrieval/status messaging now differentiates spatial results vs attribute tables.
  * Prevents invalid bounds when layers contain null geometries.

* **Tests**
  * Added unit tests covering table-mode imports, mixed selection validation, and spatial parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->