### PR TITLE
fix(gallery): open projects from the My projects tab

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectGalleryDialog.tsx
@@ -35,6 +35,7 @@ import {
   fetchMyProjects,
   fetchSharedProjects,
   GalleryError,
+  projectOpenToken,
   type SharedProject,
 } from "../../lib/share-gallery";
 import type { TFunction } from "i18next";
@@ -272,11 +273,11 @@ export function ProjectGalleryDialog({
     setOpeningId(project.id);
     setOpenError(null);
     try {
-      // Send the token for the user's own scope so unlisted/private content is
-      // authorized; public-scope opens need no auth.
       await onOpenProject(
         project.rawJsonUrl,
-        effectiveScope === "mine" ? trimmedToken : undefined,
+        effectiveScope === "mine"
+          ? projectOpenToken(project, trimmedToken)
+          : undefined,
       );
       onOpenChange(false);
     } catch (err) {

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -27,6 +27,7 @@ import { buildProjectHtml } from "../lib/html-export";
 import { ensureHtmlFileName, ensureProjectFileName } from "../lib/file-names";
 import { mergeStringLists } from "../lib/string-lists";
 import { fetchProjectFromUrl } from "../lib/project-url";
+import { getShareFetch } from "../lib/share-fetch";
 import { resolveShareBaseUrl } from "../lib/share-geolibre";
 import { shareAuthorizedFetch } from "../lib/share-gallery";
 import { normalizeProjectUrl } from "../lib/urls";
@@ -234,6 +235,12 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
           fetchImpl: shareAuthorizedFetch(
             options.authToken,
             resolveShareBaseUrl(),
+            // Matches fetchMyProjects: on desktop this routes the share host
+            // through Tauri's native HTTP, which is exempt from the WebView's
+            // CORS enforcement. Omitting it falls back to browser `fetch`,
+            // which is why listing a private project worked but opening it did
+            // not.
+            getShareFetch(),
           ),
         });
         const project = await resolveProjectXyzLayers(

--- a/apps/geolibre-desktop/src/lib/share-gallery.ts
+++ b/apps/geolibre-desktop/src/lib/share-gallery.ts
@@ -256,6 +256,24 @@ export interface FetchMyProjectsOptions {
 }
 
 /**
+ * The token to open `project`'s raw JSON with, or undefined to fetch it
+ * anonymously.
+ *
+ * Only private projects need auth — public and unlisted raw `.geolibre.json` is
+ * served to anonymous callers with `Access-Control-Allow-Origin: *`. Attaching
+ * `Authorization` when it is not needed is actively harmful: it makes the
+ * request CORS-preflighted, and the share host answers `OPTIONS` on `/api/*`
+ * but 404s it on raw project paths, so the browser blocks the open outright.
+ */
+export function projectOpenToken(
+  project: Pick<SharedProject, "visibility">,
+  token: string,
+): string | undefined {
+  if (!token) return undefined;
+  return project.visibility === "private" ? token : undefined;
+}
+
+/**
  * Wrap a fetch so requests to the share host carry the personal API token. The
  * `Authorization` header is attached only for same-origin-as-`base` URLs so the
  * token is never leaked to a third-party host (e.g. an external tile server

--- a/tests/share-gallery.test.ts
+++ b/tests/share-gallery.test.ts
@@ -4,6 +4,7 @@ import {
   fetchMyProjects,
   fetchSharedProjects,
   GalleryError,
+  projectOpenToken,
   resolveThumbnailUrl,
   shareAuthorizedFetch,
 } from "../apps/geolibre-desktop/src/lib/share-gallery";
@@ -303,5 +304,31 @@ describe("shareAuthorizedFetch", () => {
     } finally {
       globalThis.fetch = original;
     }
+  });
+});
+
+describe("projectOpenToken", () => {
+  // Attaching Authorization to a public or unlisted raw .geolibre.json is not a
+  // harmless extra: it makes the request CORS-preflighted, and the share host
+  // 404s OPTIONS on raw project paths, so the browser blocks the open. Every
+  // gallery card failed to open this way.
+  for (const visibility of ["public", "unlisted"]) {
+    it(`sends no token for ${visibility} projects, which need no auth`, () => {
+      assert.equal(
+        projectOpenToken({ visibility }, "glb_tok"),
+        undefined,
+      );
+    });
+  }
+
+  it("sends the token for private projects, which are owner-only", () => {
+    assert.equal(
+      projectOpenToken({ visibility: "private" }, "glb_tok"),
+      "glb_tok",
+    );
+  });
+
+  it("sends nothing when there is no token to send", () => {
+    assert.equal(projectOpenToken({ visibility: "private" }, ""), undefined);
   });
 });


### PR DESCRIPTION
## The bug

Every card in the **My projects** tab failed to open with:

> Could not fetch the project from `https://share.geolibre.app/giswqs/nlcd.geolibre.json`. The host may be unreachable or offline, or it may be blocking cross-origin requests (CORS).

The listing itself loaded fine, which is the tell.

## Root cause

The tab sent the share API token for **every** card. But public and unlisted raw `.geolibre.json` is served to anonymous callers with `Access-Control-Allow-Origin: *`, so the token was redundant — and not harmlessly so. The `Authorization` header makes the request CORS-*preflighted*, and the share host answers `OPTIONS` on `/api/*` but 404s it on raw project paths:

| Request | Before |
|---|---|
| `GET /giswqs/nlcd.geolibre.json` (no auth) | `200`, `access-control-allow-origin: *` |
| `OPTIONS /giswqs/nlcd.geolibre.json` (preflight) | **`404`**, no CORS headers |
| `OPTIONS /api/users/me` | `204`, `access-control-allow-headers: Authorization` |

The browser blocked the preflight, `fetch` threw `TypeError`, and `fetchProjectFromUrl` renders any rejection as that CORS message.

Confirmed in real Chromium against `web.geolibre.app`: without the header `200`, with it `TypeError: Failed to fetch`.

## The fix

1. **Only private projects carry the token** (`projectOpenToken`). Public and unlisted fetch anonymously, as they already do everywhere else.
2. **`useProjectFileActions.ts` now passes `getShareFetch()`** to `shareAuthorizedFetch`, matching `fetchMyProjects`. Omitting it silently fell back to browser `fetch` — that asymmetry is exactly why listing worked on desktop (Tauri's native, CORS-exempt HTTP) and opening did not.

## Scope

This fixes public and unlisted projects on both builds, and private ones on desktop. Private projects on the **web** build also need the share host to answer the preflight — opengeos/share.geolibre.app `fix/raw-json-cors-preflight`.

## Testing

- New `projectOpenToken` tests cover the invariant: no token for public/unlisted, token for private. The comment explains *why* sending it anyway is harmful, so it doesn't get "simplified" back.
- `npm run test:frontend` — 2819 pass
- `npm run build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization when opening private projects from the project gallery.
  - Shared project links now use the appropriate authenticated request handling, improving access reliability.
  - Public and unlisted projects no longer receive unnecessary authorization information when opened.
  - Added coverage to verify correct access behavior across private, public, and unlisted projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->