### PR TITLE
feat(browser): "New connection" action per service kind

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -96,6 +96,7 @@ import { useViewportHistory } from "../../hooks/useViewportHistory";
 import type { Command } from "../../lib/commands";
 import { IS_STORE_BUILD } from "../../lib/updates";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
+import { OPEN_ADD_DATA_EVENT } from "./add-data/open-add-data";
 import { AddNetcdfDialog } from "./AddNetcdfDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -347,6 +348,17 @@ export function TopToolbar({
     ),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
+  // Let any panel (e.g. the Browser panel's "New connection" action) open the
+  // Add Data dialog at a given kind without prop-drilling, mirroring
+  // openSettingsSection. This toolbar owns the dialog + its kind state.
+  useEffect(() => {
+    const onOpenAddData = (event: Event) => {
+      const kind = (event as CustomEvent<{ kind: AddDataKind }>).detail?.kind;
+      if (kind) setAddDataKind(kind);
+    };
+    window.addEventListener(OPEN_ADD_DATA_EVENT, onOpenAddData);
+    return () => window.removeEventListener(OPEN_ADD_DATA_EVENT, onOpenAddData);
+  }, []);
   // Deck.gl Layer kind the Add Data dialog opens on (e.g. the 3D-model entry
   // jumps straight to the scenegraph layer type).
   const [addDataDeckVizKind, setAddDataDeckVizKind] = useState<

--- a/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
@@ -1,0 +1,19 @@
+import type { AddDataKind } from "./types";
+
+/** Window event letting any panel open the Add Data dialog at a given kind. */
+export const OPEN_ADD_DATA_EVENT = "geolibre:open-add-data";
+
+/**
+ * Open the Add Data dialog preselected to `kind` from anywhere in the app,
+ * without prop-drilling (mirrors {@link openSettingsSection}). TopToolbar owns
+ * the dialog and its kind state and listens for this event. Used by the Browser
+ * panel's per-source "New connection" action.
+ *
+ * @param kind - The Add Data source to open (e.g. "wms", "wfs", "xyz").
+ */
+export function openAddData(kind: AddDataKind): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(OPEN_ADD_DATA_EVENT, { detail: { kind } }),
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -6,7 +6,6 @@ import { useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import { filterBrowserTree, type BrowserNode } from "../../lib/browser-tree";
-import type { AddDataKind } from "../layout/AddDataDialog";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
 import { openAddData } from "../layout/add-data/open-add-data";
 import type { ServiceLibraryKind } from "../layout/add-data/service-library";
@@ -141,9 +140,8 @@ export function BrowserPanel({
 
   // "New connection" on a service-kind group opens the Add Data dialog at that
   // source; saving there adds it to the library, which shows up in this tree.
-  // The five ServiceLibraryKind values are all valid AddDataKind values.
-  const newConnection = (kind: ServiceLibraryKind) =>
-    openAddData(kind as AddDataKind);
+  // ServiceLibraryKind is a subset of AddDataKind, so no cast is needed.
+  const newConnection = (kind: ServiceLibraryKind) => openAddData(kind);
 
   const hasContent = filtered.some((section) => section.children?.length);
 

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -6,7 +6,10 @@ import { useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import { filterBrowserTree, type BrowserNode } from "../../lib/browser-tree";
+import type { AddDataKind } from "../layout/AddDataDialog";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
+import { openAddData } from "../layout/add-data/open-add-data";
+import type { ServiceLibraryKind } from "../layout/add-data/service-library";
 import { BrowserTreeNode } from "./BrowserTreeNode";
 
 interface BrowserPanelProps {
@@ -136,6 +139,12 @@ export function BrowserPanel({
     }
   };
 
+  // "New connection" on a service-kind group opens the Add Data dialog at that
+  // source; saving there adds it to the library, which shows up in this tree.
+  // The five ServiceLibraryKind values are all valid AddDataKind values.
+  const newConnection = (kind: ServiceLibraryKind) =>
+    openAddData(kind as AddDataKind);
+
   const hasContent = filtered.some((section) => section.children?.length);
 
   return (
@@ -169,6 +178,7 @@ export function BrowserPanel({
                 busyId={busyId}
                 onToggle={toggle}
                 onActivate={activate}
+                onNewConnection={newConnection}
               />
             ))}
           </ul>

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -71,57 +71,59 @@ export function BrowserTreeNode({
   return (
     <li>
       <div className="flex items-center">
-      <button
-        type="button"
-        disabled={isDisabled}
-        className={cn(
-          "flex min-w-0 flex-1 items-center gap-1.5 rounded px-2 py-1 text-left text-sm",
-          "hover:bg-accent hover:text-accent-foreground",
-          "disabled:pointer-events-none disabled:opacity-50",
-          node.kind === "section" && "font-semibold",
-        )}
-        style={{ paddingLeft }}
-        aria-expanded={isGroup ? isExpanded : undefined}
-        aria-busy={isBusy || undefined}
-        onClick={() => (isGroup ? onToggle(node.id) : onActivate(node))}
-      >
-        {isGroup ? (
-          isExpanded ? (
-            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          )
-        ) : (
-          <span className="w-3.5 shrink-0" />
-        )}
-        {isBusy ? (
-          <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-        ) : (
-          <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <span className="truncate">{node.label}</span>
-        {node.builtin ? (
-          <span className="ml-1 shrink-0 rounded border px-1 text-[10px] uppercase leading-tight text-muted-foreground">
-            {t("browser.builtinBadge")}
-          </span>
-        ) : null}
-        {typeof node.count === "number" && node.count > 0 ? (
-          <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-            {node.count}
-          </span>
-        ) : null}
-      </button>
-      {node.kind === "category" && node.serviceKind ? (
         <button
           type="button"
-          className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-          title={t("browser.newConnection")}
-          aria-label={t("browser.newConnection")}
-          onClick={() => onNewConnection(node.serviceKind as ServiceLibraryKind)}
+          disabled={isDisabled}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-1.5 rounded px-2 py-1 text-left text-sm",
+            "hover:bg-accent hover:text-accent-foreground",
+            "disabled:pointer-events-none disabled:opacity-50",
+            node.kind === "section" && "font-semibold",
+          )}
+          style={{ paddingLeft }}
+          aria-expanded={isGroup ? isExpanded : undefined}
+          aria-busy={isBusy || undefined}
+          onClick={() => (isGroup ? onToggle(node.id) : onActivate(node))}
         >
-          <Plus className="h-3.5 w-3.5" />
+          {isGroup ? (
+            isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            )
+          ) : (
+            <span className="w-3.5 shrink-0" />
+          )}
+          {isBusy ? (
+            <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+          ) : (
+            <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate">{node.label}</span>
+          {node.builtin ? (
+            <span className="ml-1 shrink-0 rounded border px-1 text-[10px] uppercase leading-tight text-muted-foreground">
+              {t("browser.builtinBadge")}
+            </span>
+          ) : null}
+          {typeof node.count === "number" && node.count > 0 ? (
+            <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+              {node.count}
+            </span>
+          ) : null}
         </button>
-      ) : null}
+        {node.kind === "category" && node.serviceKind ? (
+          <button
+            type="button"
+            className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            title={t("browser.newConnection")}
+            aria-label={t("browser.newConnection")}
+            onClick={() =>
+              onNewConnection(node.serviceKind as ServiceLibraryKind)
+            }
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
       </div>
       {isGroup && isExpanded ? (
         node.children && node.children.length > 0 ? (

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -115,8 +115,8 @@ export function BrowserTreeNode({
           <button
             type="button"
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-            title={t("browser.newConnection")}
-            aria-label={t("browser.newConnection")}
+            title={t("browser.newConnection", { kind: node.label })}
+            aria-label={t("browser.newConnection", { kind: node.label })}
             onClick={() =>
               onNewConnection(node.serviceKind as ServiceLibraryKind)
             }

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -7,9 +7,11 @@ import {
   FolderOpen,
   Globe2,
   Loader2,
+  Plus,
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { ServiceLibraryKind } from "../layout/add-data/service-library";
 import type { BrowserNode } from "../../lib/browser-tree";
 
 interface BrowserTreeNodeProps {
@@ -24,6 +26,8 @@ interface BrowserTreeNodeProps {
   onToggle: (id: string) => void;
   /** Activate a leaf (add a service layer, or open a recent project). */
   onActivate: (node: BrowserNode) => void;
+  /** Add a new connection for a service-kind group (opens Add Data at it). */
+  onNewConnection: (kind: ServiceLibraryKind) => void;
 }
 
 /** The leading icon for a node, chosen by kind (and expanded state for groups). */
@@ -50,6 +54,7 @@ export function BrowserTreeNode({
   busyId,
   onToggle,
   onActivate,
+  onNewConnection,
 }: BrowserTreeNodeProps) {
   const { t } = useTranslation();
   const isGroup = Boolean(node.children);
@@ -65,11 +70,12 @@ export function BrowserTreeNode({
 
   return (
     <li>
+      <div className="flex items-center">
       <button
         type="button"
         disabled={isDisabled}
         className={cn(
-          "flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-sm",
+          "flex min-w-0 flex-1 items-center gap-1.5 rounded px-2 py-1 text-left text-sm",
           "hover:bg-accent hover:text-accent-foreground",
           "disabled:pointer-events-none disabled:opacity-50",
           node.kind === "section" && "font-semibold",
@@ -105,6 +111,18 @@ export function BrowserTreeNode({
           </span>
         ) : null}
       </button>
+      {node.kind === "category" && node.serviceKind ? (
+        <button
+          type="button"
+          className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          title={t("browser.newConnection")}
+          aria-label={t("browser.newConnection")}
+          onClick={() => onNewConnection(node.serviceKind as ServiceLibraryKind)}
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
+      </div>
       {isGroup && isExpanded ? (
         node.children && node.children.length > 0 ? (
           <ul>
@@ -117,6 +135,7 @@ export function BrowserTreeNode({
                 busyId={busyId}
                 onToggle={onToggle}
                 onActivate={onActivate}
+                onNewConnection={onNewConnection}
               />
             ))}
           </ul>

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -67,6 +67,12 @@ export function BrowserTreeNode({
   const isDisabled = !isGroup && busyId != null;
   // Indent by depth; groups reserve room for the chevron, leaves align to it.
   const paddingLeft = 8 + depth * 14;
+  // The kind group's service kind (or undefined). Captured as a const so its
+  // non-undefined narrowing survives into the button's onClick closure — a
+  // property access (node.serviceKind) would not, which is why a cast would
+  // otherwise be needed there.
+  const categoryKind =
+    node.kind === "category" ? node.serviceKind : undefined;
 
   return (
     <li>
@@ -111,15 +117,13 @@ export function BrowserTreeNode({
             </span>
           ) : null}
         </button>
-        {node.kind === "category" && node.serviceKind ? (
+        {categoryKind ? (
           <button
             type="button"
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
             title={t("browser.newConnection", { kind: node.label })}
             aria-label={t("browser.newConnection", { kind: node.label })}
-            onClick={() =>
-              onNewConnection(node.serviceKind as ServiceLibraryKind)
-            }
+            onClick={() => onNewConnection(categoryKind)}
           >
             <Plus className="h-3.5 w-3.5" />
           </button>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -8,7 +8,8 @@
     "emptyGroup": "Empty",
     "noMatches": "No matches.",
     "addFailed": "Could not add this data source.",
-    "builtinBadge": "built-in"
+    "builtinBadge": "built-in",
+    "newConnection": "New connection"
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -9,7 +9,7 @@
     "noMatches": "No matches.",
     "addFailed": "Could not add this data source.",
     "builtinBadge": "built-in",
-    "newConnection": "New connection"
+    "newConnection": "New {{kind}} connection"
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -108,6 +108,9 @@ function buildServiceKinds(
       kind: "category" as const,
       label: KIND_LABEL[kind],
       addable: false,
+      // Carried so the panel's "New connection" action knows which Add Data
+      // source to open for this group.
+      serviceKind: kind,
       count: entries.length,
       children: entries.map(
         (entry): BrowserNode => ({

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -77,6 +77,10 @@ describe("buildBrowserTree", () => {
       ["kind:xyz", "kind:wms", "kind:arcgis"],
     );
     assert.equal(services.count, 3);
+    // Each kind group carries its kind so the panel's "New connection" action
+    // can open the matching Add Data source.
+    assert.equal(find(tree, "kind:wms")?.serviceKind, "wms");
+    assert.equal(find(tree, "kind:arcgis")?.serviceKind, "arcgis");
   });
 
   it("sorts services within a kind by name", () => {


### PR DESCRIPTION
Adds a QGIS-style way to add a new connection directly from the Browser panel (follow-up to #1200/#1201).

## What

Each service-kind group in the Browser panel — **XYZ / WMS / WFS / WMTS / ArcGIS** — now has a **＋ "New connection"** button. Clicking it opens the **Add Data dialog preselected to that source**. Entering the endpoint and using the dialog's existing **"Save current"** flow adds the connection to the saved-service library, which then shows up under that group in the Browser tree.

This mirrors QGIS's Browser, where you add a connection under its provider type (PostGIS / WMS / …).

## How

- **`open-add-data.ts`** — a small window-event helper `openAddData(kind)` mirroring `openSettingsSection`, so the portaled Browser panel can open the dialog without prop-drilling. `TopToolbar` (which owns the Add Data dialog + its `kind` state) listens for the event.
- **`browser-tree`** — each kind-group node now carries its `serviceKind`.
- **`BrowserTreeNode`** — renders the ＋ button on kind-group rows only (not on service leaves), as a sibling of the row button so it doesn't nest inside it; calls `onNewConnection(kind)`.
- **`BrowserPanel`** — `onNewConnection` → `openAddData(kind)`.
- i18n `browser.newConnection`; a unit test asserting kind groups carry `serviceKind`.

## Verification

- Unit: `tests/browser-tree.test.ts` 13/13. `tsc -b` clean; eslint clean; `pre-commit` (full `npm build`) green.
- Browser: the panel shows a ＋ on each of the 5 kind groups; clicking the WMS group's ＋ opens **"Add WMS Layer"** (screenshot confirmed). The dialog's Save-to-library flow then surfaces the new entry in the tree.

## Follow-ups (not in this PR)

- A dedicated **Databases** section with browsable PostGIS/DuckDB connection → schema → table nodes.
- The ＋ currently appears only on kind groups that already have at least one entry (all five are seeded by the built-in presets, so all five show); showing provider types even when empty is a later enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick “New Connection” action to service groups in the browser tree.
  * Selecting the action opens the Add Data dialog for the relevant connection type.
  * The action is available for nested service groups.

* **Bug Fixes**
  * Corrected service group identification so the appropriate connection type opens.

* **Tests**
  * Added coverage verifying service groups retain the correct connection type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->