### PR TITLE
feat(basemaps): expand EOX Maps layers (annual s2cloudless + overlay/terrain)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -60,7 +60,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
-    "maplibre-gl-basemap-control": "^0.10.0",
+    "maplibre-gl-basemap-control": "^0.11.0",
     "maplibre-gl-components": "^0.25.4",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
-        "maplibre-gl-basemap-control": "^0.10.0",
+        "maplibre-gl-basemap-control": "^0.11.0",
         "maplibre-gl-components": "^0.25.4",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -16020,9 +16020,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.10.0.tgz",
-      "integrity": "sha512-feTSjYTOZd/touyOTz6VYHUvk2La2WhPTARBOfspv45LoJ6F9DmK7mqITMwVqfv1kDqH8mOBUSYOUFezcSms0Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.11.0.tgz",
+      "integrity": "sha512-rh6wdLRQbZFY/IPN802AYwsOSVBMtpCA00P0bGZ7ur3Lqi0sGOU8/S6sCax4kyB1rIoLTeVXlvulLYDnPB+y/w==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -21078,7 +21078,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
-        "maplibre-gl-basemap-control": "^0.10.0",
+        "maplibre-gl-basemap-control": "^0.11.0",
         "maplibre-gl-components": "^0.25.4",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -34,7 +34,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
-    "maplibre-gl-basemap-control": "^0.10.0",
+    "maplibre-gl-basemap-control": "^0.11.0",
     "maplibre-gl-components": "^0.25.4",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",


### PR DESCRIPTION
## Summary

Bumps `maplibre-gl-basemap-control` **0.10.0 → 0.11.0**, which expands the EOX Maps provider from **2 basemaps to 12**:

- **Annual Sentinel-2 cloudless mosaics** — `eox-s2cloudless-2018` … `eox-s2cloudless-2025` (previously only 2025 was available).
- **`eox-terrain`** — natural-like terrain basemap.
- **`eox-overlay`** / **`eox-overlay-bright`** — transparent reference overlays with borders and points of interest.

These appear automatically in the Basemaps panel under the EOX provider — no GeoLibre code changes required. The existing `eox-s2cloudless-2025` and `eox-terrain-light` ids are unchanged, so saved projects referencing them keep working.

Upstream: opengeos/maplibre-gl-basemap-control#26 (released as [v0.11.0](https://www.npmjs.com/package/maplibre-gl-basemap-control/v/0.11.0)).

## Notes

- No CSP change needed — EOX tiles are served over `https:`, already covered by `img-src ... https:`.

## Verification

- `npm install` resolves `maplibre-gl-basemap-control@0.11.0` in both `packages/plugins` and `apps/geolibre-desktop`.
- `npm run build` → succeeds.
- Confirmed the installed catalog exposes all 12 EOX basemaps (8 annual s2cloudless + terrain-light + terrain + overlay + overlay-bright).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the basemap control component to a newer version across the desktop app and plugin packages.
  * Users may notice improved compatibility and continued support for map basemap controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->