### PR TITLE
feat(photos): true native-resolution geotagged photo viewer

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -93,6 +93,7 @@ import {
   type CalcOutputType,
 } from "../../lib/attribute-expression";
 import { computeRowSelection } from "../../lib/attribute-selection";
+import { RESERVED_PROPERTY_KEYS } from "../../lib/field-collection";
 import {
   AREA_UNITS,
   detectGeometryFamilies,
@@ -124,6 +125,10 @@ type AttributeTableRow = {
   featureId: string;
   properties: Record<string, unknown>;
 };
+
+/** Reserved inline-image property keys (photo thumbnail + full-resolution) that
+ * hold data URLs, so they are hidden from the attribute table's columns. */
+const RESERVED_IMAGE_KEYS = new Set<string>(RESERVED_PROPERTY_KEYS);
 
 const DEFAULT_FEATURE_ID_COLUMN_WIDTH = 72;
 const DEFAULT_ATTRIBUTE_COLUMN_WIDTH = 160;
@@ -591,7 +596,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const propKeys = new Set<string>();
   for (const row of attributeRows) {
     for (const k of Object.keys(row.properties)) {
-      propKeys.add(k);
+      // The inline photo/full-resolution image keys are multi-KB-to-MB data
+      // URLs (the map popup and Identify render them as thumbnails instead); a
+      // table cell would dump the raw base64 as text and jank on large photos.
+      if (!RESERVED_IMAGE_KEYS.has(k)) propKeys.add(k);
     }
   }
   const discoveredColumns = Array.from(propKeys);

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2149,7 +2149,48 @@ body,
   max-width: 100vw;
   max-height: 100vh;
   object-fit: contain;
-  cursor: zoom-out;
+  /* Honor the source's EXIF orientation when showing the original bytes so a
+     portrait photo isn't displayed sideways. */
+  image-orientation: from-image;
+  transform-origin: center center;
+  cursor: zoom-in;
+  /* Wheel/double-click zoom animates; panning drags update transform live. */
+  transition: transform 0.12s ease-out;
+  touch-action: none;
+  will-change: transform;
+}
+
+/* Once magnified past the fit, the cursor invites panning. */
+.geolibre-photo-fullscreen-img.is-zoomed {
+  cursor: grab;
+  /* Panning should track the pointer with no lag, so drop the zoom transition. */
+  transition: none;
+}
+
+.geolibre-photo-fullscreen-img.is-zoomed:active {
+  cursor: grabbing;
+}
+
+/* Badge reporting the current zoom as a percentage of native resolution plus
+   the source pixel dimensions. */
+.geolibre-photo-fullscreen-badge {
+  position: fixed;
+  bottom: 0.75rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.25rem 0.625rem;
+  border-radius: 9999px;
+  background: rgb(0 0 0 / 0.6);
+  color: #fff;
+  font-size: 0.75rem;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  user-select: none;
+}
+
+.geolibre-photo-fullscreen-badge:empty {
+  display: none;
 }
 
 .geolibre-photo-fullscreen-close {

--- a/apps/geolibre-desktop/src/lib/field-collection.ts
+++ b/apps/geolibre-desktop/src/lib/field-collection.ts
@@ -11,6 +11,7 @@
  * `metadata.collectionSchema`. Both ride through `.geolibre.json` save/load via
  * the layer's free-form `metadata` bag, so collection layers reopen ready to use.
  */
+import { PHOTO_FULL_PROPERTY, PHOTO_PROPERTY } from "@geolibre/core";
 import type {
   Feature,
   FeatureCollection,
@@ -18,6 +19,10 @@ import type {
   Point,
   Polygon,
 } from "geojson";
+
+// Re-exported so existing importers (geotagged-photos, tests) keep a single
+// import site; the canonical definitions live in @geolibre/core's schema.
+export { PHOTO_FULL_PROPERTY, PHOTO_PROPERTY };
 
 /** The attribute field kinds a collection form can declare. */
 export type FieldType = "text" | "number" | "date" | "choice";
@@ -47,20 +52,6 @@ export interface CollectionSchema {
 export const FIELD_COLLECTION_FLAG = "fieldCollection";
 export const COLLECTION_SCHEMA_KEY = "collectionSchema";
 export const COLLECTION_GEOMETRY_KEY = "collectionGeometry";
-
-/** Property key under which a captured photo (data URL) is stored. */
-export const PHOTO_PROPERTY = "photo";
-
-/**
- * Property key under which a geotagged photo's full-resolution image (a data
- * URL of the original, un-re-encoded bytes) is stored. {@link PHOTO_PROPERTY}
- * holds the small thumbnail shown on the map marker/popup; this holds the
- * native-resolution original used by the enlarged/fullscreen viewer and a
- * "Save image" so magnifying and saving keep the source detail. Absent when the
- * source is already at or below the thumbnail cap, or a format a browser cannot
- * display at native size (TIFF/HEIC).
- */
-export const PHOTO_FULL_PROPERTY = "photo_full";
 
 /** Property keys the tool manages itself; user fields must not reuse them. */
 export const RESERVED_PROPERTY_KEYS: readonly string[] = [

--- a/apps/geolibre-desktop/src/lib/field-collection.ts
+++ b/apps/geolibre-desktop/src/lib/field-collection.ts
@@ -51,8 +51,22 @@ export const COLLECTION_GEOMETRY_KEY = "collectionGeometry";
 /** Property key under which a captured photo (data URL) is stored. */
 export const PHOTO_PROPERTY = "photo";
 
+/**
+ * Property key under which a geotagged photo's full-resolution image (a data
+ * URL of the original, un-re-encoded bytes) is stored. {@link PHOTO_PROPERTY}
+ * holds the small thumbnail shown on the map marker/popup; this holds the
+ * native-resolution original used by the enlarged/fullscreen viewer and a
+ * "Save image" so magnifying and saving keep the source detail. Absent when the
+ * source is already at or below the thumbnail cap, or a format a browser cannot
+ * display at native size (TIFF/HEIC).
+ */
+export const PHOTO_FULL_PROPERTY = "photo_full";
+
 /** Property keys the tool manages itself; user fields must not reuse them. */
-export const RESERVED_PROPERTY_KEYS: readonly string[] = [PHOTO_PROPERTY];
+export const RESERVED_PROPERTY_KEYS: readonly string[] = [
+  PHOTO_PROPERTY,
+  PHOTO_FULL_PROPERTY,
+];
 
 /**
  * Cap embedded photos so a capture session can't bloat the project JSON without

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -128,6 +128,26 @@ function sniffImageMime(bytes: Uint8Array): string | null {
   return null;
 }
 
+/**
+ * Read a Blob as a base64 data URL. Prefers `FileReader.readAsDataURL`, which
+ * runs off the main thread and streams the base64 without the ~2x intermediate
+ * UTF-16 string {@link base64FromBytes} builds, so a near-cap (tens of MB) photo
+ * doesn't spike memory or freeze the UI. Falls back to `arrayBuffer()` + manual
+ * base64 under Node (tests), where `FileReader` is unavailable.
+ */
+async function blobToDataUrl(blob: Blob): Promise<string> {
+  if (typeof FileReader === "function") {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+      reader.readAsDataURL(blob);
+    });
+  }
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  return `data:${blob.type};base64,${base64FromBytes(bytes)}`;
+}
+
 /** Base64-encode raw bytes in chunks so large images don't overflow the call
  * stack (`btoa(String.fromCharCode(...allBytes))` throws on multi-MB inputs).
  * Exported for direct testing (the DOM decode path is unavailable under Node). */
@@ -326,9 +346,12 @@ export async function createFullResolutionDataUrl(
   // can't add hundreds of MB to the project.
   if (file.size > MAX_FULL_RESOLUTION_BYTES) return null;
   try {
-    const bytes = new Uint8Array(await file.arrayBuffer());
-    const mime = sniffImageMime(bytes) ?? extensionMime;
-    return `data:${mime};base64,${base64FromBytes(bytes)}`;
+    // Sniff only the header so the MIME is correct for a mislabeled extension,
+    // then encode from a Blob retagged with that MIME. Blob.slice is a view, so
+    // this doesn't copy the image bytes just to set the type.
+    const header = new Uint8Array(await file.slice(0, 12).arrayBuffer());
+    const mime = sniffImageMime(header) ?? extensionMime;
+    return await blobToDataUrl(file.slice(0, file.size, mime));
   } catch {
     return null;
   }

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -14,9 +14,10 @@
  *
  * A second, full-resolution image (the original bytes, un-re-encoded) rides
  * along under {@link PHOTO_FULL_PROPERTY} for formats a browser can display so
- * the enlarged/fullscreen viewer and a right-click "Save image" keep native
- * detail rather than the downscaled thumbnail. It is omitted when the source is
- * already at or below the thumbnail cap (the thumbnail is then already native).
+ * the enlarged/fullscreen viewer and a right-click "Save image" keep the native
+ * detail (and PNG/WebP transparency) rather than the downscaled, re-encoded
+ * thumbnail. It is omitted only for formats a browser can't show at native size
+ * (TIFF/HEIC), mislabeled bytes, or originals past the size ceiling.
  *
  * The thumbnail and feature-shaping helpers live here (UI-free) so the Add Data
  * dialog and the map drag-and-drop handler share one implementation.
@@ -319,8 +320,8 @@ interface PhotoImages {
   thumbnail: string | null;
   /**
    * Full-resolution image (data URL of the original bytes) for the enlarged
-   * viewer, or null when the thumbnail is already native (source at/below the
-   * cap) or the format can't be shown at full size (TIFF/HEIC).
+   * viewer, or null when the format can't be shown at full size (TIFF/HEIC), the
+   * bytes are mislabeled, or the original exceeds the size ceiling.
    */
   fullResolution: string | null;
 }
@@ -338,19 +339,21 @@ export async function createFullResolutionDataUrl(
   fileName: string,
 ): Promise<string | null> {
   // Gate on the extension so TIFF/HEIC (which a browser can't show at full size)
-  // are never embedded, but derive the actual MIME from the bytes so a
-  // mislabeled extension can't produce an undecodable data URL.
-  const extensionMime = FULL_RESOLUTION_IMAGE_MIME[fileExtension(fileName)];
-  if (!extensionMime) return null;
+  // are never embedded.
+  if (!FULL_RESOLUTION_IMAGE_MIME[fileExtension(fileName)]) return null;
   // A pathologically large original falls back to thumbnail-only so one photo
   // can't add hundreds of MB to the project.
   if (file.size > MAX_FULL_RESOLUTION_BYTES) return null;
   try {
-    // Sniff only the header so the MIME is correct for a mislabeled extension,
-    // then encode from a Blob retagged with that MIME. Blob.slice is a view, so
-    // this doesn't copy the image bytes just to set the type.
+    // Derive the MIME from the actual magic bytes, not the extension: a genuine
+    // JPEG/PNG/WebP always has a recognizable signature, so a failed sniff means
+    // the file is mislabeled (e.g. a GIF/BMP named .jpg), and tagging its bytes
+    // as image/jpeg would be undecodable — skip full-res (the canvas thumbnail
+    // still works). Blob.slice is a view, so retagging the type doesn't copy the
+    // image bytes.
     const header = new Uint8Array(await file.slice(0, 12).arrayBuffer());
-    const mime = sniffImageMime(header) ?? extensionMime;
+    const mime = sniffImageMime(header);
+    if (!mime) return null;
     return await blobToDataUrl(file.slice(0, file.size, mime));
   } catch {
     return null;
@@ -402,13 +405,12 @@ async function createPhotoImages(
     // where peak memory is highest; the full-res encode reads `file`, not the
     // bitmap. The `finally` close is a safe no-op on an already-closed bitmap.
     bitmap.close();
-    // Only embed the original when it is larger than the thumbnail; at or below
-    // the cap the thumbnail is already native, so a full-res copy would just
-    // duplicate it and bloat the project.
-    const fullResolution =
-      longestEdge > PHOTO_MAX_DIMENSION
-        ? await createFullResolutionDataUrl(file, fileName)
-        : null;
+    // Embed the original whenever the format allows, even when it is at/below the
+    // thumbnail cap: the thumbnail is a re-encoded, quality-0.82 JPEG (opaque,
+    // with compression artifacts), so it is not the original even at matching
+    // dimensions. This keeps the true bytes for the viewer/save and preserves
+    // PNG/WebP transparency.
+    const fullResolution = await createFullResolutionDataUrl(file, fileName);
     return { thumbnail, fullResolution };
   } catch {
     return empty;

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -99,8 +99,9 @@ export const MAX_FULL_RESOLUTION_BYTES = 64 * 1024 * 1024;
 /**
  * Detect an image's MIME type from its leading magic bytes, so a mislabeled
  * file (e.g. a `.png` that is actually JPEG data) still gets a data URL a
- * browser can decode. Returns null when the signature is unrecognized, letting
- * the caller fall back to the extension.
+ * browser can decode. Returns null when the signature is not one of the
+ * natively displayable formats (JPEG/PNG/WebP); the caller then skips embedding
+ * the original, since trusting the extension could yield an undecodable data URL.
  */
 function sniffImageMime(bytes: Uint8Array): string | null {
   if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
@@ -362,10 +363,12 @@ export async function createFullResolutionDataUrl(
 
 /**
  * Generate the thumbnail (a downscaled JPEG capped at {@link PHOTO_MAX_DIMENSION}
- * on its longest edge) and, when the source is larger than that cap and its
- * format can be shown natively, the full-resolution image. Returns both as null
- * for HEIC/HEIF (no canvas decoder) and for any image the browser fails to
- * decode, so the caller still places the point without an inline image.
+ * on its longest edge) and, for formats a browser can show natively, the
+ * full-resolution image (the original bytes, regardless of the source's size).
+ * Returns both as null for HEIC/HEIF (no canvas decoder) and for any image the
+ * browser fails to decode, so the caller still places the point without an
+ * inline image; the full-resolution image alone is null when the format can't be
+ * shown natively, the bytes are mislabeled, or the original is over the ceiling.
  */
 async function createPhotoImages(
   file: Blob,

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -81,6 +81,39 @@ const FULL_RESOLUTION_IMAGE_MIME: Record<string, string> = {
   webp: "image/webp",
 };
 
+/**
+ * Detect an image's MIME type from its leading magic bytes, so a mislabeled
+ * file (e.g. a `.png` that is actually JPEG data) still gets a data URL a
+ * browser can decode. Returns null when the signature is unrecognized, letting
+ * the caller fall back to the extension.
+ */
+function sniffImageMime(bytes: Uint8Array): string | null {
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    return "image/png";
+  }
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
 /** Base64-encode raw bytes in chunks so large images don't overflow the call
  * stack (`btoa(String.fromCharCode(...allBytes))` throws on multi-MB inputs).
  * Exported for direct testing (the DOM decode path is unavailable under Node). */
@@ -270,10 +303,14 @@ export async function createFullResolutionDataUrl(
   file: Blob,
   fileName: string,
 ): Promise<string | null> {
-  const mime = FULL_RESOLUTION_IMAGE_MIME[fileExtension(fileName)];
-  if (!mime) return null;
+  // Gate on the extension so TIFF/HEIC (which a browser can't show at full size)
+  // are never embedded, but derive the actual MIME from the bytes so a
+  // mislabeled extension can't produce an undecodable data URL.
+  const extensionMime = FULL_RESOLUTION_IMAGE_MIME[fileExtension(fileName)];
+  if (!extensionMime) return null;
   try {
     const bytes = new Uint8Array(await file.arrayBuffer());
+    const mime = sniffImageMime(bytes) ?? extensionMime;
     return `data:${mime};base64,${base64FromBytes(bytes)}`;
   } catch {
     return null;

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -82,8 +82,9 @@ const FULL_RESOLUTION_IMAGE_MIME: Record<string, string> = {
 };
 
 /** Base64-encode raw bytes in chunks so large images don't overflow the call
- * stack (`btoa(String.fromCharCode(...allBytes))` throws on multi-MB inputs). */
-function base64FromBytes(bytes: Uint8Array): string {
+ * stack (`btoa(String.fromCharCode(...allBytes))` throws on multi-MB inputs).
+ * Exported for direct testing (the DOM decode path is unavailable under Node). */
+export function base64FromBytes(bytes: Uint8Array): string {
   let binary = "";
   const chunkSize = 0x8000;
   for (let offset = 0; offset < bytes.length; offset += chunkSize) {
@@ -263,8 +264,9 @@ interface PhotoImages {
  * cannot render in an `<img>` (TIFF/HEIC), where the viewer falls back to the
  * thumbnail. The bytes are not re-encoded, so there is no quality loss; the
  * trade-off is project-file size, since this is serialized into the project.
+ * Exported for testing.
  */
-async function createFullResolutionDataUrl(
+export async function createFullResolutionDataUrl(
   file: Blob,
   fileName: string,
 ): Promise<string | null> {
@@ -318,6 +320,11 @@ async function createPhotoImages(
     if (!context) return empty;
     context.drawImage(bitmap, 0, 0, width, height);
     const thumbnail = canvas.toDataURL("image/jpeg", PHOTO_JPEG_QUALITY);
+    // Release the decoded bitmap (a raw RGBA buffer, ~194 MB for an 8064×6048
+    // source) before reading the original bytes and building the base64 string,
+    // where peak memory is highest; the full-res encode reads `file`, not the
+    // bitmap. The `finally` close is a safe no-op on an already-closed bitmap.
+    bitmap.close();
     // Only embed the original when it is larger than the thumbnail; at or below
     // the cap the thumbnail is already native, so a full-res copy would just
     // duplicate it and bloat the project.

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -12,12 +12,18 @@
  * cannot decode (e.g. some TIFFs) is handled the same way: the point is placed,
  * the thumbnail is skipped.
  *
+ * A second, full-resolution image (the original bytes, un-re-encoded) rides
+ * along under {@link PHOTO_FULL_PROPERTY} for formats a browser can display so
+ * the enlarged/fullscreen viewer and a right-click "Save image" keep native
+ * detail rather than the downscaled thumbnail. It is omitted when the source is
+ * already at or below the thumbnail cap (the thumbnail is then already native).
+ *
  * The thumbnail and feature-shaping helpers live here (UI-free) so the Add Data
  * dialog and the map drag-and-drop handler share one implementation.
  */
 
 import type { Feature, FeatureCollection, Point } from "geojson";
-import { PHOTO_PROPERTY } from "./field-collection";
+import { PHOTO_FULL_PROPERTY, PHOTO_PROPERTY } from "./field-collection";
 
 /** Image extensions the photo importer recognizes. */
 export const PHOTO_IMAGE_EXTENSIONS = [
@@ -61,6 +67,30 @@ const HEIC_EXTENSIONS = new Set(["heic", "heif"]);
 const PHOTO_MAX_DIMENSION = 1600;
 /** JPEG quality for the generated photo image. */
 const PHOTO_JPEG_QUALITY = 0.82;
+
+/**
+ * Image MIME type, keyed by extension, for the formats a browser can render at
+ * native size directly from a data URL. Only these get a full-resolution image
+ * embedded alongside the thumbnail; TIFF/HEIC decode to a canvas thumbnail but
+ * cannot be shown natively in an `<img>`, so they fall back to the thumbnail.
+ */
+const FULL_RESOLUTION_IMAGE_MIME: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+
+/** Base64-encode raw bytes in chunks so large images don't overflow the call
+ * stack (`btoa(String.fromCharCode(...allBytes))` throws on multi-MB inputs). */
+function base64FromBytes(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
 
 function fileExtension(name: string): string {
   return name.split(".").pop()?.toLowerCase() ?? "";
@@ -161,15 +191,20 @@ function toIsoTimestamp(value: Date | string | undefined): string | undefined {
  * @param fileName - The source image's filename, stored as `name`.
  * @param exif - The parsed EXIF fields for the image.
  * @param thumbnail - A JPEG data URL thumbnail, or null when none was made.
+ * @param fullResolution - A data URL of the original, native-resolution image
+ *   for the enlarged/fullscreen viewer, or null when the thumbnail is already
+ *   native (or the format can't be shown at full size). Defaults to null.
  * @returns The GeoJSON feature properties for the photo point.
  */
 export function buildPhotoProperties(
   fileName: string,
   exif: PhotoExif,
   thumbnail: string | null,
+  fullResolution: string | null = null,
 ): Record<string, unknown> {
   const properties: Record<string, unknown> = { name: fileName };
   if (thumbnail) properties[PHOTO_PROPERTY] = thumbnail;
+  if (fullResolution) properties[PHOTO_FULL_PROPERTY] = fullResolution;
 
   const timestamp = toIsoTimestamp(exif.DateTimeOriginal ?? exif.CreateDate);
   if (timestamp) properties.timestamp = timestamp;
@@ -210,22 +245,57 @@ async function readPhotoExif(file: Blob): Promise<PhotoExif | null> {
   }
 }
 
+/** The image data URLs generated for one photo. */
+interface PhotoImages {
+  /** Downscaled JPEG thumbnail (data URL) for the map marker/popup, or null. */
+  thumbnail: string | null;
+  /**
+   * Full-resolution image (data URL of the original bytes) for the enlarged
+   * viewer, or null when the thumbnail is already native (source at/below the
+   * cap) or the format can't be shown at full size (TIFF/HEIC).
+   */
+  fullResolution: string | null;
+}
+
 /**
- * Generate a downscaled JPEG (a data URL) for an image the browser can decode,
- * capped at {@link PHOTO_MAX_DIMENSION} on its longest edge. Returns null for
- * HEIC/HEIF (no canvas decoder) and for any image the browser fails to decode,
- * so the caller still places the point without an inline image.
+ * Embed the original image bytes unchanged as a data URL so the enlarged viewer
+ * and "Save image" get native resolution. Returns null for formats a browser
+ * cannot render in an `<img>` (TIFF/HEIC), where the viewer falls back to the
+ * thumbnail. The bytes are not re-encoded, so there is no quality loss; the
+ * trade-off is project-file size, since this is serialized into the project.
  */
-async function createThumbnailDataUrl(
+async function createFullResolutionDataUrl(
   file: Blob,
   fileName: string,
 ): Promise<string | null> {
-  if (isHeicFileName(fileName)) return null;
+  const mime = FULL_RESOLUTION_IMAGE_MIME[fileExtension(fileName)];
+  if (!mime) return null;
+  try {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    return `data:${mime};base64,${base64FromBytes(bytes)}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate the thumbnail (a downscaled JPEG capped at {@link PHOTO_MAX_DIMENSION}
+ * on its longest edge) and, when the source is larger than that cap and its
+ * format can be shown natively, the full-resolution image. Returns both as null
+ * for HEIC/HEIF (no canvas decoder) and for any image the browser fails to
+ * decode, so the caller still places the point without an inline image.
+ */
+async function createPhotoImages(
+  file: Blob,
+  fileName: string,
+): Promise<PhotoImages> {
+  const empty: PhotoImages = { thumbnail: null, fullResolution: null };
+  if (isHeicFileName(fileName)) return empty;
   if (
     typeof createImageBitmap !== "function" ||
     typeof document === "undefined"
   ) {
-    return null;
+    return empty;
   }
 
   let bitmap: ImageBitmap;
@@ -233,25 +303,31 @@ async function createThumbnailDataUrl(
     // `from-image` bakes the EXIF orientation in so thumbnails aren't sideways.
     bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
   } catch {
-    return null;
+    return empty;
   }
 
+  const longestEdge = Math.max(bitmap.width, bitmap.height);
   try {
-    const scale = Math.min(
-      1,
-      PHOTO_MAX_DIMENSION / Math.max(bitmap.width, bitmap.height),
-    );
+    const scale = Math.min(1, PHOTO_MAX_DIMENSION / longestEdge);
     const width = Math.max(1, Math.round(bitmap.width * scale));
     const height = Math.max(1, Math.round(bitmap.height * scale));
     const canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;
     const context = canvas.getContext("2d");
-    if (!context) return null;
+    if (!context) return empty;
     context.drawImage(bitmap, 0, 0, width, height);
-    return canvas.toDataURL("image/jpeg", PHOTO_JPEG_QUALITY);
+    const thumbnail = canvas.toDataURL("image/jpeg", PHOTO_JPEG_QUALITY);
+    // Only embed the original when it is larger than the thumbnail; at or below
+    // the cap the thumbnail is already native, so a full-res copy would just
+    // duplicate it and bloat the project.
+    const fullResolution =
+      longestEdge > PHOTO_MAX_DIMENSION
+        ? await createFullResolutionDataUrl(file, fileName)
+        : null;
+    return { thumbnail, fullResolution };
   } catch {
-    return null;
+    return empty;
   } finally {
     bitmap.close();
   }
@@ -291,7 +367,10 @@ export async function loadGeotaggedPhotos(
     const coord = exif && isValidLngLat(exif.longitude, exif.latitude);
     if (!exif || !coord) continue;
 
-    const thumbnail = await createThumbnailDataUrl(file, fileName);
+    const { thumbnail, fullResolution } = await createPhotoImages(
+      file,
+      fileName,
+    );
     if (!thumbnail) withoutThumbnail += 1;
 
     features.push({
@@ -300,7 +379,7 @@ export async function loadGeotaggedPhotos(
         type: "Point",
         coordinates: [coord.lng, coord.lat],
       },
-      properties: buildPhotoProperties(fileName, exif, thumbnail),
+      properties: buildPhotoProperties(fileName, exif, thumbnail, fullResolution),
     });
   }
 
@@ -336,7 +415,10 @@ export async function loadPhotosAtLocation(
   for (const file of files) {
     const fileName = file.name || "photo";
     const exif = (await readPhotoExif(file)) ?? {};
-    const thumbnail = await createThumbnailDataUrl(file, fileName);
+    const { thumbnail, fullResolution } = await createPhotoImages(
+      file,
+      fileName,
+    );
     if (!thumbnail) withoutThumbnail += 1;
 
     features.push({
@@ -345,7 +427,7 @@ export async function loadPhotosAtLocation(
         type: "Point",
         coordinates: [center[0], center[1]],
       },
-      properties: buildPhotoProperties(fileName, exif, thumbnail),
+      properties: buildPhotoProperties(fileName, exif, thumbnail, fullResolution),
     });
   }
 

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -84,6 +84,18 @@ const FULL_RESOLUTION_IMAGE_MIME: Record<string, string> = {
 };
 
 /**
+ * Upper bound (bytes) on a single embedded full-resolution original. Normal
+ * high-resolution phone/DSLR photos (the reporter's are ~7 MB; 20-30 MB is
+ * typical for the largest) stay well under this and embed as intended; a
+ * pathologically large file (a giant panorama, an uncompressed original) falls
+ * back to thumbnail-only rather than adding hundreds of MB to the project from a
+ * single photo. This is a per-photo sanity ceiling, not a per-project one: many
+ * ordinary photos still grow the project roughly with their total size, which is
+ * the intended trade-off for native resolution.
+ */
+export const MAX_FULL_RESOLUTION_BYTES = 64 * 1024 * 1024;
+
+/**
  * Detect an image's MIME type from its leading magic bytes, so a mislabeled
  * file (e.g. a `.png` that is actually JPEG data) still gets a data URL a
  * browser can decode. Returns null when the signature is unrecognized, letting
@@ -310,6 +322,9 @@ export async function createFullResolutionDataUrl(
   // mislabeled extension can't produce an undecodable data URL.
   const extensionMime = FULL_RESOLUTION_IMAGE_MIME[fileExtension(fileName)];
   if (!extensionMime) return null;
+  // A pathologically large original falls back to thumbnail-only so one photo
+  // can't add hundreds of MB to the project.
+  if (file.size > MAX_FULL_RESOLUTION_BYTES) return null;
   try {
     const bytes = new Uint8Array(await file.arrayBuffer());
     const mime = sniffImageMime(bytes) ?? extensionMime;

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -55,14 +55,16 @@ const PHOTO_DROP_EXTENSIONS = new Set([
 const HEIC_EXTENSIONS = new Set(["heic", "heif"]);
 
 /**
- * Longest edge (px) of the inline JPEG generated for each photo. The original
- * file is not retained after import, so this is the only resolution available
- * later: it is sized so the resizable photo popup stays sharp when enlarged
- * (the popup display caps near 900px, doubled here for high-DPI screens) while
- * keeping the inline data URL a few hundred KB rather than the multi-MB source.
- * Budget ~250-500 KB per photo at this size/quality; since the data URL is held
- * in the store and serialized into the project file, raising it further trades
- * sharpness for project size on photo-heavy imports.
+ * Longest edge (px) of the inline JPEG thumbnail generated for each photo. This
+ * thumbnail is what the map marker/popup shows; for JPEG/PNG/WebP sources larger
+ * than the cap the original is also retained (see {@link PHOTO_FULL_PROPERTY})
+ * for the enlarged view, but the thumbnail stays this small so the marker/popup
+ * render fast. It is sized so the resizable photo popup stays sharp when
+ * enlarged (the popup display caps near 900px, doubled here for high-DPI
+ * screens) while keeping the inline data URL a few hundred KB rather than the
+ * multi-MB source. Budget ~250-500 KB per photo at this size/quality; since the
+ * data URL is held in the store and serialized into the project file, raising it
+ * further trades sharpness for project size on photo-heavy imports.
  */
 const PHOTO_MAX_DIMENSION = 1600;
 /** JPEG quality for the generated photo image. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./photo";
 export * from "./ellipsoids";
 export * from "./geojson-z";
 export * from "./color-ramp";

--- a/packages/core/src/photo.ts
+++ b/packages/core/src/photo.ts
@@ -1,0 +1,19 @@
+/**
+ * Feature-property keys for inline photo images, shared by the app and the map
+ * package so neither hardcodes a second copy that could drift. These keys are
+ * part of the project schema: they are serialized into `.geolibre.json` on a
+ * geotagged-photo or field-collection layer.
+ */
+
+/** Property key under which a photo's downscaled thumbnail (data URL) is stored. */
+export const PHOTO_PROPERTY = "photo";
+
+/**
+ * Property key under which a geotagged photo's full-resolution image (a data URL
+ * of the original, un-re-encoded bytes) is stored. {@link PHOTO_PROPERTY} holds
+ * the small thumbnail shown on the map marker/popup; this holds the
+ * native-resolution original used by the enlarged/fullscreen viewer and a "Save
+ * image". Absent when the source is already at or below the thumbnail cap, or a
+ * format a browser cannot display at native size (TIFF/HEIC).
+ */
+export const PHOTO_FULL_PROPERTY = "photo_full";

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -282,9 +282,12 @@ function openPhotoFullscreen(src: string, alt: string): void {
       image.naturalWidth > 0 && image.clientWidth > 0
         ? image.clientWidth / image.naturalWidth
         : 1;
-    // Cap magnification at PHOTO_MAX_ZOOM_FRACTION of native, but always allow at
-    // least a little zoom for images that already fit within the viewport.
-    maxZoom = Math.max(1.5, PHOTO_MAX_ZOOM_FRACTION / fitToNative);
+    // Cap magnification at PHOTO_MAX_ZOOM_FRACTION of native. The floor of 1
+    // only guards the degenerate case where the image is somehow larger than the
+    // fit (fitToNative > cap) so zoom never drops below the fit; in the normal
+    // case (fitToNative <= 1, no upscaling) this is always the native-cap branch,
+    // keeping the badge at exactly 400% of native at maximum zoom.
+    maxZoom = Math.max(1, PHOTO_MAX_ZOOM_FRACTION / fitToNative);
     // A resize (or entering fullscreen) can grow the fit ratio and shrink
     // maxZoom below the current zoom; reclamp so the 400%-of-native cap holds
     // instead of rendering (and reporting) a now-out-of-range zoom.
@@ -336,6 +339,9 @@ function openPhotoFullscreen(src: string, alt: string): void {
     return Math.hypot(a.x - b.x, a.y - b.y);
   };
   image.addEventListener("pointerdown", (event) => {
+    // Track at most two pointers; a third (e.g. an accidental palm touch) is
+    // ignored so it can't perturb the pan anchor or the pinch spread.
+    if (activePointers.size >= 2) return;
     activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
     // Arm pan/pinch state before capturing the pointer: setPointerCapture can
     // throw for a non-active pointer, and that must not skip the setup below.
@@ -460,8 +466,12 @@ function createPhotoPopupElement(
   const thumbnail =
     imageDataUrlAt(properties, PHOTO_THUMBNAIL_KEY) ??
     findPhotoDataUrl(properties);
-  const fullResolution = imageDataUrlAt(properties, PHOTO_FULL_KEY) ?? thumbnail;
   if (thumbnail) {
+    // Prefer the embedded full-resolution image, falling back to the thumbnail
+    // when the source was already native or its format can't be shown at full
+    // size; `thumbnail` is non-null here, so this is always a string.
+    const fullResolution =
+      imageDataUrlAt(properties, PHOTO_FULL_KEY) ?? thumbnail;
     const image = document.createElement("img");
     image.src = thumbnail;
     image.alt = typeof properties.name === "string" ? properties.name : "Photo";
@@ -472,7 +482,7 @@ function createPhotoPopupElement(
     // not trigger MapLibre's double-click zoom.
     image.addEventListener("dblclick", (event) => {
       event.stopPropagation();
-      openPhotoFullscreen(fullResolution ?? thumbnail, image.alt);
+      openPhotoFullscreen(fullResolution, image.alt);
     });
     root.appendChild(image);
   } else {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -373,9 +373,14 @@ function openPhotoFullscreen(src: string, alt: string): void {
     if (!activePointers.has(event.pointerId)) return;
     activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
     if (activePointers.size >= 2) {
-      // Pinch: scale zoom by how much the finger spread changed.
-      if (pinchStartDist > 0) {
-        setZoom((pinchStartZoom * pointerSpread()) / pinchStartDist);
+      const spread = pointerSpread();
+      // Re-anchor if the initial spread was zero (both fingers landed on the
+      // same spot), so pinch isn't stuck disabled for the rest of the gesture.
+      if (pinchStartDist <= 0) {
+        pinchStartDist = spread;
+        pinchStartZoom = zoom;
+      } else {
+        setZoom((pinchStartZoom * spread) / pinchStartDist);
       }
       return;
     }

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,6 +1,8 @@
 import {
   applyGroupEffects,
   isDuckDBQueryLayer,
+  PHOTO_FULL_PROPERTY,
+  PHOTO_PROPERTY,
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
@@ -129,20 +131,21 @@ function createIdentifyPopupElement(
 
   if (featureId != null) appendRow("id", featureId);
 
-  const entries = Object.entries(properties);
+  // Skip the full-resolution image: it is an internal companion to the
+  // thumbnail, so Identify shouldn't decode a multi-megapixel data URL just to
+  // show a second copy of the same photo in the same small box. Filter before
+  // the empty-state check so a feature whose only property is `photo_full` still
+  // reports "No attributes" rather than rendering an empty panel.
+  const entries = Object.entries(properties).filter(
+    ([key]) => key !== PHOTO_FULL_KEY,
+  );
   if (entries.length === 0 && featureId == null) {
     const empty = document.createElement("div");
     empty.className = "text-muted-foreground";
     empty.textContent = "No attributes";
     rows.appendChild(empty);
   } else {
-    for (const [key, value] of entries) {
-      // The full-resolution image is an internal companion to the thumbnail;
-      // skip it so Identify doesn't decode a multi-megapixel data URL just to
-      // show a second copy of the same photo in the same small thumbnail box.
-      if (key === PHOTO_FULL_KEY) continue;
-      appendRow(key, value);
-    }
+    for (const [key, value] of entries) appendRow(key, value);
   }
 
   return root;
@@ -158,12 +161,11 @@ function createIdentifyMessagePopupElement(
 /** Match an inline base64 raster image (excludes SVG, which can carry scripts). */
 const INLINE_IMAGE_DATA_URL = /^data:image\/(?!svg)[\w.+-]+;base64,/i;
 
-// Feature-property keys for geotagged/field-collection photos. Kept in sync with
-// PHOTO_PROPERTY / PHOTO_FULL_PROPERTY in the app's field-collection module (this
-// package can't import from the app): the popup shows the light thumbnail while
-// the fullscreen viewer and "Save image" use the embedded full-resolution image.
-const PHOTO_THUMBNAIL_KEY = "photo";
-const PHOTO_FULL_KEY = "photo_full";
+// Feature-property keys for geotagged/field-collection photos, from the shared
+// @geolibre/core schema: the popup shows the light thumbnail while the fullscreen
+// viewer and "Save image" use the embedded full-resolution image.
+const PHOTO_THUMBNAIL_KEY = PHOTO_PROPERTY;
+const PHOTO_FULL_KEY = PHOTO_FULL_PROPERTY;
 
 /** Return the value at `key` when it is an inline raster image data URL. */
 function imageDataUrlAt(
@@ -470,13 +472,17 @@ function createPhotoPopupElement(
     // Prefer the embedded full-resolution image, falling back to the thumbnail
     // when the source was already native or its format can't be shown at full
     // size; `thumbnail` is non-null here, so this is always a string.
-    const fullResolution =
-      imageDataUrlAt(properties, PHOTO_FULL_KEY) ?? thumbnail;
+    const fullImage = imageDataUrlAt(properties, PHOTO_FULL_KEY);
+    const fullResolution = fullImage ?? thumbnail;
     const image = document.createElement("img");
     image.src = thumbnail;
     image.alt = typeof properties.name === "string" ? properties.name : "Photo";
     image.className = "geolibre-photo-popup-img";
-    image.title = "Double-click to view at full resolution";
+    // Only promise "full resolution" when the native original is actually
+    // embedded; otherwise the double-click just opens the thumbnail fullscreen.
+    image.title = fullImage
+      ? "Double-click to view at full resolution"
+      : "Double-click to view fullscreen";
     // Double-click (not single, so it never fights the resize drag) opens the
     // photo fullscreen. The image is popup DOM, not the map canvas, so this does
     // not trigger MapLibre's double-click zoom.

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -178,11 +178,18 @@ function imageDataUrlAt(
 
 /**
  * Find the first feature property holding an inline raster image (a geotagged
- * photo or field-collection thumbnail), returning its data URL or null.
+ * photo or field-collection thumbnail), returning its data URL or null. The
+ * full-resolution key is skipped so this fallback never returns the heavy
+ * original as if it were the light thumbnail (e.g. for a hand-edited feature
+ * whose `photo` thumbnail is missing but `photo_full` is present).
  */
 function findPhotoDataUrl(properties: Record<string, unknown>): string | null {
-  for (const value of Object.values(properties)) {
-    if (typeof value === "string" && INLINE_IMAGE_DATA_URL.test(value)) {
+  for (const [key, value] of Object.entries(properties)) {
+    if (
+      key !== PHOTO_FULL_KEY &&
+      typeof value === "string" &&
+      INLINE_IMAGE_DATA_URL.test(value)
+    ) {
       return value;
     }
   }
@@ -251,6 +258,14 @@ function openPhotoFullscreen(src: string, alt: string): void {
     Math.min(max, Math.max(min, value));
 
   const applyTransform = () => {
+    // Bound the pan so the image can't be dragged fully off-screen: the image is
+    // centered, so keeping |tx|/|ty| within half its scaled size guarantees the
+    // viewport centre always sits on the photo (and its double-click-to-reset
+    // target stays reachable). clientWidth/Height are the fit-rendered size.
+    const maxTx = (image.clientWidth * zoom) / 2;
+    const maxTy = (image.clientHeight * zoom) / 2;
+    tx = clamp(tx, -maxTx, maxTx);
+    ty = clamp(ty, -maxTy, maxTy);
     image.style.transform = `translate(${tx}px, ${ty}px) scale(${zoom})`;
     image.classList.toggle("is-zoomed", zoom > 1.001);
     const nativePercent = Math.round(fitToNative * zoom * 100);

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -322,7 +322,13 @@ function openPhotoFullscreen(src: string, alt: string): void {
     } catch {
       // The pointer is already gone; pan/pinch still work without capture.
     }
-    event.preventDefault();
+    // Only suppress the default (text selection, image drag, and the mouse-
+    // compatibility event chain) when a pan or pinch is actually starting.
+    // Calling preventDefault on a plain mouse click at fit can swallow the
+    // double-click-to-zoom on some browsers, so leave that gesture untouched.
+    if (event.pointerType !== "mouse" || zoom > 1 || activePointers.size === 2) {
+      event.preventDefault();
+    }
   });
   image.addEventListener("pointermove", (event) => {
     if (!activePointers.has(event.pointerId)) return;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -268,6 +268,11 @@ function openPhotoFullscreen(src: string, alt: string): void {
   };
   if (image.complete && image.naturalWidth > 0) measure();
   else image.addEventListener("load", measure, { once: true });
+  // The fit size (and thus the native-zoom ratio and 400% cap) depends on the
+  // viewport, which changes when the browser window resizes or the viewer
+  // enters/leaves native fullscreen, so remeasure on both.
+  const onResize = () => measure();
+  window.addEventListener("resize", onResize);
 
   const setZoom = (next: number) => {
     zoom = clamp(next, 1, maxZoom);
@@ -289,40 +294,75 @@ function openPhotoFullscreen(src: string, alt: string): void {
     { passive: false },
   );
 
-  // Drag to pan once zoomed in.
-  let dragging = false;
+  // Pan (one pointer) and pinch-zoom (two pointers). Touch devices have no
+  // wheel, and `touch-action: none` disables native pinch, so drive the same
+  // zoom/pan transform from raw pointer events here.
+  const activePointers = new Map<number, { x: number; y: number }>();
   let lastX = 0;
   let lastY = 0;
+  let pinchStartDist = 0;
+  let pinchStartZoom = 1;
+  const pointerSpread = () => {
+    const [a, b] = [...activePointers.values()];
+    return Math.hypot(a.x - b.x, a.y - b.y);
+  };
   image.addEventListener("pointerdown", (event) => {
-    if (zoom <= 1) return;
-    dragging = true;
-    lastX = event.clientX;
-    lastY = event.clientY;
-    image.setPointerCapture(event.pointerId);
+    activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    // Arm pan/pinch state before capturing the pointer: setPointerCapture can
+    // throw for a non-active pointer, and that must not skip the setup below.
+    if (activePointers.size === 2) {
+      pinchStartDist = pointerSpread();
+      pinchStartZoom = zoom;
+    } else {
+      lastX = event.clientX;
+      lastY = event.clientY;
+    }
+    try {
+      image.setPointerCapture(event.pointerId);
+    } catch {
+      // The pointer is already gone; pan/pinch still work without capture.
+    }
     event.preventDefault();
   });
   image.addEventListener("pointermove", (event) => {
-    if (!dragging) return;
+    if (!activePointers.has(event.pointerId)) return;
+    activePointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    if (activePointers.size >= 2) {
+      // Pinch: scale zoom by how much the finger spread changed.
+      if (pinchStartDist > 0) {
+        setZoom((pinchStartZoom * pointerSpread()) / pinchStartDist);
+      }
+      return;
+    }
+    // Single-pointer pan, only meaningful once zoomed past the fit.
+    if (zoom <= 1) return;
     tx += event.clientX - lastX;
     ty += event.clientY - lastY;
     lastX = event.clientX;
     lastY = event.clientY;
     applyTransform();
   });
-  const endDrag = (event: PointerEvent) => {
-    if (!dragging) return;
-    dragging = false;
+  const endPointer = (event: PointerEvent) => {
+    if (!activePointers.delete(event.pointerId)) return;
     if (image.hasPointerCapture(event.pointerId)) {
       image.releasePointerCapture(event.pointerId);
     }
+    // Dropping from a pinch back to one finger: resume panning from the survivor
+    // so the image doesn't jump on the next move.
+    const [survivor] = [...activePointers.values()];
+    if (survivor) {
+      lastX = survivor.x;
+      lastY = survivor.y;
+    }
   };
-  image.addEventListener("pointerup", endDrag);
-  image.addEventListener("pointercancel", endDrag);
+  image.addEventListener("pointerup", endPointer);
+  image.addEventListener("pointercancel", endPointer);
 
   let closed = false;
   const close = () => {
     if (closed) return;
     closed = true;
+    window.removeEventListener("resize", onResize);
     document.removeEventListener("keydown", onKeyDown);
     document.removeEventListener("fullscreenchange", onFullscreenChange);
     if (document.fullscreenElement === overlay) {
@@ -334,8 +374,14 @@ function openPhotoFullscreen(src: string, alt: string): void {
     if (event.key === "Escape") close();
   };
   const onFullscreenChange = () => {
-    // Leaving native fullscreen (Esc / F11) should also dismiss the overlay.
-    if (document.fullscreenElement !== overlay) close();
+    if (document.fullscreenElement === overlay) {
+      // Entering fullscreen changes the rendered fit size; remeasure so the
+      // badge percentage and the 400%-of-native cap track the new layout.
+      requestAnimationFrame(measure);
+    } else {
+      // Leaving native fullscreen (Esc / F11) should also dismiss the overlay.
+      close();
+    }
   };
 
   closeButton.addEventListener("click", close);

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -359,11 +359,13 @@ function openPhotoFullscreen(src: string, alt: string): void {
     } catch {
       // The pointer is already gone; pan/pinch still work without capture.
     }
-    // Only suppress the default (text selection, image drag, and the mouse-
-    // compatibility event chain) when a pan or pinch is actually starting.
-    // Calling preventDefault on a plain mouse click at fit can swallow the
-    // double-click-to-zoom on some browsers, so leave that gesture untouched.
-    if (event.pointerType !== "mouse" || zoom > 1 || activePointers.size === 2) {
+    // Only suppress the default for a mouse drag while zoomed, to stop the native
+    // image ghost-drag during a pan. Touch gestures are already neutralized by
+    // `touch-action: none` on the image, so we must NOT preventDefault there: on
+    // pointerdown that would suppress the compatibility events a double-tap's
+    // dblclick is synthesized from, breaking double-tap-to-zoom on touch. A plain
+    // mouse click at fit is likewise left untouched so mouse double-click works.
+    if (event.pointerType === "mouse" && zoom > 1) {
       event.preventDefault();
     }
   });

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -136,7 +136,13 @@ function createIdentifyPopupElement(
     empty.textContent = "No attributes";
     rows.appendChild(empty);
   } else {
-    for (const [key, value] of entries) appendRow(key, value);
+    for (const [key, value] of entries) {
+      // The full-resolution image is an internal companion to the thumbnail;
+      // skip it so Identify doesn't decode a multi-megapixel data URL just to
+      // show a second copy of the same photo in the same small thumbnail box.
+      if (key === PHOTO_FULL_KEY) continue;
+      appendRow(key, value);
+    }
   }
 
   return root;
@@ -264,6 +270,14 @@ function openPhotoFullscreen(src: string, alt: string): void {
     // Cap magnification at PHOTO_MAX_ZOOM_FRACTION of native, but always allow at
     // least a little zoom for images that already fit within the viewport.
     maxZoom = Math.max(1.5, PHOTO_MAX_ZOOM_FRACTION / fitToNative);
+    // A resize (or entering fullscreen) can grow the fit ratio and shrink
+    // maxZoom below the current zoom; reclamp so the 400%-of-native cap holds
+    // instead of rendering (and reporting) a now-out-of-range zoom.
+    zoom = clamp(zoom, 1, maxZoom);
+    if (zoom === 1) {
+      tx = 0;
+      ty = 0;
+    }
     applyTransform();
   };
   if (image.complete && image.naturalWidth > 0) measure();

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -470,15 +470,15 @@ function createPhotoPopupElement(
   root.className = "geolibre-photo-popup";
 
   // The popup shows the light thumbnail; the fullscreen viewer prefers the
-  // embedded full-resolution image (falling back to the thumbnail when the
-  // source was already native or its format can't be shown at full size).
+  // embedded full-resolution image (falling back to the thumbnail when no
+  // original was embedded, e.g. a format that can't be shown at full size).
   const thumbnail =
     imageDataUrlAt(properties, PHOTO_THUMBNAIL_KEY) ??
     findPhotoDataUrl(properties);
   if (thumbnail) {
     // Prefer the embedded full-resolution image, falling back to the thumbnail
-    // when the source was already native or its format can't be shown at full
-    // size; `thumbnail` is non-null here, so this is always a string.
+    // when no original was embedded (TIFF/HEIC, mislabeled bytes, or an original
+    // over the size ceiling); `thumbnail` is non-null here, so this is a string.
     const fullImage = imageDataUrlAt(properties, PHOTO_FULL_KEY);
     const fullResolution = fullImage ?? thumbnail;
     const image = document.createElement("img");

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -152,6 +152,24 @@ function createIdentifyMessagePopupElement(
 /** Match an inline base64 raster image (excludes SVG, which can carry scripts). */
 const INLINE_IMAGE_DATA_URL = /^data:image\/(?!svg)[\w.+-]+;base64,/i;
 
+// Feature-property keys for geotagged/field-collection photos. Kept in sync with
+// PHOTO_PROPERTY / PHOTO_FULL_PROPERTY in the app's field-collection module (this
+// package can't import from the app): the popup shows the light thumbnail while
+// the fullscreen viewer and "Save image" use the embedded full-resolution image.
+const PHOTO_THUMBNAIL_KEY = "photo";
+const PHOTO_FULL_KEY = "photo_full";
+
+/** Return the value at `key` when it is an inline raster image data URL. */
+function imageDataUrlAt(
+  properties: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = properties[key];
+  return typeof value === "string" && INLINE_IMAGE_DATA_URL.test(value)
+    ? value
+    : null;
+}
+
 /**
  * Find the first feature property holding an inline raster image (a geotagged
  * photo or field-collection thumbnail), returning its data URL or null.
@@ -165,14 +183,22 @@ function findPhotoDataUrl(properties: Record<string, unknown>): string | null {
   return null;
 }
 
+/** How far past native resolution the fullscreen viewer can magnify (400%). */
+const PHOTO_MAX_ZOOM_FRACTION = 4;
+/** Per-wheel-notch zoom step. */
+const PHOTO_ZOOM_STEP = 1.15;
+
 /**
  * Open a photo in a fullscreen lightbox: a backdrop overlay with the image
- * centered (scaled to fit). Uses the native Fullscreen API so it fills the whole
- * screen, falling back to a viewport-filling overlay where fullscreen is denied.
- * Closes on the × button, a backdrop click, Escape, a double-click on the image,
- * or the user leaving native fullscreen.
+ * centered and scaled to fit. The mouse wheel zooms in on the photo (up to 400%
+ * of its native resolution) and, once zoomed past the fit, dragging pans it; a
+ * badge reports the current zoom as a percentage of native resolution alongside
+ * the source pixel dimensions. Uses the native Fullscreen API so it fills the
+ * whole screen, falling back to a viewport-filling overlay where fullscreen is
+ * denied. Closes on the × button, a backdrop click, or Escape (double-click
+ * toggles zoom rather than closing), or when the user leaves native fullscreen.
  *
- * @param src - The image data URL or URL.
+ * @param src - The image data URL or URL (native resolution where available).
  * @param alt - Accessible label for the image.
  */
 function openPhotoFullscreen(src: string, alt: string): void {
@@ -188,6 +214,11 @@ function openPhotoFullscreen(src: string, alt: string): void {
   image.className = "geolibre-photo-fullscreen-img";
   overlay.appendChild(image);
 
+  const badge = document.createElement("div");
+  badge.className = "geolibre-photo-fullscreen-badge";
+  badge.setAttribute("aria-hidden", "true");
+  overlay.appendChild(badge);
+
   const closeButton = document.createElement("button");
   closeButton.type = "button";
   closeButton.className = "geolibre-photo-fullscreen-close";
@@ -199,6 +230,94 @@ function openPhotoFullscreen(src: string, alt: string): void {
   // Move focus into the lightbox so keyboard and screen-reader users land on a
   // control inside it (and Escape/Enter act on the close button by default).
   closeButton.focus();
+
+  // Zoom is a multiple of the fit-to-screen size (1 = fit). `tx`/`ty` translate
+  // the image while panning a zoomed photo.
+  let zoom = 1;
+  let tx = 0;
+  let ty = 0;
+  // Set once the image loads: the fit-size-to-native ratio (so the badge can
+  // report zoom as a fraction of native), and the fit and max zoom multiples.
+  let fitToNative = 1;
+  let maxZoom = PHOTO_MAX_ZOOM_FRACTION;
+
+  const clamp = (value: number, min: number, max: number) =>
+    Math.min(max, Math.max(min, value));
+
+  const applyTransform = () => {
+    image.style.transform = `translate(${tx}px, ${ty}px) scale(${zoom})`;
+    image.classList.toggle("is-zoomed", zoom > 1.001);
+    const nativePercent = Math.round(fitToNative * zoom * 100);
+    badge.textContent =
+      image.naturalWidth > 0
+        ? `${nativePercent}% · ${image.naturalWidth} × ${image.naturalHeight}`
+        : "";
+  };
+
+  const measure = () => {
+    // clientWidth is the fit-rendered width (max-width/height:100%, aspect kept);
+    // dividing by naturalWidth gives how much of native the fit view shows.
+    fitToNative =
+      image.naturalWidth > 0 && image.clientWidth > 0
+        ? image.clientWidth / image.naturalWidth
+        : 1;
+    // Cap magnification at PHOTO_MAX_ZOOM_FRACTION of native, but always allow at
+    // least a little zoom for images that already fit within the viewport.
+    maxZoom = Math.max(1.5, PHOTO_MAX_ZOOM_FRACTION / fitToNative);
+    applyTransform();
+  };
+  if (image.complete && image.naturalWidth > 0) measure();
+  else image.addEventListener("load", measure, { once: true });
+
+  const setZoom = (next: number) => {
+    zoom = clamp(next, 1, maxZoom);
+    if (zoom <= 1.001) {
+      // Back at fit: recenter so a later zoom-in starts from the middle.
+      zoom = 1;
+      tx = 0;
+      ty = 0;
+    }
+    applyTransform();
+  };
+
+  overlay.addEventListener(
+    "wheel",
+    (event) => {
+      event.preventDefault();
+      setZoom(zoom * (event.deltaY < 0 ? PHOTO_ZOOM_STEP : 1 / PHOTO_ZOOM_STEP));
+    },
+    { passive: false },
+  );
+
+  // Drag to pan once zoomed in.
+  let dragging = false;
+  let lastX = 0;
+  let lastY = 0;
+  image.addEventListener("pointerdown", (event) => {
+    if (zoom <= 1) return;
+    dragging = true;
+    lastX = event.clientX;
+    lastY = event.clientY;
+    image.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  });
+  image.addEventListener("pointermove", (event) => {
+    if (!dragging) return;
+    tx += event.clientX - lastX;
+    ty += event.clientY - lastY;
+    lastX = event.clientX;
+    lastY = event.clientY;
+    applyTransform();
+  });
+  const endDrag = (event: PointerEvent) => {
+    if (!dragging) return;
+    dragging = false;
+    if (image.hasPointerCapture(event.pointerId)) {
+      image.releasePointerCapture(event.pointerId);
+    }
+  };
+  image.addEventListener("pointerup", endDrag);
+  image.addEventListener("pointercancel", endDrag);
 
   let closed = false;
   const close = () => {
@@ -224,7 +343,12 @@ function openPhotoFullscreen(src: string, alt: string): void {
   overlay.addEventListener("click", (event) => {
     if (event.target === overlay) close();
   });
-  image.addEventListener("dblclick", close);
+  // Double-click toggles between fit and 100% of native (or max, if native is
+  // beyond the cap), rather than closing, so the viewer stays a zoom surface.
+  image.addEventListener("dblclick", (event) => {
+    event.preventDefault();
+    setZoom(zoom > 1.001 ? 1 : Math.min(1 / fitToNative, maxZoom));
+  });
   document.addEventListener("keydown", onKeyDown);
   document.addEventListener("fullscreenchange", onFullscreenChange);
 
@@ -249,19 +373,25 @@ function createPhotoPopupElement(
   const root = document.createElement("div");
   root.className = "geolibre-photo-popup";
 
-  const photo = findPhotoDataUrl(properties);
-  if (photo) {
+  // The popup shows the light thumbnail; the fullscreen viewer prefers the
+  // embedded full-resolution image (falling back to the thumbnail when the
+  // source was already native or its format can't be shown at full size).
+  const thumbnail =
+    imageDataUrlAt(properties, PHOTO_THUMBNAIL_KEY) ??
+    findPhotoDataUrl(properties);
+  const fullResolution = imageDataUrlAt(properties, PHOTO_FULL_KEY) ?? thumbnail;
+  if (thumbnail) {
     const image = document.createElement("img");
-    image.src = photo;
+    image.src = thumbnail;
     image.alt = typeof properties.name === "string" ? properties.name : "Photo";
     image.className = "geolibre-photo-popup-img";
-    image.title = "Double-click to view fullscreen";
+    image.title = "Double-click to view at full resolution";
     // Double-click (not single, so it never fights the resize drag) opens the
     // photo fullscreen. The image is popup DOM, not the map canvas, so this does
     // not trigger MapLibre's double-click zoom.
     image.addEventListener("dblclick", (event) => {
       event.stopPropagation();
-      openPhotoFullscreen(photo, image.alt);
+      openPhotoFullscreen(fullResolution ?? thumbnail, image.alt);
     });
     root.appendChild(image);
   } else {

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -3,7 +3,9 @@ import { describe, it } from "node:test";
 
 import type { FeatureCollection, Point } from "geojson";
 import {
+  base64FromBytes,
   buildPhotoProperties,
+  createFullResolutionDataUrl,
   isPhotoDropFileName,
   isPhotoFileName,
   isValidLngLat,
@@ -155,6 +157,53 @@ describe("buildPhotoProperties", () => {
       null,
     );
     assert.equal(props.camera, "Canon EOS R5");
+  });
+});
+
+describe("base64FromBytes", () => {
+  it("encodes bytes the same as Buffer's base64, including chunk boundaries", () => {
+    // A payload past the 0x8000 chunk size exercises the chunked loop.
+    const bytes = new Uint8Array(0x8000 + 500);
+    for (let i = 0; i < bytes.length; i += 1) bytes[i] = (i * 31) & 0xff;
+    assert.equal(
+      base64FromBytes(bytes),
+      Buffer.from(bytes).toString("base64"),
+    );
+  });
+
+  it("handles an empty input", () => {
+    assert.equal(base64FromBytes(new Uint8Array(0)), "");
+  });
+});
+
+describe("createFullResolutionDataUrl", () => {
+  it("embeds the original bytes with the extension's MIME type", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const url = await createFullResolutionDataUrl(
+      new Blob([bytes]),
+      "IMG_1234.JPG",
+    );
+    assert.equal(
+      url,
+      `data:image/jpeg;base64,${Buffer.from(bytes).toString("base64")}`,
+    );
+  });
+
+  it("maps png/webp extensions and is case-insensitive", async () => {
+    const blob = new Blob([new Uint8Array([9])]);
+    assert.ok((await createFullResolutionDataUrl(blob, "a.png"))?.startsWith(
+      "data:image/png;base64,",
+    ));
+    assert.ok((await createFullResolutionDataUrl(blob, "a.WEBP"))?.startsWith(
+      "data:image/webp;base64,",
+    ));
+  });
+
+  it("returns null for formats a browser can't show at full size", async () => {
+    const blob = new Blob([new Uint8Array([0])]);
+    assert.equal(await createFullResolutionDataUrl(blob, "scene.tif"), null);
+    assert.equal(await createFullResolutionDataUrl(blob, "photo.heic"), null);
+    assert.equal(await createFullResolutionDataUrl(blob, "noext"), null);
   });
 });
 

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -199,6 +199,17 @@ describe("createFullResolutionDataUrl", () => {
     ));
   });
 
+  it("derives the MIME from the bytes when the extension is mislabeled", async () => {
+    // JPEG magic bytes (FF D8 FF) in a file named .png must yield image/jpeg,
+    // not image/png, so the data URL stays decodable.
+    const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const url = await createFullResolutionDataUrl(
+      new Blob([jpegBytes]),
+      "mislabeled.png",
+    );
+    assert.ok(url?.startsWith("data:image/jpeg;base64,"), url ?? "null");
+  });
+
   it("returns null for formats a browser can't show at full size", async () => {
     const blob = new Blob([new Uint8Array([0])]);
     assert.equal(await createFullResolutionDataUrl(blob, "scene.tif"), null);

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -11,7 +11,10 @@ import {
   PHOTO_IMAGE_EXTENSIONS,
   relocatePhotoFeatures,
 } from "../apps/geolibre-desktop/src/lib/geotagged-photos";
-import { PHOTO_PROPERTY } from "../apps/geolibre-desktop/src/lib/field-collection";
+import {
+  PHOTO_FULL_PROPERTY,
+  PHOTO_PROPERTY,
+} from "../apps/geolibre-desktop/src/lib/field-collection";
 
 describe("isPhotoFileName", () => {
   it("accepts the supported image extensions, case-insensitively", () => {
@@ -85,10 +88,32 @@ describe("buildPhotoProperties", () => {
     const props = buildPhotoProperties("a.heic", { latitude: 1, longitude: 2 }, null);
     assert.equal(props.name, "a.heic");
     assert.ok(!(PHOTO_PROPERTY in props));
+    assert.ok(!(PHOTO_FULL_PROPERTY in props));
     assert.ok(!("timestamp" in props));
     assert.ok(!("altitude" in props));
     assert.ok(!("direction" in props));
     assert.ok(!("camera" in props));
+  });
+
+  it("stores the full-resolution image under its own key when provided", () => {
+    const props = buildPhotoProperties(
+      "big.jpg",
+      { latitude: 1, longitude: 2 },
+      "data:image/jpeg;base64,THUMB",
+      "data:image/jpeg;base64,ORIGINAL",
+    );
+    assert.equal(props[PHOTO_PROPERTY], "data:image/jpeg;base64,THUMB");
+    assert.equal(props[PHOTO_FULL_PROPERTY], "data:image/jpeg;base64,ORIGINAL");
+  });
+
+  it("omits the full-resolution key when only a thumbnail is given", () => {
+    const props = buildPhotoProperties(
+      "small.jpg",
+      { latitude: 1, longitude: 2 },
+      "data:image/jpeg;base64,THUMB",
+    );
+    assert.equal(props[PHOTO_PROPERTY], "data:image/jpeg;base64,THUMB");
+    assert.ok(!(PHOTO_FULL_PROPERTY in props));
   });
 
   it("falls back to CreateDate and trims a make-only camera", () => {

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -6,6 +6,7 @@ import {
   base64FromBytes,
   buildPhotoProperties,
   createFullResolutionDataUrl,
+  MAX_FULL_RESOLUTION_BYTES,
   isPhotoDropFileName,
   isPhotoFileName,
   isValidLngLat,
@@ -208,6 +209,18 @@ describe("createFullResolutionDataUrl", () => {
       "mislabeled.png",
     );
     assert.ok(url?.startsWith("data:image/jpeg;base64,"), url ?? "null");
+  });
+
+  it("falls back to thumbnail-only for a pathologically large original", async () => {
+    // A fake Blob reporting a size over the ceiling (no allocation) must be
+    // skipped without reading its bytes.
+    const oversize = {
+      size: MAX_FULL_RESOLUTION_BYTES + 1,
+      arrayBuffer: async () => {
+        throw new Error("must not read bytes past the size ceiling");
+      },
+    } as unknown as Blob;
+    assert.equal(await createFullResolutionDataUrl(oversize, "huge.jpg"), null);
   });
 
   it("returns null for formats a browser can't show at full size", async () => {

--- a/tests/geotagged-photos.test.ts
+++ b/tests/geotagged-photos.test.ts
@@ -178,8 +178,8 @@ describe("base64FromBytes", () => {
 });
 
 describe("createFullResolutionDataUrl", () => {
-  it("embeds the original bytes with the extension's MIME type", async () => {
-    const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+  it("embeds the original bytes with the MIME from the magic bytes", async () => {
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x42]);
     const url = await createFullResolutionDataUrl(
       new Blob([bytes]),
       "IMG_1234.JPG",
@@ -190,14 +190,22 @@ describe("createFullResolutionDataUrl", () => {
     );
   });
 
-  it("maps png/webp extensions and is case-insensitive", async () => {
-    const blob = new Blob([new Uint8Array([9])]);
-    assert.ok((await createFullResolutionDataUrl(blob, "a.png"))?.startsWith(
-      "data:image/png;base64,",
-    ));
-    assert.ok((await createFullResolutionDataUrl(blob, "a.WEBP"))?.startsWith(
-      "data:image/webp;base64,",
-    ));
+  it("recognizes PNG and WebP signatures, case-insensitively", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    assert.ok(
+      (await createFullResolutionDataUrl(new Blob([png]), "a.PNG"))?.startsWith(
+        "data:image/png;base64,",
+      ),
+    );
+    // "RIFF" + 4 size bytes + "WEBP".
+    const webp = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    assert.ok(
+      (
+        await createFullResolutionDataUrl(new Blob([webp]), "a.webp")
+      )?.startsWith("data:image/webp;base64,"),
+    );
   });
 
   it("derives the MIME from the bytes when the extension is mislabeled", async () => {
@@ -209,6 +217,16 @@ describe("createFullResolutionDataUrl", () => {
       "mislabeled.png",
     );
     assert.ok(url?.startsWith("data:image/jpeg;base64,"), url ?? "null");
+  });
+
+  it("skips full-res for unrecognized bytes under a supported extension", async () => {
+    // A GIF (magic GIF89a) saved as .jpg decodes for a thumbnail but must not be
+    // embedded as image/jpeg, which would be undecodable.
+    const gif = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    assert.equal(
+      await createFullResolutionDataUrl(new Blob([gif]), "actually-a.jpg"),
+      null,
+    );
   });
 
   it("falls back to thumbnail-only for a pathologically large original", async () => {


### PR DESCRIPTION
## Summary

Fixes #1205.

Geotagged photos were downscaled to a 1600px JPEG thumbnail at import and the original bytes were discarded, so double-clicking to enlarge (or a right-click "Save image") only ever had a 1600x1200 image. Magnifying showed no additional detail, and saving produced a 1600x1200 file even from an 8064x6048 source.

## What changed

- **Embed the original image inline** alongside the thumbnail for formats a browser can display natively (JPEG/PNG/WebP), under a new `photo_full` feature property. It is skipped when the source is already at or below the thumbnail cap (the thumbnail is then already native) and for formats a browser can't show at full size (TIFF/HEIC). The original bytes are not re-encoded, so there is no quality loss.
- **The map popup keeps the light 1600px thumbnail** (fast, small); the **fullscreen viewer and "Save image" now use the full-resolution original**.
- **Fullscreen viewer enhancements:** mouse-wheel zoom up to **400% of native resolution**, drag-to-pan when zoomed, double-click to toggle fit / 100%, and a badge showing the current zoom as a percentage of native plus the source pixel dimensions.

The thumbnail cap was a deliberate choice to keep the inline data URL small because it is serialized into the project file; embedding the original grows projects by roughly the size of the imported photos, which is the intended trade-off for true native resolution.

## Verification

Drove the real app in a browser with Playwright using a generated 8064x6048 JPEG carrying EXIF GPS:

- Popup image is the 1600x1200 thumbnail (~235 KB).
- Double-click opens the fullscreen viewer at the true native **8064 x 6048** (~8.5 MB original bytes, not the thumbnail).
- Wheel zoom climbs and caps exactly at **400%** of native; fine detail renders crisply at 400%.
- Badge reads e.g. `12% - 8064 x 6048` at fit and `400% - 8064 x 6048` at max.
- Verified in both **light and dark** themes.

Unit tests cover the new `photo_full` property in `buildPhotoProperties` (present when provided, omitted otherwise).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded fullscreen photos to an interactive zoom/pan experience (wheel zoom, drag pan, pinch-style zoom) with a live zoom badge, improved cursors, and restored EXIF orientation.
  * Fullscreen now prefers embedded full-resolution images when available (falls back to thumbnails).
* **Bug Fixes**
  * Photo import embeds full-resolution images only for supported, browser-decodable formats and within a size limit; unsupported or undecodable formats no longer break the experience.
  * Identify popups and attribute tables no longer expose inline photo data as extra attributes/columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->