### PR TITLE
feat(browser): translate section labels; Layout toggle re-opens collapsed

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -10,7 +10,11 @@ import {
   type ProjectPreferences,
   type RuntimeEnvironmentVariable,
 } from "@geolibre/core";
-import { closeRightPanel, openRightPanel } from "@geolibre/plugins";
+import {
+  closeRightPanel,
+  collapseRightPanel,
+  openRightPanel,
+} from "@geolibre/plugins";
 import {
   Button,
   Dialog,
@@ -398,6 +402,17 @@ export function SettingsDialog({
   // persisted layout preference, so its Layout toggle acts on the live registry
   // state directly rather than through the draft settings.
   const browserPanelOpen = useRightPanelState().activeId === BROWSER_PANEL_ID;
+  // Show it collapsed on the shared Layers rail, matching its default state, so
+  // re-enabling from Settings doesn't jump to an expanded panel that buries the
+  // Layers panel.
+  const toggleBrowserPanel = (show: boolean) => {
+    if (show) {
+      openRightPanel(BROWSER_PANEL_ID);
+      collapseRightPanel(BROWSER_PANEL_ID);
+    } else {
+      closeRightPanel(BROWSER_PANEL_ID);
+    }
+  };
   // A field a deep-link asked us to focus once its section renders; cleared
   // after the focus lands so a later open without a focus request stays put.
   const [pendingFocus, setPendingFocus] = useState<SettingsFocusTarget | null>(
@@ -1227,9 +1242,7 @@ export function SettingsDialog({
               <DropdownMenuCheckboxItem
                 checked={browserPanelOpen}
                 onCheckedChange={(checked: boolean) =>
-                  checked === true
-                    ? openRightPanel(BROWSER_PANEL_ID)
-                    : closeRightPanel(BROWSER_PANEL_ID)
+                  toggleBrowserPanel(checked === true)
                 }
                 onSelect={(event: Event) => event.preventDefault()}
               >
@@ -1703,9 +1716,7 @@ export function SettingsDialog({
                         type="checkbox"
                         checked={browserPanelOpen}
                         onChange={(event) =>
-                          event.target.checked
-                            ? openRightPanel(BROWSER_PANEL_ID)
-                            : closeRightPanel(BROWSER_PANEL_ID)
+                          toggleBrowserPanel(event.target.checked)
                         }
                       />
                       <FolderTree className="h-4 w-4 text-muted-foreground" />

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import {
   BUILTIN_SERVICES,
   readUserServices,
@@ -28,14 +29,21 @@ export interface BrowserTreeState {
  * @returns The tree plus a by-id service lookup for one-click add.
  */
 export function useBrowserTree(): BrowserTreeState {
+  const { t } = useTranslation();
   const recentProjects = useAppStore((s) => s.recentProjects);
+  const servicesLabel = t("browser.services");
+  const recentLabel = t("browser.recent");
 
   return useMemo(() => {
     const services = [...BUILTIN_SERVICES, ...readUserServices()];
     const byId = new Map(services.map((entry) => [entry.id, entry]));
     return {
-      tree: buildBrowserTree({ services, recentProjects }),
+      tree: buildBrowserTree({
+        services,
+        recentProjects,
+        sectionLabels: { services: servicesLabel, recent: recentLabel },
+      }),
       serviceById: (id: string) => byId.get(id),
     };
-  }, [recentProjects]);
+  }, [recentProjects, servicesLabel, recentLabel]);
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1,6 +1,8 @@
 {
   "browser": {
     "title": "Browser",
+    "services": "Services",
+    "recent": "Recent",
     "searchPlaceholder": "Search data sources",
     "empty": "No saved services or recent projects yet.",
     "emptyGroup": "Empty",

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -54,6 +54,11 @@ export interface BrowserTreeInput {
   services: readonly ServiceLibraryEntry[];
   /** The recent-projects list from the store, most-recent first. */
   recentProjects: readonly RecentProjectEntry[];
+  /**
+   * Translated labels for the two top-level sections. Optional so the pure
+   * module (and its tests) default to English; the app passes `t()` values.
+   */
+  sectionLabels?: { services: string; recent: string };
 }
 
 /** Locale-aware, case-insensitive compare for stable label sorting. */
@@ -127,11 +132,12 @@ function buildServiceKinds(
  * @returns The top-level section nodes (Services, then Recent).
  */
 export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
+  const labels = input.sectionLabels ?? { services: "Services", recent: "Recent" };
   const kinds = buildServiceKinds(input.services);
   const servicesSection: BrowserNode = {
     id: "section:services",
     kind: "section",
-    label: "Services",
+    label: labels.services,
     addable: false,
     count: input.services.length,
     children: kinds,
@@ -149,7 +155,7 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
   const recentSection: BrowserNode = {
     id: "section:recent",
     kind: "section",
-    label: "Recent",
+    label: labels.recent,
     addable: false,
     count: recentChildren.length,
     children: recentChildren,

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -108,6 +108,22 @@ describe("buildBrowserTree", () => {
     assert.equal(leaf?.builtin, true);
   });
 
+  it("defaults the section labels to English when none are given", () => {
+    const tree = buildBrowserTree({ services: [], recentProjects: [] });
+    assert.equal(find(tree, "section:services")?.label, "Services");
+    assert.equal(find(tree, "section:recent")?.label, "Recent");
+  });
+
+  it("applies translated section labels when provided", () => {
+    const tree = buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      sectionLabels: { services: "Servicios", recent: "Recientes" },
+    });
+    assert.equal(find(tree, "section:services")?.label, "Servicios");
+    assert.equal(find(tree, "section:recent")?.label, "Recientes");
+  });
+
   it("lists recent projects in the given order with their paths", () => {
     const tree = buildBrowserTree({ services: [], recentProjects: RECENT });
     const recent = tree[1];


### PR DESCRIPTION
Follow-ups from the Browser panel review (#1200), addressing the genuine, low-risk items the bots flagged.

## Changes

- **i18n** — the Browser tree's "Services" / "Recent" section labels were hardcoded English. They're now translated: `buildBrowserTree` takes an optional `sectionLabels`, which `useBrowserTree` fills from `t("browser.services")` / `t("browser.recent")`. The kind headers (XYZ / WMS / WFS / WMTS / ArcGIS) stay as acronyms/brand names. The pure builder keeps an English default, so its unit tests are unchanged.
- **Settings → Layout "Show Browser panel"** — re-enabling now opens the panel **collapsed on the shared Layers rail** (open + collapse), matching its default on-load state, instead of opening expanded and displacing the Layers panel. The quick Settings-menu submenu toggle and the Settings-dialog checkbox share one `toggleBrowserPanel` helper.

## Verification

- Unit: `tests/browser-tree.test.ts` 11/11 (English defaults keep them valid). `tsc -b` clean; eslint clean; `pre-commit` (full `npm build`) green.
- Browser: "Services"/"Recent" render; toggling the Layout checkbox off→on re-opens the Browser as a collapsed rail entry with Layers expanded (verified via the dialog checkbox and screenshots).

## Deliberately deferred (tracked for a dedicated PR)

- **Single shared `useProjectFileActions` instance.** The Browser panel and `TopToolbar` each create their own instance, so a recent-project open triggered from both surfaces within the fetch window doesn't cross-cancel (a narrow race the reviewers rate low–medium confidence). The clean fix is to hoist one instance into `DesktopShell` and thread `handleOpenRecent`/`actionError` into both — but that touches the toolbar's Open/Save/Share/URL wiring and warrants its own PR with focused verification, rather than riding along here. A module-level shared guard is not viable because it would break the multi-instance Jupyter embed.
- **Panel title re-localization on runtime language switch** — a pre-existing platform gap in `registerRightPanel` (no re-localize API; same limitation noted for the Graticule plugin), best fixed generically in the plugin host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized labels for the Browser panel’s “Services” and “Recent” sections.
* **Bug Fixes**
  * Improved consistency between Browser panel controls in the settings menu and the Layout section.
  * Browser panel visibility toggling now preserves the default collapsed rail alignment when enabling.
* **Tests**
  * Added coverage for default and overridden Browser section label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->