### PR TITLE
fix: make deck.gl COG rasters swipeable in Layer Swipe (#1240)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -77,7 +77,7 @@
     "maplibre-gl-raster": "^0.10.1",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.10.1",
+    "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.9.2",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -936,8 +936,18 @@ body,
   z-index: 2;
 }
 
+/*
+ * The overlaid deck.gl canvas (COG rasters via CogLayerControl, ArcGIS I3S, the
+ * Tauri raster fallback) is map content and must sit UNDER the map-control
+ * panels, not over them. It lives inside `.maplibregl-control-container` (pinned
+ * to z-index 7 below), which already lifts it above the map canvas, so it only
+ * needs a low z-index within that container. #1131 raised this to 5, which put
+ * the raster above the STAC / Vantor plugin panels (z-index 3) and painted over
+ * them (opengeos/GeoLibre#1240). Back to 1: the raster still renders above the
+ * basemap, and control panels render above the raster.
+ */
 #deckgl-overlay {
-  z-index: 5;
+  z-index: 1;
 }
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "maplibre-gl-raster": "^0.10.1",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.10.1",
+        "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.9.2",
@@ -17191,9 +17191,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.10.1.tgz",
-      "integrity": "sha512-m6f7SSDBVV7Oov7rHxLHGrboD6Sf0pFQEeIDhgpYLEJHDRTp3iJck6/YvxRGQSuJBNOt+M1HpjELYLLt2tfXkg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.11.0.tgz",
+      "integrity": "sha512-QkV+e89DqeSp5rlLoY3yQ2wo7Z58yEICMhUuq8mW2CO+tSVAdNotRMiI74ZBzWVmtwY0WSLCnIwABOv2xq8vPA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -21857,7 +21857,7 @@
         "maplibre-gl-raster": "^0.10.1",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.10.1",
+        "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.9.2",

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2089,6 +2089,14 @@ export class MapController {
       ...layers
         .flatMap((layer) => this.getNamedStyleLayers(layer))
         .map(({ id, name }): [string, string] => [id, name]),
+      // Deck.gl-rendered COG rasters are custom layers absent from the map
+      // style, so getNamedStyleLayers (which filters to existing style layers)
+      // skips them. Publish their store id -> name directly so the Layer Swipe
+      // panel, which lists them by store id via its COG layerProvider, shows a
+      // friendly name instead of the raw id. See opengeos/GeoLibre#1240.
+      ...layers
+        .filter((layer) => layer.type === "cog")
+        .map((layer): [string, string] => [layer.id, layer.name]),
       // The Layer Swipe panel groups all basemap layers under "__basemap__";
       // publish the translated base-layer label last so this synthetic key
       // always wins over a layer that happens to share the id, matching the

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2093,9 +2093,14 @@ export class MapController {
       // style, so getNamedStyleLayers (which filters to existing style layers)
       // skips them. Publish their store id -> name directly so the Layer Swipe
       // panel, which lists them by store id via its COG layerProvider, shows a
-      // friendly name instead of the raw id. See opengeos/GeoLibre#1240.
+      // friendly name instead of the raw id. Scoped to "cog-url" (the
+      // CogLayerControl rasters the provider lists) to match that scope. See
+      // opengeos/GeoLibre#1240.
       ...layers
-        .filter((layer) => layer.type === "cog")
+        .filter(
+          (layer) =>
+            layer.type === "cog" && layer.metadata.sourceKind === "cog-url",
+        )
         .map((layer): [string, string] => [layer.id, layer.name]),
       // The Layer Swipe panel groups all basemap layers under "__basemap__";
       // publish the translated base-layer label last so this synthetic key

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2099,7 +2099,9 @@ export class MapController {
       ...layers
         .filter(
           (layer) =>
-            layer.type === "cog" && layer.metadata.sourceKind === "cog-url",
+            layer.type === "cog" &&
+            layer.metadata.sourceKind === "cog-url" &&
+            layer.metadata.externalNativeLayer === true,
         )
         .map((layer): [string, string] => [layer.id, layer.name]),
       // The Layer Swipe panel groups all basemap layers under "__basemap__";

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -52,7 +52,7 @@
     "maplibre-gl-raster": "^0.10.1",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.10.1",
+    "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.9.2",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -2965,6 +2965,42 @@ function notifySwipeCogChange(): void {
 }
 
 /**
+ * A lightweight fingerprint of the store's COG rasters (id/name/visibility/
+ * opacity/visualization), so the swipe subscription can skip notifying when an
+ * unrelated layer changed. Cheaper than the refreshLayers()/reconcile pass it
+ * guards.
+ */
+function swipeCogFingerprint(layers: GeoLibreLayer[]): string {
+  const parts: string[] = [];
+  for (const layer of layers) {
+    if (!isCogRasterControlLayer(layer)) continue;
+    const source = layer.source as {
+      url?: unknown;
+      bands?: unknown;
+      colormap?: unknown;
+      rescaleMin?: unknown;
+      rescaleMax?: unknown;
+      nodata?: unknown;
+    };
+    parts.push(
+      [
+        layer.id,
+        layer.name,
+        layer.visible,
+        layer.opacity,
+        source.url,
+        source.bands,
+        source.colormap,
+        source.rescaleMin,
+        source.rescaleMax,
+        source.nodata,
+      ].join("|"),
+    );
+  }
+  return parts.join(";");
+}
+
+/**
  * Subscribes to COG raster set/state changes (add/remove/visibility/opacity),
  * so the Layer Swipe plugin can keep its panel list and comparison-map mirror
  * in sync while a swipe is active.
@@ -2979,7 +3015,16 @@ export function subscribeSwipeCogChanges(listener: () => void): () => void {
   // diffing here. Swipe's own main-map hide goes through the control directly
   // (setCogRasterMainVisibility), not the store, so it cannot loop back.
   swipeCogStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
-    if (state.layers !== previous.layers) notifySwipeCogChange();
+    // Cheap reference gate first; then only notify when the COG-raster subset
+    // actually changed, so unrelated layer edits during a swipe don't trigger a
+    // needless refreshLayers()/reconcile pass. Swipe's own main-map hide goes
+    // through the control directly, not the store, so it cannot loop back.
+    if (state.layers === previous.layers) return;
+    if (
+      swipeCogFingerprint(state.layers) !== swipeCogFingerprint(previous.layers)
+    ) {
+      notifySwipeCogChange();
+    }
   });
   return () => {
     swipeCogChangeListeners.delete(listener);

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -2912,6 +2912,199 @@ function createCogRasterControl(
   return control;
 }
 
+// --- Layer Swipe COG integration -------------------------------------------
+// GeoLibre renders COG rasters (Vantor Open Data, STAC "Visualize", etc.)
+// through the CogLayerControl deck.gl overlay, so they are MapLibre custom
+// layers that Layer Swipe cannot see through getStyle(). These helpers let the
+// swipe plugin's layerProvider list them and render each per its side
+// assignment: mirror right/both onto the swipe comparison map, hide right-only
+// on the main map. See #1240 and swipe-cog-mirror.ts.
+
+/**
+ * A COG raster snapshot for the Layer Swipe provider, read from the app store
+ * (the user's intent) rather than the live control, so swipe's transient
+ * main-map visibility toggles do not perturb its decisions.
+ */
+export interface SwipeCogRasterSnapshot {
+  /** The CogLayerControl layer id (also the store layer id). */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** COG URL. */
+  url: string;
+  /** User-facing visibility from the store (not swipe's transient state). */
+  visible: boolean;
+  /** Layer opacity. */
+  opacity: number;
+  /** Band selection string (e.g. "1" or "1,2,3"). */
+  bands?: string;
+  /** Colormap name. */
+  colormap?: CogLayerControlOptions["defaultColormap"];
+  /** Rescale minimum. */
+  rescaleMin?: number;
+  /** Rescale maximum. */
+  rescaleMax?: number;
+  /** Nodata value. */
+  nodata?: number;
+}
+
+// Notified when the set/state of CogLayerControl rasters changes, so the swipe
+// provider can refresh its list and re-mirror. Backed by a single store
+// subscription while at least one listener is registered.
+const swipeCogChangeListeners = new Set<() => void>();
+let swipeCogStoreUnsubscribe: (() => void) | null = null;
+
+function notifySwipeCogChange(): void {
+  for (const listener of swipeCogChangeListeners) {
+    try {
+      listener();
+    } catch (error) {
+      console.warn("[GeoLibre] swipe COG change listener", error);
+    }
+  }
+}
+
+/**
+ * Subscribes to COG raster set/state changes (add/remove/visibility/opacity),
+ * so the Layer Swipe plugin can keep its panel list and comparison-map mirror
+ * in sync while a swipe is active.
+ *
+ * @param listener - Called after any relevant layer change.
+ * @returns An unsubscribe function.
+ */
+export function subscribeSwipeCogChanges(listener: () => void): () => void {
+  swipeCogChangeListeners.add(listener);
+  // A change to any COG raster surfaces as a store `layers` array change; the
+  // provider recompute is cheap, so notify on any layers change rather than
+  // diffing here. Swipe's own main-map hide goes through the control directly
+  // (setCogRasterMainVisibility), not the store, so it cannot loop back.
+  swipeCogStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (state.layers !== previous.layers) notifySwipeCogChange();
+  });
+  return () => {
+    swipeCogChangeListeners.delete(listener);
+    if (swipeCogChangeListeners.size === 0) {
+      swipeCogStoreUnsubscribe?.();
+      swipeCogStoreUnsubscribe = null;
+    }
+  };
+}
+
+/**
+ * Snapshots the store's CogLayerControl COG rasters for the Layer Swipe
+ * provider, in store (paint) order.
+ *
+ * @returns One snapshot per "cog-url" store layer with a URL source.
+ */
+export function getSwipeCogRasters(): SwipeCogRasterSnapshot[] {
+  const snapshots: SwipeCogRasterSnapshot[] = [];
+  for (const layer of useAppStore.getState().layers) {
+    if (!isCogRasterControlLayer(layer)) continue;
+    const source = layer.source as {
+      url?: unknown;
+      bands?: unknown;
+      colormap?: unknown;
+      rescaleMin?: unknown;
+      rescaleMax?: unknown;
+      nodata?: unknown;
+    };
+    if (typeof source.url !== "string") continue;
+    snapshots.push({
+      id: layer.id,
+      name: layer.name,
+      url: source.url,
+      visible: layer.visible,
+      opacity: layer.opacity,
+      bands: typeof source.bands === "string" ? source.bands : undefined,
+      colormap:
+        typeof source.colormap === "string"
+          ? (source.colormap as CogLayerControlOptions["defaultColormap"])
+          : undefined,
+      rescaleMin:
+        typeof source.rescaleMin === "number" ? source.rescaleMin : undefined,
+      rescaleMax:
+        typeof source.rescaleMax === "number" ? source.rescaleMax : undefined,
+      nodata: typeof source.nodata === "number" ? source.nodata : undefined,
+    });
+  }
+  return snapshots;
+}
+
+/**
+ * Shows or hides a COG raster on the main map without writing the change back
+ * to the store, so Layer Swipe can hide a right-only raster on the main map
+ * while the Layers panel still lists it as visible. Visibility is opacity-based
+ * in CogLayerControl, so the stored opacity is restored when showing it again.
+ * A no-op when the control is not mounted.
+ *
+ * @param id - The raster layer id.
+ * @param visible - Whether it should render on the main map.
+ * @param opacity - The opacity to restore when making it visible.
+ */
+export function setCogRasterMainVisibility(
+  id: string,
+  visible: boolean,
+  opacity: number
+): void {
+  cogRasterControl?.setLayerVisibility(id, visible, opacity);
+}
+
+/**
+ * Creates a hidden CogLayerControl bound to a given map (the Layer Swipe
+ * comparison map) so the swipe plugin can render COG mirrors on the swipe's
+ * clipped comparison view. The control's own UI is hidden; only its deck
+ * overlay renders.
+ *
+ * @param map - The map to mount the mirror control on.
+ * @returns The mirror control, or null if the components module fails to load.
+ */
+export async function createSwipeCogMirrorControl(
+  map: maplibregl.Map
+): Promise<CogLayerControl | null> {
+  const { CogLayerControl: CogLayerControlClass } =
+    await getComponentsConstructors();
+  const control = new CogLayerControlClass(COG_RASTER_OPTIONS);
+  map.addControl(control);
+  // Hide the panel/button: the mirror only contributes its deck overlay, which
+  // the swipe control already clips to the comparison region.
+  control.hide();
+  control.collapse();
+  return control;
+}
+
+/**
+ * Renders one COG snapshot on a mirror control, matching the main map's
+ * visualization (bands/colormap/rescale/nodata/opacity).
+ *
+ * @param control - A mirror control from {@link createSwipeCogMirrorControl}.
+ * @param snapshot - The COG raster to render.
+ */
+export async function mirrorAddCogLayer(
+  control: CogLayerControl,
+  snapshot: SwipeCogRasterSnapshot
+): Promise<void> {
+  configureCogRasterControl(control, {
+    url: snapshot.url,
+    name: snapshot.name,
+    bands: snapshot.bands,
+    colormap: snapshot.colormap,
+    rescaleMin: snapshot.rescaleMin,
+    rescaleMax: snapshot.rescaleMax,
+    nodata: snapshot.nodata,
+    opacity: snapshot.opacity,
+  });
+  await control.addLayer(snapshot.url);
+}
+
+/**
+ * Removes every mirrored raster from a mirror control.
+ *
+ * @param control - A mirror control from {@link createSwipeCogMirrorControl}.
+ */
+export function clearMirrorCogLayers(control: CogLayerControl): void {
+  control.removeLayer();
+}
+
 function createLidarControl(
   LidarControlClass: LidarControlConstructor,
   LidarLayerAdapterClass: LidarLayerAdapterConstructor

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -3140,15 +3140,18 @@ export async function createSwipeCogMirrorControl(
 
 /**
  * Renders one COG snapshot on a mirror control, matching the main map's
- * visualization (bands/colormap/rescale/nodata/opacity).
+ * visualization (bands/colormap/rescale/nodata/opacity), and returns the
+ * control-assigned layer id so the caller can later update or remove just that
+ * layer.
  *
  * @param control - A mirror control from {@link createSwipeCogMirrorControl}.
  * @param snapshot - The COG raster to render.
+ * @returns The new mirror layer id, or null if the add produced no layer.
  */
 export async function mirrorAddCogLayer(
   control: CogLayerControl,
   snapshot: SwipeCogRasterSnapshot
-): Promise<void> {
+): Promise<string | null> {
   configureCogRasterControl(control, {
     url: snapshot.url,
     name: snapshot.name,
@@ -3159,7 +3162,48 @@ export async function mirrorAddCogLayer(
     nodata: snapshot.nodata,
     opacity: snapshot.opacity,
   });
-  await control.addLayer(snapshot.url);
+  // addLayer generates the id internally and reports it via 'layeradd'; capture
+  // the one matching this URL so the caller can target it for later opacity
+  // updates / removal.
+  let layerId: string | null = null;
+  const handler: CogLayerEventHandler = (event) => {
+    if (event.url === snapshot.url && event.layerId) layerId = event.layerId;
+  };
+  control.on("layeradd", handler);
+  try {
+    await control.addLayer(snapshot.url);
+  } finally {
+    control.off("layeradd", handler);
+  }
+  return layerId;
+}
+
+/**
+ * Sets the opacity of a single mirrored raster without a reload.
+ *
+ * @param control - A mirror control from {@link createSwipeCogMirrorControl}.
+ * @param mirrorLayerId - The mirror layer id from {@link mirrorAddCogLayer}.
+ * @param opacity - The opacity (0-1).
+ */
+export function mirrorSetCogOpacity(
+  control: CogLayerControl,
+  mirrorLayerId: string,
+  opacity: number
+): void {
+  control.setLayerOpacity(mirrorLayerId, opacity);
+}
+
+/**
+ * Removes a single mirrored raster by its mirror layer id.
+ *
+ * @param control - A mirror control from {@link createSwipeCogMirrorControl}.
+ * @param mirrorLayerId - The mirror layer id from {@link mirrorAddCogLayer}.
+ */
+export function mirrorRemoveCogLayer(
+  control: CogLayerControl,
+  mirrorLayerId: string
+): void {
+  control.removeLayer(mirrorLayerId);
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -2971,7 +2971,7 @@ function notifySwipeCogChange(): void {
  * guards.
  */
 function swipeCogFingerprint(layers: GeoLibreLayer[]): string {
-  const parts: string[] = [];
+  const parts: unknown[][] = [];
   for (const layer of layers) {
     if (!isCogRasterControlLayer(layer)) continue;
     const source = layer.source as {
@@ -2982,22 +2982,22 @@ function swipeCogFingerprint(layers: GeoLibreLayer[]): string {
       rescaleMax?: unknown;
       nodata?: unknown;
     };
-    parts.push(
-      [
-        layer.id,
-        layer.name,
-        layer.visible,
-        layer.opacity,
-        source.url,
-        source.bands,
-        source.colormap,
-        source.rescaleMin,
-        source.rescaleMax,
-        source.nodata,
-      ].join("|"),
-    );
+    // JSON.stringify (not a delimiter join) so a "|"/";" in a layer name or URL
+    // cannot make two genuinely-different states collide and skip a refresh.
+    parts.push([
+      layer.id,
+      layer.name,
+      layer.visible,
+      layer.opacity,
+      source.url,
+      source.bands,
+      source.colormap,
+      source.rescaleMin,
+      source.rescaleMax,
+      source.nodata,
+    ]);
   }
-  return parts.join(";");
+  return JSON.stringify(parts);
 }
 
 /**
@@ -3162,20 +3162,13 @@ export async function mirrorAddCogLayer(
     nodata: snapshot.nodata,
     opacity: snapshot.opacity,
   });
-  // addLayer generates the id internally and reports it via 'layeradd'; capture
-  // the one matching this URL so the caller can target it for later opacity
-  // updates / removal.
-  let layerId: string | null = null;
-  const handler: CogLayerEventHandler = (event) => {
-    if (event.url === snapshot.url && event.layerId) layerId = event.layerId;
-  };
-  control.on("layeradd", handler);
-  try {
-    await control.addLayer(snapshot.url);
-  } finally {
-    control.off("layeradd", handler);
-  }
-  return layerId;
+  // addLayer generates the id internally; diff the control's layer-id set
+  // around the call to find it, rather than relying on 'layeradd' firing before
+  // the promise settles. Deterministic and independent of event/promise
+  // ordering.
+  const before = new Set(control.getLayerIds());
+  await control.addLayer(snapshot.url);
+  return control.getLayerIds().find((id) => !before.has(id)) ?? null;
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -3165,10 +3165,19 @@ export async function mirrorAddCogLayer(
   // addLayer generates the id internally; diff the control's layer-id set
   // around the call to find it, rather than relying on 'layeradd' firing before
   // the promise settles. Deterministic and independent of event/promise
-  // ordering.
+  // ordering. Assumes addLayer adds exactly one new id; if a future
+  // CogLayerControl dedupes/reuses an id and the diff is empty, log it so the
+  // caller's "retry as a fresh add" fallback is visible rather than silent.
   const before = new Set(control.getLayerIds());
   await control.addLayer(snapshot.url);
-  return control.getLayerIds().find((id) => !before.has(id)) ?? null;
+  const newId = control.getLayerIds().find((id) => !before.has(id)) ?? null;
+  if (!newId) {
+    console.debug(
+      "[GeoLibre] swipe COG mirror: no new layer id after addLayer",
+      snapshot.url,
+    );
+  }
+  return newId;
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -2994,6 +2994,12 @@ export function subscribeSwipeCogChanges(listener: () => void): () => void {
  * Snapshots the store's CogLayerControl COG rasters for the Layer Swipe
  * provider, in store (paint) order.
  *
+ * Scope: only `cog-url` rasters (Vantor / STAC, rendered by the shared
+ * CogLayerControl) are surfaced. Locally-added GeoTIFFs (`geotiff-url`,
+ * rendered on the separate geoTiffRasterOverlay) are also deck.gl custom layers
+ * with the same #1240 root cause, but they use a different renderer and are out
+ * of scope here; extend this and the mirror to cover them in a follow-up.
+ *
  * @returns One snapshot per "cog-url" store layer with a URL source.
  */
 export function getSwipeCogRasters(): SwipeCogRasterSnapshot[] {
@@ -3047,6 +3053,21 @@ export function setCogRasterMainVisibility(
   opacity: number
 ): void {
   cogRasterControl?.setLayerVisibility(id, visible, opacity);
+}
+
+/**
+ * Reads a COG raster's current visibility on the main map from the control
+ * itself, so Layer Swipe can compare against the live state rather than its own
+ * cached intent. The control's visibility is also driven independently by the
+ * store-diff subscription (a Layers-panel visibility toggle), so a cached value
+ * can drift; reading live avoids leaving a right-only raster shown after such a
+ * toggle. Defaults to visible when the control or layer is absent.
+ *
+ * @param id - The raster layer id.
+ * @returns Whether the raster currently renders on the main map.
+ */
+export function getCogRasterMainVisibility(id: string): boolean {
+  return cogRasterControl?.getLayerVisibility(id) ?? true;
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -1,6 +1,9 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
 import {
   SwipeControl,
   type SwipeControlOptions,
+  type SwipeLayerProvider,
+  type SwipeLayerSide,
   type SwipeState,
 } from "maplibre-gl-swipe";
 import type {
@@ -9,6 +12,13 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
+import {
+  getSwipeCogRasters,
+  setCogRasterMainVisibility,
+  subscribeSwipeCogChanges,
+  type SwipeCogRasterSnapshot,
+} from "./maplibre-components";
+import { SwipeCogMirror } from "./swipe-cog-mirror";
 
 /**
  * Plugin id for the Layer Swipe control. Exported so the app can coordinate it
@@ -21,6 +31,117 @@ let swipeControlPosition: GeoLibreMapControlPosition = "top-left";
 let swipeControl: SwipeControl | null = null;
 let savedSwipeState: SwipeState | null = null;
 let unsubscribeBasemap: (() => void) | null = null;
+
+// --- COG raster swipe integration ------------------------------------------
+// GeoLibre renders COG rasters on a deck.gl overlay, so they are MapLibre custom
+// layers that the swipe control cannot see through getStyle(). This provider
+// (passed to SwipeControl via the layerProvider option) lists them in the swipe
+// panel and renders each per its side assignment: right/both/none rasters are
+// mirrored onto the swipe comparison map (which the control already clips to the
+// swipe region), and right-only rasters are hidden on the main map. See #1240.
+
+// The comparison-map raster mirror, recreated whenever the swipe control makes a
+// fresh comparison map (basemap change, re-activation).
+let cogMirror: SwipeCogMirror | null = null;
+// The main-map visibility this provider last forced per raster id (with the
+// opacity to restore when showing it again), so it only toggles on change and
+// can restore visibility on teardown.
+const cogMainForced = new Map<string, { visible: boolean; opacity: number }>();
+// Side assignments accumulated during one _updateLayerVisibility pass (the
+// control calls applySide once per provider layer); reconciled together so the
+// comparison mirror syncs in a single pass.
+const cogPendingSides = new Map<string, SwipeLayerSide>();
+let cogPendingComparisonMap: MapLibreMap | undefined;
+let cogReconcileScheduled = false;
+let unsubscribeCogRasterChanges: (() => void) | null = null;
+
+const cogSwipeProvider: SwipeLayerProvider = {
+  getLayers: () =>
+    getSwipeCogRasters().map((raster) => ({
+      id: raster.id,
+      type: "raster",
+      visible: raster.visible,
+    })),
+  applySide: (id, side, comparisonMap) => {
+    cogPendingSides.set(id, side);
+    cogPendingComparisonMap = comparisonMap;
+    scheduleCogReconcile();
+  },
+  detachComparison: () => {
+    teardownCogSwipe();
+  },
+};
+
+function scheduleCogReconcile(): void {
+  if (cogReconcileScheduled) return;
+  cogReconcileScheduled = true;
+  // Coalesce the per-layer applySide calls of one visibility pass into a single
+  // reconcile so the mirror syncs its whole set at once.
+  queueMicrotask(reconcileCogSwipe);
+}
+
+function reconcileCogSwipe(): void {
+  cogReconcileScheduled = false;
+  const sides = new Map(cogPendingSides);
+  cogPendingSides.clear();
+  const comparisonMap = cogPendingComparisonMap;
+
+  // Rebuild the mirror when the comparison map changes identity (or drop it when
+  // there is none).
+  if (!comparisonMap) {
+    cogMirror?.destroy();
+    cogMirror = null;
+  } else if (!cogMirror || cogMirror.getMap() !== comparisonMap) {
+    cogMirror?.destroy();
+    cogMirror = new SwipeCogMirror(comparisonMap);
+  }
+
+  const rasters = getSwipeCogRasters();
+  const sideFor = (raster: SwipeCogRasterSnapshot): SwipeLayerSide =>
+    sides.get(raster.id) ?? "none";
+
+  // A raster shows on the comparison (right) side for right/both, and for none
+  // (unselected) so it stays full-screen like an unswiped layer. Left-only
+  // rasters are omitted, so the comparison map shows the basemap there.
+  const onComparison = (side: SwipeLayerSide): boolean =>
+    side === "right" || side === "both" || side === "none";
+
+  if (cogMirror) {
+    void cogMirror.sync(
+      rasters.filter(
+        (raster) => raster.visible && onComparison(sideFor(raster)),
+      ),
+    );
+  }
+
+  // Main map: hide right-only rasters (shown on the comparison side instead);
+  // keep every other visible raster on the main map. Hidden rasters are left
+  // untouched. Only toggle when the target differs from the last forced value.
+  for (const raster of rasters) {
+    if (!raster.visible) continue;
+    const wantVisible = sideFor(raster) !== "right";
+    if (cogMainForced.get(raster.id)?.visible !== wantVisible) {
+      cogMainForced.set(raster.id, {
+        visible: wantVisible,
+        opacity: raster.opacity,
+      });
+      setCogRasterMainVisibility(raster.id, wantVisible, raster.opacity);
+    }
+  }
+}
+
+function teardownCogSwipe(): void {
+  cogMirror?.destroy();
+  cogMirror = null;
+  cogPendingSides.clear();
+  cogPendingComparisonMap = undefined;
+  cogReconcileScheduled = false;
+  // Restore any raster this provider hid on the main map.
+  for (const [id, forced] of cogMainForced) {
+    if (!forced.visible) setCogRasterMainVisibility(id, true, forced.opacity);
+  }
+  cogMainForced.clear();
+}
 
 export const maplibreSwipePlugin: GeoLibrePlugin = {
   id: SWIPE_PLUGIN_ID,
@@ -37,6 +158,12 @@ export const maplibreSwipePlugin: GeoLibrePlugin = {
       return false;
     }
     expandSwipeControl(savedSwipeState ?? undefined);
+
+    // Keep the swipe panel's COG raster rows and comparison-map mirror in sync
+    // as rasters are added, removed, or restyled while the swipe is active.
+    unsubscribeCogRasterChanges = subscribeSwipeCogChanges(() => {
+      swipeControl?.refreshLayers();
+    });
 
     // The control reads the basemap style only on construction, so recreate it
     // when the active basemap changes to keep its basemap-layer grouping in
@@ -56,6 +183,12 @@ export const maplibreSwipePlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     unsubscribeBasemap?.();
     unsubscribeBasemap = null;
+    unsubscribeCogRasterChanges?.();
+    unsubscribeCogRasterChanges = null;
+    // Restore any main-map raster this provider hid; removeMapControl's
+    // detachComparison also tears the mirror down, but that only runs when a
+    // comparison map exists.
+    teardownCogSwipe();
     if (!swipeControl) return;
     savedSwipeState = swipeControl.getState();
     app.removeMapControl(swipeControl);
@@ -128,6 +261,10 @@ function getSwipeControlOptions(
     excludeLayers: [...INTERNAL_HELPER_LAYER_PATTERNS],
     // List only currently visible layers (plus any already selected), kept in sync live (#843).
     visibleLayersOnly: true,
+    // Surface deck.gl COG rasters (invisible to getStyle()) in the panel and
+    // render them per side: right/both on the comparison map, right-only hidden
+    // on the main map. See #1240 and swipe-cog-mirror.ts.
+    layerProvider: cogSwipeProvider,
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -98,6 +98,15 @@ function reconcileCogSwipe(): void {
   }
 
   const rasters = getSwipeCogRasters();
+
+  // Drop bookkeeping for rasters removed from the store while swiping (the loop
+  // below only visits still-present rasters, so their entries would otherwise
+  // linger until teardown).
+  const rasterIds = new Set(rasters.map((raster) => raster.id));
+  for (const id of [...cogMainForced.keys()]) {
+    if (!rasterIds.has(id)) cogMainForced.delete(id);
+  }
+
   const sideFor = (raster: SwipeCogRasterSnapshot): SwipeLayerSide =>
     sides.get(raster.id) ?? "none";
 

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types";
 import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
 import {
+  getCogRasterMainVisibility,
   getSwipeCogRasters,
   setCogRasterMainVisibility,
   subscribeSwipeCogChanges,
@@ -115,18 +116,24 @@ function reconcileCogSwipe(): void {
   }
 
   // Main map: hide right-only rasters (shown on the comparison side instead);
-  // keep every other visible raster on the main map. Hidden rasters are left
-  // untouched. Only toggle when the target differs from the last forced value.
+  // keep every other visible raster on the main map. Rasters the user hid are
+  // left untouched (their store `visible` is false). Compare against the
+  // control's LIVE visibility, not a cached value: the store-diff subscription
+  // in maplibre-components also toggles the control (a Layers-panel visibility
+  // flip), so a cached target can drift and leave a right-only raster shown.
   for (const raster of rasters) {
-    if (!raster.visible) continue;
+    if (!raster.visible) {
+      cogMainForced.delete(raster.id);
+      continue;
+    }
     const wantVisible = sideFor(raster) !== "right";
-    if (cogMainForced.get(raster.id)?.visible !== wantVisible) {
-      cogMainForced.set(raster.id, {
-        visible: wantVisible,
-        opacity: raster.opacity,
-      });
+    if (getCogRasterMainVisibility(raster.id) !== wantVisible) {
       setCogRasterMainVisibility(raster.id, wantVisible, raster.opacity);
     }
+    cogMainForced.set(raster.id, {
+      visible: wantVisible,
+      opacity: raster.opacity,
+    });
   }
 }
 

--- a/packages/plugins/src/plugins/swipe-cog-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-cog-mirror.ts
@@ -27,6 +27,11 @@ export class SwipeCogMirror {
   // The last-rendered set, so redundant syncs (e.g. on slider drag) are skipped
   // and a stale in-flight sync can detect it was superseded.
   private fingerprint = "";
+  // Rasters are added sequentially (configure + addLayer share the control's
+  // form state, so concurrent adds would race). Cap each add so one slow/hung
+  // COG server does not stall the rest of the mirror; a late resolve still adds
+  // the layer, and the next sync reconciles it.
+  private static readonly ADD_TIMEOUT_MS = 20_000;
 
   constructor(map: MapLibreMap) {
     this.map = map;
@@ -89,11 +94,27 @@ export class SwipeCogMirror {
       // while awaiting the previous addLayer.
       if (this.destroyed || this.fingerprint !== fingerprint) return;
       try {
-        await mirrorAddCogLayer(control, raster);
+        await this.addWithTimeout(control, raster);
       } catch (error) {
         console.debug("[GeoLibre] swipe COG mirror: addLayer", error);
       }
     }
+  }
+
+  private addWithTimeout(
+    control: CogLayerControl,
+    raster: SwipeCogRasterSnapshot,
+  ): Promise<void> {
+    let timer: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<void>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`mirror addLayer timed out: ${raster.id}`)),
+        SwipeCogMirror.ADD_TIMEOUT_MS,
+      );
+    });
+    return Promise.race([mirrorAddCogLayer(control, raster), timeout]).finally(
+      () => clearTimeout(timer),
+    );
   }
 
   /** Removes the mirror control from the comparison map. */

--- a/packages/plugins/src/plugins/swipe-cog-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-cog-mirror.ts
@@ -4,8 +4,32 @@ import {
   clearMirrorCogLayers,
   createSwipeCogMirrorControl,
   mirrorAddCogLayer,
+  mirrorRemoveCogLayer,
+  mirrorSetCogOpacity,
   type SwipeCogRasterSnapshot,
 } from "./maplibre-components";
+
+// The non-opacity visualization of a mirrored raster; a change here needs a
+// reload (re-add), whereas an opacity-only change is applied in place.
+function structuralFingerprint(raster: SwipeCogRasterSnapshot): string {
+  return JSON.stringify([
+    raster.url,
+    raster.bands,
+    raster.colormap,
+    raster.rescaleMin,
+    raster.rescaleMax,
+    raster.nodata,
+  ]);
+}
+
+interface MirroredEntry {
+  /** The mirror control's own layer id (for opacity/remove). */
+  mirrorId: string;
+  /** Last-applied structural fingerprint (reload trigger). */
+  structFp: string;
+  /** Last-applied opacity. */
+  opacity: number;
+}
 
 /**
  * Renders a copy of GeoLibre's deck.gl COG rasters onto the Layer Swipe
@@ -17,16 +41,20 @@ import {
  * The main map keeps rendering its rasters through the normal CogLayerControl;
  * the swipe provider hides right-only rasters there. This mirror is an
  * independent, hidden CogLayerControl bound to the comparison map, so it never
- * touches the main deck overlay or the app store.
+ * touches the main deck overlay or the app store. It diffs per raster id so an
+ * opacity nudge (or an edit to one of several mirrored rasters) does not tear
+ * down and reload the others.
  */
 export class SwipeCogMirror {
   private map: MapLibreMap;
   private control: CogLayerControl | null = null;
   private controlPromise: Promise<CogLayerControl | null> | null = null;
   private destroyed = false;
-  // The last-rendered set, so redundant syncs (e.g. on slider drag) are skipped
-  // and a stale in-flight sync can detect it was superseded.
-  private fingerprint = "";
+  // The mirrored rasters, keyed by store raster id.
+  private applied = new Map<string, MirroredEntry>();
+  // Serialises overlapping sync() calls: adds share the control's form state, so
+  // two syncs must not interleave their configure+addLayer.
+  private syncChain: Promise<void> = Promise.resolve();
 
   constructor(map: MapLibreMap) {
     this.map = map;
@@ -58,52 +86,73 @@ export class SwipeCogMirror {
   }
 
   /**
-   * Renders exactly `desired` on the comparison map. Rebuilds the mirror's
-   * layers whenever the set (or any raster's visualization) changes, matching
-   * the main map. A no-op when nothing changed.
+   * Reconciles the comparison map's mirrored rasters to `desired`: adds new
+   * ones, drops removed ones, reloads a raster whose visualization changed, and
+   * applies an opacity-only change in place (no reload / flash).
    *
    * @param desired - The rasters that should render on the comparison side.
    */
-  async sync(desired: SwipeCogRasterSnapshot[]): Promise<void> {
-    const fingerprint = JSON.stringify(
-      desired.map((raster) => [
-        raster.id,
-        raster.url,
-        raster.opacity,
-        raster.bands,
-        raster.colormap,
-        raster.rescaleMin,
-        raster.rescaleMax,
-        raster.nodata,
-      ]),
-    );
-    if (fingerprint === this.fingerprint) return;
-    this.fingerprint = fingerprint;
+  sync(desired: SwipeCogRasterSnapshot[]): Promise<void> {
+    // Serialise: chain after any in-flight sync so their sequential adds (which
+    // share the control's form state) never interleave.
+    this.syncChain = this.syncChain
+      .catch(() => {})
+      .then(() => this.reconcile(desired));
+    return this.syncChain;
+  }
+
+  private async reconcile(desired: SwipeCogRasterSnapshot[]): Promise<void> {
+    if (this.destroyed) return;
 
     // Nothing to mirror: don't mount a real CogLayerControl/deck overlay on the
-    // comparison map just to render zero layers (the common case for projects
-    // with no COG rasters). Only clear an already-mounted control.
+    // comparison map just to render zero layers (the common no-COG case).
     if (desired.length === 0) {
-      if (this.control) clearMirrorCogLayers(this.control);
+      if (this.control && this.applied.size > 0) {
+        clearMirrorCogLayers(this.control);
+        this.applied.clear();
+      }
       return;
     }
 
     const control = await this.ensureControl();
     if (!control || this.destroyed) return;
 
-    clearMirrorCogLayers(control);
-    // Adds run sequentially and each awaits fully before the next: configure +
-    // addLayer share the control's `_state`, which addLayer reads lazily *after*
-    // its async GeoTIFF load, so overlapping adds would let a later raster's
-    // settings bleed into an earlier one. A hung add would stall the rest, but
-    // the mirror loads URLs the main map already loaded, so that is unlikely and
-    // only affects the comparison side.
+    const desiredIds = new Set(desired.map((raster) => raster.id));
+    for (const [id, entry] of [...this.applied]) {
+      if (!desiredIds.has(id)) {
+        mirrorRemoveCogLayer(control, entry.mirrorId);
+        this.applied.delete(id);
+      }
+    }
+
     for (const raster of desired) {
-      // Bail if a newer sync superseded this one (or the mirror was destroyed)
-      // while awaiting the previous addLayer.
-      if (this.destroyed || this.fingerprint !== fingerprint) return;
+      if (this.destroyed) return;
+      const structFp = structuralFingerprint(raster);
+      const existing = this.applied.get(raster.id);
+
+      if (existing && existing.structFp === structFp) {
+        // Same data + visualization; only opacity may have changed.
+        if (existing.opacity !== raster.opacity) {
+          mirrorSetCogOpacity(control, existing.mirrorId, raster.opacity);
+          existing.opacity = raster.opacity;
+        }
+        continue;
+      }
+
+      // New raster, or a structural change that needs a reload.
+      if (existing) {
+        mirrorRemoveCogLayer(control, existing.mirrorId);
+        this.applied.delete(raster.id);
+      }
       try {
-        await mirrorAddCogLayer(control, raster);
+        const mirrorId = await mirrorAddCogLayer(control, raster);
+        if (mirrorId && !this.destroyed) {
+          this.applied.set(raster.id, {
+            mirrorId,
+            structFp,
+            opacity: raster.opacity,
+          });
+        }
       } catch (error) {
         console.debug("[GeoLibre] swipe COG mirror: addLayer", error);
       }
@@ -113,7 +162,7 @@ export class SwipeCogMirror {
   /** Removes the mirror control from the comparison map. */
   destroy(): void {
     this.destroyed = true;
-    this.fingerprint = "";
+    this.applied.clear();
     const control = this.control;
     this.control = null;
     this.controlPromise = null;

--- a/packages/plugins/src/plugins/swipe-cog-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-cog-mirror.ts
@@ -27,11 +27,6 @@ export class SwipeCogMirror {
   // The last-rendered set, so redundant syncs (e.g. on slider drag) are skipped
   // and a stale in-flight sync can detect it was superseded.
   private fingerprint = "";
-  // Rasters are added sequentially (configure + addLayer share the control's
-  // form state, so concurrent adds would race). Cap each add so one slow/hung
-  // COG server does not stall the rest of the mirror; a late resolve still adds
-  // the layer, and the next sync reconciles it.
-  private static readonly ADD_TIMEOUT_MS = 20_000;
 
   constructor(map: MapLibreMap) {
     this.map = map;
@@ -85,36 +80,34 @@ export class SwipeCogMirror {
     if (fingerprint === this.fingerprint) return;
     this.fingerprint = fingerprint;
 
+    // Nothing to mirror: don't mount a real CogLayerControl/deck overlay on the
+    // comparison map just to render zero layers (the common case for projects
+    // with no COG rasters). Only clear an already-mounted control.
+    if (desired.length === 0) {
+      if (this.control) clearMirrorCogLayers(this.control);
+      return;
+    }
+
     const control = await this.ensureControl();
     if (!control || this.destroyed) return;
 
     clearMirrorCogLayers(control);
+    // Adds run sequentially and each awaits fully before the next: configure +
+    // addLayer share the control's `_state`, which addLayer reads lazily *after*
+    // its async GeoTIFF load, so overlapping adds would let a later raster's
+    // settings bleed into an earlier one. A hung add would stall the rest, but
+    // the mirror loads URLs the main map already loaded, so that is unlikely and
+    // only affects the comparison side.
     for (const raster of desired) {
       // Bail if a newer sync superseded this one (or the mirror was destroyed)
       // while awaiting the previous addLayer.
       if (this.destroyed || this.fingerprint !== fingerprint) return;
       try {
-        await this.addWithTimeout(control, raster);
+        await mirrorAddCogLayer(control, raster);
       } catch (error) {
         console.debug("[GeoLibre] swipe COG mirror: addLayer", error);
       }
     }
-  }
-
-  private addWithTimeout(
-    control: CogLayerControl,
-    raster: SwipeCogRasterSnapshot,
-  ): Promise<void> {
-    let timer: ReturnType<typeof setTimeout>;
-    const timeout = new Promise<void>((_, reject) => {
-      timer = setTimeout(
-        () => reject(new Error(`mirror addLayer timed out: ${raster.id}`)),
-        SwipeCogMirror.ADD_TIMEOUT_MS,
-      );
-    });
-    return Promise.race([mirrorAddCogLayer(control, raster), timeout]).finally(
-      () => clearTimeout(timer),
-    );
   }
 
   /** Removes the mirror control from the comparison map. */

--- a/packages/plugins/src/plugins/swipe-cog-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-cog-mirror.ts
@@ -1,0 +1,117 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+import type { CogLayerControl } from "maplibre-gl-components";
+import {
+  clearMirrorCogLayers,
+  createSwipeCogMirrorControl,
+  mirrorAddCogLayer,
+  type SwipeCogRasterSnapshot,
+} from "./maplibre-components";
+
+/**
+ * Renders a copy of GeoLibre's deck.gl COG rasters onto the Layer Swipe
+ * comparison map, so a raster assigned to the right (or both) side of the swipe
+ * shows there. The comparison map's canvas is already clipped to the swipe
+ * region by the swipe control, so the mirror inherits that clip for free and
+ * only decides *which* rasters to render.
+ *
+ * The main map keeps rendering its rasters through the normal CogLayerControl;
+ * the swipe provider hides right-only rasters there. This mirror is an
+ * independent, hidden CogLayerControl bound to the comparison map, so it never
+ * touches the main deck overlay or the app store.
+ */
+export class SwipeCogMirror {
+  private map: MapLibreMap;
+  private control: CogLayerControl | null = null;
+  private controlPromise: Promise<CogLayerControl | null> | null = null;
+  private destroyed = false;
+  // The last-rendered set, so redundant syncs (e.g. on slider drag) are skipped
+  // and a stale in-flight sync can detect it was superseded.
+  private fingerprint = "";
+
+  constructor(map: MapLibreMap) {
+    this.map = map;
+  }
+
+  /** The comparison map this mirror renders onto (identity check for reuse). */
+  getMap(): MapLibreMap {
+    return this.map;
+  }
+
+  private ensureControl(): Promise<CogLayerControl | null> {
+    if (this.destroyed) return Promise.resolve(null);
+    this.controlPromise ??= createSwipeCogMirrorControl(this.map).then(
+      (control) => {
+        if (this.destroyed) {
+          if (control) this.tryRemoveControl(control);
+          return null;
+        }
+        this.control = control;
+        return control;
+      },
+      (error: unknown) => {
+        this.controlPromise = null;
+        console.warn("[GeoLibre] swipe COG mirror: control load", error);
+        return null;
+      },
+    );
+    return this.controlPromise;
+  }
+
+  /**
+   * Renders exactly `desired` on the comparison map. Rebuilds the mirror's
+   * layers whenever the set (or any raster's visualization) changes, matching
+   * the main map. A no-op when nothing changed.
+   *
+   * @param desired - The rasters that should render on the comparison side.
+   */
+  async sync(desired: SwipeCogRasterSnapshot[]): Promise<void> {
+    const fingerprint = JSON.stringify(
+      desired.map((raster) => [
+        raster.id,
+        raster.url,
+        raster.opacity,
+        raster.bands,
+        raster.colormap,
+        raster.rescaleMin,
+        raster.rescaleMax,
+        raster.nodata,
+      ]),
+    );
+    if (fingerprint === this.fingerprint) return;
+    this.fingerprint = fingerprint;
+
+    const control = await this.ensureControl();
+    if (!control || this.destroyed) return;
+
+    clearMirrorCogLayers(control);
+    for (const raster of desired) {
+      // Bail if a newer sync superseded this one (or the mirror was destroyed)
+      // while awaiting the previous addLayer.
+      if (this.destroyed || this.fingerprint !== fingerprint) return;
+      try {
+        await mirrorAddCogLayer(control, raster);
+      } catch (error) {
+        console.debug("[GeoLibre] swipe COG mirror: addLayer", error);
+      }
+    }
+  }
+
+  /** Removes the mirror control from the comparison map. */
+  destroy(): void {
+    this.destroyed = true;
+    this.fingerprint = "";
+    const control = this.control;
+    this.control = null;
+    this.controlPromise = null;
+    if (control) this.tryRemoveControl(control);
+  }
+
+  private tryRemoveControl(control: CogLayerControl): void {
+    try {
+      this.map.removeControl(control);
+    } catch (error) {
+      // The comparison map may already be gone (removed by the swipe control).
+      console.debug("[GeoLibre] swipe COG mirror: removeControl", error);
+    }
+  }
+}

--- a/packages/plugins/src/plugins/swipe-cog-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-cog-mirror.ts
@@ -32,6 +32,37 @@ interface MirroredEntry {
 }
 
 /**
+ * The mirror-control operations {@link SwipeCogMirror} depends on. Injectable so
+ * tests can exercise the diffing/serialization logic with fakes instead of a
+ * real CogLayerControl + deck.gl overlay.
+ */
+export interface SwipeCogMirrorDeps {
+  createControl: (map: MapLibreMap) => Promise<CogLayerControl | null>;
+  addLayer: (
+    control: CogLayerControl,
+    snapshot: SwipeCogRasterSnapshot,
+  ) => Promise<string | null>;
+  setOpacity: (
+    control: CogLayerControl,
+    mirrorLayerId: string,
+    opacity: number,
+  ) => void;
+  removeLayer: (control: CogLayerControl, mirrorLayerId: string) => void;
+  clearLayers: (control: CogLayerControl) => void;
+  removeControl: (map: MapLibreMap, control: CogLayerControl) => void;
+}
+
+const DEFAULT_DEPS: SwipeCogMirrorDeps = {
+  createControl: (map) => createSwipeCogMirrorControl(map),
+  addLayer: (control, snapshot) => mirrorAddCogLayer(control, snapshot),
+  setOpacity: (control, id, opacity) =>
+    mirrorSetCogOpacity(control, id, opacity),
+  removeLayer: (control, id) => mirrorRemoveCogLayer(control, id),
+  clearLayers: (control) => clearMirrorCogLayers(control),
+  removeControl: (map, control) => map.removeControl(control),
+};
+
+/**
  * Renders a copy of GeoLibre's deck.gl COG rasters onto the Layer Swipe
  * comparison map, so a raster assigned to the right (or both) side of the swipe
  * shows there. The comparison map's canvas is already clipped to the swipe
@@ -47,6 +78,7 @@ interface MirroredEntry {
  */
 export class SwipeCogMirror {
   private map: MapLibreMap;
+  private deps: SwipeCogMirrorDeps;
   private control: CogLayerControl | null = null;
   private controlPromise: Promise<CogLayerControl | null> | null = null;
   private destroyed = false;
@@ -56,8 +88,9 @@ export class SwipeCogMirror {
   // two syncs must not interleave their configure+addLayer.
   private syncChain: Promise<void> = Promise.resolve();
 
-  constructor(map: MapLibreMap) {
+  constructor(map: MapLibreMap, deps: SwipeCogMirrorDeps = DEFAULT_DEPS) {
     this.map = map;
+    this.deps = deps;
   }
 
   /** The comparison map this mirror renders onto (identity check for reuse). */
@@ -67,7 +100,7 @@ export class SwipeCogMirror {
 
   private ensureControl(): Promise<CogLayerControl | null> {
     if (this.destroyed) return Promise.resolve(null);
-    this.controlPromise ??= createSwipeCogMirrorControl(this.map).then(
+    this.controlPromise ??= this.deps.createControl(this.map).then(
       (control) => {
         if (this.destroyed) {
           if (control) this.tryRemoveControl(control);
@@ -108,7 +141,7 @@ export class SwipeCogMirror {
     // comparison map just to render zero layers (the common no-COG case).
     if (desired.length === 0) {
       if (this.control && this.applied.size > 0) {
-        clearMirrorCogLayers(this.control);
+        this.deps.clearLayers(this.control);
         this.applied.clear();
       }
       return;
@@ -120,7 +153,7 @@ export class SwipeCogMirror {
     const desiredIds = new Set(desired.map((raster) => raster.id));
     for (const [id, entry] of [...this.applied]) {
       if (!desiredIds.has(id)) {
-        mirrorRemoveCogLayer(control, entry.mirrorId);
+        this.deps.removeLayer(control, entry.mirrorId);
         this.applied.delete(id);
       }
     }
@@ -133,7 +166,7 @@ export class SwipeCogMirror {
       if (existing && existing.structFp === structFp) {
         // Same data + visualization; only opacity may have changed.
         if (existing.opacity !== raster.opacity) {
-          mirrorSetCogOpacity(control, existing.mirrorId, raster.opacity);
+          this.deps.setOpacity(control, existing.mirrorId, raster.opacity);
           existing.opacity = raster.opacity;
         }
         continue;
@@ -141,11 +174,11 @@ export class SwipeCogMirror {
 
       // New raster, or a structural change that needs a reload.
       if (existing) {
-        mirrorRemoveCogLayer(control, existing.mirrorId);
+        this.deps.removeLayer(control, existing.mirrorId);
         this.applied.delete(raster.id);
       }
       try {
-        const mirrorId = await mirrorAddCogLayer(control, raster);
+        const mirrorId = await this.deps.addLayer(control, raster);
         if (mirrorId && !this.destroyed) {
           this.applied.set(raster.id, {
             mirrorId,
@@ -171,7 +204,7 @@ export class SwipeCogMirror {
 
   private tryRemoveControl(control: CogLayerControl): void {
     try {
-      this.map.removeControl(control);
+      this.deps.removeControl(this.map, control);
     } catch (error) {
       // The comparison map may already be gone (removed by the swipe control).
       console.debug("[GeoLibre] swipe COG mirror: removeControl", error);

--- a/tests/swipe-cog-mirror.test.ts
+++ b/tests/swipe-cog-mirror.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Map as MapLibreMap } from "maplibre-gl";
+import type { CogLayerControl } from "maplibre-gl-components";
+import type { SwipeCogRasterSnapshot } from "../packages/plugins/src/plugins/maplibre-components";
+import {
+  SwipeCogMirror,
+  type SwipeCogMirrorDeps,
+} from "../packages/plugins/src/plugins/swipe-cog-mirror";
+
+// A fake CogLayerControl is opaque to the mirror (only passed through deps), so
+// a plain object stands in.
+const fakeControl = {} as CogLayerControl;
+const fakeMap = {} as MapLibreMap;
+
+interface Recorder {
+  deps: SwipeCogMirrorDeps;
+  calls: string[];
+  created: number;
+  removedControl: number;
+}
+
+function makeDeps(): Recorder {
+  const calls: string[] = [];
+  let created = 0;
+  let removedControl = 0;
+  let idCounter = 0;
+  const deps: SwipeCogMirrorDeps = {
+    createControl: async () => {
+      created += 1;
+      return fakeControl;
+    },
+    addLayer: async (_control, snapshot) => {
+      idCounter += 1;
+      const id = `m${idCounter}`;
+      calls.push(`add:${snapshot.id}=>${id}`);
+      return id;
+    },
+    setOpacity: (_control, mirrorId, opacity) => {
+      calls.push(`opacity:${mirrorId}=${opacity}`);
+    },
+    removeLayer: (_control, mirrorId) => {
+      calls.push(`remove:${mirrorId}`);
+    },
+    clearLayers: () => {
+      calls.push("clear");
+    },
+    removeControl: () => {
+      removedControl += 1;
+    },
+  };
+  return {
+    deps,
+    calls,
+    get created() {
+      return created;
+    },
+    get removedControl() {
+      return removedControl;
+    },
+  };
+}
+
+function raster(
+  id: string,
+  patch: Partial<SwipeCogRasterSnapshot> = {},
+): SwipeCogRasterSnapshot {
+  return {
+    id,
+    name: id,
+    url: `https://example.com/${id}.tif`,
+    visible: true,
+    opacity: 1,
+    bands: "1,2,3",
+    colormap: undefined,
+    rescaleMin: 0,
+    rescaleMax: 255,
+    nodata: 0,
+    ...patch,
+  };
+}
+
+describe("SwipeCogMirror", () => {
+  it("adds a new raster and mounts the control once", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    assert.equal(rec.created, 1);
+    assert.deepEqual(rec.calls, ["add:a=>m1"]);
+  });
+
+  it("applies an opacity-only change in place without re-adding", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a", { opacity: 0.5 })]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "opacity:m1=0.5"]);
+    assert.equal(rec.created, 1);
+  });
+
+  it("reloads a raster when its visualization changes", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a", { colormap: "viridis" })]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add:a=>m2"]);
+  });
+
+  it("removes a raster dropped from the desired set", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a"), raster("b")]);
+    await mirror.sync([raster("a")]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "add:b=>m2", "remove:m2"]);
+  });
+
+  it("does nothing (and never mounts a control) when desired is empty", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([]);
+    assert.equal(rec.created, 0);
+    assert.deepEqual(rec.calls, []);
+  });
+
+  it("clears mounted layers when the desired set becomes empty", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "clear"]);
+  });
+
+  it("skips redundant work when nothing changed", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a")]);
+    assert.deepEqual(rec.calls, ["add:a=>m1"]);
+  });
+
+  it("removes the control and stops rendering after destroy", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeCogMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    mirror.destroy();
+    assert.equal(rec.removedControl, 1);
+    await mirror.sync([raster("b")]);
+    // No further adds after destroy.
+    assert.deepEqual(rec.calls, ["add:a=>m1"]);
+  });
+});


### PR DESCRIPTION
## Summary

COG rasters (Vantor Open Data, STAC "Visualize") render through the CogLayerControl deck.gl overlay, so they are MapLibre **custom layers** that MapLibre omits from `getStyle()`. Layer Swipe builds both its layer list and its comparison map from `getStyle()`, so those rasters could not be listed, hidden, or clipped: the image stayed on top of everything, showed on **both** sides of the swipe divider, and never appeared in the swipe layer picker (reported in #1240).

This consumes the new `layerProvider` hook in **maplibre-gl-swipe 0.11.0** (opengeos/maplibre-gl-swipe#19) to fix it.

## What changed

- **`maplibre-swipe.ts`** — a COG `layerProvider` lists the store's `cog-url` rasters in the swipe panel and resolves each one's side. Right/both/none rasters are mirrored onto the swipe **comparison map** (already clipped to the swipe region) via a hidden `CogLayerControl`; right-only rasters are hidden on the main map. A COG is now assignable to **Left / Right / Both** and clips at the divider like a vector layer, including Vantor pre/post before-after comparisons.
- **`swipe-cog-mirror.ts`** (new) — the comparison-map mirror (a hidden `CogLayerControl`, rebuilt when the assigned set changes).
- **`maplibre-components.ts`** — snapshot/main-visibility/mirror primitives + a store subscription that refreshes the swipe list as rasters change.
- **`map-controller.ts`** — publishes deck COG layers to the swipe label bridge by store id, so the panel shows the layer name instead of the raw id.
- Bumps `maplibre-gl-swipe` to `^0.11.0` in the two `package.json` files that list it.

## Test plan

Verified end-to-end in the browser (Playwright) with a live Vantor COG (Venezuela-Earthquake-Jun-2026) plus a local points GeoJSON, in **both light and dark themes**:

- [x] The COG appears in the Layer Swipe picker (with its name, not `cog-layer-0`).
- [x] COG on **Left**: image left of the divider, basemap right.
- [x] COG on **Right**: basemap left, image right.
- [x] COG on **Both**: image full-screen.
- [x] Dragging the divider clips the COG live.
- [x] Vector points overlay the image and can be shown on both sides.
- [x] `npm run build`, `npm run test:frontend` (2580 pass), coverage gate, and `pre-commit` all green.

Fixes #1240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layer Swipe now supports COG raster layers, rendering them on the comparison map with correct side-dependent behavior, including visibility, opacity, and visualization settings.
  * COG layers appear with friendly display names in the Layer Swipe panel.
  * Layer Swipe provides live syncing and more reliable COG comparison-map mirroring as settings change.
* **Bug Fixes**
  * Improved COG synchronization and teardown so main-map COG visibility/opacity forced during comparisons is properly restored.
* **Chores**
  * Updated the Layer Swipe/maplibre-gl-swipe dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->