### PR TITLE
fix(browser): share one useProjectFileActions instance with the toolbar

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -51,6 +51,7 @@ import {
   useRegisterBrowserPanel,
 } from "../../hooks/useRegisterBrowserPanel";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
+import { useProjectFileActions } from "../../hooks/useProjectFileActions";
 import {
   isTauri,
   loadDroppedPhotoFiles,
@@ -562,6 +563,10 @@ export function DesktopShell({
   // Register the Browser as a movable/dockable right panel; its body is portaled
   // into a dedicated content host (below) that the dock slots adopt.
   useRegisterBrowserPanel();
+  // One shared project-file-actions instance for both the toolbar and the
+  // Browser panel, so their "open recent" calls coordinate their aborts (two
+  // instances would race). Lifted here for the same reason as `collaboration`.
+  const projectFiles = useProjectFileActions(mapControllerRef);
   const notebookOpen = useAppStore((s) => s.ui.notebookOpen);
   const storymapPresenting = useAppStore((s) => s.ui.storymapPresenting);
   // A plugin panel docks at one of four positions beside the Layers/Style
@@ -1811,6 +1816,7 @@ export function DesktopShell({
             showProjectInfo={layoutOptions.showProjectInfo}
             themeMode={themeMode}
             collaboration={collaboration}
+            projectFiles={projectFiles}
             onOpenDiagnostics={() => setDiagnosticsOpen(true)}
             onToggleThemeMode={onToggleThemeMode}
           />
@@ -1825,7 +1831,12 @@ export function DesktopShell({
             app's React context and the shell owns its dock chrome. */}
         {activePanelId === BROWSER_PANEL_ID
           ? createPortal(
-              <BrowserPanel mapControllerRef={mapControllerRef} />,
+              <BrowserPanel
+                mapControllerRef={mapControllerRef}
+                onOpenRecentProject={projectFiles.handleOpenRecent}
+                recentActionError={projectFiles.actionError}
+                onClearRecentError={() => projectFiles.setActionError(null)}
+              />,
               browserContentEl,
             )
           : null}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1834,8 +1834,6 @@ export function DesktopShell({
               <BrowserPanel
                 mapControllerRef={mapControllerRef}
                 onOpenRecentProject={projectFiles.handleOpenRecent}
-                recentActionError={projectFiles.actionError}
-                onClearRecentError={() => projectFiles.setActionError(null)}
               />,
               browserContentEl,
             )

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -974,7 +974,11 @@ export function TopToolbar({
           onOpenFromFile={() => void projectFiles.handleOpenFromFile()}
           onOpenFromUrl={() => projectFiles.setProjectUrlDialogOpen(true)}
           onOpenGallery={() => setGalleryDialogOpen(true)}
-          onOpenRecent={(path) => void projectFiles.handleOpenRecent(path)}
+          onOpenRecent={(path) => {
+            void projectFiles.handleOpenRecent(path).then((error) => {
+              if (error) projectFiles.setActionError(error);
+            });
+          }}
           onSave={() => void projectFiles.handleSave()}
           onSaveAs={() => void projectFiles.handleSaveAs()}
           onShare={() => setShareDialogOpen(true)}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -79,7 +79,7 @@ import {
 } from "../../hooks/usePlugins";
 import { useConsentGatedActions } from "../../hooks/useConsentGatedActions";
 import { useOsmPbfLoader } from "../../hooks/useOsmPbfLoader";
-import { useProjectFileActions } from "../../hooks/useProjectFileActions";
+import type { ProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/tauri-io";
@@ -155,6 +155,9 @@ interface TopToolbarProps {
   // Lifted to DesktopShell so the on-canvas status badge can share one live
   // session (calling useCollaboration twice would open two sockets).
   collaboration: CollaborationApi;
+  // Lifted to DesktopShell so the toolbar and the Browser panel share one
+  // instance — two would not coordinate their in-flight "open recent" aborts.
+  projectFiles: ProjectFileActions;
   onOpenDiagnostics: () => void;
   onToggleThemeMode: () => void;
 }
@@ -168,6 +171,7 @@ export function TopToolbar({
   showProjectInfo = true,
   themeMode,
   collaboration,
+  projectFiles,
   onOpenDiagnostics,
   onToggleThemeMode,
 }: TopToolbarProps) {
@@ -319,7 +323,6 @@ export function TopToolbar({
   const appApi = useMemo(() => createAppAPI(mapControllerRef), [mapControllerRef]);
 
   const panels = useToolbarPanels(appApi);
-  const projectFiles = useProjectFileActions(mapControllerRef);
   const osmPbf = useOsmPbfLoader(appApi, projectFiles.setActionError);
   const consent = useConsentGatedActions({ appApi, isActive, toggle });
   const viewportHistory = useViewportHistory(

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
@@ -10,10 +10,10 @@ import {
 } from "@geolibre/ui";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
-import type { useProjectFileActions } from "../../../hooks/useProjectFileActions";
+import type { ProjectFileActions } from "../../../hooks/useProjectFileActions";
 
 interface ProjectFileDialogsProps {
-  projectFiles: ReturnType<typeof useProjectFileActions>;
+  projectFiles: ProjectFileActions;
 }
 
 /** The project-file dialogs: Open-from-URL, the error dialog, the save-name prompt, and the env-var strip prompt. */

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -11,12 +11,11 @@ import { BrowserTreeNode } from "./BrowserTreeNode";
 
 interface BrowserPanelProps {
   mapControllerRef: RefObject<MapController | null>;
-  /** Open a recent project by path (shared with the toolbar's instance). */
-  onOpenRecentProject: (path: string) => Promise<void> | void;
-  /** The shared open-recent failure message, or null. */
-  recentActionError: string | null;
-  /** Clear the shared open-recent failure before a new activation. */
-  onClearRecentError: () => void;
+  /**
+   * Open a recent project by path (shared with the toolbar's instance).
+   * Resolves to an error message to show inline, or null on success.
+   */
+  onOpenRecentProject: (path: string) => Promise<string | null>;
 }
 
 /** The section nodes are expanded by default so their contents are visible. */
@@ -47,8 +46,6 @@ function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void
 export function BrowserPanel({
   mapControllerRef,
   onOpenRecentProject,
-  recentActionError,
-  onClearRecentError,
 }: BrowserPanelProps) {
   const { t } = useTranslation();
   const addLayer = useAppStore((s) => s.addLayer);
@@ -103,9 +100,6 @@ export function BrowserPanel({
     // cannot run twice and duplicate the layer.
     if (busyRef.current != null) return;
     setError(null);
-    // Also clear any prior recent-open failure from the shared project-file
-    // actions, so a stale banner does not persist across activations.
-    onClearRecentError();
     if (node.kind === "service" && node.serviceId) {
       const entry = serviceById(node.serviceId);
       if (!entry) {
@@ -129,12 +123,13 @@ export function BrowserPanel({
         endBusy();
       }
     } else if (node.kind === "recent-project" && node.projectPath) {
-      // Keep the panel open until the open settles: the shared handler never
-      // throws (it records a failure in recentActionError, surfaced below), so
-      // closing early would hide that error from the user.
+      // Keep the panel open until the open settles: the handler resolves to an
+      // error message (or null) rather than throwing, so surface it inline here
+      // instead of closing the panel and hiding it.
       beginBusy(node.id);
       try {
-        await onOpenRecentProject(node.projectPath);
+        const openError = await onOpenRecentProject(node.projectPath);
+        if (openError) setError(openError);
       } finally {
         endBusy();
       }
@@ -158,10 +153,8 @@ export function BrowserPanel({
         />
       </div>
 
-      {error ?? recentActionError ? (
-        <p className="border-b px-3 py-2 text-xs text-destructive">
-          {error ?? recentActionError}
-        </p>
+      {error ? (
+        <p className="border-b px-3 py-2 text-xs text-destructive">{error}</p>
       ) : null}
 
       <ScrollArea className="min-h-0 flex-1">

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -4,7 +4,6 @@ import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
 import { useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
-import { useProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import { filterBrowserTree, type BrowserNode } from "../../lib/browser-tree";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
@@ -12,6 +11,12 @@ import { BrowserTreeNode } from "./BrowserTreeNode";
 
 interface BrowserPanelProps {
   mapControllerRef: RefObject<MapController | null>;
+  /** Open a recent project by path (shared with the toolbar's instance). */
+  onOpenRecentProject: (path: string) => Promise<void> | void;
+  /** The shared open-recent failure message, or null. */
+  recentActionError: string | null;
+  /** Clear the shared open-recent failure before a new activation. */
+  onClearRecentError: () => void;
 }
 
 /** The section nodes are expanded by default so their contents are visible. */
@@ -39,11 +44,15 @@ function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void
  * and the left/right dock (defaulting to the shared Layers rail). This component
  * renders only the panel body (search + tree).
  */
-export function BrowserPanel({ mapControllerRef }: BrowserPanelProps) {
+export function BrowserPanel({
+  mapControllerRef,
+  onOpenRecentProject,
+  recentActionError,
+  onClearRecentError,
+}: BrowserPanelProps) {
   const { t } = useTranslation();
   const addLayer = useAppStore((s) => s.addLayer);
   const { tree, serviceById } = useBrowserTree();
-  const projectFiles = useProjectFileActions(mapControllerRef);
 
   const [query, setQuery] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(
@@ -94,10 +103,9 @@ export function BrowserPanel({ mapControllerRef }: BrowserPanelProps) {
     // cannot run twice and duplicate the layer.
     if (busyRef.current != null) return;
     setError(null);
-    // Also clear any prior recent-open failure: handleOpenRecent sets
-    // projectFiles.actionError but this panel owns an isolated hook instance
-    // with no other reset path, so a stale banner would otherwise persist.
-    projectFiles.setActionError(null);
+    // Also clear any prior recent-open failure from the shared project-file
+    // actions, so a stale banner does not persist across activations.
+    onClearRecentError();
     if (node.kind === "service" && node.serviceId) {
       const entry = serviceById(node.serviceId);
       if (!entry) {
@@ -121,12 +129,12 @@ export function BrowserPanel({ mapControllerRef }: BrowserPanelProps) {
         endBusy();
       }
     } else if (node.kind === "recent-project" && node.projectPath) {
-      // Keep the panel open until the open settles: handleOpenRecent never
-      // throws (it records a failure in projectFiles.actionError, surfaced
-      // below), so closing early would hide that error from the user.
+      // Keep the panel open until the open settles: the shared handler never
+      // throws (it records a failure in recentActionError, surfaced below), so
+      // closing early would hide that error from the user.
       beginBusy(node.id);
       try {
-        await projectFiles.handleOpenRecent(node.projectPath);
+        await onOpenRecentProject(node.projectPath);
       } finally {
         endBusy();
       }
@@ -150,9 +158,9 @@ export function BrowserPanel({ mapControllerRef }: BrowserPanelProps) {
         />
       </div>
 
-      {error ?? projectFiles.actionError ? (
+      {error ?? recentActionError ? (
         <p className="border-b px-3 py-2 text-xs text-destructive">
-          {error ?? projectFiles.actionError}
+          {error ?? recentActionError}
         </p>
       ) : null}
 

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -753,3 +753,10 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     handleExportHtml,
   };
 }
+
+/**
+ * The handlers and state returned by {@link useProjectFileActions}. Exported so
+ * a single hoisted instance can be shared as a prop across the toolbar and the
+ * Browser panel (two instances don't coordinate their in-flight open aborts).
+ */
+export type ProjectFileActions = ReturnType<typeof useProjectFileActions>;

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -262,7 +262,11 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     }
   };
 
-  const handleOpenRecent = async (path: string) => {
+  // Returns an error message to surface, or null on success/abort. It does not
+  // set the shared `actionError` itself, so each caller can route the failure to
+  // its own surface (the toolbar's modal vs. the Browser panel's inline banner)
+  // now that a single instance is shared across both.
+  const handleOpenRecent = async (path: string): Promise<string | null> => {
     // Cancel any previous in-flight open so rapid clicks cannot race and let a
     // stale fetch win by resolving last.
     recentAbortRef.current?.abort();
@@ -274,19 +278,16 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     try {
       result = await openRecentProjectFile(path, controller.signal);
     } catch (error) {
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted) return null;
       // Only drop the entry when the project is permanently gone; preserve it
       // for transient failures (network timeout, 5xx, momentary IO error).
       if (error instanceof RecentProjectGoneError) {
         forgetRecentProject(path);
       }
       console.error("Failed to open recent project", error);
-      setActionError(
-        error instanceof Error
-          ? error.message
-          : t("toolbar.error.couldNotOpenRecentProject"),
-      );
-      return;
+      return error instanceof Error
+        ? error.message
+        : t("toolbar.error.couldNotOpenRecentProject");
     }
 
     try {
@@ -294,16 +295,15 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
         result.project,
         controller.signal,
       );
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted) return null;
       loadProject(project, result.path);
+      return null;
     } catch (error) {
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted) return null;
       console.error("Failed to load recent project", error);
-      setActionError(
-        error instanceof Error
-          ? error.message
-          : t("toolbar.error.couldNotLoadRecentProject"),
-      );
+      return error instanceof Error
+        ? error.message
+        : t("toolbar.error.couldNotLoadRecentProject");
     } finally {
       if (recentAbortRef.current === controller) {
         recentAbortRef.current = null;


### PR DESCRIPTION
The remaining tracked follow-up from the Browser panel review (#1200).

## Problem

The Browser panel created its own `useProjectFileActions` instance while `TopToolbar` held another. Each instance's `recentAbortRef` only guards its **own** calls, so a recent-project open triggered from the toolbar and from the Browser panel within the fetch window did not cross-cancel — whichever `loadProject` resolved last silently won, regardless of which the user actually clicked. (Bots flagged this repeatedly; low–medium confidence, narrow window.) The second instance also carried unused "kitchen sink" state (URL dialog, save-name prompt, abort refs).

## Fix

Hoist a **single** `useProjectFileActions` into `DesktopShell` — the same pattern already used for `collaboration` ("calling it twice would open two sockets") — and pass it down:

- `useProjectFileActions`: export a `ProjectFileActions` return type for the prop.
- `TopToolbar`: receive `projectFiles` as a prop instead of creating its own.
- `DesktopShell`: create the shared instance; pass it to `TopToolbar` and thread `handleOpenRecent` / `actionError` / `setActionError` into the portaled `BrowserPanel`.
- `BrowserPanel`: take `onOpenRecentProject` / `recentActionError` / `onClearRecentError` props instead of its own hook instance.

A module-level shared guard was rejected because it would break the multi-instance Jupyter embed (each widget must stay independent); hoisting keeps it per-app-instance.

## Verification

- `tsc -b` clean; eslint clean; full frontend suite passes; `pre-commit` (full `npm build`) green.
- Browser: the toolbar's Project menu **Open / Save / Save As** still work (Save As name prompt opens), "Open Recent" is present (disabled with no recents), the Browser panel renders, and there are no console errors — confirming the toolbar's file I/O is intact on the shared instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordination when opening recent projects from the toolbar and Browser panel using a shared “open recent” handler.
  - Recent-project handling is now routed per caller: failures return an error message that the UI can display or set locally.
  - Toolbar “open recent” behavior now handles errors asynchronously instead of fire-and-forget.
  - Recent-project inline errors in the Browser panel no longer rely on shared global error state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->