### PR TITLE
feat(browser): Databases section — browse PostGIS schemas & tables

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -28,6 +28,7 @@ import { WmsSource } from "./add-data/sources/WmsSource";
 import { WmtsSource } from "./add-data/sources/WmtsSource";
 import { XyzSource } from "./add-data/sources/XyzSource";
 import type { AddDataKind } from "./add-data/types";
+import type { OpenAddDataPostgres } from "./add-data/open-add-data";
 import { useMartinConnection } from "./add-data/useMartinConnection";
 
 export type { AddDataKind } from "./add-data/types";
@@ -41,6 +42,12 @@ interface AddDataDialogProps {
    * (e.g. a "3D model" menu entry opens it on the scenegraph layer type).
    */
   initialDeckVizKind?: string;
+  /**
+   * Connection (and optional table) to pre-select when the dialog opens as
+   * `postgres` — set when the Browser panel opens a saved connection or a
+   * clicked PostGIS table.
+   */
+  initialPostgres?: OpenAddDataPostgres;
 }
 
 /**
@@ -51,6 +58,7 @@ interface AddDataDialogProps {
 function renderSource(
   kind: AddDataKind,
   initialDeckVizKind: string | undefined,
+  initialPostgres: OpenAddDataPostgres | undefined,
 ) {
   switch (kind) {
     case "xyz":
@@ -78,7 +86,7 @@ function renderSource(
     case "arcgis":
       return <ArcGISSource />;
     case "postgres":
-      return <PostgresSource />;
+      return <PostgresSource initialPostgres={initialPostgres} />;
     case "video":
       return <VideoSource />;
     case "deckgl-viz":
@@ -98,6 +106,7 @@ export function AddDataDialog({
   mapControllerRef,
   onOpenChange,
   initialDeckVizKind,
+  initialPostgres,
 }: AddDataDialogProps) {
   const { t } = useTranslation();
   const open = kind !== null;
@@ -153,7 +162,7 @@ export function AddDataDialog({
 
         {kind ? (
           <AddDataShellProvider value={contextValue}>
-            {renderSource(kind, initialDeckVizKind)}
+            {renderSource(kind, initialDeckVizKind, initialPostgres)}
           </AddDataShellProvider>
         ) : null}
       </DialogContent>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -356,6 +356,14 @@ export function TopToolbar({
   const [addDataPostgres, setAddDataPostgres] = useState<
     OpenAddDataPostgres | undefined
   >(undefined);
+  // Drop the prefill whenever the dialog isn't on the PostgreSQL source, so a
+  // stale prefill can't leak into a later postgres open reached via a path that
+  // sets addDataKind directly (command palette / menus) rather than through the
+  // Browser-panel event that sets the prefill. The event sets the prefill and
+  // kind together, so this never clears a freshly-set prefill.
+  useEffect(() => {
+    if (addDataKind !== "postgres") setAddDataPostgres(undefined);
+  }, [addDataKind]);
   // Let any panel (e.g. the Browser panel's "New connection" action) open the
   // Add Data dialog at a given kind without prop-drilling, mirroring
   // openSettingsSection. This toolbar owns the dialog + its kind state.

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -96,7 +96,11 @@ import { useViewportHistory } from "../../hooks/useViewportHistory";
 import type { Command } from "../../lib/commands";
 import { IS_STORE_BUILD } from "../../lib/updates";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
-import { OPEN_ADD_DATA_EVENT } from "./add-data/open-add-data";
+import {
+  OPEN_ADD_DATA_EVENT,
+  type OpenAddDataDetail,
+  type OpenAddDataPostgres,
+} from "./add-data/open-add-data";
 import { AddNetcdfDialog } from "./AddNetcdfDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -348,13 +352,20 @@ export function TopToolbar({
     ),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
+  // PostgreSQL prefill (saved connection / clicked table) from the Browser panel.
+  const [addDataPostgres, setAddDataPostgres] = useState<
+    OpenAddDataPostgres | undefined
+  >(undefined);
   // Let any panel (e.g. the Browser panel's "New connection" action) open the
   // Add Data dialog at a given kind without prop-drilling, mirroring
   // openSettingsSection. This toolbar owns the dialog + its kind state.
   useEffect(() => {
     const onOpenAddData = (event: Event) => {
-      const kind = (event as CustomEvent<{ kind: AddDataKind }>).detail?.kind;
-      if (kind) setAddDataKind(kind);
+      const detail = (event as CustomEvent<OpenAddDataDetail>).detail;
+      if (detail?.kind) {
+        setAddDataPostgres(detail.postgres);
+        setAddDataKind(detail.kind);
+      }
     };
     window.addEventListener(OPEN_ADD_DATA_EVENT, onOpenAddData);
     return () => window.removeEventListener(OPEN_ADD_DATA_EVENT, onOpenAddData);
@@ -1223,10 +1234,12 @@ export function TopToolbar({
         kind={addDataKind}
         mapControllerRef={mapControllerRef}
         initialDeckVizKind={addDataDeckVizKind}
+        initialPostgres={addDataPostgres}
         onOpenChange={(open: boolean) => {
           if (!open) {
             setAddDataKind(null);
             setAddDataDeckVizKind(undefined);
+            setAddDataPostgres(undefined);
           }
         }}
       />

--- a/apps/geolibre-desktop/src/components/layout/add-data/martin-source-match.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/martin-source-match.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure matcher for pairing a clicked Browser-panel table with the Martin source
+ * that publishes it. Extracted from PostgresSource so it unit-tests without the
+ * React component and its sidecar/Martin dependencies.
+ */
+
+/**
+ * Whether a Martin source (auto-published one-per-table) is the given schema +
+ * table. Martin names public-schema sources by the bare table and others by
+ * `schema.table`. The bare form is only matched for the public (or unknown)
+ * schema, so a `public.roads` source can't be mis-selected for a clicked
+ * `other_schema.roads` when two schemas reuse a table name.
+ *
+ * @param sourceId - The Martin catalog source id.
+ * @param schema - The clicked table's schema, or undefined when unknown.
+ * @param table - The clicked table's name.
+ * @returns True when `sourceId` names that schema's table.
+ */
+export function martinSourceMatchesTable(
+  sourceId: string,
+  schema: string | undefined,
+  table: string,
+): boolean {
+  if (schema && schema !== "public") {
+    return sourceId === `${schema}.${table}`;
+  }
+  return sourceId === table || sourceId === `public.${table}`;
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/open-add-data.ts
@@ -4,16 +4,43 @@ import type { AddDataKind } from "./types";
 export const OPEN_ADD_DATA_EVENT = "geolibre:open-add-data";
 
 /**
+ * Optional prefill payload for the PostgreSQL source, so the Browser panel can
+ * open the dialog on a specific saved connection (and, when a table was clicked,
+ * that table) rather than the default first-saved connection.
+ */
+export interface OpenAddDataPostgres {
+  /** libpq connection string to preselect in the PostgreSQL source. */
+  connection: string;
+  /** Schema of the table to preselect (with {@link table}). */
+  schema?: string;
+  /** Table to preselect once connected. */
+  table?: string;
+}
+
+/** The detail carried by {@link OPEN_ADD_DATA_EVENT}. */
+export interface OpenAddDataDetail {
+  kind: AddDataKind;
+  /** Prefill for the PostgreSQL source (only meaningful when `kind` is "postgres"). */
+  postgres?: OpenAddDataPostgres;
+}
+
+/**
  * Open the Add Data dialog preselected to `kind` from anywhere in the app,
  * without prop-drilling (mirrors {@link openSettingsSection}). TopToolbar owns
  * the dialog and its kind state and listens for this event. Used by the Browser
- * panel's per-source "New connection" action.
+ * panel's per-source "New connection" action and its PostGIS table nodes.
  *
  * @param kind - The Add Data source to open (e.g. "wms", "wfs", "xyz").
+ * @param options - Optional source-specific prefill (currently `postgres`).
  */
-export function openAddData(kind: AddDataKind): void {
+export function openAddData(
+  kind: AddDataKind,
+  options?: { postgres?: OpenAddDataPostgres },
+): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(
-    new CustomEvent(OPEN_ADD_DATA_EVENT, { detail: { kind } }),
+    new CustomEvent<OpenAddDataDetail>(OPEN_ADD_DATA_EVENT, {
+      detail: { kind, postgres: options?.postgres },
+    }),
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -88,10 +88,18 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
 
   // Clear the (shell-owned) Martin connection state so a stale server/catalog
   // from a previous connection can't be submitted (and submit is disabled)
-  // after the connection string changes. UI-only: any orphaned server process
-  // is stopped on dialog close via martin.stopTransient().
+  // after the connection string changes.
   const clearMartinState = () => {
     martinRequestRef.current += 1;
+    // A completed connect leaves a real Martin process running. stopTransient
+    // (on dialog close) only stops it while martin.server is set, so stop it
+    // here before clearing the state — otherwise it leaks, and since the Rust
+    // side refuses a second concurrent server a later reconnect would fail.
+    // An in-flight connect (server not yet set) is instead torn down by
+    // handleConnectPostgres's own staleness checks.
+    if (martin.server) {
+      void stopMartinServer().catch(() => {});
+    }
     martin.setServer(null);
     martin.setSources([]);
     martin.setSelectedSourceId("");

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -29,30 +29,13 @@ import {
   savedPostgresConnectionLabel,
 } from "../helpers";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { martinSourceMatchesTable } from "../martin-source-match";
 import type { OpenAddDataPostgres } from "../open-add-data";
 
 type PostgresLoadMode = "tiles" | "editable";
 
 function postgisTableKey(table: PostgisTableInfo): string {
   return `${table.schema}.${table.table}`;
-}
-
-/**
- * Whether a Martin source (auto-published one-per-table) is the given schema +
- * table. Martin names public-schema sources by the bare table and others by
- * `schema.table`. The bare form is only matched for the public (or unknown)
- * schema, so a `public.roads` source can't be mis-selected for a clicked
- * `other_schema.roads` when two schemas reuse a table name.
- */
-function martinSourceMatchesTable(
-  sourceId: string,
-  schema: string | undefined,
-  table: string,
-): boolean {
-  if (schema && schema !== "public") {
-    return sourceId === `${schema}.${table}`;
-  }
-  return sourceId === table || sourceId === `public.${table}`;
 }
 
 interface PostgresSourceProps {
@@ -450,6 +433,11 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
                   setSelectedTableKey("");
                   setPostgisConnection("");
                   setPostgisStatus(null);
+                  // The Browser-panel table preselect belongs to the connection
+                  // it was opened for; once the user switches connections it no
+                  // longer applies and must not preselect a same-named table in
+                  // a different database.
+                  desiredTableRef.current = null;
                 }
               }}
             >
@@ -485,6 +473,9 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
                 setSelectedTableKey("");
                 setPostgisConnection("");
                 setPostgisStatus(null);
+                // See the saved-connection handler: a connection change voids
+                // the Browser-panel table preselect.
+                desiredTableRef.current = null;
               }
             }}
           />

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -178,6 +178,9 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
         : undefined;
       const defaultTable = desiredTable ?? tables.find((table) => table.primary_key);
       setSelectedTableKey(defaultTable ? postgisTableKey(defaultTable) : "");
+      // Consumed once: a later reconnect on the same connection must not undo a
+      // manual table pick by re-applying the originally-clicked table.
+      desiredTableRef.current = null;
       setPostgisStatus(
         tables.length > 0
           ? t("addData.postgres.statusTablesFound", { count: tables.length })
@@ -234,7 +237,12 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
       martin.setStatus(t("addData.postgres.statusReadingCatalog"));
 
       const sources = await fetchMartinCatalog(server);
-      if (martinRequestRef.current !== requestToken) return;
+      if (martinRequestRef.current !== requestToken) {
+        // Mirror the earlier staleness check: a superseded request must stop
+        // its server rather than leaving it running in the background.
+        await stopMartinServer().catch(() => {});
+        return;
+      }
       martin.setSources(sources);
       // Preselect the table the user clicked in the Browser panel, if Martin
       // published it; otherwise fall back to the first source.
@@ -245,17 +253,25 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
           )
         : undefined;
       martin.setSelectedSourceId(match?.id ?? sources[0]?.id ?? "");
+      // Consumed once: a later reconnect on the same connection must not undo a
+      // manual source pick by re-applying the originally-clicked table.
+      desiredTableRef.current = null;
       martin.setStatus(
         sources.length > 0
           ? t("addData.postgres.statusFound", { count: sources.length })
           : t("addData.postgres.statusNoSources"),
       );
     } catch (err) {
-      martin.setServer(null);
-      source.setError(
-        errorMessage(err, t("addData.postgres.errorConnect")),
-      );
-      martin.setStatus(null);
+      // Ignore a superseded call's failure so it can't wipe a fresher, working
+      // connection or show a misleading error for a connection the user has
+      // already moved on from. (finally stays unguarded — clearMartinState also
+      // bumps this token without starting a request, so guarding it would leave
+      // the Connect button stuck disabled.)
+      if (martinRequestRef.current === requestToken) {
+        martin.setServer(null);
+        source.setError(errorMessage(err, t("addData.postgres.errorConnect")));
+        martin.setStatus(null);
+      }
     } finally {
       source.shell.setIsSubmitting(false);
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -108,11 +108,15 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
 
   // Reset the (shell-owned) Martin connection when the source opens, matching
   // the original dialog: a running server is preserved across reopens only
-  // after a layer was added.
+  // after a layer was added. But when opened from a Browser-panel table click
+  // (initialPostgres), that preserve behavior would leave the previous add's
+  // server/source connected — and submittable — for a *different* clicked
+  // table, so force a clean slate (stopping the old server) instead.
   useEffect(() => {
-    martin.resetOnOpen();
-    // Mount-only: `martin` is intentionally excluded from the deps — re-running
-    // resetOnOpen on every render would clear connection state mid-flow.
+    if (initialPostgres) clearMartinState();
+    else martin.resetOnOpen();
+    // Mount-only: `martin`/`clearMartinState` are intentionally excluded from
+    // the deps — re-running on every render would clear state mid-flow.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -40,16 +40,19 @@ function postgisTableKey(table: PostgisTableInfo): string {
 /**
  * Whether a Martin source (auto-published one-per-table) is the given schema +
  * table. Martin names public-schema sources by the bare table and others by
- * `schema.table`, so both forms are accepted.
+ * `schema.table`. The bare form is only matched for the public (or unknown)
+ * schema, so a `public.roads` source can't be mis-selected for a clicked
+ * `other_schema.roads` when two schemas reuse a table name.
  */
 function martinSourceMatchesTable(
   sourceId: string,
   schema: string | undefined,
   table: string,
 ): boolean {
-  if (sourceId === table) return true;
-  if (schema && sourceId === `${schema}.${table}`) return true;
-  return false;
+  if (schema && schema !== "public") {
+    return sourceId === `${schema}.${table}`;
+  }
+  return sourceId === table || sourceId === `public.${table}`;
 }
 
 interface PostgresSourceProps {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -29,6 +29,7 @@ import {
   savedPostgresConnectionLabel,
 } from "../helpers";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
+import type { OpenAddDataPostgres } from "../open-add-data";
 
 type PostgresLoadMode = "tiles" | "editable";
 
@@ -36,12 +37,40 @@ function postgisTableKey(table: PostgisTableInfo): string {
   return `${table.schema}.${table.table}`;
 }
 
-export function PostgresSource() {
+/**
+ * Whether a Martin source (auto-published one-per-table) is the given schema +
+ * table. Martin names public-schema sources by the bare table and others by
+ * `schema.table`, so both forms are accepted.
+ */
+function martinSourceMatchesTable(
+  sourceId: string,
+  schema: string | undefined,
+  table: string,
+): boolean {
+  if (sourceId === table) return true;
+  if (schema && sourceId === `${schema}.${table}`) return true;
+  return false;
+}
+
+interface PostgresSourceProps {
+  /** Prefill from the Browser panel (saved connection / clicked table). */
+  initialPostgres?: OpenAddDataPostgres;
+}
+
+export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.postgres.defaultName"));
   const { martin } = source.shell;
   const [postgresConnectionString, setPostgresConnectionString] = useState(
-    () => readSavedPostgresConnections()[0] ?? "",
+    () => initialPostgres?.connection ?? readSavedPostgresConnections()[0] ?? "",
+  );
+  // A table clicked in the Browser panel to auto-select once a Connect
+  // populates the source/table list (the user still triggers the desktop-only
+  // Connect; this just spares them re-picking the table they came in for).
+  const desiredTableRef = useRef(
+    initialPostgres?.table
+      ? { schema: initialPostgres.schema, table: initialPostgres.table }
+      : null,
   );
   const [savedPostgresConnections, setSavedPostgresConnections] = useState(() =>
     readSavedPostgresConnections(),
@@ -131,10 +160,20 @@ export function PostgresSource() {
       setSavedPostgresConnections(rememberPostgresConnection(connectionString));
       setPostgisConnection(connectionString);
       setPostgisTables(tables);
-      // Default to the first writable table (single-column primary key);
-      // read-only tables are listed but disabled, so with no writable table
-      // nothing is preselected and the submit stays disabled.
-      const defaultTable = tables.find((table) => table.primary_key);
+      // Prefer the table the user clicked in the Browser panel (when writable),
+      // else the first writable table (single-column primary key); read-only
+      // tables are listed but disabled, so with no writable table nothing is
+      // preselected and the submit stays disabled.
+      const desired = desiredTableRef.current;
+      const desiredTable = desired
+        ? tables.find(
+            (table) =>
+              table.primary_key &&
+              table.table === desired.table &&
+              (!desired.schema || table.schema === desired.schema),
+          )
+        : undefined;
+      const defaultTable = desiredTable ?? tables.find((table) => table.primary_key);
       setSelectedTableKey(defaultTable ? postgisTableKey(defaultTable) : "");
       setPostgisStatus(
         tables.length > 0
@@ -186,7 +225,15 @@ export function PostgresSource() {
 
       const sources = await fetchMartinCatalog(server);
       martin.setSources(sources);
-      martin.setSelectedSourceId(sources[0]?.id ?? "");
+      // Preselect the table the user clicked in the Browser panel, if Martin
+      // published it; otherwise fall back to the first source.
+      const desired = desiredTableRef.current;
+      const match = desired
+        ? sources.find((s) =>
+            martinSourceMatchesTable(s.id, desired.schema, desired.table),
+          )
+        : undefined;
+      martin.setSelectedSourceId(match?.id ?? sources[0]?.id ?? "");
       martin.setStatus(
         sources.length > 0
           ? t("addData.postgres.statusFound", { count: sources.length })

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -80,6 +80,23 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
   // because input edits bump that token without starting a request (guarding
   // on it in `finally` would leave isSubmitting stuck true).
   const connectFlightRef = useRef(0);
+  // Invalidation token for the tiles-mode Martin connect, mirroring
+  // listRequestRef for the editable list: a connection-string change bumps it
+  // so an in-flight connect can't revive a server/catalog for the previous
+  // database after the user has moved on.
+  const martinRequestRef = useRef(0);
+
+  // Clear the (shell-owned) Martin connection state so a stale server/catalog
+  // from a previous connection can't be submitted (and submit is disabled)
+  // after the connection string changes. UI-only: any orphaned server process
+  // is stopped on dialog close via martin.stopTransient().
+  const clearMartinState = () => {
+    martinRequestRef.current += 1;
+    martin.setServer(null);
+    martin.setSources([]);
+    martin.setSelectedSourceId("");
+    martin.setStatus(null);
+  };
 
   // Reset the (shell-owned) Martin connection when the source opens, matching
   // the original dialog: a running server is preserved across reopens only
@@ -179,6 +196,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
   };
 
   const handleConnectPostgres = async () => {
+    const requestToken = ++martinRequestRef.current;
     source.setError(null);
     martin.setStatus(null);
     source.shell.setIsSubmitting(true);
@@ -205,11 +223,18 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
         connectionString,
         defaultSrid: postgresDefaultSrid,
       });
+      if (martinRequestRef.current !== requestToken) {
+        // The connection string changed while connecting; discard this server
+        // for the now-stale database rather than showing it as connected.
+        await stopMartinServer().catch(() => {});
+        return;
+      }
       setSavedPostgresConnections(rememberPostgresConnection(connectionString));
       martin.setServer(server);
       martin.setStatus(t("addData.postgres.statusReadingCatalog"));
 
       const sources = await fetchMartinCatalog(server);
+      if (martinRequestRef.current !== requestToken) return;
       martin.setSources(sources);
       // Preselect the table the user clicked in the Browser panel, if Martin
       // published it; otherwise fall back to the first source.
@@ -433,6 +458,9 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
                   setSelectedTableKey("");
                   setPostgisConnection("");
                   setPostgisStatus(null);
+                  // A different database also invalidates the tiles-mode Martin
+                  // connection, so a layer from the old server can't be added.
+                  clearMartinState();
                   // The Browser-panel table preselect belongs to the connection
                   // it was opened for; once the user switches connections it no
                   // longer applies and must not preselect a same-named table in
@@ -474,7 +502,8 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
                 setPostgisConnection("");
                 setPostgisStatus(null);
                 // See the saved-connection handler: a connection change voids
-                // the Browser-panel table preselect.
+                // the tiles-mode Martin connection and the table preselect.
+                clearMartinState();
                 desiredTableRef.current = null;
               }
             }}

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -173,15 +173,21 @@ export function BrowserPanel({
           return listPostgisTables(connectionString);
         })
         .then((tables) => {
+          // geometry_columns returns one row per geometry column, so a table
+          // with several geometry columns appears several times; keep the first
+          // (mirrors PostgresSource.handleConnectEditable's dedup) so the tree
+          // doesn't emit duplicate node ids.
+          const seen = new Set<string>();
+          const deduped: { schema: string; table: string }[] = [];
+          for (const tbl of tables) {
+            const key = `${tbl.schema}.${tbl.table}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            deduped.push({ schema: tbl.schema, table: tbl.table });
+          }
           setConnLoads((prev) => ({
             ...prev,
-            [connectionString]: {
-              status: "loaded",
-              tables: tables.map((tbl) => ({
-                schema: tbl.schema,
-                table: tbl.table,
-              })),
-            },
+            [connectionString]: { status: "loaded", tables: deduped },
           }));
         })
         .catch((err: unknown) => {

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -1,15 +1,29 @@
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
+import { listPostgisTables } from "@geolibre/processing";
 import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
-import { useMemo, useRef, useState, type RefObject } from "react";
+import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
-import { filterBrowserTree, type BrowserNode } from "../../lib/browser-tree";
+import {
+  buildPostgisTableNodes,
+  filterBrowserTree,
+  type BrowserNode,
+} from "../../lib/browser-tree";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
 import type { AddDataKind } from "../layout/AddDataDialog";
 import { openAddData } from "../layout/add-data/open-add-data";
 import { BrowserTreeNode } from "./BrowserTreeNode";
+
+/** Async load state for one connection's spatial-table introspection. */
+type ConnectionLoad =
+  | { status: "loading" }
+  | { status: "loaded"; tables: { schema: string; table: string }[] }
+  | { status: "error"; message: string };
+
+/** The `connection:` id prefix a connection node carries (id = prefix + connString). */
+const CONNECTION_ID_PREFIX = "connection:";
 
 interface BrowserPanelProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -35,6 +49,48 @@ function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void
       collectGroupIds(node.children, into);
     }
   }
+}
+
+/**
+ * Returns a copy of the tree with each `connection` node's children replaced by
+ * the current lazy-load state: a status row while loading or on error, or the
+ * schema→table nodes once loaded. Connections with no load entry keep their
+ * empty child list (still expandable; expanding triggers the fetch).
+ *
+ * @param nodes - The base tree from {@link useBrowserTree}.
+ * @param loads - Per-connection introspection state keyed by connection string.
+ * @param loadingLabel - Translated label for the "loading tables" status row.
+ */
+function augmentConnections(
+  nodes: readonly BrowserNode[],
+  loads: Record<string, ConnectionLoad>,
+  loadingLabel: string,
+): BrowserNode[] {
+  return nodes.map((node) => {
+    if (node.kind === "connection" && node.connectionString) {
+      const load = loads[node.connectionString];
+      let children: BrowserNode[] = [];
+      if (load?.status === "loading") {
+        children = [
+          { id: `${node.id}:loading`, kind: "info", label: loadingLabel, addable: false },
+        ];
+      } else if (load?.status === "error") {
+        children = [
+          { id: `${node.id}:error`, kind: "info", label: load.message, addable: false },
+        ];
+      } else if (load?.status === "loaded") {
+        children = buildPostgisTableNodes(node.connectionString, load.tables);
+      }
+      return { ...node, children };
+    }
+    if (node.children) {
+      return {
+        ...node,
+        children: augmentConnections(node.children, loads, loadingLabel),
+      };
+    }
+    return node;
+  });
 }
 
 /**
@@ -78,9 +134,57 @@ export function BrowserPanel({
     setBusyId(null);
   };
 
+  // Lazy PostGIS introspection: keyed by connection string, populated the first
+  // time a connection node is expanded so we never hit the sidecar for a
+  // connection the user hasn't opened.
+  const [connLoads, setConnLoads] = useState<Record<string, ConnectionLoad>>(
+    {},
+  );
+  // Tracks in-flight/settled fetches so a re-expand (or the expand-all a search
+  // triggers) doesn't refetch. Cleared for a connection only via the row's
+  // refresh action.
+  const connFetchedRef = useRef<Set<string>>(new Set());
+
+  const fetchConnectionTables = useCallback((connectionString: string) => {
+    if (connFetchedRef.current.has(connectionString)) return;
+    connFetchedRef.current.add(connectionString);
+    setConnLoads((prev) => ({
+      ...prev,
+      [connectionString]: { status: "loading" },
+    }));
+    listPostgisTables(connectionString)
+      .then((tables) => {
+        setConnLoads((prev) => ({
+          ...prev,
+          [connectionString]: {
+            status: "loaded",
+            tables: tables.map((t) => ({ schema: t.schema, table: t.table })),
+          },
+        }));
+      })
+      .catch((err: unknown) => {
+        setConnLoads((prev) => ({
+          ...prev,
+          [connectionString]: {
+            status: "error",
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }));
+      });
+  }, []);
+
+  // Inject each connection node's lazily-loaded children (loading/error status
+  // rows, or schema→table nodes) before filtering, so search reaches the tables
+  // too. Connections that were never expanded keep their empty child list.
+  const loadingLabel = t("browser.loadingTables");
+  const augmented = useMemo(
+    () => augmentConnections(tree, connLoads, loadingLabel),
+    [tree, connLoads, loadingLabel],
+  );
+
   const filtered = useMemo(
-    () => filterBrowserTree(tree, query),
-    [tree, query],
+    () => filterBrowserTree(augmented, query),
+    [augmented, query],
   );
 
   // While searching, expand every group so matches deep in the tree are
@@ -92,13 +196,18 @@ export function BrowserPanel({
     return all;
   }, [query, expanded, filtered]);
 
-  const toggle = (id: string) =>
+  const toggle = (id: string) => {
+    // Kick off introspection the first time a connection is expanded.
+    if (id.startsWith(CONNECTION_ID_PREFIX) && !expanded.has(id)) {
+      fetchConnectionTables(id.slice(CONNECTION_ID_PREFIX.length));
+    }
     setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
+  };
 
   const activate = async (node: BrowserNode) => {
     // Ignore a second activation while one is still resolving (a fast
@@ -139,10 +248,17 @@ export function BrowserPanel({
       } finally {
         endBusy();
       }
-    } else if (node.kind === "connection") {
-      // Open the PostgreSQL Add Data dialog to connect, browse tables, and add
-      // layers; the saved connection is preselected in the dialog's list.
-      openAddData("postgres");
+    } else if (node.kind === "table" && node.connectionString) {
+      // Reuse the proven PostgreSQL Add Data flow (desktop Martin lifecycle) to
+      // add the table as a layer, opening it prefilled with this connection and
+      // table so the user only confirms.
+      openAddData("postgres", {
+        postgres: {
+          connection: node.connectionString,
+          schema: node.tableSchema,
+          table: node.tableName,
+        },
+      });
     }
   };
 

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -5,6 +5,7 @@ import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
+import { startGeoLibreSidecar } from "../../lib/sidecar";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import {
   buildPostgisTableNodes,
@@ -141,8 +142,8 @@ export function BrowserPanel({
     {},
   );
   // Tracks in-flight/settled fetches so a re-expand (or the expand-all a search
-  // triggers) doesn't refetch. Cleared for a connection only via the row's
-  // refresh action.
+  // triggers) doesn't refetch. A failed fetch drops its entry so re-expanding
+  // the connection retries (there is no separate refresh affordance).
   const connFetchedRef = useRef<Set<string>>(new Set());
 
   const fetchConnectionTables = useCallback((connectionString: string) => {
@@ -152,7 +153,13 @@ export function BrowserPanel({
       ...prev,
       [connectionString]: { status: "loading" },
     }));
-    listPostgisTables(connectionString)
+    // The desktop sidecar is spawned on demand and only authenticated after
+    // startGeoLibreSidecar runs, so ensure it is up before hitting /postgis —
+    // best-effort, mirroring PostgresSource.handleConnectEditable (a failed
+    // start still lets the list call surface the real error).
+    void startGeoLibreSidecar()
+      .catch(() => {})
+      .then(() => listPostgisTables(connectionString))
       .then((tables) => {
         setConnLoads((prev) => ({
           ...prev,
@@ -163,6 +170,9 @@ export function BrowserPanel({
         }));
       })
       .catch((err: unknown) => {
+        // Allow a retry: drop the fetched marker so collapsing and re-expanding
+        // the connection re-runs introspection rather than sticking on the error.
+        connFetchedRef.current.delete(connectionString);
         setConnLoads((prev) => ({
           ...prev,
           [connectionString]: {
@@ -266,7 +276,12 @@ export function BrowserPanel({
   // saving there adds it to the library/connections, which show up in this tree.
   const newConnection = (kind: AddDataKind) => openAddData(kind);
 
-  const hasContent = filtered.some((section) => section.children?.length);
+  // A section counts as content if it has children *or* an always-on ＋ action
+  // (the Databases section shows its "New connection" ＋ even with zero saved
+  // connections, so a first-run user isn't stuck on the empty-state message).
+  const hasContent = filtered.some(
+    (section) => section.children?.length || section.newConnectionKind,
+  );
 
   return (
     // Body only: the shell (PluginRightPanel / SharedSidebar) renders the header,

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -8,21 +8,16 @@ import { useTranslation } from "react-i18next";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import {
-  buildPostgisTableNodes,
+  augmentConnections,
   filterBrowserTree,
   type BrowserNode,
+  type ConnectionLoad,
 } from "../../lib/browser-tree";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
 import { errorMessage } from "../layout/add-data/helpers";
 import type { AddDataKind } from "../layout/AddDataDialog";
 import { openAddData } from "../layout/add-data/open-add-data";
 import { BrowserTreeNode } from "./BrowserTreeNode";
-
-/** Async load state for one connection's spatial-table introspection. */
-type ConnectionLoad =
-  | { status: "loading" }
-  | { status: "loaded"; tables: { schema: string; table: string }[] }
-  | { status: "error"; message: string };
 
 /** The `connection:` id prefix a connection node carries (id = prefix + connString). */
 const CONNECTION_ID_PREFIX = "connection:";
@@ -51,49 +46,6 @@ function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void
       collectGroupIds(node.children, into);
     }
   }
-}
-
-/**
- * Returns a copy of the tree with each `connection` node's children replaced by
- * the current lazy-load state: a status row while loading or on error, or the
- * schema→table nodes once loaded. Connections with no load entry keep their
- * empty child list (still expandable; expanding triggers the fetch) — so search
- * only reaches the tables of connections that have already been introspected.
- *
- * @param nodes - The base tree from {@link useBrowserTree}.
- * @param loads - Per-connection introspection state keyed by connection string.
- * @param loadingLabel - Translated label for the "loading tables" status row.
- */
-function augmentConnections(
-  nodes: readonly BrowserNode[],
-  loads: Record<string, ConnectionLoad>,
-  loadingLabel: string,
-): BrowserNode[] {
-  return nodes.map((node) => {
-    if (node.kind === "connection" && node.connectionString) {
-      const load = loads[node.connectionString];
-      let children: BrowserNode[] = [];
-      if (load?.status === "loading") {
-        children = [
-          { id: `${node.id}:loading`, kind: "info", label: loadingLabel, addable: false },
-        ];
-      } else if (load?.status === "error") {
-        children = [
-          { id: `${node.id}:error`, kind: "info", label: load.message, addable: false },
-        ];
-      } else if (load?.status === "loaded") {
-        children = buildPostgisTableNodes(node.connectionString, load.tables);
-      }
-      return { ...node, children };
-    }
-    if (node.children) {
-      return {
-        ...node,
-        children: augmentConnections(node.children, loads, loadingLabel),
-      };
-    }
-    return node;
-  });
 }
 
 /**

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -6,6 +6,7 @@ import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
+import { isTauri } from "../../lib/tauri-io";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import {
   augmentConnections,
@@ -104,6 +105,21 @@ export function BrowserPanel({
     (connectionString: string) => {
       if (connFetchedRef.current.has(connectionString)) return;
       connFetchedRef.current.add(connectionString);
+      // PostGIS browsing needs the desktop sidecar/Martin; off-Tauri, show the
+      // same localized "requires GeoLibre Desktop" message the Add Data dialog
+      // gives rather than letting startGeoLibreSidecar/fetch fail with a raw
+      // network error. Dropped from the fetched set so it can retry on desktop.
+      if (!isTauri()) {
+        connFetchedRef.current.delete(connectionString);
+        setConnLoads((prev) => ({
+          ...prev,
+          [connectionString]: {
+            status: "error",
+            message: t("addData.postgres.errorDesktopOnly"),
+          },
+        }));
+        return;
+      }
       setConnLoads((prev) => ({
         ...prev,
         [connectionString]: { status: "loading" },

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
-import { listPostgisTables } from "@geolibre/processing";
+import { fetchPostgisStatus, listPostgisTables } from "@geolibre/processing";
 import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
@@ -13,6 +13,7 @@ import {
   type BrowserNode,
 } from "../../lib/browser-tree";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
+import { errorMessage } from "../layout/add-data/helpers";
 import type { AddDataKind } from "../layout/AddDataDialog";
 import { openAddData } from "../layout/add-data/open-add-data";
 import { BrowserTreeNode } from "./BrowserTreeNode";
@@ -56,7 +57,8 @@ function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void
  * Returns a copy of the tree with each `connection` node's children replaced by
  * the current lazy-load state: a status row while loading or on error, or the
  * schema→table nodes once loaded. Connections with no load entry keep their
- * empty child list (still expandable; expanding triggers the fetch).
+ * empty child list (still expandable; expanding triggers the fetch) — so search
+ * only reaches the tables of connections that have already been introspected.
  *
  * @param nodes - The base tree from {@link useBrowserTree}.
  * @param loads - Per-connection introspection state keyed by connection string.
@@ -146,46 +148,65 @@ export function BrowserPanel({
   // the connection retries (there is no separate refresh affordance).
   const connFetchedRef = useRef<Set<string>>(new Set());
 
-  const fetchConnectionTables = useCallback((connectionString: string) => {
-    if (connFetchedRef.current.has(connectionString)) return;
-    connFetchedRef.current.add(connectionString);
-    setConnLoads((prev) => ({
-      ...prev,
-      [connectionString]: { status: "loading" },
-    }));
-    // The desktop sidecar is spawned on demand and only authenticated after
-    // startGeoLibreSidecar runs, so ensure it is up before hitting /postgis —
-    // best-effort, mirroring PostgresSource.handleConnectEditable (a failed
-    // start still lets the list call surface the real error).
-    void startGeoLibreSidecar()
-      .catch(() => {})
-      .then(() => listPostgisTables(connectionString))
-      .then((tables) => {
-        setConnLoads((prev) => ({
-          ...prev,
-          [connectionString]: {
-            status: "loaded",
-            tables: tables.map((t) => ({ schema: t.schema, table: t.table })),
-          },
-        }));
-      })
-      .catch((err: unknown) => {
-        // Allow a retry: drop the fetched marker so collapsing and re-expanding
-        // the connection re-runs introspection rather than sticking on the error.
-        connFetchedRef.current.delete(connectionString);
-        setConnLoads((prev) => ({
-          ...prev,
-          [connectionString]: {
-            status: "error",
-            message: err instanceof Error ? err.message : String(err),
-          },
-        }));
-      });
-  }, []);
+  const fetchConnectionTables = useCallback(
+    (connectionString: string) => {
+      if (connFetchedRef.current.has(connectionString)) return;
+      connFetchedRef.current.add(connectionString);
+      setConnLoads((prev) => ({
+        ...prev,
+        [connectionString]: { status: "loading" },
+      }));
+      // The desktop sidecar is spawned on demand and only authenticated after
+      // startGeoLibreSidecar runs, so ensure it is up before hitting /postgis —
+      // best-effort, mirroring PostgresSource.handleConnectEditable (a failed
+      // start still lets the status/list calls surface the real error).
+      void startGeoLibreSidecar()
+        .catch(() => {})
+        .then(() => fetchPostgisStatus())
+        .then((status) => {
+          // Same runtime gate as the Add Data dialog, so a missing postgis
+          // extra reads as the friendly "install the extra" message rather
+          // than a raw connection error from /postgis/tables.
+          if (!status.available) {
+            throw new Error(t("addData.postgres.errorRuntimeMissing"));
+          }
+          return listPostgisTables(connectionString);
+        })
+        .then((tables) => {
+          setConnLoads((prev) => ({
+            ...prev,
+            [connectionString]: {
+              status: "loaded",
+              tables: tables.map((tbl) => ({
+                schema: tbl.schema,
+                table: tbl.table,
+              })),
+            },
+          }));
+        })
+        .catch((err: unknown) => {
+          // Allow a retry: drop the fetched marker so collapsing and
+          // re-expanding the connection re-runs introspection rather than
+          // sticking on the error. Reuse the Add Data errorMessage helper for a
+          // translated fallback, matching the dialog's PostGIS entry point.
+          connFetchedRef.current.delete(connectionString);
+          setConnLoads((prev) => ({
+            ...prev,
+            [connectionString]: {
+              status: "error",
+              message: errorMessage(err, t("addData.postgres.errorConnect")),
+            },
+          }));
+        });
+    },
+    [t],
+  );
 
   // Inject each connection node's lazily-loaded children (loading/error status
-  // rows, or schema→table nodes) before filtering, so search reaches the tables
-  // too. Connections that were never expanded keep their empty child list.
+  // rows, or schema→table nodes) before filtering. Search therefore reaches the
+  // tables of connections the user has already expanded; an unexpanded
+  // connection keeps its empty child list, so its tables aren't searchable
+  // until it is first drilled into.
   const loadingLabel = t("browser.loadingTables");
   const augmented = useMemo(
     () => augmentConnections(tree, connLoads, loadingLabel),

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -7,8 +7,8 @@ import { useTranslation } from "react-i18next";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import { filterBrowserTree, type BrowserNode } from "../../lib/browser-tree";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
+import type { AddDataKind } from "../layout/AddDataDialog";
 import { openAddData } from "../layout/add-data/open-add-data";
-import type { ServiceLibraryKind } from "../layout/add-data/service-library";
 import { BrowserTreeNode } from "./BrowserTreeNode";
 
 interface BrowserPanelProps {
@@ -21,7 +21,11 @@ interface BrowserPanelProps {
 }
 
 /** The section nodes are expanded by default so their contents are visible. */
-const DEFAULT_EXPANDED = new Set(["section:services", "section:recent"]);
+const DEFAULT_EXPANDED = new Set([
+  "section:services",
+  "section:recent",
+  "section:databases",
+]);
 
 /** Collects every group node id in a tree (used to expand-all while searching). */
 function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void {
@@ -135,13 +139,16 @@ export function BrowserPanel({
       } finally {
         endBusy();
       }
+    } else if (node.kind === "connection") {
+      // Open the PostgreSQL Add Data dialog to connect, browse tables, and add
+      // layers; the saved connection is preselected in the dialog's list.
+      openAddData("postgres");
     }
   };
 
-  // "New connection" on a service-kind group opens the Add Data dialog at that
-  // source; saving there adds it to the library, which shows up in this tree.
-  // ServiceLibraryKind is a subset of AddDataKind, so no cast is needed.
-  const newConnection = (kind: ServiceLibraryKind) => openAddData(kind);
+  // A group's "New connection" (＋) opens the Add Data dialog at that source;
+  // saving there adds it to the library/connections, which show up in this tree.
+  const newConnection = (kind: AddDataKind) => openAddData(kind);
 
   const hasContent = filtered.some((section) => section.children?.length);
 

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -91,11 +91,13 @@ export function BrowserTreeNode({
   // so its non-undefined narrowing survives into the onClick closure — a
   // property access (node.newConnectionKind) would not, forcing a cast.
   const newConnectionKind = node.newConnectionKind;
-  // The Databases section's ＋ reads "New database connection"; a service-kind
-  // group's reads e.g. "New WMS connection" (distinguishable per group for
-  // screen-reader users).
+  // The Databases section's ＋ (which opens the "postgres" source) reads "New
+  // database connection"; a service-kind group's reads e.g. "New WMS
+  // connection" (distinguishable per group for screen-reader users). Keyed off
+  // the source it opens rather than node.kind, so a future section with a
+  // different ＋ source gets the right label.
   const newConnectionLabel =
-    node.kind === "section"
+    newConnectionKind === "postgres"
       ? t("browser.newDatabaseConnection")
       : t("browser.newConnection", { kind: node.label });
 

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -69,7 +69,7 @@ export function BrowserTreeNode({
       <li>
         <p
           className="truncate py-1 text-xs text-muted-foreground"
-          style={{ paddingLeft: 8 + depth * 14 + 14 }}
+          style={{ paddingLeft: 8 + depth * 14 }}
           title={node.label}
         >
           {node.label}

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -9,6 +9,7 @@ import {
   Globe2,
   Loader2,
   Plus,
+  Table,
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -40,6 +41,8 @@ function nodeIcon(node: BrowserNode, isExpanded: boolean): LucideIcon {
       return Globe2;
     case "connection":
       return Database;
+    case "table":
+      return Table;
     default:
       return isExpanded ? FolderOpen : Folder;
   }
@@ -60,6 +63,20 @@ export function BrowserTreeNode({
   onNewConnection,
 }: BrowserTreeNodeProps) {
   const { t } = useTranslation();
+  // A status row (loading / error) is non-interactive text, not a tree control.
+  if (node.kind === "info") {
+    return (
+      <li>
+        <p
+          className="truncate py-1 text-xs text-muted-foreground"
+          style={{ paddingLeft: 8 + depth * 14 + 14 }}
+          title={node.label}
+        >
+          {node.label}
+        </p>
+      </li>
+    );
+  }
   const isGroup = Boolean(node.children);
   const isExpanded = expanded.has(node.id);
   const Icon = nodeIcon(node, isExpanded);

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -71,6 +71,9 @@ export function BrowserTreeNode({
           className="truncate py-1 text-xs text-muted-foreground"
           style={{ paddingLeft: 8 + depth * 14 }}
           title={node.label}
+          // Announce the loading→tables/error transition to screen readers.
+          role="status"
+          aria-live="polite"
         >
           {node.label}
         </p>

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   ChevronRight,
   Clock,
+  Database,
   Folder,
   FolderOpen,
   Globe2,
@@ -11,7 +12,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { ServiceLibraryKind } from "../layout/add-data/service-library";
+import type { AddDataKind } from "../layout/AddDataDialog";
 import type { BrowserNode } from "../../lib/browser-tree";
 
 interface BrowserTreeNodeProps {
@@ -26,8 +27,8 @@ interface BrowserTreeNodeProps {
   onToggle: (id: string) => void;
   /** Activate a leaf (add a service layer, or open a recent project). */
   onActivate: (node: BrowserNode) => void;
-  /** Add a new connection for a service-kind group (opens Add Data at it). */
-  onNewConnection: (kind: ServiceLibraryKind) => void;
+  /** Open Add Data at `kind` for a group's "New connection" (＋) action. */
+  onNewConnection: (kind: AddDataKind) => void;
 }
 
 /** The leading icon for a node, chosen by kind (and expanded state for groups). */
@@ -37,6 +38,8 @@ function nodeIcon(node: BrowserNode, isExpanded: boolean): LucideIcon {
       return Clock;
     case "service":
       return Globe2;
+    case "connection":
+      return Database;
     default:
       return isExpanded ? FolderOpen : Folder;
   }
@@ -67,12 +70,17 @@ export function BrowserTreeNode({
   const isDisabled = !isGroup && busyId != null;
   // Indent by depth; groups reserve room for the chevron, leaves align to it.
   const paddingLeft = 8 + depth * 14;
-  // The kind group's service kind (or undefined). Captured as a const so its
-  // non-undefined narrowing survives into the button's onClick closure — a
-  // property access (node.serviceKind) would not, which is why a cast would
-  // otherwise be needed there.
-  const categoryKind =
-    node.kind === "category" ? node.serviceKind : undefined;
+  // The Add Data source this node's ＋ opens (or undefined). Captured as a const
+  // so its non-undefined narrowing survives into the onClick closure — a
+  // property access (node.newConnectionKind) would not, forcing a cast.
+  const newConnectionKind = node.newConnectionKind;
+  // The Databases section's ＋ reads "New database connection"; a service-kind
+  // group's reads e.g. "New WMS connection" (distinguishable per group for
+  // screen-reader users).
+  const newConnectionLabel =
+    node.kind === "section"
+      ? t("browser.newDatabaseConnection")
+      : t("browser.newConnection", { kind: node.label });
 
   return (
     <li>
@@ -117,13 +125,13 @@ export function BrowserTreeNode({
             </span>
           ) : null}
         </button>
-        {categoryKind ? (
+        {newConnectionKind ? (
           <button
             type="button"
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-            title={t("browser.newConnection", { kind: node.label })}
-            aria-label={t("browser.newConnection", { kind: node.label })}
-            onClick={() => onNewConnection(categoryKind)}
+            title={newConnectionLabel}
+            aria-label={newConnectionLabel}
+            onClick={() => onNewConnection(newConnectionKind)}
           >
             <Plus className="h-3.5 w-3.5" />
           </button>

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   BUILTIN_SERVICES,
@@ -7,6 +7,7 @@ import {
   type ServiceLibraryEntry,
 } from "../components/layout/add-data/service-library";
 import {
+  POSTGRES_CONNECTIONS_CHANGED_EVENT,
   readSavedPostgresConnections,
   savedPostgresConnectionLabel,
 } from "../lib/saved-postgres-connections";
@@ -39,6 +40,17 @@ export function useBrowserTree(): BrowserTreeState {
   const recentLabel = t("browser.recent");
   const databasesLabel = t("browser.databases");
 
+  // Saved connections live in localStorage (no reactive store), so re-read them
+  // when one is added/removed — otherwise a connection saved from the Add Data
+  // dialog wouldn't appear until the (still-mounted) panel is reopened.
+  const [connectionsRevision, setConnectionsRevision] = useState(0);
+  useEffect(() => {
+    const bump = () => setConnectionsRevision((n) => n + 1);
+    window.addEventListener(POSTGRES_CONNECTIONS_CHANGED_EVENT, bump);
+    return () =>
+      window.removeEventListener(POSTGRES_CONNECTIONS_CHANGED_EVENT, bump);
+  }, []);
+
   return useMemo(() => {
     const services = [...BUILTIN_SERVICES, ...readUserServices()];
     const byId = new Map(services.map((entry) => [entry.id, entry]));
@@ -65,5 +77,11 @@ export function useBrowserTree(): BrowserTreeState {
       }),
       serviceById: (id: string) => byId.get(id),
     };
-  }, [recentProjects, servicesLabel, recentLabel, databasesLabel]);
+  }, [
+    recentProjects,
+    servicesLabel,
+    recentLabel,
+    databasesLabel,
+    connectionsRevision,
+  ]);
 }

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -44,6 +44,8 @@ export function useBrowserTree(): BrowserTreeState {
     const byId = new Map(services.map((entry) => [entry.id, entry]));
     // Shown on every platform for discovery; the PostgreSQL add flow itself
     // reports when it needs GeoLibre Desktop (Martin has no mobile build).
+    // Kept in the saved list's order (most-recently-used first), deliberately
+    // unlike the alphabetized Services list — this mirrors the Recent section.
     const databaseConnections = readSavedPostgresConnections().map(
       (connectionString) => ({
         connectionString,

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -10,7 +10,6 @@ import {
   readSavedPostgresConnections,
   savedPostgresConnectionLabel,
 } from "../lib/saved-postgres-connections";
-import { isMobile } from "../lib/is-mobile";
 import { buildBrowserTree, type BrowserNode } from "../lib/browser-tree";
 
 export interface BrowserTreeState {
@@ -39,20 +38,18 @@ export function useBrowserTree(): BrowserTreeState {
   const servicesLabel = t("browser.services");
   const recentLabel = t("browser.recent");
   const databasesLabel = t("browser.databases");
-  // PostgreSQL layers rely on the desktop Martin process, which has no mobile
-  // build, so the Databases section is hidden on mobile (mirroring the Add Data
-  // PostgreSQL source). Evaluated once — the user agent is stable per session.
-  const showDatabases = useMemo(() => !isMobile(), []);
 
   return useMemo(() => {
     const services = [...BUILTIN_SERVICES, ...readUserServices()];
     const byId = new Map(services.map((entry) => [entry.id, entry]));
-    const databaseConnections = showDatabases
-      ? readSavedPostgresConnections().map((connectionString) => ({
-          connectionString,
-          label: savedPostgresConnectionLabel(connectionString),
-        }))
-      : undefined;
+    // Shown on every platform for discovery; the PostgreSQL add flow itself
+    // reports when it needs GeoLibre Desktop (Martin has no mobile build).
+    const databaseConnections = readSavedPostgresConnections().map(
+      (connectionString) => ({
+        connectionString,
+        label: savedPostgresConnectionLabel(connectionString),
+      }),
+    );
     return {
       tree: buildBrowserTree({
         services,
@@ -66,5 +63,5 @@ export function useBrowserTree(): BrowserTreeState {
       }),
       serviceById: (id: string) => byId.get(id),
     };
-  }, [recentProjects, servicesLabel, recentLabel, databasesLabel, showDatabases]);
+  }, [recentProjects, servicesLabel, recentLabel, databasesLabel]);
 }

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -6,6 +6,11 @@ import {
   readUserServices,
   type ServiceLibraryEntry,
 } from "../components/layout/add-data/service-library";
+import {
+  readSavedPostgresConnections,
+  savedPostgresConnectionLabel,
+} from "../lib/saved-postgres-connections";
+import { isMobile } from "../lib/is-mobile";
 import { buildBrowserTree, type BrowserNode } from "../lib/browser-tree";
 
 export interface BrowserTreeState {
@@ -33,17 +38,33 @@ export function useBrowserTree(): BrowserTreeState {
   const recentProjects = useAppStore((s) => s.recentProjects);
   const servicesLabel = t("browser.services");
   const recentLabel = t("browser.recent");
+  const databasesLabel = t("browser.databases");
+  // PostgreSQL layers rely on the desktop Martin process, which has no mobile
+  // build, so the Databases section is hidden on mobile (mirroring the Add Data
+  // PostgreSQL source). Evaluated once — the user agent is stable per session.
+  const showDatabases = useMemo(() => !isMobile(), []);
 
   return useMemo(() => {
     const services = [...BUILTIN_SERVICES, ...readUserServices()];
     const byId = new Map(services.map((entry) => [entry.id, entry]));
+    const databaseConnections = showDatabases
+      ? readSavedPostgresConnections().map((connectionString) => ({
+          connectionString,
+          label: savedPostgresConnectionLabel(connectionString),
+        }))
+      : undefined;
     return {
       tree: buildBrowserTree({
         services,
         recentProjects,
-        sectionLabels: { services: servicesLabel, recent: recentLabel },
+        databaseConnections,
+        sectionLabels: {
+          services: servicesLabel,
+          recent: recentLabel,
+          databases: databasesLabel,
+        },
       }),
       serviceById: (id: string) => byId.get(id),
     };
-  }, [recentProjects, servicesLabel, recentLabel]);
+  }, [recentProjects, servicesLabel, recentLabel, databasesLabel, showDatabases]);
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3,6 +3,8 @@
     "title": "Browser",
     "services": "Services",
     "recent": "Recent",
+    "databases": "Databases",
+    "newDatabaseConnection": "New database connection",
     "searchPlaceholder": "Search data sources",
     "empty": "No saved services or recent projects yet.",
     "emptyGroup": "Empty",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -11,7 +11,8 @@
     "noMatches": "No matches.",
     "addFailed": "Could not add this data source.",
     "builtinBadge": "built-in",
-    "newConnection": "New {{kind}} connection"
+    "newConnection": "New {{kind}} connection",
+    "loadingTables": "Loading tables…"
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -6,10 +6,11 @@
  * store dependencies, so it unit-tests in isolation. The `useBrowserTree` hook
  * feeds it live data and the `BrowserPanel` renders the result.
  *
- * The MVP covers two top-level sections — **Services** (grouped by service kind,
- * mirroring the Add Data web-service sources: XYZ, WMS, WFS, WMTS, ArcGIS) and
- * **Recent** (recently opened projects). Local-file and connection sections come
- * in a later phase.
+ * It covers three top-level sections — **Services** (grouped by service kind,
+ * mirroring the Add Data web-service sources: XYZ, WMS, WFS, WMTS, ArcGIS),
+ * **Recent** (recently opened projects), and **Databases** (saved PostGIS
+ * connections that expand to their schemas and spatial tables). Local-file
+ * sections come in a later phase.
  */
 
 import {
@@ -25,7 +26,10 @@ export type BrowserNodeKind =
   | "category" // a service-kind grouping (XYZ, WMS, WFS, WMTS, ArcGIS)
   | "service" // a saved-service leaf that adds a layer when activated
   | "recent-project" // a recent project that opens when activated
-  | "connection"; // a saved database connection that opens the DB add flow
+  | "connection" // a saved database connection; expands to its schemas/tables
+  | "schema" // a database schema grouping under a connection
+  | "table" // a database table leaf that opens the add flow for it
+  | "info"; // a non-interactive status row (loading / error)
 
 /** One node in the Browser tree. */
 export interface BrowserNode {
@@ -48,8 +52,12 @@ export interface BrowserNode {
    * ("postgres"). Absent means the node shows no ＋.
    */
   newConnectionKind?: AddDataKind;
-  /** The saved database connection string a `connection` node opens. */
+  /** The saved database connection string a `connection`/`table` node belongs to. */
   connectionString?: string;
+  /** The schema of a `table` node. */
+  tableSchema?: string;
+  /** The table name of a `table` node. */
+  tableName?: string;
   /** True for a built-in preset service (read-only), for badge display. */
   builtin?: boolean;
   /** The project path a recent node opens (kind `recent-project`). */
@@ -66,9 +74,9 @@ export interface BrowserTreeInput {
   recentProjects: readonly RecentProjectEntry[];
   /**
    * Saved database (PostGIS) connections to list under the Databases section.
-   * Omitted (undefined) hides the section entirely — the app passes it only on
-   * platforms where PostgreSQL layers are available (not mobile). An empty
-   * array still renders the section (with its "New connection" action).
+   * Omitted (undefined) hides the section entirely; an empty array still renders
+   * it (with its "New connection" action). The app always passes it — the
+   * PostgreSQL add flow itself reports when it needs GeoLibre Desktop.
    */
   databaseConnections?: readonly { connectionString: string; label: string }[];
   /**
@@ -187,9 +195,9 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
 
   const sections = [servicesSection, recentSection];
 
-  // The Databases section is only included where PostgreSQL layers are
-  // available (the app omits `databaseConnections` otherwise). It always shows
-  // its "New connection" (＋) action, even with no connections yet.
+  // The Databases section is included whenever `databaseConnections` is
+  // provided (the app always provides it). It always shows its "New connection"
+  // (＋) action, even with no connections yet.
   if (input.databaseConnections) {
     sections.push({
       id: "section:databases",
@@ -203,14 +211,67 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
           id: `connection:${connection.connectionString}`,
           kind: "connection",
           label: connection.label,
-          addable: true,
+          addable: false,
           connectionString: connection.connectionString,
+          // An empty child list marks it as an expandable group; the panel
+          // lazily fills it with schema/table nodes on first expand.
+          children: [],
         }),
       ),
     });
   }
 
   return sections;
+}
+
+/** A spatial table discovered under a database connection. */
+export interface PostgisTableRef {
+  schema: string;
+  table: string;
+}
+
+/**
+ * Groups a connection's spatial tables into `schema` → `table` nodes, sorted by
+ * name, for the panel to inject as a lazily-expanded connection's children.
+ * Pure so it unit-tests without the sidecar that produces the table list.
+ *
+ * @param connectionString - The owning connection (embedded in node ids + carried
+ *   on table nodes for the add flow).
+ * @param tables - The spatial tables discovered for that connection.
+ * @returns One `schema` group per distinct schema, each with its `table` leaves.
+ */
+export function buildPostgisTableNodes(
+  connectionString: string,
+  tables: readonly PostgisTableRef[],
+): BrowserNode[] {
+  const bySchema = new Map<string, PostgisTableRef[]>();
+  for (const entry of tables) {
+    const bucket = bySchema.get(entry.schema);
+    if (bucket) bucket.push(entry);
+    else bySchema.set(entry.schema, [entry]);
+  }
+  return Array.from(bySchema.keys())
+    .sort(byLabel)
+    .map((schema) => ({
+      id: `schema:${connectionString}:${schema}`,
+      kind: "schema" as const,
+      label: schema,
+      addable: false,
+      count: bySchema.get(schema)?.length ?? 0,
+      children: [...(bySchema.get(schema) ?? [])]
+        .sort((a, b) => byLabel(a.table, b.table))
+        .map(
+          (entry): BrowserNode => ({
+            id: `table:${connectionString}:${schema}.${entry.table}`,
+            kind: "table",
+            label: entry.table,
+            addable: true,
+            connectionString,
+            tableSchema: schema,
+            tableName: entry.table,
+          }),
+        ),
+    }));
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -274,6 +274,67 @@ export function buildPostgisTableNodes(
     }));
 }
 
+/** Async load state for one connection's spatial-table introspection. */
+export type ConnectionLoad =
+  | { status: "loading" }
+  | { status: "loaded"; tables: readonly PostgisTableRef[] }
+  | { status: "error"; message: string };
+
+/**
+ * Returns a copy of the tree with each `connection` node's children replaced by
+ * the current lazy-load state: a status row while loading or on error, or the
+ * schema→table nodes once loaded. Connections with no load entry keep their
+ * empty child list (still expandable; expanding triggers the fetch) — so search
+ * only reaches the tables of connections that have already been introspected.
+ * Pure so the panel's tree augmentation unit-tests without React/the sidecar.
+ *
+ * @param nodes - The base tree from {@link buildBrowserTree}.
+ * @param loads - Per-connection introspection state keyed by connection string.
+ * @param loadingLabel - Translated label for the "loading tables" status row.
+ * @returns A new tree; connection nodes get their status/table children.
+ */
+export function augmentConnections(
+  nodes: readonly BrowserNode[],
+  loads: Record<string, ConnectionLoad>,
+  loadingLabel: string,
+): BrowserNode[] {
+  return nodes.map((node) => {
+    if (node.kind === "connection" && node.connectionString) {
+      const load = loads[node.connectionString];
+      let children: BrowserNode[] = [];
+      if (load?.status === "loading") {
+        children = [
+          {
+            id: `${node.id}:loading`,
+            kind: "info",
+            label: loadingLabel,
+            addable: false,
+          },
+        ];
+      } else if (load?.status === "error") {
+        children = [
+          {
+            id: `${node.id}:error`,
+            kind: "info",
+            label: load.message,
+            addable: false,
+          },
+        ];
+      } else if (load?.status === "loaded") {
+        children = buildPostgisTableNodes(node.connectionString, load.tables);
+      }
+      return { ...node, children };
+    }
+    if (node.children) {
+      return {
+        ...node,
+        children: augmentConnections(node.children, loads, loadingLabel),
+      };
+    }
+    return node;
+  });
+}
+
 /**
  * Filters the tree to nodes whose label (or a descendant's label) matches the
  * query, case-insensitively. Returns the tree unchanged for an empty query.

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -16,14 +16,16 @@ import {
   type ServiceLibraryEntry,
   type ServiceLibraryKind,
 } from "../components/layout/add-data/service-library";
+import type { AddDataKind } from "../components/layout/add-data/types";
 import type { RecentProjectEntry } from "@geolibre/core";
 
 /** The kind of node, which determines its icon and click behavior. */
 export type BrowserNodeKind =
-  | "section" // a static top-level group (Services, Recent)
+  | "section" // a static top-level group (Services, Recent, Databases)
   | "category" // a service-kind grouping (XYZ, WMS, WFS, WMTS, ArcGIS)
   | "service" // a saved-service leaf that adds a layer when activated
-  | "recent-project"; // a recent project that opens when activated
+  | "recent-project" // a recent project that opens when activated
+  | "connection"; // a saved database connection that opens the DB add flow
 
 /** One node in the Browser tree. */
 export interface BrowserNode {
@@ -40,6 +42,14 @@ export interface BrowserNode {
   serviceId?: string;
   /** The saved-service kind, for the icon and the applier (kind `service`). */
   serviceKind?: ServiceLibraryKind;
+  /**
+   * The Add Data source this node's "New connection" (＋) action opens — set on
+   * service-kind category groups (their kind) and the Databases section
+   * ("postgres"). Absent means the node shows no ＋.
+   */
+  newConnectionKind?: AddDataKind;
+  /** The saved database connection string a `connection` node opens. */
+  connectionString?: string;
   /** True for a built-in preset service (read-only), for badge display. */
   builtin?: boolean;
   /** The project path a recent node opens (kind `recent-project`). */
@@ -55,10 +65,17 @@ export interface BrowserTreeInput {
   /** The recent-projects list from the store, most-recent first. */
   recentProjects: readonly RecentProjectEntry[];
   /**
-   * Translated labels for the two top-level sections. Optional so the pure
-   * module (and its tests) default to English; the app passes `t()` values.
+   * Saved database (PostGIS) connections to list under the Databases section.
+   * Omitted (undefined) hides the section entirely — the app passes it only on
+   * platforms where PostgreSQL layers are available (not mobile). An empty
+   * array still renders the section (with its "New connection" action).
    */
-  sectionLabels?: { services: string; recent: string };
+  databaseConnections?: readonly { connectionString: string; label: string }[];
+  /**
+   * Translated labels for the top-level sections. Optional so the pure module
+   * (and its tests) default to English; the app passes `t()` values.
+   */
+  sectionLabels?: { services: string; recent: string; databases: string };
 }
 
 /** Locale-aware, case-insensitive compare for stable label sorting. */
@@ -108,9 +125,8 @@ function buildServiceKinds(
       kind: "category" as const,
       label: KIND_LABEL[kind],
       addable: false,
-      // Carried so the panel's "New connection" action knows which Add Data
-      // source to open for this group.
-      serviceKind: kind,
+      // The panel's "New connection" (＋) action opens this Add Data source.
+      newConnectionKind: kind,
       count: entries.length,
       children: entries.map(
         (entry): BrowserNode => ({
@@ -131,11 +147,16 @@ function buildServiceKinds(
  * Builds the full Browser tree. Sections with no children are still returned so
  * the panel can render an empty-state hint under them.
  *
- * @param input - The services to list and the recent-projects list.
- * @returns The top-level section nodes (Services, then Recent).
+ * @param input - The services, recent projects, and database connections.
+ * @returns The top-level section nodes (Services, Recent, and Databases when
+ *   `databaseConnections` is provided).
  */
 export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
-  const labels = input.sectionLabels ?? { services: "Services", recent: "Recent" };
+  const labels = input.sectionLabels ?? {
+    services: "Services",
+    recent: "Recent",
+    databases: "Databases",
+  };
   const kinds = buildServiceKinds(input.services);
   const servicesSection: BrowserNode = {
     id: "section:services",
@@ -164,7 +185,32 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
     children: recentChildren,
   };
 
-  return [servicesSection, recentSection];
+  const sections = [servicesSection, recentSection];
+
+  // The Databases section is only included where PostgreSQL layers are
+  // available (the app omits `databaseConnections` otherwise). It always shows
+  // its "New connection" (＋) action, even with no connections yet.
+  if (input.databaseConnections) {
+    sections.push({
+      id: "section:databases",
+      kind: "section",
+      label: labels.databases,
+      addable: false,
+      newConnectionKind: "postgres",
+      count: input.databaseConnections.length,
+      children: input.databaseConnections.map(
+        (connection): BrowserNode => ({
+          id: `connection:${connection.connectionString}`,
+          kind: "connection",
+          label: connection.label,
+          addable: true,
+          connectionString: connection.connectionString,
+        }),
+      ),
+    });
+  }
+
+  return sections;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/saved-postgres-connections.ts
+++ b/apps/geolibre-desktop/src/lib/saved-postgres-connections.ts
@@ -12,6 +12,14 @@ export const POSTGRES_CONNECTIONS_STORAGE_KEY =
   "geolibre.postgres.connectionStrings";
 export const MAX_SAVED_POSTGRES_CONNECTIONS = 10;
 
+/**
+ * Fired on `window` after the saved-connections list is written, so same-tab
+ * views (e.g. the Browser panel's Databases section) can re-read it — the
+ * native `storage` event only fires cross-tab.
+ */
+export const POSTGRES_CONNECTIONS_CHANGED_EVENT =
+  "geolibre:postgres-connections-changed";
+
 export function uniquePostgresConnections(connections: string[]): string[] {
   return Array.from(new Set(connections));
 }
@@ -46,6 +54,9 @@ export function rememberPostgresConnection(connectionString: string): string[] {
       POSTGRES_CONNECTIONS_STORAGE_KEY,
       JSON.stringify(connections),
     );
+    // Notify same-tab listeners (the Browser panel) so a newly-saved connection
+    // appears without closing and reopening the panel.
+    window.dispatchEvent(new Event(POSTGRES_CONNECTIONS_CHANGED_EVENT));
   } catch {
     // Best-effort persistence: a quota/private-mode failure must not abort the
     // connect flow (mirrors readSavedPostgresConnections' guard).

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -2,10 +2,12 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { RecentProjectEntry } from "@geolibre/core";
 import {
+  augmentConnections,
   buildBrowserTree,
   buildPostgisTableNodes,
   filterBrowserTree,
   type BrowserNode,
+  type ConnectionLoad,
 } from "../apps/geolibre-desktop/src/lib/browser-tree";
 import type {
   ServiceLibraryEntry,
@@ -217,6 +219,63 @@ describe("buildPostgisTableNodes", () => {
 
   it("returns an empty array for no tables", () => {
     assert.deepEqual(buildPostgisTableNodes(CONN, []), []);
+  });
+});
+
+describe("augmentConnections", () => {
+  const CONN = "postgres://u@h/db";
+  const baseTree = () =>
+    buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      databaseConnections: [{ connectionString: CONN, label: "db @ h" }],
+    });
+
+  function augment(load?: ConnectionLoad): BrowserNode | undefined {
+    const loads = load ? { [CONN]: load } : {};
+    const out = augmentConnections(baseTree(), loads, "Loading tables…");
+    return find(out, `connection:${CONN}`);
+  }
+
+  it("leaves an un-introspected connection with empty children", () => {
+    assert.deepEqual(augment()?.children, []);
+  });
+
+  it("shows a single loading info row while loading", () => {
+    const children = augment({ status: "loading" })?.children;
+    assert.equal(children?.length, 1);
+    assert.equal(children?.[0].kind, "info");
+    assert.equal(children?.[0].id, `connection:${CONN}:loading`);
+    assert.equal(children?.[0].label, "Loading tables…");
+  });
+
+  it("shows the error message in an info row on error", () => {
+    const children = augment({ status: "error", message: "boom" })?.children;
+    assert.equal(children?.length, 1);
+    assert.equal(children?.[0].kind, "info");
+    assert.equal(children?.[0].id, `connection:${CONN}:error`);
+    assert.equal(children?.[0].label, "boom");
+  });
+
+  it("builds schema→table children once loaded", () => {
+    const children = augment({
+      status: "loaded",
+      tables: [
+        { schema: "public", table: "roads" },
+        { schema: "census", table: "tracts" },
+      ],
+    })?.children;
+    assert.deepEqual(
+      children?.map((c) => c.label),
+      ["census", "public"],
+    );
+    assert.equal(find([children![1]], `table:${CONN}:public.roads`)?.kind, "table");
+  });
+
+  it("does not mutate the input tree", () => {
+    const tree = baseTree();
+    augmentConnections(tree, { [CONN]: { status: "loading" } }, "Loading…");
+    assert.deepEqual(find(tree, `connection:${CONN}`)?.children, []);
   });
 });
 

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -77,10 +77,10 @@ describe("buildBrowserTree", () => {
       ["kind:xyz", "kind:wms", "kind:arcgis"],
     );
     assert.equal(services.count, 3);
-    // Each kind group carries its kind so the panel's "New connection" action
-    // can open the matching Add Data source.
-    assert.equal(find(tree, "kind:wms")?.serviceKind, "wms");
-    assert.equal(find(tree, "kind:arcgis")?.serviceKind, "arcgis");
+    // Each kind group carries the Add Data source its "New connection" action
+    // opens.
+    assert.equal(find(tree, "kind:wms")?.newConnectionKind, "wms");
+    assert.equal(find(tree, "kind:arcgis")?.newConnectionKind, "arcgis");
   });
 
   it("sorts services within a kind by name", () => {
@@ -126,6 +126,34 @@ describe("buildBrowserTree", () => {
     });
     assert.equal(find(tree, "section:services")?.label, "Servicios");
     assert.equal(find(tree, "section:recent")?.label, "Recientes");
+  });
+
+  it("omits the Databases section unless connections are provided", () => {
+    const tree = buildBrowserTree({ services: [], recentProjects: [] });
+    assert.equal(find(tree, "section:databases"), undefined);
+    assert.deepEqual(
+      tree.map((n) => n.id),
+      ["section:services", "section:recent"],
+    );
+  });
+
+  it("adds a Databases section with connection leaves + a postgres ＋", () => {
+    const tree = buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      databaseConnections: [
+        { connectionString: "postgres://u@h/db", label: "db @ h" },
+      ],
+    });
+    const db = find(tree, "section:databases");
+    assert.equal(db?.kind, "section");
+    // The section's ＋ opens the Add Data PostgreSQL source.
+    assert.equal(db?.newConnectionKind, "postgres");
+    assert.equal(db?.count, 1);
+    const conn = find(tree, "connection:postgres://u@h/db");
+    assert.equal(conn?.kind, "connection");
+    assert.equal(conn?.connectionString, "postgres://u@h/db");
+    assert.equal(conn?.label, "db @ h");
   });
 
   it("lists recent projects in the given order with their paths", () => {

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { RecentProjectEntry } from "@geolibre/core";
 import {
   buildBrowserTree,
+  buildPostgisTableNodes,
   filterBrowserTree,
   type BrowserNode,
 } from "../apps/geolibre-desktop/src/lib/browser-tree";
@@ -154,6 +155,10 @@ describe("buildBrowserTree", () => {
     assert.equal(conn?.kind, "connection");
     assert.equal(conn?.connectionString, "postgres://u@h/db");
     assert.equal(conn?.label, "db @ h");
+    // A connection is an expandable group (empty children until introspected),
+    // not an addable leaf.
+    assert.equal(conn?.addable, false);
+    assert.deepEqual(conn?.children, []);
   });
 
   it("lists recent projects in the given order with their paths", () => {
@@ -167,6 +172,51 @@ describe("buildBrowserTree", () => {
     assert.equal(one?.kind, "recent-project");
     assert.equal(one?.projectPath, "/a/one.geolibre.json");
     assert.equal(one?.addable, true);
+  });
+});
+
+describe("buildPostgisTableNodes", () => {
+  const CONN = "postgresql://u@h/db";
+
+  it("groups tables into schema → table nodes, sorted by name", () => {
+    const nodes = buildPostgisTableNodes(CONN, [
+      { schema: "public", table: "roads" },
+      { schema: "public", table: "buildings" },
+      { schema: "census", table: "tracts" },
+    ]);
+    // Schemas sorted alphabetically.
+    assert.deepEqual(
+      nodes.map((n) => n.label),
+      ["census", "public"],
+    );
+    assert.equal(nodes[0].kind, "schema");
+    assert.equal(nodes[0].id, `schema:${CONN}:census`);
+    assert.equal(nodes[0].count, 1);
+    // Tables within a schema sorted alphabetically.
+    const publicSchema = nodes[1];
+    assert.equal(publicSchema.count, 2);
+    assert.deepEqual(
+      publicSchema.children?.map((c) => c.label),
+      ["buildings", "roads"],
+    );
+  });
+
+  it("carries the connection, schema, and table onto each table node", () => {
+    const nodes = buildPostgisTableNodes(CONN, [
+      { schema: "public", table: "roads" },
+    ]);
+    const table = nodes[0].children?.[0];
+    assert.equal(table?.kind, "table");
+    assert.equal(table?.id, `table:${CONN}:public.roads`);
+    assert.equal(table?.label, "roads");
+    assert.equal(table?.addable, true);
+    assert.equal(table?.connectionString, CONN);
+    assert.equal(table?.tableSchema, "public");
+    assert.equal(table?.tableName, "roads");
+  });
+
+  it("returns an empty array for no tables", () => {
+    assert.deepEqual(buildPostgisTableNodes(CONN, []), []);
   });
 });
 

--- a/tests/martin-source-match.test.ts
+++ b/tests/martin-source-match.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { martinSourceMatchesTable } from "../apps/geolibre-desktop/src/components/layout/add-data/martin-source-match";
+
+describe("martinSourceMatchesTable", () => {
+  it("matches a public-schema table by its bare source id", () => {
+    assert.equal(martinSourceMatchesTable("roads", "public", "roads"), true);
+  });
+
+  it("matches a public-schema table by the qualified source id too", () => {
+    assert.equal(
+      martinSourceMatchesTable("public.roads", "public", "roads"),
+      true,
+    );
+  });
+
+  it("matches an unknown-schema table by the bare source id", () => {
+    assert.equal(martinSourceMatchesTable("roads", undefined, "roads"), true);
+  });
+
+  it("matches a non-public table only by its qualified source id", () => {
+    assert.equal(
+      martinSourceMatchesTable("census.roads", "census", "roads"),
+      true,
+    );
+  });
+
+  it("does not match a non-public table by a bare source id", () => {
+    // The collision the matcher exists to prevent: a public.roads source must
+    // not be selected for a clicked census.roads.
+    assert.equal(martinSourceMatchesTable("roads", "census", "roads"), false);
+    assert.equal(
+      martinSourceMatchesTable("public.roads", "census", "roads"),
+      false,
+    );
+  });
+
+  it("does not match a different table name", () => {
+    assert.equal(martinSourceMatchesTable("rivers", "public", "roads"), false);
+  });
+});


### PR DESCRIPTION
Adds a QGIS-style **Databases** section to the Browser panel, with full in-tree PostGIS browsing.

## What

The Browser panel now has a **Databases** section that lists the user's saved **PostGIS** connections with a **"New database connection" (＋)** action. Each connection is a **lazily-expandable node**: expanding it introspects the database and shows its **schemas → spatial tables**. Clicking a table opens the existing **Add Data → PostgreSQL** dialog **prefilled** with that connection (and preselecting the table once you connect), reusing the proven Martin/editable add. The ＋ opens the same dialog for a new connection.

This mirrors QGIS's Browser, where database connections expand to their schemas and tables.

## How

- **`browser-tree`** — new `"connection"` / `"schema"` / `"table"` / `"info"` node kinds. Connections are expandable groups (empty children until introspected). New pure, unit-tested `buildPostgisTableNodes` groups a connection's tables into schema → table nodes. The Databases section is built when `databaseConnections` is provided; the per-group ＋ uses `newConnectionKind: AddDataKind`.
- **`useBrowserTree`** — feeds `readSavedPostgresConnections()` on **every platform** (the mobile gate is gone; the PostgreSQL add flow itself reports when it needs GeoLibre Desktop).
- **`BrowserPanel`** — lazy introspection keyed by connection string (runs once per connection), with loading/error status rows; injects each connection's children before filtering so search reaches tables too. A table click calls `openAddData("postgres", { postgres: { connection, schema, table } })`.
- **`openAddData` → `TopToolbar` → `AddDataDialog` → `PostgresSource`** — a new optional `postgres` prefill payload (mirroring `initialDeckVizKind`): the dialog opens on the clicked connection and preselects the table once connected.
- i18n `browser.loadingTables`.

## Verification

- Unit: `tests/browser-tree.test.ts` **18/18** (incl. `buildPostgisTableNodes`). `tsc -b` clean; eslint clean; `pre-commit` (full `npm build`) green.
- **Live browser test** against a real PostGIS server (throwaway conda cluster + sidecar) loaded with real US-cities data across **`public`** (`us_cities`, 3666 rows) and **`census`** (`big_cities`, 13 rows) schemas: expand connection → lazy introspection → both schemas → both tables → click `us_cities` → **PostgreSQL dialog opens prefilled** (connection field + saved-connection dropdown both set). Screenshot captured.

## Notes

- Auto-connect + table preselection after Connect is desktop-only (Martin/sidecar) and can't run on the web dev server; the connection prefill (the core) is verified on web.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Databases** section to the browser panel (expanded by default) using saved PostgreSQL connections.
  - Implements **lazy PostGIS introspection**: tables load on first expansion, show load status, and are searchable only after being fetched.
  - Clicking a table opens **Add Data** with PostgreSQL connection, schema, and table details prefilled (including initial table selection).

- **Bug Fixes**
  - Corrected “＋” actions to open the right **Add Data** flow and improved status/info rendering and icons.
  - Prevented stale catalog state and improved initial table/source selection.

- **Tests**
  - Updated and added coverage for browser tree building, PostGIS table grouping, and matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->