### PR TITLE
fix: use CSS :lang() pseudo-class for CJK vertical text rotation

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3632,3 +3632,18 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   padding: 4px 10px;
   font-size: 11px;
 }
+
+/* ---------------------------------------------------------------------------
+ * Vertical sidebar labels: CJK scripts (zh, ja, ko) read upright in
+ * writing-mode: vertical-rl, so the 180deg rotation used for Latin scripts
+ * would make them upside-down.  The :lang() pseudo-class handles regional
+ * variants (zh-TW, zh-CN, etc.) natively.  The rule matches the same `md:`
+ * breakpoint that Tailwind generates md:rotate-180 at.
+ * ------------------------------------------------------------------------- */
+@media (min-width: 768px) {
+  :lang(zh) .md\:rotate-180,
+  :lang(ja) .md\:rotate-180,
+  :lang(ko) .md\:rotate-180 {
+    rotate: 0deg;
+  }
+}


### PR DESCRIPTION
Hello! 

I found that a "rotate" is used in the sidebar. I guess that is to ensure display English to outdise in vertical display to conform read habits. But it will make the CJK language display upside down. 


## befor：
<img width="735" height="488" alt="image" src="https://github.com/user-attachments/assets/c8d077f1-7908-42b5-9a74-66d3617b39d5" />
<img width="590" height="490" alt="image" src="https://github.com/user-attachments/assets/45eb81fa-7e8b-4afe-afb2-5e363f6a4a67" />

## after：
<img width="408" height="365" alt="image" src="https://github.com/user-attachments/assets/f87b2134-e34c-4315-8241-4c6369771ebf" />
<img width="328" height="378" alt="image" src="https://github.com/user-attachments/assets/f58676af-3016-4006-9659-df346101b246" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical sidebar labels for Chinese, Japanese, and Korean content by keeping characters upright on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->