### PR TITLE
feat(attribute-table): calculate geometry length and area in the Field Calculator

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -954,10 +954,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // three, and point/geometry-less layers get none (the row is hidden).
   const calcGeometryFamily = useMemo(
     () => detectGeometryFamily(features),
-    // Recompute only when the layer or its feature count changes — the family is
-    // stable across attribute edits and re-renders. eslint can't see that.
+    // Recompute when the layer or its feature count changes, and each time the
+    // dialog opens, so a geometry-type edit made while it was closed is picked
+    // up. The family is otherwise stable across renders (and the calc dialog is
+    // modal, so geometry cannot be edited while it is open). eslint can't see
+    // that the array identity of `features` alone is not a meaningful dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [layer?.id, features.length],
+    [layer?.id, features.length, calcOpen],
   );
   const calcAvailableMetrics = useMemo<GeometryMetric[]>(() => {
     switch (calcGeometryFamily) {
@@ -1019,6 +1022,14 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const calcColumnsKey = calcOpen ? JSON.stringify(discoveredColumns) : "";
   const calcSampleKey =
     calcOpen && calcSampleRow ? JSON.stringify(calcSampleRow.properties) : "";
+  // The preview feeds the sample feature's geometry to $length/$perimeter/$area,
+  // so key on the geometry too — a geometry change (not just a property change)
+  // must recompute the preview. Only one feature is serialized, and only while
+  // the dialog is open.
+  const calcSampleGeomKey =
+    calcOpen && calcSampleRow
+      ? JSON.stringify(features[calcSampleIndex]?.geometry ?? null)
+      : "";
   const calcPreview = useMemo<
     | { kind: "empty" }
     | { kind: "ok"; value: unknown }
@@ -1065,6 +1076,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     calcOutputType,
     calcColumnsKey,
     calcSampleKey,
+    calcSampleGeomKey,
     calcSampleIndex,
   ]);
   const calcCanSubmit =

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -94,7 +94,7 @@ import {
 } from "../../lib/attribute-expression";
 import {
   AREA_UNITS,
-  detectGeometryFamily,
+  detectGeometryFamilies,
   DISTANCE_UNITS,
   UNIT_SYMBOLS,
   type GeometryMetric,
@@ -920,9 +920,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setCalcError(null);
     // Seed the geometry measurement to a metric that suits the layer; the
     // effective-metric fallback still corrects any mismatch on render.
-    const family = detectGeometryFamily(features);
-    setCalcGeomMetric(family === "line" ? "length" : "area");
-    setCalcGeomUnit(family === "line" ? "meters" : "square-meters");
+    const families = detectGeometryFamilies(features);
+    const lineOnly = families.has("line") && !families.has("polygon");
+    setCalcGeomMetric(lineOnly ? "length" : "area");
+    setCalcGeomUnit(lineOnly ? "meters" : "square-meters");
     setCalcOpen(true);
   };
 
@@ -952,28 +953,24 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // Geometry family drives which measurements the calculator offers: a polygon
   // layer gets Area/Perimeter, a line layer gets Length, a mixed layer gets all
   // three, and point/geometry-less layers get none (the row is hidden).
-  const calcGeometryFamily = useMemo(
-    () => detectGeometryFamily(features),
+  const calcGeometryFamilies = useMemo(
+    () => detectGeometryFamilies(features),
     // Recompute when the layer or its feature count changes, and each time the
     // dialog opens, so a geometry-type edit made while it was closed is picked
-    // up. The family is otherwise stable across renders (and the calc dialog is
-    // modal, so geometry cannot be edited while it is open). eslint can't see
+    // up. The families are otherwise stable across renders (and the calc dialog
+    // is modal, so geometry cannot be edited while it is open). eslint can't see
     // that the array identity of `features` alone is not a meaningful dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [layer?.id, features.length, calcOpen],
   );
   const calcAvailableMetrics = useMemo<GeometryMetric[]>(() => {
-    switch (calcGeometryFamily) {
-      case "polygon":
-        return ["area", "perimeter"];
-      case "line":
-        return ["length"];
-      case "mixed":
-        return ["length", "perimeter", "area"];
-      default:
-        return [];
-    }
-  }, [calcGeometryFamily]);
+    // Offer only metrics the layer's geometry actually supports, so a mixed
+    // point+line layer gets Length but not a no-op Area.
+    const metrics: GeometryMetric[] = [];
+    if (calcGeometryFamilies.has("polygon")) metrics.push("area", "perimeter");
+    if (calcGeometryFamilies.has("line")) metrics.push("length");
+    return metrics;
+  }, [calcGeometryFamilies]);
   // Fall back to the first available metric/unit when the current selection is
   // not valid for this layer (e.g. an "area" choice carried over to a line layer).
   const calcEffectiveMetric = calcAvailableMetrics.includes(calcGeomMetric)

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -92,6 +92,13 @@ import {
   fieldReference,
   type CalcOutputType,
 } from "../../lib/attribute-expression";
+import {
+  AREA_UNITS,
+  detectGeometryFamily,
+  DISTANCE_UNITS,
+  UNIT_SYMBOLS,
+  type GeometryMetric,
+} from "../../lib/geometry-measure";
 import { AttributeChartDialog } from "./AttributeChartDialog";
 import { AttributeStatsDialog } from "./AttributeStatsDialog";
 import { ColumnExplorerDialog } from "./ColumnExplorerDialog";
@@ -327,6 +334,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const [calcExpression, setCalcExpression] = useState("");
   const [calcSelectedOnly, setCalcSelectedOnly] = useState(false);
   const [calcError, setCalcError] = useState<string | null>(null);
+  // Geometry-measurement helper inside the calculator: which metric and unit the
+  // "Insert" button builds a `$length/$perimeter/$area(...)` snippet from.
+  const [calcGeomMetric, setCalcGeomMetric] =
+    useState<GeometryMetric>("length");
+  const [calcGeomUnit, setCalcGeomUnit] = useState<string>("meters");
   const calcExpressionRef = useRef<HTMLTextAreaElement>(null);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
@@ -906,6 +918,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setCalcExpression("");
     setCalcSelectedOnly(false);
     setCalcError(null);
+    // Seed the geometry measurement to a metric that suits the layer; the
+    // effective-metric fallback still corrects any mismatch on render.
+    const family = detectGeometryFamily(features);
+    setCalcGeomMetric(family === "line" ? "length" : "area");
+    setCalcGeomUnit(family === "line" ? "meters" : "square-meters");
     setCalcOpen(true);
   };
 
@@ -930,6 +947,46 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     el.focus();
     el.setSelectionRange(caret, caret);
     setCalcExpression(next);
+  };
+
+  // Geometry family drives which measurements the calculator offers: a polygon
+  // layer gets Area/Perimeter, a line layer gets Length, a mixed layer gets all
+  // three, and point/geometry-less layers get none (the row is hidden).
+  const calcGeometryFamily = useMemo(
+    () => detectGeometryFamily(features),
+    // Recompute only when the layer or its feature count changes — the family is
+    // stable across attribute edits and re-renders. eslint can't see that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [layer?.id, features.length],
+  );
+  const calcAvailableMetrics = useMemo<GeometryMetric[]>(() => {
+    switch (calcGeometryFamily) {
+      case "polygon":
+        return ["area", "perimeter"];
+      case "line":
+        return ["length"];
+      case "mixed":
+        return ["length", "perimeter", "area"];
+      default:
+        return [];
+    }
+  }, [calcGeometryFamily]);
+  // Fall back to the first available metric/unit when the current selection is
+  // not valid for this layer (e.g. an "area" choice carried over to a line layer).
+  const calcEffectiveMetric = calcAvailableMetrics.includes(calcGeomMetric)
+    ? calcGeomMetric
+    : (calcAvailableMetrics[0] ?? "length");
+  const calcGeomUnitOptions =
+    calcEffectiveMetric === "area" ? AREA_UNITS : DISTANCE_UNITS;
+  const calcEffectiveUnit = (
+    calcGeomUnitOptions as readonly string[]
+  ).includes(calcGeomUnit)
+    ? calcGeomUnit
+    : calcGeomUnitOptions[0];
+
+  const insertGeometrySnippet = () => {
+    const snippet = `$${calcEffectiveMetric}(${JSON.stringify(calcEffectiveUnit)})`;
+    insertExpressionSnippet(snippet);
   };
 
   const calcNewNameTrimmed = calcNewName.trim();
@@ -973,7 +1030,14 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       const compiled = compileExpression(calcExpression, discoveredColumns);
       if (!calcSampleRow) return { kind: "ok", value: null };
       try {
-        const raw = compiled.evaluate(calcSampleRow.properties, calcSampleIndex);
+        // attributeRows map 1:1 to geojson features by index, so the sample
+        // row's geometry drives the $length/$perimeter/$area helpers in the
+        // preview (undefined for DuckDB layers, which the helpers treat as 0).
+        const raw = compiled.evaluate(
+          calcSampleRow.properties,
+          calcSampleIndex,
+          features[calcSampleIndex]?.geometry,
+        );
         return { kind: "ok", value: coerceComputedValue(raw, calcOutputType) };
       } catch (error) {
         return {
@@ -1931,6 +1995,47 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                   </button>
                 ))}
               </div>
+              {calcAvailableMetrics.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-xs text-muted-foreground">
+                    {t("attributeTable.geomMeasureLabel")}
+                  </span>
+                  <Select
+                    id="calc-geom-metric"
+                    className="h-7 w-28 py-0 text-xs"
+                    value={calcEffectiveMetric}
+                    onChange={(event) =>
+                      setCalcGeomMetric(event.target.value as GeometryMetric)
+                    }
+                  >
+                    {calcAvailableMetrics.map((metric) => (
+                      <option key={metric} value={metric}>
+                        {t(`attributeTable.geomMetric.${metric}`)}
+                      </option>
+                    ))}
+                  </Select>
+                  <Select
+                    id="calc-geom-unit"
+                    className="h-7 w-20 py-0 text-xs"
+                    value={calcEffectiveUnit}
+                    onChange={(event) => setCalcGeomUnit(event.target.value)}
+                  >
+                    {calcGeomUnitOptions.map((unit) => (
+                      <option key={unit} value={unit}>
+                        {UNIT_SYMBOLS[unit]}
+                      </option>
+                    ))}
+                  </Select>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                    onClick={insertGeometrySnippet}
+                  >
+                    {t("attributeTable.geomInsert")}
+                  </Button>
+                </div>
+              ) : null}
             </div>
             {calcPreview.kind === "syntax" ? (
               <span className="text-xs text-destructive">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2507,6 +2507,13 @@
     "insertField": "Insert {{name}}",
     "functionsLabel": "Functions:",
     "insertFunction": "Insert {{name}}()",
+    "geomMeasureLabel": "Geometry:",
+    "geomMetric": {
+      "length": "Length",
+      "perimeter": "Perimeter",
+      "area": "Area"
+    },
+    "geomInsert": "Insert",
     "sampleRowErrored": "Sample row errored (other rows may still compute): {{message}}",
     "preview": "Preview:",
     "onlySelectedFeature": "Only update the selected feature",

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -366,7 +366,10 @@ export function calculateField(
     const props = (feature.properties ?? {}) as Record<string, unknown>;
     let value: unknown;
     try {
-      value = coerceComputedValue(compiled.evaluate(props, index), outputType);
+      value = coerceComputedValue(
+        compiled.evaluate(props, index, feature.geometry),
+        outputType,
+      );
       evaluated += 1;
     } catch {
       value = null;

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -124,18 +124,22 @@ const EXPRESSION_CONSTANTS: Record<string, number> = {
  */
 export const GEOMETRY_HELPER_NAMES = ["$length", "$perimeter", "$area"] as const;
 
+/** A mutable slot the geometry helpers read, updated once per evaluated row. */
+interface GeometryHolder {
+  geometry: Geometry | null | undefined;
+}
+
 /**
- * Build the per-feature geometry helpers for one evaluation. They close over the
- * feature's geometry, so unlike the static `EXPRESSION_HELPERS` they are created
- * fresh for each row.
+ * Build the geometry helpers for a compiled expression. They close over a
+ * mutable holder (updated once per row) rather than over the geometry itself, so
+ * the three closures are allocated once per compile instead of once per feature
+ * during a bulk `calculateField` run.
  */
-function createGeometryHelpers(
-  geometry: Geometry | null | undefined,
-): Helper[] {
+function createGeometryHelpers(holder: GeometryHolder): Helper[] {
   return [
-    (unit) => measureLength(geometry, unit as DistanceUnit | undefined),
-    (unit) => measurePerimeter(geometry, unit as DistanceUnit | undefined),
-    (unit) => measureArea(geometry, unit as AreaUnit | undefined),
+    (unit) => measureLength(holder.geometry, unit as DistanceUnit | undefined),
+    (unit) => measurePerimeter(holder.geometry, unit as DistanceUnit | undefined),
+    (unit) => measureArea(holder.geometry, unit as AreaUnit | undefined),
   ];
 }
 
@@ -248,15 +252,20 @@ export function compileExpression(
 
   const helperValues = helperNames.map((name) => EXPRESSION_HELPERS[name]);
   const constantValues = constantNames.map((name) => EXPRESSION_CONSTANTS[name]);
+  // Allocate the geometry helpers once and feed each row's geometry through a
+  // shared holder, so a bulk calculation doesn't rebuild them per feature.
+  const geometryHolder: GeometryHolder = { geometry: null };
+  const geometryHelperValues = createGeometryHelpers(geometryHolder);
 
   return {
     evaluate(props, index, geometry) {
+      geometryHolder.geometry = geometry ?? null;
       const fieldValues = bareFields.map((name) => props[name]);
       return fn(
         ...fieldValues,
         ...helperValues,
         ...constantValues,
-        ...createGeometryHelpers(geometry),
+        ...geometryHelperValues,
         props,
         index,
       );

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -11,9 +11,18 @@
  *  - as bare identifiers when the field name is a valid JS identifier (`pop`),
  *  - always through the `props` object so fields with spaces/punctuation are
  *    reachable as `props["my field"]`.
- * A curated set of helper functions and the `$index` (row position) variable
- * are also in scope.
+ * A curated set of helper functions, the `$index` (row position) variable, and
+ * the geometry helpers `$length`/`$perimeter`/`$area` (which measure the
+ * feature's own geometry) are also in scope.
  */
+import type { Geometry } from "geojson";
+import {
+  measureArea,
+  measureLength,
+  measurePerimeter,
+  type AreaUnit,
+  type DistanceUnit,
+} from "./geometry-measure";
 
 /** A helper exposed to expressions by name. */
 type Helper = (...args: unknown[]) => unknown;
@@ -106,10 +115,35 @@ const EXPRESSION_CONSTANTS: Record<string, number> = {
   E: Math.E,
 };
 
+/**
+ * Geometry helper names, in scope as functions bound to each feature's own
+ * geometry: `$length(unit)` / `$perimeter(unit)` measure a line or a polygon's
+ * boundary (default meters); `$area(unit)` measures a polygon (default square
+ * meters). Units mirror the Measure tool — e.g. `$area("hectares")`,
+ * `$length("kilometers")`. Non-matching geometries return 0.
+ */
+export const GEOMETRY_HELPER_NAMES = ["$length", "$perimeter", "$area"] as const;
+
+/**
+ * Build the per-feature geometry helpers for one evaluation. They close over the
+ * feature's geometry, so unlike the static `EXPRESSION_HELPERS` they are created
+ * fresh for each row.
+ */
+function createGeometryHelpers(
+  geometry: Geometry | null | undefined,
+): Helper[] {
+  return [
+    (unit) => measureLength(geometry, unit as DistanceUnit | undefined),
+    (unit) => measurePerimeter(geometry, unit as DistanceUnit | undefined),
+    (unit) => measureArea(geometry, unit as AreaUnit | undefined),
+  ];
+}
+
 /** Names that are always in scope and therefore cannot be used as field idents. */
 const RESERVED_NAMES = new Set<string>([
   ...Object.keys(EXPRESSION_HELPERS),
   ...Object.keys(EXPRESSION_CONSTANTS),
+  ...GEOMETRY_HELPER_NAMES,
   "props",
   "$index",
 ]);
@@ -161,7 +195,11 @@ export function fieldReference(name: string): string {
 
 /** A compiled expression ready to run against each feature's properties. */
 export interface CompiledExpression {
-  evaluate: (props: Record<string, unknown>, index: number) => unknown;
+  evaluate: (
+    props: Record<string, unknown>,
+    index: number,
+    geometry?: Geometry | null,
+  ) => unknown;
 }
 
 /**
@@ -185,6 +223,7 @@ export function compileExpression(
     ...bareFields,
     ...helperNames,
     ...constantNames,
+    ...GEOMETRY_HELPER_NAMES,
     "props",
     "$index",
   ];
@@ -211,12 +250,13 @@ export function compileExpression(
   const constantValues = constantNames.map((name) => EXPRESSION_CONSTANTS[name]);
 
   return {
-    evaluate(props, index) {
+    evaluate(props, index, geometry) {
       const fieldValues = bareFields.map((name) => props[name]);
       return fn(
         ...fieldValues,
         ...helperValues,
         ...constantValues,
+        ...createGeometryHelpers(geometry),
         props,
         index,
       );

--- a/apps/geolibre-desktop/src/lib/geometry-measure.ts
+++ b/apps/geolibre-desktop/src/lib/geometry-measure.ts
@@ -90,52 +90,55 @@ export const UNIT_SYMBOLS: Record<DistanceUnit | AreaUnit, string> = {
 /** A geometry measurement the Field Calculator can insert. */
 export type GeometryMetric = "length" | "perimeter" | "area";
 
-/** The coarse geometry family of a layer, used to offer relevant metrics. */
-export type GeometryFamily = "point" | "line" | "polygon" | "mixed" | "none";
+/** A base geometry family a feature can contribute to a layer. */
+export type GeometryFamily = "point" | "line" | "polygon";
 
-function familyOf(geometry: Geometry | null | undefined): GeometryFamily | null {
+/** Add every base family reachable from `geometry` (flattening collections). */
+function collectBaseFamilies(
+  geometry: Geometry | null | undefined,
+  into: Set<GeometryFamily>,
+): void {
   switch (geometry?.type) {
     case "Point":
     case "MultiPoint":
-      return "point";
+      into.add("point");
+      break;
     case "LineString":
     case "MultiLineString":
-      return "line";
+      into.add("line");
+      break;
     case "Polygon":
     case "MultiPolygon":
-      return "polygon";
-    case "GeometryCollection": {
-      // Collections are measurable (measure* recurse into them), so classify by
-      // their members: a single family when they agree, "mixed" when they differ.
-      let family: GeometryFamily | null = null;
+      into.add("polygon");
+      break;
+    case "GeometryCollection":
+      // Collections are measurable (measure* recurse into them), so report the
+      // families they actually contain.
       for (const member of geometry.geometries) {
-        const current = familyOf(member);
-        if (!current) continue;
-        if (current === "mixed") return "mixed";
-        if (family === null) family = current;
-        else if (family !== current) return "mixed";
+        collectBaseFamilies(member, into);
       }
-      return family;
-    }
+      break;
     default:
-      return null;
+      break;
   }
 }
 
 /**
- * The dominant geometry family across a layer's features: the single family when
- * they agree, `"mixed"` when they differ, `"none"` when none carry measurable
- * geometry (e.g. a DuckDB query layer whose rows have no geometry).
+ * The set of geometry families actually present across a layer's features,
+ * flattening GeometryCollections. An empty set means no measurable geometry
+ * (e.g. a DuckDB query layer whose rows have no geometry); a set larger than one
+ * is a mixed layer. Reporting the concrete families (rather than collapsing to a
+ * single "mixed") lets the Field Calculator offer only the metrics that apply —
+ * a point+line layer gets Length, not a no-op Area.
  */
-export function detectGeometryFamily(features: Feature[]): GeometryFamily {
-  let family: GeometryFamily | null = null;
+export function detectGeometryFamilies(
+  features: Feature[],
+): Set<GeometryFamily> {
+  const families = new Set<GeometryFamily>();
   for (const feature of features) {
-    const current = familyOf(feature.geometry);
-    if (!current) continue;
-    if (family === null) family = current;
-    else if (family !== current) return "mixed";
+    collectBaseFamilies(feature.geometry, families);
   }
-  return family ?? "none";
+  return families;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/geometry-measure.ts
+++ b/apps/geolibre-desktop/src/lib/geometry-measure.ts
@@ -52,7 +52,7 @@ const AREA_FACTORS: Record<AreaUnit, number> = {
 };
 
 /** Distance units in menu order (meters first, as the sensible default). */
-export const DISTANCE_UNITS: DistanceUnit[] = [
+export const DISTANCE_UNITS: readonly DistanceUnit[] = [
   "meters",
   "kilometers",
   "feet",
@@ -62,7 +62,7 @@ export const DISTANCE_UNITS: DistanceUnit[] = [
 ];
 
 /** Area units in menu order (square meters first, as the sensible default). */
-export const AREA_UNITS: AreaUnit[] = [
+export const AREA_UNITS: readonly AreaUnit[] = [
   "square-meters",
   "square-kilometers",
   "hectares",
@@ -186,7 +186,7 @@ function lineLengthMeters(coords: Position[], radius: number): number {
 /**
  * Spherical area in square meters of a single ring (its coordinates as a closed
  * or open loop). Signed by winding order; callers take the absolute value and
- * subtract holes as needed. The longitude delta is normalized to (-180, 180] so
+ * subtract holes as needed. The longitude delta is normalized to [-180, 180) so
  * a ring edge that crosses the antimeridian (e.g. 179° → -179°) counts as the
  * short 2° step, not a 358° one, keeping areas correct near ±180°.
  */
@@ -225,9 +225,9 @@ function polygonPerimeterMeters(rings: Position[][], radius: number): number {
     // by coordinate value, not array identity — GeoJSON rings never reuse the
     // same Position instance for their first and last point.
     const first = ring[0];
-    const last = ring[ring.length - 1];
+    const last = ring.at(-1);
     const isClosed =
-      ring.length > 0 && first[0] === last[0] && first[1] === last[1];
+      !!last && first[0] === last[0] && first[1] === last[1];
     const closed = ring.length > 0 && !isClosed ? [...ring, first] : ring;
     total += lineLengthMeters(closed, radius);
   }

--- a/apps/geolibre-desktop/src/lib/geometry-measure.ts
+++ b/apps/geolibre-desktop/src/lib/geometry-measure.ts
@@ -104,6 +104,19 @@ function familyOf(geometry: Geometry | null | undefined): GeometryFamily | null 
     case "Polygon":
     case "MultiPolygon":
       return "polygon";
+    case "GeometryCollection": {
+      // Collections are measurable (measure* recurse into them), so classify by
+      // their members: a single family when they agree, "mixed" when they differ.
+      let family: GeometryFamily | null = null;
+      for (const member of geometry.geometries) {
+        const current = familyOf(member);
+        if (!current) continue;
+        if (current === "mixed") return "mixed";
+        if (family === null) family = current;
+        else if (family !== current) return "mixed";
+      }
+      return family;
+    }
     default:
       return null;
   }
@@ -123,6 +136,25 @@ export function detectGeometryFamily(features: Feature[]): GeometryFamily {
     else if (family !== current) return "mixed";
   }
   return family ?? "none";
+}
+
+/**
+ * Look up a unit's conversion factor, throwing on an unrecognized unit. The
+ * geometry helpers are called from free-text expressions, so a typo like
+ * `$area("hectare")` or `$length("km")` must surface as a per-feature error
+ * (null cell, counted in `errors`) rather than silently returning the base unit
+ * — a mistake that can be off by orders of magnitude.
+ */
+function distanceFactor(unit: DistanceUnit): number {
+  const factor = DISTANCE_FACTORS[unit];
+  if (factor === undefined) throw new Error(`Unknown distance unit: "${unit}"`);
+  return factor;
+}
+
+function areaFactor(unit: AreaUnit): number {
+  const factor = AREA_FACTORS[unit];
+  if (factor === undefined) throw new Error(`Unknown area unit: "${unit}"`);
+  return factor;
 }
 
 const DEG_TO_RAD = Math.PI / 180;
@@ -151,7 +183,9 @@ function lineLengthMeters(coords: Position[], radius: number): number {
 /**
  * Spherical area in square meters of a single ring (its coordinates as a closed
  * or open loop). Signed by winding order; callers take the absolute value and
- * subtract holes as needed.
+ * subtract holes as needed. The longitude delta is normalized to (-180, 180] so
+ * a ring edge that crosses the antimeridian (e.g. 179° → -179°) counts as the
+ * short 2° step, not a 358° one, keeping areas correct near ±180°.
  */
 function ringAreaMeters(ring: Position[], radius: number): number {
   const n = ring.length;
@@ -160,8 +194,9 @@ function ringAreaMeters(ring: Position[], radius: number): number {
   for (let i = 0; i < n; i += 1) {
     const p1 = ring[i];
     const p2 = ring[(i + 1) % n];
+    const dLon = ((p2[0] - p1[0] + 540) % 360) - 180;
     total +=
-      (p2[0] - p1[0]) *
+      dLon *
       DEG_TO_RAD *
       (2 + Math.sin(p1[1] * DEG_TO_RAD) + Math.sin(p2[1] * DEG_TO_RAD));
   }
@@ -183,11 +218,14 @@ function polygonPerimeterMeters(rings: Position[][], radius: number): number {
   let total = 0;
   for (const ring of rings) {
     // Close the ring so the final vertex→first vertex segment is counted even
-    // when the source coordinates are not explicitly closed.
-    const closed =
-      ring.length > 0 && ring[0] !== ring[ring.length - 1]
-        ? [...ring, ring[0]]
-        : ring;
+    // when the source coordinates are not explicitly closed. Compare endpoints
+    // by coordinate value, not array identity — GeoJSON rings never reuse the
+    // same Position instance for their first and last point.
+    const first = ring[0];
+    const last = ring[ring.length - 1];
+    const isClosed =
+      ring.length > 0 && first[0] === last[0] && first[1] === last[1];
+    const closed = ring.length > 0 && !isClosed ? [...ring, first] : ring;
     total += lineLengthMeters(closed, radius);
   }
   return total;
@@ -202,10 +240,9 @@ export function measureLength(
   geometry: Geometry | null | undefined,
   unit: DistanceUnit = "meters",
 ): number {
+  const factor = distanceFactor(unit);
   if (!geometry) return 0;
-  const radius = getActiveMeanRadiusMeters();
-  const factor = DISTANCE_FACTORS[unit] ?? 1;
-  return lengthMeters(geometry, radius) * factor;
+  return lengthMeters(geometry, getActiveMeanRadiusMeters()) * factor;
 }
 
 function lengthMeters(geometry: Geometry, radius: number): number {
@@ -235,10 +272,9 @@ export function measurePerimeter(
   geometry: Geometry | null | undefined,
   unit: DistanceUnit = "meters",
 ): number {
+  const factor = distanceFactor(unit);
   if (!geometry) return 0;
-  const radius = getActiveMeanRadiusMeters();
-  const factor = DISTANCE_FACTORS[unit] ?? 1;
-  return perimeterMeters(geometry, radius) * factor;
+  return perimeterMeters(geometry, getActiveMeanRadiusMeters()) * factor;
 }
 
 function perimeterMeters(geometry: Geometry, radius: number): number {
@@ -268,10 +304,9 @@ export function measureArea(
   geometry: Geometry | null | undefined,
   unit: AreaUnit = "square-meters",
 ): number {
+  const factor = areaFactor(unit);
   if (!geometry) return 0;
-  const radius = getActiveMeanRadiusMeters();
-  const factor = AREA_FACTORS[unit] ?? 1;
-  return areaMeters(geometry, radius) * factor;
+  return areaMeters(geometry, getActiveMeanRadiusMeters()) * factor;
 }
 
 function areaMeters(geometry: Geometry, radius: number): number {

--- a/apps/geolibre-desktop/src/lib/geometry-measure.ts
+++ b/apps/geolibre-desktop/src/lib/geometry-measure.ts
@@ -1,0 +1,294 @@
+/**
+ * Geodesic length, perimeter, and area of GeoJSON geometries for the attribute
+ * table's Field Calculator. These mirror the units the Measure tool offers so a
+ * "compute Area in hectares" column and a measured area agree.
+ *
+ * Distances use the great-circle (haversine) length between consecutive
+ * vertices; areas use the spherical-excess formula. Both are evaluated on a
+ * sphere whose radius is the active body's mean radius (Earth / Moon / Mars),
+ * read from `@geolibre/core`, so measurements stay consistent with the rest of
+ * the app when a non-Earth ellipsoid is active. Coordinates are assumed to be
+ * lon/lat degrees (EPSG:4326), which is what every layer in the store carries.
+ */
+import { getActiveMeanRadiusMeters } from "@geolibre/core";
+import type { Feature, Geometry, Position } from "geojson";
+
+/** Length units, matching the Measure tool's `DistanceUnit` set. */
+export type DistanceUnit =
+  | "meters"
+  | "kilometers"
+  | "miles"
+  | "feet"
+  | "yards"
+  | "nautical-miles";
+
+/** Area units, matching the Measure tool's `AreaUnit` set. */
+export type AreaUnit =
+  | "square-meters"
+  | "square-kilometers"
+  | "square-miles"
+  | "hectares"
+  | "acres"
+  | "square-feet";
+
+/** Multipliers from meters to each distance unit. */
+const DISTANCE_FACTORS: Record<DistanceUnit, number> = {
+  meters: 1,
+  kilometers: 1 / 1000,
+  miles: 1 / 1609.344,
+  feet: 1 / 0.3048,
+  yards: 1 / 0.9144,
+  "nautical-miles": 1 / 1852,
+};
+
+/** Multipliers from square meters to each area unit. */
+const AREA_FACTORS: Record<AreaUnit, number> = {
+  "square-meters": 1,
+  "square-kilometers": 1 / 1_000_000,
+  "square-miles": 1 / 2_589_988.110336,
+  hectares: 1 / 10_000,
+  acres: 1 / 4046.8564224,
+  "square-feet": 1 / 0.09290304,
+};
+
+/** Distance units in menu order (meters first, as the sensible default). */
+export const DISTANCE_UNITS: DistanceUnit[] = [
+  "meters",
+  "kilometers",
+  "feet",
+  "yards",
+  "miles",
+  "nautical-miles",
+];
+
+/** Area units in menu order (square meters first, as the sensible default). */
+export const AREA_UNITS: AreaUnit[] = [
+  "square-meters",
+  "square-kilometers",
+  "hectares",
+  "square-feet",
+  "acres",
+  "square-miles",
+];
+
+/** Short, language-neutral symbols for the unit dropdown (e.g. "km²", "ha"). */
+export const UNIT_SYMBOLS: Record<DistanceUnit | AreaUnit, string> = {
+  meters: "m",
+  kilometers: "km",
+  feet: "ft",
+  yards: "yd",
+  miles: "mi",
+  "nautical-miles": "nmi",
+  "square-meters": "m²",
+  "square-kilometers": "km²",
+  hectares: "ha",
+  "square-feet": "ft²",
+  acres: "ac",
+  "square-miles": "mi²",
+};
+
+/** A geometry measurement the Field Calculator can insert. */
+export type GeometryMetric = "length" | "perimeter" | "area";
+
+/** The coarse geometry family of a layer, used to offer relevant metrics. */
+export type GeometryFamily = "point" | "line" | "polygon" | "mixed" | "none";
+
+function familyOf(geometry: Geometry | null | undefined): GeometryFamily | null {
+  switch (geometry?.type) {
+    case "Point":
+    case "MultiPoint":
+      return "point";
+    case "LineString":
+    case "MultiLineString":
+      return "line";
+    case "Polygon":
+    case "MultiPolygon":
+      return "polygon";
+    default:
+      return null;
+  }
+}
+
+/**
+ * The dominant geometry family across a layer's features: the single family when
+ * they agree, `"mixed"` when they differ, `"none"` when none carry measurable
+ * geometry (e.g. a DuckDB query layer whose rows have no geometry).
+ */
+export function detectGeometryFamily(features: Feature[]): GeometryFamily {
+  let family: GeometryFamily | null = null;
+  for (const feature of features) {
+    const current = familyOf(feature.geometry);
+    if (!current) continue;
+    if (family === null) family = current;
+    else if (family !== current) return "mixed";
+  }
+  return family ?? "none";
+}
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/** Great-circle distance in meters between two [lon, lat] positions. */
+function haversineMeters(a: Position, b: Position, radius: number): number {
+  const lat1 = a[1] * DEG_TO_RAD;
+  const lat2 = b[1] * DEG_TO_RAD;
+  const dLat = lat2 - lat1;
+  const dLon = (b[0] - a[0]) * DEG_TO_RAD;
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * radius * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/** Summed great-circle length in meters along a run of positions. */
+function lineLengthMeters(coords: Position[], radius: number): number {
+  let total = 0;
+  for (let i = 1; i < coords.length; i += 1) {
+    total += haversineMeters(coords[i - 1], coords[i], radius);
+  }
+  return total;
+}
+
+/**
+ * Spherical area in square meters of a single ring (its coordinates as a closed
+ * or open loop). Signed by winding order; callers take the absolute value and
+ * subtract holes as needed.
+ */
+function ringAreaMeters(ring: Position[], radius: number): number {
+  const n = ring.length;
+  if (n < 3) return 0;
+  let total = 0;
+  for (let i = 0; i < n; i += 1) {
+    const p1 = ring[i];
+    const p2 = ring[(i + 1) % n];
+    total +=
+      (p2[0] - p1[0]) *
+      DEG_TO_RAD *
+      (2 + Math.sin(p1[1] * DEG_TO_RAD) + Math.sin(p2[1] * DEG_TO_RAD));
+  }
+  return (total * radius * radius) / 2;
+}
+
+/** Absolute polygon area (outer ring minus holes) in square meters. */
+function polygonAreaMeters(rings: Position[][], radius: number): number {
+  if (rings.length === 0) return 0;
+  let area = Math.abs(ringAreaMeters(rings[0], radius));
+  for (let i = 1; i < rings.length; i += 1) {
+    area -= Math.abs(ringAreaMeters(rings[i], radius));
+  }
+  return Math.max(0, area);
+}
+
+/** Summed perimeter in meters of a polygon's rings (outer + holes). */
+function polygonPerimeterMeters(rings: Position[][], radius: number): number {
+  let total = 0;
+  for (const ring of rings) {
+    // Close the ring so the final vertex→first vertex segment is counted even
+    // when the source coordinates are not explicitly closed.
+    const closed =
+      ring.length > 0 && ring[0] !== ring[ring.length - 1]
+        ? [...ring, ring[0]]
+        : ring;
+    total += lineLengthMeters(closed, radius);
+  }
+  return total;
+}
+
+/**
+ * Length in the given unit of a line geometry (meters by default). Returns 0 for
+ * geometries that have no linear extent (points, polygons — use `measurePerimeter`
+ * for a polygon's boundary). GeometryCollections sum their members.
+ */
+export function measureLength(
+  geometry: Geometry | null | undefined,
+  unit: DistanceUnit = "meters",
+): number {
+  if (!geometry) return 0;
+  const radius = getActiveMeanRadiusMeters();
+  const factor = DISTANCE_FACTORS[unit] ?? 1;
+  return lengthMeters(geometry, radius) * factor;
+}
+
+function lengthMeters(geometry: Geometry, radius: number): number {
+  switch (geometry.type) {
+    case "LineString":
+      return lineLengthMeters(geometry.coordinates, radius);
+    case "MultiLineString":
+      return geometry.coordinates.reduce(
+        (sum, line) => sum + lineLengthMeters(line, radius),
+        0,
+      );
+    case "GeometryCollection":
+      return geometry.geometries.reduce(
+        (sum, g) => sum + lengthMeters(g, radius),
+        0,
+      );
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Perimeter in the given unit of a polygon geometry (meters by default). Returns
+ * 0 for non-polygon geometries. GeometryCollections sum their members.
+ */
+export function measurePerimeter(
+  geometry: Geometry | null | undefined,
+  unit: DistanceUnit = "meters",
+): number {
+  if (!geometry) return 0;
+  const radius = getActiveMeanRadiusMeters();
+  const factor = DISTANCE_FACTORS[unit] ?? 1;
+  return perimeterMeters(geometry, radius) * factor;
+}
+
+function perimeterMeters(geometry: Geometry, radius: number): number {
+  switch (geometry.type) {
+    case "Polygon":
+      return polygonPerimeterMeters(geometry.coordinates, radius);
+    case "MultiPolygon":
+      return geometry.coordinates.reduce(
+        (sum, rings) => sum + polygonPerimeterMeters(rings, radius),
+        0,
+      );
+    case "GeometryCollection":
+      return geometry.geometries.reduce(
+        (sum, g) => sum + perimeterMeters(g, radius),
+        0,
+      );
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Area in the given unit of a polygon geometry (square meters by default).
+ * Returns 0 for non-polygon geometries. GeometryCollections sum their members.
+ */
+export function measureArea(
+  geometry: Geometry | null | undefined,
+  unit: AreaUnit = "square-meters",
+): number {
+  if (!geometry) return 0;
+  const radius = getActiveMeanRadiusMeters();
+  const factor = AREA_FACTORS[unit] ?? 1;
+  return areaMeters(geometry, radius) * factor;
+}
+
+function areaMeters(geometry: Geometry, radius: number): number {
+  switch (geometry.type) {
+    case "Polygon":
+      return polygonAreaMeters(geometry.coordinates, radius);
+    case "MultiPolygon":
+      return geometry.coordinates.reduce(
+        (sum, rings) => sum + polygonAreaMeters(rings, radius),
+        0,
+      );
+    case "GeometryCollection":
+      return geometry.geometries.reduce(
+        (sum, g) => sum + areaMeters(g, radius),
+        0,
+      );
+    default:
+      return 0;
+  }
+}

--- a/tests/geometry-measure.test.ts
+++ b/tests/geometry-measure.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { setActiveEllipsoidId } from "@geolibre/core";
+import type { FeatureCollection, Geometry } from "geojson";
+import { calculateField } from "../apps/geolibre-desktop/src/lib/attribute-columns";
+import { compileExpression } from "../apps/geolibre-desktop/src/lib/attribute-expression";
+import {
+  detectGeometryFamily,
+  measureArea,
+  measureLength,
+  measurePerimeter,
+} from "../apps/geolibre-desktop/src/lib/geometry-measure";
+
+// A 1° segment along the equator and a small square near the equator give stable
+// reference values against Earth's default mean radius (~6371008.77 m).
+const EQUATOR_SEGMENT: Geometry = {
+  type: "LineString",
+  coordinates: [
+    [0, 0],
+    [1, 0],
+  ],
+};
+
+// 0.01° × 0.01° box near the equator (roughly 1.11 km on a side).
+const SMALL_BOX: Geometry = {
+  type: "Polygon",
+  coordinates: [
+    [
+      [0, 0],
+      [0.01, 0],
+      [0.01, 0.01],
+      [0, 0.01],
+      [0, 0],
+    ],
+  ],
+};
+
+describe("geometry-measure", () => {
+  afterEach(() => {
+    // The active ellipsoid is a global singleton; keep tests independent.
+    setActiveEllipsoidId("earth");
+  });
+
+  it("measures a line's geodesic length, with unit conversion", () => {
+    const km = measureLength(EQUATOR_SEGMENT, "kilometers");
+    assert.ok(Math.abs(km - 111.19) < 0.2, `expected ~111.19 km, got ${km}`);
+    // Units are consistent multiples of the base meter value.
+    const meters = measureLength(EQUATOR_SEGMENT, "meters");
+    assert.ok(Math.abs(meters / km - 1000) < 1e-6);
+    const feet = measureLength(EQUATOR_SEGMENT, "feet");
+    assert.ok(Math.abs(feet / meters - 3.280839895) < 1e-6);
+  });
+
+  it("sums MultiLineString parts and defaults to meters", () => {
+    const multi: Geometry = {
+      type: "MultiLineString",
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+        ],
+        [
+          [0, 0],
+          [1, 0],
+        ],
+      ],
+    };
+    const single = measureLength(EQUATOR_SEGMENT);
+    assert.ok(Math.abs(measureLength(multi) - single * 2) < 1e-6);
+  });
+
+  it("returns 0 length for geometries with no linear extent", () => {
+    assert.equal(measureLength({ type: "Point", coordinates: [0, 0] }), 0);
+    assert.equal(measureLength(SMALL_BOX), 0);
+    assert.equal(measureLength(null), 0);
+  });
+
+  it("measures polygon area and perimeter", () => {
+    const sqm = measureArea(SMALL_BOX, "square-meters");
+    // ~1.11 km per side → ~1.23e6 m².
+    assert.ok(sqm > 1.2e6 && sqm < 1.26e6, `unexpected area ${sqm}`);
+    const hectares = measureArea(SMALL_BOX, "hectares");
+    assert.ok(Math.abs(sqm / hectares - 10000) < 1e-6);
+
+    const perimeterM = measurePerimeter(SMALL_BOX, "meters");
+    const sideM = measureLength(
+      { type: "LineString", coordinates: [[0, 0], [0.01, 0]] },
+      "meters",
+    );
+    // Four ~equal sides near the equator.
+    assert.ok(Math.abs(perimeterM - sideM * 4) < sideM * 0.02);
+  });
+
+  it("subtracts holes from polygon area", () => {
+    const withHole: Geometry = {
+      type: "Polygon",
+      coordinates: [
+        SMALL_BOX.type === "Polygon" ? SMALL_BOX.coordinates[0] : [],
+        [
+          [0.002, 0.002],
+          [0.008, 0.002],
+          [0.008, 0.008],
+          [0.002, 0.008],
+          [0.002, 0.002],
+        ],
+      ],
+    };
+    assert.ok(measureArea(withHole) < measureArea(SMALL_BOX));
+  });
+
+  it("returns 0 area/perimeter for non-polygon geometries", () => {
+    assert.equal(measureArea(EQUATOR_SEGMENT), 0);
+    assert.equal(measurePerimeter(EQUATOR_SEGMENT), 0);
+    assert.equal(measureArea(null), 0);
+  });
+
+  it("honors the active ellipsoid's radius", () => {
+    const earth = measureLength(EQUATOR_SEGMENT, "meters");
+    setActiveEllipsoidId("moon");
+    const moon = measureLength(EQUATOR_SEGMENT, "meters");
+    // The Moon's radius is roughly 27% of Earth's, so the same span is shorter.
+    assert.ok(moon < earth * 0.3, `moon ${moon} vs earth ${earth}`);
+  });
+
+  it("detects the dominant geometry family", () => {
+    const feature = (geometry: Geometry) =>
+      ({ type: "Feature", geometry, properties: {} }) as const;
+    assert.equal(
+      detectGeometryFamily([feature(SMALL_BOX)]),
+      "polygon",
+    );
+    assert.equal(
+      detectGeometryFamily([feature(EQUATOR_SEGMENT)]),
+      "line",
+    );
+    assert.equal(
+      detectGeometryFamily([feature(SMALL_BOX), feature(EQUATOR_SEGMENT)]),
+      "mixed",
+    );
+    assert.equal(detectGeometryFamily([]), "none");
+    assert.equal(
+      detectGeometryFamily([feature({ type: "Point", coordinates: [0, 0] })]),
+      "point",
+    );
+  });
+});
+
+describe("geometry helpers in the field calculator", () => {
+  afterEach(() => setActiveEllipsoidId("earth"));
+
+  it("exposes $length/$perimeter/$area bound to the feature geometry", () => {
+    const compiled = compileExpression('$area("hectares")', []);
+    const value = compiled.evaluate({}, 0, SMALL_BOX);
+    assert.equal(value, measureArea(SMALL_BOX, "hectares"));
+  });
+
+  it("cannot be shadowed by a same-named field, and defaults units", () => {
+    const compiled = compileExpression("$length()", ["$length"]);
+    assert.equal(
+      compiled.evaluate({ $length: 999 }, 0, EQUATOR_SEGMENT),
+      measureLength(EQUATOR_SEGMENT),
+    );
+  });
+
+  it("writes a geometry-derived column via calculateField", () => {
+    const geojson: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "f0",
+          geometry: EQUATOR_SEGMENT,
+          properties: { name: "line" },
+        },
+      ],
+    };
+    const layer = {
+      id: "l1",
+      name: "L",
+      type: "geojson" as const,
+      source: { type: "geojson" as const },
+      visible: true,
+      opacity: 1,
+      style: {},
+      metadata: {},
+      geojson,
+    };
+    const result = calculateField(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      layer as any,
+      ["name"],
+      "len_km",
+      true,
+      '$length("kilometers")',
+      "number",
+    );
+    assert.ok(result && "patch" in result);
+    const written = (result.patch.geojson as FeatureCollection).features[0]
+      .properties?.len_km as number;
+    assert.ok(Math.abs(written - 111.19) < 0.2, `got ${written}`);
+  });
+});

--- a/tests/geometry-measure.test.ts
+++ b/tests/geometry-measure.test.ts
@@ -5,7 +5,7 @@ import type { FeatureCollection, Geometry } from "geojson";
 import { calculateField } from "../apps/geolibre-desktop/src/lib/attribute-columns";
 import { compileExpression } from "../apps/geolibre-desktop/src/lib/attribute-expression";
 import {
-  detectGeometryFamily,
+  detectGeometryFamilies,
   measureArea,
   measureLength,
   measurePerimeter,
@@ -169,15 +169,20 @@ describe("geometry-measure", () => {
     // measure* recurse into the collection.
     assert.equal(measureArea(collection), measureArea(SMALL_BOX));
     assert.equal(measureLength(collection), measureLength(EQUATOR_SEGMENT));
-    // A mixed collection is classified "mixed"; a uniform one takes its family.
+    // A collection reports every base family it contains.
     const feature = (geometry: Geometry) =>
       ({ type: "Feature", geometry, properties: {} }) as const;
-    assert.equal(detectGeometryFamily([feature(collection)]), "mixed");
-    assert.equal(
-      detectGeometryFamily([
-        feature({ type: "GeometryCollection", geometries: [SMALL_BOX] }),
-      ]),
-      "polygon",
+    assert.deepEqual(
+      [...detectGeometryFamilies([feature(collection)])].sort(),
+      ["line", "polygon"],
+    );
+    assert.deepEqual(
+      [
+        ...detectGeometryFamilies([
+          feature({ type: "GeometryCollection", geometries: [SMALL_BOX] }),
+        ]),
+      ],
+      ["polygon"],
     );
   });
 
@@ -189,25 +194,28 @@ describe("geometry-measure", () => {
     assert.ok(moon < earth * 0.3, `moon ${moon} vs earth ${earth}`);
   });
 
-  it("detects the dominant geometry family", () => {
+  it("detects the set of present geometry families", () => {
     const feature = (geometry: Geometry) =>
       ({ type: "Feature", geometry, properties: {} }) as const;
-    assert.equal(
-      detectGeometryFamily([feature(SMALL_BOX)]),
+    assert.deepEqual([...detectGeometryFamilies([feature(SMALL_BOX)])], [
       "polygon",
-    );
-    assert.equal(
-      detectGeometryFamily([feature(EQUATOR_SEGMENT)]),
+    ]);
+    assert.deepEqual([...detectGeometryFamilies([feature(EQUATOR_SEGMENT)])], [
       "line",
+    ]);
+    assert.deepEqual(
+      [
+        ...detectGeometryFamilies([
+          feature(SMALL_BOX),
+          feature(EQUATOR_SEGMENT),
+        ]),
+      ].sort(),
+      ["line", "polygon"],
     );
-    assert.equal(
-      detectGeometryFamily([feature(SMALL_BOX), feature(EQUATOR_SEGMENT)]),
-      "mixed",
-    );
-    assert.equal(detectGeometryFamily([]), "none");
-    assert.equal(
-      detectGeometryFamily([feature({ type: "Point", coordinates: [0, 0] })]),
-      "point",
+    assert.equal(detectGeometryFamilies([]).size, 0);
+    assert.deepEqual(
+      [...detectGeometryFamilies([feature({ type: "Point", coordinates: [0, 0] })])],
+      ["point"],
     );
   });
 });

--- a/tests/geometry-measure.test.ts
+++ b/tests/geometry-measure.test.ts
@@ -114,6 +114,73 @@ describe("geometry-measure", () => {
     assert.equal(measureArea(null), 0);
   });
 
+  it("handles polygons that cross the antimeridian", () => {
+    // A 2°×1° box spanning 179° → -179°. Its longitude delta must be treated as
+    // the short 2° step, not a 358° one, so its area matches an equivalent box
+    // that does not cross ±180°.
+    const crossing: Geometry = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [179, 0],
+          [-179, 0],
+          [-179, 1],
+          [179, 1],
+          [179, 0],
+        ],
+      ],
+    };
+    const equivalent: Geometry = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 1],
+          [0, 1],
+          [0, 0],
+        ],
+      ],
+    };
+    const crossingArea = measureArea(crossing, "square-kilometers");
+    const equivArea = measureArea(equivalent, "square-kilometers");
+    assert.ok(
+      Math.abs(crossingArea - equivArea) / equivArea < 1e-6,
+      `crossing ${crossingArea} vs equivalent ${equivArea}`,
+    );
+    // Sanity: this is a small (~25k km²) box, not a near-global one.
+    assert.ok(crossingArea < 30000, `unexpectedly large area ${crossingArea}`);
+  });
+
+  it("throws on an unrecognized unit so a typo surfaces as an error", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.throws(() => measureArea(SMALL_BOX, "hectare" as any));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.throws(() => measureLength(EQUATOR_SEGMENT, "km" as any));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    assert.throws(() => measurePerimeter(SMALL_BOX, "kilometre" as any));
+  });
+
+  it("measures and classifies GeometryCollections by their members", () => {
+    const collection: Geometry = {
+      type: "GeometryCollection",
+      geometries: [SMALL_BOX, EQUATOR_SEGMENT],
+    };
+    // measure* recurse into the collection.
+    assert.equal(measureArea(collection), measureArea(SMALL_BOX));
+    assert.equal(measureLength(collection), measureLength(EQUATOR_SEGMENT));
+    // A mixed collection is classified "mixed"; a uniform one takes its family.
+    const feature = (geometry: Geometry) =>
+      ({ type: "Feature", geometry, properties: {} }) as const;
+    assert.equal(detectGeometryFamily([feature(collection)]), "mixed");
+    assert.equal(
+      detectGeometryFamily([
+        feature({ type: "GeometryCollection", geometries: [SMALL_BOX] }),
+      ]),
+      "polygon",
+    );
+  });
+
   it("honors the active ellipsoid's radius", () => {
     const earth = measureLength(EQUATOR_SEGMENT, "meters");
     setActiveEllipsoidId("moon");


### PR DESCRIPTION
## Summary

Enhances the **Calculate** tool (Field Calculator) under the Attribute Table so users can compute a feature's geometric **Length**, **Perimeter**, and **Area** in different units, matching the **Measure** tool, and scoped to All Features or just the selected feature. Addresses discussion #1167.

## What changed

- **New `geometry-measure.ts` helper** computes geodesic length/perimeter (haversine) and spherical-excess area of GeoJSON geometries. It uses the active body's **mean radius** (Earth / Moon / Mars) from `@geolibre/core`, so results stay consistent with the Measure tool and non-Earth ellipsoids. Units mirror the Measure tool exactly:
  - Distance: `m`, `km`, `ft`, `yd`, `mi`, `nmi`
  - Area: `m²`, `km²`, `ha`, `ft²`, `ac`, `mi²`
- **Expression engine** now exposes `$length(unit)`, `$perimeter(unit)`, and `$area(unit)`, each bound to the feature's own geometry (e.g. `$area("hectares")`, `$length("kilometers")`). They cannot be shadowed by a same-named field and default to base units.
- **Calculate dialog** gains a **Geometry** row: a metric dropdown filtered by the layer's geometry type (Area/Perimeter for polygons, Length for lines; hidden for point/geometry-less layers) plus a unit dropdown, and an **Insert** button that writes the snippet into the expression. The existing "Only update the selected feature" checkbox already covers the All / Selected scope.
- New i18n strings under `attributeTable` (`en.json`).

## Tests

- `tests/geometry-measure.test.ts`: geodesic length + spherical area with unit conversions, hole subtraction, geometry-family detection, active-ellipsoid scaling, and the `$length/$perimeter/$area` expression + `calculateField` integration.
- Full `npm run build` and `pre-commit` pass.

## Verified in the real app (Playwright, light + dark themes)

- **Polygon layer, light theme** — `$area("hectares")` on a 1°×1° cell at 40–41°N wrote **940,180 ha** (≈ 9,400 km², cross-checked against `R²·Δlon·(sin41°−sin40°)`); a 2°×2° cell wrote **3,732,406 ha**.
- **Line layer, dark theme** — `$length("kilometers")`: a 1° segment along 40°N wrote **85.18 km**; a 2° meridian + 2° parallel wrote **387.65 km**. Both match hand-computed geodesic values.
- The metric dropdown correctly showed Area/Perimeter for the polygon layer and Length for the line layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Field Calculator expressions are now geometry-aware via helper functions for **length**, **perimeter**, and **area**, using each feature’s actual geometry for evaluation and live previews.
  - Unit-aware metric options are shown based on the current layer’s supported geometry types, and geometry measurement snippets can be inserted into expressions.
- **Tests**
  - Added deterministic tests for geodesic measurement, unit conversions, antimeridian handling, geometry collections, and Field Calculator integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->