### PR TITLE
feat(view): View in Google Maps / Google Earth actions

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -8,9 +8,11 @@ import {
   DropdownMenuTrigger,
 } from "@geolibre/ui";
 import type maplibregl from "maplibre-gl";
-import { Braces, Crosshair, MapPin, ZoomIn } from "lucide-react";
+import { Braces, Crosshair, Earth, MapIcon, MapPin, ZoomIn } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
+import { googleEarthUrl, googleMapsUrl } from "../../lib/external-map-links";
+import { openExternalLink } from "../../lib/open-external";
 
 interface ContextMenuState {
   /** Monotonic id so each right-click remounts the menu at the new anchor. */
@@ -58,7 +60,7 @@ async function copyText(value: string): Promise<void> {
  * handler) yields the clicked geographic coordinate directly. The top item
  * shows that coordinate and copies it to the clipboard on click, Google-Maps
  * style; below it sits a curated set of quick actions that operate on the
- * clicked point (copy GeoJSON, recenter, zoom in).
+ * clicked point (copy GeoJSON, recenter, zoom in, open in Google Maps/Earth).
  *
  * The menu is positioned with an invisible zero-size trigger pinned at the
  * cursor: Radix anchors its content to that trigger. The whole menu is keyed by
@@ -137,6 +139,23 @@ export function MapContextMenu({
     });
   }, [menu, mapControllerRef]);
 
+  // Read the live zoom so the external site opens at the on-screen scale; if
+  // the map was torn down between right-click and selection, fall back to a
+  // city-level view rather than dropping the action.
+  const viewInGoogleMaps = useCallback(() => {
+    if (!menu) return;
+    const zoom = mapControllerRef.current?.getMap()?.getZoom() ?? 12;
+    void openExternalLink(
+      googleMapsUrl(menu.lat, menu.lng, zoom, { marker: true }),
+    );
+  }, [menu, mapControllerRef]);
+
+  const viewInGoogleEarth = useCallback(() => {
+    if (!menu) return;
+    const zoom = mapControllerRef.current?.getMap()?.getZoom() ?? 12;
+    void openExternalLink(googleEarthUrl(menu.lat, menu.lng, zoom));
+  }, [menu, mapControllerRef]);
+
   return (
     // Keyed by the right-click id so each new right-click remounts the menu with
     // a fresh anchor at the cursor. The key is tied to `menu` (not `open`), so a
@@ -185,6 +204,15 @@ export function MapContextMenu({
         <DropdownMenuItem onSelect={zoomInHere} className="gap-2">
           <ZoomIn className="h-4 w-4 shrink-0 text-muted-foreground" />
           {t("mapContextMenu.zoomInHere")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={viewInGoogleMaps} className="gap-2">
+          <MapIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          {t("mapContextMenu.viewInGoogleMaps")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={viewInGoogleEarth} className="gap-2">
+          <Earth className="h-4 w-4 shrink-0 text-muted-foreground" />
+          {t("mapContextMenu.viewInGoogleEarth")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -120,6 +120,7 @@ import { PluginToolbarMenus } from "./toolbar/PluginToolbarMenus";
 import { ProcessingMenu } from "./toolbar/ProcessingMenu";
 import { ProjectFileDialogs } from "./toolbar/ProjectFileDialogs";
 import { ProjectMenu } from "./toolbar/ProjectMenu";
+import { googleEarthUrl, googleMapsUrl } from "../../lib/external-map-links";
 import {
   ADD_DATA_KIND_COMMANDS,
   ALL_BUILT_IN_CONTROL_IDS,
@@ -959,6 +960,22 @@ export function TopToolbar({
             mapControllerRef.current?.resetNorthPitch()
           }
           onSetView={() => setSetViewOpen(true)}
+          onViewInGoogleEarth={() => {
+            const map = mapControllerRef.current?.getMap();
+            if (!map) return;
+            const center = map.getCenter();
+            void openExternalLink(
+              googleEarthUrl(center.lat, center.lng, map.getZoom()),
+            );
+          }}
+          onViewInGoogleMaps={() => {
+            const map = mapControllerRef.current?.getMap();
+            if (!map) return;
+            const center = map.getCenter();
+            void openExternalLink(
+              googleMapsUrl(center.lat, center.lng, map.getZoom()),
+            );
+          }}
           onZoomIn={() => mapControllerRef.current?.zoomIn()}
           onZoomOut={() => mapControllerRef.current?.zoomOut()}
         />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
@@ -19,9 +19,11 @@ import {
   ArrowRight,
   Compass,
   Crosshair,
+  Earth,
   Eye,
   LayoutGrid,
   Link2,
+  MapIcon,
   Mountain,
   RotateCcw,
   ZoomIn,
@@ -75,6 +77,10 @@ interface ViewMenuProps {
   onResetPitchBearing: () => void;
   /** Open the dialog for typing an exact camera (center/zoom/pitch/bearing). */
   onSetView: () => void;
+  /** Open the current map view in Google Earth in the system browser. */
+  onViewInGoogleEarth: () => void;
+  /** Open the current map view in Google Maps in the system browser. */
+  onViewInGoogleMaps: () => void;
   /** Animate the map in by one zoom level. */
   onZoomIn: () => void;
   /** Animate the map out by one zoom level. */
@@ -95,6 +101,8 @@ export function ViewMenu({
   onResetPitch,
   onResetPitchBearing,
   onSetView,
+  onViewInGoogleEarth,
+  onViewInGoogleMaps,
   onZoomIn,
   onZoomOut,
 }: ViewMenuProps) {
@@ -131,6 +139,9 @@ export function ViewMenu({
     (!showResetPitchBearing || (bearingIsNorth && pitchIsFlat));
   const showSetView = show("view.setView");
   const showSplitView = show("view.splitView");
+  const showGoogleMaps = show("view.googleMaps");
+  const showGoogleEarth = show("view.googleEarth");
+  const showExternal = showGoogleMaps || showGoogleEarth;
   const paneCount = mapLayout.rows * mapLayout.cols;
   const gridKey = `${mapLayout.rows}x${mapLayout.cols}`;
   // A custom profile could hide every item; render nothing rather than a menu
@@ -141,7 +152,8 @@ export function ViewMenu({
     !showNavigation &&
     !showReset &&
     !showSetView &&
-    !showSplitView
+    !showSplitView &&
+    !showExternal
   )
     return null;
 
@@ -325,6 +337,28 @@ export function ViewMenu({
               </DropdownMenuCheckboxItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+        )}
+        {(showZoom ||
+          showNavigation ||
+          showReset ||
+          showSetView ||
+          showSplitView) &&
+          showExternal && <DropdownMenuSeparator />}
+        {showGoogleMaps && (
+          <DropdownMenuItem onSelect={onViewInGoogleMaps}>
+            <MapIcon className="mr-2 h-3.5 w-3.5 shrink-0" />
+            <span className="whitespace-nowrap">
+              {t("toolbar.item.viewInGoogleMaps")}
+            </span>
+          </DropdownMenuItem>
+        )}
+        {showGoogleEarth && (
+          <DropdownMenuItem onSelect={onViewInGoogleEarth}>
+            <Earth className="mr-2 h-3.5 w-3.5 shrink-0" />
+            <span className="whitespace-nowrap">
+              {t("toolbar.item.viewInGoogleEarth")}
+            </span>
+          </DropdownMenuItem>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -9,9 +9,7 @@ import {
 } from "@geolibre/map";
 import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
 import type { ParseKeys } from "i18next";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import type { createAppAPI } from "../../../hooks/usePlugins";
-import { isTauri } from "../../../lib/tauri-io";
 import type { AddDataKind } from "../AddDataDialog";
 
 /** The live app API surface plugins and panels are driven through. */
@@ -195,14 +193,9 @@ export const RASTER_TOOL_COMMANDS: Array<{
   { kind: "focal", titleKey: "toolbar.rasterTool.focal" },
 ];
 
-/** Open an external link in the OS browser (Tauri) or a new tab (web). */
-export async function openExternalLink(url: string): Promise<void> {
-  if (isTauri()) {
-    await openUrl(url);
-    return;
-  }
-  window.open(url, "_blank", "noopener,noreferrer");
-}
+// Re-exported so existing toolbar imports keep working; the shared helper
+// guards the URL scheme and logs opener failures instead of rejecting.
+export { openExternalLink } from "../../../lib/open-external";
 
 /** Format a recent-project timestamp for display, or "" if unparseable. */
 export function formatRecentProjectTime(openedAt: string): string {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1079,7 +1079,9 @@
     "quickActions": "Quick actions",
     "copyGeoJson": "Copy as GeoJSON",
     "centerHere": "Center map here",
-    "zoomInHere": "Zoom in here"
+    "zoomInHere": "Zoom in here",
+    "viewInGoogleMaps": "View in Google Maps",
+    "viewInGoogleEarth": "View in Google Earth"
   },
   "onboarding": {
     "title": "Welcome to GeoLibre",
@@ -1589,6 +1591,8 @@
       "splitViewGrid2x3": "2 × 3 grid",
       "splitViewGrid3x3": "3 × 3 grid",
       "splitViewSync": "Sync views",
+      "viewInGoogleMaps": "View in Google Maps",
+      "viewInGoogleEarth": "View in Google Earth",
       "zoomIn": "Zoom In",
       "zoomOut": "Zoom Out",
       "sectionFiles": "Files",

--- a/apps/geolibre-desktop/src/lib/external-map-links.ts
+++ b/apps/geolibre-desktop/src/lib/external-map-links.ts
@@ -11,11 +11,13 @@ const GOOGLE_MAPS_MIN_ZOOM = 2;
 const GOOGLE_MAPS_MAX_ZOOM = 21;
 
 /**
- * Google Earth camera distance (metres) that shows roughly the same ground
- * extent as a web-mercator zoom-0 view: with Earth's ~35° vertical field of
- * view, the visible ground width is about 0.63 × distance, and a ~1000 px
- * viewport at zoom 0 spans ~156543 m/px × 1000 px. Halves per zoom level like
- * mercator resolution does.
+ * Scaling anchor for the zoom → Google Earth camera distance conversion, in
+ * metres: the (theoretical) distance whose ~35° field of view spans the same
+ * ground width as a web-mercator zoom-0 view (visible ground width is about
+ * 0.63 × distance, and a ~1000 px viewport at zoom 0 spans ~156543 m/px ×
+ * 1000 px). The distance halves per zoom level like mercator resolution does.
+ * Note this anchor exceeds GOOGLE_EARTH_MAX_DISTANCE, so zooms below ~2 all
+ * clamp to the same whole-globe view rather than tracking the formula.
  */
 const GOOGLE_EARTH_DISTANCE_AT_ZOOM_0 = 248_500_000;
 /** Keep the camera distance inside the range Google Earth web navigates to. */

--- a/apps/geolibre-desktop/src/lib/external-map-links.ts
+++ b/apps/geolibre-desktop/src/lib/external-map-links.ts
@@ -1,0 +1,81 @@
+// URL builders for "view this location in an external mapping site" actions
+// (map context menu + View menu). Pure functions with no DOM or map access so
+// they can be unit-tested in Node; call sites hand the result to
+// `openExternalLink`.
+
+/** Decimal places for coordinates in generated URLs (~0.1 m at the equator). */
+const COORD_PRECISION = 6;
+
+/** Zoom range Google Maps accepts in the `@lat,lng,{zoom}z` camera URL. */
+const GOOGLE_MAPS_MIN_ZOOM = 2;
+const GOOGLE_MAPS_MAX_ZOOM = 21;
+
+/**
+ * Google Earth camera distance (metres) that shows roughly the same ground
+ * extent as a web-mercator zoom-0 view: with Earth's ~35° vertical field of
+ * view, the visible ground width is about 0.63 × distance, and a ~1000 px
+ * viewport at zoom 0 spans ~156543 m/px × 1000 px. Halves per zoom level like
+ * mercator resolution does.
+ */
+const GOOGLE_EARTH_DISTANCE_AT_ZOOM_0 = 248_500_000;
+/** Keep the camera distance inside the range Google Earth web navigates to. */
+const GOOGLE_EARTH_MIN_DISTANCE = 150;
+const GOOGLE_EARTH_MAX_DISTANCE = 65_000_000;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Wrap a longitude into [-180, 180]; MapLibre lets it run past the antimeridian. */
+function wrapLongitude(lng: number): number {
+  const wrapped = ((((lng + 180) % 360) + 360) % 360) - 180;
+  // Avoid "-0.000000" in URLs.
+  return Object.is(wrapped, -0) ? 0 : wrapped;
+}
+
+/**
+ * Build a Google Maps URL centered on a coordinate at (approximately) the
+ * given web-mercator zoom. With `marker: true` the coordinate is also passed
+ * as a place query so Google Maps drops a pin on it — used by the map context
+ * menu, where the clicked point matters more than the viewport.
+ */
+export function googleMapsUrl(
+  lat: number,
+  lng: number,
+  zoom: number,
+  options?: { marker?: boolean },
+): string {
+  const latText = clamp(lat, -90, 90).toFixed(COORD_PRECISION);
+  const lngText = wrapLongitude(lng).toFixed(COORD_PRECISION);
+  // Google Maps accepts fractional zoom; two decimals is plenty.
+  const zoomText = String(
+    Number(clamp(zoom, GOOGLE_MAPS_MIN_ZOOM, GOOGLE_MAPS_MAX_ZOOM).toFixed(2)),
+  );
+  const camera = `@${latText},${lngText},${zoomText}z`;
+  return options?.marker
+    ? `https://www.google.com/maps/place/${latText},${lngText}/${camera}`
+    : `https://www.google.com/maps/${camera}`;
+}
+
+/**
+ * Build a Google Earth web URL looking straight down at a coordinate from a
+ * camera distance that matches the given web-mercator zoom. Mercator
+ * metres-per-pixel shrink with cos(latitude), so the distance does too —
+ * without the correction a high-latitude view would open far more zoomed out
+ * in Google Earth than it looks in GeoLibre.
+ */
+export function googleEarthUrl(lat: number, lng: number, zoom: number): string {
+  const clampedLat = clamp(lat, -90, 90);
+  const distance = Math.round(
+    clamp(
+      (GOOGLE_EARTH_DISTANCE_AT_ZOOM_0 *
+        Math.cos((clampedLat * Math.PI) / 180)) /
+        2 ** zoom,
+      GOOGLE_EARTH_MIN_DISTANCE,
+      GOOGLE_EARTH_MAX_DISTANCE,
+    ),
+  );
+  const latText = clampedLat.toFixed(COORD_PRECISION);
+  const lngText = wrapLongitude(lng).toFixed(COORD_PRECISION);
+  return `https://earth.google.com/web/@${latText},${lngText},0a,${distance}d,35y,0h,0t,0r`;
+}

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -225,6 +225,8 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "view.resetPitchBearing", menuId: "view", labelKey: "toolbar.item.resetPitchBearing", tier: "basic" },
   { id: "view.setView", menuId: "view", labelKey: "toolbar.item.setView", tier: "intermediate" },
   { id: "view.splitView", menuId: "view", labelKey: "toolbar.item.splitView", tier: "intermediate" },
+  { id: "view.googleMaps", menuId: "view", labelKey: "toolbar.item.viewInGoogleMaps", tier: "basic" },
+  { id: "view.googleEarth", menuId: "view", labelKey: "toolbar.item.viewInGoogleEarth", tier: "basic" },
   // Processing — ordered to mirror the Processing menu. The Whitebox toggle
   // also governs the per-category Whitebox submenus, so those categories have no
   // separate entries here. The conversion/vector/network/statistics/raster,

--- a/tests/external-map-links.test.ts
+++ b/tests/external-map-links.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  googleEarthUrl,
+  googleMapsUrl,
+} from "../apps/geolibre-desktop/src/lib/external-map-links";
+
+describe("googleMapsUrl", () => {
+  it("builds a centered camera URL", () => {
+    assert.equal(
+      googleMapsUrl(40.7128, -74.006, 12),
+      "https://www.google.com/maps/@40.712800,-74.006000,12z",
+    );
+  });
+
+  it("adds a place query so a marker is dropped when requested", () => {
+    assert.equal(
+      googleMapsUrl(40.7128, -74.006, 12, { marker: true }),
+      "https://www.google.com/maps/place/40.712800,-74.006000/@40.712800,-74.006000,12z",
+    );
+  });
+
+  it("keeps fractional zoom to two decimals", () => {
+    assert.equal(
+      googleMapsUrl(0, 0, 12.34567),
+      "https://www.google.com/maps/@0.000000,0.000000,12.35z",
+    );
+  });
+
+  it("clamps zoom to the range Google Maps accepts", () => {
+    assert.ok(googleMapsUrl(0, 0, -3).endsWith(",2z"));
+    assert.ok(googleMapsUrl(0, 0, 25).endsWith(",21z"));
+  });
+
+  it("wraps longitudes past the antimeridian and clamps latitude", () => {
+    assert.equal(
+      googleMapsUrl(0, 190, 5),
+      "https://www.google.com/maps/@0.000000,-170.000000,5z",
+    );
+    assert.equal(
+      googleMapsUrl(95, -540, 5),
+      "https://www.google.com/maps/@90.000000,-180.000000,5z",
+    );
+  });
+
+  it("never emits a negative zero longitude", () => {
+    assert.equal(
+      googleMapsUrl(0, 360, 5),
+      "https://www.google.com/maps/@0.000000,0.000000,5z",
+    );
+  });
+});
+
+describe("googleEarthUrl", () => {
+  function distanceOf(url: string): number {
+    const match = url.match(/,(\d+)d,/);
+    assert.ok(match, `no camera distance in ${url}`);
+    return Number(match[1]);
+  }
+
+  it("builds a top-down camera URL at the coordinate", () => {
+    const url = googleEarthUrl(40.7128, -74.006, 12);
+    assert.ok(
+      url.startsWith("https://earth.google.com/web/@40.712800,-74.006000,0a,"),
+      url,
+    );
+    assert.ok(url.endsWith("d,35y,0h,0t,0r"), url);
+  });
+
+  it("halves the camera distance per zoom level", () => {
+    const near = distanceOf(googleEarthUrl(0, 0, 11));
+    const far = distanceOf(googleEarthUrl(0, 0, 10));
+    assert.ok(Math.abs(far / near - 2) < 0.01, `${far} vs ${near}`);
+  });
+
+  it("shrinks the distance with cos(latitude) like mercator resolution", () => {
+    const equator = distanceOf(googleEarthUrl(0, 0, 10));
+    const sixty = distanceOf(googleEarthUrl(60, 0, 10));
+    assert.ok(Math.abs(sixty / equator - 0.5) < 0.01, `${sixty} vs ${equator}`);
+  });
+
+  it("clamps the distance at extreme zooms and latitudes", () => {
+    assert.equal(distanceOf(googleEarthUrl(89.9999, 0, 22)), 150);
+    assert.equal(distanceOf(googleEarthUrl(0, 0, -5)), 65_000_000);
+  });
+
+  it("wraps longitude into [-180, 180]", () => {
+    const url = googleEarthUrl(10, 200, 8);
+    assert.ok(url.includes("@10.000000,-160.000000,"), url);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds "View in Google Maps" and "View in Google Earth" to the map right-click context menu; they open the clicked point in the system browser at the current zoom, with a dropped pin in Google Maps.
- Adds the same two actions to the View menu, opening the current map center instead, and registers them as toggleable items in the UI profile catalog.
- New pure URL-builder module (`external-map-links.ts`) clamps zoom, wraps longitudes past the antimeridian, and converts web-mercator zoom to an equivalent Google Earth camera distance (with cos-latitude correction), covered by unit tests.

## Test plan
- [x] `tests/external-map-links.test.ts` covers URL formats, zoom clamping, longitude wrapping, and the zoom-to-distance conversion (11 tests)
- [x] Full frontend suite passes (2043 tests)
- [x] Verified in the running web app: Set View to (37.7749, -122.4194, z12.5) then View menu opens `google.com/maps/@37.774900,-122.419400,12.5z` and `earth.google.com/web/@37.774900,-122.419400,0a,33909d,...`; right-clicking an off-center point opens the place URL matching the context menu's own coordinate readout
- [x] Verified on the Tauri desktop build (Linux): both menus render, and selecting the items routes through the opener plugin, e.g. `xdg-open https://www.google.com/maps/@40.000000,-100.000000,2z` and `xdg-open https://earth.google.com/web/@47.335313,-87.896927,0a,42102522d,35y,0h,0t,0r`; the opener capability already allows `https://*`
