### PR TITLE
feat(basemaps): Layers-panel toggle + dark-mode theming

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -20,6 +20,7 @@ import {
   canEditLayerGeometry,
   detectTimeProperties,
   getLayerTimeBinding,
+  BASEMAP_CONTROL_PLUGIN_ID,
   RASTER_SOURCE_KIND,
   reloadVectorControlLayer,
   SKETCHES_SOURCE_KIND,
@@ -66,6 +67,7 @@ import {
   Separator,
   Select,
   Slider,
+  cn,
 } from "@geolibre/ui";
 import {
   CalendarClock,
@@ -82,6 +84,7 @@ import {
   GripVertical,
   Info,
   Layers,
+  Map as MapIcon,
   MoreHorizontal,
   MousePointerClick,
   Palette,
@@ -1896,6 +1899,27 @@ export function LayerPanel({
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <span className="text-sm font-semibold">Layers</span>
         <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title={t("layers.basemaps")}
+            aria-label={t("layers.basemaps")}
+            aria-pressed={isPluginActive(BASEMAP_CONTROL_PLUGIN_ID)}
+            onClick={() =>
+              togglePlugin(
+                BASEMAP_CONTROL_PLUGIN_ID,
+                createAppAPI(mapControllerRef),
+              )
+            }
+          >
+            <MapIcon
+              className={cn(
+                "h-4 w-4",
+                isPluginActive(BASEMAP_CONTROL_PLUGIN_ID) && "text-primary",
+              )}
+            />
+          </Button>
           <Button
             variant="ghost"
             size="icon"

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2477,6 +2477,7 @@
     "basemapOpacity": "Basemap opacity",
     "backgroundNameFixed": "The name of the background basemap is fixed and cannot be changed.",
     "newGroup": "New group",
+    "basemaps": "Basemaps",
     "collapseGroup": "Collapse group",
     "expandGroup": "Expand group",
     "hideGroup": "Hide group",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2263,6 +2263,143 @@ body,
   background: hsl(var(--border));
 }
 
+/* Basemaps plugin (maplibre-gl-basemap-control) — the package ships a
+   hard-coded light theme with `color-scheme: light`, so map its own classes
+   onto the app design tokens when the app is in dark mode. Scoped to the
+   package's own root/child classes, mirroring the STAC `.pc-control-*` block
+   above. Never edit the package's stylesheet in node_modules. */
+.dark .basemap-control {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  color-scheme: dark;
+  box-shadow: 0 0 0 2px rgb(0 0 0 / 0.4);
+}
+
+.dark .basemap-control-toggle {
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .basemap-control-toggle:hover {
+  background-color: hsl(var(--muted));
+}
+
+.dark .basemap-control-icon svg {
+  stroke: hsl(var(--popover-foreground));
+}
+
+.dark .basemap-control-panel {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  box-shadow: 0 8px 28px rgb(0 0 0 / 0.55), 0 0 0 1px hsl(var(--border));
+}
+
+.dark .basemap-control-header {
+  border-bottom-color: hsl(var(--border));
+}
+
+.dark .basemap-control-title,
+.dark .basemap-control-result-name,
+.dark .basemap-control-settings-heading,
+.dark .basemap-control-multiple-toggle {
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .basemap-control-settings-toggle,
+.dark .basemap-control-close,
+.dark .basemap-control-status,
+.dark .basemap-control-empty,
+.dark .basemap-control-result-meta,
+.dark .basemap-control-result-attribution,
+.dark .basemap-control-settings-intro,
+.dark .basemap-control-provider-group-label {
+  color: hsl(var(--muted-foreground));
+}
+
+.dark .basemap-control-settings-toggle:hover,
+.dark .basemap-control-close:hover {
+  color: hsl(var(--popover-foreground));
+  background: hsl(var(--accent));
+}
+
+.dark .basemap-control-settings-toggle.is-active {
+  color: hsl(var(--accent-foreground));
+  background: hsl(var(--accent));
+}
+
+.dark .basemap-control-status.is-error {
+  color: #f87171;
+}
+
+.dark .basemap-control-input,
+.dark .basemap-control-select,
+.dark .basemap-control-settings-back {
+  background: hsl(var(--background));
+  border-color: hsl(var(--border));
+  color: hsl(var(--foreground));
+  color-scheme: dark;
+}
+
+.dark .basemap-control-input::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+.dark .basemap-control-select option {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .basemap-control-input:focus,
+.dark .basemap-control-select:focus {
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 3px hsl(var(--ring) / 0.3);
+}
+
+.dark .basemap-control-multiple-checkbox {
+  accent-color: hsl(var(--ring));
+}
+
+.dark .basemap-control-result {
+  background: hsl(var(--muted));
+  border-color: hsl(var(--border));
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .basemap-control-result:hover {
+  border-color: hsl(var(--ring));
+  background: hsl(var(--accent));
+}
+
+.dark .basemap-control-result.is-active {
+  border-color: hsl(var(--ring));
+  background: hsl(var(--accent));
+}
+
+.dark .basemap-control-result-type {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.dark .basemap-control-settings-back:hover {
+  border-color: hsl(var(--ring));
+  background: hsl(var(--accent));
+}
+
+.dark .basemap-control-status-link {
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .basemap-control-results::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
+}
+
+.dark .basemap-control-resize-handle::after {
+  border-color: hsl(var(--border));
+}
+
+.dark .basemap-control-resize-handle:hover::after {
+  border-color: hsl(var(--muted-foreground));
+}
+
 .geolibre-earth-engine-control .plugin-control-toggle {
   align-items: center;
   display: flex;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2327,7 +2327,7 @@ body,
 }
 
 .dark .basemap-control-status.is-error {
-  color: #f87171;
+  color: hsl(var(--destructive));
 }
 
 .dark .basemap-control-input,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -46,6 +46,7 @@ export { osmBasemapPlugin } from "./plugins/osm-basemap";
 export { cartoLightPlugin } from "./plugins/carto-light";
 export {
   maplibreBasemapControlPlugin,
+  BASEMAP_CONTROL_PLUGIN_ID,
   setBasemapControlLabels,
   type BasemapControlLabels,
 } from "./plugins/maplibre-basemap-control";

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -47,6 +47,7 @@ export { cartoLightPlugin } from "./plugins/carto-light";
 export {
   maplibreBasemapControlPlugin,
   BASEMAP_CONTROL_PLUGIN_ID,
+  getActiveBasemapControl,
   setBasemapControlLabels,
   type BasemapControlLabels,
 } from "./plugins/maplibre-basemap-control";

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -112,8 +112,10 @@ const registeredRasterLayers = new Map<string, string>();
 let styleChangeFallback: { attemptedUrl: string; previousUrl: string } | null =
   null;
 
+export const BASEMAP_CONTROL_PLUGIN_ID = "maplibre-gl-basemap-control";
+
 export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
-  id: "maplibre-gl-basemap-control",
+  id: BASEMAP_CONTROL_PLUGIN_ID,
   name: "Basemaps",
   version: "0.3.0",
   activate: (app: GeoLibreAppAPI) => {
@@ -154,7 +156,12 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     if (!basemapControl) return;
     cleanupRuntimeEnvListener();
-    unregisterAllRasterBasemaps(app);
+    // Closing the control must not throw away the stacked raster basemaps the
+    // user assembled — they are real layers in the Layers panel. Keep them in
+    // the store and only drop the module-level link tracking; a later
+    // reactivation relinks them from the store via relinkRestoredRasterBasemaps
+    // (the same path a reopened project takes). See #1113 follow-up.
+    registeredRasterLayers.clear();
     app.removeMapControl(basemapControl);
     basemapControl = null;
     // Drop any pending style-failure fallback so a later reactivation cannot

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -114,6 +114,15 @@ let styleChangeFallback: { attemptedUrl: string; previousUrl: string } | null =
 
 export const BASEMAP_CONTROL_PLUGIN_ID = "maplibre-gl-basemap-control";
 
+/**
+ * The live BasemapControl instance while the plugin is active, or null when it
+ * is deactivated. Mirrors getActiveTimeSliderControl; used by tests to assert
+ * the panel state seeded on (re)activation.
+ */
+export function getActiveBasemapControl(): BasemapControl | null {
+  return basemapControl;
+}
+
 export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   id: BASEMAP_CONTROL_PLUGIN_ID,
   name: "Basemaps",
@@ -144,13 +153,31 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
       basemapControl = null;
       return false;
     }
-    basemapControl.setState({
-      activeBasemapId: getBasemapIdForStyleUrl(app.getActiveBasemap()),
-    });
-    // Re-link raster basemap layers restored from a reopened project so that a
-    // later switch to a style basemap or a removal can unregister them (the
-    // module state does not survive a new session).
+    // Re-link raster basemap layers restored from a reopened project (or kept
+    // from a previous activation in this session) so that a later switch to a
+    // style basemap or a removal can unregister them (the module state does not
+    // survive a new session).
     relinkRestoredRasterBasemaps();
+    // Seed the fresh control instance with every basemap already on the map —
+    // the active style basemap plus any stacked rasters we just relinked — so
+    // the reopened panel highlights them as active and a re-click on a stacked
+    // raster removes it. Without the raster ids the new instance only knows the
+    // style basemap and shows restored overlays as inactive. When rasters are
+    // stacked the map is in overlay mode, so restore that too.
+    const activeStyleId = getBasemapIdForStyleUrl(app.getActiveBasemap());
+    const stackedRasterIds = [...registeredRasterLayers.keys()];
+    const activeBasemapIds = [
+      ...new Set(
+        [activeStyleId, ...stackedRasterIds].filter(
+          (id): id is string => typeof id === "string",
+        ),
+      ),
+    ];
+    basemapControl.setState({
+      activeBasemapId: activeStyleId,
+      activeBasemapIds,
+      ...(stackedRasterIds.length > 0 ? { allowMultiple: true } : {}),
+    });
     setTimeout(() => basemapControl?.expand(), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {

--- a/tests/basemap-control-plugin.test.ts
+++ b/tests/basemap-control-plugin.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import {
+  BASEMAP_CONTROL_PLUGIN_ID,
+  getActiveBasemapControl,
+  maplibreBasemapControlPlugin as plugin,
+} from "../packages/plugins/src/plugins/maplibre-basemap-control";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
+
+/** A raster basemap layer as the control leaves it in the store when stacked. */
+function stackedRasterBasemap(basemapId: string): GeoLibreLayer {
+  return {
+    id: `basemap-${basemapId}`,
+    name: basemapId,
+    type: "raster",
+    source: { type: "raster", tiles: [`https://example.com/${basemapId}.png`] },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: { sourceKind: "maplibre-basemap-control", basemapId },
+  };
+}
+
+/**
+ * A fake app that records every unregisterExternalNativeLayer call and mirrors
+ * the real one (which removes the store layer), so a test can assert whether
+ * deactivate wiped the stacked basemaps or left them alone.
+ */
+function fakeApp(unregistered: string[]): GeoLibreAppAPI {
+  return {
+    getMap: () => ({}),
+    addMapControl: () => true,
+    removeMapControl: () => {},
+    getActiveBasemap: () => "https://tiles.openfreemap.org/styles/liberty",
+    unregisterExternalNativeLayer: (id: string) => {
+      unregistered.push(id);
+      useAppStore.getState().removeLayer(id);
+    },
+  } as unknown as GeoLibreAppAPI;
+}
+
+describe("maplibreBasemapControlPlugin lifecycle", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  afterEach(() => {
+    // Tear the control down so module-level state never leaks between tests.
+    if (getActiveBasemapControl()) plugin.deactivate?.(fakeApp([]));
+    useAppStore.setState({ layers: [] });
+  });
+
+  it("has the exported id", () => {
+    assert.equal(plugin.id, BASEMAP_CONTROL_PLUGIN_ID);
+  });
+
+  it("keeps stacked raster basemaps in the store when deactivated", () => {
+    useAppStore.getState().addLayer(stackedRasterBasemap("google-satellite"));
+    const unregistered: string[] = [];
+    const app = fakeApp(unregistered);
+
+    plugin.activate(app);
+    plugin.deactivate?.(app);
+
+    // The layer survives and nothing was unregistered/removed.
+    assert.deepEqual(unregistered, []);
+    assert.equal(
+      useAppStore
+        .getState()
+        .layers.filter(
+          (l) => l.metadata?.sourceKind === "maplibre-basemap-control",
+        ).length,
+      1,
+    );
+  });
+
+  it("relinks and highlights restored rasters on reactivation", () => {
+    useAppStore.getState().addLayer(stackedRasterBasemap("google-satellite"));
+    const app = fakeApp([]);
+
+    plugin.activate(app);
+    plugin.deactivate?.(app);
+    plugin.activate(app);
+
+    const control = getActiveBasemapControl();
+    assert.ok(control, "control should be active after reactivation");
+    const state = control.getState();
+    // The reopened panel highlights the restored raster (not just the style
+    // basemap) and is back in overlay/stack mode.
+    assert.ok(state.activeBasemapIds.includes("google-satellite"));
+    assert.equal(state.allowMultiple, true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Basemaps** button to the Layers panel header (next to the Add Group icon) that opens/closes the Basemaps plugin, fixes basemap layers being wiped when the plugin is toggled off, and themes the plugin panel for dark mode.

## Changes

**1. Layers-panel toggle button**
- New ghost icon button (lucide `Map`) in the Layers panel header, left of Add Group, wired to `togglePlugin(BASEMAP_CONTROL_PLUGIN_ID, createAppAPI(mapControllerRef))` — the same activation path as the existing Time Slider call.
- Reflects active state via `aria-pressed` and a `text-primary` tint.
- Added the `layers.basemaps` i18n string; exported a `BASEMAP_CONTROL_PLUGIN_ID` constant from `@geolibre/plugins` (mirrors `TIME_SLIDER_PLUGIN_ID`).

**2. Keep basemap layers when the plugin is toggled off**
- Previously `deactivate` called `unregisterAllRasterBasemaps`, which does a full `removeLayer` on every stacked raster basemap — closing the control deleted the user's layers.
- `deactivate` now keeps the layers in the store and only clears the module-level link tracking; a later reactivation relinks them from the store via `relinkRestoredRasterBasemaps` (the same path a reopened project takes). The style-swap call site that legitimately replaces stacked rasters is untouched.

**3. Dark-mode theming**
- `maplibre-gl-basemap-control` ships a hard-coded light stylesheet with `color-scheme: light`. Added scoped `.dark .basemap-control*` overrides in `index.css` mapping its classes onto the app design tokens (`--popover`, `--background`, `--border`, `--accent`, `--ring`, `--muted-foreground`, …), including `color-scheme: dark` on native inputs/selects so dropdown chrome, `<option>` popups, and scrollbars render dark. Per repo convention — no `node_modules` edits. Light mode is unaffected.

## Verification

- `npm run test:frontend` — all 2029 tests pass.
- `tsc -b` across `packages/plugins` and `apps/geolibre-desktop` — clean.
- Drove the real app with Playwright in both `?theme=dark` and `?theme=light`: the panel opens from the new header button, adapts to each theme with good contrast, and reports zero console errors. Toggling off keeps the basemap layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a basemap control toggle button to the Layers panel, including proper activation state feedback.
  * Added a “Basemaps” label to the layer/group UI.
* **Bug Fixes**
  * Closing the basemap control no longer removes stacked raster basemaps, preserving your existing layer setup.
  * Improved basemap control behavior when reactivated, restoring the prior selection/active basemap state.
* **Style**
  * Enhanced dark-mode styling for the basemap control to better match the app theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->