### PR TITLE
feat(terrain): double-click terrain control for vertical exaggeration

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -95,6 +95,7 @@ import { CollaborateDialog } from "./CollaborateDialog";
 import { useCollaboration } from "../../hooks/useCollaboration";
 import { MapModeBanner } from "./MapModeBanner";
 import { PixelTimeSeriesControl } from "./PixelTimeSeriesControl";
+import { TerrainSettingsDialog } from "./TerrainSettingsDialog";
 import { MapContextMenu } from "./MapContextMenu";
 import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
@@ -945,6 +946,12 @@ export function DesktopShell({
     );
   }, [t, mapReadyGeneration]);
 
+  // Keep the on-map terrain control's tooltip translated (it lives outside
+  // React). Re-runs on controller (re)init and language change.
+  useEffect(() => {
+    mapControllerRef.current?.setTerrainLabel(t("terrainSettings.controlLabel"));
+  }, [t, mapReadyGeneration]);
+
   // Keep the Layer Swipe panel's grouped base-layer label translated. That
   // panel lives outside React and reads labels from the controller bridge, so
   // re-push on language change (t identity) and controller (re)init.
@@ -1735,6 +1742,7 @@ export function DesktopShell({
               </SilentErrorBoundary>
               <MapModeBanner mapControllerRef={mapControllerRef} />
               <PixelTimeSeriesControl mapControllerRef={mapControllerRef} />
+              <TerrainSettingsDialog mapControllerRef={mapControllerRef} />
               <StoryMapComposeBar mapControllerRef={mapControllerRef} />
             </MapGrid>
           </SectionErrorBoundary>

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -15,19 +15,17 @@ import {
   Label,
   Slider,
 } from "@geolibre/ui";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  clampExaggeration,
+  EXAGGERATION_STEP,
+  MAX_EXAGGERATION,
+  MIN_EXAGGERATION,
+} from "../../lib/terrain-exaggeration";
 
-const MIN_EXAGGERATION = 0;
-const MAX_EXAGGERATION = 5;
-const EXAGGERATION_STEP = 0.1;
 // Default sourced from the map package so it can't drift from the control's.
 const DEFAULT_EXAGGERATION = DEFAULT_TERRAIN_EXAGGERATION;
-
-function clampExaggeration(value: number): number {
-  if (!Number.isFinite(value)) return DEFAULT_EXAGGERATION;
-  return Math.min(MAX_EXAGGERATION, Math.max(MIN_EXAGGERATION, value));
-}
 
 export interface TerrainSettingsDialogProps {
   mapControllerRef: React.RefObject<MapController | null>;
@@ -54,16 +52,18 @@ export function TerrainSettingsDialog({
 
   useEffect(() => {
     const handleOpen = () => {
-      // Seed the slider from the controller's current value so the dialog
-      // reflects any previously chosen exaggeration. Clamp it to the dialog's
-      // display range: the controller only floors its cache at 0, so a value
-      // written directly (e.g. via a future scripting API) could exceed the max.
-      setExaggeration(
-        clampExaggeration(
-          mapControllerRef.current?.getTerrainExaggeration() ??
-            DEFAULT_EXAGGERATION,
-        ),
+      // Seed from the controller's current value so the dialog reflects any
+      // previously chosen exaggeration. Clamp to the dialog's display range: the
+      // controller only floors its cache at 0, so a value written directly (e.g.
+      // via a future scripting API) could exceed the max. Set the draft directly
+      // too (not just via the exaggeration effect) so reopening after an
+      // uncommitted/invalid draft was abandoned via Escape shows the real value.
+      const value = clampExaggeration(
+        mapControllerRef.current?.getTerrainExaggeration() ??
+          DEFAULT_EXAGGERATION,
       );
+      setExaggeration(value);
+      setDraft(String(value));
       setOpen(true);
     };
     // Close if the terrain control is removed (e.g. hidden from the Controls
@@ -77,10 +77,30 @@ export function TerrainSettingsDialog({
     };
   }, [mapControllerRef]);
 
+  // Coalesce the live map update to one per animation frame so a fast slider
+  // drag (Radix fires onValueChange on every 0.1 step) doesn't spray dozens of
+  // setTerrain calls — each of which reprocesses the terrain mesh — per second.
+  const frameRef = useRef<number | null>(null);
+  const pendingRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    },
+    [],
+  );
+
   const applyExaggeration = (value: number) => {
     const clamped = clampExaggeration(value);
     setExaggeration(clamped);
-    mapControllerRef.current?.setTerrainExaggeration(clamped);
+    pendingRef.current = clamped;
+    if (frameRef.current === null) {
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = null;
+        const next = pendingRef.current;
+        pendingRef.current = null;
+        if (next !== null) mapControllerRef.current?.setTerrainExaggeration(next);
+      });
+    }
   };
 
   const commitDraft = () => {

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -1,4 +1,8 @@
-import { TERRAIN_SETTINGS_EVENT, type MapController } from "@geolibre/map";
+import {
+  DEFAULT_TERRAIN_EXAGGERATION,
+  TERRAIN_SETTINGS_EVENT,
+  type MapController,
+} from "@geolibre/map";
 import {
   Button,
   Dialog,
@@ -16,7 +20,8 @@ import { useTranslation } from "react-i18next";
 const MIN_EXAGGERATION = 0;
 const MAX_EXAGGERATION = 5;
 const EXAGGERATION_STEP = 0.1;
-const DEFAULT_EXAGGERATION = 1;
+// Default sourced from the map package so it can't drift from the control's.
+const DEFAULT_EXAGGERATION = DEFAULT_TERRAIN_EXAGGERATION;
 
 function clampExaggeration(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_EXAGGERATION;
@@ -83,9 +88,12 @@ export function TerrainSettingsDialog({
                 max={MAX_EXAGGERATION}
                 step={EXAGGERATION_STEP}
                 value={exaggeration}
-                onChange={(event) =>
-                  applyExaggeration(Number(event.target.value))
-                }
+                onChange={(event) => {
+                  // Ignore an emptied field (mid-edit) so it doesn't parse to 0
+                  // and momentarily flatten the terrain before the user retypes.
+                  if (event.target.value === "") return;
+                  applyExaggeration(Number(event.target.value));
+                }}
               />
             </div>
             <Slider

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -55,10 +55,14 @@ export function TerrainSettingsDialog({
   useEffect(() => {
     const handleOpen = () => {
       // Seed the slider from the controller's current value so the dialog
-      // reflects any previously chosen exaggeration.
+      // reflects any previously chosen exaggeration. Clamp it to the dialog's
+      // display range: the controller only floors its cache at 0, so a value
+      // written directly (e.g. via a future scripting API) could exceed the max.
       setExaggeration(
-        mapControllerRef.current?.getTerrainExaggeration() ??
-          DEFAULT_EXAGGERATION,
+        clampExaggeration(
+          mapControllerRef.current?.getTerrainExaggeration() ??
+            DEFAULT_EXAGGERATION,
+        ),
       );
       setOpen(true);
     };

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_TERRAIN_EXAGGERATION,
+  TERRAIN_SETTINGS_CLOSE_EVENT,
   TERRAIN_SETTINGS_EVENT,
   type MapController,
 } from "@geolibre/map";
@@ -55,8 +56,15 @@ export function TerrainSettingsDialog({
       );
       setOpen(true);
     };
+    // Close if the terrain control is removed (e.g. hidden from the Controls
+    // menu) while the dialog is open, so it isn't left responding with no effect.
+    const handleClose = () => setOpen(false);
     window.addEventListener(TERRAIN_SETTINGS_EVENT, handleOpen);
-    return () => window.removeEventListener(TERRAIN_SETTINGS_EVENT, handleOpen);
+    window.addEventListener(TERRAIN_SETTINGS_CLOSE_EVENT, handleClose);
+    return () => {
+      window.removeEventListener(TERRAIN_SETTINGS_EVENT, handleOpen);
+      window.removeEventListener(TERRAIN_SETTINGS_CLOSE_EVENT, handleClose);
+    };
   }, [mapControllerRef]);
 
   const applyExaggeration = (value: number) => {
@@ -89,10 +97,13 @@ export function TerrainSettingsDialog({
                 step={EXAGGERATION_STEP}
                 value={exaggeration}
                 onChange={(event) => {
-                  // Ignore an emptied field (mid-edit) so it doesn't parse to 0
-                  // and momentarily flatten the terrain before the user retypes.
+                  // Ignore incomplete mid-edit states (empty field → 0, or a
+                  // lone "-" → NaN) so the terrain doesn't flicker through 0/1
+                  // before the user finishes typing a value.
                   if (event.target.value === "") return;
-                  applyExaggeration(Number(event.target.value));
+                  const parsed = Number(event.target.value);
+                  if (!Number.isFinite(parsed)) return;
+                  applyExaggeration(parsed);
                 }}
               />
             </div>

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -45,6 +45,12 @@ export function TerrainSettingsDialog({
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [exaggeration, setExaggeration] = useState(DEFAULT_EXAGGERATION);
+  // Free-text draft for the number input so a fractional value like "2.5" can be
+  // typed without the controlled numeric value snapping the field mid-keystroke.
+  // Committed (parsed/clamped) on blur or Enter; kept in sync when the value
+  // changes elsewhere (slider, dialog open, reset).
+  const [draft, setDraft] = useState(String(DEFAULT_EXAGGERATION));
+  useEffect(() => setDraft(String(exaggeration)), [exaggeration]);
 
   useEffect(() => {
     const handleOpen = () => {
@@ -73,6 +79,20 @@ export function TerrainSettingsDialog({
     mapControllerRef.current?.setTerrainExaggeration(clamped);
   };
 
+  const commitDraft = () => {
+    const parsed = Number(draft);
+    if (draft.trim() === "" || !Number.isFinite(parsed)) {
+      // Revert an empty/invalid draft to the last committed value.
+      setDraft(String(exaggeration));
+      return;
+    }
+    const clamped = clampExaggeration(parsed);
+    applyExaggeration(clamped);
+    // Reflect clamping in the field even when the state value is unchanged
+    // (e.g. "7" committed while already at the max of 5).
+    setDraft(String(clamped));
+  };
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="max-w-md">
@@ -91,19 +111,16 @@ export function TerrainSettingsDialog({
               <Input
                 id="terrain-exaggeration-input"
                 type="number"
+                inputMode="decimal"
                 className="w-24"
                 min={MIN_EXAGGERATION}
                 max={MAX_EXAGGERATION}
                 step={EXAGGERATION_STEP}
-                value={exaggeration}
-                onChange={(event) => {
-                  // Ignore incomplete mid-edit states (empty field → 0, or a
-                  // lone "-" → NaN) so the terrain doesn't flicker through 0/1
-                  // before the user finishes typing a value.
-                  if (event.target.value === "") return;
-                  const parsed = Number(event.target.value);
-                  if (!Number.isFinite(parsed)) return;
-                  applyExaggeration(parsed);
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+                onBlur={commitDraft}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") event.currentTarget.blur();
                 }}
               />
             </div>

--- a/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TerrainSettingsDialog.tsx
@@ -1,0 +1,116 @@
+import { TERRAIN_SETTINGS_EVENT, type MapController } from "@geolibre/map";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Slider,
+} from "@geolibre/ui";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const MIN_EXAGGERATION = 0;
+const MAX_EXAGGERATION = 5;
+const EXAGGERATION_STEP = 0.1;
+const DEFAULT_EXAGGERATION = 1;
+
+function clampExaggeration(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_EXAGGERATION;
+  return Math.min(MAX_EXAGGERATION, Math.max(MIN_EXAGGERATION, value));
+}
+
+export interface TerrainSettingsDialogProps {
+  mapControllerRef: React.RefObject<MapController | null>;
+}
+
+/**
+ * Vertical-exaggeration dialog for 3D terrain. It is opened by double-clicking
+ * the on-map terrain control, which dispatches {@link TERRAIN_SETTINGS_EVENT}
+ * (the control lives outside React). The slider/number input applies changes
+ * live via the map controller so the effect is visible while dragging.
+ */
+export function TerrainSettingsDialog({
+  mapControllerRef,
+}: TerrainSettingsDialogProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [exaggeration, setExaggeration] = useState(DEFAULT_EXAGGERATION);
+
+  useEffect(() => {
+    const handleOpen = () => {
+      // Seed the slider from the controller's current value so the dialog
+      // reflects any previously chosen exaggeration.
+      setExaggeration(
+        mapControllerRef.current?.getTerrainExaggeration() ??
+          DEFAULT_EXAGGERATION,
+      );
+      setOpen(true);
+    };
+    window.addEventListener(TERRAIN_SETTINGS_EVENT, handleOpen);
+    return () => window.removeEventListener(TERRAIN_SETTINGS_EVENT, handleOpen);
+  }, [mapControllerRef]);
+
+  const applyExaggeration = (value: number) => {
+    const clamped = clampExaggeration(value);
+    setExaggeration(clamped);
+    mapControllerRef.current?.setTerrainExaggeration(clamped);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("terrainSettings.title")}</DialogTitle>
+          <DialogDescription>
+            {t("terrainSettings.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <Label htmlFor="terrain-exaggeration-input">
+                {t("terrainSettings.label")}
+              </Label>
+              <Input
+                id="terrain-exaggeration-input"
+                type="number"
+                className="w-24"
+                min={MIN_EXAGGERATION}
+                max={MAX_EXAGGERATION}
+                step={EXAGGERATION_STEP}
+                value={exaggeration}
+                onChange={(event) =>
+                  applyExaggeration(Number(event.target.value))
+                }
+              />
+            </div>
+            <Slider
+              aria-label={t("terrainSettings.label")}
+              min={MIN_EXAGGERATION}
+              max={MAX_EXAGGERATION}
+              step={EXAGGERATION_STEP}
+              value={[exaggeration]}
+              onValueChange={(value: number[]) => applyExaggeration(value[0])}
+            />
+          </div>
+          <div className="flex justify-between gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => applyExaggeration(DEFAULT_EXAGGERATION)}
+            >
+              {t("terrainSettings.reset")}
+            </Button>
+            <Button type="button" onClick={() => setOpen(false)}>
+              {t("terrainSettings.done")}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1046,6 +1046,14 @@
       "exit": "Stop"
     }
   },
+  "terrainSettings": {
+    "title": "Terrain exaggeration",
+    "description": "Adjust the vertical exaggeration of the 3D terrain. Higher values make hills and mountains appear steeper.",
+    "label": "Vertical exaggeration",
+    "controlLabel": "Toggle terrain (double-click for exaggeration)",
+    "reset": "Reset",
+    "done": "Done"
+  },
   "pixelTimeSeries": {
     "title": "Pixel time series",
     "empty": "Click a pixel on the map to plot its value over time. Add more pixels to compare.",

--- a/apps/geolibre-desktop/src/lib/terrain-exaggeration.ts
+++ b/apps/geolibre-desktop/src/lib/terrain-exaggeration.ts
@@ -1,0 +1,23 @@
+/**
+ * Vertical-exaggeration bounds and clamp for the terrain settings dialog. Kept
+ * in its own pure module (no React / map-package imports) so it can be unit
+ * tested in isolation. The upper bound is a UI display choice — the terrain
+ * control itself imposes no maximum.
+ */
+
+export const MIN_EXAGGERATION = 0;
+export const MAX_EXAGGERATION = 5;
+export const EXAGGERATION_STEP = 0.1;
+
+/**
+ * Clamp a vertical-exaggeration value to the dialog's display range. Non-finite
+ * input (NaN/Infinity) falls back to the minimum rather than propagating a bad
+ * value to the slider/map.
+ *
+ * @param value - The requested exaggeration.
+ * @returns The value clamped to `[MIN_EXAGGERATION, MAX_EXAGGERATION]`.
+ */
+export function clampExaggeration(value: number): number {
+  if (!Number.isFinite(value)) return MIN_EXAGGERATION;
+  return Math.min(MAX_EXAGGERATION, Math.max(MIN_EXAGGERATION, value));
+}

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -12,7 +12,9 @@ export {
   createMapController,
   type BuiltInMapControl,
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
+  TERRAIN_SETTINGS_EVENT,
 } from "./map-controller";
+export { TerrainControl, type TerrainControlOptions } from "./terrain-control";
 export {
   detectGeometryProfile,
   getLayerBounds,

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -14,6 +14,7 @@ export {
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
   DEFAULT_TERRAIN_EXAGGERATION,
   TERRAIN_SETTINGS_EVENT,
+  TERRAIN_SETTINGS_CLOSE_EVENT,
 } from "./map-controller";
 export { TerrainControl, type TerrainControlOptions } from "./terrain-control";
 export {

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -12,11 +12,14 @@ export {
   createMapController,
   type BuiltInMapControl,
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
-  DEFAULT_TERRAIN_EXAGGERATION,
   TERRAIN_SETTINGS_EVENT,
   TERRAIN_SETTINGS_CLOSE_EVENT,
 } from "./map-controller";
-export { TerrainControl, type TerrainControlOptions } from "./terrain-control";
+export {
+  TerrainControl,
+  DEFAULT_TERRAIN_EXAGGERATION,
+  type TerrainControlOptions,
+} from "./terrain-control";
 export {
   detectGeometryProfile,
   getLayerBounds,

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -12,6 +12,7 @@ export {
   createMapController,
   type BuiltInMapControl,
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
+  DEFAULT_TERRAIN_EXAGGERATION,
   TERRAIN_SETTINGS_EVENT,
 } from "./map-controller";
 export { TerrainControl, type TerrainControlOptions } from "./terrain-control";

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -102,6 +102,28 @@ const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
  * originating controller.
  */
 export const TERRAIN_SETTINGS_EVENT = "geolibre:terrain-settings-open";
+/** DOM class the LayerControl gives its container element. */
+const LAYER_CONTROL_SELECTOR = ".maplibregl-ctrl-layer-control";
+
+/**
+ * Restore `refreshed` to just before `anchor` under `parent` after a
+ * remove/re-add appended it to the end of its control corner. No-ops safely
+ * when the reinsert can't be trusted: no parent, the anchor drifted to a
+ * different parent, or `refreshed` is missing / already the anchor.
+ *
+ * Exported for unit testing; the reorder itself is only observable against a
+ * real MapLibre control DOM (see refreshLayerControl).
+ */
+export function restoreControlOrder(
+  parent: Element | null,
+  anchor: Element | null,
+  refreshed: Element | null,
+): void {
+  if (!parent) return;
+  if (anchor !== null && anchor.parentElement !== parent) return;
+  if (!refreshed || refreshed === anchor) return;
+  parent.insertBefore(refreshed, anchor);
+}
 /**
  * Window event dispatched when the terrain control is removed (e.g. hidden from
  * the Controls menu), so the React layer closes the exaggeration dialog rather
@@ -1490,19 +1512,18 @@ export class MapController {
     // (e.g. a terrain control the user enabled post-load), visibly reordering
     // the stack on every basemap/style change. Re-anchor it to its old sibling.
     const container = this.map.getContainer();
-    const previous = container.querySelector(".maplibregl-ctrl-layer-control");
+    const previous = container.querySelector(LAYER_CONTROL_SELECTOR);
     const anchor = previous?.nextElementSibling ?? null;
     const parent = previous?.parentElement ?? null;
 
     this.removeLayerControl();
     this.addLayerControl();
 
-    if (parent && (anchor === null || anchor.parentElement === parent)) {
-      const refreshed = container.querySelector(".maplibregl-ctrl-layer-control");
-      if (refreshed && refreshed !== anchor) {
-        parent.insertBefore(refreshed, anchor);
-      }
-    }
+    restoreControlOrder(
+      parent,
+      anchor,
+      container.querySelector(LAYER_CONTROL_SELECTOR),
+    );
   }
 
   private syncLayerControlState(): void {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -260,7 +260,9 @@ export class MapController {
   private globeControl: maplibregl.GlobeControl | null = null;
   private terrainControl: TerrainControl | null = null;
   private terrainExaggeration = DEFAULT_TERRAIN_EXAGGERATION;
-  private terrainLabel = "Toggle terrain (double-click for exaggeration)";
+  // Undefined until the React layer supplies a translated label; the control
+  // falls back to its own default in the meantime (single source for the string).
+  private terrainLabel: string | undefined;
   private scaleControl: maplibregl.ScaleControl | null = null;
   private attributionControl: maplibregl.AttributionControl | null = null;
   private logoControl: maplibregl.LogoControl | null = null;
@@ -2157,16 +2159,6 @@ export class MapController {
     if (!this.terrainControl) return;
     this.removeControl(this.terrainControl);
     this.terrainControl = null;
-  }
-
-  /** Whether 3D terrain is currently active. */
-  isTerrainEnabled(): boolean {
-    return this.map?.getTerrain()?.source === TERRAIN_SOURCE_ID;
-  }
-
-  /** Enable or disable 3D terrain (matches a single click on the control). */
-  setTerrainEnabled(enabled: boolean): void {
-    this.terrainControl?.setEnabled(enabled);
   }
 
   /** The current terrain vertical exaggeration. */

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -94,6 +94,12 @@ export const DEFAULT_TERRAIN_EXAGGERATION = 1;
  * outside React, so it signals through a window event rather than a callback.
  */
 export const TERRAIN_SETTINGS_EVENT = "geolibre:terrain-settings-open";
+/**
+ * Window event dispatched when the terrain control is removed (e.g. hidden from
+ * the Controls menu), so the React layer closes the exaggeration dialog rather
+ * than leaving it open with no terrain to affect.
+ */
+export const TERRAIN_SETTINGS_CLOSE_EVENT = "geolibre:terrain-settings-close";
 const EMPTY_HIGHLIGHT: FeatureCollection = {
   type: "FeatureCollection",
   features: [],
@@ -2178,6 +2184,9 @@ export class MapController {
     if (!this.terrainControl) return;
     this.removeControl(this.terrainControl);
     this.terrainControl = null;
+    // The exaggeration dialog is driven by this control; tell the React layer to
+    // close it so it isn't left open with no effect once terrain is gone.
+    window.dispatchEvent(new CustomEvent(TERRAIN_SETTINGS_CLOSE_EVENT));
   }
 
   /** The current terrain vertical exaggeration. */
@@ -2191,8 +2200,15 @@ export class MapController {
    * terrain is already enabled.
    */
   setTerrainExaggeration(exaggeration: number): void {
-    this.terrainExaggeration = exaggeration;
-    this.terrainControl?.setExaggeration(exaggeration);
+    // Clamp before caching so the cached value (which seeds the next control
+    // built on a Controls-menu toggle / style reload) can't drift from what the
+    // live control actually applies, and so the public API is safe regardless of
+    // whether the caller pre-validated. Mirrors TerrainControl.setExaggeration.
+    const safe = Number.isFinite(exaggeration)
+      ? Math.max(0, exaggeration)
+      : this.terrainExaggeration;
+    this.terrainExaggeration = safe;
+    this.terrainControl?.setExaggeration(safe);
   }
 
   /**

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -86,7 +86,8 @@ const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   attribution:
     'Elevation tiles by <a href="https://registry.opendata.aws/terrain-tiles/">AWS Open Data Terrain Tiles</a>',
 };
-const DEFAULT_TERRAIN_EXAGGERATION = 1;
+/** Default terrain vertical exaggeration; the single source shared with the UI. */
+export const DEFAULT_TERRAIN_EXAGGERATION = 1;
 /**
  * Window event dispatched when the terrain control is double-clicked, so the
  * React layer can open the vertical-exaggeration dialog. The controller lives

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -41,7 +41,10 @@ import {
 } from "./layer-sync";
 import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
 import { ResetBearingControl } from "./reset-bearing-control";
-import { TerrainControl } from "./terrain-control";
+import {
+  TerrainControl,
+  DEFAULT_TERRAIN_EXAGGERATION,
+} from "./terrain-control";
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
@@ -86,12 +89,17 @@ const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   attribution:
     'Elevation tiles by <a href="https://registry.opendata.aws/terrain-tiles/">AWS Open Data Terrain Tiles</a>',
 };
-/** Default terrain vertical exaggeration; the single source shared with the UI. */
-export const DEFAULT_TERRAIN_EXAGGERATION = 1;
 /**
  * Window event dispatched when the terrain control is double-clicked, so the
  * React layer can open the vertical-exaggeration dialog. The controller lives
  * outside React, so it signals through a window event rather than a callback.
+ *
+ * These terrain events are dispatched on `window` (not scoped to a controller
+ * instance), so they assume a single terrain-enabled map: only the primary pane
+ * enables the terrain control today (secondary panes never override the default
+ * `terrain: false`), and one dialog — bound to the primary controller — listens.
+ * A future secondary-pane terrain control would need the event scoped to its
+ * originating controller.
  */
 export const TERRAIN_SETTINGS_EVENT = "geolibre:terrain-settings-open";
 /**

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -87,10 +87,6 @@ const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
     'Elevation tiles by <a href="https://registry.opendata.aws/terrain-tiles/">AWS Open Data Terrain Tiles</a>',
 };
 const DEFAULT_TERRAIN_EXAGGERATION = 1;
-const TERRAIN_OPTIONS: maplibregl.TerrainSpecification = {
-  source: TERRAIN_SOURCE_ID,
-  exaggeration: DEFAULT_TERRAIN_EXAGGERATION,
-};
 /**
  * Window event dispatched when the terrain control is double-clicked, so the
  * React layer can open the vertical-exaggeration dialog. The controller lives

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -41,6 +41,7 @@ import {
 } from "./layer-sync";
 import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
 import { ResetBearingControl } from "./reset-bearing-control";
+import { TerrainControl } from "./terrain-control";
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
@@ -85,10 +86,17 @@ const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   attribution:
     'Elevation tiles by <a href="https://registry.opendata.aws/terrain-tiles/">AWS Open Data Terrain Tiles</a>',
 };
+const DEFAULT_TERRAIN_EXAGGERATION = 1;
 const TERRAIN_OPTIONS: maplibregl.TerrainSpecification = {
   source: TERRAIN_SOURCE_ID,
-  exaggeration: 1,
+  exaggeration: DEFAULT_TERRAIN_EXAGGERATION,
 };
+/**
+ * Window event dispatched when the terrain control is double-clicked, so the
+ * React layer can open the vertical-exaggeration dialog. The controller lives
+ * outside React, so it signals through a window event rather than a callback.
+ */
+export const TERRAIN_SETTINGS_EVENT = "geolibre:terrain-settings-open";
 const EMPTY_HIGHLIGHT: FeatureCollection = {
   type: "FeatureCollection",
   features: [],
@@ -254,7 +262,9 @@ export class MapController {
   private backgroundLabel = "Background";
   private geolocateControl: maplibregl.GeolocateControl | null = null;
   private globeControl: maplibregl.GlobeControl | null = null;
-  private terrainControl: maplibregl.TerrainControl | null = null;
+  private terrainControl: TerrainControl | null = null;
+  private terrainExaggeration = DEFAULT_TERRAIN_EXAGGERATION;
+  private terrainLabel = "Toggle terrain (double-click for exaggeration)";
   private scaleControl: maplibregl.ScaleControl | null = null;
   private attributionControl: maplibregl.AttributionControl | null = null;
   private logoControl: maplibregl.LogoControl | null = null;
@@ -2130,7 +2140,16 @@ export class MapController {
       return false;
     }
     this.addTerrainSource();
-    this.terrainControl = new maplibregl.TerrainControl(TERRAIN_OPTIONS);
+    this.terrainControl = new TerrainControl({
+      source: TERRAIN_SOURCE_ID,
+      exaggeration: this.terrainExaggeration,
+      label: this.terrainLabel,
+      // Double-clicking the button asks the React layer to open the
+      // vertical-exaggeration dialog (see TERRAIN_SETTINGS_EVENT).
+      onOpenSettings: () => {
+        window.dispatchEvent(new CustomEvent(TERRAIN_SETTINGS_EVENT));
+      },
+    });
     this.map.addControl(this.terrainControl, this.controlPositions.terrain);
     return true;
   }
@@ -2142,6 +2161,40 @@ export class MapController {
     if (!this.terrainControl) return;
     this.removeControl(this.terrainControl);
     this.terrainControl = null;
+  }
+
+  /** Whether 3D terrain is currently active. */
+  isTerrainEnabled(): boolean {
+    return this.map?.getTerrain()?.source === TERRAIN_SOURCE_ID;
+  }
+
+  /** Enable or disable 3D terrain (matches a single click on the control). */
+  setTerrainEnabled(enabled: boolean): void {
+    this.terrainControl?.setEnabled(enabled);
+  }
+
+  /** The current terrain vertical exaggeration. */
+  getTerrainExaggeration(): number {
+    return this.terrainExaggeration;
+  }
+
+  /**
+   * Set the terrain vertical exaggeration. Cached so it survives the control
+   * being re-added (Controls menu toggle, style reload) and applied live when
+   * terrain is already enabled.
+   */
+  setTerrainExaggeration(exaggeration: number): void {
+    this.terrainExaggeration = exaggeration;
+    this.terrainControl?.setExaggeration(exaggeration);
+  }
+
+  /**
+   * Update the terrain control's tooltip/aria label, e.g. after a UI language
+   * change. Cached so a re-added control picks up the latest translation.
+   */
+  setTerrainLabel(label: string): void {
+    this.terrainLabel = label;
+    this.terrainControl?.setLabel(label);
   }
 
   private addScaleControl(): boolean {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -699,8 +699,13 @@ export class MapController {
     else if (control === "compass") this.removeCompassControl();
     else if (control === "geolocate") this.removeGeolocateControl();
     else if (control === "globe") this.removeGlobeControl();
-    else if (control === "terrain") this.removeTerrainControl();
-    else if (control === "scale") this.removeScaleControl();
+    else if (control === "terrain") {
+      this.removeTerrainControl();
+      // Terrain is genuinely being hidden here (not repositioned, which goes
+      // through removeBuiltInControl), so close the exaggeration dialog — it has
+      // no control to act on now.
+      window.dispatchEvent(new CustomEvent(TERRAIN_SETTINGS_CLOSE_EVENT));
+    } else if (control === "scale") this.removeScaleControl();
     else if (control === "attribution") this.removeAttributionControl();
     else if (control === "logo") this.removeLogoControl();
     else this.removeLayerControl();
@@ -2213,9 +2218,6 @@ export class MapController {
     if (!this.terrainControl) return;
     this.removeControl(this.terrainControl);
     this.terrainControl = null;
-    // The exaggeration dialog is driven by this control; tell the React layer to
-    // close it so it isn't left open with no effect once terrain is gone.
-    window.dispatchEvent(new CustomEvent(TERRAIN_SETTINGS_CLOSE_EVENT));
   }
 
   /** The current terrain vertical exaggeration. */

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1469,8 +1469,26 @@ export class MapController {
     const nextSignature = this.createLayerControlSignature(layerControlConfig);
     if (nextSignature === this.layerControlSignature) return;
 
+    // Capture the control's spot in its corner before the remove/re-add. The
+    // LayerControl's layer list is fixed at construction, so a refresh must
+    // rebuild it — but MapLibre's addControl re-appends to the end of the
+    // corner, which would drop the control below any controls inserted after it
+    // (e.g. a terrain control the user enabled post-load), visibly reordering
+    // the stack on every basemap/style change. Re-anchor it to its old sibling.
+    const container = this.map.getContainer();
+    const previous = container.querySelector(".maplibregl-ctrl-layer-control");
+    const anchor = previous?.nextElementSibling ?? null;
+    const parent = previous?.parentElement ?? null;
+
     this.removeLayerControl();
     this.addLayerControl();
+
+    if (parent && (anchor === null || anchor.parentElement === parent)) {
+      const refreshed = container.querySelector(".maplibregl-ctrl-layer-control");
+      if (refreshed && refreshed !== anchor) {
+        parent.insertBefore(refreshed, anchor);
+      }
+    }
   }
 
   private syncLayerControlState(): void {

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -6,6 +6,9 @@ import type maplibregl from "maplibre-gl";
  */
 const DOUBLE_CLICK_MS = 250;
 
+/** Fallback exaggeration when none (or an invalid value) is supplied. */
+const DEFAULT_EXAGGERATION = 1;
+
 export interface TerrainControlOptions {
   /** The raster-DEM source id used to drive terrain. */
   source: string;
@@ -39,10 +42,19 @@ export class TerrainControl implements maplibregl.IControl {
   private label: string;
   private readonly onOpenSettings?: () => void;
   private clickTimer: ReturnType<typeof setTimeout> | null = null;
+  // Set briefly after a double-click opens the dialog so a 3rd+ rapid click
+  // can't re-arm a single-click toggle and flatten terrain under the open dialog.
+  private clicksSuppressed = false;
+  private suppressTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: TerrainControlOptions) {
     this.source = options.source;
-    this.exaggeration = options.exaggeration ?? 1;
+    // Clamp like setExaggeration so every write path validates identically: a
+    // caller (e.g. a corrupted cached value) can't seed an invalid exaggeration.
+    const requested = options.exaggeration ?? DEFAULT_EXAGGERATION;
+    this.exaggeration = Number.isFinite(requested)
+      ? Math.max(0, requested)
+      : DEFAULT_EXAGGERATION;
     // English fallback for when no translated label is supplied. The map package
     // is i18n-agnostic, so this necessarily duplicates the `terrainSettings.
     // controlLabel` string in the app's en.json — keep the two in sync.
@@ -88,6 +100,11 @@ export class TerrainControl implements maplibregl.IControl {
       clearTimeout(this.clickTimer);
       this.clickTimer = null;
     }
+    if (this.suppressTimer !== null) {
+      clearTimeout(this.suppressTimer);
+      this.suppressTimer = null;
+    }
+    this.clicksSuppressed = false;
     this.map?.off("terrain", this.handleTerrainChange);
     this.container?.remove();
     this.container = null;
@@ -96,6 +113,10 @@ export class TerrainControl implements maplibregl.IControl {
   }
 
   private readonly handleClick = () => {
+    // Ignore trailing clicks right after a double-click opened the dialog, so a
+    // 3rd+ rapid click can't schedule a fresh single-click toggle that fires
+    // (and flattens terrain) while the dialog is still open.
+    if (this.clicksSuppressed) return;
     // A second click within the double-click window opens the exaggeration
     // dialog; a lone click toggles terrain once the window elapses. Debouncing
     // (rather than toggling on every click) keeps a double-click from flickering
@@ -116,6 +137,13 @@ export class TerrainControl implements maplibregl.IControl {
     // Enable terrain first so exaggeration edits are visible live in the dialog.
     this.setEnabled(true);
     this.onOpenSettings?.();
+    // Swallow further clicks for one more window (see handleClick).
+    this.clicksSuppressed = true;
+    if (this.suppressTimer !== null) clearTimeout(this.suppressTimer);
+    this.suppressTimer = setTimeout(() => {
+      this.clicksSuppressed = false;
+      this.suppressTimer = null;
+    }, DOUBLE_CLICK_MS);
   }
 
   /** Whether 3D terrain backed by this control's DEM source is active. */

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -1,0 +1,167 @@
+import type maplibregl from "maplibre-gl";
+
+/**
+ * Clicks landing within this window of the previous one are treated as a
+ * double-click (open the exaggeration dialog) rather than two toggles.
+ */
+const DOUBLE_CLICK_MS = 250;
+
+export interface TerrainControlOptions {
+  /** The raster-DEM source id used to drive terrain. */
+  source: string;
+  /** Initial vertical exaggeration applied when terrain is enabled. */
+  exaggeration?: number;
+  /** Tooltip/aria label for the button. */
+  label?: string;
+  /**
+   * Invoked when the user double-clicks the button. Terrain is enabled first,
+   * so the caller can open a settings dialog whose exaggeration edits are
+   * immediately visible on the map.
+   */
+  onOpenSettings?: () => void;
+}
+
+/**
+ * A MapLibre control that toggles hillshaded 3D terrain, mirroring the built-in
+ * `maplibregl.TerrainControl` (it reuses the same icon classes) but adding a
+ * double-click gesture that opens a vertical-exaggeration dialog.
+ *
+ * A single click toggles terrain on/off; a double-click opens the exaggeration
+ * settings. Clicks are debounced by {@link DOUBLE_CLICK_MS} so a double-click
+ * never flickers terrain on and back off before the dialog appears.
+ */
+export class TerrainControl implements maplibregl.IControl {
+  private map: maplibregl.Map | null = null;
+  private container: HTMLDivElement | null = null;
+  private button: HTMLButtonElement | null = null;
+  private readonly source: string;
+  private exaggeration: number;
+  private label: string;
+  private readonly onOpenSettings?: () => void;
+  private clickTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(options: TerrainControlOptions) {
+    this.source = options.source;
+    this.exaggeration = options.exaggeration ?? 1;
+    this.label =
+      options.label ?? "Toggle terrain (double-click for exaggeration)";
+    this.onOpenSettings = options.onOpenSettings;
+  }
+
+  /** Keep the active (enabled) styling in sync when terrain changes elsewhere. */
+  private readonly handleTerrainChange = () => this.updateActiveState();
+
+  onAdd(map: maplibregl.Map): HTMLElement {
+    this.map = map;
+
+    const container = document.createElement("div");
+    container.className =
+      "maplibregl-ctrl maplibregl-ctrl-group geolibre-terrain-ctrl";
+
+    const button = document.createElement("button");
+    button.type = "button";
+    // Reuse MapLibre's own class so the built-in terrain (mountain) icon and its
+    // enabled-state styling apply without shipping a duplicate icon.
+    button.className = "maplibregl-ctrl-terrain";
+    const icon = document.createElement("span");
+    icon.className = "maplibregl-ctrl-icon";
+    icon.setAttribute("aria-hidden", "true");
+    button.appendChild(icon);
+    button.addEventListener("click", this.handleClick);
+
+    container.appendChild(button);
+    this.container = container;
+    this.button = button;
+
+    map.on("terrain", this.handleTerrainChange);
+    this.applyLabel();
+    this.updateActiveState();
+
+    return container;
+  }
+
+  onRemove(): void {
+    if (this.clickTimer !== null) {
+      clearTimeout(this.clickTimer);
+      this.clickTimer = null;
+    }
+    this.map?.off("terrain", this.handleTerrainChange);
+    this.container?.remove();
+    this.container = null;
+    this.button = null;
+    this.map = null;
+  }
+
+  private readonly handleClick = () => {
+    // A second click within the double-click window opens the exaggeration
+    // dialog; a lone click toggles terrain once the window elapses. Debouncing
+    // (rather than toggling on every click) keeps a double-click from flickering
+    // terrain on and back off before the dialog appears.
+    if (this.clickTimer !== null) {
+      clearTimeout(this.clickTimer);
+      this.clickTimer = null;
+      this.openSettings();
+      return;
+    }
+    this.clickTimer = setTimeout(() => {
+      this.clickTimer = null;
+      this.setEnabled(!this.isEnabled());
+    }, DOUBLE_CLICK_MS);
+  };
+
+  private openSettings(): void {
+    // Enable terrain first so exaggeration edits are visible live in the dialog.
+    this.setEnabled(true);
+    this.onOpenSettings?.();
+  }
+
+  /** Whether 3D terrain backed by this control's DEM source is active. */
+  isEnabled(): boolean {
+    return this.map?.getTerrain()?.source === this.source;
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (!this.map) return;
+    if (enabled) {
+      if (!this.isEnabled()) {
+        this.map.setTerrain({
+          source: this.source,
+          exaggeration: this.exaggeration,
+        });
+      }
+    } else if (this.isEnabled()) {
+      this.map.setTerrain(null);
+    }
+  }
+
+  getExaggeration(): number {
+    return this.exaggeration;
+  }
+
+  /** Update the vertical exaggeration, applying it live when terrain is on. */
+  setExaggeration(exaggeration: number): void {
+    this.exaggeration = exaggeration;
+    if (this.map && this.isEnabled()) {
+      this.map.setTerrain({ source: this.source, exaggeration });
+    }
+  }
+
+  /** Update the tooltip/aria label, e.g. after a UI language change. */
+  setLabel(label: string): void {
+    this.label = label;
+    this.applyLabel();
+  }
+
+  private applyLabel(): void {
+    if (!this.button) return;
+    this.button.title = this.label;
+    this.button.setAttribute("aria-label", this.label);
+  }
+
+  private updateActiveState(): void {
+    this.button?.classList.toggle(
+      "maplibregl-ctrl-terrain-enabled",
+      this.isEnabled(),
+    );
+  }
+}

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -6,8 +6,13 @@ import type maplibregl from "maplibre-gl";
  */
 const DOUBLE_CLICK_MS = 250;
 
-/** Fallback exaggeration when none (or an invalid value) is supplied. */
-const DEFAULT_EXAGGERATION = 1;
+/**
+ * Fallback exaggeration when none (or an invalid value) is supplied. Exported as
+ * the single source of truth: MapController seeds its cache from it and re-exports
+ * it for the settings dialog, so the control's fallback and the UI default can't
+ * drift apart.
+ */
+export const DEFAULT_TERRAIN_EXAGGERATION = 1;
 
 export interface TerrainControlOptions {
   /** The raster-DEM source id used to drive terrain. */
@@ -51,10 +56,10 @@ export class TerrainControl implements maplibregl.IControl {
     this.source = options.source;
     // Clamp like setExaggeration so every write path validates identically: a
     // caller (e.g. a corrupted cached value) can't seed an invalid exaggeration.
-    const requested = options.exaggeration ?? DEFAULT_EXAGGERATION;
+    const requested = options.exaggeration ?? DEFAULT_TERRAIN_EXAGGERATION;
     this.exaggeration = Number.isFinite(requested)
       ? Math.max(0, requested)
-      : DEFAULT_EXAGGERATION;
+      : DEFAULT_TERRAIN_EXAGGERATION;
     // English fallback for when no translated label is supplied. The map package
     // is i18n-agnostic, so this necessarily duplicates the `terrainSettings.
     // controlLabel` string in the app's en.json — keep the two in sync.

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -43,6 +43,9 @@ export class TerrainControl implements maplibregl.IControl {
   constructor(options: TerrainControlOptions) {
     this.source = options.source;
     this.exaggeration = options.exaggeration ?? 1;
+    // English fallback for when no translated label is supplied. The map package
+    // is i18n-agnostic, so this necessarily duplicates the `terrainSettings.
+    // controlLabel` string in the app's en.json — keep the two in sync.
     this.label =
       options.label ?? "Toggle terrain (double-click for exaggeration)";
     this.onOpenSettings = options.onOpenSettings;

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -198,9 +198,10 @@ export class TerrainControl implements maplibregl.IControl {
   }
 
   private updateActiveState(): void {
-    this.button?.classList.toggle(
-      "maplibregl-ctrl-terrain-enabled",
-      this.isEnabled(),
-    );
+    if (!this.button) return;
+    const enabled = this.isEnabled();
+    this.button.classList.toggle("maplibregl-ctrl-terrain-enabled", enabled);
+    // Expose the on/off state to assistive tech, not just via the CSS class.
+    this.button.setAttribute("aria-pressed", String(enabled));
   }
 }

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -138,11 +138,19 @@ export class TerrainControl implements maplibregl.IControl {
     return this.exaggeration;
   }
 
-  /** Update the vertical exaggeration, applying it live when terrain is on. */
+  /**
+   * Update the vertical exaggeration, applying it live when terrain is on.
+   * Defensively guards invalid input so validation isn't solely the caller's
+   * job: non-finite values are ignored and negatives clamp to 0 (flat). No
+   * upper bound — large exaggerations are valid; the dialog enforces its own
+   * display range.
+   */
   setExaggeration(exaggeration: number): void {
-    this.exaggeration = exaggeration;
+    if (!Number.isFinite(exaggeration)) return;
+    const safe = Math.max(0, exaggeration);
+    this.exaggeration = safe;
     if (this.map && this.isEnabled()) {
-      this.map.setTerrain({ source: this.source, exaggeration });
+      this.map.setTerrain({ source: this.source, exaggeration: safe });
     }
   }
 

--- a/tests/restore-control-order.test.ts
+++ b/tests/restore-control-order.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { restoreControlOrder } from "../packages/map/src/map-controller";
+
+// Minimal DOM node: just enough of the Element surface restoreControlOrder
+// touches (parentElement, nextElementSibling, insertBefore) plus append/remove
+// to build and mutate a tree. node:test has no DOM, so we stand one up here.
+class FakeNode {
+  children: FakeNode[] = [];
+  parent: FakeNode | null = null;
+
+  constructor(readonly id: string) {}
+
+  get parentElement(): FakeNode | null {
+    return this.parent;
+  }
+
+  get nextElementSibling(): FakeNode | null {
+    if (!this.parent) return null;
+    const index = this.parent.children.indexOf(this);
+    return this.parent.children[index + 1] ?? null;
+  }
+
+  append(node: FakeNode): void {
+    node.remove();
+    node.parent = this;
+    this.children.push(node);
+  }
+
+  remove(): void {
+    if (!this.parent) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = null;
+  }
+
+  insertBefore(node: FakeNode, ref: FakeNode | null): FakeNode {
+    node.remove();
+    node.parent = this;
+    if (ref === null) {
+      this.children.push(node);
+      return node;
+    }
+    const index = this.children.indexOf(ref);
+    this.children.splice(index < 0 ? this.children.length : index, 0, node);
+    return node;
+  }
+}
+
+const order = (parent: FakeNode) => parent.children.map((c) => c.id);
+
+// The helper is typed against the DOM's Element; FakeNode implements the members
+// it actually uses, so cast through unknown at the call boundary.
+const call = (
+  parent: FakeNode | null,
+  anchor: FakeNode | null,
+  refreshed: FakeNode | null,
+) =>
+  restoreControlOrder(
+    parent as unknown as Element | null,
+    anchor as unknown as Element | null,
+    refreshed as unknown as Element | null,
+  );
+
+describe("restoreControlOrder", () => {
+  it("moves a re-appended control back to just before its old sibling", () => {
+    const corner = new FakeNode("corner");
+    const fullscreen = new FakeNode("fullscreen");
+    const layerControl = new FakeNode("layer-control");
+    const terrain = new FakeNode("terrain");
+    corner.append(fullscreen);
+    corner.append(layerControl);
+    corner.append(terrain);
+
+    // Capture position as refreshLayerControl does, then simulate MapLibre's
+    // remove + re-append (which drops the rebuilt control at the end).
+    const anchor = layerControl.nextElementSibling; // terrain
+    const parent = layerControl.parentElement; // corner
+    layerControl.remove();
+    const refreshed = new FakeNode("layer-control");
+    corner.append(refreshed); // now [fullscreen, terrain, layer-control]
+
+    call(parent, anchor, refreshed);
+
+    assert.deepEqual(order(corner), ["fullscreen", "layer-control", "terrain"]);
+  });
+
+  it("leaves a control that was already last at the end (null anchor)", () => {
+    const corner = new FakeNode("corner");
+    const terrain = new FakeNode("terrain");
+    const layerControl = new FakeNode("layer-control");
+    corner.append(terrain);
+    corner.append(layerControl);
+
+    const anchor = layerControl.nextElementSibling; // null (it was last)
+    const parent = layerControl.parentElement;
+    layerControl.remove();
+    const refreshed = new FakeNode("layer-control");
+    corner.append(refreshed);
+
+    call(parent, anchor, refreshed);
+
+    assert.deepEqual(order(corner), ["terrain", "layer-control"]);
+  });
+
+  it("no-ops when the anchor drifted to a different parent", () => {
+    const corner = new FakeNode("corner");
+    const refreshed = new FakeNode("layer-control");
+    corner.append(refreshed);
+    const otherParent = new FakeNode("other");
+    const strayAnchor = new FakeNode("stray");
+    otherParent.append(strayAnchor);
+
+    call(corner, strayAnchor, refreshed);
+
+    // Untouched: refreshed stays put, stray stays under its own parent.
+    assert.deepEqual(order(corner), ["layer-control"]);
+    assert.deepEqual(order(otherParent), ["stray"]);
+  });
+
+  it("no-ops safely when parent or refreshed is missing", () => {
+    const corner = new FakeNode("corner");
+    const terrain = new FakeNode("terrain");
+    corner.append(terrain);
+
+    assert.doesNotThrow(() => call(null, terrain, terrain));
+    assert.doesNotThrow(() => call(corner, terrain, null));
+    // refreshed === anchor is a no-op, not a self-insert.
+    call(corner, terrain, terrain);
+    assert.deepEqual(order(corner), ["terrain"]);
+  });
+});

--- a/tests/terrain-control.test.ts
+++ b/tests/terrain-control.test.ts
@@ -160,6 +160,28 @@ describe("TerrainControl", () => {
     assert.equal(fake.setTerrainCalls.length, 1);
   });
 
+  it("ignores a 3rd rapid click so terrain stays on under the open dialog", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const onOpenSettings = mock.fn();
+    const { control, fake, button } = mount({ onOpenSettings });
+
+    button.emit("click"); // arms the single-click toggle
+    button.emit("click"); // double-click → opens settings, enables terrain
+    button.emit("click"); // 3rd rapid click must be swallowed, not re-armed
+    assert.equal(control.isEnabled(), true);
+    const callsAfterOpen = fake.setTerrainCalls.length;
+
+    // The suppression window elapses without any late toggle firing.
+    t.mock.timers.tick(DOUBLE_CLICK_MS);
+    assert.equal(control.isEnabled(), true);
+    assert.equal(fake.setTerrainCalls.length, callsAfterOpen);
+
+    // Once suppression lifts, a fresh click toggles normally again.
+    button.emit("click");
+    t.mock.timers.tick(DOUBLE_CLICK_MS);
+    assert.equal(control.isEnabled(), false);
+  });
+
   it("applies a new exaggeration live only while terrain is enabled", () => {
     const { control, fake } = mount();
 
@@ -201,6 +223,11 @@ describe("TerrainControl", () => {
     assert.equal(control.getExaggeration(), 0);
     // NaN/Infinity did not re-apply terrain (only the -3 clamp call did).
     assert.equal(fake.setTerrainCalls.length, enabledCall + 1);
+  });
+
+  it("clamps an invalid exaggeration passed to the constructor", () => {
+    assert.equal(mount({ exaggeration: -2 }).control.getExaggeration(), 0);
+    assert.equal(mount({ exaggeration: Number.NaN }).control.getExaggeration(), 1);
   });
 
   it("reflects the enabled state on the button class", () => {

--- a/tests/terrain-control.test.ts
+++ b/tests/terrain-control.test.ts
@@ -182,6 +182,27 @@ describe("TerrainControl", () => {
     });
   });
 
+  it("clamps invalid exaggeration values defensively", () => {
+    const { control, fake } = mount();
+    control.setEnabled(true);
+    const enabledCall = fake.setTerrainCalls.length;
+
+    // Negatives clamp to 0 (flat); non-finite values are ignored entirely.
+    control.setExaggeration(-3);
+    assert.equal(control.getExaggeration(), 0);
+    assert.deepEqual(fake.setTerrainCalls.at(-1), {
+      source: TERRAIN_SOURCE,
+      exaggeration: 0,
+    });
+
+    control.setExaggeration(Number.NaN);
+    assert.equal(control.getExaggeration(), 0);
+    control.setExaggeration(Number.POSITIVE_INFINITY);
+    assert.equal(control.getExaggeration(), 0);
+    // NaN/Infinity did not re-apply terrain (only the -3 clamp call did).
+    assert.equal(fake.setTerrainCalls.length, enabledCall + 1);
+  });
+
   it("reflects the enabled state on the button class", () => {
     const { control, button } = mount();
     assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), false);

--- a/tests/terrain-control.test.ts
+++ b/tests/terrain-control.test.ts
@@ -11,6 +11,7 @@ interface FakeElement {
   title: string;
   children: FakeElement[];
   classList: { has: (n: string) => boolean; toggle: (n: string, f?: boolean) => boolean };
+  attributes: Record<string, string>;
   setAttribute: (name: string, value: string) => void;
   appendChild: (child: FakeElement) => FakeElement;
   addEventListener: (type: string, handler: () => void) => void;
@@ -35,7 +36,10 @@ function makeFakeElement(): FakeElement {
         return next;
       },
     },
-    setAttribute: () => {},
+    attributes: {},
+    setAttribute: (name, value) => {
+      el.attributes[name] = value;
+    },
     appendChild: (child) => {
       el.children.push(child);
       return child;
@@ -230,12 +234,15 @@ describe("TerrainControl", () => {
     assert.equal(mount({ exaggeration: Number.NaN }).control.getExaggeration(), 1);
   });
 
-  it("reflects the enabled state on the button class", () => {
+  it("reflects the enabled state on the button class and aria-pressed", () => {
     const { control, button } = mount();
     assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), false);
+    assert.equal(button.attributes["aria-pressed"], "false");
     control.setEnabled(true);
     assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), true);
+    assert.equal(button.attributes["aria-pressed"], "true");
     control.setEnabled(false);
     assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), false);
+    assert.equal(button.attributes["aria-pressed"], "false");
   });
 });

--- a/tests/terrain-control.test.ts
+++ b/tests/terrain-control.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, mock } from "node:test";
+import type maplibregl from "maplibre-gl";
+import { TerrainControl } from "../packages/map/src/terrain-control";
+
+// TerrainControl.onAdd builds DOM nodes; node:test has no DOM, so stand up a
+// minimal element/document just rich enough for the methods the control calls.
+interface FakeElement {
+  className: string;
+  type: string;
+  title: string;
+  children: FakeElement[];
+  classList: { has: (n: string) => boolean; toggle: (n: string, f?: boolean) => boolean };
+  setAttribute: (name: string, value: string) => void;
+  appendChild: (child: FakeElement) => FakeElement;
+  addEventListener: (type: string, handler: () => void) => void;
+  remove: () => void;
+  emit: (type: string) => void;
+}
+
+function makeFakeElement(): FakeElement {
+  const classes = new Set<string>();
+  const listeners: Record<string, Array<() => void>> = {};
+  const el: FakeElement = {
+    className: "",
+    type: "",
+    title: "",
+    children: [],
+    classList: {
+      has: (name) => classes.has(name),
+      toggle: (name, force) => {
+        const next = force ?? !classes.has(name);
+        if (next) classes.add(name);
+        else classes.delete(name);
+        return next;
+      },
+    },
+    setAttribute: () => {},
+    appendChild: (child) => {
+      el.children.push(child);
+      return child;
+    },
+    addEventListener: (type, handler) => {
+      (listeners[type] ??= []).push(handler);
+    },
+    remove: () => {},
+    emit: (type) => {
+      for (const handler of listeners[type] ?? []) handler();
+    },
+  };
+  return el;
+}
+
+const TERRAIN_SOURCE = "geolibre-terrain-dem";
+
+interface FakeMap {
+  map: maplibregl.Map;
+  setTerrainCalls: Array<maplibregl.TerrainSpecification | null>;
+  emitTerrain: () => void;
+}
+
+function makeFakeMap(): FakeMap {
+  let terrain: maplibregl.TerrainSpecification | null = null;
+  const handlers: Record<string, Array<() => void>> = {};
+  const setTerrainCalls: Array<maplibregl.TerrainSpecification | null> = [];
+  const map = {
+    getTerrain: () => terrain,
+    setTerrain: (spec: maplibregl.TerrainSpecification | null) => {
+      terrain = spec;
+      setTerrainCalls.push(spec);
+      for (const handler of handlers.terrain ?? []) handler();
+    },
+    on: (type: string, handler: () => void) => {
+      (handlers[type] ??= []).push(handler);
+    },
+    off: (type: string, handler: () => void) => {
+      handlers[type] = (handlers[type] ?? []).filter((h) => h !== handler);
+    },
+  };
+  return {
+    map: map as unknown as maplibregl.Map,
+    setTerrainCalls,
+    emitTerrain: () => {
+      for (const handler of handlers.terrain ?? []) handler();
+    },
+  };
+}
+
+/**
+ * Mount a control on a fresh fake map and return the pieces a test drives: the
+ * control, the map spy, and the button whose click events we simulate.
+ */
+function mount(options?: { onOpenSettings?: () => void; exaggeration?: number }) {
+  const created: FakeElement[] = [];
+  (globalThis as { document?: unknown }).document = {
+    createElement: () => {
+      const el = makeFakeElement();
+      created.push(el);
+      return el;
+    },
+  };
+  const fake = makeFakeMap();
+  const control = new TerrainControl({
+    source: TERRAIN_SOURCE,
+    exaggeration: options?.exaggeration,
+    onOpenSettings: options?.onOpenSettings,
+  });
+  control.onAdd(fake.map);
+  // created[0] is the container div, created[1] the button, created[2] the icon.
+  const button = created[1];
+  return { control, fake, button };
+}
+
+describe("TerrainControl", () => {
+  afterEach(() => {
+    mock.timers.reset();
+    delete (globalThis as { document?: unknown }).document;
+  });
+
+  it("toggles terrain on after a lone click settles", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { control, fake, button } = mount();
+
+    assert.equal(control.isEnabled(), false);
+    button.emit("click");
+    // Still pending until the double-click window elapses.
+    assert.equal(fake.setTerrainCalls.length, 0);
+    t.mock.timers.tick(300);
+    assert.equal(control.isEnabled(), true);
+    assert.deepEqual(fake.setTerrainCalls.at(-1), {
+      source: TERRAIN_SOURCE,
+      exaggeration: 1,
+    });
+
+    // A second lone click toggles it back off.
+    button.emit("click");
+    t.mock.timers.tick(300);
+    assert.equal(control.isEnabled(), false);
+    assert.equal(fake.setTerrainCalls.at(-1), null);
+  });
+
+  it("opens settings on a double click without flickering terrain", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const onOpenSettings = mock.fn();
+    const { control, fake, button } = mount({ onOpenSettings });
+
+    button.emit("click");
+    button.emit("click");
+    // The second click cancels the pending toggle, so terrain is only ever
+    // enabled once (for the dialog) — never toggled on then back off.
+    assert.equal(onOpenSettings.mock.callCount(), 1);
+    assert.equal(control.isEnabled(), true);
+    assert.equal(fake.setTerrainCalls.length, 1);
+
+    // The cancelled single-click toggle must not fire late.
+    t.mock.timers.tick(300);
+    assert.equal(fake.setTerrainCalls.length, 1);
+  });
+
+  it("applies a new exaggeration live only while terrain is enabled", () => {
+    const { control, fake } = mount();
+
+    // No-op (and no setTerrain) while terrain is off, but the value is retained.
+    control.setExaggeration(2.5);
+    assert.equal(fake.setTerrainCalls.length, 0);
+    assert.equal(control.getExaggeration(), 2.5);
+
+    control.setEnabled(true);
+    assert.deepEqual(fake.setTerrainCalls.at(-1), {
+      source: TERRAIN_SOURCE,
+      exaggeration: 2.5,
+    });
+
+    // Now live: changing it re-applies terrain immediately.
+    control.setExaggeration(4);
+    assert.deepEqual(fake.setTerrainCalls.at(-1), {
+      source: TERRAIN_SOURCE,
+      exaggeration: 4,
+    });
+  });
+
+  it("reflects the enabled state on the button class", () => {
+    const { control, button } = mount();
+    assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), false);
+    control.setEnabled(true);
+    assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), true);
+    control.setEnabled(false);
+    assert.equal(button.classList.has("maplibregl-ctrl-terrain-enabled"), false);
+  });
+});

--- a/tests/terrain-control.test.ts
+++ b/tests/terrain-control.test.ts
@@ -52,6 +52,9 @@ function makeFakeElement(): FakeElement {
 }
 
 const TERRAIN_SOURCE = "geolibre-terrain-dem";
+// Mirrors the control's private DOUBLE_CLICK_MS: advancing timers by exactly the
+// debounce window fires the pending single-click toggle.
+const DOUBLE_CLICK_MS = 250;
 
 interface FakeMap {
   map: maplibregl.Map;
@@ -125,7 +128,7 @@ describe("TerrainControl", () => {
     button.emit("click");
     // Still pending until the double-click window elapses.
     assert.equal(fake.setTerrainCalls.length, 0);
-    t.mock.timers.tick(300);
+    t.mock.timers.tick(DOUBLE_CLICK_MS);
     assert.equal(control.isEnabled(), true);
     assert.deepEqual(fake.setTerrainCalls.at(-1), {
       source: TERRAIN_SOURCE,
@@ -134,7 +137,7 @@ describe("TerrainControl", () => {
 
     // A second lone click toggles it back off.
     button.emit("click");
-    t.mock.timers.tick(300);
+    t.mock.timers.tick(DOUBLE_CLICK_MS);
     assert.equal(control.isEnabled(), false);
     assert.equal(fake.setTerrainCalls.at(-1), null);
   });
@@ -153,7 +156,7 @@ describe("TerrainControl", () => {
     assert.equal(fake.setTerrainCalls.length, 1);
 
     // The cancelled single-click toggle must not fire late.
-    t.mock.timers.tick(300);
+    t.mock.timers.tick(DOUBLE_CLICK_MS);
     assert.equal(fake.setTerrainCalls.length, 1);
   });
 

--- a/tests/terrain-exaggeration.test.ts
+++ b/tests/terrain-exaggeration.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  clampExaggeration,
+  MAX_EXAGGERATION,
+  MIN_EXAGGERATION,
+} from "../apps/geolibre-desktop/src/lib/terrain-exaggeration";
+
+describe("clampExaggeration", () => {
+  it("passes through values already inside the display range", () => {
+    assert.equal(clampExaggeration(0), 0);
+    assert.equal(clampExaggeration(2.5), 2.5);
+    assert.equal(clampExaggeration(5), 5);
+  });
+
+  it("clamps to the min and max bounds", () => {
+    assert.equal(clampExaggeration(-3), MIN_EXAGGERATION);
+    assert.equal(clampExaggeration(7), MAX_EXAGGERATION);
+  });
+
+  it("falls back to the min for non-finite input", () => {
+    assert.equal(clampExaggeration(Number.NaN), MIN_EXAGGERATION);
+    assert.equal(clampExaggeration(Number.POSITIVE_INFINITY), MIN_EXAGGERATION);
+    assert.equal(clampExaggeration(Number.NEGATIVE_INFINITY), MIN_EXAGGERATION);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace MapLibre's built-in terrain control with a custom one: a single click still toggles 3D terrain, and a double-click opens a dialog to adjust the vertical exaggeration live (previously fixed at 1). Clicks are debounced so a double-click never flickers terrain on then off.
- The control reuses MapLibre's own icon classes (no duplicate asset), and the map controller caches the exaggeration and tooltip so they survive the control being re-added (Controls menu toggle, style reload). New `terrainSettings` i18n strings back the dialog.
- Add unit tests for the control's toggle, double-click, and live-exaggeration behavior.

## Test plan
- [x] `npm run typecheck` (full build) passes
- [x] Frontend unit tests pass, including new `tests/terrain-control.test.ts`
- [x] ESLint and pre-commit (with npm build hook) clean
- [x] Verified in the real app: enable Terrain via Controls menu, single-click toggles terrain, double-click opens the "Terrain exaggeration" dialog, slider changes exaggeration live (1.0 to 3.0), Reset returns to 1.0, in both light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a terrain settings dialog for 3D vertical exaggeration (localized text) with slider/number input, reset, and done actions.
  * Introduced a custom 3D terrain control with live exaggeration updates and double-click to open settings.
* **Bug Fixes**
  * Improved synchronization of terrain enabled state, exaggeration, and the on-map terrain label/tooltip.
  * Updated terrain behavior so the dialog can close correctly when terrain is toggled off, and preserved control anchor ordering during refresh.
* **Tests**
  * Added unit tests for terrain control click/double-click behavior, exaggeration validation/clamping, restore-control-order logic, and exaggeration clamping utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->