### PR TITLE
feat: terrain-aware 3D measurements in the Measure tool

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -27,6 +27,7 @@ import {
   restoreVectorLayers,
   setBookmarkLabels,
   setNonTiledRasterHandler,
+  setTerrainMeasureLabels,
   setViewStateLabels,
   startLayerGeometryEdit,
   subscribeGeometryEdit,
@@ -488,6 +489,16 @@ export function DesktopShell({
       defaultFolderName: t("bookmark.defaultFolderName"),
     });
     setViewStateLabels({ title: t("viewState.panelTitle") });
+    setTerrainMeasureLabels({
+      title: t("terrainMeasure.title"),
+      surfaceDistance: t("terrainMeasure.surfaceDistance"),
+      surfaceArea: t("terrainMeasure.surfaceArea"),
+      elevationGainLoss: t("terrainMeasure.elevationGainLoss"),
+      elevationRange: t("terrainMeasure.elevationRange"),
+      meanSlope: t("terrainMeasure.meanSlope"),
+      computing: t("terrainMeasure.computing"),
+      partialData: t("terrainMeasure.partialData"),
+    });
   }, [t]);
   // The map's Fullscreen control maximizes the map *canvas* (it calls
   // requestFullscreen on the map container). Chromium promotes that element to

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -103,6 +103,16 @@
   "viewState": {
     "panelTitle": "Info"
   },
+  "terrainMeasure": {
+    "title": "Terrain (3D)",
+    "surfaceDistance": "Surface distance",
+    "surfaceArea": "Surface area",
+    "elevationGainLoss": "Gain / loss",
+    "elevationRange": "Min / max elevation",
+    "meanSlope": "Mean slope",
+    "computing": "Computing terrain…",
+    "partialData": "Some samples had no terrain data"
+  },
   "fileNamePrompt": {
     "title": "Save file as",
     "description": "Enter a file name. The file downloads to your browser's downloads folder.",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -194,6 +194,7 @@ export {
   type PaletteLegendEntry,
 } from "./plugins/raster-palette";
 export { colormapColors, warmColormapColors } from "./plugins/colormap-colors";
+export { setTerrainMeasureLabels } from "./plugins/terrain-measure";
 export {
   closeVectorLayerPanel,
   materializeEmbeddableVectorLayers,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -2342,6 +2342,7 @@ async function openStandaloneMeasureControl(
       measureControl,
       () => (app.getMap?.() ?? null) as TerrainMapLike | null,
     );
+    makeMeasurePanelResizable(measureControl);
   }
 
   setTimeout(() => {
@@ -3417,6 +3418,37 @@ function createMeasureControl(
 ): MeasureControl {
   const control = new MeasureControlClass(MEASURE_OPTIONS);
   return control;
+}
+
+/**
+ * The MeasureControl's panel ships with a hard pixel max-height that forces
+ * its content (measurement list, terrain section) to scroll. Let the panel
+ * size to its content up to most of the viewport instead, and hand the user
+ * the native bottom-right resize handle for manual control. Reads the private
+ * `_panel` member (same access, and same loud warning on an upstream rename,
+ * as the terrain-measure attachment).
+ */
+function makeMeasurePanelResizable(control: MeasureControl): void {
+  const panel = (control as unknown as { _panel?: HTMLElement })._panel;
+  if (!panel) {
+    console.warn(
+      "MeasureControl: _panel not found; Measure panel resize styling is " +
+        "inactive. Check maplibre-gl-components."
+    );
+    return;
+  }
+  // Fit content instead of scrolling at the fixed cap, but never outgrow the
+  // viewport; the map's own chrome needs the remaining room.
+  panel.style.height = "auto";
+  panel.style.maxHeight = "min(75vh, 900px)";
+  // The native CSS resize handle (bottom-right in LTR, mirrored in RTL)
+  // requires a non-visible overflow; content scrolls once the user shrinks
+  // the panel below its natural size.
+  panel.style.overflow = "auto";
+  panel.style.resize = "both";
+  panel.style.minWidth = "220px";
+  panel.style.minHeight = "160px";
+  panel.style.maxWidth = "min(90vw, 560px)";
 }
 
 function createBookmarkControl(

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -76,7 +76,11 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
-import { attachTerrainMeasure, type TerrainMapLike } from "./terrain-measure";
+import {
+  attachTerrainMeasure,
+  measurePanelElement,
+  type TerrainMapLike,
+} from "./terrain-measure";
 import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
 import {
   KerchunkReferenceStore,
@@ -3424,19 +3428,11 @@ function createMeasureControl(
  * The MeasureControl's panel ships with a hard pixel max-height that forces
  * its content (measurement list, terrain section) to scroll. Let the panel
  * size to its content up to most of the viewport instead, and hand the user
- * the native bottom-right resize handle for manual control. Reads the private
- * `_panel` member (same access, and same loud warning on an upstream rename,
- * as the terrain-measure attachment).
+ * the native bottom-right resize handle for manual control.
  */
 function makeMeasurePanelResizable(control: MeasureControl): void {
-  const panel = (control as unknown as { _panel?: HTMLElement })._panel;
-  if (!panel) {
-    console.warn(
-      "MeasureControl: _panel not found; Measure panel resize styling is " +
-        "inactive. Check maplibre-gl-components."
-    );
-    return;
-  }
+  const panel = measurePanelElement(control);
+  if (!panel) return;
   // Fit content instead of scrolling at the fixed cap, but never outgrow the
   // viewport; the map's own chrome needs the remaining room.
   panel.style.height = "auto";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -76,6 +76,7 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
+import { attachTerrainMeasure, type TerrainMapLike } from "./terrain-measure";
 import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
 import {
   KerchunkReferenceStore,
@@ -700,6 +701,7 @@ let printControl: PrintControl | null = null;
 let searchControl: SearchControl | null = null;
 let spinGlobeControl: SpinGlobeControl | null = null;
 let measureControl: MeasureControl | null = null;
+let measureTerrainDetach: (() => void) | null = null;
 let bookmarkControl: BookmarkControl | null = null;
 let minimapControl: MinimapControl | null = null;
 let viewStateControl: ViewStateControl | null = null;
@@ -2334,6 +2336,12 @@ async function openStandaloneMeasureControl(
       return false;
     }
     measureControlMounted = true;
+    // Terrain-aware 3D readouts (surface distance/area) appended to the
+    // control's panel; requires the panel from onAdd, so attach after mounting.
+    measureTerrainDetach = attachTerrainMeasure(
+      measureControl,
+      () => (app.getMap?.() ?? null) as TerrainMapLike | null,
+    );
   }
 
   setTimeout(() => {
@@ -3805,6 +3813,8 @@ function setSearchPlacesPanelVisible(visible: boolean): void {
 }
 
 function teardownMeasureControl(app: GeoLibreAppAPI): void {
+  measureTerrainDetach?.();
+  measureTerrainDetach = null;
   if (measureControl && measureControlMounted) {
     app.removeMapControl(measureControl);
   }

--- a/packages/plugins/src/plugins/terrain-measure-geometry.ts
+++ b/packages/plugins/src/plugins/terrain-measure-geometry.ts
@@ -230,11 +230,15 @@ export function buildAreaGrid(
   if (!(widthMeters > 0) || !(heightMeters > 0)) return null;
 
   // Pick cols/rows proportional to the bbox aspect so cells come out roughly
-  // square, while keeping cols * rows <= maxSamples.
+  // square, while keeping cols * rows <= maxSamples. Cap rows so that cols'
+  // floor of 2 cannot push the product past maxSamples on very skinny
+  // polygons (a tall sliver would otherwise blow rows up unbounded).
   const aspect = widthMeters / heightMeters;
-  const rawRows = Math.sqrt(Math.max(4, maxSamples) / aspect);
-  const rows = Math.max(2, Math.round(rawRows));
-  const cols = Math.max(2, Math.floor(Math.max(4, maxSamples) / rows));
+  const budget = Math.max(4, maxSamples);
+  const rawRows = Math.sqrt(budget / aspect);
+  const rowCap = Math.max(2, Math.floor(budget / 2));
+  const rows = Math.max(2, Math.min(Math.round(rawRows), rowCap));
+  const cols = Math.max(2, Math.floor(budget / rows));
 
   const coords: LngLat[] = [];
   const inside: boolean[] = [];
@@ -320,7 +324,12 @@ export function surfaceArea(
       }
       const secant = Math.min(Math.hypot(1, dzdx, dzdy), maxSecant);
       secantSum += secant;
-      slopeSum += Math.atan(Math.hypot(dzdx, dzdy)) / DEG_TO_RAD;
+      // Clamp like the secant so a spiky DEM sample can't report a mean slope
+      // the area contribution was already protected against.
+      slopeSum += Math.min(
+        Math.atan(Math.hypot(dzdx, dzdy)) / DEG_TO_RAD,
+        MAX_SLOPE_DEG,
+      );
       sampledCount += 1;
     }
   }

--- a/packages/plugins/src/plugins/terrain-measure-geometry.ts
+++ b/packages/plugins/src/plugins/terrain-measure-geometry.ts
@@ -1,0 +1,354 @@
+/**
+ * Pure math for terrain-aware (3D) measurements.
+ *
+ * Given elevations sampled along a measured line or across a measured polygon,
+ * these helpers compute the surface (terrain-draped) distance and area that
+ * augment the Measure tool's planar readouts. Everything operates on plain
+ * numbers and `[lng, lat]` tuples with no DOM or MapLibre imports so it can be
+ * unit-tested in isolation.
+ *
+ * Distances take the active body's mean radius as a parameter (rather than
+ * hardcoding Earth) so 3D measurements stay consistent with the planar Measure
+ * tool and the Field Calculator when a planetary ellipsoid is active.
+ */
+
+import type { LngLat } from "./elevation-profile/elevation/geometry";
+
+export type { LngLat };
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/** Great-circle distance in meters between two `[lng, lat]` points. */
+export function haversineMeters(a: LngLat, b: LngLat, radius: number): number {
+  const lat1 = a[1] * DEG_TO_RAD;
+  const lat2 = b[1] * DEG_TO_RAD;
+  const dLat = lat2 - lat1;
+  const dLng = (b[0] - a[0]) * DEG_TO_RAD;
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * radius * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/**
+ * Resample a polyline to roughly one sample every `spacingMeters`, capped at
+ * `maxPoints` (both endpoints always included). Returns the sampled coordinates
+ * and each sample's cumulative along-line distance in meters.
+ */
+export function densifyLine(
+  coords: LngLat[],
+  spacingMeters: number,
+  maxPoints: number,
+  radius: number,
+): { coords: LngLat[]; distances: number[] } {
+  if (coords.length < 2) {
+    return { coords: [...coords], distances: coords.map(() => 0) };
+  }
+
+  const cumulative: number[] = [0];
+  for (let i = 1; i < coords.length; i += 1) {
+    cumulative.push(
+      cumulative[i - 1] + haversineMeters(coords[i - 1], coords[i], radius),
+    );
+  }
+  const total = cumulative[cumulative.length - 1];
+  if (total === 0) {
+    return { coords: [coords[0], coords[coords.length - 1]], distances: [0, 0] };
+  }
+
+  const target = Math.min(
+    Math.max(2, Math.floor(maxPoints)),
+    Math.max(2, Math.ceil(total / Math.max(1, spacingMeters)) + 1),
+  );
+
+  const sampledCoords: LngLat[] = [];
+  const sampledDistances: number[] = [];
+  let segment = 1;
+  for (let i = 0; i < target; i += 1) {
+    const distance = (total * i) / (target - 1);
+    while (segment < coords.length - 1 && cumulative[segment] < distance) {
+      segment += 1;
+    }
+    const segStart = cumulative[segment - 1];
+    const segLength = cumulative[segment] - segStart;
+    const t = segLength === 0 ? 0 : (distance - segStart) / segLength;
+    const a = coords[segment - 1];
+    const b = coords[segment];
+    sampledCoords.push([a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]);
+    sampledDistances.push(distance);
+  }
+  // Snap endpoints exactly onto the originals to avoid float drift.
+  sampledCoords[0] = coords[0];
+  sampledCoords[sampledCoords.length - 1] = coords[coords.length - 1];
+  return { coords: sampledCoords, distances: sampledDistances };
+}
+
+/** Terrain-aware statistics for a measured line. */
+export interface SurfaceDistanceResult {
+  /** Terrain-draped 3D length in meters (planar for segments missing data). */
+  surfaceMeters: number;
+  /** Planar (great-circle) length in meters over the same samples. */
+  planarMeters: number;
+  /** Total ascent in meters across samples with known elevation. */
+  gainMeters: number;
+  /** Total descent in meters (positive) across samples with known elevation. */
+  lossMeters: number;
+  /** Lowest sampled elevation in meters, or null if nothing was sampled. */
+  minElevationMeters: number | null;
+  /** Highest sampled elevation in meters, or null if nothing was sampled. */
+  maxElevationMeters: number | null;
+  /** Number of samples with a usable elevation. */
+  sampledCount: number;
+  /** Number of samples with no elevation (their segments fall back to planar). */
+  missingCount: number;
+}
+
+/**
+ * Compute the terrain-draped length of a sampled line. `distances` is the
+ * cumulative along-line distance per sample; `elevations` is the elevation per
+ * sample (null/NaN where unknown). Segments with an unknown endpoint elevation
+ * contribute their planar length, so a few missing DEM tiles degrade gracefully
+ * toward the planar measurement instead of dropping distance.
+ */
+export function surfaceDistance(
+  distances: number[],
+  elevations: (number | null)[],
+): SurfaceDistanceResult {
+  const planarMeters = distances.length
+    ? distances[distances.length - 1] - distances[0]
+    : 0;
+  let surfaceMeters = 0;
+  let gainMeters = 0;
+  let lossMeters = 0;
+  let minElevationMeters: number | null = null;
+  let maxElevationMeters: number | null = null;
+  let sampledCount = 0;
+  let missingCount = 0;
+  let previousKnown: number | null = null;
+
+  for (let i = 0; i < distances.length; i += 1) {
+    const raw = elevations[i];
+    const elevation = typeof raw === "number" && Number.isFinite(raw) ? raw : null;
+    if (elevation === null) {
+      missingCount += 1;
+    } else {
+      sampledCount += 1;
+      if (minElevationMeters === null || elevation < minElevationMeters) {
+        minElevationMeters = elevation;
+      }
+      if (maxElevationMeters === null || elevation > maxElevationMeters) {
+        maxElevationMeters = elevation;
+      }
+      if (previousKnown !== null) {
+        const delta = elevation - previousKnown;
+        if (delta > 0) gainMeters += delta;
+        else lossMeters += -delta;
+      }
+      previousKnown = elevation;
+    }
+
+    if (i === 0) continue;
+    const run = distances[i] - distances[i - 1];
+    const prev = elevations[i - 1];
+    const prevElevation =
+      typeof prev === "number" && Number.isFinite(prev) ? prev : null;
+    if (elevation !== null && prevElevation !== null) {
+      surfaceMeters += Math.hypot(run, elevation - prevElevation);
+    } else {
+      surfaceMeters += run;
+    }
+  }
+
+  return {
+    surfaceMeters,
+    planarMeters,
+    gainMeters,
+    lossMeters,
+    minElevationMeters,
+    maxElevationMeters,
+    sampledCount,
+    missingCount,
+  };
+}
+
+/** Ray-casting point-in-ring test on `[lng, lat]` coordinates. */
+export function pointInRing(point: LngLat, ring: LngLat[]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i, i += 1) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    const intersects =
+      yi > point[1] !== yj > point[1] &&
+      point[0] < ((xj - xi) * (point[1] - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+/** A regular sampling grid laid over a polygon's bounding box. */
+export interface AreaGrid {
+  /** All grid coordinates, row-major (row 0 = south), `cols * rows` entries. */
+  coords: LngLat[];
+  /** Whether each grid coordinate falls inside the polygon ring. */
+  inside: boolean[];
+  cols: number;
+  rows: number;
+  /** East–west spacing between grid columns in meters (at the bbox center). */
+  cellWidthMeters: number;
+  /** North–south spacing between grid rows in meters. */
+  cellHeightMeters: number;
+}
+
+/**
+ * Lay a roughly square sampling grid over a polygon ring's bounding box. The
+ * grid has at most `maxSamples` points (and at least 2x2), sized so cells are
+ * approximately square in meters. Degenerate rings return a null grid.
+ */
+export function buildAreaGrid(
+  ring: LngLat[],
+  maxSamples: number,
+  radius: number,
+): AreaGrid | null {
+  if (ring.length < 3) return null;
+  let minLng = Infinity;
+  let maxLng = -Infinity;
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  for (const [lng, lat] of ring) {
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+  }
+  if (!(maxLng > minLng) || !(maxLat > minLat)) return null;
+
+  const centerLat = (minLat + maxLat) / 2;
+  const metersPerDegLat = (Math.PI * radius) / 180;
+  const metersPerDegLng = metersPerDegLat * Math.cos(centerLat * DEG_TO_RAD);
+  const widthMeters = (maxLng - minLng) * metersPerDegLng;
+  const heightMeters = (maxLat - minLat) * metersPerDegLat;
+  if (!(widthMeters > 0) || !(heightMeters > 0)) return null;
+
+  // Pick cols/rows proportional to the bbox aspect so cells come out roughly
+  // square, while keeping cols * rows <= maxSamples.
+  const aspect = widthMeters / heightMeters;
+  const rawRows = Math.sqrt(Math.max(4, maxSamples) / aspect);
+  const rows = Math.max(2, Math.round(rawRows));
+  const cols = Math.max(2, Math.floor(Math.max(4, maxSamples) / rows));
+
+  const coords: LngLat[] = [];
+  const inside: boolean[] = [];
+  for (let r = 0; r < rows; r += 1) {
+    const lat = minLat + ((maxLat - minLat) * r) / (rows - 1);
+    for (let c = 0; c < cols; c += 1) {
+      const lng = minLng + ((maxLng - minLng) * c) / (cols - 1);
+      const point: LngLat = [lng, lat];
+      coords.push(point);
+      inside.push(pointInRing(point, ring));
+    }
+  }
+
+  return {
+    coords,
+    inside,
+    cols,
+    rows,
+    cellWidthMeters: widthMeters / (cols - 1),
+    cellHeightMeters: heightMeters / (rows - 1),
+  };
+}
+
+/** Terrain-aware statistics for a measured polygon. */
+export interface SurfaceAreaResult {
+  /** Terrain-draped 3D surface area in square meters. */
+  surfaceSquareMeters: number;
+  /** Area-weighted mean slope across sampled cells, in degrees. */
+  meanSlopeDegrees: number;
+  /** Number of interior grid samples with a usable elevation. */
+  sampledCount: number;
+  /** Number of interior grid samples missing an elevation. */
+  missingCount: number;
+}
+
+/** Steeper cells are clamped to this slope so one bad sample can't explode the area. */
+const MAX_SLOPE_DEG = 85;
+
+/**
+ * Estimate the terrain-draped surface area of a polygon from grid-sampled
+ * elevations. Each interior sample gets a slope from central differences of
+ * its neighbors; the polygon's exact planar area is then scaled by the mean
+ * secant of those slopes (the standard slope-correction `A / cos(s)`), so the
+ * grid only has to approximate the *slope distribution*, not the outline.
+ * Returns null when fewer than half the interior samples have elevations.
+ */
+export function surfaceArea(
+  grid: AreaGrid,
+  elevations: (number | null)[],
+  planarSquareMeters: number,
+): SurfaceAreaResult | null {
+  const { cols, rows, inside, cellWidthMeters, cellHeightMeters } = grid;
+  const at = (r: number, c: number): number | null => {
+    if (r < 0 || c < 0 || r >= rows || c >= cols) return null;
+    const value = elevations[r * cols + c];
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
+  };
+
+  const maxSecant = 1 / Math.cos(MAX_SLOPE_DEG * DEG_TO_RAD);
+  let secantSum = 0;
+  let slopeSum = 0;
+  let sampledCount = 0;
+  let missingCount = 0;
+
+  for (let r = 0; r < rows; r += 1) {
+    for (let c = 0; c < cols; c += 1) {
+      if (!inside[r * cols + c]) continue;
+      const here = at(r, c);
+      if (here === null) {
+        missingCount += 1;
+        continue;
+      }
+      // Central differences where both neighbors exist, one-sided otherwise.
+      const west = at(r, c - 1);
+      const east = at(r, c + 1);
+      const south = at(r - 1, c);
+      const north = at(r + 1, c);
+      const dzdx = gradient(west, here, east, cellWidthMeters);
+      const dzdy = gradient(south, here, north, cellHeightMeters);
+      if (dzdx === null || dzdy === null) {
+        missingCount += 1;
+        continue;
+      }
+      const secant = Math.min(Math.hypot(1, dzdx, dzdy), maxSecant);
+      secantSum += secant;
+      slopeSum += Math.atan(Math.hypot(dzdx, dzdy)) / DEG_TO_RAD;
+      sampledCount += 1;
+    }
+  }
+
+  if (sampledCount === 0 || sampledCount < missingCount) return null;
+
+  return {
+    surfaceSquareMeters: planarSquareMeters * (secantSum / sampledCount),
+    meanSlopeDegrees: slopeSum / sampledCount,
+    sampledCount,
+    missingCount,
+  };
+}
+
+/**
+ * Slope of the elevation across one axis: central difference when both
+ * neighbors are known, one-sided when only one is, null when neither is.
+ */
+function gradient(
+  before: number | null,
+  here: number,
+  after: number | null,
+  spacingMeters: number,
+): number | null {
+  if (before !== null && after !== null) {
+    return (after - before) / (2 * spacingMeters);
+  }
+  if (after !== null) return (after - here) / spacingMeters;
+  if (before !== null) return (here - before) / spacingMeters;
+  return null;
+}

--- a/packages/plugins/src/plugins/terrain-measure.ts
+++ b/packages/plugins/src/plugins/terrain-measure.ts
@@ -355,13 +355,19 @@ export function attachTerrainMeasure(
   const section = document.createElement("div");
   section.className = "geolibre-terrain-measure";
   section.style.borderTop = "1px solid hsl(var(--border))";
-  section.style.marginTop = "8px";
+  // The panel's children carry their own margins (it has no padding), so
+  // inset the section on all sides to keep text off the panel border.
+  section.style.margin = "8px 12px 12px";
   section.style.paddingTop = "8px";
   section.style.display = "none";
   section.style.fontSize = "12px";
   panel.appendChild(section);
 
   let current: TerrainReadout | null = null;
+  // The measurement whose computation is still in flight; tracked separately
+  // from `current` (which stays null until the promise resolves) so a removal
+  // during the "Computing terrain…" window can cancel the pending work too.
+  let pendingMeasurementId: string | null = null;
   let requestToken = 0;
 
   const hide = (): void => {
@@ -419,27 +425,37 @@ export function attachTerrainMeasure(
     const measurement = event.measurement;
     if (!measurement) return;
     const token = ++requestToken;
+    pendingMeasurementId = measurement.id;
     showComputing();
     computeTerrainReadout(measurement, getMap())
       .then((readout) => {
         if (token !== requestToken) return;
+        pendingMeasurementId = null;
         current = readout;
         render();
       })
       .catch(() => {
         if (token !== requestToken) return;
+        pendingMeasurementId = null;
         hide();
       });
   };
 
   const onClear = (): void => {
     requestToken += 1;
+    pendingMeasurementId = null;
     hide();
   };
 
   const onMeasurementRemove = (event: { measurement?: Measurement }): void => {
-    if (current && event.measurement?.id === current.measurementId) {
+    const removedId = event.measurement?.id;
+    if (!removedId) return;
+    if (
+      current?.measurementId === removedId ||
+      pendingMeasurementId === removedId
+    ) {
       requestToken += 1;
+      pendingMeasurementId = null;
       hide();
     }
   };

--- a/packages/plugins/src/plugins/terrain-measure.ts
+++ b/packages/plugins/src/plugins/terrain-measure.ts
@@ -1,0 +1,472 @@
+/**
+ * Terrain-aware (3D) augmentation for the Measure tool.
+ *
+ * The upstream MeasureControl (maplibre-gl-components) reports planar
+ * great-circle distances and spherical areas. This module listens to its
+ * measurement events and, when ground elevations are available, appends a
+ * "Terrain (3D)" section to the control's panel with the terrain-draped
+ * surface distance (plus elevation gain/loss and range) for lines, or the
+ * slope-corrected surface area (plus mean slope) for polygons — the way
+ * Google Earth measures along the ground rather than through it.
+ *
+ * Elevations come from two sources, tried in order:
+ *  1. The map's own terrain (`map.queryTerrainElevation`) when 3D terrain is
+ *     enabled — instant and offline, but only where DEM tiles are loaded.
+ *     MapLibre returns elevations multiplied by the terrain exaggeration, so
+ *     values are divided back to true meters.
+ *  2. The keyless Open-Meteo elevation API (already used by the Elevation
+ *     Profile plugin), only when the active body is Earth.
+ *
+ * When neither source can provide elevations the section stays hidden and the
+ * Measure tool behaves exactly as before.
+ */
+
+import { getActiveEllipsoid, getActiveMeanRadiusMeters } from "@geolibre/core";
+import type {
+  MeasureControl,
+  Measurement,
+} from "maplibre-gl-components";
+import {
+  fetchElevations,
+  MAX_POINTS_PER_REQUEST,
+  type FetchLike,
+} from "./elevation-profile/elevation/client";
+import {
+  buildAreaGrid,
+  densifyLine,
+  surfaceArea,
+  surfaceDistance,
+  type LngLat,
+  type SurfaceAreaResult,
+  type SurfaceDistanceResult,
+} from "./terrain-measure-geometry";
+
+/** Sample roughly every 30 m along a measured line… */
+const LINE_SAMPLE_SPACING_METERS = 30;
+/** …but never more than 200 samples per line (2 remote requests). */
+const LINE_MAX_SAMPLES = 200;
+/** At most ~256 grid samples across a measured polygon. */
+const AREA_MAX_SAMPLES = 256;
+
+/** Upstream unit ids (mirrors maplibre-gl-components' DistanceUnit/AreaUnit). */
+type DistanceUnit =
+  | "meters"
+  | "kilometers"
+  | "miles"
+  | "feet"
+  | "yards"
+  | "nautical-miles";
+type AreaUnit =
+  | "square-meters"
+  | "square-kilometers"
+  | "square-miles"
+  | "hectares"
+  | "acres"
+  | "square-feet";
+
+const DISTANCE_FACTORS: Record<DistanceUnit, number> = {
+  meters: 1,
+  kilometers: 1 / 1000,
+  miles: 1 / 1609.344,
+  feet: 1 / 0.3048,
+  yards: 1 / 0.9144,
+  "nautical-miles": 1 / 1852,
+};
+
+const AREA_FACTORS: Record<AreaUnit, number> = {
+  "square-meters": 1,
+  "square-kilometers": 1 / 1_000_000,
+  "square-miles": 1 / 2_589_988.110336,
+  hectares: 1 / 10_000,
+  acres: 1 / 4046.8564224,
+  "square-feet": 1 / 0.09290304,
+};
+
+const UNIT_SYMBOLS: Record<DistanceUnit | AreaUnit, string> = {
+  meters: "m",
+  kilometers: "km",
+  feet: "ft",
+  yards: "yd",
+  miles: "mi",
+  "nautical-miles": "nmi",
+  "square-meters": "m²",
+  "square-kilometers": "km²",
+  hectares: "ha",
+  "square-feet": "ft²",
+  acres: "ac",
+  "square-miles": "mi²",
+};
+
+/** Distance units whose users expect elevations in feet rather than meters. */
+const IMPERIAL_DISTANCE_UNITS: ReadonlySet<DistanceUnit> = new Set([
+  "miles",
+  "feet",
+  "yards",
+]);
+
+const FEET_PER_METER = 1 / 0.3048;
+
+/**
+ * User-facing strings for the terrain section. Defaults are English; the
+ * desktop shell pushes translated values via {@link setTerrainMeasureLabels}
+ * since this package is framework-agnostic and has no react-i18next access.
+ */
+const terrainMeasureLabels = {
+  title: "Terrain (3D)",
+  surfaceDistance: "Surface distance",
+  surfaceArea: "Surface area",
+  elevationGainLoss: "Gain / loss",
+  elevationRange: "Min / max elevation",
+  meanSlope: "Mean slope",
+  computing: "Computing terrain…",
+  partialData: "Some samples had no terrain data",
+};
+
+/** Override the terrain-measure labels with translated text. */
+export function setTerrainMeasureLabels(
+  labels: Partial<typeof terrainMeasureLabels>,
+): void {
+  for (const [key, value] of Object.entries(labels)) {
+    // Only overwrite when the caller actually supplied the key; an omitted key
+    // keeps the English default rather than being blanked out.
+    if (value !== undefined)
+      terrainMeasureLabels[key as keyof typeof terrainMeasureLabels] = value;
+  }
+}
+
+/** The slice of the MapLibre map the samplers need (stubbed in tests). */
+export interface TerrainMapLike {
+  getTerrain?: () => { exaggeration?: number } | null | undefined;
+  queryTerrainElevation?: (lngLat: [number, number]) => number | null;
+}
+
+/**
+ * Sample elevations from the map's enabled 3D terrain, in true meters
+ * (MapLibre's `queryTerrainElevation` bakes the exaggeration in, so it is
+ * divided back out). Returns null when terrain is not enabled.
+ */
+export function sampleMapTerrain(
+  map: TerrainMapLike | null | undefined,
+  points: LngLat[],
+): (number | null)[] | null {
+  if (!map?.getTerrain || !map.queryTerrainElevation) return null;
+  const terrain = map.getTerrain();
+  if (!terrain) return null;
+  const exaggeration =
+    typeof terrain.exaggeration === "number" && terrain.exaggeration > 0
+      ? terrain.exaggeration
+      : 1;
+  return points.map((point) => {
+    const elevation = map.queryTerrainElevation!(point);
+    return typeof elevation === "number" && Number.isFinite(elevation)
+      ? elevation / exaggeration
+      : null;
+  });
+}
+
+/**
+ * Sample elevations from the Open-Meteo API, chunked to its 100-point request
+ * limit. A failed chunk yields nulls for its points rather than throwing, so a
+ * flaky network degrades the readout instead of breaking the Measure tool.
+ */
+export async function sampleRemoteElevations(
+  points: LngLat[],
+  fetchImpl?: FetchLike,
+): Promise<(number | null)[]> {
+  const results: (number | null)[] = [];
+  for (let i = 0; i < points.length; i += MAX_POINTS_PER_REQUEST) {
+    const chunk = points.slice(i, i + MAX_POINTS_PER_REQUEST);
+    try {
+      const elevations = await fetchElevations(chunk, fetchImpl);
+      for (const elevation of elevations) {
+        results.push(Number.isFinite(elevation) ? elevation : null);
+      }
+    } catch {
+      for (let j = 0; j < chunk.length; j += 1) results.push(null);
+    }
+  }
+  return results;
+}
+
+/** The computed terrain readout for the most recent measurement. */
+type TerrainReadout =
+  | { kind: "distance"; measurementId: string; result: SurfaceDistanceResult }
+  | { kind: "area"; measurementId: string; result: SurfaceAreaResult };
+
+interface MeasureStateLike {
+  distanceUnit: DistanceUnit;
+  areaUnit: AreaUnit;
+}
+
+/** The private panel element of the upstream MeasureControl. */
+interface MeasureControlInternals {
+  _panel?: HTMLElement;
+}
+
+/**
+ * Compute the terrain readout for a completed measurement, or null when no
+ * elevation source produced any usable samples.
+ */
+export async function computeTerrainReadout(
+  measurement: Measurement,
+  map: TerrainMapLike | null,
+  fetchImpl?: FetchLike,
+): Promise<TerrainReadout | null> {
+  const radius = getActiveMeanRadiusMeters();
+  const coords: LngLat[] = measurement.points.map((p) => [p.lng, p.lat]);
+
+  if (measurement.mode === "distance") {
+    if (coords.length < 2) return null;
+    const line = densifyLine(
+      coords,
+      LINE_SAMPLE_SPACING_METERS,
+      LINE_MAX_SAMPLES,
+      radius,
+    );
+    const elevations = await sampleElevations(line.coords, map, fetchImpl);
+    if (!elevations) return null;
+    const result = surfaceDistance(line.distances, elevations);
+    if (result.sampledCount === 0) return null;
+    return { kind: "distance", measurementId: measurement.id, result };
+  }
+
+  if (coords.length < 3 || !measurement.area) return null;
+  // Close the ring for the point-in-polygon test; drawn points are unclosed.
+  const ring: LngLat[] = [...coords, coords[0]];
+  const grid = buildAreaGrid(ring, AREA_MAX_SAMPLES, radius);
+  if (!grid) return null;
+  const elevations = await sampleElevations(grid.coords, map, fetchImpl);
+  if (!elevations) return null;
+  const result = surfaceArea(grid, elevations, measurement.area);
+  if (!result) return null;
+  return { kind: "area", measurementId: measurement.id, result };
+}
+
+/**
+ * Sample elevations for the given points: map terrain first, the remote API
+ * (Earth only) when terrain is off or produced nothing usable. Returns null
+ * when no source is available.
+ */
+async function sampleElevations(
+  points: LngLat[],
+  map: TerrainMapLike | null,
+  fetchImpl?: FetchLike,
+): Promise<(number | null)[] | null> {
+  const fromTerrain = sampleMapTerrain(map, points);
+  if (fromTerrain && fromTerrain.some((e) => e !== null)) return fromTerrain;
+  if (getActiveEllipsoid().id !== "earth") return null;
+  const fromRemote = await sampleRemoteElevations(points, fetchImpl);
+  return fromRemote.some((e) => e !== null) ? fromRemote : null;
+}
+
+function formatNumber(value: number): string {
+  const digits = Math.abs(value) >= 100 ? 0 : Math.abs(value) >= 10 ? 1 : 2;
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  });
+}
+
+function formatDistanceValue(meters: number, unit: DistanceUnit): string {
+  const factor = DISTANCE_FACTORS[unit] ?? 1;
+  const symbol = UNIT_SYMBOLS[unit] ?? "m";
+  return `${formatNumber(meters * factor)} ${symbol}`;
+}
+
+function formatAreaValue(squareMeters: number, unit: AreaUnit): string {
+  const factor = AREA_FACTORS[unit] ?? 1;
+  const symbol = UNIT_SYMBOLS[unit] ?? "m²";
+  return `${formatNumber(squareMeters * factor)} ${symbol}`;
+}
+
+/** Elevations follow the distance unit's family: feet for imperial, else meters. */
+function formatElevationValue(meters: number, unit: DistanceUnit): string {
+  if (IMPERIAL_DISTANCE_UNITS.has(unit)) {
+    return `${Math.round(meters * FEET_PER_METER)} ft`;
+  }
+  return `${Math.round(meters)} m`;
+}
+
+/** Rows of the rendered terrain section, as label/value pairs. */
+export function terrainReadoutRows(
+  readout: TerrainReadout,
+  units: MeasureStateLike,
+): Array<[string, string]> {
+  if (readout.kind === "distance") {
+    const { result } = readout;
+    const rows: Array<[string, string]> = [
+      [
+        terrainMeasureLabels.surfaceDistance,
+        formatDistanceValue(result.surfaceMeters, units.distanceUnit),
+      ],
+      [
+        terrainMeasureLabels.elevationGainLoss,
+        `↑ ${formatElevationValue(result.gainMeters, units.distanceUnit)}  ↓ ${formatElevationValue(result.lossMeters, units.distanceUnit)}`,
+      ],
+    ];
+    if (
+      result.minElevationMeters !== null &&
+      result.maxElevationMeters !== null
+    ) {
+      rows.push([
+        terrainMeasureLabels.elevationRange,
+        `${formatElevationValue(result.minElevationMeters, units.distanceUnit)} / ${formatElevationValue(result.maxElevationMeters, units.distanceUnit)}`,
+      ]);
+    }
+    return rows;
+  }
+  const { result } = readout;
+  return [
+    [
+      terrainMeasureLabels.surfaceArea,
+      formatAreaValue(result.surfaceSquareMeters, units.areaUnit),
+    ],
+    [terrainMeasureLabels.meanSlope, `${result.meanSlopeDegrees.toFixed(1)}°`],
+  ];
+}
+
+/** Whether the readout should carry the partial-data footnote. */
+export function terrainReadoutIsPartial(readout: TerrainReadout): boolean {
+  return readout.result.missingCount > 0;
+}
+
+/**
+ * Attach the terrain section to a mounted MeasureControl. Returns a detach
+ * function that unsubscribes and removes the injected DOM. Call after the
+ * control has been added to the map (its panel exists from `onAdd`).
+ */
+export function attachTerrainMeasure(
+  control: MeasureControl,
+  getMap: () => TerrainMapLike | null,
+): () => void {
+  // `_panel` is a private member of MeasureControl as of
+  // maplibre-gl-components@0.25.x. If a future version renames it, the terrain
+  // section silently disappears while planar measuring keeps working — warn
+  // loudly so the regression is caught when bumping the dependency.
+  const panel = (control as unknown as MeasureControlInternals)._panel;
+  if (!panel) {
+    console.warn(
+      "MeasureControl: _panel not found; the Terrain (3D) section is " +
+        "inactive. Check maplibre-gl-components.",
+    );
+    return () => {};
+  }
+
+  const section = document.createElement("div");
+  section.className = "geolibre-terrain-measure";
+  section.style.borderTop = "1px solid hsl(var(--border))";
+  section.style.marginTop = "8px";
+  section.style.paddingTop = "8px";
+  section.style.display = "none";
+  section.style.fontSize = "12px";
+  panel.appendChild(section);
+
+  let current: TerrainReadout | null = null;
+  let requestToken = 0;
+
+  const hide = (): void => {
+    current = null;
+    section.style.display = "none";
+    section.replaceChildren();
+  };
+
+  const render = (): void => {
+    if (!current) {
+      hide();
+      return;
+    }
+    const units = control.getState() as unknown as MeasureStateLike;
+    section.replaceChildren();
+    section.style.display = "block";
+    section.appendChild(sectionTitle());
+    for (const [label, value] of terrainReadoutRows(current, units)) {
+      const row = document.createElement("div");
+      row.style.display = "flex";
+      row.style.justifyContent = "space-between";
+      row.style.gap = "8px";
+      row.style.marginTop = "2px";
+      const labelEl = document.createElement("span");
+      labelEl.style.opacity = "0.75";
+      labelEl.textContent = label;
+      const valueEl = document.createElement("span");
+      valueEl.style.fontWeight = "600";
+      valueEl.textContent = value;
+      row.append(labelEl, valueEl);
+      section.appendChild(row);
+    }
+    if (terrainReadoutIsPartial(current)) {
+      const note = document.createElement("div");
+      note.style.opacity = "0.6";
+      note.style.marginTop = "4px";
+      note.textContent = terrainMeasureLabels.partialData;
+      section.appendChild(note);
+    }
+  };
+
+  const showComputing = (): void => {
+    section.replaceChildren();
+    section.style.display = "block";
+    section.appendChild(sectionTitle());
+    const note = document.createElement("div");
+    note.style.opacity = "0.6";
+    note.textContent = terrainMeasureLabels.computing;
+    section.appendChild(note);
+  };
+
+  const onDrawEnd = (event: {
+    measurement?: Measurement;
+  }): void => {
+    const measurement = event.measurement;
+    if (!measurement) return;
+    const token = ++requestToken;
+    showComputing();
+    computeTerrainReadout(measurement, getMap())
+      .then((readout) => {
+        if (token !== requestToken) return;
+        current = readout;
+        render();
+      })
+      .catch(() => {
+        if (token !== requestToken) return;
+        hide();
+      });
+  };
+
+  const onClear = (): void => {
+    requestToken += 1;
+    hide();
+  };
+
+  const onMeasurementRemove = (event: { measurement?: Measurement }): void => {
+    if (current && event.measurement?.id === current.measurementId) {
+      requestToken += 1;
+      hide();
+    }
+  };
+
+  const onUnitChange = (): void => {
+    if (current) render();
+  };
+
+  control.on("drawend", onDrawEnd);
+  control.on("clear", onClear);
+  control.on("measurementremove", onMeasurementRemove);
+  control.on("unitchange", onUnitChange);
+
+  return () => {
+    requestToken += 1;
+    control.off("drawend", onDrawEnd);
+    control.off("clear", onClear);
+    control.off("measurementremove", onMeasurementRemove);
+    control.off("unitchange", onUnitChange);
+    section.remove();
+  };
+}
+
+function sectionTitle(): HTMLElement {
+  const title = document.createElement("div");
+  title.style.fontWeight = "700";
+  title.style.marginBottom = "2px";
+  title.textContent = terrainMeasureLabels.title;
+  return title;
+}

--- a/packages/plugins/src/plugins/terrain-measure.ts
+++ b/packages/plugins/src/plugins/terrain-measure.ts
@@ -173,19 +173,25 @@ export async function sampleRemoteElevations(
   points: LngLat[],
   fetchImpl?: FetchLike,
 ): Promise<(number | null)[]> {
-  const results: (number | null)[] = [];
+  const chunks: LngLat[][] = [];
   for (let i = 0; i < points.length; i += MAX_POINTS_PER_REQUEST) {
-    const chunk = points.slice(i, i + MAX_POINTS_PER_REQUEST);
-    try {
-      const elevations = await fetchElevations(chunk, fetchImpl);
-      for (const elevation of elevations) {
-        results.push(Number.isFinite(elevation) ? elevation : null);
-      }
-    } catch {
-      for (let j = 0; j < chunk.length; j += 1) results.push(null);
-    }
+    chunks.push(points.slice(i, i + MAX_POINTS_PER_REQUEST));
   }
-  return results;
+  // The chunks are independent, so fire them concurrently; Promise.all
+  // preserves their order for reassembly.
+  const chunkResults = await Promise.all(
+    chunks.map(async (chunk) => {
+      try {
+        const elevations = await fetchElevations(chunk, fetchImpl);
+        return elevations.map((elevation) =>
+          Number.isFinite(elevation) ? elevation : null,
+        );
+      } catch {
+        return chunk.map(() => null);
+      }
+    }),
+  );
+  return chunkResults.flat();
 }
 
 /** The computed terrain readout for the most recent measurement. */
@@ -201,6 +207,28 @@ interface MeasureStateLike {
 /** The private panel element of the upstream MeasureControl. */
 interface MeasureControlInternals {
   _panel?: HTMLElement;
+}
+
+/**
+ * The MeasureControl's panel element. `_panel` is a private member as of
+ * maplibre-gl-components@0.25.x; if a future version renames it, everything
+ * layered on the panel (the terrain section, the resize styling) silently
+ * disappears while planar measuring keeps working — so warn loudly to catch
+ * the regression when bumping the dependency. Shared by this module and
+ * `makeMeasurePanelResizable` so an upstream rename needs one fix.
+ */
+export function measurePanelElement(
+  control: MeasureControl,
+): HTMLElement | null {
+  const panel = (control as unknown as MeasureControlInternals)._panel;
+  if (!panel) {
+    console.warn(
+      "MeasureControl: _panel not found; the Terrain (3D) section and panel " +
+        "resize styling are inactive. Check maplibre-gl-components.",
+    );
+    return null;
+  }
+  return panel;
 }
 
 /**
@@ -339,16 +367,8 @@ export function attachTerrainMeasure(
   control: MeasureControl,
   getMap: () => TerrainMapLike | null,
 ): () => void {
-  // `_panel` is a private member of MeasureControl as of
-  // maplibre-gl-components@0.25.x. If a future version renames it, the terrain
-  // section silently disappears while planar measuring keeps working — warn
-  // loudly so the regression is caught when bumping the dependency.
-  const panel = (control as unknown as MeasureControlInternals)._panel;
+  const panel = measurePanelElement(control);
   if (!panel) {
-    console.warn(
-      "MeasureControl: _panel not found; the Terrain (3D) section is " +
-        "inactive. Check maplibre-gl-components.",
-    );
     return () => {};
   }
 
@@ -426,6 +446,10 @@ export function attachTerrainMeasure(
     if (!measurement) return;
     const token = ++requestToken;
     pendingMeasurementId = measurement.id;
+    // Drop the previous readout now: it no longer matches what the section
+    // shows ("Computing…"), and a stale id here would let the removal of an
+    // older measurement cancel this newer in-flight computation.
+    current = null;
     showComputing();
     computeTerrainReadout(measurement, getMap())
       .then((readout) => {

--- a/tests/terrain-measure.test.ts
+++ b/tests/terrain-measure.test.ts
@@ -322,6 +322,31 @@ describe("terrain-measure readout", () => {
     assert.equal(terrainReadoutIsPartial(readout), false);
   });
 
+  it("flags a readout as partial when some samples have no elevation", async () => {
+    const patchyMap: TerrainMapLike = {
+      getTerrain: () => ({ exaggeration: 1 }),
+      // Northern half of the line has no loaded DEM tile.
+      queryTerrainElevation: (point) => (point[1] > 0.005 ? null : 100),
+    };
+    const readout = await computeTerrainReadout(
+      {
+        id: "m-partial",
+        mode: "distance",
+        points: [
+          { lng: 0, lat: 0 },
+          { lng: 0, lat: 0.01 },
+        ],
+        distance: 1113,
+      },
+      patchyMap,
+    );
+    assert.ok(readout);
+    if (readout.kind !== "distance") assert.fail("expected a distance readout");
+    assert.equal(terrainReadoutIsPartial(readout), true);
+    assert.ok(readout.result.missingCount > 0);
+    assert.ok(readout.result.sampledCount > 0);
+  });
+
   it("renders unit-aware rows", async () => {
     const readout = await computeTerrainReadout(
       {
@@ -342,7 +367,7 @@ describe("terrain-measure readout", () => {
     });
     assert.equal(rows.length, 3);
     assert.match(rows[0][1], /km$/);
-    assert.match(rows[1][1], /m/);
+    assert.match(rows[1][1], /\bm$/);
     const imperialRows = terrainReadoutRows(readout, {
       distanceUnit: "miles",
       areaUnit: "acres",

--- a/tests/terrain-measure.test.ts
+++ b/tests/terrain-measure.test.ts
@@ -1,0 +1,358 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { setActiveEllipsoidId } from "@geolibre/core";
+
+import {
+  buildAreaGrid,
+  densifyLine,
+  haversineMeters,
+  pointInRing,
+  surfaceArea,
+  surfaceDistance,
+  type LngLat,
+} from "../packages/plugins/src/plugins/terrain-measure-geometry";
+import {
+  computeTerrainReadout,
+  sampleMapTerrain,
+  sampleRemoteElevations,
+  terrainReadoutIsPartial,
+  terrainReadoutRows,
+  type TerrainMapLike,
+} from "../packages/plugins/src/plugins/terrain-measure";
+import type { FetchLike } from "../packages/plugins/src/plugins/elevation-profile/elevation/client";
+
+const EARTH_RADIUS = 6371008.8;
+
+const closeTo = (actual: number, expected: number, delta: number): void => {
+  assert.ok(
+    Math.abs(actual - expected) <= delta,
+    `expected ${actual} to be within ${delta} of ${expected}`,
+  );
+};
+
+describe("terrain-measure geometry: densifyLine", () => {
+  it("keeps endpoints and spaces samples evenly", () => {
+    // ~1113 m of longitude at the equator.
+    const coords: LngLat[] = [
+      [0, 0],
+      [0.01, 0],
+    ];
+    const { coords: sampled, distances } = densifyLine(
+      coords,
+      100,
+      500,
+      EARTH_RADIUS,
+    );
+    assert.deepEqual(sampled[0], coords[0]);
+    assert.deepEqual(sampled[sampled.length - 1], coords[1]);
+    // ~1113 m at 100 m spacing → 13 samples (ceil(1113/100) + 1).
+    assert.equal(sampled.length, 13);
+    assert.equal(distances[0], 0);
+    closeTo(distances[distances.length - 1], 1113, 2);
+    // Even spacing.
+    closeTo(distances[1] - distances[0], distances[2] - distances[1], 1e-6);
+  });
+
+  it("caps the sample count at maxPoints", () => {
+    const coords: LngLat[] = [
+      [0, 0],
+      [1, 0],
+    ];
+    const { coords: sampled } = densifyLine(coords, 1, 50, EARTH_RADIUS);
+    assert.equal(sampled.length, 50);
+  });
+
+  it("handles degenerate input", () => {
+    assert.deepEqual(densifyLine([], 10, 10, EARTH_RADIUS).coords, []);
+    const same: LngLat[] = [
+      [5, 5],
+      [5, 5],
+    ];
+    assert.deepEqual(densifyLine(same, 10, 10, EARTH_RADIUS).distances, [0, 0]);
+  });
+});
+
+describe("terrain-measure geometry: surfaceDistance", () => {
+  it("equals the planar distance over flat terrain", () => {
+    const result = surfaceDistance([0, 100, 200], [50, 50, 50]);
+    closeTo(result.surfaceMeters, 200, 1e-9);
+    closeTo(result.planarMeters, 200, 1e-9);
+    assert.equal(result.gainMeters, 0);
+    assert.equal(result.lossMeters, 0);
+  });
+
+  it("computes the 3-4-5 slope", () => {
+    // 400 m run with 300 m rise → 500 m along the surface.
+    const result = surfaceDistance([0, 400], [0, 300]);
+    closeTo(result.surfaceMeters, 500, 1e-9);
+    assert.equal(result.gainMeters, 300);
+    assert.equal(result.lossMeters, 0);
+    assert.equal(result.minElevationMeters, 0);
+    assert.equal(result.maxElevationMeters, 300);
+  });
+
+  it("accumulates gain and loss over a ridge", () => {
+    const result = surfaceDistance([0, 100, 200], [0, 80, 20]);
+    assert.equal(result.gainMeters, 80);
+    assert.equal(result.lossMeters, 60);
+    closeTo(result.surfaceMeters, Math.hypot(100, 80) + Math.hypot(100, 60), 1e-9);
+  });
+
+  it("falls back to planar length across missing samples", () => {
+    const result = surfaceDistance([0, 100, 200], [0, null, 100]);
+    // Both segments touch the null sample, so both fall back to planar.
+    closeTo(result.surfaceMeters, 200, 1e-9);
+    assert.equal(result.sampledCount, 2);
+    assert.equal(result.missingCount, 1);
+  });
+});
+
+describe("terrain-measure geometry: pointInRing / buildAreaGrid", () => {
+  const square: LngLat[] = [
+    [0, 0],
+    [1, 0],
+    [1, 1],
+    [0, 1],
+    [0, 0],
+  ];
+
+  it("classifies inside and outside points", () => {
+    assert.equal(pointInRing([0.5, 0.5], square), true);
+    assert.equal(pointInRing([1.5, 0.5], square), false);
+    assert.equal(pointInRing([-0.5, 0.5], square), false);
+  });
+
+  it("builds a bounded grid with interior flags", () => {
+    const grid = buildAreaGrid(square, 100, EARTH_RADIUS);
+    assert.ok(grid);
+    assert.ok(grid.cols * grid.rows <= 100);
+    assert.ok(grid.cols >= 2 && grid.rows >= 2);
+    assert.equal(grid.coords.length, grid.cols * grid.rows);
+    assert.ok(grid.inside.some(Boolean));
+    assert.ok(grid.cellWidthMeters > 0 && grid.cellHeightMeters > 0);
+  });
+
+  it("returns null for degenerate rings", () => {
+    assert.equal(buildAreaGrid([], 100, EARTH_RADIUS), null);
+    const line: LngLat[] = [
+      [0, 0],
+      [1, 0],
+      [2, 0],
+    ];
+    assert.equal(buildAreaGrid(line, 100, EARTH_RADIUS), null);
+  });
+});
+
+describe("terrain-measure geometry: surfaceArea", () => {
+  const square: LngLat[] = [
+    [0, 0],
+    [0.01, 0],
+    [0.01, 0.01],
+    [0, 0.01],
+    [0, 0],
+  ];
+
+  it("returns the planar area over flat terrain", () => {
+    const grid = buildAreaGrid(square, 64, EARTH_RADIUS)!;
+    const elevations = grid.coords.map(() => 100);
+    const result = surfaceArea(grid, elevations, 1_000_000);
+    assert.ok(result);
+    closeTo(result.surfaceSquareMeters, 1_000_000, 1e-6);
+    closeTo(result.meanSlopeDegrees, 0, 1e-9);
+    assert.equal(result.missingCount, 0);
+  });
+
+  it("scales the area by the slope secant on a uniform incline", () => {
+    const grid = buildAreaGrid(square, 64, EARTH_RADIUS)!;
+    // Elevation rises 1 m per meter eastward → 45° slope, secant √2.
+    const elevations = grid.coords.map(
+      (_, i) => (i % grid.cols) * grid.cellWidthMeters,
+    );
+    const result = surfaceArea(grid, elevations, 1_000_000);
+    assert.ok(result);
+    closeTo(result.surfaceSquareMeters, 1_000_000 * Math.SQRT2, 1000);
+    closeTo(result.meanSlopeDegrees, 45, 0.1);
+  });
+
+  it("returns null when most samples are missing", () => {
+    const grid = buildAreaGrid(square, 64, EARTH_RADIUS)!;
+    const elevations = grid.coords.map(() => null);
+    assert.equal(surfaceArea(grid, elevations, 1_000_000), null);
+  });
+});
+
+describe("terrain-measure geometry: haversineMeters", () => {
+  it("measures a degree of longitude at the equator", () => {
+    const meters = haversineMeters([0, 0], [1, 0], EARTH_RADIUS);
+    closeTo(meters, 111195, 10);
+  });
+
+  it("scales with the body radius", () => {
+    const earth = haversineMeters([0, 0], [1, 0], EARTH_RADIUS);
+    const half = haversineMeters([0, 0], [1, 0], EARTH_RADIUS / 2);
+    closeTo(half, earth / 2, 1e-6);
+  });
+});
+
+describe("terrain-measure samplers", () => {
+  it("sampleMapTerrain returns null when terrain is off", () => {
+    const map: TerrainMapLike = {
+      getTerrain: () => null,
+      queryTerrainElevation: () => 100,
+    };
+    assert.equal(sampleMapTerrain(map, [[0, 0]]), null);
+    assert.equal(sampleMapTerrain(null, [[0, 0]]), null);
+  });
+
+  it("sampleMapTerrain divides the exaggeration back out", () => {
+    const map: TerrainMapLike = {
+      getTerrain: () => ({ exaggeration: 2 }),
+      queryTerrainElevation: () => 200,
+    };
+    assert.deepEqual(sampleMapTerrain(map, [[0, 0]]), [100]);
+  });
+
+  it("sampleMapTerrain passes through nulls for unloaded tiles", () => {
+    const map: TerrainMapLike = {
+      getTerrain: () => ({ exaggeration: 1 }),
+      queryTerrainElevation: (point) => (point[0] === 0 ? 50 : null),
+    };
+    assert.deepEqual(
+      sampleMapTerrain(map, [
+        [0, 0],
+        [1, 1],
+      ]),
+      [50, null],
+    );
+  });
+
+  it("sampleRemoteElevations chunks requests and survives a failed chunk", async () => {
+    const calls: number[] = [];
+    const fetchImpl: FetchLike = async (url) => {
+      const count = (url.match(/latitude=([^&]*)/)?.[1] ?? "").split(",").length;
+      calls.push(count);
+      if (calls.length === 2) return new Response("boom", { status: 500 });
+      return new Response(
+        JSON.stringify({ elevation: Array(count).fill(7) }),
+        { status: 200 },
+      );
+    };
+    const points: LngLat[] = Array.from({ length: 150 }, (_, i) => [
+      i / 1000,
+      0,
+    ]);
+    const elevations = await sampleRemoteElevations(points, fetchImpl);
+    assert.deepEqual(calls, [100, 50]);
+    assert.equal(elevations.length, 150);
+    assert.equal(elevations[0], 7);
+    assert.equal(elevations[149], null);
+  });
+});
+
+describe("terrain-measure readout", () => {
+  const slopeMap: TerrainMapLike = {
+    getTerrain: () => ({ exaggeration: 1 }),
+    // 0.75 m of elevation per meter of northward ground distance → a 3-4-5
+    // slope along a south-to-north line.
+    queryTerrainElevation: (point) =>
+      point[1] * ((Math.PI * EARTH_RADIUS) / 180) * 0.75,
+  };
+
+  it("computes a 3-4-5 surface distance from map terrain", async () => {
+    const readout = await computeTerrainReadout(
+      {
+        id: "m1",
+        mode: "distance",
+        points: [
+          { lng: 0, lat: 0 },
+          { lng: 0, lat: 0.01 },
+        ],
+        distance: 1113,
+      },
+      slopeMap,
+    );
+    assert.ok(readout);
+    if (readout.kind !== "distance") assert.fail("expected a distance readout");
+    const planar = readout.result.planarMeters;
+    closeTo(readout.result.surfaceMeters, planar * 1.25, planar * 0.001);
+    assert.equal(terrainReadoutIsPartial(readout), false);
+  });
+
+  it("renders unit-aware rows", async () => {
+    const readout = await computeTerrainReadout(
+      {
+        id: "m2",
+        mode: "distance",
+        points: [
+          { lng: 0, lat: 0 },
+          { lng: 0, lat: 0.01 },
+        ],
+        distance: 1113,
+      },
+      slopeMap,
+    );
+    assert.ok(readout);
+    const rows = terrainReadoutRows(readout, {
+      distanceUnit: "kilometers",
+      areaUnit: "square-kilometers",
+    });
+    assert.equal(rows.length, 3);
+    assert.match(rows[0][1], /km$/);
+    assert.match(rows[1][1], /m/);
+    const imperialRows = terrainReadoutRows(readout, {
+      distanceUnit: "miles",
+      areaUnit: "acres",
+    });
+    assert.match(imperialRows[0][1], /mi$/);
+    assert.match(imperialRows[1][1], /ft/);
+  });
+
+  it("computes a slope-corrected area readout", async () => {
+    const readout = await computeTerrainReadout(
+      {
+        id: "m3",
+        mode: "area",
+        points: [
+          { lng: 0, lat: 0 },
+          { lng: 0.01, lat: 0 },
+          { lng: 0.01, lat: 0.01 },
+          { lng: 0, lat: 0.01 },
+        ],
+        area: 1_000_000,
+      },
+      slopeMap,
+    );
+    assert.ok(readout);
+    if (readout.kind !== "area") assert.fail("expected an area readout");
+    // sec(atan(0.75)) = 1.25 on a uniform 3-4-5 incline.
+    closeTo(readout.result.surfaceSquareMeters, 1_250_000, 5_000);
+    const rows = terrainReadoutRows(readout, {
+      distanceUnit: "meters",
+      areaUnit: "hectares",
+    });
+    assert.match(rows[0][1], /ha$/);
+    assert.match(rows[1][1], /°$/);
+  });
+
+  it("returns null when the only source is terrain and it is off (non-Earth)", async () => {
+    setActiveEllipsoidId("moon");
+    try {
+      const readout = await computeTerrainReadout(
+        {
+          id: "m4",
+          mode: "distance",
+          points: [
+            { lng: 0, lat: 0 },
+            { lng: 0, lat: 0.01 },
+          ],
+          distance: 1113,
+        },
+        { getTerrain: () => null, queryTerrainElevation: () => null },
+      );
+      assert.equal(readout, null);
+    } finally {
+      setActiveEllipsoidId("earth");
+    }
+  });
+});

--- a/tests/terrain-measure.test.ts
+++ b/tests/terrain-measure.test.ts
@@ -133,6 +133,34 @@ describe("terrain-measure geometry: pointInRing / buildAreaGrid", () => {
     assert.ok(grid.cellWidthMeters > 0 && grid.cellHeightMeters > 0);
   });
 
+  it("keeps the grid within maxSamples for very skinny polygons", () => {
+    // A ~10 m x 5000 m north-south sliver: without a row cap, rows would
+    // blow past the budget while cols sits at its floor of 2.
+    const sliver: LngLat[] = [
+      [0, 0],
+      [0.0001, 0],
+      [0.0001, 0.045],
+      [0, 0.045],
+      [0, 0],
+    ];
+    const grid = buildAreaGrid(sliver, 256, EARTH_RADIUS);
+    assert.ok(grid);
+    assert.ok(
+      grid.cols * grid.rows <= 256,
+      `expected ${grid.cols}x${grid.rows} <= 256 samples`,
+    );
+    const wide: LngLat[] = [
+      [0, 0],
+      [0.045, 0],
+      [0.045, 0.0001],
+      [0, 0.0001],
+      [0, 0],
+    ];
+    const wideGrid = buildAreaGrid(wide, 256, EARTH_RADIUS);
+    assert.ok(wideGrid);
+    assert.ok(wideGrid.cols * wideGrid.rows <= 256);
+  });
+
   it("returns null for degenerate rings", () => {
     assert.equal(buildAreaGrid([], 100, EARTH_RADIUS), null);
     const line: LngLat[] = [
@@ -173,6 +201,21 @@ describe("terrain-measure geometry: surfaceArea", () => {
     assert.ok(result);
     closeTo(result.surfaceSquareMeters, 1_000_000 * Math.SQRT2, 1000);
     closeTo(result.meanSlopeDegrees, 45, 0.1);
+  });
+
+  it("clamps the mean slope like the area's secant", () => {
+    const grid = buildAreaGrid(square, 64, EARTH_RADIUS)!;
+    // A pathological spike: elevation rises 1000 m per meter eastward.
+    const elevations = grid.coords.map(
+      (_, i) => (i % grid.cols) * grid.cellWidthMeters * 1000,
+    );
+    const result = surfaceArea(grid, elevations, 1_000_000);
+    assert.ok(result);
+    // Both readouts are protected by the same 85-degree cap, so they can't
+    // silently disagree on spiky DEM data.
+    assert.ok(result.meanSlopeDegrees <= 85);
+    closeTo(result.meanSlopeDegrees, 85, 0.01);
+    closeTo(result.surfaceSquareMeters, 1_000_000 / Math.cos((85 * Math.PI) / 180), 1);
   });
 
   it("returns null when most samples are missing", () => {


### PR DESCRIPTION
## Summary
- Completing a measurement in the Measure tool now shows a **Terrain (3D)** panel section: terrain-draped surface distance, elevation gain/loss, and min/max elevation for lines; slope-corrected surface area and mean slope for polygons.
- Elevations come from the map's enabled 3D terrain via `queryTerrainElevation` (dividing MapLibre's baked-in exaggeration back out), falling back to the keyless Open-Meteo elevation API already used by the Elevation Profile plugin (Earth only, so planetary mode never queries Earth elevations). When no source is available the section stays hidden and planar measuring is unchanged; missing DEM samples degrade per-segment toward the planar value.
- Pure math lives in `terrain-measure-geometry.ts` (radius-parameterized for the active ellipsoid); panel integration, samplers, unit-aware formatting, and a `setTerrainMeasureLabels` i18n setter live in `terrain-measure.ts`, attached/detached with the Measure control's lifecycle.

## Test plan
- [x] 23 new unit tests in `tests/terrain-measure.test.ts` (3-4-5 slope cases, missing-elevation fallback, grid/area math, exaggeration correction, remote request chunking with stubbed fetch, unit-aware rows, non-Earth guard)
- [x] Full frontend suite passes (2630 pass, 0 fail); `tsc -b` and production build clean; pre-commit hooks pass
- [x] Verified in the running app over Zermatt: line across the Gornergrat flank read planar 1.64 km / surface 1.97 km with gain 423 m, loss 248 m, range 2948-3270 m (an independent Open-Meteo spot check of the endpoint, 3167 m, falls inside the range); unit switch re-rendered as 1.23 mi with elevations in feet; polygon read planar 2.09 km2 / surface 2.31 km2 at 23.6 deg mean slope, consistent with the convexity bound sec(23.6 deg) = 1.091 <= 2.31/2.09; Clear All hides the section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 3D terrain measurements to the Measure tool.
  * Displays terrain-adjusted surface distance and area, elevation gain/loss, elevation range, and mean slope.
  * Supports terrain data from the map and remote elevation services.
  * Shows progress indicators and partial-data notices when applicable.
  * Added localized labels for all terrain measurement results.

* **Bug Fixes**
  * Preserves existing measurement behavior when terrain data is unavailable.

* **Tests**
  * Added coverage for terrain calculations, sampling, unit conversions, and incomplete elevation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->