### PR TITLE
feat(processing): populate subset bbox from the map view

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -181,18 +181,10 @@ function isDataInputParameter(param: WhiteboxToolParameter): boolean {
   );
 }
 
-/**
- * Whether a parameter is the geographic bounding box of a tool that also takes a
- * companion CRS (`bbox` + `bbox_crs`), so the field can offer a "Use map extent"
- * shortcut that fills both from the current map view (GeoLibre#1213). This covers
- * the COG/WMS/XYZ subset extractors and any future WASM tool with the same pair,
- * without hard-coding tool ids. The `bbox` string is a comma-joined
- * `minX,minY,maxX,maxY`, matching what those tools parse.
- *
- * @param tool - The tool whose parameters are being rendered.
- * @param param - The parameter under consideration.
- * @returns True when `param` is the map-extent bbox field for `tool`.
- */
+// A `bbox` string param paired with a `bbox_crs` param is the geographic extent
+// of a subset tool, so the field can offer a "Use map extent" shortcut that
+// fills both from the current map view (GeoLibre#1213). Matching on the pair
+// covers every COG/WMS/XYZ (and future) extractor without hard-coding tool ids.
 function isMapExtentParameter(
   tool: WhiteboxTool,
   param: WhiteboxToolParameter,
@@ -836,7 +828,10 @@ export function ProcessingDialog({
   // to keep the pair consistent (a stale `bbox_crs` would misread the extent).
   const handleUseMapExtent = () => {
     const bounds = mapControllerRef.current?.readView().bbox;
-    if (!bounds) return;
+    if (!bounds) {
+      setError(t("processing.whitebox.mapExtentUnavailable"));
+      return;
+    }
     const fmt = (value: number) => Number(value.toFixed(6)).toString();
     updateValue("bbox", bounds.map(fmt).join(","));
     updateValue("bbox_crs", 4326);

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -44,6 +44,7 @@ import {
   Play,
   RefreshCw,
   Save,
+  Scan,
   Search,
   Server,
   ServerOff,
@@ -177,6 +178,29 @@ function downloadBytes(bytes: Uint8Array, filename: string): void {
 function isDataInputParameter(param: WhiteboxToolParameter): boolean {
   return ["raster_in", "vector_in", "lidar_in", "file_in"].includes(
     parameterKind(param),
+  );
+}
+
+/**
+ * Whether a parameter is the geographic bounding box of a tool that also takes a
+ * companion CRS (`bbox` + `bbox_crs`), so the field can offer a "Use map extent"
+ * shortcut that fills both from the current map view (GeoLibre#1213). This covers
+ * the COG/WMS/XYZ subset extractors and any future WASM tool with the same pair,
+ * without hard-coding tool ids. The `bbox` string is a comma-joined
+ * `minX,minY,maxX,maxY`, matching what those tools parse.
+ *
+ * @param tool - The tool whose parameters are being rendered.
+ * @param param - The parameter under consideration.
+ * @returns True when `param` is the map-extent bbox field for `tool`.
+ */
+function isMapExtentParameter(
+  tool: WhiteboxTool,
+  param: WhiteboxToolParameter,
+): boolean {
+  return (
+    param.name === "bbox" &&
+    parameterKind(param) === "string" &&
+    Boolean(tool.params?.some((other) => other.name === "bbox_crs"))
   );
 }
 
@@ -806,6 +830,18 @@ export function ProcessingDialog({
     setValues((prev) => ({ ...prev, [name]: value }));
   };
 
+  // Fill a subset tool's `bbox` (and companion `bbox_crs`) from the current map
+  // view (GeoLibre#1213). The map reads in EPSG:4326, so the bbox is written as
+  // WGS84 `west,south,east,north` and the CRS is set to 4326 in the same gesture
+  // to keep the pair consistent (a stale `bbox_crs` would misread the extent).
+  const handleUseMapExtent = () => {
+    const bounds = mapControllerRef.current?.readView().bbox;
+    if (!bounds) return;
+    const fmt = (value: number) => Number(value.toFixed(6)).toString();
+    updateValue("bbox", bounds.map(fmt).join(","));
+    updateValue("bbox_crs", 4326);
+  };
+
   const handleRunLocalChange = (nextRunLocal: boolean) => {
     setRunLocal(nextRunLocal);
     // A `vector_out` param holds an output-format string in WASM mode but a
@@ -1326,6 +1362,11 @@ export function ProcessingDialog({
                       onPickFile={(fileName, bytes) =>
                         handlePickInputFile(param.name, fileName, bytes)
                       }
+                      onUseMapExtent={
+                        isMapExtentParameter(selectedTool, param)
+                          ? handleUseMapExtent
+                          : undefined
+                      }
                     />
                   ))
                 )}
@@ -1411,6 +1452,9 @@ interface ParameterFieldProps {
   layers: GeoLibreLayer[];
   onChange: (value: unknown) => void;
   onPickFile?: (fileName: string, bytes: Uint8Array) => void;
+  /** When set, renders a "Use map extent" button that fills this bbox field
+   * (and its companion CRS) from the current map view. */
+  onUseMapExtent?: () => void;
   toolId: string;
   runLocal: boolean;
   value: unknown;
@@ -1421,6 +1465,7 @@ function ParameterField({
   layers,
   onChange,
   onPickFile,
+  onUseMapExtent,
   toolId,
   runLocal,
   value,
@@ -1521,6 +1566,28 @@ function ParameterField({
           value={valueText}
           onChange={onChange}
         />
+      ) : onUseMapExtent ? (
+        <div className="grid gap-1.5">
+          <Input
+            id={`whitebox-${param.name}`}
+            type="text"
+            value={valueText}
+            placeholder={t("processing.whitebox.mapExtentPlaceholder")}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onChange(event.target.value)
+            }
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="justify-self-start"
+            onClick={onUseMapExtent}
+          >
+            <Scan className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("processing.whitebox.useMapExtent")}
+          </Button>
+        </div>
       ) : (
         <Input
           id={`whitebox-${param.name}`}

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -836,12 +836,20 @@ export function ProcessingDialog({
       return;
     }
     const [west, south, east, north] = bounds;
-    // getBounds() is not normalized across the antimeridian: a view wrapping
-    // 180° (common for Pacific extents) yields west >= east, which the subset
-    // extractors read as an inverted/empty box. Block it rather than filling a
-    // silently wrong bbox, matching RasterSubsetPanel's antimeridian handling.
-    if (!(west < east) || !(south < north)) {
-      setError(t("processing.whitebox.mapExtentAntimeridian"));
+    // getBounds() is not normalized: a view wrapping 180° yields west >= east,
+    // and at low zoom (multiple world copies) the corners can fall outside
+    // ±180°/±90° while still ordered. Either produces a box the subset
+    // extractors mis-clip or reject, so block it rather than filling a silently
+    // wrong bbox, matching RasterSubsetPanel.parseBbox's ordering + range checks.
+    if (
+      !(west < east) ||
+      !(south < north) ||
+      west < -180 ||
+      east > 180 ||
+      south < -90 ||
+      north > 90
+    ) {
+      setError(t("processing.whitebox.mapExtentInvalid"));
       return;
     }
     const fmt = (value: number) => Number(value.toFixed(6)).toString();

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -116,7 +116,7 @@ function parameterKind(param: WhiteboxToolParameter): string {
       ? (schemaObject.dataset as Record<string, unknown>)
       : {};
   const dataKind = String(
-    param.data_kind ?? dataset.kind ?? param.type ?? "",
+    param.data_kind ?? schemaObject.data_kind ?? dataset.kind ?? param.type ?? "",
   ).toLowerCase();
   const role = String(param.io_role ?? schemaObject.kind ?? "").toLowerCase();
   if (role === "input") return datasetParameterKind(dataKind, "in");

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -827,14 +827,28 @@ export function ProcessingDialog({
   // WGS84 `west,south,east,north` and the CRS is set to 4326 in the same gesture
   // to keep the pair consistent (a stale `bbox_crs` would misread the extent).
   const handleUseMapExtent = () => {
+    // Clear any stale banner (e.g. a prior "map not ready") so a later success
+    // doesn't leave it lingering, mirroring RasterSubsetPanel.handleUseView.
+    setError(null);
     const bounds = mapControllerRef.current?.readView().bbox;
     if (!bounds) {
       setError(t("processing.whitebox.mapExtentUnavailable"));
       return;
     }
+    const [west, south, east, north] = bounds;
+    // getBounds() is not normalized across the antimeridian: a view wrapping
+    // 180° (common for Pacific extents) yields west >= east, which the subset
+    // extractors read as an inverted/empty box. Block it rather than filling a
+    // silently wrong bbox, matching RasterSubsetPanel's antimeridian handling.
+    if (!(west < east) || !(south < north)) {
+      setError(t("processing.whitebox.mapExtentAntimeridian"));
+      return;
+    }
     const fmt = (value: number) => Number(value.toFixed(6)).toString();
     updateValue("bbox", bounds.map(fmt).join(","));
-    updateValue("bbox_crs", 4326);
+    // Store as a string to match the file's convention that every int/double
+    // field value is a string (NumberStepperInput always emits one).
+    updateValue("bbox_crs", String(4326));
   };
 
   const handleRunLocalChange = (nextRunLocal: boolean) => {
@@ -1506,6 +1520,32 @@ function ParameterField({
             </option>
           ))}
         </Select>
+      ) : onUseMapExtent ? (
+        // Checked before the path/data-input branches: once isMapExtentParameter
+        // has identified this bbox field, the "Use map extent" affordance should
+        // always win, even if the param's description happens to contain a word
+        // (path/file/…) that isPathParameter's heuristic would otherwise match.
+        <div className="grid gap-1.5">
+          <Input
+            id={`whitebox-${param.name}`}
+            type="text"
+            value={valueText}
+            placeholder={t("processing.whitebox.mapExtentPlaceholder")}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onChange(event.target.value)
+            }
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="justify-self-start"
+            onClick={onUseMapExtent}
+          >
+            <Scan className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("processing.whitebox.useMapExtent")}
+          </Button>
+        </div>
       ) : isDataInputParameter(param) && availableLayers.length > 0 ? (
         <LayerOrPathInput
           id={`whitebox-${param.name}`}
@@ -1561,28 +1601,6 @@ function ParameterField({
           value={valueText}
           onChange={onChange}
         />
-      ) : onUseMapExtent ? (
-        <div className="grid gap-1.5">
-          <Input
-            id={`whitebox-${param.name}`}
-            type="text"
-            value={valueText}
-            placeholder={t("processing.whitebox.mapExtentPlaceholder")}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              onChange(event.target.value)
-            }
-          />
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="justify-self-start"
-            onClick={onUseMapExtent}
-          >
-            <Scan className="h-3.5 w-3.5" aria-hidden="true" />
-            {t("processing.whitebox.useMapExtent")}
-          </Button>
-        </div>
       ) : (
         <Input
           id={`whitebox-${param.name}`}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2551,7 +2551,7 @@
       "useMapExtent": "Use map extent",
       "mapExtentPlaceholder": "minX,minY,maxX,maxY",
       "mapExtentUnavailable": "The map view is not available yet. Wait for the map to load, then try again.",
-      "mapExtentAntimeridian": "The current map view wraps the 180° meridian, so it can't be used as a bounding box. Pan so the view no longer crosses the antimeridian, then try again."
+      "mapExtentInvalid": "The current map view can't be used as a bounding box: it wraps the 180° meridian or extends beyond valid longitude/latitude bounds. Adjust the view, then try again."
     },
     "sidecar": {
       "unavailableTitle": "The processing server isn't available.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2547,7 +2547,9 @@
       "filterBySource": "Filter by source",
       "allSources": "All sources",
       "geolibreTools": "GeoLibre tools",
-      "whiteboxTools": "Whitebox tools"
+      "whiteboxTools": "Whitebox tools",
+      "useMapExtent": "Use map extent",
+      "mapExtentPlaceholder": "minX,minY,maxX,maxY"
     },
     "sidecar": {
       "unavailableTitle": "The processing server isn't available.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2550,7 +2550,8 @@
       "whiteboxTools": "Whitebox tools",
       "useMapExtent": "Use map extent",
       "mapExtentPlaceholder": "minX,minY,maxX,maxY",
-      "mapExtentUnavailable": "The map view is not available yet. Wait for the map to load, then try again."
+      "mapExtentUnavailable": "The map view is not available yet. Wait for the map to load, then try again.",
+      "mapExtentAntimeridian": "The current map view wraps the 180° meridian, so it can't be used as a bounding box. Pan so the view no longer crosses the antimeridian, then try again."
     },
     "sidecar": {
       "unavailableTitle": "The processing server isn't available.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2549,7 +2549,8 @@
       "geolibreTools": "GeoLibre tools",
       "whiteboxTools": "Whitebox tools",
       "useMapExtent": "Use map extent",
-      "mapExtentPlaceholder": "minX,minY,maxX,maxY"
+      "mapExtentPlaceholder": "minX,minY,maxX,maxY",
+      "mapExtentUnavailable": "The map view is not available yet. Wait for the map to load, then try again."
     },
     "sidecar": {
       "unavailableTitle": "The processing server isn't available.",

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -473,6 +473,18 @@ export function outputBaseName(toolId: string, paramName: string): string {
 }
 
 /**
+ * GeoLibre-authored subset extractors whose single result COG is written to a
+ * plain-string `output` path (no typed `raster_out` param). Their produced file
+ * is surfaced explicitly after the run; see the fallback in
+ * {@link runWhiteboxToolWasm}.
+ */
+const SUBSET_OUTPUT_TOOL_IDS = new Set([
+  "extract_cog_subset",
+  "extract_wms_subset",
+  "extract_xyz_tile_subset",
+]);
+
+/**
  * Run a Whitebox tool in the browser via WASM. Mirrors `runWhiteboxTool` but
  * executes locally and returns an already-completed {@link WhiteboxJob}. Output
  * values are inline: a `FeatureCollection` for `vector_out`, or a `Uint8Array`
@@ -636,14 +648,13 @@ export async function runWhiteboxToolWasm(
       // leave this output out
     }
   }
-  // A tool that declares no typed output parameter still writes a result file:
-  // the GeoLibre COG/WMS/XYZ subset extractors type their `output` as a plain
+  // The GeoLibre COG/WMS/XYZ subset extractors type their `output` as a plain
   // string path (not a `raster_out`), so the loop above maps nothing. Surface
-  // each produced file as raw bytes, keyed by its stem, so the result COG still
-  // reaches the map/download instead of being silently dropped. Scoped to the
-  // no-typed-output case so normal tools (whose files are already mapped) are
-  // unaffected.
-  if (outputs.length === 0) {
+  // their single produced result COG as raw bytes so it still reaches the map
+  // instead of being silently dropped. Scoped to those tool ids (not "any tool
+  // with no typed output") so an unrelated tool's scratch/sidecar/log file is
+  // never mistaken for a result and pushed through the raster loader.
+  if (outputs.length === 0 && SUBSET_OUTPUT_TOOL_IDS.has(request.tool_id)) {
     for (const [file, bytes] of Object.entries(files)) {
       // Skip files we supplied as inputs (e.g. a local `input` raster written to
       // /work before the run) so an unchanged input isn't re-added as a spurious

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -312,7 +312,7 @@ function paramKind(p: WhiteboxToolParameter): string {
       ? (schema.dataset as Record<string, unknown>)
       : {};
   const dataKind = String(
-    p.data_kind ?? dataset.kind ?? p.type ?? "",
+    p.data_kind ?? schema.data_kind ?? dataset.kind ?? p.type ?? "",
   ).toLowerCase();
   const role = String(p.io_role ?? schema.kind ?? "").toLowerCase();
   if (role === "input") return datasetParameterKind(dataKind, "in");

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -645,6 +645,10 @@ export async function runWhiteboxToolWasm(
   // unaffected.
   if (outputs.length === 0) {
     for (const [file, bytes] of Object.entries(files)) {
+      // Skip files we supplied as inputs (e.g. a local `input` raster written to
+      // /work before the run) so an unchanged input isn't re-added as a spurious
+      // second layer alongside the real result.
+      if (file in input) continue;
       out[file.replace(/\.[^.]+$/, "")] = bytes;
     }
   }

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -520,10 +520,19 @@ export async function runWhiteboxToolWasm(
     ) {
       // Prefer bytes the caller resolved (the dialog fetches the layer's data);
       // otherwise try to fetch the parameter as a URL.
+      const provided = request.parameters[name];
+      const hasValue =
+        typeof provided === "string" ? provided.length > 0 : provided != null;
       const bytes =
         request.layer_inputs?.[name]?.bytes ??
-        (await fetchBytes(request.parameters[name]));
+        (hasValue ? await fetchBytes(provided) : null);
       if (!bytes) {
+        // An optional data input the user left blank is simply omitted rather
+        // than force-fetched: e.g. extract_cog_subset's `input` when a `url` is
+        // supplied instead (the tool reads the COG by byte-range from that url).
+        // Only a required input, or one with a value that could not be fetched,
+        // is a hard error.
+        if (!param.required && !hasValue) continue;
         throw new Error(
           `Could not read input "${name}" in the browser. Its data is not fetchable here (only available via the sidecar); turn off "Run locally (WASM)" to use the sidecar.`,
         );
@@ -625,6 +634,18 @@ export async function runWhiteboxToolWasm(
       if (isFeatureCollection(parsed)) out[entry.name] = parsed;
     } catch {
       // leave this output out
+    }
+  }
+  // A tool that declares no typed output parameter still writes a result file:
+  // the GeoLibre COG/WMS/XYZ subset extractors type their `output` as a plain
+  // string path (not a `raster_out`), so the loop above maps nothing. Surface
+  // each produced file as raw bytes, keyed by its stem, so the result COG still
+  // reaches the map/download instead of being silently dropped. Scoped to the
+  // no-typed-output case so normal tools (whose files are already mapped) are
+  // unaffected.
+  if (outputs.length === 0) {
+    for (const [file, bytes] of Object.entries(files)) {
+      out[file.replace(/\.[^.]+$/, "")] = bytes;
     }
   }
   return job(request.tool_id, "succeeded", stdout, out, null);


### PR DESCRIPTION
## Summary
- Adds a "Use map extent" button to the bounding-box field of the COG/WMS/XYZ subset extractors in the Processing (Whitebox) dialog, so the extent no longer has to be typed by hand (closes #1213).
- Clicking it fills the `bbox` param with the current map view as `minX,minY,maxX,maxY` and sets `bbox_crs` to 4326 in the same gesture, keeping the extent and CRS consistent.
- The button is scoped generically to any tool exposing a `bbox` string param alongside a `bbox_crs` param, so it applies to all three subset tools without hard-coded tool IDs and stays inline with the other Whitebox tools (no floating panel).

## Test plan
- [x] `tsc -b` and the processing test suites pass
- [x] `pre-commit run --files` (eslint + npm build) passes
- [x] Verified in the running app with a real map view: on Extract COG Subset, the button fills the bbox to match MapLibre `getBounds()` exactly (world view and after jumping to London) and sets `bbox_crs` to 4326
- [x] Confirmed the button renders only on the bbox field (not other string params) and does not appear on non-subset tools such as Reproject Raster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Use map extent” option for bounding-box parameters, automatically populating `west,south,east,north` (rounded) and setting CRS to `4326`, with validation including antimeridian wrap handling.
* **Localization**
  * Extended processing “whitebox” text to include the new option, input guidance, and status/validation messages for missing or invalid map extents.
* **Bug Fixes**
  * Improved WASM tool input handling so optional blank inputs don’t fail runs.
  * Improved tool output retrieval: when no typed outputs are produced, generated files are returned as raw bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->