### PR TITLE
fix(diagnostics): suppress benign three.js multiple-instances warning

### DIFF
--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -67,8 +67,16 @@ const TAURI_IPC_FALLBACK_WARNING =
 // projection is active — globe simply ignores the around-point and the camera
 // still moves correctly. It is harmless but fires on routine interaction, so it
 // is kept out of the diagnostics panel (still echoed to the console for devs).
+//
+// three.js warns this once when more than one copy of its module ends up in the
+// bundle. Several first- and third-party deps (deck.gl mesh layers, the 3D
+// tiles / lidar / splat plugins, mapillary-js) each pull in three at slightly
+// different versions, so a single deduped copy is not guaranteed. The warning
+// is cosmetic — our three usage does not rely on cross-copy identity — so it is
+// kept out of the diagnostics panel (still echoed to the console for devs).
 const BENIGN_CONSOLE_WARNINGS = [
   "Easing around a point is not supported under globe projection.",
+  "WARNING: Multiple instances of Three.js being imported.",
 ];
 
 /** Whether a console.warn message is a known-benign warning to drop entirely. */

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -300,6 +300,19 @@ describe("diagnostics startup transient suppression", () => {
     assert.equal(getDiagnosticsSnapshot().totalCount, 0);
   });
 
+  it("keeps the benign three.js multiple-instances warning out of diagnostics but echoes it", () => {
+    let echoed: unknown[] | null = null;
+    console.warn = (...args: unknown[]) => {
+      echoed = args;
+    };
+    install();
+    const message = "WARNING: Multiple instances of Three.js being imported.";
+    console.warn(message);
+    // Echoed to the console for contributors, but not recorded in the panel.
+    assert.deepEqual(echoed, [message]);
+    assert.equal(getDiagnosticsSnapshot().totalCount, 0);
+  });
+
   it("flags an unmarked non-ok response as an error", async () => {
     win.fetch = (() =>
       Promise.resolve(


### PR DESCRIPTION
## Summary

The web version's **Diagnostics** panel was showing a `WARNING: Multiple instances of Three.js being imported.` warning on every visit. This PR keeps that cosmetic warning out of the panel.

## Root cause

three.js emits this warning once when more than one copy of its module ends up in the bundle. Several first- and third-party deps each pull in `three` at slightly different versions, so a single deduped copy is not guaranteed (five copies spanning 0.134.0 → 0.185.1 currently resolve in `node_modules`):

- `@deck.gl/mesh-layers` (mesh/scenegraph layers bundle three)
- the 3D-tiles / lidar / splat MapLibre plugins
- `mapillary-js`

Our three usage does not rely on cross-copy identity, so the warning is purely cosmetic.

## Change

Rather than a risky bundler dedupe across incompatible three versions, this uses the mechanism the codebase already has for exactly this case — the `BENIGN_CONSOLE_WARNINGS` allowlist in `apps/geolibre-desktop/src/lib/diagnostics.ts` (which already drops MapLibre's globe-easing warning). The warning is still echoed to the raw console for developers; it just isn't recorded as a warning in the Diagnostics panel.

- `apps/geolibre-desktop/src/lib/diagnostics.ts` — add the three.js warning to `BENIGN_CONSOLE_WARNINGS` with an explanatory comment.
- `tests/diagnostics.test.ts` — add a test mirroring the existing globe-easing case (echoed but not recorded).

## Testing

- `node --import tsx --test tests/diagnostics.test.ts` — 26/26 pass, including the new case.
- `pre-commit run --files ...` — all hooks pass (including the full `npm build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a known, harmless Three.js startup warning from appearing in the diagnostics panel.
  * The warning remains available in the developer console for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->