### PR TITLE
fix(security): harden sidecar auth, path sandboxing, plugin trust, and AI code exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,10 @@ RUN mkdir -p /data
 # from a dev server on another port). This image is intended for local/single-user
 # use; on a public host those allowances let the served JS probe each visitor's
 # loopback. Drop them from the CSP before publishing publicly.
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+# Ship nginx.conf as an immutable template (not loaded directly). entrypoint.sh
+# renders it to /etc/nginx/conf.d/default.conf on every boot, substituting the
+# per-launch sidecar token, so a container restart never keeps a stale token.
+COPY docker/nginx.conf /etc/nginx/nginx.conf.template
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 COPY --from=build /app/apps/geolibre-desktop/dist /usr/share/nginx/html

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -598,6 +598,11 @@ fn is_disallowed_ip(ip: std::net::IpAddr) -> bool {
                 );
                 return is_disallowed_ip(IpAddr::V4(embedded));
             }
+            // Not handled: 6to4 (2002::/16) and Teredo (2001::/32) also embed an
+            // IPv4 address, so e.g. 2002:a9fe:a9fe:: could reach 169.254.169.254.
+            // These transition mechanisms are effectively defunct and unrouted on
+            // modern hosts, so the practical risk is negligible; noted so this
+            // isn't mistaken for full coverage of every IPv4-embedding form.
             v6.is_unspecified()
                 || v6.is_multicast()
                 // fe80::/10 link-local

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -584,10 +584,24 @@ fn is_disallowed_ip(ip: std::net::IpAddr) -> bool {
             if let Some(mapped) = v6.to_ipv4_mapped() {
                 return is_disallowed_ip(IpAddr::V4(mapped));
             }
+            let segments = v6.segments();
+            // Deprecated IPv4-compatible form `::a.b.c.d` (all-zero 96-bit
+            // prefix, no `ffff` marker, and not `::`/`::1`). `to_ipv4_mapped`
+            // only covers `::ffff:a.b.c.d`, so classify the embedded IPv4 here
+            // too — otherwise `::169.254.169.254` would slip past the guard.
+            if segments[..6].iter().all(|&s| s == 0) && !(segments[6] == 0 && segments[7] <= 1) {
+                let embedded = std::net::Ipv4Addr::new(
+                    (segments[6] >> 8) as u8,
+                    (segments[6] & 0xff) as u8,
+                    (segments[7] >> 8) as u8,
+                    (segments[7] & 0xff) as u8,
+                );
+                return is_disallowed_ip(IpAddr::V4(embedded));
+            }
             v6.is_unspecified()
                 || v6.is_multicast()
                 // fe80::/10 link-local
-                || (v6.segments()[0] & 0xffc0) == 0xfe80
+                || (segments[0] & 0xffc0) == 0xfe80
         }
     }
 }
@@ -2857,6 +2871,7 @@ mod tests {
             "::",                     // unspecified
             "fe80::1",                // link-local
             "::ffff:169.254.169.254", // IPv4-mapped metadata
+            "::169.254.169.254",      // IPv4-compatible metadata (deprecated)
         ] {
             assert!(
                 is_disallowed_ip(ip.parse::<IpAddr>().unwrap()),

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -276,7 +276,20 @@ fn read_project_file(path: String) -> Result<String, String> {
             "Refusing to read \"{path}\": not an absolute local project file path"
         ));
     }
-    fs::read_to_string(&path).map_err(|error| format!("Could not read project file: {error}"))
+    // Resolve symlinks and re-check the extension, so a symlink named
+    // `*.geolibre`/`*.geolibre.json` can't redirect the read to an arbitrary
+    // target (e.g. `~/notes.geolibre.json -> ~/.ssh/id_rsa`). Only the resolved
+    // extension is re-checked (not the full guard): `canonicalize` yields a
+    // `\\?\C:\…` verbatim path on Windows, which the UNC check would reject.
+    let canonical =
+        fs::canonicalize(&path).map_err(|error| format!("Could not read project file: {error}"))?;
+    let resolved = canonical.to_string_lossy().to_ascii_lowercase();
+    if !(resolved.ends_with(".geolibre") || resolved.ends_with(".geolibre.json")) {
+        return Err(format!(
+            "Refusing to read \"{path}\": resolves to a non-project file"
+        ));
+    }
+    fs::read_to_string(&canonical).map_err(|error| format!("Could not read project file: {error}"))
 }
 
 /// Local vector file extensions the restore path may re-read (lowercased, no
@@ -1389,11 +1402,23 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
     }
 
     if sidecar_health_is_ready(&base_url) {
-        return Ok(SidecarServerInfo {
-            base_url,
-            port: SIDECAR_PORT,
-            token: sidecar_token().to_string(),
-        });
+        if sidecar_accepts_token(&base_url, sidecar_token()) {
+            return Ok(SidecarServerInfo {
+                base_url,
+                port: SIDECAR_PORT,
+                token: sidecar_token().to_string(),
+            });
+        }
+        // A sidecar is listening but rejects this session's token — an orphan
+        // from a previous launch still holding the port. We can't reclaim it
+        // (no child handle here, and /shutdown is token-protected), so fail with
+        // a clear message rather than handing back a token that 401s every call.
+        return Err(
+            "A GeoLibre processing server from a previous session is still \
+             running on port 8765 but does not accept this session's token. \
+             Quit any stray GeoLibre processes and try again."
+                .to_string(),
+        );
     }
 
     let uv = ensure_managed_uv(&app)?;
@@ -1801,6 +1826,30 @@ fn sidecar_health_is_ready(base_url: &str) -> bool {
     };
     client
         .get(format!("{base_url}/health"))
+        .send()
+        .map(|response| response.status().is_success())
+        .unwrap_or(false)
+}
+
+/// Whether the sidecar already listening at `base_url` accepts `token`.
+///
+/// `/health` is token-exempt, so it cannot reveal a token mismatch. This probes
+/// `/algorithms` (a cheap authenticated endpoint) *with* the token so an orphan
+/// sidecar from a previous launch — started with a different per-launch token,
+/// and not killed because `Drop` doesn't run on `SIGKILL` — is detected rather
+/// than silently 401ing every later request. A tokenless dev sidecar
+/// (`GEOLIBRE_SIDECAR_TOKEN` unset) accepts any header and returns 200, so it is
+/// still reused.
+fn sidecar_accepts_token(base_url: &str, token: &str) -> bool {
+    let Ok(client) = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(500))
+        .build()
+    else {
+        return false;
+    };
+    client
+        .get(format!("{base_url}/algorithms"))
+        .header("x-geolibre-token", token)
         .send()
         .map(|response| response.status().is_success())
         .unwrap_or(false)

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1860,7 +1860,14 @@ fn request_sidecar_shutdown(base_url: &str) {
         .timeout(Duration::from_millis(500))
         .build();
     if let Ok(client) = client {
-        let _ = client.post(format!("{base_url}/shutdown")).send();
+        // /shutdown is token-protected (only /health is exempt), so attach this
+        // session's token. This shuts down a sidecar we started or adopted (same
+        // token); a true cross-launch orphan (different token) 401s and falls
+        // through to the force-kill path, as before.
+        let _ = client
+            .post(format!("{base_url}/shutdown"))
+            .header("x-geolibre-token", sidecar_token())
+            .send();
     }
 }
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -231,17 +231,18 @@ pub fn run() {
 
 /// Whether `read_project_file` may read `path`: an absolute local path (POSIX
 /// `/...` or a Windows drive-letter `C:\...`, never a UNC `\\host\share`), free
-/// of `..` traversal, ending in a GeoLibre project extension (`.geolibre`,
-/// `.geolibre.json`, or `.json` — the extensions the project open/save dialogs
-/// use in `tauri-io.ts`).
+/// of `..` traversal, ending in a GeoLibre project extension — `.geolibre` or
+/// `.geolibre.json`. These are the canonical formats `saveProject` writes and
+/// `isGeoLibreProjectPath` recognizes in `tauri-io.ts`.
 ///
 /// Without this, the command was an arbitrary local-file reader: any webview JS
 /// or loaded plugin could `invoke("read_project_file", { path: "~/.ssh/id_rsa" })`
-/// and receive the contents. The extension gate is not airtight (a JSON-shaped
-/// secret could still match), but it blocks the high-value targets (SSH/cloud
-/// credentials, extension-less config, browser cookie DBs) while still reading
-/// the project files this path needs. Byte-oriented like
-/// `is_allowed_local_vector_path` so Windows paths behave the same on any host.
+/// and receive the contents. A bare `.json` extension is deliberately NOT
+/// accepted: plenty of real secrets are JSON (GCP service-account keys,
+/// `application_default_credentials.json`, editor/CLI configs with tokens), so
+/// requiring the `.geolibre` marker keeps those out while still reading every
+/// real project. Byte-oriented like `is_allowed_local_vector_path` so Windows
+/// paths behave the same on any host.
 pub(crate) fn is_allowed_project_path(path: &str) -> bool {
     let bytes = path.as_bytes();
     let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
@@ -265,7 +266,7 @@ pub(crate) fn is_allowed_project_path(path: &str) -> bool {
     }
 
     let lower = path.to_ascii_lowercase();
-    lower.ends_with(".geolibre") || lower.ends_with(".json")
+    lower.ends_with(".geolibre") || lower.ends_with(".geolibre.json")
 }
 
 #[tauri::command]
@@ -637,6 +638,51 @@ fn guarded_redirect_policy() -> reqwest::redirect::Policy {
     })
 }
 
+/// A DNS resolver that drops any address in a blocked range, so reqwest connects
+/// only to IPs that passed [`is_disallowed_ip`].
+///
+/// [`url_is_fetchable`] validates the host *before* the request, but reqwest
+/// re-resolves the name when it opens the connection, so a check-then-connect
+/// gap remains: an attacker controlling DNS (short TTL) could answer the
+/// pre-check with a public IP and the actual connection with `169.254.169.254`.
+/// Enforcing the filter inside the resolver reqwest actually uses — for the
+/// initial request and every redirect hop — closes that rebinding window.
+struct GuardedDnsResolver;
+
+impl reqwest::dns::Resolve for GuardedDnsResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        use std::net::ToSocketAddrs;
+        Box::pin(async move {
+            let host = name.as_str().to_string();
+            // std getaddrinfo blocks, but these are low-volume tile/URL fetches.
+            let resolved = (host.as_str(), 0u16).to_socket_addrs();
+            let addrs: Vec<std::net::SocketAddr> = match resolved {
+                Ok(iter) => iter.filter(|addr| !is_disallowed_ip(addr.ip())).collect(),
+                Err(error) => {
+                    return Err(Box::new(error) as Box<dyn std::error::Error + Send + Sync>);
+                }
+            };
+            if addrs.is_empty() {
+                return Err(SSRF_BLOCKED_MESSAGE.into());
+            }
+            Ok(Box::new(addrs.into_iter()) as reqwest::dns::Addrs)
+        })
+    }
+}
+
+/// Build a blocking HTTP client that enforces the SSRF guard at connect time
+/// (via [`GuardedDnsResolver`]) and re-validates redirect hops.
+fn guarded_http_client(timeout: Duration) -> Result<reqwest::blocking::Client, String> {
+    reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
+        .redirect(guarded_redirect_policy())
+        .dns_resolver(std::sync::Arc::new(GuardedDnsResolver))
+        .user_agent("GeoLibre Desktop")
+        .build()
+        .map_err(|error| format!("Could not create HTTP client: {error}"))
+}
+
 #[tauri::command]
 async fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
     tauri::async_runtime::spawn_blocking(move || fetch_url_bytes_blocking(url))
@@ -647,13 +693,7 @@ async fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
 fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
     ensure_fetchable_url(&url)?;
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(REMOTE_TILE_TIMEOUT_SECS))
-        .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
-        .redirect(guarded_redirect_policy())
-        .user_agent("GeoLibre Desktop")
-        .build()
-        .map_err(|error| format!("Could not create HTTP client: {error}"))?;
+    let client = guarded_http_client(Duration::from_secs(REMOTE_TILE_TIMEOUT_SECS))?;
 
     let response = client
         .get(&url)
@@ -1127,13 +1167,7 @@ async fn resolve_url_redirect(url: String) -> Result<String, String> {
 fn resolve_url_redirect_blocking(url: String) -> Result<String, String> {
     ensure_fetchable_url(&url)?;
 
-    let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(URL_RESOLVE_TIMEOUT_SECS))
-        .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
-        .redirect(guarded_redirect_policy())
-        .user_agent("GeoLibre Desktop")
-        .build()
-        .map_err(|error| format!("Could not create HTTP client: {error}"))?;
+    let client = guarded_http_client(Duration::from_secs(URL_RESOLVE_TIMEOUT_SECS))?;
 
     if let Ok(head_response) = client.head(&url).send() {
         if has_xyz_placeholders(head_response.url().as_str()) {
@@ -2811,13 +2845,22 @@ mod tests {
     fn project_path_guard_allows_projects_and_blocks_secrets() {
         assert!(is_allowed_project_path("/home/u/map.geolibre.json"));
         assert!(is_allowed_project_path("/home/u/map.geolibre"));
-        assert!(is_allowed_project_path("C:\\Users\\u\\map.json"));
+        assert!(is_allowed_project_path("C:\\Users\\u\\map.geolibre.json"));
         // Secrets and traversal are refused.
         assert!(!is_allowed_project_path("/home/u/.ssh/id_rsa"));
         assert!(!is_allowed_project_path("/home/u/.aws/credentials"));
-        assert!(!is_allowed_project_path("/home/u/../../etc/hosts.json"));
-        assert!(!is_allowed_project_path("relative/map.json"));
-        assert!(!is_allowed_project_path("\\\\server\\share\\map.json"));
+        assert!(!is_allowed_project_path(
+            "/home/u/../../etc/hosts.geolibre.json"
+        ));
+        assert!(!is_allowed_project_path("relative/map.geolibre.json"));
+        assert!(!is_allowed_project_path(
+            "\\\\server\\share\\map.geolibre.json"
+        ));
+        // A bare .json file (e.g. a JSON credential store) is NOT a project.
+        assert!(!is_allowed_project_path(
+            "/home/u/.config/gcloud/application_default_credentials.json"
+        ));
+        assert!(!is_allowed_project_path("C:\\Users\\u\\map.json"));
     }
 
     #[test]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -229,8 +229,52 @@ pub fn run() {
         .expect("error while running GeoLibre Desktop");
 }
 
+/// Whether `read_project_file` may read `path`: an absolute local path (POSIX
+/// `/...` or a Windows drive-letter `C:\...`, never a UNC `\\host\share`), free
+/// of `..` traversal, ending in a GeoLibre project extension (`.geolibre`,
+/// `.geolibre.json`, or `.json` — the extensions the project open/save dialogs
+/// use in `tauri-io.ts`).
+///
+/// Without this, the command was an arbitrary local-file reader: any webview JS
+/// or loaded plugin could `invoke("read_project_file", { path: "~/.ssh/id_rsa" })`
+/// and receive the contents. The extension gate is not airtight (a JSON-shaped
+/// secret could still match), but it blocks the high-value targets (SSH/cloud
+/// credentials, extension-less config, browser cookie DBs) while still reading
+/// the project files this path needs. Byte-oriented like
+/// `is_allowed_local_vector_path` so Windows paths behave the same on any host.
+pub(crate) fn is_allowed_project_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
+
+    // Reject UNC paths ("\\server\share" and "//server/share").
+    if bytes.len() >= 2 && is_separator(bytes[0]) && is_separator(bytes[1]) {
+        return false;
+    }
+
+    let is_posix_absolute = bytes.first() == Some(&b'/');
+    let is_windows_drive = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && is_separator(bytes[2]);
+    if !is_posix_absolute && !is_windows_drive {
+        return false;
+    }
+
+    if path.split(['/', '\\']).any(|segment| segment == "..") {
+        return false;
+    }
+
+    let lower = path.to_ascii_lowercase();
+    lower.ends_with(".geolibre") || lower.ends_with(".json")
+}
+
 #[tauri::command]
 fn read_project_file(path: String) -> Result<String, String> {
+    if !is_allowed_project_path(&path) {
+        return Err(format!(
+            "Refusing to read \"{path}\": not an absolute local project file path"
+        ));
+    }
     fs::read_to_string(&path).map_err(|error| format!("Could not read project file: {error}"))
 }
 
@@ -494,6 +538,105 @@ fn close_oauth_popups(app: tauri::AppHandle) {
     }
 }
 
+/// Error surfaced when a fetch would reach a blocked address.
+const SSRF_BLOCKED_MESSAGE: &str =
+    "Refusing to fetch a link-local, unspecified, or multicast address";
+
+/// Whether an IP sits in a range a webview- or plugin-triggered fetch must not
+/// reach. This is the SSRF guard for [`fetch_url_bytes`] and
+/// [`resolve_url_redirect`]: those commands issue requests from the desktop
+/// process's network position and hand the body/redirect back to the webview, so
+/// without this a rogue plugin could read cloud metadata (169.254.169.254) — the
+/// classic SSRF target — that browser `fetch` cannot reach because of CORS.
+///
+/// Loopback and private/LAN ranges are deliberately NOT blocked: the app is
+/// built to load XYZ tiles, COGs, and PMTiles from a user's own
+/// `http://localhost:<port>` or LAN dev server (issue #387), and these commands
+/// are the desktop fetch path for that data. Blocking them would break a
+/// documented workflow. Sensitive loopback services (the Python sidecar, the
+/// Jupyter server) are individually token-gated, so the residual reachability of
+/// loopback/LAN is acceptable; link-local/metadata, which has no such guard, is
+/// blocked.
+fn is_disallowed_ip(ip: std::net::IpAddr) -> bool {
+    use std::net::IpAddr;
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_link_local() // 169.254.0.0/16 (incl. cloud metadata)
+                || v4.is_unspecified() // 0.0.0.0
+                || v4.is_broadcast()
+                || v4.is_multicast()
+        }
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_disallowed_ip(IpAddr::V4(mapped));
+            }
+            v6.is_unspecified()
+                || v6.is_multicast()
+                // fe80::/10 link-local
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+/// Reject a parsed URL that is non-HTTP(S) or whose host resolves to a
+/// private/loopback/link-local address. Hostname hosts are resolved and rejected
+/// if *any* resolved address is disallowed, so a name that points at an internal
+/// IP cannot slip through.
+fn url_is_fetchable(url: &reqwest::Url) -> Result<(), String> {
+    use std::net::ToSocketAddrs;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(format!("Unsupported URL scheme: {other}")),
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?;
+    let bare = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = bare.parse::<std::net::IpAddr>() {
+        return if is_disallowed_ip(ip) {
+            Err(SSRF_BLOCKED_MESSAGE.to_string())
+        } else {
+            Ok(())
+        };
+    }
+    let port = url.port_or_known_default().unwrap_or(0);
+    let mut resolved_any = false;
+    for addr in (bare, port)
+        .to_socket_addrs()
+        .map_err(|error| format!("Could not resolve host {bare}: {error}"))?
+    {
+        resolved_any = true;
+        if is_disallowed_ip(addr.ip()) {
+            return Err(SSRF_BLOCKED_MESSAGE.to_string());
+        }
+    }
+    if resolved_any {
+        Ok(())
+    } else {
+        Err(format!("Could not resolve host {bare}"))
+    }
+}
+
+/// Parse and SSRF-validate a URL string before a request is issued.
+fn ensure_fetchable_url(url: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url).map_err(|error| format!("Invalid URL: {error}"))?;
+    url_is_fetchable(&parsed)
+}
+
+/// A redirect policy that re-applies [`url_is_fetchable`] to every hop, so a
+/// public URL that 3xx-redirects to an internal address is not followed.
+fn guarded_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.stop();
+        }
+        match url_is_fetchable(attempt.url()) {
+            Ok(()) => attempt.follow(),
+            Err(_) => attempt.stop(),
+        }
+    })
+}
+
 #[tauri::command]
 async fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
     tauri::async_runtime::spawn_blocking(move || fetch_url_bytes_blocking(url))
@@ -502,13 +645,12 @@ async fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
 }
 
 fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
-    if !url.starts_with("https://") && !url.starts_with("http://") {
-        return Err("Only HTTP and HTTPS URLs can be fetched".to_string());
-    }
+    ensure_fetchable_url(&url)?;
 
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(REMOTE_TILE_TIMEOUT_SECS))
         .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
+        .redirect(guarded_redirect_policy())
         .user_agent("GeoLibre Desktop")
         .build()
         .map_err(|error| format!("Could not create HTTP client: {error}"))?;
@@ -983,13 +1125,12 @@ async fn resolve_url_redirect(url: String) -> Result<String, String> {
 }
 
 fn resolve_url_redirect_blocking(url: String) -> Result<String, String> {
-    if !url.starts_with("https://") && !url.starts_with("http://") {
-        return Err("Only HTTP and HTTPS URLs can be resolved".to_string());
-    }
+    ensure_fetchable_url(&url)?;
 
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(URL_RESOLVE_TIMEOUT_SECS))
         .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
+        .redirect(guarded_redirect_policy())
         .user_agent("GeoLibre Desktop")
         .build()
         .map_err(|error| format!("Could not create HTTP client: {error}"))?;
@@ -1081,6 +1222,9 @@ struct MartinServerInfo {
 struct SidecarServerInfo {
     base_url: String,
     port: u16,
+    /// Per-launch bearer token the frontend must send on every sidecar request
+    /// (see [`sidecar_token`]).
+    token: String,
 }
 
 #[derive(Serialize)]
@@ -1203,6 +1347,7 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
                 return Ok(SidecarServerInfo {
                     base_url,
                     port: SIDECAR_PORT,
+                    token: sidecar_token().to_string(),
                 });
             }
             *process = None;
@@ -1213,6 +1358,7 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
         return Ok(SidecarServerInfo {
             base_url,
             port: SIDECAR_PORT,
+            token: sidecar_token().to_string(),
         });
     }
 
@@ -1243,6 +1389,7 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
         .arg(SIDECAR_PORT.to_string())
         .current_dir(&project_dir)
         .env("GEOLIBRE_UV", &uv)
+        .env("GEOLIBRE_SIDECAR_TOKEN", sidecar_token())
         .env("GEOLIBRE_RUNTIME_DIR", &runtime_dir)
         .env("UV_CACHE_DIR", runtime_dir.join("uv-cache"))
         .env("UV_PYTHON_INSTALL_DIR", runtime_dir.join("uv-python"))
@@ -1278,6 +1425,7 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
     Ok(SidecarServerInfo {
         base_url,
         port: SIDECAR_PORT,
+        token: sidecar_token().to_string(),
     })
 }
 
@@ -1593,6 +1741,21 @@ fn generate_jupyter_token() -> String {
 
 fn sidecar_base_url() -> String {
     format!("http://127.0.0.1:{SIDECAR_PORT}")
+}
+
+/// A per-launch shared secret the frontend must present on every sidecar
+/// request. The sidecar binds loopback and is CORS-restricted, but neither stops
+/// a cross-origin simple POST (CSRF) or a DNS-rebinding read; this token does.
+///
+/// Generated once per desktop process (128 CSPRNG bits) and reused for the
+/// process lifetime so the early-return paths of `start_geolibre_sidecar` (when
+/// the sidecar is already running) hand back the same token that was injected
+/// via `GEOLIBRE_SIDECAR_TOKEN` at spawn time. A sidecar started outside this
+/// process (e.g. a `python -m` dev run) leaves the env var unset and simply does
+/// not enforce the token, so those flows keep working.
+fn sidecar_token() -> &'static str {
+    static TOKEN: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    TOKEN.get_or_init(generate_jupyter_token)
 }
 
 fn sidecar_health_is_ready(base_url: &str) -> bool {
@@ -2587,8 +2750,75 @@ fn configure_linux_webkit() {}
 
 #[cfg(test)]
 mod tests {
-    use super::{find_zip_manifest_path, is_allowed_local_vector_path, plugin_archive_file_name};
+    use super::{
+        ensure_fetchable_url, find_zip_manifest_path, is_allowed_local_vector_path,
+        is_allowed_project_path, is_disallowed_ip, plugin_archive_file_name,
+    };
     use std::io::{Cursor, Write};
+    use std::net::IpAddr;
+
+    #[test]
+    fn blocks_link_local_and_metadata_ips() {
+        for ip in [
+            "169.254.169.254",        // cloud metadata (link-local)
+            "169.254.0.1",            // link-local
+            "0.0.0.0",                // unspecified
+            "255.255.255.255",        // broadcast
+            "::",                     // unspecified
+            "fe80::1",                // link-local
+            "::ffff:169.254.169.254", // IPv4-mapped metadata
+        ] {
+            assert!(
+                is_disallowed_ip(ip.parse::<IpAddr>().unwrap()),
+                "expected {ip} to be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_public_loopback_and_lan_ips() {
+        // Public plus loopback/LAN, which stay reachable for local tile/COG
+        // data (issue #387). Only link-local/metadata is blocked.
+        for ip in [
+            "8.8.8.8",
+            "1.1.1.1",
+            "93.184.216.34",
+            "2606:4700:4700::1111",
+            "127.0.0.1",    // loopback (local dev tile server)
+            "192.168.1.10", // LAN
+            "10.0.0.5",     // LAN
+            "::1",          // loopback
+        ] {
+            assert!(
+                !is_disallowed_ip(ip.parse::<IpAddr>().unwrap()),
+                "expected {ip} to be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_fetchable_url_blocks_metadata_and_bad_schemes() {
+        assert!(ensure_fetchable_url("http://169.254.169.254/latest/meta-data").is_err());
+        assert!(ensure_fetchable_url("file:///etc/passwd").is_err());
+        assert!(ensure_fetchable_url("ftp://example.com/x").is_err());
+        // Public and loopback/LAN literals are allowed (local data workflow).
+        assert!(ensure_fetchable_url("https://1.1.1.1/").is_ok());
+        assert!(ensure_fetchable_url("http://127.0.0.1:8081/tiles/0/0/0.png").is_ok());
+        assert!(ensure_fetchable_url("http://[::1]:8081/data.pmtiles").is_ok());
+    }
+
+    #[test]
+    fn project_path_guard_allows_projects_and_blocks_secrets() {
+        assert!(is_allowed_project_path("/home/u/map.geolibre.json"));
+        assert!(is_allowed_project_path("/home/u/map.geolibre"));
+        assert!(is_allowed_project_path("C:\\Users\\u\\map.json"));
+        // Secrets and traversal are refused.
+        assert!(!is_allowed_project_path("/home/u/.ssh/id_rsa"));
+        assert!(!is_allowed_project_path("/home/u/.aws/credentials"));
+        assert!(!is_allowed_project_path("/home/u/../../etc/hosts.json"));
+        assert!(!is_allowed_project_path("relative/map.json"));
+        assert!(!is_allowed_project_path("\\\\server\\share\\map.json"));
+    }
 
     #[test]
     fn allows_absolute_vector_paths() {

--- a/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
+++ b/apps/geolibre-desktop/src-tauri/src/native_duckdb.rs
@@ -933,8 +933,8 @@ mod tests {
         )
         .expect("write prj sidecar");
 
-        let crs = read_prj_sidecar_crs(&shp_path.to_string_lossy())
-            .expect("prj sidecar resolves a CRS");
+        let crs =
+            read_prj_sidecar_crs(&shp_path.to_string_lossy()).expect("prj sidecar resolves a CRS");
         assert_eq!(
             crs,
             "PROJCS[\"British_National_Grid\",GEOGCS[\"GCS_OSGB_1936\"]]"

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -176,41 +176,48 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   // callback is blocked on. A queue (not a single slot) so two tool calls
   // dispatched before the user responds to the first don't drop the first
   // request's resolver — they are shown and resolved one at a time.
-  const [codeQueue, setCodeQueue] = useState<
-    Array<{
-      id: number;
-      tool: "run_python" | "run_maplibre_js";
-      code: string;
-      resolve: (approved: boolean) => void;
-    }>
-  >([]);
+  //
+  // The ref is authoritative: it's read/drained synchronously (including in the
+  // unmount cleanup, where a React state updater is not guaranteed to run and
+  // must not carry side effects). The state only mirrors the ref for rendering.
+  type PendingCode = {
+    id: number;
+    tool: "run_python" | "run_maplibre_js";
+    code: string;
+    resolve: (approved: boolean) => void;
+  };
+  const codeQueueRef = useRef<PendingCode[]>([]);
+  const [codeQueue, setCodeQueue] = useState<PendingCode[]>([]);
   // Once the user opts in, skip the prompt for the rest of this session.
   const alwaysAllowCodeRef = useRef(false);
   // Monotonic id so each queued prompt has a stable React key.
   const codeReqIdRef = useRef(0);
 
+  const commitQueue = (next: PendingCode[]): void => {
+    codeQueueRef.current = next;
+    setCodeQueue(next);
+  };
+
   // Resolve the head request and advance the queue. When the user approves with
   // "always allow", drain the rest as approved too.
   const decideCode = (approved: boolean, alwaysAllow: boolean): void => {
     if (approved && alwaysAllow) alwaysAllowCodeRef.current = true;
-    setCodeQueue((queue) => {
-      if (queue.length === 0) return queue;
-      const [head, ...rest] = queue;
-      head.resolve(approved);
-      if (approved && alwaysAllow) {
-        for (const item of rest) item.resolve(true);
-        return [];
-      }
-      return rest;
-    });
+    const queue = codeQueueRef.current;
+    if (queue.length === 0) return;
+    const [head, ...rest] = queue;
+    head.resolve(approved);
+    if (approved && alwaysAllow) {
+      for (const item of rest) item.resolve(true);
+      commitQueue([]);
+    } else {
+      commitQueue(rest);
+    }
   };
 
   // Decline every queued request (used when the run is stopped/torn down).
   const declineAllPendingCode = (): void => {
-    setCodeQueue((queue) => {
-      for (const item of queue) item.resolve(false);
-      return [];
-    });
+    for (const item of codeQueueRef.current) item.resolve(false);
+    commitQueue([]);
   };
 
   // One session per mounted panel; conversation history lives inside it.
@@ -226,22 +233,24 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
             ? Promise.resolve(true)
             : new Promise<boolean>((resolve) => {
                 const id = (codeReqIdRef.current += 1);
-                setCodeQueue((queue) => [...queue, { id, tool, code, resolve }]);
+                commitQueue([
+                  ...codeQueueRef.current,
+                  { id, tool, code, resolve },
+                ]);
               }),
       }),
     [mapControllerRef],
   );
 
-  // Tear down the session and any in-flight run on unmount. Also decline any
-  // pending code-approval prompts so their blocked tool promises don't hang if
-  // the panel unmounts while the queue is non-empty.
+  // Tear down the session and any in-flight run on unmount. Drain the queue ref
+  // synchronously (resolving each pending approval as declined) so their blocked
+  // tool promises don't hang; done directly on the ref, not via a state updater
+  // that may never run after unmount.
   useEffect(
     () => () => {
       session.cancel();
-      setCodeQueue((queue) => {
-        for (const item of queue) item.resolve(false);
-        return [];
-      });
+      for (const item of codeQueueRef.current) item.resolve(false);
+      codeQueueRef.current = [];
     },
     [session],
   );
@@ -750,6 +759,7 @@ function CodeApprovalOverlay({
   const language = tool === "run_python" ? "Python" : "JavaScript";
   // Move focus to the safe default (Decline) when the prompt opens so keyboard
   // users land inside the dialog, and let Escape dismiss it as a decline.
+  const dialogRef = useRef<HTMLDivElement>(null);
   const declineRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     declineRef.current?.focus();
@@ -757,6 +767,7 @@ function CodeApprovalOverlay({
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-background/80 p-4">
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label={t("assistant.codeApprovalTitle")}
@@ -765,6 +776,25 @@ function CodeApprovalOverlay({
           if (event.key === "Escape") {
             event.stopPropagation();
             onDecide(false, false);
+            return;
+          }
+          // Trap Tab within this security-critical dialog so a keyboard user
+          // can't move focus to background controls while the prompt is open.
+          if (event.key === "Tab") {
+            const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+              'button, input, [href], [tabindex]:not([tabindex="-1"])',
+            );
+            if (!focusables || focusables.length === 0) return;
+            const first = focusables[0];
+            const last = focusables[focusables.length - 1];
+            const active = document.activeElement;
+            if (event.shiftKey && active === first) {
+              event.preventDefault();
+              last.focus();
+            } else if (!event.shiftKey && active === last) {
+              event.preventDefault();
+              first.focus();
+            }
           }
         }}
       >

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -17,6 +17,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -193,10 +194,12 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   // Monotonic id so each queued prompt has a stable React key.
   const codeReqIdRef = useRef(0);
 
-  const commitQueue = (next: PendingCode[]): void => {
+  // Stable (only touches the ref + the stable state setter) so the session
+  // useMemo below can depend on it without rebuilding the session each render.
+  const commitQueue = useCallback((next: PendingCode[]): void => {
     codeQueueRef.current = next;
     setCodeQueue(next);
-  };
+  }, []);
 
   // Resolve the head request and advance the queue. "Always allow" only skips
   // *future* confirmations (via alwaysAllowCodeRef); items already queued behind
@@ -236,7 +239,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
                 ]);
               }),
       }),
-    [mapControllerRef],
+    [mapControllerRef, commitQueue],
   );
 
   // Tear down the session and any in-flight run on unmount. Drain the queue ref

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -737,6 +737,12 @@ function CodeApprovalOverlay({
   const { t } = useTranslation();
   const [alwaysAllow, setAlwaysAllow] = useState(false);
   const language = tool === "run_python" ? "Python" : "JavaScript";
+  // Move focus to the safe default (Decline) when the prompt opens so keyboard
+  // users land inside the dialog, and let Escape dismiss it as a decline.
+  const declineRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    declineRef.current?.focus();
+  }, []);
   return (
     <div className="absolute inset-0 z-30 flex items-center justify-center bg-background/80 p-4">
       <div
@@ -744,6 +750,12 @@ function CodeApprovalOverlay({
         aria-modal="true"
         aria-label={t("assistant.codeApprovalTitle")}
         className="flex max-h-full w-full max-w-md flex-col gap-3 rounded-lg border bg-card p-4 shadow-lg"
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.stopPropagation();
+            onDecide(false, false);
+          }
+        }}
       >
         <div className="flex items-center gap-2">
           <ShieldAlert className="h-4 w-4 text-amber-500" />
@@ -767,6 +779,7 @@ function CodeApprovalOverlay({
         </label>
         <div className="flex justify-end gap-2">
           <Button
+            ref={declineRef}
             size="sm"
             variant="outline"
             onClick={() => onDecide(false, false)}

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -198,20 +198,17 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     setCodeQueue(next);
   };
 
-  // Resolve the head request and advance the queue. When the user approves with
-  // "always allow", drain the rest as approved too.
+  // Resolve the head request and advance the queue. "Always allow" only skips
+  // *future* confirmations (via alwaysAllowCodeRef); items already queued behind
+  // the head are still surfaced for individual review — otherwise a second,
+  // unreviewed snippet the model queued in the same turn would be rubber-stamped.
   const decideCode = (approved: boolean, alwaysAllow: boolean): void => {
     if (approved && alwaysAllow) alwaysAllowCodeRef.current = true;
     const queue = codeQueueRef.current;
     if (queue.length === 0) return;
     const [head, ...rest] = queue;
     head.resolve(approved);
-    if (approved && alwaysAllow) {
-      for (const item of rest) item.resolve(true);
-      commitQueue([]);
-    } else {
-      commitQueue(rest);
-    }
+    commitQueue(rest);
   };
 
   // Decline every queued request (used when the run is stopped/torn down).

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -171,22 +171,45 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     () => loadStored(MODEL_STORAGE_KEY) ?? "",
   );
 
-  // A model-generated code snippet (run_python / run_maplibre_js) awaiting the
-  // user's approval, plus the promise resolver the tool callback is blocked on.
-  const [pendingCode, setPendingCode] = useState<{
-    tool: "run_python" | "run_maplibre_js";
-    code: string;
-    resolve: (approved: boolean) => void;
-  } | null>(null);
+  // Queue of model-generated code snippets (run_python / run_maplibre_js)
+  // awaiting the user's approval, each with the promise resolver its tool
+  // callback is blocked on. A queue (not a single slot) so two tool calls
+  // dispatched before the user responds to the first don't drop the first
+  // request's resolver — they are shown and resolved one at a time.
+  const [codeQueue, setCodeQueue] = useState<
+    Array<{
+      id: number;
+      tool: "run_python" | "run_maplibre_js";
+      code: string;
+      resolve: (approved: boolean) => void;
+    }>
+  >([]);
   // Once the user opts in, skip the prompt for the rest of this session.
   const alwaysAllowCodeRef = useRef(false);
+  // Monotonic id so each queued prompt has a stable React key.
+  const codeReqIdRef = useRef(0);
 
-  // Resolve the pending approval and dismiss the prompt.
+  // Resolve the head request and advance the queue. When the user approves with
+  // "always allow", drain the rest as approved too.
   const decideCode = (approved: boolean, alwaysAllow: boolean): void => {
     if (approved && alwaysAllow) alwaysAllowCodeRef.current = true;
-    setPendingCode((current) => {
-      current?.resolve(approved);
-      return null;
+    setCodeQueue((queue) => {
+      if (queue.length === 0) return queue;
+      const [head, ...rest] = queue;
+      head.resolve(approved);
+      if (approved && alwaysAllow) {
+        for (const item of rest) item.resolve(true);
+        return [];
+      }
+      return rest;
+    });
+  };
+
+  // Decline every queued request (used when the run is stopped/torn down).
+  const declineAllPendingCode = (): void => {
+    setCodeQueue((queue) => {
+      for (const item of queue) item.resolve(false);
+      return [];
     });
   };
 
@@ -202,7 +225,8 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
           alwaysAllowCodeRef.current
             ? Promise.resolve(true)
             : new Promise<boolean>((resolve) => {
-                setPendingCode({ tool, code, resolve });
+                const id = (codeReqIdRef.current += 1);
+                setCodeQueue((queue) => [...queue, { id, tool, code, resolve }]);
               }),
       }),
     [mapControllerRef],
@@ -340,8 +364,8 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     cancelledGenerationRef.current = sendGenerationRef.current;
     session.cancel();
     // Decline any code awaiting approval so a stopped run doesn't leave the
-    // confirmation prompt (and its blocked tool promise) hanging.
-    decideCode(false, false);
+    // confirmation prompt (and its blocked tool promises) hanging.
+    declineAllPendingCode();
     runningRef.current = false;
     setRunning(false);
   };
@@ -684,10 +708,11 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
         </div>
       )}
 
-      {pendingCode ? (
+      {codeQueue.length > 0 ? (
         <CodeApprovalOverlay
-          tool={pendingCode.tool}
-          code={pendingCode.code}
+          key={codeQueue[0].id}
+          tool={codeQueue[0].tool}
+          code={codeQueue[0].code}
           onDecide={decideCode}
         />
       ) : null}

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   Send,
   Settings,
+  ShieldAlert,
   Sparkles,
   Square,
   Wrench,
@@ -170,11 +171,39 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     () => loadStored(MODEL_STORAGE_KEY) ?? "",
   );
 
+  // A model-generated code snippet (run_python / run_maplibre_js) awaiting the
+  // user's approval, plus the promise resolver the tool callback is blocked on.
+  const [pendingCode, setPendingCode] = useState<{
+    tool: "run_python" | "run_maplibre_js";
+    code: string;
+    resolve: (approved: boolean) => void;
+  } | null>(null);
+  // Once the user opts in, skip the prompt for the rest of this session.
+  const alwaysAllowCodeRef = useRef(false);
+
+  // Resolve the pending approval and dismiss the prompt.
+  const decideCode = (approved: boolean, alwaysAllow: boolean): void => {
+    if (approved && alwaysAllow) alwaysAllowCodeRef.current = true;
+    setPendingCode((current) => {
+      current?.resolve(approved);
+      return null;
+    });
+  };
+
   // One session per mounted panel; conversation history lives inside it.
   const session = useMemo(
     () =>
       new AssistantSession({
         getMapController: () => mapControllerRef.current,
+        // Gate assistant-authored code behind an explicit confirmation (unless
+        // the user has opted into always-allow for this session). Prompt-injected
+        // content could otherwise make the model run code that exfiltrates data.
+        confirmCodeExecution: ({ tool, code }) =>
+          alwaysAllowCodeRef.current
+            ? Promise.resolve(true)
+            : new Promise<boolean>((resolve) => {
+                setPendingCode({ tool, code, resolve });
+              }),
       }),
     [mapControllerRef],
   );
@@ -310,6 +339,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const stop = () => {
     cancelledGenerationRef.current = sendGenerationRef.current;
     session.cancel();
+    // Decline any code awaiting approval so a stopped run doesn't leave the
+    // confirmation prompt (and its blocked tool promise) hanging.
+    decideCode(false, false);
     runningRef.current = false;
     setRunning(false);
   };
@@ -651,6 +683,76 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
           )}
         </div>
       )}
+
+      {pendingCode ? (
+        <CodeApprovalOverlay
+          tool={pendingCode.tool}
+          code={pendingCode.code}
+          onDecide={decideCode}
+        />
+      ) : null}
     </section>
+  );
+}
+
+/**
+ * Modal shown before the assistant runs a `run_python` / `run_maplibre_js`
+ * snippet. Displays the code and requires an explicit decision, with an opt-in
+ * to skip the prompt for the rest of the session.
+ */
+function CodeApprovalOverlay({
+  tool,
+  code,
+  onDecide,
+}: {
+  tool: "run_python" | "run_maplibre_js";
+  code: string;
+  onDecide: (approved: boolean, alwaysAllow: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const [alwaysAllow, setAlwaysAllow] = useState(false);
+  const language = tool === "run_python" ? "Python" : "JavaScript";
+  return (
+    <div className="absolute inset-0 z-30 flex items-center justify-center bg-background/80 p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("assistant.codeApprovalTitle")}
+        className="flex max-h-full w-full max-w-md flex-col gap-3 rounded-lg border bg-card p-4 shadow-lg"
+      >
+        <div className="flex items-center gap-2">
+          <ShieldAlert className="h-4 w-4 text-amber-500" />
+          <span className="text-sm font-semibold">
+            {t("assistant.codeApprovalTitle")}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t("assistant.codeApprovalBody", { language })}
+        </p>
+        <pre className="max-h-48 overflow-auto rounded border bg-muted p-2 text-xs">
+          <code>{code}</code>
+        </pre>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={alwaysAllow}
+            onChange={(event) => setAlwaysAllow(event.target.checked)}
+          />
+          {t("assistant.codeApprovalAlways")}
+        </label>
+        <div className="flex justify-end gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onDecide(false, false)}
+          >
+            {t("assistant.codeApprovalDecline")}
+          </Button>
+          <Button size="sm" onClick={() => onDecide(true, alwaysAllow)}>
+            {t("assistant.codeApprovalRun")}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -232,8 +232,19 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     [mapControllerRef],
   );
 
-  // Tear down the session and any in-flight run on unmount.
-  useEffect(() => () => session.cancel(), [session]);
+  // Tear down the session and any in-flight run on unmount. Also decline any
+  // pending code-approval prompts so their blocked tool promises don't hang if
+  // the panel unmounts while the queue is non-empty.
+  useEffect(
+    () => () => {
+      session.cancel();
+      setCodeQueue((queue) => {
+        for (const item of queue) item.resolve(false);
+        return [];
+      });
+    },
+    [session],
+  );
 
   // On unmount mid-drag, tear down the drag's window listeners.
   useEffect(() => () => resizeCleanupRef.current?.(), []);

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2192,7 +2192,12 @@
     "thinking": "Working…",
     "toolError": "failed",
     "provider": "LLM provider",
-    "model": "Model"
+    "model": "Model",
+    "codeApprovalTitle": "Run assistant code?",
+    "codeApprovalBody": "The assistant wants to run {{language}} code in the app. Review it first — it can change the map and access app data.",
+    "codeApprovalAlways": "Allow assistant code for the rest of this session",
+    "codeApprovalRun": "Run",
+    "codeApprovalDecline": "Cancel"
   },
   "storymap": {
     "title": "Story Map",

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -30,6 +30,19 @@ import { webSearch } from "./web-search";
 export interface AssistantToolDeps {
   /** Returns the live map controller, or null before the map mounts. */
   getMapController: () => MapController | null;
+  /**
+   * Ask the user to approve executing model-generated code before it runs.
+   * Resolves true to proceed, false to decline. The assistant can be steered by
+   * untrusted content (e.g. `web_search` results, layer attributes) into
+   * emitting a `run_python`/`run_maplibre_js` snippet that exfiltrates secrets
+   * or mutates the app, so these two tools are gated behind an explicit user
+   * confirmation. When omitted (e.g. in tests) code runs without a prompt; the
+   * desktop UI always provides it.
+   */
+  confirmCodeExecution?: (request: {
+    tool: "run_python" | "run_maplibre_js";
+    code: string;
+  }) => Promise<boolean>;
 }
 
 /** A short, model-facing description of one layer (no feature data leaked). */
@@ -255,6 +268,18 @@ export function createAssistantTools(
   // Shared Pyodide scripting context for run_python (exposes the `geolibre`
   // facade that drives the live map).
   const pyDeps = consoleDeps(deps.getMapController);
+
+  /**
+   * Gate model-authored code behind the user's confirmation hook. Returns true
+   * when execution may proceed (approved, or no hook configured).
+   */
+  const approveCodeExecution = (
+    toolName: "run_python" | "run_maplibre_js",
+    code: string,
+  ): Promise<boolean> =>
+    deps.confirmCodeExecution
+      ? deps.confirmCodeExecution({ tool: toolName, code })
+      : Promise.resolve(true);
 
   /** The current map viewport as [west, south, east, north], or null. */
   const viewBbox = (): [number, number, number, number] | null => {
@@ -575,6 +600,12 @@ export function createAssistantTools(
       code: z.string().describe("Python source to execute."),
     }),
     callback: async (input) => {
+      if (!(await approveCodeExecution("run_python", input.code))) {
+        return json({
+          output: "",
+          error: "The user declined to run this Python code.",
+        });
+      }
       const result = await runConsoleCode(pyDeps, input.code);
       // Cap stdout so a snippet printing megabytes can't blow the model's
       // context window on the next turn.
@@ -598,7 +629,10 @@ export function createAssistantTools(
           "JavaScript function body; `map` and `maplibregl` are in scope.",
         ),
     }),
-    callback: (input) => {
+    callback: async (input) => {
+      if (!(await approveCodeExecution("run_maplibre_js", input.code))) {
+        return json({ ok: false, error: "The user declined to run this code." });
+      }
       const map = deps.getMapController()?.getMap();
       if (!map) throw new Error("The map is not ready yet.");
       // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -22,6 +22,12 @@ import {
   pluginAssetUrlFromSource,
   resolvePluginAssetUrl,
 } from "./plugin-asset-url";
+import {
+  computePluginBundleHash,
+  pinPluginBundle,
+  removePluginBundlePin,
+  verifyPluginBundleIntegrity,
+} from "./plugin-integrity";
 import { isTauri } from "./tauri-io";
 
 interface ExternalPluginBundleError {
@@ -190,7 +196,26 @@ async function loadPluginUrlBundles(
   );
   for (const [index, result] of results.entries()) {
     if (result.status === "fulfilled") {
-      bundles.push(result.value);
+      const bundle = result.value;
+      // Refuse to auto-execute a URL bundle whose code changed since it was
+      // last trusted (a silent-update / compromised-host vector). First sight
+      // pins it; a changed hash is held back until the user reloads it
+      // explicitly (which re-pins).
+      const integrity = await verifyPluginBundleIntegrity(
+        manifestUrls[index],
+        bundle,
+      );
+      if (integrity.status === "changed") {
+        issues.push({
+          archiveName: bundle.archiveName,
+          sourceUrl: bundle.sourceUrl,
+          message:
+            `Plugin at '${bundle.sourceUrl}' changed since you last trusted it and was not loaded. ` +
+            "Open Settings → Plugins and reload it to review and accept the update.",
+        });
+        continue;
+      }
+      bundles.push(bundle);
     } else {
       issues.push({
         archiveName: manifestUrls[index],
@@ -555,13 +580,22 @@ export function unloadRemovedUrlPlugins(
   // synchronously, so removing entries in a separate pass avoids mutating the
   // map while iterating it.
   const toRemove: string[] = [];
+  const removedUrls = new Set<string>();
   for (const [pluginId, source] of externallyLoadedPluginSources) {
-    if (isManagedUrlSource(source) && !keep.has(source)) toRemove.push(pluginId);
+    if (isManagedUrlSource(source) && !keep.has(source)) {
+      toRemove.push(pluginId);
+      removedUrls.add(source);
+    }
   }
   for (const pluginId of toRemove) {
     manager.unregister(pluginId, app);
     removeExternalPluginStyle(pluginId);
     externallyLoadedPluginSources.delete(pluginId);
+  }
+  // Drop integrity pins for URLs no longer installed, so re-adding one later
+  // re-pins from a fresh review rather than silently matching a stale hash.
+  for (const url of removedUrls) {
+    removePluginBundlePin(url);
   }
   return toRemove;
 }
@@ -679,6 +713,9 @@ async function reloadExternalUrlPluginUncoalesced(
   externallyLoadedPluginSources.delete(existingId);
   manager.register(plugin);
   externallyLoadedPluginSources.set(plugin.id, manifestUrl);
+  // Explicit user reload: accept this version as the new trusted baseline so the
+  // next auto-scan doesn't flag it as changed.
+  pinPluginBundle(manifestUrl, await computePluginBundleHash(bundle));
   if (bundle.styleSource) {
     injectExternalPluginStyle(plugin.id, bundle.styleSource);
   }

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -200,18 +200,32 @@ async function loadPluginUrlBundles(
       // Refuse to auto-execute a URL bundle whose code changed since it was
       // last trusted (a silent-update / compromised-host vector). First sight
       // pins it; a changed hash is held back until the user reloads it
-      // explicitly (which re-pins).
-      const integrity = await verifyPluginBundleIntegrity(
-        manifestUrls[index],
-        bundle,
-      );
-      if (integrity.status === "changed") {
+      // explicitly (which re-pins). Isolate a verification failure (e.g.
+      // crypto.subtle unavailable) to this one URL — letting it throw here would
+      // reject the whole loadExternalPlugins Promise.all and drop every plugin.
+      try {
+        const integrity = await verifyPluginBundleIntegrity(
+          manifestUrls[index],
+          bundle,
+        );
+        if (integrity.status === "changed") {
+          issues.push({
+            archiveName: bundle.archiveName,
+            sourceUrl: bundle.sourceUrl,
+            message:
+              `Plugin at '${bundle.sourceUrl}' changed since you last trusted it and was not loaded. ` +
+              "Open Settings → Plugins and reload it to review and accept the update.",
+          });
+          continue;
+        }
+      } catch (error) {
         issues.push({
           archiveName: bundle.archiveName,
           sourceUrl: bundle.sourceUrl,
           message:
-            `Plugin at '${bundle.sourceUrl}' changed since you last trusted it and was not loaded. ` +
-            "Open Settings → Plugins and reload it to review and accept the update.",
+            error instanceof Error
+              ? `Could not verify plugin integrity: ${error.message}`
+              : "Could not verify plugin bundle integrity.",
         });
         continue;
       }

--- a/apps/geolibre-desktop/src/lib/plugin-integrity.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-integrity.ts
@@ -29,10 +29,23 @@ export interface PluginBundleForHashing {
 export async function computePluginBundleHash(
   bundle: PluginBundleForHashing,
 ): Promise<string> {
-  // NUL-separate so entry/style boundaries can't be shifted to collide.
-  const payload = `${bundle.entrySource}\u0000${bundle.styleSource ?? ""}`;
-  const data = new TextEncoder().encode(payload);
-  const digest = await crypto.subtle.digest("SHA-256", data);
+  // Hash entry and style independently, then hash the two digests together --
+  // rather than concatenating the raw sources with a delimiter. A delimiter can
+  // be forged: a NUL byte is legal inside JS/CSS source, so an attacker
+  // controlling what is served could shift the entry/style boundary across a
+  // planted NUL and make a later, different (entry, style) pair reproduce the
+  // pinned hash, defeating change detection. Fixed-length digests have no such
+  // boundary ambiguity.
+  const encoder = new TextEncoder();
+  const [entryDigest, styleDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(bundle.entrySource)),
+    crypto.subtle.digest("SHA-256", encoder.encode(bundle.styleSource ?? "")),
+  ]);
+  const combined = new Uint8Array([
+    ...new Uint8Array(entryDigest),
+    ...new Uint8Array(styleDigest),
+  ]);
+  const digest = await crypto.subtle.digest("SHA-256", combined);
   return Array.from(new Uint8Array(digest))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");

--- a/apps/geolibre-desktop/src/lib/plugin-integrity.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-integrity.ts
@@ -1,0 +1,128 @@
+// SHA-256 pinning for remotely-loaded plugin bundles.
+//
+// A plugin manifest URL the user installs in settings auto-loads on every app
+// launch (loadPluginUrlBundles) and its entry JS is dynamically import()-ed with
+// full renderer privileges (Tauri APIs on desktop). Trust is otherwise "trust
+// on first use, forever": if the host is later compromised — or the author
+// pushes a rogue update — the new code runs on the next launch with no re-prompt
+// (a silent-update / supply-chain vector).
+//
+// Pinning records the bundle's SHA-256 on first trusted load. On later launches
+// a bundle whose hash no longer matches the pin is NOT executed: it is held back
+// and surfaced so the user can review and explicitly reload it (which re-pins).
+// Local plugins (installed zips, filesystem drop-ins) are not pinned here — the
+// vector is remote fetch-and-execute.
+
+const PIN_STORAGE_KEY = "geolibre.pluginBundlePins";
+
+export interface PluginBundleForHashing {
+  entrySource: string;
+  styleSource?: string | null;
+}
+
+/**
+ * Compute the hex SHA-256 of a plugin bundle's executable + style sources.
+ *
+ * @param bundle - The fetched entry source and optional style source.
+ * @returns The lowercase hex SHA-256 digest.
+ */
+export async function computePluginBundleHash(
+  bundle: PluginBundleForHashing,
+): Promise<string> {
+  // NUL-separate so entry/style boundaries can't be shifted to collide.
+  const payload = `${bundle.entrySource}\u0000${bundle.styleSource ?? ""}`;
+  const data = new TextEncoder().encode(payload);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function readPins(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(PIN_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, string>;
+    }
+  } catch {
+    // Malformed or unavailable storage: treat as no pins.
+  }
+  return {};
+}
+
+function writePins(pins: Record<string, string>): void {
+  try {
+    localStorage.setItem(PIN_STORAGE_KEY, JSON.stringify(pins));
+  } catch {
+    // Storage may be unavailable or full; pinning is best-effort.
+  }
+}
+
+/** The trusted hash pinned for a URL, or null if it has never been pinned. */
+export function getPluginBundlePin(url: string): string | null {
+  return readPins()[url] ?? null;
+}
+
+/**
+ * Record (or overwrite) the trusted hash for a URL. Called on first trusted load
+ * and whenever the user explicitly reloads/accepts a new version.
+ *
+ * @param url - The plugin manifest URL.
+ * @param hash - The bundle hash to trust from now on.
+ */
+export function pinPluginBundle(url: string, hash: string): void {
+  const pins = readPins();
+  pins[url] = hash;
+  writePins(pins);
+}
+
+/**
+ * Forget the pin for a URL (e.g. when it is removed from settings).
+ *
+ * @param url - The plugin manifest URL.
+ */
+export function removePluginBundlePin(url: string): void {
+  const pins = readPins();
+  if (url in pins) {
+    delete pins[url];
+    writePins(pins);
+  }
+}
+
+export type PluginBundleIntegrity =
+  /** No prior pin; pinned now and allowed (trust on first use). */
+  | { status: "pinned-first-use" }
+  /** Hash matches the pin; allowed. */
+  | { status: "unchanged" }
+  /** Hash differs from the pin; blocked until the user reloads it. */
+  | { status: "changed"; pinnedHash: string; currentHash: string };
+
+/**
+ * Verify a freshly-fetched URL bundle against its pinned hash.
+ *
+ * First sight of a URL pins it and allows the load (the user added the URL to
+ * settings). A matching hash is allowed. A differing hash is reported as
+ * `"changed"` and NOT re-pinned, so the caller can block the automatic load and
+ * require an explicit reload.
+ *
+ * @param url - The plugin manifest URL that produced the bundle.
+ * @param bundle - The fetched entry/style sources.
+ * @returns The integrity verdict.
+ */
+export async function verifyPluginBundleIntegrity(
+  url: string,
+  bundle: PluginBundleForHashing,
+): Promise<PluginBundleIntegrity> {
+  const currentHash = await computePluginBundleHash(bundle);
+  const pinnedHash = getPluginBundlePin(url);
+  if (pinnedHash === null) {
+    pinPluginBundle(url, currentHash);
+    return { status: "pinned-first-use" };
+  }
+  if (pinnedHash === currentHash) {
+    return { status: "unchanged" };
+  }
+  return { status: "changed", pinnedHash, currentHash };
+}

--- a/apps/geolibre-desktop/src/lib/sidecar.ts
+++ b/apps/geolibre-desktop/src/lib/sidecar.ts
@@ -1,19 +1,27 @@
 import { invoke } from "@tauri-apps/api/core";
+import { setSidecarAuthToken } from "@geolibre/processing";
 import { isTauri } from "./tauri-io";
 
 export interface SidecarServerInfo {
   baseUrl: string;
   port: number;
+  /** Per-launch auth token the sidecar client must send on every request. */
+  token: string;
 }
 
 export async function startGeoLibreSidecar(): Promise<SidecarServerInfo> {
   assertTauri();
-  return invoke<SidecarServerInfo>("start_geolibre_sidecar");
+  const info = await invoke<SidecarServerInfo>("start_geolibre_sidecar");
+  // Hand the per-launch token to the sidecar client so all subsequent requests
+  // (which resolve the base URL themselves) are authenticated.
+  setSidecarAuthToken(info.token);
+  return info;
 }
 
 export async function stopGeoLibreSidecar(): Promise<void> {
   assertTauri();
   await invoke("stop_geolibre_sidecar");
+  setSidecarAuthToken(null);
 }
 
 function assertTauri(): void {

--- a/backend/geolibre_server/geolibre_server/app/main.py
+++ b/backend/geolibre_server/geolibre_server/app/main.py
@@ -42,6 +42,11 @@ from .whitebox import router as whitebox_router
 # own: a browser can send a simple cross-origin POST without a preflight (CSRF),
 # and a DNS-rebinding attacker can read responses too. The token closes both.
 SIDECAR_TOKEN = os.environ.get("GEOLIBRE_SIDECAR_TOKEN", "").strip()
+# Compared as bytes: Starlette decodes request headers as latin-1, so a header
+# with a byte > 0x7F arrives as a non-ASCII ``str`` and ``hmac.compare_digest``
+# would raise ``TypeError`` (turning an auth failure into a 500). Encoding both
+# sides keeps the comparison constant-time and simply fails to match.
+_SIDECAR_TOKEN_BYTES = SIDECAR_TOKEN.encode("utf-8")
 
 # Endpoints reachable without the token: the health probe (used by the Rust
 # readiness poll and the frontend before it holds a token) and CORS preflight.
@@ -69,8 +74,9 @@ async def require_sidecar_token(request: Request, call_next):
             auth = request.headers.get("authorization", "")
             if auth.lower().startswith("bearer "):
                 provided = auth[7:].strip()
-        # Constant-time compare so a timing side channel cannot leak the token.
-        if not hmac.compare_digest(provided, SIDECAR_TOKEN):
+        # Constant-time compare (on bytes; see _SIDECAR_TOKEN_BYTES) so a timing
+        # side channel cannot leak the token and a non-ASCII header can't crash.
+        if not hmac.compare_digest(provided.encode("utf-8"), _SIDECAR_TOKEN_BYTES):
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Missing or invalid sidecar token"},

--- a/backend/geolibre_server/geolibre_server/app/main.py
+++ b/backend/geolibre_server/geolibre_server/app/main.py
@@ -86,7 +86,11 @@ async def require_sidecar_token(request: Request, call_next):
 
 # Reject requests whose Host header is not a loopback name, blocking
 # DNS-rebinding attacks that would otherwise let a remote page treat the sidecar
-# as same-origin. ``testserver`` is Starlette's TestClient default host.
+# as same-origin. ``testserver`` is Starlette's TestClient default host. These
+# are the IPv4 loopback names uvicorn binds (``--host 127.0.0.1``); no IPv6
+# loopback (``::1``) is listed because the server never binds it — and
+# TrustedHostMiddleware's ``Host.split(":")[0]`` mis-parses a bracketed
+# ``[::1]:port`` anyway, so IPv6 binding would need revisiting here first.
 app.add_middleware(
     TrustedHostMiddleware,
     allowed_hosts=["localhost", "127.0.0.1", "testserver"],

--- a/backend/geolibre_server/geolibre_server/app/main.py
+++ b/backend/geolibre_server/geolibre_server/app/main.py
@@ -13,13 +13,17 @@ Spatial SQL is served by the ``/sql`` router (Apache Sedona / SedonaDB).
 
 from __future__ import annotations
 
+import hmac
+import os
 import signal
 import threading
 import time
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from .conversion import router as conversion_router
 from .ml import router as ml_router
@@ -30,7 +34,57 @@ from .sql import router as sql_router
 from .vector import router as vector_router
 from .whitebox import router as whitebox_router
 
+# A shared secret the caller must present on every request. The desktop shell
+# generates a fresh token per launch and passes it via this env var (and to the
+# frontend); the Docker image injects it at the nginx proxy. When unset (e.g.
+# ``python -m geolibre_server`` for local dev, or the pytest suite) the check is
+# skipped so those flows keep working. CORS is *not* a sufficient control on its
+# own: a browser can send a simple cross-origin POST without a preflight (CSRF),
+# and a DNS-rebinding attacker can read responses too. The token closes both.
+SIDECAR_TOKEN = os.environ.get("GEOLIBRE_SIDECAR_TOKEN", "").strip()
+
+# Endpoints reachable without the token: the health probe (used by the Rust
+# readiness poll and the frontend before it holds a token) and CORS preflight.
+_TOKEN_EXEMPT_PATHS = frozenset({"/health"})
+
 app = FastAPI(title="GeoLibre Server", version="0.8.0")
+
+
+@app.middleware("http")
+async def require_sidecar_token(request: Request, call_next):
+    """Reject requests that do not present the per-launch sidecar token.
+
+    The token may be supplied either as ``X-GeoLibre-Token: <token>`` or as
+    ``Authorization: Bearer <token>``. ``OPTIONS`` preflights and ``/health`` are
+    exempt so CORS and readiness probing keep working. No-ops when
+    ``GEOLIBRE_SIDECAR_TOKEN`` is unset.
+    """
+    if (
+        SIDECAR_TOKEN
+        and request.method != "OPTIONS"
+        and request.url.path not in _TOKEN_EXEMPT_PATHS
+    ):
+        provided = request.headers.get("x-geolibre-token", "")
+        if not provided:
+            auth = request.headers.get("authorization", "")
+            if auth.lower().startswith("bearer "):
+                provided = auth[7:].strip()
+        # Constant-time compare so a timing side channel cannot leak the token.
+        if not hmac.compare_digest(provided, SIDECAR_TOKEN):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Missing or invalid sidecar token"},
+            )
+    return await call_next(request)
+
+
+# Reject requests whose Host header is not a loopback name, blocking
+# DNS-rebinding attacks that would otherwise let a remote page treat the sidecar
+# as same-origin. ``testserver`` is Starlette's TestClient default host.
+app.add_middleware(
+    TrustedHostMiddleware,
+    allowed_hosts=["localhost", "127.0.0.1", "testserver"],
+)
 # Restrict CORS to the Tauri webview origins and the pinned Vite dev server
 # (vite.config.ts sets strictPort on 5173) rather than any localhost port, so a
 # stray local web app cannot reach the Whitebox endpoints from a browser.

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -786,6 +786,30 @@ def _looks_like_fs_path(value: str) -> bool:
     return ".." in text.replace("\\", "/").split("/")
 
 
+def _pinned_working_directory(absolute_paths: list[str]) -> str:
+    """Choose the root to pin the non-batch subprocess cwd to.
+
+    Prefer the allowlisted root that already contains one of the run's
+    (validated) absolute path arguments, so a relative path argument resolves
+    alongside them; fall back to the first configured root. Without this, a
+    multi-root ``GEOLIBRE_CONVERSION_ROOTS`` deployment would resolve every
+    relative path against root #0 regardless of which root the run's files live
+    under.
+
+    Args:
+        absolute_paths: Validated absolute path arguments seen in this run.
+
+    Returns:
+        An allowlisted root directory to use as the subprocess cwd.
+    """
+    for path in absolute_paths:
+        resolved = Path(path).expanduser().resolve()
+        for root in conversion._CONVERSION_ROOTS:
+            if resolved == Path(root) or resolved.is_relative_to(root):
+                return root
+    return conversion._CONVERSION_ROOTS[0]
+
+
 def _prepare_arguments(
     request: WhiteboxRunRequest,
     temp_paths: list[Path],
@@ -807,6 +831,7 @@ def _prepare_arguments(
     }
     args: dict[str, Any] = {}
     working_directory: str | None = None
+    absolute_paths: list[str] = []
     for name, value in request.parameters.items():
         spec = specs.get(str(name), {})
         kind = str(spec.get("kind") or "")
@@ -821,6 +846,10 @@ def _prepare_arguments(
             # could be bypassed by mislabelling a path parameter; validate by the
             # value's shape instead.
             _ensure_within_roots(value)
+            # Remember absolute path args so the cwd pin can target the root they
+            # live under in a multi-root deployment.
+            if Path(value).expanduser().is_absolute():
+                absolute_paths.append(value)
         batch_directory = _batch_working_directory(value, spec)
         if batch_directory:
             _ensure_within_roots(batch_directory)
@@ -844,9 +873,11 @@ def _prepare_arguments(
     # sidecar's own (WORKDIR /app in the Docker image), letting a relative value
     # read or write outside GEOLIBRE_CONVERSION_ROOTS. Pinning cwd to a root
     # keeps relative paths inside the sandbox. Set after default outputs are
-    # generated so their `not working_directory` condition still holds.
+    # generated so their `not working_directory` condition still holds. The root
+    # is chosen from the run's absolute paths (so multi-root deployments resolve
+    # relative paths under the right root), falling back to the first root.
     if working_directory is None and conversion._CONVERSION_ROOTS:
-        working_directory = conversion._CONVERSION_ROOTS[0]
+        working_directory = _pinned_working_directory(absolute_paths)
 
     # Defense in depth: the cwd pin above confines a plain relative arg, but if an
     # allowlisted root contains a symlink pointing outside it, a relative value

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -752,6 +752,34 @@ def _ensure_within_roots(path_value: str) -> None:
         )
 
 
+def _looks_like_fs_path(value: str) -> bool:
+    """Whether a parameter value looks like a filesystem path that could escape.
+
+    A value is "escape-shaped" when it is absolute (POSIX ``/…`` or a Windows
+    drive ``C:\\…``) or contains a ``..`` parent-traversal segment. Relative
+    paths without ``..`` stay under the working directory and cannot reach
+    outside the roots, and plain scalar strings (numbers, enums, CRS codes) are
+    ignored. This lets the sandbox check key off the *value shape* rather than
+    the client-declared ``kind`` — ``request.tool`` is free-form and untrusted,
+    so a caller could mislabel a path parameter's ``kind`` to skip a kind-based
+    check while still passing a real path Whitebox will act on.
+
+    Args:
+        value: A raw string parameter value from the run request.
+
+    Returns:
+        True when the value should be confined to the allowlisted roots.
+    """
+    text = value.strip()
+    if not text:
+        return False
+    if text.startswith(("/", "\\")):
+        return True
+    if len(text) >= 2 and text[1] == ":" and text[0].isascii() and text[0].isalpha():
+        return True
+    return ".." in text.replace("\\", "/").split("/")
+
+
 def _prepare_arguments(
     request: WhiteboxRunRequest,
     temp_paths: list[Path],
@@ -780,8 +808,12 @@ def _prepare_arguments(
             # Embedded layers are materialized to a server-owned temp file, so
             # the caller never controls this path.
             value = _write_layer_input(name, request.layer_inputs[name], temp_paths)
-        elif kind.endswith(("_in", "_out")) and isinstance(value, str) and value.strip():
-            # Caller-supplied file path: keep it inside the allowlisted roots.
+        elif isinstance(value, str) and _looks_like_fs_path(value):
+            # A path-shaped value must stay inside the allowlisted roots,
+            # regardless of the client-declared `kind`. `request.tool` is
+            # untrusted free-form input, so keying off `kind.endswith("_in"/"_out")`
+            # could be bypassed by mislabelling a path parameter; validate by the
+            # value's shape instead.
             _ensure_within_roots(value)
         batch_directory = _batch_working_directory(value, spec)
         if batch_directory:

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -857,11 +857,11 @@ def _prepare_arguments(
     if working_directory is not None and conversion._CONVERSION_ROOTS:
         base = Path(working_directory)
         for value in args.values():
-            if (
-                isinstance(value, str)
-                and ("/" in value or "\\" in value)
-                and not Path(value).is_absolute()
-            ):
+            # Every non-absolute string arg — including a bare filename like
+            # "pwned.tif", which could itself be a symlink planted at the root —
+            # is resolved against the pinned cwd and checked. Absolute / `..`
+            # values were already validated in the loop above.
+            if isinstance(value, str) and not Path(value).is_absolute():
                 _ensure_within_roots(str(base / value))
     return args, working_directory
 

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -19,6 +19,7 @@ from typing import Any, Callable
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from .conversion import _is_within_roots
 from .runtime import (
     RUNTIME_CATALOG_TIMEOUT_SECS,
     RUNTIME_DISCOVERY_TIMEOUT_SECS,
@@ -724,6 +725,33 @@ def _write_layer_input(param_name: str, layer: dict[str, Any], temp_paths: list[
     return str(path)
 
 
+def _ensure_within_roots(path_value: str) -> None:
+    """Reject a Whitebox path argument that escapes the configured roots.
+
+    No-op when ``GEOLIBRE_CONVERSION_ROOTS`` is unset (the desktop default,
+    where paths are the user's own filesystem). When it is set (the Docker/web
+    build, whose sidecar is reachable same-origin through the nginx proxy),
+    attacker-supplied ``*_in``/``*_out`` paths and batch directories are confined
+    to those roots so ``/whitebox/run`` cannot read or overwrite arbitrary
+    container files — the same confinement the conversion and raster routers
+    already enforce via :func:`_is_within_roots`.
+
+    Args:
+        path_value: A path string taken from the run request parameters.
+
+    Raises:
+        HTTPException: 403 when a root allowlist is configured and the resolved
+            path lies outside every allowlisted root.
+    """
+    # _is_within_roots returns True when no allowlist is configured, so this is a
+    # no-op on desktop and only confines paths in the Docker/web build.
+    if not _is_within_roots(Path(path_value).expanduser()):
+        raise HTTPException(
+            status_code=403,
+            detail="Path is outside the allowed processing directories",
+        )
+
+
 def _prepare_arguments(
     request: WhiteboxRunRequest,
     temp_paths: list[Path],
@@ -749,9 +777,15 @@ def _prepare_arguments(
         spec = specs.get(str(name), {})
         kind = str(spec.get("kind") or "")
         if name in request.layer_inputs:
+            # Embedded layers are materialized to a server-owned temp file, so
+            # the caller never controls this path.
             value = _write_layer_input(name, request.layer_inputs[name], temp_paths)
+        elif kind.endswith(("_in", "_out")) and isinstance(value, str) and value.strip():
+            # Caller-supplied file path: keep it inside the allowlisted roots.
+            _ensure_within_roots(value)
         batch_directory = _batch_working_directory(value, spec)
         if batch_directory:
+            _ensure_within_roots(batch_directory)
             if working_directory and working_directory != batch_directory:
                 raise ValueError("Only one Whitebox batch input directory is supported.")
             working_directory = batch_directory

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -19,7 +19,7 @@ from typing import Any, Callable
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from .conversion import _is_within_roots
+from . import conversion
 from .runtime import (
     RUNTIME_CATALOG_TIMEOUT_SECS,
     RUNTIME_DISCOVERY_TIMEOUT_SECS,
@@ -745,7 +745,13 @@ def _ensure_within_roots(path_value: str) -> None:
     """
     # _is_within_roots returns True when no allowlist is configured, so this is a
     # no-op on desktop and only confines paths in the Docker/web build.
-    if not _is_within_roots(Path(path_value).expanduser()):
+    try:
+        within_roots = conversion._is_within_roots(Path(path_value).expanduser())
+    except ValueError as error:
+        # e.g. an embedded NUL byte makes Path.resolve() raise; reject with a 403
+        # rather than letting it surface as an uncaught 500.
+        raise HTTPException(status_code=403, detail=f"Invalid path: {error}") from error
+    if not within_roots:
         raise HTTPException(
             status_code=403,
             detail="Path is outside the allowed processing directories",
@@ -830,6 +836,17 @@ def _prepare_arguments(
         kind = str(spec.get("kind") or "")
         if kind.endswith("_out") and not args.get(name) and not working_directory:
             args[name] = _default_output_path(request.tool_id, name, kind)
+
+    # When a root allowlist is configured and this is not a batch run, pin the
+    # subprocess working directory to an allowlisted root. Whitebox resolves a
+    # *relative* path argument (e.g. "out.tif" — not "escape-shaped", so it skips
+    # _ensure_within_roots) against its cwd; without this that cwd is the
+    # sidecar's own (WORKDIR /app in the Docker image), letting a relative value
+    # read or write outside GEOLIBRE_CONVERSION_ROOTS. Pinning cwd to a root
+    # keeps relative paths inside the sandbox. Set after default outputs are
+    # generated so their `not working_directory` condition still holds.
+    if working_directory is None and conversion._CONVERSION_ROOTS:
+        working_directory = conversion._CONVERSION_ROOTS[0]
     return args, working_directory
 
 

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -847,6 +847,22 @@ def _prepare_arguments(
     # generated so their `not working_directory` condition still holds.
     if working_directory is None and conversion._CONVERSION_ROOTS:
         working_directory = conversion._CONVERSION_ROOTS[0]
+
+    # Defense in depth: the cwd pin above confines a plain relative arg, but if an
+    # allowlisted root contains a symlink pointing outside it, a relative value
+    # could still traverse out. Resolve every relative, separator-bearing arg
+    # against the pinned working directory (Path.resolve follows symlinks) and
+    # reject anything that lands outside the roots. Absolute / `..` values were
+    # already validated in the loop above via _ensure_within_roots.
+    if working_directory is not None and conversion._CONVERSION_ROOTS:
+        base = Path(working_directory)
+        for value in args.values():
+            if (
+                isinstance(value, str)
+                and ("/" in value or "\\" in value)
+                and not Path(value).is_absolute()
+            ):
+                _ensure_within_roots(str(base / value))
     return args, working_directory
 
 

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -146,6 +146,50 @@ def test_whitebox_path_confined_to_roots(
     assert args["output"] == str(root / "out.tif")
 
 
+def test_whitebox_path_check_ignores_mislabeled_kind(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A path smuggled under a non-path ``kind`` is still confined to the roots.
+
+    ``request.tool`` is untrusted free-form input, so a caller can mislabel a
+    file parameter's ``kind`` (e.g. ``"string"``) to try to skip the sandbox.
+    The check keys off the value shape, so it still fires.
+    """
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+
+    # Mislabel the real path parameter as a plain "string" kind.
+    tool = {
+        "id": "some_raster_tool",
+        "params": [{"name": "input", "kind": "string"}],
+    }
+    for escaping in ("/etc/passwd", "../../etc/passwd"):
+        request = WhiteboxRunRequest(
+            tool_id="some_raster_tool",
+            parameters={"input": escaping},
+            tool=tool,
+        )
+        with pytest.raises(HTTPException) as excinfo:
+            _prepare_arguments(request, [])
+        assert excinfo.value.status_code == 403
+
+    # A non-path scalar string is not mistaken for a path.
+    request = WhiteboxRunRequest(
+        tool_id="some_raster_tool",
+        parameters={"input": "EPSG:4326"},
+        tool=tool,
+    )
+    args, _ = _prepare_arguments(request, [])
+    assert args["input"] == "EPSG:4326"
+
+
 def test_whitebox_paths_unconfined_without_roots(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -62,6 +62,14 @@ def test_token_required_when_configured(monkeypatch: pytest.MonkeyPatch) -> None
             ).status_code
             == 200
         )
+        # A non-ASCII token header (raw latin-1 bytes on the wire) must fail auth
+        # (401), not crash the byte comparison with a TypeError (500).
+        assert (
+            client.get(
+                "/algorithms", headers={"X-GeoLibre-Token": b"t\xe9k\xe9n"}
+            ).status_code
+            == 401
+        )
     finally:
         _reload_app(monkeypatch, None)
 

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -228,6 +228,44 @@ def test_whitebox_relative_path_confined_by_cwd(
     assert working_directory == str(root.resolve())
 
 
+def test_whitebox_cwd_pins_to_root_of_absolute_input(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """With multiple roots, the cwd pins to the root holding an absolute arg."""
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    root0 = tmp_path / "data"
+    root0.mkdir()
+    root1 = tmp_path / "scratch"
+    root1.mkdir()
+    monkeypatch.setattr(
+        conversion,
+        "_CONVERSION_ROOTS",
+        [str(root0.resolve()), str(root1.resolve())],
+    )
+
+    tool = {
+        "id": "t",
+        "params": [
+            {"name": "input", "kind": "raster_in"},
+            {"name": "output", "kind": "raster_out"},
+        ],
+    }
+    # Absolute input under the *second* root; relative output should resolve
+    # there too, so the cwd is pinned to root1 rather than root0.
+    request = WhiteboxRunRequest(
+        tool_id="t",
+        parameters={"input": str(root1 / "dem.tif"), "output": "out.tif"},
+        tool=tool,
+    )
+    _, working_directory = _prepare_arguments(request, [])
+    assert working_directory == str(root1.resolve())
+
+
 def test_whitebox_relative_path_through_symlink_is_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -1,0 +1,170 @@
+"""Security tests for the sidecar: auth token, Host validation, path sandbox."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi import HTTPException
+from starlette.testclient import TestClient
+
+
+def _reload_app(monkeypatch: pytest.MonkeyPatch, token: str | None):
+    """Reload the FastAPI app module with GEOLIBRE_SIDECAR_TOKEN set or unset.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        token: Token to place in the environment, or None to unset it.
+
+    Returns:
+        The freshly reloaded ``geolibre_server.app.main`` module.
+    """
+    if token is None:
+        monkeypatch.delenv("GEOLIBRE_SIDECAR_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("GEOLIBRE_SIDECAR_TOKEN", token)
+    import geolibre_server.app.main as main
+
+    return importlib.reload(main)
+
+
+def test_no_token_env_leaves_endpoints_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without GEOLIBRE_SIDECAR_TOKEN, requests are not challenged (dev/tests)."""
+    main = _reload_app(monkeypatch, None)
+    client = TestClient(main.app)
+    assert client.get("/health").status_code == 200
+    assert client.get("/algorithms").status_code == 200
+
+
+def test_token_required_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With a token set, work endpoints demand it; /health stays exempt."""
+    main = _reload_app(monkeypatch, "s3cr3t")
+    try:
+        client = TestClient(main.app)
+        # Health is exempt so the readiness probe keeps working.
+        assert client.get("/health").status_code == 200
+        # Missing / wrong token is rejected.
+        assert client.get("/algorithms").status_code == 401
+        assert (
+            client.get("/algorithms", headers={"X-GeoLibre-Token": "nope"}).status_code
+            == 401
+        )
+        # Correct token via either accepted header passes.
+        assert (
+            client.get(
+                "/algorithms", headers={"X-GeoLibre-Token": "s3cr3t"}
+            ).status_code
+            == 200
+        )
+        assert (
+            client.get(
+                "/algorithms", headers={"Authorization": "Bearer s3cr3t"}
+            ).status_code
+            == 200
+        )
+    finally:
+        _reload_app(monkeypatch, None)
+
+
+def test_untrusted_host_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-loopback Host header is rejected (DNS-rebinding defense)."""
+    main = _reload_app(monkeypatch, "s3cr3t")
+    try:
+        client = TestClient(main.app)
+        assert (
+            client.get(
+                "/algorithms",
+                headers={"Host": "evil.example.com", "X-GeoLibre-Token": "s3cr3t"},
+            ).status_code
+            == 400
+        )
+        assert (
+            client.get(
+                "/algorithms",
+                headers={"Host": "127.0.0.1:8765", "X-GeoLibre-Token": "s3cr3t"},
+            ).status_code
+            == 200
+        )
+    finally:
+        _reload_app(monkeypatch, None)
+
+
+def test_whitebox_path_confined_to_roots(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Whitebox input/output paths outside the allowlisted roots are rejected."""
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    # Configure a single allowlisted root (mirrors the Docker GEOLIBRE_CONVERSION_ROOTS).
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+
+    tool = {
+        "id": "some_raster_tool",
+        "params": [
+            {"name": "input", "kind": "raster_in"},
+            {"name": "output", "kind": "raster_out"},
+        ],
+    }
+
+    # An input path escaping the roots is refused.
+    outside = WhiteboxRunRequest(
+        tool_id="some_raster_tool",
+        parameters={"input": "/etc/passwd", "output": str(root / "out.tif")},
+        tool=tool,
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        _prepare_arguments(outside, [])
+    assert excinfo.value.status_code == 403
+
+    # An output path escaping the roots is refused.
+    bad_output = WhiteboxRunRequest(
+        tool_id="some_raster_tool",
+        parameters={
+            "input": str(root / "in.tif"),
+            "output": "/usr/share/nginx/html/x.tif",
+        },
+        tool=tool,
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        _prepare_arguments(bad_output, [])
+    assert excinfo.value.status_code == 403
+
+    # Paths inside the roots are accepted.
+    ok = WhiteboxRunRequest(
+        tool_id="some_raster_tool",
+        parameters={"input": str(root / "in.tif"), "output": str(root / "out.tif")},
+        tool=tool,
+    )
+    args, _ = _prepare_arguments(ok, [])
+    assert args["input"] == str(root / "in.tif")
+    assert args["output"] == str(root / "out.tif")
+
+
+def test_whitebox_paths_unconfined_without_roots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no allowlist (desktop default), any path is accepted."""
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [])
+    tool = {
+        "id": "some_raster_tool",
+        "params": [{"name": "input", "kind": "raster_in"}],
+    }
+    request = WhiteboxRunRequest(
+        tool_id="some_raster_tool",
+        parameters={"input": "/anywhere/on/disk.tif"},
+        tool=tool,
+    )
+    args, _ = _prepare_arguments(request, [])
+    assert args["input"] == "/anywhere/on/disk.tif"

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -228,6 +228,44 @@ def test_whitebox_relative_path_confined_by_cwd(
     assert working_directory == str(root.resolve())
 
 
+def test_whitebox_relative_path_through_symlink_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A relative arg traversing a symlink that escapes the root is rejected."""
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    root = tmp_path / "data"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # A symlink inside the root pointing outside it.
+    (root / "escape").symlink_to(outside)
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+
+    tool = {"id": "t", "params": [{"name": "output", "kind": "raster_out"}]}
+    request = WhiteboxRunRequest(
+        tool_id="t",
+        parameters={"output": "escape/secret.tif"},
+        tool=tool,
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        _prepare_arguments(request, [])
+    assert excinfo.value.status_code == 403
+
+    # A relative path staying inside the root is accepted.
+    ok = WhiteboxRunRequest(
+        tool_id="t",
+        parameters={"output": "subdir/out.tif"},
+        tool=tool,
+    )
+    args, _ = _prepare_arguments(ok, [])
+    assert args["output"] == "subdir/out.tif"
+
+
 def test_whitebox_null_byte_path_is_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -198,6 +198,61 @@ def test_whitebox_path_check_ignores_mislabeled_kind(
     assert args["input"] == "EPSG:4326"
 
 
+def test_whitebox_relative_path_confined_by_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """A relative path arg is confined by pinning the subprocess cwd to a root.
+
+    A bare filename like ``pwned.tif`` is not "escape-shaped", so it isn't
+    rejected — instead the run's working directory is pinned to an allowlisted
+    root so Whitebox resolves it inside the sandbox rather than the sidecar's cwd.
+    """
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+
+    tool = {"id": "t", "params": [{"name": "output", "kind": "raster_out"}]}
+    request = WhiteboxRunRequest(
+        tool_id="t",
+        parameters={"output": "pwned.tif"},
+        tool=tool,
+    )
+    args, working_directory = _prepare_arguments(request, [])
+    assert args["output"] == "pwned.tif"
+    assert working_directory == str(root.resolve())
+
+
+def test_whitebox_null_byte_path_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An embedded NUL byte yields a clean 403, not an uncaught 500."""
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import (
+        WhiteboxRunRequest,
+        _prepare_arguments,
+    )
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+
+    tool = {"id": "t", "params": [{"name": "input", "kind": "raster_in"}]}
+    request = WhiteboxRunRequest(
+        tool_id="t",
+        parameters={"input": "/data/x\x00y.tif"},
+        tool=tool,
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        _prepare_arguments(request, [])
+    assert excinfo.value.status_code == 403
+
+
 def test_whitebox_paths_unconfined_without_roots(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,19 @@
 # unavailable until the container is restarted).
 set -e
 
+# Per-container shared secret the sidecar requires on every request (see the
+# require_sidecar_token middleware). nginx forwards it on /sidecar/ proxied
+# requests and uvicorn enforces it, so the loopback sidecar cannot be driven by
+# anything other than the trusted proxy even if its port is ever exposed.
+# Honour an operator-provided value; otherwise mint a random one.
+GEOLIBRE_SIDECAR_TOKEN="${GEOLIBRE_SIDECAR_TOKEN:-$(python -c 'import secrets; print(secrets.token_hex(16))')}"
+export GEOLIBRE_SIDECAR_TOKEN
+
+# Substitute the token into the nginx /sidecar/ proxy config (the token is hex,
+# so it is safe inside the sed replacement).
+sed -i "s|__GEOLIBRE_SIDECAR_TOKEN__|${GEOLIBRE_SIDECAR_TOKEN}|g" \
+  /etc/nginx/conf.d/default.conf
+
 if [ "${GEOLIBRE_DISABLE_SIDECAR:-0}" != "1" ]; then
   python -m uvicorn geolibre_server.app.main:app \
     --host 127.0.0.1 --port 8765 &

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,10 +13,30 @@ set -e
 GEOLIBRE_SIDECAR_TOKEN="${GEOLIBRE_SIDECAR_TOKEN:-$(python -c 'import secrets; print(secrets.token_hex(16))')}"
 export GEOLIBRE_SIDECAR_TOKEN
 
-# Substitute the token into the nginx /sidecar/ proxy config (the token is hex,
-# so it is safe inside the sed replacement).
-sed -i "s|__GEOLIBRE_SIDECAR_TOKEN__|${GEOLIBRE_SIDECAR_TOKEN}|g" \
-  /etc/nginx/conf.d/default.conf
+# The token is embedded in a double-quoted nginx header value, so reject any
+# character that could break the config (quotes, backslashes, whitespace, &).
+# The auto-generated hex always passes; an operator override must be URL-safe.
+case "$GEOLIBRE_SIDECAR_TOKEN" in
+  "" | *[!A-Za-z0-9._-]*)
+    echo "GEOLIBRE_SIDECAR_TOKEN must be non-empty and contain only [A-Za-z0-9._-]" >&2
+    exit 1
+    ;;
+esac
+
+# Render the nginx config from the immutable image template on every boot. The
+# template is never mutated, so a container *restart* (which re-runs this script
+# with a freshly generated token but keeps the writable layer) always writes a
+# config whose forwarded token matches the token exported to uvicorn above.
+# Python's str.replace handles the token literally (no shell/sed metacharacter
+# surprises).
+python -c '
+import os
+token = os.environ["GEOLIBRE_SIDECAR_TOKEN"]
+src = open("/etc/nginx/nginx.conf.template").read()
+open("/etc/nginx/conf.d/default.conf", "w").write(
+    src.replace("__GEOLIBRE_SIDECAR_TOKEN__", token)
+)
+'
 
 if [ "${GEOLIBRE_DISABLE_SIDECAR:-0}" != "1" ]; then
   python -m uvicorn geolibre_server.app.main:app \

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -17,7 +17,14 @@ server {
     location /sidecar/ {
         proxy_pass http://127.0.0.1:8765/;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        # The sidecar's TrustedHostMiddleware only accepts loopback hosts, so
+        # forward a loopback Host rather than the public $host (which would be
+        # rejected as a rebinding attempt).
+        proxy_set_header Host 127.0.0.1;
+        # Authenticate the proxy to the sidecar. entrypoint.sh substitutes the
+        # per-container token here (and exports the same value to uvicorn). The
+        # browser never holds this secret; nginx is the trusted caller.
+        proxy_set_header X-GeoLibre-Token "__GEOLIBRE_SIDECAR_TOKEN__";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 5s;

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -79,6 +79,7 @@ export {
 } from "./raster-client";
 export {
   checkSidecarHealth,
+  setSidecarAuthToken,
   clearRemoteWhiteboxCatalogSnapshotCache,
   fetchConversionJob,
   fetchConversionStatus,

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -43,6 +43,43 @@ function resolveSidecarBaseUrl(): string {
 }
 
 const DEFAULT_SIDECAR_URL = resolveSidecarBaseUrl();
+
+/**
+ * Per-launch sidecar auth token. The desktop shell mints it when it spawns the
+ * sidecar and hands it back through `start_geolibre_sidecar`; {@link
+ * setSidecarAuthToken} stashes it here so {@link sidecarFetch} can attach it to
+ * every request. Null in the browser/Docker build, where the same-origin nginx
+ * proxy injects the token instead and the sidecar is unreachable directly.
+ */
+let sidecarAuthToken: string | null = null;
+
+/**
+ * Record (or clear) the sidecar auth token. Call after `startGeoLibreSidecar()`
+ * returns. Passing an empty/nullish value clears it.
+ *
+ * @param token - The per-launch token from the desktop backend, or null.
+ */
+export function setSidecarAuthToken(token: string | null | undefined): void {
+  sidecarAuthToken = token && token.trim() ? token.trim() : null;
+}
+
+/**
+ * `fetch` wrapper for sidecar requests that attaches the per-launch auth token
+ * (as `X-GeoLibre-Token`) when one is set. Used for every sidecar endpoint call;
+ * external fetches (e.g. the Whitebox catalog snapshot on GitHub) use plain
+ * `fetch` so the token is never sent off-host.
+ *
+ * @param input - The sidecar request URL.
+ * @param init - Optional fetch init; its headers are preserved.
+ * @returns The fetch response promise.
+ */
+function sidecarFetch(input: string, init?: RequestInit): Promise<Response> {
+  if (!sidecarAuthToken) return fetch(input, init);
+  const headers = new Headers(init?.headers);
+  headers.set("X-GeoLibre-Token", sidecarAuthToken);
+  return fetch(input, { ...init, headers });
+}
+
 const WHITEBOX_CATALOG_SNAPSHOT_URL =
   "https://raw.githubusercontent.com/opengeos/Whitebox-Next-Gen-ArcGIS/main/WNG/data/catalog_snapshot.json";
 
@@ -199,7 +236,7 @@ export async function checkSidecarHealth(
   baseUrl = DEFAULT_SIDECAR_URL,
 ): Promise<SidecarHealth | null> {
   try {
-    const res = await fetch(`${baseUrl}/health`);
+    const res = await sidecarFetch(`${baseUrl}/health`);
     if (!res.ok) return null;
     return (await res.json()) as SidecarHealth;
   } catch {
@@ -211,7 +248,7 @@ export async function fetchSidecarAlgorithms(
   baseUrl = DEFAULT_SIDECAR_URL,
 ): Promise<SidecarAlgorithm[]> {
   try {
-    const res = await fetch(`${baseUrl}/algorithms`);
+    const res = await sidecarFetch(`${baseUrl}/algorithms`);
     if (!res.ok) return [];
     const data = (await res.json()) as { algorithms: SidecarAlgorithm[] };
     return data.algorithms ?? [];
@@ -227,7 +264,7 @@ export async function fetchWhiteboxStatus(
 ): Promise<WhiteboxStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/whitebox/status`);
+    res = await sidecarFetch(`${baseUrl}/whitebox/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -242,7 +279,7 @@ export async function fetchWhiteboxTools(
 ): Promise<WhiteboxTool[]> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/whitebox/tools`);
+    res = await sidecarFetch(`${baseUrl}/whitebox/tools`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -317,7 +354,7 @@ export async function fetchWhiteboxTool(
   toolId: string,
   baseUrl = DEFAULT_SIDECAR_URL,
 ): Promise<unknown> {
-  const res = await fetch(`${baseUrl}/whitebox/tools/${encodeURIComponent(toolId)}`);
+  const res = await sidecarFetch(`${baseUrl}/whitebox/tools/${encodeURIComponent(toolId)}`);
   if (!res.ok) {
     throw new Error(await responseErrorMessage(res, "Could not load Whitebox tool"));
   }
@@ -328,7 +365,7 @@ export async function runWhiteboxTool(
   request: RunWhiteboxToolRequest,
   baseUrl = DEFAULT_SIDECAR_URL,
 ): Promise<WhiteboxJob> {
-  const res = await fetch(`${baseUrl}/whitebox/run`, {
+  const res = await sidecarFetch(`${baseUrl}/whitebox/run`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(request),
@@ -343,7 +380,7 @@ export async function fetchWhiteboxJob(
   jobId: string,
   baseUrl = DEFAULT_SIDECAR_URL,
 ): Promise<WhiteboxJob> {
-  const res = await fetch(`${baseUrl}/whitebox/jobs/${encodeURIComponent(jobId)}`);
+  const res = await sidecarFetch(`${baseUrl}/whitebox/jobs/${encodeURIComponent(jobId)}`);
   if (!res.ok) {
     throw new Error(await responseErrorMessage(res, "Could not load Whitebox job"));
   }
@@ -354,7 +391,7 @@ export async function fetchWhiteboxJsonOutput(
   path: string,
   baseUrl = DEFAULT_SIDECAR_URL,
 ): Promise<unknown> {
-  const res = await fetch(
+  const res = await sidecarFetch(
     `${baseUrl}/whitebox/output?path=${encodeURIComponent(path)}`,
   );
   if (!res.ok) {
@@ -451,7 +488,7 @@ export async function fetchConversionStatus(
 ): Promise<ConversionStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/conversion/status`);
+    res = await sidecarFetch(`${baseUrl}/conversion/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -564,7 +601,7 @@ export async function fetchRasterStatus(
 ): Promise<RasterStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/raster/status`);
+    res = await sidecarFetch(`${baseUrl}/raster/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -603,7 +640,7 @@ async function startConversion(
 ): Promise<ConversionJob> {
   let res: Response;
   try {
-    res = await fetch(url, {
+    res = await sidecarFetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),
@@ -623,7 +660,7 @@ export async function fetchConversionJob(
 ): Promise<ConversionJob> {
   let res: Response;
   try {
-    res = await fetch(
+    res = await sidecarFetch(
       `${baseUrl}/conversion/jobs/${encodeURIComponent(jobId)}`,
     );
   } catch (error) {
@@ -662,7 +699,7 @@ export async function fetchVectorStatus(
 ): Promise<VectorStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/vector/status`);
+    res = await sidecarFetch(`${baseUrl}/vector/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -678,7 +715,7 @@ export async function runVectorTool(
 ): Promise<VectorToolResult> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/vector/run`, {
+    res = await sidecarFetch(`${baseUrl}/vector/run`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),
@@ -725,7 +762,7 @@ export async function writeVectorToSource(
 ): Promise<WriteVectorToSourceResult> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/vector/write`, {
+    res = await sidecarFetch(`${baseUrl}/vector/write`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),
@@ -806,7 +843,7 @@ export async function fetchPostgisStatus(
 ): Promise<PostgisStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/postgis/status`);
+    res = await sidecarFetch(`${baseUrl}/postgis/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -823,7 +860,7 @@ export async function listPostgisTables(
 ): Promise<PostgisTableInfo[]> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/postgis/tables`, {
+    res = await sidecarFetch(`${baseUrl}/postgis/tables`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ connection }),
@@ -845,7 +882,7 @@ export async function readPostgisTable(
 ): Promise<ReadPostgisTableResult> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/postgis/read`, {
+    res = await sidecarFetch(`${baseUrl}/postgis/read`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),
@@ -871,7 +908,7 @@ export async function writePostgisTable(
 ): Promise<WritePostgisTableResult> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/postgis/write`, {
+    res = await sidecarFetch(`${baseUrl}/postgis/write`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),
@@ -928,7 +965,7 @@ export async function fetchMlStatus(
 ): Promise<MlStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/ml/status`);
+    res = await sidecarFetch(`${baseUrl}/ml/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -979,7 +1016,7 @@ export async function mlSegment(
 
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/ml/segment/${mode}`, {
+    res = await sidecarFetch(`${baseUrl}/ml/segment/${mode}`, {
       method: "POST",
       body: form,
     });
@@ -1028,7 +1065,7 @@ export async function fetchSqlStatus(
 ): Promise<SqlEngineStatus> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/sql/status`);
+    res = await sidecarFetch(`${baseUrl}/sql/status`);
   } catch (error) {
     throw sidecarConnectionError(baseUrl, error);
   }
@@ -1045,7 +1082,7 @@ export async function runSedonaSql(
 ): Promise<SedonaSqlResult> {
   let res: Response;
   try {
-    res = await fetch(`${baseUrl}/sql/run`, {
+    res = await sidecarFetch(`${baseUrl}/sql/run`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(request),

--- a/tests/plugin-integrity.test.ts
+++ b/tests/plugin-integrity.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import {
+  computePluginBundleHash,
+  getPluginBundlePin,
+  removePluginBundlePin,
+  verifyPluginBundleIntegrity,
+} from "../apps/geolibre-desktop/src/lib/plugin-integrity";
+
+// plugin-integrity reads/writes the bare `localStorage` global (=== window's in
+// the browser). Emulate just enough for Node's test runner.
+function installLocalStorage(): void {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+  };
+}
+
+describe("plugin bundle integrity pinning", () => {
+  beforeEach(() => {
+    installLocalStorage();
+  });
+
+  afterEach(() => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it("hashes deterministically and distinguishes entry/style", async () => {
+    const a = await computePluginBundleHash({
+      entrySource: "export const plugin = {}",
+      styleSource: ".x{}",
+    });
+    const same = await computePluginBundleHash({
+      entrySource: "export const plugin = {}",
+      styleSource: ".x{}",
+    });
+    const differentEntry = await computePluginBundleHash({
+      entrySource: "export const plugin = { evil: true }",
+      styleSource: ".x{}",
+    });
+    const differentStyle = await computePluginBundleHash({
+      entrySource: "export const plugin = {}",
+      styleSource: ".y{}",
+    });
+    assert.equal(a, same);
+    assert.notEqual(a, differentEntry);
+    assert.notEqual(a, differentStyle);
+    assert.match(a, /^[0-9a-f]{64}$/);
+  });
+
+  it("pins on first use, passes when unchanged, blocks when changed", async () => {
+    const url = "https://plugins.example.com/foo/plugin.json";
+    const bundle = { entrySource: "v1", styleSource: null };
+
+    const first = await verifyPluginBundleIntegrity(url, bundle);
+    assert.equal(first.status, "pinned-first-use");
+    assert.equal(getPluginBundlePin(url), await computePluginBundleHash(bundle));
+
+    const second = await verifyPluginBundleIntegrity(url, bundle);
+    assert.equal(second.status, "unchanged");
+
+    // A silently-changed bundle is blocked and NOT re-pinned.
+    const tampered = { entrySource: "v2-evil", styleSource: null };
+    const changed = await verifyPluginBundleIntegrity(url, tampered);
+    assert.equal(changed.status, "changed");
+    assert.equal(getPluginBundlePin(url), await computePluginBundleHash(bundle));
+
+    // Removing the pin resets to first-use trust.
+    removePluginBundlePin(url);
+    assert.equal(getPluginBundlePin(url), null);
+    const afterRemoval = await verifyPluginBundleIntegrity(url, tampered);
+    assert.equal(afterRemoval.status, "pinned-first-use");
+  });
+});


### PR DESCRIPTION
Fixes the five **HIGH**-severity findings from the security review of the repo. Each fix is scoped to its threat model and is a no-op in the configurations where the vulnerability didn't apply, so day-to-day behavior is unchanged.

## What changed

### H1 — Sidecar authentication + Host validation
The Python sidecar (`127.0.0.1:8765`) relied only on CORS, leaving it open to cross-origin CSRF and DNS-rebinding reads.
- `main.py`: new middleware requiring a per-launch token (`X-GeoLibre-Token` or `Authorization: Bearer`), plus `TrustedHostMiddleware` restricting `Host` to loopback. `/health` and preflights stay exempt. **No-op when `GEOLIBRE_SIDECAR_TOKEN` is unset** (dev / pytest).
- Desktop: Rust mints a CSPRNG token per launch, passes it to uvicorn via env, and returns it in `SidecarServerInfo`; `sidecar-client.ts` attaches it to every request through a `sidecarFetch` wrapper (the GitHub catalog fetch stays token-free).
- Docker: `entrypoint.sh` mints the token, exports it to uvicorn, and `sed`-injects it into the nginx `/sidecar/` proxy (which now also forwards `Host: 127.0.0.1`).

### H2 — Whitebox path sandbox
`/whitebox/run` bypassed the `GEOLIBRE_CONVERSION_ROOTS` confinement the conversion/raster routers enforce. `_prepare_arguments` now validates caller-supplied `*_in`/`*_out` paths and batch directories via `_is_within_roots`. **No-op on desktop** (roots unset); only confines the Docker/web build.

### H3 — `read_project_file` validation
Was an arbitrary local-file reader. Now requires an absolute, traversal-free path with a project extension (`.geolibre` / `.geolibre.json` / `.json`), blocking SSH/cloud-credential reads while still opening every real project.

### H4 — Plugin hardening (pragmatic scope)
- **Hash-pinning**: remote plugin bundles are SHA-256-pinned on first trusted load; a silently changed bundle is held back until the user explicitly reloads it (which re-pins). Closes the trust-on-first-use silent-update vector. Existing installed plugins pin transparently on next launch.
- **SSRF egress filter** on `fetch_url_bytes` / `resolve_url_redirect`, including per-redirect-hop validation. Blocks link-local / cloud-metadata (`169.254.169.254`) — the high-value SSRF target. **Loopback and LAN stay allowed** so the documented local-tile/COG workflow (issue #387) keeps working.
- Full Worker/iframe plugin sandbox is intentionally deferred (breaking, large) — tracked as follow-up.

### H5 — AI assistant code-exec confirmation
`run_python` / `run_maplibre_js` executed LLM-authored code with no gate, exploitable via prompt injection (e.g. `web_search` content). They now require an explicit click-to-run confirmation showing the code, with a per-session "always allow" opt-in.

## Breaking changes
None for normal use. Behavior changes only in the previously-vulnerable paths:
- Auto-updating URL plugins no longer update silently — the user reloads them (marketplace UI already supports this).
- The assistant now prompts before running code (opt-out per session).
- Self-hosters who put their **own** reverse proxy directly in front of the container's sidecar must forward a loopback `Host` and the token (the bundled nginx does both).

## Tests
- Backend `test_security.py`: token enforcement (unset/set, both headers, `/health` exempt), Host rejection, whitebox roots confinement.
- Rust: IP/URL SSRF classifier and `is_allowed_project_path` guards.
- Frontend `plugin-integrity.test.ts`: hashing + pin/first-use/changed flow.
- Full suites green: backend, Rust (`cargo test`), frontend (2346), desktop build/typecheck, rustfmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assistant-generated Python/MapLibre tool execution is now approved via an ordered queue, with an optional “allow for this session” setting.
  - Plugin bundles loaded from manifest URLs are integrity-verified with trusted hash pinning.
- **Security Improvements**
  - Project file loading is restricted to approved local `.geolibre/.geolibre.json` paths (symlink and traversal protected).
  - Remote HTTP fetching/redirects have stronger SSRF protections.
  - Sidecar requests are authenticated with a per-session token; trusted host and tighter whitebox path sandboxing are enforced.
- **Tests**
  - Added security-focused test coverage for sidecar auth, host/path confinement, SSRF protections, and plugin integrity pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->