### PR TITLE
feat(browser): Favorites section (Phase 4)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -430,6 +430,12 @@ export function BrowserPanel({
   // Toggle a node's presence in the Favorites section; the favorites change
   // event refreshes the tree via useBrowserTree. The descriptor carries enough
   // to rebuild + activate the favorited node without the live original.
+  //
+  // The label/payload are snapshotted at favorite time and not refreshed while
+  // the original still exists — intentional, matching the "rebuild without the
+  // live original" design. There's no rename for services/connections today, so
+  // this is currently unreachable; a future rename feature should re-sync (or
+  // accept) the stored label.
   const toggleFavorite = (node: BrowserNode) => {
     if (favoriteIds.has(node.id)) {
       removeFavorite(node.id);

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -305,9 +305,16 @@ export function BrowserPanel({
       if (!entry) {
         // The saved-service list is read when the panel opens, so an entry can
         // vanish (removed via the Add Data dialog, or in another tab) between
-        // the tree being built and this click; surface it rather than silently
-        // doing nothing.
-        setError(t("browser.addFailed"));
+        // the tree being built and this click.
+        if (favoriteIds.has(node.id)) {
+          // A favorite can outlive its saved service (removed anywhere, with no
+          // change event to prune it). Self-heal: drop the dead favorite so it
+          // stops erroring on every click, and say why.
+          removeFavorite(node.id);
+          setError(t("browser.favoriteMissing"));
+        } else {
+          setError(t("browser.addFailed"));
+        }
         return;
       }
       beginBusy(node.id);
@@ -449,6 +456,7 @@ export function BrowserPanel({
       label: node.label,
       serviceId: node.serviceId,
       serviceKind: node.serviceKind,
+      builtin: node.builtin,
       connectionString: node.connectionString,
       path: node.path,
     });

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -457,7 +457,6 @@ export function BrowserPanel({
       serviceId: node.serviceId,
       serviceKind: node.serviceKind,
       builtin: node.builtin,
-      connectionString: node.connectionString,
       path: node.path,
     });
   };

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -13,6 +13,11 @@ import {
   pickLocalDirectory,
 } from "../../lib/tauri-io";
 import { pinFolder, unpinFolder } from "../../lib/browser-folders";
+import {
+  addFavorite,
+  isFavoritableKind,
+  removeFavorite,
+} from "../../lib/browser-favorites";
 import { useBrowserTree } from "../../hooks/useBrowserTree";
 import {
   augmentConnections,
@@ -50,6 +55,7 @@ interface BrowserPanelProps {
 
 /** The section nodes are expanded by default so their contents are visible. */
 const DEFAULT_EXPANDED = new Set([
+  "section:favorites",
   "section:services",
   "section:recent",
   "section:databases",
@@ -85,7 +91,7 @@ export function BrowserPanel({
 }: BrowserPanelProps) {
   const { t } = useTranslation();
   const addLayer = useAppStore((s) => s.addLayer);
-  const { tree, serviceById } = useBrowserTree();
+  const { tree, serviceById, favoriteIds } = useBrowserTree();
 
   const [query, setQuery] = useState("");
   const [expanded, setExpanded] = useState<Set<string>>(
@@ -421,6 +427,27 @@ export function BrowserPanel({
     unpinFolder(path);
   };
 
+  // Toggle a node's presence in the Favorites section; the favorites change
+  // event refreshes the tree via useBrowserTree. The descriptor carries enough
+  // to rebuild + activate the favorited node without the live original.
+  const toggleFavorite = (node: BrowserNode) => {
+    if (favoriteIds.has(node.id)) {
+      removeFavorite(node.id);
+      return;
+    }
+    const kind = node.kind;
+    if (!isFavoritableKind(kind)) return;
+    addFavorite({
+      id: node.id,
+      kind,
+      label: node.label,
+      serviceId: node.serviceId,
+      serviceKind: node.serviceKind,
+      connectionString: node.connectionString,
+      path: node.path,
+    });
+  };
+
   // A section counts as content if it has children *or* an always-on ＋ action
   // (Databases' "New connection" and Files' "Add folder" show even with zero
   // entries, so a first-run user isn't stuck on the empty-state message).
@@ -465,6 +492,8 @@ export function BrowserPanel({
                 onNewConnection={newConnection}
                 onAddFolder={addFolder}
                 onRemoveFolder={removeFolder}
+                favoriteIds={favoriteIds}
+                onToggleFavorite={toggleFavorite}
               />
             ))}
           </ul>

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -10,12 +10,14 @@ import {
   Globe2,
   Loader2,
   Plus,
+  Star,
   Table,
   X,
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AddDataKind } from "../layout/AddDataDialog";
+import { isFavoritableKind } from "../../lib/browser-favorites";
 import type { BrowserNode } from "../../lib/browser-tree";
 
 interface BrowserTreeNodeProps {
@@ -36,6 +38,10 @@ interface BrowserTreeNodeProps {
   onAddFolder: () => void;
   /** Unpin a pinned root folder (its ×), by path. */
   onRemoveFolder: (path: string) => void;
+  /** Ids of currently-favorited nodes, for the star fill state. */
+  favoriteIds: ReadonlySet<string>;
+  /** Toggle a favoritable node's favorite state (its ☆/★). */
+  onToggleFavorite: (node: BrowserNode) => void;
 }
 
 /** The leading icon for a node, chosen by kind (and expanded state for groups). */
@@ -71,6 +77,8 @@ export function BrowserTreeNode({
   onNewConnection,
   onAddFolder,
   onRemoveFolder,
+  favoriteIds,
+  onToggleFavorite,
 }: BrowserTreeNodeProps) {
   const { t } = useTranslation();
   // A status row (loading / error) is non-interactive text, not a tree control.
@@ -122,10 +130,14 @@ export function BrowserTreeNode({
       : null;
   // Pinned root folders show a × to unpin them from the Files section.
   const removePath = node.removable ? node.path : undefined;
+  // Favoritable nodes (services, connections, folders, files) show a star to
+  // pin/unpin them to the Favorites section.
+  const favoritable = isFavoritableKind(node.kind);
+  const favorited = favoritable && favoriteIds.has(node.id);
 
   return (
     <li>
-      <div className="flex items-center">
+      <div className="group flex items-center">
         <button
           type="button"
           disabled={isDisabled}
@@ -166,6 +178,34 @@ export function BrowserTreeNode({
             </span>
           ) : null}
         </button>
+        {favoritable ? (
+          <button
+            type="button"
+            className={cn(
+              "mr-1 shrink-0 rounded p-1 hover:bg-accent hover:text-accent-foreground",
+              favorited
+                ? "text-amber-500"
+                : // Unpinned: reveal on row hover / keyboard focus to reduce clutter.
+                  "text-muted-foreground opacity-0 focus:opacity-100 group-hover:opacity-100",
+            )}
+            title={
+              favorited
+                ? t("browser.unfavorite", { name: node.label })
+                : t("browser.favorite", { name: node.label })
+            }
+            aria-label={
+              favorited
+                ? t("browser.unfavorite", { name: node.label })
+                : t("browser.favorite", { name: node.label })
+            }
+            aria-pressed={favorited}
+            onClick={() => onToggleFavorite(node)}
+          >
+            <Star
+              className={cn("h-3.5 w-3.5", favorited && "fill-current")}
+            />
+          </button>
+        ) : null}
         {removePath ? (
           <button
             type="button"
@@ -204,6 +244,8 @@ export function BrowserTreeNode({
                 onNewConnection={onNewConnection}
                 onAddFolder={onAddFolder}
                 onRemoveFolder={onRemoveFolder}
+                favoriteIds={favoriteIds}
+                onToggleFavorite={onToggleFavorite}
               />
             ))}
           </ul>

--- a/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
+++ b/apps/geolibre-desktop/src/hooks/useBrowserTree.ts
@@ -16,6 +16,10 @@ import {
   PINNED_FOLDERS_CHANGED_EVENT,
   readPinnedFolders,
 } from "../lib/browser-folders";
+import {
+  FAVORITES_CHANGED_EVENT,
+  readBrowserFavorites,
+} from "../lib/browser-favorites";
 import { isTauri } from "../lib/tauri-io";
 import { buildBrowserTree, type BrowserNode } from "../lib/browser-tree";
 
@@ -24,6 +28,8 @@ export interface BrowserTreeState {
   tree: BrowserNode[];
   /** Looks a saved-service entry up by id, for the applier. */
   serviceById: (id: string) => ServiceLibraryEntry | undefined;
+  /** Ids of currently-favorited nodes, for the star fill state. */
+  favoriteIds: Set<string>;
 }
 
 /**
@@ -46,6 +52,7 @@ export function useBrowserTree(): BrowserTreeState {
   const recentLabel = t("browser.recent");
   const databasesLabel = t("browser.databases");
   const filesLabel = t("browser.files");
+  const favoritesLabel = t("browser.favorites");
 
   // Saved connections live in localStorage (no reactive store), so re-read them
   // when one is added/removed — otherwise a connection saved from the Add Data
@@ -53,17 +60,21 @@ export function useBrowserTree(): BrowserTreeState {
   // pinned folders are the same story (see the Files section below).
   const [connectionsRevision, setConnectionsRevision] = useState(0);
   const [foldersRevision, setFoldersRevision] = useState(0);
+  const [favoritesRevision, setFavoritesRevision] = useState(0);
   useEffect(() => {
     const bumpConnections = () => setConnectionsRevision((n) => n + 1);
     const bumpFolders = () => setFoldersRevision((n) => n + 1);
+    const bumpFavorites = () => setFavoritesRevision((n) => n + 1);
     window.addEventListener(POSTGRES_CONNECTIONS_CHANGED_EVENT, bumpConnections);
     window.addEventListener(PINNED_FOLDERS_CHANGED_EVENT, bumpFolders);
+    window.addEventListener(FAVORITES_CHANGED_EVENT, bumpFavorites);
     return () => {
       window.removeEventListener(
         POSTGRES_CONNECTIONS_CHANGED_EVENT,
         bumpConnections,
       );
       window.removeEventListener(PINNED_FOLDERS_CHANGED_EVENT, bumpFolders);
+      window.removeEventListener(FAVORITES_CHANGED_EVENT, bumpFavorites);
     };
   }, []);
 
@@ -92,20 +103,24 @@ export function useBrowserTree(): BrowserTreeState {
           })),
         }
       : undefined;
+    const favorites = readBrowserFavorites();
     return {
       tree: buildBrowserTree({
         services,
         recentProjects,
         databaseConnections,
         files,
+        favorites,
         sectionLabels: {
           services: servicesLabel,
           recent: recentLabel,
           databases: databasesLabel,
           files: filesLabel,
+          favorites: favoritesLabel,
         },
       }),
       serviceById: (id: string) => byId.get(id),
+      favoriteIds: new Set(favorites.map((fav) => fav.id)),
     };
   }, [
     recentProjects,
@@ -113,7 +128,9 @@ export function useBrowserTree(): BrowserTreeState {
     recentLabel,
     databasesLabel,
     filesLabel,
+    favoritesLabel,
     connectionsRevision,
     foldersRevision,
+    favoritesRevision,
   ]);
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -23,7 +23,8 @@
     "folderTruncated": "Showing first {{shown}} of {{total}}",
     "favorites": "Favorites",
     "favorite": "Add “{{name}}” to favorites",
-    "unfavorite": "Remove “{{name}}” from favorites"
+    "unfavorite": "Remove “{{name}}” from favorites",
+    "favoriteMissing": "That data source no longer exists — removed from Favorites."
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -20,7 +20,10 @@
     "loadFolderFailed": "Could not read this folder.",
     "unpinFolder": "Remove “{{name}}” from the list",
     "loadingFolder": "Loading…",
-    "folderTruncated": "Showing first {{shown}} of {{total}}"
+    "folderTruncated": "Showing first {{shown}} of {{total}}",
+    "favorites": "Favorites",
+    "favorite": "Add “{{name}}” to favorites",
+    "unfavorite": "Remove “{{name}}” from favorites"
   },
   "about": {
     "trigger": "About",

--- a/apps/geolibre-desktop/src/lib/browser-favorites.ts
+++ b/apps/geolibre-desktop/src/lib/browser-favorites.ts
@@ -1,0 +1,117 @@
+/**
+ * Persistence for the Browser panel's Favorites — nodes the user has pinned to a
+ * quick-access section at the top of the tree (services, database connections,
+ * folders, files). A localStorage-backed, most-recently-added-first list, global
+ * (not per-project), mirroring `browser-folders.ts`. UI-free so it unit-tests in
+ * isolation.
+ *
+ * A favorite stores enough to rebuild and activate its node without looking up
+ * the live original (which may have been deleted), keyed by the node's stable
+ * id so add/remove/lookup are by id.
+ */
+
+import type { ServiceLibraryKind } from "../components/layout/add-data/service-library";
+
+export const FAVORITES_STORAGE_KEY = "geolibre.browser.favorites";
+export const MAX_FAVORITES = 100;
+
+/** Fired on `window` after the favorites list is written (same-tab refresh). */
+export const FAVORITES_CHANGED_EVENT = "geolibre:favorites-changed";
+
+/** The kinds of node that can be favorited. */
+export type FavoriteKind = "service" | "connection" | "folder" | "file";
+
+/** A pinned Browser-tree node, with enough to rebuild + activate it. */
+export interface BrowserFavorite {
+  /** The favorited node's stable id (e.g. `service:x`, `connection:y`, `folder:/p`). */
+  id: string;
+  kind: FavoriteKind;
+  label: string;
+  /** Service identity (kind `service`). */
+  serviceId?: string;
+  serviceKind?: ServiceLibraryKind;
+  /** Connection string (kind `connection`). */
+  connectionString?: string;
+  /** Absolute path (kind `folder`/`file`). */
+  path?: string;
+}
+
+/** Whether a node kind can be favorited. */
+export function isFavoritableKind(kind: string): kind is FavoriteKind {
+  return (
+    kind === "service" ||
+    kind === "connection" ||
+    kind === "folder" ||
+    kind === "file"
+  );
+}
+
+function isValidFavorite(value: unknown): value is BrowserFavorite {
+  if (!value || typeof value !== "object") return false;
+  const fav = value as Record<string, unknown>;
+  return (
+    typeof fav.id === "string" &&
+    typeof fav.label === "string" &&
+    typeof fav.kind === "string" &&
+    isFavoritableKind(fav.kind)
+  );
+}
+
+/** Dedupe favorites by id, keeping the first occurrence (most-recent). */
+function uniqueById(favorites: BrowserFavorite[]): BrowserFavorite[] {
+  const seen = new Set<string>();
+  const out: BrowserFavorite[] = [];
+  for (const fav of favorites) {
+    if (seen.has(fav.id)) continue;
+    seen.add(fav.id);
+    out.push(fav);
+  }
+  return out;
+}
+
+export function readBrowserFavorites(): BrowserFavorite[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = window.localStorage.getItem(FAVORITES_STORAGE_KEY);
+    if (!value) return [];
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? uniqueById(parsed.filter(isValidFavorite))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeBrowserFavorites(favorites: BrowserFavorite[]): BrowserFavorite[] {
+  const next = uniqueById(favorites).slice(0, MAX_FAVORITES);
+  if (typeof window === "undefined") return next;
+  try {
+    window.localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(next));
+    window.dispatchEvent(new Event(FAVORITES_CHANGED_EVENT));
+  } catch {
+    // Best-effort persistence (mirrors readBrowserFavorites' guard).
+  }
+  return next;
+}
+
+/** Whether a node id is currently favorited. */
+export function isFavorite(id: string): boolean {
+  return readBrowserFavorites().some((fav) => fav.id === id);
+}
+
+/** Add a favorite to the front of the list (deduped by id, capped). */
+export function addFavorite(favorite: BrowserFavorite): BrowserFavorite[] {
+  if (!favorite.id) return readBrowserFavorites();
+  return writeBrowserFavorites([
+    favorite,
+    ...readBrowserFavorites().filter((fav) => fav.id !== favorite.id),
+  ]);
+}
+
+/** Remove a favorite by node id. */
+export function removeFavorite(id: string): BrowserFavorite[] {
+  return writeBrowserFavorites(
+    readBrowserFavorites().filter((fav) => fav.id !== id),
+  );
+}

--- a/apps/geolibre-desktop/src/lib/browser-favorites.ts
+++ b/apps/geolibre-desktop/src/lib/browser-favorites.ts
@@ -18,12 +18,19 @@ export const MAX_FAVORITES = 100;
 /** Fired on `window` after the favorites list is written (same-tab refresh). */
 export const FAVORITES_CHANGED_EVENT = "geolibre:favorites-changed";
 
-/** The kinds of node that can be favorited. */
-export type FavoriteKind = "service" | "connection" | "folder" | "file";
+/**
+ * The kinds of node that can be favorited. Database connections are excluded on
+ * purpose: a connection node's id embeds the raw (credential-bearing)
+ * connection string, so favoriting one would persist that credential in a
+ * second localStorage key with a larger, longer-lived cap than the saved-
+ * connections store — and connections already have their own Databases section,
+ * so favoriting them is redundant.
+ */
+export type FavoriteKind = "service" | "folder" | "file";
 
 /** A pinned Browser-tree node, with enough to rebuild + activate it. */
 export interface BrowserFavorite {
-  /** The favorited node's stable id (e.g. `service:x`, `connection:y`, `folder:/p`). */
+  /** The favorited node's stable id (e.g. `service:x`, `folder:/p`, `file:/p/a`). */
   id: string;
   kind: FavoriteKind;
   label: string;
@@ -32,20 +39,13 @@ export interface BrowserFavorite {
   serviceKind?: ServiceLibraryKind;
   /** Whether the favorited service is a built-in preset, for the badge. */
   builtin?: boolean;
-  /** Connection string (kind `connection`). */
-  connectionString?: string;
   /** Absolute path (kind `folder`/`file`). */
   path?: string;
 }
 
 /** Whether a node kind can be favorited. */
 export function isFavoritableKind(kind: string): kind is FavoriteKind {
-  return (
-    kind === "service" ||
-    kind === "connection" ||
-    kind === "folder" ||
-    kind === "file"
-  );
+  return kind === "service" || kind === "folder" || kind === "file";
 }
 
 function isValidFavorite(value: unknown): value is BrowserFavorite {
@@ -65,8 +65,6 @@ function isValidFavorite(value: unknown): value is BrowserFavorite {
   switch (fav.kind) {
     case "service":
       return typeof fav.serviceId === "string";
-    case "connection":
-      return typeof fav.connectionString === "string";
     case "folder":
     case "file":
       return typeof fav.path === "string";
@@ -111,11 +109,6 @@ function writeBrowserFavorites(favorites: BrowserFavorite[]): BrowserFavorite[] 
     // Best-effort persistence (mirrors readBrowserFavorites' guard).
   }
   return next;
-}
-
-/** Whether a node id is currently favorited. */
-export function isFavorite(id: string): boolean {
-  return readBrowserFavorites().some((fav) => fav.id === id);
 }
 
 /** Add a favorite to the front of the list (deduped by id, capped). */

--- a/apps/geolibre-desktop/src/lib/browser-favorites.ts
+++ b/apps/geolibre-desktop/src/lib/browser-favorites.ts
@@ -30,6 +30,8 @@ export interface BrowserFavorite {
   /** Service identity (kind `service`). */
   serviceId?: string;
   serviceKind?: ServiceLibraryKind;
+  /** Whether the favorited service is a built-in preset, for the badge. */
+  builtin?: boolean;
   /** Connection string (kind `connection`). */
   connectionString?: string;
   /** Absolute path (kind `folder`/`file`). */
@@ -49,12 +51,26 @@ export function isFavoritableKind(kind: string): kind is FavoriteKind {
 function isValidFavorite(value: unknown): value is BrowserFavorite {
   if (!value || typeof value !== "object") return false;
   const fav = value as Record<string, unknown>;
-  return (
-    typeof fav.id === "string" &&
-    typeof fav.label === "string" &&
-    typeof fav.kind === "string" &&
-    isFavoritableKind(fav.kind)
-  );
+  if (
+    typeof fav.id !== "string" ||
+    typeof fav.label !== "string" ||
+    typeof fav.kind !== "string" ||
+    !isFavoritableKind(fav.kind)
+  ) {
+    return false;
+  }
+  // Require the kind-specific field each rebuild path needs, so a corrupted
+  // entry (e.g. a folder with no path) is dropped rather than rendering as a
+  // permanently-empty, non-expanding node.
+  switch (fav.kind) {
+    case "service":
+      return typeof fav.serviceId === "string";
+    case "connection":
+      return typeof fav.connectionString === "string";
+    case "folder":
+    case "file":
+      return typeof fav.path === "string";
+  }
 }
 
 /** Dedupe favorites by id, keeping the first occurrence (most-recent). */
@@ -75,8 +91,10 @@ export function readBrowserFavorites(): BrowserFavorite[] {
     const value = window.localStorage.getItem(FAVORITES_STORAGE_KEY);
     if (!value) return [];
     const parsed = JSON.parse(value);
+    // Cap on read too (not just write), so a hand-edited/corrupted store can't
+    // feed an unbounded list into the tree.
     return Array.isArray(parsed)
-      ? uniqueById(parsed.filter(isValidFavorite))
+      ? uniqueById(parsed.filter(isValidFavorite)).slice(0, MAX_FAVORITES)
       : [];
   } catch {
     return [];

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -361,7 +361,6 @@ export interface FavoriteNodeInput {
   serviceId?: string;
   serviceKind?: ServiceLibraryKind;
   builtin?: boolean;
-  connectionString?: string;
   path?: string;
 }
 
@@ -390,15 +389,6 @@ export function buildFavoriteNodes(
           serviceKind: fav.serviceKind,
           // Keep the "built-in" badge on a favorited preset service.
           builtin: fav.builtin,
-        };
-      case "connection":
-        return {
-          id: fav.id,
-          kind: "connection",
-          label: fav.label,
-          addable: false,
-          connectionString: fav.connectionString,
-          children: [],
         };
       case "folder":
         return {

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -97,6 +97,12 @@ export interface BrowserTreeInput {
     folders: readonly { path: string; label: string }[];
   };
   /**
+   * The user's favorited nodes (services / connections / folders / files) to
+   * list in a quick-access Favorites section at the top. Omitted or empty hides
+   * the section. {@link FavoriteNodeInput} matches `BrowserFavorite`.
+   */
+  favorites?: readonly FavoriteNodeInput[];
+  /**
    * Translated labels for the top-level sections. Optional so the pure module
    * (and its tests) default to English; the app passes `t()` values.
    */
@@ -105,6 +111,7 @@ export interface BrowserTreeInput {
     recent: string;
     databases: string;
     files?: string;
+    favorites?: string;
   };
 }
 
@@ -187,6 +194,7 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
     recent: "Recent",
     databases: "Databases",
     files: "Files",
+    favorites: "Favorites",
   };
   const kinds = buildServiceKinds(input.services);
   const servicesSection: BrowserNode = {
@@ -216,7 +224,21 @@ export function buildBrowserTree(input: BrowserTreeInput): BrowserNode[] {
     children: recentChildren,
   };
 
-  const sections = [servicesSection, recentSection];
+  const sections: BrowserNode[] = [];
+
+  // Favorites lead the tree when the user has pinned anything, for quick access.
+  if (input.favorites && input.favorites.length > 0) {
+    sections.push({
+      id: "section:favorites",
+      kind: "section",
+      label: labels.favorites ?? "Favorites",
+      addable: false,
+      count: input.favorites.length,
+      children: buildFavoriteNodes(input.favorites),
+    });
+  }
+
+  sections.push(servicesSection, recentSection);
 
   // The Databases section is included whenever `databaseConnections` is
   // provided (the app always provides it). It always shows its "New connection"
@@ -328,6 +350,71 @@ export function buildDirectoryNodes(
       }),
     );
   return [...folders, ...files];
+}
+
+/** A favorited node descriptor (structural subset of `BrowserFavorite`). */
+export interface FavoriteNodeInput {
+  id: string;
+  kind: "service" | "connection" | "folder" | "file";
+  label: string;
+  serviceId?: string;
+  serviceKind?: ServiceLibraryKind;
+  connectionString?: string;
+  path?: string;
+}
+
+/**
+ * Rebuilds each favorite descriptor into the tree node it represents, so the
+ * Favorites section renders and activates its entries the same way as the
+ * originals — reusing the same node ids, so the panel's expand/introspect state
+ * (keyed by id / connection string / path) is shared with the original node.
+ * Pure so it unit-tests without the store or filesystem.
+ *
+ * @param favorites - The user's favorited node descriptors.
+ * @returns One node per favorite (service/connection/folder/file).
+ */
+export function buildFavoriteNodes(
+  favorites: readonly FavoriteNodeInput[],
+): BrowserNode[] {
+  return favorites.map((fav): BrowserNode => {
+    switch (fav.kind) {
+      case "service":
+        return {
+          id: fav.id,
+          kind: "service",
+          label: fav.label,
+          addable: true,
+          serviceId: fav.serviceId,
+          serviceKind: fav.serviceKind,
+        };
+      case "connection":
+        return {
+          id: fav.id,
+          kind: "connection",
+          label: fav.label,
+          addable: false,
+          connectionString: fav.connectionString,
+          children: [],
+        };
+      case "folder":
+        return {
+          id: fav.id,
+          kind: "folder",
+          label: fav.label,
+          addable: false,
+          path: fav.path,
+          children: [],
+        };
+      case "file":
+        return {
+          id: fav.id,
+          kind: "file",
+          label: fav.label,
+          addable: true,
+          path: fav.path,
+        };
+    }
+  });
 }
 
 /** A spatial table discovered under a database connection. */

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -18,6 +18,7 @@ import {
   type ServiceLibraryKind,
 } from "../components/layout/add-data/service-library";
 import type { AddDataKind } from "../components/layout/add-data/types";
+import type { FavoriteKind } from "./browser-favorites";
 import type { RecentProjectEntry } from "@geolibre/core";
 
 /** The kind of node, which determines its icon and click behavior. */
@@ -355,7 +356,7 @@ export function buildDirectoryNodes(
 /** A favorited node descriptor (structural subset of `BrowserFavorite`). */
 export interface FavoriteNodeInput {
   id: string;
-  kind: "service" | "connection" | "folder" | "file";
+  kind: FavoriteKind;
   label: string;
   serviceId?: string;
   serviceKind?: ServiceLibraryKind;

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -360,6 +360,7 @@ export interface FavoriteNodeInput {
   label: string;
   serviceId?: string;
   serviceKind?: ServiceLibraryKind;
+  builtin?: boolean;
   connectionString?: string;
   path?: string;
 }
@@ -387,6 +388,8 @@ export function buildFavoriteNodes(
           addable: true,
           serviceId: fav.serviceId,
           serviceKind: fav.serviceKind,
+          // Keep the "built-in" badge on a favorited preset service.
+          builtin: fav.builtin,
         };
       case "connection":
         return {

--- a/tests/browser-favorites.test.ts
+++ b/tests/browser-favorites.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  addFavorite,
+  FAVORITES_CHANGED_EVENT,
+  isFavorite,
+  isFavoritableKind,
+  MAX_FAVORITES,
+  readBrowserFavorites,
+  removeFavorite,
+  type BrowserFavorite,
+} from "../apps/geolibre-desktop/src/lib/browser-favorites";
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(k: string) {
+    return this.store.has(k) ? this.store.get(k)! : null;
+  }
+  setItem(k: string, v: string) {
+    this.store.set(k, v);
+  }
+  removeItem(k: string) {
+    this.store.delete(k);
+  }
+}
+
+beforeEach(() => {
+  const events: unknown[] = [];
+  (globalThis as unknown as { window: unknown }).window = {
+    localStorage: new MemoryStorage(),
+    dispatchEvent: (e: unknown) => {
+      events.push(e);
+      return true;
+    },
+    __events: events,
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+});
+
+const svc = (id: string): BrowserFavorite => ({
+  id: `service:${id}`,
+  kind: "service",
+  label: id,
+  serviceId: id,
+  serviceKind: "xyz",
+});
+
+describe("isFavoritableKind", () => {
+  it("accepts the favoritable kinds and rejects others", () => {
+    for (const k of ["service", "connection", "folder", "file"]) {
+      assert.equal(isFavoritableKind(k), true);
+    }
+    for (const k of ["section", "category", "recent-project", "table", "info"]) {
+      assert.equal(isFavoritableKind(k), false);
+    }
+  });
+});
+
+describe("favorites persistence", () => {
+  it("adds to the front, most-recent first", () => {
+    addFavorite(svc("a"));
+    addFavorite(svc("b"));
+    assert.deepEqual(
+      readBrowserFavorites().map((f) => f.id),
+      ["service:b", "service:a"],
+    );
+  });
+
+  it("dedupes by id, moving an existing favorite to the front", () => {
+    addFavorite(svc("a"));
+    addFavorite(svc("b"));
+    addFavorite(svc("a"));
+    assert.deepEqual(
+      readBrowserFavorites().map((f) => f.id),
+      ["service:a", "service:b"],
+    );
+  });
+
+  it("reports and removes by id", () => {
+    addFavorite(svc("a"));
+    assert.equal(isFavorite("service:a"), true);
+    removeFavorite("service:a");
+    assert.equal(isFavorite("service:a"), false);
+    assert.deepEqual(readBrowserFavorites(), []);
+  });
+
+  it("caps the list at MAX_FAVORITES", () => {
+    for (let i = 0; i < MAX_FAVORITES + 5; i++) addFavorite(svc(`s${i}`));
+    assert.equal(readBrowserFavorites().length, MAX_FAVORITES);
+  });
+
+  it("dispatches a change event on write", () => {
+    addFavorite(svc("a"));
+    const events = (
+      globalThis as unknown as { window: { __events: Event[] } }
+    ).window.__events;
+    assert.ok(events.some((e) => (e as Event).type === FAVORITES_CHANGED_EVENT));
+  });
+
+  it("drops malformed persisted entries", () => {
+    (
+      globalThis as unknown as { window: { localStorage: MemoryStorage } }
+    ).window.localStorage.setItem(
+      "geolibre.browser.favorites",
+      JSON.stringify([
+        { id: "service:a", kind: "service", label: "a" },
+        { id: "x", kind: "recent-project", label: "bad" }, // not favoritable
+        { kind: "service", label: "no id" }, // missing id
+        "nonsense",
+      ]),
+    );
+    assert.deepEqual(
+      readBrowserFavorites().map((f) => f.id),
+      ["service:a"],
+    );
+  });
+});

--- a/tests/browser-favorites.test.ts
+++ b/tests/browser-favorites.test.ts
@@ -100,21 +100,45 @@ describe("favorites persistence", () => {
     assert.ok(events.some((e) => (e as Event).type === FAVORITES_CHANGED_EVENT));
   });
 
-  it("drops malformed persisted entries", () => {
+  it("drops malformed and kind-incomplete persisted entries", () => {
     (
       globalThis as unknown as { window: { localStorage: MemoryStorage } }
     ).window.localStorage.setItem(
       "geolibre.browser.favorites",
       JSON.stringify([
-        { id: "service:a", kind: "service", label: "a" },
+        { id: "service:a", kind: "service", label: "a", serviceId: "a" },
         { id: "x", kind: "recent-project", label: "bad" }, // not favoritable
         { kind: "service", label: "no id" }, // missing id
+        { id: "service:b", kind: "service", label: "no serviceId" }, // missing serviceId
+        { id: "folder:/x", kind: "folder", label: "no path" }, // missing path
         "nonsense",
       ]),
     );
+    // Only the fully-formed service survives.
     assert.deepEqual(
       readBrowserFavorites().map((f) => f.id),
       ["service:a"],
     );
+  });
+
+  it("caps an oversized persisted list on read", () => {
+    const many = Array.from({ length: MAX_FAVORITES + 10 }, (_u, i) => ({
+      id: `service:s${i}`,
+      kind: "service",
+      label: `s${i}`,
+      serviceId: `s${i}`,
+    }));
+    (
+      globalThis as unknown as { window: { localStorage: MemoryStorage } }
+    ).window.localStorage.setItem(
+      "geolibre.browser.favorites",
+      JSON.stringify(many),
+    );
+    assert.equal(readBrowserFavorites().length, MAX_FAVORITES);
+  });
+
+  it("round-trips the builtin flag for a favorited preset service", () => {
+    addFavorite({ ...svc("osm"), builtin: true });
+    assert.equal(readBrowserFavorites()[0].builtin, true);
   });
 });

--- a/tests/browser-favorites.test.ts
+++ b/tests/browser-favorites.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import {
   addFavorite,
   FAVORITES_CHANGED_EVENT,
-  isFavorite,
   isFavoritableKind,
   MAX_FAVORITES,
   readBrowserFavorites,
@@ -50,10 +49,11 @@ const svc = (id: string): BrowserFavorite => ({
 
 describe("isFavoritableKind", () => {
   it("accepts the favoritable kinds and rejects others", () => {
-    for (const k of ["service", "connection", "folder", "file"]) {
+    for (const k of ["service", "folder", "file"]) {
       assert.equal(isFavoritableKind(k), true);
     }
-    for (const k of ["section", "category", "recent-project", "table", "info"]) {
+    // "connection" is deliberately not favoritable (credential in the node id).
+    for (const k of ["connection", "section", "category", "recent-project", "table", "info"]) {
       assert.equal(isFavoritableKind(k), false);
     }
   });
@@ -79,11 +79,10 @@ describe("favorites persistence", () => {
     );
   });
 
-  it("reports and removes by id", () => {
+  it("removes by id", () => {
     addFavorite(svc("a"));
-    assert.equal(isFavorite("service:a"), true);
+    assert.equal(readBrowserFavorites().length, 1);
     removeFavorite("service:a");
-    assert.equal(isFavorite("service:a"), false);
     assert.deepEqual(readBrowserFavorites(), []);
   });
 

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -6,6 +6,7 @@ import {
   augmentFolders,
   buildBrowserTree,
   buildDirectoryNodes,
+  buildFavoriteNodes,
   buildPostgisTableNodes,
   filterBrowserTree,
   MAX_DIRECTORY_ENTRIES,
@@ -223,6 +224,49 @@ describe("buildPostgisTableNodes", () => {
 
   it("returns an empty array for no tables", () => {
     assert.deepEqual(buildPostgisTableNodes(CONN, []), []);
+  });
+});
+
+describe("buildFavoriteNodes", () => {
+  it("rebuilds each favorite kind into its node", () => {
+    const nodes = buildFavoriteNodes([
+      { id: "service:s1", kind: "service", label: "Basemap", serviceId: "s1", serviceKind: "xyz" },
+      { id: "connection:c", kind: "connection", label: "db", connectionString: "c" },
+      { id: "folder:/d", kind: "folder", label: "d", path: "/d" },
+      { id: "file:/d/a.geojson", kind: "file", label: "a.geojson", path: "/d/a.geojson" },
+    ]);
+    assert.deepEqual(
+      nodes.map((n) => `${n.kind}:${n.addable}`),
+      ["service:true", "connection:false", "folder:false", "file:true"],
+    );
+    // Groups (connection/folder) are expandable with empty children; the ids
+    // match the originals so the panel's per-id/-path state is shared.
+    assert.deepEqual(nodes[1].children, []);
+    assert.deepEqual(nodes[2].children, []);
+    assert.equal(nodes[0].serviceId, "s1");
+    assert.equal(nodes[3].path, "/d/a.geojson");
+  });
+});
+
+describe("buildBrowserTree — Favorites section", () => {
+  it("omits the Favorites section when there are no favorites", () => {
+    const tree = buildBrowserTree({ services: [], recentProjects: [] });
+    assert.equal(find(tree, "section:favorites"), undefined);
+    assert.equal(tree[0].id, "section:services");
+  });
+
+  it("leads with a Favorites section when favorites exist", () => {
+    const tree = buildBrowserTree({
+      services: [],
+      recentProjects: [],
+      favorites: [
+        { id: "service:s1", kind: "service", label: "Basemap", serviceId: "s1" },
+      ],
+    });
+    // Favorites is the first section.
+    assert.equal(tree[0].id, "section:favorites");
+    assert.equal(tree[0].count, 1);
+    assert.equal(find(tree, "service:s1")?.label, "Basemap");
   });
 });
 

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -230,21 +230,20 @@ describe("buildPostgisTableNodes", () => {
 describe("buildFavoriteNodes", () => {
   it("rebuilds each favorite kind into its node", () => {
     const nodes = buildFavoriteNodes([
-      { id: "service:s1", kind: "service", label: "Basemap", serviceId: "s1", serviceKind: "xyz" },
-      { id: "connection:c", kind: "connection", label: "db", connectionString: "c" },
+      { id: "service:s1", kind: "service", label: "Basemap", serviceId: "s1", serviceKind: "xyz", builtin: true },
       { id: "folder:/d", kind: "folder", label: "d", path: "/d" },
       { id: "file:/d/a.geojson", kind: "file", label: "a.geojson", path: "/d/a.geojson" },
     ]);
     assert.deepEqual(
       nodes.map((n) => `${n.kind}:${n.addable}`),
-      ["service:true", "connection:false", "folder:false", "file:true"],
+      ["service:true", "folder:false", "file:true"],
     );
-    // Groups (connection/folder) are expandable with empty children; the ids
-    // match the originals so the panel's per-id/-path state is shared.
+    // A favorited folder is an expandable group with empty children; the id
+    // matches the original so the panel's per-path state is shared.
     assert.deepEqual(nodes[1].children, []);
-    assert.deepEqual(nodes[2].children, []);
     assert.equal(nodes[0].serviceId, "s1");
-    assert.equal(nodes[3].path, "/d/a.geojson");
+    assert.equal(nodes[0].builtin, true); // built-in badge preserved
+    assert.equal(nodes[2].path, "/d/a.geojson");
   });
 });
 


### PR DESCRIPTION
Phase 4 of the QGIS-style Browser panel: a **Favorites** section for quick access to frequently-used sources, following #1200–#1208.

## What

A **star (☆/★)** on favoritable rows — **services, database connections, folders, files** — pins/unpins that node. Favorited entries appear in a **Favorites** section that leads the tree. The star is filled + amber when favorited (shown on both the Favorites entry and the original row); unfilled and revealed on row hover/focus otherwise, to avoid clutter.

Because rebuilt favorite nodes **reuse the original node ids**, a favorited connection or folder shares the same lazy-introspect/expand state as its original — expanding either expands both, and activation (add service/file layer, open PostGIS dialog) works identically.

## How

- **Persistence** (`browser-favorites.ts`): `addFavorite`/`removeFavorite`/`readBrowserFavorites`/`isFavorite`, deduped by id, MRU-first, capped, validated on read, with a same-tab `favorites-changed` event so `useBrowserTree` refreshes without reopening the panel. A `BrowserFavorite` descriptor carries enough (id, kind, label, serviceId/connectionString/path) to rebuild + activate without the live original (which may have been deleted).
- **Pure model** (`browser-tree.ts`): `buildFavoriteNodes` (favorite descriptor → tree node per kind) + the Favorites section prepended in `buildBrowserTree` when non-empty; `isFavoritableKind` gates the star.
- **Wiring**: `BrowserTreeNode` renders the star (hover-revealed when unpinned); `BrowserPanel.toggleFavorite` builds the descriptor and add/removes; `useBrowserTree` feeds favorites + returns `favoriteIds` for the fill state.
- i18n: `browser.favorites` / `favorite` / `unfavorite`.

## Verification

- **54** unit tests (`browser-favorites.test.ts`: persistence, dedupe, cap, malformed-entry filtering, `isFavoritableKind`; `browser-tree.test.ts`: `buildFavoriteNodes` per kind + the Favorites section). `tsc -b`, eslint, `pre-commit` (full `npm build`) all clean.
- **Web smoke** (Playwright): starring OpenStreetMap creates a Favorites section with it (filled star in both Favorites and Services → XYZ); unstarring removes it and hides the now-empty section. Screenshot captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Favorites section to the browser panel when favorites are available.
  - Added a star control to toggle eligible items as favorites (with accessible labeling).
  - Favorites are saved locally (most-recently-added-first) and the browser tree refreshes automatically.
  - Added localized UI text for favorite/unfavorite actions.
- **Bug Fixes**
  - If a favorited data source is no longer present, the stale favorite is removed and a dedicated “favorite missing” message is shown.
- **Tests**
  - Extended coverage for favorites validation, deduping, ordering, storage limits, change events, and Favorites section rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->