### PR TITLE
fix: route share.geolibre.app through native HTTP on desktop

### DIFF
--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -19,14 +19,15 @@
       ]
     },
     {
-      "comment": "Geocoding (place search / reverse geocode) is routed through the native HTTP client so it bypasses the WebView's CORS — public Nominatim's CDN intermittently omits the CORS header on cached responses, which the WebView rejects as 'Search failed'. Also lets us send a User-Agent as Nominatim's policy requires. Scoped to the built-in geocoder provider hosts only (keep in sync with the GEOCODING_PROVIDERS registry / lib/geocoding-fetch.ts); custom/self-hosted endpoints fall back to the browser fetch.",
+      "comment": "Hosts routed through the native HTTP client to bypass the WebView's CORS. Geocoding (place search / reverse geocode): public Nominatim's CDN intermittently omits the CORS header on cached responses (rejected as 'Search failed'), and the native client can send the User-Agent Nominatim's policy requires — keep the geocoder hosts in sync with the GEOCODING_PROVIDERS registry / lib/geocoding-fetch.ts. share.geolibre.app (project Share + gallery): its CORS policy allows the web origin but not the Tauri WebView origin, so browser fetches fail as 'Could not reach share.geolibre.app' — see lib/share-fetch.ts. Any other host (custom/self-hosted geocoder, third-party project URL) falls back to the browser fetch.",
       "identifier": "http:default",
       "allow": [
         { "url": "https://nominatim.openstreetmap.org/*" },
         { "url": "https://api.geocode.earth/*" },
         { "url": "https://geocode.arcgis.com/*" },
         { "url": "https://api.mapbox.com/*" },
-        { "url": "https://maps.googleapis.com/*" }
+        { "url": "https://maps.googleapis.com/*" },
+        { "url": "https://share.geolibre.app/*" }
       ]
     }
   ]

--- a/apps/geolibre-desktop/src/lib/share-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/share-fetch.ts
@@ -1,0 +1,84 @@
+// The fetch used by the share.geolibre.app client: project upload
+// (`share-geolibre.ts`) and the gallery reads (`share-gallery.ts`).
+//
+// Defaults to the WebView's browser `fetch`. The desktop build swaps in a
+// native-HTTP-backed fetch (`installNativeShareFetch`) that bypasses the
+// WebView's CORS enforcement for the share host — the share server's CORS
+// policy allows the web origin but not the Tauri WebView origin
+// (`tauri://localhost` / `http://tauri.localhost`), so a plain browser `fetch`
+// from the desktop app throws a `TypeError` that surfaces to the user as
+// "Could not reach share.geolibre.app." This mirrors the geocoding fix in
+// `geocoding-fetch.ts`.
+
+import { resolveShareBaseUrl } from "./share-geolibre";
+
+/**
+ * The active share fetch. Browser `fetch` by default; the desktop build
+ * overrides it via {@link installNativeShareFetch}. Callers read it lazily
+ * through {@link getShareFetch} so the override applies even to modules imported
+ * before install runs.
+ */
+let shareFetch: typeof globalThis.fetch = (input, init) => fetch(input, init);
+
+/** The fetch the share client should use; the desktop build overrides it. */
+export function getShareFetch(): typeof globalThis.fetch {
+  return shareFetch;
+}
+
+/** Override the share fetch. Exposed for {@link installNativeShareFetch} and tests. */
+export function setShareFetch(fetchImpl: typeof globalThis.fetch): void {
+  shareFetch = fetchImpl;
+}
+
+/** Restore the default browser `fetch` (used to reset state between tests). */
+export function resetShareFetch(): void {
+  shareFetch = (input, init) => fetch(input, init);
+}
+
+/** The request URL's host, or null when it cannot be parsed. */
+function requestHost(input: RequestInfo | URL): string | null {
+  try {
+    const href =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    return new URL(href).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Route requests to the share host through Tauri's native HTTP client instead of
+ * the WebView's `fetch`, bypassing browser CORS enforcement. Requests to any
+ * other host keep the browser `fetch` unchanged, so the native, CORS-exempt
+ * client stays scoped to the single share host — which must also be listed in
+ * the `http:default` capability scope (`src-tauri/capabilities/default.json`).
+ *
+ * The host is resolved from {@link resolveShareBaseUrl} (the configured or
+ * production share URL) at install time, so a `VITE_GEOLIBRE_SHARE_URL` override
+ * is honored.
+ *
+ * Loaded lazily and only in the desktop build so the web/embedded bundles never
+ * pull in `@tauri-apps/plugin-http`.
+ */
+export async function installNativeShareFetch(): Promise<void> {
+  let shareHost: string | null;
+  try {
+    shareHost = new URL(resolveShareBaseUrl()).host;
+  } catch {
+    shareHost = null;
+  }
+  if (!shareHost) return;
+  const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+  setShareFetch((input, init) => {
+    if (requestHost(input) !== shareHost) {
+      // Not the share host (e.g. a third-party thumbnail or project URL): keep
+      // the browser fetch, unchanged and outside the native capability scope.
+      return fetch(input, init);
+    }
+    return tauriFetch(input, init);
+  });
+}

--- a/apps/geolibre-desktop/src/lib/share-gallery.ts
+++ b/apps/geolibre-desktop/src/lib/share-gallery.ts
@@ -7,6 +7,7 @@
 // with a personal API token to also return the signed-in user's `unlisted` and
 // `private` projects.
 
+import { getShareFetch } from "./share-fetch";
 import { resolveShareBaseUrl } from "./share-geolibre";
 
 /**
@@ -190,7 +191,9 @@ export async function fetchSharedProjects(
   options: FetchSharedProjectsOptions = {},
 ): Promise<FetchSharedProjectsResult> {
   const base = (options.baseUrl ?? resolveShareBaseUrl()).replace(/\/+$/, "");
-  const fetchImpl = options.fetchImpl ?? fetch;
+  // See share-fetch.ts: on desktop this routes the share host through Tauri's
+  // native HTTP client so the gallery listing isn't blocked by WebView CORS.
+  const fetchImpl = options.fetchImpl ?? getShareFetch();
 
   const params = new URLSearchParams();
   if (options.limit != null) params.set("limit", String(options.limit));
@@ -308,9 +311,14 @@ export async function fetchMyProjects(
   options: FetchMyProjectsOptions,
 ): Promise<SharedProject[]> {
   const base = (options.baseUrl ?? resolveShareBaseUrl()).replace(/\/+$/, "");
-  // One auth path for both production and tests: the injected fetch (if any)
-  // flows through the same same-origin gating as the global fetch.
-  const authFetch = shareAuthorizedFetch(options.token, base, options.fetchImpl);
+  // One auth path for both production and tests: the injected fetch (or the
+  // share fetch, which the desktop build routes natively to bypass CORS — see
+  // share-fetch.ts) flows through the same same-origin token gating.
+  const authFetch = shareAuthorizedFetch(
+    options.token,
+    base,
+    options.fetchImpl ?? getShareFetch(),
+  );
 
   const timeout = AbortSignal.timeout(LISTING_TIMEOUT_MS);
   const signal = options.signal

--- a/apps/geolibre-desktop/src/lib/share-geolibre.ts
+++ b/apps/geolibre-desktop/src/lib/share-geolibre.ts
@@ -3,6 +3,7 @@
 // user created on the website. Used by the Project > Share action.
 
 import { DEFAULT_PROJECT_NAME } from "@geolibre/core";
+import { getShareFetch } from "./share-fetch";
 
 export type ShareVisibility = "public" | "unlisted" | "private";
 
@@ -54,7 +55,7 @@ export interface ShareUploadOptions {
   /** Override the share host; defaults to the configured/production URL. */
   baseUrl?: string;
   signal?: AbortSignal;
-  /** Injected for testing; defaults to the global fetch. */
+  /** Injected for testing; defaults to the share fetch (see share-fetch.ts). */
   fetchImpl?: typeof fetch;
 }
 
@@ -140,7 +141,9 @@ export async function uploadProjectToShare(
   }
 
   const base = (options.baseUrl ?? resolveShareBaseUrl()).replace(/\/+$/, "");
-  const fetchImpl = options.fetchImpl ?? fetch;
+  // Defaults to the share fetch, which the desktop build routes through Tauri's
+  // native HTTP client to bypass WebView CORS (see share-fetch.ts).
+  const fetchImpl = options.fetchImpl ?? getShareFetch();
 
   // Bound the request so a stalled server can't leave the dialog spinning
   // forever; combine it with the caller's abort signal (dialog close).

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -59,6 +59,18 @@ if (isTauri()) {
       // silent unhandled rejection.
       console.error("[GeoLibre] Failed to install native geocoding fetch", error);
     });
+  // Likewise route share.geolibre.app (project Share + gallery) through the
+  // native HTTP client: the share server's CORS policy allows the web origin but
+  // not the Tauri WebView origin, so a browser fetch fails as "Could not reach
+  // share.geolibre.app." Lazy + desktop-only so web/embedded never import the
+  // Tauri HTTP plugin.
+  void import("./lib/share-fetch")
+    .then(({ installNativeShareFetch }) => installNativeShareFetch())
+    .catch((error: unknown) => {
+      // On failure the share client stays on the browser fetch (the CORS-blocked
+      // path this fixes); surface it rather than swallow the rejection.
+      console.error("[GeoLibre] Failed to install native share fetch", error);
+    });
 }
 // Recover from chunks orphaned by a web redeploy (stale lazy import → 404). A
 // no-op in the desktop build, whose chunks are bundled locally.

--- a/tests/share-fetch.test.ts
+++ b/tests/share-fetch.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  getShareFetch,
+  resetShareFetch,
+  setShareFetch,
+} from "../apps/geolibre-desktop/src/lib/share-fetch";
+import { uploadProjectToShare } from "../apps/geolibre-desktop/src/lib/share-geolibre";
+import {
+  fetchMyProjects,
+  fetchSharedProjects,
+} from "../apps/geolibre-desktop/src/lib/share-gallery";
+
+// A minimal JSON Response for a share endpoint.
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("share fetch override", () => {
+  afterEach(() => resetShareFetch());
+
+  it("defaults to the global fetch and is overridable + resettable", async () => {
+    const original = globalThis.fetch;
+    try {
+      let calledDefault = 0;
+      globalThis.fetch = (() => {
+        calledDefault += 1;
+        return Promise.resolve(new Response("ok"));
+      }) as typeof fetch;
+
+      // Default share fetch delegates to whatever globalThis.fetch is.
+      await getShareFetch()("https://example.com/");
+      assert.equal(calledDefault, 1);
+
+      // Override wins.
+      let calledOverride = 0;
+      setShareFetch((() => {
+        calledOverride += 1;
+        return Promise.resolve(new Response("ok"));
+      }) as typeof fetch);
+      await getShareFetch()("https://example.com/");
+      assert.equal(calledOverride, 1);
+      assert.equal(calledDefault, 1);
+
+      // Reset restores the default (global fetch) path.
+      resetShareFetch();
+      await getShareFetch()("https://example.com/");
+      assert.equal(calledDefault, 2);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  // Regression guard for the desktop CORS fix: the share client functions must
+  // route through the installed share fetch when no fetchImpl is passed, so the
+  // desktop build's native (CORS-exempt) fetch actually gets used.
+  it("uploadProjectToShare uses the installed share fetch", async () => {
+    let seen: string | null = null;
+    setShareFetch(((input: RequestInfo | URL) => {
+      seen = typeof input === "string" ? input : input.toString();
+      return Promise.resolve(
+        jsonResponse({
+          project: {
+            projectUrl: "https://share.geolibre.app/u/p",
+            rawJsonUrl: "https://share.geolibre.app/u/p.geolibre.json",
+          },
+        }),
+      );
+    }) as typeof fetch);
+
+    await uploadProjectToShare({
+      token: "tok",
+      filename: "p.geolibre.json",
+      content: "{}",
+      visibility: "public",
+    });
+    assert.equal(seen, "https://share.geolibre.app/api/projects");
+  });
+
+  it("fetchSharedProjects uses the installed share fetch", async () => {
+    let seen: string | null = null;
+    setShareFetch(((input: RequestInfo | URL) => {
+      seen = typeof input === "string" ? input : input.toString();
+      return Promise.resolve(jsonResponse({ projects: [] }));
+    }) as typeof fetch);
+
+    await fetchSharedProjects();
+    assert.equal(seen, "https://share.geolibre.app/api/projects");
+  });
+
+  it("fetchMyProjects uses the installed share fetch (with auth)", async () => {
+    const seen: string[] = [];
+    let auth: string | null = null;
+    setShareFetch(((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      seen.push(url);
+      auth = new Headers(init?.headers).get("Authorization");
+      if (url.endsWith("/api/users/me")) {
+        return Promise.resolve(jsonResponse({ user: { username: "giswqs" } }));
+      }
+      return Promise.resolve(jsonResponse({ projects: [] }));
+    }) as typeof fetch);
+
+    await fetchMyProjects({ token: "tok" });
+    assert.deepEqual(seen, [
+      "https://share.geolibre.app/api/users/me",
+      "https://share.geolibre.app/api/users/giswqs/projects",
+    ]);
+    // The share-host request carries the bearer token via shareAuthorizedFetch.
+    assert.equal(auth, "Bearer tok");
+  });
+});


### PR DESCRIPTION
## Summary
- On the Tauri desktop build, the project Share action fails with "Could not reach share.geolibre.app. Check your internet connection." This is a CORS block, not a network or CSP issue: the Share client uses the WebView browser `fetch`, and the share server's CORS policy allows the web origin but not the Tauri WebView origin, so the cross-origin request throws.
- Route the share host through Tauri's native HTTP client (`@tauri-apps/plugin-http`), which is not bound by CORS, exactly as the existing geocoding fix does. Added a centralized, overridable share fetch (`lib/share-fetch.ts`); `installNativeShareFetch()` runs desktop-only and lazily, so web and embedded bundles never import the plugin.
- Applied to the whole share client, not just upload: the gallery / "My Projects" reads hit the same host and had the same latent failure on desktop. Added `https://share.geolibre.app/*` to the `http:default` capability scope.

## Test plan
- [x] `tests/share-fetch.test.ts` (new): default/override/reset of the share fetch, and that upload plus both gallery reads route through the installed fetch (with bearer token) - 43 share tests pass
- [x] Desktop app type-check clean; pre-commit (eslint + build) passes
- [x] Web build unaffected: the default share fetch is the browser `fetch`; only the desktop build swaps in the native path
- [ ] In a packaged desktop build, sign in with a share API token and confirm Share uploads succeed with no CORS/network error in the console
- [ ] In the packaged desktop build, open the project gallery and "My Projects" and confirm listings load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop app now uses a dedicated share connection path, helping share-related actions work more reliably in the app.
  * Share requests can now be handled separately from the browser default, with support for desktop-specific routing.

* **Bug Fixes**
  * Improved handling of share uploads and project listings to avoid browser security blocking in desktop mode.
  * Share host access now includes the app’s share domain for smoother desktop sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->