### PR TITLE
feat(browser): Local files in the Browser panel (Phase 3)

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -438,6 +438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1701,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-opener",
+ "tauri-plugin-persisted-scope",
  "webkit2gtk-sys",
  "zip",
 ]
@@ -4718,6 +4728,22 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-persisted-scope"
+version = "2.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b560a5962bf975d38fb4ec98a0e64e52929992ec708acb812add9c1ab8d186d"
+dependencies = [
+ "aho-corasick",
+ "bincode",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -34,6 +34,9 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
+# Persists the fs scope the folder picker grants, so Browser-panel pinned
+# folders stay readable across app restarts (no re-pick required).
+tauri-plugin-persisted-scope = "2"
 duckdb = { version = "1.10504.0", features = ["bundled", "parquet"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "dialog:default",
     "fs:default",
+    "fs:allow-read-dir",
     "fs:allow-read-file",
     "fs:allow-read-text-file",
     "fs:allow-write-file",

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -209,7 +209,6 @@ pub fn run() {
             read_local_file,
             read_project_file,
             read_shapefile_siblings,
-            list_directory,
             resolve_url_redirect,
             read_mbtiles_metadata,
             read_mbtiles_tile,
@@ -446,21 +445,11 @@ fn read_shapefile_siblings(path: String) -> Result<Vec<ShapefileSibling>, String
     Ok(siblings)
 }
 
-/// One entry of a directory listing returned by [`list_directory`].
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct DirectoryEntry {
-    name: String,
-    /// Absolute path of the entry.
-    path: String,
-    is_directory: bool,
-}
-
-/// Whether `path` is a safe absolute local path to list: an absolute POSIX
-/// (`/...`) or Windows drive-letter (`C:\...`) path, never a UNC (`\\host\share`)
-/// share, and free of `..` traversal segments. Mirrors the path guards in
-/// [`is_allowed_local_vector_path`] minus the file-extension check (this lists
-/// directories, not vector files).
+/// Whether `path` is a safe absolute local path: an absolute POSIX (`/...`) or
+/// Windows drive-letter (`C:\...`) path, never a UNC (`\\host\share`) share, and
+/// free of `..` traversal segments. The shared absolute/non-UNC/no-traversal
+/// guard behind [`is_allowed_local_vector_path`], kept separate so that
+/// byte-parsing lives in one place rather than being duplicated per caller.
 fn is_safe_absolute_path(path: &str) -> bool {
     let bytes = path.as_bytes();
     let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
@@ -476,69 +465,6 @@ fn is_safe_absolute_path(path: &str) -> bool {
         return false;
     }
     !path.split(['/', '\\']).any(|segment| segment == "..")
-}
-
-/// List a local directory's immediate entries (non-recursive) for the Browser
-/// panel's Files tree.
-///
-/// The JS `fs` plugin can only read paths the user explicitly picked or dropped,
-/// so it cannot lazily browse arbitrary subfolders or the current project's
-/// folder; this reads the directory directly, guarded by [`is_safe_absolute_path`]
-/// (absolute, non-UNC, no `..` traversal) — mirroring [`read_local_file`] /
-/// [`read_shapefile_siblings`]. Filtering to loadable file types is left to the
-/// JS side. An unreadable directory is returned as an error the panel surfaces
-/// inline.
-///
-/// SECURITY: unlike the file-content read commands, this has no extension
-/// allowlist (it lists directories), so any caller reaching this from the
-/// webview can enumerate entry *names* in any directory the process can read.
-/// That is a deliberate trade-off: the enumeration is name-only (no content),
-/// bounded to the same trust surface as the existing `read_local_file`
-/// content-read primitive, and needed so Project Home / pinned folders work
-/// without a runtime fs-scope grant. If tighter bounding is wanted later, track
-/// the granted roots (pinned folders + project dir) in Tauri state and reject
-/// paths outside them here.
-#[tauri::command]
-fn list_directory(path: String) -> Result<Vec<DirectoryEntry>, String> {
-    if !is_safe_absolute_path(&path) {
-        return Err(format!(
-            "Refusing to list \"{path}\": not a safe absolute local path"
-        ));
-    }
-    let entries =
-        fs::read_dir(&path).map_err(|error| format!("Could not read directory: {error}"))?;
-    let mut result = Vec::new();
-    for entry in entries.flatten() {
-        let entry_path = entry.path();
-        let (Some(name), Some(path_str)) = (
-            entry_path.file_name().and_then(|name| name.to_str()),
-            entry_path.to_str(),
-        ) else {
-            continue;
-        };
-        // `file_type()` avoids an extra stat where the OS already knows the kind,
-        // but it does NOT follow symlinks (a symlink reports its own type, not the
-        // target's), so resolve symlinks — and the unknown case — via `is_dir()`,
-        // which follows them. Otherwise a symlinked directory (common for mounted
-        // data dirs) would be classified as neither folder nor loadable file and
-        // vanish from the tree.
-        let is_directory = entry
-            .file_type()
-            .map(|file_type| {
-                if file_type.is_symlink() {
-                    entry_path.is_dir()
-                } else {
-                    file_type.is_dir()
-                }
-            })
-            .unwrap_or_else(|_| entry_path.is_dir());
-        result.push(DirectoryEntry {
-            name: name.to_string(),
-            path: path_str.to_string(),
-            is_directory,
-        });
-    }
-    Ok(result)
 }
 
 /// Read the optional admin UI-profile file (`<app_config_dir>/admin-profile.json`).

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -335,31 +335,10 @@ const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
 /// Windows-style paths a project may carry regardless of the host the binary
 /// runs on.
 pub(crate) fn is_allowed_local_vector_path(path: &str) -> bool {
-    let bytes = path.as_bytes();
-    let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
-
-    // Reject UNC paths first. Both the Windows form ("\\server\share") and the
-    // forward-slash form ("//server/share") start with two separators and can
-    // make Windows auto-authenticate against a remote host, so neither may slip
-    // through the POSIX-absolute check below.
-    if bytes.len() >= 2 && is_separator(bytes[0]) && is_separator(bytes[1]) {
-        return false;
-    }
-
-    // Absolute local path only: POSIX "/..." or a Windows drive-letter "C:\..."
-    // / "C:/...".
-    let is_posix_absolute = bytes.first() == Some(&b'/');
-    let is_windows_drive = bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && is_separator(bytes[2]);
-    if !is_posix_absolute && !is_windows_drive {
-        return false;
-    }
-
-    // Reject a "/../" or "\..\" traversal segment (but not a ".." inside a
-    // filename like "v1..2.gpkg"), matching `hasPathTraversal`.
-    if path.split(['/', '\\']).any(|segment| segment == "..") {
+    // Absolute, non-UNC, no `..` traversal — the shared guard used by
+    // `list_directory` too, so the byte-parsing lives in one place and can't
+    // diverge between the two security-relevant path checks.
+    if !is_safe_absolute_path(path) {
         return false;
     }
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -182,6 +182,9 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        // Must init after the fs plugin: it restores previously-granted fs
+        // scope (e.g. Browser-panel pinned folders) so they survive a restart.
+        .plugin(tauri_plugin_persisted_scope::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
         .manage(EarthEngineOAuthState::default())
@@ -334,9 +337,9 @@ const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
 /// Windows-style paths a project may carry regardless of the host the binary
 /// runs on.
 pub(crate) fn is_allowed_local_vector_path(path: &str) -> bool {
-    // Absolute, non-UNC, no `..` traversal — the shared guard used by
-    // `list_directory` too, so the byte-parsing lives in one place and can't
-    // diverge between the two security-relevant path checks.
+    // Absolute, non-UNC, no `..` traversal — split into `is_safe_absolute_path`
+    // so the security-relevant byte-parsing lives in one place rather than being
+    // duplicated.
     if !is_safe_absolute_path(path) {
         return false;
     }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -184,6 +184,15 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         // Must init after the fs plugin: it restores previously-granted fs
         // scope (e.g. Browser-panel pinned folders) so they survive a restart.
+        //
+        // SECURITY / SCOPE NOTE (deliberate, maintainer-approved): this persists
+        // *every* dialog-granted fs scope for the life of the install, not just
+        // Browser-panel folder pins — "Open Vector File", "Open Raster", "Save
+        // Project As", etc. also extend fs scope to the picked path, and all of
+        // those now survive a restart. There is also no per-path "forget", so
+        // unpinning a folder in the Browser panel removes the UI pin but does
+        // not revoke its (persisted) read scope. Accepted for durable pins;
+        // revisit if a narrower per-source scope or a revoke path is wanted.
         .plugin(tauri_plugin_persisted_scope::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -509,6 +509,16 @@ fn is_safe_absolute_path(path: &str) -> bool {
 /// [`read_shapefile_siblings`]. Filtering to loadable file types is left to the
 /// JS side. An unreadable directory is returned as an error the panel surfaces
 /// inline.
+///
+/// SECURITY: unlike the file-content read commands, this has no extension
+/// allowlist (it lists directories), so any caller reaching this from the
+/// webview can enumerate entry *names* in any directory the process can read.
+/// That is a deliberate trade-off: the enumeration is name-only (no content),
+/// bounded to the same trust surface as the existing `read_local_file`
+/// content-read primitive, and needed so Project Home / pinned folders work
+/// without a runtime fs-scope grant. If tighter bounding is wanted later, track
+/// the granted roots (pinned folders + project dir) in Tauri state and reject
+/// paths outside them here.
 #[tauri::command]
 fn list_directory(path: String) -> Result<Vec<DirectoryEntry>, String> {
     if !is_safe_absolute_path(&path) {
@@ -527,11 +537,21 @@ fn list_directory(path: String) -> Result<Vec<DirectoryEntry>, String> {
         ) else {
             continue;
         };
-        // `file_type()` avoids an extra stat where the OS already knows the kind;
-        // fall back to `is_dir()` (which follows symlinks) when it is unavailable.
+        // `file_type()` avoids an extra stat where the OS already knows the kind,
+        // but it does NOT follow symlinks (a symlink reports its own type, not the
+        // target's), so resolve symlinks — and the unknown case — via `is_dir()`,
+        // which follows them. Otherwise a symlinked directory (common for mounted
+        // data dirs) would be classified as neither folder nor loadable file and
+        // vanish from the tree.
         let is_directory = entry
             .file_type()
-            .map(|file_type| file_type.is_dir())
+            .map(|file_type| {
+                if file_type.is_symlink() {
+                    entry_path.is_dir()
+                } else {
+                    file_type.is_dir()
+                }
+            })
             .unwrap_or_else(|_| entry_path.is_dir());
         result.push(DirectoryEntry {
             name: name.to_string(),
@@ -2937,7 +2957,7 @@ fn configure_linux_webkit() {}
 mod tests {
     use super::{
         ensure_fetchable_url, find_zip_manifest_path, is_allowed_local_vector_path,
-        is_allowed_project_path, is_disallowed_ip, plugin_archive_file_name,
+        is_allowed_project_path, is_disallowed_ip, is_safe_absolute_path, plugin_archive_file_name,
     };
     use std::io::{Cursor, Write};
     use std::net::IpAddr;
@@ -3117,5 +3137,30 @@ mod tests {
         assert_eq!(plugin_archive_file_name("..hidden"), "hidden.zip");
         // A name that sanitizes away entirely falls back to a fixed stem.
         assert_eq!(plugin_archive_file_name("..."), "plugin.zip");
+    }
+
+    #[test]
+    fn is_safe_absolute_path_accepts_absolute_local_dirs() {
+        assert!(is_safe_absolute_path("/home/user/data"));
+        assert!(is_safe_absolute_path("/data"));
+        assert!(is_safe_absolute_path("C:\\Users\\me\\gis"));
+        assert!(is_safe_absolute_path("C:/Users/me/gis"));
+        // A ".." inside a name (not a traversal segment) is fine.
+        assert!(is_safe_absolute_path("/home/user/v1..2"));
+    }
+
+    #[test]
+    fn is_safe_absolute_path_rejects_unc_traversal_and_relative() {
+        // UNC shares (both forms) can auto-authenticate against a remote host.
+        assert!(!is_safe_absolute_path("\\\\server\\share"));
+        assert!(!is_safe_absolute_path("//server/share"));
+        // `..` traversal segments.
+        assert!(!is_safe_absolute_path("/home/user/../etc"));
+        assert!(!is_safe_absolute_path("C:\\a\\..\\b"));
+        // Relative / non-absolute and empty input.
+        assert!(!is_safe_absolute_path("home/user"));
+        assert!(!is_safe_absolute_path("./data"));
+        assert!(!is_safe_absolute_path(""));
+        assert!(!is_safe_absolute_path("C:")); // drive letter without a separator
     }
 }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -209,6 +209,7 @@ pub fn run() {
             read_local_file,
             read_project_file,
             read_shapefile_siblings,
+            list_directory,
             resolve_url_redirect,
             read_mbtiles_metadata,
             read_mbtiles_tile,
@@ -464,6 +465,81 @@ fn read_shapefile_siblings(path: String) -> Result<Vec<ShapefileSibling>, String
         }
     }
     Ok(siblings)
+}
+
+/// One entry of a directory listing returned by [`list_directory`].
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DirectoryEntry {
+    name: String,
+    /// Absolute path of the entry.
+    path: String,
+    is_directory: bool,
+}
+
+/// Whether `path` is a safe absolute local path to list: an absolute POSIX
+/// (`/...`) or Windows drive-letter (`C:\...`) path, never a UNC (`\\host\share`)
+/// share, and free of `..` traversal segments. Mirrors the path guards in
+/// [`is_allowed_local_vector_path`] minus the file-extension check (this lists
+/// directories, not vector files).
+fn is_safe_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
+    if bytes.len() >= 2 && is_separator(bytes[0]) && is_separator(bytes[1]) {
+        return false;
+    }
+    let is_posix_absolute = bytes.first() == Some(&b'/');
+    let is_windows_drive = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && is_separator(bytes[2]);
+    if !is_posix_absolute && !is_windows_drive {
+        return false;
+    }
+    !path.split(['/', '\\']).any(|segment| segment == "..")
+}
+
+/// List a local directory's immediate entries (non-recursive) for the Browser
+/// panel's Files tree.
+///
+/// The JS `fs` plugin can only read paths the user explicitly picked or dropped,
+/// so it cannot lazily browse arbitrary subfolders or the current project's
+/// folder; this reads the directory directly, guarded by [`is_safe_absolute_path`]
+/// (absolute, non-UNC, no `..` traversal) — mirroring [`read_local_file`] /
+/// [`read_shapefile_siblings`]. Filtering to loadable file types is left to the
+/// JS side. An unreadable directory is returned as an error the panel surfaces
+/// inline.
+#[tauri::command]
+fn list_directory(path: String) -> Result<Vec<DirectoryEntry>, String> {
+    if !is_safe_absolute_path(&path) {
+        return Err(format!(
+            "Refusing to list \"{path}\": not a safe absolute local path"
+        ));
+    }
+    let entries =
+        fs::read_dir(&path).map_err(|error| format!("Could not read directory: {error}"))?;
+    let mut result = Vec::new();
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        let (Some(name), Some(path_str)) = (
+            entry_path.file_name().and_then(|name| name.to_str()),
+            entry_path.to_str(),
+        ) else {
+            continue;
+        };
+        // `file_type()` avoids an extra stat where the OS already knows the kind;
+        // fall back to `is_dir()` (which follows symlinks) when it is unavailable.
+        let is_directory = entry
+            .file_type()
+            .map(|file_type| file_type.is_dir())
+            .unwrap_or_else(|_| entry_path.is_dir());
+        result.push(DirectoryEntry {
+            name: name.to_string(),
+            path: path_str.to_string(),
+            is_directory,
+        });
+    }
+    Ok(result)
 }
 
 /// Read the optional admin UI-profile file (`<app_config_dir>/admin-profile.json`).

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1247,9 +1247,13 @@ export function DesktopShell({
             return accepted;
           },
         });
-        // A declined large-file prompt is a cancellation, not a failure.
-        if (cancelled) return null;
-        if (!importedLayers.length) return t("browser.addFileFailed");
+        // A declined large-file prompt is a cancellation, not a failure — but
+        // loadDroppedVectorPaths can still return valid layers (e.g. KML ground
+        // overlays / models) alongside a declined placemark-vector load, so only
+        // treat an *empty* result as a cancel/no-op; otherwise add what loaded.
+        if (!importedLayers.length) {
+          return cancelled ? null : t("browser.addFileFailed");
+        }
         addImportedVectorLayers(importedLayers);
         return null;
       } catch (error) {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1237,7 +1237,11 @@ export function DesktopShell({
           );
           return count > 0 ? null : t("browser.addFileFailed");
         }
-        const importedLayers = await loadDroppedVectorPaths([path]);
+        const importedLayers = await loadDroppedVectorPaths([path], {
+          // Same large-dataset confirmation the drag-and-drop / Open Vector File
+          // paths use, so clicking a big file in the tree can't silently hang.
+          onLargeDataset: confirmLargeVectorDataset,
+        });
         if (!importedLayers.length) return t("browser.addFileFailed");
         addImportedVectorLayers(importedLayers);
         return null;

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1237,11 +1237,18 @@ export function DesktopShell({
           );
           return count > 0 ? null : t("browser.addFileFailed");
         }
+        let cancelled = false;
         const importedLayers = await loadDroppedVectorPaths([path], {
           // Same large-dataset confirmation the drag-and-drop / Open Vector File
           // paths use, so clicking a big file in the tree can't silently hang.
-          onLargeDataset: confirmLargeVectorDataset,
+          onLargeDataset: (dataset) => {
+            const accepted = confirmLargeVectorDataset(dataset);
+            cancelled = !accepted;
+            return accepted;
+          },
         });
+        // A declined large-file prompt is a cancellation, not a failure.
+        if (cancelled) return null;
         if (!importedLayers.length) return t("browser.addFileFailed");
         addImportedVectorLayers(importedLayers);
         return null;

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -53,6 +53,7 @@ import {
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
 import { useProjectFileActions } from "../../hooks/useProjectFileActions";
 import {
+  isRasterFileName,
   isTauri,
   loadDroppedPhotoFiles,
   loadDroppedPhotoPaths,
@@ -1223,6 +1224,32 @@ export function DesktopShell({
     [],
   );
 
+  // Add a single local file (clicked in the Browser panel's Files tree) as a
+  // layer, reusing the same loaders + store dispatch as the drag-and-drop path.
+  // Resolves to an inline error message, or null on success. Vector/raster only
+  // (the Files tree filters to those); MBTiles go through the Add Data dialog.
+  const addFilePath = useCallback(
+    async (path: string): Promise<string | null> => {
+      try {
+        if (isRasterFileName(path)) {
+          const count = await addDroppedRasters(
+            await loadDroppedRasterPaths([path]),
+          );
+          return count > 0 ? null : t("browser.addFileFailed");
+        }
+        const importedLayers = await loadDroppedVectorPaths([path]);
+        if (!importedLayers.length) return t("browser.addFileFailed");
+        addImportedVectorLayers(importedLayers);
+        return null;
+      } catch (error) {
+        return error instanceof Error
+          ? error.message
+          : t("browser.addFileFailed");
+      }
+    },
+    [addDroppedRasters, addImportedVectorLayers, t],
+  );
+
   const finishDrop = useCallback(
     (importedLayers: ImportedVectorLayer[], rasterCount: number) => {
       if (!importedLayers.length && !rasterCount) {
@@ -1834,6 +1861,7 @@ export function DesktopShell({
               <BrowserPanel
                 mapControllerRef={mapControllerRef}
                 onOpenRecentProject={projectFiles.handleOpenRecent}
+                onAddFilePath={addFilePath}
               />,
               browserContentEl,
             )

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -244,8 +244,9 @@ export function BrowserPanel({
         folderLoads,
         foldersLoadingLabel,
         isLoadableFilePath,
+        (shown, total) => t("browser.folderTruncated", { shown, total }),
       ),
-    [tree, connLoads, loadingLabel, folderLoads, foldersLoadingLabel],
+    [tree, connLoads, loadingLabel, folderLoads, foldersLoadingLabel, t],
   );
 
   const filtered = useMemo(

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -6,13 +6,21 @@ import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
-import { isTauri } from "../../lib/tauri-io";
+import {
+  isLoadableFilePath,
+  isTauri,
+  listDirectory,
+  pickLocalPathWithFallback,
+} from "../../lib/tauri-io";
+import { pinFolder, unpinFolder } from "../../lib/browser-folders";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import {
   augmentConnections,
+  augmentFolders,
   filterBrowserTree,
   type BrowserNode,
   type ConnectionLoad,
+  type FolderLoad,
 } from "../../lib/browser-tree";
 import { applyServiceEntry } from "../layout/add-data/apply-service";
 import { errorMessage } from "../layout/add-data/helpers";
@@ -20,8 +28,9 @@ import type { AddDataKind } from "../layout/AddDataDialog";
 import { openAddData } from "../layout/add-data/open-add-data";
 import { BrowserTreeNode } from "./BrowserTreeNode";
 
-/** The `connection:` id prefix a connection node carries (id = prefix + connString). */
+/** The `connection:` / `folder:` id prefixes (id = prefix + connString/path). */
 const CONNECTION_ID_PREFIX = "connection:";
+const FOLDER_ID_PREFIX = "folder:";
 
 interface BrowserPanelProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -30,6 +39,13 @@ interface BrowserPanelProps {
    * Resolves to an error message to show inline, or null on success.
    */
   onOpenRecentProject: (path: string) => Promise<string | null>;
+  /**
+   * Add a local file (by absolute path) as a layer — vector/raster/MBTiles,
+   * dispatched by the shell which owns the store add-paths. Resolves to an error
+   * message to show inline, or null on success. Absent off-desktop (no Files
+   * section renders there).
+   */
+  onAddFilePath?: (path: string) => Promise<string | null>;
 }
 
 /** The section nodes are expanded by default so their contents are visible. */
@@ -37,6 +53,7 @@ const DEFAULT_EXPANDED = new Set([
   "section:services",
   "section:recent",
   "section:databases",
+  "section:files",
 ]);
 
 /** Collects every group node id in a tree (used to expand-all while searching). */
@@ -64,6 +81,7 @@ function collectGroupIds(nodes: readonly BrowserNode[], into: Set<string>): void
 export function BrowserPanel({
   mapControllerRef,
   onOpenRecentProject,
+  onAddFilePath,
 }: BrowserPanelProps) {
   const { t } = useTranslation();
   const addLayer = useAppStore((s) => s.addLayer);
@@ -176,15 +194,57 @@ export function BrowserPanel({
     [t],
   );
 
+  // Lazy directory listing for the Files section: keyed by absolute path,
+  // populated the first time a folder is expanded (same pattern as connections).
+  const [folderLoads, setFolderLoads] = useState<Record<string, FolderLoad>>(
+    {},
+  );
+  const folderFetchedRef = useRef<Set<string>>(new Set());
+
+  const fetchFolder = useCallback(
+    (path: string) => {
+      if (folderFetchedRef.current.has(path)) return;
+      folderFetchedRef.current.add(path);
+      setFolderLoads((prev) => ({ ...prev, [path]: { status: "loading" } }));
+      listDirectory(path)
+        .then((entries) => {
+          setFolderLoads((prev) => ({
+            ...prev,
+            [path]: { status: "loaded", entries },
+          }));
+        })
+        .catch((err: unknown) => {
+          // Drop the marker so a re-expand retries (a folder can also change on
+          // disk); surface the message inline via the status row.
+          folderFetchedRef.current.delete(path);
+          setFolderLoads((prev) => ({
+            ...prev,
+            [path]: {
+              status: "error",
+              message: err instanceof Error ? err.message : String(err),
+            },
+          }));
+        });
+    },
+    [],
+  );
+
   // Inject each connection node's lazily-loaded children (loading/error status
   // rows, or schema→table nodes) before filtering. Search therefore reaches the
   // tables of connections the user has already expanded; an unexpanded
   // connection keeps its empty child list, so its tables aren't searchable
-  // until it is first drilled into.
+  // until it is first drilled into. Folder listings are injected the same way.
   const loadingLabel = t("browser.loadingTables");
+  const foldersLoadingLabel = t("browser.loadingFolder");
   const augmented = useMemo(
-    () => augmentConnections(tree, connLoads, loadingLabel),
-    [tree, connLoads, loadingLabel],
+    () =>
+      augmentFolders(
+        augmentConnections(tree, connLoads, loadingLabel),
+        folderLoads,
+        foldersLoadingLabel,
+        isLoadableFilePath,
+      ),
+    [tree, connLoads, loadingLabel, folderLoads, foldersLoadingLabel],
   );
 
   const filtered = useMemo(
@@ -202,9 +262,12 @@ export function BrowserPanel({
   }, [query, expanded, filtered]);
 
   const toggle = (id: string) => {
-    // Kick off introspection the first time a connection is expanded.
+    // Kick off introspection/listing the first time a connection or folder is
+    // expanded.
     if (id.startsWith(CONNECTION_ID_PREFIX) && !expanded.has(id)) {
       fetchConnectionTables(id.slice(CONNECTION_ID_PREFIX.length));
+    } else if (id.startsWith(FOLDER_ID_PREFIX) && !expanded.has(id)) {
+      fetchFolder(id.slice(FOLDER_ID_PREFIX.length));
     }
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -264,6 +327,17 @@ export function BrowserPanel({
           table: node.tableName,
         },
       });
+    } else if (node.kind === "file" && node.path && onAddFilePath) {
+      // Add the clicked file as a layer via the shell's dispatcher (which owns
+      // the vector/raster/MBTiles store add-paths); it resolves to an error
+      // message or null, surfaced inline like the recent-project open.
+      beginBusy(node.id);
+      try {
+        const addError = await onAddFilePath(node.path);
+        if (addError) setError(addError);
+      } finally {
+        endBusy();
+      }
     }
   };
 
@@ -271,11 +345,30 @@ export function BrowserPanel({
   // saving there adds it to the library/connections, which show up in this tree.
   const newConnection = (kind: AddDataKind) => openAddData(kind);
 
+  // The Files section's ＋ picks a folder to pin (native directory dialog); the
+  // pinned-folders change event refreshes the tree via useBrowserTree.
+  const addFolder = async () => {
+    setError(null);
+    try {
+      const picked = await pickLocalPathWithFallback({ directory: true });
+      if (picked) pinFolder(picked);
+    } catch (err) {
+      console.error("Failed to add folder", err);
+      setError(t("browser.addFolderFailed"));
+    }
+  };
+
+  // A pinned root folder's (×) unpins it from the Files section.
+  const removeFolder = (path: string) => unpinFolder(path);
+
   // A section counts as content if it has children *or* an always-on ＋ action
-  // (the Databases section shows its "New connection" ＋ even with zero saved
-  // connections, so a first-run user isn't stuck on the empty-state message).
+  // (Databases' "New connection" and Files' "Add folder" show even with zero
+  // entries, so a first-run user isn't stuck on the empty-state message).
   const hasContent = filtered.some(
-    (section) => section.children?.length || section.newConnectionKind,
+    (section) =>
+      section.children?.length ||
+      section.newConnectionKind ||
+      section.addFolderAction,
   );
 
   return (
@@ -310,6 +403,8 @@ export function BrowserPanel({
                 onToggle={toggle}
                 onActivate={activate}
                 onNewConnection={newConnection}
+                onAddFolder={addFolder}
+                onRemoveFolder={removeFolder}
               />
             ))}
           </ul>

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -215,18 +215,19 @@ export function BrowserPanel({
         })
         .catch((err: unknown) => {
           // Drop the marker so a re-expand retries (a folder can also change on
-          // disk); surface the message inline via the status row.
+          // disk); surface the message inline via the status row, using the
+          // translated fallback helper like fetchConnectionTables does.
           folderFetchedRef.current.delete(path);
           setFolderLoads((prev) => ({
             ...prev,
             [path]: {
               status: "error",
-              message: err instanceof Error ? err.message : String(err),
+              message: errorMessage(err, t("browser.loadFolderFailed")),
             },
           }));
         });
     },
-    [],
+    [t],
   );
 
   // Inject each connection node's lazily-loaded children (loading/error status

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -365,6 +365,11 @@ export function BrowserPanel({
   // markers and collapse them — so re-pinning the same path re-reads from disk
   // and expands cleanly (toggle only fetches on a collapsed→expanded change;
   // the panel stays mounted while hidden, so this state would otherwise persist).
+  //
+  // Note: this removes the pin from the UI/localStorage but does NOT revoke the
+  // underlying fs scope the picker granted (persisted app-wide via
+  // tauri-plugin-persisted-scope, see src-tauri/src/lib.rs) — there is no clean
+  // per-path "forget". Unpin means "stop listing it here", not "revoke access".
   const removeFolder = (path: string) => {
     const isWithin = (candidate: string) =>
       candidate === path ||

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -358,8 +358,18 @@ export function BrowserPanel({
     }
   };
 
-  // A pinned root folder's (×) unpins it from the Files section.
-  const removeFolder = (path: string) => unpinFolder(path);
+  // A pinned root folder's (×) unpins it from the Files section. Also drop its
+  // cached listing so re-pinning the same path later re-reads it from disk
+  // rather than showing a stale listing (the panel stays mounted while hidden).
+  const removeFolder = (path: string) => {
+    folderFetchedRef.current.delete(path);
+    setFolderLoads((prev) => {
+      if (!(path in prev)) return prev;
+      const { [path]: _removed, ...rest } = prev;
+      return rest;
+    });
+    unpinFolder(path);
+  };
 
   // A section counts as content if it has children *or* an always-on ＋ action
   // (Databases' "New connection" and Files' "Add folder" show even with zero

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -10,7 +10,7 @@ import {
   isLoadableFilePath,
   isTauri,
   listDirectory,
-  pickLocalPathWithFallback,
+  pickLocalDirectory,
 } from "../../lib/tauri-io";
 import { pinFolder, unpinFolder } from "../../lib/browser-folders";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
@@ -351,7 +351,7 @@ export function BrowserPanel({
   const addFolder = async () => {
     setError(null);
     try {
-      const picked = await pickLocalPathWithFallback({ directory: true });
+      const picked = await pickLocalDirectory();
       if (picked) pinFolder(picked);
     } catch (err) {
       console.error("Failed to add folder", err);

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -359,15 +359,37 @@ export function BrowserPanel({
     }
   };
 
-  // A pinned root folder's (×) unpins it from the Files section. Also drop its
-  // cached listing so re-pinning the same path later re-reads it from disk
-  // rather than showing a stale listing (the panel stays mounted while hidden).
+  // A pinned root folder's (×) unpins it from the Files section. Also reset the
+  // folder and any expanded descendants — clear their cached listings + fetch
+  // markers and collapse them — so re-pinning the same path re-reads from disk
+  // and expands cleanly (toggle only fetches on a collapsed→expanded change;
+  // the panel stays mounted while hidden, so this state would otherwise persist).
   const removeFolder = (path: string) => {
-    folderFetchedRef.current.delete(path);
+    const isWithin = (candidate: string) =>
+      candidate === path ||
+      candidate.startsWith(`${path}/`) ||
+      candidate.startsWith(`${path}\\`);
+    for (const key of [...folderFetchedRef.current]) {
+      if (isWithin(key)) folderFetchedRef.current.delete(key);
+    }
     setFolderLoads((prev) => {
-      if (!(path in prev)) return prev;
-      const { [path]: _removed, ...rest } = prev;
-      return rest;
+      const next: Record<string, FolderLoad> = {};
+      for (const [key, value] of Object.entries(prev)) {
+        if (!isWithin(key)) next[key] = value;
+      }
+      return next;
+    });
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (const id of prev) {
+        if (
+          id.startsWith(FOLDER_ID_PREFIX) &&
+          isWithin(id.slice(FOLDER_ID_PREFIX.length))
+        ) {
+          next.delete(id);
+        }
+      }
+      return next;
     });
     unpinFolder(path);
   };

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -200,20 +200,29 @@ export function BrowserPanel({
     {},
   );
   const folderFetchedRef = useRef<Set<string>>(new Set());
+  // Per-path fetch generation: bumped when a folder is (re)fetched or unpinned,
+  // so a slow listDirectory that resolves after the folder was unpinned/re-pinned
+  // can't clobber newer state with its stale result.
+  const folderGenRef = useRef<Map<string, number>>(new Map());
 
   const fetchFolder = useCallback(
     (path: string) => {
       if (folderFetchedRef.current.has(path)) return;
       folderFetchedRef.current.add(path);
+      const generation = (folderGenRef.current.get(path) ?? 0) + 1;
+      folderGenRef.current.set(path, generation);
+      const isCurrent = () => folderGenRef.current.get(path) === generation;
       setFolderLoads((prev) => ({ ...prev, [path]: { status: "loading" } }));
       listDirectory(path)
         .then((entries) => {
+          if (!isCurrent()) return; // superseded by an unpin/re-pin mid-fetch
           setFolderLoads((prev) => ({
             ...prev,
             [path]: { status: "loaded", entries },
           }));
         })
         .catch((err: unknown) => {
+          if (!isCurrent()) return;
           // Drop the marker so a re-expand retries (a folder can also change on
           // disk); surface the message inline via the status row, using the
           // translated fallback helper like fetchConnectionTables does.
@@ -371,12 +380,24 @@ export function BrowserPanel({
   // tauri-plugin-persisted-scope, see src-tauri/src/lib.rs) — there is no clean
   // per-path "forget". Unpin means "stop listing it here", not "revoke access".
   const removeFolder = (path: string) => {
+    setError(null);
+    // `path` may itself end in a separator (a normalized root: "/" or "C:\"),
+    // so build the descendant prefix from the path's own trailing separator
+    // rather than blindly appending one (which would yield "//" / "C:\\" and
+    // match no real descendant).
+    const separator = path.includes("\\") ? "\\" : "/";
+    const prefix = path.endsWith(separator) ? path : `${path}${separator}`;
     const isWithin = (candidate: string) =>
-      candidate === path ||
-      candidate.startsWith(`${path}/`) ||
-      candidate.startsWith(`${path}\\`);
+      candidate === path || candidate.startsWith(prefix);
     for (const key of [...folderFetchedRef.current]) {
       if (isWithin(key)) folderFetchedRef.current.delete(key);
+    }
+    // Invalidate any in-flight fetch for the folder/descendants so a late
+    // resolution can't repopulate cleared state.
+    for (const key of [...folderGenRef.current.keys()]) {
+      if (isWithin(key)) {
+        folderGenRef.current.set(key, (folderGenRef.current.get(key) ?? 0) + 1);
+      }
     }
     setFolderLoads((prev) => {
       const next: Record<string, FolderLoad> = {};

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -170,8 +170,8 @@ export function BrowserTreeNode({
           <button
             type="button"
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-            title={t("browser.unpinFolder")}
-            aria-label={t("browser.unpinFolder")}
+            title={t("browser.unpinFolder", { name: node.label })}
+            aria-label={t("browser.unpinFolder", { name: node.label })}
             onClick={() => onRemoveFolder(removePath)}
           >
             <X className="h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -4,12 +4,14 @@ import {
   ChevronRight,
   Clock,
   Database,
+  File,
   Folder,
   FolderOpen,
   Globe2,
   Loader2,
   Plus,
   Table,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -26,10 +28,14 @@ interface BrowserTreeNodeProps {
   busyId: string | null;
   /** Toggle a group node's expanded state. */
   onToggle: (id: string) => void;
-  /** Activate a leaf (add a service layer, or open a recent project). */
+  /** Activate a leaf (add a service/file layer, or open a recent project). */
   onActivate: (node: BrowserNode) => void;
   /** Open Add Data at `kind` for a group's "New connection" (＋) action. */
   onNewConnection: (kind: AddDataKind) => void;
+  /** Pick a folder to pin, for the Files section's "Add folder" (＋) action. */
+  onAddFolder: () => void;
+  /** Unpin a pinned root folder (its ×), by path. */
+  onRemoveFolder: (path: string) => void;
 }
 
 /** The leading icon for a node, chosen by kind (and expanded state for groups). */
@@ -43,6 +49,8 @@ function nodeIcon(node: BrowserNode, isExpanded: boolean): LucideIcon {
       return Database;
     case "table":
       return Table;
+    case "file":
+      return File;
     default:
       return isExpanded ? FolderOpen : Folder;
   }
@@ -61,6 +69,8 @@ export function BrowserTreeNode({
   onToggle,
   onActivate,
   onNewConnection,
+  onAddFolder,
+  onRemoveFolder,
 }: BrowserTreeNodeProps) {
   const { t } = useTranslation();
   // A status row (loading / error) is non-interactive text, not a tree control.
@@ -103,6 +113,15 @@ export function BrowserTreeNode({
     newConnectionKind === "postgres"
       ? t("browser.newDatabaseConnection")
       : t("browser.newConnection", { kind: node.label });
+  // The trailing ＋ affordance: a service/database group opens Add Data; the
+  // Files section opens a folder picker. At most one applies per node.
+  const plusAction = newConnectionKind
+    ? { label: newConnectionLabel, run: () => onNewConnection(newConnectionKind) }
+    : node.addFolderAction
+      ? { label: t("browser.addFolder"), run: onAddFolder }
+      : null;
+  // Pinned root folders show a × to unpin them from the Files section.
+  const removePath = node.removable ? node.path : undefined;
 
   return (
     <li>
@@ -147,13 +166,24 @@ export function BrowserTreeNode({
             </span>
           ) : null}
         </button>
-        {newConnectionKind ? (
+        {removePath ? (
           <button
             type="button"
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-            title={newConnectionLabel}
-            aria-label={newConnectionLabel}
-            onClick={() => onNewConnection(newConnectionKind)}
+            title={t("browser.unpinFolder")}
+            aria-label={t("browser.unpinFolder")}
+            onClick={() => onRemoveFolder(removePath)}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+        {plusAction ? (
+          <button
+            type="button"
+            className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            title={plusAction.label}
+            aria-label={plusAction.label}
+            onClick={plusAction.run}
           >
             <Plus className="h-3.5 w-3.5" />
           </button>
@@ -172,6 +202,8 @@ export function BrowserTreeNode({
                 onToggle={onToggle}
                 onActivate={onActivate}
                 onNewConnection={onNewConnection}
+                onAddFolder={onAddFolder}
+                onRemoveFolder={onRemoveFolder}
               />
             ))}
           </ul>

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -13,14 +13,11 @@ import {
 } from "../lib/saved-postgres-connections";
 import {
   folderLabel,
+  parentDirectory,
   PINNED_FOLDERS_CHANGED_EVENT,
   readPinnedFolders,
 } from "../lib/browser-folders";
-import {
-  isAbsoluteLocalPath,
-  isTauri,
-  parentDirectory,
-} from "../lib/tauri-io";
+import { isAbsoluteLocalPath, isTauri } from "../lib/tauri-io";
 import { buildBrowserTree, type BrowserNode } from "../lib/browser-tree";
 
 export interface BrowserTreeState {

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -11,6 +11,16 @@ import {
   readSavedPostgresConnections,
   savedPostgresConnectionLabel,
 } from "../lib/saved-postgres-connections";
+import {
+  folderLabel,
+  PINNED_FOLDERS_CHANGED_EVENT,
+  readPinnedFolders,
+} from "../lib/browser-folders";
+import {
+  isAbsoluteLocalPath,
+  isTauri,
+  parentDirectory,
+} from "../lib/tauri-io";
 import { buildBrowserTree, type BrowserNode } from "../lib/browser-tree";
 
 export interface BrowserTreeState {
@@ -36,19 +46,30 @@ export interface BrowserTreeState {
 export function useBrowserTree(): BrowserTreeState {
   const { t } = useTranslation();
   const recentProjects = useAppStore((s) => s.recentProjects);
+  const projectPath = useAppStore((s) => s.projectPath);
   const servicesLabel = t("browser.services");
   const recentLabel = t("browser.recent");
   const databasesLabel = t("browser.databases");
+  const filesLabel = t("browser.files");
 
   // Saved connections live in localStorage (no reactive store), so re-read them
   // when one is added/removed — otherwise a connection saved from the Add Data
-  // dialog wouldn't appear until the (still-mounted) panel is reopened.
+  // dialog wouldn't appear until the (still-mounted) panel is reopened. The
+  // pinned folders are the same story (see the Files section below).
   const [connectionsRevision, setConnectionsRevision] = useState(0);
+  const [foldersRevision, setFoldersRevision] = useState(0);
   useEffect(() => {
-    const bump = () => setConnectionsRevision((n) => n + 1);
-    window.addEventListener(POSTGRES_CONNECTIONS_CHANGED_EVENT, bump);
-    return () =>
-      window.removeEventListener(POSTGRES_CONNECTIONS_CHANGED_EVENT, bump);
+    const bumpConnections = () => setConnectionsRevision((n) => n + 1);
+    const bumpFolders = () => setFoldersRevision((n) => n + 1);
+    window.addEventListener(POSTGRES_CONNECTIONS_CHANGED_EVENT, bumpConnections);
+    window.addEventListener(PINNED_FOLDERS_CHANGED_EVENT, bumpFolders);
+    return () => {
+      window.removeEventListener(
+        POSTGRES_CONNECTIONS_CHANGED_EVENT,
+        bumpConnections,
+      );
+      window.removeEventListener(PINNED_FOLDERS_CHANGED_EVENT, bumpFolders);
+    };
   }, []);
 
   return useMemo(() => {
@@ -64,24 +85,48 @@ export function useBrowserTree(): BrowserTreeState {
         label: savedPostgresConnectionLabel(connectionString),
       }),
     );
+    // The Files section is desktop-only: directory reading needs the Tauri
+    // `list_directory` command. Project Home is the folder of the open project
+    // file (skipped for a URL-backed or unsaved project); pinned folders are the
+    // user's localStorage list (MRU-first).
+    const files = isTauri()
+      ? {
+          projectHome:
+            projectPath && isAbsoluteLocalPath(projectPath)
+              ? (() => {
+                  const dir = parentDirectory(projectPath);
+                  return { path: dir, label: folderLabel(dir) };
+                })()
+              : null,
+          folders: readPinnedFolders().map((path) => ({
+            path,
+            label: folderLabel(path),
+          })),
+        }
+      : undefined;
     return {
       tree: buildBrowserTree({
         services,
         recentProjects,
         databaseConnections,
+        files,
         sectionLabels: {
           services: servicesLabel,
           recent: recentLabel,
           databases: databasesLabel,
+          files: filesLabel,
         },
       }),
       serviceById: (id: string) => byId.get(id),
     };
   }, [
     recentProjects,
+    projectPath,
     servicesLabel,
     recentLabel,
     databasesLabel,
+    filesLabel,
     connectionsRevision,
+    foldersRevision,
   ]);
 }

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -13,11 +13,10 @@ import {
 } from "../lib/saved-postgres-connections";
 import {
   folderLabel,
-  parentDirectory,
   PINNED_FOLDERS_CHANGED_EVENT,
   readPinnedFolders,
 } from "../lib/browser-folders";
-import { isAbsoluteLocalPath, isTauri } from "../lib/tauri-io";
+import { isTauri } from "../lib/tauri-io";
 import { buildBrowserTree, type BrowserNode } from "../lib/browser-tree";
 
 export interface BrowserTreeState {
@@ -43,7 +42,6 @@ export interface BrowserTreeState {
 export function useBrowserTree(): BrowserTreeState {
   const { t } = useTranslation();
   const recentProjects = useAppStore((s) => s.recentProjects);
-  const projectPath = useAppStore((s) => s.projectPath);
   const servicesLabel = t("browser.services");
   const recentLabel = t("browser.recent");
   const databasesLabel = t("browser.databases");
@@ -82,19 +80,12 @@ export function useBrowserTree(): BrowserTreeState {
         label: savedPostgresConnectionLabel(connectionString),
       }),
     );
-    // The Files section is desktop-only: directory reading needs the Tauri
-    // `list_directory` command. Project Home is the folder of the open project
-    // file (skipped for a URL-backed or unsaved project); pinned folders are the
-    // user's localStorage list (MRU-first).
+    // The Files section is desktop-only: directory reading uses the fs plugin's
+    // readDir, which only works within the scope the OS folder dialog grants, so
+    // the section lists the user's pinned folders (localStorage, MRU-first) that
+    // were added via the picker.
     const files = isTauri()
       ? {
-          projectHome:
-            projectPath && isAbsoluteLocalPath(projectPath)
-              ? (() => {
-                  const dir = parentDirectory(projectPath);
-                  return { path: dir, label: folderLabel(dir) };
-                })()
-              : null,
           folders: readPinnedFolders().map((path) => ({
             path,
             label: folderLabel(path),
@@ -118,7 +109,6 @@ export function useBrowserTree(): BrowserTreeState {
     };
   }, [
     recentProjects,
-    projectPath,
     servicesLabel,
     recentLabel,
     databasesLabel,

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -18,7 +18,7 @@
     "addFolderFailed": "Could not add this folder.",
     "addFileFailed": "Could not add this file.",
     "loadFolderFailed": "Could not read this folder.",
-    "unpinFolder": "Remove folder “{{name}}”",
+    "unpinFolder": "Remove “{{name}}” from the list",
     "loadingFolder": "Loading…",
     "folderTruncated": "Showing first {{shown}} of {{total}}"
   },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -17,7 +17,8 @@
     "addFolder": "Add folder",
     "addFolderFailed": "Could not add this folder.",
     "addFileFailed": "Could not add this file.",
-    "unpinFolder": "Remove folder",
+    "loadFolderFailed": "Could not read this folder.",
+    "unpinFolder": "Remove folder “{{name}}”",
     "loadingFolder": "Loading…"
   },
   "about": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -12,7 +12,13 @@
     "addFailed": "Could not add this data source.",
     "builtinBadge": "built-in",
     "newConnection": "New {{kind}} connection",
-    "loadingTables": "Loading tables…"
+    "loadingTables": "Loading tables…",
+    "files": "Files",
+    "addFolder": "Add folder",
+    "addFolderFailed": "Could not add this folder.",
+    "addFileFailed": "Could not add this file.",
+    "unpinFolder": "Remove folder",
+    "loadingFolder": "Loading…"
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -19,7 +19,8 @@
     "addFileFailed": "Could not add this file.",
     "loadFolderFailed": "Could not read this folder.",
     "unpinFolder": "Remove folder “{{name}}”",
-    "loadingFolder": "Loading…"
+    "loadingFolder": "Loading…",
+    "folderTruncated": "Showing first {{shown}} of {{total}}"
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/lib/browser-folders.ts
+++ b/apps/geolibre-desktop/src/lib/browser-folders.ts
@@ -1,0 +1,76 @@
+/**
+ * Persistence for the folders the user has pinned into the Browser panel's Files
+ * section — a small localStorage-backed, most-recently-added-first list. Global
+ * (not per-project), mirroring `saved-postgres-connections.ts`. UI-free so it
+ * unit-tests in isolation.
+ */
+
+export const PINNED_FOLDERS_STORAGE_KEY = "geolibre.browser.pinnedFolders";
+export const MAX_PINNED_FOLDERS = 20;
+
+/**
+ * Fired on `window` after the pinned-folders list is written, so the Browser
+ * panel can re-read it in the same tab (the native `storage` event is cross-tab
+ * only), mirroring the saved-connections change event.
+ */
+export const PINNED_FOLDERS_CHANGED_EVENT = "geolibre:pinned-folders-changed";
+
+function uniquePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths));
+}
+
+/** The trailing path segment (folder name) of an absolute path, for the label. */
+export function folderLabel(path: string): string {
+  const trimmed = path.replace(/[/\\]+$/, "");
+  const segments = trimmed.split(/[/\\]/);
+  return segments[segments.length - 1] || trimmed || path;
+}
+
+export function readPinnedFolders(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = window.localStorage.getItem(PINNED_FOLDERS_STORAGE_KEY);
+    if (!value) return [];
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? uniquePaths(
+          parsed.filter((item): item is string => typeof item === "string"),
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writePinnedFolders(paths: string[]): string[] {
+  const next = uniquePaths(paths).slice(0, MAX_PINNED_FOLDERS);
+  if (typeof window === "undefined") return next;
+  try {
+    window.localStorage.setItem(
+      PINNED_FOLDERS_STORAGE_KEY,
+      JSON.stringify(next),
+    );
+    window.dispatchEvent(new Event(PINNED_FOLDERS_CHANGED_EVENT));
+  } catch {
+    // Best-effort persistence: a quota/private-mode failure must not throw
+    // (mirrors readPinnedFolders' guard and rememberPostgresConnection).
+  }
+  return next;
+}
+
+/** Add a folder to the front of the pinned list (deduped, capped). */
+export function pinFolder(path: string): string[] {
+  const trimmed = path.trim();
+  if (!trimmed) return readPinnedFolders();
+  return writePinnedFolders([
+    trimmed,
+    ...readPinnedFolders().filter((value) => value !== trimmed),
+  ]);
+}
+
+/** Remove a folder from the pinned list. */
+export function unpinFolder(path: string): string[] {
+  return writePinnedFolders(
+    readPinnedFolders().filter((value) => value !== path),
+  );
+}

--- a/apps/geolibre-desktop/src/lib/browser-folders.ts
+++ b/apps/geolibre-desktop/src/lib/browser-folders.ts
@@ -26,6 +26,28 @@ export function folderLabel(path: string): string {
   return segments[segments.length - 1] || trimmed || path;
 }
 
+/**
+ * The parent directory of an absolute path (the text before its last path
+ * separator), used to derive the Browser panel's "Project Home" from the open
+ * project file's path. Kept here (with folderLabel) so the path string-logic is
+ * pure and unit-tested.
+ *
+ * @param path - An absolute file path.
+ * @returns The containing directory (the filesystem root for a top-level file).
+ */
+export function parentDirectory(path: string): string {
+  const trimmed = path.replace(/[/\\]+$/, "");
+  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  if (index > 0) {
+    const parent = trimmed.slice(0, index);
+    // Restore the separator on a Windows drive root ("C:" -> "C:\"), matching
+    // the POSIX-root case below so the result stays an absolute path the Rust
+    // `is_safe_absolute_path` guard accepts.
+    return /^[a-zA-Z]:$/.test(parent) ? `${parent}\\` : parent;
+  }
+  return index === 0 ? "/" : trimmed;
+}
+
 export function readPinnedFolders(): string[] {
   if (typeof window === "undefined") return [];
   try {

--- a/apps/geolibre-desktop/src/lib/browser-folders.ts
+++ b/apps/geolibre-desktop/src/lib/browser-folders.ts
@@ -19,6 +19,20 @@ function uniquePaths(paths: string[]): string[] {
   return Array.from(new Set(paths));
 }
 
+/**
+ * Normalize a folder path for storage/dedupe: trim, then strip trailing path
+ * separators so `/data/gis` and `/data/gis/` are the same pin — but preserve a
+ * POSIX root (`/`) and a Windows drive root (`C:\`), since a bare `C:` is not a
+ * valid absolute path. (Case-insensitive Windows paths are left as-is; the
+ * native picker returns a consistent form.)
+ */
+export function normalizeFolderPath(path: string): string {
+  const stripped = path.trim().replace(/[/\\]+$/, "");
+  if (stripped === "") return "/";
+  if (/^[a-zA-Z]:$/.test(stripped)) return `${stripped}\\`;
+  return stripped;
+}
+
 /** The trailing path segment (folder name) of an absolute path, for the label. */
 export function folderLabel(path: string): string {
   const trimmed = path.replace(/[/\\]+$/, "");
@@ -58,19 +72,20 @@ function writePinnedFolders(paths: string[]): string[] {
   return next;
 }
 
-/** Add a folder to the front of the pinned list (deduped, capped). */
+/** Add a folder to the front of the pinned list (normalized, deduped, capped). */
 export function pinFolder(path: string): string[] {
-  const trimmed = path.trim();
-  if (!trimmed) return readPinnedFolders();
+  if (!path.trim()) return readPinnedFolders();
+  const normalized = normalizeFolderPath(path);
   return writePinnedFolders([
-    trimmed,
-    ...readPinnedFolders().filter((value) => value !== trimmed),
+    normalized,
+    ...readPinnedFolders().filter((value) => value !== normalized),
   ]);
 }
 
 /** Remove a folder from the pinned list. */
 export function unpinFolder(path: string): string[] {
+  const normalized = normalizeFolderPath(path);
   return writePinnedFolders(
-    readPinnedFolders().filter((value) => value !== path),
+    readPinnedFolders().filter((value) => value !== normalized),
   );
 }

--- a/apps/geolibre-desktop/src/lib/browser-folders.ts
+++ b/apps/geolibre-desktop/src/lib/browser-folders.ts
@@ -48,7 +48,14 @@ export function readPinnedFolders(): string[] {
     const parsed = JSON.parse(value);
     return Array.isArray(parsed)
       ? uniquePaths(
-          parsed.filter((item): item is string => typeof item === "string"),
+          parsed
+            .filter(
+              (item): item is string =>
+                typeof item === "string" && item.trim().length > 0,
+            )
+            // Normalize on read too, so a legacy entry stored un-normalized
+            // (e.g. a trailing separator) dedupes against a normalized pin.
+            .map(normalizeFolderPath),
         )
       : [];
   } catch {

--- a/apps/geolibre-desktop/src/lib/browser-folders.ts
+++ b/apps/geolibre-desktop/src/lib/browser-folders.ts
@@ -26,28 +26,6 @@ export function folderLabel(path: string): string {
   return segments[segments.length - 1] || trimmed || path;
 }
 
-/**
- * The parent directory of an absolute path (the text before its last path
- * separator), used to derive the Browser panel's "Project Home" from the open
- * project file's path. Kept here (with folderLabel) so the path string-logic is
- * pure and unit-tested.
- *
- * @param path - An absolute file path.
- * @returns The containing directory (the filesystem root for a top-level file).
- */
-export function parentDirectory(path: string): string {
-  const trimmed = path.replace(/[/\\]+$/, "");
-  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (index > 0) {
-    const parent = trimmed.slice(0, index);
-    // Restore the separator on a Windows drive root ("C:" -> "C:\"), matching
-    // the POSIX-root case below so the result stays an absolute path the Rust
-    // `is_safe_absolute_path` guard accepts.
-    return /^[a-zA-Z]:$/.test(parent) ? `${parent}\\` : parent;
-  }
-  return index === 0 ? "/" : trimmed;
-}
-
 export function readPinnedFolders(): string[] {
   if (typeof window === "undefined") return [];
   try {

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -29,6 +29,8 @@ export type BrowserNodeKind =
   | "connection" // a saved database connection; expands to its schemas/tables
   | "schema" // a database schema grouping under a connection
   | "table" // a database table leaf that opens the add flow for it
+  | "folder" // a filesystem directory; expands to its subfolders/loadable files
+  | "file" // a loadable file on disk that adds a layer when activated
   | "info"; // a non-interactive status row (loading / error)
 
 /** One node in the Browser tree. */
@@ -52,12 +54,18 @@ export interface BrowserNode {
    * ("postgres"). Absent means the node shows no ＋.
    */
   newConnectionKind?: AddDataKind;
+  /** True on the Files section, whose ＋ opens a folder picker (kind `section`). */
+  addFolderAction?: boolean;
   /** The saved database connection string a `connection`/`table` node belongs to. */
   connectionString?: string;
   /** The schema of a `table` node. */
   tableSchema?: string;
   /** The table name of a `table` node. */
   tableName?: string;
+  /** Absolute filesystem path of a `folder`/`file` node. */
+  path?: string;
+  /** True for a pinned root folder the user can unpin (kind `folder`). */
+  removable?: boolean;
   /** True for a built-in preset service (read-only), for badge display. */
   builtin?: boolean;
   /** The project path a recent node opens (kind `recent-project`). */
@@ -80,10 +88,26 @@ export interface BrowserTreeInput {
    */
   databaseConnections?: readonly { connectionString: string; label: string }[];
   /**
+   * Filesystem roots to list under the Files section: the current project's
+   * folder (Project Home) and the user's pinned folders. Omitted (undefined)
+   * hides the section — the app passes it only on desktop (`isTauri()`), where
+   * directory reading is available. An empty `folders` array still renders the
+   * section with its "Add folder" (＋) action.
+   */
+  files?: {
+    projectHome?: { path: string; label: string } | null;
+    folders: readonly { path: string; label: string }[];
+  };
+  /**
    * Translated labels for the top-level sections. Optional so the pure module
    * (and its tests) default to English; the app passes `t()` values.
    */
-  sectionLabels?: { services: string; recent: string; databases: string };
+  sectionLabels?: {
+    services: string;
+    recent: string;
+    databases: string;
+    files?: string;
+  };
 }
 
 /** Locale-aware, case-insensitive compare for stable label sorting. */
@@ -164,6 +188,7 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
     services: "Services",
     recent: "Recent",
     databases: "Databases",
+    files: "Files",
   };
   const kinds = buildServiceKinds(input.services);
   const servicesSection: BrowserNode = {
@@ -221,7 +246,98 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
     });
   }
 
+  // The Files section is included only on desktop (the app passes `files` when
+  // `isTauri()`). It always shows its "Add folder" (＋) action; Project Home
+  // (when a project file is open) comes first, then the user's pinned folders.
+  if (input.files) {
+    const folderChildren: BrowserNode[] = [];
+    if (input.files.projectHome) {
+      folderChildren.push({
+        id: `folder:${input.files.projectHome.path}`,
+        kind: "folder",
+        label: input.files.projectHome.label,
+        addable: false,
+        path: input.files.projectHome.path,
+        // Expandable group, lazily filled with subfolders/files on first expand.
+        children: [],
+      });
+    }
+    for (const folder of input.files.folders) {
+      folderChildren.push({
+        id: `folder:${folder.path}`,
+        kind: "folder",
+        label: folder.label,
+        addable: false,
+        path: folder.path,
+        // Pinned roots can be unpinned; subfolders (added on expand) cannot.
+        removable: true,
+        children: [],
+      });
+    }
+    sections.push({
+      id: "section:files",
+      kind: "section",
+      label: labels.files ?? "Files",
+      addable: false,
+      addFolderAction: true,
+      count: folderChildren.length,
+      children: folderChildren,
+    });
+  }
+
   return sections;
+}
+
+/** One entry of a directory listing (from the sidecar-free `list_directory`). */
+export interface DirectoryEntry {
+  name: string;
+  /** Absolute path of the entry. */
+  path: string;
+  isDirectory: boolean;
+}
+
+/**
+ * Turns a directory listing into `folder` → (lazily expandable) and `file`
+ * (addable) nodes: subdirectories first, then loadable files, each group sorted
+ * by name; hidden dotfiles are skipped. Pure so it unit-tests without the
+ * filesystem — the caller supplies the "is this file loadable" predicate (the
+ * app passes the tauri-io format check).
+ *
+ * @param entries - The directory's entries.
+ * @param isLoadable - Whether a file name is a loadable geospatial format.
+ * @returns Folder nodes (expandable) followed by loadable-file nodes.
+ */
+export function buildDirectoryNodes(
+  entries: readonly DirectoryEntry[],
+  isLoadable: (name: string) => boolean,
+): BrowserNode[] {
+  const visible = entries.filter((entry) => !entry.name.startsWith("."));
+  const folders = visible
+    .filter((entry) => entry.isDirectory)
+    .sort((a, b) => byLabel(a.name, b.name))
+    .map(
+      (entry): BrowserNode => ({
+        id: `folder:${entry.path}`,
+        kind: "folder",
+        label: entry.name,
+        addable: false,
+        path: entry.path,
+        children: [],
+      }),
+    );
+  const files = visible
+    .filter((entry) => !entry.isDirectory && isLoadable(entry.name))
+    .sort((a, b) => byLabel(a.name, b.name))
+    .map(
+      (entry): BrowserNode => ({
+        id: `file:${entry.path}`,
+        kind: "file",
+        label: entry.name,
+        addable: true,
+        path: entry.path,
+      }),
+    );
+  return [...folders, ...files];
 }
 
 /** A spatial table discovered under a database connection. */
@@ -333,6 +449,68 @@ export function augmentConnections(
     }
     return node;
   });
+}
+
+/** Async load state for one folder's directory listing. */
+export type FolderLoad =
+  | { status: "loading" }
+  | { status: "loaded"; entries: readonly DirectoryEntry[] }
+  | { status: "error"; message: string };
+
+/**
+ * Returns a copy of the tree with each `folder` node's children replaced by its
+ * lazy-load state: a status row while loading or on error, or the subfolder/file
+ * nodes once loaded. Unlike {@link augmentConnections}, folders nest, so a loaded
+ * folder's built children are themselves augmented — an expanded subfolder deep
+ * in the tree gets its own listing. Pure (the filesystem read happens elsewhere).
+ *
+ * @param nodes - The tree (typically already run through augmentConnections).
+ * @param loads - Per-folder listing state keyed by absolute path.
+ * @param loadingLabel - Translated label for the "loading" status row.
+ * @param isLoadable - Whether a file name is a loadable geospatial format.
+ * @returns A new tree; folder nodes get their status/subfolder/file children.
+ */
+export function augmentFolders(
+  nodes: readonly BrowserNode[],
+  loads: Record<string, FolderLoad>,
+  loadingLabel: string,
+  isLoadable: (name: string) => boolean,
+): BrowserNode[] {
+  const recurse = (list: readonly BrowserNode[]): BrowserNode[] =>
+    list.map((node) => {
+      if (node.kind === "folder" && node.path) {
+        const load = loads[node.path];
+        let children: BrowserNode[] = [];
+        if (load?.status === "loading") {
+          children = [
+            {
+              id: `${node.id}:loading`,
+              kind: "info",
+              label: loadingLabel,
+              addable: false,
+            },
+          ];
+        } else if (load?.status === "error") {
+          children = [
+            {
+              id: `${node.id}:error`,
+              kind: "info",
+              label: load.message,
+              addable: false,
+            },
+          ];
+        } else if (load?.status === "loaded") {
+          // Recurse so an already-expanded subfolder also gets its listing.
+          children = recurse(buildDirectoryNodes(load.entries, isLoadable));
+        }
+        return { ...node, children };
+      }
+      if (node.children) {
+        return { ...node, children: recurse(node.children) };
+      }
+      return node;
+    });
+  return recurse(nodes);
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -448,10 +448,14 @@ export type FolderLoad =
   | { status: "error"; message: string };
 
 /**
- * Cap on the number of direct children shown per folder. A pathological folder
- * (a drive root, `Downloads`, a build dir) could otherwise mount thousands of
- * unvirtualized rows and stall the panel; beyond the cap the folder shows a
- * "showing first N" status row instead. (Full virtualization is a follow-up.)
+ * Cap on the number of direct children *rendered* per folder. A pathological
+ * folder (a drive root, `Downloads`, a build dir) could otherwise mount
+ * thousands of unvirtualized rows and stall the panel; beyond the cap the folder
+ * shows a "showing first N" status row instead. Note this bounds only the render
+ * cost — `readDir` still reads (and IPC-returns) the whole directory, and
+ * `buildDirectoryNodes` still sorts it — so this prevents the DOM stall, not the
+ * underlying read cost. Full virtualization (and an earlier read-side cap) is a
+ * follow-up.
  */
 export const MAX_DIRECTORY_ENTRIES = 500;
 

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -274,7 +274,11 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
   return sections;
 }
 
-/** One entry of a directory listing (from the sidecar-free `list_directory`). */
+/**
+ * One entry of a directory listing. Structurally matches `LocalDirectoryEntry`
+ * in tauri-io.ts (which `listDirectory` returns); duplicated here so this pure
+ * model stays decoupled from tauri-io and unit-tests without the filesystem.
+ */
 export interface DirectoryEntry {
   name: string;
   /** Absolute path of the entry. */

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -263,6 +263,9 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
       });
     }
     for (const folder of input.files.folders) {
+      // Skip a pin that duplicates Project Home, or the two would share the id
+      // `folder:${path}` (and the panel's per-path load/expand state).
+      if (folder.path === input.files.projectHome?.path) continue;
       folderChildren.push({
         id: `folder:${folder.path}`,
         kind: "folder",

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -88,14 +88,12 @@ export interface BrowserTreeInput {
    */
   databaseConnections?: readonly { connectionString: string; label: string }[];
   /**
-   * Filesystem roots to list under the Files section: the current project's
-   * folder (Project Home) and the user's pinned folders. Omitted (undefined)
-   * hides the section — the app passes it only on desktop (`isTauri()`), where
-   * directory reading is available. An empty `folders` array still renders the
-   * section with its "Add folder" (＋) action.
+   * The user's pinned folders to list under the Files section. Omitted
+   * (undefined) hides the section — the app passes it only on desktop
+   * (`isTauri()`), where directory reading is available. An empty `folders`
+   * array still renders the section with its "Add folder" (＋) action.
    */
   files?: {
-    projectHome?: { path: string; label: string } | null;
     folders: readonly { path: string; label: string }[];
   };
   /**
@@ -247,44 +245,29 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
   }
 
   // The Files section is included only on desktop (the app passes `files` when
-  // `isTauri()`). It always shows its "Add folder" (＋) action; Project Home
-  // (when a project file is open) comes first, then the user's pinned folders.
+  // `isTauri()`). It always shows its "Add folder" (＋) action and lists the
+  // user's pinned folders, each lazily expanded to its subfolders/files.
   if (input.files) {
-    const folderChildren: BrowserNode[] = [];
-    if (input.files.projectHome) {
-      folderChildren.push({
-        id: `folder:${input.files.projectHome.path}`,
-        kind: "folder",
-        label: input.files.projectHome.label,
-        addable: false,
-        path: input.files.projectHome.path,
-        // Expandable group, lazily filled with subfolders/files on first expand.
-        children: [],
-      });
-    }
-    for (const folder of input.files.folders) {
-      // Skip a pin that duplicates Project Home, or the two would share the id
-      // `folder:${path}` (and the panel's per-path load/expand state).
-      if (folder.path === input.files.projectHome?.path) continue;
-      folderChildren.push({
-        id: `folder:${folder.path}`,
-        kind: "folder",
-        label: folder.label,
-        addable: false,
-        path: folder.path,
-        // Pinned roots can be unpinned; subfolders (added on expand) cannot.
-        removable: true,
-        children: [],
-      });
-    }
     sections.push({
       id: "section:files",
       kind: "section",
       label: labels.files ?? "Files",
       addable: false,
       addFolderAction: true,
-      count: folderChildren.length,
-      children: folderChildren,
+      count: input.files.folders.length,
+      children: input.files.folders.map(
+        (folder): BrowserNode => ({
+          id: `folder:${folder.path}`,
+          kind: "folder",
+          label: folder.label,
+          addable: false,
+          path: folder.path,
+          // Pinned roots can be unpinned; subfolders (added on expand) cannot.
+          removable: true,
+          // Expandable group, lazily filled with subfolders/files on expand.
+          children: [],
+        }),
+      ),
     });
   }
 

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -448,6 +448,14 @@ export type FolderLoad =
   | { status: "error"; message: string };
 
 /**
+ * Cap on the number of direct children shown per folder. A pathological folder
+ * (a drive root, `Downloads`, a build dir) could otherwise mount thousands of
+ * unvirtualized rows and stall the panel; beyond the cap the folder shows a
+ * "showing first N" status row instead. (Full virtualization is a follow-up.)
+ */
+export const MAX_DIRECTORY_ENTRIES = 500;
+
+/**
  * Returns a copy of the tree with each `folder` node's children replaced by its
  * lazy-load state: a status row while loading or on error, or the subfolder/file
  * nodes once loaded. Unlike {@link augmentConnections}, folders nest, so a loaded
@@ -458,6 +466,8 @@ export type FolderLoad =
  * @param loads - Per-folder listing state keyed by absolute path.
  * @param loadingLabel - Translated label for the "loading" status row.
  * @param isLoadable - Whether a file name is a loadable geospatial format.
+ * @param truncatedLabel - Optional label for the "showing first N of M" row a
+ *   folder gets when its direct children exceed {@link MAX_DIRECTORY_ENTRIES}.
  * @returns A new tree; folder nodes get their status/subfolder/file children.
  */
 export function augmentFolders(
@@ -465,6 +475,7 @@ export function augmentFolders(
   loads: Record<string, FolderLoad>,
   loadingLabel: string,
   isLoadable: (name: string) => boolean,
+  truncatedLabel?: (shown: number, total: number) => string,
 ): BrowserNode[] {
   const recurse = (list: readonly BrowserNode[]): BrowserNode[] =>
     list.map((node) => {
@@ -490,8 +501,24 @@ export function augmentFolders(
             },
           ];
         } else if (load?.status === "loaded") {
-          // Recurse so an already-expanded subfolder also gets its listing.
-          children = recurse(buildDirectoryNodes(load.entries, isLoadable));
+          const direct = buildDirectoryNodes(load.entries, isLoadable);
+          if (direct.length > MAX_DIRECTORY_ENTRIES) {
+            // Cap the direct children, then append a truncation status row so a
+            // huge folder can't stall the panel. Recurse before capping's info
+            // row so an expanded subfolder within the kept slice still loads.
+            children = recurse(direct.slice(0, MAX_DIRECTORY_ENTRIES));
+            children.push({
+              id: `${node.id}:truncated`,
+              kind: "info",
+              label: truncatedLabel
+                ? truncatedLabel(MAX_DIRECTORY_ENTRIES, direct.length)
+                : `Showing first ${MAX_DIRECTORY_ENTRIES} of ${direct.length}`,
+              addable: false,
+            });
+          } else {
+            // Recurse so an already-expanded subfolder also gets its listing.
+            children = recurse(direct);
+          }
         }
         return { ...node, children };
       }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -177,6 +177,58 @@ export function isRestorableVectorPath(path: string): boolean {
   return RESTORABLE_VECTOR_PATH.test(path);
 }
 
+/**
+ * Whether a file name is a geospatial format the Browser panel's Files tree can
+ * add with one click — vectors and GeoTIFF/COG rasters. Deliberately stricter
+ * than the lenient drop-path filter (which accepts anything explicitly dropped).
+ * MBTiles are excluded for now: vector MBTiles need source-layer selection, so
+ * they go through the Add Data dialog rather than a one-click tree add.
+ *
+ * @param name - The file name (or path) to test.
+ * @returns True when the extension is a one-click-loadable geospatial format.
+ */
+export function isLoadableFilePath(name: string): boolean {
+  return isRestorableVectorPath(name) || isRasterFileName(name);
+}
+
+/**
+ * The parent directory of an absolute path (the text before its last path
+ * separator), used to derive the Browser panel's "Project Home" from the open
+ * project file's path.
+ *
+ * @param path - An absolute file path.
+ * @returns The containing directory (or the filesystem root for a top-level file).
+ */
+export function parentDirectory(path: string): string {
+  const trimmed = path.replace(/[/\\]+$/, "");
+  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  if (index > 0) return trimmed.slice(0, index);
+  return index === 0 ? "/" : trimmed;
+}
+
+/** One entry of a local directory listing (see the Rust `list_directory`). */
+export interface LocalDirectoryEntry {
+  name: string;
+  /** Absolute path of the entry. */
+  path: string;
+  isDirectory: boolean;
+}
+
+/**
+ * List a local directory's immediate entries via the Tauri `list_directory`
+ * command (desktop only; resolves to `[]` off-desktop). Filtering to loadable
+ * file types is the caller's job.
+ *
+ * @param path - Absolute directory path to list.
+ * @returns The directory's entries (folders and files).
+ */
+export async function listDirectory(
+  path: string,
+): Promise<LocalDirectoryEntry[]> {
+  if (!isTauri()) return [];
+  return invoke<LocalDirectoryEntry[]>("list_directory", { path });
+}
+
 // Built at call time so the filter-group label shown in the native file dialog
 // is translated (a module-level constant would freeze the English string).
 function vectorFileDialogFilters(): FileDialogFilter[] {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -6,6 +6,7 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import {
+  readDir,
   readFile,
   readTextFile,
   readTextFileLines,
@@ -200,18 +201,29 @@ export interface LocalDirectoryEntry {
 }
 
 /**
- * List a local directory's immediate entries via the Tauri `list_directory`
- * command (desktop only; resolves to `[]` off-desktop). Filtering to loadable
+ * List a local directory's immediate entries via the `fs` plugin's `readDir`
+ * (desktop only; resolves to `[]` off-desktop). This works only within the fs
+ * scope the OS folder dialog grants for a picked directory (and its subtree),
+ * so the Browser panel only lists folders the user added via the picker — no
+ * new unbounded filesystem-read primitive. `readDir` returns names + type flags
+ * only, so the absolute path of each entry is joined here. Filtering to loadable
  * file types is the caller's job.
  *
- * @param path - Absolute directory path to list.
+ * @param path - Absolute directory path to list (a picker-granted folder or a
+ *   descendant of one).
  * @returns The directory's entries (folders and files).
  */
 export async function listDirectory(
   path: string,
 ): Promise<LocalDirectoryEntry[]> {
   if (!isTauri()) return [];
-  return invoke<LocalDirectoryEntry[]>("list_directory", { path });
+  const entries = await readDir(path);
+  const base = /[/\\]$/.test(path) ? path : `${path}/`;
+  return entries.map((entry) => ({
+    name: entry.name,
+    path: `${base}${entry.name}`,
+    isDirectory: entry.isDirectory,
+  }));
 }
 
 // Built at call time so the filter-group label shown in the native file dialog
@@ -2110,6 +2122,24 @@ export async function pickLocalPathWithFallback(
   // require a real path. Return null so callers surface the desktop-only
   // message rather than passing a non-resolvable bare file name.
   return null;
+}
+
+/**
+ * Open the native folder picker and return the chosen directory (desktop only;
+ * null off-desktop or on cancel). `recursive: true` extends the granted fs scope
+ * to the picked directory's subtree, so the Browser panel can lazily {@link
+ * listDirectory} subfolders within it — not just its top level.
+ *
+ * @returns The picked absolute directory path, or null.
+ */
+export async function pickLocalDirectory(): Promise<string | null> {
+  if (!isTauri()) return null;
+  const selected = await open({
+    directory: true,
+    multiple: false,
+    recursive: true,
+  });
+  return typeof selected === "string" ? selected : null;
 }
 
 export async function pickSavePathWithFallback(

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -202,7 +202,13 @@ export function isLoadableFilePath(name: string): boolean {
 export function parentDirectory(path: string): string {
   const trimmed = path.replace(/[/\\]+$/, "");
   const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (index > 0) return trimmed.slice(0, index);
+  if (index > 0) {
+    const parent = trimmed.slice(0, index);
+    // Restore the separator on a Windows drive root ("C:" -> "C:\"), matching
+    // the POSIX-root case below so the result stays an absolute path the Rust
+    // `is_safe_absolute_path` guard accepts.
+    return /^[a-zA-Z]:$/.test(parent) ? `${parent}\\` : parent;
+  }
   return index === 0 ? "/" : trimmed;
 }
 

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -192,7 +192,7 @@ export function isLoadableFilePath(name: string): boolean {
   return isRestorableVectorPath(name) || isRasterFileName(name);
 }
 
-/** One entry of a local directory listing (see the Rust `list_directory`). */
+/** One entry of a local directory listing (from {@link listDirectory}). */
 export interface LocalDirectoryEntry {
   name: string;
   /** Absolute path of the entry. */
@@ -218,7 +218,10 @@ export async function listDirectory(
 ): Promise<LocalDirectoryEntry[]> {
   if (!isTauri()) return [];
   const entries = await readDir(path);
-  const base = /[/\\]$/.test(path) ? path : `${path}/`;
+  // Join with the parent's own separator style so a Windows path stays
+  // all-backslash (readDir returns names only, no path).
+  const sep = path.includes("\\") ? "\\" : "/";
+  const base = /[/\\]$/.test(path) ? path : `${path}${sep}`;
   return entries.map((entry) => ({
     name: entry.name,
     path: `${base}${entry.name}`,

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -191,27 +191,6 @@ export function isLoadableFilePath(name: string): boolean {
   return isRestorableVectorPath(name) || isRasterFileName(name);
 }
 
-/**
- * The parent directory of an absolute path (the text before its last path
- * separator), used to derive the Browser panel's "Project Home" from the open
- * project file's path.
- *
- * @param path - An absolute file path.
- * @returns The containing directory (or the filesystem root for a top-level file).
- */
-export function parentDirectory(path: string): string {
-  const trimmed = path.replace(/[/\\]+$/, "");
-  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (index > 0) {
-    const parent = trimmed.slice(0, index);
-    // Restore the separator on a Windows drive root ("C:" -> "C:\"), matching
-    // the POSIX-root case below so the result stays an absolute path the Rust
-    // `is_safe_absolute_path` guard accepts.
-    return /^[a-zA-Z]:$/.test(parent) ? `${parent}\\` : parent;
-  }
-  return index === 0 ? "/" : trimmed;
-}
-
 /** One entry of a local directory listing (see the Rust `list_directory`). */
 export interface LocalDirectoryEntry {
   name: string;

--- a/tests/browser-folders.test.ts
+++ b/tests/browser-folders.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   folderLabel,
   MAX_PINNED_FOLDERS,
+  parentDirectory,
   pinFolder,
   PINNED_FOLDERS_CHANGED_EVENT,
   readPinnedFolders,
@@ -48,6 +49,21 @@ describe("folderLabel", () => {
     assert.equal(folderLabel("/home/u/gis"), "gis");
     assert.equal(folderLabel("/home/u/gis/"), "gis");
     assert.equal(folderLabel("C:\\data\\gis"), "gis");
+  });
+});
+
+describe("parentDirectory", () => {
+  it("returns the containing directory for a nested path", () => {
+    assert.equal(parentDirectory("/home/u/proj.geolibre.json"), "/home/u");
+    assert.equal(parentDirectory("C:\\Users\\me\\proj.json"), "C:\\Users\\me");
+  });
+
+  it("returns the root for a top-level POSIX file", () => {
+    assert.equal(parentDirectory("/project.json"), "/");
+  });
+
+  it("restores the separator on a Windows drive root", () => {
+    assert.equal(parentDirectory("C:\\project.json"), "C:\\");
   });
 });
 

--- a/tests/browser-folders.test.ts
+++ b/tests/browser-folders.test.ts
@@ -79,6 +79,18 @@ describe("pinned folders persistence", () => {
     assert.deepEqual(readPinnedFolders(), ["C:\\"]);
   });
 
+  it("normalizes legacy un-normalized stored entries on read", () => {
+    // Simulate an older build that stored a trailing-slash path.
+    (
+      globalThis as unknown as { window: { localStorage: MemoryStorage } }
+    ).window.localStorage.setItem(
+      "geolibre.browser.pinnedFolders",
+      JSON.stringify(["/data/gis/", "/data/gis"]),
+    );
+    // Both collapse to the normalized form and dedupe to one.
+    assert.deepEqual(readPinnedFolders(), ["/data/gis"]);
+  });
+
   it("unpins a folder", () => {
     pinFolder("/a");
     pinFolder("/b");

--- a/tests/browser-folders.test.ts
+++ b/tests/browser-folders.test.ts
@@ -65,6 +65,20 @@ describe("pinned folders persistence", () => {
     assert.deepEqual(readPinnedFolders(), ["/a", "/b"]);
   });
 
+  it("normalizes trailing separators so a folder isn't pinned twice", () => {
+    pinFolder("/data/gis");
+    pinFolder("/data/gis/"); // trailing slash — same folder
+    assert.deepEqual(readPinnedFolders(), ["/data/gis"]);
+    // Unpin with the trailing-slash form still removes it.
+    unpinFolder("/data/gis/");
+    assert.deepEqual(readPinnedFolders(), []);
+  });
+
+  it("preserves a Windows drive root when normalizing", () => {
+    pinFolder("C:\\");
+    assert.deepEqual(readPinnedFolders(), ["C:\\"]);
+  });
+
   it("unpins a folder", () => {
     pinFolder("/a");
     pinFolder("/b");

--- a/tests/browser-folders.test.ts
+++ b/tests/browser-folders.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  folderLabel,
+  MAX_PINNED_FOLDERS,
+  pinFolder,
+  PINNED_FOLDERS_CHANGED_EVENT,
+  readPinnedFolders,
+  unpinFolder,
+} from "../apps/geolibre-desktop/src/lib/browser-folders";
+
+// Minimal localStorage + window stub so the module's browser guards run under
+// node --test (mirrors how the app persists pinned folders in the browser).
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(k: string) {
+    return this.store.has(k) ? this.store.get(k)! : null;
+  }
+  setItem(k: string, v: string) {
+    this.store.set(k, v);
+  }
+  removeItem(k: string) {
+    this.store.delete(k);
+  }
+  clear() {
+    this.store.clear();
+  }
+}
+
+beforeEach(() => {
+  const events: unknown[] = [];
+  (globalThis as unknown as { window: unknown }).window = {
+    localStorage: new MemoryStorage(),
+    dispatchEvent: (e: unknown) => {
+      events.push(e);
+      return true;
+    },
+    __events: events,
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+});
+
+describe("folderLabel", () => {
+  it("returns the trailing folder name", () => {
+    assert.equal(folderLabel("/home/u/gis"), "gis");
+    assert.equal(folderLabel("/home/u/gis/"), "gis");
+    assert.equal(folderLabel("C:\\data\\gis"), "gis");
+  });
+});
+
+describe("pinned folders persistence", () => {
+  it("pins to the front, most-recently-added first", () => {
+    pinFolder("/a");
+    pinFolder("/b");
+    assert.deepEqual(readPinnedFolders(), ["/b", "/a"]);
+  });
+
+  it("dedupes and moves an existing pin to the front", () => {
+    pinFolder("/a");
+    pinFolder("/b");
+    pinFolder("/a");
+    assert.deepEqual(readPinnedFolders(), ["/a", "/b"]);
+  });
+
+  it("unpins a folder", () => {
+    pinFolder("/a");
+    pinFolder("/b");
+    unpinFolder("/a");
+    assert.deepEqual(readPinnedFolders(), ["/b"]);
+  });
+
+  it("caps the list at MAX_PINNED_FOLDERS", () => {
+    for (let i = 0; i < MAX_PINNED_FOLDERS + 5; i++) pinFolder(`/f${i}`);
+    assert.equal(readPinnedFolders().length, MAX_PINNED_FOLDERS);
+  });
+
+  it("dispatches a change event on write", () => {
+    pinFolder("/a");
+    const events = (
+      globalThis as unknown as { window: { __events: Event[] } }
+    ).window.__events;
+    assert.ok(events.some((e) => (e as Event).type === PINNED_FOLDERS_CHANGED_EVENT));
+  });
+
+  it("ignores blank paths", () => {
+    pinFolder("   ");
+    assert.deepEqual(readPinnedFolders(), []);
+  });
+});

--- a/tests/browser-folders.test.ts
+++ b/tests/browser-folders.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   folderLabel,
   MAX_PINNED_FOLDERS,
-  parentDirectory,
   pinFolder,
   PINNED_FOLDERS_CHANGED_EVENT,
   readPinnedFolders,
@@ -49,21 +48,6 @@ describe("folderLabel", () => {
     assert.equal(folderLabel("/home/u/gis"), "gis");
     assert.equal(folderLabel("/home/u/gis/"), "gis");
     assert.equal(folderLabel("C:\\data\\gis"), "gis");
-  });
-});
-
-describe("parentDirectory", () => {
-  it("returns the containing directory for a nested path", () => {
-    assert.equal(parentDirectory("/home/u/proj.geolibre.json"), "/home/u");
-    assert.equal(parentDirectory("C:\\Users\\me\\proj.json"), "C:\\Users\\me");
-  });
-
-  it("returns the root for a top-level POSIX file", () => {
-    assert.equal(parentDirectory("/project.json"), "/");
-  });
-
-  it("restores the separator on a Windows drive root", () => {
-    assert.equal(parentDirectory("C:\\project.json"), "C:\\");
   });
 });
 

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -8,6 +8,7 @@ import {
   buildDirectoryNodes,
   buildPostgisTableNodes,
   filterBrowserTree,
+  MAX_DIRECTORY_ENTRIES,
   type BrowserNode,
   type ConnectionLoad,
   type DirectoryEntry,
@@ -365,6 +366,30 @@ describe("augmentFolders", () => {
     assert.equal(folder?.children?.length, 1);
     assert.equal(folder?.children?.[0].kind, "info");
     assert.equal(folder?.children?.[0].label, "Permission denied");
+  });
+
+  it("caps a huge folder and appends a truncation row", () => {
+    const entries: DirectoryEntry[] = Array.from(
+      { length: MAX_DIRECTORY_ENTRIES + 3 },
+      (_unused, i) => ({
+        name: `f${String(i).padStart(5, "0")}.geojson`,
+        path: `/d/f${i}.geojson`,
+        isDirectory: false,
+      }),
+    );
+    const out = augmentFolders(
+      baseTree(),
+      { "/d": { status: "loaded", entries } },
+      "Loading…",
+      isLoadable,
+      (shown, total) => `first ${shown}/${total}`,
+    );
+    const children = find(out, "folder:/d")?.children ?? [];
+    // MAX kept file nodes + one truncation info row.
+    assert.equal(children.length, MAX_DIRECTORY_ENTRIES + 1);
+    const last = children[children.length - 1];
+    assert.equal(last.kind, "info");
+    assert.equal(last.label, `first ${MAX_DIRECTORY_ENTRIES}/${entries.length}`);
   });
 
   it("recurses so an already-expanded subfolder also gets its listing", () => {

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -3,11 +3,14 @@ import { describe, it } from "node:test";
 import type { RecentProjectEntry } from "@geolibre/core";
 import {
   augmentConnections,
+  augmentFolders,
   buildBrowserTree,
+  buildDirectoryNodes,
   buildPostgisTableNodes,
   filterBrowserTree,
   type BrowserNode,
   type ConnectionLoad,
+  type DirectoryEntry,
 } from "../apps/geolibre-desktop/src/lib/browser-tree";
 import type {
   ServiceLibraryEntry,
@@ -219,6 +222,159 @@ describe("buildPostgisTableNodes", () => {
 
   it("returns an empty array for no tables", () => {
     assert.deepEqual(buildPostgisTableNodes(CONN, []), []);
+  });
+});
+
+describe("buildBrowserTree — Files section", () => {
+  it("omits the Files section unless files input is provided", () => {
+    const tree = buildBrowserTree({ services: [], recentProjects: [] });
+    assert.equal(find(tree, "section:files"), undefined);
+  });
+
+  it("adds a Files section with an Add-folder action, Project Home, and pins", () => {
+    const tree = buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      files: {
+        projectHome: { path: "/home/u/proj", label: "proj" },
+        folders: [{ path: "/data/gis", label: "gis" }],
+      },
+    });
+    const files = find(tree, "section:files");
+    assert.equal(files?.kind, "section");
+    assert.equal(files?.addFolderAction, true);
+    assert.equal(files?.count, 2);
+    // Project Home first, then pinned folders.
+    assert.deepEqual(
+      files?.children?.map((c) => c.label),
+      ["proj", "gis"],
+    );
+    const home = find(tree, "folder:/home/u/proj");
+    assert.equal(home?.kind, "folder");
+    assert.equal(home?.path, "/home/u/proj");
+    assert.equal(home?.removable, undefined); // Project Home can't be unpinned
+    assert.deepEqual(home?.children, []); // expandable, lazily filled
+    // Pinned folder is removable.
+    assert.equal(find(tree, "folder:/data/gis")?.removable, true);
+  });
+
+  it("renders the Files section with only the Add-folder action when empty", () => {
+    const tree = buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      files: { projectHome: null, folders: [] },
+    });
+    const files = find(tree, "section:files");
+    assert.equal(files?.addFolderAction, true);
+    assert.equal(files?.children?.length, 0);
+  });
+});
+
+describe("buildDirectoryNodes", () => {
+  const entries: DirectoryEntry[] = [
+    { name: "roads.geojson", path: "/d/roads.geojson", isDirectory: false },
+    { name: "sub", path: "/d/sub", isDirectory: true },
+    { name: "notes.txt", path: "/d/notes.txt", isDirectory: false },
+    { name: "aaa", path: "/d/aaa", isDirectory: true },
+    { name: ".hidden", path: "/d/.hidden", isDirectory: true },
+  ];
+  const isLoadable = (name: string) => name.endsWith(".geojson");
+
+  it("lists folders first (sorted), then loadable files (sorted)", () => {
+    const nodes = buildDirectoryNodes(entries, isLoadable);
+    assert.deepEqual(
+      nodes.map((n) => `${n.kind}:${n.label}`),
+      ["folder:aaa", "folder:sub", "file:roads.geojson"],
+    );
+  });
+
+  it("drops non-loadable files and hidden dotfiles", () => {
+    const nodes = buildDirectoryNodes(entries, isLoadable);
+    assert.equal(
+      nodes.find((n) => n.label === "notes.txt"),
+      undefined,
+    );
+    assert.equal(
+      nodes.find((n) => n.label === ".hidden"),
+      undefined,
+    );
+  });
+
+  it("makes folders expandable groups and files addable leaves", () => {
+    const nodes = buildDirectoryNodes(entries, isLoadable);
+    const folder = nodes.find((n) => n.kind === "folder");
+    assert.deepEqual(folder?.children, []);
+    assert.equal(folder?.addable, false);
+    const file = nodes.find((n) => n.kind === "file");
+    assert.equal(file?.addable, true);
+    assert.equal(file?.path, "/d/roads.geojson");
+  });
+});
+
+describe("augmentFolders", () => {
+  const isLoadable = (name: string) => name.endsWith(".geojson");
+  const baseTree = () =>
+    buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      files: { projectHome: null, folders: [{ path: "/d", label: "d" }] },
+    });
+
+  it("injects a loading row while a folder is loading", () => {
+    const out = augmentFolders(
+      baseTree(),
+      { "/d": { status: "loading" } },
+      "Loading…",
+      isLoadable,
+    );
+    const folder = find(out, "folder:/d");
+    assert.equal(folder?.children?.length, 1);
+    assert.equal(folder?.children?.[0].kind, "info");
+    assert.equal(folder?.children?.[0].label, "Loading…");
+  });
+
+  it("injects subfolder/file nodes once loaded", () => {
+    const out = augmentFolders(
+      baseTree(),
+      {
+        "/d": {
+          status: "loaded",
+          entries: [
+            { name: "sub", path: "/d/sub", isDirectory: true },
+            { name: "a.geojson", path: "/d/a.geojson", isDirectory: false },
+          ],
+        },
+      },
+      "Loading…",
+      isLoadable,
+    );
+    assert.deepEqual(
+      find(out, "folder:/d")?.children?.map((c) => c.label),
+      ["sub", "a.geojson"],
+    );
+  });
+
+  it("recurses so an already-expanded subfolder also gets its listing", () => {
+    const out = augmentFolders(
+      baseTree(),
+      {
+        "/d": {
+          status: "loaded",
+          entries: [{ name: "sub", path: "/d/sub", isDirectory: true }],
+        },
+        "/d/sub": {
+          status: "loaded",
+          entries: [
+            { name: "b.geojson", path: "/d/sub/b.geojson", isDirectory: false },
+          ],
+        },
+      },
+      "Loading…",
+      isLoadable,
+    );
+    const sub = find(out, "folder:/d/sub");
+    assert.equal(sub?.children?.length, 1);
+    assert.equal(sub?.children?.[0].label, "b.geojson");
   });
 });
 

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -231,59 +231,38 @@ describe("buildBrowserTree — Files section", () => {
     assert.equal(find(tree, "section:files"), undefined);
   });
 
-  it("adds a Files section with an Add-folder action, Project Home, and pins", () => {
+  it("adds a Files section with an Add-folder action and removable pins", () => {
     const tree = buildBrowserTree({
       services: [],
       recentProjects: [],
       files: {
-        projectHome: { path: "/home/u/proj", label: "proj" },
-        folders: [{ path: "/data/gis", label: "gis" }],
+        folders: [
+          { path: "/data/gis", label: "gis" },
+          { path: "/home/u/maps", label: "maps" },
+        ],
       },
     });
     const files = find(tree, "section:files");
     assert.equal(files?.kind, "section");
     assert.equal(files?.addFolderAction, true);
     assert.equal(files?.count, 2);
-    // Project Home first, then pinned folders.
+    // Pinned folders are listed in the given (MRU) order.
     assert.deepEqual(
       files?.children?.map((c) => c.label),
-      ["proj", "gis"],
+      ["gis", "maps"],
     );
-    const home = find(tree, "folder:/home/u/proj");
-    assert.equal(home?.kind, "folder");
-    assert.equal(home?.path, "/home/u/proj");
-    assert.equal(home?.removable, undefined); // Project Home can't be unpinned
-    assert.deepEqual(home?.children, []); // expandable, lazily filled
-    // Pinned folder is removable.
-    assert.equal(find(tree, "folder:/data/gis")?.removable, true);
-  });
-
-  it("skips a pinned folder that duplicates Project Home", () => {
-    const tree = buildBrowserTree({
-      services: [],
-      recentProjects: [],
-      files: {
-        projectHome: { path: "/home/u/proj", label: "proj" },
-        folders: [
-          { path: "/home/u/proj", label: "proj" }, // same as Project Home
-          { path: "/data/gis", label: "gis" },
-        ],
-      },
-    });
-    const files = find(tree, "section:files");
-    // Only Project Home + the distinct pin — no duplicate folder:/home/u/proj.
-    assert.deepEqual(
-      files?.children?.map((c) => c.path),
-      ["/home/u/proj", "/data/gis"],
-    );
-    assert.equal(files?.count, 2);
+    const pin = find(tree, "folder:/data/gis");
+    assert.equal(pin?.kind, "folder");
+    assert.equal(pin?.path, "/data/gis");
+    assert.equal(pin?.removable, true); // pinned roots can be unpinned
+    assert.deepEqual(pin?.children, []); // expandable, lazily filled
   });
 
   it("renders the Files section with only the Add-folder action when empty", () => {
     const tree = buildBrowserTree({
       services: [],
       recentProjects: [],
-      files: { projectHome: null, folders: [] },
+      files: { folders: [] },
     });
     const files = find(tree, "section:files");
     assert.equal(files?.addFolderAction, true);
@@ -338,7 +317,7 @@ describe("augmentFolders", () => {
     buildBrowserTree({
       services: [],
       recentProjects: [],
-      files: { projectHome: null, folders: [{ path: "/d", label: "d" }] },
+      files: { folders: [{ path: "/d", label: "d" }] },
     });
 
   it("injects a loading row while a folder is loading", () => {

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -258,6 +258,27 @@ describe("buildBrowserTree — Files section", () => {
     assert.equal(find(tree, "folder:/data/gis")?.removable, true);
   });
 
+  it("skips a pinned folder that duplicates Project Home", () => {
+    const tree = buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      files: {
+        projectHome: { path: "/home/u/proj", label: "proj" },
+        folders: [
+          { path: "/home/u/proj", label: "proj" }, // same as Project Home
+          { path: "/data/gis", label: "gis" },
+        ],
+      },
+    });
+    const files = find(tree, "section:files");
+    // Only Project Home + the distinct pin — no duplicate folder:/home/u/proj.
+    assert.deepEqual(
+      files?.children?.map((c) => c.path),
+      ["/home/u/proj", "/data/gis"],
+    );
+    assert.equal(files?.count, 2);
+  });
+
   it("renders the Files section with only the Add-folder action when empty", () => {
     const tree = buildBrowserTree({
       services: [],

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -375,6 +375,19 @@ describe("augmentFolders", () => {
     );
   });
 
+  it("injects an error row when a folder fails to load", () => {
+    const out = augmentFolders(
+      baseTree(),
+      { "/d": { status: "error", message: "Permission denied" } },
+      "Loading…",
+      isLoadable,
+    );
+    const folder = find(out, "folder:/d");
+    assert.equal(folder?.children?.length, 1);
+    assert.equal(folder?.children?.[0].kind, "info");
+    assert.equal(folder?.children?.[0].label, "Permission denied");
+  });
+
   it("recurses so an already-expanded subfolder also gets its listing", () => {
     const out = augmentFolders(
       baseTree(),


### PR DESCRIPTION
Phase 3 of the QGIS-style Browser panel: a **filesystem tree** (desktop only), following #1200–#1204.

## What

A new **Files** section that lists the user's **pinned folders** — added via the section's **"Add folder" (＋)** native picker, each with a **×** to unpin. Folders are **lazily expanded**: expanding one lists its subfolders + loadable files (vectors and GeoTIFF/COG rasters), with loading/error status rows and a "showing first N" row for very large folders. **Clicking a file adds it as a layer**, reusing the shell's existing drag-and-drop loaders + store dispatch.

## Security / scope model

Directory listing uses the fs plugin's **`readDir`** (gated by `fs:allow-read-dir`), which only works within the fs scope the **OS folder dialog grants** — `addFolder` picks with `recursive: true` so the grant covers the picked folder's subtree. **No unbounded filesystem-read primitive** is introduced; only folders the user explicitly picks (and their descendants) are readable. (An earlier revision added a scope-bypassing Rust `list_directory` command — removed after review in favor of this bounded approach.)

**`tauri-plugin-persisted-scope`** is added so pins survive an app restart. Maintainer-approved trade-offs, documented in `lib.rs` and `BrowserPanel.removeFolder`:
- It persists **every** dialog-granted fs scope app-wide (Open Vector/Raster, Save As, …), permanently — not just Browser folders.
- Unpinning a folder removes the UI pin + cached state but does **not** revoke its (persisted) fs scope — "stop listing here", not "revoke access". No clean per-path forget exists; a narrower per-source scope / revoke path is a possible follow-up.

**Project Home was dropped**: reading the open project's folder would require listing a directory the user never picked, which this scope model doesn't allow.

## How

- **Pure model** (`browser-tree.ts`): `folder`/`file` node kinds; `buildDirectoryNodes` (folders-first, loadable-file whitelist, dotfile skip); `augmentFolders` (recursive lazy children, `MAX_DIRECTORY_ENTRIES` cap + truncation row); the Files section in `buildBrowserTree`.
- **Persistence** (`browser-folders.ts`): `pinFolder`/`unpinFolder`/`readPinnedFolders`, path-normalized (trailing-separator, drive-root-safe), capped + MRU-first, with a same-tab change event so `useBrowserTree` refreshes without reopening the panel.
- **Wiring**: `tauri-io` gains `listDirectory` (readDir-backed), `isLoadableFilePath`, `pickLocalDirectory`; `BrowserPanel` gets lazy folder expansion + file-add (with the large-dataset guard; a declined prompt is a cancel, not an error) + add/unpin folder; `DesktopShell` provides the vector/raster file→layer dispatcher.
- **Rust**: `is_allowed_local_vector_path` refactored to share the tested `is_safe_absolute_path` guard. No scope-bypassing command.

MBTiles are intentionally excluded from the one-click tree (vector MBTiles need source-layer selection → Add Data dialog).

## Verification

- **43** frontend tree/folder unit tests + **14** Rust lib tests (incl. `is_safe_absolute_path`). `tsc -b`, eslint, `pre-commit` (full `npm build`), `cargo check` (incl. the new plugin), `cargo fmt --check` all clean.
- **Web smoke** (Playwright): the panel renders Services/Recent/Databases and the Files section is correctly hidden off-desktop (`isTauri()`), no console errors.
- The filesystem interaction (folder picker, `readDir`, file-add) is desktop-only and can't run on the web dev server — needs manual desktop verification, like the Martin/PostGIS add.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a desktop **Files** section to the browser with pinned folders, folder picker, and local persistence.
  * Enabled lazy directory browsing with expandable subfolders, loading progress, truncation for large folders, and inline errors.
  * Added one-click loading from the tree for loadable raster/vector files (with large-dataset handling).
  * Folder-picker filesystem access is now persisted across app restarts.
* **Bug Fixes**
  * Refined local absolute-path safety validation to better block UNC paths and traversal while allowing valid drive paths.
* **Tests**
  * Expanded unit coverage for pinned-folder persistence/limits, directory node building, lazy folder augmentation, and absolute-path safety rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->