### PR TITLE
feat(layers): add a GeoEditor toggle button to the Layers panel header

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -21,6 +21,7 @@ import {
   detectTimeProperties,
   getLayerTimeBinding,
   BASEMAP_CONTROL_PLUGIN_ID,
+  GEO_EDITOR_PLUGIN_ID,
   RASTER_SOURCE_KIND,
   reloadVectorControlLayer,
   SKETCHES_SOURCE_KIND,
@@ -92,6 +93,7 @@ import {
   PanelLeftOpen,
   Pencil,
   PencilRuler,
+  PenTool,
   RefreshCw,
   Save,
   SquarePen,
@@ -1917,6 +1919,24 @@ export function LayerPanel({
               className={cn(
                 "h-4 w-4",
                 isPluginActive(BASEMAP_CONTROL_PLUGIN_ID) && "text-primary",
+              )}
+            />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title={t("layers.geoEditor")}
+            aria-label={t("layers.geoEditor")}
+            aria-pressed={isPluginActive(GEO_EDITOR_PLUGIN_ID)}
+            onClick={() =>
+              togglePlugin(GEO_EDITOR_PLUGIN_ID, createAppAPI(mapControllerRef))
+            }
+          >
+            <PenTool
+              className={cn(
+                "h-4 w-4",
+                isPluginActive(GEO_EDITOR_PLUGIN_ID) && "text-primary",
               )}
             />
           </Button>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2524,6 +2524,7 @@
     "backgroundNameFixed": "The name of the background basemap is fixed and cannot be changed.",
     "newGroup": "New group",
     "basemaps": "Basemaps",
+    "geoEditor": "GeoEditor",
     "collapseGroup": "Collapse group",
     "expandGroup": "Expand group",
     "hideGroup": "Hide group",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2834,3 +2834,257 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   background-color: hsl(var(--accent)) !important;
   color: hsl(var(--accent-foreground)) !important;
 }
+
+/*
+ * GeoEditor control (maplibre-gl-geo-editor). The component stylesheet
+ * hardcodes light-theme colors (#fff surfaces, #333 text, #e5e5e5 borders)
+ * with no theme hooks, so the toolbar, dialogs, and attribute panel stay
+ * light when the app is in dark mode. Remap every neutral surface, text, and
+ * border color onto the app's design tokens (which switch with the `.dark`
+ * class on <html>) so the control tracks the in-app theme. The blue
+ * active-tool/primary color (#3388ff) is left as upstream ships it — it is
+ * legible on both themes. index.css is imported after the component
+ * stylesheet, so these same-specificity rules win the cascade.
+ */
+.geo-editor-toolbar {
+  background: hsl(var(--background));
+  box-shadow: 0 0 0 2px hsl(var(--border));
+}
+
+.geo-editor-tool-group:not(:last-child) {
+  border-bottom-color: hsl(var(--border));
+}
+
+.geo-editor-toolbar--horizontal .geo-editor-tool-group:not(:last-child) {
+  border-right-color: hsl(var(--border));
+}
+
+.geo-editor-tool-group-label {
+  color: hsl(var(--muted-foreground));
+}
+
+/* Inside the ctrl-group, MapLibre's `.maplibregl-ctrl button` (higher
+   specificity than the component's `.geo-editor-tool-button`) already forces
+   a transparent button background, so only the icon color needs remapping.
+   MapLibre's hover tint (rgba(0,0,0,.05)) is invisible on a dark toolbar, so
+   out-specificity it with a token-based highlight. */
+.geo-editor-tool-button {
+  color: hsl(var(--foreground));
+}
+
+.geo-editor-control button.geo-editor-tool-button:not(:disabled):hover {
+  background-color: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+/* Dialogs (save/open/clear confirmations). */
+.geo-editor-dialog {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.geo-editor-dialog-header,
+.geo-editor-dialog-footer {
+  border-color: hsl(var(--border));
+}
+
+.geo-editor-dialog-title,
+.geo-editor-label {
+  color: hsl(var(--foreground));
+}
+
+.geo-editor-dialog-close {
+  color: hsl(var(--muted-foreground));
+}
+
+.geo-editor-dialog-close:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+/* Text inputs, selects, and textareas default to the UA's light chrome. */
+.geo-editor-input,
+.geo-editor-rotate-popup-input,
+.geo-editor-rotate-popup-select,
+.geo-editor-attribute-input,
+.geo-editor-attribute-select,
+.geo-editor-attribute-textarea {
+  background: hsl(var(--background));
+  border-color: hsl(var(--border));
+  color: hsl(var(--foreground));
+}
+
+.geo-editor-attribute-input:disabled,
+.geo-editor-attribute-select:disabled,
+.geo-editor-attribute-textarea:disabled {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+.geo-editor-slider {
+  background: hsl(var(--muted));
+}
+
+.geo-editor-btn--secondary,
+.geo-editor-rotate-popup-cancel {
+  background: hsl(var(--secondary));
+  border-color: hsl(var(--border));
+  color: hsl(var(--secondary-foreground));
+}
+
+.geo-editor-btn--secondary:hover,
+.geo-editor-rotate-popup-cancel:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.geo-editor-stats {
+  background: hsl(var(--muted));
+}
+
+.geo-editor-stat-value {
+  color: hsl(var(--foreground));
+}
+
+.geo-editor-stat-label {
+  color: hsl(var(--muted-foreground));
+}
+
+/* Feature-properties and numeric-rotation popups rendered on the map. Their
+   content sits in MapLibre's always-white `.maplibregl-popup-content`, so the
+   popup surface (and its anchor tip) must be themed along with the text —
+   otherwise the token-mapped text goes light-on-white in dark mode. Mirrors
+   the `.geolibre-identify-popup` treatment above. */
+.geo-editor-properties-popup .maplibregl-popup-content,
+.geo-editor-rotate-popup .maplibregl-popup-content {
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--popover-foreground));
+}
+
+.geo-editor-properties-popup .maplibregl-popup-close-button,
+.geo-editor-rotate-popup .maplibregl-popup-close-button {
+  color: hsl(var(--muted-foreground));
+}
+
+:is(.geo-editor-properties-popup, .geo-editor-rotate-popup):is(
+    .maplibregl-popup-anchor-top,
+    .maplibregl-popup-anchor-top-left,
+    .maplibregl-popup-anchor-top-right
+  )
+  .maplibregl-popup-tip {
+  border-bottom-color: hsl(var(--popover));
+}
+
+:is(.geo-editor-properties-popup, .geo-editor-rotate-popup):is(
+    .maplibregl-popup-anchor-bottom,
+    .maplibregl-popup-anchor-bottom-left,
+    .maplibregl-popup-anchor-bottom-right
+  )
+  .maplibregl-popup-tip {
+  border-top-color: hsl(var(--popover));
+}
+
+.geo-editor-popup-table td {
+  border-bottom-color: hsl(var(--border));
+}
+
+.geo-editor-popup-key,
+.geo-editor-rotate-popup-title {
+  color: hsl(var(--foreground));
+}
+
+.geo-editor-popup-value,
+.geo-editor-popup-empty,
+.geo-editor-rotate-popup-row span {
+  color: hsl(var(--muted-foreground));
+}
+
+/* Attribute editing panel. */
+.geo-editor-attribute-panel {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.geo-editor-attribute-panel-header,
+.geo-editor-attribute-panel-footer {
+  background: hsl(var(--muted));
+  border-color: hsl(var(--border));
+}
+
+.geo-editor-attribute-panel-title,
+.geo-editor-attribute-label,
+.geo-editor-attribute-checkbox-label {
+  color: hsl(var(--foreground));
+}
+
+.geo-editor-attribute-panel-close {
+  color: hsl(var(--muted-foreground));
+}
+
+.geo-editor-attribute-panel-close:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.geo-editor-attribute-readonly {
+  background-color: hsl(var(--muted));
+  border-color: hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+}
+
+.geo-editor-attribute-readonly-null,
+.geo-editor-attribute-empty {
+  color: hsl(var(--muted-foreground));
+}
+
+.geo-editor-attribute-extra-section {
+  border-top-color: hsl(var(--border));
+}
+
+.geo-editor-attribute-extra-section-title {
+  color: hsl(var(--muted-foreground));
+}
+
+/* Native widgets (date pickers, selects, checkboxes) follow the app theme,
+   not the OS, inside GeoEditor surfaces. */
+.geo-editor-control,
+.geo-editor-dialog,
+.geo-editor-attribute-panel,
+.geo-editor-rotate-popup-form {
+  color-scheme: light;
+}
+
+.dark .geo-editor-control,
+.dark .geo-editor-dialog,
+.dark .geo-editor-attribute-panel,
+.dark .geo-editor-rotate-popup-form {
+  color-scheme: dark;
+}
+
+/* The pastel info/warning/error/success fills would glare on dark surfaces;
+   swap them for translucent tints of the same hues. */
+.dark .geo-editor-message--info,
+.dark .geo-editor-attribute-geometry-badge {
+  background: rgba(51, 136, 255, 0.15);
+  border-color: rgba(51, 136, 255, 0.4);
+  color: #9cc7ff;
+}
+
+.dark .geo-editor-message--warning {
+  background: rgba(255, 193, 7, 0.12);
+  border-color: rgba(255, 193, 7, 0.35);
+  color: #ffd75e;
+}
+
+.dark .geo-editor-message--error {
+  background: rgba(220, 53, 69, 0.15);
+  border-color: rgba(220, 53, 69, 0.4);
+  color: #f1919c;
+}
+
+.dark .geo-editor-message--success {
+  background: rgba(40, 167, 69, 0.15);
+  border-color: rgba(40, 167, 69, 0.4);
+  color: #7fd493;
+}

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2985,6 +2985,16 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   border-top-color: hsl(var(--popover));
 }
 
+:is(.geo-editor-properties-popup, .geo-editor-rotate-popup).maplibregl-popup-anchor-left
+  .maplibregl-popup-tip {
+  border-right-color: hsl(var(--popover));
+}
+
+:is(.geo-editor-properties-popup, .geo-editor-rotate-popup).maplibregl-popup-anchor-right
+  .maplibregl-popup-tip {
+  border-left-color: hsl(var(--popover));
+}
+
 .geo-editor-popup-table td {
   border-bottom-color: hsl(var(--border));
 }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -303,6 +303,7 @@ export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreFemaWmsPlugin } from "./plugins/maplibre-fema-wms";
 export {
   maplibreGeoEditorPlugin,
+  GEO_EDITOR_PLUGIN_ID,
   canEditLayerGeometry,
   SKETCHES_SOURCE_KIND,
   startLayerGeometryEdit,

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -135,8 +135,10 @@ const GEOMAN_EDIT_SYNC_EVENTS = [
   "gm:rotateend",
 ] as const;
 
+export const GEO_EDITOR_PLUGIN_ID = "maplibre-gl-geo-editor";
+
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
-  id: "maplibre-gl-geo-editor",
+  id: GEO_EDITOR_PLUGIN_ID,
   name: "GeoEditor",
   version: "0.9.0",
   activate: (app: GeoLibreAppAPI) => {

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  GEO_EDITOR_PLUGIN_ID,
+  maplibreGeoEditorPlugin as plugin,
+} from "../packages/plugins/src/plugins/maplibre-geo-editor";
+
+describe("maplibreGeoEditorPlugin", () => {
+  // The Layers panel toggle keys its active-state highlight on the exported
+  // constant, so the two must never drift apart.
+  it("has the exported id", () => {
+    assert.equal(plugin.id, GEO_EDITOR_PLUGIN_ID);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a GeoEditor toggle button in the Layers panel header, right after the Basemaps button, so the editor can be activated in one click instead of going through the Plugins menu
- Exports a `GEO_EDITOR_PLUGIN_ID` constant from `@geolibre/plugins` (mirroring `BASEMAP_CONTROL_PLUGIN_ID`) and reuses the existing plugin toggle wiring, including the active-state highlight and `aria-pressed`
- Adds the `layers.geoEditor` i18n key

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:frontend` passes (2098 tests)
- [x] Verified in the browser: clicking the new button adds the GeoEditor control to the map with the full draw/edit toolbar, the button highlights, and clicking again removes the control and clears the highlight, with no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Geo Editor icon toggle to the Layers panel header for quick enable/disable.
  * Added the English “GeoEditor” label for the Geo Editor control.
* **Style**
  * Updated Geo Editor UI styling to better match light/dark mode, including toolbars, dialogs, popups, form elements, and message variants.
* **Tests**
  * Added a check to ensure the Geo Editor plugin identifier remains consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->