### PR TITLE
fix(controls): recover when the component-controls chunk fails to load

### DIFF
--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1186,18 +1186,27 @@ interface StacCogTextureHelper {
   ) => string;
 }
 
-const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
-  // Load the splatting control from maplibre-gl-splat directly: the copy
-  // re-exported (and bundled) by maplibre-gl-components lags behind, so its
-  // sample-data dropdown would be missing if taken from there.
-  // Load the dedicated splat control separately, but do not let a failure here
-  // take down every other component control. Promise.all rejects the whole
-  // shared promise if any input rejects, so a single failed splat import (a
-  // code-split chunk network hiccup, a missing dev-checkout package) would have
-  // broken BookmarkControl, MeasureControl, etc. for the life of the page. On
-  // failure, fall back to the (older) GaussianSplatControl bundled in
-  // maplibre-gl-components so the rest of the controls still load.
-  componentsConstructorsPromise ??= Promise.all([
+type ComponentsModule = typeof import("maplibre-gl-components");
+type SplatModule = typeof import("maplibre-gl-splat");
+/** @internal The dynamic-import pair {@link getComponentsConstructors} builds from. */
+export type ComponentsModules = [ComponentsModule | undefined, SplatModule | null];
+
+// The pair of dynamic imports getComponentsConstructors builds from. Split out
+// as an injectable seam so a test can simulate the vite:preloadError +
+// preventDefault() case (see getComponentsConstructors), where a failed import
+// RESOLVES to `undefined` instead of rejecting.
+//
+// Load the splatting control from maplibre-gl-splat directly: the copy
+// re-exported (and bundled) by maplibre-gl-components lags behind, so its
+// sample-data dropdown would be missing if taken from there. Do not let a
+// failure here take down every other component control. Promise.all rejects the
+// whole shared promise if any input rejects, so a single failed splat import (a
+// code-split chunk network hiccup, a missing dev-checkout package) would have
+// broken BookmarkControl, MeasureControl, etc. for the life of the page. On
+// failure, fall back to the (older) GaussianSplatControl bundled in
+// maplibre-gl-components so the rest of the controls still load.
+const defaultLoadComponentsModules = (): Promise<ComponentsModules> =>
+  Promise.all([
     import("maplibre-gl-components"),
     import("maplibre-gl-splat").catch((error: unknown) => {
       console.warn(
@@ -1206,7 +1215,26 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       );
       return null;
     }),
-  ]).then(([components, splat]) => {
+  ]);
+
+let loadComponentsModules = defaultLoadComponentsModules;
+
+/**
+ * Test-only seam: swap the component-module loader and reset the memoized
+ * singleton. Passing `null` restores the real dynamic imports.
+ *
+ * @internal
+ */
+export function __setComponentsModuleLoaderForTests(
+  loader: (() => Promise<ComponentsModules>) | null
+): void {
+  loadComponentsModules = loader ?? defaultLoadComponentsModules;
+  componentsConstructorsPromise = null;
+}
+
+/** @internal Exported so the lazy component-control loader can be unit-tested. */
+export const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
+  componentsConstructorsPromise ??= loadComponentsModules().then(([components, splat]) => {
     // A `vite:preloadError` handler that calls preventDefault() makes the
     // failed dynamic import RESOLVE to `undefined` instead of rejecting. The
     // stale-chunk reload guard (installStaleChunkReload) does exactly this when

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1207,6 +1207,19 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       return null;
     }),
   ]).then(([components, splat]) => {
+    // A `vite:preloadError` handler that calls preventDefault() makes the
+    // failed dynamic import RESOLVE to `undefined` instead of rejecting. The
+    // stale-chunk reload guard (installStaleChunkReload) does exactly this when
+    // it defers a reload to protect unsaved work: a chunk orphaned by a
+    // redeploy then fails, but the reload is withheld. Destructuring that
+    // `undefined` module throws the cryptic "Cannot destructure property
+    // 'AddVectorControl' of 'undefined'"; turn it into a clear, actionable
+    // error (the .catch below keeps it from poisoning the shared singleton).
+    if (!components) {
+      throw new Error(
+        "The map controls could not be loaded, most likely because the app was updated in the background. Reload the page to finish loading them."
+      );
+    }
     const {
       AddVectorControl: AddVectorControlClass,
       BookmarkControl: BookmarkControlClass,
@@ -1259,6 +1272,15 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       ViewStateControl: ViewStateControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     };
+  }).catch((error: unknown) => {
+    // Never memoize a failure. This shared singleton backs every component
+    // control (COG, FlatGeobuf, PMTiles, Zarr, Bookmark, Measure, Minimap,
+    // Search, Print, ...), so a cached rejection would break all of them for
+    // the life of the page. Clearing it lets the next action retry the import
+    // once the cause clears (a transient chunk-load hiccup, or a reload after a
+    // redeploy).
+    componentsConstructorsPromise = null;
+    throw error;
   });
   return componentsConstructorsPromise;
 };

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1188,8 +1188,17 @@ interface StacCogTextureHelper {
 
 type ComponentsModule = typeof import("maplibre-gl-components");
 type SplatModule = typeof import("maplibre-gl-splat");
+// Both elements can be `undefined` at runtime, not just rejected: a
+// `vite:preloadError` handler that calls preventDefault() makes a failed dynamic
+// import RESOLVE to `undefined` (see getComponentsConstructors). An `undefined`
+// splat is handled the same as a rejected one (null) - both fall back to the
+// bundled GaussianSplatControl via optional chaining - so only `components`
+// being absent is fatal.
 /** @internal The dynamic-import pair {@link getComponentsConstructors} builds from. */
-export type ComponentsModules = [ComponentsModule | undefined, SplatModule | null];
+export type ComponentsModules = [
+  ComponentsModule | undefined,
+  SplatModule | null | undefined,
+];
 
 // The pair of dynamic imports getComponentsConstructors builds from. Split out
 // as an injectable seam so a test can simulate the vite:preloadError +

--- a/tests/components-constructors-loader.test.ts
+++ b/tests/components-constructors-loader.test.ts
@@ -55,13 +55,22 @@ describe("getComponentsConstructors", () => {
 
   it("memoizes a successful load so concurrent controls share one import", async () => {
     let calls = 0;
-    __setComponentsModuleLoaderForTests((): Promise<ComponentsModules> => {
-      calls += 1;
-      return Promise.resolve([fakeComponentsModule, null]);
-    });
+    const resolvers: Array<(modules: ComponentsModules) => void> = [];
+    __setComponentsModuleLoaderForTests(
+      (): Promise<ComponentsModules> => {
+        calls += 1;
+        return new Promise((resolve) => resolvers.push(resolve));
+      }
+    );
 
-    const first = await getComponentsConstructors();
-    const second = await getComponentsConstructors();
+    // Issue both calls before the loader resolves so this exercises the actual
+    // in-flight dedup (the synchronous `??=` assignment), not just reuse of an
+    // already-settled promise. A naive impl that re-triggers the loader for
+    // calls made before the first resolves would fail this.
+    const firstPromise = getComponentsConstructors();
+    const secondPromise = getComponentsConstructors();
+    for (const resolve of resolvers) resolve([fakeComponentsModule, null]);
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
 
     assert.equal(calls, 1);
     assert.equal(first, second);

--- a/tests/components-constructors-loader.test.ts
+++ b/tests/components-constructors-loader.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  __setComponentsModuleLoaderForTests,
+  getComponentsConstructors,
+  type ComponentsModules,
+} from "../packages/plugins/src/plugins/maplibre-components.ts";
+
+// Regression tests for the shared `getComponentsConstructors` singleton that
+// lazy-loads maplibre-gl-components for every component control (COG,
+// FlatGeobuf, PMTiles, Zarr, Bookmark, Measure, ...). See issue #1130: a
+// `vite:preloadError` handler that calls preventDefault() (the stale-chunk
+// reload guard, when it defers a reload to protect unsaved work) makes the
+// failed dynamic import RESOLVE to `undefined` instead of rejecting.
+
+// A minimal stand-in for the maplibre-gl-components namespace. The constructors
+// are never invoked here, so an empty object is enough to pass the loader's
+// `if (!components)` guard and reach the success path.
+const fakeComponentsModule = {} as unknown as NonNullable<ComponentsModules[0]>;
+
+afterEach(() => {
+  // Restore the real dynamic imports and clear the memoized singleton.
+  __setComponentsModuleLoaderForTests(null);
+});
+
+describe("getComponentsConstructors", () => {
+  it("throws a clear, actionable error (not the cryptic destructure) when the module resolves to undefined", async () => {
+    __setComponentsModuleLoaderForTests(
+      (): Promise<ComponentsModules> => Promise.resolve([undefined, null])
+    );
+
+    await assert.rejects(
+      getComponentsConstructors(),
+      (error: Error) =>
+        /could not be loaded/i.test(error.message) &&
+        /reload the page/i.test(error.message) &&
+        !/destructure/i.test(error.message)
+    );
+  });
+
+  it("does not memoize a failure: a later call retries the import", async () => {
+    let calls = 0;
+    __setComponentsModuleLoaderForTests((): Promise<ComponentsModules> => {
+      calls += 1;
+      return Promise.resolve([undefined, null]);
+    });
+
+    await assert.rejects(getComponentsConstructors(), /could not be loaded/i);
+    await assert.rejects(getComponentsConstructors(), /could not be loaded/i);
+
+    // A cached rejection would leave this at 1 and break every component
+    // control for the life of the page; the retry re-invokes the loader.
+    assert.equal(calls, 2);
+  });
+
+  it("memoizes a successful load so concurrent controls share one import", async () => {
+    let calls = 0;
+    __setComponentsModuleLoaderForTests((): Promise<ComponentsModules> => {
+      calls += 1;
+      return Promise.resolve([fakeComponentsModule, null]);
+    });
+
+    const first = await getComponentsConstructors();
+    const second = await getComponentsConstructors();
+
+    assert.equal(calls, 1);
+    assert.equal(first, second);
+  });
+
+  it("recovers once the import succeeds after an earlier failure", async () => {
+    let calls = 0;
+    __setComponentsModuleLoaderForTests((): Promise<ComponentsModules> => {
+      calls += 1;
+      return calls === 1
+        ? Promise.resolve([undefined, null])
+        : Promise.resolve([fakeComponentsModule, null]);
+    });
+
+    await assert.rejects(getComponentsConstructors(), /could not be loaded/i);
+    const recovered = await getComponentsConstructors();
+
+    assert.ok(recovered);
+    assert.equal(calls, 2);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #1130. A user of the Vantor Open Data plugin hit:

> Failed to add B0300011000DF210: Cannot destructure property 'AddVectorControl' of 'e' as it is undefined.

## Root cause

The error comes from `getComponentsConstructors` in `maplibre-components.ts`, the shared singleton that lazy-loads `maplibre-gl-components` for every component control.

The chain is:

1. A lazy chunk fails to load. This happens when a static-host deploy replaces content-hashed chunks and a tab still holds a cached import graph pointing at a now-deleted chunk (the exact case `stale-chunk-reload.ts` exists for), or on a transient network error.
2. GeoLibre's `installStaleChunkReload` handler catches Vite's `vite:preloadError`. When the project has **unsaved changes**, it must not reload (that would discard the user's map and trip the beforeunload guard), so it records a diagnostic and calls `event.preventDefault()` **without** reloading.
3. Per Vite's contract, `preventDefault()` on `vite:preloadError` makes the failed `import()` **resolve to `undefined`** instead of rejecting.
4. `getComponentsConstructors` destructured that `undefined` module (`const { AddVectorControl, ... } = components`), throwing the cryptic message above.
5. The rejected promise was memoized, so **every** component control (COG, FlatGeobuf, PMTiles, Zarr, Bookmark, Measure, Minimap, Search, Print, ...) stayed broken for the life of the page.

## Fix

In `getComponentsConstructors`:

- Guard against an `undefined` resolved module and throw a clear, actionable error ("...the app was updated in the background. Reload the page...") instead of the cryptic destructure crash.
- Stop memoizing the failure: clear the shared singleton on rejection so a later action can retry the import rather than every control being dead until a manual reload.

## Verification

Driven in the real production web build (Playwright, service worker blocked so a `404` on the component chunk could be injected):

- **Before:** with the project dirty and the `maplibre-gl-components` chunk `404`ing, opening a component control reproduced the exact `Cannot destructure property 'AddVectorControl' of 'e' as it is undefined`, and subsequent controls stayed broken even after the chunk recovered.
- **After:** the same conditions surface the clear "reload the page" message, a retry re-attempts the import (no cached failure), the normal path still mounts every control (light and dark themes, 0 console errors), and the Vantor COG visualize still works ("Added 1 COG layer(s)").
- `npm run build` and `npm run test:frontend` (2098 passing) are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading map-based components, including clearer errors for stale or missing modules.
  * Prevented failed loads from being cached, so the app can retry automatically after a transient issue.
  * Added safer handling when an optional related module fails to load.
* **Tests**
  * Added coverage for loader retry behavior, single-load memoization, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->