### PR TITLE
ci(tiles): auto-deploy tiles worker on workers/tiles changes

### DIFF
--- a/.github/workflows/deploy-tiles.yml
+++ b/.github/workflows/deploy-tiles.yml
@@ -1,0 +1,31 @@
+name: Deploy tiles
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "workers/tiles/**"
+      - ".github/workflows/deploy-tiles.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-tiles-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy planetary tile proxy to Cloudflare Workers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: workers/tiles

--- a/.github/workflows/deploy-tiles.yml
+++ b/.github/workflows/deploy-tiles.yml
@@ -19,6 +19,9 @@ jobs:
   deploy:
     name: Deploy planetary tile proxy to Cloudflare Workers
     runs-on: ubuntu-latest
+    # workflow_dispatch can target any branch; only ever deploy main to
+    # production so a manual run can't publish unmerged code.
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-tiles.yml
+++ b/.github/workflows/deploy-tiles.yml
@@ -26,6 +26,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Unlike the viewer/collab workers, this one has a real runtime dependency
+      # (upng-js) that wrangler must bundle, so the workspace deps have to be
+      # installed before deploy. wrangler-action does not install for us.
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v4
         with:


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy-tiles.yml` to auto-deploy the `geolibre-tiles` Cloudflare Worker (`tiles.geolibre.app`) whenever anything under `workers/tiles/**` changes on `main` (plus `workflow_dispatch` for manual runs).

## Why

The planetary `/wms/` route added in #1196 was merged into source but the worker was **never redeployed**, so every celestial body served via WMS — Pluto, Mercury, Venus, Io, Europa, Ganymede, Callisto, Titan, Charon — returned 404, while only Earth, Moon, and Mars (direct + `/opm/` passthrough) rendered. There was no CI wiring `wrangler deploy` to merges, so worker changes only shipped when someone ran it by hand.

## How

Mirrors the existing `deploy-viewer.yml` / `deploy-collab.yml` workflows exactly (same `cloudflare/wrangler-action@v4`, same `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets, path-scoped trigger, concurrency guard).

The worker has already been manually redeployed to restore the missing bodies; this prevents the regression from recurring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated deployment for tile-related updates.
  * Deployments run automatically when relevant changes reach the main branch and can also be started manually.
  * Prevented overlapping deployments for the same branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->