### PR TITLE
refactor(3d-tiles): dedupe Google X-GOOG-API-KEY resolution into @geolibre/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,10 @@ export {
 } from "./runtime-env";
 export {
   GOOGLE_MAPS_API_KEY_HEADER,
+  googleMapsApiKeyHeaderValue,
   isGooglePhotorealisticTilesetUrl,
+  nonEmptyRecord,
+  persistedThreeDTilesRequestHeaders,
   resolveThreeDTilesRequestHeaders,
+  stripGoogleMapsApiKeyHeader,
 } from "./three-d-tiles";

--- a/packages/core/src/three-d-tiles.ts
+++ b/packages/core/src/three-d-tiles.ts
@@ -32,7 +32,8 @@ function isMaskedKey(value: string): boolean {
   return /^\*+$/.test(value.trim());
 }
 
-function stripApiKeyHeader(
+/** Drop the `X-GOOG-API-KEY` header (case-insensitive), keeping the rest. */
+export function stripGoogleMapsApiKeyHeader(
   headers: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
   if (!headers) return undefined;
@@ -42,7 +43,11 @@ function stripApiKeyHeader(
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
-function apiKeyFromHeaders(
+/**
+ * The real `X-GOOG-API-KEY` value from `headers`, or `undefined` when absent,
+ * blank, or a masked placeholder.
+ */
+export function googleMapsApiKeyHeaderValue(
   headers: Record<string, string> | undefined,
 ): string | undefined {
   if (!headers) return undefined;
@@ -54,7 +59,8 @@ function apiKeyFromHeaders(
   return value;
 }
 
-function nonEmptyRecord(
+/** Collapse an empty record to `undefined`, otherwise pass it through. */
+export function nonEmptyRecord(
   value: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
   return value && Object.keys(value).length > 0 ? value : undefined;
@@ -73,12 +79,29 @@ export function resolveThreeDTilesRequestHeaders(
   googleMapsApiKey?: string,
 ): Record<string, string> | undefined {
   if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
-  const nonGoogleHeaders = stripApiKeyHeader(headers);
+  const nonGoogleHeaders = stripGoogleMapsApiKeyHeader(headers);
   const apiKey =
-    apiKeyFromHeaders(headers) ?? googleMapsApiKey ?? getGoogleMapsApiKey();
+    googleMapsApiKeyHeaderValue(headers) ??
+    googleMapsApiKey ??
+    getGoogleMapsApiKey();
   if (!apiKey) return nonEmptyRecord(nonGoogleHeaders);
   return {
     ...(nonGoogleHeaders ?? {}),
     [GOOGLE_MAPS_API_KEY_HEADER]: apiKey,
   };
+}
+
+/**
+ * The request headers to persist on a 3D Tiles layer record. Non-Google
+ * tilesets keep their headers; Google Photorealistic tiles keep any non-key
+ * custom headers but never persist the `X-GOOG-API-KEY` value, so shared
+ * projects do not carry the key in plain text (it is re-injected at render
+ * time by `resolveThreeDTilesRequestHeaders`).
+ */
+export function persistedThreeDTilesRequestHeaders(
+  url: string,
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
+  return nonEmptyRecord(stripGoogleMapsApiKeyHeader(headers));
 }

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -1,6 +1,12 @@
 import {
   DEFAULT_LAYER_STYLE,
-  getGoogleMapsApiKey,
+  GOOGLE_MAPS_API_KEY_HEADER,
+  googleMapsApiKeyHeaderValue,
+  isGooglePhotorealisticTilesetUrl,
+  nonEmptyRecord,
+  persistedThreeDTilesRequestHeaders,
+  resolveThreeDTilesRequestHeaders,
+  stripGoogleMapsApiKeyHeader,
   type GeoLibreLayer,
   useAppStore,
 } from "@geolibre/core";
@@ -47,7 +53,6 @@ const GOOGLE_PHOTOREALISTIC_TILES_LABEL =
 const ARCGIS_I3S_SAMPLE_TILES_URL =
   "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer/layers/0";
 const ARCGIS_I3S_SAMPLE_TILES_LABEL = "San Francisco Buildings (ArcGIS I3S)";
-const GOOGLE_MAPS_API_KEY_HEADER = "X-GOOG-API-KEY";
 const GOOGLE_MAPS_API_KEY_MASK = "********";
 const GOOGLE_PHOTOREALISTIC_SOURCE_KIND =
   "google-photorealistic-3d-tiles";
@@ -1799,55 +1804,6 @@ function stringRecordValue(
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
-function resolveThreeDTilesRequestHeaders(
-  url: string,
-  headers: Record<string, string> | undefined,
-  googleMapsApiKey?: string,
-): Record<string, string> | undefined {
-  if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
-
-  const nonGoogleHeaders = stripGoogleMapsApiKeyHeader(headers);
-  const apiKey =
-    googleMapsApiKeyHeaderValue(headers) ??
-    googleMapsApiKey ??
-    getGoogleMapsApiKey();
-  if (!apiKey) return nonEmptyRecord(nonGoogleHeaders);
-  return {
-    ...(nonGoogleHeaders ?? {}),
-    [GOOGLE_MAPS_API_KEY_HEADER]: apiKey,
-  };
-}
-
-function persistedThreeDTilesRequestHeaders(
-  url: string,
-  headers: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!isGooglePhotorealisticTilesetUrl(url)) return headers;
-  return nonEmptyRecord(stripGoogleMapsApiKeyHeader(headers));
-}
-
-function stripGoogleMapsApiKeyHeader(
-  headers: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!headers) return undefined;
-  const entries = Object.entries(headers).filter(
-    ([name]) => name.toLowerCase() !== GOOGLE_MAPS_API_KEY_HEADER.toLowerCase(),
-  );
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
-
-function googleMapsApiKeyHeaderValue(
-  headers: Record<string, string> | undefined,
-): string | undefined {
-  if (!headers) return undefined;
-  const entry = Object.entries(headers).find(
-    ([name]) => name.toLowerCase() === GOOGLE_MAPS_API_KEY_HEADER.toLowerCase(),
-  );
-  const value = entry?.[1].trim();
-  if (!value || googleMapsApiKeyIsMask(value)) return undefined;
-  return value;
-}
-
 function rememberGoogleMapsApiKeyFromHeaders(
   panel: HTMLElement,
   headers: Record<string, string> | undefined,
@@ -1858,22 +1814,6 @@ function rememberGoogleMapsApiKeyFromHeaders(
     return apiKey;
   }
   return googleTilesApiKeysByPanel.get(panel);
-}
-
-function googleMapsApiKeyIsMask(value: string): boolean {
-  return /^\*+$/.test(value.trim());
-}
-
-function isGooglePhotorealisticTilesetUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.hostname === "tile.googleapis.com" &&
-      parsed.pathname === "/v1/3dtiles/root.json"
-    );
-  } catch {
-    return false;
-  }
 }
 
 function isGooglePhotorealisticTilesetLayerUrl(layer: GeoLibreLayer): boolean {
@@ -1929,12 +1869,6 @@ function serializeGooglePhotorealisticPanelRequestHeaders(
       ]),
     ),
   );
-}
-
-function nonEmptyRecord(
-  value: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  return value && Object.keys(value).length > 0 ? value : undefined;
 }
 
 function recordsEqual(

--- a/tests/three-d-tiles.test.ts
+++ b/tests/three-d-tiles.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  googleMapsApiKeyHeaderValue,
   isGooglePhotorealisticTilesetUrl,
+  nonEmptyRecord,
+  persistedThreeDTilesRequestHeaders,
   resolveThreeDTilesRequestHeaders,
+  stripGoogleMapsApiKeyHeader,
 } from "../packages/core/src/three-d-tiles";
 
 // Shared 3D-Tiles header resolution: Google Photorealistic tiles keep their
@@ -53,5 +57,74 @@ describe("resolveThreeDTilesRequestHeaders", () => {
       false,
     );
     assert.equal(isGooglePhotorealisticTilesetUrl("not a url"), false);
+  });
+});
+
+// The persistence + header helpers were duplicated in the MapLibre plugin until
+// they were centralized here (issue #1142). The plugin now imports them, so the
+// tests live with the shared implementation both render paths depend on.
+
+describe("persistedThreeDTilesRequestHeaders", () => {
+  it("passes non-Google tileset headers through unchanged", () => {
+    const headers = { Authorization: "Bearer x" };
+    assert.equal(
+      persistedThreeDTilesRequestHeaders("https://example.com/tileset.json", headers),
+      headers,
+    );
+  });
+
+  it("strips the Google key so it never persists in a shared project", () => {
+    assert.deepEqual(
+      persistedThreeDTilesRequestHeaders(GOOGLE, {
+        "X-GOOG-API-KEY": "secret",
+        Authorization: "Bearer x",
+      }),
+      { Authorization: "Bearer x" },
+    );
+  });
+
+  it("collapses to undefined when only the key header was present", () => {
+    assert.equal(
+      persistedThreeDTilesRequestHeaders(GOOGLE, { "X-GOOG-API-KEY": "secret" }),
+      undefined,
+    );
+  });
+});
+
+describe("stripGoogleMapsApiKeyHeader", () => {
+  it("removes the key header case-insensitively and keeps the rest", () => {
+    assert.deepEqual(
+      stripGoogleMapsApiKeyHeader({ "x-goog-api-key": "secret", Accept: "json" }),
+      { Accept: "json" },
+    );
+  });
+
+  it("returns undefined for empty or missing input", () => {
+    assert.equal(stripGoogleMapsApiKeyHeader(undefined), undefined);
+    assert.equal(stripGoogleMapsApiKeyHeader({ "X-GOOG-API-KEY": "secret" }), undefined);
+  });
+});
+
+describe("googleMapsApiKeyHeaderValue", () => {
+  it("returns the real key value, case-insensitively", () => {
+    assert.equal(
+      googleMapsApiKeyHeaderValue({ "x-goog-api-key": " key " }),
+      "key",
+    );
+  });
+
+  it("ignores a masked placeholder and missing values", () => {
+    assert.equal(googleMapsApiKeyHeaderValue({ "X-GOOG-API-KEY": "****" }), undefined);
+    assert.equal(googleMapsApiKeyHeaderValue({ Accept: "json" }), undefined);
+    assert.equal(googleMapsApiKeyHeaderValue(undefined), undefined);
+  });
+});
+
+describe("nonEmptyRecord", () => {
+  it("passes a non-empty record through and collapses an empty one", () => {
+    const record = { a: "1" };
+    assert.equal(nonEmptyRecord(record), record);
+    assert.equal(nonEmptyRecord({}), undefined);
+    assert.equal(nonEmptyRecord(undefined), undefined);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1139. The `maplibre-3d-tiles` plugin kept its own copies of the Google Photorealistic 3D Tiles strip / re-inject / masked-key logic that #1139 centralized in `@geolibre/core` (`packages/core/src/three-d-tiles.ts`) for the Cesium globe path. The two implementations could silently drift.

This migrates the plugin to import the shared resolver/helpers from core, deleting the local duplicates.

## Changes

- **`@geolibre/core`**: export the shared header helpers `stripGoogleMapsApiKeyHeader`, `googleMapsApiKeyHeaderValue`, and `nonEmptyRecord`, and add a new exported `persistedThreeDTilesRequestHeaders` (previously only in the plugin). Existing private `stripApiKeyHeader`/`apiKeyFromHeaders` were renamed to the exported names.
- **`packages/plugins/src/plugins/maplibre-3d-tiles.ts`**: delete the local `resolveThreeDTilesRequestHeaders`, `persistedThreeDTilesRequestHeaders`, `stripGoogleMapsApiKeyHeader`, `googleMapsApiKeyHeaderValue`, `googleMapsApiKeyIsMask`, `nonEmptyRecord`, `isGooglePhotorealisticTilesetUrl`, and the `GOOGLE_MAPS_API_KEY_HEADER` constant; import them from `@geolibre/core` instead. UI-specific bits (the mask placeholder, panel wiring) stay in the plugin.
- **Tests**: add coverage in `tests/three-d-tiles.test.ts` for the newly shared helpers (`persistedThreeDTilesRequestHeaders`, `stripGoogleMapsApiKeyHeader`, `googleMapsApiKeyHeaderValue`, `nonEmptyRecord`) — logic the plugin never had dedicated coverage for.

## Verification

- `npm run build` and `npm run test:frontend` pass (2228 tests, +9 new).
- Drove the real app with Playwright in both dark and light themes: opened the 3D Tiles panel, entered the Google Photorealistic tileset URL (layer name auto-fills, `X-GOOG-API-KEY` placeholder appears), and round-tripped an API key through the mask/reveal toggle. 0 console errors throughout.

Pure refactor: no behavior change (the moved code was identical to core's, which already backed the Cesium path).

Fixes #1142