### PR TITLE
fix(deck): render 3D Z points as solid icons

### DIFF
--- a/packages/plugins/src/plugins/deckgl-viz/elevation.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/elevation.ts
@@ -5,7 +5,13 @@ import {
   transformGeojsonElevation,
 } from "@geolibre/core";
 import type { Layer } from "@deck.gl/core";
-import type { FeatureCollection } from "geojson";
+import type {
+  Feature,
+  FeatureCollection,
+  Geometry,
+  GeometryCollection,
+  Position,
+} from "geojson";
 import type { GeoLibreDeckGL } from "../../types";
 import { colorToRgba } from "../deck-style-utils";
 
@@ -44,6 +50,26 @@ const elevationDataCache = new WeakMap<
   { verticalScale: number; offset: number; data: FeatureCollection }
 >();
 
+const DOT_ICON_SIZE = 64;
+const DOT_ICON_ATLAS = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${DOT_ICON_SIZE}" height="${DOT_ICON_SIZE}" viewBox="0 0 ${DOT_ICON_SIZE} ${DOT_ICON_SIZE}"><circle cx="32" cy="32" r="30" fill="white"/></svg>`,
+)}`;
+const DOT_ICON_MAPPING = {
+  dot: {
+    x: 0,
+    y: 0,
+    width: DOT_ICON_SIZE,
+    height: DOT_ICON_SIZE,
+    anchorX: DOT_ICON_SIZE / 2,
+    anchorY: DOT_ICON_SIZE / 2,
+    mask: true,
+  },
+};
+
+interface PointDatum {
+  position: [number, number, number];
+}
+
 function elevationData(
   geojson: FeatureCollection,
   verticalScale: number,
@@ -62,59 +88,148 @@ function elevationData(
   return data;
 }
 
+function isPointGeometry(geometry: Geometry): boolean {
+  return geometry.type === "Point" || geometry.type === "MultiPoint";
+}
+
+function pointDatum(position: Position): PointDatum {
+  const [lng = 0, lat = 0, z = 0] = position;
+  return {
+    position: [lng, lat, Number.isFinite(z) ? z : 0],
+  };
+}
+
+function collectPointPositions(geometry: Geometry, points: PointDatum[]): void {
+  if (geometry.type === "Point") {
+    points.push(pointDatum(geometry.coordinates));
+    return;
+  }
+  if (geometry.type === "MultiPoint") {
+    for (const position of geometry.coordinates) points.push(pointDatum(position));
+    return;
+  }
+  if (geometry.type === "GeometryCollection") {
+    for (const child of geometry.geometries) collectPointPositions(child, points);
+  }
+}
+
+function geometryWithoutPoints(geometry: Geometry): Geometry | null {
+  if (isPointGeometry(geometry)) return null;
+  if (geometry.type !== "GeometryCollection") return geometry;
+
+  const geometries = geometry.geometries
+    .map((child) => geometryWithoutPoints(child))
+    .filter((child): child is Geometry => child !== null);
+
+  if (geometries.length === 0) return null;
+  if (geometries.length === 1) return geometries[0];
+  return { type: "GeometryCollection", geometries } satisfies GeometryCollection;
+}
+
+function splitPointFeatures(data: FeatureCollection): {
+  nonPointData: FeatureCollection;
+  pointData: PointDatum[];
+} {
+  const pointData: PointDatum[] = [];
+  const nonPointFeatures: Feature[] = [];
+
+  for (const feature of data.features) {
+    const geometry = feature.geometry;
+    if (!geometry) {
+      nonPointFeatures.push(feature);
+      continue;
+    }
+
+    collectPointPositions(geometry, pointData);
+    const nonPointGeometry = geometryWithoutPoints(geometry);
+    if (nonPointGeometry) {
+      nonPointFeatures.push({ ...feature, geometry: nonPointGeometry });
+    }
+  }
+
+  if (pointData.length === 0) {
+    return { nonPointData: data, pointData };
+  }
+
+  return {
+    nonPointData: { ...data, features: nonPointFeatures },
+    pointData,
+  };
+}
+
 /**
- * Builds the deck.gl layer that renders a Z-enabled vector layer in 3D. The
+ * Builds the deck.gl layers that render a Z-enabled vector layer in 3D. The
  * layer's regular symbology (fill/stroke color, stroke width, circle radius,
  * fill opacity) drives the deck styling so the Style panel keeps working, and
  * lines/points are billboarded so they stay readable from tilted 3D views.
+ * Points use an IconLayer dot instead of GeoJsonLayer's ScatterplotLayer
+ * sublayer because ScatterplotLayer can lose its fill at real GPS altitudes in
+ * an interleaved MapboxOverlay, leaving only hollow rings.
  *
  * @param deckGL - The host's deck.gl module bundle.
  * @param layer - The store layer to render (must satisfy
  *   {@link isElevation3dLayer}).
  */
-export function buildElevation3dLayer(
+export function buildElevation3dLayers(
   deckGL: GeoLibreDeckGL,
   layer: GeoLibreLayer,
-): Layer {
+): Layer[] {
   const style = layer.style;
   const rawScale = styleValue(style, "elevation3dVerticalScale");
   const rawOffset = styleValue(style, "elevation3dOffset");
   const verticalScale = Number.isFinite(rawScale) ? rawScale : 1;
   const offset = Number.isFinite(rawOffset) ? rawOffset : 0;
   const geojson = layer.geojson as FeatureCollection;
-  // GeoJsonLayer forwards getLineWidth/lineWidthUnits to the point sublayer's
-  // circle outline too, but the Style panel treats point-only layers as
-  // always pixel-stroked (its meters semantics only cover line/polygon
-  // outlines, matching the 2D MapLibre render). Force pixels for point-only
-  // data so a stale "meters" unit cannot render outlines at map scale.
-  const pointOnly = geojson.features.every(
-    (feature) =>
-      feature.geometry?.type === "Point" ||
-      feature.geometry?.type === "MultiPoint",
+  const data = elevationData(geojson, verticalScale, offset);
+  const { nonPointData, pointData } = splitPointFeatures(data);
+  const fillColor = colorToRgba(
+    styleValue(style, "fillColor"),
+    styleValue(style, "fillOpacity"),
   );
-  return new deckGL.layers.GeoJsonLayer({
-    id: layer.id,
-    data: elevationData(geojson, verticalScale, offset),
-    filled: true,
-    stroked: true,
-    extruded: false,
-    getFillColor: colorToRgba(
-      styleValue(style, "fillColor"),
-      styleValue(style, "fillOpacity"),
-    ),
-    getLineColor: colorToRgba(styleValue(style, "strokeColor"), 1),
-    getLineWidth: styleValue(style, "strokeWidth"),
-    lineWidthUnits:
-      !pointOnly && styleValue(style, "strokeWidthUnit") === "meters"
-        ? "meters"
-        : "pixels",
-    lineWidthMinPixels: 1,
-    lineBillboard: true,
-    getPointRadius: styleValue(style, "circleRadius"),
-    pointRadiusUnits: "pixels",
-    pointRadiusMinPixels: 1,
-    pointBillboard: true,
-    opacity: layer.opacity,
-    pickable: true,
-  });
+  const deckLayers: Layer[] = [];
+
+  if (nonPointData.features.length > 0) {
+    deckLayers.push(
+      new deckGL.layers.GeoJsonLayer({
+        id: layer.id,
+        data: nonPointData,
+        filled: true,
+        stroked: true,
+        extruded: false,
+        getFillColor: fillColor,
+        getLineColor: colorToRgba(styleValue(style, "strokeColor"), 1),
+        getLineWidth: styleValue(style, "strokeWidth"),
+        lineWidthUnits:
+          styleValue(style, "strokeWidthUnit") === "meters"
+            ? "meters"
+            : "pixels",
+        lineWidthMinPixels: 1,
+        lineBillboard: true,
+        opacity: layer.opacity,
+        pickable: true,
+      }),
+    );
+  }
+
+  if (pointData.length > 0) {
+    deckLayers.push(
+      new deckGL.layers.IconLayer<PointDatum>({
+        id: `${layer.id}-points`,
+        data: pointData,
+        getPosition: (datum: PointDatum) => datum.position,
+        getIcon: () => "dot",
+        iconAtlas: DOT_ICON_ATLAS,
+        iconMapping: DOT_ICON_MAPPING,
+        getSize: Math.max(1, styleValue(style, "circleRadius") * 2),
+        getColor: fillColor,
+        sizeUnits: "pixels",
+        sizeMinPixels: 1,
+        billboard: true,
+        opacity: layer.opacity,
+        pickable: true,
+      }),
+    );
+  }
+
+  return deckLayers;
 }

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -6,7 +6,7 @@ import {
   ensureSharedDeckOverlay,
   setSharedDeckLayers,
 } from "../shared-deck-overlay";
-import { buildElevation3dLayer, isElevation3dLayer } from "./elevation";
+import { buildElevation3dLayers, isElevation3dLayer } from "./elevation";
 import {
   type DeckVizBuildContext,
   getDeckVizLayerDef,
@@ -153,7 +153,7 @@ function renderDeckVizLayers(): void {
           }),
         );
       } else if (isElevation3dLayer(layer)) {
-        deckLayers.push(buildElevation3dLayer(deckGL, layer));
+        deckLayers.push(...buildElevation3dLayers(deckGL, layer));
       }
     } catch (error) {
       console.warn("[GeoLibre] deckgl-viz: failed to build layer", error);

--- a/tests/elevation-3d.test.ts
+++ b/tests/elevation-3d.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../packages/core/src/index";
 import { syncLayer } from "../packages/map/src/layer-sync";
 import {
-  buildElevation3dLayer,
+  buildElevation3dLayers,
   isElevation3dLayer,
 } from "../packages/plugins/src/plugins/deckgl-viz/elevation";
 import type { GeoLibreDeckGL } from "../packages/plugins/src/types";
@@ -279,8 +279,15 @@ describe("isElevation3dLayer", () => {
   });
 });
 
-describe("buildElevation3dLayer", () => {
+describe("buildElevation3dLayers", () => {
   class FakeGeoJsonLayer {
+    props: Record<string, unknown>;
+
+    constructor(props: Record<string, unknown>) {
+      this.props = props;
+    }
+  }
+  class FakeIconLayer {
     props: Record<string, unknown>;
 
     constructor(props: Record<string, unknown>) {
@@ -289,7 +296,7 @@ describe("buildElevation3dLayer", () => {
   }
 
   const fakeDeckGL = {
-    layers: { GeoJsonLayer: FakeGeoJsonLayer },
+    layers: { GeoJsonLayer: FakeGeoJsonLayer, IconLayer: FakeIconLayer },
   } as unknown as GeoLibreDeckGL;
 
   it("maps the layer style onto billboarded deck.gl props", () => {
@@ -305,19 +312,17 @@ describe("buildElevation3dLayer", () => {
         fillOpacity: 0.5,
       },
     });
-    const built = buildElevation3dLayer(
+    const [built] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
+    ) as unknown as FakeGeoJsonLayer[];
     assert.equal(built.props.id, "layer-1");
     assert.equal(built.props.opacity, 0.5);
     assert.equal(built.props.lineBillboard, true);
-    assert.equal(built.props.pointBillboard, true);
     assert.equal(built.props.extruded, false);
     assert.deepEqual(built.props.getLineColor, [0, 255, 0, 255]);
     assert.deepEqual(built.props.getFillColor, [255, 0, 0, 128]);
     assert.equal(built.props.getLineWidth, 4);
-    assert.equal(built.props.getPointRadius, 9);
     // The identity transform still sanitizes into a copy; the copy is cached
     // so subsequent rebuilds reuse it.
     const coordinates = (
@@ -326,10 +331,10 @@ describe("buildElevation3dLayer", () => {
       }
     ).coordinates;
     assert.deepEqual(coordinates[0], [6.86, 45.83, 1035]);
-    const rebuilt = buildElevation3dLayer(
+    const [rebuilt] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
+    ) as unknown as FakeGeoJsonLayer[];
     assert.equal(rebuilt.props.data, built.props.data);
   });
 
@@ -342,10 +347,10 @@ describe("buildElevation3dLayer", () => {
         strokeColor: "transparent",
       },
     });
-    const built = buildElevation3dLayer(
+    const [built] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
+    ) as unknown as FakeGeoJsonLayer[];
     assert.deepEqual(built.props.getFillColor, [0, 0, 0, 0]);
     assert.deepEqual(built.props.getLineColor, [0, 0, 0, 0]);
   });
@@ -358,14 +363,14 @@ describe("buildElevation3dLayer", () => {
         strokeWidthUnit: "meters",
       },
     });
-    const built = buildElevation3dLayer(
+    const [built] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
+    ) as unknown as FakeGeoJsonLayer[];
     assert.equal(built.props.lineWidthUnits, "meters");
   });
 
-  it("forces pixel widths for point-only data even with a meters unit", () => {
+  it("skips GeoJsonLayer entirely for point-only data", () => {
     const layer = geojsonLayer({
       style: {
         ...DEFAULT_LAYER_STYLE,
@@ -383,11 +388,97 @@ describe("buildElevation3dLayer", () => {
         ],
       },
     });
-    const built = buildElevation3dLayer(
+    const [built] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
-    assert.equal(built.props.lineWidthUnits, "pixels");
+    ) as unknown as FakeIconLayer[];
+    assert.equal(built.props.id, "layer-1-points");
+    assert.equal(built.props.sizeUnits, "pixels");
+    assert.equal(built.props.billboard, true);
+  });
+
+  it("renders high-altitude points with a solid IconLayer dot instead of GeoJsonLayer points", () => {
+    const layer = geojsonLayer({
+      opacity: 0.75,
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        elevation3dEnabled: true,
+        fillColor: "#336699",
+        fillOpacity: 0.5,
+        circleRadius: 8,
+      },
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "MultiPoint",
+              coordinates: [
+                [6.86, 45.83, 3150],
+                [6.87, 45.84, 3627],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const built = buildElevation3dLayers(fakeDeckGL, layer) as unknown as [
+      FakeIconLayer,
+    ];
+    assert.equal(built.length, 1);
+    assert.equal(built[0].props.id, "layer-1-points");
+    assert.equal(built[0].props.getSize, 16);
+    assert.deepEqual(built[0].props.getColor, [51, 102, 153, 128]);
+    assert.equal(built[0].props.opacity, 0.75);
+    const data = built[0].props.data as Array<{ position: number[] }>;
+    assert.deepEqual(data.map((datum) => datum.position), [
+      [6.86, 45.83, 3150],
+      [6.87, 45.84, 3627],
+    ]);
+  });
+
+  it("splits mixed geometry so GeoJsonLayer never owns the point sublayer", () => {
+    const layer = geojsonLayer({
+      style: { ...DEFAULT_LAYER_STYLE, elevation3dEnabled: true },
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [6.86, 45.83, 3150] },
+          },
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [6.86, 45.83, 3150],
+                [6.87, 45.84, 3627],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const built = buildElevation3dLayers(fakeDeckGL, layer) as unknown as [
+      FakeGeoJsonLayer,
+      FakeIconLayer,
+    ];
+    assert.equal(built.length, 2);
+    assert.equal(built[0].props.id, "layer-1");
+    assert.equal(
+      ((built[0].props.data as FeatureCollection).features[0].geometry as {
+        type: string;
+      }).type,
+      "LineString",
+    );
+    assert.equal(built[1].props.id, "layer-1-points");
   });
 
   it("rescales Z values when exaggeration or offset are set", () => {
@@ -399,10 +490,10 @@ describe("buildElevation3dLayer", () => {
         elevation3dOffset: 100,
       },
     });
-    const built = buildElevation3dLayer(
+    const [built] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
+    ) as unknown as FakeGeoJsonLayer[];
     const data = built.props.data as FeatureCollection;
     const coordinates = (
       data.features[0].geometry as { coordinates: number[][] }
@@ -411,10 +502,10 @@ describe("buildElevation3dLayer", () => {
     assert.deepEqual(coordinates[1], [6.87, 45.84, 4360]);
 
     // The rescan is cached per source collection and transform.
-    const rebuilt = buildElevation3dLayer(
+    const [rebuilt] = buildElevation3dLayers(
       fakeDeckGL,
       layer,
-    ) as unknown as FakeGeoJsonLayer;
+    ) as unknown as FakeGeoJsonLayer[];
     assert.equal(rebuilt.props.data, data);
   });
 });


### PR DESCRIPTION
## Summary
- split 3D-Z point geometries out of GeoJsonLayer so deck.gl does not use the ScatterplotLayer point sublayer at altitude
- render Point/MultiPoint features as a solid masked IconLayer dot at real Z coordinates
- update elevation 3D tests for point-only, mixed geometry, and high-altitude point rendering

Fixes #1152

## Tests
- node --import tsx --test tests/elevation-3d.test.ts
- npm run build
- npm run test:frontend
- npm run lint (passes with existing unrelated React hook warnings)

## Manual validation
- Loaded Google Photorealistic 3D Tiles using GOOGLE_MAPS_API_KEY from .zshrc
- Loaded /home/qiusheng/Documents/GitHub/data/summit.gpx with Track Points enabled
- Enabled 3D (Z values) on summit Track Points and confirmed the point-only layer builds as IconLayer with real altitude positions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved 3D elevation rendering for geojson layers by splitting point and non-point features into separate visual layers.
  * Point data now renders with dedicated dot markers, while lines and polygons continue to render with elevation styling.

* **Bug Fixes**
  * Better handles mixed geometries and geometry collections, including more reliable Z value normalization.
  * Preserves cached elevation transforms for consistent and efficient re-rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->