### PR TITLE
fix(i18n): update Browser panel label live on language change

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useRegisterBrowserPanel.ts
+++ b/apps/geolibre-desktop/src/hooks/useRegisterBrowserPanel.ts
@@ -35,16 +35,29 @@ export function useRegisterBrowserPanel(): void {
   useEffect(() => {
     // i18n.t (not the useTranslation hook) so registration carries no
     // render-time dependency; the body still localizes live via useTranslation.
-    const dispose = registerRightPanel({
-      id: BROWSER_PANEL_ID,
-      title: i18n.t("browser.title"),
-      dock: "replace-layers",
-      render: () => {},
-    });
+    const register = () =>
+      registerRightPanel({
+        id: BROWSER_PANEL_ID,
+        title: i18n.t("browser.title"),
+        dock: "replace-layers",
+        render: () => {},
+      });
+    let dispose = register();
     // Default on, but docked collapsed to the Layers rail (open then collapse),
     // so it is present without burying the map on first load.
     openRightPanel(BROWSER_PANEL_ID);
     collapseRightPanel(BROWSER_PANEL_ID);
-    return dispose;
+    // Re-register with the localized title when the language changes, so the
+    // header/rail label updates live instead of only after a page reload.
+    // Re-registration replaces the registry entry in place, keeping the panel's
+    // open/collapsed/dock state, so we neither re-open nor re-collapse here.
+    const onLanguageChanged = () => {
+      dispose = register();
+    };
+    i18n.on("languageChanged", onLanguageChanged);
+    return () => {
+      i18n.off("languageChanged", onLanguageChanged);
+      dispose();
+    };
   }, []);
 }


### PR DESCRIPTION
## Summary

Changing the language in Settings did not update the **Browser** label in the sidebar until the page was reloaded (#1274). The Browser (Data Source Manager) right panel registered its title once in a mount-only `useEffect` using `i18n.t("browser.title")`, so the sidebar rail/header label stayed in the old language until a fresh mount.

## Fix

Re-register the panel with the freshly localized title on i18next's `languageChanged` event. Re-registration replaces the registry entry in place, so the panel's open/collapsed/dock state is preserved (no re-open/re-collapse). The listener is cleaned up on unmount.

## Verification

Drove the real web app with Playwright, switching the language via Settings → Language:

- **Before fix:** rail label stayed `Browser` after switching to Chinese.
- **After fix:** rail label updated live to `浏览器` with no reload, and back to `Browser` when switching to English.
- Confirmed in both **light** and **dark** themes.

Fixes #1274