### PR TITLE
fix(terrain): unclamp map center while terrain is on to stop zoom snapping over steep relief

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2277,6 +2277,10 @@ export class MapController {
   private removeTerrainControl(): void {
     if (this.map?.getTerrain()?.source === TERRAIN_SOURCE_ID) {
       this.map.setTerrain(null);
+      // Mirror TerrainControl.setEnabled(false): restore MapLibre's default
+      // center-clamping, which the control turned off to stop terrain from
+      // recomputing (and snapping) the zoom while zooming over steep relief.
+      this.map.setCenterClampedToGround(true);
     }
     if (!this.terrainControl) return;
     this.removeControl(this.terrainControl);

--- a/packages/map/src/terrain-control.ts
+++ b/packages/map/src/terrain-control.ts
@@ -160,6 +160,19 @@ export class TerrainControl implements maplibregl.IControl {
     if (!this.map) return;
     if (enabled) {
       if (!this.isEnabled()) {
+        // Unclamp the map center from the terrain surface before enabling
+        // terrain. With the default (clamped) behavior MapLibre re-solves the
+        // zoom every frame to hold the camera at a constant height above the
+        // terrain elevation *under the center*; over steep terrain that sampled
+        // elevation jumps as higher-resolution DEM tiles stream in, so a
+        // cursor-anchored scroll-zoom snaps backward by up to ~2 zoom levels
+        // (zoom-in gestures fail to accumulate) and the camera can dip toward
+        // the surface, producing flicker / black flashes over high, steep relief
+        // (e.g. zooming into a mountain-summit track). Anchoring the center at
+        // sea level removes the per-frame zoom recomputation so zoom accumulates
+        // smoothly, and keeps the camera above ground at steep pitch (per
+        // MapLibre's own guidance for setCenterClampedToGround).
+        this.map.setCenterClampedToGround(false);
         this.map.setTerrain({
           source: this.source,
           exaggeration: this.exaggeration,
@@ -167,6 +180,8 @@ export class TerrainControl implements maplibregl.IControl {
       }
     } else if (this.isEnabled()) {
       this.map.setTerrain(null);
+      // Restore MapLibre's default center clamping now that terrain is off.
+      this.map.setCenterClampedToGround(true);
     }
   }
 

--- a/tests/terrain-control.test.ts
+++ b/tests/terrain-control.test.ts
@@ -63,6 +63,7 @@ const DOUBLE_CLICK_MS = 250;
 interface FakeMap {
   map: maplibregl.Map;
   setTerrainCalls: Array<maplibregl.TerrainSpecification | null>;
+  clampCalls: boolean[];
   emitTerrain: () => void;
 }
 
@@ -70,12 +71,18 @@ function makeFakeMap(): FakeMap {
   let terrain: maplibregl.TerrainSpecification | null = null;
   const handlers: Record<string, Array<() => void>> = {};
   const setTerrainCalls: Array<maplibregl.TerrainSpecification | null> = [];
+  const clampCalls: boolean[] = [];
   const map = {
     getTerrain: () => terrain,
     setTerrain: (spec: maplibregl.TerrainSpecification | null) => {
       terrain = spec;
       setTerrainCalls.push(spec);
       for (const handler of handlers.terrain ?? []) handler();
+    },
+    // The control unclamps the center from the terrain surface while terrain is
+    // on to stop MapLibre from snapping the zoom over steep relief.
+    setCenterClampedToGround: (value: boolean) => {
+      clampCalls.push(value);
     },
     on: (type: string, handler: () => void) => {
       (handlers[type] ??= []).push(handler);
@@ -87,6 +94,7 @@ function makeFakeMap(): FakeMap {
   return {
     map: map as unknown as maplibregl.Map,
     setTerrainCalls,
+    clampCalls,
     emitTerrain: () => {
       for (const handler of handlers.terrain ?? []) handler();
     },
@@ -232,6 +240,25 @@ describe("TerrainControl", () => {
   it("clamps an invalid exaggeration passed to the constructor", () => {
     assert.equal(mount({ exaggeration: -2 }).control.getExaggeration(), 0);
     assert.equal(mount({ exaggeration: Number.NaN }).control.getExaggeration(), 1);
+  });
+
+  it("unclamps the center while terrain is on and re-clamps when off", () => {
+    const { control, fake } = mount();
+
+    // Enabling terrain unclamps the center (false) BEFORE applying terrain, so
+    // the first frame is already free of the constant-altitude zoom recompute.
+    control.setEnabled(true);
+    assert.deepEqual(fake.clampCalls, [false]);
+    assert.equal(fake.setTerrainCalls.at(-1)?.source, TERRAIN_SOURCE);
+
+    // Disabling terrain restores MapLibre's default center clamping (true).
+    control.setEnabled(false);
+    assert.deepEqual(fake.clampCalls, [false, true]);
+    assert.equal(fake.setTerrainCalls.at(-1), null);
+
+    // Redundant calls (already in the requested state) don't touch clamping.
+    control.setEnabled(false);
+    assert.deepEqual(fake.clampCalls, [false, true]);
   });
 
   it("reflects the enabled state on the button class and aria-pressed", () => {


### PR DESCRIPTION
## Problem

Enabling 3D terrain and zooming in past zoom ~13 over steep, high relief (reported while zooming into a mountain-summit GPX track — e.g. `summit.gpx`, with a satellite basemap) is unusable: the **zoom level changes abruptly**, the view **flickers / flashes black**, and you effectively **can't zoom into the track**.

## Root cause

Inherent MapLibre terrain camera behavior, **not** a GeoLibre logic bug — I reproduced it with bare `maplibre-gl@5.24` + GeoLibre's exact terrain source config and zero GeoLibre code.

With MapLibre's default `centerClampedToGround: true`, enabling terrain makes the transform re-solve zoom **every frame** (`recalculateZoom`) to hold the camera at a constant height above the terrain elevation *under the map center*. Over high, steep relief that sampled elevation jumps as higher-resolution DEM tiles stream in, so a cursor-anchored scroll-zoom and the per-frame recompute fight each other.

Measured (bare-engine repro, Mt Rainier, cold DEM tiles, 6 trials each):

| scenario | result |
|---|---|
| terrain OFF | smooth, 0 backward snaps |
| terrain ON (default clamp) | **3–4 / 6 trials snap backward up to ~2.1 zoom levels** |
| terrain ON, 10 zoom-**in** ticks | zoom went 13 → **12.45** (net zoomed *out*) |

The backward snap is the abrupt zoom change; the camera dipping toward the surface during it is the flicker/black flash; the failure to accumulate is why you couldn't zoom to the summit.

## Fix

While terrain is on, anchor the map center at sea level (`setCenterClampedToGround(false)`); restore the default (`true`) when terrain is turned off. This removes the per-frame zoom recomputation so zoom accumulates smoothly, and keeps the camera above ground at steep pitch — which is exactly what MapLibre's docs recommend `false` for.

After the fix (same harness): backward snaps **3–4/6 → 0/6 trials**, worst-case back-jump **1.67 → 0.00**, camera stays **~990 m above** the summit surface.

- `TerrainControl.setEnabled()` toggles the clamp alongside `setTerrain`.
- `MapController.removeTerrainControl()` restores the clamp when terrain is torn down via the Controls menu.

### Tradeoff

With the center unclamped, panning across terrain no longer holds the camera at a constant height above the ground surface (the reference becomes sea level). This is the standard mode for aggressive terrain navigation and is a clear net win for the reported scenario; happy to gate it (e.g. only at high pitch) or expose a setting if preferred.

## Verification

- New unit test asserts the clamp toggles `false` on enable / `true` on disable; full frontend suite passes (2268 tests).
- End-to-end in the real app: clicking the terrain button flips `getCenterClampedToGround()` to `false` and enables terrain with no console errors; toggling off restores `true`.
- `pre-commit run --files` (eslint + npm build) passes on all three changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terrain toggling now correctly updates map center behavior, restoring the default clamping after terrain is turned off.
  * Removing terrain control also resets center clamping to the expected default state.
* **Tests**
  * Expanded coverage to verify center clamping changes when terrain is enabled and disabled.
  * Added checks to ensure repeated toggles do not trigger extra updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->