### PR TITLE
feat(raster): normalized-difference index builder for any HTTP COG

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -73,7 +73,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.7.0",
+    "maplibre-gl-raster": "^0.8.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -508,9 +508,13 @@ export function RasterSymbologySection({
     const a = clamp(
       guessBandForRole(preset.roleA, bandNames) ?? state.bands[0] ?? 1,
     );
-    const b = clamp(
+    let b = clamp(
       guessBandForRole(preset.roleB, bandNames) ?? (a === 2 ? 1 : 2),
     );
+    // Both roles can resolve to the same band (ambiguous band names, or a
+    // single-band clamp); (A - B) / (A + B) with A === B is a constant 0, so
+    // nudge B to a distinct band when the image has one.
+    if (b === a) b = clamp(a === 1 ? 2 : 1);
     return {
       mode: "index",
       index: preset.id,
@@ -695,31 +699,33 @@ export function RasterSymbologySection({
         <IndexControls
           state={state}
           bandOptions={bandOptions}
-          onPreset={(id) => commit({ statePatch: indexPatchFor(id) })}
+          onPreset={(id) =>
+            commit({ statePatch: indexPatchFor(id), symbology: null })
+          }
           onBands={(bands) => commit({ statePatch: { bands } })}
         />
       ) : (
-      <div className="space-y-2">
-        <Label htmlFor="rasterBand">Band</Label>
-        <Select
-          id="rasterBand"
-          value={String(band)}
-          disabled={bandOptions.length === 0}
-          onChange={(event) =>
-            commit({ statePatch: { bands: [Number(event.target.value)] } })
-          }
-        >
-          {bandOptions.length === 0 ? (
-            <option value={String(band)}>{`Band ${band}`}</option>
-          ) : (
-            bandOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))
-          )}
-        </Select>
-      </div>
+        <div className="space-y-2">
+          <Label htmlFor="rasterBand">Band</Label>
+          <Select
+            id="rasterBand"
+            value={String(band)}
+            disabled={bandOptions.length === 0}
+            onChange={(event) =>
+              commit({ statePatch: { bands: [Number(event.target.value)] } })
+            }
+          >
+            {bandOptions.length === 0 ? (
+              <option value={String(band)}>{`Band ${band}`}</option>
+            ) : (
+              bandOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))
+            )}
+          </Select>
+        </div>
       )}
 
       <div className="space-y-2">
@@ -951,9 +957,9 @@ function IndexControls({
       <div className="space-y-2">
         <Label>{`Bands (${preset.roleA}, ${preset.roleB})`}</Label>
         <div className="grid grid-cols-2 gap-2">
-          {operands.map(({ role, slot, value }) => (
+          {operands.map(({ slot, value }) => (
             <Select
-              key={role}
+              key={slot}
               aria-label={`index-band-${slot === 0 ? "a" : "b"}`}
               value={String(value)}
               disabled={bandOptions.length === 0}
@@ -971,6 +977,12 @@ function IndexControls({
             </Select>
           ))}
         </div>
+        {bandA === bandB && (
+          <p className="text-[10px] text-amber-600 dark:text-amber-500">
+            Operands A and B are the same band; the index is 0 everywhere. Pick
+            two different bands.
+          </p>
+        )}
       </div>
     </>
   );

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -30,14 +30,22 @@ import {
   Separator,
   Textarea,
 } from "@geolibre/ui";
-import { COLORMAP_OPTIONS } from "maplibre-gl-raster";
+import {
+  COLORMAP_OPTIONS,
+  CUSTOM_NORMALIZED_DIFFERENCE,
+  guessBandForRole,
+  indexById,
+  NORMALIZED_DIFFERENCE_INDICES,
+} from "maplibre-gl-raster";
 import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createAppAPI } from "../../hooks/usePlugins";
 
 type RasterStateRecord = {
-  mode: "single" | "rgb";
+  mode: "single" | "rgb" | "index";
   bands: number[];
+  /** Normalized-difference preset id (index mode only), e.g. "ndvi". */
+  index?: string;
   colormap: string;
   reversed: boolean;
   rescale: [number, number][] | null;
@@ -100,8 +108,10 @@ function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
       ? (raw.rescale as [number, number][])
       : null;
   return {
-    mode: raw.mode === "rgb" ? "rgb" : "single",
+    mode:
+      raw.mode === "rgb" ? "rgb" : raw.mode === "index" ? "index" : "single",
     bands: bands.length > 0 ? bands : [1],
+    index: typeof raw.index === "string" ? raw.index : undefined,
     colormap: typeof raw.colormap === "string" ? raw.colormap : DEFAULT_RAMP,
     // Reverse lives on rasterState now; migrate projects saved before that move
     // (the flag used to live on rasterSymbology) so they keep their reversal.
@@ -487,6 +497,29 @@ export function RasterSymbologySection({
     </div>
   ) : null;
 
+  // Builds the state patch for a normalized-difference index preset: assigns
+  // each operand a band (guessed from band names, else 1 and 2), applies the
+  // preset's default colormap, and resets rescale to the [-1, 1] auto range.
+  // Mirrors the upstream control's own preset seeding so the two panels agree.
+  function indexPatchFor(presetId: string): Partial<RasterStateRecord> {
+    const preset = indexById(presetId) ?? NORMALIZED_DIFFERENCE_INDICES[0];
+    const max = bandCount ?? Math.max(2, ...state.bands);
+    const clamp = (b: number) => Math.min(Math.max(1, b), Math.max(1, max));
+    const a = clamp(
+      guessBandForRole(preset.roleA, bandNames) ?? state.bands[0] ?? 1,
+    );
+    const b = clamp(
+      guessBandForRole(preset.roleB, bandNames) ?? (a === 2 ? 1 : 2),
+    );
+    return {
+      mode: "index",
+      index: preset.id,
+      bands: [a, b],
+      colormap: preset.colormap,
+      rescale: null,
+    };
+  }
+
   // --- Mode ---
   const modeControl = (
     <div className="space-y-2">
@@ -496,17 +529,25 @@ export function RasterSymbologySection({
         value={state.mode}
         disabled={bandCount === null}
         onChange={(event) => {
-          const mode = event.target.value as "single" | "rgb";
+          const mode = event.target.value as "single" | "rgb" | "index";
           if (mode === "rgb") {
             const bands =
               state.bands.length >= 3 ? state.bands.slice(0, 3) : [1, 2, 3];
             commit({ statePatch: { mode, bands }, symbology: null });
+          } else if (mode === "index") {
+            commit({
+              statePatch: indexPatchFor(state.index ?? "ndvi"),
+              symbology: null,
+            });
           } else {
             commit({ statePatch: { mode } });
           }
         }}
       >
         <option value="single">Single band (pseudocolor)</option>
+        {(bandCount === null || bandCount >= 2) && (
+          <option value="index">Index (normalized difference)</option>
+        )}
         {(bandCount === null || bandCount >= 3) && (
           <option value="rgb">RGB composite</option>
         )}
@@ -650,6 +691,14 @@ export function RasterSymbologySection({
       <p className="text-xs font-semibold">Raster symbology</p>
       {modeControl}
 
+      {state.mode === "index" ? (
+        <IndexControls
+          state={state}
+          bandOptions={bandOptions}
+          onPreset={(id) => commit({ statePatch: indexPatchFor(id) })}
+          onBands={(bands) => commit({ statePatch: { bands } })}
+        />
+      ) : (
       <div className="space-y-2">
         <Label htmlFor="rasterBand">Band</Label>
         <Select
@@ -671,6 +720,7 @@ export function RasterSymbologySection({
           )}
         </Select>
       </div>
+      )}
 
       <div className="space-y-2">
         <Label htmlFor="rasterRamp">Color ramp</Label>
@@ -850,6 +900,79 @@ function RgbControls({
         </div>
       ))}
     </div>
+  );
+}
+
+/** Index-mode operand editor: a normalized-difference preset selector plus a
+ * band picker for each operand (A, B) of `(A - B) / (A + B)`, labelled with
+ * the preset's roles. Mirrors the upstream control's index UI so editing an
+ * index layer works from either panel; the color ramp / rescale below apply to
+ * the computed [-1, 1] result. */
+function IndexControls({
+  state,
+  bandOptions,
+  onPreset,
+  onBands,
+}: {
+  state: RasterStateRecord;
+  bandOptions: { value: number; label: string }[];
+  onPreset: (presetId: string) => void;
+  onBands: (bands: number[]) => void;
+}) {
+  const preset = indexById(state.index) ?? NORMALIZED_DIFFERENCE_INDICES[0];
+  const presets = [...NORMALIZED_DIFFERENCE_INDICES, CUSTOM_NORMALIZED_DIFFERENCE];
+  const bandA = state.bands[0] ?? 1;
+  const bandB = state.bands[1] ?? 2;
+  const operands: { role: string; slot: 0 | 1; value: number }[] = [
+    { role: preset.roleA, slot: 0, value: bandA },
+    { role: preset.roleB, slot: 1, value: bandB },
+  ];
+  const setOperand = (slot: 0 | 1, value: number) => {
+    const next = [bandA, bandB];
+    next[slot] = value;
+    onBands(next);
+  };
+  return (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="rasterIndexPreset">Index</Label>
+        <Select
+          id="rasterIndexPreset"
+          value={preset.id}
+          onChange={(event) => onPreset(event.target.value)}
+        >
+          {presets.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label>{`Bands (${preset.roleA}, ${preset.roleB})`}</Label>
+        <div className="grid grid-cols-2 gap-2">
+          {operands.map(({ role, slot, value }) => (
+            <Select
+              key={role}
+              aria-label={`index-band-${slot === 0 ? "a" : "b"}`}
+              value={String(value)}
+              disabled={bandOptions.length === 0}
+              onChange={(event) => setOperand(slot, Number(event.target.value))}
+            >
+              {bandOptions.length === 0 ? (
+                <option value={String(value)}>{`Band ${value}`}</option>
+              ) : (
+                bandOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))
+              )}
+            </Select>
+          ))}
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.7.0",
+        "maplibre-gl-raster": "^0.8.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",
@@ -184,28 +184,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.2",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.2.tgz",
-      "integrity": "sha512-s1wEVDAtEwkS7Ajgep6PZKJLFqybRkmD3Byz+iVVsSpbDY0gjROXE9aOft6V3PMqynn3NTcycV5whga9tCzmKA==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
@@ -2553,13 +2531,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-      "extraneous": true,
-      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cogeotiff/core": {
       "version": "9.5.0",
@@ -16489,9 +16460,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.7.0.tgz",
-      "integrity": "sha512-t71Ng1BHoJChJULfxBIn1POZpUDnf8p17mNrhAOlCtsTkiC1sTaCWh8xlXomJEM3zak+t8LkLk2EysCg+lfNgw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.8.0.tgz",
+      "integrity": "sha512-RMl4GNWzIkNQ/ONzpahBPz3mkMo/UBLXMbAt3L5OwkVnhs6vBStFWliW8FAhkjnrBxClZ4fWNl5R7kxamvXfsw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21121,7 +21092,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.7.0",
+        "maplibre-gl-raster": "^0.8.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.10.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -48,7 +48,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.7.0",
+    "maplibre-gl-raster": "^0.8.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.10.1",

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -43,6 +43,12 @@ const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
     label: "Elevation (DEM)",
     url: "https://data.source.coop/giswqs/opengeos/dem.tif",
   },
+  {
+    // A multiband Sentinel-2 L2A scene: good for RGB composites and the
+    // normalized-difference index mode (NDVI and friends).
+    label: "Sentinel-2 (multiband)",
+    url: "https://data.source.coop/opengeos/geoai/S2C-MSIL2A-20250920T162001-subset.tif",
+  },
 ];
 
 // This type mirrors undocumented private members of RasterControl from

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -272,6 +272,7 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
 const SYNCED_RASTER_STATE_KEYS = [
   "mode",
   "bands",
+  "index",
   "colormap",
   "reversed",
   "rescale",
@@ -401,8 +402,17 @@ export function savedRasterState(
   const candidate = raw as Record<string, unknown>;
   const state: Partial<RasterLayerState> = {};
 
-  if (candidate.mode === "rgb" || candidate.mode === "single") {
+  if (
+    candidate.mode === "rgb" ||
+    candidate.mode === "single" ||
+    candidate.mode === "index"
+  ) {
     state.mode = candidate.mode;
+  }
+  // The normalized-difference preset id (index mode). The control tolerates
+  // unknown ids (falls back to the first preset), so no allowlist here.
+  if (typeof candidate.index === "string" && candidate.index) {
+    state.index = candidate.index;
   }
   if (
     Array.isArray(candidate.bands) &&

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -549,6 +549,23 @@ describe("savedRasterState", () => {
     assert.equal(savedRasterState(layer).rescale, null);
   });
 
+  it("round-trips index mode and the preset id", () => {
+    const state = rasterState({
+      mode: "index",
+      bands: [4, 3],
+      index: "ndvi",
+      colormap: "rdylgn",
+      rescale: [[-1, 1]],
+    });
+    const layer = createRasterStoreLayer(rasterInfo({ state }));
+
+    const saved = savedRasterState(layer);
+    assert.equal(saved.mode, "index");
+    assert.equal(saved.index, "ndvi");
+    assert.deepEqual(saved.bands, [4, 3]);
+    assert.equal(saved.colormap, "rdylgn");
+  });
+
   it("drops malformed fields from hand-edited project files", () => {
     const layer = createRasterStoreLayer(rasterInfo());
     layer.metadata.rasterState = {


### PR DESCRIPTION
## What

Adds an **index builder** to the raster panel so users can compute NDVI and related spectral indices for any HTTP COG **directly in the viewer**, with no download and no Python sidecar. Fixes #1110.

The heavy lifting lives upstream in [`maplibre-gl-raster` v0.8.0](https://github.com/opengeos/maplibre-gl-raster/pull/30), which adds an `index` render mode that computes a normalized-difference index `(A - B) / (A + B)` of two bands entirely on the GPU and colors the `[-1, 1]` result. This PR consumes it and wires it into GeoLibre.

## Changes

- **Bump** `maplibre-gl-raster` to `^0.8.0` (app + plugins packages).
- **Persistence** (`raster-layer-sync.ts`): allow `mode: "index"` and round-trip the preset `index` id through `metadata.rasterState`, so index layers survive project save/load.
- **Style panel** (`RasterSymbologySection.tsx`): a new "Index (normalized difference)" render mode with a preset selector (NDVI, NDWI, NDMI, NBR, NDBI, NDSI, Custom) and a band picker per operand, labelled with the preset's roles (e.g. NIR, Red). Mirrors the upstream Add Raster Layer panel so either surface can edit an index layer, and they stay in sync.
- **Sample data** (`maplibre-raster.ts`): add a multiband Sentinel-2 L2A scene to the "Load sample data" list, an ideal demo for index mode.

## How it works

For a generic HTTP COG there is no TiTiler `expression=` path (rendering is fully client-side via deck.gl-raster + cog-tiler-wasm). The upstream release adds a `NormalizedDifference` GPU shader that slots into the existing `CompositeBands -> nodata -> rescale -> colormap` pipeline. Presets pre-fill sensible band roles and a default ramp; operand bands are seeded from GDAL band names when the file carries them. Index mode requires the default GPU engine (the `cog-tiler-wasm` engine has no band-math endpoint).

## Testing

- `npm run build` clean (0 TS errors); `pre-commit` (eslint + build) clean.
- `npm run test:frontend`: 2029 pass, 0 fail, including a new index round-trip test in `raster-layer-sync.test.ts`.
- Verified in the real app on the new multiband Sentinel-2 sample: computed a true NDVI (NIR / Red) that renders live on the RdYlGn ramp, edited it from both the Add Raster Layer panel and the Style panel (they stay in sync), and confirmed it works in **both light and dark themes** with no console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Index (normalized difference)” raster display mode with preset selection and separate band pickers for operands A and B.
  * Added a new one-click Sentinel-2 multiband sample to the raster panel.
* **Bug Fixes**
  * Saved raster visualization settings now restore index-mode presets, bands, and colormap correctly.
  * Raster visualization state syncing now includes index-mode changes.
* **Tests**
  * Added round-trip test coverage for index-mode raster settings.
* **Chores**
  * Updated the raster rendering dependency to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->