### PR TITLE
feat(basemaps): add a planet switcher to the Layers panel

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
@@ -80,7 +80,7 @@ export function BasemapPickerDialog({
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const setBasemapStyleUrl = useAppStore((s) => s.setBasemapStyleUrl);
   const setMapView = useAppStore((s) => s.setMapView);
-  const setPreferences = useAppStore((s) => s.setPreferences);
+  const applyPlanetaryBasemap = useAppStore((s) => s.applyPlanetaryBasemap);
 
   const openFreeMapPresets = useMemo(() => getOpenFreeMapPresets(), []);
   // Protomaps styles need an API key (VITE_PROTOMAPS_API_KEY). It can come from
@@ -155,14 +155,7 @@ export function BasemapPickerDialog({
   // measurements (distance/area/scale) use that body's radius, and the globe
   // control renders it as the correct sphere.
   const applyPlanetary = (basemap: PlanetaryBasemap) => {
-    setBasemapStyleUrl(basemap.styleUrl);
-    const prefs = useAppStore.getState().preferences;
-    if (prefs.map.ellipsoidId !== basemap.ellipsoidId) {
-      setPreferences({
-        ...prefs,
-        map: { ...prefs.map, ellipsoidId: basemap.ellipsoidId },
-      });
-    }
+    applyPlanetaryBasemap(basemap);
     onOpenChange(false);
   };
 

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -15,6 +15,7 @@ import type { ParseKeys, TFunction } from "i18next";
 import {
   DEFAULT_BASEMAP,
   getPlanetaryBasemapById,
+  getPlanetaryBasemapByStyleUrl,
   isDuckDBQueryLayer,
   PLANET_SWITCHER_OPTIONS,
   useAppStore,
@@ -488,21 +489,14 @@ export function LayerPanel({
   const applyPlanetaryBasemap = useAppStore((s) => s.applyPlanetaryBasemap);
   const restoreEarthBasemap = useAppStore((s) => s.restoreEarthBasemap);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
-  const ellipsoidId = useAppStore(
-    (s) => s.preferences.map.ellipsoidId ?? "earth",
-  );
-  // The body the switcher reflects. For the Moon/Mars it follows the project's
-  // ellipsoid, so any Moon/Mars basemap (from this switcher or the full picker)
-  // shows a selection. Earth is only "selected" when its own imagery basemap is
-  // active — a default Earth project (e.g. Liberty) shows nothing selected.
-  const onEarthImageryBasemap =
-    basemapStyleUrl === getPlanetaryBasemapById("earth-usgs-imagery")?.styleUrl;
+  // The body the switcher reflects, derived from the active *basemap* — not the
+  // ellipsoid, which Settings lets diverge from the basemap (e.g. Mars scale
+  // under an Earth style). Any planetary basemap resolves to its body: the
+  // Moon/Mars mosaics (from this switcher or the full picker) and Earth's own
+  // imagery. A normal Earth basemap (e.g. Liberty) resolves to nothing, so
+  // nothing is selected until a planetary basemap is applied.
   const selectedPlanet =
-    ellipsoidId !== "earth"
-      ? ellipsoidId
-      : onEarthImageryBasemap
-        ? "earth"
-        : undefined;
+    getPlanetaryBasemapByStyleUrl(basemapStyleUrl)?.ellipsoidId;
   // The Earth basemap to fall back to when a planet is deselected — the last one
   // active while no planet was selected (e.g. Liberty). Tracked in a ref so it
   // survives the planet round-trip. Starts undefined (not seeded from the mount
@@ -727,14 +721,12 @@ export function LayerPanel({
   // dropdown). Selecting a body applies its basemap and syncs the ellipsoid;
   // deselecting the active body returns to Earth and restores the basemap that
   // was showing before (e.g. Liberty).
-  const togglePlanet = (ellipsoidId: EllipsoidId, selected: boolean) => {
+  const togglePlanet = (body: EllipsoidId, selected: boolean) => {
     if (!selected) {
       restoreEarthBasemap(previousEarthBasemap.current ?? DEFAULT_BASEMAP);
       return;
     }
-    const option = PLANET_SWITCHER_OPTIONS.find(
-      (o) => o.ellipsoidId === ellipsoidId,
-    );
+    const option = PLANET_SWITCHER_OPTIONS.find((o) => o.ellipsoidId === body);
     const basemap = option && getPlanetaryBasemapById(option.basemapId);
     if (basemap) applyPlanetaryBasemap(basemap);
   };

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -485,8 +485,7 @@ export function LayerPanel({
   const basemapOpacity = useAppStore((s) => s.basemapOpacity);
   const setBasemapVisible = useAppStore((s) => s.setBasemapVisible);
   const setBasemapOpacity = useAppStore((s) => s.setBasemapOpacity);
-  const setBasemapStyleUrl = useAppStore((s) => s.setBasemapStyleUrl);
-  const setPreferences = useAppStore((s) => s.setPreferences);
+  const applyPlanetaryBasemap = useAppStore((s) => s.applyPlanetaryBasemap);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   // The planet the switcher currently reflects: the body whose switcher basemap
   // is applied, or undefined when neither is (e.g. a default Earth project on an
@@ -706,22 +705,13 @@ export function LayerPanel({
   };
 
   // Switch the map's celestial body (like Google Earth's planet dropdown):
-  // apply the body's basemap and set the project ellipsoid so measurements and
-  // the globe control use that body's radius.
+  // apply the body's basemap, which also syncs the project ellipsoid.
   const switchPlanet = (ellipsoidId: string) => {
     const option = PLANET_SWITCHER_OPTIONS.find(
       (o) => o.ellipsoidId === ellipsoidId,
     );
     const basemap = option && getPlanetaryBasemapById(option.basemapId);
-    if (!basemap) return;
-    setBasemapStyleUrl(basemap.styleUrl);
-    const prefs = useAppStore.getState().preferences;
-    if (prefs.map.ellipsoidId !== basemap.ellipsoidId) {
-      setPreferences({
-        ...prefs,
-        map: { ...prefs.map, ellipsoidId: basemap.ellipsoidId },
-      });
-    }
+    if (basemap) applyPlanetaryBasemap(basemap);
   };
 
   const beginRename = (layer: GeoLibreLayer) => {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -88,6 +88,7 @@ import {
   ChevronRight,
   ChevronUp,
   Download,
+  Earth,
   Eye,
   EyeOff,
   Folder,
@@ -100,7 +101,6 @@ import {
   Map as MapIcon,
   MoreHorizontal,
   MousePointerClick,
-  Orbit,
   Palette,
   PanelLeftClose,
   PanelLeftOpen,
@@ -487,9 +487,14 @@ export function LayerPanel({
   const setBasemapOpacity = useAppStore((s) => s.setBasemapOpacity);
   const setBasemapStyleUrl = useAppStore((s) => s.setBasemapStyleUrl);
   const setPreferences = useAppStore((s) => s.setPreferences);
-  const activeEllipsoidId = useAppStore(
-    (s) => s.preferences.map.ellipsoidId ?? "earth",
-  );
+  const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
+  // The planet the switcher currently reflects: the body whose switcher basemap
+  // is applied, or undefined when neither is (e.g. a default Earth project on an
+  // OpenFreeMap basemap) — so nothing is pre-selected until the user picks one.
+  const selectedPlanet = PLANET_SWITCHER_OPTIONS.find(
+    (option) =>
+      getPlanetaryBasemapById(option.basemapId)?.styleUrl === basemapStyleUrl,
+  )?.ellipsoidId;
   const setLayerVisibility = useAppStore((s) => s.setLayerVisibility);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const reorderLayer = useAppStore((s) => s.reorderLayer);
@@ -1937,10 +1942,12 @@ export function LayerPanel({
                 title={t("planetSwitcher.label")}
                 aria-label={t("planetSwitcher.label")}
               >
-                <Orbit
+                <Earth
                   className={cn(
                     "h-4 w-4",
-                    activeEllipsoidId !== "earth" && "text-primary",
+                    selectedPlanet &&
+                      selectedPlanet !== "earth" &&
+                      "text-primary",
                   )}
                 />
               </Button>
@@ -1948,7 +1955,7 @@ export function LayerPanel({
             <DropdownMenuContent align="start">
               <DropdownMenuLabel>{t("planetSwitcher.label")}</DropdownMenuLabel>
               <DropdownMenuRadioGroup
-                value={activeEllipsoidId}
+                value={selectedPlanet ?? ""}
                 onValueChange={switchPlanet}
               >
                 {PLANET_SWITCHER_OPTIONS.map((option) => (

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -505,8 +505,11 @@ export function LayerPanel({
         : undefined;
   // The Earth basemap to fall back to when a planet is deselected — the last one
   // active while no planet was selected (e.g. Liberty). Tracked in a ref so it
-  // survives the planet round-trip.
-  const previousEarthBasemap = useRef(basemapStyleUrl);
+  // survives the planet round-trip. Starts undefined (not seeded from the mount
+  // value, which could be a planetary basemap if the panel mounted while off
+  // Earth) and is only ever set to a genuine Earth basemap by the guard below,
+  // so a deselect never restores a planetary sentinel.
+  const previousEarthBasemap = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!selectedPlanet) previousEarthBasemap.current = basemapStyleUrl;
   }, [selectedPlanet, basemapStyleUrl]);
@@ -724,7 +727,7 @@ export function LayerPanel({
   // dropdown). Selecting a body applies its basemap and syncs the ellipsoid;
   // deselecting the active body returns to Earth and restores the basemap that
   // was showing before (e.g. Liberty).
-  const togglePlanet = (ellipsoidId: string, selected: boolean) => {
+  const togglePlanet = (ellipsoidId: EllipsoidId, selected: boolean) => {
     if (!selected) {
       restoreEarthBasemap(previousEarthBasemap.current ?? DEFAULT_BASEMAP);
       return;

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -100,6 +100,7 @@ import {
   Map as MapIcon,
   MoreHorizontal,
   MousePointerClick,
+  Orbit,
   Palette,
   PanelLeftClose,
   PanelLeftOpen,
@@ -215,32 +216,6 @@ const PLANET_SWITCHER_LABEL_KEYS: Record<EllipsoidId, ParseKeys> = {
   moon: "planetSwitcher.moon",
   mars: "planetSwitcher.mars",
 };
-
-/**
- * A globe encircled by a tilted orbit with a small satellite — the planet
- * switcher's trigger icon, in the spirit of Google Earth's planet control. Drawn
- * inline (lucide has no planet-with-orbit glyph) in the lucide stroke style so it
- * sits cleanly beside the other header icons.
- */
-function PlanetOrbitIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <circle cx="12" cy="12" r="4.25" />
-      <ellipse cx="12" cy="12" rx="10.5" ry="4" transform="rotate(-30 12 12)" />
-      <circle cx="20.1" cy="7.3" r="1.35" fill="currentColor" stroke="none" />
-    </svg>
-  );
-}
 
 type LayerRefreshStatus = {
   type: "refreshing" | "success" | "error" | "warning";
@@ -513,13 +488,21 @@ export function LayerPanel({
   const applyPlanetaryBasemap = useAppStore((s) => s.applyPlanetaryBasemap);
   const restoreEarthBasemap = useAppStore((s) => s.restoreEarthBasemap);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
-  // The planet the switcher currently reflects: the body whose switcher basemap
-  // is applied, or undefined when neither is (e.g. a default Earth project on an
-  // OpenFreeMap basemap) — so nothing is pre-selected until the user picks one.
-  const selectedPlanet = PLANET_SWITCHER_OPTIONS.find(
-    (option) =>
-      getPlanetaryBasemapById(option.basemapId)?.styleUrl === basemapStyleUrl,
-  )?.ellipsoidId;
+  const ellipsoidId = useAppStore(
+    (s) => s.preferences.map.ellipsoidId ?? "earth",
+  );
+  // The body the switcher reflects. For the Moon/Mars it follows the project's
+  // ellipsoid, so any Moon/Mars basemap (from this switcher or the full picker)
+  // shows a selection. Earth is only "selected" when its own imagery basemap is
+  // active — a default Earth project (e.g. Liberty) shows nothing selected.
+  const onEarthImageryBasemap =
+    basemapStyleUrl === getPlanetaryBasemapById("earth-usgs-imagery")?.styleUrl;
+  const selectedPlanet =
+    ellipsoidId !== "earth"
+      ? ellipsoidId
+      : onEarthImageryBasemap
+        ? "earth"
+        : undefined;
   // The Earth basemap to fall back to when a planet is deselected — the last one
   // active while no planet was selected (e.g. Liberty). Tracked in a ref so it
   // survives the planet round-trip.
@@ -1971,7 +1954,7 @@ export function LayerPanel({
                 title={t("planetSwitcher.label")}
                 aria-label={t("planetSwitcher.label")}
               >
-                <PlanetOrbitIcon
+                <Orbit
                   className={cn(
                     "h-4 w-4",
                     selectedPlanet &&

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -12,8 +12,17 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import type { ParseKeys, TFunction } from "i18next";
-import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
-import type { GeoLibreLayer, LayerGroup } from "@geolibre/core";
+import {
+  getPlanetaryBasemapById,
+  isDuckDBQueryLayer,
+  PLANET_SWITCHER_OPTIONS,
+  useAppStore,
+} from "@geolibre/core";
+import type {
+  EllipsoidId,
+  GeoLibreLayer,
+  LayerGroup,
+} from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import {
   buildTimeBinding,
@@ -57,6 +66,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -88,6 +100,7 @@ import {
   Map as MapIcon,
   MoreHorizontal,
   MousePointerClick,
+  Orbit,
   Palette,
   PanelLeftClose,
   PanelLeftOpen,
@@ -196,6 +209,13 @@ const REFRESH_INTERVAL_OPTIONS: ReadonlyArray<{
 ];
 const CUSTOM_REFRESH_INTERVAL_VALUE = "custom";
 const REFRESH_STATUS_DURATION_MS = 4_000;
+
+/** Menu labels for the planet switcher, keyed by celestial body. */
+const PLANET_SWITCHER_LABEL_KEYS: Record<EllipsoidId, ParseKeys> = {
+  earth: "planetSwitcher.earth",
+  moon: "planetSwitcher.moon",
+  mars: "planetSwitcher.mars",
+};
 
 type LayerRefreshStatus = {
   type: "refreshing" | "success" | "error" | "warning";
@@ -465,6 +485,11 @@ export function LayerPanel({
   const basemapOpacity = useAppStore((s) => s.basemapOpacity);
   const setBasemapVisible = useAppStore((s) => s.setBasemapVisible);
   const setBasemapOpacity = useAppStore((s) => s.setBasemapOpacity);
+  const setBasemapStyleUrl = useAppStore((s) => s.setBasemapStyleUrl);
+  const setPreferences = useAppStore((s) => s.setPreferences);
+  const activeEllipsoidId = useAppStore(
+    (s) => s.preferences.map.ellipsoidId ?? "earth",
+  );
   const setLayerVisibility = useAppStore((s) => s.setLayerVisibility);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const reorderLayer = useAppStore((s) => s.reorderLayer);
@@ -673,6 +698,25 @@ export function LayerPanel({
       .getState()
       .layerGroups.find((g) => g.id === id);
     if (group) beginGroupRename(group);
+  };
+
+  // Switch the map's celestial body (like Google Earth's planet dropdown):
+  // apply the body's basemap and set the project ellipsoid so measurements and
+  // the globe control use that body's radius.
+  const switchPlanet = (ellipsoidId: string) => {
+    const option = PLANET_SWITCHER_OPTIONS.find(
+      (o) => o.ellipsoidId === ellipsoidId,
+    );
+    const basemap = option && getPlanetaryBasemapById(option.basemapId);
+    if (!basemap) return;
+    setBasemapStyleUrl(basemap.styleUrl);
+    const prefs = useAppStore.getState().preferences;
+    if (prefs.map.ellipsoidId !== basemap.ellipsoidId) {
+      setPreferences({
+        ...prefs,
+        map: { ...prefs.map, ellipsoidId: basemap.ellipsoidId },
+      });
+    }
   };
 
   const beginRename = (layer: GeoLibreLayer) => {
@@ -1884,6 +1928,40 @@ export function LayerPanel({
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <span className="text-sm font-semibold">{t("sharedRail.layers")}</span>
         <div className="flex items-center gap-1">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                title={t("planetSwitcher.label")}
+                aria-label={t("planetSwitcher.label")}
+              >
+                <Orbit
+                  className={cn(
+                    "h-4 w-4",
+                    activeEllipsoidId !== "earth" && "text-primary",
+                  )}
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuLabel>{t("planetSwitcher.label")}</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={activeEllipsoidId}
+                onValueChange={switchPlanet}
+              >
+                {PLANET_SWITCHER_OPTIONS.map((option) => (
+                  <DropdownMenuRadioItem
+                    key={option.ellipsoidId}
+                    value={option.ellipsoidId}
+                  >
+                    {t(PLANET_SWITCHER_LABEL_KEYS[option.ellipsoidId])}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Button
             variant="ghost"
             size="icon"

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { useTranslation } from "react-i18next";
 import type { ParseKeys, TFunction } from "i18next";
 import {
+  DEFAULT_BASEMAP,
   getPlanetaryBasemapById,
   isDuckDBQueryLayer,
   PLANET_SWITCHER_OPTIONS,
@@ -64,11 +65,10 @@ import {
   DialogTitle,
   DialogDescription,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -88,7 +88,6 @@ import {
   ChevronRight,
   ChevronUp,
   Download,
-  Earth,
   Eye,
   EyeOff,
   Folder,
@@ -216,6 +215,32 @@ const PLANET_SWITCHER_LABEL_KEYS: Record<EllipsoidId, ParseKeys> = {
   moon: "planetSwitcher.moon",
   mars: "planetSwitcher.mars",
 };
+
+/**
+ * A globe encircled by a tilted orbit with a small satellite — the planet
+ * switcher's trigger icon, in the spirit of Google Earth's planet control. Drawn
+ * inline (lucide has no planet-with-orbit glyph) in the lucide stroke style so it
+ * sits cleanly beside the other header icons.
+ */
+function PlanetOrbitIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4.25" />
+      <ellipse cx="12" cy="12" rx="10.5" ry="4" transform="rotate(-30 12 12)" />
+      <circle cx="20.1" cy="7.3" r="1.35" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
 
 type LayerRefreshStatus = {
   type: "refreshing" | "success" | "error" | "warning";
@@ -486,6 +511,7 @@ export function LayerPanel({
   const setBasemapVisible = useAppStore((s) => s.setBasemapVisible);
   const setBasemapOpacity = useAppStore((s) => s.setBasemapOpacity);
   const applyPlanetaryBasemap = useAppStore((s) => s.applyPlanetaryBasemap);
+  const restoreEarthBasemap = useAppStore((s) => s.restoreEarthBasemap);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   // The planet the switcher currently reflects: the body whose switcher basemap
   // is applied, or undefined when neither is (e.g. a default Earth project on an
@@ -494,6 +520,13 @@ export function LayerPanel({
     (option) =>
       getPlanetaryBasemapById(option.basemapId)?.styleUrl === basemapStyleUrl,
   )?.ellipsoidId;
+  // The Earth basemap to fall back to when a planet is deselected — the last one
+  // active while no planet was selected (e.g. Liberty). Tracked in a ref so it
+  // survives the planet round-trip.
+  const previousEarthBasemap = useRef(basemapStyleUrl);
+  useEffect(() => {
+    if (!selectedPlanet) previousEarthBasemap.current = basemapStyleUrl;
+  }, [selectedPlanet, basemapStyleUrl]);
   const setLayerVisibility = useAppStore((s) => s.setLayerVisibility);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const reorderLayer = useAppStore((s) => s.reorderLayer);
@@ -704,9 +737,15 @@ export function LayerPanel({
     if (group) beginGroupRename(group);
   };
 
-  // Switch the map's celestial body (like Google Earth's planet dropdown):
-  // apply the body's basemap, which also syncs the project ellipsoid.
-  const switchPlanet = (ellipsoidId: string) => {
+  // Toggle a celestial body in the switcher (like Google Earth's planet
+  // dropdown). Selecting a body applies its basemap and syncs the ellipsoid;
+  // deselecting the active body returns to Earth and restores the basemap that
+  // was showing before (e.g. Liberty).
+  const togglePlanet = (ellipsoidId: string, selected: boolean) => {
+    if (!selected) {
+      restoreEarthBasemap(previousEarthBasemap.current ?? DEFAULT_BASEMAP);
+      return;
+    }
     const option = PLANET_SWITCHER_OPTIONS.find(
       (o) => o.ellipsoidId === ellipsoidId,
     );
@@ -1932,7 +1971,7 @@ export function LayerPanel({
                 title={t("planetSwitcher.label")}
                 aria-label={t("planetSwitcher.label")}
               >
-                <Earth
+                <PlanetOrbitIcon
                   className={cn(
                     "h-4 w-4",
                     selectedPlanet &&
@@ -1944,19 +1983,17 @@ export function LayerPanel({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start">
               <DropdownMenuLabel>{t("planetSwitcher.label")}</DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={selectedPlanet ?? ""}
-                onValueChange={switchPlanet}
-              >
-                {PLANET_SWITCHER_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem
-                    key={option.ellipsoidId}
-                    value={option.ellipsoidId}
-                  >
-                    {t(PLANET_SWITCHER_LABEL_KEYS[option.ellipsoidId])}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
+              {PLANET_SWITCHER_OPTIONS.map((option) => (
+                <DropdownMenuCheckboxItem
+                  key={option.ellipsoidId}
+                  checked={selectedPlanet === option.ellipsoidId}
+                  onCheckedChange={(checked) =>
+                    togglePlanet(option.ellipsoidId, checked)
+                  }
+                >
+                  {t(PLANET_SWITCHER_LABEL_KEYS[option.ellipsoidId])}
+                </DropdownMenuCheckboxItem>
+              ))}
             </DropdownMenuContent>
           </DropdownMenu>
           <Button

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -100,6 +100,12 @@
     "sectionMoon": "Der Mond",
     "sectionMars": "Mars"
   },
+  "planetSwitcher": {
+    "label": "Himmelskörper",
+    "earth": "Erde",
+    "moon": "Mond",
+    "mars": "Mars"
+  },
   "common": {
     "pickColorFromScreen": "Farbe vom Bildschirm auswählen",
     "save": "Speichern",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -100,6 +100,12 @@
     "sectionMoon": "The Moon",
     "sectionMars": "Mars"
   },
+  "planetSwitcher": {
+    "label": "Celestial body",
+    "earth": "Earth",
+    "moon": "The Moon",
+    "mars": "Mars"
+  },
   "common": {
     "pickColorFromScreen": "Pick a color from the screen",
     "save": "Save",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -103,7 +103,7 @@
   "planetSwitcher": {
     "label": "Celestial body",
     "earth": "Earth",
-    "moon": "The Moon",
+    "moon": "Moon",
     "mars": "Mars"
   },
   "common": {

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -100,6 +100,12 @@
     "sectionMoon": "La Luna",
     "sectionMars": "Marte"
   },
+  "planetSwitcher": {
+    "label": "Cuerpo celeste",
+    "earth": "Tierra",
+    "moon": "Luna",
+    "mars": "Marte"
+  },
   "common": {
     "pickColorFromScreen": "Elegir un color de la pantalla",
     "save": "Guardar",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -100,6 +100,12 @@
     "sectionMoon": "La Lune",
     "sectionMars": "Mars"
   },
+  "planetSwitcher": {
+    "label": "Corps céleste",
+    "earth": "Terre",
+    "moon": "Lune",
+    "mars": "Mars"
+  },
   "common": {
     "pickColorFromScreen": "Choisir une couleur à l'écran",
     "save": "Enregistrer",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -100,6 +100,12 @@
     "sectionMoon": "चंद्रमा",
     "sectionMars": "मंगल"
   },
+  "planetSwitcher": {
+    "label": "खगोलीय पिंड",
+    "earth": "पृथ्वी",
+    "moon": "चंद्रमा",
+    "mars": "मंगल"
+  },
   "common": {
     "pickColorFromScreen": "स्क्रीन से रंग चुनें",
     "save": "सहेजें",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -99,6 +99,12 @@
     "sectionMoon": "Bulan",
     "sectionMars": "Mars"
   },
+  "planetSwitcher": {
+    "label": "Benda langit",
+    "earth": "Bumi",
+    "moon": "Bulan",
+    "mars": "Mars"
+  },
   "common": {
     "pickColorFromScreen": "Pilih warna dari layar",
     "save": "Simpan",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -100,6 +100,12 @@
     "sectionMoon": "La Luna",
     "sectionMars": "Marte"
   },
+  "planetSwitcher": {
+    "label": "Corpo celeste",
+    "earth": "Terra",
+    "moon": "Luna",
+    "mars": "Marte"
+  },
   "common": {
     "pickColorFromScreen": "Preleva un colore dallo schermo",
     "save": "Salva",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -99,6 +99,12 @@
     "sectionMoon": "月",
     "sectionMars": "火星"
   },
+  "planetSwitcher": {
+    "label": "天体",
+    "earth": "地球",
+    "moon": "月",
+    "mars": "火星"
+  },
   "common": {
     "pickColorFromScreen": "画面から色を選択",
     "save": "保存",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -99,6 +99,12 @@
     "sectionMoon": "달",
     "sectionMars": "화성"
   },
+  "planetSwitcher": {
+    "label": "천체",
+    "earth": "지구",
+    "moon": "달",
+    "mars": "화성"
+  },
   "common": {
     "pickColorFromScreen": "화면에서 색상 선택",
     "save": "저장",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -100,6 +100,12 @@
     "sectionMoon": "De Maan",
     "sectionMars": "Mars"
   },
+  "planetSwitcher": {
+    "label": "Hemellichaam",
+    "earth": "Aarde",
+    "moon": "Maan",
+    "mars": "Mars"
+  },
   "common": {
     "pickColorFromScreen": "Kies een kleur van het scherm",
     "save": "Opslaan",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -100,6 +100,12 @@
     "sectionMoon": "A Lua",
     "sectionMars": "Marte"
   },
+  "planetSwitcher": {
+    "label": "Corpo celeste",
+    "earth": "Terra",
+    "moon": "Lua",
+    "mars": "Marte"
+  },
   "common": {
     "pickColorFromScreen": "Escolher uma cor da tela",
     "save": "Salvar",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -102,6 +102,12 @@
     "sectionMoon": "Луна",
     "sectionMars": "Марс"
   },
+  "planetSwitcher": {
+    "label": "Небесное тело",
+    "earth": "Земля",
+    "moon": "Луна",
+    "mars": "Марс"
+  },
   "common": {
     "pickColorFromScreen": "Выбрать цвет с экрана",
     "save": "Сохранить",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -100,6 +100,12 @@
     "sectionMoon": "Ay",
     "sectionMars": "Mars"
   },
+  "planetSwitcher": {
+    "label": "Gök cismi",
+    "earth": "Dünya",
+    "moon": "Ay",
+    "mars": "Mars"
+  },
   "common": {
     "pickColorFromScreen": "Ekrandan bir renk seç",
     "save": "Kaydet",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -99,6 +99,12 @@
     "sectionMoon": "月球",
     "sectionMars": "火星"
   },
+  "planetSwitcher": {
+    "label": "天体",
+    "earth": "地球",
+    "moon": "月球",
+    "mars": "火星"
+  },
   "common": {
     "pickColorFromScreen": "从屏幕上拾取颜色",
     "save": "保存",

--- a/packages/core/src/ellipsoids.ts
+++ b/packages/core/src/ellipsoids.ts
@@ -114,10 +114,12 @@ export function getActiveSemiMajorAxisMeters(): number {
 // --- Planetary basemaps ----------------------------------------------------
 
 /**
- * A raster basemap for a non-Earth body. The tiles are XYZ PNGs in the standard
- * Web-Mercator scheme (of that body), so MapLibre renders them directly. The
- * `styleUrl` is a `geolibre://basemap/<id>` sentinel; the map controller expands
- * it into a raster style at apply time (it is not a fetchable URL).
+ * A raster basemap for a celestial body — the Moon and Mars mosaics, plus the
+ * Earth satellite imagery the planet switcher pairs with Earth. The tiles are
+ * XYZ (or TMS, see {@link scheme}) images in that body's Web-Mercator scheme, so
+ * MapLibre renders them directly. The `styleUrl` is a `geolibre://basemap/<id>`
+ * sentinel; the map controller expands it into a raster style at apply time (it
+ * is not a fetchable URL).
  */
 export interface PlanetaryBasemap {
   id: string;
@@ -254,6 +256,22 @@ export const PLANETARY_BASEMAPS: readonly PlanetaryBasemap[] = [
     attribution: OPM_ATTRIBUTION,
     ellipsoidId: "moon",
   },
+  // --- Earth --------------------------------------------------------------
+  // Satellite imagery the planet switcher pairs with Earth. Not shown in the
+  // basemap picker's Moon/Mars sections (PLANETARY_BODY_ORDER excludes Earth) —
+  // Earth basemaps live in the OpenFreeMap/Protomaps picker. USGS's National Map
+  // ImageryOnly tiles are global Web-Mercator XYZ with open CORS.
+  {
+    id: "earth-usgs-imagery",
+    name: "USGS Imagery",
+    styleUrl: `${PLANETARY_BASEMAP_SENTINEL_PREFIX}earth-usgs-imagery`,
+    tileUrl:
+      "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}",
+    maxZoom: 16,
+    attribution:
+      '<a href="https://www.usgs.gov/programs/national-geospatial-program/national-map">USGS The National Map</a>',
+    ellipsoidId: "earth",
+  },
 ] as const;
 
 /** The celestial bodies with basemaps, in the order the UI groups them. */
@@ -303,3 +321,26 @@ export function getPlanetaryBasemapByStyleUrl(
     : id;
   return PLANETARY_BASEMAPS.find((b) => b.id === resolvedId);
 }
+
+/** Look a planetary basemap up by its stable id. */
+export function getPlanetaryBasemapById(
+  id: string,
+): PlanetaryBasemap | undefined {
+  return PLANETARY_BASEMAPS.find((b) => b.id === id);
+}
+
+/**
+ * The celestial bodies offered by the Layers-panel planet switcher, in menu
+ * order (like Google Earth's planet dropdown). Each body is paired with the
+ * basemap the switcher applies for it — USGS satellite imagery for Earth, the
+ * OpenPlanetaryMap Hillshaded Albedo mosaic for the Moon, and the OpenPlanetaryMap
+ * Viking mosaic for Mars.
+ */
+export const PLANET_SWITCHER_OPTIONS = [
+  { ellipsoidId: "earth", basemapId: "earth-usgs-imagery" },
+  { ellipsoidId: "moon", basemapId: "moon-hillshaded-albedo" },
+  { ellipsoidId: "mars", basemapId: "mars-viking-mdim21" },
+] as const satisfies readonly {
+  ellipsoidId: EllipsoidId;
+  basemapId: string;
+}[];

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -53,7 +53,7 @@ import {
   type StoryMap,
 } from "./types";
 import { hasSimpleStyleProperties } from "./vector-color";
-import { setActiveEllipsoidId } from "./ellipsoids";
+import { DEFAULT_ELLIPSOID_ID, setActiveEllipsoidId } from "./ellipsoids";
 import type { PlanetaryBasemap } from "./ellipsoids";
 
 export type ConversionToolKind =
@@ -276,6 +276,12 @@ export interface AppState {
    * by both the basemap picker and the Layers-panel planet switcher.
    */
   applyPlanetaryBasemap: (basemap: PlanetaryBasemap) => void;
+  /**
+   * Return to Earth: apply `styleUrl` (typically the Earth basemap that was
+   * active before a planet was selected, e.g. Liberty) and reset the ellipsoid
+   * to Earth. Used when a planet is deselected in the switcher.
+   */
+  restoreEarthBasemap: (styleUrl: string) => void;
   setBasemapVisible: (visible: boolean) => void;
   setBasemapOpacity: (opacity: number) => void;
   setPreferences: (preferences: ProjectPreferences) => void;
@@ -819,6 +825,21 @@ export const useAppStore = create<AppState>()(
                   map: {
                     ...state.preferences.map,
                     ellipsoidId: basemap.ellipsoidId,
+                  },
+                },
+          isDirty: true,
+        })),
+      restoreEarthBasemap: (styleUrl) =>
+        set((state) => ({
+          basemapStyleUrl: styleUrl,
+          preferences:
+            state.preferences.map.ellipsoidId === DEFAULT_ELLIPSOID_ID
+              ? state.preferences
+              : {
+                  ...state.preferences,
+                  map: {
+                    ...state.preferences.map,
+                    ellipsoidId: DEFAULT_ELLIPSOID_ID,
                   },
                 },
           isDirty: true,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -54,6 +54,7 @@ import {
 } from "./types";
 import { hasSimpleStyleProperties } from "./vector-color";
 import { setActiveEllipsoidId } from "./ellipsoids";
+import type { PlanetaryBasemap } from "./ellipsoids";
 
 export type ConversionToolKind =
   | "vector-to-vector"
@@ -269,6 +270,12 @@ export interface AppState {
   /** Remove one secondary pane and collapse the grid back toward 1x1. */
   removeSecondaryMapView: (id: string) => void;
   setBasemapStyleUrl: (url: string) => void;
+  /**
+   * Apply a planetary basemap and sync the project's ellipsoid to the body it
+   * depicts, so measurements and the globe control use that body's radius. Used
+   * by both the basemap picker and the Layers-panel planet switcher.
+   */
+  applyPlanetaryBasemap: (basemap: PlanetaryBasemap) => void;
   setBasemapVisible: (visible: boolean) => void;
   setBasemapOpacity: (opacity: number) => void;
   setPreferences: (preferences: ProjectPreferences) => void;
@@ -801,6 +808,21 @@ export const useAppStore = create<AppState>()(
           };
         }),
       setBasemapStyleUrl: (url) => set({ basemapStyleUrl: url, isDirty: true }),
+      applyPlanetaryBasemap: (basemap) =>
+        set((state) => ({
+          basemapStyleUrl: basemap.styleUrl,
+          preferences:
+            state.preferences.map.ellipsoidId === basemap.ellipsoidId
+              ? state.preferences
+              : {
+                  ...state.preferences,
+                  map: {
+                    ...state.preferences.map,
+                    ellipsoidId: basemap.ellipsoidId,
+                  },
+                },
+          isDirty: true,
+        })),
       setBasemapVisible: (visible) =>
         set({ basemapVisible: visible, isDirty: true }),
       setBasemapOpacity: (opacity) =>

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -53,7 +53,11 @@ import {
   type StoryMap,
 } from "./types";
 import { hasSimpleStyleProperties } from "./vector-color";
-import { DEFAULT_ELLIPSOID_ID, setActiveEllipsoidId } from "./ellipsoids";
+import {
+  DEFAULT_ELLIPSOID_ID,
+  getPlanetaryBasemapByStyleUrl,
+  setActiveEllipsoidId,
+} from "./ellipsoids";
 import type { PlanetaryBasemap } from "./ellipsoids";
 
 export type ConversionToolKind =
@@ -1549,10 +1553,32 @@ function finishHistoryStep(): void {
   const selectionDangling =
     s.selectedLayerId !== null &&
     !s.layers.some((layer) => layer.id === s.selectedLayerId);
+  // The basemap is in the undo history but the ellipsoid preference is not, so a
+  // step that restores a different basemap can leave the two out of sync (e.g.
+  // undoing a switch to Mars would keep the Mars radius under an Earth basemap).
+  // Re-derive the ellipsoid from the restored basemap's body — Earth for a
+  // non-planetary basemap — so measurements always match what's shown.
+  const restoredEllipsoidId =
+    getPlanetaryBasemapByStyleUrl(s.basemapStyleUrl)?.ellipsoidId ??
+    DEFAULT_ELLIPSOID_ID;
+  const ellipsoidPatch =
+    s.preferences.map.ellipsoidId !== restoredEllipsoidId
+      ? {
+          preferences: {
+            ...s.preferences,
+            map: { ...s.preferences.map, ellipsoidId: restoredEllipsoidId },
+          },
+        }
+      : {};
   useAppStore.setState(
     selectionDangling
-      ? { isDirty: true, selectedLayerId: null, selectedFeatureId: null }
-      : { isDirty: true },
+      ? {
+          isDirty: true,
+          selectedLayerId: null,
+          selectedFeatureId: null,
+          ...ellipsoidPatch,
+        }
+      : { isDirty: true, ...ellipsoidPatch },
   );
   // The setState above must not leave a coalesce window open for the next edit.
   cancelHistoryCoalesce();

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1548,20 +1548,23 @@ useAppStore.subscribe((state) => {
  * drop a `selectedLayerId` that no longer points at an existing layer (selection
  * is intentionally not tracked in history, so it can dangle after a restore).
  */
-function finishHistoryStep(): void {
+function finishHistoryStep(previousBasemapStyleUrl: string): void {
   const s = useAppStore.getState();
   const selectionDangling =
     s.selectedLayerId !== null &&
     !s.layers.some((layer) => layer.id === s.selectedLayerId);
   // The basemap is in the undo history but the ellipsoid preference is not, so a
-  // step that restores a different basemap can leave the two out of sync (e.g.
+  // step that restores a *different* basemap can leave the two out of sync (e.g.
   // undoing a switch to Mars would keep the Mars radius under an Earth basemap).
   // Re-derive the ellipsoid from the restored basemap's body — Earth for a
-  // non-planetary basemap — so measurements always match what's shown.
+  // non-planetary basemap — but only when this step actually changed the
+  // basemap. Steps that leave the basemap untouched must not touch the ellipsoid,
+  // which the user can set independently of the basemap in Settings.
   const restoredEllipsoidId =
     getPlanetaryBasemapByStyleUrl(s.basemapStyleUrl)?.ellipsoidId ??
     DEFAULT_ELLIPSOID_ID;
   const ellipsoidPatch =
+    s.basemapStyleUrl !== previousBasemapStyleUrl &&
     s.preferences.map.ellipsoidId !== restoredEllipsoidId
       ? {
           preferences: {
@@ -1594,8 +1597,9 @@ export function undo(): void {
   const temporal = useAppStore.temporal.getState();
   if (temporal.pastStates.length === 0) return; // nothing to undo; stay clean
   cancelHistoryCoalesce(); // break any in-flight burst so the next edit records
+  const previousBasemapStyleUrl = useAppStore.getState().basemapStyleUrl;
   temporal.undo();
-  finishHistoryStep();
+  finishHistoryStep(previousBasemapStyleUrl);
 }
 
 /** Step the history forward one entry and mark the project dirty. */
@@ -1603,8 +1607,9 @@ export function redo(): void {
   const temporal = useAppStore.temporal.getState();
   if (temporal.futureStates.length === 0) return; // nothing to redo; stay clean
   cancelHistoryCoalesce(); // break any in-flight burst so the next edit records
+  const previousBasemapStyleUrl = useAppStore.getState().basemapStyleUrl;
   temporal.redo();
-  finishHistoryStep();
+  finishHistoryStep(previousBasemapStyleUrl);
 }
 
 /** Empty both the undo and redo stacks (e.g. on new/loaded project). */

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -235,11 +235,12 @@ function resolveMapStyle(
 }
 
 /**
- * A single-source raster style for a non-Earth body. The tiles are PNGs in that
- * body's Web-Mercator scheme (XYZ, or TMS when `basemap.scheme` says so), so
- * MapLibre renders them like any raster basemap. A dark background shows
+ * A single-source raster style for a celestial body — the Moon/Mars mosaics or
+ * the Earth satellite imagery the planet switcher uses. The tiles are images in
+ * that body's Web-Mercator scheme (XYZ, or TMS when `basemap.scheme` says so),
+ * so MapLibre renders them like any raster basemap. A dark background shows
  * through at zoom levels the source doesn't cover, matching how the planetary
- * tiles fade to black at the poles.
+ * tiles fade to black at the poles (and reading as space around the globe).
  */
 function createPlanetaryMapStyle(
   basemap: PlanetaryBasemap,

--- a/tests/planetary-basemap.test.ts
+++ b/tests/planetary-basemap.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import { useAppStore, undo } from "../packages/core/src/store";
+import { getPlanetaryBasemapById } from "../packages/core/src/ellipsoids";
+import { setHistoryCoalesceMs } from "../packages/core/src/history";
+
+const mars = getPlanetaryBasemapById("mars-viking-mdim21")!;
+const moon = getPlanetaryBasemapById("moon-hillshaded-albedo")!;
+const earth = getPlanetaryBasemapById("earth-usgs-imagery")!;
+
+describe("applyPlanetaryBasemap", () => {
+  beforeEach(() => {
+    setHistoryCoalesceMs(0);
+    useAppStore.getState().newProject({ name: "reset" });
+  });
+
+  it("applies the basemap and syncs the ellipsoid to the body", () => {
+    useAppStore.getState().applyPlanetaryBasemap(mars);
+    const state = useAppStore.getState();
+    assert.equal(state.basemapStyleUrl, mars.styleUrl);
+    assert.equal(state.preferences.map.ellipsoidId, "mars");
+  });
+
+  it("leaves the other map preferences untouched", () => {
+    const before = useAppStore.getState().preferences.map;
+    useAppStore.getState().applyPlanetaryBasemap(moon);
+    const after = useAppStore.getState().preferences.map;
+    assert.deepEqual(after, { ...before, ellipsoidId: "moon" });
+  });
+
+  it("does not rewrite preferences when the ellipsoid already matches", () => {
+    // The default project is already on Earth, so applying an Earth basemap
+    // must not touch (or replace the reference of) the preferences object.
+    const before = useAppStore.getState().preferences;
+    useAppStore.getState().applyPlanetaryBasemap(earth);
+    const state = useAppStore.getState();
+    assert.equal(state.basemapStyleUrl, earth.styleUrl);
+    assert.equal(state.preferences, before);
+  });
+});
+
+describe("restoreEarthBasemap", () => {
+  beforeEach(() => {
+    setHistoryCoalesceMs(0);
+    useAppStore.getState().newProject({ name: "reset" });
+  });
+
+  it("applies the given basemap and resets the ellipsoid to Earth", () => {
+    useAppStore.getState().applyPlanetaryBasemap(mars);
+    useAppStore.getState().restoreEarthBasemap("https://example.com/style.json");
+    const state = useAppStore.getState();
+    assert.equal(state.basemapStyleUrl, "https://example.com/style.json");
+    assert.equal(state.preferences.map.ellipsoidId, "earth");
+  });
+});
+
+describe("undo keeps the ellipsoid in sync with the restored basemap", () => {
+  beforeEach(() => {
+    setHistoryCoalesceMs(0);
+    useAppStore.getState().newProject({ name: "reset" });
+  });
+
+  it("re-derives Earth after undoing a switch to a planetary basemap", () => {
+    assert.equal(useAppStore.getState().preferences.map.ellipsoidId, "earth");
+    useAppStore.getState().applyPlanetaryBasemap(mars);
+    assert.equal(useAppStore.getState().preferences.map.ellipsoidId, "mars");
+    undo();
+    const state = useAppStore.getState();
+    assert.notEqual(state.basemapStyleUrl, mars.styleUrl);
+    // The basemap reverted to Earth, so the ellipsoid must follow — otherwise
+    // measurements would use the Mars radius under an Earth basemap.
+    assert.equal(state.preferences.map.ellipsoidId, "earth");
+  });
+});

--- a/tests/planetary-basemap.test.ts
+++ b/tests/planetary-basemap.test.ts
@@ -71,4 +71,21 @@ describe("undo keeps the ellipsoid in sync with the restored basemap", () => {
     // measurements would use the Mars radius under an Earth basemap.
     assert.equal(state.preferences.map.ellipsoidId, "earth");
   });
+
+  it("leaves a manually-set ellipsoid alone on an undo that keeps the basemap", () => {
+    // The ellipsoid can be set independently of the basemap (Settings), e.g. to
+    // measure imported Mars data while staying on an Earth basemap.
+    const prefs = useAppStore.getState().preferences;
+    useAppStore.getState().setPreferences({
+      ...prefs,
+      map: { ...prefs.map, ellipsoidId: "mars" },
+    });
+    // An unrelated undoable action that doesn't touch the basemap, then undo.
+    useAppStore
+      .getState()
+      .addGeoJsonLayer("A", { type: "FeatureCollection", features: [] });
+    undo();
+    // The basemap never changed, so the manual ellipsoid must survive.
+    assert.equal(useAppStore.getState().preferences.map.ellipsoidId, "mars");
+  });
 });


### PR DESCRIPTION
## What

Adds a planetary (orbit) icon **before the basemaps icon** in the Layers-panel header, with a dropdown that switches the map between **Earth**, **The Moon**, and **Mars** — like Google Earth's planet selector. Picking a body applies its basemap and sets the project ellipsoid so measurements (distance/area/scale) and the globe control use that body's radius.

| Body | Basemap |
|---|---|
| Earth | USGS The National Map ImageryOnly satellite imagery |
| The Moon | OpenPlanetaryMap Hillshaded Albedo |
| Mars | OpenPlanetaryMap Viking MDIM2.1 |

The USGS imagery is global Web-Mercator XYZ and serves `Access-Control-Allow-Origin: *`, so it renders directly in MapLibre with no proxy. The Moon/Mars mosaics go through the existing `tiles.geolibre.app` CORS worker.

## Changes

- **`packages/core`** — add the Earth USGS imagery entry to `PLANETARY_BASEMAPS` (kept out of the picker's Moon/Mars sections, which exclude Earth via `PLANETARY_BODY_ORDER`), a `getPlanetaryBasemapById` lookup, and a `PLANET_SWITCHER_OPTIONS` config pairing each body with its basemap.
- **desktop app** — render the switcher as a `DropdownMenu` radio group in the Layers header; the orbit icon highlights (`text-primary`) when the map is on a non-Earth body. New `planetSwitcher` i18n keys.

## Testing

- `npm run test:frontend` — **2278 pass / 0 fail**
- `npm run build` + `pre-commit` (build + eslint) — pass
- **End-to-end in the real app** (Playwright, live tile sources): the dropdown shows Earth / The Moon / Mars; selecting each renders the correct globe (Earth USGS imagery, Moon hillshaded albedo, Mars Viking) with **34 USGS + 68 worker tiles, 0 failures**, Diagnostics: 0. The orbit icon sits first in the header, before the basemaps map icon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a planet switcher to the Layers panel, offering Earth, Moon, and Mars options.
  * Selecting a planet updates the map imagery and related planetary settings.
  * Added Earth satellite imagery as a selectable basemap.
* **Improvements**
  * Basemap selection now applies planetary basemaps through the shared app action for consistent updates.
* **Localization**
  * Added localized labels for the celestial body options (Earth, Moon, Mars).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->