### PR TITLE
fix(assistant): make the Anthropic provider load in production builds

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -69,7 +69,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.10.1",
-    "maplibre-gl-geoagent": "^0.5.4",
+    "maplibre-gl-geoagent": "^0.5.5",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -981,7 +981,22 @@ export default defineConfig({
     } satisfies RollupOptions,
   },
   resolve: {
-    dedupe: ["react", "react-dom", "maplibre-gl"],
+    // `@anthropic-ai/sdk` (and the other assistant provider SDKs) are optional
+    // peers of `@strands-agents/sdk`, which is hoisted to the monorepo root. When
+    // a provider SDK can't hoist to root alongside it (e.g. a duplicate version
+    // pulled in by another dependency), strands' bare `import '@anthropic-ai/sdk'`
+    // is unresolvable from the root and the production build emits a throwing stub
+    // ("Cannot destructure property 'AnthropicModel' … is undefined"). Deduping
+    // these forces resolution from this app's node_modules — where they are always
+    // installed — so the build is deterministic across environments (see #331).
+    dedupe: [
+      "react",
+      "react-dom",
+      "maplibre-gl",
+      "@anthropic-ai/sdk",
+      "openai",
+      "@google/genai",
+    ],
     alias: {
       "@": path.resolve(__dirname, "./src"),
       module: path.resolve(__dirname, "./src/lib/browser-node-module.ts"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.10.1",
-        "maplibre-gl-geoagent": "^0.5.4",
+        "maplibre-gl-geoagent": "^0.5.5",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
@@ -16883,12 +16883,12 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.4.tgz",
-      "integrity": "sha512-xk9EzoLc2lMExqmKJRhQlK/Yvs509G9dfUESOCh9NU8L5PMVWkKLMgiHKJOmku+srvlQvrB1I4vq5LbDIyCorQ==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.5.5.tgz",
+      "integrity": "sha512-9Gi44pZ6bz5xtyi5GtTb5ttqITlchrsQYBhd0EVzvxgnE+yK14UDeyR/FWef6MlAa6kSYKo4AmTwYjh7SaWWlw==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.92.0",
+        "@anthropic-ai/sdk": "^0.111.0",
         "@google/earthengine": "^1.7.25",
         "@google/genai": "^1.52.0",
         "@strands-agents/sdk": "^1.1.0",
@@ -16912,12 +16912,13 @@
       }
     },
     "node_modules/maplibre-gl-geoagent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
-      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
+      "version": "0.111.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.111.0.tgz",
+      "integrity": "sha512-1hUqKi+uJQoS5X90+InwHbFAXMvgq0DnsC5hVLEeSRaODiU5WvmqDAcVCmGS2wC0pN9Z8jtWCbWw7JLzeDdm/Q==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -21848,7 +21849,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.10.1",
-        "maplibre-gl-geoagent": "^0.5.4",
+        "maplibre-gl-geoagent": "^0.5.5",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -43,7 +43,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.10.1",
-    "maplibre-gl-geoagent": "^0.5.4",
+    "maplibre-gl-geoagent": "^0.5.5",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",


### PR DESCRIPTION
## Problem

The AI assistant's **Anthropic** provider fails at runtime on the web build with:

> Cannot destructure property 'AnthropicModel' of '(intermediate value)' as it is undefined.

OpenAI works; Google works (any failure there is an API-key issue). Inspecting the deployed bundle, the `anthropic-*.js` chunk is a **176-byte throwing stub**:

```js
throw new Error('Could not resolve "@anthropic-ai/sdk" imported by "@strands-agents/sdk". Is it installed?');
export { r as AnthropicModel }; var r;   // undefined
```

## Root cause — a dependency-hoisting conflict

`@strands-agents/sdk` is hoisted to the **monorepo root** `node_modules`. Its provider models (`models/anthropic`, `models/openai`, `models/google`) `import` the corresponding SDK, which is an **optional peer** — so the consumer must supply it, resolvable from root.

- `openai` and `@google/genai` each resolve to a **single version → hoist to root → strands resolves them** → work.
- `@anthropic-ai/sdk` had a **version conflict**: the app pinned `^0.111.0`, but `maplibre-gl-geoagent` pinned `^0.92.0`. npm couldn't hoist one version, so it nested **both** — root had *no* `@anthropic-ai/sdk`, strands' `import '@anthropic-ai/sdk'` was `MODULE_NOT_FOUND` at build time, and rolldown emitted the throwing stub.

This is environment-sensitive: local builds happened to resolve the nested copy, but the CI build did not — so the deployed bundle shipped the stub even though the code was correct.

## Fix (two parts)

1. **Upstream:** bump `maplibre-gl-geoagent` `^0.5.4 → ^0.5.5`, which aligns its `@anthropic-ai/sdk` range to `^0.111.0` (opengeos/maplibre-gl-geoagent#30). geoagent never imports the SDK directly (only via `@strands-agents/sdk/models/anthropic`), so this is API-safe and removes the version conflict.
2. **Build determinism:** add `@anthropic-ai/sdk`, `openai`, `@google/genai` to Vite's `resolve.dedupe` (already used for `react`/`maplibre-gl`) so they always resolve from this app's `node_modules` regardless of how npm hoists them — the production build is now deterministic across environments.

## Verification

- `npm run build -w geolibre-desktop` ✅ — the `anthropic-*.js` chunk is now a **real** module re-exporting `AnthropicModel` from the bundled SDK (0 "Could not resolve", real `x-api-key`/`anthropic-version` in the chunk).
- `whitebox-wasm`/`cog-tiler-wasm` and the rest of the bundle unaffected; lockfile change is minimal (geoagent bump only).
- **Final confirmation** should be the Cloudflare preview build for this PR — its `anthropic-*.js` chunk must be a real module, not the stub. (My local environment resolves the nested copy either way, so CI is the true test.)

Fixes the Anthropic provider in the deployed web app. Unrelated: a Google `API_KEY_SERVICE_BLOCKED` 403 some users hit is a Google Cloud key/project restriction, not a GeoLibre bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production build reliability by ensuring assistant and provider integrations resolve consistently.
  * Updated the map-related integration to the latest compatible patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->