### PR TITLE
fix(set-view): surface smart-paste behind a labeled toggle button

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
@@ -15,7 +15,7 @@ import {
 } from "@geolibre/ui";
 import type { MapController } from "@geolibre/map";
 import type { ParseKeys } from "i18next";
-import { ClipboardPaste, Info } from "lucide-react";
+import { ChevronDown, ClipboardPaste, Info } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { parseLatLon } from "../../lib/coordinates";
@@ -114,11 +114,11 @@ export function SetViewDialog({
   const [pasteStatus, setPasteStatus] = useState<"idle" | "ok" | "error">(
     "idle",
   );
-  // The smart-paste field is hidden until the user reveals it from the paste
-  // icon next to the heading (hover, click, or keyboard focus), so the dialog
-  // leads with the precise fields and the paste shortcut adds no clutter by
-  // default (#828). Once open it stays open so it never covers or shifts the
-  // controls below mid-interaction; it resets closed each time the dialog opens.
+  // The smart-paste field lives behind a clearly labeled, always-visible toggle
+  // button under the heading: the dialog still leads with the precise fields and
+  // the paste shortcut adds no clutter by default (#828), while the button gives
+  // the shortcut an obvious affordance instead of hiding it behind a hover-only
+  // icon (#1033). Collapsed each time the dialog opens; clicking toggles it.
   const [pasteOpen, setPasteOpen] = useState(false);
 
   // Fill all three center representations from one decimal lon/lat, so the value
@@ -478,34 +478,38 @@ export function SetViewDialog({
         <form className="space-y-5" noValidate onSubmit={handleSubmit}>
           {/* Segment A: coordinates, with a DD/DMS/DDM manual-entry toggle. */}
           <section className="space-y-3">
-            {/* Smart paste is tucked behind the paste icon next to the heading:
-                the field stays hidden so the dialog leads with the precise
-                fields. Hovering, clicking, or keyboard-focusing the icon reveals
-                it inline on demand (#828). Revealing inline (rather than as a
-                floating overlay) means the panel never covers or intercepts the
-                controls below it. */}
-            <div className="flex items-center gap-1.5">
-              <SectionHeading>
-                {t("toolbar.setView.sectionCoordinates")}
-              </SectionHeading>
-              <button
-                type="button"
-                aria-label={t("toolbar.setView.smartPaste")}
-                aria-expanded={pasteOpen}
-                aria-controls="set-view-paste-panel"
-                // Hover, click, and keyboard activation all simply reveal the
-                // panel; it then stays open (until the dialog reopens) rather
-                // than toggling, so a hover-then-click never closes it.
-                onClick={() => setPasteOpen(true)}
-                onMouseEnter={() => setPasteOpen(true)}
+            <SectionHeading>
+              {t("toolbar.setView.sectionCoordinates")}
+            </SectionHeading>
+            {/* Smart paste sits behind a clearly labeled, always-visible toggle
+                button: the panel stays collapsed so the dialog leads with the
+                precise fields (#828), but the button gives the shortcut an
+                obvious affordance rather than hiding it behind a hover-only icon
+                (#1033). Clicking toggles the panel, which expands inline (not as
+                a floating overlay) so it never covers the controls below it. */}
+            <button
+              type="button"
+              aria-expanded={pasteOpen}
+              aria-controls="set-view-paste-panel"
+              onClick={() => setPasteOpen((open) => !open)}
+              className={cn(
+                "flex w-full cursor-pointer items-center gap-2 rounded-md border border-input px-3 py-2 text-sm font-medium transition-colors",
+                "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                pasteOpen ? "text-foreground" : "text-muted-foreground",
+              )}
+            >
+              <ClipboardPaste className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span className="flex-1 text-left">
+                {t("toolbar.setView.smartPaste")}
+              </span>
+              <ChevronDown
                 className={cn(
-                  "inline-flex cursor-pointer rounded hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  pasteOpen ? "text-foreground" : "text-muted-foreground",
+                  "h-4 w-4 shrink-0 transition-transform",
+                  pasteOpen && "rotate-180",
                 )}
-              >
-                <ClipboardPaste className="h-3.5 w-3.5" aria-hidden="true" />
-              </button>
-            </div>
+                aria-hidden="true"
+              />
+            </button>
             {pasteOpen && (
               <div
                 id="set-view-paste-panel"
@@ -513,7 +517,7 @@ export function SetViewDialog({
               >
                 <div className="flex items-center gap-1.5">
                   <Label htmlFor="set-view-paste">
-                    {t("toolbar.setView.smartPaste")}
+                    {t("toolbar.setView.smartPasteInputLabel")}
                   </Label>
                   <InfoTooltip
                     title={t("toolbar.setView.smartPasteInfoLabel")}

--- a/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
@@ -490,7 +490,10 @@ export function SetViewDialog({
             <button
               type="button"
               aria-expanded={pasteOpen}
-              aria-controls="set-view-paste-panel"
+              // Only reference the panel while it is actually mounted: it is
+              // conditionally rendered below, so pointing aria-controls at a
+              // missing id when collapsed would be a dangling reference.
+              aria-controls={pasteOpen ? "set-view-paste-panel" : undefined}
               onClick={() => setPasteOpen((open) => !open)}
               className={cn(
                 "flex w-full cursor-pointer items-center gap-2 rounded-md border border-input px-3 py-2 text-sm font-medium transition-colors",

--- a/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
@@ -487,17 +487,17 @@ export function SetViewDialog({
                 obvious affordance rather than hiding it behind a hover-only icon
                 (#1033). Clicking toggles the panel, which expands inline (not as
                 a floating overlay) so it never covers the controls below it. */}
-            <button
+            <Button
               type="button"
+              variant="outline"
               aria-expanded={pasteOpen}
               // Only reference the panel while it is actually mounted: it is
               // conditionally rendered below, so pointing aria-controls at a
               // missing id when collapsed would be a dangling reference.
               aria-controls={pasteOpen ? "set-view-paste-panel" : undefined}
-              onClick={() => setPasteOpen((open) => !open)}
+              onClick={() => setPasteOpen((isOpen) => !isOpen)}
               className={cn(
-                "flex w-full cursor-pointer items-center gap-2 rounded-md border border-input px-3 py-2 text-sm font-medium transition-colors",
-                "hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                "w-full justify-start font-medium",
                 pasteOpen ? "text-foreground" : "text-muted-foreground",
               )}
             >
@@ -512,7 +512,7 @@ export function SetViewDialog({
                 )}
                 aria-hidden="true"
               />
-            </button>
+            </Button>
             {pasteOpen && (
               <div
                 id="set-view-paste-panel"

--- a/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SetViewDialog.tsx
@@ -497,7 +497,7 @@ export function SetViewDialog({
               aria-controls={pasteOpen ? "set-view-paste-panel" : undefined}
               onClick={() => setPasteOpen((isOpen) => !isOpen)}
               className={cn(
-                "w-full justify-start font-medium",
+                "w-full justify-start",
                 pasteOpen ? "text-foreground" : "text-muted-foreground",
               )}
             >

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1311,6 +1311,7 @@
       "description": "Move the map to an exact camera.",
       "sectionCoordinates": "Coordinates",
       "smartPaste": "Paste coordinates",
+      "smartPasteInputLabel": "Coordinate string",
       "smartPastePlaceholder": "e.g. 51.5074, -0.1278 or 51°30'26\"N, 0°07'39\"W",
       "smartPasteInfo": "Type or paste a full coordinate string in DD, DMS, or DDM, then run Process input. GeoLibre detects the format and fills the longitude and latitude fields below. Adjust zoom, pitch, and bearing separately before going.",
       "smartPasteInfoLabel": "About pasting coordinates",


### PR DESCRIPTION
## Summary

The **Set View** dialog hid its coordinate smart-paste field behind a tiny clipboard icon that only revealed the panel on hover, with no visual cue that it was interactive. As reported in #1033, keyboard and intentional-workflow users could not discover it, and it required precise mouse positioning to trigger.

This replaces the hover-only icon with a clearly labeled, always-visible toggle button (clipboard icon + "Paste coordinates" + chevron) under the **Coordinates** heading:

- The button is a permanent, obvious affordance rather than a hidden hover target.
- It toggles on click and keyboard activation (no more hover-to-reveal).
- The panel stays **collapsed by default**, so the dialog still leads with the precise longitude/latitude fields, preserving the low-clutter intent of #828.
- The expanded panel's field label changed from a redundant second "Paste coordinates" to "Coordinate string" (new `smartPasteInputLabel` i18n key).

## Before / after

| Before (hidden behind hover icon) | After (labeled toggle, collapsed) | After (expanded) |
| --- | --- | --- |
| Only a bare clipboard icon next to the COORDINATES heading | Full-width "Paste coordinates" button with chevron | Panel with the coordinate-string input + Process input |

## Testing

Verified in the running web app with Playwright in **both light and dark themes**:

- Dialog opens with the paste panel collapsed and the labeled toggle button visible.
- Clicking the button expands the panel; clicking again collapses it.
- Typing `51.5074, -0.1278` and pressing **Process input** fills the longitude/latitude fields correctly and shows the confirmation.
- `npm run typecheck` (full build) and `pre-commit run --files ...` (eslint + build) pass.

Fixes #1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the map view “paste coordinates” workflow with an always-visible toggle under the coordinates heading to show or hide the smart-paste input.
  * Added a “Coordinate string” label for the smart-paste input.
* **Bug Fixes**
  * Adjusted smart-paste panel behavior so it starts collapsed whenever the dialog opens and expands/collapses more consistently via the toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->