### PR TITLE
feat(ui): default to Advanced interface and skip the welcome dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoLibre
 
-[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://web.geolibre.app/)
 [![GeoLibre shared project](https://img.shields.io/badge/GeoLibre-share-green.svg)](https://share.geolibre.app)
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -137,9 +137,13 @@ export const DEFAULT_DESKTOP_LAYOUT_SETTINGS: DesktopLayoutSettings = {
 };
 
 export const DEFAULT_UI_PROFILE_SETTINGS: UiProfileSettings = {
+  // Ship the Advanced interface by default (`enabled: false` shows every item,
+  // which `activeInterfaceProfile` reports as "advanced") and skip the
+  // first-launch welcome dialog (`onboarded: true`). Users can still switch to a
+  // curated preset from the Settings dialog.
   enabled: false,
   level: null,
-  onboarded: false,
+  onboarded: true,
   locked: false,
   hiddenDataSources: [],
   hiddenPlugins: [],

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![Launch GeoLibre Web](https://img.shields.io/badge/Launch-GeoLibre%20Web-green.svg)](https://web.geolibre.app/)
 [![GeoLibre shared project](https://img.shields.io/badge/GeoLibre-share-green.svg)](https://share.geolibre.app)
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)

--- a/docs/ui-profiles.md
+++ b/docs/ui-profiles.md
@@ -10,15 +10,16 @@ inside a saved `.geolibre.json` project.
 
 ### Onboarding
 
-On first launch (when no administrator profile is present) GeoLibre asks for an
-experience level:
+By default GeoLibre starts on the **Advanced** interface — everything visible —
+and does not show a first-launch welcome dialog. Choose a simpler experience
+level at any time from **Settings → Interface** (see below):
 
 - **Beginner** — only the essential data sources and tools.
 - **Intermediate** — common data sources, services, and plugins.
-- **Advanced** — everything GeoLibre offers.
+- **Advanced** — everything GeoLibre offers (the default).
 
-Choosing *Skip — show everything* keeps the full interface. The wizard appears
-only once; you can revisit the choice later in **Settings → Interface**.
+An administrator profile can pre-configure the interface for a whole deployment
+and lock these controls.
 
 ### Settings → Interface
 

--- a/tests/ui-profile.test.ts
+++ b/tests/ui-profile.test.ts
@@ -247,7 +247,8 @@ describe("normalizeUiProfileSettings (via the store)", () => {
     });
     assert.equal(result.enabled, false);
     assert.equal(result.level, null);
-    assert.equal(result.onboarded, false);
+    // Non-boolean falls back to the default (welcome dialog off by default).
+    assert.equal(result.onboarded, true);
     assert.equal(result.locked, false);
     // Non-strings dropped, duplicates/blank removed.
     assert.deepEqual(result.hiddenDataSources, ["postgres"]);


### PR DESCRIPTION
## What

- **Disable the first-launch welcome dialog** by default — flip the default `uiProfile.onboarded` from `false` to `true`. The onboarding wizard only renders when `!uiProfile.onboarded` (`useUiProfileBootstrap.ts`), so fresh installs no longer open on the experience-level chooser.
- **Show the Advanced interface by default** — no visibility change was needed: the existing `enabled: false` default already reveals every menu, data source, and plugin, and `activeInterfaceProfile()` reports that state as `"advanced"` (`ui-profile.ts`). Added a comment documenting that this default *is* the Advanced interface.

## Notes

- Existing users with a stored `uiProfile` in localStorage are untouched — this only changes the default for fresh installs / cleared storage.
- Users can still switch to a curated Beginner/Intermediate preset from the Settings dialog.
- Updated the one test in `tests/ui-profile.test.ts` that asserted the tampered-value fallback for `onboarded`, since the default flipped.

## Test

- `node --import tsx --test tests/ui-profile.test.ts` — 21 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Advanced interface is now enabled by default for new installations.
  * The first-launch welcome dialog is skipped by default.

* **Bug Fixes**
  * Improved handling of invalid onboarding settings to maintain the correct default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->