### PR TITLE
fix(earth-engine): open desktop OAuth in the system browser

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/earth_engine_oauth.rs
+++ b/apps/geolibre-desktop/src-tauri/src/earth_engine_oauth.rs
@@ -309,10 +309,15 @@ fn auth_page(client_id: &str, state: &str) -> String {
   <script>
     const clientId = {client_id_json};
     const state = {state_json};
+    // Minimal Earth Engine scopes: tiles/thumbnails need `earthengine`, and the
+    // EE control's "Export" writes to Drive via the non-sensitive `drive.file`
+    // scope. `cloud-platform` is intentionally omitted (GeoLibre never uses it),
+    // keeping the app clear of Google's broad/restricted-scope verification. Keep
+    // in sync with EARTH_ENGINE_OAUTH_SCOPES in
+    // packages/plugins/src/plugins/earth-engine-auth.ts.
     const scope = [
       "https://www.googleapis.com/auth/earthengine",
-      "https://www.googleapis.com/auth/cloud-platform",
-      "https://www.googleapis.com/auth/drive"
+      "https://www.googleapis.com/auth/drive.file"
     ].join(" ");
     const button = document.getElementById("sign-in");
     const status = document.getElementById("status");

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -72,6 +72,21 @@ if (!process.env.VITE_CESIUM_TOKEN) {
   }
 }
 
+// Earth Engine OAuth client ID: same bare→prefixed bridge as the Google Maps
+// and Cesium keys. The app reads `import.meta.env.VITE_GEE_OAUTH_CLIENT_ID`, so
+// a bare `GEE_OAUTH_CLIENT_ID` (shell/.zshrc or an .env file) is surfaced under
+// the prefixed name here; otherwise Vite ignores the unprefixed var and the
+// plugin falls back to its hardcoded DEFAULT_GEE_OAUTH_CLIENT_ID.
+if (!process.env.VITE_GEE_OAUTH_CLIENT_ID) {
+  const geeOauthClientId =
+    process.env.GEE_OAUTH_CLIENT_ID ||
+    FILE_ENV.VITE_GEE_OAUTH_CLIENT_ID ||
+    FILE_ENV.GEE_OAUTH_CLIENT_ID;
+  if (geeOauthClientId) {
+    process.env.VITE_GEE_OAUTH_CLIENT_ID = geeOauthClientId;
+  }
+}
+
 // Tauri sets TAURI_ENV_* env vars while running its beforeBuildCommand
 // (`npm run build`), so their presence flags a desktop build. Used below to drop
 // the service worker from the desktop bundle.

--- a/packages/plugins/src/plugins/earth-engine-auth.ts
+++ b/packages/plugins/src/plugins/earth-engine-auth.ts
@@ -5,6 +5,22 @@ import { invoke } from "@tauri-apps/api/core";
 export const DEFAULT_GEE_OAUTH_CLIENT_ID =
   "937635412428-qc3albpo6dtm2jdp2o5mk8biqlh0i6vo.apps.googleusercontent.com";
 
+// The OAuth scopes GeoLibre requests for Earth Engine. Deliberately minimal so
+// the app can pass Google's OAuth verification without the broad `cloud-platform`
+// scope: the @google/earthengine SDK requests earthengine + cloud-platform +
+// full drive by default, but GeoLibre only displays tiles/thumbnails and exports
+// to Drive — it never touches Cloud Storage, BigQuery, or project/asset
+// management, so cloud-platform is unnecessary. Keep this in sync with the scope
+// list in the desktop helper page (src-tauri/src/earth_engine_oauth.rs).
+//   - earthengine: request/display Earth Engine map tiles and visualizations.
+//   - drive.file:  the EE control's "Export" writes to Google Drive; drive.file
+//     is the non-sensitive per-file scope, avoiding the restricted full-drive
+//     scope (and its CASA security assessment).
+export const EARTH_ENGINE_OAUTH_SCOPES = [
+  "https://www.googleapis.com/auth/earthengine",
+  "https://www.googleapis.com/auth/drive.file",
+];
+
 export type EarthEngineImportMetaEnv = {
   VITE_GEE_OAUTH_CLIENT_ID?: unknown;
   VITE_GEE_PROJECT_ID?: unknown;
@@ -37,6 +53,7 @@ type EarthEngineApi = {
       onFailure: (error: unknown) => void,
       extraScopes?: unknown,
       onImmediateFailed?: () => void,
+      suppressDefaultScopes?: boolean,
     ) => void;
     authenticateViaPopup?: (
       onSuccess: () => void,
@@ -229,12 +246,16 @@ async function authenticateEarthEngineViaBrowser(
       reject(new Error("Earth Engine OAuth authentication is unavailable."));
       return;
     }
+    // Suppress the SDK's default scopes (earthengine + cloud-platform + full
+    // drive) and request only EARTH_ENGINE_OAUTH_SCOPES, so the web path asks
+    // for the same minimal set as the desktop helper page.
     earthEngine.data.authenticateViaOauth(
       oauthClientId,
       onSuccess,
       onFailure,
-      undefined,
+      EARTH_ENGINE_OAUTH_SCOPES,
       onImmediateFailed,
+      true,
     );
   });
 }

--- a/packages/plugins/src/plugins/earth-engine-auth.ts
+++ b/packages/plugins/src/plugins/earth-engine-auth.ts
@@ -247,17 +247,18 @@ async function authenticateEarthEngineViaTauri(
     { clientId: oauthClientId },
   );
 
-  const popup = window.open(
-    session.url,
-    "geolibre-earth-engine-oauth",
-    "popup,width=520,height=680",
-  );
-  if (!popup) {
-    throw new Error("Earth Engine sign-in popup was blocked.");
-  }
+  // Open the loopback OAuth helper page (served by the Rust
+  // `start_earth_engine_oauth` command on 127.0.0.1) in the SYSTEM BROWSER, not
+  // an in-app child webview. Routing it through window.open spawned a second app
+  // window on Linux (WebKitGTK) and crashed the macOS WKWebView, because Tauri's
+  // on_new_window handler turns window.open into a native child window. The
+  // browser runs Google Identity Services against the registered
+  // http://localhost origin and POSTs the token back to the loopback server,
+  // which we poll for below.
+  const { openUrl } = await import("@tauri-apps/plugin-opener");
+  await openUrl(session.url);
 
-  const token = await waitForTauriEarthEngineToken(session.state, popup);
-  popup.close();
+  const token = await waitForTauriEarthEngineToken(session.state);
   return normalizeEarthEngineAccessToken(token);
 }
 
@@ -269,21 +270,16 @@ async function loadEarthEngine(): Promise<EarthEngineApi> {
 
 async function waitForTauriEarthEngineToken(
   state: string,
-  popup: Window,
 ): Promise<TauriEarthEngineOAuthToken> {
-  let closedPolls = 0;
+  // The helper page now runs in the system browser, so there is no popup window
+  // handle to watch for cancellation; poll the loopback server for the token and
+  // fall back to the timeout below if the user abandons the browser sign-in.
   for (let poll = 0; poll < 300; poll += 1) {
     const token = await invoke<TauriEarthEngineOAuthToken | null>(
       "poll_earth_engine_oauth",
       { stateId: state },
     );
     if (token) return token;
-    if (popup.closed) {
-      closedPolls += 1;
-      if (closedPolls > 2) {
-        throw new Error("Earth Engine sign-in was cancelled.");
-      }
-    }
     await delay(1000);
   }
   throw new Error("Earth Engine sign-in timed out.");

--- a/packages/plugins/src/plugins/earth-engine-auth.ts
+++ b/packages/plugins/src/plugins/earth-engine-auth.ts
@@ -3,7 +3,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export const DEFAULT_GEE_OAUTH_CLIENT_ID =
-  "141292844612-gitmgm28jkmkujonfkrkvdaqjiqt6qkf.apps.googleusercontent.com";
+  "937635412428-qc3albpo6dtm2jdp2o5mk8biqlh0i6vo.apps.googleusercontent.com";
 
 export type EarthEngineImportMetaEnv = {
   VITE_GEE_OAUTH_CLIENT_ID?: unknown;


### PR DESCRIPTION
## Problem

Desktop Earth Engine sign-in fails on Linux and macOS (the web build is fine):

- **Linux (WebKitGTK):** clicking **Sign in to Earth Engine** opens a *second full GeoLibre app window* instead of a Google login.
- **macOS (WKWebView):** clicking **Sign in to Earth Engine** crashes and exits the app.

Additionally: a locally-configured `GEE_OAUTH_CLIENT_ID` was silently ignored, and the app requested the broad `cloud-platform` + full `drive` scopes it never uses, forcing Google's heavyweight OAuth verification.

## Changes

1. **Open OAuth in the system browser** (`earth-engine-auth.ts`): use `@tauri-apps/plugin-opener` (`openUrl`) instead of `window.open`. Tauri's `on_new_window` handler was turning `window.open` into a native in-app child webview — the second window on Linux and the WKWebView crash on macOS. The Rust loopback server on `127.0.0.1:5173` already receives the token and the frontend already polls `poll_earth_engine_oauth`, so no in-app window is needed. This removes the only trigger of the child-window handler.

2. **Bridge `GEE_OAUTH_CLIENT_ID`** (`vite.config.ts`): surface a bare `GEE_OAUTH_CLIENT_ID` (shell/`.env`) as `VITE_GEE_OAUTH_CLIENT_ID`, matching the existing `GOOGLE_MAPS_API_KEY` / `CESIUM_TOKEN` bridges. Also refreshed `DEFAULT_GEE_OAUTH_CLIENT_ID`.

3. **Drop the `cloud-platform` scope; use `drive.file`** (`earth_engine_oauth.rs` + `earth-engine-auth.ts`): GeoLibre only displays EE tiles/thumbnails and exports to Drive — it never uses Cloud Storage, BigQuery, or project/asset management, so `cloud-platform` is unnecessary (it was only pulled in as an `@google/earthengine` SDK default). Both auth paths now request only **`earthengine` + `drive.file`**:
   - Desktop helper page: updated the scope list.
   - Web path: pass `suppressDefaultScopes=true` with an explicit `EARTH_ENGINE_OAUTH_SCOPES` list so the SDK doesn't append its `earthengine`+`cloud-platform`+full-`drive` defaults.

   This keeps the app clear of the restricted full-`drive` scope (and its CASA assessment); `drive.file` is non-sensitive, leaving `earthengine` as the only sensitive scope to justify.

No new dependencies or capabilities. `@tauri-apps/plugin-opener` is already a dep of `packages/plugins`; `opener:allow-open-url` already permits `http://*`.

## Verification checklist (Google Cloud, OAuth consent screen)

- **Data Access** → registered scopes should be exactly `earthengine` (sensitive) + `drive.file` (non-sensitive). Remove `cloud-platform`.
- **Audience** → publishing status **In production** (Testing always shows the unverified warning).
- Provide the sensitive-scope **justification** + **demo video** for `earthengine`.

## Testing

Needs a desktop rebuild (`npm run tauri:build` / `npm run tauri:dev`):
1. Earth Engine panel → **Auth** → **Sign in to Earth Engine** opens the **system browser** (no second window, no crash).
2. Consent screen lists only the Earth Engine (+ Drive per-file) permissions.
3. Complete consent; the panel flips to authenticated once the token is polled back.

> The OAuth client's authorized JavaScript origins must include `http://localhost:5173` (the origin the desktop helper page is served from).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Earth Engine sign-in in the desktop app by opening the OAuth flow in the system browser and removing reliance on a persistent pop-up.
  * OAuth completion now uses more reliable token polling.
  * Reduced requested Google OAuth permissions to the minimal set for the Earth Engine flow.
  * Updated OAuth configuration to match the new client ID.
* **Configuration**
  * Added support for setting `GEE_OAUTH_CLIENT_ID` (auto-mapped to the VITE-prefixed OAuth setting when needed).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->