### PR TITLE
fix(pwa): exclude bundled drop-in plugins from the SW precache

### DIFF
--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -718,6 +718,11 @@ function pwaPlugin(): Plugin[] {
     // its own service worker scoped to /jupyterlite/. Keep it entirely out of
     // the app shell precache, or first visit would balloon by thousands of files.
     "**/jupyterlite/**",
+    // Bundled drop-in plugins (public/plugins/<id>/) load at runtime through
+    // the external-plugin path (fetch → blob import), so they never need to be
+    // in the app-shell precache — and a large private plugin bundle would
+    // otherwise trip workbox's maximumFileSizeToCacheInBytes and fail the build.
+    "**/plugins/**",
   ];
   // Note: the 4 KB public/pyodide/pyodide-worker.js shim is intentionally left
   // in the precache (revisioned, so no stale-after-deploy risk). The heavy


### PR DESCRIPTION
## Summary
- Add `**/plugins/**` to the workbox `globIgnores` list so bundled drop-in plugins under `public/plugins/` are excluded from the service worker app-shell precache.
- Previously any bundled plugin whose built bundle exceeded the 4 MiB `maximumFileSizeToCacheInBytes` cap failed the production build (`vite-plugin-pwa` reports the oversized asset and errors in `closeBundle`).
- Precaching drop-ins was never needed: they load at runtime through the external-plugin path (fetch, then blob import), the same as manifest-URL plugins.

## Test plan
- [x] `npm run build` succeeds with a 5 MB drop-in plugin present under `public/plugins/` (previously failed)
- [x] Docker image built from this branch serves the app and the plugin bundle correctly
- [x] `pre-commit run --files apps/geolibre-desktop/vite.config.ts` passes (includes eslint and the full npm build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PWA startup behavior by preventing runtime-loaded plugin bundles from being included in the initial app-shell cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->