### PR TITLE
feat(map): switch scale bar between metric, imperial, and nautical units

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import {
   useAppStore,
   type MapPreferences,
   type MapProjection,
+  type MapScaleUnit,
   type ProjectPreferences,
   type RuntimeEnvironmentVariable,
 } from "@geolibre/core";
@@ -1620,6 +1621,33 @@ export function SettingsDialog({
                     </Select>
                     <p className="text-xs text-muted-foreground">
                       {t("settings.map.ellipsoidHint")}
+                    </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="settings-scale-unit">
+                      {t("settings.map.scaleUnit")}
+                    </Label>
+                    <Select
+                      id="settings-scale-unit"
+                      value={draftPreferences.map.scaleUnit}
+                      onChange={(event) =>
+                        updateMapPreferences({
+                          scaleUnit: event.target.value as MapScaleUnit,
+                        })
+                      }
+                    >
+                      <option value="metric">
+                        {t("settings.map.scaleUnitMetric")}
+                      </option>
+                      <option value="imperial">
+                        {t("settings.map.scaleUnitImperial")}
+                      </option>
+                      <option value="nautical">
+                        {t("settings.map.scaleUnitNautical")}
+                      </option>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.map.scaleUnitHint")}
                     </p>
                   </div>
                 </div>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1306,6 +1306,11 @@
       "renderWorldCopies": "Render world copies",
       "ellipsoid": "Celestial body",
       "ellipsoidHint": "Sets the radius used for distance, area, and scale measurements. Pick a matching planetary basemap under Add Data.",
+      "scaleUnit": "Scale bar units",
+      "scaleUnitMetric": "Metric (m / km)",
+      "scaleUnitImperial": "Imperial (ft / mi)",
+      "scaleUnitNautical": "Nautical (nmi)",
+      "scaleUnitHint": "Choose the units shown on the scale bar at the bottom of the map.",
       "errorBoundsUnavailable": "The map bounds are not available yet."
     },
     "layout": {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -20,6 +20,7 @@ import {
   type LegendConfig,
   type LegendItemOverride,
   type MapGridLayout,
+  type MapScaleUnit,
   type MapViewState,
   type ProcessingModel,
   type SecondaryMapView,
@@ -745,6 +746,9 @@ function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
       ellipsoidId: getEllipsoid(
         (map as Partial<ProjectPreferences["map"]>).ellipsoidId,
       ).id,
+      scaleUnit: normalizeScaleUnit(
+        (map as Partial<ProjectPreferences["map"]>).scaleUnit,
+      ),
     },
     environmentVariables: Array.isArray(candidate.environmentVariables)
       ? candidate.environmentVariables
@@ -794,6 +798,11 @@ function normalizeGeocodingPreferences(
         ? candidate.email.trim()
         : undefined,
   };
+}
+
+/** Coerce an unknown value to a supported scale unit, defaulting to metric. */
+function normalizeScaleUnit(value: unknown): MapScaleUnit {
+  return value === "imperial" || value === "nautical" ? value : "metric";
 }
 
 function normalizeBounds(bounds: unknown): ProjectPreferences["map"]["bounds"] {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -708,6 +708,12 @@ export interface CollaborationState {
 /** Map projection the renderer uses. Mirrors the GlobeControl toggle. */
 export type MapProjection = "globe" | "mercator";
 
+/**
+ * Unit system the scale bar reports distances in. `"metric"` uses m/km,
+ * `"imperial"` uses ft/mi, and `"nautical"` uses nautical miles.
+ */
+export type MapScaleUnit = "metric" | "imperial" | "nautical";
+
 export interface MapPreferences {
   restrictBounds: boolean;
   bounds: [number, number, number, number];
@@ -722,6 +728,11 @@ export interface MapPreferences {
    * with planetary basemaps. Defaults to `"earth"` (WGS 84).
    */
   ellipsoidId: string;
+  /**
+   * Unit system the scale bar displays. Defaults to `"metric"`; switch to
+   * `"imperial"` for feet/miles or `"nautical"` for nautical miles.
+   */
+  scaleUnit: MapScaleUnit;
 }
 
 export interface RuntimeEnvironmentVariable {
@@ -785,6 +796,7 @@ export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
     renderWorldCopies: true,
     projection: "globe",
     ellipsoidId: "earth",
+    scaleUnit: "metric",
   },
   environmentVariables: [],
   geocoding: {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -878,9 +878,12 @@ export class MapController {
       createMapTransformConstraint(preferences, this.map, minZoom, maxZoom),
     );
     this.applyView(this.readView());
-    // The ellipsoid can change here (Settings' celestial-body dropdown) without
-    // the basemap changing, so redraw the body-aware scale bar now — the store's
-    // ellipsoid subscription has already updated the active-radius singleton.
+    // The ellipsoid or the scale unit can change here (Settings' dropdowns)
+    // without the basemap changing, so push the unit and redraw the body-aware
+    // scale bar now — the store's ellipsoid subscription has already updated the
+    // active-radius singleton. setUnit redraws only when the unit differs, so
+    // refresh() still covers an ellipsoid-only change.
+    this.scaleControl?.setUnit(preferences.scaleUnit);
     this.scaleControl?.refresh();
   }
 
@@ -2357,9 +2360,12 @@ export class MapController {
       return false;
     }
     // A body-aware scale bar (MapLibre's built-in ScaleControl assumes Earth's
-    // radius, so it is wrong on Moon/Mars/Mercury/etc.). Metric only, matching
-    // the previous configuration.
-    this.scaleControl = new PlanetaryScaleControl({ maxWidth: 120 });
+    // radius, so it is wrong on Moon/Mars/Mercury/etc.). The unit system follows
+    // the project's map preference (metric / imperial / nautical).
+    this.scaleControl = new PlanetaryScaleControl({
+      maxWidth: 120,
+      unit: this.mapPreferences.scaleUnit,
+    });
     this.map.addControl(this.scaleControl, this.controlPositions.scale);
     return true;
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -881,10 +881,12 @@ export class MapController {
     // The ellipsoid or the scale unit can change here (Settings' dropdowns)
     // without the basemap changing, so push the unit and redraw the body-aware
     // scale bar now — the store's ellipsoid subscription has already updated the
-    // active-radius singleton. setUnit redraws only when the unit differs, so
-    // refresh() still covers an ellipsoid-only change.
-    this.scaleControl?.setUnit(preferences.scaleUnit);
-    this.scaleControl?.refresh();
+    // active-radius singleton. setUnit redraws when the unit differs and reports
+    // it, so only refresh() when it did not (e.g. an ellipsoid-only change), to
+    // avoid recomputing the bar twice.
+    if (!this.scaleControl?.setUnit(preferences.scaleUnit)) {
+      this.scaleControl?.refresh();
+    }
   }
 
   readView(): MapViewState {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -881,12 +881,11 @@ export class MapController {
     // The ellipsoid or the scale unit can change here (Settings' dropdowns)
     // without the basemap changing, so push the unit and redraw the body-aware
     // scale bar now — the store's ellipsoid subscription has already updated the
-    // active-radius singleton. setUnit redraws when the unit differs and reports
-    // it, so only refresh() when it did not (e.g. an ellipsoid-only change), to
-    // avoid recomputing the bar twice.
-    if (!this.scaleControl?.setUnit(preferences.scaleUnit)) {
-      this.scaleControl?.refresh();
-    }
+    // active-radius singleton. setUnit only stores the unit, so the single
+    // refresh() below redraws the bar once for whatever changed (unit, radius,
+    // or both).
+    this.scaleControl?.setUnit(preferences.scaleUnit);
+    this.scaleControl?.refresh();
   }
 
   readView(): MapViewState {

--- a/packages/map/src/planetary-scale-control.ts
+++ b/packages/map/src/planetary-scale-control.ts
@@ -31,11 +31,16 @@ export class PlanetaryScaleControl implements maplibregl.IControl {
     this.unit = options.unit ?? "metric";
   }
 
-  /** Switch the unit system and redraw immediately if the bar is on the map. */
-  setUnit(unit: MapScaleUnit): void {
-    if (this.unit === unit) return;
+  /**
+   * Switch the unit system, redrawing immediately when it changed. Returns
+   * `true` if the unit differed (and the bar was redrawn) so callers can skip a
+   * redundant {@link refresh}.
+   */
+  setUnit(unit: MapScaleUnit): boolean {
+    if (this.unit === unit) return false;
     this.unit = unit;
     this.update();
+    return true;
   }
 
   onAdd(map: maplibregl.Map): HTMLElement {

--- a/packages/map/src/planetary-scale-control.ts
+++ b/packages/map/src/planetary-scale-control.ts
@@ -1,4 +1,4 @@
-import { getActiveMeanRadiusMeters } from "@geolibre/core";
+import { getActiveMeanRadiusMeters, type MapScaleUnit } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
 
 /**
@@ -15,16 +15,27 @@ import maplibregl from "maplibre-gl";
  *
  * The radius is read lazily on each update, and {@link refresh} lets the map
  * controller redraw the bar the instant the basemap (and thus the body) changes,
- * without waiting for the next pan.
+ * without waiting for the next pan. The unit system (metric / imperial /
+ * nautical) is set with {@link setUnit} and follows the project's map
+ * preferences.
  */
 export class PlanetaryScaleControl implements maplibregl.IControl {
   private map: maplibregl.Map | null = null;
   private container: HTMLElement | null = null;
   private readonly maxWidth: number;
+  private unit: MapScaleUnit;
   private readonly onMove = () => this.update();
 
-  constructor(options: { maxWidth?: number } = {}) {
+  constructor(options: { maxWidth?: number; unit?: MapScaleUnit } = {}) {
     this.maxWidth = options.maxWidth ?? 100;
+    this.unit = options.unit ?? "metric";
+  }
+
+  /** Switch the unit system and redraw immediately if the bar is on the map. */
+  setUnit(unit: MapScaleUnit): void {
+    if (this.unit === unit) return;
+    this.unit = unit;
+    this.update();
   }
 
   onAdd(map: maplibregl.Map): HTMLElement {
@@ -71,7 +82,7 @@ export class PlanetaryScaleControl implements maplibregl.IControl {
       return;
     }
     container.style.display = "";
-    setMetricScale(container, this.maxWidth, maxMeters);
+    setScale(container, this.maxWidth, maxMeters, this.unit);
   }
 }
 
@@ -115,18 +126,45 @@ function formatNum(value: number): string {
   return Number.parseFloat(value.toPrecision(12)).toString();
 }
 
-/** Size the bar and label to a round metric distance (km above 1 km, else m). */
-function setMetricScale(
+const FEET_PER_METER = 3.2808398950131235; // 1 / 0.3048
+const FEET_PER_MILE = 5280;
+const METERS_PER_NAUTICAL_MILE = 1852;
+
+/** Size the bar and label to a round distance in the requested unit system. */
+function setScale(
   el: HTMLElement,
   maxWidth: number,
   maxMeters: number,
+  unit: MapScaleUnit,
 ): void {
-  const inKm = maxMeters >= 1000;
-  const span = inKm ? maxMeters / 1000 : maxMeters;
+  const { span, label } = scaleSpan(maxMeters, unit);
   const rounded = getRoundNum(span);
   // rounded ≤ span, so the bar is never wider than maxWidth; clamp anyway as a
   // hard guard against any pathological span slipping through.
   const width = Math.min(maxWidth, maxWidth * (rounded / span));
   el.style.width = `${width}px`;
-  el.textContent = `${formatNum(rounded)} ${inKm ? "km" : "m"}`;
+  el.textContent = `${formatNum(rounded)} ${label}`;
+}
+
+/**
+ * Convert a ground distance in metres into the unit the bar rounds and labels
+ * with: km/m for metric, mi/ft for imperial, and nautical miles for nautical.
+ * The unit crosses to the larger denomination once the span exceeds one of it.
+ */
+export function scaleSpan(
+  maxMeters: number,
+  unit: MapScaleUnit,
+): { span: number; label: string } {
+  if (unit === "imperial") {
+    const feet = maxMeters * FEET_PER_METER;
+    return feet >= FEET_PER_MILE
+      ? { span: feet / FEET_PER_MILE, label: "mi" }
+      : { span: feet, label: "ft" };
+  }
+  if (unit === "nautical") {
+    return { span: maxMeters / METERS_PER_NAUTICAL_MILE, label: "nmi" };
+  }
+  return maxMeters >= 1000
+    ? { span: maxMeters / 1000, label: "km" }
+    : { span: maxMeters, label: "m" };
 }

--- a/packages/map/src/planetary-scale-control.ts
+++ b/packages/map/src/planetary-scale-control.ts
@@ -32,15 +32,13 @@ export class PlanetaryScaleControl implements maplibregl.IControl {
   }
 
   /**
-   * Switch the unit system, redrawing immediately when it changed. Returns
-   * `true` if the unit differed (and the bar was redrawn) so callers can skip a
-   * redundant {@link refresh}.
+   * Set the unit system. This only stores the unit; the bar is redrawn on the
+   * next {@link refresh} (or map move), so callers that change the unit outside
+   * a move should follow with `refresh()`. Keeping it a pure setter lets the map
+   * controller change the unit and the radius and then redraw exactly once.
    */
-  setUnit(unit: MapScaleUnit): boolean {
-    if (this.unit === unit) return false;
+  setUnit(unit: MapScaleUnit): void {
     this.unit = unit;
-    this.update();
-    return true;
   }
 
   onAdd(map: maplibregl.Map): HTMLElement {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -121,6 +121,30 @@ describe("project parsing", () => {
     assert.equal(reloaded.preferences.map.projection, "mercator");
   });
 
+  it("round-trips the scale unit preference and defaults unknown values to metric", () => {
+    const base = createEmptyProject("Scale");
+    assert.equal(base.preferences.map.scaleUnit, "metric");
+    const imperial = {
+      ...base,
+      preferences: {
+        ...base.preferences,
+        map: { ...base.preferences.map, scaleUnit: "imperial" as const },
+      },
+    };
+    const reloaded = parseProject(serializeProject(imperial));
+    assert.equal(reloaded.preferences.map.scaleUnit, "imperial");
+    // A hand-edited project with a bogus unit falls back to metric.
+    const bogus = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Bogus",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        preferences: { map: { scaleUnit: "furlongs" } },
+      }),
+    );
+    assert.equal(bogus.preferences.map.scaleUnit, "metric");
+  });
+
   it("normalizes a legend config, dropping malformed overrides", () => {
     const project = parseProject(
       JSON.stringify({

--- a/tests/planetary-scale-control.test.ts
+++ b/tests/planetary-scale-control.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   greatCircleMeters,
   getRoundNum,
+  scaleSpan,
 } from "../packages/map/src/planetary-scale-control";
 import { getEllipsoid, meanRadiusMeters } from "../packages/core/src/ellipsoids";
 
@@ -67,5 +68,35 @@ describe("getRoundNum", () => {
   it("returns 0 for non-positive input", () => {
     assert.equal(getRoundNum(0), 0);
     assert.equal(getRoundNum(-5), 0);
+  });
+});
+
+describe("scaleSpan", () => {
+  it("uses m below 1 km and km above for metric", () => {
+    assert.deepEqual(scaleSpan(500, "metric"), { span: 500, label: "m" });
+    assert.deepEqual(scaleSpan(2500, "metric"), { span: 2.5, label: "km" });
+    assert.deepEqual(scaleSpan(1000, "metric"), { span: 1, label: "km" });
+  });
+
+  it("uses ft below a mile and mi above for imperial", () => {
+    // 100 m ≈ 328.08 ft (under a mile) → feet.
+    const short = scaleSpan(100, "imperial");
+    assert.equal(short.label, "ft");
+    assert.ok(Math.abs(short.span - 328.084) < 1e-2, `${short.span}`);
+    // Exactly one statute mile (1609.344 m) → 1 mi.
+    const mile = scaleSpan(1609.344, "imperial");
+    assert.equal(mile.label, "mi");
+    assert.ok(Math.abs(mile.span - 1) < 1e-6, `${mile.span}`);
+    // 10 km ≈ 6.2137 mi.
+    const long = scaleSpan(10000, "imperial");
+    assert.equal(long.label, "mi");
+    assert.ok(Math.abs(long.span - 6.21371) < 1e-4, `${long.span}`);
+  });
+
+  it("reports nautical miles for nautical", () => {
+    const nm = scaleSpan(1852, "nautical");
+    assert.equal(nm.label, "nmi");
+    assert.ok(Math.abs(nm.span - 1) < 1e-9, `${nm.span}`);
+    assert.ok(Math.abs(scaleSpan(9260, "nautical").span - 5) < 1e-9);
   });
 });


### PR DESCRIPTION
## Summary

Adds a **scale bar unit** setting so the map scale bar can report **metric (m / km)**, **imperial (ft / mi)**, or **nautical (nmi)** distances. Requested in discussion #1227 by a user whose field works in the imperial system and needs feet/miles on the scale bar.

## What changed

- **`MapPreferences.scaleUnit`** (`"metric" | "imperial" | "nautical"`, default `"metric"`) added to the project schema, defaults, and load-time normalization (unknown values fall back to metric).
- **`PlanetaryScaleControl`** now takes a `unit` and a `setUnit()` method, converting the measured ground span to ft/mi or nmi and labeling the bar accordingly (imperial crosses from feet to miles past one statute mile). Metric behavior is unchanged.
- **`MapController`** seeds the control with the project's unit and pushes unit changes live when preferences are applied (alongside the existing ellipsoid refresh).
- **Settings → Map Preferences** gains a "Scale bar units" dropdown, with new `en.json` strings.

The scale bar remains body-aware (correct on Moon/Mars/etc.), so imperial/nautical are correct on every celestial body too.

## Testing

- Unit tests for the ft/mi/nmi conversions (`scaleSpan`) and for round-tripping/normalizing the new preference.
- Full frontend suite green (`npm run test:frontend`), production build green, pre-commit clean.
- Verified end to end in the browser: the scale bar reads `1000 km` (metric), `1000 mi` and `300 ft` at higher zoom (imperial), and `0.05 nmi` (nautical), and renders correctly in both dark and light themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Settings → Map control to choose scale bar units: **metric**, **imperial**, or **nautical**.
  * Scale bars now display distance labels formatted according to the selected unit, with updated unit-aware span calculation.
* **Bug Fixes**
  * Project preferences now safely normalize invalid/unknown scale unit values to **metric**.
* **Tests**
  * Added/extended tests to verify scale unit parsing/round-tripping and unit span calculations for metric, imperial, and nautical.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->