### PR TITLE
fix(vector): load macOS-zipped and 3D MultiPatch shapefiles in the vector panel

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -79,7 +79,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.8.5",
+    "maplibre-gl-vector": "^0.9.0",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.8.5",
+        "maplibre-gl-vector": "^0.9.0",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -16629,9 +16629,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.5.tgz",
-      "integrity": "sha512-bf0Ic4inn5Q3xi8OWaCZ0E5hulUDDPrjV757uPJq2Ye9IYT8BqQ0mwFadFZqrxE/ld+dInP7WLwdiierYYLo8A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.9.0.tgz",
+      "integrity": "sha512-VIDBIKu9CwDnAj7wbhnwmbN7okPtGEfkShufEthfibkFUH0dpQPBUdue6FHentjDZkvMpJ2oL8XM4VVIHQF7Rw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21098,7 +21098,7 @@
         "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.8.5",
+        "maplibre-gl-vector": "^0.9.0",
         "netcdfjs": "^4.0.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -54,7 +54,7 @@
     "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.8.5",
+    "maplibre-gl-vector": "^0.9.0",
     "netcdfjs": "^4.0.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",


### PR DESCRIPTION
## Problem

The **Add Vector Layer** panel failed on two shapefile cases:

1. A zipped shapefile created by macOS Finder failed with:
   ```
   IO Error: GDAL Error (4): `t_vector_<id>.shp' not recognized as a supported file format.
   ```
   The panel picked the `__MACOSX/._<name>.shp` AppleDouble resource fork (a few hundred bytes) instead of the real `.shp`.

2. A 3D building (ESRI **MultiPatch**) shapefile failed with:
   ```
   Could not parse WKB input: WKB type 'TIN Z' is not supported! (type id: 1016, SRID: 0)
   ```
   The panel's DuckDB engine could not parse the TIN / PolyhedralSurface geometry.

(Both bugs live in the upstream `maplibre-gl-vector` package, which powers the panel and runs its own DuckDB engine. Drag-and-drop uses GeoLibre's own loader and was unaffected.)

## Fix

Bump `maplibre-gl-vector` to **0.9.0**, which:
- ignores macOS `__MACOSX` / AppleDouble entries when locating the `.shp` in a zip (opengeos/maplibre-gl-vector#38), and
- decodes TIN / Triangle / PolyhedralSurface surfaces to MultiPolygons and reprojects them to WGS84 (opengeos/maplibre-gl-vector#39).

## Verification

Drove the Add Vector Layer panel with Playwright using the reported dataset (a macOS-zipped 16k-feature 3D building shapefile): it now loads and renders as building footprints over Cambridge, MA, correctly reprojected from the custom NAD83 Massachusetts `.prj`. Confirmed in both **light and dark** themes. `npm run build` and pre-commit pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the map rendering library used by the desktop app and plugins to a newer version, which may improve map compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->