### PR TITLE
feat(style): render vector layers with Z coordinates in true 3D

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1235,14 +1235,16 @@ export function StylePanel({
   );
   // Whether the layer's coordinates carry real Z values (e.g. GPX track
   // elevations), which unlocks the "3D (Z values)" visualization mode.
-  // Memoized because the scan touches every coordinate when no Z is present.
-  // Kept before the early returns below so the hook order stays stable.
+  // Memoized on the geojson reference (not the layer object, which is
+  // recreated on every style edit) because the scan touches every coordinate
+  // when no Z is present. Kept before the early returns below so the hook
+  // order stays stable.
   const supportsElevation3d = useMemo(
     () =>
       layer?.type === "geojson" && layer.geojson
         ? geojsonHasZCoordinates(layer.geojson)
         : false,
-    [layer],
+    [layer?.type, layer?.geojson],
   );
 
   const resizeHandle = (
@@ -3004,7 +3006,7 @@ export function StylePanel({
   const elevation3dControls = (
     <>
       <div className="space-y-2">
-        <Label htmlFor="fillColor">Fill color</Label>
+        <Label htmlFor="fillColor">{t("style.elevation3d.fillColor")}</Label>
         <ColorField
           id="fillColor"
           value={style.fillColor}
@@ -3016,7 +3018,9 @@ export function StylePanel({
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="strokeColor">Outline color</Label>
+        <Label htmlFor="strokeColor">
+          {t("style.elevation3d.outlineColor")}
+        </Label>
         <ColorField
           id="strokeColor"
           value={style.strokeColor}
@@ -3029,7 +3033,7 @@ export function StylePanel({
       </div>
       <NumericStyleInput
         id="strokeWidth"
-        label="Stroke width"
+        label={t("style.elevation3d.strokeWidth")}
         min={0}
         max={20}
         step={0.5}
@@ -3038,7 +3042,7 @@ export function StylePanel({
       />
       <NumericStyleInput
         id="fillOpacity"
-        label="Fill opacity"
+        label={t("style.elevation3d.fillOpacity")}
         min={0}
         max={1}
         step={0.05}
@@ -3048,7 +3052,7 @@ export function StylePanel({
       {geometryFlags.hasPoint ? (
         <NumericStyleInput
           id="circleRadius"
-          label="Circle radius"
+          label={t("style.elevation3d.circleRadius")}
           min={1}
           max={50}
           step={1}
@@ -3291,7 +3295,10 @@ export function StylePanel({
             right edge of a control (e.g. the "Transparent" label). */}
         <div className="space-y-4 p-3 pr-5">
           {beforeIdControl}
-          {zoomRangeControls}
+          {/* The 3D Z-value render (deck.gl) does not honor the MapLibre
+              min/max zoom range, so hide the controls rather than show a
+              silently-ignored setting. */}
+          {!elevation3dEnabled && zoomRangeControls}
           {hasExtrusionControls && (
             <div className="space-y-2">
               <Label>Visualization</Label>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3075,7 +3075,9 @@ export function StylePanel({
         value={style.fillOpacity}
         onChange={(fillOpacity) => setLayerStyle(layer.id, { fillOpacity })}
       />
-      {geometryFlags.hasPoint ? (
+      {/* Sketches mix geometry types under one style, so "Circle radius" is
+          suppressed there for the same reason as in the 2D controls (#483). */}
+      {geometryFlags.hasPoint && !isSketchLayer ? (
         <NumericStyleInput
           id="circleRadius"
           label={t("style.elevation3d.circleRadius")}
@@ -3348,7 +3350,7 @@ export function StylePanel({
                   <input
                     type="radio"
                     name={`style-mode-${layer.id}`}
-                    checked={extrusionEnabled}
+                    checked={extrusionEnabled && !elevation3dActive}
                     onChange={() => {
                       setVectorStyleError(null);
                       setLayerStyle(layer.id, {

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3050,12 +3050,19 @@ export function StylePanel({
           transparentSwatchLabel={t("style.symbology.transparentSwatch")}
         />
       </div>
+      {/* The 3D render honors meter-based widths (lineWidthUnits), so mirror
+          the 2D control's range/label switch or the tighter pixel clamp would
+          silently destroy a meters width on the next edit. */}
       <NumericStyleInput
         id="strokeWidth"
-        label={t("style.elevation3d.strokeWidth")}
+        label={
+          strokeWidthInMeters
+            ? `${t("style.elevation3d.strokeWidth")} (meters)`
+            : t("style.elevation3d.strokeWidth")
+        }
         min={0}
-        max={20}
-        step={0.5}
+        max={strokeWidthInMeters ? 100000 : 20}
+        step={strokeWidthInMeters ? 1 : 0.5}
         value={style.strokeWidth}
         onChange={(strokeWidth) => setLayerStyle(layer.id, { strokeWidth })}
       />

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3360,7 +3360,7 @@ export function StylePanel({
                   3D extrusion
                 </label>
                 {supportsElevation3d && (
-                  <label className="flex h-9 items-center gap-2 rounded-md border border-input bg-background px-3 text-sm">
+                  <label className="col-span-2 flex h-9 items-center gap-2 rounded-md border border-input bg-background px-3 text-sm">
                     <input
                       type="radio"
                       name={`style-mode-${layer.id}`}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1671,7 +1671,13 @@ export function StylePanel({
             ))}
           </optgroup>
         )}
-        {basemapStyleLayerIds.length > 0 && basemapStyleLayersVisible && (
+        {/* The 3D Z-value render (deck.gl overlay) honors store order for
+            user layers but has no MapLibre layer to insert below a basemap
+            style layer, so hide that group rather than offer a silently
+            ignored setting. */}
+        {basemapStyleLayerIds.length > 0 &&
+          basemapStyleLayersVisible &&
+          !elevation3dEnabled && (
           <optgroup label="Basemap layers">
             {basemapStyleLayerIds.map((styleLayerId) => (
               <option key={styleLayerId} value={styleLayerId}>
@@ -1681,7 +1687,9 @@ export function StylePanel({
           </optgroup>
         )}
       </Select>
-      {basemapStyleLayerIds.length > 0 && !valueIsBasemapStyleLayer && (
+      {basemapStyleLayerIds.length > 0 &&
+        !valueIsBasemapStyleLayer &&
+        !elevation3dEnabled && (
         <label className="flex items-center gap-2 text-xs text-muted-foreground">
           <input
             type="checkbox"

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -3057,7 +3057,7 @@ export function StylePanel({
         id="strokeWidth"
         label={
           strokeWidthInMeters
-            ? `${t("style.elevation3d.strokeWidth")} (meters)`
+            ? t("style.elevation3d.strokeWidthMeters")
             : t("style.elevation3d.strokeWidth")
         }
         min={0}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -12,6 +12,7 @@ import {
   type VectorStyleStop,
   createEqualIntervalBreaks,
   createQuantileBreaks,
+  geojsonHasZCoordinates,
   interpolateRampColors,
   parseJsonExpression,
   styleValue,
@@ -1232,6 +1233,17 @@ export function StylePanel({
         : { hasPoint: true, hasLine: true, hasPolygon: true },
     [layer],
   );
+  // Whether the layer's coordinates carry real Z values (e.g. GPX track
+  // elevations), which unlocks the "3D (Z values)" visualization mode.
+  // Memoized because the scan touches every coordinate when no Z is present.
+  // Kept before the early returns below so the hook order stays stable.
+  const supportsElevation3d = useMemo(
+    () =>
+      layer?.type === "geojson" && layer.geojson
+        ? geojsonHasZCoordinates(layer.geojson)
+        : false,
+    [layer],
+  );
 
   const resizeHandle = (
     <div
@@ -1347,6 +1359,7 @@ export function StylePanel({
     strokeWidthUnit === "meters" && !supportsPointRenderer;
   const pointRenderer = styleValue(style, "pointRenderer");
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
+  const elevation3dEnabled = styleValue(style, "elevation3dEnabled");
   const extrusionHeightPropertyOptions = getAttributePropertyNames(layer);
   const vectorStylePropertyOptions = extrusionHeightPropertyOptions;
   const labels: LabelStyle = {
@@ -2985,6 +2998,92 @@ export function StylePanel({
     </>
   );
 
+  // Controls for the "3D (Z values)" mode: only the knobs the deck.gl render
+  // honors (flat colors, widths, and the elevation transform). Data-driven
+  // symbology, point renderers, patterns, markers, and labels are 2D-only.
+  const elevation3dControls = (
+    <>
+      <div className="space-y-2">
+        <Label htmlFor="fillColor">Fill color</Label>
+        <ColorField
+          id="fillColor"
+          value={style.fillColor}
+          onChange={(fillColor) => setLayerStyle(layer.id, { fillColor })}
+          allowTransparent
+          fallbackColor={DEFAULT_LAYER_STYLE.fillColor}
+          transparentLabel={t("style.symbology.transparent")}
+          transparentSwatchLabel={t("style.symbology.transparentSwatch")}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="strokeColor">Outline color</Label>
+        <ColorField
+          id="strokeColor"
+          value={style.strokeColor}
+          onChange={(strokeColor) => setLayerStyle(layer.id, { strokeColor })}
+          allowTransparent
+          fallbackColor={DEFAULT_LAYER_STYLE.strokeColor}
+          transparentLabel={t("style.symbology.transparent")}
+          transparentSwatchLabel={t("style.symbology.transparentSwatch")}
+        />
+      </div>
+      <NumericStyleInput
+        id="strokeWidth"
+        label="Stroke width"
+        min={0}
+        max={20}
+        step={0.5}
+        value={style.strokeWidth}
+        onChange={(strokeWidth) => setLayerStyle(layer.id, { strokeWidth })}
+      />
+      <NumericStyleInput
+        id="fillOpacity"
+        label="Fill opacity"
+        min={0}
+        max={1}
+        step={0.05}
+        value={style.fillOpacity}
+        onChange={(fillOpacity) => setLayerStyle(layer.id, { fillOpacity })}
+      />
+      {geometryFlags.hasPoint ? (
+        <NumericStyleInput
+          id="circleRadius"
+          label="Circle radius"
+          min={1}
+          max={50}
+          step={1}
+          value={style.circleRadius}
+          onChange={(circleRadius) => setLayerStyle(layer.id, { circleRadius })}
+        />
+      ) : null}
+      <Separator />
+      <NumericStyleInput
+        id="elevation3dVerticalScale"
+        label={t("style.elevation3d.verticalScale")}
+        min={0}
+        max={100}
+        step={0.1}
+        value={styleValue(style, "elevation3dVerticalScale")}
+        onChange={(elevation3dVerticalScale) =>
+          setLayerStyle(layer.id, { elevation3dVerticalScale })
+        }
+        tooltip={t("style.elevation3d.verticalScaleTooltip")}
+      />
+      <NumericStyleInput
+        id="elevation3dOffset"
+        label={t("style.elevation3d.offset")}
+        min={-10000}
+        max={10000}
+        step={10}
+        value={styleValue(style, "elevation3dOffset")}
+        onChange={(elevation3dOffset) =>
+          setLayerStyle(layer.id, { elevation3dOffset })
+        }
+        tooltip={t("style.elevation3d.offsetTooltip")}
+      />
+    </>
+  );
+
   if (hasRasterPaintControls) {
     return (
       <aside aria-label="Layer style" className={STYLE_PANEL_ASIDE_CLASS}>
@@ -3201,10 +3300,13 @@ export function StylePanel({
                   <input
                     type="radio"
                     name={`style-mode-${layer.id}`}
-                    checked={!extrusionEnabled}
+                    checked={!extrusionEnabled && !elevation3dEnabled}
                     onChange={() => {
                       setExtrusionError(null);
-                      setLayerStyle(layer.id, { extrusionEnabled: false });
+                      setLayerStyle(layer.id, {
+                        extrusionEnabled: false,
+                        elevation3dEnabled: false,
+                      });
                     }}
                   />
                   2D
@@ -3216,22 +3318,48 @@ export function StylePanel({
                     checked={extrusionEnabled}
                     onChange={() => {
                       setVectorStyleError(null);
-                      setLayerStyle(layer.id, { extrusionEnabled: true });
+                      setLayerStyle(layer.id, {
+                        extrusionEnabled: true,
+                        elevation3dEnabled: false,
+                      });
                     }}
                   />
                   3D extrusion
                 </label>
+                {supportsElevation3d && (
+                  <label className="flex h-9 items-center gap-2 rounded-md border border-input bg-background px-3 text-sm">
+                    <input
+                      type="radio"
+                      name={`style-mode-${layer.id}`}
+                      checked={elevation3dEnabled}
+                      onChange={() => {
+                        setExtrusionError(null);
+                        setLayerStyle(layer.id, {
+                          extrusionEnabled: false,
+                          elevation3dEnabled: true,
+                        });
+                      }}
+                    />
+                    {t("style.elevation3d.mode")}
+                  </label>
+                )}
               </div>
             </div>
           )}
-          {/* Data-driven coloring doesn't apply to the heatmap renderer. */}
-          {pointRenderer === "heatmap" ? null : vectorSymbologyControls}
-          {!hasExtrusionControls || !extrusionEnabled ? (
+          {/* Data-driven coloring doesn't apply to the heatmap renderer or the
+              flat-styled 3D Z-value render. */}
+          {pointRenderer === "heatmap" || elevation3dEnabled
+            ? null
+            : vectorSymbologyControls}
+          {elevation3dEnabled ? (
+            elevation3dControls
+          ) : !hasExtrusionControls || !extrusionEnabled ? (
             twoDimensionalControls
           ) : (
             extrusionControls
           )}
-          {(!hasExtrusionControls || !extrusionEnabled) && (
+          {!elevation3dEnabled &&
+            (!hasExtrusionControls || !extrusionEnabled) && (
             <>
               {showProportionalControls && (
                 <>
@@ -3254,8 +3382,8 @@ export function StylePanel({
             </>
           )}
           {/* Attribute labels apply to vector features, not the heatmap density
-              surface or the 3D extrusion render. */}
-          {!extrusionEnabled && pointRenderer !== "heatmap" ? (
+              surface or the 3D extrusion / 3D Z-value renders. */}
+          {!extrusionEnabled && !elevation3dEnabled && pointRenderer !== "heatmap" ? (
             <>
               <Separator />
               <p className="text-sm font-semibold">
@@ -3270,9 +3398,11 @@ export function StylePanel({
       <p className="p-2 text-[10px] text-muted-foreground">
         {extrusionEnabled
           ? "3D extrusion settings apply when saved."
-          : isDeckVectorLayer
-            ? "Changes apply live to DuckDB deck.gl layer styling."
-            : "Changes apply live to MapLibre paint properties."}
+          : elevation3dEnabled
+            ? t("style.elevation3d.footer")
+            : isDeckVectorLayer
+              ? "Changes apply live to DuckDB deck.gl layer styling."
+              : "Changes apply live to MapLibre paint properties."}
       </p>
     </aside>
   );

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1362,6 +1362,11 @@ export function StylePanel({
   const pointRenderer = styleValue(style, "pointRenderer");
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
   const elevation3dEnabled = styleValue(style, "elevation3dEnabled");
+  // Effective 3D Z-value mode: the saved flag can outlive the data's Z values
+  // (e.g. a processing tool rewrote the geometry), in which case the renderer
+  // falls back to 2D — the panel must match so a Visualization radio is
+  // always selected and 2D controls stay usable.
+  const elevation3dActive = elevation3dEnabled && supportsElevation3d;
   const extrusionHeightPropertyOptions = getAttributePropertyNames(layer);
   const vectorStylePropertyOptions = extrusionHeightPropertyOptions;
   const labels: LabelStyle = {
@@ -1635,10 +1640,16 @@ export function StylePanel({
   const basemapStyleLayerIds =
     mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
   const otherLayers = layers.filter((l) => l.id !== layer.id);
+  // While 3D (Z values) is active the basemap group below is hidden, so a
+  // saved basemap target surfaces under "Saved (unavailable)" instead of
+  // leaving the select pointing at a missing option.
+  const beforeIdHiddenByElevation3d =
+    elevation3dActive && basemapStyleLayerIds.includes(draftBeforeId);
   const orphanedBeforeId =
     draftBeforeId &&
-    !basemapStyleLayerIds.includes(draftBeforeId) &&
-    !otherLayers.some((l) => l.id === draftBeforeId)
+    (beforeIdHiddenByElevation3d ||
+      (!basemapStyleLayerIds.includes(draftBeforeId) &&
+        !otherLayers.some((l) => l.id === draftBeforeId)))
       ? draftBeforeId
       : null;
   // The basemap style exposes dozens of internal layer ids that overwhelm the
@@ -1677,7 +1688,7 @@ export function StylePanel({
             ignored setting. */}
         {basemapStyleLayerIds.length > 0 &&
           basemapStyleLayersVisible &&
-          !elevation3dEnabled && (
+          !elevation3dActive && (
           <optgroup label="Basemap layers">
             {basemapStyleLayerIds.map((styleLayerId) => (
               <option key={styleLayerId} value={styleLayerId}>
@@ -1689,7 +1700,7 @@ export function StylePanel({
       </Select>
       {basemapStyleLayerIds.length > 0 &&
         !valueIsBasemapStyleLayer &&
-        !elevation3dEnabled && (
+        !elevation3dActive && (
         <label className="flex items-center gap-2 text-xs text-muted-foreground">
           <input
             type="checkbox"
@@ -3306,7 +3317,7 @@ export function StylePanel({
           {/* The 3D Z-value render (deck.gl) does not honor the MapLibre
               min/max zoom range, so hide the controls rather than show a
               silently-ignored setting. */}
-          {!elevation3dEnabled && zoomRangeControls}
+          {!elevation3dActive && zoomRangeControls}
           {hasExtrusionControls && (
             <div className="space-y-2">
               <Label>Visualization</Label>
@@ -3315,7 +3326,7 @@ export function StylePanel({
                   <input
                     type="radio"
                     name={`style-mode-${layer.id}`}
-                    checked={!extrusionEnabled && !elevation3dEnabled}
+                    checked={!extrusionEnabled && !elevation3dActive}
                     onChange={() => {
                       setExtrusionError(null);
                       setLayerStyle(layer.id, {
@@ -3346,7 +3357,7 @@ export function StylePanel({
                     <input
                       type="radio"
                       name={`style-mode-${layer.id}`}
-                      checked={elevation3dEnabled}
+                      checked={elevation3dActive}
                       onChange={() => {
                         setExtrusionError(null);
                         setLayerStyle(layer.id, {
@@ -3363,17 +3374,17 @@ export function StylePanel({
           )}
           {/* Data-driven coloring doesn't apply to the heatmap renderer or the
               flat-styled 3D Z-value render. */}
-          {pointRenderer === "heatmap" || elevation3dEnabled
+          {pointRenderer === "heatmap" || elevation3dActive
             ? null
             : vectorSymbologyControls}
-          {elevation3dEnabled ? (
+          {elevation3dActive ? (
             elevation3dControls
           ) : !hasExtrusionControls || !extrusionEnabled ? (
             twoDimensionalControls
           ) : (
             extrusionControls
           )}
-          {!elevation3dEnabled &&
+          {!elevation3dActive &&
             (!hasExtrusionControls || !extrusionEnabled) && (
             <>
               {showProportionalControls && (
@@ -3398,7 +3409,7 @@ export function StylePanel({
           )}
           {/* Attribute labels apply to vector features, not the heatmap density
               surface or the 3D extrusion / 3D Z-value renders. */}
-          {!extrusionEnabled && !elevation3dEnabled && pointRenderer !== "heatmap" ? (
+          {!extrusionEnabled && !elevation3dActive && pointRenderer !== "heatmap" ? (
             <>
               <Separator />
               <p className="text-sm font-semibold">
@@ -3413,7 +3424,7 @@ export function StylePanel({
       <p className="p-2 text-[10px] text-muted-foreground">
         {extrusionEnabled
           ? "3D extrusion settings apply when saved."
-          : elevation3dEnabled
+          : elevation3dActive
             ? t("style.elevation3d.footer")
             : isDeckVectorLayer
               ? "Changes apply live to DuckDB deck.gl layer styling."

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2391,7 +2391,7 @@
       "verticalScaleTooltip": "Multiplies each coordinate's Z value. 1 renders true elevations; larger values emphasize relief.",
       "offset": "Altitude offset (m)",
       "offsetTooltip": "Constant height in meters added to every feature, e.g. to lift a track above 3D buildings or terrain.",
-      "footer": "Rendered in 3D at coordinate Z values via deck.gl. Changes apply live."
+      "footer": "Rendered in 3D at coordinate Z values via deck.gl. Changes apply live. Identify and feature highlighting are not available in this mode."
     },
     "symbology": {
       "colormap": "Colormap",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2384,6 +2384,7 @@
       "fillColor": "Fill color",
       "outlineColor": "Outline color",
       "strokeWidth": "Stroke width",
+      "strokeWidthMeters": "Stroke width (meters)",
       "fillOpacity": "Fill opacity",
       "circleRadius": "Circle radius",
       "verticalScale": "Vertical exaggeration",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2379,6 +2379,14 @@
       "expressionHint": "A MapLibre expression (JSON). Overrides the field when set.",
       "expressionInvalid": "Not a valid MapLibre expression (must be a JSON array). This value is ignored."
     },
+    "elevation3d": {
+      "mode": "3D (Z values)",
+      "verticalScale": "Vertical exaggeration",
+      "verticalScaleTooltip": "Multiplies each coordinate's Z value. 1 renders true elevations; larger values emphasize relief.",
+      "offset": "Altitude offset (m)",
+      "offsetTooltip": "Constant height in meters added to every feature, e.g. to lift a track above 3D buildings or terrain.",
+      "footer": "Rendered in 3D at coordinate Z values via deck.gl. Changes apply live."
+    },
     "symbology": {
       "colormap": "Colormap",
       "modeSingle": "Single symbology",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2381,6 +2381,11 @@
     },
     "elevation3d": {
       "mode": "3D (Z values)",
+      "fillColor": "Fill color",
+      "outlineColor": "Outline color",
+      "strokeWidth": "Stroke width",
+      "fillOpacity": "Fill opacity",
+      "circleRadius": "Circle radius",
       "verticalScale": "Vertical exaggeration",
       "verticalScaleTooltip": "Multiplies each coordinate's Z value. 1 renders true elevations; larger values emphasize relief.",
       "offset": "Altitude offset (m)",

--- a/packages/core/src/geojson-z.ts
+++ b/packages/core/src/geojson-z.ts
@@ -1,0 +1,153 @@
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJSON,
+  Geometry,
+  Position,
+} from "geojson";
+
+/**
+ * Helpers for vector data whose coordinates carry a Z value (elevation), e.g.
+ * GPX tracks with `<ele>` readings or LineStringZ/PointZ geometries. MapLibre's
+ * 2D style layers ignore the third coordinate, so layers that want to render
+ * their Z values use these helpers to detect and rescale elevations before
+ * handing the data to a deck.gl overlay.
+ */
+
+/**
+ * Returns true when any coordinate in the GeoJSON carries a finite, non-zero
+ * Z value. All-zero Z arrays are treated as flat data because rendering them
+ * "in 3D" would be indistinguishable from the 2D result.
+ *
+ * @param geojson - Any GeoJSON object (geometry, feature, or collection).
+ */
+export function geojsonHasZCoordinates(
+  geojson: GeoJSON | null | undefined,
+): boolean {
+  if (!geojson) return false;
+  return someGeometry(geojson, (geometry) =>
+    somePosition(geometry, (position) => {
+      const z = position[2];
+      return typeof z === "number" && Number.isFinite(z) && z !== 0;
+    }),
+  );
+}
+
+/**
+ * Returns a copy of the GeoJSON with every coordinate's Z value mapped to
+ * `z * verticalScale + offset` (missing Z treated as 0). Used to apply
+ * vertical exaggeration and a constant altitude offset before 3D rendering.
+ * When the transform is the identity (`verticalScale === 1 && offset === 0`)
+ * the input is returned unchanged.
+ *
+ * @param geojson - The feature collection to transform.
+ * @param verticalScale - Multiplier applied to each Z value.
+ * @param offset - Constant altitude in meters added after scaling.
+ */
+export function transformGeojsonElevation(
+  geojson: FeatureCollection,
+  verticalScale: number,
+  offset: number,
+): FeatureCollection {
+  if (verticalScale === 1 && offset === 0) return geojson;
+  const mapPosition = (position: Position): Position => [
+    position[0],
+    position[1],
+    (typeof position[2] === "number" && Number.isFinite(position[2])
+      ? position[2]
+      : 0) *
+      verticalScale +
+      offset,
+  ];
+  return {
+    ...geojson,
+    features: geojson.features.map((feature) => ({
+      ...feature,
+      geometry: mapGeometryPositions(feature.geometry, mapPosition),
+    })),
+  };
+}
+
+function someGeometry(
+  geojson: GeoJSON,
+  predicate: (geometry: Geometry) => boolean,
+): boolean {
+  switch (geojson.type) {
+    case "FeatureCollection":
+      return geojson.features.some((feature) =>
+        feature.geometry ? someGeometry(feature.geometry, predicate) : false,
+      );
+    case "Feature":
+      return geojson.geometry
+        ? someGeometry(geojson.geometry, predicate)
+        : false;
+    case "GeometryCollection":
+      return geojson.geometries.some((geometry) =>
+        someGeometry(geometry, predicate),
+      );
+    default:
+      return predicate(geojson);
+  }
+}
+
+function somePosition(
+  geometry: Geometry,
+  predicate: (position: Position) => boolean,
+): boolean {
+  switch (geometry.type) {
+    case "Point":
+      return predicate(geometry.coordinates);
+    case "MultiPoint":
+    case "LineString":
+      return geometry.coordinates.some(predicate);
+    case "MultiLineString":
+    case "Polygon":
+      return geometry.coordinates.some((ring) => ring.some(predicate));
+    case "MultiPolygon":
+      return geometry.coordinates.some((polygon) =>
+        polygon.some((ring) => ring.some(predicate)),
+      );
+    case "GeometryCollection":
+      return geometry.geometries.some((child) =>
+        somePosition(child, predicate),
+      );
+    default:
+      return false;
+  }
+}
+
+function mapGeometryPositions(
+  geometry: Feature["geometry"],
+  mapPosition: (position: Position) => Position,
+): Feature["geometry"] {
+  if (!geometry) return geometry;
+  switch (geometry.type) {
+    case "Point":
+      return { ...geometry, coordinates: mapPosition(geometry.coordinates) };
+    case "MultiPoint":
+    case "LineString":
+      return { ...geometry, coordinates: geometry.coordinates.map(mapPosition) };
+    case "MultiLineString":
+    case "Polygon":
+      return {
+        ...geometry,
+        coordinates: geometry.coordinates.map((ring) => ring.map(mapPosition)),
+      };
+    case "MultiPolygon":
+      return {
+        ...geometry,
+        coordinates: geometry.coordinates.map((polygon) =>
+          polygon.map((ring) => ring.map(mapPosition)),
+        ),
+      };
+    case "GeometryCollection":
+      return {
+        ...geometry,
+        geometries: geometry.geometries.map(
+          (child) => mapGeometryPositions(child, mapPosition) as Geometry,
+        ),
+      };
+    default:
+      return geometry;
+  }
+}

--- a/packages/core/src/geojson-z.ts
+++ b/packages/core/src/geojson-z.ts
@@ -50,6 +50,9 @@ export function transformGeojsonElevation(
   offset: number,
 ): FeatureCollection {
   if (verticalScale === 1 && offset === 0) return geojson;
+  // Positions are normalized to [x, y, z]; a 4th measure value (M), which
+  // some producers emit, is intentionally dropped — nothing downstream of
+  // this render path consumes it.
   const mapPosition = (position: Position): Position => [
     position[0],
     position[1],

--- a/packages/core/src/geojson-z.ts
+++ b/packages/core/src/geojson-z.ts
@@ -14,10 +14,16 @@ import type {
  * handing the data to a deck.gl overlay.
  */
 
+// Proving the *negative* (no Z anywhere) walks every coordinate, so cache the
+// verdict per GeoJSON object — the map sync, the deck overlay, and the Style
+// panel all ask the same question about the same (immutable) data.
+const hasZCache = new WeakMap<object, boolean>();
+
 /**
  * Returns true when any coordinate in the GeoJSON carries a finite, non-zero
  * Z value. All-zero Z arrays are treated as flat data because rendering them
- * "in 3D" would be indistinguishable from the 2D result.
+ * "in 3D" would be indistinguishable from the 2D result. The result is
+ * cached per GeoJSON object, so repeated calls on the same data are free.
  *
  * @param geojson - Any GeoJSON object (geometry, feature, or collection).
  */
@@ -25,20 +31,25 @@ export function geojsonHasZCoordinates(
   geojson: GeoJSON | null | undefined,
 ): boolean {
   if (!geojson) return false;
-  return someGeometry(geojson, (geometry) =>
+  const cached = hasZCache.get(geojson);
+  if (cached !== undefined) return cached;
+  const result = someGeometry(geojson, (geometry) =>
     somePosition(geometry, (position) => {
       const z = position[2];
       return typeof z === "number" && Number.isFinite(z) && z !== 0;
     }),
   );
+  hasZCache.set(geojson, result);
+  return result;
 }
 
 /**
  * Returns a copy of the GeoJSON with every coordinate's Z value mapped to
- * `z * verticalScale + offset` (missing Z treated as 0). Used to apply
- * vertical exaggeration and a constant altitude offset before 3D rendering.
- * When the transform is the identity (`verticalScale === 1 && offset === 0`)
- * the input is returned unchanged.
+ * `z * verticalScale + offset` (missing or non-finite Z treated as 0). Used
+ * to apply vertical exaggeration and a constant altitude offset before 3D
+ * rendering. The identity transform (`verticalScale === 1 && offset === 0`)
+ * still produces a copy so the non-finite-Z sanitization applies on every
+ * path — WebGL does not handle NaN positions gracefully.
  *
  * @param geojson - The feature collection to transform.
  * @param verticalScale - Multiplier applied to each Z value.
@@ -49,7 +60,6 @@ export function transformGeojsonElevation(
   verticalScale: number,
   offset: number,
 ): FeatureCollection {
-  if (verticalScale === 1 && offset === 0) return geojson;
   // Positions are normalized to [x, y, z]; a 4th measure value (M), which
   // some producers emit, is intentionally dropped — nothing downstream of
   // this render path consumes it.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./geojson-z";
 export * from "./color-ramp";
 export * from "./paths";
 export * from "./routing";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -263,6 +263,18 @@ export interface LayerStyle {
   extrusionAdvancedStyleEnabled: boolean;
   extrusionColorExpression: string;
   extrusionHeightExpression: string;
+  /**
+   * When true, a vector layer whose coordinates carry Z values (e.g. a GPX
+   * track with elevations) renders in true 3D through the shared deck.gl
+   * overlay instead of MapLibre's flat 2D layers, so features sit at their
+   * own altitude. Orthogonal to {@link extrusionEnabled}, which extrudes flat
+   * polygons by an attribute; only one of the two should be on at a time.
+   */
+  elevation3dEnabled: boolean;
+  /** Multiplier applied to each coordinate's Z value (vertical exaggeration). */
+  elevation3dVerticalScale: number;
+  /** Constant altitude offset in meters added after the vertical scale. */
+  elevation3dOffset: number;
   vectorStyleMode: VectorStyleMode;
   vectorStyleProperty: string;
   vectorStyleClassCount: number;
@@ -372,6 +384,9 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
   extrusionAdvancedStyleEnabled: false,
   extrusionColorExpression: "",
   extrusionHeightExpression: "",
+  elevation3dEnabled: false,
+  elevation3dVerticalScale: 1,
+  elevation3dOffset: 0,
   vectorStyleMode: "single",
   vectorStyleProperty: "",
   vectorStyleClassCount: 5,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -304,6 +304,14 @@ export function syncLayer(
   if (isPlaceholderLayer(layer)) return;
 
   if (layer.type === "geojson" && layer.geojson) {
+    // 3D Z-value rendering hands the layer to the shared deck.gl overlay
+    // (deckgl-viz plugin), which honors coordinate Z values that MapLibre's
+    // flat 2D layers ignore. Drop any MapLibre rendering so the layer is not
+    // drawn twice; toggling back off re-adds it through the paths below.
+    if (styleValue(layer.style, "elevation3dEnabled")) {
+      removeLayerFromMap(map, layer.id, layer);
+      return;
+    }
     if (shouldUseTiledRendering(layer.geojson)) {
       syncGeoJsonVtLayer(map, layer, beforeId);
     } else {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -314,7 +314,7 @@ export function syncLayer(
     // the flag never leaves a layer invisible; the Z scan is cached per
     // GeoJSON object.
     if (
-      styleValue(layer.style, "elevation3dEnabled") &&
+      styleValue(layer.style, "elevation3dEnabled") === true &&
       geojsonHasZCoordinates(layer.geojson)
     ) {
       removeLayerFromMap(map, layer.id, layer);

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
+  geojsonHasZCoordinates,
   type LayerStyle,
   shouldUseTiledRendering,
   styleValue,
@@ -308,7 +309,14 @@ export function syncLayer(
     // (deckgl-viz plugin), which honors coordinate Z values that MapLibre's
     // flat 2D layers ignore. Drop any MapLibre rendering so the layer is not
     // drawn twice; toggling back off re-adds it through the paths below.
-    if (styleValue(layer.style, "elevation3dEnabled")) {
+    // Data without real Z coordinates keeps the normal 2D render even if the
+    // flag is set (e.g. a saved flag after a tool dropped the Z values), so
+    // the flag never leaves a layer invisible; the Z scan is cached per
+    // GeoJSON object.
+    if (
+      styleValue(layer.style, "elevation3dEnabled") &&
+      geojsonHasZCoordinates(layer.geojson)
+    ) {
       removeLayerFromMap(map, layer.id, layer);
       return;
     }

--- a/packages/plugins/src/plugins/deck-style-utils.ts
+++ b/packages/plugins/src/plugins/deck-style-utils.ts
@@ -16,6 +16,10 @@ export function colorToRgba(
   alpha: number,
 ): [number, number, number, number] {
   const normalized = color.trim();
+  // The Style panel's ColorField can emit the "transparent" sentinel
+  // (TRANSPARENT_COLOR in @geolibre/ui); render it invisible instead of
+  // letting it fall through to the invalid-color fallback blue.
+  if (normalized.toLowerCase() === "transparent") return [0, 0, 0, 0];
   const hex =
     normalized.length === 4 && normalized.startsWith("#")
       ? `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`

--- a/packages/plugins/src/plugins/deckgl-viz/elevation.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/elevation.ts
@@ -91,7 +91,8 @@ export function buildElevation3dLayer(
     ),
     getLineColor: colorToRgba(styleValue(style, "strokeColor"), 1),
     getLineWidth: styleValue(style, "strokeWidth"),
-    lineWidthUnits: "pixels",
+    lineWidthUnits:
+      styleValue(style, "strokeWidthUnit") === "meters" ? "meters" : "pixels",
     lineWidthMinPixels: 1,
     lineBillboard: true,
     getPointRadius: styleValue(style, "circleRadius"),

--- a/packages/plugins/src/plugins/deckgl-viz/elevation.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/elevation.ts
@@ -81,13 +81,20 @@ export function buildElevation3dLayer(
   const rawOffset = styleValue(style, "elevation3dOffset");
   const verticalScale = Number.isFinite(rawScale) ? rawScale : 1;
   const offset = Number.isFinite(rawOffset) ? rawOffset : 0;
+  const geojson = layer.geojson as FeatureCollection;
+  // GeoJsonLayer forwards getLineWidth/lineWidthUnits to the point sublayer's
+  // circle outline too, but the Style panel treats point-only layers as
+  // always pixel-stroked (its meters semantics only cover line/polygon
+  // outlines, matching the 2D MapLibre render). Force pixels for point-only
+  // data so a stale "meters" unit cannot render outlines at map scale.
+  const pointOnly = geojson.features.every(
+    (feature) =>
+      feature.geometry?.type === "Point" ||
+      feature.geometry?.type === "MultiPoint",
+  );
   return new deckGL.layers.GeoJsonLayer({
     id: layer.id,
-    data: elevationData(
-      layer.geojson as FeatureCollection,
-      verticalScale,
-      offset,
-    ),
+    data: elevationData(geojson, verticalScale, offset),
     filled: true,
     stroked: true,
     extruded: false,
@@ -98,7 +105,9 @@ export function buildElevation3dLayer(
     getLineColor: colorToRgba(styleValue(style, "strokeColor"), 1),
     getLineWidth: styleValue(style, "strokeWidth"),
     lineWidthUnits:
-      styleValue(style, "strokeWidthUnit") === "meters" ? "meters" : "pixels",
+      !pointOnly && styleValue(style, "strokeWidthUnit") === "meters"
+        ? "meters"
+        : "pixels",
     lineWidthMinPixels: 1,
     lineBillboard: true,
     getPointRadius: styleValue(style, "circleRadius"),

--- a/packages/plugins/src/plugins/deckgl-viz/elevation.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/elevation.ts
@@ -1,5 +1,6 @@
 import {
   type GeoLibreLayer,
+  geojsonHasZCoordinates,
   styleValue,
   transformGeojsonElevation,
 } from "@geolibre/core";
@@ -17,7 +18,10 @@ import { colorToRgba } from "../deck-style-utils";
 
 /**
  * Whether a store layer should render through the deck.gl overlay's 3D
- * elevation path instead of MapLibre's 2D layers.
+ * elevation path instead of MapLibre's 2D layers. Data without any real Z
+ * coordinates (e.g. after a processing tool dropped them) renders 2D even if
+ * the style flag is set, matching the Style panel and the map-side sync;
+ * the Z scan is cached per GeoJSON object.
  *
  * @param layer - The store layer to test.
  */
@@ -25,13 +29,16 @@ export function isElevation3dLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "geojson" &&
     !!layer.geojson &&
-    styleValue(layer.style, "elevation3dEnabled") === true
+    styleValue(layer.style, "elevation3dEnabled") === true &&
+    geojsonHasZCoordinates(layer.geojson)
   );
 }
 
 // One entry per source FeatureCollection so the coordinate rescan only runs
 // when the exaggeration/offset changes, not on every overlay rebuild (opacity
-// toggles, other layers changing, animation frames).
+// toggles, other layers changing, animation frames). The transform always
+// runs (even for the identity) so non-finite Z values are sanitized before
+// they reach WebGL.
 const elevationDataCache = new WeakMap<
   FeatureCollection,
   { verticalScale: number; offset: number; data: FeatureCollection }
@@ -42,7 +49,6 @@ function elevationData(
   verticalScale: number,
   offset: number,
 ): FeatureCollection {
-  if (verticalScale === 1 && offset === 0) return geojson;
   const cached = elevationDataCache.get(geojson);
   if (
     cached &&

--- a/packages/plugins/src/plugins/deckgl-viz/elevation.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/elevation.ts
@@ -1,0 +1,104 @@
+import {
+  type GeoLibreLayer,
+  styleValue,
+  transformGeojsonElevation,
+} from "@geolibre/core";
+import type { Layer } from "@deck.gl/core";
+import type { FeatureCollection } from "geojson";
+import type { GeoLibreDeckGL } from "../../types";
+import { colorToRgba } from "../deck-style-utils";
+
+/**
+ * 3D Z-value rendering for ordinary vector (geojson) layers. When a layer's
+ * style enables `elevation3dEnabled`, the map-side sync drops its flat
+ * MapLibre rendering and the deck.gl overlay draws it instead, so coordinate
+ * Z values (e.g. GPX track elevations) place features at their real altitude.
+ */
+
+/**
+ * Whether a store layer should render through the deck.gl overlay's 3D
+ * elevation path instead of MapLibre's 2D layers.
+ *
+ * @param layer - The store layer to test.
+ */
+export function isElevation3dLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "geojson" &&
+    !!layer.geojson &&
+    styleValue(layer.style, "elevation3dEnabled") === true
+  );
+}
+
+// One entry per source FeatureCollection so the coordinate rescan only runs
+// when the exaggeration/offset changes, not on every overlay rebuild (opacity
+// toggles, other layers changing, animation frames).
+const elevationDataCache = new WeakMap<
+  FeatureCollection,
+  { verticalScale: number; offset: number; data: FeatureCollection }
+>();
+
+function elevationData(
+  geojson: FeatureCollection,
+  verticalScale: number,
+  offset: number,
+): FeatureCollection {
+  if (verticalScale === 1 && offset === 0) return geojson;
+  const cached = elevationDataCache.get(geojson);
+  if (
+    cached &&
+    cached.verticalScale === verticalScale &&
+    cached.offset === offset
+  ) {
+    return cached.data;
+  }
+  const data = transformGeojsonElevation(geojson, verticalScale, offset);
+  elevationDataCache.set(geojson, { verticalScale, offset, data });
+  return data;
+}
+
+/**
+ * Builds the deck.gl layer that renders a Z-enabled vector layer in 3D. The
+ * layer's regular symbology (fill/stroke color, stroke width, circle radius,
+ * fill opacity) drives the deck styling so the Style panel keeps working, and
+ * lines/points are billboarded so they stay readable from tilted 3D views.
+ *
+ * @param deckGL - The host's deck.gl module bundle.
+ * @param layer - The store layer to render (must satisfy
+ *   {@link isElevation3dLayer}).
+ */
+export function buildElevation3dLayer(
+  deckGL: GeoLibreDeckGL,
+  layer: GeoLibreLayer,
+): Layer {
+  const style = layer.style;
+  const rawScale = styleValue(style, "elevation3dVerticalScale");
+  const rawOffset = styleValue(style, "elevation3dOffset");
+  const verticalScale = Number.isFinite(rawScale) ? rawScale : 1;
+  const offset = Number.isFinite(rawOffset) ? rawOffset : 0;
+  return new deckGL.layers.GeoJsonLayer({
+    id: layer.id,
+    data: elevationData(
+      layer.geojson as FeatureCollection,
+      verticalScale,
+      offset,
+    ),
+    filled: true,
+    stroked: true,
+    extruded: false,
+    getFillColor: colorToRgba(
+      styleValue(style, "fillColor"),
+      styleValue(style, "fillOpacity"),
+    ),
+    getLineColor: colorToRgba(styleValue(style, "strokeColor"), 1),
+    getLineWidth: styleValue(style, "strokeWidth"),
+    lineWidthUnits: "pixels",
+    lineWidthMinPixels: 1,
+    lineBillboard: true,
+    getPointRadius: styleValue(style, "circleRadius"),
+    pointRadiusUnits: "pixels",
+    pointRadiusMinPixels: 1,
+    pointBillboard: true,
+    opacity: layer.opacity,
+    pickable: true,
+  });
+}

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -3,6 +3,7 @@ import type { Layer } from "@deck.gl/core";
 import type { MapboxOverlay } from "@deck.gl/mapbox";
 import type { GeoLibreAppAPI, GeoLibreDeckGL } from "../../types";
 import { ensureMercatorProjection } from "../map-projection-utils";
+import { buildElevation3dLayer, isElevation3dLayer } from "./elevation";
 import {
   type DeckVizBuildContext,
   getDeckVizLayerDef,
@@ -11,10 +12,11 @@ import { deckVizRows, isDeckVizLayer, readDeckVizConfig } from "./store-layer";
 
 /**
  * Owns the single deck.gl overlay that renders every Deck.gl Layer in the
- * store. Mirrors the store-subscription pattern of the raster overlay: the
- * store is the source of truth, this module rebuilds the overlay's layer list
- * whenever the layer set, visibility, or opacity changes, and drives an
- * animation clock for animated layer types (Trips).
+ * store, plus ordinary vector layers whose style enables 3D Z-value rendering
+ * (see ./elevation.ts). Mirrors the store-subscription pattern of the raster
+ * overlay: the store is the source of truth, this module rebuilds the
+ * overlay's layer list whenever the layer set, visibility, or opacity
+ * changes, and drives an animation clock for animated layer types (Trips).
  */
 
 // Data-time units advanced per real second for animated layers.
@@ -142,12 +144,15 @@ export function deactivateDeckViz(app: GeoLibreAppAPI): void {
 function renderDeckVizLayers(): void {
   if (!overlay || !deckGL || !appRef) return;
 
-  const vizLayers = useAppStore.getState().layers.filter(isDeckVizLayer);
+  const storeLayers = useAppStore.getState().layers;
+  const vizLayers = storeLayers.filter(isDeckVizLayer);
+  const hasRenderableLayers =
+    vizLayers.length > 0 || storeLayers.some(isElevation3dLayer);
 
   // The deck.gl overlay renders in a Mercator viewport and does not align with
   // MapLibre's globe projection, so force Mercator while deck layers are shown
   // (same contract as the DuckDB deck overlay).
-  if (vizLayers.length > 0) {
+  if (hasRenderableLayers) {
     ensureMercatorProjection(appRef.getMap?.());
   }
 
@@ -155,7 +160,7 @@ function renderDeckVizLayers(): void {
   // the next animation frame so a project restore that races map init does not
   // depend on a later store change to mount.
   if (!overlayMounted) {
-    if (vizLayers.length === 0) return;
+    if (!hasRenderableLayers) return;
     // Add at top-left: MapboxOverlay's overlaid canvas is positioned `left:0`
     // to fill the map, which only aligns when its control container is the
     // left corner. The host's addControl otherwise defaults to top-right,
@@ -177,16 +182,25 @@ function renderDeckVizLayers(): void {
     .filter((entry): entry is RenderEntry => entry !== null);
 
   const currentTime = updateAnimationClock(contexts);
+  const contextById = new Map(contexts.map((entry) => [entry.id, entry]));
 
+  // Walk the store order (first-is-top) so deck-viz layers and 3D Z-value
+  // vector layers interleave exactly as the Layers panel shows them.
   const deckLayers: Layer[] = [];
-  for (const entry of contexts) {
+  for (const layer of storeLayers) {
+    if (!layer.visible) continue;
+    const entry = contextById.get(layer.id);
     try {
-      deckLayers.push(
-        entry.def.build(deckGL, entry.id, {
-          ...entry.ctx,
-          currentTime,
-        }),
-      );
+      if (entry) {
+        deckLayers.push(
+          entry.def.build(deckGL, entry.id, {
+            ...entry.ctx,
+            currentTime,
+          }),
+        );
+      } else if (isElevation3dLayer(layer)) {
+        deckLayers.push(buildElevation3dLayer(deckGL, layer));
+      }
     } catch (error) {
       console.warn("[GeoLibre] deckgl-viz: failed to build layer", error);
     }

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -365,6 +365,31 @@ describe("buildElevation3dLayer", () => {
     assert.equal(built.props.lineWidthUnits, "meters");
   });
 
+  it("forces pixel widths for point-only data even with a meters unit", () => {
+    const layer = geojsonLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        elevation3dEnabled: true,
+        strokeWidthUnit: "meters",
+      },
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [6.86, 45.83, 1035] },
+          },
+        ],
+      },
+    });
+    const built = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    assert.equal(built.props.lineWidthUnits, "pixels");
+  });
+
   it("rescales Z values when exaggeration or offset are set", () => {
     const layer = geojsonLayer({
       style: {

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -7,6 +7,7 @@ import {
   geojsonHasZCoordinates,
   transformGeojsonElevation,
 } from "../packages/core/src/index";
+import { syncLayer } from "../packages/map/src/layer-sync";
 import {
   buildElevation3dLayer,
   isElevation3dLayer,
@@ -43,6 +44,88 @@ function geojsonLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
     ...overrides,
   } as GeoLibreLayer;
 }
+
+// Stateful fake MapLibre map (mirrors point-renderer-sync.test.ts): tracks
+// sources and layers across sync passes so the tests can assert what the
+// elevation3d branch removes and what a toggle back to 2D re-adds.
+function makeMap() {
+  const sources = new Map<string, Record<string, unknown>>();
+  const layers = new Map<string, Record<string, unknown>>();
+  const map = {
+    getSource: (id: string) =>
+      sources.has(id) ? { type: "geojson", setData: () => {} } : undefined,
+    addSource: (id: string, spec: Record<string, unknown>) => {
+      sources.set(id, spec);
+    },
+    removeSource: (id: string) => {
+      sources.delete(id);
+    },
+    getLayer: (id: string) =>
+      layers.has(id) ? { id, ...layers.get(id) } : undefined,
+    addLayer: (spec: Record<string, unknown>) => {
+      layers.set(spec.id as string, spec);
+    },
+    removeLayer: (id: string) => {
+      layers.delete(id);
+    },
+    getFilter: (id: string) => layers.get(id)?.filter,
+    setFilter: () => {},
+    setPaintProperty: () => {},
+    setLayoutProperty: () => {},
+    setLayerZoomRange: () => {},
+    moveLayer: () => {},
+    getStyle: () => ({
+      layers: [...layers.values()],
+      sources: Object.fromEntries(sources),
+    }),
+    once: () => {},
+  };
+  return { map, sources, layers };
+}
+
+describe("syncLayer with elevation3dEnabled", () => {
+  it("drops the MapLibre rendering for Z-bearing data and restores it when toggled off", () => {
+    const { map, sources, layers } = makeMap();
+    const layer = geojsonLayer({});
+
+    // Baseline 2D render creates a source and at least one style layer.
+    syncLayer(map as never, layer);
+    assert.equal(sources.size, 1);
+    assert.ok(layers.size > 0);
+
+    // Enabling the 3D Z-value mode hands the layer to the deck.gl overlay,
+    // so every MapLibre source/layer for it must be removed.
+    syncLayer(
+      map as never,
+      geojsonLayer({
+        style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+      }),
+    );
+    assert.equal(sources.size, 0);
+    assert.equal(layers.size, 0);
+
+    // Toggling back to 2D re-adds the MapLibre rendering.
+    syncLayer(map as never, layer);
+    assert.equal(sources.size, 1);
+    assert.ok(layers.size > 0);
+  });
+
+  it("keeps the 2D render when the flag is set but the data has no Z values", () => {
+    const { map, sources, layers } = makeMap();
+    syncLayer(
+      map as never,
+      geojsonLayer({
+        style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+        geojson: track([
+          [6.86, 45.83],
+          [6.87, 45.84],
+        ]),
+      }),
+    );
+    assert.equal(sources.size, 1);
+    assert.ok(layers.size > 0);
+  });
+});
 
 describe("geojsonHasZCoordinates", () => {
   it("detects Z on LineString coordinates", () => {

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -118,9 +118,17 @@ describe("geojsonHasZCoordinates", () => {
 });
 
 describe("transformGeojsonElevation", () => {
-  it("returns the input unchanged for the identity transform", () => {
-    const data = track([[6.86, 45.83, 1000]]);
-    assert.equal(transformGeojsonElevation(data, 1, 0), data);
+  it("sanitizes non-finite Z even for the identity transform", () => {
+    const data = track([
+      [6.86, 45.83, 1000],
+      [6.87, 45.84, Number.NaN],
+    ]);
+    const result = transformGeojsonElevation(data, 1, 0);
+    const coordinates = (
+      result.features[0].geometry as { coordinates: number[][] }
+    ).coordinates;
+    assert.deepEqual(coordinates[0], [6.86, 45.83, 1000]);
+    assert.deepEqual(coordinates[1], [6.87, 45.84, 0]);
   });
 
   it("applies vertical scale and offset without mutating the input", () => {
@@ -171,6 +179,21 @@ describe("isElevation3dLayer", () => {
       false,
     );
   });
+
+  it("treats the flag as inert when the data carries no Z values", () => {
+    assert.equal(
+      isElevation3dLayer(
+        geojsonLayer({
+          style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+          geojson: track([
+            [6.86, 45.83],
+            [6.87, 45.84],
+          ]),
+        }),
+      ),
+      false,
+    );
+  });
 });
 
 describe("buildElevation3dLayer", () => {
@@ -212,8 +235,19 @@ describe("buildElevation3dLayer", () => {
     assert.deepEqual(built.props.getFillColor, [255, 0, 0, 128]);
     assert.equal(built.props.getLineWidth, 4);
     assert.equal(built.props.getPointRadius, 9);
-    // Identity elevation transform passes the source data straight through.
-    assert.equal(built.props.data, layer.geojson);
+    // The identity transform still sanitizes into a copy; the copy is cached
+    // so subsequent rebuilds reuse it.
+    const coordinates = (
+      (built.props.data as FeatureCollection).features[0].geometry as {
+        coordinates: number[][];
+      }
+    ).coordinates;
+    assert.deepEqual(coordinates[0], [6.86, 45.83, 1035]);
+    const rebuilt = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    assert.equal(rebuilt.props.data, built.props.data);
   });
 
   it("renders the transparent color sentinel invisible", () => {

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { FeatureCollection } from "geojson";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  geojsonHasZCoordinates,
+  transformGeojsonElevation,
+} from "../packages/core/src/index";
+import {
+  buildElevation3dLayer,
+  isElevation3dLayer,
+} from "../packages/plugins/src/plugins/deckgl-viz/elevation";
+import type { GeoLibreDeckGL } from "../packages/plugins/src/types";
+
+function track(coordinates: number[][]): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: {},
+        geometry: { type: "LineString", coordinates },
+      },
+    ],
+  };
+}
+
+function geojsonLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Track",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: track([
+      [6.86, 45.83, 1035],
+      [6.87, 45.84, 1420],
+    ]),
+    ...overrides,
+  } as GeoLibreLayer;
+}
+
+describe("geojsonHasZCoordinates", () => {
+  it("detects Z on LineString coordinates", () => {
+    assert.equal(
+      geojsonHasZCoordinates(
+        track([
+          [6.86, 45.83, 1035],
+          [6.87, 45.84, 1420],
+        ]),
+      ),
+      true,
+    );
+  });
+
+  it("detects Z on a bare Point geometry and inside GeometryCollections", () => {
+    assert.equal(
+      geojsonHasZCoordinates({ type: "Point", coordinates: [1, 2, 3] }),
+      true,
+    );
+    assert.equal(
+      geojsonHasZCoordinates({
+        type: "GeometryCollection",
+        geometries: [
+          { type: "Point", coordinates: [1, 2] },
+          {
+            type: "MultiPolygon",
+            coordinates: [
+              [
+                [
+                  [0, 0, 5],
+                  [1, 0, 5],
+                  [1, 1, 5],
+                  [0, 0, 5],
+                ],
+              ],
+            ],
+          },
+        ],
+      }),
+      true,
+    );
+  });
+
+  it("returns false for 2D data, all-zero Z, non-finite Z, and empty input", () => {
+    assert.equal(
+      geojsonHasZCoordinates(
+        track([
+          [6.86, 45.83],
+          [6.87, 45.84],
+        ]),
+      ),
+      false,
+    );
+    assert.equal(
+      geojsonHasZCoordinates(
+        track([
+          [6.86, 45.83, 0],
+          [6.87, 45.84, 0],
+        ]),
+      ),
+      false,
+    );
+    assert.equal(
+      geojsonHasZCoordinates(track([[6.86, 45.83, Number.NaN]])),
+      false,
+    );
+    assert.equal(geojsonHasZCoordinates(null), false);
+    assert.equal(
+      geojsonHasZCoordinates({ type: "FeatureCollection", features: [] }),
+      false,
+    );
+  });
+});
+
+describe("transformGeojsonElevation", () => {
+  it("returns the input unchanged for the identity transform", () => {
+    const data = track([[6.86, 45.83, 1000]]);
+    assert.equal(transformGeojsonElevation(data, 1, 0), data);
+  });
+
+  it("applies vertical scale and offset without mutating the input", () => {
+    const data = track([
+      [6.86, 45.83, 1000],
+      [6.87, 45.84],
+    ]);
+    const result = transformGeojsonElevation(data, 2, 50);
+    const coordinates = (
+      result.features[0].geometry as { coordinates: number[][] }
+    ).coordinates;
+    assert.deepEqual(coordinates[0], [6.86, 45.83, 2050]);
+    // A missing Z is treated as 0 so the offset still lifts the vertex.
+    assert.deepEqual(coordinates[1], [6.87, 45.84, 50]);
+    const original = (
+      data.features[0].geometry as { coordinates: number[][] }
+    ).coordinates;
+    assert.deepEqual(original[0], [6.86, 45.83, 1000]);
+  });
+});
+
+describe("isElevation3dLayer", () => {
+  it("matches geojson layers with the style flag enabled", () => {
+    const layer = geojsonLayer({
+      style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+    });
+    assert.equal(isElevation3dLayer(layer), true);
+  });
+
+  it("rejects layers without the flag, without data, or of other types", () => {
+    assert.equal(isElevation3dLayer(geojsonLayer({})), false);
+    assert.equal(
+      isElevation3dLayer(
+        geojsonLayer({
+          style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+          geojson: undefined,
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      isElevation3dLayer(
+        geojsonLayer({
+          type: "raster",
+          style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+        }),
+      ),
+      false,
+    );
+  });
+});
+
+describe("buildElevation3dLayer", () => {
+  class FakeGeoJsonLayer {
+    props: Record<string, unknown>;
+
+    constructor(props: Record<string, unknown>) {
+      this.props = props;
+    }
+  }
+
+  const fakeDeckGL = {
+    layers: { GeoJsonLayer: FakeGeoJsonLayer },
+  } as unknown as GeoLibreDeckGL;
+
+  it("maps the layer style onto billboarded deck.gl props", () => {
+    const layer = geojsonLayer({
+      opacity: 0.5,
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        elevation3dEnabled: true,
+        fillColor: "#ff0000",
+        strokeColor: "#00ff00",
+        strokeWidth: 4,
+        circleRadius: 9,
+        fillOpacity: 0.5,
+      },
+    });
+    const built = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    assert.equal(built.props.id, "layer-1");
+    assert.equal(built.props.opacity, 0.5);
+    assert.equal(built.props.lineBillboard, true);
+    assert.equal(built.props.pointBillboard, true);
+    assert.equal(built.props.extruded, false);
+    assert.deepEqual(built.props.getLineColor, [0, 255, 0, 255]);
+    assert.deepEqual(built.props.getFillColor, [255, 0, 0, 128]);
+    assert.equal(built.props.getLineWidth, 4);
+    assert.equal(built.props.getPointRadius, 9);
+    // Identity elevation transform passes the source data straight through.
+    assert.equal(built.props.data, layer.geojson);
+  });
+
+  it("rescales Z values when exaggeration or offset are set", () => {
+    const layer = geojsonLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        elevation3dEnabled: true,
+        elevation3dVerticalScale: 3,
+        elevation3dOffset: 100,
+      },
+    });
+    const built = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    const data = built.props.data as FeatureCollection;
+    const coordinates = (
+      data.features[0].geometry as { coordinates: number[][] }
+    ).coordinates;
+    assert.deepEqual(coordinates[0], [6.86, 45.83, 3205]);
+    assert.deepEqual(coordinates[1], [6.87, 45.84, 4360]);
+
+    // The rescan is cached per source collection and transform.
+    const rebuilt = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    assert.equal(rebuilt.props.data, data);
+  });
+});

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -216,6 +216,21 @@ describe("buildElevation3dLayer", () => {
     assert.equal(built.props.data, layer.geojson);
   });
 
+  it("honors a meter-based stroke width unit", () => {
+    const layer = geojsonLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        elevation3dEnabled: true,
+        strokeWidthUnit: "meters",
+      },
+    });
+    const built = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    assert.equal(built.props.lineWidthUnits, "meters");
+  });
+
   it("rescales Z values when exaggeration or offset are set", () => {
     const layer = geojsonLayer({
       style: {

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -216,6 +216,23 @@ describe("buildElevation3dLayer", () => {
     assert.equal(built.props.data, layer.geojson);
   });
 
+  it("renders the transparent color sentinel invisible", () => {
+    const layer = geojsonLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        elevation3dEnabled: true,
+        fillColor: "transparent",
+        strokeColor: "transparent",
+      },
+    });
+    const built = buildElevation3dLayer(
+      fakeDeckGL,
+      layer,
+    ) as unknown as FakeGeoJsonLayer;
+    assert.deepEqual(built.props.getFillColor, [0, 0, 0, 0]);
+    assert.deepEqual(built.props.getLineColor, [0, 0, 0, 0]);
+  });
+
   it("honors a meter-based stroke width unit", () => {
     const layer = geojsonLayer({
       style: {


### PR DESCRIPTION
## Summary

Fixes #1122

Vector layers whose coordinates carry Z values (e.g. GPX tracks with `<ele>` elevations, which the GPX parser already preserves as LineStringZ/PointZ) previously rendered flat at altitude 0 because MapLibre's 2D style layers ignore the third coordinate.

This PR adds a third **3D (Z values)** option to the Style panel's Visualization chooser, alongside the existing 2D and 3D extrusion modes. The option only appears when the layer's data actually contains non-zero Z coordinates.

## How it works

- **`@geolibre/core`**: new `LayerStyle` fields `elevation3dEnabled`, `elevation3dVerticalScale`, and `elevation3dOffset`, plus `geojsonHasZCoordinates` / `transformGeojsonElevation` helpers. The fields persist through the existing `.geolibre.json` style round-trip for free.
- **`@geolibre/map`**: `syncLayer` removes the flat MapLibre rendering while the mode is on so the layer is not drawn twice; toggling back to 2D re-adds it through the normal paths.
- **`@geolibre/plugins`**: the shared deck.gl overlay (deckgl-viz plugin, active by default) now also renders these layers as a billboarded `GeoJsonLayer`, which honors coordinate Z, interleaved with deck-viz layers in store order. Fill/stroke colors, stroke width, circle radius, and opacity come from the regular layer style, so the Style panel keeps working and changes apply live.
- **Style panel**: when the mode is active it shows only the knobs the 3D render honors (colors, widths, circle radius) plus **Vertical exaggeration** and **Altitude offset (m)** controls; 2D-only sections (data-driven symbology, point renderers, patterns, markers, labels) are hidden. New strings are translatable via `en.json`.

## Testing

- New `tests/elevation-3d.test.ts` (9 tests): Z detection across geometry types, elevation transform (scale/offset, immutability, caching), layer matching, and deck prop mapping.
- Full frontend suite: 2078 pass, 0 fail. `npm run build` clean.
- Verified in the running app with Playwright using a GPX hiking track (60 trackpoints, 1050 m to 2366 m, plus 2 waypoints): flat baseline reproduced, then with 3D (Z values) enabled the track and waypoints render at their real altitude in a tilted view, vertical exaggeration updates live, and switching back to 2D restores the MapLibre rendering. Checked in both light and dark themes; no new console errors.

## Notes

- Draping arbitrary 2D vectors onto terrain/3D tiles (the issue's second bullet) is left as a follow-up; this PR covers the primary use case of visualizing data that carries its own Z values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **3D (Z values)** mode for GeoJSON layers that only activates when real Z coordinates are present (otherwise falls back to 2D).
  * Added **vertical exaggeration** and **altitude offset** controls with live deck.gl 3D updates.
  * Updated the style UI to show elevation-specific options and hide incompatible controls during 3D elevation mode.
* **Bug Fixes**
  * Prevented elevation 3D layers from rendering twice.
  * Improved handling of the **“transparent”** color value in styling.
* **Tests**
  * Added tests for Z detection, elevation transforms, and elevation 3D deck.gl layer building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->