### PR TITLE
feat(kml): render KML/KMZ Collada (.dae) 3D models

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1031,10 +1031,14 @@ export function DesktopShell({
         if (importedLayer.type === "deckgl-viz") {
           const layerId = importedLayer.id;
           requestAnimationFrame(() => {
-            const current = useAppStore
-              .getState()
-              .layers.find((layer) => layer.id === layerId);
-            if (current) mapControllerRef.current?.fitLayer(current);
+            requestAnimationFrame(() => {
+              window.setTimeout(() => {
+                const current = useAppStore
+                  .getState()
+                  .layers.find((layer) => layer.id === layerId);
+                if (current) mapControllerRef.current?.fitLayer(current);
+              }, 50);
+            });
           });
         } else {
           mapControllerRef.current?.fitLayer(importedLayer);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1023,7 +1023,23 @@ export function DesktopShell({
       const importedLayer = useAppStore
         .getState()
         .layers.find((layer) => layer.id === lastLayerId);
-      if (importedLayer) mapControllerRef.current?.fitLayer(importedLayer);
+      if (importedLayer) {
+        // A deck.gl-backed layer (e.g. a KML <Model> scenegraph) mounts its
+        // overlay on the next render; fitting synchronously here races that
+        // mount and the camera move is lost. Defer the fit past the mount so
+        // it frames the model. MapLibre-native layers fit synchronously.
+        if (importedLayer.type === "deckgl-viz") {
+          const layerId = importedLayer.id;
+          requestAnimationFrame(() => {
+            const current = useAppStore
+              .getState()
+              .layers.find((layer) => layer.id === layerId);
+            if (current) mapControllerRef.current?.fitLayer(current);
+          });
+        } else {
+          mapControllerRef.current?.fitLayer(importedLayer);
+        }
+      }
     },
     [addGeoJsonLayer, addImageOverlayLayer, addLayer],
   );

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -50,10 +50,12 @@ import {
   loadDroppedRasterFiles,
   loadDroppedRasterPaths,
   isLoadedImageOverlay,
+  isLoadedModel,
   loadDroppedVectorFiles,
   loadDroppedVectorPaths,
   type DroppedRaster,
 } from "../../lib/tauri-io";
+import { buildKmlModelLayer } from "../../lib/kml-model-layer";
 import {
   isPhotoDropFileName,
   type GeotaggedPhotoResult,
@@ -475,6 +477,7 @@ export function DesktopShell({
   const togglingGeometryEditRef = useRef(false);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const addImageOverlayLayer = useAppStore((s) => s.addImageOverlayLayer);
+  const addLayer = useAppStore((s) => s.addLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const pythonConsoleOpen = useAppStore((s) => s.ui.pythonConsoleOpen);
   const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
@@ -1001,6 +1004,13 @@ export function DesktopShell({
           );
           continue;
         }
+        // A KML/KMZ <Model> becomes a deck.gl scenegraph layer.
+        if (isLoadedModel(layer)) {
+          const modelLayer = buildKmlModelLayer(layer);
+          addLayer(modelLayer);
+          lastLayerId = modelLayer.id;
+          continue;
+        }
         // `||` (not `??`) so an empty-string name falls back to the path, and
         // matches the name shown in the drop confirmation toast.
         lastLayerId = addGeoJsonLayer(
@@ -1015,7 +1025,7 @@ export function DesktopShell({
         .layers.find((layer) => layer.id === lastLayerId);
       if (importedLayer) mapControllerRef.current?.fitLayer(importedLayer);
     },
-    [addGeoJsonLayer, addImageOverlayLayer],
+    [addGeoJsonLayer, addImageOverlayLayer, addLayer],
   );
 
   const addDroppedPhotos = useCallback(

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -793,7 +793,7 @@ body,
 }
 
 #deckgl-overlay {
-  z-index: 1;
+  z-index: 5;
 }
 
 /*

--- a/apps/geolibre-desktop/src/lib/collada-to-glb.ts
+++ b/apps/geolibre-desktop/src/lib/collada-to-glb.ts
@@ -1,0 +1,98 @@
+import { LoadingManager, Mesh } from "three";
+import { ColladaLoader } from "three/addons/loaders/ColladaLoader.js";
+import { GLTFExporter } from "three/addons/exporters/GLTFExporter.js";
+
+/**
+ * Convert COLLADA (`.dae`) text into a binary glTF (GLB) so a KML `<Model>` can
+ * be rendered by the existing glTF scenegraph layer instead of needing a
+ * dedicated COLLADA renderer.
+ *
+ * Texture references inside the DAE are resolved through `resolveTexture` (for a
+ * KMZ, this maps a packaged image's relative path to a blob URL of the archive
+ * entry). Textures load asynchronously, so the conversion waits for the loading
+ * manager to settle (bounded by `textureTimeoutMs`) before exporting; an
+ * unresolved or slow texture yields an untextured model rather than aborting.
+ *
+ * @param daeText - The raw COLLADA XML text.
+ * @param resolveTexture - Maps a texture URL/path referenced by the DAE to a
+ *   loadable URL (e.g. an archive blob URL), or returns undefined to leave it
+ *   unchanged.
+ * @param basePath - Base URL/path COLLADA texture references resolve against
+ *   (the `.dae`'s directory); leave empty when `resolveTexture` maps raw paths.
+ * @param textureTimeoutMs - Maximum time to wait for textures to load.
+ * @returns The model encoded as GLB bytes.
+ */
+export async function convertDaeToGlb(
+  daeText: string,
+  resolveTexture?: (url: string) => string | undefined,
+  basePath = "",
+  textureTimeoutMs = 8000,
+): Promise<Uint8Array> {
+  const manager = new LoadingManager();
+  if (resolveTexture) {
+    manager.setURLModifier((url) => resolveTexture(url) ?? url);
+  }
+
+  const loader = new ColladaLoader(manager);
+  // ColladaLoader.parse is synchronous for geometry but kicks off async texture
+  // loads through the manager; the scene is returned immediately.
+  const collada = loader.parse(daeText, basePath);
+
+  // Some COLLADA meshes ship without vertex normals, which makes lit PBR
+  // shading fall back to flat geometric normals (luma.gl warns); compute them
+  // so the exported model shades correctly.
+  collada.scene.traverse((object) => {
+    if (object instanceof Mesh && !object.geometry.getAttribute("normal")) {
+      object.geometry.computeVertexNormals();
+    }
+  });
+
+  await waitForManager(manager, textureTimeoutMs);
+
+  const exporter = new GLTFExporter();
+  const glb = await new Promise<ArrayBuffer>((resolve, reject) => {
+    exporter.parse(
+      collada.scene,
+      (result) => {
+        if (result instanceof ArrayBuffer) resolve(result);
+        else reject(new Error("GLTFExporter did not return binary GLB output."));
+      },
+      (error) => reject(error),
+      { binary: true },
+    );
+  });
+  return new Uint8Array(glb);
+}
+
+/**
+ * Resolve once the loading manager reports all in-flight loads finished, or when
+ * `timeoutMs` elapses (so a missing/hanging texture never blocks the model).
+ * `ColladaLoader.parse` starts any texture loads synchronously, so if nothing
+ * has started shortly after parse there are no textures and this resolves right
+ * away instead of waiting out the timeout.
+ */
+function waitForManager(
+  manager: LoadingManager,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve) => {
+    let started = false;
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    manager.onStart = () => {
+      started = true;
+    };
+    manager.onLoad = finish;
+    timer = setTimeout(finish, timeoutMs);
+    // No texture load kicked off during parse -> untextured model, resolve now.
+    setTimeout(() => {
+      if (!started) finish();
+    }, 50);
+  });
+}

--- a/apps/geolibre-desktop/src/lib/collada-to-glb.ts
+++ b/apps/geolibre-desktop/src/lib/collada-to-glb.ts
@@ -1,6 +1,8 @@
-import { Box3, LoadingManager, Mesh, Vector3 } from "three";
+import { Box3, LoadingManager, Mesh, Object3D, Vector3 } from "three";
 import { ColladaLoader } from "three/addons/loaders/ColladaLoader.js";
 import { GLTFExporter } from "three/addons/exporters/GLTFExporter.js";
+
+const LARGE_MODEL_HORIZONTAL_SPAN_METERS = 1000;
 
 /** The result of converting a COLLADA `.dae` to a GLB. */
 export interface ConvertedModel {
@@ -15,6 +17,10 @@ export interface ConvertedModel {
    * anchor. `0` when the scene is empty.
    */
   radiusMeters: number;
+  /** Minimum model-space up-axis coordinate after COLLADA unit/up-axis handling. */
+  verticalMinMeters: number;
+  /** Maximum model-space up-axis coordinate after COLLADA unit/up-axis handling. */
+  verticalMaxMeters: number;
 }
 
 // The largest distance from the origin (0,0,0) to any of the 8 corners of a
@@ -32,6 +38,41 @@ function radiusFromOrigin(box: Box3): number {
     }
   }
   return max;
+}
+
+function horizontalSpan(box: Box3): number {
+  if (box.isEmpty()) return 0;
+  return Math.max(box.max.x - box.min.x, box.max.z - box.min.z);
+}
+
+function recenterAuthoredHorizontalGeometry(scene: Object3D): void {
+  const authoredBox = new Box3();
+  const visited = new Set<string>();
+  scene.traverse((object) => {
+    if (!(object instanceof Mesh)) return;
+    const geometry = object.geometry;
+    const position = geometry.getAttribute("position");
+    if (!position) return;
+    const key = geometry.uuid;
+    if (visited.has(key)) return;
+    visited.add(key);
+    const geometryBox =
+      geometry.boundingBox ?? new Box3().setFromBufferAttribute(position);
+    authoredBox.union(geometryBox);
+  });
+  if (authoredBox.isEmpty()) return;
+
+  const centerX = (authoredBox.min.x + authoredBox.max.x) / 2;
+  const centerY = (authoredBox.min.y + authoredBox.max.y) / 2;
+  visited.clear();
+  scene.traverse((object) => {
+    if (!(object instanceof Mesh)) return;
+    const geometry = object.geometry;
+    const key = geometry.uuid;
+    if (visited.has(key)) return;
+    visited.add(key);
+    geometry.translate(-centerX, -centerY, 0);
+  });
 }
 
 /**
@@ -97,7 +138,21 @@ export async function convertDaeToGlb(
   // Measure the model (world-space, so the DAE's <unit> scale and Z-up→Y-up
   // conversion are already baked in) before exporting, so the caller can frame
   // the whole thing.
-  const radiusMeters = radiusFromOrigin(new Box3().setFromObject(collada.scene));
+  const sourceBox = new Box3().setFromObject(collada.scene);
+  if (horizontalSpan(sourceBox) >= LARGE_MODEL_HORIZONTAL_SPAN_METERS) {
+    // SketchUp/KMZ geological sections and terrain slabs often carry large
+    // local east/north offsets, leaving the visual mesh kilometers away from
+    // the KML <Location>. Recenter the authored vertices for large horizontal
+    // models; building-scale assets keep their authored origin.
+    recenterAuthoredHorizontalGeometry(collada.scene);
+  }
+  const box = new Box3().setFromObject(collada.scene);
+  const radiusMeters = radiusFromOrigin(box);
+  // ColladaLoader normalizes Z_UP assets to glTF's Y-up frame before export.
+  // That Y axis becomes deck.gl's vertical axis after ScenegraphLayer's
+  // standard glTF roll, so carry it for KML vertical anchoring.
+  const verticalMinMeters = box.isEmpty() ? 0 : box.min.y;
+  const verticalMaxMeters = box.isEmpty() ? 0 : box.max.y;
 
   // Wait for textures only when a load actually started during parse; otherwise
   // there are none and there is nothing to wait for. A missing/hanging texture
@@ -121,5 +176,10 @@ export async function convertDaeToGlb(
       { binary: true },
     );
   });
-  return { glb: new Uint8Array(glb), radiusMeters };
+  return {
+    glb: new Uint8Array(glb),
+    radiusMeters,
+    verticalMinMeters,
+    verticalMaxMeters,
+  };
 }

--- a/apps/geolibre-desktop/src/lib/collada-to-glb.ts
+++ b/apps/geolibre-desktop/src/lib/collada-to-glb.ts
@@ -1,6 +1,38 @@
-import { LoadingManager, Mesh } from "three";
+import { Box3, LoadingManager, Mesh, Vector3 } from "three";
 import { ColladaLoader } from "three/addons/loaders/ColladaLoader.js";
 import { GLTFExporter } from "three/addons/exporters/GLTFExporter.js";
+
+/** The result of converting a COLLADA `.dae` to a GLB. */
+export interface ConvertedModel {
+  /** The model encoded as binary glTF (GLB) bytes. */
+  glb: Uint8Array;
+  /**
+   * The model's extent as the maximum distance (in meters, after the DAE's
+   * `<unit>` scale) from its origin — the point a KML `<Location>` anchors to —
+   * to any corner of its bounding box. A KML/SketchUp model's origin is often a
+   * corner rather than the center and the mesh can span kilometers, so callers
+   * use this to frame the whole model instead of zooming to a tiny box at the
+   * anchor. `0` when the scene is empty.
+   */
+  radiusMeters: number;
+}
+
+// The largest distance from the origin (0,0,0) to any of the 8 corners of a
+// bounding box. Rotation-invariant, so it bounds the model's horizontal footprint
+// under any `<Orientation>`/deck.gl transform, which is what framing needs.
+function radiusFromOrigin(box: Box3): number {
+  if (box.isEmpty()) return 0;
+  const corner = new Vector3();
+  let max = 0;
+  for (const x of [box.min.x, box.max.x]) {
+    for (const y of [box.min.y, box.max.y]) {
+      for (const z of [box.min.z, box.max.z]) {
+        max = Math.max(max, corner.set(x, y, z).length());
+      }
+    }
+  }
+  return max;
+}
 
 /**
  * Convert COLLADA (`.dae`) text into a binary glTF (GLB) so a KML `<Model>` can
@@ -20,14 +52,14 @@ import { GLTFExporter } from "three/addons/exporters/GLTFExporter.js";
  * @param basePath - Base URL/path COLLADA texture references resolve against
  *   (the `.dae`'s directory); leave empty when `resolveTexture` maps raw paths.
  * @param textureTimeoutMs - Maximum time to wait for textures to load.
- * @returns The model encoded as GLB bytes.
+ * @returns The model's GLB bytes and its extent (see {@link ConvertedModel}).
  */
 export async function convertDaeToGlb(
   daeText: string,
   resolveTexture?: (url: string) => string | undefined,
   basePath = "",
   textureTimeoutMs = 8000,
-): Promise<Uint8Array> {
+): Promise<ConvertedModel> {
   const manager = new LoadingManager();
   if (resolveTexture) {
     manager.setURLModifier((url) => resolveTexture(url) ?? url);
@@ -62,6 +94,11 @@ export async function convertDaeToGlb(
     }
   });
 
+  // Measure the model (world-space, so the DAE's <unit> scale and Z-up→Y-up
+  // conversion are already baked in) before exporting, so the caller can frame
+  // the whole thing.
+  const radiusMeters = radiusFromOrigin(new Box3().setFromObject(collada.scene));
+
   // Wait for textures only when a load actually started during parse; otherwise
   // there are none and there is nothing to wait for. A missing/hanging texture
   // never blocks the model past `textureTimeoutMs` (yielding an untextured one).
@@ -84,5 +121,5 @@ export async function convertDaeToGlb(
       { binary: true },
     );
   });
-  return new Uint8Array(glb);
+  return { glb: new Uint8Array(glb), radiusMeters };
 }

--- a/apps/geolibre-desktop/src/lib/collada-to-glb.ts
+++ b/apps/geolibre-desktop/src/lib/collada-to-glb.ts
@@ -33,9 +33,24 @@ export async function convertDaeToGlb(
     manager.setURLModifier((url) => resolveTexture(url) ?? url);
   }
 
+  // Wire the manager's start/done handlers BEFORE parsing: `ColladaLoader.parse`
+  // starts texture loads synchronously, so `onStart` must already be attached to
+  // observe them, and `onLoad` must be attached to catch completion.
+  let started = false;
+  let loaded = false;
+  manager.onStart = () => {
+    started = true;
+  };
+  const texturesLoaded = new Promise<void>((resolve) => {
+    manager.onLoad = () => {
+      loaded = true;
+      resolve();
+    };
+  });
+
   const loader = new ColladaLoader(manager);
-  // ColladaLoader.parse is synchronous for geometry but kicks off async texture
-  // loads through the manager; the scene is returned immediately.
+  // Geometry is returned synchronously; textures load asynchronously through the
+  // manager wired above.
   const collada = loader.parse(daeText, basePath);
 
   // Some COLLADA meshes ship without vertex normals, which makes lit PBR
@@ -47,7 +62,15 @@ export async function convertDaeToGlb(
     }
   });
 
-  await waitForManager(manager, textureTimeoutMs);
+  // Wait for textures only when a load actually started during parse; otherwise
+  // there are none and there is nothing to wait for. A missing/hanging texture
+  // never blocks the model past `textureTimeoutMs` (yielding an untextured one).
+  if (started && !loaded) {
+    await Promise.race([
+      texturesLoaded,
+      new Promise<void>((resolve) => setTimeout(resolve, textureTimeoutMs)),
+    ]);
+  }
 
   const exporter = new GLTFExporter();
   const glb = await new Promise<ArrayBuffer>((resolve, reject) => {
@@ -62,37 +85,4 @@ export async function convertDaeToGlb(
     );
   });
   return new Uint8Array(glb);
-}
-
-/**
- * Resolve once the loading manager reports all in-flight loads finished, or when
- * `timeoutMs` elapses (so a missing/hanging texture never blocks the model).
- * `ColladaLoader.parse` starts any texture loads synchronously, so if nothing
- * has started shortly after parse there are no textures and this resolves right
- * away instead of waiting out the timeout.
- */
-function waitForManager(
-  manager: LoadingManager,
-  timeoutMs: number,
-): Promise<void> {
-  return new Promise((resolve) => {
-    let started = false;
-    let settled = false;
-    let timer: ReturnType<typeof setTimeout>;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve();
-    };
-    manager.onStart = () => {
-      started = true;
-    };
-    manager.onLoad = finish;
-    timer = setTimeout(finish, timeoutMs);
-    // No texture load kicked off during parse -> untextured model, resolve now.
-    setTimeout(() => {
-      if (!started) finish();
-    }, 50);
-  });
 }

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
@@ -57,6 +57,14 @@ export interface DuckDbVectorLoadOptions {
    * falls back to the file's own CRS.
    */
   overrideSourceCrs?: string;
+  /**
+   * Skip the KML/KMZ `<Model>` (COLLADA→GLB) conversion, returning only the
+   * vector features. Set by callers that discard models anyway — e.g. re-reading
+   * a referenced (not embedded) local layer's features on project reopen — so
+   * they don't pay for the expensive conversion (or a remote-mesh fetch) they
+   * never use.
+   */
+  skipModels?: boolean;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/kml-model-layer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model-layer.ts
@@ -1,0 +1,50 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import {
+  DEFAULT_DECK_VIZ_STYLE,
+  createDeckVizStoreLayer,
+  type DeckVizConfig,
+} from "@geolibre/plugins";
+import { kmlModelBounds, kmlModelName, kmlModelRow } from "./kml-model";
+import type { LoadedModel } from "./tauri-io";
+
+/**
+ * Build the store layer for a KML `<Model>` 3D model: a deck.gl scenegraph
+ * layer that renders the model's (self-contained) GLB at its geographic
+ * location. Reuses the existing glTF scenegraph path, so the deck.gl overlay
+ * (active by default) renders it with no extra wiring.
+ *
+ * The DAE-derived GLB is in meters, so `sizeScale` is 1 (true size) and the
+ * KML `<Scale>` becomes the per-model scale factor. Heading is applied as the
+ * model bearing; `<Orientation>` tilt/roll are not yet applied (the scenegraph
+ * layer only exposes a single bearing).
+ *
+ * @param model - A resolved KML model descriptor.
+ * @returns The corresponding GeoLibre store layer.
+ */
+export function buildKmlModelLayer(model: LoadedModel): GeoLibreLayer {
+  const config: DeckVizConfig = {
+    layerKind: "scenegraph",
+    format: "csv-rows",
+    fieldMapping: {
+      lng: "lng",
+      lat: "lat",
+      altitude: "altitude",
+      bearing: "bearing",
+      scale: "scale",
+    },
+    style: DEFAULT_DECK_VIZ_STYLE,
+    scenegraph: {
+      modelUrl: model.url,
+      sizeScale: 1,
+      bearing: 0,
+      altitude: 0,
+    },
+  };
+  return createDeckVizStoreLayer({
+    name: kmlModelName(model),
+    config,
+    rows: [kmlModelRow(model)],
+    sourcePath: model.path,
+    bounds: kmlModelBounds(model),
+  });
+}

--- a/apps/geolibre-desktop/src/lib/kml-model-layer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model-layer.ts
@@ -4,7 +4,12 @@ import {
   createDeckVizStoreLayer,
   type DeckVizConfig,
 } from "@geolibre/plugins";
-import { kmlModelBounds, kmlModelDisplayName, kmlModelRow } from "./kml-model";
+import {
+  kmlModelBounds,
+  kmlModelDisplayName,
+  kmlModelRow,
+  kmlModelTranslation,
+} from "./kml-model";
 import type { LoadedModel } from "./tauri-io";
 
 /**
@@ -36,7 +41,9 @@ export function buildKmlModelLayer(model: LoadedModel): GeoLibreLayer {
     scenegraph: {
       modelUrl: model.url,
       sizeScale: 1,
+      sizeMinPixels: 0,
       bearing: 0,
+      translation: kmlModelTranslation(model),
       altitude: 0,
     },
   };

--- a/apps/geolibre-desktop/src/lib/kml-model-layer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model-layer.ts
@@ -4,7 +4,7 @@ import {
   createDeckVizStoreLayer,
   type DeckVizConfig,
 } from "@geolibre/plugins";
-import { kmlModelBounds, kmlModelName, kmlModelRow } from "./kml-model";
+import { kmlModelBounds, kmlModelDisplayName, kmlModelRow } from "./kml-model";
 import type { LoadedModel } from "./tauri-io";
 
 /**
@@ -41,7 +41,7 @@ export function buildKmlModelLayer(model: LoadedModel): GeoLibreLayer {
     },
   };
   return createDeckVizStoreLayer({
-    name: kmlModelName(model),
+    name: kmlModelDisplayName(model),
     config,
     rows: [kmlModelRow(model)],
     sourcePath: model.path,

--- a/apps/geolibre-desktop/src/lib/kml-model.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model.ts
@@ -90,8 +90,16 @@ export function kmlModelBounds(
   ];
 }
 
-/** The display name for a model layer, falling back to a path-derived name. */
-export function kmlModelName(model: LoadedModel): string {
+/**
+ * The display name for a model layer, falling back to a path-derived name.
+ *
+ * By the time a {@link LoadedModel} reaches here its `name` was already
+ * resolved to a non-empty string upstream (`kmlModelName` in `tauri-io.ts`,
+ * which also does index-based disambiguation for unnamed models), so the
+ * fallback below is defensive — it only fires for a directly-constructed
+ * `LoadedModel` with an empty name (as in the unit tests).
+ */
+export function kmlModelDisplayName(model: LoadedModel): string {
   // `||` (not `??`) so an empty name falls back to a path-derived one.
   return model.name || `${modelNameFromPath(model.path)} model`;
 }

--- a/apps/geolibre-desktop/src/lib/kml-model.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model.ts
@@ -65,6 +65,11 @@ const METERS_PER_DEGREE_LAT = 111320;
  * to find it — so the extent grows with the model's `radiusMeters`. Models with
  * no known extent fall back to a small point pad.
  *
+ * `radiusMeters` is measured on the unscaled GLB, but the scenegraph renders
+ * the model scaled by `kmlModelUniformScale(model.scale)` (see
+ * {@link kmlModelRow}), so apply that same factor here or a non-default
+ * `<Scale>` would under- or over-frame the model.
+ *
  * @param model - A resolved KML model descriptor.
  * @param minPad - Minimum half-width of the extent in degrees (used when the
  *   model is tiny or its extent is unknown).
@@ -76,7 +81,7 @@ export function kmlModelBounds(
 ): [number, number, number, number] {
   const radius =
     Number.isFinite(model.radiusMeters) && model.radiusMeters > 0
-      ? model.radiusMeters * 1.1 // a little breathing room around the model
+      ? model.radiusMeters * kmlModelUniformScale(model.scale) * 1.1 // scaled, with breathing room
       : 0;
   const latPad = Math.max(minPad, radius / METERS_PER_DEGREE_LAT);
   // Guard the cosine against a divide-by-zero at the poles.

--- a/apps/geolibre-desktop/src/lib/kml-model.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model.ts
@@ -51,23 +51,42 @@ export function kmlModelRow(model: LoadedModel): {
   };
 }
 
+// Meters per degree of latitude (WGS84 mean). Longitude degrees shrink by
+// cos(latitude), so a fixed meter extent spans more longitude near the poles.
+const METERS_PER_DEGREE_LAT = 111320;
+
 /**
- * A small padded extent around the model's point so "Zoom to layer" frames it
- * instead of snapping to a single point at maximum zoom.
+ * A geographic extent around the model that frames the whole thing on load.
+ *
+ * A KML `<Location>` anchors the model's *origin*, which for SketchUp/Google
+ * Earth exports is often a corner of a mesh that spans kilometers (a building,
+ * a terrain slice, a geological cross-section). A fixed tiny box around that
+ * corner would leave the model mostly off-screen — the user has to zoom way out
+ * to find it — so the extent grows with the model's `radiusMeters`. Models with
+ * no known extent fall back to a small point pad.
  *
  * @param model - A resolved KML model descriptor.
- * @param pad - Half-width of the extent in degrees.
+ * @param minPad - Minimum half-width of the extent in degrees (used when the
+ *   model is tiny or its extent is unknown).
  * @returns `[west, south, east, north]` in WGS84 degrees.
  */
 export function kmlModelBounds(
   model: LoadedModel,
-  pad = 0.002,
+  minPad = 0.002,
 ): [number, number, number, number] {
+  const radius =
+    Number.isFinite(model.radiusMeters) && model.radiusMeters > 0
+      ? model.radiusMeters * 1.1 // a little breathing room around the model
+      : 0;
+  const latPad = Math.max(minPad, radius / METERS_PER_DEGREE_LAT);
+  // Guard the cosine against a divide-by-zero at the poles.
+  const cosLat = Math.max(Math.cos((model.latitude * Math.PI) / 180), 1e-6);
+  const lngPad = Math.max(minPad, radius / (METERS_PER_DEGREE_LAT * cosLat));
   return [
-    model.longitude - pad,
-    model.latitude - pad,
-    model.longitude + pad,
-    model.latitude + pad,
+    model.longitude - lngPad,
+    model.latitude - latPad,
+    model.longitude + lngPad,
+    model.latitude + latPad,
   ];
 }
 

--- a/apps/geolibre-desktop/src/lib/kml-model.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model.ts
@@ -1,0 +1,78 @@
+import type { LoadedModel } from "./tauri-io";
+
+/**
+ * Pure, dependency-free helpers for turning a KML `<Model>` into deck.gl
+ * scenegraph inputs. Kept separate from `kml-model-layer.ts` (which pulls in the
+ * plugins/deck.gl runtime) so this logic can be unit tested.
+ */
+
+/**
+ * Collapse a KML `<Scale>` (x/y/z) into the single factor the scenegraph layer
+ * applies. Uniform scale is the common case (all three equal); a non-uniform
+ * scale is averaged so the model still renders at a sensible overall size.
+ *
+ * @param scale - The per-axis scale factors.
+ * @returns A single positive scale factor (1 when the average is not positive).
+ */
+export function kmlModelUniformScale(scale: {
+  x: number;
+  y: number;
+  z: number;
+}): number {
+  const average = (scale.x + scale.y + scale.z) / 3;
+  return average > 0 ? average : 1;
+}
+
+/** Base file name without directory or extension (e.g. "a/town.kmz" -> "town"). */
+export function modelNameFromPath(path: string): string {
+  return (path.split(/[\\/]/).pop() ?? path).replace(/\.[^.]+$/, "");
+}
+
+/**
+ * The single scenegraph data row for a model: its location, altitude, heading
+ * (as bearing), and collapsed scale factor.
+ *
+ * @param model - A resolved KML model descriptor.
+ * @returns The row consumed by the scenegraph layer's field mapping.
+ */
+export function kmlModelRow(model: LoadedModel): {
+  lng: number;
+  lat: number;
+  altitude: number;
+  bearing: number;
+  scale: number;
+} {
+  return {
+    lng: model.longitude,
+    lat: model.latitude,
+    altitude: model.altitude,
+    bearing: model.heading,
+    scale: kmlModelUniformScale(model.scale),
+  };
+}
+
+/**
+ * A small padded extent around the model's point so "Zoom to layer" frames it
+ * instead of snapping to a single point at maximum zoom.
+ *
+ * @param model - A resolved KML model descriptor.
+ * @param pad - Half-width of the extent in degrees.
+ * @returns `[west, south, east, north]` in WGS84 degrees.
+ */
+export function kmlModelBounds(
+  model: LoadedModel,
+  pad = 0.002,
+): [number, number, number, number] {
+  return [
+    model.longitude - pad,
+    model.latitude - pad,
+    model.longitude + pad,
+    model.latitude + pad,
+  ];
+}
+
+/** The display name for a model layer, falling back to a path-derived name. */
+export function kmlModelName(model: LoadedModel): string {
+  // `||` (not `??`) so an empty name falls back to a path-derived one.
+  return model.name || `${modelNameFromPath(model.path)} model`;
+}

--- a/apps/geolibre-desktop/src/lib/kml-model.ts
+++ b/apps/geolibre-desktop/src/lib/kml-model.ts
@@ -51,6 +51,25 @@ export function kmlModelRow(model: LoadedModel): {
   };
 }
 
+/**
+ * Large KML models such as geological cross-sections often encode depth/elevation
+ * as positive local-up coordinates from the model origin. In deck.gl that makes
+ * the whole wall tower into the sky. For kilometer-scale vertical models, shift
+ * the converted scene down so its top aligns with the KML anchor altitude; leave
+ * normal building-scale models untouched.
+ */
+export function kmlModelTranslation(model: LoadedModel): [number, number, number] {
+  const min = Number.isFinite(model.verticalMinMeters)
+    ? model.verticalMinMeters
+    : 0;
+  const max = Number.isFinite(model.verticalMaxMeters)
+    ? model.verticalMaxMeters
+    : 0;
+  const verticalSpan = max - min;
+  if (verticalSpan < 1000 || max <= 0) return [0, 0, 0];
+  return [0, 0, -max * kmlModelUniformScale(model.scale)];
+}
+
 // Meters per degree of latitude (WGS84 mean). Longitude degrees shrink by
 // cos(latitude), so a fixed meter extent spans more longitude near the poles.
 const METERS_PER_DEGREE_LAT = 111320;

--- a/apps/geolibre-desktop/src/lib/kml-overlays.ts
+++ b/apps/geolibre-desktop/src/lib/kml-overlays.ts
@@ -48,34 +48,53 @@ export function normalizeArchivePath(value: string): string {
 }
 
 /**
- * Find the archive entry a GroundOverlay's href points at. Hrefs are written
- * relative to the archive root, but authors nest images inconsistently, so this
+ * Find the *key* of the archive entry an href points at. Hrefs are written
+ * relative to the archive root, but authors nest files inconsistently, so this
  * tries an exact match, then a normalized-path match, then a unique basename.
  *
+ * Callers that need to resolve sibling files (e.g. a `.dae`'s textures relative
+ * to where it was actually found) use the returned key rather than the guessed
+ * href, since the basename tier can match a differently-nested entry.
+ *
  * @param entries - The unzipped archive entries, keyed by entry name.
- * @param href - The overlay's `<Icon><href>` value.
+ * @param href - The href value to resolve.
+ * @returns The matching entry's key, or undefined when none is found.
+ */
+export function findArchiveEntryKey(
+  entries: Record<string, Uint8Array>,
+  href: string,
+): string | undefined {
+  // `Object.hasOwn`, not a truthy `entries[href]`, so an href like "__proto__"
+  // or "constructor" cannot resolve an inherited prototype member instead of a
+  // real archive entry.
+  if (Object.hasOwn(entries, href)) return href;
+
+  const target = normalizeArchivePath(href);
+  for (const name of Object.keys(entries)) {
+    if (normalizeArchivePath(name) === target) return name;
+  }
+
+  const base = target.split("/").pop();
+  if (base) {
+    const matches = Object.keys(entries).filter(
+      (name) => normalizeArchivePath(name).split("/").pop() === base,
+    );
+    if (matches.length === 1) return matches[0];
+  }
+  return undefined;
+}
+
+/**
+ * Find the archive entry an href points at (see {@link findArchiveEntryKey}).
+ *
+ * @param entries - The unzipped archive entries, keyed by entry name.
+ * @param href - The href value to resolve.
  * @returns The matching entry's bytes, or undefined when none is found.
  */
 export function findArchiveEntry(
   entries: Record<string, Uint8Array>,
   href: string,
 ): Uint8Array | undefined {
-  // `Object.hasOwn`, not a truthy `entries[href]`, so an href like "__proto__"
-  // or "constructor" cannot resolve an inherited prototype member instead of a
-  // real archive entry.
-  if (Object.hasOwn(entries, href)) return entries[href];
-
-  const target = normalizeArchivePath(href);
-  for (const [name, data] of Object.entries(entries)) {
-    if (normalizeArchivePath(name) === target) return data;
-  }
-
-  const base = target.split("/").pop();
-  if (base) {
-    const matches = Object.entries(entries).filter(
-      ([name]) => normalizeArchivePath(name).split("/").pop() === base,
-    );
-    if (matches.length === 1) return matches[0][1];
-  }
-  return undefined;
+  const key = findArchiveEntryKey(entries, href);
+  return key === undefined ? undefined : entries[key];
 }

--- a/apps/geolibre-desktop/src/lib/kml.ts
+++ b/apps/geolibre-desktop/src/lib/kml.ts
@@ -219,6 +219,114 @@ export function latLonBoxCorners(
   });
 }
 
+/**
+ * A `<Model>` 3D model extracted from a KML document: a mesh (typically a
+ * COLLADA `.dae`) placed at a geographic location. The mesh is referenced by
+ * {@link href} (an archive-relative path in a KMZ, or an absolute URL); the
+ * caller resolves and renders it.
+ */
+export interface KmlModel {
+  /** The enclosing Placemark's `<name>`, when present. */
+  name?: string;
+  /** The `<Link><href>` (or `<Icon><href>`): an archive-relative path or URL. */
+  href: string;
+  /** `<Location>` longitude in WGS84 degrees. */
+  longitude: number;
+  /** `<Location>` latitude in WGS84 degrees. */
+  latitude: number;
+  /** `<Location>` altitude in meters (default 0). */
+  altitude: number;
+  /** `<Orientation>` heading (rotation about the up axis), degrees (default 0). */
+  heading: number;
+  /** `<Orientation>` tilt (rotation about the east axis), degrees (default 0). */
+  tilt: number;
+  /** `<Orientation>` roll (rotation about the north axis), degrees (default 0). */
+  roll: number;
+  /** `<Scale>` factors along the model's x/y/z axes (default 1 each). */
+  scale: { x: number; y: number; z: number };
+}
+
+/**
+ * Parse the `<Model>` 3D models out of a KML document. Like
+ * {@link parseKmlGroundOverlays} this never throws: a document with no models
+ * (or invalid KML) yields an empty array.
+ *
+ * @param text - The raw KML XML text.
+ * @returns The document's models, in document order.
+ */
+export function parseKmlModels(text: string): KmlModel[] {
+  const document = new DOMParser().parseFromString(text, "application/xml");
+  if (document.querySelector("parsererror")) return [];
+  const root = document.documentElement;
+  if (!root || root.localName.toLowerCase() !== "kml") return [];
+
+  const models: KmlModel[] = [];
+  for (const element of descendants(root, "Model")) {
+    const model = modelFromElement(element);
+    if (model) models.push(model);
+  }
+  return models;
+}
+
+function modelFromElement(element: Element): KmlModel | null {
+  // KML 2.2 uses <Link><href>; some exports use <Icon><href>.
+  const link = directChild(element, "Link") ?? directChild(element, "Icon");
+  const href = link ? childText(link, "href") : undefined;
+  if (!href) return null;
+
+  const location = directChild(element, "Location");
+  const longitude = Number(location && childText(location, "longitude"));
+  const latitude = Number(location && childText(location, "latitude"));
+  if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) return null;
+  if (longitude < -180 || longitude > 180 || latitude < -90 || latitude > 90) {
+    return null;
+  }
+  const altitude = numberOr(location && childText(location, "altitude"), 0);
+
+  const orientation = directChild(element, "Orientation");
+  const heading = numberOr(orientation && childText(orientation, "heading"), 0);
+  const tilt = numberOr(orientation && childText(orientation, "tilt"), 0);
+  const roll = numberOr(orientation && childText(orientation, "roll"), 0);
+
+  const scaleEl = directChild(element, "Scale");
+  const scale = {
+    x: numberOr(scaleEl && childText(scaleEl, "x"), 1),
+    y: numberOr(scaleEl && childText(scaleEl, "y"), 1),
+    z: numberOr(scaleEl && childText(scaleEl, "z"), 1),
+  };
+
+  const name = enclosingPlacemarkName(element);
+
+  return {
+    ...(name !== undefined ? { name } : {}),
+    href,
+    longitude,
+    latitude,
+    altitude,
+    heading,
+    tilt,
+    roll,
+    scale,
+  };
+}
+
+// A <Model> is normally wrapped in a <Placemark> whose <name> labels it.
+function enclosingPlacemarkName(element: Element): string | undefined {
+  let node: Element | null = element.parentElement;
+  while (node) {
+    if (node.localName.toLowerCase() === "placemark") {
+      return childText(node, "name");
+    }
+    node = node.parentElement;
+  }
+  return undefined;
+}
+
+function numberOr(value: string | undefined | null, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 function placemarkProperties(
   placemark: Element,
   styles: Map<string, KmlStyle>,

--- a/apps/geolibre-desktop/src/lib/kml.ts
+++ b/apps/geolibre-desktop/src/lib/kml.ts
@@ -281,7 +281,18 @@ function modelFromElement(element: Element): KmlModel | null {
   if (longitude < -180 || longitude > 180 || latitude < -90 || latitude > 90) {
     return null;
   }
-  const altitude = numberOr(location && childText(location, "altitude"), 0);
+  // KML's default altitudeMode is clampToGround, which ignores <altitude> and
+  // drapes the model on the terrain; only `absolute` and `relativeToGround`
+  // define a vertical offset. There's no client-side DEM to clamp against, so
+  // treat clamped modes as ground level (0) — otherwise a stale/leftover
+  // <altitude> (common in SketchUp/Google Earth exports) leaves the model
+  // floating in the air.
+  const altitudeMode = childText(element, "altitudeMode")?.toLowerCase();
+  const honorsAltitude =
+    altitudeMode === "absolute" || altitudeMode === "relativetoground";
+  const altitude = honorsAltitude
+    ? numberOr(location && childText(location, "altitude"), 0)
+    : 0;
 
   const orientation = directChild(element, "Orientation");
   const heading = numberOr(orientation && childText(orientation, "heading"), 0);

--- a/apps/geolibre-desktop/src/lib/restore-local-layers.ts
+++ b/apps/geolibre-desktop/src/lib/restore-local-layers.ts
@@ -62,10 +62,12 @@ export async function restoreLocalFileLayers(): Promise<void> {
     Array.from(byPath, async ([path, layers]) => {
       try {
         // A KMZ/KML file can yield image overlays alongside its vector layers;
-        // only the vector entries carry the `geojson` these layers reload.
-        const loaded = (await loadDroppedVectorPaths([path])).filter(
-          isLoadedVectorLayer,
-        );
+        // only the vector entries carry the `geojson` these layers reload. Skip
+        // the KML `<Model>` (COLLADA→GLB) conversion — including any remote-mesh
+        // fetch — since the models are discarded by the filter below anyway.
+        const loaded = (
+          await loadDroppedVectorPaths([path], { skipModels: true })
+        ).filter(isLoadedVectorLayer);
         if (loaded.length === 0) {
           dropLayers(layers, path);
           return;

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -885,9 +885,21 @@ async function modelsFromKmz(
     // findArchiveEntryKey can match a differently-nested entry. Fall back to a
     // bare basename for textures stored elsewhere in the archive.
     const daeDir = archiveDirname(normalizeArchivePath(daeKey));
-    const resolveTexture = (texturePath: string): Uint8Array | undefined =>
-      findArchiveEntry(entries, daeDir + texturePath) ??
-      findArchiveEntry(entries, texturePath);
+    const resolveTexture = (texturePath: string): Uint8Array | undefined => {
+      const bytes =
+        findArchiveEntry(entries, daeDir + texturePath) ??
+        findArchiveEntry(entries, texturePath);
+      // Cap a single packaged texture (same limit as ground-overlay images) so
+      // an oversized bundled image can't blow up the decode/GPU upload before
+      // the GLB-size cap ever measures the result; skip it (untextured) instead.
+      if (bytes && bytes.length > MAX_OVERLAY_IMAGE_BYTES) {
+        console.warn(
+          `Skipping a KML model texture "${texturePath}": ${Math.round(bytes.length / (1024 * 1024))} MB, over the ${Math.round(MAX_OVERLAY_IMAGE_BYTES / (1024 * 1024))} MB limit.`,
+        );
+        return undefined;
+      }
+      return bytes;
+    };
     const converted = await daeToGlbDataUrl(
       new TextDecoder("utf-8").decode(data),
       model.href,

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -738,14 +738,36 @@ function groundOverlaysFromKml(
 // to avoid bloating projects and memory.
 const MAX_MODEL_GLB_BYTES = 24 * 1024 * 1024;
 
+// Cap the raw `.dae` source too, so an enormous mesh is rejected up front rather
+// than after the expensive parse/normal-compute/export. COLLADA is verbose XML,
+// so the source limit is more generous than the GLB output limit.
+const MAX_DAE_SOURCE_BYTES = 64 * 1024 * 1024;
+
+// The display name for a model layer. An unnamed `<Model>` falls back to a
+// path-derived name; when a file has several such models the 1-based `index`
+// disambiguates them so they are not all named identically.
+function kmlModelName(
+  model: KmlModel,
+  path: string,
+  index: number,
+  total: number,
+): string {
+  const named = model.name?.trim();
+  if (named) return named;
+  const base = `${pathWithoutExtension(fileBaseName(path))} model`;
+  return total > 1 ? `${base} ${index + 1}` : base;
+}
+
 function kmlModelLayer(
   model: KmlModel,
   url: string,
   path: string,
+  index: number,
+  total: number,
 ): LoadedModel {
   return {
     kind: "model",
-    name: model.name?.trim() || `${pathWithoutExtension(fileBaseName(path))} model`,
+    name: kmlModelName(model, path, index, total),
     path,
     url,
     longitude: model.longitude,
@@ -818,10 +840,11 @@ async function modelsFromKmz(
     );
 
   const models: LoadedModel[] = [];
-  for (const { model, baseDir } of parsed) {
+  const total = parsed.length;
+  for (const [index, { model, baseDir }] of parsed.entries()) {
     if (isHttpUrl(model.href)) {
       const url = await fetchDaeAsGlbDataUrl(model.href);
-      if (url) models.push(kmlModelLayer(model, url, path));
+      if (url) models.push(kmlModelLayer(model, url, path, index, total));
       continue;
     }
     const daeEntry = baseDir + model.href;
@@ -830,6 +853,12 @@ async function modelsFromKmz(
     if (!data) {
       console.warn(
         `Skipping a KML model: its mesh "${model.href}" was not found in the KMZ archive.`,
+      );
+      continue;
+    }
+    if (data.length > MAX_DAE_SOURCE_BYTES) {
+      console.warn(
+        `Skipping a KML model: its mesh "${model.href}" is ${Math.round(data.length / (1024 * 1024))} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
       );
       continue;
     }
@@ -842,7 +871,7 @@ async function modelsFromKmz(
       model.href,
       resolveTexture,
     );
-    if (url) models.push(kmlModelLayer(model, url, path));
+    if (url) models.push(kmlModelLayer(model, url, path, index, total));
   }
   return models;
 }
@@ -860,6 +889,12 @@ async function fetchDaeAsGlbDataUrl(href: string): Promise<string | null> {
       return null;
     }
     const daeText = await response.text();
+    if (daeText.length > MAX_DAE_SOURCE_BYTES) {
+      console.warn(
+        `Skipping a KML model: "${href}" is ${Math.round(daeText.length / (1024 * 1024))} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
+      );
+      return null;
+    }
     const basePath = href.slice(0, href.lastIndexOf("/") + 1);
     return await daeToGlbDataUrl(daeText, href, undefined, basePath);
   } catch (error) {
@@ -875,8 +910,9 @@ async function modelsFromKml(
   path: string,
 ): Promise<LoadedModel[]> {
   if (!/<model[\s/>]/i.test(text)) return [];
+  const parsed = parseKmlModels(text);
   const models: LoadedModel[] = [];
-  for (const model of parseKmlModels(text)) {
+  for (const [index, model] of parsed.entries()) {
     if (!isHttpUrl(model.href)) {
       console.warn(
         `Skipping a KML model: its mesh "${model.href}" is a relative path, which a standalone KML (unlike a KMZ) cannot resolve. Only absolute URLs are supported.`,
@@ -884,7 +920,7 @@ async function modelsFromKml(
       continue;
     }
     const url = await fetchDaeAsGlbDataUrl(model.href);
-    if (url) models.push(kmlModelLayer(model, url, path));
+    if (url) models.push(kmlModelLayer(model, url, path, index, parsed.length));
   }
   return models;
 }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -47,6 +47,7 @@ import {
 } from "./kml";
 import {
   findArchiveEntry,
+  findArchiveEntryKey,
   imageMimeFromName,
   normalizeArchivePath,
 } from "./kml-overlays";
@@ -859,30 +860,29 @@ async function modelsFromKmz(
         models.push(kmlModelLayer(model, converted, path, index, total));
       continue;
     }
-    const daeEntry = baseDir + model.href;
-    const data =
-      findArchiveEntry(entries, daeEntry) ?? findArchiveEntry(entries, model.href);
-    if (!data) {
+    const daeKey =
+      findArchiveEntryKey(entries, baseDir + model.href) ??
+      findArchiveEntryKey(entries, model.href);
+    if (daeKey === undefined) {
       console.warn(
         `Skipping a KML model: its mesh "${model.href}" was not found in the KMZ archive.`,
       );
       continue;
     }
+    const data = entries[daeKey];
     if (data.length > MAX_DAE_SOURCE_BYTES) {
       console.warn(
         `Skipping a KML model: its mesh "${model.href}" is ${Math.round(data.length / (1024 * 1024))} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
       );
       continue;
     }
-    // `daeEntry` is the guessed path (`baseDir + href`); the mesh may actually
-    // have been found via the bare-href fallback above, so also try the href's
-    // own directory before the bare-basename fallback, so textures resolve when
-    // the href already carries the full archive-relative path.
-    const daeDir = archiveDirname(normalizeArchivePath(daeEntry));
-    const hrefDir = archiveDirname(normalizeArchivePath(model.href));
+    // Resolve textures relative to where the `.dae` was actually found (its
+    // matched key), not the guessed `baseDir + href` — the basename fallback in
+    // findArchiveEntryKey can match a differently-nested entry. Fall back to a
+    // bare basename for textures stored elsewhere in the archive.
+    const daeDir = archiveDirname(normalizeArchivePath(daeKey));
     const resolveTexture = (texturePath: string): Uint8Array | undefined =>
       findArchiveEntry(entries, daeDir + texturePath) ??
-      findArchiveEntry(entries, hrefDir + texturePath) ??
       findArchiveEntry(entries, texturePath);
     const converted = await daeToGlbDataUrl(
       new TextDecoder("utf-8").decode(data),

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -751,7 +751,9 @@ const MAX_DAE_SOURCE_BYTES = 64 * 1024 * 1024;
 
 // The display name for a model layer. An unnamed `<Model>` falls back to a
 // path-derived name; when a file has several such models the 1-based `index`
-// disambiguates them so they are not all named identically.
+// disambiguates them so they are not all named identically. This resolves the
+// name once here at load time; `kmlModelDisplayName` (kml-model.ts) is the
+// downstream reader whose own fallback is only a defensive/test-time path.
 function kmlModelName(
   model: KmlModel,
   path: string,

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -38,8 +38,18 @@ import {
 } from "./geotagged-photos";
 import { parseGpxLayer } from "./gpx";
 import { isTauri } from "./is-tauri";
-import { parseKmlGroundOverlays, parseKmlText, type KmlGroundOverlay } from "./kml";
-import { findArchiveEntry, imageMimeFromName } from "./kml-overlays";
+import {
+  parseKmlGroundOverlays,
+  parseKmlModels,
+  parseKmlText,
+  type KmlGroundOverlay,
+  type KmlModel,
+} from "./kml";
+import {
+  findArchiveEntry,
+  imageMimeFromName,
+  normalizeArchivePath,
+} from "./kml-overlays";
 
 // Re-exported so existing `import { isTauri } from "./tauri-io"` consumers keep
 // working; the implementation lives in the lightweight ./is-tauri module.
@@ -204,11 +214,34 @@ export interface LoadedImageOverlay {
 }
 
 /**
- * A single result from a vector-file load: either a vector layer or an image
- * overlay. A KMZ/KML file can yield a mix of both (placemarks plus ground
- * overlays), mirroring how a GPX file yields several vector layers.
+ * A 3D model produced by a KML/KMZ `<Model>` (a COLLADA `.dae` converted to a
+ * self-contained GLB). The caller turns it into a deck.gl scenegraph layer. The
+ * `kind` tag distinguishes it from a vector layer in a mixed load result.
  */
-export type LoadedLayer = LoadedVectorLayer | LoadedImageOverlay;
+export interface LoadedModel {
+  kind: "model";
+  name: string;
+  path: string;
+  /** GLB model as a `data:` URL (textures embedded), renderable as glTF. */
+  url: string;
+  /** Model location in WGS84 degrees and meters. */
+  longitude: number;
+  latitude: number;
+  altitude: number;
+  /** `<Orientation>` heading/tilt/roll in degrees. */
+  heading: number;
+  tilt: number;
+  roll: number;
+  /** `<Scale>` factors along the model's x/y/z axes. */
+  scale: { x: number; y: number; z: number };
+}
+
+/**
+ * A single result from a vector-file load: a vector layer, an image overlay, or
+ * a 3D model. A KMZ/KML file can yield a mix (placemarks plus ground overlays
+ * plus models), mirroring how a GPX file yields several vector layers.
+ */
+export type LoadedLayer = LoadedVectorLayer | LoadedImageOverlay | LoadedModel;
 
 /** Narrow a {@link LoadedLayer} to its image-overlay variant. */
 export function isLoadedImageOverlay(
@@ -217,11 +250,16 @@ export function isLoadedImageOverlay(
   return "kind" in layer && layer.kind === "image-overlay";
 }
 
+/** Narrow a {@link LoadedLayer} to its 3D-model variant. */
+export function isLoadedModel(layer: LoadedLayer): layer is LoadedModel {
+  return "kind" in layer && layer.kind === "model";
+}
+
 /** Narrow a {@link LoadedLayer} to its vector variant. */
 export function isLoadedVectorLayer(
   layer: LoadedLayer,
 ): layer is LoadedVectorLayer {
-  return !isLoadedImageOverlay(layer);
+  return !("kind" in layer);
 }
 
 // Auxiliary files that accompany Shapefiles (spatial indexes, metadata, etc.)
@@ -695,6 +733,162 @@ function groundOverlaysFromKml(
   return overlays;
 }
 
+// A KML `<Model>` GLB is inlined as a base64 `data:` URL on the layer (textures
+// embedded) and persisted in the project file at ~4/3 its byte size, so cap it
+// to avoid bloating projects and memory.
+const MAX_MODEL_GLB_BYTES = 24 * 1024 * 1024;
+
+function kmlModelLayer(
+  model: KmlModel,
+  url: string,
+  path: string,
+): LoadedModel {
+  return {
+    kind: "model",
+    name: model.name?.trim() || `${pathWithoutExtension(fileBaseName(path))} model`,
+    path,
+    url,
+    longitude: model.longitude,
+    latitude: model.latitude,
+    altitude: model.altitude,
+    heading: model.heading,
+    tilt: model.tilt,
+    roll: model.roll,
+    scale: model.scale,
+  };
+}
+
+// Convert a COLLADA `.dae` (as text) to a self-contained GLB data URL, resolving
+// any textures the DAE references. `resolveTexture` maps a raw texture path to a
+// blob URL of an archive entry (for a KMZ); the created blob URLs are revoked
+// once the GLTF exporter has embedded the pixels. Returns null on failure so one
+// bad model does not abort the rest of the load.
+async function daeToGlbDataUrl(
+  daeText: string,
+  href: string,
+  resolveTexture?: (path: string) => Uint8Array | undefined,
+  basePath = "",
+): Promise<string | null> {
+  const blobUrls: string[] = [];
+  const modifier = resolveTexture
+    ? (url: string): string | undefined => {
+        const bytes = resolveTexture(url);
+        if (!bytes) return undefined;
+        const blob = URL.createObjectURL(
+          new Blob([bytes as BlobPart], { type: imageMimeFromName(url) }),
+        );
+        blobUrls.push(blob);
+        return blob;
+      }
+    : undefined;
+  try {
+    const { convertDaeToGlb } = await import("./collada-to-glb");
+    const glb = await convertDaeToGlb(daeText, modifier, basePath);
+    if (glb.length > MAX_MODEL_GLB_BYTES) {
+      console.warn(
+        `Skipping a KML model: "${href}" converts to ${Math.round(glb.length / (1024 * 1024))} MB, over the ${Math.round(MAX_MODEL_GLB_BYTES / (1024 * 1024))} MB inline limit.`,
+      );
+      return null;
+    }
+    return await bytesToDataUrl(glb, "model/gltf-binary");
+  } catch (error) {
+    console.warn(`Could not convert the KML model "${href}" to glTF.`, error);
+    return null;
+  } finally {
+    for (const url of blobUrls) URL.revokeObjectURL(url);
+  }
+}
+
+// Resolve the `<Model>` 3D models in an archive's KML documents. Each model's
+// `.dae` is read from the archive (relative to its KML's directory) or fetched
+// from an absolute URL, converted to a self-contained GLB, and returned as an
+// image-free model descriptor. Models that cannot be resolved are skipped.
+async function modelsFromKmz(
+  entries: Record<string, Uint8Array>,
+  kmlDocs: { name: string; text: string }[],
+  path: string,
+): Promise<LoadedModel[]> {
+  const parsed = kmlDocs
+    .filter((doc) => /<model[\s/>]/i.test(doc.text))
+    .flatMap((doc) =>
+      parseKmlModels(doc.text).map((model) => ({
+        model,
+        baseDir: archiveDirname(doc.name),
+      })),
+    );
+
+  const models: LoadedModel[] = [];
+  for (const { model, baseDir } of parsed) {
+    if (isHttpUrl(model.href)) {
+      const url = await fetchDaeAsGlbDataUrl(model.href);
+      if (url) models.push(kmlModelLayer(model, url, path));
+      continue;
+    }
+    const daeEntry = baseDir + model.href;
+    const data =
+      findArchiveEntry(entries, daeEntry) ?? findArchiveEntry(entries, model.href);
+    if (!data) {
+      console.warn(
+        `Skipping a KML model: its mesh "${model.href}" was not found in the KMZ archive.`,
+      );
+      continue;
+    }
+    const daeDir = archiveDirname(normalizeArchivePath(daeEntry));
+    const resolveTexture = (texturePath: string): Uint8Array | undefined =>
+      findArchiveEntry(entries, daeDir + texturePath) ??
+      findArchiveEntry(entries, texturePath);
+    const url = await daeToGlbDataUrl(
+      new TextDecoder("utf-8").decode(data),
+      model.href,
+      resolveTexture,
+    );
+    if (url) models.push(kmlModelLayer(model, url, path));
+  }
+  return models;
+}
+
+// Fetch an absolute-URL `.dae`, convert it to a GLB data URL. Textures resolve
+// against the mesh's URL directory (best effort; a CORS-blocked fetch is
+// skipped). Returns null on any failure.
+async function fetchDaeAsGlbDataUrl(href: string): Promise<string | null> {
+  try {
+    const response = await fetch(href);
+    if (!response.ok) {
+      console.warn(
+        `Skipping a KML model: fetching "${href}" returned ${response.status}.`,
+      );
+      return null;
+    }
+    const daeText = await response.text();
+    const basePath = href.slice(0, href.lastIndexOf("/") + 1);
+    return await daeToGlbDataUrl(daeText, href, undefined, basePath);
+  } catch (error) {
+    console.warn(`Skipping a KML model: could not fetch "${href}".`, error);
+    return null;
+  }
+}
+
+// Models in a standalone (non-archived) KML can only be resolved when the mesh
+// href is an absolute URL; a relative path needs the archive's packaged files.
+async function modelsFromKml(
+  text: string,
+  path: string,
+): Promise<LoadedModel[]> {
+  if (!/<model[\s/>]/i.test(text)) return [];
+  const models: LoadedModel[] = [];
+  for (const model of parseKmlModels(text)) {
+    if (!isHttpUrl(model.href)) {
+      console.warn(
+        `Skipping a KML model: its mesh "${model.href}" is a relative path, which a standalone KML (unlike a KMZ) cannot resolve. Only absolute URLs are supported.`,
+      );
+      continue;
+    }
+    const url = await fetchDaeAsGlbDataUrl(model.href);
+    if (url) models.push(kmlModelLayer(model, url, path));
+  }
+  return models;
+}
+
 // Merge the vector placemarks from every KML in an archive, tolerating entries
 // with no readable vector content (returning an empty collection) so an
 // overlay-only archive still loads its overlays. Declining an oversized entry
@@ -757,9 +951,12 @@ async function loadKmzLayers(
     }));
 
   // Ground overlays are drawn under vector placemarks (as in Google Earth), so
-  // they are added first: a later store index renders on top.
+  // they are added first: a later store index renders on top. 3D models render
+  // in the deck.gl overlay (always above MapLibre layers), so their array order
+  // does not affect stacking.
   const layers: LoadedLayer[] = [
     ...(await groundOverlaysFromKmz(entries, kmlDocs, path)),
+    ...(await modelsFromKmz(entries, kmlDocs, path)),
   ];
 
   // Declining the oversized-vector prompt must not throw away the archive's
@@ -778,7 +975,7 @@ async function loadKmzLayers(
   if (layers.length === 0) {
     if (cancellation) throw cancellation;
     throw new Error(
-      "The KMZ archive did not contain readable placemarks or ground overlays.",
+      "The KMZ archive did not contain readable placemarks, ground overlays, or 3D models.",
     );
   }
   return layers;
@@ -1908,8 +2105,9 @@ export async function loadDroppedVectorFiles(
       // placemarks (which makes the vector load throw).
       const text = await file.text();
       const overlays = groundOverlaysFromKml(text, file.name);
+      const models = await modelsFromKml(text, file.name);
       // Overlays go under the placemarks (added first), matching the KMZ path.
-      layers.push(...overlays);
+      layers.push(...overlays, ...models);
       try {
         // Only add a vector layer when it actually has features: the DuckDB
         // fallback for an overlay-only KML can return an empty collection, and
@@ -1918,14 +2116,14 @@ export async function loadDroppedVectorFiles(
         if (vector.data.features.length > 0) layers.push(vector);
       } catch (error) {
         // Declining the oversized-vector prompt, or a genuine parse failure,
-        // still leaves the ground overlays already added above (a real
-        // non-cancellation failure with no overlays to salvage is rethrown).
+        // still leaves any ground overlays/models already added above (a real
+        // non-cancellation failure with nothing to salvage is rethrown).
         // Cancellation is not surfaced; other failures are logged so they are
         // not fully invisible.
         if (!isVectorLoadCancelled(error)) {
-          if (!overlays.length) throw error;
+          if (!overlays.length && !models.length) throw error;
           console.warn(
-            `Loaded ground overlays from "${file.name}" but could not read its vector placemarks.`,
+            `Loaded ground overlays/models from "${file.name}" but could not read its vector placemarks.`,
             error,
           );
         }
@@ -2133,9 +2331,11 @@ export async function loadDroppedVectorPaths(
     if (extension === "kml") {
       // Load placemarks and ground overlays independently so an overlay-only
       // KML still contributes its overlays when the vector load throws.
-      const overlays = groundOverlaysFromKml(await readLocalFileText(path), path);
+      const kmlText = await readLocalFileText(path);
+      const overlays = groundOverlaysFromKml(kmlText, path);
+      const models = await modelsFromKml(kmlText, path);
       // Overlays go under the placemarks (added first), matching the KMZ path.
-      layers.push(...overlays);
+      layers.push(...overlays, ...models);
       try {
         // Only add a vector layer when it actually has features (an overlay-only
         // KML's DuckDB fallback can return an empty collection).
@@ -2143,14 +2343,14 @@ export async function loadDroppedVectorPaths(
         if (vector.data.features.length > 0) layers.push(vector);
       } catch (error) {
         // Declining the oversized-vector prompt, or a genuine parse failure,
-        // still leaves the ground overlays already added above (a real
-        // non-cancellation failure with no overlays to salvage is rethrown).
+        // still leaves any ground overlays/models already added above (a real
+        // non-cancellation failure with nothing to salvage is rethrown).
         // Cancellation is not surfaced; other failures are logged so they are
         // not fully invisible.
         if (!isVectorLoadCancelled(error)) {
-          if (!overlays.length) throw error;
+          if (!overlays.length && !models.length) throw error;
           console.warn(
-            `Loaded ground overlays from "${path}" but could not read its vector placemarks.`,
+            `Loaded ground overlays/models from "${path}" but could not read its vector placemarks.`,
             error,
           );
         }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -240,6 +240,9 @@ export interface LoadedModel {
    * bounding-box corner), used to frame it on load. `0` when unknown.
    */
   radiusMeters: number;
+  /** Model-space vertical bounds after COLLADA unit/up-axis handling. */
+  verticalMinMeters: number;
+  verticalMaxMeters: number;
 }
 
 /**
@@ -768,7 +771,12 @@ function kmlModelName(
 
 function kmlModelLayer(
   model: KmlModel,
-  converted: { url: string; radiusMeters: number },
+  converted: {
+    url: string;
+    radiusMeters: number;
+    verticalMinMeters: number;
+    verticalMaxMeters: number;
+  },
   path: string,
   index: number,
   total: number,
@@ -786,6 +794,8 @@ function kmlModelLayer(
     roll: model.roll,
     scale: model.scale,
     radiusMeters: converted.radiusMeters,
+    verticalMinMeters: converted.verticalMinMeters,
+    verticalMaxMeters: converted.verticalMaxMeters,
   };
 }
 
@@ -799,7 +809,12 @@ async function daeToGlbDataUrl(
   href: string,
   resolveTexture?: (path: string) => Uint8Array | undefined,
   basePath = "",
-): Promise<{ url: string; radiusMeters: number } | null> {
+): Promise<{
+  url: string;
+  radiusMeters: number;
+  verticalMinMeters: number;
+  verticalMaxMeters: number;
+} | null> {
   const blobUrls: string[] = [];
   const modifier = resolveTexture
     ? (url: string): string | undefined => {
@@ -814,11 +829,12 @@ async function daeToGlbDataUrl(
     : undefined;
   try {
     const { convertDaeToGlb } = await import("./collada-to-glb");
-    const { glb, radiusMeters } = await convertDaeToGlb(
-      daeText,
-      modifier,
-      basePath,
-    );
+    const { glb, radiusMeters, verticalMinMeters, verticalMaxMeters } =
+      await convertDaeToGlb(
+        daeText,
+        modifier,
+        basePath,
+      );
     if (glb.length > MAX_MODEL_GLB_BYTES) {
       console.warn(
         `Skipping a KML model: "${href}" converts to ${Math.round(glb.length / (1024 * 1024))} MB, over the ${Math.round(MAX_MODEL_GLB_BYTES / (1024 * 1024))} MB inline limit.`,
@@ -826,7 +842,7 @@ async function daeToGlbDataUrl(
       return null;
     }
     const url = await bytesToDataUrl(glb, "model/gltf-binary");
-    return { url, radiusMeters };
+    return { url, radiusMeters, verticalMinMeters, verticalMaxMeters };
   } catch (error) {
     console.warn(`Could not convert the KML model "${href}" to glTF.`, error);
     return null;
@@ -916,7 +932,12 @@ async function modelsFromKmz(
 // skipped). Returns null on any failure.
 async function fetchDaeAsGlbDataUrl(
   href: string,
-): Promise<{ url: string; radiusMeters: number } | null> {
+): Promise<{
+  url: string;
+  radiusMeters: number;
+  verticalMinMeters: number;
+  verticalMaxMeters: number;
+} | null> {
   try {
     // Bound the fetch so an unresponsive host can't hang the whole KML/KMZ load
     // (models are resolved sequentially), mirroring the texture-load timeout.

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -845,7 +845,9 @@ async function modelsFromKmz(
   path: string,
 ): Promise<LoadedModel[]> {
   const parsed = kmlDocs
-    .filter((doc) => /<model[\s/>]/i.test(doc.text))
+    // `(?:\w+:)?` so a namespace-prefixed `<kml:Model>` (valid but rare) isn't
+    // filtered out before `parseKmlModels` (which matches by localName) runs.
+    .filter((doc) => /<(?:\w+:)?model[\s/>]/i.test(doc.text))
     .flatMap((doc) =>
       parseKmlModels(doc.text).map((model) => ({
         model,
@@ -913,6 +915,16 @@ async function fetchDaeAsGlbDataUrl(
       );
       return null;
     }
+    // Best-effort size guard before buffering the whole body (mirrors the
+    // Content-Length pre-check in `openRecentProjectFile`). A chunked response
+    // with no Content-Length still falls through to the post-read check below.
+    const contentLength = response.headers.get("content-length");
+    if (contentLength !== null && Number(contentLength) > MAX_DAE_SOURCE_BYTES) {
+      console.warn(
+        `Skipping a KML model: "${href}" is ${Math.round(Number(contentLength) / (1024 * 1024))} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
+      );
+      return null;
+    }
     const daeText = await response.text();
     // Measure real byte size (not UTF-16 code units) so the cap matches the
     // archive path's `Uint8Array.length` check.
@@ -937,7 +949,9 @@ async function modelsFromKml(
   text: string,
   path: string,
 ): Promise<LoadedModel[]> {
-  if (!/<model[\s/>]/i.test(text)) return [];
+  // `(?:\w+:)?` so a namespace-prefixed `<kml:Model>` isn't skipped before
+  // `parseKmlModels` (which matches by localName) runs.
+  if (!/<(?:\w+:)?model[\s/>]/i.test(text)) return [];
   const parsed = parseKmlModels(text);
   const models: LoadedModel[] = [];
   for (const [index, model] of parsed.entries()) {
@@ -1021,7 +1035,9 @@ async function loadKmzLayers(
   // does not affect stacking.
   const layers: LoadedLayer[] = [
     ...(await groundOverlaysFromKmz(entries, kmlDocs, path)),
-    ...(await modelsFromKmz(entries, kmlDocs, path)),
+    // Skip the expensive COLLADA→GLB conversion when the caller only wants
+    // vector features (e.g. re-reading a referenced local layer on reopen).
+    ...(options?.skipModels ? [] : await modelsFromKmz(entries, kmlDocs, path)),
   ];
 
   // Declining the oversized-vector prompt must not throw away the archive's
@@ -2170,7 +2186,9 @@ export async function loadDroppedVectorFiles(
       // placemarks (which makes the vector load throw).
       const text = await file.text();
       const overlays = groundOverlaysFromKml(text, file.name);
-      const models = await modelsFromKml(text, file.name);
+      const models = options?.skipModels
+        ? []
+        : await modelsFromKml(text, file.name);
       // Overlays go under the placemarks (added first), matching the KMZ path.
       layers.push(...overlays, ...models);
       try {
@@ -2398,7 +2416,9 @@ export async function loadDroppedVectorPaths(
       // KML still contributes its overlays when the vector load throws.
       const kmlText = await readLocalFileText(path);
       const overlays = groundOverlaysFromKml(kmlText, path);
-      const models = await modelsFromKml(kmlText, path);
+      const models = options?.skipModels
+        ? []
+        : await modelsFromKml(kmlText, path);
       // Overlays go under the placemarks (added first), matching the KMZ path.
       layers.push(...overlays, ...models);
       try {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -234,6 +234,11 @@ export interface LoadedModel {
   roll: number;
   /** `<Scale>` factors along the model's x/y/z axes. */
   scale: { x: number; y: number; z: number };
+  /**
+   * The model's extent in meters (max distance from its anchored origin to any
+   * bounding-box corner), used to frame it on load. `0` when unknown.
+   */
+  radiusMeters: number;
 }
 
 /**
@@ -760,7 +765,7 @@ function kmlModelName(
 
 function kmlModelLayer(
   model: KmlModel,
-  url: string,
+  converted: { url: string; radiusMeters: number },
   path: string,
   index: number,
   total: number,
@@ -769,7 +774,7 @@ function kmlModelLayer(
     kind: "model",
     name: kmlModelName(model, path, index, total),
     path,
-    url,
+    url: converted.url,
     longitude: model.longitude,
     latitude: model.latitude,
     altitude: model.altitude,
@@ -777,6 +782,7 @@ function kmlModelLayer(
     tilt: model.tilt,
     roll: model.roll,
     scale: model.scale,
+    radiusMeters: converted.radiusMeters,
   };
 }
 
@@ -790,7 +796,7 @@ async function daeToGlbDataUrl(
   href: string,
   resolveTexture?: (path: string) => Uint8Array | undefined,
   basePath = "",
-): Promise<string | null> {
+): Promise<{ url: string; radiusMeters: number } | null> {
   const blobUrls: string[] = [];
   const modifier = resolveTexture
     ? (url: string): string | undefined => {
@@ -805,14 +811,19 @@ async function daeToGlbDataUrl(
     : undefined;
   try {
     const { convertDaeToGlb } = await import("./collada-to-glb");
-    const glb = await convertDaeToGlb(daeText, modifier, basePath);
+    const { glb, radiusMeters } = await convertDaeToGlb(
+      daeText,
+      modifier,
+      basePath,
+    );
     if (glb.length > MAX_MODEL_GLB_BYTES) {
       console.warn(
         `Skipping a KML model: "${href}" converts to ${Math.round(glb.length / (1024 * 1024))} MB, over the ${Math.round(MAX_MODEL_GLB_BYTES / (1024 * 1024))} MB inline limit.`,
       );
       return null;
     }
-    return await bytesToDataUrl(glb, "model/gltf-binary");
+    const url = await bytesToDataUrl(glb, "model/gltf-binary");
+    return { url, radiusMeters };
   } catch (error) {
     console.warn(`Could not convert the KML model "${href}" to glTF.`, error);
     return null;
@@ -843,8 +854,9 @@ async function modelsFromKmz(
   const total = parsed.length;
   for (const [index, { model, baseDir }] of parsed.entries()) {
     if (isHttpUrl(model.href)) {
-      const url = await fetchDaeAsGlbDataUrl(model.href);
-      if (url) models.push(kmlModelLayer(model, url, path, index, total));
+      const converted = await fetchDaeAsGlbDataUrl(model.href);
+      if (converted)
+        models.push(kmlModelLayer(model, converted, path, index, total));
       continue;
     }
     const daeEntry = baseDir + model.href;
@@ -866,12 +878,13 @@ async function modelsFromKmz(
     const resolveTexture = (texturePath: string): Uint8Array | undefined =>
       findArchiveEntry(entries, daeDir + texturePath) ??
       findArchiveEntry(entries, texturePath);
-    const url = await daeToGlbDataUrl(
+    const converted = await daeToGlbDataUrl(
       new TextDecoder("utf-8").decode(data),
       model.href,
       resolveTexture,
     );
-    if (url) models.push(kmlModelLayer(model, url, path, index, total));
+    if (converted)
+      models.push(kmlModelLayer(model, converted, path, index, total));
   }
   return models;
 }
@@ -879,7 +892,9 @@ async function modelsFromKmz(
 // Fetch an absolute-URL `.dae`, convert it to a GLB data URL. Textures resolve
 // against the mesh's URL directory (best effort; a CORS-blocked fetch is
 // skipped). Returns null on any failure.
-async function fetchDaeAsGlbDataUrl(href: string): Promise<string | null> {
+async function fetchDaeAsGlbDataUrl(
+  href: string,
+): Promise<{ url: string; radiusMeters: number } | null> {
   try {
     const response = await fetch(href);
     if (!response.ok) {
@@ -919,8 +934,9 @@ async function modelsFromKml(
       );
       continue;
     }
-    const url = await fetchDaeAsGlbDataUrl(model.href);
-    if (url) models.push(kmlModelLayer(model, url, path, index, parsed.length));
+    const converted = await fetchDaeAsGlbDataUrl(model.href);
+    if (converted)
+      models.push(kmlModelLayer(model, converted, path, index, parsed.length));
   }
   return models;
 }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -874,9 +874,15 @@ async function modelsFromKmz(
       );
       continue;
     }
+    // `daeEntry` is the guessed path (`baseDir + href`); the mesh may actually
+    // have been found via the bare-href fallback above, so also try the href's
+    // own directory before the bare-basename fallback, so textures resolve when
+    // the href already carries the full archive-relative path.
     const daeDir = archiveDirname(normalizeArchivePath(daeEntry));
+    const hrefDir = archiveDirname(normalizeArchivePath(model.href));
     const resolveTexture = (texturePath: string): Uint8Array | undefined =>
       findArchiveEntry(entries, daeDir + texturePath) ??
+      findArchiveEntry(entries, hrefDir + texturePath) ??
       findArchiveEntry(entries, texturePath);
     const converted = await daeToGlbDataUrl(
       new TextDecoder("utf-8").decode(data),
@@ -896,7 +902,9 @@ async function fetchDaeAsGlbDataUrl(
   href: string,
 ): Promise<{ url: string; radiusMeters: number } | null> {
   try {
-    const response = await fetch(href);
+    // Bound the fetch so an unresponsive host can't hang the whole KML/KMZ load
+    // (models are resolved sequentially), mirroring the texture-load timeout.
+    const response = await fetch(href, { signal: AbortSignal.timeout(15000) });
     if (!response.ok) {
       console.warn(
         `Skipping a KML model: fetching "${href}" returned ${response.status}.`,
@@ -904,9 +912,12 @@ async function fetchDaeAsGlbDataUrl(
       return null;
     }
     const daeText = await response.text();
-    if (daeText.length > MAX_DAE_SOURCE_BYTES) {
+    // Measure real byte size (not UTF-16 code units) so the cap matches the
+    // archive path's `Uint8Array.length` check.
+    const daeBytes = new Blob([daeText]).size;
+    if (daeBytes > MAX_DAE_SOURCE_BYTES) {
       console.warn(
-        `Skipping a KML model: "${href}" is ${Math.round(daeText.length / (1024 * 1024))} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
+        `Skipping a KML model: "${href}" is ${Math.round(daeBytes / (1024 * 1024))} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
       );
       return null;
     }

--- a/apps/geolibre-desktop/src/types/three-addons.d.ts
+++ b/apps/geolibre-desktop/src/types/three-addons.d.ts
@@ -1,0 +1,25 @@
+// three.js ships its addon examples (`three/addons/*`) as JavaScript without
+// bundled type declarations under that import path, so declare the minimal
+// surface used by the COLLADA -> GLB conversion.
+declare module "three/addons/loaders/ColladaLoader.js" {
+  import type { Group, LoadingManager } from "three";
+  export class ColladaLoader {
+    constructor(manager?: LoadingManager);
+    parse(text: string, path: string): { scene: Group };
+  }
+}
+
+declare module "three/addons/exporters/GLTFExporter.js" {
+  import type { Object3D } from "three";
+  export interface GLTFExporterOptions {
+    binary?: boolean;
+  }
+  export class GLTFExporter {
+    parse(
+      input: Object3D,
+      onDone: (result: ArrayBuffer | object) => void,
+      onError: (error: unknown) => void,
+      options?: GLTFExporterOptions,
+    ): void;
+  }
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1018,6 +1018,23 @@ export class MapController {
         return;
       }
     }
+    // A glTF scenegraph model (e.g. a KML `<Model>`) is a 3D object: viewed
+    // straight down it is edge-on and effectively invisible (a vertical
+    // geological cross-section shows as a hairline). Frame it at a tilt so it
+    // reads as a 3D object on load, pulling back slightly so its vertical extent
+    // fits. The user can flatten the pitch afterward.
+    if (layer.metadata.customLayerType === "scenegraph") {
+      const camera = this.map.cameraForBounds(box, { padding: 40 });
+      if (camera?.center && typeof camera.zoom === "number") {
+        this.map.flyTo({
+          center: camera.center,
+          zoom: Math.max(camera.zoom - 0.75, 0),
+          pitch: 60,
+          duration: 800,
+        });
+        return;
+      }
+    }
     this.map.fitBounds(box, { padding: 40, duration: 800 });
   }
 

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -111,7 +111,7 @@ async function runEnsureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
     }
   }
   boundMap = map;
-  overlay = new deckGL.mapbox.MapboxOverlay({ interleaved: false, layers: [] });
+  overlay = new deckGL.mapbox.MapboxOverlay({ interleaved: true, layers: [] });
   overlayMounted = false;
   storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     if (state.layers !== previous.layers) renderDeckVizLayers();
@@ -161,10 +161,9 @@ function renderDeckVizLayers(): void {
   // depend on a later store change to mount.
   if (!overlayMounted) {
     if (!hasRenderableLayers) return;
-    // Add at top-left: MapboxOverlay's overlaid canvas is positioned `left:0`
-    // to fill the map, which only aligns when its control container is the
-    // left corner. The host's addControl otherwise defaults to top-right,
-    // pushing the canvas a full map-width to the right (off screen).
+    // Add at top-left for consistency with other deck.gl controls. Interleaved
+    // mode renders through MapLibre's WebGL context, so bearing/pitch camera
+    // updates stay in lockstep with the map for large geospatial models.
     if (!appRef.addMapControl(overlay, "top-left")) {
       if (mountRetries < MAX_MOUNT_RETRIES) {
         mountRetries += 1;

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -86,8 +86,14 @@ export interface DeckVizScenegraphConfig {
   modelUrl: string;
   /** Overall size multiplier in meters (ScenegraphLayer `sizeScale`). */
   sizeScale: number;
+  /** Minimum rendered pixels for one model unit. */
+  sizeMinPixels?: number;
   /** Heading in degrees clockwise from north, applied as the model's yaw. */
   bearing: number;
+  /** Extra roll in degrees applied after yaw. Defaults to deck.gl's glTF example. */
+  orientationRoll?: number;
+  /** Constant translation from the anchor point, [x, y, z] in meters. */
+  translation?: [number, number, number];
   /**
    * Constant altitude in meters, added to the per-instance altitude (or used
    * alone when no altitude column is mapped).
@@ -98,7 +104,10 @@ export interface DeckVizScenegraphConfig {
 export const DEFAULT_DECK_VIZ_SCENEGRAPH: DeckVizScenegraphConfig = {
   modelUrl: "",
   sizeScale: 1000,
+  sizeMinPixels: 1,
   bearing: 0,
+  orientationRoll: 90,
+  translation: [0, 0, 0],
   altitude: 0,
 };
 
@@ -867,7 +876,8 @@ const DEFINITIONS: DeckVizLayerDef[] = [
         // Floor the on-screen size so distant models stay visible; leave the
         // ceiling unset so zooming in scales the model up naturally instead of
         // clamping a single large asset (building, turbine) to a small dot.
-        sizeMinPixels: 1,
+        sizeMinPixels:
+          sg.sizeMinPixels ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeMinPixels ?? 1,
         getPosition: (record: AnyRecord) => {
           const [lng, lat] = position(record);
           const altitude =
@@ -879,8 +889,10 @@ const DEFINITIONS: DeckVizLayerDef[] = [
         getOrientation: (record: AnyRecord): [number, number, number] => [
           0,
           hasBearing ? readNumber(record, bearingKey) : sg.bearing,
-          90,
+          sg.orientationRoll ?? DEFAULT_DECK_VIZ_SCENEGRAPH.orientationRoll ?? 90,
         ],
+        getTranslation:
+          sg.translation ?? DEFAULT_DECK_VIZ_SCENEGRAPH.translation ?? [0, 0, 0],
         ...(hasScale
           ? {
               getScale: (record: AnyRecord): [number, number, number] => {

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -183,11 +183,30 @@ function readScenegraphConfig(
     sizeScale: Number.isFinite(candidate.sizeScale)
       ? (candidate.sizeScale as number)
       : DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale,
+    sizeMinPixels: Number.isFinite(candidate.sizeMinPixels)
+      ? (candidate.sizeMinPixels as number)
+      : DEFAULT_DECK_VIZ_SCENEGRAPH.sizeMinPixels,
     bearing: Number.isFinite(candidate.bearing)
       ? (candidate.bearing as number)
       : DEFAULT_DECK_VIZ_SCENEGRAPH.bearing,
+    orientationRoll: Number.isFinite(candidate.orientationRoll)
+      ? (candidate.orientationRoll as number)
+      : DEFAULT_DECK_VIZ_SCENEGRAPH.orientationRoll,
+    translation: readScenegraphTranslation(candidate.translation),
     altitude: Number.isFinite(candidate.altitude)
       ? (candidate.altitude as number)
       : DEFAULT_DECK_VIZ_SCENEGRAPH.altitude,
   };
+}
+
+function readScenegraphTranslation(
+  raw: unknown,
+): [number, number, number] {
+  if (!Array.isArray(raw) || raw.length !== 3) {
+    return DEFAULT_DECK_VIZ_SCENEGRAPH.translation ?? [0, 0, 0];
+  }
+  const values = raw.map((value) => Number(value));
+  return values.every((value) => Number.isFinite(value))
+    ? (values as [number, number, number])
+    : DEFAULT_DECK_VIZ_SCENEGRAPH.translation ?? [0, 0, 0];
 }

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -305,7 +305,10 @@ describe("scenegraph (glTF 3D model) layer", () => {
     assert.ok(config?.scenegraph);
     assert.equal(config.scenegraph.modelUrl, "https://example.com/model.glb");
     assert.equal(config.scenegraph.sizeScale, 250);
+    assert.equal(config.scenegraph.sizeMinPixels, 1);
     assert.equal(config.scenegraph.bearing, 45);
+    assert.equal(config.scenegraph.orientationRoll, 90);
+    assert.deepEqual(config.scenegraph.translation, [0, 0, 0]);
     assert.equal(config.scenegraph.altitude, 100);
   });
 
@@ -326,7 +329,10 @@ describe("scenegraph (glTF 3D model) layer", () => {
       config?.scenegraph?.sizeScale,
       DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale,
     );
+    assert.equal(config?.scenegraph?.sizeMinPixels, 1);
     assert.equal(config?.scenegraph?.bearing, 0);
+    assert.equal(config?.scenegraph?.orientationRoll, 90);
+    assert.deepEqual(config?.scenegraph?.translation, [0, 0, 0]);
   });
 
   it("builds a ScenegraphLayer whose accessors fold in transform + columns", () => {
@@ -354,7 +360,10 @@ describe("scenegraph (glTF 3D model) layer", () => {
       scenegraph: {
         modelUrl: "https://example.com/model.glb",
         sizeScale: 300,
+        sizeMinPixels: 0,
         bearing: 10,
+        orientationRoll: 0,
+        translation: [0, 0, -500],
         altitude: 25,
       },
     });
@@ -362,6 +371,7 @@ describe("scenegraph (glTF 3D model) layer", () => {
     const props = captured.props!;
     assert.equal(props.scenegraph, "https://example.com/model.glb");
     assert.equal(props.sizeScale, 300);
+    assert.equal(props.sizeMinPixels, 0);
     assert.equal(props.opacity, 0.5);
     const record = { lng: -122.4, lat: 37.8, alt: 50, heading: 90 };
     const position = (props.getPosition as (r: unknown) => number[])(record);
@@ -370,8 +380,9 @@ describe("scenegraph (glTF 3D model) layer", () => {
     const orientation = (
       props.getOrientation as (r: unknown) => number[]
     )(record);
-    // bearing column (90) drives yaw; trailing 90° roll stands the model up
-    assert.deepEqual(orientation, [0, 90, 90]);
+    // bearing column (90) drives yaw; configured roll lets KML models opt out
+    assert.deepEqual(orientation, [0, 90, 0]);
+    assert.deepEqual(props.getTranslation, [0, 0, -500]);
   });
 
   it("uses the constant bearing/altitude when no columns are mapped", () => {

--- a/tests/kml-model-layer.test.ts
+++ b/tests/kml-model-layer.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  kmlModelBounds,
+  kmlModelName,
+  kmlModelRow,
+  kmlModelUniformScale,
+  modelNameFromPath,
+} from "../apps/geolibre-desktop/src/lib/kml-model";
+import type { LoadedModel } from "../apps/geolibre-desktop/src/lib/tauri-io";
+
+function model(patch: Partial<LoadedModel> = {}): LoadedModel {
+  return {
+    kind: "model",
+    name: "House",
+    path: "town.kmz",
+    url: "data:model/gltf-binary;base64,AAAA",
+    longitude: -100,
+    latitude: 40,
+    altitude: 12,
+    heading: 45,
+    tilt: 0,
+    roll: 0,
+    scale: { x: 1, y: 1, z: 1 },
+    ...patch,
+  };
+}
+
+describe("kmlModelUniformScale", () => {
+  it("returns a uniform scale unchanged", () => {
+    assert.equal(kmlModelUniformScale({ x: 3, y: 3, z: 3 }), 3);
+  });
+
+  it("averages a non-uniform scale", () => {
+    assert.equal(kmlModelUniformScale({ x: 2, y: 4, z: 6 }), 4);
+  });
+
+  it("falls back to 1 for a non-positive average", () => {
+    assert.equal(kmlModelUniformScale({ x: 0, y: 0, z: 0 }), 1);
+    assert.equal(kmlModelUniformScale({ x: -1, y: -1, z: -1 }), 1);
+  });
+});
+
+describe("kmlModelRow", () => {
+  it("maps location, altitude, heading, and scale into one row", () => {
+    assert.deepEqual(kmlModelRow(model()), {
+      lng: -100,
+      lat: 40,
+      altitude: 12,
+      bearing: 45,
+      scale: 1,
+    });
+  });
+});
+
+describe("kmlModelBounds", () => {
+  it("pads a point extent that brackets the model location", () => {
+    const [w, s, e, n] = kmlModelBounds(model());
+    assert.ok(w < -100 && e > -100, "extent brackets the longitude");
+    assert.ok(s < 40 && n > 40, "extent brackets the latitude");
+  });
+});
+
+describe("model naming", () => {
+  it("strips the directory and extension", () => {
+    assert.equal(modelNameFromPath("a/b/town.kmz"), "town");
+    assert.equal(modelNameFromPath("model.dae"), "model");
+  });
+
+  it("keeps the model name when present", () => {
+    assert.equal(kmlModelName(model()), "House");
+  });
+
+  it("falls back to a path-derived name when unnamed", () => {
+    assert.equal(kmlModelName(model({ name: "" })), "town model");
+  });
+});

--- a/tests/kml-model-layer.test.ts
+++ b/tests/kml-model-layer.test.ts
@@ -22,6 +22,7 @@ function model(patch: Partial<LoadedModel> = {}): LoadedModel {
     tilt: 0,
     roll: 0,
     scale: { x: 1, y: 1, z: 1 },
+    radiusMeters: 0,
     ...patch,
   };
 }
@@ -58,6 +59,22 @@ describe("kmlModelBounds", () => {
     const [w, s, e, n] = kmlModelBounds(model());
     assert.ok(w < -100 && e > -100, "extent brackets the longitude");
     assert.ok(s < 40 && n > 40, "extent brackets the latitude");
+  });
+
+  it("grows the extent to frame a large model", () => {
+    // A ~33 km-radius model (e.g. a geological cross-section) should get an
+    // extent far wider than the point-pad fallback so it frames on load.
+    const [w, s, e, n] = kmlModelBounds(model({ radiusMeters: 33_000 }));
+    const [w0, s0] = kmlModelBounds(model({ radiusMeters: 0 }));
+    assert.ok(e - w > 0.5, "longitude extent spans the model's width");
+    assert.ok(n - s > 0.5, "latitude extent spans the model's height");
+    assert.ok(w < w0 && s < s0, "large extent is wider than the point pad");
+  });
+
+  it("falls back to the point pad for a model with no known extent", () => {
+    const [w, s, e, n] = kmlModelBounds(model({ radiusMeters: 0 }));
+    assert.ok(Math.abs(e - w - 0.004) < 1e-9, "longitude pad is 2 * minPad");
+    assert.ok(Math.abs(n - s - 0.004) < 1e-9, "latitude pad is 2 * minPad");
   });
 });
 

--- a/tests/kml-model-layer.test.ts
+++ b/tests/kml-model-layer.test.ts
@@ -4,6 +4,7 @@ import {
   kmlModelBounds,
   kmlModelDisplayName,
   kmlModelRow,
+  kmlModelTranslation,
   kmlModelUniformScale,
   modelNameFromPath,
 } from "../apps/geolibre-desktop/src/lib/kml-model";
@@ -23,6 +24,8 @@ function model(patch: Partial<LoadedModel> = {}): LoadedModel {
     roll: 0,
     scale: { x: 1, y: 1, z: 1 },
     radiusMeters: 0,
+    verticalMinMeters: 0,
+    verticalMaxMeters: 0,
     ...patch,
   };
 }
@@ -86,6 +89,24 @@ describe("kmlModelBounds", () => {
     const [w, s, e, n] = kmlModelBounds(model({ radiusMeters: 0 }));
     assert.ok(Math.abs(e - w - 0.004) < 1e-9, "longitude pad is 2 * minPad");
     assert.ok(Math.abs(n - s - 0.004) < 1e-9, "latitude pad is 2 * minPad");
+  });
+});
+
+describe("kmlModelTranslation", () => {
+  it("leaves building-scale vertical models anchored normally", () => {
+    assert.deepEqual(
+      kmlModelTranslation(model({ verticalMinMeters: 0, verticalMaxMeters: 50 })),
+      [0, 0, 0],
+    );
+  });
+
+  it("lowers kilometer-scale vertical models so their top aligns to the anchor", () => {
+    assert.deepEqual(
+      kmlModelTranslation(
+        model({ verticalMinMeters: 0, verticalMaxMeters: 5_600 }),
+      ),
+      [0, 0, -5_600],
+    );
   });
 });
 

--- a/tests/kml-model-layer.test.ts
+++ b/tests/kml-model-layer.test.ts
@@ -71,6 +71,17 @@ describe("kmlModelBounds", () => {
     assert.ok(w < w0 && s < s0, "large extent is wider than the point pad");
   });
 
+  it("scales the extent by the KML <Scale> factor", () => {
+    // The mesh renders scaled by the uniform <Scale>, so the framing extent
+    // must scale too — a 10x-scaled model needs a ~10x-wider box.
+    const base = model({ radiusMeters: 1_000, scale: { x: 1, y: 1, z: 1 } });
+    const scaled = model({ radiusMeters: 1_000, scale: { x: 10, y: 10, z: 10 } });
+    const [bw, , be] = kmlModelBounds(base);
+    const [sw, , se] = kmlModelBounds(scaled);
+    const ratio = (se - sw) / (be - bw);
+    assert.ok(ratio > 9 && ratio < 11, `expected ~10x wider extent, got ${ratio}`);
+  });
+
   it("falls back to the point pad for a model with no known extent", () => {
     const [w, s, e, n] = kmlModelBounds(model({ radiusMeters: 0 }));
     assert.ok(Math.abs(e - w - 0.004) < 1e-9, "longitude pad is 2 * minPad");

--- a/tests/kml-model-layer.test.ts
+++ b/tests/kml-model-layer.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   kmlModelBounds,
-  kmlModelName,
+  kmlModelDisplayName,
   kmlModelRow,
   kmlModelUniformScale,
   modelNameFromPath,
@@ -85,10 +85,10 @@ describe("model naming", () => {
   });
 
   it("keeps the model name when present", () => {
-    assert.equal(kmlModelName(model()), "House");
+    assert.equal(kmlModelDisplayName(model()), "House");
   });
 
   it("falls back to a path-derived name when unnamed", () => {
-    assert.equal(kmlModelName(model({ name: "" })), "town model");
+    assert.equal(kmlModelDisplayName(model({ name: "" })), "town model");
   });
 });

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -162,6 +162,10 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
     getProjection: () => ({ type: "mercator" }),
     flyTo: record("flyTo"),
     fitBounds: record("fitBounds"),
+    cameraForBounds: (...args: unknown[]) => {
+      calls.push({ method: "cameraForBounds", args });
+      return { center: { lng: 51.9, lat: 35.7 }, zoom: 8.5 };
+    },
     addControl: record("addControl"),
     removeControl: record("removeControl"),
     once: () => {},
@@ -497,6 +501,31 @@ describe("MapController camera and query helpers", () => {
     controller.fitBounds([0, 0, Number.NaN, 1]);
 
     assert.equal(fake.calls.length, 0);
+  });
+
+  it("frames a scenegraph model layer at a tilt so it is not edge-on", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+
+    controller.fitLayer(
+      pointLayer("model", {
+        type: "deckgl-viz",
+        source: { type: "deckgl-viz" },
+        geojson: undefined,
+        metadata: {
+          customLayerType: "scenegraph",
+          bounds: [51.5, 35.3, 52.3, 36.1],
+        },
+      }),
+    );
+
+    const flyTo = fake.calls.find((c) => c.method === "flyTo");
+    assert.ok(flyTo, "a scenegraph fit flies (with pitch) rather than fitBounds");
+    assert.equal((flyTo.args[0] as { pitch: number }).pitch, 60);
+    assert.ok(
+      !fake.calls.some((c) => c.method === "fitBounds"),
+      "does not also fit bounds top-down",
+    );
   });
 
   it("identifies features across a synced layer's style layers", () => {


### PR DESCRIPTION
## Summary

Adds support for KML/KMZ **`<Placemark><Model>`** 3D models (COLLADA `.dae`), the second of the three asks in #1119 (GroundOverlay merged in #1125; TimeSpan animation is a follow-up). Google Earth exports that place a 3D model previously loaded nothing.

## What changed

- **KML parser** (`kml.ts`): new `parseKmlModels()` reads `<Model>` elements: `<Link><href>`, `<Location>` (lon/lat/alt), `<Orientation>` (heading/tilt/roll), and `<Scale>` (x/y/z).
- **DAE → GLB conversion** (`collada-to-glb.ts`, new): converts COLLADA to a self-contained binary glTF using **three.js** (`ColladaLoader` → `GLTFExporter`). Packaged textures resolve through a loading-manager URL modifier and are embedded into the GLB; missing vertex normals are computed so lit shading is correct. No new npm dependency — three.js is already a dependency.
- **Loaders** (`tauri-io.ts`): the KMZ/KML load path now also emits 3D-model layers. Each model's `.dae` is read from the archive (relative to its KML's directory, then a global fallback) or fetched from an absolute URL, converted, and inlined as a `data:` GLB URL (capped at 24 MB) so it persists with the project. A `LoadedModel` variant joins the `LoadedLayer` union alongside vector and overlay results.
- **Rendering** (`kml-model-layer.ts` + `kml-model.ts`): builds a deck.gl **scenegraph** layer through the existing glTF 3D-model path (the deckgl-viz overlay is active by default, so it renders with no extra wiring). Heading is applied as the model bearing and altitude is honored; a non-uniform `<Scale>` is averaged to one factor. The pure placement math lives in `kml-model.ts` for unit testing.
- **DesktopShell**: the drop path branches on the model kind and adds the scenegraph layer.

A KMZ can now yield any mix of vector placemarks, ground overlays, and 3D models.

## Scope / follow-ups

Per the plan for #1119, this is the DAE-models PR. `<Orientation>` **tilt/roll** and true **non-uniform** scale are not yet applied (the shared scenegraph layer exposes only a single bearing and uniform scale); these are noted as follow-ups. TimeSpan-based GroundOverlay animation is a separate upcoming PR.

## Testing

- New unit tests (`tests/kml-model-layer.test.ts`) for the placement math (scale averaging, row/bounds, naming). Full frontend suite green (2098 pass); build and pre-commit pass.
- Verified end to end in the real app: dropped a KMZ containing `<Model>` → `cube.dae`; the loader produced a self-contained GLB model layer, and a tilted camera showed the 3D cube rendered at the model's coordinates (correct location, shaded faces from computed normals). Regression-checked that vector and GroundOverlay KMZ still load.

Part of #1119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing KML/KMZ 3D `<Model>` layers and rendering them with deck.gl scenegraph (position/orientation/scale).
  * Added COLLADA (DAE) → self-contained GLB conversion for textured 3D models, including automatic model extent calculation.
* **Bug Fixes**
  * Improved KML model parsing to safely skip invalid/unrenderable models.
  * Updated layer “fit” behavior to avoid timing issues with deck.gl-backed layers.
  * Refined KMZ ground-overlay icon resolution and expanded model loading for drag-and-drop and restore flows.
* **Tests**
  * Added unit tests covering KML model scaling, bounds, row mapping, and display name parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->