### PR TITLE
chore: bump maplibre-gl-basemap-control to ^0.12.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -61,7 +61,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
-    "maplibre-gl-basemap-control": "^0.11.0",
+    "maplibre-gl-basemap-control": "^0.12.0",
     "maplibre-gl-components": "^0.25.4",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
-        "maplibre-gl-basemap-control": "^0.11.0",
+        "maplibre-gl-basemap-control": "^0.12.0",
         "maplibre-gl-components": "^0.25.4",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -16234,9 +16234,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.11.0.tgz",
-      "integrity": "sha512-rh6wdLRQbZFY/IPN802AYwsOSVBMtpCA00P0bGZ7ur3Lqi0sGOU8/S6sCax4kyB1rIoLTeVXlvulLYDnPB+y/w==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.12.0.tgz",
+      "integrity": "sha512-EKOWr+Qd4IdexXrkbknFGjqGAMYmV+MiTbC78H1y+FjfvpEWWCEjuLbX+BurtO9F/R01kHbkmJqHEq90WnxHcw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -21318,7 +21318,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
-        "maplibre-gl-basemap-control": "^0.11.0",
+        "maplibre-gl-basemap-control": "^0.12.0",
         "maplibre-gl-components": "^0.25.4",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -35,7 +35,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
-    "maplibre-gl-basemap-control": "^0.11.0",
+    "maplibre-gl-basemap-control": "^0.12.0",
     "maplibre-gl-components": "^0.25.4",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",


### PR DESCRIPTION
## Summary

Bumps `maplibre-gl-basemap-control` from `^0.11.0` to `^0.12.0` in both workspaces that depend on it (`apps/geolibre-desktop` and `packages/plugins`), and refreshes `package-lock.json` (resolves to `0.12.0` from npm).

## What's in 0.12.0

- The base Google basemaps (**Maps / Satellite / Terrain / Hybrid**) now load from Google's authorized [Map Tiles API](https://developers.google.com/maps/documentation/tile) when a `googleMapsApiKey` is configured, and fall back to keyless public tiles otherwise.
- New optional in-panel API key prompt: selecting a Google basemap without a key shows an inline input to upgrade to the official tiles.

Additive, backward-compatible release — no API changes for existing GeoLibre usage.

Release: https://github.com/opengeos/maplibre-gl-basemap-control/releases/tag/v0.12.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the basemap control component to version 0.12.0 for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->