### PR TITLE
feat(docker): optional HTTP Basic Auth for the web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,10 @@ FROM python:3.12-slim-bookworm AS runtime
 ARG TARGETARCH
 
 # libexpat1 is a runtime dependency of rasterio (pulled in by rio-cogeo) that
-# the slim base image does not ship.
+# the slim base image does not ship. openssl provides `openssl passwd` used by
+# entrypoint.sh to hash the optional Basic Auth password.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends nginx libexpat1 \
+  && apt-get install -y --no-install-recommends nginx libexpat1 openssl \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /etc/nginx/sites-enabled/default
 
@@ -80,12 +81,18 @@ RUN mkdir -p /data
 # loopback. Drop them from the CSP before publishing publicly.
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+  # Default auth snippet (disabled). entrypoint.sh rewrites it at start based
+  # on GEOLIBRE_AUTH_USER/GEOLIBRE_AUTH_PASSWORD; baking a valid default keeps
+  # `nginx -t` and non-entrypoint invocations working.
+  && printf '# Basic Auth disabled (GEOLIBRE_AUTH_USER/GEOLIBRE_AUTH_PASSWORD not set).\n' > /etc/nginx/geolibre-auth.conf
 COPY --from=build /app/apps/geolibre-desktop/dist /usr/share/nginx/html
 
 EXPOSE 80
 
+# /healthz is exempt from the optional Basic Auth, so the check keeps passing
+# when GEOLIBRE_AUTH_USER/GEOLIBRE_AUTH_PASSWORD are set.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1/', timeout=4).status==200 else 1)" || exit 1
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1/healthz', timeout=4).status==200 else 1)" || exit 1
 
 CMD ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -187,6 +187,30 @@ behavior):
 docker run --rm -p 8080:80 -e GEOLIBRE_DISABLE_SIDECAR=1 geolibre
 ```
 
+### Password protection (optional)
+
+Set `GEOLIBRE_AUTH_USER` and `GEOLIBRE_AUTH_PASSWORD` to put the whole
+container (the app and the `/sidecar` API) behind HTTP Basic Auth:
+
+```bash
+docker run --rm -p 8080:80 \
+  -e GEOLIBRE_AUTH_USER=admin \
+  -e GEOLIBRE_AUTH_PASSWORD='change-me' \
+  geolibre
+```
+
+The browser prompts for the credentials on first visit. `/healthz` stays
+unauthenticated so the container health check keeps working. When the
+variables are unset (the default), no authentication is applied.
+
+This is a single shared credential, not per-user accounts. Basic Auth sends
+credentials with every request, so on anything beyond a trusted local network
+put a TLS-terminating reverse proxy (Caddy, Traefik, nginx) in front of the
+container. For multi-user or SSO needs, use an auth proxy such as
+`oauth2-proxy` or Authelia in front of the unmodified image instead. Also see
+the note in `docker/nginx.conf` about dropping the `localhost` CSP allowances
+before exposing the image publicly.
+
 The published image is available from GitHub Container Registry:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ The browser prompts for the credentials on first visit. `/healthz` stays
 unauthenticated so the container health check keeps working. When the
 variables are unset (the default), no authentication is applied.
 
+As with any Docker env var, a password passed with `-e` lands in your shell
+history and is readable on the host via `docker inspect`. Beyond quick local
+testing, prefer `--env-file` with a permission-restricted file, or a secrets
+manager.
+
 This is a single shared credential, not per-user accounts. Basic Auth sends
 credentials with every request, so on anything beyond a trusted local network
 put a TLS-terminating reverse proxy (Caddy, Traefik, nginx) in front of the

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,6 +26,16 @@ if [ -n "${GEOLIBRE_AUTH_USER:-}" ] || [ -n "${GEOLIBRE_AUTH_PASSWORD:-}" ]; the
       exit 1
       ;;
   esac
+  # An embedded newline would make `openssl passwd -stdin` hash each line
+  # separately and corrupt the single-entry htpasswd; fail loudly instead.
+  NL='
+'
+  case "${GEOLIBRE_AUTH_USER}${GEOLIBRE_AUTH_PASSWORD}" in
+    *"$NL"*)
+      echo "ERROR: GEOLIBRE_AUTH_USER and GEOLIBRE_AUTH_PASSWORD must not contain newlines." >&2
+      exit 1
+      ;;
+  esac
   # -stdin keeps the password out of the openssl process's argv.
   HASH=$(printf '%s\n' "$GEOLIBRE_AUTH_PASSWORD" | openssl passwd -apr1 -stdin)
   printf '%s:%s\n' "$GEOLIBRE_AUTH_USER" "$HASH" > "$HTPASSWD"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,14 +25,21 @@ if [ -n "${GEOLIBRE_AUTH_USER:-}" ] || [ -n "${GEOLIBRE_AUTH_PASSWORD:-}" ]; the
       echo "ERROR: GEOLIBRE_AUTH_USER must not contain ':' (htpasswd field separator)." >&2
       exit 1
       ;;
+    '#'*)
+      echo "ERROR: GEOLIBRE_AUTH_USER must not start with '#' (htpasswd treats such lines as comments)." >&2
+      exit 1
+      ;;
   esac
   # An embedded newline would make `openssl passwd -stdin` hash each line
-  # separately and corrupt the single-entry htpasswd; fail loudly instead.
+  # separately and corrupt the single-entry htpasswd; a CR (e.g. from a
+  # CRLF-terminated --env-file) would silently become part of the stored
+  # credential. Fail loudly instead.
   NL='
 '
+  CR=$(printf '\r')
   case "${GEOLIBRE_AUTH_USER}${GEOLIBRE_AUTH_PASSWORD}" in
-    *"$NL"*)
-      echo "ERROR: GEOLIBRE_AUTH_USER and GEOLIBRE_AUTH_PASSWORD must not contain newlines." >&2
+    *"$NL"*|*"$CR"*)
+      echo "ERROR: GEOLIBRE_AUTH_USER and GEOLIBRE_AUTH_PASSWORD must not contain newlines or carriage returns." >&2
       exit 1
       ;;
   esac

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,8 +36,9 @@ if [ -n "${GEOLIBRE_AUTH_USER:-}" ] || [ -n "${GEOLIBRE_AUTH_PASSWORD:-}" ]; the
       exit 1
       ;;
   esac
-  # -stdin keeps the password out of the openssl process's argv.
-  HASH=$(printf '%s\n' "$GEOLIBRE_AUTH_PASSWORD" | openssl passwd -apr1 -stdin)
+  # -6 = SHA-512 crypt (supported by nginx via glibc crypt(), stronger than
+  # the MD5-based apr1); -stdin keeps the password out of openssl's argv.
+  HASH=$(printf '%s\n' "$GEOLIBRE_AUTH_PASSWORD" | openssl passwd -6 -stdin)
   printf '%s:%s\n' "$GEOLIBRE_AUTH_USER" "$HASH" > "$HTPASSWD"
   # nginx workers (www-data) open the htpasswd at request time.
   chown root:www-data "$HTPASSWD"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,43 @@
 # unavailable until the container is restarted).
 set -e
 
+AUTH_CONF=/etc/nginx/geolibre-auth.conf
+HTPASSWD=/etc/nginx/.htpasswd
+
+# Optional HTTP Basic Auth: when both GEOLIBRE_AUTH_USER and
+# GEOLIBRE_AUTH_PASSWORD are set, protect the whole server (app + /sidecar
+# proxy) behind a single credential. The snippet and htpasswd are rewritten on
+# every start so toggling the env vars across restarts behaves as expected.
+# /healthz is exempted in nginx.conf so the container HEALTHCHECK keeps
+# passing. Basic Auth is cleartext without TLS; front the container with an
+# HTTPS proxy on untrusted networks.
+if [ -n "${GEOLIBRE_AUTH_USER:-}" ] || [ -n "${GEOLIBRE_AUTH_PASSWORD:-}" ]; then
+  if [ -z "${GEOLIBRE_AUTH_USER:-}" ] || [ -z "${GEOLIBRE_AUTH_PASSWORD:-}" ]; then
+    echo "ERROR: GEOLIBRE_AUTH_USER and GEOLIBRE_AUTH_PASSWORD must be set together." >&2
+    exit 1
+  fi
+  case "$GEOLIBRE_AUTH_USER" in
+    *:*)
+      echo "ERROR: GEOLIBRE_AUTH_USER must not contain ':' (htpasswd field separator)." >&2
+      exit 1
+      ;;
+  esac
+  # -stdin keeps the password out of the openssl process's argv.
+  HASH=$(printf '%s\n' "$GEOLIBRE_AUTH_PASSWORD" | openssl passwd -apr1 -stdin)
+  printf '%s:%s\n' "$GEOLIBRE_AUTH_USER" "$HASH" > "$HTPASSWD"
+  # nginx workers (www-data) open the htpasswd at request time.
+  chown root:www-data "$HTPASSWD"
+  chmod 640 "$HTPASSWD"
+  cat > "$AUTH_CONF" <<'EOF'
+auth_basic "GeoLibre";
+auth_basic_user_file /etc/nginx/.htpasswd;
+EOF
+  echo "HTTP Basic Auth enabled for user '$GEOLIBRE_AUTH_USER'."
+else
+  printf '# Basic Auth disabled (GEOLIBRE_AUTH_USER/GEOLIBRE_AUTH_PASSWORD not set).\n' > "$AUTH_CONF"
+  rm -f "$HTPASSWD"
+fi
+
 if [ "${GEOLIBRE_DISABLE_SIDECAR:-0}" != "1" ]; then
   python -m uvicorn geolibre_server.app.main:app \
     --host 127.0.0.1 --port 8765 &

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,25 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Optional HTTP Basic Auth. entrypoint.sh rewrites this snippet on every
+    # container start: when GEOLIBRE_AUTH_USER/GEOLIBRE_AUTH_PASSWORD are set
+    # it enables auth_basic with a generated htpasswd, otherwise it leaves the
+    # snippet empty (no auth, the default). Living at server level, the
+    # directives inherit into every location below, including the /sidecar/
+    # proxy. Basic Auth sends credentials with each request, so pair it with
+    # TLS (a reverse proxy in front) on anything but a trusted network.
+    include /etc/nginx/geolibre-auth.conf;
+
+    # Unauthenticated health endpoint for the container HEALTHCHECK (and any
+    # external monitor). Must stay outside auth or enabling a password would
+    # flip the container to unhealthy.
+    location = /healthz {
+        auth_basic off;
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
     gzip on;
     gzip_vary on;
     gzip_proxied any;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -122,6 +122,18 @@ docker pull ghcr.io/opengeos/geolibre:latest
 docker run --rm -p 8080:80 ghcr.io/opengeos/geolibre:latest
 ```
 
+To require a username and password, set `GEOLIBRE_AUTH_USER` and
+`GEOLIBRE_AUTH_PASSWORD`; nginx then protects the app and the `/sidecar` API
+with HTTP Basic Auth (a single shared credential). Pair it with a
+TLS-terminating reverse proxy outside trusted networks:
+
+```bash
+docker run --rm -p 8080:80 \
+  -e GEOLIBRE_AUTH_USER=admin \
+  -e GEOLIBRE_AUTH_PASSWORD='change-me' \
+  ghcr.io/opengeos/geolibre:latest
+```
+
 For deployments under a URL subpath, pass the app base at build time:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "1.10.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "1.10.0",
+      "version": "2.0.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -26,7 +26,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "1.10.0",
+      "version": "2.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@carbonplan/zarr-layer": "^0.6.0",
@@ -21249,7 +21249,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "1.10.0",
+      "version": "2.0.0",
       "dependencies": {
         "uuid": "^14.0.1",
         "zundo": "^2.3.0",
@@ -21262,7 +21262,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "1.10.0",
+      "version": "2.0.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@maplibre/geojson-vt": "^6.1.1",
@@ -21290,7 +21290,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "1.10.0",
+      "version": "2.0.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.6.0",
         "@deck.gl/aggregation-layers": "9.3.6",
@@ -21357,7 +21357,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "1.10.0",
+      "version": "2.0.0",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2",
         "@geolibre/core": "*",
@@ -21393,7 +21393,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "1.10.0",
+      "version": "2.0.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-dropdown-menu": "^2.1.20",


### PR DESCRIPTION
## Summary

Adds opt-in password protection to the Docker web image. Setting `GEOLIBRE_AUTH_USER` and `GEOLIBRE_AUTH_PASSWORD` on the container puts the whole server (static app + `/sidecar` API proxy) behind HTTP Basic Auth:

```bash
docker run --rm -p 8080:80 \
  -e GEOLIBRE_AUTH_USER=admin \
  -e GEOLIBRE_AUTH_PASSWORD='change-me' \
  ghcr.io/opengeos/geolibre:latest
```

When the variables are unset (the default), behavior is unchanged.

## How it works

- `docker/entrypoint.sh` rewrites `/etc/nginx/geolibre-auth.conf` on every start: with both vars set it hashes the password (`openssl passwd -apr1`, read via stdin so it never appears in argv) into `/etc/nginx/.htpasswd` (root:www-data, 640) and enables `auth_basic`; otherwise it writes an empty snippet and removes any stale htpasswd, so toggling across restarts behaves as expected.
- `docker/nginx.conf` includes the snippet at server level so it inherits into every location, including `/sidecar/`.
- New unauthenticated `location = /healthz` backs the container HEALTHCHECK, so enabling auth does not flip the container unhealthy.
- Setting only one of the two variables aborts startup with a clear error instead of silently serving open.
- Docs: new "Password protection (optional)" section in README and a note in `docs/getting-started.md`, including the caveats (single shared credential; pair with a TLS-terminating proxy outside trusted networks; see the existing CSP note before public exposure).

Also syncs `package-lock.json` workspace versions to 2.0.0 (drift left over from the v2.0.0 release, regenerated by `npm install`).

## Testing

- Built a runtime-stage replica image (same base, packages, configs) and verified: no/wrong credentials return 401, correct credentials (including a password containing `$` and `:`) return 200, `/healthz` returns 200 without credentials, auth-disabled container serves 200 as before.
- Both containers report `healthy` via the new HEALTHCHECK; `/etc/nginx/.htpasswd` is root:www-data 640.
- Half-configured container (only `GEOLIBRE_AUTH_USER`) exits 1 with an error message.
- `pre-commit run --files` (including the full npm build) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP Basic Authentication for both the main app and the `/sidecar` API using container environment settings.
  * Introduced an unauthenticated `GET /healthz` endpoint and updated the container health check to use it.
  * Enabled in-container password hashing to securely generate the Basic Auth credentials.
* **Documentation**
  * Updated Docker “Run” and getting-started instructions with example environment variables, notes that `/healthz` remains unauthenticated, shared-credential behavior, and a recommendation to use an external TLS-terminating reverse proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->