### PR TITLE
feat(add-data): GEBCO ocean bathymetry WMS sample with attribution

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -59,6 +59,17 @@ export const DEFAULT_XYZ_URL =
 export const DEFAULT_WMS_ENDPOINT =
   "https://imagery.nationalmap.gov/arcgis/services/USGSNAIPImagery/ImageServer/WMSServer";
 export const DEFAULT_WMS_LAYERS = "USGSNAIPImagery:FalseColorComposite";
+// GEBCO global ocean bathymetry — a keyless WMS 1.3.0 service serving the latest
+// GEBCO grid as a shaded-relief image (Web Mercator supported, so it renders on
+// MapLibre). Sourced from the General Bathymetric Chart of the Oceans; requires
+// attribution and must not be used for navigation. See gebco.net/data-products.
+export const GEBCO_WMS_ENDPOINT = "https://wms.gebco.net/mapserv";
+export const GEBCO_WMS_LAYERS = "GEBCO_LATEST";
+// GEBCO's license requires its imagery credit the source. `attributionForTileUrl`
+// (helpers) attaches this to any GEBCO WMS layer, however it was added (the sample
+// below or a hand-pasted wms.gebco.net URL).
+export const GEBCO_ATTRIBUTION =
+  'Imagery reproduced from the GEBCO Compilation Group (2024) GEBCO Grid, <a href="https://www.gebco.net" target="_blank" rel="noreferrer">GEBCO</a>';
 export const DEFAULT_WFS_ENDPOINT = "https://ahocevar.com/geoserver/wfs";
 export const DEFAULT_WFS_TYPE_NAME = "topp:states";
 // EOX "Sentinel-2 cloudless" — a global, keyless RESTful WMTS imagery layer

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -68,6 +68,10 @@ export const GEBCO_WMS_LAYERS = "GEBCO_LATEST";
 // GEBCO's license requires its imagery credit the source. `attributionForTileUrl`
 // (helpers) attaches this to any GEBCO WMS layer, however it was added (the sample
 // below or a hand-pasted wms.gebco.net URL).
+// NOTE: the `GEBCO_LATEST` layer always resolves to GEBCO's newest annual grid,
+// but the year below is not derived from anything — unlike the EOX credit above,
+// whose year lives in the tile URL. Bump this year by hand when GEBCO ships a new
+// annual release (e.g. GEBCO_2027) so the citation does not drift from the data.
 export const GEBCO_ATTRIBUTION =
   'Imagery reproduced from the GEBCO Compilation Group (2026) GEBCO Grid, <a href="https://www.gebco.net" target="_blank" rel="noreferrer">GEBCO</a>';
 export const DEFAULT_WFS_ENDPOINT = "https://ahocevar.com/geoserver/wfs";

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -69,7 +69,7 @@ export const GEBCO_WMS_LAYERS = "GEBCO_LATEST";
 // (helpers) attaches this to any GEBCO WMS layer, however it was added (the sample
 // below or a hand-pasted wms.gebco.net URL).
 export const GEBCO_ATTRIBUTION =
-  'Imagery reproduced from the GEBCO Compilation Group (2024) GEBCO Grid, <a href="https://www.gebco.net" target="_blank" rel="noreferrer">GEBCO</a>';
+  'Imagery reproduced from the GEBCO Compilation Group (2026) GEBCO Grid, <a href="https://www.gebco.net" target="_blank" rel="noreferrer">GEBCO</a>';
 export const DEFAULT_WFS_ENDPOINT = "https://ahocevar.com/geoserver/wfs";
 export const DEFAULT_WFS_TYPE_NAME = "topp:states";
 // EOX "Sentinel-2 cloudless" — a global, keyless RESTful WMTS imagery layer

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -72,7 +72,9 @@ export function attributionForTileUrl(url: string): string | undefined {
     }
     // Any GEBCO WMS host (the `.gebco.net` suffix, with the bare-domain case)
     // carries the required GEBCO credit; the suffix check avoids lookalikes like
-    // `evil-gebco.net`.
+    // `evil-gebco.net`. Unlike the EOX branch this matches on host alone (no
+    // LAYERS check) because wms.gebco.net serves only the bathymetry grid today;
+    // if GEBCO ever hosts a differently-licensed product here, gate on the layer.
     const isGebcoHost =
       hostname === "gebco.net" || hostname.endsWith(".gebco.net");
     if (isGebcoHost) {

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -11,6 +11,7 @@ import { isTauri } from "../../../lib/is-tauri";
 import {
   DELIMITED_TEXT_DELIMITERS,
   EOX_S2CLOUDLESS_ATTRIBUTION,
+  GEBCO_ATTRIBUTION,
   GPX_PROXY_PATH,
   WFS_PROXY_PATH,
   WMS_PROXY_PATH,
@@ -51,10 +52,12 @@ export function createBaseLayer(
 
 /**
  * Attribution required for known keyless tile hosts whose license mandates a
- * credit (currently EOX Sentinel-2 cloudless, CC BY 4.0). Returns the
- * attribution string for a recognized host so the tile layer credits its source
- * in MapLibre's attribution control, or `undefined` for unrecognized/invalid
- * URLs.
+ * credit (EOX Sentinel-2 cloudless under CC BY 4.0; GEBCO bathymetry). Returns
+ * the attribution string for a recognized host so the tile layer credits its
+ * source in MapLibre's attribution control, or `undefined` for
+ * unrecognized/invalid URLs. Keying off the host (not an exact URL) means the
+ * credit attaches however the layer was added — a sample preset or a
+ * hand-pasted service URL, including the WMS GetMap template built from it.
  */
 export function attributionForTileUrl(url: string): string | undefined {
   try {
@@ -66,6 +69,14 @@ export function attributionForTileUrl(url: string): string | undefined {
     const isEoxHost = hostname === "eox.at" || hostname.endsWith(".eox.at");
     if (isEoxHost && href.includes("s2cloudless")) {
       return EOX_S2CLOUDLESS_ATTRIBUTION;
+    }
+    // Any GEBCO WMS host (the `.gebco.net` suffix, with the bare-domain case)
+    // carries the required GEBCO credit; the suffix check avoids lookalikes like
+    // `evil-gebco.net`.
+    const isGebcoHost =
+      hostname === "gebco.net" || hostname.endsWith(".gebco.net");
+    if (isGebcoHost) {
+      return GEBCO_ATTRIBUTION;
     }
   } catch {
     // Relative or malformed URL — no known attribution to attach.

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -20,6 +20,8 @@ import {
   DEFAULT_WMS_LAYERS,
   DEFAULT_WMTS_URL,
   DEFAULT_XYZ_URL,
+  GEBCO_WMS_ENDPOINT,
+  GEBCO_WMS_LAYERS,
   MAX_SAVED_SERVICES,
   SERVICE_LIBRARY_STORAGE_KEY,
 } from "./constants";
@@ -313,6 +315,24 @@ export const BUILTIN_SERVICES: readonly ServiceLibraryEntry[] = [
       format: "image/png",
       transparent: true,
       tileSize: "256",
+    },
+  },
+  {
+    id: "builtin-wms-gebco",
+    name: "GEBCO Ocean Bathymetry",
+    category: "Imagery",
+    kind: "wms",
+    builtin: true,
+    fields: {
+      endpoint: GEBCO_WMS_ENDPOINT,
+      layers: GEBCO_WMS_LAYERS,
+      styles: "",
+      format: "image/png",
+      transparent: true,
+      tileSize: "256",
+      // GEBCO serves the latest grid over WMS 1.3.0; pin it so the saved
+      // service does not fall back to 1.1.1's flipped-axis GetMap.
+      version: "1.3.0",
     },
   },
   {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -2,8 +2,14 @@ import { Button, Input, Label, Select } from "@geolibre/ui";
 import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
 import {
+  DEFAULT_WMS_ENDPOINT,
+  DEFAULT_WMS_LAYERS,
+  GEBCO_WMS_ENDPOINT,
+  GEBCO_WMS_LAYERS,
+} from "../constants";
+import {
+  attributionForTileUrl,
   createBaseLayer,
   createWmsTileUrl,
   fetchWmsCapabilities,
@@ -222,6 +228,10 @@ export function WmsSource() {
       tileSize,
       version,
     });
+    // Credit known keyless services (e.g. GEBCO) in the map's attribution
+    // control, whether the endpoint came from a sample preset or was pasted by
+    // hand. The GetMap template still carries the service host, so match on it.
+    const attribution = attributionForTileUrl(tileUrl);
     source.addAndClose(
       createBaseLayer(
         name,
@@ -236,6 +246,7 @@ export function WmsSource() {
           format: wmsFormat,
           transparent: wmsTransparent,
           version,
+          ...(attribution ? { attribution } : {}),
         },
         { service: "wms" },
       ),
@@ -428,6 +439,14 @@ export function WmsSource() {
             {
               label: t("addData.wms.sampleLabel"),
               value: { endpoint: DEFAULT_WMS_ENDPOINT, layers: DEFAULT_WMS_LAYERS },
+            },
+            {
+              label: t("addData.wms.sampleLabelGebco"),
+              value: {
+                endpoint: GEBCO_WMS_ENDPOINT,
+                layers: GEBCO_WMS_LAYERS,
+                version: "1.3.0",
+              },
             },
           ]}
           onSelect={applyFields}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -249,6 +249,7 @@
     "wms": {
       "defaultName": "WMS Layer",
       "sampleLabel": "USGS NAIP imagery",
+      "sampleLabelGebco": "GEBCO ocean bathymetry",
       "errorUrl": "Enter a WMS service URL.",
       "errorLayers": "Enter one or more WMS layer names.",
       "urlPlaceholder": "https://example.com/geoserver/wms",

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { FeatureCollection } from "geojson";
-import { EOX_S2CLOUDLESS_ATTRIBUTION } from "../apps/geolibre-desktop/src/components/layout/add-data/constants";
+import {
+  EOX_S2CLOUDLESS_ATTRIBUTION,
+  GEBCO_ATTRIBUTION,
+} from "../apps/geolibre-desktop/src/components/layout/add-data/constants";
 import {
   appendQuery,
   attributionForTileUrl,
@@ -430,6 +433,21 @@ describe("attributionForTileUrl", () => {
     );
   });
 
+  it("credits GEBCO bathymetry on the WMS host and its subdomains", () => {
+    // The GetMap template built from the sample endpoint carries the host.
+    assert.equal(
+      attributionForTileUrl(
+        "https://wms.gebco.net/mapserv?SERVICE=WMS&REQUEST=GetMap&LAYERS=GEBCO_LATEST&BBOX={bbox-epsg-3857}",
+      ),
+      GEBCO_ATTRIBUTION,
+    );
+    // Bare-domain case also matches the `.gebco.net` suffix rule.
+    assert.equal(
+      attributionForTileUrl("https://gebco.net/mapserv?LAYERS=GEBCO_LATEST"),
+      GEBCO_ATTRIBUTION,
+    );
+  });
+
   it("returns undefined for other hosts, lookalikes, and malformed URLs", () => {
     assert.equal(
       attributionForTileUrl("https://tile.openstreetmap.org/{z}/{x}/{y}.png"),
@@ -443,6 +461,11 @@ describe("attributionForTileUrl", () => {
     // Lookalike host must not match the `.eox.at` suffix check.
     assert.equal(
       attributionForTileUrl("https://evil-eox.at/s2cloudless/{z}/{y}/{x}.jpg"),
+      undefined,
+    );
+    // Lookalike host must not match the `.gebco.net` suffix check.
+    assert.equal(
+      attributionForTileUrl("https://evil-gebco.net/mapserv?LAYERS=GEBCO_LATEST"),
       undefined,
     );
     assert.equal(attributionForTileUrl("not a url"), undefined);


### PR DESCRIPTION
## Summary
- Add the keyless GEBCO global ocean bathymetry service (`wms.gebco.net`, `GEBCO_LATEST` shaded relief) as a WMS sample preset in the Add WMS Layer panel.
- Attach GEBCO's required source credit to the map's attribution control, matched by host (`*.gebco.net`) via the existing `attributionForTileUrl` helper so it also applies when the endpoint is pasted by hand.

## Test plan
- [x] `tsc --noEmit` passes for the desktop app
- [x] ESLint passes on the changed files
- [x] Add Data -> WMS -> Sample data lists "GEBCO ocean bathymetry"; selecting it fills endpoint, layers, and version 1.3.0
- [x] Adding the layer renders GEBCO bathymetry on the map
- [x] Attribution control shows the GEBCO credit with a working link, no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GEBCO ocean bathymetry as a new WMS sample in the Add Data interface (with the appropriate endpoint, layer, and pinned WMS version).
  * Automatically applies the correct attribution for GEBCO map tiles from GEBCO domains.
* **Documentation**
  * Added a localized label: “GEBCO ocean bathymetry” for the new sample.
* **Tests**
  * Extended attribution detection coverage for GEBCO tile URLs (including negative host cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->