### PR TITLE
fix(effects): draw the atmospheric halo on Earth only

### DIFF
--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -1,4 +1,5 @@
 import type { Map as MapLibreMap } from "maplibre-gl";
+import { getActiveEllipsoid } from "@geolibre/core";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 
 /**
@@ -855,7 +856,12 @@ class EffectsEngine {
       this.starsDirty = false;
     }
     this.updateAndDrawComets();
-    this.drawHalo(getGeoglifyGlobeCircle(this.map));
+    // The atmospheric halo is Earth-only — other celestial bodies (Moon, Mars,
+    // Pluto, …) are airless or don't share Earth's blue glow, so we keep the
+    // space backdrop, starfield, and comets but skip the halo for them.
+    if (getActiveEllipsoid().id === "earth") {
+      this.drawHalo(getGeoglifyGlobeCircle(this.map));
+    }
 
     this.start();
   }


### PR DESCRIPTION
## What

Gates the atmospheric **halo** in the `maplibre-atmosphere-effects` plugin so it renders only when the active celestial body is **Earth**.

## Why

The effects plugin drew its blue atmospheric halo behind the globe for *every* body. Airless / non-Earth bodies (Moon, Mars, Pluto, Mercury, …) shouldn't carry Earth's atmospheric glow.

## How

In `EffectsEngine.tick()`, wrap the `drawHalo(...)` call in `getActiveEllipsoid().id === "earth"` (imported from `@geolibre/core`, whose module singleton is already kept in sync with the store's active ellipsoid). The engine loop re-reads state each frame, so switching planets updates the halo immediately with no extra wiring.

**Stars are kept.** Only the halo is gated — the deep-space backdrop, parallax starfield, and comets still render for all bodies.

## Notes

Isolated `tsc -b packages/plugins` surfaces 4 pre-existing `maplibre-raster.ts` `attribution` errors that are unrelated to this change (they reproduce with this diff stashed); the full workspace build is unaffected. This diff adds no type errors.