### PR TITLE
refactor(add-data): shared applyServiceEntry dispatcher + layer builders

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -1,0 +1,453 @@
+/**
+ * Turns a saved {@link ServiceLibraryEntry} (kind + field bag) into a map layer,
+ * without the Add Data dialog. This is the shared core the dialog's web-service
+ * sources and the Browser panel both build on:
+ *
+ * - **Pure layer builders** (`buildXyzLayer` / `buildWmsLayer` / `buildWmtsLayer`
+ *   / `buildWfsGeoJsonLayer`) construct a {@link GeoLibreLayer} from resolved
+ *   parameters. They have no React, network, or MapLibre dependencies, so the
+ *   dialog sources call them from their submit handlers and they unit-test in
+ *   isolation.
+ * - **Field mappers** (`*FieldsToParams` / `wfsFieldsToRequest` /
+ *   `arcgisFieldsToOptions`) translate a stored `ServiceFields` bag into those
+ *   parameters, mirroring how each source's `applyFields` reads the same fields.
+ * - **`applyServiceEntry`** is the imperative dispatcher the Browser panel calls:
+ *   it maps the entry's fields, does any async resolution (XYZ short-URL,
+ *   WFS GetFeature), and adds the resulting layer to the store. The heavy,
+ *   browser-only dependencies (the XYZ MapLibre protocol, the ArcGIS plugin, the
+ *   WFS fetch) are imported dynamically so this module's pure exports stay
+ *   importable under Node for tests.
+ */
+
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+// Type-only: erased at compile time, so importing it does not pull maplibre-gl
+// (which `xyz-url` imports at runtime) into the pure builder surface.
+import type { ArcGISLayerType, ArcGISSourceType } from "@geolibre/plugins";
+import type { FeatureCollection } from "geojson";
+import type { RefObject } from "react";
+import type { ResolvedXyzTileUrl } from "../../../lib/xyz-url";
+import {
+  attributionForTileUrl,
+  createBaseLayer,
+  createWmsTileUrl,
+  normalizeWmsVersion,
+  stripOgcOperationParams,
+  wmsVersionFromEndpoint,
+} from "./helpers";
+import {
+  serviceFieldBoolean,
+  serviceFieldString,
+  type ServiceFields,
+  type ServiceLibraryEntry,
+} from "./service-library";
+
+/** Parses a tile-size field, falling back to the MapLibre default of 256. */
+function toTileSize(value: string): number {
+  return Number(value) || 256;
+}
+
+// --- XYZ -------------------------------------------------------------------
+
+export interface XyzLayerParams {
+  name: string;
+  /** A tile URL already resolved by `xyz-url` (redirect-followed for shortUrl). */
+  tileUrl: ResolvedXyzTileUrl;
+  tileSize: string;
+  shortUrl: boolean;
+}
+
+/**
+ * Builds an XYZ raster tile layer from an already-resolved tile URL. The URL
+ * resolution (and, for `shortUrl`, the MapLibre protocol registration) happens
+ * in the caller so this stays pure; see {@link applyServiceEntry}'s xyz branch.
+ *
+ * @param params - The layer name, resolved tile URL, tile size, and shortUrl flag.
+ * @returns The constructed XYZ layer.
+ */
+export function buildXyzLayer(params: XyzLayerParams): GeoLibreLayer {
+  const { name, tileUrl, tileSize, shortUrl } = params;
+  return createBaseLayer(
+    name,
+    "xyz",
+    {
+      type: "raster",
+      tiles: [tileUrl.renderUrl],
+      tileSize: toTileSize(tileSize),
+      url: tileUrl.originalUrl,
+    },
+    {
+      originalUrl: shortUrl ? tileUrl.originalUrl : undefined,
+      resolvedUrl: tileUrl.redirected ? tileUrl.url : undefined,
+      sourceKind: "xyz-url",
+    },
+  );
+}
+
+/** The XYZ fields needed to resolve a tile URL and build the layer. */
+export interface XyzRequest {
+  url: string;
+  tileSize: string;
+  shortUrl: boolean;
+}
+
+/** Reads the XYZ fields from a saved entry, mirroring `XyzSource.applyFields`. */
+export function xyzFieldsToRequest(fields: ServiceFields): XyzRequest {
+  return {
+    url: serviceFieldString(fields, "url"),
+    tileSize: serviceFieldString(fields, "tileSize", "256"),
+    shortUrl: serviceFieldBoolean(fields, "shortUrl", false),
+  };
+}
+
+// --- WMS -------------------------------------------------------------------
+
+export interface WmsLayerParams {
+  name: string;
+  endpoint: string;
+  layers: string;
+  styles: string;
+  format: string;
+  transparent: boolean;
+  tileSize: string;
+  version: string;
+}
+
+/**
+ * Builds a WMS raster layer whose tiles are a GetMap request template. Strips
+ * any leftover OGC operation parameters from the endpoint and normalizes the
+ * protocol version, matching `WmsSource`'s submit path exactly.
+ *
+ * @param params - The layer name and WMS request parameters.
+ * @returns The constructed WMS layer.
+ */
+export function buildWmsLayer(params: WmsLayerParams): GeoLibreLayer {
+  const endpoint = stripOgcOperationParams(params.endpoint.trim(), "WMS");
+  const version = normalizeWmsVersion(params.version);
+  const layers = params.layers.trim();
+  const styles = params.styles.trim();
+  const tileSize = toTileSize(params.tileSize);
+  const tileUrl = createWmsTileUrl({
+    endpoint,
+    layers,
+    styles,
+    format: params.format,
+    transparent: params.transparent,
+    tileSize,
+    version,
+  });
+  const attribution = attributionForTileUrl(tileUrl);
+  return createBaseLayer(
+    params.name,
+    "wms",
+    {
+      type: "raster",
+      tiles: [tileUrl],
+      tileSize,
+      url: endpoint,
+      layers,
+      styles,
+      format: params.format,
+      transparent: params.transparent,
+      version,
+      ...(attribution ? { attribution } : {}),
+    },
+    { service: "wms" },
+  );
+}
+
+/** Reads the WMS fields from a saved entry, mirroring `WmsSource.applyFields`. */
+export function wmsFieldsToParams(
+  entry: ServiceLibraryEntry,
+): WmsLayerParams {
+  const { fields } = entry;
+  const endpoint = serviceFieldString(fields, "endpoint");
+  // A saved service predating the version field falls back to the endpoint's
+  // own VERSION parameter (if any) rather than silently resetting to 1.1.1.
+  const savedVersion = serviceFieldString(fields, "version");
+  const detectedVersion = wmsVersionFromEndpoint(endpoint);
+  return {
+    name: entry.name,
+    endpoint,
+    layers: serviceFieldString(fields, "layers"),
+    styles: serviceFieldString(fields, "styles"),
+    format: serviceFieldString(fields, "format", "image/png"),
+    transparent: serviceFieldBoolean(fields, "transparent", true),
+    tileSize: serviceFieldString(fields, "tileSize", "256"),
+    version: normalizeWmsVersion(savedVersion || detectedVersion || "1.1.1"),
+  };
+}
+
+// --- WMTS ------------------------------------------------------------------
+
+export interface WmtsLayerParams {
+  name: string;
+  url: string;
+  tileSize: string;
+}
+
+/**
+ * Builds a WMTS raster layer from a tile URL template, matching `WmtsSource`.
+ *
+ * @param params - The layer name, tile URL template, and tile size.
+ * @returns The constructed WMTS layer.
+ */
+export function buildWmtsLayer(params: WmtsLayerParams): GeoLibreLayer {
+  const url = params.url.trim();
+  const attribution = attributionForTileUrl(url);
+  return createBaseLayer(
+    params.name,
+    "wmts",
+    {
+      type: "raster",
+      tiles: [url],
+      tileSize: toTileSize(params.tileSize),
+      url,
+      ...(attribution ? { attribution } : {}),
+    },
+    { service: "wmts" },
+  );
+}
+
+/** Reads the WMTS fields from a saved entry, mirroring `WmtsSource.applyFields`. */
+export function wmtsFieldsToParams(
+  entry: ServiceLibraryEntry,
+): WmtsLayerParams {
+  return {
+    name: entry.name,
+    url: serviceFieldString(entry.fields, "url"),
+    tileSize: serviceFieldString(entry.fields, "tileSize", "256"),
+  };
+}
+
+// --- WFS -------------------------------------------------------------------
+
+/** A resolved WFS GetFeature request, ready for `fetchWfsGeoJson`. */
+export interface WfsRequest {
+  endpoint: string;
+  typeName: string;
+  version: string;
+  outputFormat: string;
+  srsName: string;
+  maxFeatures: string | undefined;
+}
+
+/** Reads the WFS fields from a saved entry, mirroring `WfsSource`. */
+export function wfsFieldsToRequest(entry: ServiceLibraryEntry): WfsRequest {
+  const { fields } = entry;
+  const maxFeatures = serviceFieldString(fields, "maxFeatures", "1000").trim();
+  return {
+    // Strip leftover operation params (a pasted GetCapabilities URL) so the
+    // GetFeature request is not built with a conflicting duplicate REQUEST.
+    endpoint: stripOgcOperationParams(
+      serviceFieldString(fields, "endpoint").trim(),
+      "WFS",
+    ),
+    typeName: serviceFieldString(fields, "typeName").trim(),
+    version: serviceFieldString(fields, "version", "2.0.0"),
+    outputFormat: serviceFieldString(
+      fields,
+      "outputFormat",
+      "application/json",
+    ).trim(),
+    srsName: serviceFieldString(fields, "srsName", "EPSG:4326").trim(),
+    maxFeatures: maxFeatures || undefined,
+  };
+}
+
+export interface WfsLayerParams {
+  name: string;
+  /** The GetFeature URL that actually returned GeoJSON (post output-format retry). */
+  featureUrl: string;
+  data: FeatureCollection;
+  typeName: string;
+  version: string;
+  /** The output format that worked, which may differ from the requested one. */
+  outputFormat: string;
+  srsName: string;
+}
+
+/**
+ * Builds a GeoJSON layer from fetched WFS GetFeature data, matching `WfsSource`'s
+ * submit path (an embedded `geojson` collection and `sourcePath` alongside the
+ * base record).
+ *
+ * @param params - The layer name, feature URL, fetched data, and WFS metadata.
+ * @returns The constructed GeoJSON layer.
+ */
+export function buildWfsGeoJsonLayer(params: WfsLayerParams): GeoLibreLayer {
+  return {
+    ...createBaseLayer(
+      params.name,
+      "geojson",
+      {
+        type: "geojson",
+        url: params.featureUrl,
+        service: "wfs",
+        typeName: params.typeName,
+        version: params.version,
+        outputFormat: params.outputFormat,
+        srsName: params.srsName || undefined,
+      },
+      {
+        featureCount: params.data.features.length,
+        service: "wfs",
+        sourceKind: "wfs-getfeature",
+        typeName: params.typeName,
+      },
+    ),
+    geojson: params.data,
+    sourcePath: params.featureUrl,
+  };
+}
+
+// --- ArcGIS ----------------------------------------------------------------
+
+export interface ArcGISOptions {
+  name: string;
+  layerType: ArcGISLayerType;
+  sourceType: ArcGISSourceType;
+  url: string | undefined;
+  itemId: string | undefined;
+  portalUrl: string | undefined;
+}
+
+/** Reads the ArcGIS fields from a saved entry, mirroring `ArcGISSource`. */
+export function arcgisFieldsToOptions(
+  entry: ServiceLibraryEntry,
+): ArcGISOptions {
+  const { fields } = entry;
+  return {
+    name: entry.name,
+    layerType:
+      serviceFieldString(fields, "layerType") === "vector-tile"
+        ? "vector-tile"
+        : "feature",
+    sourceType:
+      serviceFieldString(fields, "sourceType") === "portal-item"
+        ? "portal-item"
+        : "url",
+    url: serviceFieldString(fields, "url").trim() || undefined,
+    itemId: serviceFieldString(fields, "itemId").trim() || undefined,
+    portalUrl: serviceFieldString(fields, "portalUrl").trim() || undefined,
+  };
+}
+
+// --- Dispatcher ------------------------------------------------------------
+
+export interface ApplyServiceDeps {
+  /** Store action to add the built layer. */
+  addLayer: (layer: GeoLibreLayer, beforeLayerId?: string | null) => void;
+  /** Map controller ref, used for the ArcGIS plugin path and to fit new layers. */
+  mapControllerRef: RefObject<MapController | null>;
+  /** Insert-before layer id, or null/undefined for the top of the stack. */
+  beforeLayerId?: string | null;
+}
+
+/**
+ * Adds a saved service-library entry to the map as a layer, resolving async
+ * work (XYZ short-URL redirect, WFS GetFeature fetch) and delegating ArcGIS to
+ * its plugin. This is the single entry point the Browser panel calls to load a
+ * saved service in one click; the Add Data dialog keeps its own form-driven
+ * submit but shares the pure builders above.
+ *
+ * @param entry - The saved service to load.
+ * @param deps - The store add action, map controller ref, and insert position.
+ * @throws If the entry is missing a required field (e.g. an XYZ URL).
+ */
+export async function applyServiceEntry(
+  entry: ServiceLibraryEntry,
+  deps: ApplyServiceDeps,
+): Promise<void> {
+  const { addLayer, mapControllerRef, beforeLayerId = null } = deps;
+
+  switch (entry.kind) {
+    case "xyz": {
+      const request = xyzFieldsToRequest(entry.fields);
+      if (!request.url.trim()) throw new Error("This service has no tile URL.");
+      // xyz-url imports maplibre-gl at module load, so import it lazily to keep
+      // this module's pure exports usable outside the browser (unit tests).
+      const xyzUrl = await import("../../../lib/xyz-url");
+      if (request.shortUrl) xyzUrl.registerXyzTileProtocol();
+      const tileUrl = request.shortUrl
+        ? await xyzUrl.resolveXyzTileUrlTemplate(request.url)
+        : xyzUrl.createXyzTileUrlTemplate(request.url);
+      addLayer(
+        buildXyzLayer({
+          name: entry.name,
+          tileUrl,
+          tileSize: request.tileSize,
+          shortUrl: request.shortUrl,
+        }),
+        beforeLayerId,
+      );
+      return;
+    }
+    case "wms": {
+      const params = wmsFieldsToParams(entry);
+      if (!params.endpoint.trim()) throw new Error("This service has no URL.");
+      if (!params.layers.trim()) {
+        throw new Error("This service has no layers.");
+      }
+      addLayer(buildWmsLayer(params), beforeLayerId);
+      return;
+    }
+    case "wmts": {
+      const params = wmtsFieldsToParams(entry);
+      if (!params.url.trim()) throw new Error("This service has no tile URL.");
+      addLayer(buildWmtsLayer(params), beforeLayerId);
+      return;
+    }
+    case "arcgis": {
+      const options = arcgisFieldsToOptions(entry);
+      const { createAppAPI } = await import("../../../hooks/usePlugins");
+      const { addArcGISLayer } = await import("@geolibre/plugins");
+      await addArcGISLayer(createAppAPI(mapControllerRef), {
+        beforeLayerId,
+        itemId: options.itemId,
+        layerType: options.layerType,
+        name: options.name,
+        portalUrl: options.portalUrl,
+        sourceType: options.sourceType,
+        // Tokens are never persisted to the service library, so none is sent.
+        token: undefined,
+        url: options.url,
+      });
+      return;
+    }
+    case "wfs": {
+      const request = wfsFieldsToRequest(entry);
+      if (!request.endpoint) throw new Error("This service has no URL.");
+      if (!request.typeName) throw new Error("This service has no feature type.");
+      const { fetchWfsGeoJson } = await import("../../../lib/layer-refresh");
+      const { data, url, outputFormat } = await fetchWfsGeoJson(
+        {
+          endpoint: request.endpoint,
+          typeName: request.typeName,
+          version: request.version,
+          outputFormat: request.outputFormat,
+          srsName: request.srsName,
+          maxFeatures: request.maxFeatures,
+        },
+        { useWfsProxy: true },
+      );
+      const layer = buildWfsGeoJsonLayer({
+        name: entry.name,
+        featureUrl: url,
+        data,
+        typeName: request.typeName,
+        version: request.version,
+        outputFormat,
+        srsName: request.srsName,
+      });
+      addLayer(layer, beforeLayerId);
+      mapControllerRef.current?.fitLayer(layer);
+      return;
+    }
+    default: {
+      // Exhaustiveness guard: a new ServiceLibraryKind must add a branch here.
+      const exhaustive: never = entry.kind;
+      throw new Error(`Unsupported service kind: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -42,9 +42,14 @@ import {
   type ServiceLibraryEntry,
 } from "./service-library";
 
-/** Parses a tile-size field, falling back to the MapLibre default of 256. */
+/**
+ * Parses a tile-size field, falling back to the MapLibre default of 256 for a
+ * non-numeric, zero, or negative value (a negative size would otherwise reach
+ * the raster source unchecked, since `Number("-256")` is truthy).
+ */
 function toTileSize(value: string): number {
-  return Number(value) || 256;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 256;
 }
 
 // --- XYZ -------------------------------------------------------------------
@@ -351,9 +356,16 @@ export interface ApplyServiceDeps {
  * saved service in one click; the Add Data dialog keeps its own form-driven
  * submit but shares the pure builders above.
  *
+ * The validation guards below throw plain English messages rather than `t()`
+ * strings so this module stays React/i18n-free and importable under Node for
+ * the unit tests. That is a deliberate boundary: the UI caller (the Browser
+ * panel) owns translation — it surfaces these by catching and remapping on the
+ * error's kind, or by validating the entry with `t()` before calling. The
+ * messages are developer-facing fallbacks, not the user-visible copy.
+ *
  * @param entry - The saved service to load.
  * @param deps - The store add action, map controller ref, and insert position.
- * @throws If the entry is missing a required field (e.g. an XYZ URL).
+ * @throws If the entry is missing or has an invalid required field.
  */
 export async function applyServiceEntry(
   entry: ServiceLibraryEntry,
@@ -419,6 +431,15 @@ export async function applyServiceEntry(
       const request = wfsFieldsToRequest(entry);
       if (!request.endpoint) throw new Error("This service has no URL.");
       if (!request.typeName) throw new Error("This service has no feature type.");
+      // Mirror WfsSource.handleSubmit's remaining guards: the save path
+      // (ServiceLibrarySection) only validates the entry name, so a saved WFS
+      // entry can carry an empty output format or a non-numeric max features.
+      if (!request.outputFormat) {
+        throw new Error("This service has no output format.");
+      }
+      if (request.maxFeatures && !Number.isFinite(Number(request.maxFeatures))) {
+        throw new Error("This service's max features value is not numeric.");
+      }
       const { fetchWfsGeoJson } = await import("../../../lib/layer-refresh");
       const { data, url, outputFormat } = await fetchWfsGeoJson(
         {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -3,6 +3,7 @@ import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { fetchWfsGeoJson } from "../../../../lib/layer-refresh";
+import { buildWfsGeoJsonLayer } from "../apply-service";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
 import {
   fetchWfsFeatureTypes,
@@ -10,7 +11,6 @@ import {
   stripOgcOperationParams,
   type WfsFeatureTypeOption,
 } from "../helpers";
-import { buildWfsGeoJsonLayer } from "../apply-service";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldString,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from "react-i18next";
 import { fetchWfsGeoJson } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
 import {
-  createBaseLayer,
   fetchWfsFeatureTypes,
   serviceRequestErrorMessage,
   stripOgcOperationParams,
   type WfsFeatureTypeOption,
 } from "../helpers";
+import { buildWfsGeoJsonLayer } from "../apply-service";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldString,
@@ -215,29 +215,15 @@ export function WfsSource() {
       setWfsOutputFormat(resolvedOutputFormat);
     }
     source.addAndClose(
-      {
-        ...createBaseLayer(
-          name,
-          "geojson",
-          {
-            type: "geojson",
-            url: featureUrl,
-            service: "wfs",
-            typeName: wfsTypeName.trim(),
-            version: wfsVersion,
-            outputFormat: resolvedOutputFormat,
-            srsName: wfsSrsName.trim() || undefined,
-          },
-          {
-            featureCount: data.features.length,
-            service: "wfs",
-            sourceKind: "wfs-getfeature",
-            typeName: wfsTypeName.trim(),
-          },
-        ),
-        geojson: data,
-        sourcePath: featureUrl,
-      },
+      buildWfsGeoJsonLayer({
+        name,
+        featureUrl,
+        data,
+        typeName: wfsTypeName.trim(),
+        version: wfsVersion,
+        outputFormat: resolvedOutputFormat,
+        srsName: wfsSrsName.trim(),
+      }),
       { fit: true },
     );
   });

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -9,16 +9,13 @@ import {
   GEBCO_WMS_LAYERS,
 } from "../constants";
 import {
-  attributionForTileUrl,
-  createBaseLayer,
-  createWmsTileUrl,
   fetchWmsCapabilities,
   normalizeWmsVersion,
   serviceRequestErrorMessage,
-  stripOgcOperationParams,
   wmsVersionFromEndpoint,
   type WmsLayerOption,
 } from "../helpers";
+import { buildWmsLayer } from "../apply-service";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldBoolean,
@@ -214,42 +211,20 @@ export function WmsSource() {
     if (!wmsLayers.trim()) {
       throw new Error(t("addData.wms.errorLayers"));
     }
-    const tileSize = Number(wmsTileSize) || 256;
-    // Strip any leftover operation params (a pasted GetCapabilities URL) so the
-    // GetMap request is not built with a conflicting duplicate REQUEST.
-    const endpoint = stripOgcOperationParams(wmsEndpoint.trim(), "WMS");
-    const version = normalizeWmsVersion(wmsVersion);
-    const tileUrl = createWmsTileUrl({
-      endpoint,
-      layers: wmsLayers.trim(),
-      styles: wmsStyles.trim(),
-      format: wmsFormat,
-      transparent: wmsTransparent,
-      tileSize,
-      version,
-    });
-    // Credit known keyless services (e.g. GEBCO) in the map's attribution
-    // control, whether the endpoint came from a sample preset or was pasted by
-    // hand. The GetMap template still carries the service host, so match on it.
-    const attribution = attributionForTileUrl(tileUrl);
+    // buildWmsLayer strips any leftover operation params (a pasted
+    // GetCapabilities URL), normalizes the version, and credits known keyless
+    // services (e.g. GEBCO) in the map's attribution control.
     source.addAndClose(
-      createBaseLayer(
+      buildWmsLayer({
         name,
-        "wms",
-        {
-          type: "raster",
-          tiles: [tileUrl],
-          tileSize,
-          url: endpoint,
-          layers: wmsLayers.trim(),
-          styles: wmsStyles.trim(),
-          format: wmsFormat,
-          transparent: wmsTransparent,
-          version,
-          ...(attribution ? { attribution } : {}),
-        },
-        { service: "wms" },
-      ),
+        endpoint: wmsEndpoint,
+        layers: wmsLayers,
+        styles: wmsStyles,
+        format: wmsFormat,
+        transparent: wmsTransparent,
+        tileSize: wmsTileSize,
+        version: wmsVersion,
+      }),
     );
   });
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -2,6 +2,7 @@ import { Button, Input, Label, Select } from "@geolibre/ui";
 import { ListTree, Loader2 } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { buildWmsLayer } from "../apply-service";
 import {
   DEFAULT_WMS_ENDPOINT,
   DEFAULT_WMS_LAYERS,
@@ -15,7 +16,6 @@ import {
   wmsVersionFromEndpoint,
   type WmsLayerOption,
 } from "../helpers";
-import { buildWmsLayer } from "../apply-service";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldBoolean,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
@@ -1,8 +1,8 @@
 import { Input, Label } from "@geolibre/ui";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { buildWmtsLayer } from "../apply-service";
 import { DEFAULT_WMTS_URL } from "../constants";
-import { attributionForTileUrl, createBaseLayer } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldString,
@@ -28,24 +28,11 @@ export function WmtsSource() {
 
   const handleSubmit = source.runSubmit(() => {
     const name = source.layerName.trim() || t("addData.wmts.defaultName");
-    const url = wmtsUrl.trim();
-    if (!url) {
+    if (!wmtsUrl.trim()) {
       throw new Error(t("addData.wmts.errorUrl"));
     }
-    const attribution = attributionForTileUrl(url);
     source.addAndClose(
-      createBaseLayer(
-        name,
-        "wmts",
-        {
-          type: "raster",
-          tiles: [url],
-          tileSize: Number(wmtsTileSize) || 256,
-          url,
-          ...(attribution ? { attribution } : {}),
-        },
-        { service: "wmts" },
-      ),
+      buildWmtsLayer({ name, url: wmtsUrl, tileSize: wmtsTileSize }),
     );
   });
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -6,8 +6,8 @@ import {
   registerXyzTileProtocol,
   resolveXyzTileUrlTemplate,
 } from "../../../../lib/xyz-url";
+import { buildXyzLayer } from "../apply-service";
 import { DEFAULT_XYZ_URL } from "../constants";
-import { createBaseLayer } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldBoolean,
@@ -43,21 +43,12 @@ export function XyzSource() {
       ? await resolveXyzTileUrlTemplate(xyzUrl)
       : createXyzTileUrlTemplate(xyzUrl);
     source.addAndClose(
-      createBaseLayer(
+      buildXyzLayer({
         name,
-        "xyz",
-        {
-          type: "raster",
-          tiles: [tileUrl.renderUrl],
-          tileSize: Number(xyzTileSize) || 256,
-          url: tileUrl.originalUrl,
-        },
-        {
-          originalUrl: xyzShortUrl ? tileUrl.originalUrl : undefined,
-          resolvedUrl: tileUrl.redirected ? tileUrl.url : undefined,
-          sourceKind: "xyz-url",
-        },
-      ),
+        tileUrl,
+        tileSize: xyzTileSize,
+        shortUrl: xyzShortUrl,
+      }),
     );
   });
 

--- a/tests/apply-service.test.ts
+++ b/tests/apply-service.test.ts
@@ -56,6 +56,24 @@ describe("buildXyzLayer", () => {
     assert.equal(metadata.resolvedUrl, undefined);
   });
 
+  it("falls back to tile size 256 for a negative or non-numeric value", () => {
+    const negative = buildXyzLayer({
+      name: "Neg",
+      tileUrl: {
+        originalUrl: "https://x",
+        renderUrl: "https://x",
+        url: "https://x",
+        redirected: false,
+      },
+      tileSize: "-256",
+      shortUrl: false,
+    });
+    assert.equal(
+      (negative.source as Record<string, unknown>).tileSize,
+      256,
+    );
+  });
+
   it("records the original and resolved URLs for a redirected short URL", () => {
     const layer = buildXyzLayer({
       name: "Short",
@@ -339,6 +357,31 @@ describe("applyServiceEntry", () => {
     await assert.rejects(
       () => applyServiceEntry(entry("wfs", { endpoint: "" }), deps),
       /no URL/i,
+    );
+    // WFS mirrors WfsSource's output-format and numeric max-features guards.
+    await assert.rejects(
+      () =>
+        applyServiceEntry(
+          entry("wfs", {
+            endpoint: "https://e/wfs",
+            typeName: "t",
+            outputFormat: "",
+          }),
+          deps,
+        ),
+      /output format/i,
+    );
+    await assert.rejects(
+      () =>
+        applyServiceEntry(
+          entry("wfs", {
+            endpoint: "https://e/wfs",
+            typeName: "t",
+            maxFeatures: "abc",
+          }),
+          deps,
+        ),
+      /max features/i,
     );
     assert.equal(added.length, 0);
   });

--- a/tests/apply-service.test.ts
+++ b/tests/apply-service.test.ts
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import { GEBCO_ATTRIBUTION } from "../apps/geolibre-desktop/src/components/layout/add-data/constants";
+import {
+  applyServiceEntry,
+  arcgisFieldsToOptions,
+  buildWfsGeoJsonLayer,
+  buildWmsLayer,
+  buildWmtsLayer,
+  buildXyzLayer,
+  wfsFieldsToRequest,
+  wmsFieldsToParams,
+  wmtsFieldsToParams,
+  xyzFieldsToRequest,
+} from "../apps/geolibre-desktop/src/components/layout/add-data/apply-service";
+import type {
+  ServiceFields,
+  ServiceLibraryEntry,
+  ServiceLibraryKind,
+} from "../apps/geolibre-desktop/src/components/layout/add-data/service-library";
+
+/** Builds a service-library entry for a test with the given kind and fields. */
+function entry(
+  kind: ServiceLibraryKind,
+  fields: ServiceFields,
+  name = "Test service",
+): ServiceLibraryEntry {
+  return { id: "test-id", name, category: "", kind, fields };
+}
+
+describe("buildXyzLayer", () => {
+  it("builds a raster XYZ layer with the rendered tile URL", () => {
+    const layer = buildXyzLayer({
+      name: "Imagery",
+      tileUrl: {
+        originalUrl: "https://x/{z}/{x}/{y}.png",
+        renderUrl: "https://x/{z}/{x}/{y}.png",
+        url: "https://x/{z}/{x}/{y}.png",
+        redirected: false,
+      },
+      tileSize: "256",
+      shortUrl: false,
+    });
+    assert.equal(layer.type, "xyz");
+    assert.equal(layer.name, "Imagery");
+    const source = layer.source as Record<string, unknown>;
+    assert.equal(source.type, "raster");
+    assert.deepEqual(source.tiles, ["https://x/{z}/{x}/{y}.png"]);
+    assert.equal(source.tileSize, 256);
+    // A non-shortUrl, non-redirected layer records no original/resolved URL.
+    const metadata = layer.metadata as Record<string, unknown>;
+    assert.equal(metadata.sourceKind, "xyz-url");
+    assert.equal(metadata.originalUrl, undefined);
+    assert.equal(metadata.resolvedUrl, undefined);
+  });
+
+  it("records the original and resolved URLs for a redirected short URL", () => {
+    const layer = buildXyzLayer({
+      name: "Short",
+      tileUrl: {
+        originalUrl: "https://short.example/abc",
+        renderUrl: "geolibre-xyz://abc/{z}/{x}/{y}",
+        url: "https://cdn.example/{z}/{x}/{y}.png",
+        redirected: true,
+      },
+      tileSize: "",
+      shortUrl: true,
+    });
+    const source = layer.source as Record<string, unknown>;
+    // An empty tile size falls back to the MapLibre default of 256.
+    assert.equal(source.tileSize, 256);
+    assert.equal(source.url, "https://short.example/abc");
+    const metadata = layer.metadata as Record<string, unknown>;
+    assert.equal(metadata.originalUrl, "https://short.example/abc");
+    assert.equal(metadata.resolvedUrl, "https://cdn.example/{z}/{x}/{y}.png");
+  });
+});
+
+describe("buildWmsLayer", () => {
+  it("builds a GetMap tile template, stripping operation params", () => {
+    const layer = buildWmsLayer({
+      name: "WMS",
+      // A pasted GetCapabilities URL: its operation params must be stripped.
+      endpoint: "https://example.com/wms?REQUEST=GetCapabilities&SERVICE=WMS",
+      layers: " topp:states ",
+      styles: "",
+      format: "image/png",
+      transparent: true,
+      tileSize: "512",
+      version: "1.3.0",
+    });
+    assert.equal(layer.type, "wms");
+    const source = layer.source as Record<string, unknown>;
+    assert.equal(source.tileSize, 512);
+    assert.equal(source.layers, "topp:states");
+    assert.equal(source.version, "1.3.0");
+    // Endpoint is stripped of the leftover REQUEST/SERVICE params.
+    assert.equal(source.url, "https://example.com/wms");
+    const tileUrl = (source.tiles as string[])[0];
+    assert.match(tileUrl, /REQUEST=GetMap/);
+    assert.match(tileUrl, /LAYERS=topp%3Astates/);
+    // WMS 1.3.0 uses CRS (not SRS) for the coordinate system parameter.
+    assert.match(tileUrl, /[?&]CRS=EPSG%3A3857/);
+    assert.equal((layer.metadata as Record<string, unknown>).service, "wms");
+  });
+
+  it("attaches the GEBCO attribution for a GEBCO endpoint", () => {
+    const layer = buildWmsLayer({
+      name: "GEBCO",
+      endpoint: "https://wms.gebco.net/mapserv",
+      layers: "GEBCO_LATEST",
+      styles: "",
+      format: "image/png",
+      transparent: true,
+      tileSize: "256",
+      version: "1.3.0",
+    });
+    assert.equal(
+      (layer.source as Record<string, unknown>).attribution,
+      GEBCO_ATTRIBUTION,
+    );
+  });
+});
+
+describe("buildWmtsLayer", () => {
+  it("builds a raster layer and trims the URL", () => {
+    const layer = buildWmtsLayer({
+      name: "WMTS",
+      url: "  https://tiles.example/{z}/{x}/{y}.png  ",
+      tileSize: "256",
+    });
+    assert.equal(layer.type, "wmts");
+    const source = layer.source as Record<string, unknown>;
+    assert.deepEqual(source.tiles, ["https://tiles.example/{z}/{x}/{y}.png"]);
+    assert.equal(source.attribution, undefined);
+  });
+
+  it("attaches the GEBCO attribution for a GEBCO tile host", () => {
+    const layer = buildWmtsLayer({
+      name: "GEBCO tiles",
+      url: "https://tiles.gebco.net/{z}/{x}/{y}.png",
+      tileSize: "256",
+    });
+    assert.equal(
+      (layer.source as Record<string, unknown>).attribution,
+      GEBCO_ATTRIBUTION,
+    );
+  });
+});
+
+describe("buildWfsGeoJsonLayer", () => {
+  it("embeds the fetched collection and records the feature count", () => {
+    const data: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", geometry: null, properties: {} },
+        { type: "Feature", geometry: null, properties: {} },
+      ],
+    };
+    const layer = buildWfsGeoJsonLayer({
+      name: "States",
+      featureUrl: "https://example.com/wfs?REQUEST=GetFeature",
+      data,
+      typeName: "topp:states",
+      version: "2.0.0",
+      outputFormat: "application/json",
+      srsName: "EPSG:4326",
+    });
+    assert.equal(layer.type, "geojson");
+    assert.equal(layer.geojson, data);
+    assert.equal(layer.sourcePath, "https://example.com/wfs?REQUEST=GetFeature");
+    const metadata = layer.metadata as Record<string, unknown>;
+    assert.equal(metadata.featureCount, 2);
+    assert.equal(metadata.sourceKind, "wfs-getfeature");
+    assert.equal(metadata.typeName, "topp:states");
+  });
+
+  it("omits an empty srsName from the source", () => {
+    const layer = buildWfsGeoJsonLayer({
+      name: "No SRS",
+      featureUrl: "https://example.com/wfs",
+      data: { type: "FeatureCollection", features: [] },
+      typeName: "t",
+      version: "2.0.0",
+      outputFormat: "application/json",
+      srsName: "",
+    });
+    assert.equal((layer.source as Record<string, unknown>).srsName, undefined);
+  });
+});
+
+describe("field mappers", () => {
+  it("reads XYZ fields with defaults", () => {
+    assert.deepEqual(xyzFieldsToRequest({ url: "https://x" }), {
+      url: "https://x",
+      tileSize: "256",
+      shortUrl: false,
+    });
+    assert.deepEqual(
+      xyzFieldsToRequest({ url: "https://x", tileSize: "512", shortUrl: true }),
+      { url: "https://x", tileSize: "512", shortUrl: true },
+    );
+  });
+
+  it("resolves the WMS version from a saved field over the endpoint", () => {
+    const params = wmsFieldsToParams(
+      entry("wms", {
+        endpoint: "https://e/wms?VERSION=1.1.1",
+        layers: "a",
+        version: "1.3.0",
+      }),
+    );
+    // An explicit saved version wins over the endpoint's VERSION parameter.
+    assert.equal(params.version, "1.3.0");
+    assert.equal(params.layers, "a");
+    assert.equal(params.format, "image/png");
+    assert.equal(params.transparent, true);
+  });
+
+  it("falls back to the endpoint VERSION when no version field is saved", () => {
+    const params = wmsFieldsToParams(
+      entry("wms", { endpoint: "https://e/wms?VERSION=1.3.0", layers: "a" }),
+    );
+    assert.equal(params.version, "1.3.0");
+  });
+
+  it("defaults the WMS version to 1.1.1 when neither source has it", () => {
+    const params = wmsFieldsToParams(
+      entry("wms", { endpoint: "https://e/wms", layers: "a" }),
+    );
+    assert.equal(params.version, "1.1.1");
+  });
+
+  it("reads WMTS fields with defaults", () => {
+    assert.deepEqual(wmtsFieldsToParams(entry("wmts", { url: "https://t" })), {
+      name: "Test service",
+      url: "https://t",
+      tileSize: "256",
+    });
+  });
+
+  it("strips WFS operation params and maps an empty maxFeatures to undefined", () => {
+    const request = wfsFieldsToRequest(
+      entry("wfs", {
+        endpoint: "https://e/wfs?REQUEST=GetCapabilities",
+        typeName: " topp:states ",
+        maxFeatures: "   ",
+      }),
+    );
+    assert.equal(request.endpoint, "https://e/wfs");
+    assert.equal(request.typeName, "topp:states");
+    assert.equal(request.version, "2.0.0");
+    assert.equal(request.outputFormat, "application/json");
+    assert.equal(request.srsName, "EPSG:4326");
+    assert.equal(request.maxFeatures, undefined);
+  });
+
+  it("detects ArcGIS vector-tile / portal-item and trims blanks to undefined", () => {
+    assert.deepEqual(
+      arcgisFieldsToOptions(
+        entry("arcgis", {
+          layerType: "vector-tile",
+          sourceType: "portal-item",
+          itemId: " abc ",
+          url: "",
+          portalUrl: "",
+        }),
+      ),
+      {
+        name: "Test service",
+        layerType: "vector-tile",
+        sourceType: "portal-item",
+        url: undefined,
+        itemId: "abc",
+        portalUrl: undefined,
+      },
+    );
+    // Unknown/absent values fall back to the feature + url defaults.
+    const defaults = arcgisFieldsToOptions(entry("arcgis", { url: "https://s" }));
+    assert.equal(defaults.layerType, "feature");
+    assert.equal(defaults.sourceType, "url");
+    assert.equal(defaults.url, "https://s");
+  });
+});
+
+describe("applyServiceEntry", () => {
+  /** A dispatcher deps stub that records the layers added to the store. */
+  function stubDeps() {
+    const added: { layer: GeoLibreLayer; beforeLayerId: string | null }[] = [];
+    return {
+      added,
+      deps: {
+        addLayer: (layer: GeoLibreLayer, beforeLayerId: string | null = null) => {
+          added.push({ layer, beforeLayerId });
+        },
+        mapControllerRef: { current: null },
+      },
+    };
+  }
+
+  it("adds a WMS layer through the store, honoring the insert position", async () => {
+    const { added, deps } = stubDeps();
+    await applyServiceEntry(
+      entry("wms", { endpoint: "https://e/wms", layers: "a" }, "My WMS"),
+      { ...deps, beforeLayerId: "layer-2" },
+    );
+    assert.equal(added.length, 1);
+    assert.equal(added[0].layer.type, "wms");
+    assert.equal(added[0].layer.name, "My WMS");
+    assert.equal(added[0].beforeLayerId, "layer-2");
+  });
+
+  it("adds a WMTS layer through the store", async () => {
+    const { added, deps } = stubDeps();
+    await applyServiceEntry(entry("wmts", { url: "https://t/{z}/{x}/{y}" }), deps);
+    assert.equal(added.length, 1);
+    assert.equal(added[0].layer.type, "wmts");
+    assert.equal(added[0].beforeLayerId, null);
+  });
+
+  it("throws (before any layer is added) when required fields are missing", async () => {
+    const { added, deps } = stubDeps();
+    await assert.rejects(
+      () => applyServiceEntry(entry("wms", { endpoint: "https://e" }), deps),
+      /no layers/i,
+    );
+    await assert.rejects(
+      () => applyServiceEntry(entry("wmts", { url: "  " }), deps),
+      /no tile URL/i,
+    );
+    // XYZ validates before the (browser-only) maplibre import, so this is safe
+    // to assert under Node.
+    await assert.rejects(
+      () => applyServiceEntry(entry("xyz", { url: "" }), deps),
+      /no tile URL/i,
+    );
+    await assert.rejects(
+      () => applyServiceEntry(entry("wfs", { endpoint: "" }), deps),
+      /no URL/i,
+    );
+    assert.equal(added.length, 0);
+  });
+});

--- a/tests/apply-service.test.ts
+++ b/tests/apply-service.test.ts
@@ -338,6 +338,57 @@ describe("applyServiceEntry", () => {
     assert.equal(added[0].beforeLayerId, null);
   });
 
+  it("fetches WFS GeoJSON, adds the layer, and fits the map to it", async () => {
+    const added: { layer: GeoLibreLayer; beforeLayerId: string | null }[] = [];
+    const fitted: GeoLibreLayer[] = [];
+    const fc: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [1, 2] },
+          properties: { id: 1 },
+        },
+      ],
+    };
+    const realFetch = globalThis.fetch;
+    // Stub the network so the wfs branch drives its real dynamic import +
+    // fetchWfsGeoJson + buildWfsGeoJsonLayer + addLayer/fitLayer wiring.
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(fc), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof globalThis.fetch;
+    try {
+      await applyServiceEntry(
+        entry(
+          "wfs",
+          { endpoint: "https://e/wfs", typeName: "topp:states" },
+          "States",
+        ),
+        {
+          addLayer: (layer, beforeLayerId = null) => {
+            added.push({ layer, beforeLayerId });
+          },
+          mapControllerRef: {
+            current: { fitLayer: (layer: GeoLibreLayer) => fitted.push(layer) },
+          } as unknown as Parameters<
+            typeof applyServiceEntry
+          >[1]["mapControllerRef"],
+        },
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    assert.equal(added.length, 1);
+    assert.equal(added[0].layer.type, "geojson");
+    assert.equal(added[0].layer.name, "States");
+    assert.equal(added[0].layer.geojson?.features.length, 1);
+    // The map is fit to the freshly added WFS layer (the same object).
+    assert.equal(fitted.length, 1);
+    assert.equal(fitted[0], added[0].layer);
+  });
+
   it("throws (before any layer is added) when required fields are missing", async () => {
     const { added, deps } = stubDeps();
     await assert.rejects(


### PR DESCRIPTION
## What & why

Extracts the per-kind **"saved service fields → map layer"** logic out of the Add Data web-service sources into a new, dependency-light module, `apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts`.

This is **groundwork for a QGIS-style Browser / Data Source Manager panel**: the Browser needs to add a saved service to the map in one click, without going through the dialog form. Today that logic lives inside each Source component's submit handler, so a second caller would have to duplicate it. This PR gives both callers one shared path.

Landing it first (with unit tests, no new UI) also **de-risks the Add Data dialog** by making the layer-construction logic testable in isolation.

## What's in it

**New module — `apply-service.ts`:**
- **Pure layer builders** — `buildXyzLayer` / `buildWmsLayer` / `buildWmtsLayer` / `buildWfsGeoJsonLayer` construct a `GeoLibreLayer` from resolved params, with no React / network / MapLibre imports, so they unit-test in isolation.
- **Field mappers** — `xyzFieldsToRequest` / `wmsFieldsToParams` / `wmtsFieldsToParams` / `wfsFieldsToRequest` / `arcgisFieldsToOptions` translate a stored `ServiceFields` bag into those params, mirroring each source's `applyFields` (including the WMS saved-vs-endpoint-vs-default version resolution).
- **`applyServiceEntry(entry, deps)`** — the imperative dispatcher a future Browser panel will call: maps fields, resolves async work (XYZ short-URL redirect, WFS GetFeature), delegates ArcGIS to its plugin, and adds the layer to the store. Browser-only deps (`xyz-url`→maplibre, `@geolibre/plugins`, the WFS fetch) are **dynamically imported** so the pure exports load under Node for tests.

**Refactor — sources route through the builders:**
The XYZ / WMS / WMTS / WFS sources now build their layer via the extracted helpers instead of an inline `createBaseLayer` call (net **−61 lines**). Behavior is unchanged: each source passes its live form state to the builder, which reproduces the previous output exactly. ArcGIS already delegated to `addArcGISLayer`, so its source is untouched.

**Tests — `tests/apply-service.test.ts` (18 cases):** the builders, the field mappers, and the tile-kind dispatch + validation paths.

## Verification
- New tests: 18/18 pass. Full frontend suite: **2453 pass, 0 fail, 1 pre-existing skip**.
- `pre-commit run --files` (full `npm build` + eslint): **green**.
- No new type errors; no behavior change to Add Data.

## Follow-ups (not in this PR)
- The Browser panel itself (consumes `applyServiceEntry`) — the next PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying saved XYZ, WMS, WMTS, WFS, and ArcGIS service entries directly from the Browser panel.
  * Inputs are validated, service parameters are mapped/resolved, and layers are inserted into the map store (with WFS also fitting the map).
* **Bug Fixes**
  * Standardized layer construction across formats for consistent URL/template handling, normalization, and attribution/metadata behavior.
* **Tests**
  * Added automated coverage for layer building, saved-field mapping, validation errors, and end-to-end apply behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Note: one intentional behavior change
`toTileSize` now falls back to 256 for a **negative** tile size as well as NaN/0 (the old per-source `Number(value) || 256` passed `-256` straight through). A negative tile size reaching the raster source was a latent bug; this hardens it for both the builders and the dialog sources. So the refactor is output-identical *except* for that pathological input.
