### PR TITLE
chore(processing): regenerate Whitebox menu catalog for geolibre-wasm 0.6.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,5 +89,6 @@ The browser build proxies the sidecar at `/sidecar` (same-origin, no CORS); conf
 - Tauri CSP allowlists tile/style hosts (OpenFreeMap, CARTO) — new external map/tile hosts must be added there.
 - Map/tile-host CORS for selected release assets is handled by a dev-server raster proxy.
 - For MapLibre control styling fixes, add scoped overrides in `apps/geolibre-desktop/src/index.css`, never edit `node_modules`.
+- The Processing **menu** (`ProcessingMenu.tsx`) renders from a checked-in, auto-generated catalog, `apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts` (do not hand-edit). Whenever `geolibre-wasm` is bumped (in `packages/processing/package.json`) — including Dependabot PRs — run `node scripts/gen-whitebox-menu-catalog.mjs` and commit the result, or new/renamed WASM tools silently miss the menu (the Processing **dialog** lists them dynamically, so the gap only shows in the menu).
 - UI strings are translatable via **react-i18next**; catalogs live in `apps/geolibre-desktop/src/i18n/locales/*.json` (`en.json` is the source of truth, typed by `i18next.d.ts`). Use `t()` for new user-facing strings; a `?locale`/`?lang` query param sets the embed language. See `docs/i18n.md`.
 - Reference docs: `docs/architecture.md`, `docs/project-format.md`, `docs/plugin-api.md`, `docs/python.md`, `docs/i18n.md`, `docs/contributing.md`.

--- a/apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts
@@ -31,7 +31,7 @@ export interface WhiteboxMenuCategory {
   subcategories: WhiteboxMenuSubcategory[];
 }
 
-/** 746 tools across 9 categories. */
+/** 753 tools across 9 categories. */
 export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
   {
     key: "conversion",
@@ -40,10 +40,14 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
       {
         label: "GeoLibre",
         tools: [
+          { id: "h3_to_vector", name: "H3 Cells to Polygons" },
+          { id: "h3_polyfill", name: "H3 Polyfill" },
+          { id: "raster_to_h3", name: "Raster to H3 Bins" },
           { id: "write_pmtiles", name: "Raster to PMTiles" },
           { id: "raster_to_tiles", name: "Raster to XYZ Tiles" },
           { id: "read_geoparquet", name: "Read GeoParquet" },
           { id: "vector_convert", name: "Vector Convert" },
+          { id: "vector_to_h3", name: "Vector to H3 Bins" },
           { id: "write_geoparquet", name: "Write GeoParquet" },
         ],
       },
@@ -390,6 +394,9 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
         label: "GeoLibre",
         tools: [
           { id: "dem_filter", name: "DEM Filter" },
+          { id: "extract_cog_subset", name: "Extract COG Subset" },
+          { id: "extract_wms_subset", name: "Extract WMS Subset" },
+          { id: "extract_xyz_tile_subset", name: "Extract XYZ Tile Subset" },
           { id: "raster_normalize", name: "Raster Normalize" },
           { id: "render_raster_png", name: "Render Raster to PNG" },
           { id: "reproject_raster", name: "Reproject Raster" },


### PR DESCRIPTION
## Problem

The Processing **menu** (`ProcessingMenu.tsx`) renders from a checked-in, auto-generated catalog file, `apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts`. When #1163 bumped `geolibre-wasm` to `0.6.0`, it added new WASM tools but never re-ran the generator, so the catalog went stale and the new tools never appeared in the menu:

- **Raster → GeoLibre:** `extract_cog_subset`, `extract_wms_subset`, `extract_xyz_tile_subset`
- **Conversion → GeoLibre:** `h3_to_vector`, `h3_polyfill`, `raster_to_h3`, `vector_to_h3`

(The Processing **dialog** lists WASM tools dynamically, so the gap only showed in the menu.)

## Changes

- Regenerated `whitebox-menu-catalog.ts` via `node scripts/gen-whitebox-menu-catalog.mjs` (746 → 753 tools). The Whitebox snapshot is unchanged; only the GeoLibre-authored tool entries were added.
- Documented in `CLAUDE.md` that every `geolibre-wasm` bump (including Dependabot PRs) must regenerate and commit the catalog, so this doesn't drift again.

## Test plan

- `node scripts/gen-whitebox-menu-catalog.mjs` is deterministic; re-running produces no further diff.
- Open Processing menu → Raster → GeoLibre and Conversion → GeoLibre; the seven tools above are now listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Processing menu with seven additional Whitebox tools.
  * Added H3/vector conversion tools and raster subset extraction options for COG, WMS, and XYZ tiles.
* **Documentation**
  * Updated developer guidance for keeping the Whitebox Processing catalog current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->