### PR TITLE
feat(conversion): run COG, FlatGeobuf, Shapefile, GeoPackage conversions in the browser

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -225,6 +225,11 @@ export function ProcessingMenu({
               {t("toolbar.conversion.vectorToPmtiles")}
             </DropdownMenuItem>
             <DropdownMenuItem
+              onSelect={() => setConversionOpen("raster-to-pmtiles")}
+            >
+              {t("toolbar.conversion.rasterToPmtiles")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
               onSelect={() => setConversionOpen("raster-to-cog")}
             >
               {t("toolbar.conversion.rasterToCog")}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -137,6 +137,10 @@ export const CONVERSION_COMMANDS: Array<{
   },
   { kind: "csv-to-geoparquet", titleKey: "toolbar.conversion.csvToGeoparquet" },
   { kind: "vector-to-pmtiles", titleKey: "toolbar.conversion.vectorToPmtiles" },
+  {
+    kind: "raster-to-pmtiles",
+    titleKey: "toolbar.conversion.rasterToPmtiles",
+  },
   { kind: "raster-to-cog", titleKey: "toolbar.conversion.rasterToCog" },
 ];
 

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -456,7 +456,10 @@ export function ConversionDialog() {
   const [layerName, setLayerName] = useState("data");
   const [minZoom, setMinZoom] = useState("0");
   const [maxZoom, setMaxZoom] = useState("14");
-  const [colormap, setColormap] = useState<PmtilesColormap>("viridis");
+  // Empty means "leave it to the tool", which is what makes colormap optional:
+  // write_pmtiles marks it optional and picks viridis itself, so the dialog
+  // omits the flag rather than pinning a default of its own.
+  const [colormap, setColormap] = useState<PmtilesColormap | "">("");
   const [resampling, setResampling] =
     useState<PmtilesResamplingMethod>("bilinear");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
@@ -530,7 +533,7 @@ export function ConversionDialog() {
     setLayerName("data");
     setMinZoom("0");
     setMaxZoom("14");
-    setColormap("viridis");
+    setColormap("");
     setResampling("bilinear");
     setError(null);
     setJob(null);
@@ -904,7 +907,8 @@ export function ConversionDialog() {
           minZoom: parsedMin,
           maxZoom: parsedMax,
           band: 1,
-          colormap,
+          // Omitted when unset, so the tool applies its own default.
+          colormap: colormap || undefined,
           method: resampling,
         },
       );
@@ -1402,9 +1406,12 @@ export function ConversionDialog() {
                   id="conversion-colormap"
                   value={colormap}
                   onChange={(event) =>
-                    setColormap(event.target.value as PmtilesColormap)
+                    setColormap(event.target.value as PmtilesColormap | "")
                   }
                 >
+                  <option value="">
+                    {t("toolbar.conversion.colormapDefault")}
+                  </option>
                   {PMTILES_COLORMAPS.map((option) => (
                     <option key={option} value={option}>
                       {option}

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -1,5 +1,8 @@
 import { useAppStore, type ConversionToolKind } from "@geolibre/core";
 import {
+  COG_WASM_COMPRESSIONS,
+  PMTILES_COLORMAPS,
+  PMTILES_RESAMPLING_METHODS,
   fetchConversionJob,
   fetchConversionStatus,
   runCsvToGeoParquet,
@@ -10,7 +13,10 @@ import {
   runVectorToPmtiles,
   runVectorToShapefile,
   runVectorToVector,
+  type CogWasmCompression,
   type ConversionJob,
+  type PmtilesColormap,
+  type PmtilesResamplingMethod,
 } from "@geolibre/processing";
 import {
   Button,
@@ -34,6 +40,7 @@ import {
   Save,
   Server,
 } from "lucide-react";
+import type { ParseKeys } from "i18next";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -57,6 +64,10 @@ const BROWSER_JOB_ID = "browser-duckdb-wasm";
 const SHAPEFILE_SIDECAR_EXTENSIONS = new Set(["dbf", "shx", "prj", "cpg"]);
 
 const GEOPARQUET_MIME_TYPE = "application/vnd.apache.parquet";
+
+const GEOTIFF_MIME_TYPE = "image/tiff";
+
+const PMTILES_MIME_TYPE = "application/vnd.pmtiles";
 
 function fileExtension(name: string): string {
   const index = name.lastIndexOf(".");
@@ -149,6 +160,16 @@ interface ConversionToolConfig {
   defaultOutputName: string;
   compressions?: string[];
   defaultCompression?: string;
+  /** Input filters when running in-browser, for tools whose WASM engine reads a
+   * narrower set of formats than the sidecar's GDAL. Falls back to
+   * `inputFilters`. */
+  browserInputFilters?: FileDialogFilter[];
+  /** Compression choices when running in-browser, for tools whose WASM encoder
+   * supports fewer codecs than the sidecar's. Falls back to `compressions`. */
+  browserCompressions?: string[];
+  /** Extra note shown only when the in-browser engine is in use, calling out
+   * where it diverges from the sidecar. */
+  browserNote?: string;
 }
 
 const VECTOR_INPUT_EXTENSIONS = [
@@ -226,6 +247,69 @@ const VECTOR_TO_VECTOR_OUTPUT_EXTENSIONS = [
 /** The in-browser writer for an output extension, or null when unsupported. */
 function browserExportFormatForExtension(extension: string) {
   return BROWSER_OUTPUT_FORMATS[extension] ?? null;
+}
+
+// Conversions with a client-side engine (DuckDB-WASM, the pure-JS writers, or
+// geolibre-wasm). On desktop these still prefer the sidecar, whose GDAL/rio-cogeo
+// stack reads more input formats and preserves dtypes and codecs the WASM
+// writers cannot — so this set only takes effect in the browser build.
+//
+// Vector to PMTiles is absent deliberately: geolibre-wasm's `write_pmtiles`
+// renders *rasters*, and `PmtilesExtractor` only subsets an existing archive, so
+// there is no client-side vector tiler to replace the sidecar's freestiler.
+const WEB_RUNTIME_KINDS: ReadonlySet<ConversionToolKind> = new Set([
+  "vector-to-vector",
+  "vector-to-geoparquet",
+  "csv-to-geoparquet",
+  "vector-to-flatgeobuf",
+  "vector-to-shapefile",
+  "vector-to-geopackage",
+  "raster-to-cog",
+]);
+
+// Raster to PMTiles has no sidecar endpoint at all — geolibre-wasm is its only
+// engine — so it runs client-side on desktop too.
+const WASM_ONLY_KINDS: ReadonlySet<ConversionToolKind> = new Set([
+  "raster-to-pmtiles",
+]);
+
+/** Whether a tool runs client-side rather than through the Python sidecar. */
+function conversionUsesBrowserRuntime(
+  kind: ConversionToolKind,
+  desktop: boolean,
+): boolean {
+  if (WASM_ONLY_KINDS.has(kind)) return true;
+  return !desktop && WEB_RUNTIME_KINDS.has(kind);
+}
+
+// Vector output extensions no JS writer covers but geolibre-wasm's
+// `vector_convert` does, so in-browser Vector to Vector can offer them too.
+// FlatGeobuf has no registered IANA media type; octet-stream is what the
+// browser save picker needs to offer a plain binary download.
+const WASM_VECTOR_OUTPUT_FORMATS: Record<
+  string,
+  { description: string; mimeType: string }
+> = {
+  fgb: { description: "FlatGeobuf", mimeType: "application/octet-stream" },
+};
+
+const WASM_VECTOR_OUTPUT_EXTENSIONS = new Set(
+  Object.keys(WASM_VECTOR_OUTPUT_FORMATS),
+);
+
+/** Names the engine backing a tool's client-side path, for the status line. */
+function browserRuntimeMessageKey(kind: ConversionToolKind): ParseKeys {
+  switch (kind) {
+    case "raster-to-cog":
+    case "raster-to-pmtiles":
+    case "vector-to-flatgeobuf":
+      return "toolbar.conversion.runsInBrowserWasm";
+    case "vector-to-shapefile":
+    case "vector-to-geopackage":
+      return "toolbar.conversion.runsInBrowserWriters";
+    default:
+      return "toolbar.conversion.runsInBrowserDuckDb";
+  }
 }
 
 const TOOL_CONFIGS: Record<ConversionToolKind, ConversionToolConfig> = {
@@ -312,6 +396,16 @@ const TOOL_CONFIGS: Record<ConversionToolKind, ConversionToolConfig> = {
     outputFilters: [{ name: "PMTiles", extensions: ["pmtiles"] }],
     defaultOutputName: "tiles.pmtiles",
   },
+  "raster-to-pmtiles": {
+    title: "Raster to PMTiles",
+    description:
+      "Render a raster into a single PMTiles archive of Web Mercator PNG tiles, ready for cloud-native serving. Runs entirely in WebAssembly, so it needs no sidecar on either the web or desktop app.",
+    inputLabel: "Input raster file",
+    inputFilters: [{ name: "GeoTIFF", extensions: ["tif", "tiff"] }],
+    outputLabel: "Output PMTiles file",
+    outputFilters: [{ name: "PMTiles", extensions: ["pmtiles"] }],
+    defaultOutputName: "raster.pmtiles",
+  },
   "raster-to-cog": {
     title: "Raster to COG",
     description:
@@ -323,11 +417,17 @@ const TOOL_CONFIGS: Record<ConversionToolKind, ConversionToolConfig> = {
         extensions: ["tif", "tiff", "img", "vrt", "asc", "nc", "jp2", "hgt"],
       },
     ],
+    // The in-browser encoder is geolibre-wasm's GeoTiffReader, which reads
+    // GeoTIFF only; the other formats above need the sidecar's GDAL.
+    browserInputFilters: [{ name: "GeoTIFF", extensions: ["tif", "tiff"] }],
     outputLabel: "Output COG file",
     outputFilters: [{ name: "GeoTIFF", extensions: ["tif", "tiff"] }],
     defaultOutputName: "output_cog.tif",
     compressions: ["deflate", "zstd", "lzw", "webp", "jpeg", "packbits", "raw"],
+    browserCompressions: [...COG_WASM_COMPRESSIONS],
     defaultCompression: "deflate",
+    browserNote:
+      "In the browser, 8-bit rasters keep their type and everything else (Int16 DEMs, Float64, …) is written as Float32. The desktop app preserves the original type.",
   },
 };
 
@@ -356,6 +456,9 @@ export function ConversionDialog() {
   const [layerName, setLayerName] = useState("data");
   const [minZoom, setMinZoom] = useState("0");
   const [maxZoom, setMaxZoom] = useState("14");
+  const [colormap, setColormap] = useState<PmtilesColormap>("viridis");
+  const [resampling, setResampling] =
+    useState<PmtilesResamplingMethod>("bilinear");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [startingServer, setStartingServer] = useState(false);
@@ -365,18 +468,20 @@ export function ConversionDialog() {
 
   const config = kind ? TOOL_CONFIGS[kind] : null;
   const desktop = isTauri();
-  // These conversions run entirely in-browser with DuckDB-WASM (plus the
-  // bundled JS writers) and never need the Python sidecar. On desktop the same
-  // tools prefer the sidecar, which covers every format. FlatGeobuf and PMTiles
-  // have no WASM writer, so they stay sidecar-only.
-  const usesBrowserRuntime =
-    !desktop &&
-    (kind === "vector-to-vector" ||
-      kind === "vector-to-geoparquet" ||
-      kind === "csv-to-geoparquet");
+  const usesBrowserRuntime = kind ? conversionUsesBrowserRuntime(kind, desktop) : false;
   const isCsv = kind === "csv-to-geoparquet";
   const isPmtiles = kind === "vector-to-pmtiles";
-  const showCompression = Boolean(config?.compressions);
+  const isRasterPmtiles = kind === "raster-to-pmtiles";
+  const isRasterInput = kind === "raster-to-cog" || kind === "raster-to-pmtiles";
+  // The WASM encoder supports fewer codecs and reads fewer formats than the
+  // sidecar's GDAL, so both lists resolve per runtime.
+  const compressionOptions = usesBrowserRuntime
+    ? (config?.browserCompressions ?? config?.compressions)
+    : config?.compressions;
+  const showCompression = Boolean(compressionOptions?.length);
+  const inputFilters = usesBrowserRuntime
+    ? (config?.browserInputFilters ?? config?.inputFilters ?? [])
+    : (config?.inputFilters ?? []);
   // Row group size is a Parquet concept, so it is shown only for the
   // GeoParquet writers — not for Raster to COG, which also has a compression
   // option.
@@ -384,18 +489,17 @@ export function ConversionDialog() {
     kind === "vector-to-geoparquet" || kind === "csv-to-geoparquet";
 
   const checkRuntime = useCallback(async () => {
-    if (usesBrowserRuntime) {
+    if (usesBrowserRuntime && kind) {
       setRuntimeAvailable(true);
-      setRuntimeMessage("Conversion runs in your browser with DuckDB-WASM.");
+      setRuntimeMessage(i18n.t(browserRuntimeMessageKey(kind)));
       return;
     }
     if (!desktop) {
-      // FlatGeobuf / PMTiles have no in-browser writer and need the sidecar,
-      // which a pure web build cannot start.
+      // Only Vector to PMTiles reaches this: it is the one conversion with no
+      // client-side engine (see WEB_RUNTIME_KINDS), and a pure web build cannot
+      // start the sidecar it needs.
       setRuntimeAvailable(false);
-      setRuntimeMessage(
-        "This conversion needs the GeoLibre desktop app or a running sidecar.",
-      );
+      setRuntimeMessage(i18n.t("toolbar.conversion.needsDesktop"));
       return;
     }
     setRuntimeAvailable(null);
@@ -426,6 +530,8 @@ export function ConversionDialog() {
     setLayerName("data");
     setMinZoom("0");
     setMaxZoom("14");
+    setColormap("viridis");
+    setResampling("bilinear");
     setError(null);
     setJob(null);
     void checkRuntime();
@@ -484,7 +590,7 @@ export function ConversionDialog() {
     // Allow multi-select so Shapefile sidecars (.dbf/.shx/.prj/.cpg) can be
     // provided alongside the .shp file.
     input.multiple = true;
-    input.accept = config.inputFilters
+    input.accept = inputFilters
       .flatMap((filter) => filter.extensions)
       .concat([...SHAPEFILE_SIDECAR_EXTENSIONS])
       .map((extension) => `.${extension}`)
@@ -528,34 +634,36 @@ export function ConversionDialog() {
     if (path) setOutputPath(path);
   };
 
-  // In-browser path for the generic Vector to Vector tool: read any format with
-  // DuckDB-WASM (ST_Read), then write the subset the browser can produce by
-  // dispatching on the output extension. Arbitrary GDAL formats need the desktop
-  // sidecar; this is only reached on the web build.
-  const runBrowserVectorToVector = async (mainFile: File, siblings: File[]) => {
-    if (!kind) return;
-    const toolId = kind;
-    // The in-browser DuckDB reader cannot open a zipped Shapefile (ST_Read needs
-    // GDAL's /vsizip/, which only the sidecar uses); guide the user instead of
-    // failing deep in the loader. The desktop app reads .zip inputs directly.
-    if (fileExtension(mainFile.name) === "zip") {
-      setError(i18n.t("toolbar.conversion.zipInputBrowserError"));
-      return;
-    }
-    const outputName =
-      outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name);
-    const outputExtension = fileExtension(outputName);
-    const format = browserExportFormatForExtension(outputExtension);
-    if (!format) {
-      setError(
-        outputExtension
-          ? i18n.t("toolbar.conversion.browserOutputUnsupported", {
-              extension: outputExtension,
-            })
-          : i18n.t("toolbar.conversion.outputExtensionRequired"),
-      );
-      return;
-    }
+  /** Read a browser-selected file into the {name, data} shape the WASM tools take. */
+  const toWasmFile = async (file: File) => ({
+    name: file.name,
+    data: new Uint8Array(await file.arrayBuffer()),
+  });
+
+  // The in-browser DuckDB reader cannot open a zipped Shapefile (ST_Read needs
+  // GDAL's /vsizip/, which only the sidecar uses); guide the user instead of
+  // failing deep in the loader. The desktop app reads .zip inputs directly.
+  const rejectZipInput = (mainFile: File): boolean => {
+    if (fileExtension(mainFile.name) !== "zip") return false;
+    setError(i18n.t("toolbar.conversion.zipInputBrowserError"));
+    return true;
+  };
+
+  /**
+   * Read any vector input to GeoJSON with DuckDB-WASM, then hand it to one of the
+   * bundled JS writers. Backs in-browser Vector to Vector as well as the
+   * fixed-format Shapefile/GeoPackage writers.
+   *
+   * Returns once the job state has been set; `null` from the loader means the
+   * user declined the large-dataset prompt.
+   */
+  const runBrowserVectorExport = async (
+    toolId: ConversionToolKind,
+    mainFile: File,
+    siblings: File[],
+    format: NonNullable<ReturnType<typeof browserExportFormatForExtension>>,
+    outputName: string,
+  ) => {
     setError(null);
     setJob(
       browserConversionJob(toolId, "running", [
@@ -625,6 +733,207 @@ export function ConversionDialog() {
     }
   };
 
+  /**
+   * In-browser vector conversion through geolibre-wasm's `vector_convert`, for
+   * the formats the JS writers do not cover (FlatGeobuf). Unlike the DuckDB
+   * path this streams the file straight into the WASI tool, so it never
+   * materializes a GeoJSON copy.
+   */
+  const runBrowserVectorViaWasm = async (
+    toolId: ConversionToolKind,
+    mainFile: File,
+    siblings: File[],
+    outputName: string,
+  ) => {
+    setError(null);
+    setJob(
+      browserConversionJob(toolId, "running", [
+        i18n.t("toolbar.conversion.convertingWithWasm", { name: mainFile.name }),
+      ]),
+    );
+    try {
+      const { convertVectorWithWasm } = await import("@geolibre/processing");
+      const result = await convertVectorWithWasm(
+        await toWasmFile(mainFile),
+        outputName,
+        await Promise.all(siblings.map(toWasmFile)),
+      );
+      const extension = fileExtension(outputName);
+      const format = WASM_VECTOR_OUTPUT_FORMATS[extension];
+      const savedName = await saveBinaryFileWithFallback(result.data, {
+        defaultName: outputName,
+        filters: config?.outputFilters ?? [],
+        mimeType: format?.mimeType ?? "application/octet-stream",
+        browserTypes: format
+          ? [
+              {
+                description: format.description,
+                accept: { [format.mimeType]: [`.${extension}`] },
+              },
+            ]
+          : [],
+      });
+      setJob(
+        browserConversionJob(toolId, "succeeded", [
+          ...result.messages,
+          savedName
+            ? i18n.t("toolbar.conversion.savedFile", { name: savedName })
+            : i18n.t("toolbar.conversion.saveCanceled"),
+        ]),
+      );
+    } catch (err) {
+      const detail =
+        err instanceof Error ? err.message : "Could not convert this file.";
+      setJob(browserConversionJob(toolId, "failed", [detail], detail));
+    }
+  };
+
+  // In-browser path for the generic Vector to Vector tool: dispatch on the
+  // output extension to whichever client-side engine can write it. Arbitrary
+  // GDAL formats (KML, GML, …) still need the desktop sidecar.
+  const runBrowserVectorToVector = async (mainFile: File, siblings: File[]) => {
+    if (!kind || rejectZipInput(mainFile)) return;
+    const outputName =
+      outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name);
+    const outputExtension = fileExtension(outputName);
+    if (WASM_VECTOR_OUTPUT_EXTENSIONS.has(outputExtension)) {
+      await runBrowserVectorViaWasm(kind, mainFile, siblings, outputName);
+      return;
+    }
+    const format = browserExportFormatForExtension(outputExtension);
+    if (!format) {
+      setError(
+        outputExtension
+          ? i18n.t("toolbar.conversion.browserOutputUnsupported", {
+              extension: outputExtension,
+            })
+          : i18n.t("toolbar.conversion.outputExtensionRequired"),
+      );
+      return;
+    }
+    await runBrowserVectorExport(kind, mainFile, siblings, format, outputName);
+  };
+
+  /** In-browser Raster to COG via geolibre-wasm's CogBuilder. */
+  const runBrowserRasterToCog = async (mainFile: File) => {
+    if (!kind) return;
+    const toolId = kind;
+    const outputName =
+      outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name);
+    setError(null);
+    setJob(
+      browserConversionJob(toolId, "running", [
+        i18n.t("toolbar.conversion.convertingWithWasm", { name: mainFile.name }),
+      ]),
+    );
+    try {
+      const { convertGeoTiffToCog, readGeoTiffInfo } = await import(
+        "@geolibre/processing"
+      );
+      const bytes = new Uint8Array(await mainFile.arrayBuffer());
+      // Header-only read: cheap, and it lets us report the shape and warn about
+      // an already-tiled input before decoding any pixels.
+      const info = await readGeoTiffInfo(bytes);
+      if (!info.ok) {
+        throw new Error(i18n.t("toolbar.conversion.notAGeoTiff"));
+      }
+      const data = await convertGeoTiffToCog(bytes, {
+        compression: compression as CogWasmCompression,
+      });
+      const savedName = await saveBinaryFileWithFallback(data, {
+        defaultName: outputName,
+        filters: config?.outputFilters ?? [],
+        mimeType: GEOTIFF_MIME_TYPE,
+        browserTypes: [
+          {
+            description: "GeoTIFF",
+            accept: { [GEOTIFF_MIME_TYPE]: [".tif", ".tiff"] },
+          },
+        ],
+      });
+      setJob(
+        browserConversionJob(toolId, "succeeded", [
+          i18n.t("toolbar.conversion.rasterShape", {
+            width: info.width,
+            height: info.height,
+            bands: info.bands,
+          }),
+          i18n.t("toolbar.conversion.wroteCog", { compression }),
+          savedName
+            ? i18n.t("toolbar.conversion.savedFile", { name: savedName })
+            : i18n.t("toolbar.conversion.saveCanceled"),
+        ]),
+      );
+    } catch (err) {
+      const detail =
+        err instanceof Error ? err.message : "Could not convert this file.";
+      setJob(browserConversionJob(toolId, "failed", [detail], detail));
+    }
+  };
+
+  /** Raster to PMTiles via geolibre-wasm's `write_pmtiles`, on web and desktop. */
+  const runBrowserRasterToPmtiles = async (mainFile: File) => {
+    if (!kind) return;
+    const toolId = kind;
+    const parsedMin = Number.parseInt(minZoom, 10);
+    const parsedMax = Number.parseInt(maxZoom, 10);
+    if (
+      !Number.isFinite(parsedMin) ||
+      !Number.isFinite(parsedMax) ||
+      parsedMin < 0 ||
+      parsedMin > parsedMax ||
+      parsedMax > 24
+    ) {
+      setError(i18n.t("toolbar.conversion.zoomRangeError"));
+      return;
+    }
+    const outputName =
+      outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name);
+    setError(null);
+    setJob(
+      browserConversionJob(toolId, "running", [
+        i18n.t("toolbar.conversion.convertingWithWasm", { name: mainFile.name }),
+      ]),
+    );
+    try {
+      const { renderRasterToPmtiles } = await import("@geolibre/processing");
+      const result = await renderRasterToPmtiles(
+        await toWasmFile(mainFile),
+        outputName,
+        {
+          minZoom: parsedMin,
+          maxZoom: parsedMax,
+          band: 1,
+          colormap,
+          method: resampling,
+        },
+      );
+      const savedName = await saveBinaryFileWithFallback(result.data, {
+        defaultName: outputName,
+        filters: config?.outputFilters ?? [],
+        mimeType: PMTILES_MIME_TYPE,
+        browserTypes: [
+          {
+            description: "PMTiles",
+            accept: { [PMTILES_MIME_TYPE]: [".pmtiles"] },
+          },
+        ],
+      });
+      setJob(
+        browserConversionJob(toolId, "succeeded", [
+          ...result.messages,
+          savedName
+            ? i18n.t("toolbar.conversion.savedFile", { name: savedName })
+            : i18n.t("toolbar.conversion.saveCanceled"),
+        ]),
+      );
+    } catch (err) {
+      const detail =
+        err instanceof Error ? err.message : "Could not convert this file.";
+      setJob(browserConversionJob(toolId, "failed", [detail], detail));
+    }
+  };
+
   const runBrowserConversion = async () => {
     // Only reached when usesBrowserRuntime is true, which requires a kind.
     if (!kind) return;
@@ -636,6 +945,35 @@ export function ConversionDialog() {
     }
     if (kind === "vector-to-vector") {
       await runBrowserVectorToVector(mainFile, siblings);
+      return;
+    }
+    if (kind === "raster-to-cog") {
+      await runBrowserRasterToCog(mainFile);
+      return;
+    }
+    if (kind === "raster-to-pmtiles") {
+      await runBrowserRasterToPmtiles(mainFile);
+      return;
+    }
+    if (kind === "vector-to-flatgeobuf") {
+      if (rejectZipInput(mainFile)) return;
+      await runBrowserVectorViaWasm(
+        kind,
+        mainFile,
+        siblings,
+        outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name),
+      );
+      return;
+    }
+    if (kind === "vector-to-shapefile" || kind === "vector-to-geopackage") {
+      if (rejectZipInput(mainFile)) return;
+      await runBrowserVectorExport(
+        kind,
+        mainFile,
+        siblings,
+        kind === "vector-to-shapefile" ? "shapefile" : "geopackage",
+        outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name),
+      );
       return;
     }
     const parsedRowGroupSize = Number.parseInt(rowGroupSize, 10);
@@ -811,8 +1149,13 @@ export function ConversionDialog() {
             max_zoom: parsedMax,
           }),
         );
-      } else {
+      } else if (kind === "raster-to-cog") {
         setJob(await runRasterToCog({ input_path, output_path, compression }));
+      } else {
+        // raster-to-pmtiles is the only remaining kind and has no sidecar
+        // endpoint; conversionUsesBrowserRuntime always routes it to the WASM
+        // path above, so reaching here means those two have drifted apart.
+        setError(`${kind} has no sidecar conversion.`);
       }
     } catch (err) {
       setError(
@@ -837,6 +1180,9 @@ export function ConversionDialog() {
         </DialogHeader>
 
         <div className="grid gap-4">
+          {usesBrowserRuntime && config?.browserNote && (
+            <p className="text-xs text-muted-foreground">{config.browserNote}</p>
+          )}
           {runtimeAvailable === false && (
             <div className="grid gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
               <p className="flex items-start gap-2 text-sm text-destructive">
@@ -889,7 +1235,7 @@ export function ConversionDialog() {
                 <FolderOpen className="h-4 w-4" />
               </Button>
             </div>
-            {usesBrowserRuntime && !isCsv && (
+            {usesBrowserRuntime && !isCsv && !isRasterInput && (
               <p className="text-xs text-muted-foreground">
                 For Shapefiles, select the .shp together with its .dbf, .shx,
                 and .prj files.
@@ -991,7 +1337,7 @@ export function ConversionDialog() {
                   value={compression}
                   onChange={(event) => setCompression(event.target.value)}
                 >
-                  {(config?.compressions ?? []).map((option) => (
+                  {(compressionOptions ?? []).map((option) => (
                     <option key={option} value={option}>
                       {option}
                     </option>
@@ -1038,6 +1384,65 @@ export function ConversionDialog() {
                 <Label htmlFor="conversion-max-zoom">Max zoom</Label>
                 <Input
                   id="conversion-max-zoom"
+                  inputMode="numeric"
+                  value={maxZoom}
+                  onChange={(event) => setMaxZoom(event.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          {isRasterPmtiles && (
+            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_5rem_5rem] gap-4">
+              <div className="grid gap-1.5">
+                <Label htmlFor="conversion-colormap">
+                  {t("toolbar.conversion.colormap")}
+                </Label>
+                <Select
+                  id="conversion-colormap"
+                  value={colormap}
+                  onChange={(event) =>
+                    setColormap(event.target.value as PmtilesColormap)
+                  }
+                >
+                  {PMTILES_COLORMAPS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="conversion-resampling">
+                  {t("toolbar.conversion.resampling")}
+                </Label>
+                <Select
+                  id="conversion-resampling"
+                  value={resampling}
+                  onChange={(event) =>
+                    setResampling(event.target.value as PmtilesResamplingMethod)
+                  }
+                >
+                  {PMTILES_RESAMPLING_METHODS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="conversion-raster-min-zoom">Min zoom</Label>
+                <Input
+                  id="conversion-raster-min-zoom"
+                  inputMode="numeric"
+                  value={minZoom}
+                  onChange={(event) => setMinZoom(event.target.value)}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="conversion-raster-max-zoom">Max zoom</Label>
+                <Input
+                  id="conversion-raster-max-zoom"
                   inputMode="numeric"
                   value={maxZoom}
                   onChange={(event) => setMaxZoom(event.target.value)}

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -297,6 +297,45 @@ const WASM_VECTOR_OUTPUT_EXTENSIONS = new Set(
   Object.keys(WASM_VECTOR_OUTPUT_FORMATS),
 );
 
+/** Deepest zoom either PMTiles tool accepts. */
+const MAX_PMTILES_ZOOM = 24;
+
+/** A parsed zoom range; an undefined bound was left blank by the user. */
+interface PmtilesZoomRange {
+  minZoom?: number;
+  maxZoom?: number;
+}
+
+/**
+ * Parse the shared min/max zoom inputs, enforcing `0 ≤ min ≤ max ≤ 24`. Blank
+ * means "unset" and is returned as undefined — Vector to PMTiles rejects that
+ * (the sidecar requires both), while Raster to PMTiles passes it through so
+ * `write_pmtiles` applies its own native-resolution default.
+ *
+ * @returns The parsed bounds, or null when the input is out of range.
+ */
+function parseZoomRange(
+  rawMin: string,
+  rawMax: string,
+): PmtilesZoomRange | null {
+  const parse = (raw: string): number | null | undefined => {
+    const text = raw.trim();
+    if (!text) return undefined;
+    const value = Number.parseInt(text, 10);
+    if (!Number.isFinite(value) || value < 0 || value > MAX_PMTILES_ZOOM) {
+      return null;
+    }
+    return value;
+  };
+  const minZoom = parse(rawMin);
+  const maxZoom = parse(rawMax);
+  if (minZoom === null || maxZoom === null) return null;
+  if (minZoom !== undefined && maxZoom !== undefined && minZoom > maxZoom) {
+    return null;
+  }
+  return { minZoom, maxZoom };
+}
+
 /** Names the engine backing a tool's client-side path, for the status line. */
 function browserRuntimeMessageKey(kind: ConversionToolKind): ParseKeys {
   switch (kind) {
@@ -517,7 +556,7 @@ export function ConversionDialog() {
         err instanceof Error ? err.message : "Could not connect to sidecar.",
       );
     }
-  }, [desktop, usesBrowserRuntime]);
+  }, [desktop, kind, usesBrowserRuntime]);
 
   // Reset per-tool state when the dialog opens or the tool changes.
   useEffect(() => {
@@ -531,8 +570,12 @@ export function ConversionDialog() {
     setLatColumn("latitude");
     setCsvColumns([]);
     setLayerName("data");
-    setMinZoom("0");
-    setMaxZoom("14");
+    // Vector to PMTiles tiles the whole pyramid and its sidecar needs explicit
+    // bounds; Raster to PMTiles starts blank so write_pmtiles picks the zoom
+    // matching the raster's own resolution.
+    const rasterPmtiles = kind === "raster-to-pmtiles";
+    setMinZoom(rasterPmtiles ? "" : "0");
+    setMaxZoom(rasterPmtiles ? "" : "14");
     setColormap("");
     setResampling("bilinear");
     setError(null);
@@ -878,15 +921,8 @@ export function ConversionDialog() {
   const runBrowserRasterToPmtiles = async (mainFile: File) => {
     if (!kind) return;
     const toolId = kind;
-    const parsedMin = Number.parseInt(minZoom, 10);
-    const parsedMax = Number.parseInt(maxZoom, 10);
-    if (
-      !Number.isFinite(parsedMin) ||
-      !Number.isFinite(parsedMax) ||
-      parsedMin < 0 ||
-      parsedMin > parsedMax ||
-      parsedMax > 24
-    ) {
+    const zooms = parseZoomRange(minZoom, maxZoom);
+    if (!zooms) {
       setError(i18n.t("toolbar.conversion.zoomRangeError"));
       return;
     }
@@ -899,13 +935,23 @@ export function ConversionDialog() {
       ]),
     );
     try {
-      const { renderRasterToPmtiles } = await import("@geolibre/processing");
+      const { readGeoTiffInfo, renderRasterToPmtiles } = await import(
+        "@geolibre/processing"
+      );
+      const bytes = new Uint8Array(await mainFile.arrayBuffer());
+      // Header-only check, matching runBrowserRasterToCog: a non-TIFF would
+      // otherwise surface write_pmtiles' raw "unknown raster format" text.
+      if (!(await readGeoTiffInfo(bytes)).ok) {
+        throw new Error(i18n.t("toolbar.conversion.notAGeoTiff"));
+      }
       const result = await renderRasterToPmtiles(
-        await toWasmFile(mainFile),
+        { name: mainFile.name, data: bytes },
         outputName,
         {
-          minZoom: parsedMin,
-          maxZoom: parsedMax,
+          // Blank bounds are omitted so write_pmtiles picks the native zoom for
+          // the raster's resolution, rather than this dialog forcing a 0-14
+          // pyramid that a wide-extent raster would take a long time to render.
+          ...zooms,
           band: 1,
           // Omitted when unset, so the tool applies its own default.
           colormap: colormap || undefined,
@@ -961,11 +1007,18 @@ export function ConversionDialog() {
     }
     if (kind === "vector-to-flatgeobuf") {
       if (rejectZipInput(mainFile)) return;
+      // vector_convert picks its driver from the output extension, but this tool
+      // is fixed-format: force .fgb so a typed name like "data.gpkg" cannot
+      // silently produce a GeoPackage under the "Vector to FlatGeobuf" title.
+      // The sidecar forces output_format="flatgeobuf" for the same reason, and
+      // the Shapefile/GeoPackage branches below hard-code their format too.
+      const requested =
+        outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name);
       await runBrowserVectorViaWasm(
         kind,
         mainFile,
         siblings,
-        outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name),
+        `${stripExtension(requested) || "output"}.fgb`,
       );
       return;
     }
@@ -1132,16 +1185,15 @@ export function ConversionDialog() {
           }),
         );
       } else if (kind === "vector-to-pmtiles") {
-        const parsedMin = Number.parseInt(minZoom, 10);
-        const parsedMax = Number.parseInt(maxZoom, 10);
+        // Unlike Raster to PMTiles, the sidecar requires both bounds, so a blank
+        // (undefined) one is an error rather than a "let the engine decide".
+        const zooms = parseZoomRange(minZoom, maxZoom);
         if (
-          !Number.isFinite(parsedMin) ||
-          !Number.isFinite(parsedMax) ||
-          parsedMin < 0 ||
-          parsedMin > parsedMax ||
-          parsedMax > 24
+          !zooms ||
+          zooms.minZoom === undefined ||
+          zooms.maxZoom === undefined
         ) {
-          setError("Zoom levels must satisfy 0 ≤ min ≤ max ≤ 24.");
+          setError(i18n.t("toolbar.conversion.zoomRangeError"));
           return;
         }
         setJob(
@@ -1149,8 +1201,8 @@ export function ConversionDialog() {
             input_path,
             output_path,
             layer_name: layerName.trim() || "data",
-            min_zoom: parsedMin,
-            max_zoom: parsedMax,
+            min_zoom: zooms.minZoom,
+            max_zoom: zooms.maxZoom,
           }),
         );
       } else if (kind === "raster-to-cog") {
@@ -1443,6 +1495,7 @@ export function ConversionDialog() {
                   id="conversion-raster-min-zoom"
                   inputMode="numeric"
                   value={minZoom}
+                  placeholder={t("toolbar.conversion.zoomNative")}
                   onChange={(event) => setMinZoom(event.target.value)}
                 />
               </div>
@@ -1452,6 +1505,7 @@ export function ConversionDialog() {
                   id="conversion-raster-max-zoom"
                   inputMode="numeric"
                   value={maxZoom}
+                  placeholder={t("toolbar.conversion.zoomNative")}
                   onChange={(event) => setMaxZoom(event.target.value)}
                 />
               </div>

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -327,8 +327,10 @@ function parseZoomRange(
   const parse = (raw: string): number | null | undefined => {
     const text = raw.trim();
     if (!text) return undefined;
-    const value = Number.parseInt(text, 10);
-    if (!Number.isFinite(value) || value < 0 || value > MAX_PMTILES_ZOOM) {
+    // Number, not parseInt: parseInt truncates, so "3.5"/"3abc" would silently
+    // become zoom 3 rather than being rejected.
+    const value = Number(text);
+    if (!Number.isInteger(value) || value < 0 || value > MAX_PMTILES_ZOOM) {
       return null;
     }
     return value;

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -153,6 +153,12 @@ function splitBrowserSelection(files: File[]): {
 interface ConversionToolConfig {
   title: string;
   description: string;
+  /** Translation keys for {@link title}/{@link description}. TOOL_CONFIGS is
+   * module-level, so it cannot call `t()` itself without freezing the language
+   * at import; the dialog resolves these at render and falls back to the
+   * literals above. The older tools have not been migrated yet. */
+  titleKey?: ParseKeys;
+  descriptionKey?: ParseKeys;
   inputLabel: string;
   inputFilters: FileDialogFilter[];
   outputLabel: string;
@@ -167,9 +173,9 @@ interface ConversionToolConfig {
   /** Compression choices when running in-browser, for tools whose WASM encoder
    * supports fewer codecs than the sidecar's. Falls back to `compressions`. */
   browserCompressions?: string[];
-  /** Extra note shown only when the in-browser engine is in use, calling out
-   * where it diverges from the sidecar. */
-  browserNote?: string;
+  /** Translation key for an extra note shown only when the in-browser engine is
+   * in use, calling out where it diverges from the sidecar. */
+  browserNoteKey?: ParseKeys;
 }
 
 const VECTOR_INPUT_EXTENSIONS = [
@@ -437,8 +443,10 @@ const TOOL_CONFIGS: Record<ConversionToolKind, ConversionToolConfig> = {
   },
   "raster-to-pmtiles": {
     title: "Raster to PMTiles",
+    titleKey: "toolbar.conversion.rasterToPmtiles",
     description:
       "Render a raster into a single PMTiles archive of Web Mercator PNG tiles, ready for cloud-native serving. Runs entirely in WebAssembly, so it needs no sidecar on either the web or desktop app.",
+    descriptionKey: "toolbar.conversion.rasterToPmtilesDesc",
     inputLabel: "Input raster file",
     inputFilters: [{ name: "GeoTIFF", extensions: ["tif", "tiff"] }],
     outputLabel: "Output PMTiles file",
@@ -465,8 +473,7 @@ const TOOL_CONFIGS: Record<ConversionToolKind, ConversionToolConfig> = {
     compressions: ["deflate", "zstd", "lzw", "webp", "jpeg", "packbits", "raw"],
     browserCompressions: [...COG_WASM_COMPRESSIONS],
     defaultCompression: "deflate",
-    browserNote:
-      "In the browser, 8-bit rasters keep their type and everything else (Int16 DEMs, Float64, …) is written as Float32. The desktop app preserves the original type.",
+    browserNoteKey: "toolbar.conversion.cogBrowserNote",
   },
 };
 
@@ -774,7 +781,7 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof Error ? err.message : "Could not convert this file.";
+        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -829,7 +836,7 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof Error ? err.message : "Could not convert this file.";
+        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -912,7 +919,7 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof Error ? err.message : "Could not convert this file.";
+        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -979,7 +986,7 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof Error ? err.message : "Could not convert this file.";
+        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -1101,7 +1108,7 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof Error ? err.message : "Could not convert this file.";
+        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -1211,7 +1218,7 @@ export function ConversionDialog() {
         // raster-to-pmtiles is the only remaining kind and has no sidecar
         // endpoint; conversionUsesBrowserRuntime always routes it to the WASM
         // path above, so reaching here means those two have drifted apart.
-        setError(`${kind} has no sidecar conversion.`);
+        setError(i18n.t("toolbar.conversion.noSidecarConversion", { kind }));
       }
     } catch (err) {
       setError(
@@ -1231,13 +1238,21 @@ export function ConversionDialog() {
     >
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle>{config?.title ?? "Conversion"}</DialogTitle>
-          <DialogDescription>{config?.description ?? ""}</DialogDescription>
+          <DialogTitle>
+            {config?.titleKey ? t(config.titleKey) : (config?.title ?? "Conversion")}
+          </DialogTitle>
+          <DialogDescription>
+            {config?.descriptionKey
+              ? t(config.descriptionKey)
+              : (config?.description ?? "")}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-4">
-          {usesBrowserRuntime && config?.browserNote && (
-            <p className="text-xs text-muted-foreground">{config.browserNote}</p>
+          {usesBrowserRuntime && config?.browserNoteKey && (
+            <p className="text-xs text-muted-foreground">
+              {t(config.browserNoteKey)}
+            </p>
           )}
           {runtimeAvailable === false && (
             <div className="grid gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
@@ -1428,7 +1443,7 @@ export function ConversionDialog() {
                 />
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="conversion-min-zoom">Min zoom</Label>
+                <Label htmlFor="conversion-min-zoom">{t("toolbar.conversion.minZoom")}</Label>
                 <Input
                   id="conversion-min-zoom"
                   inputMode="numeric"
@@ -1437,7 +1452,7 @@ export function ConversionDialog() {
                 />
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="conversion-max-zoom">Max zoom</Label>
+                <Label htmlFor="conversion-max-zoom">{t("toolbar.conversion.maxZoom")}</Label>
                 <Input
                   id="conversion-max-zoom"
                   inputMode="numeric"
@@ -1490,7 +1505,7 @@ export function ConversionDialog() {
                 </Select>
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="conversion-raster-min-zoom">Min zoom</Label>
+                <Label htmlFor="conversion-raster-min-zoom">{t("toolbar.conversion.minZoom")}</Label>
                 <Input
                   id="conversion-raster-min-zoom"
                   inputMode="numeric"
@@ -1500,7 +1515,7 @@ export function ConversionDialog() {
                 />
               </div>
               <div className="grid gap-1.5">
-                <Label htmlFor="conversion-raster-max-zoom">Max zoom</Label>
+                <Label htmlFor="conversion-raster-max-zoom">{t("toolbar.conversion.maxZoom")}</Label>
                 <Input
                   id="conversion-raster-max-zoom"
                   inputMode="numeric"

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -211,12 +211,13 @@ const VECTOR_TO_VECTOR_INPUT_EXTENSIONS = [
   "gpx",
 ];
 
-// In-browser writers, keyed by output extension. DuckDB-WASM cannot write GDAL
-// vector formats (its virtual filesystem lacks the random-access seek/write the
-// GDAL drivers need), so the web build is limited to GeoParquet (DuckDB) plus
-// the pure-JS GeoJSON/CSV/GeoPackage/Shapefile writers. The Shapefile writer
-// always emits a zip, so `.zip` (not bare `.shp`) is the browser Shapefile
-// option; a bare `.shp` is produced only by the desktop sidecar.
+// In-browser JS writers, keyed by output extension. DuckDB-WASM cannot write
+// GDAL vector formats (its virtual filesystem lacks the random-access
+// seek/write the GDAL drivers need), so these are GeoParquet (DuckDB) plus the
+// pure-JS GeoJSON/CSV/GeoPackage/Shapefile writers. Extensions no JS writer
+// covers are handled by geolibre-wasm — see WASM_VECTOR_OUTPUT_FORMATS. The
+// Shapefile writer always emits a zip, so `.zip` (not bare `.shp`) is the
+// browser Shapefile option; a bare `.shp` is produced only by the sidecar.
 const BROWSER_OUTPUT_FORMATS: Record<
   string,
   "geojson" | "csv" | "geoparquet" | "geopackage" | "shapefile"
@@ -232,7 +233,8 @@ const BROWSER_OUTPUT_FORMATS: Record<
 
 // Output extensions the generic Vector to Vector tool offers. The sidecar
 // (native DuckDB spatial) writes every one of these via a GDAL driver; the
-// in-browser runtime can only produce the BROWSER_OUTPUT_FORMATS subset.
+// in-browser runtime produces the BROWSER_OUTPUT_FORMATS subset plus
+// WASM_VECTOR_OUTPUT_EXTENSIONS.
 const VECTOR_TO_VECTOR_OUTPUT_EXTENSIONS = [
   "geojson",
   "geojsonl",
@@ -306,6 +308,36 @@ const WASM_VECTOR_OUTPUT_EXTENSIONS = new Set(
 /** Deepest zoom either PMTiles tool accepts. */
 const MAX_PMTILES_ZOOM = 24;
 
+// Plain decimal digits only. `Number` alone would accept JS numeric-literal
+// quirks that these small integer fields should not take: "0x10" reads as 16
+// and "1e1" as 10, both of which look like valid zooms.
+const PLAIN_INTEGER_PATTERN = /^\d+$/;
+
+/**
+ * Parse an optional plain-integer field.
+ *
+ * @returns The value, `undefined` when blank (leave it to the engine), or
+ * `null` when it is not a plain non-negative integer.
+ */
+function parsePlainInteger(raw: string): number | null | undefined {
+  const text = raw.trim();
+  if (!text) return undefined;
+  if (!PLAIN_INTEGER_PATTERN.test(text)) return null;
+  return Number(text);
+}
+
+/**
+ * Parse the 1-based band field. Blank leaves it to `write_pmtiles`, which
+ * defaults to band 1.
+ *
+ * @returns The band, `undefined` when blank, or `null` when not a positive integer.
+ */
+function parseBand(raw: string): number | null | undefined {
+  const value = parsePlainInteger(raw);
+  if (value === null || value === undefined) return value;
+  return value >= 1 ? value : null;
+}
+
 /** A parsed zoom range; an undefined bound was left blank by the user. */
 interface PmtilesZoomRange {
   minZoom?: number;
@@ -325,15 +357,11 @@ function parseZoomRange(
   rawMax: string,
 ): PmtilesZoomRange | null {
   const parse = (raw: string): number | null | undefined => {
-    const text = raw.trim();
-    if (!text) return undefined;
-    // Number, not parseInt: parseInt truncates, so "3.5"/"3abc" would silently
-    // become zoom 3 rather than being rejected.
-    const value = Number(text);
-    if (!Number.isInteger(value) || value < 0 || value > MAX_PMTILES_ZOOM) {
-      return null;
-    }
-    return value;
+    // parsePlainInteger, not parseInt: parseInt truncates, so "3.5"/"3abc"
+    // would silently become zoom 3 rather than being rejected.
+    const value = parsePlainInteger(raw);
+    if (value === null || value === undefined) return value;
+    return value > MAX_PMTILES_ZOOM ? null : value;
   };
   const minZoom = parse(rawMin);
   const maxZoom = parse(rawMax);
@@ -354,6 +382,12 @@ function browserRuntimeMessageKey(kind: ConversionToolKind): ParseKeys {
     case "vector-to-shapefile":
     case "vector-to-geopackage":
       return "toolbar.conversion.runsInBrowserWriters";
+    case "vector-to-vector":
+      // The banner is set when the dialog opens, before an output extension is
+      // typed, and this tool's engine depends on it (.fgb goes through
+      // vector_convert, everything else through DuckDB). Name both rather than
+      // claim one and be wrong for .fgb.
+      return "toolbar.conversion.runsInBrowserVectorEngines";
     default:
       return "toolbar.conversion.runsInBrowserDuckDb";
   }
@@ -363,7 +397,7 @@ const TOOL_CONFIGS: Record<ConversionToolKind, ConversionToolConfig> = {
   "vector-to-vector": {
     title: "Vector to Vector",
     description:
-      "Convert between any vector formats DuckDB's spatial extension supports. The input and output formats are detected from the file extensions. The desktop app writes any format (FlatGeobuf, GeoPackage, Shapefile, KML, GML, …); the browser writes GeoJSON, CSV, GeoParquet, GeoPackage, and Shapefile.",
+      "Convert between any vector formats DuckDB's spatial extension supports. The input and output formats are detected from the file extensions. The desktop app writes any format (FlatGeobuf, GeoPackage, Shapefile, KML, GML, …); the browser writes GeoJSON, CSV, GeoParquet, GeoPackage, FlatGeobuf, and Shapefile.",
     inputLabel: "Input vector file",
     inputFilters: [
       { name: "Vector", extensions: VECTOR_TO_VECTOR_INPUT_EXTENSIONS },
@@ -507,6 +541,8 @@ export function ConversionDialog() {
   // Empty means "leave it to the tool", which is what makes colormap optional:
   // write_pmtiles marks it optional and picks viridis itself, so the dialog
   // omits the flag rather than pinning a default of its own.
+  // Blank means "leave it to the tool", which renders band 1.
+  const [band, setBand] = useState("");
   const [colormap, setColormap] = useState<PmtilesColormap | "">("");
   const [resampling, setResampling] =
     useState<PmtilesResamplingMethod>("bilinear");
@@ -585,6 +621,7 @@ export function ConversionDialog() {
     const rasterPmtiles = kind === "raster-to-pmtiles";
     setMinZoom(rasterPmtiles ? "" : "0");
     setMaxZoom(rasterPmtiles ? "" : "14");
+    setBand("");
     setColormap("");
     setResampling("bilinear");
     setError(null);
@@ -935,6 +972,11 @@ export function ConversionDialog() {
       setError(i18n.t("toolbar.conversion.zoomRangeError"));
       return;
     }
+    const parsedBand = parseBand(band);
+    if (parsedBand === null) {
+      setError(i18n.t("toolbar.conversion.bandError"));
+      return;
+    }
     const outputName =
       outputPath.trim() || defaultOutputNameForKind(kind, mainFile.name);
     setError(null);
@@ -949,9 +991,22 @@ export function ConversionDialog() {
       );
       const bytes = new Uint8Array(await mainFile.arrayBuffer());
       // Header-only check, matching runBrowserRasterToCog: a non-TIFF would
-      // otherwise surface write_pmtiles' raw "unknown raster format" text.
-      if (!(await readGeoTiffInfo(bytes)).ok) {
-        throw new Error(i18n.t("toolbar.conversion.notAGeoTiff"));
+      // otherwise surface write_pmtiles' raw "unknown raster format" text. The
+      // message is this tool's own: unlike Raster to COG, there is no sidecar
+      // route, so pointing at the desktop app would be a dead end.
+      const info = await readGeoTiffInfo(bytes);
+      if (!info.ok) {
+        throw new Error(i18n.t("toolbar.conversion.notAGeoTiffRasterOnly"));
+      }
+      // The header already carries the band count, so an out-of-range band gets
+      // a real message instead of the tool's raw failure.
+      if (parsedBand !== undefined && parsedBand > info.bands) {
+        throw new Error(
+          i18n.t("toolbar.conversion.bandOutOfRange", {
+            band: parsedBand,
+            bands: info.bands,
+          }),
+        );
       }
       const result = await renderRasterToPmtiles(
         { name: mainFile.name, data: bytes },
@@ -961,7 +1016,7 @@ export function ConversionDialog() {
           // the raster's resolution, rather than this dialog forcing a 0-14
           // pyramid that a wide-extent raster would take a long time to render.
           ...zooms,
-          band: 1,
+          band: parsedBand,
           // Omitted when unset, so the tool applies its own default.
           colormap: colormap || undefined,
           method: resampling,
@@ -1466,7 +1521,19 @@ export function ConversionDialog() {
           )}
 
           {isRasterPmtiles && (
-            <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_5rem_5rem] gap-4">
+            <div className="grid grid-cols-[5rem_minmax(0,1fr)_minmax(0,1fr)_5rem_5rem] gap-4">
+              <div className="grid gap-1.5">
+                <Label htmlFor="conversion-band">
+                  {t("toolbar.conversion.band")}
+                </Label>
+                <Input
+                  id="conversion-band"
+                  inputMode="numeric"
+                  value={band}
+                  placeholder="1"
+                  onChange={(event) => setBand(event.target.value)}
+                />
+              </div>
               <div className="grid gap-1.5">
                 <Label htmlFor="conversion-colormap">
                   {t("toolbar.conversion.colormap")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1750,7 +1750,8 @@
       "zoomRangeError": "Zoom levels must satisfy 0 ≤ min ≤ max ≤ 24.",
       "colormap": "Colormap",
       "resampling": "Resampling",
-      "colormapDefault": "Default (viridis)"
+      "colormapDefault": "Default (viridis)",
+      "zoomNative": "native"
     },
     "vectorTool": {
       "buffer": "Buffer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1752,12 +1752,17 @@
       "resampling": "Resampling",
       "colormapDefault": "Default (viridis)",
       "zoomNative": "native",
-      "rasterToPmtilesDesc": "Render a raster into a single PMTiles archive of Web Mercator PNG tiles, ready for cloud-native serving. Runs entirely in WebAssembly, so it needs no sidecar on either the web or desktop app.",
+      "rasterToPmtilesDesc": "Render a raster into a single PMTiles archive of Web Mercator PNG tiles, ready for cloud-native serving. One band is rendered through a colormap, so multi-band imagery is not drawn in true colour. Runs entirely in WebAssembly, so it needs no sidecar on either the web or desktop app.",
       "cogBrowserNote": "In the browser, 8-bit rasters keep their type and everything else (Int16 DEMs, Float64, …) is written as Float32. The desktop app preserves the original type.",
       "noSidecarConversion": "{{kind}} has no sidecar conversion.",
       "minZoom": "Min zoom",
       "maxZoom": "Max zoom",
-      "convertFailed": "Could not convert this file."
+      "convertFailed": "Could not convert this file.",
+      "notAGeoTiffRasterOnly": "This file is not a readable GeoTIFF. Raster to PMTiles reads GeoTIFF only, on both the web and desktop app.",
+      "band": "Band",
+      "bandError": "Band must be a positive whole number.",
+      "bandOutOfRange": "Band {{band}} does not exist; this raster has {{bands}} band(s).",
+      "runsInBrowserVectorEngines": "Conversion runs in your browser with DuckDB-WASM, or geolibre-wasm for FlatGeobuf output."
     },
     "vectorTool": {
       "buffer": "Buffer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1751,7 +1751,13 @@
       "colormap": "Colormap",
       "resampling": "Resampling",
       "colormapDefault": "Default (viridis)",
-      "zoomNative": "native"
+      "zoomNative": "native",
+      "rasterToPmtilesDesc": "Render a raster into a single PMTiles archive of Web Mercator PNG tiles, ready for cloud-native serving. Runs entirely in WebAssembly, so it needs no sidecar on either the web or desktop app.",
+      "cogBrowserNote": "In the browser, 8-bit rasters keep their type and everything else (Int16 DEMs, Float64, …) is written as Float32. The desktop app preserves the original type.",
+      "noSidecarConversion": "{{kind}} has no sidecar conversion.",
+      "minZoom": "Min zoom",
+      "maxZoom": "Max zoom",
+      "convertFailed": "Could not convert this file."
     },
     "vectorTool": {
       "buffer": "Buffer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1725,7 +1725,7 @@
     "conversion": {
       "vectorToVector": "Vector to Vector",
       "zipInputBrowserError": "Zipped Shapefiles can only be converted in the GeoLibre desktop app. In the browser, select the unzipped .shp together with its .dbf, .shx, and .prj files.",
-      "browserOutputUnsupported": "In the browser, the output can be GeoJSON, CSV, GeoParquet, GeoPackage, or Shapefile (.zip). \".{{extension}}\" output needs the GeoLibre desktop app.",
+      "browserOutputUnsupported": "In the browser, the output can be GeoJSON, CSV, GeoParquet, GeoPackage, FlatGeobuf, or Shapefile (.zip). \".{{extension}}\" output needs the GeoLibre desktop app.",
       "outputExtensionRequired": "Add a file extension to the output name to choose the format.",
       "readingWithDuckDb": "Reading {{name}} with DuckDB-WASM",
       "readFeatures": "Read {{features}} features from {{name}}",
@@ -1737,7 +1737,19 @@
       "vectorToGeopackage": "Vector to GeoPackage",
       "csvToGeoparquet": "CSV to GeoParquet",
       "vectorToPmtiles": "Vector to PMTiles",
-      "rasterToCog": "Raster to COG"
+      "rasterToCog": "Raster to COG",
+      "rasterToPmtiles": "Raster to PMTiles",
+      "needsDesktop": "This conversion needs the GeoLibre desktop app or a running sidecar.",
+      "runsInBrowserDuckDb": "Conversion runs in your browser with DuckDB-WASM.",
+      "runsInBrowserWriters": "Conversion runs in your browser with DuckDB-WASM and the bundled writers.",
+      "runsInBrowserWasm": "Conversion runs in your browser with geolibre-wasm. No sidecar needed.",
+      "convertingWithWasm": "Converting {{name}} with geolibre-wasm",
+      "rasterShape": "Read {{width}}×{{height}} raster with {{bands}} band(s)",
+      "wroteCog": "Wrote a tiled COG with overviews ({{compression}})",
+      "notAGeoTiff": "This file is not a readable GeoTIFF. In the browser, Raster to COG reads GeoTIFF only; other formats need the desktop app.",
+      "zoomRangeError": "Zoom levels must satisfy 0 ≤ min ≤ max ≤ 24.",
+      "colormap": "Colormap",
+      "resampling": "Resampling"
     },
     "vectorTool": {
       "buffer": "Buffer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1749,7 +1749,8 @@
       "notAGeoTiff": "This file is not a readable GeoTIFF. In the browser, Raster to COG reads GeoTIFF only; other formats need the desktop app.",
       "zoomRangeError": "Zoom levels must satisfy 0 ≤ min ≤ max ≤ 24.",
       "colormap": "Colormap",
-      "resampling": "Resampling"
+      "resampling": "Resampling",
+      "colormapDefault": "Default (viridis)"
     },
     "vectorTool": {
       "buffer": "Buffer",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -68,6 +68,7 @@ export type ConversionToolKind =
   | "vector-to-geopackage"
   | "csv-to-geoparquet"
   | "vector-to-pmtiles"
+  | "raster-to-pmtiles"
   | "raster-to-cog";
 
 /**

--- a/packages/processing/src/cog-convert.ts
+++ b/packages/processing/src/cog-convert.ts
@@ -38,6 +38,30 @@ export interface GeoTiffInfo {
  * data ships with and the upstream reader's expectations. */
 const COG_TILE_SIZE = 512;
 
+/**
+ * Compressions {@link CogBuilder} can encode for *any* pixel type, and so the
+ * set the browser build offers for Raster to COG.
+ *
+ * Deliberately narrower than the sidecar's rio-cogeo list: `zstd` and `raw` are
+ * not implemented by CogBuilder at all, and `webp`/`jpeg`/`jpegxl` reject
+ * anything but 8-bit samples ("Unsupported sample format"), which would fail on
+ * the Int16/Float32 DEMs this tool is most often pointed at. Desktop keeps the
+ * full rio-cogeo list via the sidecar.
+ */
+export const COG_WASM_COMPRESSIONS = [
+  "deflate",
+  "lzw",
+  "packbits",
+  "none",
+] as const;
+
+export type CogWasmCompression = (typeof COG_WASM_COMPRESSIONS)[number];
+
+export interface ConvertGeoTiffToCogOptions {
+  /** Tile compression codec. Defaults to `"deflate"`. */
+  compression?: CogWasmCompression;
+}
+
 let wasmReady: Promise<void> | null = null;
 
 /**
@@ -115,10 +139,12 @@ function overviewLevels(width: number, height: number): Uint32Array {
  * file small. Multi-band data is encoded pixel-interleaved, matching the reader.
  *
  * @param bytes - The raw source GeoTIFF bytes.
+ * @param options - Optional encoder settings; see {@link ConvertGeoTiffToCogOptions}.
  * @returns The COG file bytes.
  */
 export async function convertGeoTiffToCog(
   bytes: Uint8Array,
+  options: ConvertGeoTiffToCogOptions = {},
 ): Promise<Uint8Array> {
   await initCogWasm();
   const reader = new GeoTiffReader(bytes);
@@ -139,7 +165,7 @@ export async function convertGeoTiffToCog(
         builder.set_nodata(nodata);
       }
       builder.set_tile_size(COG_TILE_SIZE);
-      builder.set_compression("deflate");
+      builder.set_compression(options.compression ?? "deflate");
       builder.set_overview_levels(overviewLevels(width, height));
 
       // read_all_f64 is the one reader that decodes any source dtype (Int16,

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -170,8 +170,23 @@ export {
   readGeoTiffInfo,
   isTiledGeoTiff,
   convertGeoTiffToCog,
+  COG_WASM_COMPRESSIONS,
+  type CogWasmCompression,
+  type ConvertGeoTiffToCogOptions,
   type GeoTiffInfo,
 } from "./cog-convert";
+export {
+  convertVectorWithWasm,
+  initConvertTools,
+  renderRasterToPmtiles,
+  PMTILES_COLORMAPS,
+  PMTILES_RESAMPLING_METHODS,
+  type PmtilesColormap,
+  type PmtilesResamplingMethod,
+  type RasterToPmtilesOptions,
+  type WasmConvertFile,
+  type WasmConvertResult,
+} from "./wasm-convert";
 export {
   extractPmtiles,
   pmtilesTileTypeKind,

--- a/packages/processing/src/wasm-convert.ts
+++ b/packages/processing/src/wasm-convert.ts
@@ -1,0 +1,217 @@
+// In-browser format conversion backed by the `geolibre-wasm/tools` WASI runner
+// (the same ~18 MB binary wasm-client.ts and raster-subset.ts use, loaded
+// lazily and shared once downloaded). These wrap two GeoLibre-authored tools:
+//
+//   - `vector_convert`  — any vector format -> any vector format (driver picked
+//                         from the output extension). Used for the formats the
+//                         pure-JS writers in vector-exporter.ts cannot produce,
+//                         notably FlatGeobuf.
+//   - `write_pmtiles`   — render a *raster* into a Web Mercator PNG tile pyramid
+//                         packed as a single PMTiles archive.
+//
+// Both run entirely client-side, so the web build no longer needs the Python
+// sidecar for them. Note `write_pmtiles` is raster-only: there is no vector
+// tiler in geolibre-wasm, so Vector to PMTiles remains sidecar-backed
+// (freestiler) and desktop-only.
+import type { RunToolOptions, ToolResult } from "geolibre-wasm/tools";
+
+/** The subset of `geolibre-wasm/tools` these converters use. */
+interface ConvertToolsModule {
+  initTools: (
+    source?: URL | Response | BufferSource | string,
+  ) => Promise<WebAssembly.Module>;
+  runTool: (tool: string, opts?: RunToolOptions) => Promise<ToolResult>;
+}
+
+let toolsModulePromise: Promise<ConvertToolsModule> | null = null;
+
+/**
+ * Lazily import the WASI tool runner once. Mirrors {@link loadSubsetModule} in
+ * raster-subset.ts: the memoized promise is reset on failure so a transient
+ * error (e.g. a network blip during the chunk download) retries on the next
+ * call instead of staying permanently rejected for the session.
+ */
+function loadToolsModule(): Promise<ConvertToolsModule> {
+  toolsModulePromise ??= (
+    import("geolibre-wasm/tools") as unknown as Promise<ConvertToolsModule>
+  ).catch((error) => {
+    toolsModulePromise = null;
+    throw error;
+  });
+  return toolsModulePromise;
+}
+
+/**
+ * Compile the WASI runner ahead of the first conversion. Optional in the browser
+ * and in bundlers, where the runner resolves its own bundled `.wasm` asset on
+ * demand; hosts without that resolution (node, tests) pass the wasm bytes.
+ *
+ * The source must be handed to *this* module rather than to a separately
+ * imported copy of `geolibre-wasm/tools`: the compiled module is cached in the
+ * tool runner's own module scope, and a second instance of it would not see it.
+ * Mirrors {@link initCogWasm} in cog-convert.ts.
+ *
+ * @param source - Optional wasm bytes / URL / Response for non-browser hosts.
+ */
+export async function initConvertTools(
+  source?: URL | Response | BufferSource | string,
+): Promise<void> {
+  const { initTools } = await loadToolsModule();
+  await initTools(source);
+}
+
+/** An input file for a WASM conversion: its name (the extension drives format
+ * detection) and its raw bytes. */
+export interface WasmConvertFile {
+  name: string;
+  data: Uint8Array;
+}
+
+/** A finished WASM conversion: the output bytes plus the tool's log lines, which
+ * the Conversion dialog renders in the same log pane as sidecar jobs. */
+export interface WasmConvertResult {
+  data: Uint8Array;
+  messages: string[];
+}
+
+/**
+ * The tools report failures as an exit code plus a human-readable trailing
+ * stdout line (e.g. `validation error: unsupported output path: ...`) rather
+ * than by throwing, so surface that line instead of a bare "exit 1".
+ */
+function assertToolSucceeded(tool: string, result: ToolResult): void {
+  if (result.exitCode === 0) return;
+  const detail = [...result.stdout]
+    .reverse()
+    .find((line) => /error|unsupported|unknown|invalid/i.test(line));
+  throw new Error(
+    detail?.trim() || `${tool} failed with exit code ${result.exitCode}.`,
+  );
+}
+
+/** Pull the single expected output out of a tool's virtual /work filesystem. */
+function requireOutput(
+  tool: string,
+  result: ToolResult,
+  outputName: string,
+): Uint8Array {
+  const data = result.files[outputName];
+  if (!data) {
+    throw new Error(`${tool} produced no ${outputName} output.`);
+  }
+  return data;
+}
+
+/**
+ * Convert a vector dataset to another vector format entirely in the browser.
+ * The output driver is chosen by `outputName`'s extension (`.fgb`, `.gpkg`,
+ * `.shp`, `.geojson`, `.parquet`, ...).
+ *
+ * Multi-file datasets (a Shapefile's `.dbf`/`.shx`/`.prj`) are supported by
+ * passing the companions as `siblings`; they are placed alongside the main file
+ * in the tool's virtual filesystem so the driver can find them.
+ *
+ * @param input - The main input file (name + bytes).
+ * @param outputName - Output file name; its extension selects the driver.
+ * @param siblings - Companion files for multi-file formats.
+ * @returns The converted bytes and the tool's log lines.
+ */
+export async function convertVectorWithWasm(
+  input: WasmConvertFile,
+  outputName: string,
+  siblings: WasmConvertFile[] = [],
+): Promise<WasmConvertResult> {
+  const { runTool } = await loadToolsModule();
+  const files: Record<string, Uint8Array> = { [input.name]: input.data };
+  for (const sibling of siblings) files[sibling.name] = sibling.data;
+  const result = await runTool("vector_convert", {
+    args: [`--input=/work/${input.name}`, `--output=/work/${outputName}`],
+    input: files,
+  });
+  assertToolSucceeded("vector_convert", result);
+  return {
+    data: requireOutput("vector_convert", result, outputName),
+    messages: result.stdout,
+  };
+}
+
+/** Colormaps `write_pmtiles` can render a single band with. */
+export const PMTILES_COLORMAPS = [
+  "viridis",
+  "magma",
+  "turbo",
+  "terrain",
+  "grayscale",
+] as const;
+
+export type PmtilesColormap = (typeof PMTILES_COLORMAPS)[number];
+
+/** Resampling methods `write_pmtiles` can build the pyramid with. */
+export const PMTILES_RESAMPLING_METHODS = [
+  "bilinear",
+  "nearest",
+  "cubic",
+] as const;
+
+export type PmtilesResamplingMethod = (typeof PMTILES_RESAMPLING_METHODS)[number];
+
+export interface RasterToPmtilesOptions {
+  /** Minimum zoom. Defaults to a single native zoom matching the resolution. */
+  minZoom?: number;
+  /** Maximum zoom. Defaults to `minZoom`. */
+  maxZoom?: number;
+  /** 1-based band to render. Defaults to 1. */
+  band?: number;
+  /** Colormap for the rendered tiles. Defaults to `"viridis"`. */
+  colormap?: PmtilesColormap;
+  /** Resampling method. Defaults to `"bilinear"`. */
+  method?: PmtilesResamplingMethod;
+  /** Value mapped to the low end of the colormap. Defaults to the band minimum. */
+  min?: number;
+  /** Value mapped to the high end of the colormap. Defaults to the band maximum. */
+  max?: number;
+}
+
+/**
+ * Render a raster into a single PMTiles archive (a Web Mercator PNG tile
+ * pyramid) in the browser. The input must carry a source CRS; the tool
+ * reprojects to EPSG:3857 itself.
+ *
+ * Every option is optional — omitted flags let the tool pick its own defaults
+ * (native zoom, band 1, viridis, bilinear, band min/max stretch) rather than
+ * having this wrapper hard-code a second set.
+ *
+ * @param input - The input raster file (name + bytes).
+ * @param outputName - Output archive name, e.g. `dem.pmtiles`.
+ * @param options - Zoom range, band, colormap, resampling, and value stretch.
+ * @returns The PMTiles bytes and the tool's log lines.
+ */
+export async function renderRasterToPmtiles(
+  input: WasmConvertFile,
+  outputName: string,
+  options: RasterToPmtilesOptions = {},
+): Promise<WasmConvertResult> {
+  const { runTool } = await loadToolsModule();
+  const args = [`--input=/work/${input.name}`, `--output=/work/${outputName}`];
+  const flags: Array<[string, number | string | undefined]> = [
+    ["min_zoom", options.minZoom],
+    ["max_zoom", options.maxZoom],
+    ["band", options.band],
+    ["colormap", options.colormap],
+    ["method", options.method],
+    ["min", options.min],
+    ["max", options.max],
+  ];
+  for (const [name, value] of flags) {
+    if (value !== undefined) args.push(`--${name}=${value}`);
+  }
+  const result = await runTool("write_pmtiles", {
+    args,
+    input: { [input.name]: input.data },
+  });
+  assertToolSucceeded("write_pmtiles", result);
+  return {
+    data: requireOutput("write_pmtiles", result, outputName),
+    messages: result.stdout,
+  };
+}

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { before, describe, it } from "node:test";
 import { GeoTiffReader } from "geolibre-wasm";
 import {
+  COG_WASM_COMPRESSIONS,
   convertGeoTiffToCog,
   initCogWasm,
   isTiledGeoTiff,
@@ -73,5 +74,38 @@ describe("convertGeoTiffToCog", () => {
     } finally {
       reader.free();
     }
+  });
+
+  // Raster to COG lets the user pick a codec on the web, so every advertised
+  // choice has to survive an Int16 source — webp/jpeg/jpegxl do not (they reject
+  // anything but 8-bit samples) and zstd/raw are not implemented at all, which
+  // is why COG_WASM_COMPRESSIONS is narrower than the sidecar's rio-cogeo list.
+  for (const compression of COG_WASM_COMPRESSIONS) {
+    it(`encodes a valid tiled COG with ${compression} compression`, async () => {
+      const cog = await convertGeoTiffToCog(stripedTiff, { compression });
+      const out = await readGeoTiffInfo(cog);
+      assert.equal(out.ok, true);
+      assert.equal(out.tiled, true);
+      assert.equal(out.width, 32);
+      assert.equal(out.height, 32);
+
+      const reader = new GeoTiffReader(cog);
+      try {
+        assert.equal(reader.read_band_f32(0)[0], -11);
+      } finally {
+        reader.free();
+      }
+    });
+  }
+
+  it("defaults to deflate, which compresses better than storing raw", async () => {
+    const [deflate, none] = await Promise.all([
+      convertGeoTiffToCog(stripedTiff),
+      convertGeoTiffToCog(stripedTiff, { compression: "none" }),
+    ]);
+    assert.ok(
+      deflate.byteLength < none.byteLength,
+      `deflate (${deflate.byteLength}) should be smaller than none (${none.byteLength})`,
+    );
   });
 });

--- a/tests/wasm-convert.test.ts
+++ b/tests/wasm-convert.test.ts
@@ -118,6 +118,48 @@ describe("wasm-convert", () => {
       assert.ok(result.messages.length > 0);
     });
 
+    // Colormap is optional in the dialog: leaving it unset omits the flag so the
+    // tool applies its own default, rather than the UI pinning one of its own.
+    it("omits optional flags, matching the tool's own defaults", async () => {
+      const [omitted, explicit] = await Promise.all([
+        renderRasterToPmtiles({ name: "dem.tif", data: stripedTiff }, "a.pmtiles", {
+          minZoom: 0,
+          maxZoom: 3,
+        }),
+        renderRasterToPmtiles({ name: "dem.tif", data: stripedTiff }, "b.pmtiles", {
+          minZoom: 0,
+          maxZoom: 3,
+          colormap: "viridis",
+          method: "bilinear",
+        }),
+      ]);
+      assert.deepEqual(
+        omitted.data,
+        explicit.data,
+        "omitting colormap/method should equal the tool's documented defaults",
+      );
+    });
+
+    it("honours an explicit colormap", async () => {
+      const [viridis, magma] = await Promise.all([
+        renderRasterToPmtiles({ name: "dem.tif", data: stripedTiff }, "v.pmtiles", {
+          minZoom: 0,
+          maxZoom: 3,
+          colormap: "viridis",
+        }),
+        renderRasterToPmtiles({ name: "dem.tif", data: stripedTiff }, "m.pmtiles", {
+          minZoom: 0,
+          maxZoom: 3,
+          colormap: "magma",
+        }),
+      ]);
+      assert.notDeepEqual(
+        viridis.data,
+        magma.data,
+        "a different colormap should change the rendered tiles",
+      );
+    });
+
     it("rejects a vector input, which write_pmtiles cannot render", async () => {
       await assert.rejects(
         renderRasterToPmtiles(

--- a/tests/wasm-convert.test.ts
+++ b/tests/wasm-convert.test.ts
@@ -91,6 +91,21 @@ describe("wasm-convert", () => {
       );
     });
 
+    // The driver comes purely from the output extension, which is why the
+    // fixed-format Vector to FlatGeobuf tool forces .fgb on the name it passes
+    // rather than trusting whatever the user typed.
+    it("picks the driver from the output extension, not the input", async () => {
+      const result = await convertVectorWithWasm(
+        { name: "points.geojson", data: pointsGeoJson },
+        "points.gpkg",
+      );
+      assert.equal(
+        new TextDecoder().decode(result.data.subarray(0, 15)),
+        "SQLite format 3",
+        "a .gpkg output name should yield a GeoPackage",
+      );
+    });
+
     // The tools report failures via exit code + a trailing stdout line rather
     // than by throwing, so the wrapper has to turn that into a real Error.
     it("surfaces the tool's own message when the output format is unsupported", async () => {
@@ -157,6 +172,28 @@ describe("wasm-convert", () => {
         viridis.data,
         magma.data,
         "a different colormap should change the rendered tiles",
+      );
+    });
+
+    // Raster to PMTiles leaves the zoom inputs blank by default so the tool
+    // renders a single native zoom for the raster's resolution, instead of the
+    // dialog forcing the 0-14 pyramid Vector to PMTiles uses.
+    it("renders the native zoom when the range is omitted", async () => {
+      const native = await renderRasterToPmtiles(
+        { name: "dem.tif", data: stripedTiff },
+        "native.pmtiles",
+        {},
+      );
+      assert.ok(hasMagic(native.data, PMTILES_MAGIC));
+
+      const pyramid = await renderRasterToPmtiles(
+        { name: "dem.tif", data: stripedTiff },
+        "pyramid.pmtiles",
+        { minZoom: 0, maxZoom: 14 },
+      );
+      assert.ok(
+        native.data.byteLength < pyramid.data.byteLength,
+        `native (${native.data.byteLength}) should be smaller than a forced 0-14 pyramid (${pyramid.data.byteLength})`,
       );
     });
 

--- a/tests/wasm-convert.test.ts
+++ b/tests/wasm-convert.test.ts
@@ -16,6 +16,51 @@ const fixture = (name: string) =>
 // The same tiny 32x32 Int16 GeoTIFF cog-convert.test.ts uses.
 const stripedTiff = fixture("striped.tif");
 
+/**
+ * Build a small 3-band 8-bit RGB GeoTIFF in memory, so the band-selection test
+ * has a multi-band source without checking another binary fixture into the repo.
+ * Each band gets a distinct gradient, so rendering a different band must produce
+ * different tiles.
+ */
+async function makeRgbTiff(): Promise<Uint8Array> {
+  const initWasm = (await import("geolibre-wasm")).default;
+  const { CogBuilder } = await import("geolibre-wasm");
+  await initWasm({
+    module_or_path: readFileSync(
+      fileURLToPath(
+        new URL(
+          "../node_modules/geolibre-wasm/geolibre_wasm_bg.wasm",
+          import.meta.url,
+        ),
+      ),
+    ),
+  });
+  const width = 64;
+  const height = 64;
+  const bands = 3;
+  const pixels = new Uint8Array(width * height * bands);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * bands;
+      pixels[i] = x * 4;
+      pixels[i + 1] = y * 4;
+      pixels[i + 2] = 128;
+    }
+  }
+  const builder = new CogBuilder(width, height, bands);
+  try {
+    builder.set_epsg(4326);
+    builder.set_geo_transform(Float64Array.from([-83, 0.01, 0, 40, 0, -0.01]));
+    builder.set_tile_size(512);
+    builder.set_compression("deflate");
+    return builder.write_u8(pixels);
+  } finally {
+    builder.free();
+  }
+}
+
+let rgbTiff: Uint8Array;
+
 const pointsGeoJson = new TextEncoder().encode(
   JSON.stringify({
     type: "FeatureCollection",
@@ -58,6 +103,7 @@ describe("wasm-convert", () => {
         ),
       ),
     );
+    rgbTiff = await makeRgbTiff();
   });
 
   describe("convertVectorWithWasm", () => {
@@ -194,6 +240,29 @@ describe("wasm-convert", () => {
       assert.ok(
         native.data.byteLength < pyramid.data.byteLength,
         `native (${native.data.byteLength}) should be smaller than a forced 0-14 pyramid (${pyramid.data.byteLength})`,
+      );
+    });
+
+    // The dialog exposes a band selector, so band has to actually reach the tool
+    // rather than being pinned to 1.
+    it("renders the requested band of a multi-band raster", async () => {
+      const [first, second] = await Promise.all([
+        renderRasterToPmtiles({ name: "rgb.tif", data: rgbTiff }, "b1.pmtiles", {
+          minZoom: 0,
+          maxZoom: 3,
+          band: 1,
+        }),
+        renderRasterToPmtiles({ name: "rgb.tif", data: rgbTiff }, "b2.pmtiles", {
+          minZoom: 0,
+          maxZoom: 3,
+          band: 2,
+        }),
+      ]);
+      assert.ok(hasMagic(first.data, PMTILES_MAGIC));
+      assert.notDeepEqual(
+        first.data,
+        second.data,
+        "a different band should change the rendered tiles",
       );
     });
 

--- a/tests/wasm-convert.test.ts
+++ b/tests/wasm-convert.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { before, describe, it } from "node:test";
+import {
+  convertVectorWithWasm,
+  initConvertTools,
+  renderRasterToPmtiles,
+} from "../packages/processing/src/wasm-convert";
+
+const fixture = (name: string) =>
+  new Uint8Array(
+    readFileSync(fileURLToPath(new URL(`./fixtures/${name}`, import.meta.url))),
+  );
+
+// The same tiny 32x32 Int16 GeoTIFF cog-convert.test.ts uses.
+const stripedTiff = fixture("striped.tif");
+
+const pointsGeoJson = new TextEncoder().encode(
+  JSON.stringify({
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { name: "a", rank: 1 },
+        geometry: { type: "Point", coordinates: [-83.0, 40.0] },
+      },
+      {
+        type: "Feature",
+        properties: { name: "b", rank: 2 },
+        geometry: { type: "Point", coordinates: [-82.5, 40.5] },
+      },
+    ],
+  }),
+);
+
+/** Whether `bytes` starts with the given signature. */
+function hasMagic(bytes: Uint8Array, magic: number[]): boolean {
+  return magic.every((byte, index) => bytes[index] === byte);
+}
+
+const FLATGEOBUF_MAGIC = [0x66, 0x67, 0x62, 0x03]; // "fgb" + spec version 3
+const PMTILES_MAGIC = [...new TextEncoder().encode("PMTiles")];
+
+describe("wasm-convert", () => {
+  before(async () => {
+    // In the browser the WASI runner resolves its own bundled asset; under
+    // node:test we feed it the wasm bytes directly. A file:// URL is not an
+    // option here — initTools fetches what it is given, and node's fetch has no
+    // file scheme.
+    await initConvertTools(
+      readFileSync(
+        fileURLToPath(
+          new URL(
+            "../node_modules/geolibre-wasm/geolibre-cli.wasm",
+            import.meta.url,
+          ),
+        ),
+      ),
+    );
+  });
+
+  describe("convertVectorWithWasm", () => {
+    it("writes a FlatGeobuf the browser's JS writers cannot produce", async () => {
+      const result = await convertVectorWithWasm(
+        { name: "points.geojson", data: pointsGeoJson },
+        "points.fgb",
+      );
+      assert.ok(
+        hasMagic(result.data, FLATGEOBUF_MAGIC),
+        "output should carry the FlatGeobuf magic bytes",
+      );
+      assert.ok(result.data.byteLength > 0);
+      assert.ok(result.messages.length > 0, "tool log lines should be surfaced");
+    });
+
+    it("round-trips back to GeoJSON with the features intact", async () => {
+      const fgb = await convertVectorWithWasm(
+        { name: "points.geojson", data: pointsGeoJson },
+        "points.fgb",
+      );
+      const back = await convertVectorWithWasm(
+        { name: "points.fgb", data: fgb.data },
+        "back.geojson",
+      );
+      const parsed = JSON.parse(new TextDecoder().decode(back.data));
+      assert.equal(parsed.features.length, 2);
+      assert.deepEqual(
+        parsed.features.map((f: { properties: { name: string } }) => f.properties.name),
+        ["a", "b"],
+      );
+    });
+
+    // The tools report failures via exit code + a trailing stdout line rather
+    // than by throwing, so the wrapper has to turn that into a real Error.
+    it("surfaces the tool's own message when the output format is unsupported", async () => {
+      await assert.rejects(
+        convertVectorWithWasm(
+          { name: "points.geojson", data: pointsGeoJson },
+          "points.pmtiles",
+        ),
+        /unsupported output path|unsupported vector format/i,
+      );
+    });
+  });
+
+  describe("renderRasterToPmtiles", () => {
+    it("renders a raster into a PMTiles archive", async () => {
+      const result = await renderRasterToPmtiles(
+        { name: "dem.tif", data: stripedTiff },
+        "dem.pmtiles",
+        { minZoom: 0, maxZoom: 4, colormap: "terrain", method: "nearest" },
+      );
+      assert.ok(
+        hasMagic(result.data, PMTILES_MAGIC),
+        "output should carry the PMTiles magic bytes",
+      );
+      assert.ok(result.messages.length > 0);
+    });
+
+    it("rejects a vector input, which write_pmtiles cannot render", async () => {
+      await assert.rejects(
+        renderRasterToPmtiles(
+          { name: "points.geojson", data: pointsGeoJson },
+          "points.pmtiles",
+        ),
+        /unknown raster format/i,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Most Conversion tools were gated behind the Python sidecar, so the web build could only tell users to install the desktop app. Most of them already have a client-side engine.

## Now working on the web

| Tool | Engine |
|---|---|
| Raster to COG | `geolibre-wasm` `CogBuilder` — the converter that already fixes striped GeoTIFFs on Add Data, now with a compression option |
| Vector to FlatGeobuf | `geolibre-wasm` `vector_convert` — also unblocks `.fgb` output for in-browser Vector to Vector |
| Vector to Shapefile | the pure-JS writer in `vector-exporter.ts`, which already worked and was simply not wired up |
| Vector to GeoPackage | same |

**Desktop keeps preferring the sidecar** for all of these: rio-cogeo/GDAL read more input formats and preserve dtypes and codecs the WASM writers cannot. The dialog resolves input filters and compression choices per runtime, so the web build only offers what its encoder can actually produce.

## Vector to PMTiles stays sidecar-only

This one can't move. `geolibre-wasm`'s PMTiles writer, `write_pmtiles`, is named **"Raster to PMTiles"** — it renders a *raster* into a PNG tile pyramid. `PmtilesExtractor` only subsets an *existing* archive. Verified against real fixtures rather than the docs:

```
write_pmtiles(raster striped.tif)   → exit 0, 5938 bytes ✓
write_pmtiles(vector smoke.geojson) → exit 1: "unknown raster format: .geojson"
vector_convert(→ out.pmtiles)       → exit 1: "Unknown or unsupported vector format"
```

There's no client-side vector tiler to replace the sidecar's `freestiler`, so it keeps its existing message.

## New: Raster to PMTiles

That raster tiler is worth exposing on its own, so this adds it as a new tool (colormap, resampling, zoom range). It has no sidecar endpoint, so it runs in WASM on desktop too.

## Notes on the COG limits

`CogBuilder` does **not** implement `zstd` or `raw`, and `webp`/`jpeg`/`jpegxl` reject non-8-bit samples (an Int16 DEM fails with `Unsupported sample format`). So the web list is the four universally-safe lossless codecs — `deflate`, `lzw`, `packbits`, `none` — each covered by a test. Web input is GeoTIFF-only (the dialog otherwise advertises `img`/`vrt`/`nc`/`jp2`/`hgt`, which need GDAL), and dtype narrows to u8/f32 where rio-cogeo preserves Int16. Both divergences are surfaced in the dialog rather than left to fail at runtime.

## Verification

Driven in a real browser with Playwright against the web dev server, all five downloading valid files with correct magic bytes and no console errors:

| Tool | Output | Verified |
|---|---|---|
| Raster to COG | `striped.tif`, 3719 B | `II` — and re-read: `tiled: true`, `Deflate`, EPSG 4326, nodata preserved (source was striped/uncompressed) |
| Raster to PMTiles | `striped.pmtiles`, 5938 B | `PMTiles` |
| Vector to FlatGeobuf | `smoke.fgb`, 968 B | `fgb\x03` |
| Vector to GeoPackage | `smoke.gpkg`, 49152 B | `SQLite format 3` |
| Vector to Shapefile | `smoke.zip`, 877 B | `PK` |

Vector to PMTiles was confirmed to still show its sidecar message with Convert disabled on web.

Also: 2811 frontend tests pass (10 new), coverage gate green, `wasm-convert.ts` at 96% lines.

## Open question

The Conversion submenu is still hidden on mobile (`ProcessingMenu.tsx`), on the rationale that it needs the sidecar. That's now true only of Vector to PMTiles. I left the gate alone since enabling an 18 MB WASM runtime and a full raster decode on phones is a separate judgment call — happy to follow up either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **raster-to-PMTiles** to the Processing menu conversion submenu.
  * Added browser-side raster and vector conversion support, including **FlatGeobuf** output.
  * Added a dedicated PMTiles configuration panel (native zoom/min-max zoom, colormap, resampling, band selection, and value stretching).
  * Added selectable compression options for browser-based **raster-to-COG** conversion and updated related conversion guidance/status text.

* **Bug Fixes**
  * Improved validation and clearer errors for unsupported/invalid conversion paths and inputs (including rejecting PMTiles via the sidecar route).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->