### PR TITLE
feat(browser): keyboard navigation (Phase 5 · Polish)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -378,7 +378,12 @@ export function BrowserPanel({
         }
         break;
       case "ArrowLeft":
-        if (row.isGroup && row.isExpanded) {
+        // Collapse only a genuinely-expanded group. During a search,
+        // effectiveExpanded force-expands matching groups that aren't in the
+        // raw `expanded` set, and toggling those would just re-add them (no
+        // visible collapse) — so for a search-only-expanded group, fall through
+        // to moving to the parent instead of silently doing nothing.
+        if (row.isGroup && row.isExpanded && expanded.has(row.id)) {
           event.preventDefault();
           toggle(row.id); // collapse in place
           return;

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -360,8 +360,13 @@ export function BrowserPanel({
           toggle(row.id); // expand in place
           return;
         }
-        // An expanded group's first child is the next visible row.
-        if (row.isGroup && row.isExpanded) targetId = visibleRows[index + 1]?.id;
+        // Move to the group's first navigable child. Found by parentId rather
+        // than positional adjacency, since the group's only children may be
+        // non-navigable info rows (a connection/folder still loading or errored)
+        // or it may be an empty group — in which case Right Arrow is a no-op.
+        if (row.isGroup && row.isExpanded) {
+          targetId = visibleRows.find((candidate) => candidate.parentId === row.id)?.id;
+        }
         break;
       case "ArrowLeft":
         if (row.isGroup && row.isExpanded) {
@@ -594,6 +599,7 @@ export function BrowserPanel({
                 expanded={effectiveExpanded}
                 busyId={busyId}
                 activeRowId={currentRowId}
+                onRowFocus={setActiveRowId}
                 onToggle={toggle}
                 onActivate={activate}
                 onNewConnection={newConnection}

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -336,6 +336,15 @@ export function BrowserPanel({
   };
 
   const onTreeKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    // Only navigate when a treeitem row is focused. A row's secondary buttons
+    // (star/×/＋) are Tab-reachable; an Arrow key fired from one of those must
+    // not hijack nav and yank focus to another row.
+    if (
+      !(event.target instanceof HTMLElement) ||
+      !event.target.hasAttribute("data-browser-row")
+    ) {
+      return;
+    }
     if (!currentRowId) return;
     const index = visibleRows.findIndex((row) => row.id === currentRowId);
     if (index === -1) return;

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -3,7 +3,14 @@ import type { MapController } from "@geolibre/map";
 import { fetchPostgisStatus, listPostgisTables } from "@geolibre/processing";
 import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
-import { useCallback, useMemo, useRef, useState, type RefObject } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
 import {
@@ -23,6 +30,7 @@ import {
   augmentConnections,
   augmentFolders,
   filterBrowserTree,
+  flattenVisibleTree,
   type BrowserNode,
   type ConnectionLoad,
   type FolderLoad,
@@ -294,6 +302,84 @@ export function BrowserPanel({
     });
   };
 
+  // Keyboard navigation (WAI-ARIA tree pattern). The visible rows, flattened
+  // top-to-bottom, are what Arrow Up/Down step through; Right/Left expand/
+  // collapse or move to child/parent. Roving tabindex: only `activeRowId` is
+  // tab-reachable, so the whole tree is one Tab stop and arrows move within it.
+  const treeRef = useRef<HTMLUListElement>(null);
+  const visibleRows = useMemo(
+    // "info" rows (loading/error status) are non-interactive text, not tree
+    // items, so they're excluded from keyboard navigation.
+    () =>
+      flattenVisibleTree(filtered, effectiveExpanded).filter(
+        (row) => row.kind !== "info",
+      ),
+    [filtered, effectiveExpanded],
+  );
+  const [activeRowId, setActiveRowId] = useState<string | null>(null);
+  // Fall back to the first row when nothing is active yet, or the active row
+  // scrolled out of existence (filtered away / its parent collapsed).
+  const currentRowId =
+    activeRowId && visibleRows.some((row) => row.id === activeRowId)
+      ? activeRowId
+      : (visibleRows[0]?.id ?? null);
+
+  const focusRow = (id: string) => {
+    setActiveRowId(id);
+    // The button already exists (only its tabIndex flips), so focus it now
+    // rather than waiting for the roving-tabindex re-render. Escape only `"`/`\`
+    // for the quoted attribute value — CSS.escape is for identifiers and would
+    // wrongly escape the `:`/`/` that ids like `section:services` contain.
+    const escaped = id.replace(/["\\]/g, "\\$&");
+    const selector = `[data-browser-row="${escaped}"]`;
+    treeRef.current?.querySelector<HTMLElement>(selector)?.focus();
+  };
+
+  const onTreeKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    if (!currentRowId) return;
+    const index = visibleRows.findIndex((row) => row.id === currentRowId);
+    if (index === -1) return;
+    const row = visibleRows[index];
+    let targetId: string | null | undefined;
+    switch (event.key) {
+      case "ArrowDown":
+        targetId = visibleRows[index + 1]?.id;
+        break;
+      case "ArrowUp":
+        targetId = visibleRows[index - 1]?.id;
+        break;
+      case "Home":
+        targetId = visibleRows[0]?.id;
+        break;
+      case "End":
+        targetId = visibleRows[visibleRows.length - 1]?.id;
+        break;
+      case "ArrowRight":
+        if (row.isGroup && !row.isExpanded) {
+          event.preventDefault();
+          toggle(row.id); // expand in place
+          return;
+        }
+        // An expanded group's first child is the next visible row.
+        if (row.isGroup && row.isExpanded) targetId = visibleRows[index + 1]?.id;
+        break;
+      case "ArrowLeft":
+        if (row.isGroup && row.isExpanded) {
+          event.preventDefault();
+          toggle(row.id); // collapse in place
+          return;
+        }
+        targetId = row.parentId; // move to parent
+        break;
+      default:
+        return; // let Enter/Space reach the focused button's onClick natively
+    }
+    if (targetId) {
+      event.preventDefault();
+      focusRow(targetId);
+    }
+  };
+
   const activate = async (node: BrowserNode) => {
     // Ignore a second activation while one is still resolving (a fast
     // double-click, or clicking another entry mid-fetch), so an async add
@@ -492,7 +578,14 @@ export function BrowserPanel({
 
       <ScrollArea className="min-h-0 flex-1">
         {hasContent ? (
-          <ul className="py-1" aria-busy={busyId != null}>
+          <ul
+            ref={treeRef}
+            className="py-1"
+            role="tree"
+            aria-label={t("browser.title")}
+            aria-busy={busyId != null}
+            onKeyDown={onTreeKeyDown}
+          >
             {filtered.map((section) => (
               <BrowserTreeNode
                 key={section.id}
@@ -500,6 +593,7 @@ export function BrowserPanel({
                 depth={0}
                 expanded={effectiveExpanded}
                 busyId={busyId}
+                activeRowId={currentRowId}
                 onToggle={toggle}
                 onActivate={activate}
                 onNewConnection={newConnection}

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -166,7 +166,14 @@ export function BrowserTreeNode({
           tabIndex={node.id === activeRowId ? 0 : -1}
           data-browser-row={node.id}
           onFocus={() => onRowFocus(node.id)}
-          onClick={() => (isGroup ? onToggle(node.id) : onActivate(node))}
+          onClick={() => {
+            // Also sync from onClick: some browsers (WebKit) don't focus a
+            // button on mouse click, so onFocus alone would leave the roving
+            // active row stale after a click.
+            onRowFocus(node.id);
+            if (isGroup) onToggle(node.id);
+            else onActivate(node);
+          }}
         >
           {isGroup ? (
             isExpanded ? (
@@ -215,6 +222,7 @@ export function BrowserTreeNode({
                 : t("browser.favorite", { name: node.label })
             }
             aria-pressed={favorited}
+            tabIndex={node.id === activeRowId ? 0 : -1}
             onClick={() => onToggleFavorite(node)}
           >
             <Star
@@ -228,6 +236,7 @@ export function BrowserTreeNode({
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
             title={t("browser.unpinFolder", { name: node.label })}
             aria-label={t("browser.unpinFolder", { name: node.label })}
+            tabIndex={node.id === activeRowId ? 0 : -1}
             onClick={() => onRemoveFolder(removePath)}
           >
             <X className="h-3.5 w-3.5" />
@@ -239,6 +248,7 @@ export function BrowserTreeNode({
             className="mr-1 shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
             title={plusAction.label}
             aria-label={plusAction.label}
+            tabIndex={node.id === activeRowId ? 0 : -1}
             onClick={plusAction.run}
           >
             <Plus className="h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -30,6 +30,8 @@ interface BrowserTreeNodeProps {
   busyId: string | null;
   /** Id of the row that is the tree's single tab stop (roving tabindex). */
   activeRowId: string | null;
+  /** Sync the active row when a row receives focus (mouse click or Tab). */
+  onRowFocus: (id: string) => void;
   /** Toggle a group node's expanded state. */
   onToggle: (id: string) => void;
   /** Activate a leaf (add a service/file layer, or open a recent project). */
@@ -75,6 +77,7 @@ export function BrowserTreeNode({
   expanded,
   busyId,
   activeRowId,
+  onRowFocus,
   onToggle,
   onActivate,
   onNewConnection,
@@ -159,6 +162,7 @@ export function BrowserTreeNode({
           // Arrow-key handler moves the active row and focuses it.
           tabIndex={node.id === activeRowId ? 0 : -1}
           data-browser-row={node.id}
+          onFocus={() => onRowFocus(node.id)}
           onClick={() => (isGroup ? onToggle(node.id) : onActivate(node))}
         >
           {isGroup ? (
@@ -249,6 +253,7 @@ export function BrowserTreeNode({
                 expanded={expanded}
                 busyId={busyId}
                 activeRowId={activeRowId}
+                onRowFocus={onRowFocus}
                 onToggle={onToggle}
                 onActivate={onActivate}
                 onNewConnection={onNewConnection}

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -28,6 +28,8 @@ interface BrowserTreeNodeProps {
   expanded: ReadonlySet<string>;
   /** Id of the leaf whose activation is in flight, or null when idle. */
   busyId: string | null;
+  /** Id of the row that is the tree's single tab stop (roving tabindex). */
+  activeRowId: string | null;
   /** Toggle a group node's expanded state. */
   onToggle: (id: string) => void;
   /** Activate a leaf (add a service/file layer, or open a recent project). */
@@ -72,6 +74,7 @@ export function BrowserTreeNode({
   depth,
   expanded,
   busyId,
+  activeRowId,
   onToggle,
   onActivate,
   onNewConnection,
@@ -148,8 +151,14 @@ export function BrowserTreeNode({
             node.kind === "section" && "font-semibold",
           )}
           style={{ paddingLeft }}
+          role="treeitem"
+          aria-level={depth + 1}
           aria-expanded={isGroup ? isExpanded : undefined}
           aria-busy={isBusy || undefined}
+          // Roving tabindex: only the active row is a tab stop; the panel's
+          // Arrow-key handler moves the active row and focuses it.
+          tabIndex={node.id === activeRowId ? 0 : -1}
+          data-browser-row={node.id}
           onClick={() => (isGroup ? onToggle(node.id) : onActivate(node))}
         >
           {isGroup ? (
@@ -231,7 +240,7 @@ export function BrowserTreeNode({
       </div>
       {isGroup && isExpanded ? (
         node.children && node.children.length > 0 ? (
-          <ul>
+          <ul role="group">
             {node.children.map((child) => (
               <BrowserTreeNode
                 key={child.id}
@@ -239,6 +248,7 @@ export function BrowserTreeNode({
                 depth={depth + 1}
                 expanded={expanded}
                 busyId={busyId}
+                activeRowId={activeRowId}
                 onToggle={onToggle}
                 onActivate={onActivate}
                 onNewConnection={onNewConnection}

--- a/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserTreeNode.tsx
@@ -90,7 +90,8 @@ export function BrowserTreeNode({
   // A status row (loading / error) is non-interactive text, not a tree control.
   if (node.kind === "info") {
     return (
-      <li>
+      // role="none" so the status row isn't an extra listitem in the tree.
+      <li role="none">
         <p
           className="truncate py-1 text-xs text-muted-foreground"
           style={{ paddingLeft: 8 + depth * 14 }}
@@ -142,7 +143,9 @@ export function BrowserTreeNode({
   const favorited = favoritable && favoriteIds.has(node.id);
 
   return (
-    <li>
+    // role="none": the treeitem role lives on the inner button, so the <li>
+    // must not add a listitem role to the tree/group.
+    <li role="none">
       <div className="group flex items-center">
         <button
           type="button"

--- a/apps/geolibre-desktop/src/lib/browser-tree.ts
+++ b/apps/geolibre-desktop/src/lib/browser-tree.ts
@@ -615,6 +615,54 @@ export function augmentFolders(
   return recurse(nodes);
 }
 
+/** One visible row of the tree, flattened in render (top-to-bottom) order. */
+export interface VisibleRow {
+  id: string;
+  kind: BrowserNodeKind;
+  /** Nesting depth (0 for top-level sections). */
+  depth: number;
+  /** True when the node is a group (has a `children` array). */
+  isGroup: boolean;
+  /** True when the group is currently expanded. */
+  isExpanded: boolean;
+  /** The parent group's id, or null for a top-level row. */
+  parentId: string | null;
+}
+
+/**
+ * Flattens the tree into the rows currently visible on screen, in top-to-bottom
+ * order — i.e. descending into a group only when it is expanded. This is the
+ * model the panel's keyboard navigation moves through (Arrow Up/Down step
+ * between adjacent visible rows; Left/Right and parent/child use `parentId` /
+ * `isGroup` / `isExpanded`). Pure so it unit-tests without the DOM.
+ *
+ * @param nodes - The (already filtered) tree to flatten.
+ * @param expanded - Ids of the currently expanded groups.
+ * @returns The visible rows, in order.
+ */
+export function flattenVisibleTree(
+  nodes: readonly BrowserNode[],
+  expanded: ReadonlySet<string>,
+): VisibleRow[] {
+  const rows: VisibleRow[] = [];
+  const walk = (
+    list: readonly BrowserNode[],
+    depth: number,
+    parentId: string | null,
+  ): void => {
+    for (const node of list) {
+      const isGroup = Boolean(node.children);
+      const isExpanded = isGroup && expanded.has(node.id);
+      rows.push({ id: node.id, kind: node.kind, depth, isGroup, isExpanded, parentId });
+      if (isGroup && isExpanded && node.children) {
+        walk(node.children, depth + 1, node.id);
+      }
+    }
+  };
+  walk(nodes, 0, null);
+  return rows;
+}
+
 /**
  * Filters the tree to nodes whose label (or a descendant's label) matches the
  * query, case-insensitively. Returns the tree unchanged for an empty query.

--- a/tests/browser-tree.test.ts
+++ b/tests/browser-tree.test.ts
@@ -9,6 +9,7 @@ import {
   buildFavoriteNodes,
   buildPostgisTableNodes,
   filterBrowserTree,
+  flattenVisibleTree,
   MAX_DIRECTORY_ENTRIES,
   type BrowserNode,
   type ConnectionLoad,
@@ -513,6 +514,51 @@ describe("augmentConnections", () => {
     const tree = baseTree();
     augmentConnections(tree, { [CONN]: { status: "loading" } }, "Loading…");
     assert.deepEqual(find(tree, `connection:${CONN}`)?.children, []);
+  });
+});
+
+describe("flattenVisibleTree", () => {
+  const tree = buildBrowserTree({
+    services: [service("s1", "OSM", "xyz"), service("s2", "States", "wms")],
+    recentProjects: RECENT,
+  });
+
+  it("descends only into expanded groups, in top-to-bottom order", () => {
+    // Expand Services and the XYZ kind group, but not Recent or WMS.
+    const expanded = new Set(["section:services", "kind:xyz"]);
+    const rows = flattenVisibleTree(tree, expanded);
+    assert.deepEqual(
+      rows.map((r) => r.id),
+      [
+        "section:services",
+        "kind:xyz",
+        "service:s1", // XYZ expanded → its service shows
+        "kind:wms", // WMS collapsed → its service hidden
+        "section:recent", // Recent collapsed → its projects hidden
+      ],
+    );
+  });
+
+  it("reports depth, group/expanded state, kind, and parentId", () => {
+    const rows = flattenVisibleTree(tree, new Set(["section:services"]));
+    const services = rows.find((r) => r.id === "section:services")!;
+    assert.equal(services.depth, 0);
+    assert.equal(services.kind, "section");
+    assert.equal(services.isGroup, true);
+    assert.equal(services.isExpanded, true);
+    assert.equal(services.parentId, null);
+    const xyz = rows.find((r) => r.id === "kind:xyz")!;
+    assert.equal(xyz.depth, 1);
+    assert.equal(xyz.isExpanded, false); // group, but not in the expanded set
+    assert.equal(xyz.parentId, "section:services");
+  });
+
+  it("returns only the top-level sections when nothing is expanded", () => {
+    const rows = flattenVisibleTree(tree, new Set());
+    assert.deepEqual(
+      rows.map((r) => r.id),
+      ["section:services", "section:recent"],
+    );
   });
 });
 


### PR DESCRIPTION
First slice of Phase 5 (Polish) for the Browser panel: **keyboard navigation** of the tree (WAI-ARIA tree pattern), following #1200–#1209.

## What

The Browser tree is now fully keyboard-navigable and is a single Tab stop (roving tabindex):

- **↑ / ↓** — move the active row between adjacent visible rows
- **→** — expand a collapsed group, or move into the first child of an expanded group
- **←** — collapse an expanded group, or move to the parent
- **Home / End** — jump to the first / last visible row
- **Enter / Space** — activate the focused row (add a service/file layer, open a recent project, add a table) via its native button click

ARIA: the container is `role="tree"`, rows are `role="treeitem"` with `aria-level` (+ `aria-expanded` on groups), and child lists are `role="group"`. Non-interactive loading/error status rows are excluded from navigation.

## How

- New pure, unit-tested `flattenVisibleTree(nodes, expanded)` → the top-to-bottom visible-row model (id, kind, depth, isGroup, isExpanded, parentId) that the Arrow handler walks; it descends only into expanded groups.
- `BrowserPanel` owns the roving `activeRowId` + a `keydown` handler on the `role="tree"` container, and focuses the target row imperatively (the button exists; only its tabindex flips).
- `BrowserTreeNode` adds the treeitem roles + `tabIndex={id === activeRowId ? 0 : -1}` + a `data-browser-row` hook for focus targeting.

## Verification

- **59** unit tests (incl. `flattenVisibleTree`: order, expanded-only descent, depth/kind/parentId, nothing-expanded). `tsc -b`, eslint, `pre-commit` (full `npm build`) all clean.
- **Web smoke** (Playwright): ↓/↑ move the roving focus; → / ← expand/collapse (aria-expanded flips); Home jumps to the top; **Enter on the OpenStreetMap service added it as a layer**. Screenshot captured.
- Verification also caught + fixed a focus bug (`focusRow` used `CSS.escape` inside a *quoted* attribute selector, double-escaping the `:` in ids like `section:services`).

## Remaining Polish (follow-ups)

Command-palette "Open Browser panel" action; drag-a-node-to-map. (Empty/error states are already handled.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Upgraded the browser tree to a WAI-ARIA compliant “tree” with roving focus, improving keyboard navigation across the currently visible rows.
  * Added row-to-row movement (ArrowUp/ArrowDown), quick jumps (Home/End), and intuitive expand/collapse (ArrowLeft/ArrowRight), with better focus/aria state consistency for assistive technologies.
* **New Features**
  * Implemented visible-row flattening to drive deterministic navigation based on expanded/collapsed state.
* **Tests**
  * Added unit tests for visible-row flattening, covering ordering, row metadata (depth/parent), and expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->