### PR TITLE
feat(basemaps): per-project ellipsoid + Mars/Moon basemaps

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -2,6 +2,7 @@ import {
   BLANK_BASEMAP,
   createDefaultMapView,
   OPENFREEMAP_BASEMAPS,
+  PLANETARY_BASEMAPS,
   PROTOMAPS_BASEMAPS,
   useAppStore,
   type MapViewState,
@@ -50,6 +51,7 @@ const THREE_D_MAP_VIEW: MapViewState = {
 type BasemapChoice =
   | (typeof OPENFREEMAP_BASEMAPS)[number]["id"]
   | (typeof PROTOMAPS_BASEMAPS)[number]["id"]
+  | (typeof PLANETARY_BASEMAPS)[number]["id"]
   | typeof CUSTOM_BASEMAP_ID
   | typeof BLANK_BASEMAP_ID;
 
@@ -142,6 +144,12 @@ export function NewProjectDialog({
       ),
     [protomapsPresets, selectedBasemapId],
   );
+  // Planetary basemaps are a separate list because selecting one also sets the
+  // project's celestial body (so measurements use that body's radius).
+  const selectedPlanetary = useMemo(
+    () => PLANETARY_BASEMAPS.find((basemap) => basemap.id === selectedBasemapId),
+    [selectedBasemapId],
+  );
   const isCustomUrlValid = useMemo(() => {
     if (!customStyleUrl) return false;
     try {
@@ -153,7 +161,7 @@ export function NewProjectDialog({
   }, [customStyleUrl]);
   const canCreate = isCustomSelected
     ? isCustomUrlValid
-    : isBlankSelected || Boolean(selectedPreset);
+    : isBlankSelected || Boolean(selectedPreset) || Boolean(selectedPlanetary);
 
   const resetForm = () => {
     setSelectedBasemapId(DEFAULT_BASEMAP_ID);
@@ -175,12 +183,15 @@ export function NewProjectDialog({
       ? customStyleUrl
       : isBlankSelected
         ? BLANK_BASEMAP
-        : selectedPreset?.styleUrl;
+        : (selectedPreset ?? selectedPlanetary)?.styleUrl;
     if (basemapStyleUrl == null) return;
 
     newProject({
       name: projectName.trim() || DEFAULT_PROJECT_NAME,
       basemapStyleUrl,
+      // A planetary basemap seeds the matching celestial body; other basemaps
+      // leave the project on the default Earth ellipsoid.
+      ellipsoidId: selectedPlanetary?.ellipsoidId,
       mapView:
         selectedBasemapId === LIBERTY_3D_ID
           ? THREE_D_MAP_VIEW
@@ -309,6 +320,23 @@ export function NewProjectDialog({
                     </div>
                   </div>
                 ) : null}
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    {t("basemapPicker.sectionPlanetary")}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    {PLANETARY_BASEMAPS.map((basemap) => (
+                      <BasemapButton
+                        key={basemap.id}
+                        id={basemap.id}
+                        name={basemap.name}
+                        selected={selectedBasemapId === basemap.id}
+                        onSelect={setSelectedBasemapId}
+                      />
+                    ))}
+                  </div>
+                </div>
 
                 <div className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PROJECT_PREFERENCES,
+  ELLIPSOIDS,
   GEOCODING_PROVIDERS,
   getGeocodingProvider,
   normalizeGeocodingProviderId,
@@ -1509,6 +1510,29 @@ export function SettingsDialog({
                     />
                     {t("settings.map.renderWorldCopies")}
                   </label>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="settings-ellipsoid">
+                      {t("settings.map.ellipsoid")}
+                    </Label>
+                    <Select
+                      id="settings-ellipsoid"
+                      value={draftPreferences.map.ellipsoidId}
+                      onChange={(event) =>
+                        updateMapPreferences({
+                          ellipsoidId: event.target.value,
+                        })
+                      }
+                    >
+                      {ELLIPSOIDS.map((ellipsoid) => (
+                        <option key={ellipsoid.id} value={ellipsoid.id}>
+                          {ellipsoid.name}
+                        </option>
+                      ))}
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.map.ellipsoidHint")}
+                    </p>
+                  </div>
                 </div>
               ) : null}
               {effectiveSection === "layout" ? (

--- a/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
@@ -1,4 +1,9 @@
-import { BLANK_BASEMAP, useAppStore } from "@geolibre/core";
+import {
+  BLANK_BASEMAP,
+  PLANETARY_BASEMAPS,
+  useAppStore,
+  type PlanetaryBasemap,
+} from "@geolibre/core";
 import {
   Button,
   cn,
@@ -73,6 +78,7 @@ export function BasemapPickerDialog({
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const setBasemapStyleUrl = useAppStore((s) => s.setBasemapStyleUrl);
   const setMapView = useAppStore((s) => s.setMapView);
+  const setPreferences = useAppStore((s) => s.setPreferences);
 
   const openFreeMapPresets = useMemo(() => getOpenFreeMapPresets(), []);
   // Protomaps styles need an API key (VITE_PROTOMAPS_API_KEY). It can come from
@@ -92,7 +98,15 @@ export function BasemapPickerDialog({
   }, [open]);
 
   const allPresets = useMemo(
-    () => [...openFreeMapPresets, ...protomapsPresets],
+    () => [
+      ...openFreeMapPresets,
+      ...protomapsPresets,
+      ...PLANETARY_BASEMAPS.map((b) => ({
+        id: b.id,
+        name: b.name,
+        styleUrl: b.styleUrl,
+      })),
+    ],
     [openFreeMapPresets, protomapsPresets],
   );
 
@@ -131,6 +145,21 @@ export function BasemapPickerDialog({
     if (preset.id === LIBERTY_3D_ID) {
       // Tilt the current view into 3D in place, preserving center and zoom.
       setMapView({ pitch: THREE_D_PITCH }, true);
+    }
+    onOpenChange(false);
+  };
+
+  // Selecting a planetary basemap also switches the project's celestial body so
+  // measurements (distance/area/scale) use that body's radius, and the globe
+  // control renders it as the correct sphere.
+  const applyPlanetary = (basemap: PlanetaryBasemap) => {
+    setBasemapStyleUrl(basemap.styleUrl);
+    const prefs = useAppStore.getState().preferences;
+    if (prefs.map.ellipsoidId !== basemap.ellipsoidId) {
+      setPreferences({
+        ...prefs,
+        map: { ...prefs.map, ellipsoidId: basemap.ellipsoidId },
+      });
     }
     onOpenChange(false);
   };
@@ -193,6 +222,22 @@ export function BasemapPickerDialog({
               </div>
             </div>
           ) : null}
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("basemapPicker.sectionPlanetary")}
+            </p>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {PLANETARY_BASEMAPS.map((basemap) => (
+                <PresetButton
+                  key={basemap.id}
+                  name={basemap.name}
+                  selected={activeChoice === basemap.id}
+                  onSelect={() => applyPlanetary(basemap)}
+                />
+              ))}
+            </div>
+          </div>
 
           <div className="space-y-2">
             <p className="text-xs font-medium text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -473,12 +473,6 @@ export function LayerPanel({
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
   const [basemapPickerOpen, setBasemapPickerOpen] = useState(false);
-  // Transient note shown when the user double-clicks the Background name (the
-  // rename gesture on every other layer). The background name is fixed, so
-  // instead of staying silent we surface a short-lived message explaining why
-  // (#838). The timer ref clears it after the standard status duration.
-  const [backgroundNameNotice, setBackgroundNameNotice] = useState(false);
-  const backgroundNoticeTimerRef = useRef<number | null>(null);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(
     null,
   );
@@ -706,26 +700,6 @@ export function LayerPanel({
     setEditingLayerId(null);
     setEditingName("");
   };
-
-  const showBackgroundNameNotice = useCallback(() => {
-    if (backgroundNoticeTimerRef.current !== null) {
-      window.clearTimeout(backgroundNoticeTimerRef.current);
-    }
-    setBackgroundNameNotice(true);
-    backgroundNoticeTimerRef.current = window.setTimeout(() => {
-      backgroundNoticeTimerRef.current = null;
-      setBackgroundNameNotice(false);
-    }, REFRESH_STATUS_DURATION_MS);
-  }, []);
-
-  useEffect(
-    () => () => {
-      if (backgroundNoticeTimerRef.current !== null) {
-        window.clearTimeout(backgroundNoticeTimerRef.current);
-      }
-    },
-    [],
-  );
 
   const clearRefreshStatusTimer = useCallback((layerId: string) => {
     const timer = refreshStatusTimersRef.current.get(layerId);
@@ -2698,28 +2672,13 @@ export function LayerPanel({
                 )}
               </button>
               <Layers className="h-3.5 w-3.5 text-muted-foreground" />
-              <span
-                className="flex-1 truncate text-sm font-medium"
-                title={t("layers.backgroundNameFixed")}
-                onDoubleClick={(e: ReactMouseEvent) => {
-                  // The card's own onDoubleClick opens the basemap picker; on
-                  // the name we instead explain that the name is fixed, since
-                  // that is where users attempt the rename gesture (#838).
-                  e.stopPropagation();
-                  showBackgroundNameNotice();
-                }}
-              >
+              <span className="flex-1 truncate text-sm font-medium">
                 {t("layers.background")}
               </span>
               <span className="text-[10px] uppercase text-muted-foreground">
                 {t("layers.typeBasemap")}
               </span>
             </div>
-            {backgroundNameNotice && (
-              <p className="mt-1 text-[10px] text-amber-600">
-                {t("layers.backgroundNameFixed")}
-              </p>
-            )}
             <LayerOpacitySlider
               label={t("layers.opacity")}
               ariaLabel={t("layers.basemapOpacity")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -96,7 +96,8 @@
   "basemapPicker": {
     "title": "Change basemap",
     "applyCustom": "Apply",
-    "invalidUrl": "Enter a valid HTTP or HTTPS style URL."
+    "invalidUrl": "Enter a valid HTTP or HTTPS style URL.",
+    "sectionPlanetary": "Planetary"
   },
   "common": {
     "pickColorFromScreen": "Pick a color from the screen",
@@ -1165,6 +1166,8 @@
       "maxZoom": "Max zoom",
       "maxPitch": "Max pitch",
       "renderWorldCopies": "Render world copies",
+      "ellipsoid": "Celestial body",
+      "ellipsoidHint": "Sets the radius used for distance, area, and scale measurements. Pick a matching planetary basemap under Add Data.",
       "errorBoundsUnavailable": "The map bounds are not available yet."
     },
     "layout": {
@@ -2521,7 +2524,6 @@
     "opacityValueInputAria": "{{label}} value",
     "opacityValueEditAria": "Edit {{label}} value",
     "basemapOpacity": "Basemap opacity",
-    "backgroundNameFixed": "The name of the background basemap is fixed and cannot be changed.",
     "newGroup": "New group",
     "basemaps": "Basemaps",
     "collapseGroup": "Collapse group",

--- a/packages/core/src/ellipsoids.ts
+++ b/packages/core/src/ellipsoids.ts
@@ -1,0 +1,212 @@
+/**
+ * Celestial-body ellipsoids and the planetary basemaps that pair with them.
+ *
+ * GeoLibre is Earth-centric by construction: MapLibre only renders Web Mercator
+ * and all vector data is kept as WGS84 lon/lat GeoJSON. This module does *not*
+ * change that — MapLibre still treats the planet as a unit sphere and there is
+ * no true multi-CRS rendering (see maplibre-gl-js#168). What it adds is a
+ * per-project notion of *which body* the coordinates describe, so that:
+ *
+ *   - distance / area / scale measurements use that body's radius instead of a
+ *     hardcoded Earth radius, and
+ *   - Moon / Mars basemaps (published in a Web-Mercator tiling scheme) can be
+ *     selected like any other basemap.
+ *
+ * The active ellipsoid is a lightweight module-level singleton kept in sync with
+ * the project's map preferences (see the store's `setPreferences`). Measurement
+ * helpers read it lazily at call time, so callers in other packages don't need
+ * the value threaded through their signatures — a deliberate prototype-friendly
+ * shortcut over a full CRS/context refactor.
+ */
+
+/** A biaxial (rotational) ellipsoid describing a celestial body. */
+export interface Ellipsoid {
+  /** Stable id persisted in the project (`map.ellipsoidId`). */
+  id: string;
+  /** Human-readable name shown in the UI. */
+  name: string;
+  /** Equatorial (semi-major) radius in metres — the "web mercator" radius. */
+  semiMajorAxisMeters: number;
+  /**
+   * Inverse flattening `1/f`. `0` denotes a perfect sphere (Moon), in which case
+   * the polar radius equals {@link semiMajorAxisMeters}.
+   */
+  inverseFlattening: number;
+}
+
+/**
+ * Built-in ellipsoids. Earth is WGS 84; the Moon and Mars use IAU-adopted
+ * figures. The Moon is modelled as a sphere (its flattening is negligible).
+ */
+export const ELLIPSOIDS = [
+  {
+    id: "earth",
+    name: "Earth (WGS 84)",
+    semiMajorAxisMeters: 6378137,
+    inverseFlattening: 298.257223563,
+  },
+  {
+    id: "moon",
+    name: "Moon",
+    semiMajorAxisMeters: 1737400,
+    inverseFlattening: 0,
+  },
+  {
+    id: "mars",
+    name: "Mars (IAU 2000)",
+    semiMajorAxisMeters: 3396190,
+    inverseFlattening: 169.894447,
+  },
+] as const satisfies readonly Ellipsoid[];
+
+export type EllipsoidId = (typeof ELLIPSOIDS)[number]["id"];
+
+export const DEFAULT_ELLIPSOID_ID: EllipsoidId = "earth";
+
+/** Look an ellipsoid up by id, falling back to Earth for unknown ids. */
+export function getEllipsoid(id: string | undefined): Ellipsoid {
+  return (
+    ELLIPSOIDS.find((e) => e.id === id) ??
+    ELLIPSOIDS.find((e) => e.id === DEFAULT_ELLIPSOID_ID)!
+  );
+}
+
+/**
+ * Mean radius `R = (2a + b) / 3` in metres, where `b` is the polar radius
+ * derived from the inverse flattening. This is the radius used for spherical
+ * (haversine) distance and area math.
+ */
+export function meanRadiusMeters(ellipsoid: Ellipsoid): number {
+  const a = ellipsoid.semiMajorAxisMeters;
+  if (!ellipsoid.inverseFlattening) return a;
+  const f = 1 / ellipsoid.inverseFlattening;
+  const b = a * (1 - f);
+  return (2 * a + b) / 3;
+}
+
+// --- Active ellipsoid singleton -------------------------------------------
+
+let activeEllipsoidId: EllipsoidId = DEFAULT_ELLIPSOID_ID;
+
+/**
+ * Point the measurement helpers at a body. Unknown ids fall back to Earth so a
+ * malformed project can never break measurements. Safe to call on every
+ * preferences change; it is a cheap assignment.
+ */
+export function setActiveEllipsoidId(id: string | undefined): void {
+  activeEllipsoidId = getEllipsoid(id).id as EllipsoidId;
+}
+
+export function getActiveEllipsoid(): Ellipsoid {
+  return getEllipsoid(activeEllipsoidId);
+}
+
+/** Mean radius (metres) of the active body — for haversine distance/area. */
+export function getActiveMeanRadiusMeters(): number {
+  return meanRadiusMeters(getActiveEllipsoid());
+}
+
+/** Semi-major axis (metres) of the active body — for its Web-Mercator scale. */
+export function getActiveSemiMajorAxisMeters(): number {
+  return getActiveEllipsoid().semiMajorAxisMeters;
+}
+
+// --- Planetary basemaps ----------------------------------------------------
+
+/**
+ * A raster basemap for a non-Earth body. The tiles are XYZ PNGs in the standard
+ * Web-Mercator scheme (of that body), so MapLibre renders them directly. The
+ * `styleUrl` is a `geolibre://basemap/<id>` sentinel; the map controller expands
+ * it into a raster style at apply time (it is not a fetchable URL).
+ */
+export interface PlanetaryBasemap {
+  id: string;
+  name: string;
+  /** Sentinel stored as the basemap style URL. */
+  styleUrl: string;
+  /** XYZ tile template. */
+  tileUrl: string;
+  /** Max native zoom of the source (MapLibre overzooms beyond this). */
+  maxZoom: number;
+  /** Attribution shown on the map. */
+  attribution: string;
+  /** The body this basemap depicts, so selecting it can set the ellipsoid. */
+  ellipsoidId: EllipsoidId;
+}
+
+export const PLANETARY_BASEMAP_SENTINEL_PREFIX = "geolibre://basemap/";
+
+const USGS_ATTRIBUTION =
+  '<a href="https://astrogeology.usgs.gov">USGS Astrogeology</a> / NASA';
+
+const OPM_ATTRIBUTION =
+  '<a href="https://www.openplanetary.org/opm">OpenPlanetaryMap</a> / USGS / NASA';
+
+// USGS Astrogeology MapServer serves these global mosaics as Web-Mercator XYZ
+// tiles (`tilemode=gmap`) with open CORS, so MapLibre renders them directly.
+// These are the photographic mosaics Google Earth/Moon use — the Viking
+// colorized mosaic for Mars and the LRO WAC mosaic for the Moon — rather than a
+// stylized cartographic basemap.
+//
+// MapServer's gmap `tile=` parameter wants the tile coordinates space-separated
+// (`x y z`). We encode the separators as `%20`, NOT `+`: the Linux Tauri webview
+// (WebKitGTK) re-encodes a literal `+` in the request URL to `%2B`, which
+// MapServer then reads as a literal plus rather than a space, so every tile
+// comes back as an HTML error and the map goes black. `%20` is the canonical
+// space encoding and survives both Chromium and WebKit unchanged.
+export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
+  // Cartographic OpenPlanetaryMap basemaps (colorized shaded relief + labels).
+  // These are pre-rendered on a Fastly CDN, so they load fast and reliably —
+  // the "just works" choice when the USGS imagery below is slow.
+  {
+    id: "mars-opm",
+    name: "Mars (OpenPlanetaryMap)",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-opm`,
+    tileUrl:
+      "https://cartocdn-gusc.global.ssl.fastly.net/opmbuilder/api/v1/map/named/opm-mars-basemap-v0-2/all/{z}/{x}/{y}.png",
+    maxZoom: 6,
+    attribution: OPM_ATTRIBUTION,
+    ellipsoidId: "mars",
+  },
+  {
+    id: "moon-opm",
+    name: "Moon (OpenPlanetaryMap)",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-opm`,
+    tileUrl:
+      "https://cartocdn-gusc.global.ssl.fastly.net/opmbuilder/api/v1/map/named/opm-moon-basemap-v0-1/all/{z}/{x}/{y}.png",
+    maxZoom: 6,
+    attribution: OPM_ATTRIBUTION,
+    ellipsoidId: "moon",
+  },
+  // Photographic mosaics (the Google Earth/Moon look), served on demand by the
+  // USGS Astrogeology MapServer. Higher fidelity but slower — the cgi-bin
+  // renders each tile per request rather than serving from a CDN.
+  {
+    id: "mars-viking",
+    name: "Mars (Viking imagery)",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-viking`,
+    tileUrl:
+      "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/mars/mars_simp_cyl.map&layers=MDIM21_color&mode=tile&tilemode=gmap&tile={x}%20{y}%20{z}",
+    maxZoom: 7,
+    attribution: `Mars Viking MDIM 2.1 — ${USGS_ATTRIBUTION}`,
+    ellipsoidId: "mars",
+  },
+  {
+    id: "moon-lroc",
+    name: "Moon (LRO imagery)",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-lroc`,
+    tileUrl:
+      "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/earth/moon_simp_cyl.map&layers=LROC_WAC&mode=tile&tilemode=gmap&tile={x}%20{y}%20{z}",
+    maxZoom: 7,
+    attribution: `LRO LROC WAC — ${USGS_ATTRIBUTION}`,
+    ellipsoidId: "moon",
+  },
+] as const;
+
+/** Resolve a `geolibre://basemap/<id>` sentinel to its planetary basemap. */
+export function getPlanetaryBasemapByStyleUrl(
+  styleUrl: string | undefined,
+): PlanetaryBasemap | undefined {
+  if (!styleUrl?.startsWith(PLANETARY_BASEMAP_SENTINEL_PREFIX)) return undefined;
+  return PLANETARY_BASEMAPS.find((b) => b.styleUrl === styleUrl);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./ellipsoids";
 export * from "./geojson-z";
 export * from "./color-ramp";
 export * from "./paths";

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -40,6 +40,7 @@ import {
   DEFAULT_LAYER_GROUP_OPACITY,
   normalizeGroupContiguity,
 } from "./layer-groups";
+import { getEllipsoid } from "./ellipsoids";
 
 /** Placeholder name a project carries before the user names it. */
 export const DEFAULT_PROJECT_NAME = "Untitled Project";
@@ -723,6 +724,10 @@ function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
         (map as Partial<ProjectPreferences["map"]>).projection === "mercator"
           ? "mercator"
           : "globe",
+      // Coerce unknown/missing bodies to Earth so measurements never break.
+      ellipsoidId: getEllipsoid(
+        (map as Partial<ProjectPreferences["map"]>).ellipsoidId,
+      ).id,
     },
     environmentVariables: Array.isArray(candidate.environmentVariables)
       ? candidate.environmentVariables

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -48,6 +48,8 @@ export const DEFAULT_PROJECT_NAME = "Untitled Project";
 export interface CreateProjectOptions {
   basemapStyleUrl?: string;
   mapView?: MapViewState;
+  /** Celestial body the project describes; defaults to Earth when omitted. */
+  ellipsoidId?: string;
 }
 
 export function createDefaultMapView(): MapViewState {
@@ -73,7 +75,15 @@ export function createEmptyProject(
     layers: [],
     layerGroups: [],
     styles: {},
-    preferences: DEFAULT_PROJECT_PREFERENCES,
+    preferences: options.ellipsoidId
+      ? {
+          ...DEFAULT_PROJECT_PREFERENCES,
+          map: {
+            ...DEFAULT_PROJECT_PREFERENCES.map,
+            ellipsoidId: getEllipsoid(options.ellipsoidId).id,
+          },
+        }
+      : DEFAULT_PROJECT_PREFERENCES,
     legend: { ...DEFAULT_LEGEND_CONFIG },
     metadata: {},
   };

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -53,6 +53,7 @@ import {
   type StoryMap,
 } from "./types";
 import { hasSimpleStyleProperties } from "./vector-color";
+import { setActiveEllipsoidId } from "./ellipsoids";
 
 export type ConversionToolKind =
   | "vector-to-vector"
@@ -1413,6 +1414,15 @@ export const useAppStore = create<AppState>()(
     }
   )
 );
+
+// Mirror the project's ellipsoid into the module-level singleton the
+// measurement helpers read. One subscription covers every path that changes
+// preferences (setPreferences, load/new project, undo/redo) without threading
+// the value through each call site. Fires immediately to seed the initial value.
+useAppStore.subscribe((state) => {
+  setActiveEllipsoidId(state.preferences.map.ellipsoidId);
+});
+setActiveEllipsoidId(useAppStore.getState().preferences.map.ellipsoidId);
 
 /**
  * After an undo/redo restores the tracked slice, mark the project dirty and

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1418,11 +1418,17 @@ export const useAppStore = create<AppState>()(
 // Mirror the project's ellipsoid into the module-level singleton the
 // measurement helpers read. One subscription covers every path that changes
 // preferences (setPreferences, load/new project, undo/redo) without threading
-// the value through each call site. Fires immediately to seed the initial value.
+// the value through each call site. The subscription runs on every store
+// mutation (e.g. setPointerCoords on each mousemove), so guard on the id to skip
+// the redundant work for a value that changes at most once per session.
+let lastEllipsoidId = useAppStore.getState().preferences.map.ellipsoidId;
+setActiveEllipsoidId(lastEllipsoidId);
 useAppStore.subscribe((state) => {
-  setActiveEllipsoidId(state.preferences.map.ellipsoidId);
+  const id = state.preferences.map.ellipsoidId;
+  if (id === lastEllipsoidId) return;
+  lastEllipsoidId = id;
+  setActiveEllipsoidId(id);
 });
-setActiveEllipsoidId(useAppStore.getState().preferences.map.ellipsoidId);
 
 /**
  * After an undo/redo restores the tracked slice, mark the project dirty and

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -710,6 +710,12 @@ export interface MapPreferences {
   maxPitch: number;
   renderWorldCopies: boolean;
   projection: MapProjection;
+  /**
+   * Celestial body / ellipsoid the project's coordinates describe (keys into the
+   * ellipsoid registry in `@geolibre/core`). Drives measurement radii and pairs
+   * with planetary basemaps. Defaults to `"earth"` (WGS 84).
+   */
+  ellipsoidId: string;
 }
 
 export interface RuntimeEnvironmentVariable {
@@ -772,6 +778,7 @@ export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
     maxPitch: 85,
     renderWorldCopies: true,
     projection: "globe",
+    ellipsoidId: "earth",
   },
   environmentVariables: [],
   geocoding: {

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -1,4 +1,5 @@
 import { styleValue, type LayerStyle } from "./types";
+import { getActiveSemiMajorAxisMeters } from "./ellipsoids";
 
 /**
  * A data-driven color value for a vector paint property: either a plain CSS
@@ -98,6 +99,16 @@ export function simpleStyleNumberValue(
  */
 export const MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0 = (2 * Math.PI * 6378137) / 512;
 
+/**
+ * Same ground resolution as {@link MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0} but for
+ * the project's active body: its circumference over the 512px zoom-0 world. On
+ * Earth this equals the constant; on the Moon/Mars it uses that body's radius so
+ * a stroke width given in ground meters renders at the correct on-screen size.
+ */
+function mercatorMetersPerPixelAtZoom0(): number {
+  return (2 * Math.PI * getActiveSemiMajorAxisMeters()) / 512;
+}
+
 // Largest zoom MapLibre renders; used as the upper interpolation stop.
 const MAX_MERCATOR_ZOOM = 24;
 
@@ -120,7 +131,7 @@ const MAX_MERCATOR_ZOOM = 24;
  * @returns A MapLibre `interpolate` expression array.
  */
 export function metersWidthExpression(meters: number): unknown[] {
-  const widthAtZoom0 = meters / MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0;
+  const widthAtZoom0 = meters / mercatorMetersPerPixelAtZoom0();
   return [
     "interpolate",
     ["exponential", 2],

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -104,8 +104,11 @@ export const MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0 = (2 * Math.PI * 6378137) / 512
  * the project's active body: its circumference over the 512px zoom-0 world. On
  * Earth this equals the constant; on the Moon/Mars it uses that body's radius so
  * a stroke width given in ground meters renders at the correct on-screen size.
+ * Exported so the Mapbox-style importer can reverse {@link metersWidthExpression}
+ * with the same ellipsoid-aware factor the exporter used (keeping the round trip
+ * correct on non-Earth projects), rather than the Earth-only constant.
  */
-function mercatorMetersPerPixelAtZoom0(): number {
+export function mercatorMetersPerPixelAtZoom0(): number {
   return (2 * Math.PI * getActiveSemiMajorAxisMeters()) / 512;
 }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2,6 +2,7 @@ import {
   BLANK_BASEMAP,
   DEFAULT_BASEMAP,
   DEFAULT_PROJECT_PREFERENCES,
+  getPlanetaryBasemapByStyleUrl,
   useAppStore,
 } from "@geolibre/core";
 import type {
@@ -10,6 +11,7 @@ import type {
   MapPreferences,
   MapProjection,
   MapViewState,
+  PlanetaryBasemap,
   StoryChapterAnimation,
   StoryChapterLocation,
 } from "@geolibre/core";
@@ -216,7 +218,44 @@ function resolveMapStyle(
   styleUrl: string | undefined,
 ): string | maplibregl.StyleSpecification {
   if (styleUrl === BLANK_BASEMAP) return createBlankMapStyle();
+  const planetary = getPlanetaryBasemapByStyleUrl(styleUrl);
+  if (planetary) return createPlanetaryMapStyle(planetary);
   return styleUrl ?? DEFAULT_BASEMAP;
+}
+
+/**
+ * A single-source raster style for a non-Earth body. The tiles are XYZ PNGs in
+ * that body's Web-Mercator scheme, so MapLibre renders them like any raster
+ * basemap. A dark background shows through at zoom levels the source doesn't
+ * cover, matching how the planetary tiles fade to black at the poles.
+ */
+function createPlanetaryMapStyle(
+  basemap: PlanetaryBasemap,
+): maplibregl.StyleSpecification {
+  return {
+    version: 8,
+    sources: {
+      "planetary-basemap": {
+        type: "raster",
+        tiles: [basemap.tileUrl],
+        tileSize: 256,
+        maxzoom: basemap.maxZoom,
+        attribution: basemap.attribution,
+      },
+    },
+    layers: [
+      {
+        id: BLANK_BACKGROUND_LAYER_ID,
+        type: "background",
+        paint: { "background-color": "#000000" },
+      },
+      {
+        id: "planetary-basemap",
+        type: "raster",
+        source: "planetary-basemap",
+      },
+    ],
+  };
 }
 
 interface LayerControlConfig {
@@ -1459,7 +1498,14 @@ export class MapController {
     this.layerControlSignature =
       this.createLayerControlSignature(layerControlConfig);
     this.layerControl = new LayerControl({
-      basemapStyleUrl: this.basemapStyleUrl,
+      // The layer control fetches this URL to introspect the basemap's layers.
+      // Planetary basemaps use a non-fetchable `geolibre://` sentinel (expanded
+      // to an inline raster style by resolveMapStyle), so hand the control the
+      // blank sentinel instead — like blank/raster basemaps it then skips the
+      // fetch and shows a single background entry.
+      basemapStyleUrl: getPlanetaryBasemapByStyleUrl(this.basemapStyleUrl)
+        ? BLANK_BASEMAP
+        : this.basemapStyleUrl,
       collapsed: true,
       panelWidth: 340,
       panelMinWidth: 240,

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_LAYER_STYLE,
-  MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0,
+  mercatorMetersPerPixelAtZoom0,
   type LabelStyle,
   type LayerStyle,
   type VectorStyleStop,
@@ -427,7 +427,7 @@ function parseLineWidth(
       const widthAtZoom0 = asFiniteNumber(array[4]);
       if (widthAtZoom0 !== null) {
         patch.strokeWidth =
-          widthAtZoom0 * MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0;
+          widthAtZoom0 * mercatorMetersPerPixelAtZoom0();
         patch.strokeWidthUnit = "meters";
         return;
       }

--- a/packages/processing/src/statistics-tools.ts
+++ b/packages/processing/src/statistics-tools.ts
@@ -4,6 +4,7 @@ import centroid from "@turf/centroid";
 import { featureCollection, polygon as turfPolygon } from "@turf/helpers";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
+import { getActiveMeanRadiusMeters } from "@geolibre/core";
 import type { ProcessingAlgorithm, ProcessingContext } from "./types";
 
 /**
@@ -19,8 +20,14 @@ import type { ProcessingAlgorithm, ProcessingContext } from "./types";
 const MAX_WEIGHTS_FEATURES = 5000;
 /** Hard cap on KDE grid cells so a tiny cell size can't allocate forever. */
 const MAX_KDE_CELLS = 40000;
-/** Mean Earth radius in kilometres, for the haversine helper. */
-const EARTH_RADIUS_KM = 6371;
+/**
+ * Mean radius of the project's active body in kilometres, for the haversine
+ * helper. Read lazily so spatial-stats distances (KDE bandwidth, distance-band
+ * weights) are correct on the Moon/Mars, not just Earth.
+ */
+function activeMeanRadiusKm(): number {
+  return getActiveMeanRadiusMeters() / 1000;
+}
 
 const WEIGHTS_TYPE_OPTIONS = [
   { value: "knn", label: "K nearest neighbors" },
@@ -50,7 +57,7 @@ function haversineKm(
     Math.cos(lat1 * toRad) *
       Math.cos(lat2 * toRad) *
       Math.sin(dLon / 2) ** 2;
-  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(a)));
+  return 2 * activeMeanRadiusKm() * Math.asin(Math.min(1, Math.sqrt(a)));
 }
 
 /** Standard-normal CDF via an Abramowitz-Stegun erf approximation. */


### PR DESCRIPTION
Closes #1128 (partial — see scope note).

Lets GeoLibre be used on the **Moon and Mars**, not just Earth. A per-project *celestial body* drives measurement radii and pairs with planetary basemaps. This does **not** attempt true multi-CRS rendering — MapLibre still treats the planet as a unit sphere; that remains upstream ([maplibre-gl-js#168](https://github.com/maplibre/maplibre-gl-js/issues/168)).

## What's included

- **Ellipsoid registry** (`@geolibre/core/ellipsoids.ts`): Earth (WGS 84) / Moon / Mars with radii + flattening, a mean-radius helper, and a module-level "active ellipsoid" singleton kept in sync by one store subscription.
- **Schema**: `MapPreferences.ellipsoidId` (default `"earth"`), normalized in `project.ts` (unknown ids coerce to Earth).
- **Parameterized measurements**: spatial-stats haversine (`statistics-tools`) and meter-based stroke widths (`vector-color`) now use the active body's radius. WMS EPSG:3857 identify is deliberately left Earth-bound (3857 is Earth on every WMS server).
- **Four planetary basemaps** via a `geolibre://basemap/<id>` sentinel that `map-controller` expands into an inline raster style:
  | Basemap | Source | Speed | Look |
  |---|---|---|---|
  | Mars / Moon (OpenPlanetaryMap) | OPM, Fastly CDN | Fast | Cartographic |
  | Mars (Viking imagery) | USGS Astrogeology | Slower | Photographic (Google-Earth look) |
  | Moon (LRO imagery) | USGS Astrogeology | Slower | Photographic (Google-Moon look) |
  
  USGS gmap tile separators are encoded as `%20`, not `+` — WebKitGTK (the Linux Tauri webview) re-encodes a literal `+` to `%2B`, which MapServer reads as a plus and every tile 500s (black map). `%20` survives both Chromium and WebKit.
- **UI**: ellipsoid selector in Settings → Map; a *Planetary* section in the basemap picker that also switches the body. The layer control gets the blank sentinel for planetary basemaps so it skips its style fetch.
- **Also**: double-clicking anywhere on the Background layer card now opens the Change basemap dialog (removed the "name is fixed" notice).

## Scope limits (out of this PR)

Turf-based vector tools (buffer/area/distance), the backend `estimate_utm_crs`, export WKT, and 3D-tiles remain Earth-bound; ellipsoid-accurate non-Mercator CRS rendering is upstream (#168). Rationale in [the issue thread](https://github.com/opengeos/GeoLibre/issues/1128).

## Verification

- `npm run build` ✓ · `npm run test:frontend` (2084 pass) ✓ · `npm run lint` (0 errors) ✓
- Browser-verified (Chromium/Playwright): all four basemaps render (34 tiles each, 0 failures, 0 console errors); ellipsoid follows the basemap pick and the Settings dropdown drives it.

⚠️ **WebKit caveat**: the `%20` fix is proven via curl (server-side) + Chromium (MapLibre preserves `%20`), but I could not run the final click-through in WebKitGTK itself (Playwright's WebKit needs system libs unavailable on the dev box). Please sanity-check the imagery basemaps in a desktop (`tauri:dev`) build. The USGS `cgi-bin` imagery is inherently slower than the CDN-backed OPM maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting planetary basemaps and celestial body/ellipsoid settings.
  * Map measurements and related styling now adapt to the selected body for more accurate results.

* **Bug Fixes**
  * Map style handling now works better with non-Earth basemaps.
  * Removed an outdated background rename warning from the layers panel.

* **UI/Localization**
  * Added new labels and hints for planetary basemaps and ellipsoid selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->