### PR TITLE
fix(wfs): retry alternate GeoJSON output formats so ArcGIS WFS loads (#1160)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -2,10 +2,7 @@ import { Button, Input, Label, Select } from "@geolibre/ui";
 import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  createWfsGetFeatureUrl,
-  fetchGeoJsonFeatureCollection,
-} from "../../../../lib/layer-refresh";
+import { fetchWfsGeoJson } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
 import {
   createBaseLayer,
@@ -178,17 +175,25 @@ export function WfsSource() {
     // Strip any leftover operation params (a pasted GetCapabilities URL) so the
     // GetFeature request is not built with a conflicting duplicate REQUEST,
     // which would make the server return capabilities XML instead of features.
-    const featureUrl = createWfsGetFeatureUrl({
-      endpoint: stripOgcOperationParams(wfsEndpoint.trim(), "WFS"),
-      typeName: wfsTypeName.trim(),
-      version: wfsVersion,
-      outputFormat: wfsOutputFormat.trim(),
-      srsName: wfsSrsName.trim(),
-      maxFeatures: wfsMaxFeatures.trim() || undefined,
-    });
-    const data = await fetchGeoJsonFeatureCollection(featureUrl, {
-      useWfsProxy: true,
-    });
+    // fetchWfsGeoJson retries alternate GeoJSON output formats when the server
+    // answers the requested one with XML (e.g. an ArcGIS WFS that advertises
+    // GeoJSON as "GEOJSON" rather than "application/json"), so it returns the
+    // URL and output format that actually worked.
+    const {
+      data,
+      url: featureUrl,
+      outputFormat: resolvedOutputFormat,
+    } = await fetchWfsGeoJson(
+      {
+        endpoint: stripOgcOperationParams(wfsEndpoint.trim(), "WFS"),
+        typeName: wfsTypeName.trim(),
+        version: wfsVersion,
+        outputFormat: wfsOutputFormat.trim(),
+        srsName: wfsSrsName.trim(),
+        maxFeatures: wfsMaxFeatures.trim() || undefined,
+      },
+      { useWfsProxy: true },
+    );
     source.addAndClose(
       {
         ...createBaseLayer(
@@ -200,7 +205,7 @@ export function WfsSource() {
             service: "wfs",
             typeName: wfsTypeName.trim(),
             version: wfsVersion,
-            outputFormat: wfsOutputFormat.trim(),
+            outputFormat: resolvedOutputFormat,
             srsName: wfsSrsName.trim() || undefined,
           },
           {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -197,8 +197,11 @@ export function WfsSource() {
     // The fallback may have loaded the layer under a different output format
     // than the user entered (e.g. "GEOJSON" instead of "application/json"). The
     // resolved value is what gets persisted to source.outputFormat, so note the
-    // substitution in case a user later inspects the saved project and finds a
-    // format they did not type.
+    // substitution (in case a user later inspects the saved project and finds a
+    // format they did not type) and adopt it as the form's output format. That
+    // updates wfsFormCache too, so adding another feature type from the same
+    // service this session skips straight to the working token instead of
+    // re-paying the retry cost.
     const requestedOutputFormat = wfsOutputFormat.trim();
     if (
       requestedOutputFormat &&
@@ -207,6 +210,7 @@ export function WfsSource() {
       console.info(
         `WFS: "${requestedOutputFormat}" returned XML; loaded the layer with "${resolvedOutputFormat}" instead.`,
       );
+      setWfsOutputFormat(resolvedOutputFormat);
     }
     source.addAndClose(
       {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -194,6 +194,20 @@ export function WfsSource() {
       },
       { useWfsProxy: true },
     );
+    // The fallback may have loaded the layer under a different output format
+    // than the user entered (e.g. "GEOJSON" instead of "application/json"). The
+    // resolved value is what gets persisted to source.outputFormat, so note the
+    // substitution in case a user later inspects the saved project and finds a
+    // format they did not type.
+    const requestedOutputFormat = wfsOutputFormat.trim();
+    if (
+      requestedOutputFormat &&
+      resolvedOutputFormat.toLowerCase() !== requestedOutputFormat.toLowerCase()
+    ) {
+      console.info(
+        `WFS: "${requestedOutputFormat}" returned XML; loaded the layer with "${resolvedOutputFormat}" instead.`,
+      );
+    }
     source.addAndClose(
       {
         ...createBaseLayer(

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -29,6 +29,25 @@ export interface LayerRefreshConfig {
   intervalMs: number;
 }
 
+// Raised when a GetFeature response is XML rather than the requested GeoJSON.
+// Exported so the output-format fallback (fetchWfsGeoJson) can recognize this
+// specific failure and retry with a different outputFormat token.
+export const WFS_XML_RESPONSE_ERROR =
+  "The service returned XML instead of GeoJSON. Check the layer name and output format.";
+
+// Output-format tokens that commonly yield GeoJSON across WFS implementations.
+// GeoServer/MapServer honor "application/json"; ArcGIS Server advertises its
+// GeoJSON output as "GEOJSON" (uppercase) and answers "application/json" with a
+// GML ExceptionReport instead. Trying these in turn lets an ArcGIS WFS load
+// without the user having to know its exact format token.
+const WFS_GEOJSON_OUTPUT_FORMATS = [
+  "application/json",
+  "GEOJSON",
+  "json",
+  "geojson",
+  "application/geo+json",
+];
+
 export function createWfsGetFeatureUrl(options: {
   endpoint: string;
   typeName: string;
@@ -83,12 +102,73 @@ export async function fetchGeoJsonFeatureCollection(
     return parseGeoJsonFeatureCollection(JSON.parse(text));
   } catch (error) {
     if (/^\s*</.test(text)) {
-      throw new Error(
-        "The service returned XML instead of GeoJSON. Check the layer name and output format.",
-      );
+      throw new Error(WFS_XML_RESPONSE_ERROR);
     }
     throw error;
   }
+}
+
+/**
+ * Fetches a WFS GetFeature response as GeoJSON, retrying with alternate
+ * GeoJSON output-format tokens when the server answers the requested format
+ * with XML (a GML `ExceptionReport` or a GML feature dump). ArcGIS Server, for
+ * example, does not honor the usual `application/json` and instead advertises
+ * its GeoJSON output as `GEOJSON`; a plain fetch of `application/json` returns
+ * XML and the layer fails to load. Retrying the known GeoJSON aliases makes
+ * such services load transparently.
+ *
+ * Only an XML-instead-of-GeoJSON failure triggers a retry; a network error,
+ * timeout, or a malformed JSON body is re-thrown immediately, since a different
+ * outputFormat would not fix it. The resolved request URL and the output format
+ * that succeeded are returned so the caller can persist them (so a later layer
+ * refresh reuses the working format rather than the rejected one).
+ *
+ * @param params - The GetFeature parameters (the requested outputFormat is
+ *   tried first, then the remaining GeoJSON aliases).
+ * @param options - WFS proxy routing and an optional abort signal.
+ * @returns The parsed FeatureCollection plus the URL and outputFormat that worked.
+ */
+export async function fetchWfsGeoJson(
+  params: {
+    endpoint: string;
+    typeName: string;
+    version: string;
+    outputFormat: string;
+    srsName: string;
+    maxFeatures?: string;
+  },
+  options: { useWfsProxy?: boolean; signal?: AbortSignal } = {},
+): Promise<{ data: FeatureCollection; url: string; outputFormat: string }> {
+  const requested = params.outputFormat.trim();
+  // Try the user's requested format first, then the remaining GeoJSON aliases
+  // (case-insensitively deduped so we do not re-request the same token).
+  const candidates = [
+    requested,
+    ...WFS_GEOJSON_OUTPUT_FORMATS.filter(
+      (format) => format.toLowerCase() !== requested.toLowerCase(),
+    ),
+  ];
+
+  let lastError: unknown;
+  for (const outputFormat of candidates) {
+    const url = createWfsGetFeatureUrl({ ...params, outputFormat });
+    try {
+      const data = await fetchGeoJsonFeatureCollection(url, options);
+      return { data, url, outputFormat };
+    } catch (error) {
+      lastError = error;
+      // Keep trying other formats only when this one returned XML; any other
+      // failure (network, timeout, bad JSON) is not an output-format problem.
+      if (
+        !(error instanceof Error && error.message === WFS_XML_RESPONSE_ERROR)
+      ) {
+        throw error;
+      }
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(WFS_XML_RESPONSE_ERROR);
 }
 
 export async function refreshGeoJsonLayer(

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -35,6 +35,30 @@ export interface LayerRefreshConfig {
 export const WFS_XML_RESPONSE_ERROR =
   "The service returned XML instead of GeoJSON. Check the layer name and output format.";
 
+/**
+ * Error thrown when a GetFeature response body is XML instead of GeoJSON.
+ * Carries `isHtml` so the output-format fallback can tell a genuine WFS/OWS/GML
+ * response (a real format rejection worth retrying with another outputFormat)
+ * apart from an HTML error page — a corporate proxy block, a WAF challenge, an
+ * auth-redirect login page, or a load-balancer 5xx page — which no outputFormat
+ * would fix and which should fail immediately rather than drive pointless
+ * retries. The message stays `WFS_XML_RESPONSE_ERROR` for backward compatibility
+ * with callers that match on it.
+ */
+export class WfsXmlResponseError extends Error {
+  readonly isHtml: boolean;
+  constructor(isHtml: boolean) {
+    super(WFS_XML_RESPONSE_ERROR);
+    this.name = "WfsXmlResponseError";
+    this.isHtml = isHtml;
+  }
+}
+
+/** True when an XML-ish body looks like an HTML page rather than WFS/OWS XML. */
+function xmlBodyLooksLikeHtml(text: string): boolean {
+  return /^\s*<(?:!doctype\s+html|html[\s>])/i.test(text);
+}
+
 // Output-format tokens that commonly yield GeoJSON across WFS implementations.
 // GeoServer/MapServer honor "application/json"; ArcGIS Server advertises its
 // GeoJSON output as "GEOJSON" (uppercase) and answers "application/json" with a
@@ -102,7 +126,7 @@ export async function fetchGeoJsonFeatureCollection(
     return parseGeoJsonFeatureCollection(JSON.parse(text));
   } catch (error) {
     if (/^\s*</.test(text)) {
-      throw new Error(WFS_XML_RESPONSE_ERROR);
+      throw new WfsXmlResponseError(xmlBodyLooksLikeHtml(text));
     }
     throw error;
   }
@@ -117,14 +141,17 @@ export async function fetchGeoJsonFeatureCollection(
  * XML and the layer fails to load. Retrying the known GeoJSON aliases makes
  * such services load transparently.
  *
- * Only an XML-instead-of-GeoJSON failure triggers a retry; a network error,
- * timeout, or a malformed JSON body is re-thrown immediately, since a different
- * outputFormat would not fix it. The resolved request URL and the output format
- * that succeeded are returned so the caller can persist them (so a later layer
- * refresh reuses the working format rather than the rejected one).
+ * Only a genuine WFS/OWS/GML XML response triggers a retry. A network error,
+ * timeout, or malformed JSON body is re-thrown immediately (a different
+ * outputFormat would not fix it), and so is an HTML error page (a proxy/WAF/auth
+ * page), so a server whose problem is unrelated to the output format is not
+ * hammered with the full alias list. The resolved request URL and the output
+ * format that succeeded are returned so the caller can persist them (so a later
+ * layer refresh reuses the working format rather than the rejected one).
  *
- * @param params - The GetFeature parameters (the requested outputFormat is
- *   tried first, then the remaining GeoJSON aliases).
+ * @param params - The GetFeature parameters. The requested outputFormat is
+ *   tried first, then the remaining GeoJSON aliases; an empty requested format
+ *   is skipped so no `outputFormat=` request is issued.
  * @param options - WFS proxy routing and an optional abort signal.
  * @returns The parsed FeatureCollection plus the URL and outputFormat that worked.
  */
@@ -140,10 +167,12 @@ export async function fetchWfsGeoJson(
   options: { useWfsProxy?: boolean; signal?: AbortSignal } = {},
 ): Promise<{ data: FeatureCollection; url: string; outputFormat: string }> {
   const requested = params.outputFormat.trim();
-  // Try the user's requested format first, then the remaining GeoJSON aliases
-  // (case-insensitively deduped so we do not re-request the same token).
+  // Try the user's requested format first (when non-empty), then the remaining
+  // GeoJSON aliases (case-insensitively deduped so a token is not requested
+  // twice). An empty requested format is dropped rather than sent as
+  // `outputFormat=`.
   const candidates = [
-    requested,
+    ...(requested ? [requested] : []),
     ...WFS_GEOJSON_OUTPUT_FORMATS.filter(
       (format) => format.toLowerCase() !== requested.toLowerCase(),
     ),
@@ -157,18 +186,18 @@ export async function fetchWfsGeoJson(
       return { data, url, outputFormat };
     } catch (error) {
       lastError = error;
-      // Keep trying other formats only when this one returned XML; any other
-      // failure (network, timeout, bad JSON) is not an output-format problem.
-      if (
-        !(error instanceof Error && error.message === WFS_XML_RESPONSE_ERROR)
-      ) {
+      // Keep trying other formats only when the server returned a WFS/OWS/GML
+      // XML body (a real format rejection). Any other failure — network,
+      // timeout, bad JSON, or an HTML error page — is not fixable by a
+      // different outputFormat, so surface it immediately.
+      if (!(error instanceof WfsXmlResponseError) || error.isHtml) {
         throw error;
       }
     }
   }
   throw lastError instanceof Error
     ? lastError
-    : new Error(WFS_XML_RESPONSE_ERROR);
+    : new WfsXmlResponseError(false);
 }
 
 export async function refreshGeoJsonLayer(

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -54,9 +54,20 @@ export class WfsXmlResponseError extends Error {
   }
 }
 
-/** True when an XML-ish body looks like an HTML page rather than WFS/OWS XML. */
-function xmlBodyLooksLikeHtml(text: string): boolean {
-  return /^\s*<(?:!doctype\s+html|html[\s>])/i.test(text);
+/**
+ * True when an XML-ish response looks like an HTML page (a proxy/WAF/auth/error
+ * page) rather than a genuine WFS/OWS/GML document. A `text/html` content type
+ * is decisive; otherwise the head of the body is sniffed for HTML structure
+ * tags, tolerating a leading XML prolog, doctype, comment, or `<head>`-only
+ * fragment before the real markup. WFS/OWS/GML responses never contain
+ * `<html>`/`<head>`/`<body>`/`<title>`, so this does not misclassify them.
+ */
+function looksLikeHtmlResponse(text: string, contentType: string | null): boolean {
+  if (contentType && /text\/html/i.test(contentType)) return true;
+  const head = text.slice(0, 512);
+  return /<\s*(?:!doctype\s+html|html[\s>]|head[\s>]|body[\s>]|title[\s>])/i.test(
+    head,
+  );
 }
 
 // Output-format tokens that commonly yield GeoJSON across WFS implementations.
@@ -126,7 +137,9 @@ export async function fetchGeoJsonFeatureCollection(
     return parseGeoJsonFeatureCollection(JSON.parse(text));
   } catch (error) {
     if (/^\s*</.test(text)) {
-      throw new WfsXmlResponseError(xmlBodyLooksLikeHtml(text));
+      throw new WfsXmlResponseError(
+        looksLikeHtmlResponse(text, response.headers.get("content-type")),
+      );
     }
     throw error;
   }
@@ -148,6 +161,12 @@ export async function fetchGeoJsonFeatureCollection(
  * hammered with the full alias list. The resolved request URL and the output
  * format that succeeded are returned so the caller can persist them (so a later
  * layer refresh reuses the working format rather than the rejected one).
+ *
+ * All attempts share a single {@link FETCH_TIMEOUT_MS} budget rather than each
+ * getting a fresh timeout, so a server that is slow to reject each format cannot
+ * stack up N × 30s of hang before the error surfaces. The budget is the same
+ * ceiling a single non-fallback fetch already has, so a legitimately large
+ * GeoJSON download is not penalized relative to today.
  *
  * @param params - The GetFeature parameters. The requested outputFormat is
  *   tried first, then the remaining GeoJSON aliases; an empty requested format
@@ -178,11 +197,23 @@ export async function fetchWfsGeoJson(
     ),
   ];
 
+  // One deadline shared across every attempt, so N slow rejections cannot stack
+  // N separate timeouts. Combined with the caller's signal (if any) and passed
+  // down; fetchGeoJsonFeatureCollection ANDs its own per-call timeout on top,
+  // but this budget is what bounds the total wall time.
+  const budget = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, budget])
+    : budget;
+
   let lastError: unknown;
   for (const outputFormat of candidates) {
     const url = createWfsGetFeatureUrl({ ...params, outputFormat });
     try {
-      const data = await fetchGeoJsonFeatureCollection(url, options);
+      const data = await fetchGeoJsonFeatureCollection(url, {
+        ...options,
+        signal,
+      });
       return { data, url, outputFormat };
     } catch (error) {
       lastError = error;

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -259,4 +259,39 @@ describe("fetchWfsGeoJson output-format fallback", () => {
     await assert.rejects(fetchWfsGeoJson(baseParams));
     assert.equal(calls, 1, "a non-XML parse error must not trigger a retry");
   });
+
+  it("does not retry when the body is an HTML error page (proxy/WAF)", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      // A corporate proxy / WAF / auth page starts with "<" but is not a WFS
+      // format rejection, so trying other output formats is pointless.
+      return new Response("<!DOCTYPE html><html><body>Blocked</body></html>", {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    await assert.rejects(fetchWfsGeoJson(baseParams), (error: Error) => {
+      assert.equal(error.message, WFS_XML_RESPONSE_ERROR);
+      return true;
+    });
+    assert.equal(calls, 1, "an HTML error page must not trigger format retries");
+  });
+
+  it("skips an empty requested format instead of requesting outputFormat=", async () => {
+    const requestedFormats: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requestedFormats.push(
+        new URL(url).searchParams.get("outputFormat") ?? "",
+      );
+      return new Response(JSON.stringify(FEATURE_COLLECTION), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchWfsGeoJson({ ...baseParams, outputFormat: "" });
+    // The first (and only) request uses the first GeoJSON alias, never "".
+    assert.equal(requestedFormats[0], "application/json");
+    assert.ok(!requestedFormats.includes(""), "no empty outputFormat request");
+    assert.equal(result.data.features.length, 1);
+  });
 });

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -278,6 +278,56 @@ describe("fetchWfsGeoJson output-format fallback", () => {
     assert.equal(calls, 1, "an HTML error page must not trigger format retries");
   });
 
+  it("detects HTML that starts with a prolog/comment before <html> (no retry)", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      // Leading XML prolog + comment before the real HTML — the narrow
+      // start-anchored check would miss this; the head sniff catches it.
+      return new Response(
+        '<?xml version="1.0"?><!-- WAF --><html><head><title>Blocked</title></head></html>',
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    await assert.rejects(fetchWfsGeoJson(baseParams));
+    assert.equal(calls, 1, "prolog-prefixed HTML must not trigger retries");
+  });
+
+  it("detects HTML via a text/html content type even without HTML tags", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response("<blocked>proxy denied</blocked>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }) as typeof fetch;
+
+    await assert.rejects(fetchWfsGeoJson(baseParams));
+    assert.equal(calls, 1, "a text/html response must not trigger retries");
+  });
+
+  it("still retries a real OWS ExceptionReport (not misread as HTML)", async () => {
+    const formats: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const format = new URL(url).searchParams.get("outputFormat") ?? "";
+      formats.push(format);
+      if (format === "GEOJSON") {
+        return new Response(JSON.stringify(FEATURE_COLLECTION), { status: 200 });
+      }
+      return new Response(
+        '<?xml version="1.0"?><ows:ExceptionReport><ows:Exception/></ows:ExceptionReport>',
+        { status: 200, headers: { "content-type": "application/xml" } },
+      );
+    }) as typeof fetch;
+
+    const result = await fetchWfsGeoJson(baseParams);
+    assert.equal(result.outputFormat, "GEOJSON");
+    assert.deepEqual(formats, ["application/json", "GEOJSON"]);
+  });
+
   it("skips an empty requested format instead of requesting outputFormat=", async () => {
     const requestedFormats: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL) => {

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import {
+  fetchWfsGeoJson,
   isRefreshableLayer,
   isVectorControlRefreshLayer,
+  WFS_XML_RESPONSE_ERROR,
 } from "../apps/geolibre-desktop/src/lib/layer-refresh";
 
 function makeLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
@@ -143,5 +145,118 @@ describe("isVectorControlRefreshLayer / isRefreshableLayer", () => {
     });
 
     assert.equal(isRefreshableLayer(layer), false);
+  });
+});
+
+describe("fetchWfsGeoJson output-format fallback", () => {
+  const originalFetch = globalThis.fetch;
+  const FEATURE_COLLECTION = {
+    type: "FeatureCollection",
+    features: [
+      { type: "Feature", geometry: null, properties: { name: "x" } },
+    ],
+  };
+
+  const baseParams = {
+    endpoint: "https://geo.example.com/WFSServer",
+    typeName: "ANM:Area",
+    version: "2.0.0",
+    outputFormat: "application/json",
+    srsName: "EPSG:4326",
+    maxFeatures: "1000",
+  };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses the requested format when the server honors it (no retries)", async () => {
+    const requestedFormats: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requestedFormats.push(
+        new URL(url).searchParams.get("outputFormat") ?? "",
+      );
+      return new Response(JSON.stringify(FEATURE_COLLECTION), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await fetchWfsGeoJson(baseParams);
+    assert.equal(result.outputFormat, "application/json");
+    assert.equal(result.data.features.length, 1);
+    assert.deepEqual(requestedFormats, ["application/json"]);
+    assert.match(result.url, /outputFormat=application%2Fjson/);
+  });
+
+  it("retries with an alternate GeoJSON token when the requested one returns XML", async () => {
+    const requestedFormats: string[] = [];
+    // Emulate an ArcGIS WFS: it answers "application/json" with a GML
+    // ExceptionReport (XML) but returns GeoJSON for the "GEOJSON" token.
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const format = new URL(url).searchParams.get("outputFormat") ?? "";
+      requestedFormats.push(format);
+      if (format === "GEOJSON") {
+        return new Response(JSON.stringify(FEATURE_COLLECTION), { status: 200 });
+      }
+      return new Response("<ExceptionReport>bad format</ExceptionReport>", {
+        status: 200,
+      });
+    }) as typeof fetch;
+
+    const result = await fetchWfsGeoJson(baseParams);
+    assert.equal(result.outputFormat, "GEOJSON");
+    assert.equal(result.data.features.length, 1);
+    // The requested format is tried first, then the ArcGIS "GEOJSON" alias.
+    assert.deepEqual(requestedFormats, ["application/json", "GEOJSON"]);
+    assert.match(result.url, /outputFormat=GEOJSON/);
+  });
+
+  it("does not re-request the requested token as an alias", async () => {
+    const requestedFormats: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      requestedFormats.push(
+        new URL(url).searchParams.get("outputFormat") ?? "",
+      );
+      const format = new URL(url).searchParams.get("outputFormat") ?? "";
+      // Only the second alias ("json") yields GeoJSON here.
+      return format === "json"
+        ? new Response(JSON.stringify(FEATURE_COLLECTION), { status: 200 })
+        : new Response("<ExceptionReport/>", { status: 200 });
+    }) as typeof fetch;
+
+    // Request "GEOJSON" (uppercase): it must not be tried twice even though it
+    // is also in the alias list.
+    const result = await fetchWfsGeoJson({
+      ...baseParams,
+      outputFormat: "GEOJSON",
+    });
+    assert.equal(result.outputFormat, "json");
+    assert.equal(
+      requestedFormats.filter((f) => f === "GEOJSON").length,
+      1,
+      "the requested GEOJSON token should be requested exactly once",
+    );
+  });
+
+  it("throws the XML error when no format yields GeoJSON", async () => {
+    globalThis.fetch = (async () =>
+      new Response("<ExceptionReport/>", { status: 200 })) as typeof fetch;
+
+    await assert.rejects(fetchWfsGeoJson(baseParams), (error: Error) => {
+      assert.equal(error.message, WFS_XML_RESPONSE_ERROR);
+      return true;
+    });
+  });
+
+  it("does not retry on a non-XML failure (bad JSON body)", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response("not json at all", { status: 200 });
+    }) as typeof fetch;
+
+    await assert.rejects(fetchWfsGeoJson(baseParams));
+    assert.equal(calls, 1, "a non-XML parse error must not trigger a retry");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1160. A WFS layer from an ArcGIS Server WFS service (e.g. `https://geo.anm.gov.co/webgis/services/ANM/ServiciosANM/MapServer/WFSServer`) failed to load with:

> The service returned XML instead of GeoJSON. Check the layer name and output format.

### Root cause

GeoLibre defaults the WFS `outputFormat` to `application/json`. ArcGIS Server WFS does **not** honor that token: it advertises its GeoJSON output as `GEOJSON` (uppercase) and answers an `application/json` GetFeature request with a GML `ExceptionReport` (XML). The XML body then trips GeoLibre's "returned XML instead of GeoJSON" guard, so the layer never loads. Requesting `outputFormat=GEOJSON` returns valid GeoJSON.

### Fix

New `fetchWfsGeoJson` helper tries the user's requested output format first and, when the server responds with XML, retries the known GeoJSON aliases (`GEOJSON`, `json`, `geojson`, `application/geo+json`). The request URL and the output format that actually worked are persisted on the layer, so a later refresh reuses the working token rather than the rejected one. Only an XML-instead-of-GeoJSON failure triggers a retry; a network error, timeout, or malformed-JSON body is re-thrown immediately (a different output format would not fix those). The user can still override the format manually.

### Verification

Drove the real app with the reporter's ArcGIS service, keeping the default `application/json` output format (the failing case):

- Retrieved the 14 feature types, selected `Area_Indigena_Restringida`, and clicked Add layer.
- The layer loaded and rendered over Colombia (previously it errored out). Confirmed in **both light and dark themes** with 0 console errors.

Added unit tests for `fetchWfsGeoJson` covering: honoring the requested format with no retries, retrying to `GEOJSON` on an XML response, not re-requesting the requested token as an alias, throwing the XML error when no format yields GeoJSON, and not retrying on a non-XML failure. Full frontend suite and production build pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WFS layer loading by automatically selecting the first working GeoJSON output format when the service returns XML.
  * Avoids unnecessary retry attempts when the requested format matches an accepted alias.
  * Stores the resolved working output format in new layer metadata for consistent behavior during the session.
* **Tests**
  * Added coverage for output-format fallback and retry behavior, including XML vs HTML detection and ensuring non-GeoJSON failures don’t trigger retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->