### PR TITLE
feat(knowledge-cards): Wikipedia place info card from the map

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -16,6 +16,9 @@ import { useTranslation } from "react-i18next";
  * (CollaborationStatusBadge), already accounts for this badge: it lifts itself
  * to `bottom-20` (above this `bottom-12`) when a session is active and bounds
  * are restricted. If yet another bottom-left control is added, revisit both.
+ * (The KnowledgeCardPanel also opens bottom-left at `bottom-12`, but as a large
+ * transient `z-20` panel it overlays these small `z-10` badges while open rather
+ * than stacking with them.)
  */
 export function BoundsRestrictionIndicator() {
   const { t } = useTranslation();

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -71,7 +71,9 @@ export function CollaborationStatusBadge({
   );
   // Shares the bottom-left corner with the MapLibre scale control and the
   // bounds-restriction badge, so lift the badge above whichever of those is
-  // showing (see the positioning note below).
+  // showing (see the positioning note below). The KnowledgeCardPanel also opens
+  // in this corner, but as a large transient z-20 panel it overlays this z-10
+  // badge while open rather than participating in this stacking.
   const restrictBounds = useAppStore((s) => s.preferences.map.restrictBounds);
 
   const [expanded, setExpanded] = useState(false);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -87,6 +87,11 @@ import {
 } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { hasReverseGeocodeConsent } from "../../lib/reverse-geocode-consent";
+import {
+  hasKnowledgeCardConsent,
+  recordKnowledgeCardConsent,
+} from "../../lib/knowledge-consent";
+import { wikipediaLang } from "../../lib/knowledge";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { useEmbedBridge } from "../../hooks/useEmbedBridge";
 import { useRasterIdentify } from "../../hooks/useRasterIdentify";
@@ -105,6 +110,11 @@ import { PixelTimeSeriesControl } from "./PixelTimeSeriesControl";
 import { RasterSubsetPanel } from "./RasterSubsetPanel";
 import { TerrainSettingsDialog } from "./TerrainSettingsDialog";
 import { MapContextMenu } from "./MapContextMenu";
+import {
+  KnowledgeCardPanel,
+  type KnowledgePlace,
+} from "./KnowledgeCardPanel";
+import { KnowledgeCardConsentDialog } from "./KnowledgeCardConsentDialog";
 import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
@@ -476,6 +486,31 @@ export function DesktopShell({
   const activeResizeCleanupRef = useRef<(() => void) | null>(null);
   useEffect(() => () => activeResizeCleanupRef.current?.(), []);
   const mapControllerRef = useRef<MapController | null>(null);
+  // The place shown in the Wikipedia knowledge card, or null when it is closed.
+  // `pendingKnowledgePlace` holds the target while the one-time consent notice
+  // is open, so it can be applied only after the user acknowledges it.
+  const [knowledgePlace, setKnowledgePlace] = useState<KnowledgePlace | null>(
+    null,
+  );
+  const [pendingKnowledgePlace, setPendingKnowledgePlace] =
+    useState<KnowledgePlace | null>(null);
+  const [knowledgeNoticeOpen, setKnowledgeNoticeOpen] = useState(false);
+  // Open a knowledge card for a clicked point, gating the first lookup behind a
+  // one-time privacy notice since it sends the coordinate to Wikipedia.
+  const handleExplorePlace = useCallback((lat: number, lng: number) => {
+    if (hasKnowledgeCardConsent()) {
+      setKnowledgePlace({ lat, lng });
+    } else {
+      setPendingKnowledgePlace({ lat, lng });
+      setKnowledgeNoticeOpen(true);
+    }
+  }, []);
+  const confirmKnowledgeConsent = useCallback(() => {
+    recordKnowledgeCardConsent();
+    setKnowledgeNoticeOpen(false);
+    setKnowledgePlace(pendingKnowledgePlace);
+    setPendingKnowledgePlace(null);
+  }, [pendingKnowledgePlace]);
   // The COG/WMS/XYZ layer whose bounding-box subset is being extracted in the
   // floating Extract Subset panel, or null when that panel is closed.
   const [rasterSubsetLayer, setRasterSubsetLayer] =
@@ -1854,6 +1889,21 @@ export function DesktopShell({
               <MapContextMenu
                 mapControllerRef={mapControllerRef}
                 mapReadyGeneration={mapReadyGeneration}
+                onExplorePlace={handleExplorePlace}
+              />
+              <KnowledgeCardPanel
+                place={knowledgePlace}
+                lang={wikipediaLang(i18n.language)}
+                onClose={() => setKnowledgePlace(null)}
+                onFlyTo={(lat, lon) =>
+                  mapControllerRef.current?.flyTo({
+                    center: [lon, lat],
+                    zoom: Math.max(
+                      mapControllerRef.current?.getMap()?.getZoom() ?? 12,
+                      14,
+                    ),
+                  })
+                }
               />
               <BoundsRestrictionIndicator />
               {/* Isolate the collaboration badge in its own boundary: it renders
@@ -1885,6 +1935,11 @@ export function DesktopShell({
           <SectionErrorBoundary label="Route animation panel">
             <RouteAnimationPanel mapControllerRef={mapControllerRef} />
           </SectionErrorBoundary>
+          <KnowledgeCardConsentDialog
+            open={knowledgeNoticeOpen}
+            onOpenChange={setKnowledgeNoticeOpen}
+            onConfirm={confirmKnowledgeConsent}
+          />
           {/* Rendered here (not in TopToolbar) so the dialog the status badge
               reopens stays mounted even in toolbar-hidden layouts (#754). */}
           {collaboration.enabled && (

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1937,7 +1937,13 @@ export function DesktopShell({
           </SectionErrorBoundary>
           <KnowledgeCardConsentDialog
             open={knowledgeNoticeOpen}
-            onOpenChange={setKnowledgeNoticeOpen}
+            onOpenChange={(open) => {
+              setKnowledgeNoticeOpen(open);
+              // Clear the paired pending place when the notice is dismissed
+              // (Cancel/Escape/overlay), mirroring dismissRoutingNotice so no
+              // stale target lingers. Confirm sets the place before this runs.
+              if (!open) setPendingKnowledgePlace(null);
+            }}
             onConfirm={confirmKnowledgeConsent}
           />
           {/* Rendered here (not in TopToolbar) so the dialog the status badge

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -511,6 +511,14 @@ export function DesktopShell({
     setKnowledgePlace(pendingKnowledgePlace);
     setPendingKnowledgePlace(null);
   }, [pendingKnowledgePlace]);
+  // Stable identity (mapControllerRef is a ref) so the card's openNearby
+  // useCallback, which depends on this, keeps its memoization across renders.
+  const handleKnowledgeFlyTo = useCallback((lat: number, lon: number) => {
+    mapControllerRef.current?.flyTo({
+      center: [lon, lat],
+      zoom: Math.max(mapControllerRef.current?.getMap()?.getZoom() ?? 12, 14),
+    });
+  }, []);
   // The COG/WMS/XYZ layer whose bounding-box subset is being extracted in the
   // floating Extract Subset panel, or null when that panel is closed.
   const [rasterSubsetLayer, setRasterSubsetLayer] =
@@ -1895,15 +1903,7 @@ export function DesktopShell({
                 place={knowledgePlace}
                 lang={wikipediaLang(i18n.language)}
                 onClose={() => setKnowledgePlace(null)}
-                onFlyTo={(lat, lon) =>
-                  mapControllerRef.current?.flyTo({
-                    center: [lon, lat],
-                    zoom: Math.max(
-                      mapControllerRef.current?.getMap()?.getZoom() ?? 12,
-                      14,
-                    ),
-                  })
-                }
+                onFlyTo={handleKnowledgeFlyTo}
               />
               <BoundsRestrictionIndicator />
               {/* Isolate the collaboration badge in its own boundary: it renders

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardConsentDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardConsentDialog.tsx
@@ -1,0 +1,47 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+
+interface KnowledgeCardConsentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Acknowledge the notice and proceed to open the card. */
+  onConfirm: () => void;
+}
+
+/**
+ * One-time privacy notice shown before the first knowledge-card lookup, since
+ * opening a card sends the clicked/searched coordinate to Wikipedia's public
+ * API. Mirrors the Directions and reverse-geocode consent notices.
+ */
+export function KnowledgeCardConsentDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: KnowledgeCardConsentDialogProps) {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("knowledgeCard.noticeTitle")}</DialogTitle>
+          <DialogDescription>
+            {t("knowledgeCard.noticeDesc")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button onClick={onConfirm}>{t("toolbar.item.continue")}</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -93,7 +93,13 @@ export function KnowledgeCardPanel({
         const places = await nearbyPromise;
         if (signal.aborted) return;
         if (!main && places.length > 0) {
-          main = await fetchArticleSummary(places[0].title, { lang, signal });
+          // A failed fallback summary (e.g. a transient 5xx) must not discard
+          // the nearby list we already have: degrade to no summary so the card
+          // still shows the neighbours rather than dropping to the error state.
+          main = await fetchArticleSummary(places[0].title, {
+            lang,
+            signal,
+          }).catch(() => null);
         }
         if (signal.aborted) return;
         setNearby(places);
@@ -139,7 +145,11 @@ export function KnowledgeCardPanel({
   const otherNearby = nearby.filter((n) => n.title !== summary?.title);
 
   return (
-    <div className="pointer-events-auto absolute bottom-3 left-3 z-20 flex max-h-[calc(100%-6rem)] w-[min(22rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-lg border bg-background shadow-xl">
+    // Bottom-left, but lifted to `bottom-12` (matching BoundsRestrictionIndicator)
+    // so it clears MapLibre's bottom-left scale/attribution control. As a large
+    // z-20 panel it overlays the small bottom-left badges while open; see the
+    // stacking notes in BoundsRestrictionIndicator and CollaborationStatusBadge.
+    <div className="pointer-events-auto absolute bottom-12 left-2 z-20 flex max-h-[calc(100%-7.5rem)] w-[min(22rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-lg border bg-background shadow-xl">
       <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
         <div className="flex min-w-0 items-center gap-2 text-sm font-semibold">
           <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -167,16 +177,12 @@ export function KnowledgeCardPanel({
           <div className="px-3 py-6 text-xs text-destructive">
             {t("knowledgeCard.error")}
           </div>
-        ) : status === "empty" ? (
-          <div className="px-3 py-6 text-xs text-muted-foreground">
-            {t("knowledgeCard.empty")}
-          </div>
         ) : summary ? (
           <div className="flex flex-col gap-2 px-3 py-3">
             {summary.thumbnailUrl ? (
               <img
                 src={summary.thumbnailUrl}
-                alt=""
+                alt={summary.title}
                 loading="lazy"
                 className="max-h-40 w-full rounded-md object-cover"
               />
@@ -198,6 +204,13 @@ export function KnowledgeCardPanel({
               <ExternalLink className="h-3.5 w-3.5" />
               {t("knowledgeCard.readMore")}
             </Button>
+          </div>
+        ) : nearby.length === 0 ? (
+          // Only truly empty when there is neither a summary nor any neighbour;
+          // if the primary summary failed but nearby places loaded, fall through
+          // to the list below instead of a contradictory "nothing found".
+          <div className="px-3 py-6 text-xs text-muted-foreground">
+            {t("knowledgeCard.empty")}
           </div>
         ) : null}
 

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -37,6 +37,8 @@ type CardStatus = "loading" | "ready" | "empty" | "error";
 
 /** Round a metre distance to a compact "120 m" / "3.4 km" label. */
 function formatDistance(distanceM: number): string {
+  // An unknown distance (a malformed row parsed to Infinity) has no label.
+  if (!Number.isFinite(distanceM)) return "";
   // Round before the unit check so a value just under a boundary (e.g. 999.6)
   // doesn't render past it ("1000 m" instead of "1.0 km").
   const rounded = Math.round(distanceM);
@@ -144,7 +146,13 @@ export function KnowledgeCardPanel({
             lang,
             signal,
           }).catch(() => [] as WikiNearbyPlace[]);
-          const main = await fetchArticleSummary(item.title, { lang, signal });
+          // Degrade a failed article fetch to null (consistent with the main
+          // load) so a transient error keeps the refreshed nearby list instead
+          // of erroring out and discarding it.
+          const main = await fetchArticleSummary(item.title, {
+            lang,
+            signal,
+          }).catch(() => null);
           const places = await nearbyPromise;
           if (signal.aborted) return;
           setNearby(places);

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -1,0 +1,231 @@
+import { Button } from "@geolibre/ui";
+import {
+  BookOpen,
+  ExternalLink,
+  Loader2,
+  MapPin,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  fetchArticleSummary,
+  fetchNearbyPlaces,
+  type WikiNearbyPlace,
+  type WikiSummary,
+} from "../../lib/knowledge";
+import { openExternalLink } from "../../lib/open-external";
+
+/** A place to explore: a clicked/searched coordinate, optionally with a title. */
+export interface KnowledgePlace {
+  lat: number;
+  lng: number;
+  /** Article title to open directly (e.g. from a place-search selection). */
+  title?: string;
+}
+
+interface KnowledgeCardPanelProps {
+  place: KnowledgePlace | null;
+  /** Wikipedia language edition to query (already normalised by the caller). */
+  lang: string;
+  onClose: () => void;
+  /** Recentre the map on a nearby article the user opens from the card. */
+  onFlyTo?: (lat: number, lon: number) => void;
+}
+
+type CardStatus = "loading" | "ready" | "empty" | "error";
+
+/** Round a metre distance to a compact "120 m" / "3.4 km" label. */
+function formatDistance(distanceM: number): string {
+  if (distanceM < 1000) return `${Math.round(distanceM)} m`;
+  return `${(distanceM / 1000).toFixed(distanceM < 10_000 ? 1 : 0)} km`;
+}
+
+/**
+ * Google Earth-style "knowledge card": a slide-in panel over the map that
+ * shows a Wikipedia summary, thumbnail, and nearby articles for a clicked or
+ * searched place. Opening a nearby article swaps the card's main content and
+ * flies the map to it. Purely informational and not persisted in the project.
+ *
+ * The panel owns its fetch lifecycle keyed on `place`: each new place aborts
+ * the previous requests so a fast series of clicks never renders stale content.
+ */
+export function KnowledgeCardPanel({
+  place,
+  lang,
+  onClose,
+  onFlyTo,
+}: KnowledgeCardPanelProps) {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<CardStatus>("loading");
+  const [summary, setSummary] = useState<WikiSummary | null>(null);
+  const [nearby, setNearby] = useState<WikiNearbyPlace[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Load the card whenever the target place changes. When the place carries a
+  // title (from search) we open that article directly; otherwise we pick the
+  // nearest geotagged article to the clicked point. The nearby list is fetched
+  // either way so the user can hop between neighbouring places.
+  useEffect(() => {
+    abortRef.current?.abort();
+    if (!place) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const { signal } = controller;
+    setStatus("loading");
+    setSummary(null);
+    setNearby([]);
+
+    void (async () => {
+      try {
+        const nearbyPromise = fetchNearbyPlaces(place.lat, place.lng, {
+          lang,
+          signal,
+        });
+        let main: WikiSummary | null = null;
+        if (place.title) {
+          main = await fetchArticleSummary(place.title, { lang, signal });
+        }
+        const places = await nearbyPromise;
+        if (signal.aborted) return;
+        if (!main && places.length > 0) {
+          main = await fetchArticleSummary(places[0].title, { lang, signal });
+        }
+        if (signal.aborted) return;
+        setNearby(places);
+        setSummary(main);
+        setStatus(main ? "ready" : "empty");
+      } catch {
+        if (signal.aborted) return;
+        setStatus("error");
+      }
+    })();
+
+    return () => controller.abort();
+  }, [place, lang]);
+
+  const openNearby = useCallback(
+    (item: WikiNearbyPlace) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const { signal } = controller;
+      setStatus("loading");
+      onFlyTo?.(item.lat, item.lon);
+      void (async () => {
+        try {
+          const main = await fetchArticleSummary(item.title, { lang, signal });
+          if (signal.aborted) return;
+          setSummary(main);
+          setStatus(main ? "ready" : "empty");
+        } catch {
+          if (signal.aborted) return;
+          setStatus("error");
+        }
+      })();
+    },
+    [lang, onFlyTo],
+  );
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  if (!place) return null;
+
+  // Nearby articles other than the one currently shown as the main card.
+  const otherNearby = nearby.filter((n) => n.title !== summary?.title);
+
+  return (
+    <div className="pointer-events-auto absolute bottom-3 left-3 z-20 flex max-h-[calc(100%-6rem)] w-[min(22rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-lg border bg-background shadow-xl">
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-semibold">
+          <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="truncate">
+            {summary?.title ?? t("knowledgeCard.title")}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={t("common.close")}
+          onClick={onClose}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {status === "loading" ? (
+          <div className="flex items-center gap-2 px-3 py-6 text-xs text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("knowledgeCard.loading")}
+          </div>
+        ) : status === "error" ? (
+          <div className="px-3 py-6 text-xs text-destructive">
+            {t("knowledgeCard.error")}
+          </div>
+        ) : status === "empty" ? (
+          <div className="px-3 py-6 text-xs text-muted-foreground">
+            {t("knowledgeCard.empty")}
+          </div>
+        ) : summary ? (
+          <div className="flex flex-col gap-2 px-3 py-3">
+            {summary.thumbnailUrl ? (
+              <img
+                src={summary.thumbnailUrl}
+                alt=""
+                loading="lazy"
+                className="max-h-40 w-full rounded-md object-cover"
+              />
+            ) : null}
+            {summary.description ? (
+              <p className="text-xs italic text-muted-foreground">
+                {summary.description}
+              </p>
+            ) : null}
+            <p className="whitespace-pre-line text-xs leading-relaxed text-foreground">
+              {summary.extract}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-1 w-full gap-2"
+              onClick={() => void openExternalLink(summary.contentUrl)}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              {t("knowledgeCard.readMore")}
+            </Button>
+          </div>
+        ) : null}
+
+        {otherNearby.length > 0 ? (
+          <div className="border-t px-3 py-2">
+            <div className="mb-1 text-xs font-medium text-muted-foreground">
+              {t("knowledgeCard.nearby")}
+            </div>
+            <ul className="flex flex-col">
+              {otherNearby.map((item) => (
+                <li key={item.pageId}>
+                  <button
+                    type="button"
+                    className="flex w-full items-start gap-2 rounded px-1.5 py-1.5 text-left text-xs hover:bg-muted"
+                    onClick={() => openNearby(item)}
+                  >
+                    <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1 truncate">{item.title}</span>
+                    <span className="shrink-0 text-[10px] text-muted-foreground">
+                      {formatDistance(item.distanceM)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="border-t px-3 py-1.5 text-[10px] text-muted-foreground">
+        {t("knowledgeCard.attribution")}
+      </div>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -78,10 +78,14 @@ export function KnowledgeCardPanel({
 
     void (async () => {
       try {
+        // The nearby list is secondary content: swallow its failures to an
+        // empty list so a transient error there (rate limit, network blip)
+        // can never discard an already-fetched primary summary and drop the
+        // whole card to the error state.
         const nearbyPromise = fetchNearbyPlaces(place.lat, place.lng, {
           lang,
           signal,
-        });
+        }).catch(() => [] as WikiNearbyPlace[]);
         let main: WikiSummary | null = null;
         if (place.title) {
           main = await fetchArticleSummary(place.title, { lang, signal });

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -78,14 +78,17 @@ export function KnowledgeCardPanel({
 
     void (async () => {
       try {
-        // The nearby list is secondary content: swallow its failures to an
-        // empty list so a transient error there (rate limit, network blip)
-        // can never discard an already-fetched primary summary and drop the
-        // whole card to the error state.
-        const nearbyPromise = fetchNearbyPlaces(place.lat, place.lng, {
-          lang,
-          signal,
-        }).catch(() => [] as WikiNearbyPlace[]);
+        // With a title the summary is the primary content, so the nearby list
+        // is secondary: swallow its failures to an empty list so a transient
+        // error there can't discard an already-fetched summary. On a map click
+        // the nearby list IS the primary content (it picks the main article),
+        // so let its failure surface as an error rather than a misleading
+        // "nothing found here".
+        const nearbyPromise = place.title
+          ? fetchNearbyPlaces(place.lat, place.lng, { lang, signal }).catch(
+              () => [] as WikiNearbyPlace[],
+            )
+          : fetchNearbyPlaces(place.lat, place.lng, { lang, signal });
         let main: WikiSummary | null = null;
         if (place.title) {
           main = await fetchArticleSummary(place.title, { lang, signal });

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -236,7 +236,11 @@ export function KnowledgeCardPanel({
           </div>
         ) : null}
 
-        {otherNearby.length > 0 ? (
+        {/* Only show the list once the content has settled: while a hop is
+            loading (or after it errors) the summary/nearby state still holds the
+            previous article, so gating on status avoids flashing a stale list
+            below the spinner or error message. */}
+        {status !== "loading" && status !== "error" && otherNearby.length > 0 ? (
           <div className="border-t px-3 py-2">
             <div className="mb-1 text-xs font-medium text-muted-foreground">
               {t("knowledgeCard.nearby")}

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -134,7 +134,12 @@ export function KnowledgeCardPanel({
       const controller = new AbortController();
       abortRef.current = controller;
       const { signal } = controller;
+      // Clear the previous article's content before fetching, mirroring the
+      // main load, so the header doesn't keep showing the old title while the
+      // hop is loading.
       setStatus("loading");
+      setSummary(null);
+      setNearby([]);
       onFlyTo?.(item.lat, item.lon);
       void (async () => {
         try {

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -37,8 +37,12 @@ type CardStatus = "loading" | "ready" | "empty" | "error";
 
 /** Round a metre distance to a compact "120 m" / "3.4 km" label. */
 function formatDistance(distanceM: number): string {
-  if (distanceM < 1000) return `${Math.round(distanceM)} m`;
-  return `${(distanceM / 1000).toFixed(distanceM < 10_000 ? 1 : 0)} km`;
+  // Round before the unit check so a value just under a boundary (e.g. 999.6)
+  // doesn't render past it ("1000 m" instead of "1.0 km").
+  const rounded = Math.round(distanceM);
+  if (rounded < 1000) return `${rounded} m`;
+  const km = rounded / 1000;
+  return `${km.toFixed(km < 10 ? 1 : 0)} km`;
 }
 
 /**
@@ -91,7 +95,12 @@ export function KnowledgeCardPanel({
           : fetchNearbyPlaces(place.lat, place.lng, { lang, signal });
         let main: WikiSummary | null = null;
         if (place.title) {
-          main = await fetchArticleSummary(place.title, { lang, signal });
+          // Degrade a failed title lookup to null (like the fallback below) so
+          // a transient 5xx doesn't discard an already-resolved nearby list;
+          // execution then falls through to the nearest-article fallback.
+          main = await fetchArticleSummary(place.title, { lang, signal }).catch(
+            () => null,
+          );
         }
         const places = await nearbyPromise;
         if (signal.aborted) return;

--- a/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/layout/KnowledgeCardPanel.tsx
@@ -124,8 +124,18 @@ export function KnowledgeCardPanel({
       onFlyTo?.(item.lat, item.lon);
       void (async () => {
         try {
+          // Re-centre the nearby list on the opened article too, so hopping to
+          // a neighbour updates the whole card (list and re-clickability), not
+          // just the summary. The list stays secondary, so its failures don't
+          // sink the summary.
+          const nearbyPromise = fetchNearbyPlaces(item.lat, item.lon, {
+            lang,
+            signal,
+          }).catch(() => [] as WikiNearbyPlace[]);
           const main = await fetchArticleSummary(item.title, { lang, signal });
+          const places = await nearbyPromise;
           if (signal.aborted) return;
+          setNearby(places);
           setSummary(main);
           setStatus(main ? "ready" : "empty");
         } catch {

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -8,7 +8,15 @@ import {
   DropdownMenuTrigger,
 } from "@geolibre/ui";
 import type maplibregl from "maplibre-gl";
-import { Braces, Crosshair, Earth, MapIcon, MapPin, ZoomIn } from "lucide-react";
+import {
+  BookOpen,
+  Braces,
+  Crosshair,
+  Earth,
+  MapIcon,
+  MapPin,
+  ZoomIn,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { googleEarthUrl, googleMapsUrl } from "../../lib/external-map-links";
@@ -74,9 +82,12 @@ async function copyText(value: string): Promise<void> {
 export function MapContextMenu({
   mapControllerRef,
   mapReadyGeneration,
+  onExplorePlace,
 }: {
   mapControllerRef: RefObject<MapController | null>;
   mapReadyGeneration: number;
+  /** Open a Wikipedia knowledge card for the clicked coordinate. */
+  onExplorePlace?: (lat: number, lng: number) => void;
 }) {
   const { t } = useTranslation();
   // `menu` keeps the last anchor/coordinate even while closing, so the exit
@@ -139,6 +150,13 @@ export function MapContextMenu({
     });
   }, [menu, mapControllerRef]);
 
+  // Open a Wikipedia knowledge card for the clicked point (Google Earth-style
+  // "what's here"). The consent gate lives in the shell handler.
+  const explorePlace = useCallback(() => {
+    if (!menu) return;
+    onExplorePlace?.(menu.lat, menu.lng);
+  }, [menu, onExplorePlace]);
+
   // Read the live zoom so the external site opens at the on-screen scale; if
   // the map was torn down between right-click and selection, fall back to a
   // city-level view rather than dropping the action.
@@ -193,6 +211,12 @@ export function MapContextMenu({
         <DropdownMenuLabel className="text-xs text-muted-foreground">
           {t("mapContextMenu.quickActions")}
         </DropdownMenuLabel>
+        {onExplorePlace ? (
+          <DropdownMenuItem onSelect={explorePlace} className="gap-2">
+            <BookOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+            {t("mapContextMenu.whatsHere")}
+          </DropdownMenuItem>
+        ) : null}
         <DropdownMenuItem onSelect={copyGeoJson} className="gap-2">
           <Braces className="h-4 w-4 shrink-0 text-muted-foreground" />
           {t("mapContextMenu.copyGeoJson")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1176,11 +1176,23 @@
   "mapContextMenu": {
     "copyCoordinatesHint": "Copy coordinates to clipboard",
     "quickActions": "Quick actions",
+    "whatsHere": "What's here?",
     "copyGeoJson": "Copy as GeoJSON",
     "centerHere": "Center map here",
     "zoomInHere": "Zoom in here",
     "viewInGoogleMaps": "View in Google Maps",
     "viewInGoogleEarth": "View in Google Earth"
+  },
+  "knowledgeCard": {
+    "title": "Place info",
+    "loading": "Looking up this place…",
+    "empty": "No Wikipedia articles found near this place.",
+    "error": "Could not load place info. Please try again.",
+    "readMore": "Read more on Wikipedia",
+    "nearby": "Nearby places",
+    "attribution": "Content from Wikipedia, licensed CC BY-SA.",
+    "noticeTitle": "Knowledge cards use Wikipedia",
+    "noticeDesc": "Opening a knowledge card sends the coordinates of the place you clicked (and the title of any nearby article you open) to Wikipedia's public API to fetch a summary and photo — your coordinates leave your device for those requests."
   },
   "onboarding": {
     "title": "Welcome to GeoLibre",

--- a/apps/geolibre-desktop/src/lib/knowledge-consent.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge-consent.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared consent gate for the Knowledge Cards (Wikipedia place info) tool.
+ *
+ * Opening a knowledge card sends the clicked/searched coordinate (and, when you
+ * open a nearby article, its title) to Wikipedia's public API, so the user
+ * acknowledges a one-time privacy notice before the first lookup. The
+ * acknowledgment is a persisted per-device flag, mirroring the reverse-geocode
+ * consent so every activation path is gated on it.
+ */
+export const KNOWLEDGE_CARD_CONSENT_KEY =
+  "geolibre:knowledge-card-wikipedia-notice";
+
+/** Whether the user has acknowledged the knowledge-card privacy notice. */
+export function hasKnowledgeCardConsent(): boolean {
+  try {
+    return localStorage.getItem(KNOWLEDGE_CARD_CONSENT_KEY) === "1";
+  } catch {
+    // localStorage unavailable (private mode): treat as not acknowledged so the
+    // notice is shown rather than silently sending coordinates.
+    return false;
+  }
+}
+
+/** Record that the user acknowledged the knowledge-card privacy notice. */
+export function recordKnowledgeCardConsent(): void {
+  try {
+    localStorage.setItem(KNOWLEDGE_CARD_CONSENT_KEY, "1");
+  } catch {
+    // Ignore: the notice will simply show again next time.
+  }
+}

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -155,10 +155,10 @@ export function parseGeosearch(json: unknown): WikiNearbyPlace[] {
 export function parseSummary(json: unknown, lang: string): WikiSummary | null {
   const r = json as Record<string, unknown> | null | undefined;
   if (!r || typeof r.title !== "string") return null;
-  // Disambiguation and "not found" documents carry no useful card content.
-  if (r.type === "disambiguation" || r.type === "https://mediawiki.org/wiki/HyperSwitch/errors/not_found") {
-    return null;
-  }
+  // Disambiguation pages return HTTP 200 but carry no single-place content, so
+  // they reach this parser; a missing article ("not found") is a 404 handled by
+  // fetchArticleSummary before the body is ever parsed here.
+  if (r.type === "disambiguation") return null;
   const extract = typeof r.extract === "string" ? r.extract : "";
   const thumbnail = r.thumbnail as { source?: unknown } | undefined;
   const contentUrls = r.content_urls as
@@ -206,12 +206,24 @@ export async function fetchNearbyPlaces(
   return parseGeosearch(json);
 }
 
-/** Fetch the summary + thumbnail for a single article title, or null. */
+/**
+ * Fetch the summary + thumbnail for a single article title, or null when there
+ * is no usable article. A 404 (a missing or renamed title) resolves to null so
+ * the card shows the friendly empty state instead of a generic error; other
+ * non-OK responses still throw and surface as an error.
+ */
 export async function fetchArticleSummary(
   title: string,
   options: { lang?: string; signal?: AbortSignal } = {},
 ): Promise<WikiSummary | null> {
   const lang = wikipediaLang(options.lang);
-  const json = await getJson(buildSummaryUrl(title, lang), options.signal);
-  return parseSummary(json, lang);
+  const response = await fetch(buildSummaryUrl(title, lang), {
+    signal: options.signal,
+    headers: { Accept: "application/json" },
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`Wikipedia request failed: ${response.status}`);
+  }
+  return parseSummary(await response.json(), lang);
 }

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -175,7 +175,10 @@ export function parseGeosearch(json: unknown): WikiNearbyPlace[] {
       title: r.title,
       lat,
       lon,
-      distanceM: Number.isFinite(Number(r.dist)) ? Number(r.dist) : 0,
+      // Unknown distance sorts last (Infinity), never as the nearest article.
+      distanceM: Number.isFinite(Number(r.dist))
+        ? Number(r.dist)
+        : Number.POSITIVE_INFINITY,
     });
   }
   // The API returns nearest-first, but sort defensively so the card can always
@@ -233,7 +236,10 @@ async function fetchWithTimeout(
 ): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  signal?.addEventListener("abort", () => controller.abort(), { once: true });
+  // `abort` only fires on a future transition, so honour a signal that is
+  // already aborted by cancelling up front rather than starting the fetch.
+  if (signal?.aborted) controller.abort();
+  else signal?.addEventListener("abort", () => controller.abort(), { once: true });
   try {
     return await fetch(url, {
       signal: controller.signal,

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -6,9 +6,11 @@
  * and a plain-language summary + thumbnail for a chosen article (the REST
  * summary endpoint). Both are anonymous cross-origin GETs — Wikimedia serves
  * `Access-Control-Allow-Origin: *` for `origin=*` API calls and for the REST
- * summary route — so no proxy, key, or custom header (which would force a CORS
- * preflight) is needed, and the calls work in both the desktop and web builds
- * under their existing `connect-src https:` CSP.
+ * summary route — so no proxy or API key is needed. We send only
+ * `Accept: application/json`, a CORS-safelisted header that triggers no
+ * preflight; adding any non-safelisted header would, so keep requests to
+ * safelisted headers. The calls work in both the desktop and web builds under
+ * their existing `connect-src https:` CSP.
  *
  * All network functions send the queried coordinate/title to Wikimedia, so the
  * caller gates the first use behind a one-time consent notice (see

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -1,0 +1,217 @@
+/**
+ * Wikipedia "knowledge card" client (Google Earth-style place info).
+ *
+ * Given a clicked or searched coordinate we ask Wikipedia's public API two
+ * things: which geotagged articles sit near that point (the geosearch list),
+ * and a plain-language summary + thumbnail for a chosen article (the REST
+ * summary endpoint). Both are anonymous cross-origin GETs — Wikimedia serves
+ * `Access-Control-Allow-Origin: *` for `origin=*` API calls and for the REST
+ * summary route — so no proxy, key, or custom header (which would force a CORS
+ * preflight) is needed, and the calls work in both the desktop and web builds
+ * under their existing `connect-src https:` CSP.
+ *
+ * All network functions send the queried coordinate/title to Wikimedia, so the
+ * caller gates the first use behind a one-time consent notice (see
+ * {@link ./knowledge-consent}), mirroring the reverse-geocode tool.
+ *
+ * The URL builders and response parsers are pure and exported for unit testing.
+ */
+
+/** A geotagged Wikipedia article near a point, from the geosearch API. */
+export interface WikiNearbyPlace {
+  pageId: number;
+  title: string;
+  lat: number;
+  lon: number;
+  /** Great-circle distance from the query point in metres (from the API). */
+  distanceM: number;
+}
+
+/** A plain-language article summary from the REST summary endpoint. */
+export interface WikiSummary {
+  title: string;
+  /** Plain-text summary extract. */
+  extract: string;
+  /** Short one-line description (e.g. "Capital of France"), when present. */
+  description?: string;
+  /** Thumbnail image URL, when the article has a lead image. */
+  thumbnailUrl?: string;
+  /** Canonical desktop article URL for the "Read more" link. */
+  contentUrl: string;
+  /** Article coordinates, when the article is geotagged. */
+  lat?: number;
+  lon?: number;
+  /** Wikipedia language edition the summary came from. */
+  lang: string;
+}
+
+/** Default search radius in metres (the API caps `gsradius` at 10 000). */
+export const DEFAULT_NEARBY_RADIUS_M = 10_000;
+/** Default number of nearby articles to request. */
+export const DEFAULT_NEARBY_LIMIT = 12;
+/** Wikimedia's hard cap on `gsradius` (metres) and `gslimit`. */
+const MAX_RADIUS_M = 10_000;
+const MIN_RADIUS_M = 10;
+const MAX_LIMIT = 50;
+
+interface NearbyOptions {
+  lang?: string;
+  radiusM?: number;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Normalise a UI locale to a Wikipedia language edition subdomain. Wikipedia
+ * editions are keyed by the base language code (`pt`, not `pt-BR`), lowercase
+ * ASCII letters only; anything else falls back to English so we never build a
+ * request against a non-existent subdomain.
+ */
+export function wikipediaLang(locale: string | undefined | null): string {
+  const base = (locale ?? "").split(/[-_]/)[0]?.toLowerCase() ?? "";
+  return /^[a-z]{2,3}$/.test(base) ? base : "en";
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Whether a coordinate pair is finite and within valid lat/lon bounds. */
+export function isValidLatLon(lat: number, lon: number): boolean {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lon) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lon >= -180 &&
+    lon <= 180
+  );
+}
+
+/** Build the geosearch API URL for articles near a point. */
+export function buildGeosearchUrl(
+  lat: number,
+  lon: number,
+  {
+    lang,
+    radiusM = DEFAULT_NEARBY_RADIUS_M,
+    limit = DEFAULT_NEARBY_LIMIT,
+  }: NearbyOptions = {},
+): string {
+  const host = `${wikipediaLang(lang)}.wikipedia.org`;
+  const params = new URLSearchParams({
+    action: "query",
+    format: "json",
+    list: "geosearch",
+    gscoord: `${lat}|${lon}`,
+    gsradius: String(Math.round(clamp(radiusM, MIN_RADIUS_M, MAX_RADIUS_M))),
+    gslimit: String(Math.round(clamp(limit, 1, MAX_LIMIT))),
+    // Anonymous cross-origin access; returns permissive CORS headers.
+    origin: "*",
+  });
+  return `https://${host}/w/api.php?${params.toString()}`;
+}
+
+/** Build the REST summary URL for a single article title. */
+export function buildSummaryUrl(title: string, lang?: string): string {
+  const host = `${wikipediaLang(lang)}.wikipedia.org`;
+  // The REST route wants the title with spaces as underscores, then
+  // percent-encoded so slashes and other reserved characters survive.
+  const slug = encodeURIComponent(title.replace(/ /g, "_"));
+  return `https://${host}/api/rest_v1/page/summary/${slug}`;
+}
+
+/** Parse a geosearch JSON response into typed, sorted nearby places. */
+export function parseGeosearch(json: unknown): WikiNearbyPlace[] {
+  const rows = (json as { query?: { geosearch?: unknown } })?.query?.geosearch;
+  if (!Array.isArray(rows)) return [];
+  const places: WikiNearbyPlace[] = [];
+  for (const row of rows) {
+    const r = row as Record<string, unknown>;
+    const pageId = Number(r.pageid);
+    const lat = Number(r.lat);
+    const lon = Number(r.lon);
+    if (
+      typeof r.title !== "string" ||
+      !Number.isFinite(pageId) ||
+      !isValidLatLon(lat, lon)
+    ) {
+      continue;
+    }
+    places.push({
+      pageId,
+      title: r.title,
+      lat,
+      lon,
+      distanceM: Number.isFinite(Number(r.dist)) ? Number(r.dist) : 0,
+    });
+  }
+  // The API returns nearest-first, but sort defensively so the card can always
+  // treat the first entry as the closest article.
+  return places.sort((a, b) => a.distanceM - b.distanceM);
+}
+
+/** Parse a REST summary JSON response into a typed summary, or null. */
+export function parseSummary(json: unknown, lang: string): WikiSummary | null {
+  const r = json as Record<string, unknown> | null | undefined;
+  if (!r || typeof r.title !== "string") return null;
+  // Disambiguation and "not found" documents carry no useful card content.
+  if (r.type === "disambiguation" || r.type === "https://mediawiki.org/wiki/HyperSwitch/errors/not_found") {
+    return null;
+  }
+  const extract = typeof r.extract === "string" ? r.extract : "";
+  const thumbnail = r.thumbnail as { source?: unknown } | undefined;
+  const contentUrls = r.content_urls as
+    | { desktop?: { page?: unknown } }
+    | undefined;
+  const coordinates = r.coordinates as { lat?: unknown; lon?: unknown } | undefined;
+  const lat = Number(coordinates?.lat);
+  const lon = Number(coordinates?.lon);
+  const geotagged = isValidLatLon(lat, lon);
+  return {
+    title: r.title,
+    extract,
+    description:
+      typeof r.description === "string" ? r.description : undefined,
+    thumbnailUrl:
+      typeof thumbnail?.source === "string" ? thumbnail.source : undefined,
+    contentUrl:
+      typeof contentUrls?.desktop?.page === "string"
+        ? contentUrls.desktop.page
+        : `https://${wikipediaLang(lang)}.wikipedia.org/wiki/${encodeURIComponent(
+            r.title.replace(/ /g, "_"),
+          )}`,
+    lat: geotagged ? lat : undefined,
+    lon: geotagged ? lon : undefined,
+    lang,
+  };
+}
+
+async function getJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  const response = await fetch(url, { signal, headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`Wikipedia request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+/** Fetch geotagged Wikipedia articles near a point (nearest first). */
+export async function fetchNearbyPlaces(
+  lat: number,
+  lon: number,
+  options: NearbyOptions = {},
+): Promise<WikiNearbyPlace[]> {
+  if (!isValidLatLon(lat, lon)) return [];
+  const json = await getJson(buildGeosearchUrl(lat, lon, options), options.signal);
+  return parseGeosearch(json);
+}
+
+/** Fetch the summary + thumbnail for a single article title, or null. */
+export async function fetchArticleSummary(
+  title: string,
+  options: { lang?: string; signal?: AbortSignal } = {},
+): Promise<WikiSummary | null> {
+  const lang = wikipediaLang(options.lang);
+  const json = await getJson(buildSummaryUrl(title, lang), options.signal);
+  return parseSummary(json, lang);
+}

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -83,6 +83,19 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+/**
+ * Wrap a longitude into [-180, 180]. MapLibre reports unwrapped longitudes once
+ * the map has been panned across the antimeridian (e.g. `190` or `-370`), which
+ * the Wikipedia API would reject; normalising keeps those real clicks valid.
+ */
+export function normalizeLon(lon: number): number {
+  if (!Number.isFinite(lon)) return lon;
+  // Leave in-range values exactly as given; only wrap when out of range, so
+  // ordinary longitudes are never perturbed by the modulo's floating-point drift.
+  if (lon >= -180 && lon <= 180) return lon;
+  return ((((lon + 180) % 360) + 360) % 360) - 180;
+}
+
 /** Whether a coordinate pair is finite and within valid lat/lon bounds. */
 export function isValidLatLon(lat: number, lon: number): boolean {
   return (
@@ -110,7 +123,7 @@ export function buildGeosearchUrl(
     action: "query",
     format: "json",
     list: "geosearch",
-    gscoord: `${lat}|${lon}`,
+    gscoord: `${lat}|${normalizeLon(lon)}`,
     gsradius: String(Math.round(clamp(radiusM, MIN_RADIUS_M, MAX_RADIUS_M))),
     gslimit: String(Math.round(clamp(limit, 1, MAX_LIMIT))),
     // Anonymous cross-origin access; returns permissive CORS headers.
@@ -233,8 +246,14 @@ export async function fetchNearbyPlaces(
   lon: number,
   options: NearbyOptions = {},
 ): Promise<WikiNearbyPlace[]> {
-  if (!isValidLatLon(lat, lon)) return [];
-  const json = await getJson(buildGeosearchUrl(lat, lon, options), options.signal);
+  // Wrap the longitude first: a click past the antimeridian arrives unwrapped
+  // (e.g. 190) and would otherwise fail the bounds check and return nothing.
+  const wrappedLon = normalizeLon(lon);
+  if (!isValidLatLon(lat, wrappedLon)) return [];
+  const json = await getJson(
+    buildGeosearchUrl(lat, wrappedLon, options),
+    options.signal,
+  );
   return parseGeosearch(json);
 }
 

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -61,6 +61,11 @@ interface NearbyOptions {
   signal?: AbortSignal;
 }
 
+/** Split a locale on its region separator, e.g. `pt-BR` / `zh_Hans`. */
+const LOCALE_SEPARATOR_RE = /[-_]/;
+/** A bare 2-3 letter language code, the shape of a Wikipedia edition subdomain. */
+const LANGUAGE_CODE_RE = /^[a-z]{2,3}$/;
+
 /**
  * Normalise a UI locale to a Wikipedia language edition subdomain. Wikipedia
  * editions are keyed by the base language code (`pt`, not `pt-BR`), lowercase
@@ -68,8 +73,8 @@ interface NearbyOptions {
  * request against a non-existent subdomain.
  */
 export function wikipediaLang(locale: string | undefined | null): string {
-  const base = (locale ?? "").split(/[-_]/)[0]?.toLowerCase() ?? "";
-  return /^[a-z]{2,3}$/.test(base) ? base : "en";
+  const base = (locale ?? "").split(LOCALE_SEPARATOR_RE)[0]?.toLowerCase() ?? "";
+  return LANGUAGE_CODE_RE.test(base) ? base : "en";
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -187,8 +192,33 @@ export function parseSummary(json: unknown, lang: string): WikiSummary | null {
   };
 }
 
+/** Abort a Wikipedia request after this long if nothing else cancels it (ms). */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * `fetch` with a default timeout combined with the caller's abort signal, so a
+ * stalled network can never hang a request — and the card stuck in "loading" —
+ * indefinitely. Either the caller aborting or the timeout firing cancels it.
+ */
+async function fetchWithTimeout(
+  url: string,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  signal?.addEventListener("abort", () => controller.abort(), { once: true });
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 async function getJson(url: string, signal?: AbortSignal): Promise<unknown> {
-  const response = await fetch(url, { signal, headers: { Accept: "application/json" } });
+  const response = await fetchWithTimeout(url, signal);
   if (!response.ok) {
     throw new Error(`Wikipedia request failed: ${response.status}`);
   }
@@ -217,10 +247,10 @@ export async function fetchArticleSummary(
   options: { lang?: string; signal?: AbortSignal } = {},
 ): Promise<WikiSummary | null> {
   const lang = wikipediaLang(options.lang);
-  const response = await fetch(buildSummaryUrl(title, lang), {
-    signal: options.signal,
-    headers: { Accept: "application/json" },
-  });
+  const response = await fetchWithTimeout(
+    buildSummaryUrl(title, lang),
+    options.signal,
+  );
   if (response.status === 404) return null;
   if (!response.ok) {
     throw new Error(`Wikipedia request failed: ${response.status}`);

--- a/apps/geolibre-desktop/src/lib/knowledge.ts
+++ b/apps/geolibre-desktop/src/lib/knowledge.ts
@@ -108,6 +108,18 @@ export function isValidLatLon(lat: number, lon: number): boolean {
   );
 }
 
+/** Decimals used when formatting a coordinate for the `gscoord` parameter. */
+const COORD_DECIMALS = 6;
+
+/**
+ * Format a coordinate for `gscoord` with fixed decimals. A raw template
+ * interpolation would emit exponential notation for a near-zero value (e.g.
+ * `5e-8` near the equator/prime meridian), which the API does not parse.
+ */
+function formatCoord(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(COORD_DECIMALS) : String(value);
+}
+
 /** Build the geosearch API URL for articles near a point. */
 export function buildGeosearchUrl(
   lat: number,
@@ -123,7 +135,7 @@ export function buildGeosearchUrl(
     action: "query",
     format: "json",
     list: "geosearch",
-    gscoord: `${lat}|${normalizeLon(lon)}`,
+    gscoord: `${formatCoord(lat)}|${formatCoord(normalizeLon(lon))}`,
     gsradius: String(Math.round(clamp(radiusM, MIN_RADIUS_M, MAX_RADIUS_M))),
     gslimit: String(Math.round(clamp(limit, 1, MAX_LIMIT))),
     // Anonymous cross-origin access; returns permissive CORS headers.

--- a/tests/knowledge.test.ts
+++ b/tests/knowledge.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildGeosearchUrl,
+  buildSummaryUrl,
+  isValidLatLon,
+  parseGeosearch,
+  parseSummary,
+  wikipediaLang,
+} from "../apps/geolibre-desktop/src/lib/knowledge";
+
+describe("wikipediaLang", () => {
+  it("keeps a plain two-letter code", () => {
+    assert.equal(wikipediaLang("fr"), "fr");
+  });
+  it("strips a region suffix", () => {
+    assert.equal(wikipediaLang("pt-BR"), "pt");
+    assert.equal(wikipediaLang("zh_Hans"), "zh");
+  });
+  it("falls back to English for empty or malformed input", () => {
+    assert.equal(wikipediaLang(""), "en");
+    assert.equal(wikipediaLang(undefined), "en");
+    assert.equal(wikipediaLang("123"), "en");
+    assert.equal(wikipediaLang("english"), "en");
+  });
+});
+
+describe("isValidLatLon", () => {
+  it("accepts in-range finite coordinates", () => {
+    assert.ok(isValidLatLon(0, 0));
+    assert.ok(isValidLatLon(-90, 180));
+  });
+  it("rejects out-of-range or non-finite coordinates", () => {
+    assert.ok(!isValidLatLon(91, 0));
+    assert.ok(!isValidLatLon(0, 181));
+    assert.ok(!isValidLatLon(Number.NaN, 0));
+    assert.ok(!isValidLatLon(0, Infinity));
+  });
+});
+
+describe("buildGeosearchUrl", () => {
+  it("targets the language edition host with an anonymous CORS origin", () => {
+    const url = new URL(buildGeosearchUrl(48.8584, 2.2945, { lang: "fr" }));
+    assert.equal(url.hostname, "fr.wikipedia.org");
+    assert.equal(url.pathname, "/w/api.php");
+    assert.equal(url.searchParams.get("list"), "geosearch");
+    assert.equal(url.searchParams.get("gscoord"), "48.8584|2.2945");
+    assert.equal(url.searchParams.get("origin"), "*");
+  });
+  it("clamps radius and limit to the API maxima", () => {
+    const url = new URL(
+      buildGeosearchUrl(0, 0, { radiusM: 999_999, limit: 999 }),
+    );
+    assert.equal(url.searchParams.get("gsradius"), "10000");
+    assert.equal(url.searchParams.get("gslimit"), "50");
+  });
+  it("defaults to the English edition", () => {
+    const url = new URL(buildGeosearchUrl(0, 0));
+    assert.equal(url.hostname, "en.wikipedia.org");
+  });
+});
+
+describe("buildSummaryUrl", () => {
+  it("encodes spaces as underscores and escapes reserved characters", () => {
+    assert.equal(
+      buildSummaryUrl("Eiffel Tower", "en"),
+      "https://en.wikipedia.org/api/rest_v1/page/summary/Eiffel_Tower",
+    );
+    assert.equal(
+      buildSummaryUrl("AC/DC", "en"),
+      "https://en.wikipedia.org/api/rest_v1/page/summary/AC%2FDC",
+    );
+  });
+});
+
+describe("parseGeosearch", () => {
+  it("returns typed places sorted nearest-first and drops invalid rows", () => {
+    const places = parseGeosearch({
+      query: {
+        geosearch: [
+          { pageid: 2, title: "Far", lat: 1, lon: 1, dist: 900 },
+          { pageid: 1, title: "Near", lat: 0.1, lon: 0.1, dist: 120 },
+          { pageid: 3, title: "Bad coords", lat: 200, lon: 0, dist: 50 },
+          { title: "Missing id", lat: 0, lon: 0, dist: 10 },
+        ],
+      },
+    });
+    assert.equal(places.length, 2);
+    assert.equal(places[0].title, "Near");
+    assert.equal(places[1].title, "Far");
+    assert.equal(places[0].distanceM, 120);
+  });
+  it("returns an empty array for malformed input", () => {
+    assert.deepEqual(parseGeosearch(null), []);
+    assert.deepEqual(parseGeosearch({ query: {} }), []);
+  });
+});
+
+describe("parseSummary", () => {
+  it("maps a full summary document", () => {
+    const summary = parseSummary(
+      {
+        title: "Paris",
+        description: "Capital of France",
+        extract: "Paris is the capital of France.",
+        thumbnail: { source: "https://example.org/paris.jpg" },
+        content_urls: { desktop: { page: "https://en.wikipedia.org/wiki/Paris" } },
+        coordinates: { lat: 48.8566, lon: 2.3522 },
+      },
+      "en",
+    );
+    assert.ok(summary);
+    assert.equal(summary.title, "Paris");
+    assert.equal(summary.thumbnailUrl, "https://example.org/paris.jpg");
+    assert.equal(summary.contentUrl, "https://en.wikipedia.org/wiki/Paris");
+    assert.equal(summary.lat, 48.8566);
+    assert.equal(summary.lang, "en");
+  });
+  it("synthesizes a content URL when the API omits one", () => {
+    const summary = parseSummary(
+      { title: "Some Place", extract: "…" },
+      "de",
+    );
+    assert.ok(summary);
+    assert.equal(
+      summary.contentUrl,
+      "https://de.wikipedia.org/wiki/Some_Place",
+    );
+    assert.equal(summary.thumbnailUrl, undefined);
+    assert.equal(summary.lat, undefined);
+  });
+  it("returns null for disambiguation, not-found, and empty documents", () => {
+    assert.equal(parseSummary({ title: "X", type: "disambiguation" }, "en"), null);
+    assert.equal(
+      parseSummary(
+        {
+          title: "X",
+          type: "https://mediawiki.org/wiki/HyperSwitch/errors/not_found",
+        },
+        "en",
+      ),
+      null,
+    );
+    assert.equal(parseSummary(null, "en"), null);
+    assert.equal(parseSummary({ extract: "no title" }, "en"), null);
+  });
+});

--- a/tests/knowledge.test.ts
+++ b/tests/knowledge.test.ts
@@ -58,14 +58,19 @@ describe("normalizeLon", () => {
 describe("buildGeosearchUrl", () => {
   it("wraps an unwrapped longitude into range for gscoord", () => {
     const url = new URL(buildGeosearchUrl(10, 190));
-    assert.equal(url.searchParams.get("gscoord"), "10|-170");
+    assert.equal(url.searchParams.get("gscoord"), "10.000000|-170.000000");
+  });
+
+  it("formats near-zero coordinates as decimals, not exponential", () => {
+    const url = new URL(buildGeosearchUrl(5e-8, 5e-8));
+    assert.equal(url.searchParams.get("gscoord"), "0.000000|0.000000");
   });
   it("targets the language edition host with an anonymous CORS origin", () => {
     const url = new URL(buildGeosearchUrl(48.8584, 2.2945, { lang: "fr" }));
     assert.equal(url.hostname, "fr.wikipedia.org");
     assert.equal(url.pathname, "/w/api.php");
     assert.equal(url.searchParams.get("list"), "geosearch");
-    assert.equal(url.searchParams.get("gscoord"), "48.8584|2.2945");
+    assert.equal(url.searchParams.get("gscoord"), "48.858400|2.294500");
     assert.equal(url.searchParams.get("origin"), "*");
   });
   it("clamps radius and limit to the API maxima", () => {

--- a/tests/knowledge.test.ts
+++ b/tests/knowledge.test.ts
@@ -120,6 +120,19 @@ describe("parseGeosearch", () => {
     assert.deepEqual(parseGeosearch(null), []);
     assert.deepEqual(parseGeosearch({ query: {} }), []);
   });
+  it("sorts a row with unknown distance last, not first", () => {
+    const places = parseGeosearch({
+      query: {
+        geosearch: [
+          { pageid: 5, title: "Unknown distance", lat: 0.2, lon: 0.2 },
+          { pageid: 6, title: "Close", lat: 0.1, lon: 0.1, dist: 50 },
+        ],
+      },
+    });
+    assert.equal(places[0].title, "Close");
+    assert.equal(places[1].title, "Unknown distance");
+    assert.equal(places[1].distanceM, Number.POSITIVE_INFINITY);
+  });
 });
 
 describe("parseSummary", () => {

--- a/tests/knowledge.test.ts
+++ b/tests/knowledge.test.ts
@@ -5,6 +5,7 @@ import {
   buildSummaryUrl,
   fetchArticleSummary,
   isValidLatLon,
+  normalizeLon,
   parseGeosearch,
   parseSummary,
   wikipediaLang,
@@ -39,7 +40,26 @@ describe("isValidLatLon", () => {
   });
 });
 
+describe("normalizeLon", () => {
+  it("leaves an in-range longitude unchanged", () => {
+    assert.equal(normalizeLon(2.2945), 2.2945);
+    assert.equal(normalizeLon(-179), -179);
+  });
+  it("wraps longitudes past the antimeridian into [-180, 180]", () => {
+    assert.equal(normalizeLon(190), -170);
+    assert.equal(normalizeLon(-370), -10);
+    assert.equal(normalizeLon(200), -160);
+  });
+  it("passes non-finite values through untouched", () => {
+    assert.ok(Number.isNaN(normalizeLon(Number.NaN)));
+  });
+});
+
 describe("buildGeosearchUrl", () => {
+  it("wraps an unwrapped longitude into range for gscoord", () => {
+    const url = new URL(buildGeosearchUrl(10, 190));
+    assert.equal(url.searchParams.get("gscoord"), "10|-170");
+  });
   it("targets the language edition host with an anonymous CORS origin", () => {
     const url = new URL(buildGeosearchUrl(48.8584, 2.2945, { lang: "fr" }));
     assert.equal(url.hostname, "fr.wikipedia.org");

--- a/tests/knowledge.test.ts
+++ b/tests/knowledge.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   buildGeosearchUrl,
   buildSummaryUrl,
+  fetchArticleSummary,
   isValidLatLon,
   parseGeosearch,
   parseSummary,
@@ -129,19 +130,50 @@ describe("parseSummary", () => {
     assert.equal(summary.thumbnailUrl, undefined);
     assert.equal(summary.lat, undefined);
   });
-  it("returns null for disambiguation, not-found, and empty documents", () => {
+  it("returns null for disambiguation, null, and titleless documents", () => {
     assert.equal(parseSummary({ title: "X", type: "disambiguation" }, "en"), null);
-    assert.equal(
-      parseSummary(
-        {
-          title: "X",
-          type: "https://mediawiki.org/wiki/HyperSwitch/errors/not_found",
-        },
-        "en",
-      ),
-      null,
-    );
     assert.equal(parseSummary(null, "en"), null);
     assert.equal(parseSummary({ extract: "no title" }, "en"), null);
+  });
+});
+
+describe("fetchArticleSummary", () => {
+  function withFetch<T>(
+    stub: () => Promise<unknown>,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    const original = globalThis.fetch;
+    globalThis.fetch = stub as typeof globalThis.fetch;
+    return run().finally(() => {
+      globalThis.fetch = original;
+    });
+  }
+
+  it("resolves a 404 (missing or renamed title) to null instead of throwing", async () => {
+    const result = await withFetch(
+      async () => ({ status: 404, ok: false, json: async () => ({}) }),
+      () => fetchArticleSummary("No Such Article", { lang: "en" }),
+    );
+    assert.equal(result, null);
+  });
+
+  it("throws on other non-OK responses", async () => {
+    await withFetch(
+      async () => ({ status: 500, ok: false, json: async () => ({}) }),
+      () => assert.rejects(fetchArticleSummary("Whatever", { lang: "en" })),
+    );
+  });
+
+  it("parses a 200 summary body", async () => {
+    const result = await withFetch(
+      async () => ({
+        status: 200,
+        ok: true,
+        json: async () => ({ title: "Paris", extract: "Capital." }),
+      }),
+      () => fetchArticleSummary("Paris", { lang: "en" }),
+    );
+    assert.equal(result?.title, "Paris");
+    assert.equal(result?.extract, "Capital.");
   });
 });


### PR DESCRIPTION
## Summary
- Adds a Google Earth-style Knowledge Card: right-click the map and choose "What's here?" to open a slide-in panel with the nearest Wikipedia article's summary, thumbnail, description, a "Read more on Wikipedia" link, and a list of nearby geotagged places (click one to swap the card and fly there).
- Uses Wikipedia's CORS-enabled geosearch and REST summary APIs directly, so no CSP change, proxy, or API key is needed and it works in both the desktop and web builds. Language follows the UI locale with an English fallback.
- Sending the clicked coordinate to Wikipedia is gated behind a one-time privacy notice, mirroring the existing reverse-geocode and Directions consent flows.

## Test plan
- [x] New unit tests (tests/knowledge.test.ts, 14 cases) cover URL building, coordinate and language validation, and geosearch/summary parsing including disambiguation and not-found documents
- [x] tsc -b passes with no type errors
- [x] ESLint clean on the changed files
- [x] Existing i18n catalog tests still pass
- [x] Verified end to end in a real browser against live Wikipedia (context menu, consent dialog, populated card) in both light and dark themes
- [ ] Optional follow-up: also open the card from the Layers panel place-search selection (the panel already accepts an optional article title)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “What’s here” action in the map context menu to open localized Wikipedia knowledge cards for clicked coordinates.
  * Introduced a one-time privacy consent notice that gates first knowledge-card activation (then remembers consent for the device).
  * Knowledge cards show loading/empty/error states, article summaries with “Read more,” nearby places, and can recenter the map.
* **Tests**
  * Added automated coverage for language normalization, coordinate validation, URL building, JSON parsing, and knowledge-card fetch behavior (including 404 handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->