### PR TITLE
fix(plugins): cache the pinned product across panel rebuilds

### DIFF
--- a/packages/plugins/src/plugins/maplibre-source-coop.ts
+++ b/packages/plugins/src/plugins/maplibre-source-coop.ts
@@ -221,6 +221,14 @@ const extraProducts = new Map<string, SourceCoopProduct>();
  * back to the fallback and re-request the metadata each time — the same reason
  * `catalog` is cached above. Kept separate from `extraProducts` so a pinned
  * panel never quietly changes what the browse panel's search turns up.
+ *
+ * Deliberately kept for the life of the module, with no expiry: a hit only ever
+ * supplies the header's title and description, and a product is not renamed
+ * mid-session in practice. The file listing — the part that is actually data —
+ * is never cached and re-lists on every mount, so nothing the user acts on can
+ * go stale here. Only a successful fetch is cached (see `enrichPinnedProduct`),
+ * so a failed enrichment is retried on the next mount rather than being pinned
+ * to the fallback title.
  */
 const pinnedProducts = new Map<string, SourceCoopProduct>();
 

--- a/packages/plugins/src/plugins/maplibre-source-coop.ts
+++ b/packages/plugins/src/plugins/maplibre-source-coop.ts
@@ -214,6 +214,15 @@ const mountedPanels = new Set<() => void>();
 let catalog: SourceCoopProduct[] | null = null;
 /** Products discovered by browsing an account or resolving an id, merged into search. */
 const extraProducts = new Map<string, SourceCoopProduct>();
+/**
+ * Enriched records for pinned products, keyed `account/product` and cached
+ * across panel rebuilds. A language change remounts every panel (see
+ * {@link setSourceCoopLabels}), which would otherwise drop the fetched title
+ * back to the fallback and re-request the metadata each time — the same reason
+ * `catalog` is cached above. Kept separate from `extraProducts` so a pinned
+ * panel never quietly changes what the browse panel's search turns up.
+ */
+const pinnedProducts = new Map<string, SourceCoopProduct>();
 
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
@@ -393,7 +402,9 @@ function buildPanel(
   let view: View = pinned
     ? {
         kind: "product",
-        product: synthesizeProduct(pinned.accountId, pinned.productId, pinned.title),
+        product:
+          pinnedProducts.get(`${pinned.accountId}/${pinned.productId}`) ??
+          synthesizeProduct(pinned.accountId, pinned.productId, pinned.title),
         prefix: `${pinned.productId}/`,
       }
     : { kind: "browse" };
@@ -880,6 +891,10 @@ function buildPanel(
    */
   async function enrichPinnedProduct(): Promise<void> {
     if (!pinned) return;
+    const id = `${pinned.accountId}/${pinned.productId}`;
+    // Enriched on an earlier mount, and already used for the initial `view`
+    // above — so a language change costs no request and shows no flash.
+    if (pinnedProducts.has(id)) return;
     const controller = new AbortController();
     enrichInflight = controller;
     const product = await fetchProduct(
@@ -887,15 +902,19 @@ function buildPanel(
       pinned.productId,
       clientOptions(app, controller.signal),
     );
+    // Cached even if the panel has gone away: the record is still valid, so the
+    // next mount reads it from here instead of asking again. An abort that
+    // landed mid-flight leaves `product` null (`fetchProduct` maps a rejection
+    // to null), so nothing is cached in that case.
+    if (product) pinnedProducts.set(id, product);
     // The panel was torn down (or rebuilt for a language change) while this was
-    // in flight — `root` is detached, so rendering into it would be wasted work.
-    // Checked explicitly rather than relying on the abort: `fetchProduct` maps a
-    // rejection to null, so an abort that lands mid-flight is already handled
-    // below, but one that lands after the fetch resolves is not.
-    if (controller.signal.aborted) return;
+    // in flight — `root` is detached, so rendering into it is wasted work. The
+    // abort is checked explicitly because one that lands *after* the fetch
+    // resolves leaves `product` set and would otherwise render.
+    if (controller.signal.aborted || !product) return;
     // The user may have navigated into a subfolder meanwhile, so keep the
     // current prefix and swap only the record.
-    if (!product || view.kind !== "product") return;
+    if (view.kind !== "product") return;
     view = { ...view, product };
     render();
   }


### PR DESCRIPTION
## Summary
- Follow-up to #1263, from review feedback that landed after it merged.
- A language change remounts every Source Cooperative panel, which rebuilt a pinned panel's view from `synthesizeProduct`. That flashed the Natural Earth header back to the fallback title and re-fetched the product metadata on every locale switch. The enriched record is now cached at module scope, keyed `account/product`, mirroring how `catalog` already solves this for browse mode: the initial view reads from the cache and the enrichment short-circuits on a hit.
- The cache is kept separate from `extraProducts` so a pinned panel never quietly changes what the browse panel's search turns up. The record is cached even when the fetch resolves after teardown, since it stays valid for the next mount.

## Test plan
- [x] `npm run typecheck` (full build) clean
- [x] `npm run test:frontend` green: 2784 passing, 0 failing
- [x] `npm run lint`: 0 errors (23 pre-existing warnings, none in the touched file)
- [x] Verified in-app against real data: opened Plugins > Web Services > Natural Earth, then switched the UI language to French via Settings > Language. The panel keeps its enriched title and description ("Natural Earth Data") instead of reverting to the fallback, and the remount issues zero additional metadata requests (1 total, unchanged from first mount).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned product details now persist across panel rebuilds (for example, after changing language settings).
  * Avoided redundant product metadata fetches by reusing cached pinned product info.
  * Improved resilience when lookups are cancelled or return no result, preventing incomplete details from being shown.
  * Added safeguards to stop unintended product swapping or re-rendering when a request is aborted or the panel is no longer showing the product view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->