### PR TITLE
fix(print-layout): honor scale bar unit preference (imperial/metric/nautical)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -131,6 +131,9 @@ export function PrintLayoutDialog({
   const projectName = useAppStore((s) => s.projectName);
   const legendConfig = useAppStore((s) => s.legend);
   const setLegendConfig = useAppStore((s) => s.setLegend);
+  // Follow the map's scale-bar unit preference so the printed bar matches the
+  // on-screen one (metric / imperial / nautical).
+  const scaleUnit = useAppStore((s) => s.preferences.map.scaleUnit);
 
   const [title, setTitle] = useState("");
   const [subtitle, setSubtitle] = useState("");
@@ -565,6 +568,7 @@ export function PrintLayoutDialog({
       titleAlign,
       showLegend,
       showScaleBar,
+      scaleUnit,
       showNorthArrow,
       navigationGrouped,
       showFooter,
@@ -636,6 +640,7 @@ export function PrintLayoutDialog({
       titleAlign,
       showLegend,
       showScaleBar,
+      scaleUnit,
       showNorthArrow,
       navigationGrouped,
       showFooter,

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -8,7 +8,12 @@
  * (PNG / PDF), so the preview is faithful to the output.
  */
 
-import type { MapScaleUnit } from "@geolibre/core";
+import {
+  formatRoundNum,
+  getRoundNum,
+  scaleDenomination,
+  type MapScaleUnit,
+} from "@geolibre/core";
 
 export type PaperSizeId =
   | "a4"
@@ -819,57 +824,37 @@ function drawNorthArrow(
 }
 
 /**
- * Round a span down to a "nice" `1 / 2 / 3 / 5 / 10 × 10ⁿ` value. This is the
- * same nice-number set the on-screen bar uses (`getRoundNum` in
- * `@geolibre/map`'s `PlanetaryScaleControl`), so the printed bar rounds the same
- * ground span to the same value the map does, in whichever unit it is measured.
+ * Round a positive span with the shared cartographic rounder ({@link
+ * getRoundNum} — the same one the on-screen `PlanetaryScaleControl` uses), so
+ * the printed bar snaps a given ground span to the same value the map does.
+ * Falls back to 1 for a non-positive span (a zero/negative body width) so the
+ * bar geometry never turns into NaN — `getRoundNum` returns 0 there.
  */
-function niceDistance(span: number): number {
-  // Guard against a zero/negative body width: Math.log10(0) is -Infinity, which
-  // would propagate as NaN through the scale-bar geometry.
-  if (span <= 0) return 1;
-  const pow = Math.pow(10, Math.floor(Math.log10(span)));
-  const frac = span / pow;
-  const nice = frac >= 10 ? 10 : frac >= 5 ? 5 : frac >= 3 ? 3 : frac >= 2 ? 2 : 1;
-  return nice * pow;
+function niceSpan(span: number): number {
+  return span > 0 ? getRoundNum(span) : 1;
 }
 
-const FEET_PER_METER = 3.2808398950131235; // 1 / 0.3048
-const METERS_PER_FOOT = 0.3048;
-const METERS_PER_MILE = 1609.344; // 5280 ft
-const METERS_PER_NAUTICAL_MILE = 1852;
-
 /**
- * Pick the denomination the scale bar rounds and labels with for a ground span
- * of `maxMeters` in the requested unit system, mirroring the on-screen bar
- * (`scaleSpan` in `@geolibre/map`): km/m/cm for metric, mi/ft for imperial, and
- * nautical miles for nautical. Returns the metres in one unit of that
- * denomination so the caller can round in unit space and convert back.
+ * The denomination the print bar rounds and labels distances with. Delegates to
+ * the shared {@link scaleDenomination} (km/m, mi/ft, nmi) and adds one
+ * print-only refinement: a metric sub-metre span (street/parcel zoom) labels in
+ * centimetres rather than showing a useless "0.x m". Returns the size in metres
+ * of one unit of that denomination so the caller can round in unit space and
+ * convert the result back to metres (and thus pixels).
  */
-function pickScaleDenomination(
+function printScaleDenomination(
   maxMeters: number,
   unit: MapScaleUnit,
 ): { metersPerUnit: number; label: string } {
-  if (unit === "imperial") {
-    const feet = maxMeters * FEET_PER_METER;
-    return feet >= 5280
-      ? { metersPerUnit: METERS_PER_MILE, label: "mi" }
-      : { metersPerUnit: METERS_PER_FOOT, label: "ft" };
+  if (unit === "metric" && maxMeters > 0 && maxMeters < 1) {
+    return { metersPerUnit: 0.01, label: "cm" };
   }
-  if (unit === "nautical") {
-    return { metersPerUnit: METERS_PER_NAUTICAL_MILE, label: "nmi" };
-  }
-  if (maxMeters >= 1000) return { metersPerUnit: 1000, label: "km" };
-  // Below a metre (street/parcel zoom) label in centimetres instead of showing
-  // a useless "0.0 m".
-  if (maxMeters >= 1) return { metersPerUnit: 1, label: "m" };
-  return { metersPerUnit: 0.01, label: "cm" };
+  return scaleDenomination(maxMeters, unit);
 }
 
 /** Format a rounded span in its denomination, trimming trailing-zero noise. */
 function formatSpanLabel(span: number, label: string): string {
-  const clean = Number.parseFloat(span.toPrecision(12)).toString();
-  return `${clean} ${label}`;
+  return `${formatRoundNum(span)} ${label}`;
 }
 
 /**
@@ -894,9 +879,9 @@ function drawScaleBar(
   // Round to a nice number in the target unit (feet, miles, km, ...) so the bar
   // lands on a readable value in that system, then convert back to metres for
   // the pixel width.
-  const { metersPerUnit, label } = pickScaleDenomination(maxMeters, scaleUnit);
-  const niceSpan = niceDistance(maxMeters / metersPerUnit);
-  const distance = niceSpan * metersPerUnit;
+  const { metersPerUnit, label } = printScaleDenomination(maxMeters, scaleUnit);
+  const rounded = niceSpan(maxMeters / metersPerUnit);
+  const distance = rounded * metersPerUnit;
   const barWidth = distance / metersPerPixel;
   const barHeight = unit * 1.1;
   const x0 = rightX - barWidth;
@@ -938,7 +923,7 @@ function drawScaleBar(
   ctx.font = `500 ${unit * 1.7}px system-ui, sans-serif`;
   ctx.textAlign = "right";
   ctx.textBaseline = "bottom";
-  ctx.fillText(formatSpanLabel(niceSpan, label), rightX, y0 - unit * 0.5);
+  ctx.fillText(formatSpanLabel(rounded, label), rightX, y0 - unit * 0.5);
   ctx.restore();
   return backingTop;
 }

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -818,17 +818,19 @@ function drawNorthArrow(
   ctx.restore();
 }
 
-/** Round a distance down to a "nice" 1/2/5 × 10ⁿ value. */
-function niceDistance(meters: number): number {
+/**
+ * Round a span down to a "nice" `1 / 2 / 3 / 5 / 10 × 10ⁿ` value. This is the
+ * same nice-number set the on-screen bar uses (`getRoundNum` in
+ * `@geolibre/map`'s `PlanetaryScaleControl`), so the printed bar rounds the same
+ * ground span to the same value the map does, in whichever unit it is measured.
+ */
+function niceDistance(span: number): number {
   // Guard against a zero/negative body width: Math.log10(0) is -Infinity, which
   // would propagate as NaN through the scale-bar geometry.
-  if (meters <= 0) return 1;
-  const pow = Math.pow(10, Math.floor(Math.log10(meters)));
-  const frac = meters / pow;
-  let nice: number;
-  if (frac >= 5) nice = 5;
-  else if (frac >= 2) nice = 2;
-  else nice = 1;
+  if (span <= 0) return 1;
+  const pow = Math.pow(10, Math.floor(Math.log10(span)));
+  const frac = span / pow;
+  const nice = frac >= 10 ? 10 : frac >= 5 ? 5 : frac >= 3 ? 3 : frac >= 2 ? 2 : 1;
   return nice * pow;
 }
 

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -8,6 +8,8 @@
  * (PNG / PDF), so the preview is faithful to the output.
  */
 
+import type { MapScaleUnit } from "@geolibre/core";
+
 export type PaperSizeId =
   | "a4"
   | "a3"
@@ -155,6 +157,13 @@ export interface LayoutOptions {
   titleAlign?: "left" | "center" | "right";
   showLegend: boolean;
   showScaleBar: boolean;
+  /**
+   * Unit system the scale bar labels distances in: `"metric"` (km/m/cm),
+   * `"imperial"` (mi/ft), or `"nautical"` (nmi). Follows the project's map
+   * preference so the printed bar matches the on-screen bar. Defaults to
+   * `"metric"` when omitted.
+   */
+  scaleUnit?: MapScaleUnit;
   showNorthArrow: boolean;
   /**
    * Group the north arrow directly above the scale bar in the lower-right
@@ -682,6 +691,7 @@ export function drawLayout(
       outputMpp,
       unit,
       scaleRatio,
+      opts.scaleUnit ?? "metric",
     );
   }
   if (opts.showNorthArrow) {
@@ -822,15 +832,42 @@ function niceDistance(meters: number): number {
   return nice * pow;
 }
 
-function formatDistance(meters: number): string {
-  if (meters >= 1000) {
-    const km = meters / 1000;
-    return `${km % 1 === 0 ? km : km.toFixed(1)} km`;
+const FEET_PER_METER = 3.2808398950131235; // 1 / 0.3048
+const METERS_PER_FOOT = 0.3048;
+const METERS_PER_MILE = 1609.344; // 5280 ft
+const METERS_PER_NAUTICAL_MILE = 1852;
+
+/**
+ * Pick the denomination the scale bar rounds and labels with for a ground span
+ * of `maxMeters` in the requested unit system, mirroring the on-screen bar
+ * (`scaleSpan` in `@geolibre/map`): km/m/cm for metric, mi/ft for imperial, and
+ * nautical miles for nautical. Returns the metres in one unit of that
+ * denomination so the caller can round in unit space and convert back.
+ */
+function pickScaleDenomination(
+  maxMeters: number,
+  unit: MapScaleUnit,
+): { metersPerUnit: number; label: string } {
+  if (unit === "imperial") {
+    const feet = maxMeters * FEET_PER_METER;
+    return feet >= 5280
+      ? { metersPerUnit: METERS_PER_MILE, label: "mi" }
+      : { metersPerUnit: METERS_PER_FOOT, label: "ft" };
   }
+  if (unit === "nautical") {
+    return { metersPerUnit: METERS_PER_NAUTICAL_MILE, label: "nmi" };
+  }
+  if (maxMeters >= 1000) return { metersPerUnit: 1000, label: "km" };
   // Below a metre (street/parcel zoom) label in centimetres instead of showing
   // a useless "0.0 m".
-  if (meters >= 1) return `${Math.round(meters)} m`;
-  return `${Math.round(meters * 100)} cm`;
+  if (maxMeters >= 1) return { metersPerUnit: 1, label: "m" };
+  return { metersPerUnit: 0.01, label: "cm" };
+}
+
+/** Format a rounded span in its denomination, trimming trailing-zero noise. */
+function formatSpanLabel(span: number, label: string): string {
+  const clean = Number.parseFloat(span.toPrecision(12)).toString();
+  return `${clean} ${label}`;
 }
 
 /**
@@ -849,9 +886,15 @@ function drawScaleBar(
   metersPerPixel: number,
   unit: number,
   scaleRatio = 0,
+  scaleUnit: MapScaleUnit = "metric",
 ): number {
   const maxMeters = maxWidthPx * metersPerPixel;
-  const distance = niceDistance(maxMeters);
+  // Round to a nice number in the target unit (feet, miles, km, ...) so the bar
+  // lands on a readable value in that system, then convert back to metres for
+  // the pixel width.
+  const { metersPerUnit, label } = pickScaleDenomination(maxMeters, scaleUnit);
+  const niceSpan = niceDistance(maxMeters / metersPerUnit);
+  const distance = niceSpan * metersPerUnit;
   const barWidth = distance / metersPerPixel;
   const barHeight = unit * 1.1;
   const x0 = rightX - barWidth;
@@ -893,7 +936,7 @@ function drawScaleBar(
   ctx.font = `500 ${unit * 1.7}px system-ui, sans-serif`;
   ctx.textAlign = "right";
   ctx.textBaseline = "bottom";
-  ctx.fillText(formatDistance(distance), rightX, y0 - unit * 0.5);
+  ctx.fillText(formatSpanLabel(niceSpan, label), rightX, y0 - unit * 0.5);
   ctx.restore();
   return backingTop;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./color-ramp";
 export * from "./paths";
 export * from "./routing";
 export * from "./vector-color";
+export * from "./scale-units";
 export * from "./project";
 export * from "./layer-groups";
 export { createSampleStoryMap } from "./storymap-sample";

--- a/packages/core/src/scale-units.ts
+++ b/packages/core/src/scale-units.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared scale-bar unit maths.
+ *
+ * The on-screen scale bar (`PlanetaryScaleControl` in `@geolibre/map`) and the
+ * Print Layout scale bar (`apps/geolibre-desktop/src/lib/print-layout.ts`) both
+ * need to pick a "nice" round distance in the user's chosen unit system
+ * (metric / imperial / nautical). Keeping that logic in one place here means the
+ * two bars round a given ground span to the same value and share the same unit
+ * constants, so a change to one can never silently diverge from the other.
+ */
+
+import type { MapScaleUnit } from "./types";
+
+/** Conversion constants shared by every scale-bar denomination. */
+export const FEET_PER_METER = 3.2808398950131235; // 1 / 0.3048
+export const METERS_PER_FOOT = 0.3048;
+export const FEET_PER_MILE = 5280;
+export const METERS_PER_MILE = 1609.344; // 5280 ft
+export const METERS_PER_NAUTICAL_MILE = 1852;
+
+/**
+ * The largest `1 / 2 / 3 / 5 / 10 × 10ⁿ` number that does not exceed `num`, so
+ * the bar lands on a readable round value. Uses log10 for the magnitude (unlike
+ * MapLibre's digit-count trick, which returns 1 for any `0 < num < 1` and so
+ * rounds *up* — producing a bar wider than the max width for sub-unit spans).
+ * Returns 0 for a non-positive input so callers can clamp or fall back.
+ */
+export function getRoundNum(num: number): number {
+  if (!(num > 0)) return 0;
+  const pow10 = Math.pow(10, Math.floor(Math.log10(num)));
+  const d = num / pow10;
+  const nice = d >= 10 ? 10 : d >= 5 ? 5 : d >= 3 ? 3 : d >= 2 ? 2 : 1;
+  return pow10 * nice;
+}
+
+/** Trim trailing-zero noise from a rounded value (e.g. 0.5, 2, 300). */
+export function formatRoundNum(value: number): string {
+  return Number.parseFloat(value.toPrecision(12)).toString();
+}
+
+/**
+ * The denomination a scale bar rounds and labels distances with for a ground
+ * span of `maxMeters` in the requested unit system: km/m for metric, mi/ft for
+ * imperial, and nautical miles for nautical. The unit crosses to the larger
+ * denomination once the span exceeds one of it. `metersPerUnit` is the size of
+ * one unit of that denomination in metres, so a caller can round the span in
+ * unit space and convert the result back to metres (and thus pixels).
+ */
+export function scaleDenomination(
+  maxMeters: number,
+  unit: MapScaleUnit,
+): { metersPerUnit: number; label: string } {
+  if (unit === "imperial") {
+    const feet = maxMeters * FEET_PER_METER;
+    return feet >= FEET_PER_MILE
+      ? { metersPerUnit: METERS_PER_MILE, label: "mi" }
+      : { metersPerUnit: METERS_PER_FOOT, label: "ft" };
+  }
+  if (unit === "nautical") {
+    return { metersPerUnit: METERS_PER_NAUTICAL_MILE, label: "nmi" };
+  }
+  return maxMeters >= 1000
+    ? { metersPerUnit: 1000, label: "km" }
+    : { metersPerUnit: 1, label: "m" };
+}
+
+/**
+ * Convert a ground distance in metres into the span (already divided into the
+ * bar's denomination) and its label — the shape the on-screen control consumes.
+ * Derived from {@link scaleDenomination} so the two never diverge.
+ */
+export function scaleSpan(
+  maxMeters: number,
+  unit: MapScaleUnit,
+): { span: number; label: string } {
+  const { metersPerUnit, label } = scaleDenomination(maxMeters, unit);
+  return { span: maxMeters / metersPerUnit, label };
+}

--- a/packages/map/src/planetary-scale-control.ts
+++ b/packages/map/src/planetary-scale-control.ts
@@ -1,5 +1,16 @@
-import { getActiveMeanRadiusMeters, type MapScaleUnit } from "@geolibre/core";
+import {
+  formatRoundNum,
+  getActiveMeanRadiusMeters,
+  getRoundNum,
+  scaleSpan,
+  type MapScaleUnit,
+} from "@geolibre/core";
 import maplibregl from "maplibre-gl";
+
+// Re-exported so the nice-number rounding and unit conversion — now shared with
+// the Print Layout scale bar in `@geolibre/core` — can still be imported from
+// this module (and covered by planetary-scale-control.test.ts).
+export { getRoundNum, scaleSpan } from "@geolibre/core";
 
 /**
  * A metric scale bar that respects the active celestial body's radius.
@@ -112,27 +123,6 @@ export function greatCircleMeters(
   return 2 * radiusMeters * Math.asin(Math.min(1, Math.sqrt(h)));
 }
 
-// The largest "1 / 2 / 3 / 5 / 10 × 10ⁿ" number that does not exceed `num`, so
-// the bar lands on a readable round value. Uses log10 for the magnitude (unlike
-// MapLibre's digit-count trick, which returns 1 for any 0 < num < 1 and so
-// rounds *up* — producing a bar wider than maxWidth for sub-unit spans).
-export function getRoundNum(num: number): number {
-  if (!(num > 0)) return 0;
-  const pow10 = Math.pow(10, Math.floor(Math.log10(num)));
-  const d = num / pow10;
-  const nice = d >= 10 ? 10 : d >= 5 ? 5 : d >= 3 ? 3 : d >= 2 ? 2 : 1;
-  return pow10 * nice;
-}
-
-/** Trim trailing-zero noise from a rounded value (e.g. 0.5, 2, 300). */
-function formatNum(value: number): string {
-  return Number.parseFloat(value.toPrecision(12)).toString();
-}
-
-const FEET_PER_METER = 3.2808398950131235; // 1 / 0.3048
-const FEET_PER_MILE = 5280;
-const METERS_PER_NAUTICAL_MILE = 1852;
-
 /** Size the bar and label to a round distance in the requested unit system. */
 function setScale(
   el: HTMLElement,
@@ -146,28 +136,5 @@ function setScale(
   // hard guard against any pathological span slipping through.
   const width = Math.min(maxWidth, maxWidth * (rounded / span));
   el.style.width = `${width}px`;
-  el.textContent = `${formatNum(rounded)} ${label}`;
-}
-
-/**
- * Convert a ground distance in metres into the unit the bar rounds and labels
- * with: km/m for metric, mi/ft for imperial, and nautical miles for nautical.
- * The unit crosses to the larger denomination once the span exceeds one of it.
- */
-export function scaleSpan(
-  maxMeters: number,
-  unit: MapScaleUnit,
-): { span: number; label: string } {
-  if (unit === "imperial") {
-    const feet = maxMeters * FEET_PER_METER;
-    return feet >= FEET_PER_MILE
-      ? { span: feet / FEET_PER_MILE, label: "mi" }
-      : { span: feet, label: "ft" };
-  }
-  if (unit === "nautical") {
-    return { span: maxMeters / METERS_PER_NAUTICAL_MILE, label: "nmi" };
-  }
-  return maxMeters >= 1000
-    ? { span: maxMeters / 1000, label: "km" }
-    : { span: maxMeters, label: "m" };
+  el.textContent = `${formatRoundNum(rounded)} ${label}`;
 }

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -252,6 +252,70 @@ describe("drawLayout cartographic furniture", () => {
     );
   });
 
+  it("labels the scale bar in metric by default", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        showScaleBar: true,
+        metersPerPixel: 10,
+        mapImage: {} as CanvasImageSource,
+        mapImageWidth: 400,
+        mapImageHeight: 400,
+      }),
+    );
+    assert.ok(
+      fills.some((f) => /^\d[\d.]* (km|m|cm)$/.test(f.text)),
+      "expected a metric distance label (km/m/cm)",
+    );
+    assert.ok(
+      !fills.some((f) => /(mi|ft|nmi)$/.test(f.text)),
+      "did not expect an imperial/nautical label under metric",
+    );
+  });
+
+  it("labels the scale bar in imperial when scaleUnit is imperial", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        showScaleBar: true,
+        scaleUnit: "imperial",
+        metersPerPixel: 10,
+        mapImage: {} as CanvasImageSource,
+        mapImageWidth: 400,
+        mapImageHeight: 400,
+      }),
+    );
+    assert.ok(
+      fills.some((f) => /^\d[\d.]* (mi|ft)$/.test(f.text)),
+      "expected an imperial distance label (mi/ft)",
+    );
+    assert.ok(
+      !fills.some((f) => /(km|nmi)$/.test(f.text) || / m$| cm$/.test(f.text)),
+      "did not expect a metric/nautical label under imperial",
+    );
+  });
+
+  it("labels the scale bar in nautical miles when scaleUnit is nautical", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        showScaleBar: true,
+        scaleUnit: "nautical",
+        metersPerPixel: 10,
+        mapImage: {} as CanvasImageSource,
+        mapImageWidth: 400,
+        mapImageHeight: 400,
+      }),
+    );
+    assert.ok(
+      fills.some((f) => /^\d[\d.]* nmi$/.test(f.text)),
+      "expected a nautical-mile distance label (nmi)",
+    );
+  });
+
   it("does not draw a scale ratio for a pixel screen size", () => {
     const { canvas, fills } = recordingCanvas();
     drawLayout(


### PR DESCRIPTION
## Summary

The Print Layout scale bar was hardcoded to metric (km/m/cm), so it ignored the **Settings > Map Preferences > Scale bar units** choice that already drives the on-screen scale bar. A user who switched the map to imperial still got a metric bar in the printed/exported layout.

This wires the print layout scale bar to the same `preferences.map.scaleUnit` value:

- **Imperial** labels distances in miles/feet
- **Nautical** labels distances in nautical miles (nmi)
- **Metric** keeps km/m/cm (unchanged default)

The rounding now happens in the target unit's denomination (so the bar lands on a readable round value like "1000 mi" or "500 ft"), mirroring the map's `PlanetaryScaleControl` behavior. The representative-fraction label (1:N) is unitless and unchanged.

Follow-up to #1228, addressing the request in discussion #1227.

## Changes

- `apps/geolibre-desktop/src/lib/print-layout.ts`: `drawScaleBar` takes a `MapScaleUnit`; a new `pickScaleDenomination` picks km/m/cm, mi/ft, or nmi and the bar rounds/labels in that unit. New optional `LayoutOptions.scaleUnit` (defaults to `"metric"`).
- `apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx`: reads `s.preferences.map.scaleUnit` and passes it into the layout options so the preview and export match the on-screen bar.
- `tests/print-layout.test.ts`: added coverage asserting the drawn label is metric by default, imperial (mi/ft) when set to imperial, and nmi when set to nautical.

## Verification

- Full `npm run build` and `pre-commit run --files` (including the npm-build hook) pass.
- `node --test tests/print-layout.test.ts` — 26 pass.
- Drove the real web app with Playwright: set **Scale bar units → Imperial** in Settings, opened Print Layout, and confirmed the preview scale bar reads **"1000 mi"** (with the 1:32,507,476 ratio). Verified the dialog renders correctly in both light and dark themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Print layouts and exports now honor the selected metric, imperial, or nautical scale unit.
  * Scale bars use clearer, context-appropriate distance labels and rounded values.
  * The print preview updates automatically when the preferred scale unit changes.

* **Bug Fixes**
  * Improved consistency between on-screen scale bars and printed or exported layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->