### PR TITLE
feat(basemaps): replace planetary basemaps with the OpenPlanetaryMap set

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -2,6 +2,7 @@ import {
   BLANK_BASEMAP,
   createDefaultMapView,
   OPENFREEMAP_BASEMAPS,
+  PLANETARY_BASEMAP_GROUPS,
   PLANETARY_BASEMAPS,
   PROTOMAPS_BASEMAPS,
   useAppStore,
@@ -12,6 +13,7 @@ import {
   resolveProtomapsPresets,
   type PresetBasemap,
 } from "../../lib/basemap-presets";
+import { planetaryBodySectionKey } from "../../lib/planetary-sections";
 import {
   Button,
   cn,
@@ -321,22 +323,24 @@ export function NewProjectDialog({
                   </div>
                 ) : null}
 
-                <div className="space-y-2">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    {t("basemapPicker.sectionPlanetary")}
-                  </p>
-                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {PLANETARY_BASEMAPS.map((basemap) => (
-                      <BasemapButton
-                        key={basemap.id}
-                        id={basemap.id}
-                        name={basemap.name}
-                        selected={selectedBasemapId === basemap.id}
-                        onSelect={setSelectedBasemapId}
-                      />
-                    ))}
+                {PLANETARY_BASEMAP_GROUPS.map((group) => (
+                  <div key={group.ellipsoidId} className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {t(planetaryBodySectionKey(group.ellipsoidId))}
+                    </p>
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                      {group.basemaps.map((basemap) => (
+                        <BasemapButton
+                          key={basemap.id}
+                          id={basemap.id}
+                          name={basemap.name}
+                          selected={selectedBasemapId === basemap.id}
+                          onSelect={setSelectedBasemapId}
+                        />
+                      ))}
+                    </div>
                   </div>
-                </div>
+                ))}
 
                 <div className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
@@ -1,5 +1,6 @@
 import {
   BLANK_BASEMAP,
+  PLANETARY_BASEMAP_GROUPS,
   PLANETARY_BASEMAPS,
   useAppStore,
   type PlanetaryBasemap,
@@ -24,6 +25,7 @@ import {
   resolveProtomapsPresets,
   type PresetBasemap,
 } from "../../lib/basemap-presets";
+import { planetaryBodySectionKey } from "../../lib/planetary-sections";
 
 // Picking the "Liberty 3D" preset applies the Liberty style and tilts the
 // current camera into a 3D perspective in place (matching the New Project
@@ -223,21 +225,23 @@ export function BasemapPickerDialog({
             </div>
           ) : null}
 
-          <div className="space-y-2">
-            <p className="text-xs font-medium text-muted-foreground">
-              {t("basemapPicker.sectionPlanetary")}
-            </p>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-              {PLANETARY_BASEMAPS.map((basemap) => (
-                <PresetButton
-                  key={basemap.id}
-                  name={basemap.name}
-                  selected={activeChoice === basemap.id}
-                  onSelect={() => applyPlanetary(basemap)}
-                />
-              ))}
+          {PLANETARY_BASEMAP_GROUPS.map((group) => (
+            <div key={group.ellipsoidId} className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                {t(planetaryBodySectionKey(group.ellipsoidId))}
+              </p>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {group.basemaps.map((basemap) => (
+                  <PresetButton
+                    key={basemap.id}
+                    name={basemap.name}
+                    selected={activeChoice === basemap.id}
+                    onSelect={() => applyPlanetary(basemap)}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
+          ))}
 
           <div className="space-y-2">
             <p className="text-xs font-medium text-muted-foreground">

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -97,7 +97,8 @@
     "title": "Basiskarte ändern",
     "applyCustom": "Anwenden",
     "invalidUrl": "Geben Sie eine gültige HTTP- oder HTTPS-Style-URL ein.",
-    "sectionPlanetary": "Planetenkarten"
+    "sectionMoon": "Der Mond",
+    "sectionMars": "Mars"
   },
   "common": {
     "pickColorFromScreen": "Farbe vom Bildschirm auswählen",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -97,7 +97,8 @@
     "title": "Change basemap",
     "applyCustom": "Apply",
     "invalidUrl": "Enter a valid HTTP or HTTPS style URL.",
-    "sectionPlanetary": "Planetary"
+    "sectionMoon": "The Moon",
+    "sectionMars": "Mars"
   },
   "common": {
     "pickColorFromScreen": "Pick a color from the screen",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -97,7 +97,8 @@
     "title": "Cambiar mapa base",
     "applyCustom": "Aplicar",
     "invalidUrl": "Introduzca una URL de estilo HTTP o HTTPS válida.",
-    "sectionPlanetary": "Planetario"
+    "sectionMoon": "La Luna",
+    "sectionMars": "Marte"
   },
   "common": {
     "pickColorFromScreen": "Elegir un color de la pantalla",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -97,7 +97,8 @@
     "title": "Changer de fond de carte",
     "applyCustom": "Appliquer",
     "invalidUrl": "Entrez une URL de style HTTP ou HTTPS valide.",
-    "sectionPlanetary": "Planétaire"
+    "sectionMoon": "La Lune",
+    "sectionMars": "Mars"
   },
   "common": {
     "pickColorFromScreen": "Choisir une couleur à l'écran",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -97,7 +97,8 @@
     "title": "बेसमैप बदलें",
     "applyCustom": "लागू करें",
     "invalidUrl": "एक मान्य HTTP या HTTPS स्टाइल URL दर्ज करें।",
-    "sectionPlanetary": "प्लैनेटरी"
+    "sectionMoon": "चंद्रमा",
+    "sectionMars": "मंगल"
   },
   "common": {
     "pickColorFromScreen": "स्क्रीन से रंग चुनें",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -96,7 +96,8 @@
     "title": "Ganti peta dasar",
     "applyCustom": "Terapkan",
     "invalidUrl": "Masukkan URL gaya HTTP atau HTTPS yang valid.",
-    "sectionPlanetary": "Planet"
+    "sectionMoon": "Bulan",
+    "sectionMars": "Mars"
   },
   "common": {
     "pickColorFromScreen": "Pilih warna dari layar",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -97,7 +97,8 @@
     "title": "Cambia mappa di base",
     "applyCustom": "Applica",
     "invalidUrl": "Inserisci un URL di stile valido, in formato HTTP o HTTPS.",
-    "sectionPlanetary": "Planetario"
+    "sectionMoon": "La Luna",
+    "sectionMars": "Marte"
   },
   "common": {
     "pickColorFromScreen": "Preleva un colore dallo schermo",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -96,7 +96,8 @@
     "title": "ベースマップを変更",
     "applyCustom": "適用",
     "invalidUrl": "有効なHTTPまたはHTTPSのスタイルURLを入力してください。",
-    "sectionPlanetary": "Planetary"
+    "sectionMoon": "月",
+    "sectionMars": "火星"
   },
   "common": {
     "pickColorFromScreen": "画面から色を選択",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -96,7 +96,8 @@
     "title": "베이스맵 변경",
     "applyCustom": "적용",
     "invalidUrl": "유효한 HTTP 또는 HTTPS 스타일 URL을 입력하세요.",
-    "sectionPlanetary": "행성"
+    "sectionMoon": "달",
+    "sectionMars": "화성"
   },
   "common": {
     "pickColorFromScreen": "화면에서 색상 선택",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -97,7 +97,8 @@
     "title": "Basiskaart wijzigen",
     "applyCustom": "Toepassen",
     "invalidUrl": "Voer een geldige HTTP- of HTTPS-stijl-URL in.",
-    "sectionPlanetary": "Planetair"
+    "sectionMoon": "De Maan",
+    "sectionMars": "Mars"
   },
   "common": {
     "pickColorFromScreen": "Kies een kleur van het scherm",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -97,7 +97,8 @@
     "title": "Alterar mapa base",
     "applyCustom": "Aplicar",
     "invalidUrl": "Digite uma URL de estilo HTTP ou HTTPS válida.",
-    "sectionPlanetary": "Planetário"
+    "sectionMoon": "A Lua",
+    "sectionMars": "Marte"
   },
   "common": {
     "pickColorFromScreen": "Escolher uma cor da tela",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -99,7 +99,8 @@
     "title": "Изменить базовую карту",
     "applyCustom": "Применить",
     "invalidUrl": "Введите корректный URL стиля (HTTP или HTTPS).",
-    "sectionPlanetary": "Планетарные"
+    "sectionMoon": "Луна",
+    "sectionMars": "Марс"
   },
   "common": {
     "pickColorFromScreen": "Выбрать цвет с экрана",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -97,7 +97,8 @@
     "title": "Temel haritayı değiştir",
     "applyCustom": "Uygula",
     "invalidUrl": "Geçerli bir HTTP veya HTTPS stil URL'si girin.",
-    "sectionPlanetary": "Gezegensel"
+    "sectionMoon": "Ay",
+    "sectionMars": "Mars"
   },
   "common": {
     "pickColorFromScreen": "Ekrandan bir renk seç",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -96,7 +96,8 @@
     "title": "更改底图",
     "applyCustom": "应用",
     "invalidUrl": "请输入有效的 HTTP 或 HTTPS 样式 URL。",
-    "sectionPlanetary": "星球"
+    "sectionMoon": "月球",
+    "sectionMars": "火星"
   },
   "common": {
     "pickColorFromScreen": "从屏幕上拾取颜色",

--- a/apps/geolibre-desktop/src/lib/planetary-sections.ts
+++ b/apps/geolibre-desktop/src/lib/planetary-sections.ts
@@ -5,11 +5,19 @@ import type { EllipsoidId } from "@geolibre/core";
  * body it depicts. Shared by the New Project and Change Basemap panels, which
  * both render {@link PLANETARY_BASEMAP_GROUPS} as one section per body.
  *
- * Returns a literal key so the typed `t()` accepts it. Bodies without a
- * dedicated heading fall back to the Mars section (the only other grouped body).
+ * Returns a literal key so the typed `t()` accepts it. Throws for a body with
+ * no dedicated heading so a future basemap group (e.g. Mercury) added without a
+ * matching section fails loudly instead of being silently captioned "Mars".
  */
 export function planetaryBodySectionKey(ellipsoidId: EllipsoidId) {
-  return ellipsoidId === "moon"
-    ? ("basemapPicker.sectionMoon" as const)
-    : ("basemapPicker.sectionMars" as const);
+  switch (ellipsoidId) {
+    case "moon":
+      return "basemapPicker.sectionMoon" as const;
+    case "mars":
+      return "basemapPicker.sectionMars" as const;
+    default:
+      throw new Error(
+        `no planetary basemap section heading for "${ellipsoidId}"`,
+      );
+  }
 }

--- a/apps/geolibre-desktop/src/lib/planetary-sections.ts
+++ b/apps/geolibre-desktop/src/lib/planetary-sections.ts
@@ -1,0 +1,15 @@
+import type { EllipsoidId } from "@geolibre/core";
+
+/**
+ * The i18n key for a planetary basemap section heading, keyed by the celestial
+ * body it depicts. Shared by the New Project and Change Basemap panels, which
+ * both render {@link PLANETARY_BASEMAP_GROUPS} as one section per body.
+ *
+ * Returns a literal key so the typed `t()` accepts it. Bodies without a
+ * dedicated heading fall back to the Mars section (the only other grouped body).
+ */
+export function planetaryBodySectionKey(ellipsoidId: EllipsoidId) {
+  return ellipsoidId === "moon"
+    ? ("basemapPicker.sectionMoon" as const)
+    : ("basemapPicker.sectionMars" as const);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13804,6 +13804,10 @@
       "resolved": "apps/geolibre-desktop",
       "link": true
     },
+    "node_modules/geolibre-tiles-worker": {
+      "resolved": "workers/tiles",
+      "link": true
+    },
     "node_modules/geolibre-viewer-worker": {
       "resolved": "workers/viewer",
       "link": true
@@ -21426,9 +21430,24 @@
       }
     },
     "workers/collab/node_modules/@cloudflare/workers-types": {
-      "version": "5.20260707.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260707.1.tgz",
-      "integrity": "sha512-oTiTTaRNR4mMbuiQo2ijAYMAvjFVWn0uDDfawdT2XS4t6hSa7hNPelDV9aWv/pXuz5ew+HPCabE8TMBy7qLwGQ==",
+      "version": "5.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260710.1.tgz",
+      "integrity": "sha512-4ooaY2Pb5XGwDn8Fzm6jnTAJkIX0R5LBvL9euQpp2T58sQItlAQd9yivAlkwGhpY5cM1u81/9HaXwKAjXwtyzA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "workers/tiles": {
+      "name": "geolibre-tiles-worker",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260707.1",
+        "wrangler": "^4.107.0"
+      }
+    },
+    "workers/tiles/node_modules/@cloudflare/workers-types": {
+      "version": "5.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260710.1.tgz",
+      "integrity": "sha512-4ooaY2Pb5XGwDn8Fzm6jnTAJkIX0R5LBvL9euQpp2T58sQItlAQd9yivAlkwGhpY5cM1u81/9HaXwKAjXwtyzA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -21441,9 +21460,9 @@
       }
     },
     "workers/viewer/node_modules/@cloudflare/workers-types": {
-      "version": "5.20260707.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260707.1.tgz",
-      "integrity": "sha512-oTiTTaRNR4mMbuiQo2ijAYMAvjFVWn0uDDfawdT2XS4t6hSa7hNPelDV9aWv/pXuz5ew+HPCabE8TMBy7qLwGQ==",
+      "version": "5.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260710.1.tgz",
+      "integrity": "sha512-4ooaY2Pb5XGwDn8Fzm6jnTAJkIX0R5LBvL9euQpp2T58sQItlAQd9yivAlkwGhpY5cM1u81/9HaXwKAjXwtyzA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:frontend:coverage": "node --import tsx --test --experimental-test-coverage --test-coverage-lines=78 --test-coverage-branches=78 --test-coverage-functions=63 --test-coverage-exclude=\"tests/**\" --test-coverage-exclude=\"e2e/**\" --test-coverage-exclude=\"**/*.config.*\" tests/*.test.ts",
     "test:backend": "python -m pytest backend/geolibre_server/tests",
     "test:backend:coverage": "python -m pytest backend/geolibre_server/tests --cov=geolibre_server --cov-report=term-missing --cov-fail-under=55",
-    "test:worker": "npm run typecheck -w geolibre-viewer-worker && npm run typecheck -w geolibre-collab-worker",
+    "test:worker": "npm run typecheck -w geolibre-viewer-worker && npm run typecheck -w geolibre-collab-worker && npm run typecheck -w geolibre-tiles-worker",
     "test:e2e": "playwright test",
     "check:rust": "cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml",
     "ci": "npm run lint && npm run build && npm run test:frontend:coverage && npm run test:worker && npm run test:backend:coverage && npm run check:rust",

--- a/packages/core/src/ellipsoids.ts
+++ b/packages/core/src/ellipsoids.ts
@@ -124,8 +124,15 @@ export interface PlanetaryBasemap {
   name: string;
   /** Sentinel stored as the basemap style URL. */
   styleUrl: string;
-  /** XYZ tile template. */
+  /** XYZ (or TMS, see {@link scheme}) tile template. */
   tileUrl: string;
+  /**
+   * Tile row ordering. OpenPlanetaryMap's single-layer raster mosaics (the S3
+   * datasets) are published as **TMS** (tile origin bottom-left, Y flipped),
+   * whereas the CARTO `opmbuilder` named maps are standard **XYZ**. Omit for
+   * XYZ; MapLibre defaults to `"xyz"` when `scheme` is absent.
+   */
+  scheme?: "tms";
   /** Max native zoom of the source (MapLibre overzooms beyond this). */
   maxZoom: number;
   /** Attribution shown on the map. */
@@ -136,32 +143,70 @@ export interface PlanetaryBasemap {
 
 export const PLANETARY_BASEMAP_SENTINEL_PREFIX = "geolibre://basemap/";
 
-const USGS_ATTRIBUTION =
-  '<a href="https://astrogeology.usgs.gov">USGS Astrogeology</a> / NASA';
-
 const OPM_ATTRIBUTION =
-  '<a href="https://www.openplanetary.org/opm">OpenPlanetaryMap</a> / USGS / NASA';
+  '<a href="https://www.openplanetary.org/opm">OpenPlanetaryMap</a>';
 
-// USGS Astrogeology MapServer serves these global mosaics as Web-Mercator XYZ
-// tiles (`tilemode=gmap`) with open CORS, so MapLibre renders them directly.
-// These are the photographic mosaics Google Earth/Moon use — the Viking
-// colorized mosaic for Mars and the LRO WAC mosaic for the Moon — rather than a
-// stylized cartographic basemap.
+/** Data-source credit joined with the OpenPlanetaryMap attribution. */
+const opmCredit = (source: string) => `${source} · ${OPM_ATTRIBUTION}`;
+
+// The GeoLibre tiles Worker (workers/tiles), which adds CORS to the OPM S3
+// mosaics that lack it. Its dataset keys mirror the DATASETS map in that Worker.
+// Tile path: `${TILE_PROXY_BASE}/<dataset>/{z}/{x}/{y}.png`.
+const TILE_PROXY_BASE = "https://tiles.geolibre.app/opm";
+
+// The OpenPlanetaryMap Mars and Moon basemaps
+// (https://openplanetarymap.org/basemaps/). Every one is a pre-rendered raster
+// served from a CDN — fast and reliable, unlike the USGS Astrogeology MapServer
+// these replace, which rendered every tile per request from a cgi-bin.
 //
-// MapServer's gmap `tile=` parameter wants the tile coordinates space-separated
-// (`x y z`). We encode the separators as `%20`, NOT `+`: the Linux Tauri webview
-// (WebKitGTK) re-encodes a literal `+` in the request URL to `%2B`, which
-// MapServer then reads as a literal plus rather than a space, so every tile
-// comes back as an HTML error and the map goes black. `%20` is the canonical
-// space encoding and survives both Chromium and WebKit unchanged.
+// Two tiling schemes are in play (see PlanetaryBasemap.scheme):
+//   - The single-layer OPM mosaics (MOLA/Viking/hillshade/Moon albedo) are TMS.
+//   - The multi-layer CARTO `opmbuilder` named maps are standard XYZ.
+// maxZoom is each source's probed max native zoom, so MapLibre overzooms (blurs)
+// rather than 404s.
+//
+// CORS: MapLibre GL fetches raster tiles with `fetch()`, which enforces CORS.
+// The CARTO `opmbuilder` named maps send `Access-Control-Allow-Origin: *`, so
+// they are referenced directly. The single-layer OPM mosaics are served from S3
+// buckets that send NO CORS header, so the browser blocks them — those go
+// through the GeoLibre tiles Worker (workers/tiles, tiles.geolibre.app), which
+// re-emits each tile with CORS and edge-caches it. See TILE_PROXY_BASE.
 export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
-  // Cartographic OpenPlanetaryMap basemaps (colorized shaded relief + labels).
-  // These are pre-rendered on a Fastly CDN, so they load fast and reliably —
-  // the "just works" choice when the USGS imagery below is slow.
+  // --- Mars ---------------------------------------------------------------
   {
-    id: "mars-opm",
-    name: "Mars (OpenPlanetaryMap)",
-    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-opm`,
+    id: "mars-colour-mola-elevation",
+    name: "Mars Colour MOLA Elevation",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-colour-mola-elevation`,
+    tileUrl: `${TILE_PROXY_BASE}/mars-mola-color-noshade/{z}/{x}/{y}.png`,
+    scheme: "tms",
+    maxZoom: 6,
+    attribution: opmCredit("NASA / MOLA"),
+    ellipsoidId: "mars",
+  },
+  {
+    id: "mars-viking-mdim21",
+    name: "Mars Viking MDIM2.1",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-viking-mdim21`,
+    tileUrl: `${TILE_PROXY_BASE}/mars-viking-mdim21/{z}/{x}/{y}.png`,
+    scheme: "tms",
+    maxZoom: 7,
+    attribution: opmCredit("NASA / Viking / USGS"),
+    ellipsoidId: "mars",
+  },
+  {
+    id: "mars-hillshade",
+    name: "Mars Hillshade",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-hillshade`,
+    tileUrl: `${TILE_PROXY_BASE}/mars-hillshade/{z}/{x}/{y}.png`,
+    scheme: "tms",
+    maxZoom: 6,
+    attribution: opmCredit("NASA / MOLA"),
+    ellipsoidId: "mars",
+  },
+  {
+    id: "mars-basemap-v0-2",
+    name: "OPM Mars Basemap v0.2",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-basemap-v0-2`,
     tileUrl:
       "https://cartocdn-gusc.global.ssl.fastly.net/opmbuilder/api/v1/map/named/opm-mars-basemap-v0-2/all/{z}/{x}/{y}.png",
     maxZoom: 6,
@@ -169,39 +214,67 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
     ellipsoidId: "mars",
   },
   {
-    id: "moon-opm",
-    name: "Moon (OpenPlanetaryMap)",
-    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-opm`,
+    id: "mars-shaded-colour-mola-elevation",
+    name: "Mars Shaded Colour MOLA Elevation",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-shaded-colour-mola-elevation`,
+    tileUrl: `${TILE_PROXY_BASE}/mars-mola-color/{z}/{x}/{y}.png`,
+    scheme: "tms",
+    maxZoom: 6,
+    attribution: opmCredit("NASA / MOLA"),
+    ellipsoidId: "mars",
+  },
+  {
+    id: "mars-shaded-grayscale-mola-elevation",
+    name: "Mars Shaded Grayscale MOLA Elevation",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-shaded-grayscale-mola-elevation`,
+    tileUrl: `${TILE_PROXY_BASE}/mars-mola-gray/{z}/{x}/{y}.png`,
+    scheme: "tms",
+    maxZoom: 9,
+    attribution: opmCredit("NASA / MOLA"),
+    ellipsoidId: "mars",
+  },
+  // --- The Moon -----------------------------------------------------------
+  {
+    id: "moon-hillshaded-albedo",
+    name: "Moon Hillshaded Albedo",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-hillshaded-albedo`,
+    tileUrl: `${TILE_PROXY_BASE}/moon-hillshaded-albedo/{z}/{x}/{y}.png`,
+    scheme: "tms",
+    maxZoom: 6,
+    attribution: opmCredit("NASA / LOLA / USGS"),
+    ellipsoidId: "moon",
+  },
+  {
+    id: "moon-basemap-v0-1",
+    name: "OPM Moon Basemap v0.1",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-basemap-v0-1`,
     tileUrl:
       "https://cartocdn-gusc.global.ssl.fastly.net/opmbuilder/api/v1/map/named/opm-moon-basemap-v0-1/all/{z}/{x}/{y}.png",
     maxZoom: 6,
     attribution: OPM_ATTRIBUTION,
     ellipsoidId: "moon",
   },
-  // Photographic mosaics (the Google Earth/Moon look), served on demand by the
-  // USGS Astrogeology MapServer. Higher fidelity but slower — the cgi-bin
-  // renders each tile per request rather than serving from a CDN.
-  {
-    id: "mars-viking",
-    name: "Mars (Viking imagery)",
-    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-viking`,
-    tileUrl:
-      "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/mars/mars_simp_cyl.map&layers=MDIM21_color&mode=tile&tilemode=gmap&tile={x}%20{y}%20{z}",
-    maxZoom: 7,
-    attribution: `Mars Viking MDIM 2.1 — ${USGS_ATTRIBUTION}`,
-    ellipsoidId: "mars",
-  },
-  {
-    id: "moon-lroc",
-    name: "Moon (LRO imagery)",
-    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-lroc`,
-    tileUrl:
-      "https://planetarymaps.usgs.gov/cgi-bin/mapserv?map=/maps/earth/moon_simp_cyl.map&layers=LROC_WAC&mode=tile&tilemode=gmap&tile={x}%20{y}%20{z}",
-    maxZoom: 7,
-    attribution: `LRO LROC WAC — ${USGS_ATTRIBUTION}`,
-    ellipsoidId: "moon",
-  },
 ] as const;
+
+/** The celestial bodies with basemaps, in the order the UI groups them. */
+const PLANETARY_BODY_ORDER: readonly EllipsoidId[] = ["moon", "mars"];
+
+/** A celestial body paired with the planetary basemaps that depict it. */
+export interface PlanetaryBasemapGroup {
+  ellipsoidId: EllipsoidId;
+  basemaps: readonly PlanetaryBasemap[];
+}
+
+/**
+ * {@link PLANETARY_BASEMAPS} grouped by celestial body, so the New Project and
+ * Change Basemap panels can render one section per body (The Moon, Mars)
+ * instead of a single flat "Planetary" list.
+ */
+export const PLANETARY_BASEMAP_GROUPS: readonly PlanetaryBasemapGroup[] =
+  PLANETARY_BODY_ORDER.map((ellipsoidId) => ({
+    ellipsoidId,
+    basemaps: PLANETARY_BASEMAPS.filter((b) => b.ellipsoidId === ellipsoidId),
+  })).filter((group) => group.basemaps.length > 0);
 
 /** Resolve a `geolibre://basemap/<id>` sentinel to its planetary basemap. */
 export function getPlanetaryBasemapByStyleUrl(

--- a/packages/core/src/ellipsoids.ts
+++ b/packages/core/src/ellipsoids.ts
@@ -175,7 +175,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   // --- Mars ---------------------------------------------------------------
   {
     id: "mars-colour-mola-elevation",
-    name: "Mars Colour MOLA Elevation",
+    name: "Colour MOLA Elevation",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-colour-mola-elevation`,
     tileUrl: `${TILE_PROXY_BASE}/mars-mola-color-noshade/{z}/{x}/{y}.png`,
     scheme: "tms",
@@ -185,7 +185,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   },
   {
     id: "mars-viking-mdim21",
-    name: "Mars Viking MDIM2.1",
+    name: "Viking MDIM2.1",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-viking-mdim21`,
     tileUrl: `${TILE_PROXY_BASE}/mars-viking-mdim21/{z}/{x}/{y}.png`,
     scheme: "tms",
@@ -195,7 +195,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   },
   {
     id: "mars-hillshade",
-    name: "Mars Hillshade",
+    name: "Hillshade",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-hillshade`,
     tileUrl: `${TILE_PROXY_BASE}/mars-hillshade/{z}/{x}/{y}.png`,
     scheme: "tms",
@@ -205,7 +205,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   },
   {
     id: "mars-basemap-v0-2",
-    name: "OPM Mars Basemap v0.2",
+    name: "OPM Basemap v0.2",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-basemap-v0-2`,
     tileUrl:
       "https://cartocdn-gusc.global.ssl.fastly.net/opmbuilder/api/v1/map/named/opm-mars-basemap-v0-2/all/{z}/{x}/{y}.png",
@@ -215,7 +215,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   },
   {
     id: "mars-shaded-colour-mola-elevation",
-    name: "Mars Shaded Colour MOLA Elevation",
+    name: "Shaded Colour MOLA Elevation",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-shaded-colour-mola-elevation`,
     tileUrl: `${TILE_PROXY_BASE}/mars-mola-color/{z}/{x}/{y}.png`,
     scheme: "tms",
@@ -225,7 +225,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   },
   {
     id: "mars-shaded-grayscale-mola-elevation",
-    name: "Mars Shaded Grayscale MOLA Elevation",
+    name: "Shaded Grayscale MOLA Elevation",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}mars-shaded-grayscale-mola-elevation`,
     tileUrl: `${TILE_PROXY_BASE}/mars-mola-gray/{z}/{x}/{y}.png`,
     scheme: "tms",
@@ -236,7 +236,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   // --- The Moon -----------------------------------------------------------
   {
     id: "moon-hillshaded-albedo",
-    name: "Moon Hillshaded Albedo",
+    name: "Hillshaded Albedo",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-hillshaded-albedo`,
     tileUrl: `${TILE_PROXY_BASE}/moon-hillshaded-albedo/{z}/{x}/{y}.png`,
     scheme: "tms",
@@ -246,7 +246,7 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
   },
   {
     id: "moon-basemap-v0-1",
-    name: "OPM Moon Basemap v0.1",
+    name: "OPM Basemap v0.1",
     styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}moon-basemap-v0-1`,
     tileUrl:
       "https://cartocdn-gusc.global.ssl.fastly.net/opmbuilder/api/v1/map/named/opm-moon-basemap-v0-1/all/{z}/{x}/{y}.png",

--- a/packages/core/src/ellipsoids.ts
+++ b/packages/core/src/ellipsoids.ts
@@ -276,10 +276,30 @@ export const PLANETARY_BASEMAP_GROUPS: readonly PlanetaryBasemapGroup[] =
     basemaps: PLANETARY_BASEMAPS.filter((b) => b.ellipsoidId === ellipsoidId),
   })).filter((group) => group.basemaps.length > 0);
 
+// Basemap ids the OpenPlanetaryMap migration renamed or dropped, mapped to the
+// nearest current basemap. Lets a project saved before the migration keep a
+// planetary basemap (instead of falling back to Earth) the next time it opens:
+// the two OPM composites kept their exact tiles under new ids, Viking maps to
+// the equivalent OPM mosaic, and the retired LRO imagery maps to the flagship
+// Moon basemap.
+const LEGACY_PLANETARY_BASEMAP_IDS: Record<string, string> = {
+  "mars-opm": "mars-basemap-v0-2",
+  "moon-opm": "moon-basemap-v0-1",
+  "mars-viking": "mars-viking-mdim21",
+  "moon-lroc": "moon-basemap-v0-1",
+};
+
 /** Resolve a `geolibre://basemap/<id>` sentinel to its planetary basemap. */
 export function getPlanetaryBasemapByStyleUrl(
   styleUrl: string | undefined,
 ): PlanetaryBasemap | undefined {
   if (!styleUrl?.startsWith(PLANETARY_BASEMAP_SENTINEL_PREFIX)) return undefined;
-  return PLANETARY_BASEMAPS.find((b) => b.styleUrl === styleUrl);
+  const id = styleUrl.slice(PLANETARY_BASEMAP_SENTINEL_PREFIX.length);
+  const resolvedId = Object.prototype.hasOwnProperty.call(
+    LEGACY_PLANETARY_BASEMAP_IDS,
+    id,
+  )
+    ? LEGACY_PLANETARY_BASEMAP_IDS[id]
+    : id;
+  return PLANETARY_BASEMAPS.find((b) => b.id === resolvedId);
 }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_BASEMAP,
   DEFAULT_PROJECT_PREFERENCES,
   getPlanetaryBasemapByStyleUrl,
+  PLANETARY_BASEMAP_SENTINEL_PREFIX,
   useAppStore,
 } from "@geolibre/core";
 import type {
@@ -220,6 +221,13 @@ function resolveMapStyle(
   if (styleUrl === BLANK_BASEMAP) return createBlankMapStyle();
   const planetary = getPlanetaryBasemapByStyleUrl(styleUrl);
   if (planetary) return createPlanetaryMapStyle(planetary);
+  // A planetary sentinel that no longer resolves (e.g. a project saved with a
+  // basemap id that has since been renamed) must not be handed to MapLibre as a
+  // style URL — it would try to fetch the `geolibre://` sentinel and blank the
+  // map. Fall back to the default basemap instead.
+  if (styleUrl?.startsWith(PLANETARY_BASEMAP_SENTINEL_PREFIX)) {
+    return DEFAULT_BASEMAP;
+  }
   return styleUrl ?? DEFAULT_BASEMAP;
 }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -235,8 +235,8 @@ function resolveMapStyle(
  * A single-source raster style for a non-Earth body. The tiles are PNGs in that
  * body's Web-Mercator scheme (XYZ, or TMS when `basemap.scheme` says so), so
  * MapLibre renders them like any raster basemap. A dark background shows
- * through at zoom levels the source doesn't
- * cover, matching how the planetary tiles fade to black at the poles.
+ * through at zoom levels the source doesn't cover, matching how the planetary
+ * tiles fade to black at the poles.
  */
 function createPlanetaryMapStyle(
   basemap: PlanetaryBasemap,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -224,9 +224,10 @@ function resolveMapStyle(
 }
 
 /**
- * A single-source raster style for a non-Earth body. The tiles are XYZ PNGs in
- * that body's Web-Mercator scheme, so MapLibre renders them like any raster
- * basemap. A dark background shows through at zoom levels the source doesn't
+ * A single-source raster style for a non-Earth body. The tiles are PNGs in that
+ * body's Web-Mercator scheme (XYZ, or TMS when `basemap.scheme` says so), so
+ * MapLibre renders them like any raster basemap. A dark background shows
+ * through at zoom levels the source doesn't
  * cover, matching how the planetary tiles fade to black at the poles.
  */
 function createPlanetaryMapStyle(
@@ -240,6 +241,9 @@ function createPlanetaryMapStyle(
         tiles: [basemap.tileUrl],
         tileSize: 256,
         maxzoom: basemap.maxZoom,
+        // OpenPlanetaryMap's S3 mosaics are TMS (flipped Y); the CARTO named
+        // maps are XYZ. MapLibre defaults to "xyz" when scheme is omitted.
+        ...(basemap.scheme ? { scheme: basemap.scheme } : {}),
         attribution: basemap.attribution,
       },
     },

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -226,6 +226,9 @@ function resolveMapStyle(
   // style URL — it would try to fetch the `geolibre://` sentinel and blank the
   // map. Fall back to the default basemap instead.
   if (styleUrl?.startsWith(PLANETARY_BASEMAP_SENTINEL_PREFIX)) {
+    console.warn(
+      `Unknown planetary basemap "${styleUrl}"; falling back to the default basemap.`,
+    );
     return DEFAULT_BASEMAP;
   }
   return styleUrl ?? DEFAULT_BASEMAP;

--- a/workers/tiles/package.json
+++ b/workers/tiles/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "geolibre-tiles-worker",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260707.1",
+    "wrangler": "^4.107.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  }
+}

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -147,9 +147,11 @@ export default {
       headers,
     });
     // Cache successes long and upstream misses briefly (see NEGATIVE_CACHE_
-    // CONTROL); skip 5xx so a transient upstream failure isn't pinned. Only GET
-    // reaches here, so the request is always a valid Cache API key.
-    if (originResponse.status < 500) {
+    // CONTROL). Skip 5xx and 429 so a transient upstream failure or throttle
+    // isn't pinned as a blank tile for the negative TTL — only genuine 403/404
+    // past-native-zoom misses are worth caching. Only GET reaches here, so the
+    // request is always a valid Cache API key.
+    if (originResponse.status < 500 && originResponse.status !== 429) {
       ctx.waitUntil(cache.put(request, response.clone()));
     }
     return response;

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -1,0 +1,130 @@
+// tiles.geolibre.app
+//
+// A CORS-adding, edge-caching reverse proxy for the OpenPlanetaryMap raster
+// mosaics used by GeoLibre's planetary basemaps.
+//
+// Why this exists: MapLibre GL fetches raster tiles with `fetch()`, which
+// enforces CORS. OpenPlanetaryMap's single-layer mosaics are served straight
+// from S3 buckets that send no `Access-Control-Allow-Origin` header, so the
+// browser blocks them and the map renders black. (The openplanetarymap.org site
+// gets away with it because Leaflet loads tiles as plain <img> elements, which
+// are not CORS-checked.) A same-origin dev proxy exists, but the web build
+// (nginx), desktop build (Tauri) and Jupyter embed have no shared proxy — a
+// public Worker is the one URL that works uniformly across all of them.
+//
+// The Worker fetches each tile server-side (no CORS applies server-to-server),
+// re-emits it with `Access-Control-Allow-Origin: *`, and caches it at the edge
+// so repeat requests are served from Cloudflare's PoP rather than round-tripping
+// to S3 — faster and gentler on the upstream than hitting S3 directly.
+//
+// URL scheme (keeps this a named-dataset proxy, never an open proxy):
+//   tiles.geolibre.app/opm/<dataset>/<z>/<x>/<y>.png
+// where <dataset> is a key in DATASETS below. The tiles are TMS (flipped Y);
+// MapLibre applies the flip before the request reaches the Worker, so the Worker
+// treats <z>/<x>/<y> as opaque and forwards them unchanged.
+
+/** Allowlisted OpenPlanetaryMap tile datasets → their upstream base URL. */
+const DATASETS: Record<string, string> = {
+  "mars-mola-color-noshade":
+    "https://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/mola_color-noshade_global",
+  "mars-viking-mdim21":
+    "https://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/viking_mdim21_global",
+  "mars-hillshade":
+    "https://s3.us-east-2.amazonaws.com/opmmarstiles/hillshade-tiles",
+  "mars-mola-color":
+    "https://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/mola-color",
+  "mars-mola-gray":
+    "https://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/mola-gray",
+  "moon-hillshaded-albedo":
+    "https://s3.amazonaws.com/opmbuilder/301_moon/tiles/w/hillshaded-albedo",
+};
+
+// `/opm/<dataset>/<z>/<x>/<y>.png`. z/x/y are constrained to integers so the
+// Worker can never be coerced into fetching an arbitrary upstream path.
+const TILE_PATH = /^\/opm\/([a-z0-9-]+)\/(\d{1,2})\/(\d{1,7})\/(\d{1,7})\.png$/;
+
+const CORS_HEADERS: Record<string, string> = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, HEAD, OPTIONS",
+  "access-control-max-age": "86400",
+};
+
+// Cache tiles for a day at the edge and let browsers hold them for an hour. The
+// mosaics are static, so a long TTL is safe and keeps the map responsive.
+const CACHE_CONTROL = "public, max-age=3600, s-maxage=86400";
+
+interface Env {}
+
+export default {
+  async fetch(
+    request: Request,
+    _env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { ...CORS_HEADERS, allow: "GET, HEAD, OPTIONS" },
+      });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname === "/" || url.pathname === "") {
+      return new Response(
+        "GeoLibre planetary tile proxy. Usage: /opm/<dataset>/<z>/<x>/<y>.png\n" +
+          `Datasets: ${Object.keys(DATASETS).join(", ")}\n`,
+        { status: 200, headers: { "content-type": "text/plain; charset=utf-8" } },
+      );
+    }
+
+    const match = TILE_PATH.exec(url.pathname);
+    if (!match) {
+      return new Response("Not Found", { status: 404, headers: CORS_HEADERS });
+    }
+    const [, dataset, z, x, y] = match;
+    const base = DATASETS[dataset];
+    if (!base) {
+      return new Response(`Unknown dataset: ${dataset}`, {
+        status: 404,
+        headers: CORS_HEADERS,
+      });
+    }
+
+    // Serve from the edge cache when we can; the cache key is the incoming
+    // request URL (method + path), which uniquely identifies the tile.
+    const cache = caches.default;
+    const cached = await cache.match(request);
+    if (cached) return cached;
+
+    const upstream = `${base}/${z}/${x}/${y}.png`;
+    let originResponse: Response;
+    try {
+      originResponse = await fetch(upstream, {
+        cf: { cacheEverything: true, cacheTtl: 86400 },
+      });
+    } catch {
+      return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
+    }
+
+    // Pass upstream errors (e.g. 403/404 for tiles past a mosaic's native zoom)
+    // straight through, with CORS, so MapLibre just leaves that tile blank.
+    const headers = new Headers(CORS_HEADERS);
+    headers.set(
+      "content-type",
+      originResponse.headers.get("content-type") ?? "image/png",
+    );
+    headers.set("cache-control", CACHE_CONTROL);
+
+    const response = new Response(originResponse.body, {
+      status: originResponse.status,
+      headers,
+    });
+    if (originResponse.ok) {
+      ctx.waitUntil(cache.put(request, response.clone()));
+    }
+    return response;
+  },
+};

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -122,7 +122,10 @@ export default {
       status: originResponse.status,
       headers,
     });
-    if (originResponse.ok) {
+    // Only GET responses are cacheable — the Cache API rejects a HEAD request
+    // as a cache key with a TypeError, so guard the put even though MapLibre
+    // only ever issues GET.
+    if (originResponse.ok && request.method === "GET") {
       ctx.waitUntil(cache.put(request, response.clone()));
     }
     return response;

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -45,13 +45,18 @@ const TILE_PATH = /^\/opm\/([a-z0-9-]+)\/(\d{1,2})\/(\d{1,7})\/(\d{1,7})\.png$/;
 
 const CORS_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",
-  "access-control-allow-methods": "GET, HEAD, OPTIONS",
+  "access-control-allow-methods": "GET, OPTIONS",
   "access-control-max-age": "86400",
 };
 
 // Cache tiles for a day at the edge and let browsers hold them for an hour. The
 // mosaics are static, so a long TTL is safe and keeps the map responsive.
 const CACHE_CONTROL = "public, max-age=3600, s-maxage=86400";
+
+// Cache upstream misses (403/404 past a mosaic's native zoom) briefly, so a
+// repeated bad tile is answered from the edge instead of re-hitting the OPM
+// buckets every time.
+const NEGATIVE_CACHE_CONTROL = "public, max-age=300";
 
 interface Env {}
 
@@ -64,10 +69,13 @@ export default {
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
-    if (request.method !== "GET" && request.method !== "HEAD") {
+    // Only GET is proxied. MapLibre issues GET for every tile; supporting HEAD
+    // would just complicate the Cache API keying (which requires GET) for no
+    // real consumer.
+    if (request.method !== "GET") {
       return new Response("Method Not Allowed", {
         status: 405,
-        headers: { ...CORS_HEADERS, allow: "GET, HEAD, OPTIONS" },
+        headers: { ...CORS_HEADERS, allow: "GET, OPTIONS" },
       });
     }
 
@@ -93,6 +101,14 @@ export default {
       });
     }
 
+    // Reject coordinates outside the tile pyramid for this zoom (x, y < 2**z)
+    // before touching upstream, so out-of-range /z/x/y can't be looped over to
+    // hammer the third-party OPM S3 buckets through this Worker.
+    const dim = 2 ** Number(z);
+    if (Number(x) >= dim || Number(y) >= dim) {
+      return new Response("Not Found", { status: 404, headers: CORS_HEADERS });
+    }
+
     // Serve from the edge cache when we can; the cache key is the incoming
     // request URL (method + path), which uniquely identifies the tile.
     const cache = caches.default;
@@ -116,16 +132,19 @@ export default {
       "content-type",
       originResponse.headers.get("content-type") ?? "image/png",
     );
-    headers.set("cache-control", CACHE_CONTROL);
+    headers.set(
+      "cache-control",
+      originResponse.ok ? CACHE_CONTROL : NEGATIVE_CACHE_CONTROL,
+    );
 
     const response = new Response(originResponse.body, {
       status: originResponse.status,
       headers,
     });
-    // Only GET responses are cacheable — the Cache API rejects a HEAD request
-    // as a cache key with a TypeError, so guard the put even though MapLibre
-    // only ever issues GET.
-    if (originResponse.ok && request.method === "GET") {
+    // Cache successes long and upstream misses briefly (see NEGATIVE_CACHE_
+    // CONTROL); skip 5xx so a transient upstream failure isn't pinned. Only GET
+    // reaches here, so the request is always a valid Cache API key.
+    if (originResponse.status < 500) {
       ctx.waitUntil(cache.put(request, response.clone()));
     }
     return response;

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -93,7 +93,12 @@ export default {
       return new Response("Not Found", { status: 404, headers: CORS_HEADERS });
     }
     const [, dataset, z, x, y] = match;
-    const base = DATASETS[dataset];
+    // Look up own properties only — a bare object literal inherits keys like
+    // "constructor" from Object.prototype (and `[a-z0-9-]+` matches it), which
+    // would otherwise resolve to a truthy function and slip past the 404 below.
+    const base = Object.prototype.hasOwnProperty.call(DATASETS, dataset)
+      ? DATASETS[dataset]
+      : undefined;
     if (!base) {
       return new Response(`Unknown dataset: ${dataset}`, {
         status: 404,

--- a/workers/tiles/tsconfig.json
+++ b/workers/tiles/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/tiles/wrangler.toml
+++ b/workers/tiles/wrangler.toml
@@ -1,0 +1,10 @@
+name = "geolibre-tiles"
+main = "src/index.ts"
+compatibility_date = "2025-03-01"
+
+# Binds the custom domain on deploy. Because geolibre.app is managed in this
+# Cloudflare account, the DNS record and TLS certificate are provisioned
+# automatically on the first `wrangler deploy`.
+[[routes]]
+pattern = "tiles.geolibre.app"
+custom_domain = true


### PR DESCRIPTION
## What & why

The four planetary basemaps were slow — two per-request USGS Astrogeology MapServer imagery mosaics (rendered per tile from a cgi-bin) plus two CARTO composites. This replaces them with the **eight OpenPlanetaryMap Mars & Moon basemaps** from https://openplanetarymap.org/basemaps/, and splits the single **Planetary** section in the New Project and Change Basemap panels into per-body **The Moon** and **Mars** sections. (Mercury was intentionally left out.)

## The CORS problem and the fix

Most OPM mosaics (MOLA colour/grayscale, Viking MDIM2.1, hillshade, Moon hillshaded-albedo) are single-layer rasters served from S3 buckets in the **TMS** scheme with **no `Access-Control-Allow-Origin` header**. MapLibre GL fetches raster tiles with `fetch()` (which enforces CORS), so they render as a **black globe** — the openplanetarymap.org site only avoids this because Leaflet loads tiles as plain `<img>` elements (not CORS-checked).

Fix: a new **Cloudflare Worker** (`workers/tiles`, `tiles.geolibre.app`) fetches each tile server-side, re-emits it with `Access-Control-Allow-Origin: *`, and **edge-caches** it — so the mosaics load fast and work uniformly across the web, desktop (Tauri), and Jupyter builds. The Worker is a named-dataset proxy (not an open proxy): it rejects unknown datasets and path traversal with 404, and passes past-native-zoom 403s through so MapLibre just leaves the tile blank. The two CORS-enabled CARTO named maps (OPM Mars Basemap v0.2, OPM Moon Basemap v0.1) are referenced directly. No CSP changes were needed (both CSPs already allow `https:` tile hosts).

## Changes

- **`packages/core`** — 8 OPM basemaps with a new `PlanetaryBasemap.scheme` (`"tms"`) field, probed native `maxZoom` per source, and a `PLANETARY_BASEMAP_GROUPS` export grouped by body; the 6 CORS-less mosaics point at the tiles Worker.
- **`packages/map`** — pass the tile `scheme` through to the MapLibre raster source.
- **desktop app** — render planetary basemaps as per-body sections in both the New Project dialog and the Change Basemap panel; new `sectionMoon` / `sectionMars` i18n keys across all 15 locales; shared `lib/planetary-sections.ts` helper.
- **`workers/tiles`** — the CORS / edge-cache proxy Worker (deployed to `tiles.geolibre.app`); wired into `npm run test:worker`.

## Testing

- `npm run test:frontend` — **2278 pass / 0 fail**
- `npm run test:worker` — all three workers typecheck
- `npm run build` — passes
- `pre-commit run --files` on the changed set — all hooks pass (incl. npm build + eslint)
- **End-to-end against the live deployed Worker**: 68 tiles fetched from `tiles.geolibre.app`, all HTTP 200, 0 failures; Mars (Viking, hillshade, grayscale MOLA) and Moon (hillshaded albedo) globes render with correct TMS orientation and **Diagnostics: 0**.


> Note: the `workers/tiles` Worker is already deployed to `tiles.geolibre.app`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Planetary basemaps are now organized by celestial body, with separate **Moon** and **Mars** sections in the basemap picker (including updated localized labels).
* **Bug Fixes / Improvements**
  * Improved planetary raster basemap rendering with correct tile scheme handling (TMS vs XYZ) and a more resilient fallback when a special planetary style doesn’t resolve.
  * Enhanced planetary tile loading via a cached, CORS-friendly tile service for smoother map rendering.
* **Documentation**
  * Updated basemap guidance to reflect the new tile-scheme behavior.
* **Tests**
  * Extended worker type checking to include the tiles worker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->