### PR TITLE
docs: add Terms of Service page for Earth Engine OAuth verification

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -12,6 +12,8 @@ GeoLibre runs locally on your device. It does not require an account, and it doe
 not collect analytics, telemetry, or usage data. Your geospatial data and
 projects stay on your device unless you choose to share or export them.
 
+Your use of the app is also governed by our [Terms of Service](terms.md).
+
 ## Data processed locally
 
 The files and projects you open, create, and analyze in GeoLibre (vector and

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,100 @@
+# Terms of Service
+
+_Last updated: July 10, 2026_
+
+GeoLibre ("GeoLibre", "the app") is a free, open-source GIS application
+developed by the OpenGeos community. By downloading, installing, or using
+GeoLibre — including its desktop, web, and embedded builds — you agree to these
+Terms of Service ("Terms"). If you do not agree, do not use the app.
+
+## The service
+
+GeoLibre lets you view, create, analyze, and share geospatial data. It runs
+locally on your device and does not require an account. Some optional features
+connect to third-party services (for example basemap providers, geocoding
+services, AI/LLM providers, and cloud data catalogs such as Google Earth Engine);
+those features are described in our [Privacy Policy](privacy.md).
+
+## License
+
+GeoLibre is open-source software distributed under the terms of its license, as
+published in the project repository at
+<https://github.com/opengeos/GeoLibre>. Your use, modification, and
+redistribution of the software are governed by that license. These Terms
+supplement, and do not replace, the software license.
+
+## Acceptable use
+
+You agree to use GeoLibre lawfully and responsibly. In particular, you agree not
+to:
+
+- use the app to violate any applicable law or regulation, or to infringe the
+  rights of others;
+- use the app to access, store, or distribute data you are not authorized to
+  use;
+- misuse, overload, or attempt to gain unauthorized access to any third-party
+  service that the app connects to, or use such a service in a way that breaches
+  that service's own terms; or
+- remove, disable, or circumvent any security or authentication mechanism in the
+  app or the services it connects to.
+
+## Google Earth Engine and other third-party services
+
+Optional GeoLibre features let you authenticate with and access third-party
+services, including **Google Earth Engine**, using your own credentials.
+
+- When you connect to a third-party service, you do so under **your own account**
+  with that provider, and your use is subject to **that provider's terms of
+  service and privacy policy** in addition to these Terms. For Google Earth
+  Engine, this includes the
+  [Earth Engine Terms of Service](https://earthengine.google.com/terms/) and the
+  [Google APIs Terms of Service](https://developers.google.com/terms).
+- GeoLibre uses Google OAuth solely to obtain, on your behalf and with your
+  consent, the access token needed to make Earth Engine requests you initiate.
+  GeoLibre does not sell your data, and does not use Google user data for
+  advertising or for any purpose other than providing the features you request.
+  See the [Privacy Policy](privacy.md) for details on what is sent where.
+- You are responsible for ensuring you have the necessary rights and quota to use
+  any third-party service through the app, and for complying with that service's
+  usage limits and licensing terms for the data you access.
+
+GeoLibre does not control these third-party services and is not responsible for
+their availability, content, or conduct.
+
+## Your content
+
+GeoLibre does not claim ownership of the data, files, or projects you open or
+create with it. You retain all rights to your content. Because your content is
+processed locally on your device, you are responsible for backing it up and for
+the lawful use of any data you load.
+
+## Disclaimer of warranties
+
+GeoLibre is provided **"as is" and "as available", without warranties of any
+kind**, express or implied, including but not limited to warranties of
+merchantability, fitness for a particular purpose, accuracy, and
+non-infringement. The developers do not warrant that the app will be
+uninterrupted, error-free, or free of harmful components, or that any analysis or
+output it produces is accurate or fit for any particular purpose. You use the app
+and rely on its output at your own risk.
+
+## Limitation of liability
+
+To the maximum extent permitted by law, in no event shall the OpenGeos community,
+the project maintainers, or contributors be liable for any indirect, incidental,
+special, consequential, or punitive damages, or for any loss of data, profits, or
+goodwill, arising out of or in connection with your use of (or inability to use)
+GeoLibre, even if advised of the possibility of such damages.
+
+## Changes to the app and these Terms
+
+GeoLibre is under active development, and features may be added, changed, or
+removed at any time. We may also update these Terms from time to time. The
+current version is always available at <https://geolibre.app/terms/>. Your
+continued use of the app after changes take effect constitutes acceptance of the
+revised Terms.
+
+## Contact
+
+Questions about these Terms can be directed to the project at
+<https://github.com/opengeos/GeoLibre/issues>.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -2,7 +2,7 @@
 
 _Last updated: July 10, 2026_
 
-GeoLibre ("GeoLibre", "the app") is a free, open-source GIS application
+GeoLibre ("the app") is a free, open-source GIS application
 developed by the OpenGeos community. By downloading, installing, or using
 GeoLibre — including its desktop, web, and embedded builds — you agree to these
 Terms of Service ("Terms"). If you do not agree, do not use the app.
@@ -17,10 +17,10 @@ those features are described in our [Privacy Policy](privacy.md).
 
 ## License
 
-GeoLibre is open-source software distributed under the terms of its license, as
-published in the project repository at
-<https://github.com/opengeos/GeoLibre>. Your use, modification, and
-redistribution of the software are governed by that license. These Terms
+GeoLibre is open-source software distributed under the MIT License, as published
+in the project repository at
+<https://github.com/opengeos/GeoLibre/blob/main/LICENSE>. Your use, modification,
+and redistribution of the software are governed by that license. These Terms
 supplement, and do not replace, the software license.
 
 ## Acceptable use
@@ -64,9 +64,11 @@ their availability, content, or conduct.
 ## Your content
 
 GeoLibre does not claim ownership of the data, files, or projects you open or
-create with it. You retain all rights to your content. Because your content is
-processed locally on your device, you are responsible for backing it up and for
-the lawful use of any data you load.
+create with it. You retain all rights to your content. Most processing occurs
+locally on your device. If you enable an online feature, such as real-time
+collaboration or a third-party integration, applicable data may be transmitted
+to that service as described in our [Privacy Policy](privacy.md). You are
+responsible for backing up your content and for its lawful use.
 
 ## Disclaimer of warranties
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - How to Cite: citation.md
       - Acknowledgements: acknowledgements.md
       - Privacy Policy: privacy.md
+      - Terms of Service: terms.md
 
 plugins:
   - search


### PR DESCRIPTION
## Why

Google's OAuth app verification for **Earth Engine** authentication requires a hosted **Application Terms of Service** link (alongside the existing Privacy Policy). The repo had a Privacy Policy but no Terms of Service.

## What

- **`docs/terms.md`** (new) — Terms of Service page matching the existing Privacy Policy's tone/structure. Includes a dedicated **Google Earth Engine and other third-party services** section covering the points reviewers check:
  - Users authenticate under their own Google account, subject to Google's [Earth Engine ToS](https://earthengine.google.com/terms/) and [Google APIs ToS](https://developers.google.com/terms).
  - OAuth is used only to obtain, with user consent, the access token for user-initiated Earth Engine requests — **no data selling, no advertising use, no unrelated use of Google user data** (Limited Use language).
  - Standard license, acceptable-use, disclaimer, and limitation-of-liability clauses.
- **`mkdocs.yml`** — added `Terms of Service: terms.md` to the nav after Privacy Policy.
- **`docs/privacy.md`** — cross-link to the new Terms page.

## Result

Once merged and deployed, the ToS URL is **https://geolibre.app/terms/**, mirroring **https://geolibre.app/privacy/**. Both can be supplied on the Google OAuth consent screen / verification form.

## Notes for reviewer

- The license section links to the repo rather than naming a specific license (e.g. MIT) — happy to make it explicit.
- Effective date set to July 10, 2026; disclaimer/liability wording is boilerplate — please review before it goes public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Terms of Service document outlining acceptable use, third-party integration details, user content, warranty/disclaimer terms, and liability limits.
  * Updated the Privacy Policy summary to reference and link to the Terms of Service.
  * Updated the documentation site navigation to include a “Terms of Service” entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->