### PR TITLE
feat(diagnostics): capture native Tauri HTTP requests in the network log; classify failed fetch() errors

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -251,12 +251,12 @@ async function fetchCapabilitiesText(
     // but race it against the caller's abort + a 30s cap so this call still
     // returns promptly (matching the browser fetch branch below) rather than
     // hanging on a slow host or a superseded request.
-    const { invoke } = await import("@tauri-apps/api/core");
+    const { fetchUrlBytes } = await import("../../../lib/native-http");
     const timeout = AbortSignal.timeout(30_000);
     const abort = signal ? AbortSignal.any([signal, timeout]) : timeout;
     try {
       const bytes = await Promise.race([
-        invoke<number[] | Uint8Array>("fetch_url_bytes", { url: requestUrl }),
+        fetchUrlBytes(requestUrl, { context: "OGC GetCapabilities" }),
         rejectOnAbort(abort),
       ]);
       const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -5,6 +5,8 @@
 
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
+import type { TFunction } from "i18next";
+import { classifyFetchFailure } from "../../../lib/fetch-error";
 import { isTauri } from "../../../lib/is-tauri";
 import {
   DELIMITED_TEXT_DELIMITERS,
@@ -201,6 +203,25 @@ export function errorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string" && error.trim()) return error;
   return fallback;
+}
+
+/**
+ * Builds a translated, user-facing message for a failed service request in the
+ * Add Data forms. A network/TLS/CORS or timeout failure (the ones the browser
+ * or native path report opaquely) maps to a localized hint; anything else keeps
+ * the error's own message so a service exception or status text still shows
+ * through. This routes the fetch-error classification through `t()` so the form
+ * does not surface an untranslated string next to its localized labels.
+ */
+export function serviceRequestErrorMessage(
+  error: unknown,
+  t: TFunction,
+  fallback: string,
+): string {
+  const { kind } = classifyFetchFailure(error);
+  if (kind === "network") return t("addData.common.networkFailure");
+  if (kind === "timeout") return t("addData.common.requestTimedOut");
+  return errorMessage(error, fallback);
 }
 
 function isViteDevServer(): boolean {

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -275,11 +275,15 @@ async function fetchCapabilitiesText(
     const { fetchUrlBytes } = await import("../../../lib/native-http");
     const timeout = AbortSignal.timeout(30_000);
     const abort = signal ? AbortSignal.any([signal, timeout]) : timeout;
+    const bytesPromise = fetchUrlBytes(requestUrl, {
+      context: "OGC GetCapabilities",
+    });
+    // If the abort/timeout wins the race, the native call is left unobserved;
+    // swallow its later rejection so it does not surface as an unhandled
+    // rejection (it is still recorded in diagnostics by the native-http wrapper).
+    bytesPromise.catch(() => {});
     try {
-      const bytes = await Promise.race([
-        fetchUrlBytes(requestUrl, { context: "OGC GetCapabilities" }),
-        rejectOnAbort(abort),
-      ]);
+      const bytes = await Promise.race([bytesPromise, rejectOnAbort(abort)]);
       const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
       return { ok: true, status: 200, text: decodeXmlBytes(array) };
     } catch (error) {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -4,9 +4,9 @@ import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { fetchWfsGeoJson } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
+import { fetchFailureMessage } from "../../../../lib/fetch-error";
 import {
   createBaseLayer,
-  errorMessage,
   fetchWfsFeatureTypes,
   stripOgcOperationParams,
   type WfsFeatureTypeOption,
@@ -128,7 +128,7 @@ export function WfsSource() {
     } catch (error) {
       if (isStale()) return;
       setTypeOptions([]);
-      setRetrieveError(errorMessage(error, t("addData.wfs.retrieveError")));
+      setRetrieveError(fetchFailureMessage(error, t("addData.wfs.retrieveError")));
     } finally {
       if (token === retrieveTokenRef.current) setIsRetrieving(false);
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -4,10 +4,10 @@ import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { fetchWfsGeoJson } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
-import { fetchFailureMessage } from "../../../../lib/fetch-error";
 import {
   createBaseLayer,
   fetchWfsFeatureTypes,
+  serviceRequestErrorMessage,
   stripOgcOperationParams,
   type WfsFeatureTypeOption,
 } from "../helpers";
@@ -128,7 +128,9 @@ export function WfsSource() {
     } catch (error) {
       if (isStale()) return;
       setTypeOptions([]);
-      setRetrieveError(fetchFailureMessage(error, t("addData.wfs.retrieveError")));
+      setRetrieveError(
+        serviceRequestErrorMessage(error, t, t("addData.wfs.retrieveError")),
+      );
     } finally {
       if (token === retrieveTokenRef.current) setIsRetrieving(false);
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -3,12 +3,12 @@ import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
-import { fetchFailureMessage } from "../../../../lib/fetch-error";
 import {
   createBaseLayer,
   createWmsTileUrl,
   fetchWmsCapabilities,
   normalizeWmsVersion,
+  serviceRequestErrorMessage,
   stripOgcOperationParams,
   wmsVersionFromEndpoint,
   type WmsLayerOption,
@@ -158,7 +158,9 @@ export function WmsSource() {
     } catch (error) {
       if (isStale()) return;
       setLayerOptions([]);
-      setRetrieveError(fetchFailureMessage(error, t("addData.wms.retrieveError")));
+      setRetrieveError(
+        serviceRequestErrorMessage(error, t, t("addData.wms.retrieveError")),
+      );
     } finally {
       if (token === retrieveTokenRef.current) setIsRetrieving(false);
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -3,10 +3,10 @@ import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
+import { fetchFailureMessage } from "../../../../lib/fetch-error";
 import {
   createBaseLayer,
   createWmsTileUrl,
-  errorMessage,
   fetchWmsCapabilities,
   normalizeWmsVersion,
   stripOgcOperationParams,
@@ -158,7 +158,7 @@ export function WmsSource() {
     } catch (error) {
       if (isStale()) return;
       setLayerOptions([]);
-      setRetrieveError(errorMessage(error, t("addData.wms.retrieveError")));
+      setRetrieveError(fetchFailureMessage(error, t("addData.wms.retrieveError")));
     } finally {
       if (token === retrieveTokenRef.current) setIsRetrieving(false);
     }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -75,6 +75,7 @@ import {
   type InstalledWebPlugin,
 } from "../lib/external-plugins";
 import { appendDiagnostic } from "../lib/diagnostics";
+import { fetchUrlBytes } from "../lib/native-http";
 import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
 import {
   createWmsTileUrl,
@@ -969,9 +970,7 @@ async function fetchRemoteArrayBuffer(url: string): Promise<ArrayBuffer> {
 
   if (isTauriRuntime()) {
     try {
-      const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
-        url,
-      });
+      const bytes = await fetchUrlBytes(url, { context: "plugin resource" });
       return normalizeBytes(bytes);
     } catch {
       // Fall back to browser fetch for web builds and during local development.

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -208,7 +208,9 @@
       "noFileSelected": "No file selected",
       "loading": "Loading...",
       "workspaceLayerPlaceholder": "workspace:layer",
-      "requestFailed": "Request failed with status {{status}}"
+      "requestFailed": "Request failed with status {{status}}",
+      "networkFailure": "Could not reach the service. Check that the host is reachable and that its TLS certificate, firewall, and proxy settings allow the request; in the browser it may also be blocked by CORS, so try the desktop app.",
+      "requestTimedOut": "The request timed out. The host may be slow, unreachable, or blocked by a firewall or proxy."
     },
     "serviceLibrary": {
       "title": "Saved services",

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -447,7 +447,7 @@ export function installDiagnosticsCapture(): () => void {
           ? `${method} aborted`
           : benignStartup
             ? `${method} request failed (benign Tauri custom-protocol warm-up)`
-            : failure
+            : failure && failure.kind !== "unknown"
               ? `${method} request failed (${failure.label})`
               : `${method} request failed`,
         detail:

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -239,7 +239,13 @@ function safeStringify(value: unknown): string {
   }
 }
 
-function formatUnknown(value: unknown): string {
+/**
+ * Renders an arbitrary thrown value as a diagnostics detail string: an Error's
+ * stack (or message), a string as-is, anything else JSON-stringified. Exported
+ * so callers that build their own records (e.g. native-http.ts) format errors
+ * the same way.
+ */
+export function formatUnknown(value: unknown): string {
   if (value instanceof Error) return value.stack ?? value.message;
   if (typeof value === "string") return value;
   return safeStringify(value);
@@ -324,7 +330,10 @@ export function appendDiagnostic(input: DiagnosticInput): void {
     ...input,
     id: `diagnostic-${Date.now()}-${sequence++}`,
     timestamp: input.timestamp ?? new Date().toISOString(),
-    message: truncate(input.message),
+    // Runtime/plugin/console emitters can forward an arbitrary error or console
+    // string (which may embed a tokenized URL) into either field, so redact both
+    // the same way as the `url` field before storing/exporting them.
+    message: truncate(redactUrlsInText(input.message)),
     detail: input.detail ? truncate(redactUrlsInText(input.detail)) : undefined,
     source: input.source ? truncate(input.source) : undefined,
     url: input.url ? truncate(redactUrl(input.url)) : undefined,

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -271,6 +271,21 @@ function redactUrl(raw: string): string {
   }
 }
 
+// Matches an http(s) URL embedded in free text, stopping before whitespace or a
+// closing delimiter so a URL inside `(...)` or quotes is captured without its
+// surrounding punctuation.
+const EMBEDDED_URL = /https?:\/\/[^\s)"'<>]+/g;
+
+// A record's `detail` often carries a raw error string, and a native
+// (Rust/reqwest) error embeds the full request URL verbatim — including any
+// `api_key`/`token` query param that `redactUrl` strips from the record's `url`
+// field. The detail is rendered in the panel and included in the "Copy JSON"
+// export, so redact any URLs it contains the same way, keeping secrets out of
+// exported diagnostics.
+function redactUrlsInText(text: string): string {
+  return text.replace(EMBEDDED_URL, (match) => redactUrl(match));
+}
+
 function requestUrl(input: Parameters<typeof fetch>[0]): string {
   if (input instanceof Request) return input.url;
   if (input instanceof URL) return input.toString();
@@ -310,7 +325,7 @@ export function appendDiagnostic(input: DiagnosticInput): void {
     id: `diagnostic-${Date.now()}-${sequence++}`,
     timestamp: input.timestamp ?? new Date().toISOString(),
     message: truncate(input.message),
-    detail: input.detail ? truncate(input.detail) : undefined,
+    detail: input.detail ? truncate(redactUrlsInText(input.detail)) : undefined,
     source: input.source ? truncate(input.source) : undefined,
     url: input.url ? truncate(redactUrl(input.url)) : undefined,
   };

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from "react";
+import { classifyFetchFailure } from "./fetch-error";
 import { isTauri } from "./is-tauri";
 
 export type DiagnosticCategory = "console" | "map" | "network" | "runtime";
@@ -431,6 +432,13 @@ export function installDiagnosticsCapture(): () => void {
       // It mirrors the unhandled-rejection downgrade below; genuine failures
       // outside the window are still flagged as errors.
       const benignStartup = !isAbort && !optional && isBenignStartupFetch(error);
+      // Classify a genuine failure (network/TLS/CORS vs. timeout) so the panel
+      // record interprets the otherwise-opaque browser error and carries an
+      // actionable hint (issue #1175). Aborts, optional-resource failures, and
+      // the benign startup warm-up keep their existing handling above.
+      const classified = !isAbort && !optional && !benignStartup;
+      const failure = classified ? classifyFetchFailure(error) : null;
+      const rawDetail = isAbort ? undefined : formatUnknown(error);
       appendDiagnostic({
         category: "network",
         level:
@@ -439,8 +447,13 @@ export function installDiagnosticsCapture(): () => void {
           ? `${method} aborted`
           : benignStartup
             ? `${method} request failed (benign Tauri custom-protocol warm-up)`
-            : `${method} request failed`,
-        detail: isAbort ? undefined : formatUnknown(error),
+            : failure
+              ? `${method} request failed (${failure.label})`
+              : `${method} request failed`,
+        detail:
+          failure?.hint && rawDetail
+            ? `${failure.hint}\n\n${rawDetail}`
+            : rawDetail,
         durationMs: Math.round(performance.now() - startedAt),
         method,
         url,

--- a/apps/geolibre-desktop/src/lib/fetch-error.ts
+++ b/apps/geolibre-desktop/src/lib/fetch-error.ts
@@ -1,0 +1,109 @@
+/**
+ * Classifies a failed outbound request (a browser `fetch()` rejection or a
+ * native Tauri HTTP command error) into an actionable category with a hint.
+ *
+ * The browser deliberately collapses distinct network failures — a CORS
+ * rejection, a TLS/certificate error, a DNS failure, a refused connection,
+ * blocked mixed content — into one indistinguishable `TypeError: Failed to
+ * fetch` (`Load failed` on WebKit), so the exact cause often cannot be pinned
+ * down from the thrown value. The hint therefore enumerates the common causes so
+ * a user or admin knows what to investigate. The native (Rust/reqwest) path does
+ * carry a descriptive message, so its errors can be narrowed further by keyword.
+ */
+
+export type FetchFailureKind = "abort" | "timeout" | "network" | "unknown";
+
+export interface FetchFailure {
+  kind: FetchFailureKind;
+  /** Short label for a diagnostics record message (e.g. "network/TLS/CORS"). */
+  label: string;
+  /** One-sentence actionable hint, or null when none applies (aborts). */
+  hint: string | null;
+}
+
+// Browser fetch collapses every network-layer failure into this opaque message.
+const BROWSER_NETWORK_MESSAGES = ["failed to fetch", "load failed"];
+
+// Keywords a native reqwest error uses for the same underlying failures. Matched
+// case-insensitively against the error text so the native path can be narrowed
+// to a network failure even though it never throws a browser TypeError.
+const NATIVE_NETWORK_KEYWORDS = [
+  "certificate",
+  "tls",
+  "ssl",
+  "handshake",
+  "dns",
+  "resolve",
+  "connect",
+  "connection",
+  "unreachable",
+  "network",
+  "refused",
+];
+
+const NETWORK_HINT =
+  "The request could not be completed. In the browser this is usually a CORS rejection (the server sent no Access-Control-Allow-Origin header for this origin), a TLS/certificate error, blocked mixed content, or an unreachable host. Try the desktop app, which is not subject to browser CORS, or check the host's certificate, firewall, and proxy rules.";
+
+const TIMEOUT_HINT =
+  "The request exceeded its time limit. The host may be slow, unreachable, or blocked by a firewall or proxy.";
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "";
+}
+
+function isBrowserNetworkMessage(lowerMessage: string): boolean {
+  return BROWSER_NETWORK_MESSAGES.some((needle) =>
+    lowerMessage.includes(needle),
+  );
+}
+
+function isNativeNetworkMessage(lowerMessage: string): boolean {
+  return NATIVE_NETWORK_KEYWORDS.some((needle) =>
+    lowerMessage.includes(needle),
+  );
+}
+
+/**
+ * Classifies a thrown fetch/native-HTTP failure. Aborts and timeouts are
+ * identified by their `DOMException`/`Error` name (or a "timed out" message from
+ * a wrapped race), network failures by the browser's opaque message or the
+ * native path's descriptive keywords; everything else is left `unknown` so its
+ * own message is preserved rather than being mislabeled.
+ */
+export function classifyFetchFailure(error: unknown): FetchFailure {
+  const name = error instanceof Error ? error.name : "";
+  if (name === "AbortError") {
+    return { kind: "abort", label: "aborted", hint: null };
+  }
+  if (name === "TimeoutError") {
+    return { kind: "timeout", label: "timed out", hint: TIMEOUT_HINT };
+  }
+
+  const lowerMessage = messageOf(error).toLowerCase();
+  if (lowerMessage.includes("timed out") || lowerMessage.includes("timeout")) {
+    return { kind: "timeout", label: "timed out", hint: TIMEOUT_HINT };
+  }
+  if (isBrowserNetworkMessage(lowerMessage)) {
+    return { kind: "network", label: "network/TLS/CORS", hint: NETWORK_HINT };
+  }
+  if (isNativeNetworkMessage(lowerMessage)) {
+    return { kind: "network", label: "network", hint: NETWORK_HINT };
+  }
+  return { kind: "unknown", label: "request failed", hint: null };
+}
+
+/**
+ * Builds a user-facing message for a failed request: the classified hint when
+ * the failure is a recognized network/timeout kind, otherwise the error's own
+ * message, falling back to the provided default. Used by the Add Data forms so
+ * the originating UI surfaces an actionable hint rather than a bare "Failed to
+ * fetch".
+ */
+export function fetchFailureMessage(error: unknown, fallback: string): string {
+  const { hint } = classifyFetchFailure(error);
+  if (hint) return hint;
+  const message = messageOf(error).trim();
+  return message || fallback;
+}

--- a/apps/geolibre-desktop/src/lib/fetch-error.ts
+++ b/apps/geolibre-desktop/src/lib/fetch-error.ts
@@ -24,13 +24,13 @@ export interface FetchFailure {
 // Browser fetch collapses every network-layer failure into this opaque message.
 const BROWSER_NETWORK_MESSAGES = ["failed to fetch", "load failed"];
 
-// Phrases a native reqwest error uses for the same underlying failures. Matched
-// case-insensitively against the error text so the native path can be narrowed
-// to a network failure even though it never throws a browser TypeError. Kept to
-// specific multi-word phrases (rather than bare words like "connect"/"network")
-// so a request URL embedded in reqwest's message — e.g. `error sending request
-// for url (https://host/connect)` — cannot collide with a keyword and
-// misclassify an unrelated failure.
+// Keywords a native reqwest error uses for the same underlying failures. Matched
+// case-insensitively against the error text (with any embedded request URL
+// stripped first — see `classifyFetchFailure`) so the native path can be
+// narrowed to a network failure even though it never throws a browser
+// TypeError. Because the URL is removed before matching, a word appearing only
+// in the URL's path or query (e.g. a `/certificate` path or `?timeout=30`
+// param) cannot collide with these keywords.
 const NATIVE_NETWORK_KEYWORDS = [
   "certificate",
   "tls",
@@ -105,9 +105,7 @@ export function classifyFetchFailure(error: unknown): FetchFailure {
   }
 
   const lowerMessage = message.toLowerCase();
-  if (lowerMessage.includes("timed out") || lowerMessage.includes("timeout")) {
-    return { kind: "timeout", label: "timed out", hint: TIMEOUT_HINT };
-  }
+  // The browser's opaque TypeError carries no URL, so match it on the full text.
   if (isBrowserNetworkMessage(lowerMessage)) {
     return {
       kind: "network",
@@ -115,7 +113,17 @@ export function classifyFetchFailure(error: unknown): FetchFailure {
       hint: BROWSER_NETWORK_HINT,
     };
   }
-  if (isNativeNetworkMessage(lowerMessage)) {
+  // A native reqwest error embeds the full request URL (usually in parens);
+  // strip it before keyword/timeout matching so a word in the URL's path or
+  // query — a `?timeout=30` param, a `/certificate` path — cannot collide with a
+  // keyword and misclassify the failure.
+  const causeText = lowerMessage
+    .replace(/\(https?:\/\/[^)]*\)/g, " ")
+    .replace(/https?:\/\/\S+/g, " ");
+  if (causeText.includes("timed out") || causeText.includes("timeout")) {
+    return { kind: "timeout", label: "timed out", hint: TIMEOUT_HINT };
+  }
+  if (isNativeNetworkMessage(causeText)) {
     return { kind: "network", label: "network", hint: NATIVE_NETWORK_HINT };
   }
   return { kind: "unknown", label: "request failed", hint: null };

--- a/apps/geolibre-desktop/src/lib/fetch-error.ts
+++ b/apps/geolibre-desktop/src/lib/fetch-error.ts
@@ -24,33 +24,56 @@ export interface FetchFailure {
 // Browser fetch collapses every network-layer failure into this opaque message.
 const BROWSER_NETWORK_MESSAGES = ["failed to fetch", "load failed"];
 
-// Keywords a native reqwest error uses for the same underlying failures. Matched
+// Phrases a native reqwest error uses for the same underlying failures. Matched
 // case-insensitively against the error text so the native path can be narrowed
-// to a network failure even though it never throws a browser TypeError.
+// to a network failure even though it never throws a browser TypeError. Kept to
+// specific multi-word phrases (rather than bare words like "connect"/"network")
+// so a request URL embedded in reqwest's message — e.g. `error sending request
+// for url (https://host/connect)` — cannot collide with a keyword and
+// misclassify an unrelated failure.
 const NATIVE_NETWORK_KEYWORDS = [
   "certificate",
   "tls",
   "ssl",
   "handshake",
-  "dns",
-  "resolve",
-  "connect",
-  "connection",
+  "dns error",
+  "failed to lookup",
+  "connection refused",
+  "connection reset",
+  "connect error",
+  "tcp connect",
   "unreachable",
-  "network",
-  "refused",
+  "os error",
 ];
 
-const NETWORK_HINT =
+// Shown for a browser fetch failure: the browser cannot say which of these
+// happened, and the desktop app bypasses browser CORS, so "try the desktop app"
+// is genuinely useful advice here.
+const BROWSER_NETWORK_HINT =
   "The request could not be completed. In the browser this is usually a CORS rejection (the server sent no Access-Control-Allow-Origin header for this origin), a TLS/certificate error, blocked mixed content, or an unreachable host. Try the desktop app, which is not subject to browser CORS, or check the host's certificate, firewall, and proxy rules.";
+
+// Shown for a native (Tauri/reqwest) failure: this path already runs in the
+// desktop app and is not subject to browser CORS, so the CORS / "try the desktop
+// app" advice is dropped and only the transport-level guidance is kept.
+const NATIVE_NETWORK_HINT =
+  "The request could not be completed. This is usually a TLS/certificate error, a DNS failure, a refused connection, or an unreachable host. Check the host's certificate, firewall, and proxy rules.";
 
 const TIMEOUT_HINT =
   "The request exceeded its time limit. The host may be slow, unreachable, or blocked by a firewall or proxy.";
 
-function messageOf(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  return "";
+/**
+ * Reads an error's `name` and `message` across the shapes fetch failures arrive
+ * in. `DOMException` (e.g. an `AbortError`/`TimeoutError` from
+ * `AbortSignal.timeout()`) is not guaranteed to be `instanceof Error` on every
+ * runtime — notably a known inconsistency on WebKit, the desktop app's macOS
+ * webview — so it is matched explicitly, mirroring the guard in `diagnostics.ts`.
+ */
+function errorNameAndMessage(error: unknown): { name: string; message: string } {
+  if (error instanceof Error || error instanceof DOMException) {
+    return { name: error.name, message: error.message };
+  }
+  if (typeof error === "string") return { name: "", message: error };
+  return { name: "", message: "" };
 }
 
 function isBrowserNetworkMessage(lowerMessage: string): boolean {
@@ -73,7 +96,7 @@ function isNativeNetworkMessage(lowerMessage: string): boolean {
  * own message is preserved rather than being mislabeled.
  */
 export function classifyFetchFailure(error: unknown): FetchFailure {
-  const name = error instanceof Error ? error.name : "";
+  const { name, message } = errorNameAndMessage(error);
   if (name === "AbortError") {
     return { kind: "abort", label: "aborted", hint: null };
   }
@@ -81,29 +104,19 @@ export function classifyFetchFailure(error: unknown): FetchFailure {
     return { kind: "timeout", label: "timed out", hint: TIMEOUT_HINT };
   }
 
-  const lowerMessage = messageOf(error).toLowerCase();
+  const lowerMessage = message.toLowerCase();
   if (lowerMessage.includes("timed out") || lowerMessage.includes("timeout")) {
     return { kind: "timeout", label: "timed out", hint: TIMEOUT_HINT };
   }
   if (isBrowserNetworkMessage(lowerMessage)) {
-    return { kind: "network", label: "network/TLS/CORS", hint: NETWORK_HINT };
+    return {
+      kind: "network",
+      label: "network/TLS/CORS",
+      hint: BROWSER_NETWORK_HINT,
+    };
   }
   if (isNativeNetworkMessage(lowerMessage)) {
-    return { kind: "network", label: "network", hint: NETWORK_HINT };
+    return { kind: "network", label: "network", hint: NATIVE_NETWORK_HINT };
   }
   return { kind: "unknown", label: "request failed", hint: null };
-}
-
-/**
- * Builds a user-facing message for a failed request: the classified hint when
- * the failure is a recognized network/timeout kind, otherwise the error's own
- * message, falling back to the provided default. Used by the Add Data forms so
- * the originating UI surfaces an actionable hint rather than a bare "Failed to
- * fetch".
- */
-export function fetchFailureMessage(error: unknown, fallback: string): string {
-  const { hint } = classifyFetchFailure(error);
-  if (hint) return hint;
-  const message = messageOf(error).trim();
-  return message || fallback;
 }

--- a/apps/geolibre-desktop/src/lib/native-http.ts
+++ b/apps/geolibre-desktop/src/lib/native-http.ts
@@ -1,0 +1,141 @@
+/**
+ * Thin wrappers around the native Tauri HTTP commands (`fetch_url_bytes`,
+ * `resolve_url_redirect`) that record every call in the Diagnostics network log.
+ *
+ * These commands run in Rust and never pass through `window.fetch`, so the
+ * diagnostics fetch interceptor cannot see them; their failures used to surface
+ * only in the UI that started the request. Routing every native call through
+ * here makes them visible in the Diagnostics panel — success entries are gated
+ * behind "Log all network requests" like ordinary fetches, while failures are
+ * always recorded and classified with an actionable hint (issue #1175).
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { appendDiagnostic, type DiagnosticInput } from "./diagnostics";
+import { classifyFetchFailure } from "./fetch-error";
+
+/** The native HTTP commands exposed by the Tauri backend. */
+export type NativeHttpCommand = "fetch_url_bytes" | "resolve_url_redirect";
+
+interface NativeHttpOptions {
+  /** Short feature label (e.g. "WFS GetCapabilities") added to the record. */
+  context?: string;
+}
+
+function formatNativeError(error: unknown): string {
+  if (error instanceof Error) return error.stack ?? error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+}
+
+function recordSource(command: NativeHttpCommand, context?: string): string {
+  return context ? `native ${command} — ${context}` : `native ${command}`;
+}
+
+/**
+ * Builds the info-level diagnostics record for a successful native HTTP call.
+ * Exported for testing (the wrapper cannot run without the Tauri runtime).
+ */
+export function nativeHttpSuccessRecord(
+  command: NativeHttpCommand,
+  url: string,
+  durationMs: number,
+  context?: string,
+): DiagnosticInput {
+  return {
+    category: "network",
+    level: "info",
+    message: `GET ${command}`,
+    durationMs,
+    method: "GET",
+    source: recordSource(command, context),
+    url,
+  };
+}
+
+/**
+ * Builds the error-level diagnostics record for a failed native HTTP call,
+ * classifying the failure and prepending an actionable hint to the raw error.
+ * Exported for testing (the wrapper cannot run without the Tauri runtime).
+ */
+export function nativeHttpFailureRecord(
+  command: NativeHttpCommand,
+  url: string,
+  error: unknown,
+  durationMs: number,
+  context?: string,
+): DiagnosticInput {
+  const { label, hint } = classifyFetchFailure(error);
+  const rawError = formatNativeError(error);
+  return {
+    category: "network",
+    level: "error",
+    message: `GET ${command} failed (${label})`,
+    detail: hint ? `${hint}\n\n${rawError}` : rawError,
+    durationMs,
+    method: "GET",
+    source: recordSource(command, context),
+    url,
+  };
+}
+
+async function invokeNativeHttp<T>(
+  command: NativeHttpCommand,
+  url: string,
+  options?: NativeHttpOptions,
+): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    const result = await invoke<T>(command, { url });
+    appendDiagnostic(
+      nativeHttpSuccessRecord(
+        command,
+        url,
+        Math.round(performance.now() - startedAt),
+        options?.context,
+      ),
+    );
+    return result;
+  } catch (error) {
+    appendDiagnostic(
+      nativeHttpFailureRecord(
+        command,
+        url,
+        error,
+        Math.round(performance.now() - startedAt),
+        options?.context,
+      ),
+    );
+    throw error;
+  }
+}
+
+/**
+ * Fetches a URL's bytes through the native `fetch_url_bytes` command (not
+ * subject to browser CORS), recording the request in the diagnostics log.
+ *
+ * @param url - The absolute HTTP(S) URL to fetch.
+ * @param options - Optional context label for the diagnostics record.
+ * @returns The response body bytes (Tauri may hand back a plain number array).
+ */
+export function fetchUrlBytes(
+  url: string,
+  options?: NativeHttpOptions,
+): Promise<number[] | Uint8Array> {
+  return invokeNativeHttp<number[] | Uint8Array>("fetch_url_bytes", url, options);
+}
+
+/**
+ * Resolves a redirecting/short URL to its final XYZ template through the native
+ * `resolve_url_redirect` command, recording the request in the diagnostics log.
+ *
+ * @param url - The short or redirecting HTTP(S) URL to resolve.
+ * @param options - Optional context label for the diagnostics record.
+ * @returns The resolved URL.
+ */
+export function resolveUrlRedirect(
+  url: string,
+  options?: NativeHttpOptions,
+): Promise<string> {
+  return invokeNativeHttp<string>("resolve_url_redirect", url, options);
+}

--- a/apps/geolibre-desktop/src/lib/native-http.ts
+++ b/apps/geolibre-desktop/src/lib/native-http.ts
@@ -11,7 +11,11 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
-import { appendDiagnostic, type DiagnosticInput } from "./diagnostics";
+import {
+  appendDiagnostic,
+  formatUnknown,
+  type DiagnosticInput,
+} from "./diagnostics";
 import { classifyFetchFailure } from "./fetch-error";
 
 /** The native HTTP commands exposed by the Tauri backend. */
@@ -20,12 +24,6 @@ export type NativeHttpCommand = "fetch_url_bytes" | "resolve_url_redirect";
 interface NativeHttpOptions {
   /** Short feature label (e.g. "WFS GetCapabilities") added to the record. */
   context?: string;
-}
-
-function formatNativeError(error: unknown): string {
-  if (error instanceof Error) return error.stack ?? error.message;
-  if (typeof error === "string") return error;
-  return String(error);
 }
 
 function recordSource(command: NativeHttpCommand, context?: string): string {
@@ -66,7 +64,7 @@ export function nativeHttpFailureRecord(
   context?: string,
 ): DiagnosticInput {
   const { kind, label, hint } = classifyFetchFailure(error);
-  const rawError = formatNativeError(error);
+  const rawError = formatUnknown(error);
   return {
     category: "network",
     level: "error",

--- a/apps/geolibre-desktop/src/lib/native-http.ts
+++ b/apps/geolibre-desktop/src/lib/native-http.ts
@@ -65,12 +65,18 @@ export function nativeHttpFailureRecord(
   durationMs: number,
   context?: string,
 ): DiagnosticInput {
-  const { label, hint } = classifyFetchFailure(error);
+  const { kind, label, hint } = classifyFetchFailure(error);
   const rawError = formatNativeError(error);
   return {
     category: "network",
     level: "error",
-    message: `GET ${command} failed (${label})`,
+    // Only append the classification when it says something useful; an ordinary
+    // non-2xx status is "unknown" (label "request failed"), and appending it
+    // would read as the redundant "failed (request failed)".
+    message:
+      kind !== "unknown"
+        ? `GET ${command} failed (${label})`
+        : `GET ${command} failed`,
     detail: hint ? `${hint}\n\n${rawError}` : rawError,
     durationMs,
     method: "GET",

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -321,8 +321,8 @@ async function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown>
   if (isTauri()) {
     // `fetch_url_bytes` cannot be cancelled mid-flight, so race it against the
     // abort/timeout to still return promptly on a slow or hung host.
-    const { invoke } = await import("@tauri-apps/api/core");
-    const bytesPromise = invoke<number[] | Uint8Array>("fetch_url_bytes", { url });
+    const { fetchUrlBytes } = await import("./native-http");
+    const bytesPromise = fetchUrlBytes(url, { context: "OGC vector tiles" });
     // If the abort/timeout wins the race, the invoke promise is left unobserved;
     // swallow a later rejection so it does not surface as an unhandled rejection.
     bytesPromise.catch(() => {});

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -1,6 +1,6 @@
 import type { GeoLibreLayer, GeoLibreProject } from "@geolibre/core";
-import { invoke } from "@tauri-apps/api/core";
 import { addProtocol, type RequestParameters } from "maplibre-gl";
+import { fetchUrlBytes, resolveUrlRedirect } from "./native-http";
 import { isTauri } from "./tauri-io";
 
 const XYZ_TILE_PROTOCOL = "geolibre-xyz";
@@ -82,9 +82,7 @@ export function registerXyzTileProtocol(): void {
 
   addProtocol(XYZ_TILE_PROTOCOL, async (request) => {
     const url = parseXyzTileRequest(request);
-    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
-      url,
-    });
+    const bytes = await fetchUrlBytes(url, { context: "XYZ tile" });
     const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
     return {
       data: array.buffer.slice(
@@ -213,7 +211,7 @@ async function resolveShortXyzUrl(
       console.warn("Falling back to desktop URL resolver", error);
     }
 
-    return invoke<string>("resolve_url_redirect", { url });
+    return resolveUrlRedirect(url, { context: "XYZ URL resolve" });
   }
 
   return resolveShortXyzUrlWithFetch(url, signal);

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -1,6 +1,7 @@
 import type { GeoLibreLayer, GeoLibreProject } from "@geolibre/core";
+import { invoke } from "@tauri-apps/api/core";
 import { addProtocol, type RequestParameters } from "maplibre-gl";
-import { fetchUrlBytes, resolveUrlRedirect } from "./native-http";
+import { resolveUrlRedirect } from "./native-http";
 import { isTauri } from "./tauri-io";
 
 const XYZ_TILE_PROTOCOL = "geolibre-xyz";
@@ -82,7 +83,14 @@ export function registerXyzTileProtocol(): void {
 
   addProtocol(XYZ_TILE_PROTOCOL, async (request) => {
     const url = parseXyzTileRequest(request);
-    const bytes = await fetchUrlBytes(url, { context: "XYZ tile" });
+    // This handler runs once per tile, so — unlike the one-shot native calls
+    // routed through native-http — it deliberately calls `invoke` directly and
+    // is NOT recorded in diagnostics: a fast pan over a tile server's coverage
+    // edge returns 404s in bulk, and recording each would re-render the panel
+    // per tile and evict more relevant entries from the 500-record ring buffer.
+    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
+      url,
+    });
     const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
     return {
       data: array.buffer.slice(

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -19,7 +19,13 @@ import {
   parseVideoCorner,
   resolveDelimitedTextDelimiter,
   savedPostgresConnectionLabel,
+  serviceRequestErrorMessage,
 } from "../apps/geolibre-desktop/src/components/layout/add-data/helpers";
+import type { TFunction } from "i18next";
+
+// A minimal `t` stub: returns the key so the branch taken is observable, and
+// echoes the fallback for the default branch.
+const fakeT = ((key: string) => key) as unknown as TFunction;
 
 describe("add-data path helpers", () => {
   it("extracts the file name from POSIX and Windows paths", () => {
@@ -440,5 +446,47 @@ describe("attributionForTileUrl", () => {
       undefined,
     );
     assert.equal(attributionForTileUrl("not a url"), undefined);
+  });
+});
+
+describe("serviceRequestErrorMessage", () => {
+  it("maps a network/TLS/CORS failure to the localized network message", () => {
+    assert.equal(
+      serviceRequestErrorMessage(new TypeError("Failed to fetch"), fakeT, "fallback"),
+      "addData.common.networkFailure",
+    );
+  });
+
+  it("maps a native TLS error string to the localized network message", () => {
+    assert.equal(
+      serviceRequestErrorMessage(
+        "Request failed: invalid peer certificate",
+        fakeT,
+        "fallback",
+      ),
+      "addData.common.networkFailure",
+    );
+  });
+
+  it("maps a timeout to the localized timeout message", () => {
+    assert.equal(
+      serviceRequestErrorMessage(new Error("The request timed out."), fakeT, "fallback"),
+      "addData.common.requestTimedOut",
+    );
+  });
+
+  it("falls through to the error's own message for an unclassified failure", () => {
+    assert.equal(
+      serviceRequestErrorMessage(
+        new Error("The WFS service returned an error."),
+        fakeT,
+        "fallback",
+      ),
+      "The WFS service returned an error.",
+    );
+  });
+
+  it("uses the fallback when an unclassified error carries no message", () => {
+    assert.equal(serviceRequestErrorMessage({}, fakeT, "fallback"), "fallback");
   });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -88,6 +88,22 @@ describe("diagnostics network info capture", () => {
     assert.equal(snapshot.warningCount, 1);
   });
 
+  it("redacts sensitive query params from a URL embedded in the detail", () => {
+    appendDiagnostic({
+      category: "network",
+      level: "error",
+      message: "GET fetch_url_bytes failed (network)",
+      // A native reqwest error embeds the full request URL, including secrets.
+      detail:
+        "error sending request for url (https://tiles.example.com/1/2/3.png?api_key=SECRET123): connection refused",
+    });
+    const [record] = getDiagnosticsSnapshot().records;
+    // The param value is replaced with the REDACTED marker (URL-encoded in the
+    // query string); the important guarantee is the secret no longer appears.
+    assert.ok(record.detail?.includes("REDACTED"));
+    assert.ok(!record.detail?.includes("SECRET123"));
+  });
+
   it("does not filter info-level entries from other categories", () => {
     appendDiagnostic({
       category: "console",

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -406,4 +406,20 @@ describe("diagnostics startup transient suppression", () => {
     assert.equal(record.level, "error");
     assert.equal(getDiagnosticsSnapshot().errorCount, 1);
   });
+
+  it("classifies a genuine fetch network failure with an actionable hint", async () => {
+    win.fetch = (() =>
+      Promise.reject(new TypeError("Failed to fetch"))) as unknown as typeof fetch;
+    install();
+    await (win.fetch as typeof fetch)("https://example.com/data").catch(
+      () => {},
+    );
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.level, "error");
+    // The opaque browser error is interpreted rather than left as a raw stack.
+    assert.match(record.message, /network\/TLS\/CORS/);
+    assert.ok(record.detail?.includes("CORS"));
+    // The raw error is still preserved after the hint.
+    assert.ok(record.detail?.includes("Failed to fetch"));
+  });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -422,4 +422,18 @@ describe("diagnostics startup transient suppression", () => {
     // The raw error is still preserved after the hint.
     assert.ok(record.detail?.includes("Failed to fetch"));
   });
+
+  it("does not append a redundant label for an unclassified failure", async () => {
+    win.fetch = (() =>
+      Promise.reject(new Error("some opaque failure"))) as unknown as typeof fetch;
+    install();
+    await (win.fetch as typeof fetch)("https://example.com/data").catch(
+      () => {},
+    );
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.level, "error");
+    // An "unknown" classification must not render "request failed (request failed)".
+    assert.equal(record.message, "GET request failed");
+    assert.ok(!/\(request failed\)/.test(record.message));
+  });
 });

--- a/tests/fetch-error.test.ts
+++ b/tests/fetch-error.test.ts
@@ -1,10 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import {
-  classifyFetchFailure,
-  fetchFailureMessage,
-} from "../apps/geolibre-desktop/src/lib/fetch-error";
+import { classifyFetchFailure } from "../apps/geolibre-desktop/src/lib/fetch-error";
 
 describe("classifyFetchFailure", () => {
   it("classifies an AbortError as an abort with no hint", () => {
@@ -30,31 +27,49 @@ describe("classifyFetchFailure", () => {
     const result = classifyFetchFailure(new TypeError("Failed to fetch"));
     assert.equal(result.kind, "network");
     assert.equal(result.label, "network/TLS/CORS");
+    // The browser hint keeps the CORS / "try the desktop app" advice.
     assert.ok(result.hint?.includes("CORS"));
+    assert.ok(result.hint?.includes("desktop app"));
   });
 
   it("classifies the WebKit 'Load failed' TypeError as network", () => {
     assert.equal(classifyFetchFailure(new TypeError("Load failed")).kind, "network");
   });
 
-  it("classifies a native reqwest TLS certificate error string as network", () => {
+  it("classifies a native reqwest TLS certificate error string as network without the CORS advice", () => {
     const result = classifyFetchFailure(
       "Request failed: error sending request: invalid peer certificate",
     );
     assert.equal(result.kind, "network");
+    assert.equal(result.label, "network");
+    // The native path already runs in the desktop app, so its hint drops the
+    // CORS / "try the desktop app" sentence.
     assert.ok(result.hint);
+    assert.ok(!result.hint?.includes("CORS"));
+    assert.ok(!result.hint?.includes("desktop app"));
   });
 
-  it("classifies a native DNS/connection error string as network", () => {
+  it("classifies native DNS/connection error strings as network", () => {
     assert.equal(
       classifyFetchFailure("Request failed: dns error: failed to lookup host")
         .kind,
       "network",
     );
     assert.equal(
-      classifyFetchFailure("Request failed: connection refused").kind,
+      classifyFetchFailure("Request failed: connection refused (os error 111)")
+        .kind,
       "network",
     );
+  });
+
+  it("does not misclassify a non-network error whose URL contains a network word", () => {
+    // "connect" appears only as a URL path substring, not as a real error cause,
+    // so the tightened phrase matching must leave it unclassified.
+    const result = classifyFetchFailure(
+      "error decoding response body for url (https://host/api/connect): invalid json",
+    );
+    assert.equal(result.kind, "unknown");
+    assert.equal(result.hint, null);
   });
 
   it("leaves an unrecognized error as unknown with no hint", () => {
@@ -64,26 +79,9 @@ describe("classifyFetchFailure", () => {
     assert.equal(result.kind, "unknown");
     assert.equal(result.hint, null);
   });
-});
 
-describe("fetchFailureMessage", () => {
-  it("returns the classified hint for a network failure", () => {
-    const message = fetchFailureMessage(
-      new TypeError("Failed to fetch"),
-      "fallback",
-    );
-    assert.ok(message.includes("CORS"));
-  });
-
-  it("returns the error's own message when it is not a recognized failure", () => {
-    const message = fetchFailureMessage(
-      new Error("The WFS service returned an error."),
-      "fallback",
-    );
-    assert.equal(message, "The WFS service returned an error.");
-  });
-
-  it("falls back when the error carries no message", () => {
-    assert.equal(fetchFailureMessage({}, "fallback"), "fallback");
+  it("reads the message from a non-Error, non-DOMException value safely", () => {
+    assert.equal(classifyFetchFailure({}).kind, "unknown");
+    assert.equal(classifyFetchFailure(undefined).kind, "unknown");
   });
 });

--- a/tests/fetch-error.test.ts
+++ b/tests/fetch-error.test.ts
@@ -62,6 +62,22 @@ describe("classifyFetchFailure", () => {
     );
   });
 
+  it("does not misclassify a network failure whose URL has a 'timeout' query param", () => {
+    // The real cause is a refused connection; `timeout=30` is only a URL param,
+    // so stripping the embedded URL must keep this classified as network.
+    const result = classifyFetchFailure(
+      "error sending request for url (https://host/wfs?timeout=30): connection refused",
+    );
+    assert.equal(result.kind, "network");
+  });
+
+  it("still classifies a genuine native timeout message", () => {
+    assert.equal(
+      classifyFetchFailure("error sending request: operation timed out").kind,
+      "timeout",
+    );
+  });
+
   it("does not misclassify a non-network error whose URL contains a network word", () => {
     // "connect" appears only as a URL path substring, not as a real error cause,
     // so the tightened phrase matching must leave it unclassified.

--- a/tests/fetch-error.test.ts
+++ b/tests/fetch-error.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  classifyFetchFailure,
+  fetchFailureMessage,
+} from "../apps/geolibre-desktop/src/lib/fetch-error";
+
+describe("classifyFetchFailure", () => {
+  it("classifies an AbortError as an abort with no hint", () => {
+    const error = new DOMException("aborted", "AbortError");
+    const result = classifyFetchFailure(error);
+    assert.equal(result.kind, "abort");
+    assert.equal(result.hint, null);
+  });
+
+  it("classifies a TimeoutError DOMException as a timeout with a hint", () => {
+    const error = new DOMException("timed out", "TimeoutError");
+    const result = classifyFetchFailure(error);
+    assert.equal(result.kind, "timeout");
+    assert.ok(result.hint && result.hint.length > 0);
+  });
+
+  it("classifies a wrapped 'timed out' message as a timeout", () => {
+    const result = classifyFetchFailure(new Error("The request timed out."));
+    assert.equal(result.kind, "timeout");
+  });
+
+  it("classifies the browser 'Failed to fetch' TypeError as network/TLS/CORS", () => {
+    const result = classifyFetchFailure(new TypeError("Failed to fetch"));
+    assert.equal(result.kind, "network");
+    assert.equal(result.label, "network/TLS/CORS");
+    assert.ok(result.hint?.includes("CORS"));
+  });
+
+  it("classifies the WebKit 'Load failed' TypeError as network", () => {
+    assert.equal(classifyFetchFailure(new TypeError("Load failed")).kind, "network");
+  });
+
+  it("classifies a native reqwest TLS certificate error string as network", () => {
+    const result = classifyFetchFailure(
+      "Request failed: error sending request: invalid peer certificate",
+    );
+    assert.equal(result.kind, "network");
+    assert.ok(result.hint);
+  });
+
+  it("classifies a native DNS/connection error string as network", () => {
+    assert.equal(
+      classifyFetchFailure("Request failed: dns error: failed to lookup host")
+        .kind,
+      "network",
+    );
+    assert.equal(
+      classifyFetchFailure("Request failed: connection refused").kind,
+      "network",
+    );
+  });
+
+  it("leaves an unrecognized error as unknown with no hint", () => {
+    const result = classifyFetchFailure(
+      new Error("Request failed with status 500"),
+    );
+    assert.equal(result.kind, "unknown");
+    assert.equal(result.hint, null);
+  });
+});
+
+describe("fetchFailureMessage", () => {
+  it("returns the classified hint for a network failure", () => {
+    const message = fetchFailureMessage(
+      new TypeError("Failed to fetch"),
+      "fallback",
+    );
+    assert.ok(message.includes("CORS"));
+  });
+
+  it("returns the error's own message when it is not a recognized failure", () => {
+    const message = fetchFailureMessage(
+      new Error("The WFS service returned an error."),
+      "fallback",
+    );
+    assert.equal(message, "The WFS service returned an error.");
+  });
+
+  it("falls back when the error carries no message", () => {
+    assert.equal(fetchFailureMessage({}, "fallback"), "fallback");
+  });
+});

--- a/tests/native-http.test.ts
+++ b/tests/native-http.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+// native-http imports diagnostics, which reads localStorage at import time, and
+// @tauri-apps/api/core; stub the globals both touch before importing.
+const storage = new Map<string, string>();
+(globalThis as { window?: unknown }).window = {
+  localStorage: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+  },
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+
+type NativeHttpModule =
+  typeof import("../apps/geolibre-desktop/src/lib/native-http");
+let nativeHttpSuccessRecord: NativeHttpModule["nativeHttpSuccessRecord"];
+let nativeHttpFailureRecord: NativeHttpModule["nativeHttpFailureRecord"];
+
+before(async () => {
+  ({ nativeHttpSuccessRecord, nativeHttpFailureRecord } = await import(
+    "../apps/geolibre-desktop/src/lib/native-http"
+  ));
+});
+
+describe("nativeHttpSuccessRecord", () => {
+  it("builds an info-level network record with the command and context", () => {
+    const record = nativeHttpSuccessRecord(
+      "fetch_url_bytes",
+      "https://example.com/wms",
+      42,
+      "WFS GetCapabilities",
+    );
+    assert.equal(record.category, "network");
+    assert.equal(record.level, "info");
+    assert.equal(record.method, "GET");
+    assert.equal(record.durationMs, 42);
+    assert.equal(record.url, "https://example.com/wms");
+    assert.match(record.message, /fetch_url_bytes/);
+    assert.equal(record.source, "native fetch_url_bytes — WFS GetCapabilities");
+  });
+
+  it("omits the context suffix from the source when none is given", () => {
+    const record = nativeHttpSuccessRecord("resolve_url_redirect", "https://x/y", 5);
+    assert.equal(record.source, "native resolve_url_redirect");
+  });
+});
+
+describe("nativeHttpFailureRecord", () => {
+  it("classifies a native TLS error and prepends the hint to the raw error", () => {
+    const record = nativeHttpFailureRecord(
+      "fetch_url_bytes",
+      "https://example.com/wms",
+      "Request failed: invalid peer certificate",
+      100,
+      "WFS GetCapabilities",
+    );
+    assert.equal(record.level, "error");
+    assert.match(record.message, /failed \(network\)/);
+    // The hint comes first, then the raw error is preserved for debugging.
+    assert.ok(record.detail?.includes("CORS"));
+    assert.ok(record.detail?.includes("invalid peer certificate"));
+  });
+
+  it("keeps the raw error alone when the failure is unclassified", () => {
+    const record = nativeHttpFailureRecord(
+      "fetch_url_bytes",
+      "https://example.com/tile",
+      "Request failed with status 500 Internal Server Error",
+      10,
+    );
+    assert.equal(record.level, "error");
+    assert.match(record.message, /failed \(request failed\)/);
+    assert.equal(record.detail, "Request failed with status 500 Internal Server Error");
+  });
+});

--- a/tests/native-http.test.ts
+++ b/tests/native-http.test.ts
@@ -59,8 +59,10 @@ describe("nativeHttpFailureRecord", () => {
     );
     assert.equal(record.level, "error");
     assert.match(record.message, /failed \(network\)/);
-    // The hint comes first, then the raw error is preserved for debugging.
-    assert.ok(record.detail?.includes("CORS"));
+    // The native hint comes first (no CORS / "try the desktop app" advice, since
+    // this path already runs in the desktop app), then the raw error follows.
+    assert.ok(record.detail?.includes("certificate"));
+    assert.ok(!record.detail?.includes("CORS"));
     assert.ok(record.detail?.includes("invalid peer certificate"));
   });
 

--- a/tests/native-http.test.ts
+++ b/tests/native-http.test.ts
@@ -74,7 +74,9 @@ describe("nativeHttpFailureRecord", () => {
       10,
     );
     assert.equal(record.level, "error");
-    assert.match(record.message, /failed \(request failed\)/);
+    // An "unknown" classification (an ordinary non-2xx status) must not render
+    // the redundant "failed (request failed)".
+    assert.equal(record.message, "GET fetch_url_bytes failed");
     assert.equal(record.detail, "Request failed with status 500 Internal Server Error");
   });
 });


### PR DESCRIPTION
Fixes #1175

## Problem

The desktop Diagnostics panel network log only intercepted `window.fetch`. Several desktop features make outbound requests through the native Tauri HTTP commands (`fetch_url_bytes`, `resolve_url_redirect`), which run in Rust and never pass through `window.fetch`, so they were **invisible in the panel** — their errors surfaced only in the originating UI. Captured `fetch()` failures also stored the raw `TypeError: Failed to fetch` without interpreting it, and the originating UI (e.g. the WFS Add Data form) surfaced only the bare error with no context (CORS origin, TLS, permission, etc.).

## Changes

- **`lib/fetch-error.ts` (new):** a shared classifier that maps a failed request to `abort` / `timeout` / `network` (TLS/CORS) plus an actionable hint. The browser collapses distinct network failures into one opaque `Failed to fetch`, so the hint enumerates the common causes; the native (reqwest) path is narrowed further by keyword (certificate, dns, connection refused, ...).
- **`lib/native-http.ts` (new):** thin `fetchUrlBytes` / `resolveUrlRedirect` wrappers around the native commands that record every call in the diagnostics network log. Success entries are gated behind "Log all network requests" like ordinary fetches; failures are always recorded and classified with a hint plus the raw error. All call sites (XYZ tiles/URL resolve, OGC vector tiles, WFS/WMS GetCapabilities, plugin resources) now route through these.
- **`lib/diagnostics.ts`:** the patched-fetch failure record now interprets the otherwise-opaque browser error, adding the classification label to the message and the hint to the detail.
- **WFS/WMS Add Data forms:** surface the classified hint (`fetchFailureMessage`) instead of a bare raw error, so a native-path TLS/DNS failure is explained rather than shown verbatim.

## Verification

- New unit tests for the classifier (`tests/fetch-error.test.ts`), the native-http record builders (`tests/native-http.test.ts`), and the panel enrichment (`tests/diagnostics.test.ts`). Full frontend suite passes (2336 tests); production build and scoped `pre-commit` (eslint + build) pass.
- Drove the real app with Playwright in **both light and dark themes**:
  - A genuine `fetch()` network failure renders in the panel as `GET request failed (network/TLS/CORS)` with the full hint and the raw error preserved.
  - A native `fetch_url_bytes` TLS-certificate failure renders in the panel classified `(network)`, tagged with the `native fetch_url_bytes — WFS GetCapabilities` source, hint, and raw error.
  - The WFS Add Data form continues to surface a helpful cross-origin message on failure (no regression).

This is a GeoLibre-only change; no upstream package release was required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop request error messaging with translated, categorized guidance for timeouts and network/TLS/CORS-style failures across WFS/WMS capability retrieval, plugin/resource fetching, OGC vector tiles, and XYZ URL redirects.
  * Enhanced diagnostics: sensitive URL query values are redacted, and network diagnostics now include more actionable, failure-specific labels and hints.
* **Tests**
  * Added/expanded automated coverage for request failure classification, diagnostics redaction and formatting, and native request reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->