### PR TITLE
fix(desktop): resolve bundled Jupyter sidecar in installed builds

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2949,6 +2949,16 @@ mod tests {
             resolve_sidecar_in_resource_dir(root.path()).expect("sidecar should be found");
         assert_eq!(resolved, project.canonicalize().unwrap());
 
+        // The plain (0-level) layout used by portable builds, where the sidecar
+        // sits at `backend/geolibre_server` directly under the resource dir.
+        let plain_root = ScratchDir::new("sidecar-plain");
+        let plain_project = plain_root.path().join("backend").join("geolibre_server");
+        std::fs::create_dir_all(&plain_project).unwrap();
+        std::fs::write(plain_project.join("pyproject.toml"), "[project]\n").unwrap();
+        let plain_resolved = resolve_sidecar_in_resource_dir(plain_root.path())
+            .expect("plain sidecar should be found");
+        assert_eq!(plain_resolved, plain_project.canonicalize().unwrap());
+
         // A resource dir without the project (and without a pyproject marker)
         // resolves to nothing rather than a false positive.
         let empty = ScratchDir::new("sidecar-empty");

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2133,12 +2133,7 @@ fn sidecar_project_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     }
 
     if let Ok(resource_dir) = app.path().resource_dir() {
-        if let Ok(path) =
-            validate_sidecar_project_dir(resource_dir.join("backend").join("geolibre_server"))
-        {
-            return Ok(path);
-        }
-        if let Ok(path) = validate_sidecar_project_dir(resource_dir.join("geolibre_server")) {
+        if let Some(path) = resolve_sidecar_in_resource_dir(&resource_dir) {
             return Ok(path);
         }
     }
@@ -2151,6 +2146,31 @@ fn sidecar_project_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
             .join("backend")
             .join("geolibre_server"),
     )
+}
+
+/// Locate the bundled Python sidecar project under a Tauri resource directory.
+///
+/// Tauri bundles the `../../../backend/geolibre_server` resource by rewriting
+/// every leading `..` in the source path to an `_up_` directory, so in an
+/// installed build the project lands at
+/// `<resource_dir>/_up_/_up_/_up_/backend/geolibre_server` rather than directly
+/// under the resource dir (issue #1223). We probe the plain locations first,
+/// then a few `_up_` depths so the lookup keeps working if the number of `..`
+/// segments in the resource path ever changes.
+fn resolve_sidecar_in_resource_dir(resource_dir: &std::path::Path) -> Option<PathBuf> {
+    let mut prefix = resource_dir.to_path_buf();
+    for _ in 0..=4 {
+        if let Ok(path) =
+            validate_sidecar_project_dir(prefix.join("backend").join("geolibre_server"))
+        {
+            return Some(path);
+        }
+        if let Ok(path) = validate_sidecar_project_dir(prefix.join("geolibre_server")) {
+            return Some(path);
+        }
+        prefix = prefix.join("_up_");
+    }
+    None
 }
 
 fn validate_sidecar_project_dir(path: PathBuf) -> Result<PathBuf, String> {
@@ -2875,9 +2895,47 @@ mod tests {
     use super::{
         ensure_fetchable_url, find_zip_manifest_path, is_allowed_local_vector_path,
         is_allowed_project_path, is_disallowed_ip, is_safe_absolute_path, plugin_archive_file_name,
+        resolve_sidecar_in_resource_dir,
     };
     use std::io::{Cursor, Write};
     use std::net::IpAddr;
+    use std::path::PathBuf;
+
+    // Build a throwaway directory tree under the system temp dir. Uses the
+    // process id (no rand dependency) and removes any leftover from a prior run.
+    fn scratch_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("geolibre-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    // Regression for issue #1223: installed builds place the bundled sidecar at
+    // `<resource_dir>/_up_/_up_/_up_/backend/geolibre_server`, so the resolver
+    // must follow the `_up_` chain rather than only checking the resource root.
+    #[test]
+    fn resolves_bundled_sidecar_under_up_prefix() {
+        let root = scratch_dir("sidecar-up");
+        let project = root
+            .join("_up_")
+            .join("_up_")
+            .join("_up_")
+            .join("backend")
+            .join("geolibre_server");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("pyproject.toml"), "[project]\n").unwrap();
+
+        let resolved = resolve_sidecar_in_resource_dir(&root).expect("sidecar should be found");
+        assert_eq!(resolved, project.canonicalize().unwrap());
+
+        // A resource dir without the project (and without a pyproject marker)
+        // resolves to nothing rather than a false positive.
+        let empty = scratch_dir("sidecar-empty");
+        assert!(resolve_sidecar_in_resource_dir(&empty).is_none());
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&empty);
+    }
 
     #[test]
     fn blocks_link_local_and_metadata_ips() {

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2158,8 +2158,11 @@ fn sidecar_project_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 /// then a few `_up_` depths so the lookup keeps working if the number of `..`
 /// segments in the resource path ever changes.
 fn resolve_sidecar_in_resource_dir(resource_dir: &std::path::Path) -> Option<PathBuf> {
+    // Plain resource root plus a few `_up_` levels of margin over the observed
+    // 3-level bundle depth, so the lookup survives a change in Tauri's bundling.
+    const MAX_UP_DEPTH: usize = 4;
     let mut prefix = resource_dir.to_path_buf();
-    for _ in 0..=4 {
+    for _ in 0..=MAX_UP_DEPTH {
         if let Ok(path) =
             validate_sidecar_project_dir(prefix.join("backend").join("geolibre_server"))
         {
@@ -2901,13 +2904,29 @@ mod tests {
     use std::net::IpAddr;
     use std::path::PathBuf;
 
-    // Build a throwaway directory tree under the system temp dir. Uses the
-    // process id (no rand dependency) and removes any leftover from a prior run.
-    fn scratch_dir(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("geolibre-{name}-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
+    // A throwaway directory tree under the system temp dir that removes itself
+    // on drop, so scratch dirs are cleaned up even when an assertion panics.
+    // Uses the process id (no rand dependency) and clears any leftover from a
+    // prior run at construction.
+    struct ScratchDir(PathBuf);
+
+    impl ScratchDir {
+        fn new(name: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!("geolibre-{name}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
     }
 
     // Regression for issue #1223: installed builds place the bundled sidecar at
@@ -2915,8 +2934,9 @@ mod tests {
     // must follow the `_up_` chain rather than only checking the resource root.
     #[test]
     fn resolves_bundled_sidecar_under_up_prefix() {
-        let root = scratch_dir("sidecar-up");
+        let root = ScratchDir::new("sidecar-up");
         let project = root
+            .path()
             .join("_up_")
             .join("_up_")
             .join("_up_")
@@ -2925,16 +2945,14 @@ mod tests {
         std::fs::create_dir_all(&project).unwrap();
         std::fs::write(project.join("pyproject.toml"), "[project]\n").unwrap();
 
-        let resolved = resolve_sidecar_in_resource_dir(&root).expect("sidecar should be found");
+        let resolved =
+            resolve_sidecar_in_resource_dir(root.path()).expect("sidecar should be found");
         assert_eq!(resolved, project.canonicalize().unwrap());
 
         // A resource dir without the project (and without a pyproject marker)
         // resolves to nothing rather than a false positive.
-        let empty = scratch_dir("sidecar-empty");
-        assert!(resolve_sidecar_in_resource_dir(&empty).is_none());
-
-        let _ = std::fs::remove_dir_all(&root);
-        let _ = std::fs::remove_dir_all(&empty);
+        let empty = ScratchDir::new("sidecar-empty");
+        assert!(resolve_sidecar_in_resource_dir(empty.path()).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1223. Installed desktop builds could not open the **Jupyter Notebook** (or start the FastAPI sidecar). It surfaced differently per platform but has a single root cause:

- **Linux / Arch:** `Could not resolve sidecar project path: No such file or directory (os error 2)`
- **Windows:** the Jupyter panel showed `127.0.0.1 refused to connect` (the server never started)

It works under `npm run tauri:dev` because dev falls back to the source tree, which masks the bug.

## Root cause

Tauri bundles the `../../../backend/geolibre_server` resource by rewriting every leading `..` to an `_up_` directory. In a packaged build the sidecar therefore lands at:

```
<resource_dir>/_up_/_up_/_up_/backend/geolibre_server
```

`sidecar_project_dir` only probed `resource_dir/backend/geolibre_server` and `resource_dir/geolibre_server`. Both miss, so it fell through to the dev-only `CARGO_MANIFEST_DIR` path, which does not exist on an installed machine, producing `os error 2`. The same resolver backs both the Jupyter server and the FastAPI sidecar, so both were broken in installed builds.

## Fix

- Follow the `_up_` chain when probing the resource dir, with a small depth margin so the lookup survives a change in the number of `..` segments.
- Extract the probing into a pure `resolve_sidecar_in_resource_dir` helper and add a regression test that reproduces the real bundled `_up_/_up_/_up_/backend/geolibre_server` layout (and asserts no false positive on an empty resource dir).

## Verification

- Confirmed the actual `deb` bundle places the project at `<resource_dir>/_up_/_up_/_up_/backend/geolibre_server/pyproject.toml` (the layout the new test reproduces).
- `cargo test` (all 15 crate tests pass, including the new one), `cargo fmt --check`, `cargo check`, and `pre-commit run` (full npm build) all green.

This is a Rust-only, GeoLibre-side change; no upstream package or release was involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop startup reliability by correctly locating the bundled backend in packaged applications.
  * Prevented failures when resource paths contain rewritten parent-directory segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->