### PR TITLE
fix(assistant): persist AI provider API keys across restarts (#1249)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -249,16 +249,6 @@ function createDraftId(): string {
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-// Every env var name any AI provider field reads (canonical names plus the
-// aliases provider.ts also honors). The AI Providers section owns these keys,
-// so on save any value still sitting in the project's Environment variables is
-// migrated into the device-local store — see saveSettings.
-const AI_PROVIDER_ENV_KEYS: ReadonlySet<string> = new Set(
-  Object.values(PROVIDER_FIELDS).flatMap((fields: readonly ProviderField[]) =>
-    fields.flatMap((field) => [field.envKey, ...(field.aliases ?? [])]),
-  ),
-);
-
 function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
   return {
     map: { ...preferences.map },
@@ -1132,39 +1122,7 @@ export function SettingsDialog({
       return;
     }
 
-    // Migrate any AI provider credential still held in the project's Environment
-    // variables into the device-local store, even when the user never re-typed
-    // it this session (e.g. a key loaded from a `.geolibre.json`). Without this,
-    // an untouched row keeps getting serialized into the shared project file,
-    // defeating the point of the device-local store. A value already in the
-    // device store wins; the migrated rows are then dropped from the project.
-    const aiProviderEnvToSave: Record<string, string> = {
-      ...draftDesktopSettings.aiProviderEnv,
-    };
-    const migratedEnvKeys = new Set<string>();
-    for (const variable of normalized.environmentVariables) {
-      if (
-        variable.enabled &&
-        variable.value &&
-        AI_PROVIDER_ENV_KEYS.has(variable.key)
-      ) {
-        if (!(variable.key in aiProviderEnvToSave)) {
-          aiProviderEnvToSave[variable.key] = variable.value;
-        }
-        migratedEnvKeys.add(variable.key);
-      }
-    }
-    const preferencesToSave =
-      migratedEnvKeys.size > 0
-        ? {
-            ...normalized,
-            environmentVariables: normalized.environmentVariables.filter(
-              (variable) => !migratedEnvKeys.has(variable.key),
-            ),
-          }
-        : normalized;
-
-    setPreferences(preferencesToSave);
+    setPreferences(normalized);
     // When a level preset is still active, recompute its hidden lists from the
     // current plugin registry at save time. The draft was snapshotted when the
     // dialog opened, so this picks up any external plugins that loaded since
@@ -1188,7 +1146,7 @@ export function SettingsDialog({
       layout: draftDesktopSettings.layout,
       shareToken: draftDesktopSettings.shareToken,
       cesiumIonToken: draftDesktopSettings.cesiumIonToken,
-      aiProviderEnv: aiProviderEnvToSave,
+      aiProviderEnv: draftDesktopSettings.aiProviderEnv,
       uiProfile: committedUiProfile,
       updates: draftDesktopSettings.updates,
     });

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -249,6 +249,16 @@ function createDraftId(): string {
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+// Every env var name any AI provider field reads (canonical names plus the
+// aliases provider.ts also honors). The AI Providers section owns these keys,
+// so on save any value still sitting in the project's Environment variables is
+// migrated into the device-local store — see saveSettings.
+const AI_PROVIDER_ENV_KEYS: ReadonlySet<string> = new Set(
+  Object.values(PROVIDER_FIELDS).flatMap((fields: readonly ProviderField[]) =>
+    fields.flatMap((field) => [field.envKey, ...(field.aliases ?? [])]),
+  ),
+);
+
 function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
   return {
     map: { ...preferences.map },
@@ -1122,7 +1132,39 @@ export function SettingsDialog({
       return;
     }
 
-    setPreferences(normalized);
+    // Migrate any AI provider credential still held in the project's Environment
+    // variables into the device-local store, even when the user never re-typed
+    // it this session (e.g. a key loaded from a `.geolibre.json`). Without this,
+    // an untouched row keeps getting serialized into the shared project file,
+    // defeating the point of the device-local store. A value already in the
+    // device store wins; the migrated rows are then dropped from the project.
+    const aiProviderEnvToSave: Record<string, string> = {
+      ...draftDesktopSettings.aiProviderEnv,
+    };
+    const migratedEnvKeys = new Set<string>();
+    for (const variable of normalized.environmentVariables) {
+      if (
+        variable.enabled &&
+        variable.value &&
+        AI_PROVIDER_ENV_KEYS.has(variable.key)
+      ) {
+        if (!(variable.key in aiProviderEnvToSave)) {
+          aiProviderEnvToSave[variable.key] = variable.value;
+        }
+        migratedEnvKeys.add(variable.key);
+      }
+    }
+    const preferencesToSave =
+      migratedEnvKeys.size > 0
+        ? {
+            ...normalized,
+            environmentVariables: normalized.environmentVariables.filter(
+              (variable) => !migratedEnvKeys.has(variable.key),
+            ),
+          }
+        : normalized;
+
+    setPreferences(preferencesToSave);
     // When a level preset is still active, recompute its hidden lists from the
     // current plugin registry at save time. The draft was snapshotted when the
     // dialog opened, so this picks up any external plugins that loaded since
@@ -1146,7 +1188,7 @@ export function SettingsDialog({
       layout: draftDesktopSettings.layout,
       shareToken: draftDesktopSettings.shareToken,
       cesiumIonToken: draftDesktopSettings.cesiumIonToken,
-      aiProviderEnv: draftDesktopSettings.aiProviderEnv,
+      aiProviderEnv: aiProviderEnvToSave,
       uiProfile: committedUiProfile,
       updates: draftDesktopSettings.updates,
     });

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -238,6 +238,7 @@ interface DraftDesktopSettings {
   layout: DesktopLayoutSettings;
   shareToken: string;
   cesiumIonToken: string;
+  aiProviderEnv: Record<string, string>;
   uiProfile: UiProfileSettings;
   updates: UpdateSettings;
 }
@@ -267,6 +268,7 @@ function cloneDesktopSettings(settings: DesktopSettings): DraftDesktopSettings {
     layout: { ...settings.layout },
     shareToken: settings.shareToken,
     cesiumIonToken: settings.cesiumIonToken,
+    aiProviderEnv: { ...settings.aiProviderEnv },
     uiProfile: {
       ...settings.uiProfile,
       hiddenDataSources: [...settings.uiProfile.hiddenDataSources],
@@ -490,6 +492,20 @@ export function SettingsDialog({
     }
     return env;
   }, [draftPreferences.environmentVariables]);
+  // Device-local AI provider credentials (Settings → AI Providers). The AI
+  // section reads and writes these instead of the project's Environment
+  // variables so a key persists across restarts without entering the shared
+  // project file. Non-empty entries only, matching the live runtime projection.
+  const draftAiEnv = useMemo(() => {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      draftDesktopSettings.aiProviderEnv,
+    )) {
+      const name = key.trim();
+      if (name && value) env[name] = value;
+    }
+    return env;
+  }, [draftDesktopSettings.aiProviderEnv]);
   // AI keys read from the user's OS environment (desktop only). This dialog is
   // mounted eagerly at startup — before the App-root loader populates the cache
   // and before the async Tauri read resolves — so a mount-only read would freeze
@@ -511,14 +527,19 @@ export function SettingsDialog({
   // plain spread would disagree in the alias-collision case (e.g. an empty
   // project GOOGLE_API_KEY row shadows the whole Google OS alias group).
   const scopedOsEnv = useMemo(
-    () => scopeOsEnvToProject(osEnv, new Set(Object.keys(draftEnv))),
-    [osEnv, draftEnv],
+    () =>
+      scopeOsEnvToProject(
+        osEnv,
+        new Set([...Object.keys(draftEnv), ...Object.keys(draftAiEnv)]),
+      ),
+    [osEnv, draftEnv, draftAiEnv],
   );
-  // Merge OS env under the draft so a provider configured purely via a system
-  // environment variable still reports "ready" — draft values win the overlap.
+  // Merge OS env under the drafts so a provider configured purely via a system
+  // environment variable still reports "ready". Precedence mirrors the live
+  // runtime merge: OS < device AI keys < project Environment variables.
   const effectiveEnv = useMemo(
-    () => ({ ...scopedOsEnv, ...draftEnv }),
-    [scopedOsEnv, draftEnv],
+    () => ({ ...scopedOsEnv, ...draftAiEnv, ...draftEnv }),
+    [scopedOsEnv, draftAiEnv, draftEnv],
   );
   const configuredProviders = useMemo(
     () => new Set(availableProviders(effectiveEnv)),
@@ -559,8 +580,22 @@ export function SettingsDialog({
       const key = variable.key.trim();
       if (variable.enabled && key) seededProjectEnv[key] = variable.value;
     }
+    const seededAiEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      useDesktopSettingsStore.getState().desktopSettings.aiProviderEnv,
+    )) {
+      const name = key.trim();
+      if (name && value) seededAiEnv[name] = value;
+    }
     const seededEnv = {
-      ...scopeOsEnvToProject(readOsEnv(), new Set(Object.keys(seededProjectEnv))),
+      ...scopeOsEnvToProject(
+        readOsEnv(),
+        new Set([
+          ...Object.keys(seededProjectEnv),
+          ...Object.keys(seededAiEnv),
+        ]),
+      ),
+      ...seededAiEnv,
       ...seededProjectEnv,
     };
     setAiProvider(availableProviders(seededEnv)[0] ?? "google");
@@ -684,11 +719,18 @@ export function SettingsDialog({
     ...(field.aliases ?? []),
   ];
 
-  // The value of an env-var-backed AI provider field, or "" when unset. Only an
-  // enabled row counts: a var disabled in the Environment section must read as
-  // empty so the field matches the (also enabled-only) status banner. An aliased
-  // value (e.g. an existing GOOGLE_API_KEY) is surfaced rather than hidden.
+  // The value of an env-var-backed AI provider field, or "" when unset. Reads
+  // the device-local AI credential store first (where the AI section now saves
+  // keys so they persist across restarts), then falls back to a matching value
+  // still held in the project's Environment variables — e.g. one loaded from a
+  // `.geolibre.json` or set by hand under the Environment section — so an
+  // existing credential stays visible and editable here. An aliased value (e.g.
+  // an existing GOOGLE_API_KEY) is surfaced rather than hidden.
   const getProviderField = (field: ProviderField): string => {
+    for (const key of fieldEnvKeys(field)) {
+      const value = draftDesktopSettings.aiProviderEnv[key];
+      if (value) return value;
+    }
     for (const key of fieldEnvKeys(field)) {
       const row = draftPreferences.environmentVariables.find(
         (variable) => variable.key === key && variable.enabled,
@@ -708,37 +750,31 @@ export function SettingsDialog({
     return null;
   };
 
-  // Write an AI provider field through to its backing env var. Edits the enabled
-  // row the user already has (canonical or alias) so re-entering a credential
-  // never creates a duplicate key; otherwise drops any same-named disabled rows
-  // (so a deliberately disabled var is not silently re-enabled with its old
-  // value) and appends a fresh enabled row under the canonical name. Clearing
-  // removes the row so the Environment list never accrues empty entries.
+  // Write an AI provider field through to the device-local credential store,
+  // keyed by the field's canonical env var name. Any alias entry is dropped so
+  // re-entering a credential never leaves a stale duplicate under an alias, and
+  // clearing removes the entry so the store never accrues empty values. The
+  // matching rows are also removed from the project's Environment variables:
+  // these keys now live device-local, so a leftover project row must not shadow
+  // the device value at runtime (project env has higher precedence) nor get
+  // serialized into a shared project file.
   const setProviderField = (field: ProviderField, value: string) => {
     const keys = fieldEnvKeys(field);
+    setDraftDesktopSettings((current) => {
+      const next = { ...current.aiProviderEnv };
+      for (const key of keys) delete next[key];
+      if (value !== "") next[field.envKey] = value;
+      return { ...current, aiProviderEnv: next };
+    });
     setDraftPreferences((current) => {
-      const enabledIndex = current.environmentVariables.findIndex(
-        (variable) => keys.includes(variable.key) && variable.enabled,
-      );
-      if (enabledIndex !== -1) {
-        const next = current.environmentVariables.slice();
-        if (value === "") {
-          next.splice(enabledIndex, 1);
-        } else {
-          next[enabledIndex] = { ...next[enabledIndex], value };
-        }
-        return { ...current, environmentVariables: next };
+      if (!current.environmentVariables.some((v) => keys.includes(v.key))) {
+        return current;
       }
-      if (value === "") return current;
-      const kept = current.environmentVariables.filter(
-        (variable) => !keys.includes(variable.key),
-      );
       return {
         ...current,
-        environmentVariables: [
-          ...kept,
-          { id: createDraftId(), key: field.envKey, value, enabled: true },
-        ],
+        environmentVariables: current.environmentVariables.filter(
+          (v) => !keys.includes(v.key),
+        ),
       };
     });
     setError(null);
@@ -1110,6 +1146,7 @@ export function SettingsDialog({
       layout: draftDesktopSettings.layout,
       shareToken: draftDesktopSettings.shareToken,
       cesiumIonToken: draftDesktopSettings.cesiumIonToken,
+      aiProviderEnv: draftDesktopSettings.aiProviderEnv,
       uiProfile: committedUiProfile,
       updates: draftDesktopSettings.updates,
     });
@@ -2359,7 +2396,7 @@ export function SettingsDialog({
                   )}
                   <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
                     <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
-                    <span>{t("settings.env.secretsWarning")}</span>
+                    <span>{t("settings.ai.secretsNote")}</span>
                   </div>
                   {PROVIDER_FIELDS[aiProvider].some(
                     (field) => osFieldEnvName(field) !== null,

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -226,17 +226,18 @@ export function normalizeDesktopSettings(settings: unknown): DesktopSettings {
 }
 
 /**
- * Coerce a persisted (or tampered) value into a clean env-var record: string
- * keys with a non-empty trimmed name mapped to string values. Anything else is
- * dropped so a malformed localStorage entry cannot inject non-string values
- * into the runtime environment.
+ * Coerce a persisted (or tampered) value into a clean env-var record: entries
+ * with a non-empty trimmed name mapped to a non-empty string value. Blank keys,
+ * blank values, and non-string values are dropped so a malformed localStorage
+ * entry cannot inject bad values into the runtime environment and the persisted
+ * blob never accrues empty leftovers (every consumer treats a blank as unset).
  */
 function normalizeEnvRecord(value: unknown): Record<string, string> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const result: Record<string, string> = {};
   for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
     const name = key.trim();
-    if (name && typeof entry === "string") result[name] = entry;
+    if (name && typeof entry === "string" && entry) result[name] = entry;
   }
   return result;
 }

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -51,6 +51,19 @@ export interface DesktopSettings {
    */
   cesiumIonToken: string;
   /**
+   * AI Assistant provider credentials (Settings → AI Providers), keyed by the
+   * runtime environment variable each field maps to (e.g. `ANTHROPIC_API_KEY`,
+   * `OPENAI_API_KEY`, `OLLAMA_BASE_URL`). Stored here — device-local
+   * localStorage, not the shared project file — so a personal API key survives
+   * app restarts (the desktop webview persists localStorage across launches)
+   * yet is never serialized into a `.geolibre.json` a user shares. Projected
+   * into `window.__GEOLIBRE_RUNTIME_ENV__` at runtime by
+   * `useRuntimeEnvironmentVariables`, below any explicit project Environment
+   * variable of the same name. Same "secret in localStorage" trade-off as
+   * {@link cesiumIonToken}.
+   */
+  aiProviderEnv: Record<string, string>;
+  /**
    * Appearance preferences (the accent color scheme). The light/dark mode is
    * handled separately by `useThemeMode` (it tracks the OS / embed preference).
    */
@@ -168,6 +181,7 @@ const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   pluginManifestUrls: [],
   shareToken: "",
   cesiumIonToken: "",
+  aiProviderEnv: {},
   theme: DEFAULT_THEME_SETTINGS,
   uiProfile: DEFAULT_UI_PROFILE_SETTINGS,
   updates: DEFAULT_UPDATE_SETTINGS,
@@ -180,7 +194,7 @@ export const EXPERIENCE_LEVELS: readonly ExperienceLevel[] = [
   "advanced",
 ];
 
-function normalizeDesktopSettings(settings: unknown): DesktopSettings {
+export function normalizeDesktopSettings(settings: unknown): DesktopSettings {
   if (!settings || typeof settings !== "object") {
     return DEFAULT_DESKTOP_SETTINGS;
   }
@@ -204,10 +218,27 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
       typeof candidate.cesiumIonToken === "string"
         ? candidate.cesiumIonToken.trim()
         : "",
+    aiProviderEnv: normalizeEnvRecord(candidate.aiProviderEnv),
     theme: normalizeThemeSettings(candidate.theme),
     uiProfile: normalizeUiProfileSettings(candidate.uiProfile),
     updates: normalizeUpdateSettings(candidate.updates),
   };
+}
+
+/**
+ * Coerce a persisted (or tampered) value into a clean env-var record: string
+ * keys with a non-empty trimmed name mapped to string values. Anything else is
+ * dropped so a malformed localStorage entry cannot inject non-string values
+ * into the runtime environment.
+ */
+function normalizeEnvRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const name = key.trim();
+    if (name && typeof entry === "string") result[name] = entry;
+  }
+  return result;
 }
 
 function normalizeThemeSettings(theme: unknown): ThemeSettings {

--- a/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
+++ b/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
@@ -1,7 +1,7 @@
 import { normalizeGeocodingProviderId, useAppStore } from "@geolibre/core";
 import { useEffect, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { scopeOsEnvToProject, type RuntimeEnv } from "../lib/assistant/provider";
+import { mergeRuntimeEnv, type RuntimeEnv } from "../lib/assistant/provider";
 import { loadOsEnvVars, readOsEnv } from "../lib/assistant/os-env";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
@@ -84,24 +84,15 @@ export function useRuntimeEnvironmentVariables() {
       ? { VITE_CESIUM_TOKEN: cesiumIonToken.trim() }
       : {};
 
-    const runtimeEnv = {
-      // OS-provided AI keys sit at the lowest precedence: an explicit value in
-      // the project's Environment variables (or a derived geocoder var) always
-      // wins, then the device-local AI provider keys, and the OS environment
-      // only fills the remaining gaps. scopeOsEnvToProject also drops OS aliases
-      // covered by a project or device credential under a different alias, so the
-      // "explicit value always wins" guarantee holds across alias collisions too.
-      ...scopeOsEnvToProject(
-        osEnv,
-        new Set([...Object.keys(projectEnv), ...Object.keys(aiEnv)]),
-      ),
-      // Device-local AI keys outrank the OS environment but yield to an explicit
-      // same-named project Environment variable (spread last below).
-      ...aiEnv,
-      ...geocoderEnv,
-      ...cesiumEnv,
-      ...projectEnv,
-    };
+    // Precedence (low -> high): OS env < device AI keys < geocoder < cesium <
+    // explicit project Environment variables. See mergeRuntimeEnv for details.
+    const runtimeEnv = mergeRuntimeEnv({
+      osEnv,
+      aiEnv,
+      geocoderEnv,
+      cesiumEnv,
+      projectEnv,
+    });
 
     // Always keep the global env in sync so plugins can read it when they
     // activate, even before the first change event.

--- a/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
+++ b/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
@@ -14,6 +14,12 @@ export function useRuntimeEnvironmentVariables() {
   const cesiumIonToken = useDesktopSettingsStore(
     (s) => s.desktopSettings.cesiumIonToken,
   );
+  // Device-local AI Assistant provider credentials (Settings → AI Providers).
+  // Projected below so the assistant picks them up after a restart without the
+  // keys ever living in the shared project file. See useDesktopSettings.ts.
+  const aiProviderEnv = useDesktopSettingsStore(
+    (s) => s.desktopSettings.aiProviderEnv,
+  );
   const lastSerializedEnv = useRef<string | null>(null);
   const isFirstRender = useRef(true);
 
@@ -58,6 +64,14 @@ export function useRuntimeEnvironmentVariables() {
         .map((variable) => [variable.key.trim(), variable.value]),
     );
 
+    // Device-local AI provider credentials, keyed by env var name. Empty values
+    // are dropped so a blank entry never blanks out a build-time or OS value.
+    const aiEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(aiProviderEnv)) {
+      const name = key.trim();
+      if (name && value) aiEnv[name] = value;
+    }
+
     // Only inject the Cesium token when set: an empty value would override (and
     // so blank out) a build-time VITE_CESIUM_TOKEN via getRuntimeEnvironment's
     // spread. A free-form env-var row of the same name still wins over this.
@@ -68,10 +82,17 @@ export function useRuntimeEnvironmentVariables() {
     const runtimeEnv = {
       // OS-provided AI keys sit at the lowest precedence: an explicit value in
       // the project's Environment variables (or a derived geocoder var) always
-      // wins, and the OS environment only fills the gaps. scopeOsEnvToProject
-      // also drops OS aliases the project defines under a different alias, so the
-      // "project always wins" guarantee holds across alias collisions too.
-      ...scopeOsEnvToProject(osEnv, new Set(Object.keys(projectEnv))),
+      // wins, then the device-local AI provider keys, and the OS environment
+      // only fills the remaining gaps. scopeOsEnvToProject also drops OS aliases
+      // covered by a project or device credential under a different alias, so the
+      // "explicit value always wins" guarantee holds across alias collisions too.
+      ...scopeOsEnvToProject(
+        osEnv,
+        new Set([...Object.keys(projectEnv), ...Object.keys(aiEnv)]),
+      ),
+      // Device-local AI keys outrank the OS environment but yield to an explicit
+      // same-named project Environment variable (spread last below).
+      ...aiEnv,
       ...geocoderEnv,
       ...cesiumEnv,
       ...projectEnv,
@@ -101,5 +122,5 @@ export function useRuntimeEnvironmentVariables() {
     window.dispatchEvent(
       new CustomEvent("geolibre:runtime-env-change", { detail: runtimeEnv }),
     );
-  }, [environmentVariables, geocoding, cesiumIonToken, osEnv]);
+  }, [environmentVariables, geocoding, cesiumIonToken, aiProviderEnv, osEnv]);
 }

--- a/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
+++ b/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
@@ -1,5 +1,6 @@
 import { normalizeGeocodingProviderId, useAppStore } from "@geolibre/core";
 import { useEffect, useRef, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { scopeOsEnvToProject, type RuntimeEnv } from "../lib/assistant/provider";
 import { loadOsEnvVars, readOsEnv } from "../lib/assistant/os-env";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
@@ -17,8 +18,12 @@ export function useRuntimeEnvironmentVariables() {
   // Device-local AI Assistant provider credentials (Settings → AI Providers).
   // Projected below so the assistant picks them up after a restart without the
   // keys ever living in the shared project file. See useDesktopSettings.ts.
+  // useShallow keeps the reference stable across unrelated setDesktopSettings
+  // updates (e.g. dragging the accent-color picker), which normalizeDesktopSettings
+  // would otherwise churn into a fresh object every time — needlessly re-running
+  // this effect and re-rendering the host.
   const aiProviderEnv = useDesktopSettingsStore(
-    (s) => s.desktopSettings.aiProviderEnv,
+    useShallow((s) => s.desktopSettings.aiProviderEnv),
   );
   const lastSerializedEnv = useRef<string | null>(null);
   const isFirstRender = useRef(true);

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1420,6 +1420,7 @@
       "optionalMark": "(optional)",
       "statusReady": "{{provider}} is configured and ready to use.",
       "statusIncomplete": "Fill in the required fields below to enable {{provider}}.",
+      "secretsNote": "Credentials are saved locally on this device, not in the project file you share, so they persist across restarts. Anyone with access to this device could read them.",
       "getCredentials": "Where to get {{provider}} credentials",
       "showValue": "Show {{name}}",
       "hideValue": "Hide {{name}}",

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -142,6 +142,50 @@ export function scopeOsEnvToProject(
   return scoped;
 }
 
+/** The environment sources merged into the runtime env, from lowest to highest precedence. */
+export interface RuntimeEnvSources {
+  /** Variables read from the OS environment (desktop only). Lowest precedence. */
+  osEnv: RuntimeEnv;
+  /** Device-local AI provider credentials (Settings -> AI Providers). */
+  aiEnv: Record<string, string>;
+  /** Derived `VITE_GEOCODER_*` variables from the geocoding preference. */
+  geocoderEnv: Record<string, string>;
+  /** The device-local Cesium Ion token as `VITE_CESIUM_TOKEN`, or empty. */
+  cesiumEnv: Record<string, string>;
+  /** The project's explicit Environment variables. Highest precedence. */
+  projectEnv: Record<string, string>;
+}
+
+/**
+ * Merge the runtime environment sources into a single record, applying the
+ * precedence the app relies on: an explicit project Environment variable wins,
+ * then the device-local AI provider keys, and the OS environment only fills the
+ * remaining gaps. {@link scopeOsEnvToProject} additionally drops OS aliases that
+ * a project or device credential already covers under a different alias, so the
+ * "explicit value always wins" guarantee holds across alias collisions too.
+ *
+ * Extracted from `useRuntimeEnvironmentVariables` so the precedence ordering can
+ * be unit-tested directly (swapping two spreads here is an easy silent bug).
+ */
+export function mergeRuntimeEnv({
+  osEnv,
+  aiEnv,
+  geocoderEnv,
+  cesiumEnv,
+  projectEnv,
+}: RuntimeEnvSources): RuntimeEnv {
+  return {
+    ...scopeOsEnvToProject(
+      osEnv,
+      new Set([...Object.keys(projectEnv), ...Object.keys(aiEnv)]),
+    ),
+    ...aiEnv,
+    ...geocoderEnv,
+    ...cesiumEnv,
+    ...projectEnv,
+  };
+}
+
 /**
  * Selectable models per provider, recommended/newest first. The first entry is
  * the provider default. Users can pin any other id via `GEOLIBRE_ASSISTANT_MODEL`

--- a/tests/assistant-provider-persistence.test.ts
+++ b/tests/assistant-provider-persistence.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { normalizeDesktopSettings } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+
+// AI provider credentials entered in Settings → AI Providers are stored in the
+// device-local `DesktopSettings.aiProviderEnv` (localStorage) so they survive
+// app restarts (issue #1249). normalizeDesktopSettings is the load-path guard
+// that restores those keys from persisted storage, so these tests pin the
+// round-trip and the defensiveness against malformed/legacy data.
+describe("DesktopSettings.aiProviderEnv persistence", () => {
+  it("defaults to an empty record", () => {
+    assert.deepEqual(normalizeDesktopSettings(undefined).aiProviderEnv, {});
+    assert.deepEqual(normalizeDesktopSettings({}).aiProviderEnv, {});
+  });
+
+  it("restores stored provider credentials verbatim", () => {
+    const stored = {
+      aiProviderEnv: {
+        ANTHROPIC_API_KEY: "sk-ant-123",
+        OPENAI_API_KEY: "sk-openai-456",
+        OLLAMA_BASE_URL: "http://localhost:11434",
+      },
+    };
+    assert.deepEqual(normalizeDesktopSettings(stored).aiProviderEnv, {
+      ANTHROPIC_API_KEY: "sk-ant-123",
+      OPENAI_API_KEY: "sk-openai-456",
+      OLLAMA_BASE_URL: "http://localhost:11434",
+    });
+  });
+
+  it("drops non-string values and blank keys from tampered storage", () => {
+    const stored = {
+      aiProviderEnv: {
+        ANTHROPIC_API_KEY: "sk-ant-123",
+        OPENAI_API_KEY: 42,
+        GEMINI_API_KEY: null,
+        "   ": "orphan",
+        "  AWS_REGION  ": "us-east-1",
+      },
+    };
+    assert.deepEqual(normalizeDesktopSettings(stored).aiProviderEnv, {
+      ANTHROPIC_API_KEY: "sk-ant-123",
+      AWS_REGION: "us-east-1",
+    });
+  });
+
+  it("tolerates a non-record aiProviderEnv", () => {
+    for (const bad of [null, "nope", 7, ["ANTHROPIC_API_KEY"]]) {
+      assert.deepEqual(
+        normalizeDesktopSettings({ aiProviderEnv: bad }).aiProviderEnv,
+        {},
+      );
+    }
+  });
+
+  it("normalizes legacy settings with no aiProviderEnv field", () => {
+    const legacy = {
+      shareToken: "tok",
+      cesiumIonToken: "cesium",
+      layout: { toolbarLabels: false },
+    };
+    assert.deepEqual(normalizeDesktopSettings(legacy).aiProviderEnv, {});
+  });
+});

--- a/tests/assistant-provider-persistence.test.ts
+++ b/tests/assistant-provider-persistence.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { normalizeDesktopSettings } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+import { mergeRuntimeEnv } from "../apps/geolibre-desktop/src/lib/assistant/provider";
+
+const NO_SOURCES = {
+  osEnv: {},
+  aiEnv: {},
+  geocoderEnv: {},
+  cesiumEnv: {},
+  projectEnv: {},
+};
 
 // AI provider credentials entered in Settings → AI Providers are stored in the
 // device-local `DesktopSettings.aiProviderEnv` (localStorage) so they survive
@@ -61,5 +70,70 @@ describe("DesktopSettings.aiProviderEnv persistence", () => {
       layout: { toolbarLabels: false },
     };
     assert.deepEqual(normalizeDesktopSettings(legacy).aiProviderEnv, {});
+  });
+});
+
+// The precedence order in mergeRuntimeEnv is the part most likely to regress
+// silently (swapping two spreads). Pin the guarantees the app relies on:
+// OS env < device AI keys < project Environment variables, with OS aliases
+// dropped when a project or device credential covers the same credential group.
+describe("mergeRuntimeEnv precedence", () => {
+  it("lets device AI keys override the OS environment", () => {
+    const merged = mergeRuntimeEnv({
+      ...NO_SOURCES,
+      osEnv: { ANTHROPIC_API_KEY: "from-os" },
+      aiEnv: { ANTHROPIC_API_KEY: "from-device" },
+    });
+    assert.equal(merged.ANTHROPIC_API_KEY, "from-device");
+  });
+
+  it("lets an explicit project Environment variable override a device AI key", () => {
+    const merged = mergeRuntimeEnv({
+      ...NO_SOURCES,
+      osEnv: { ANTHROPIC_API_KEY: "from-os" },
+      aiEnv: { ANTHROPIC_API_KEY: "from-device" },
+      projectEnv: { ANTHROPIC_API_KEY: "from-project" },
+    });
+    assert.equal(merged.ANTHROPIC_API_KEY, "from-project");
+  });
+
+  it("falls back to the OS value when nothing else provides the key", () => {
+    const merged = mergeRuntimeEnv({
+      ...NO_SOURCES,
+      osEnv: { OPENAI_API_KEY: "from-os" },
+    });
+    assert.equal(merged.OPENAI_API_KEY, "from-os");
+  });
+
+  it("drops an OS alias when a device key covers the same credential group", () => {
+    // Device sets the canonical GEMINI_API_KEY; the OS-provided GOOGLE_API_KEY
+    // alias must not survive to shadow it via firstValue's alias ordering.
+    const merged = mergeRuntimeEnv({
+      ...NO_SOURCES,
+      osEnv: { GOOGLE_API_KEY: "from-os-alias" },
+      aiEnv: { GEMINI_API_KEY: "from-device" },
+    });
+    assert.equal(merged.GEMINI_API_KEY, "from-device");
+    assert.equal(merged.GOOGLE_API_KEY, undefined);
+  });
+
+  it("drops an OS alias when a project key covers the same credential group", () => {
+    const merged = mergeRuntimeEnv({
+      ...NO_SOURCES,
+      osEnv: { GEMINI_API_KEY: "from-os" },
+      projectEnv: { GOOGLE_API_KEY: "from-project-alias" },
+    });
+    assert.equal(merged.GOOGLE_API_KEY, "from-project-alias");
+    assert.equal(merged.GEMINI_API_KEY, undefined);
+  });
+
+  it("includes derived geocoder and cesium values", () => {
+    const merged = mergeRuntimeEnv({
+      ...NO_SOURCES,
+      geocoderEnv: { VITE_GEOCODER_PROVIDER: "nominatim" },
+      cesiumEnv: { VITE_CESIUM_TOKEN: "tok" },
+    });
+    assert.equal(merged.VITE_GEOCODER_PROVIDER, "nominatim");
+    assert.equal(merged.VITE_CESIUM_TOKEN, "tok");
   });
 });

--- a/tests/assistant-provider-persistence.test.ts
+++ b/tests/assistant-provider-persistence.test.ts
@@ -28,12 +28,13 @@ describe("DesktopSettings.aiProviderEnv persistence", () => {
     });
   });
 
-  it("drops non-string values and blank keys from tampered storage", () => {
+  it("drops non-string values, blank values, and blank keys from tampered storage", () => {
     const stored = {
       aiProviderEnv: {
         ANTHROPIC_API_KEY: "sk-ant-123",
         OPENAI_API_KEY: 42,
         GEMINI_API_KEY: null,
+        OLLAMA_MODEL: "",
         "   ": "orphan",
         "  AWS_REGION  ": "us-east-1",
       },


### PR DESCRIPTION
Fixes #1249

## Problem

AI provider credentials entered in **Settings -> AI Providers** (e.g. an Anthropic API key) worked for the current session but were lost on restart. After closing and reopening the app, the "Set up the AI Assistant" screen returned and the key had to be re-entered.

Root cause: the keys were written only to the in-memory project preferences (`preferences.environmentVariables`), which has no persistence middleware and resets to its defaults on every launch. Unlike `cesiumIonToken` and `shareToken` (device-local, localStorage-backed), AI keys had nowhere durable to live.

## Fix

Store AI provider credentials **device-local**, in the localStorage-backed `DesktopSettings` via a new `aiProviderEnv` map, exactly mirroring how `cesiumIonToken`/`shareToken` already persist:

- `useRuntimeEnvironmentVariables` projects `aiProviderEnv` into `window.__GEOLIBRE_RUNTIME_ENV__` via the pure, unit-tested `mergeRuntimeEnv`, at precedence OS env < device AI keys < explicit project Environment variables (an explicit project var still wins).
- The Settings **AI Providers** section now reads and writes this device store. When the user actually edits a provider field, the matching row is moved out of the project `Environment variables` (so the higher-precedence project row can't shadow the new device value). Keys a user deliberately places in the **Environment variables** section are left project-scoped, so a shared org key in a checked-in `.geolibre.json` is never silently rewritten by an unrelated Settings save.
- Added `normalizeDesktopSettings` guarding for `aiProviderEnv` (drops non-string/blank values and blank keys, tolerates legacy settings with no field).

Because the desktop (Tauri) webview persists localStorage across restarts, a key entered in the AI Providers section now survives closing and reopening the app, and it is not written into a shared `.geolibre.json`; the section's warning was updated to reflect device-local storage.

## Verification

Drove the real app with Playwright (`npm run dev`), in both light and dark themes:

1. Settings -> AI Providers -> Anthropic -> enter key -> Save. Confirmed the key now lands in `localStorage` under `geolibre.desktopSettings.aiProviderEnv`.
2. Reloaded the page (restart simulation): the key persisted, `window.__GEOLIBRE_RUNTIME_ENV__.ANTHROPIC_API_KEY` was restored, the provider auto-selected as "Anthropic (configured)", the field repopulated, and the AI Assistant panel opened directly in **chat mode** (no setup screen).
3. Cleared the field + Save: the entry is removed from `localStorage`, and the status reverts to "not configured".

Also: `npm run build`, `npm run test:frontend` (all pass, plus new `tests/assistant-provider-persistence.test.ts`), `tsc -b`, and `pre-commit run --files` on the changed files.
