### PR TITLE
feat(processing): populate subset tool URLs from loaded layers

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -66,6 +66,11 @@ import {
 } from "../../lib/tauri-io";
 import { clamp } from "../../lib/clamp";
 import { fetchableUrl } from "../../lib/url-utils";
+import {
+  layersForSubsetUrl,
+  subsetUrlFieldValues,
+  subsetUrlToolKind,
+} from "../../lib/subset-tool-url";
 import { clearPrintExtent, drawPrintExtent } from "../../lib/print-extent";
 import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
 import { SidecarHelpBanner } from "./SidecarHelpBanner";
@@ -199,6 +204,22 @@ function isMapExtentParameter(
     param.name === "bbox" &&
     parameterKind(param) === "string" &&
     Boolean(tool.params?.some((other) => other.name === "bbox_crs"))
+  );
+}
+
+// The `url` string param of a COG/WMS/XYZ subset extractor, whose value can be
+// filled from a compatible layer already loaded in the map (GeoLibre#1271). The
+// tool-kind lookup keeps this to the subset extractors without hard-coding each
+// id here; layer eligibility and the derived field values live in
+// `subset-tool-url.ts`.
+function isSubsetUrlParameter(
+  tool: WhiteboxTool,
+  param: WhiteboxToolParameter,
+): boolean {
+  return (
+    param.name === "url" &&
+    parameterKind(param) === "string" &&
+    subsetUrlToolKind(tool.id) !== null
   );
 }
 
@@ -1051,6 +1072,27 @@ export function ProcessingDialog({
     setValues((prev) => ({ ...prev, [name]: value }));
   };
 
+  // Fill a subset extractor's `url` (and the companion fields it needs to run:
+  // WMS layers/styles, XYZ tile_size/subdomains) from a loaded raster layer
+  // (GeoLibre#1271), so a COG/WMS/XYZ added to the map can be subset without
+  // retyping its url. A COG's local `input` is cleared in the same gesture since
+  // the extractor takes exactly one source, and a url makes it a byte-range read
+  // instead of a full download.
+  const handlePopulateSubsetUrl = (layer: GeoLibreLayer) => {
+    if (!selectedTool) return;
+    const fields = subsetUrlFieldValues(selectedTool.id, layer);
+    if (!fields) return;
+    const hasInput = selectedTool.params?.some((param) => param.name === "input");
+    setValues((prev) => ({
+      ...prev,
+      ...(hasInput ? { input: "" } : {}),
+      ...fields,
+    }));
+    for (const name of Object.keys(fields)) browsedInputsRef.current.delete(name);
+    if (hasInput) browsedInputsRef.current.delete("input");
+    setError(null);
+  };
+
   // Fill a subset tool's `bbox` (and companion `bbox_crs`) from the current map
   // view (GeoLibre#1213). The map reads in EPSG:4326, so the bbox is written as
   // WGS84 `west,south,east,north` and the CRS is set to 4326 in the same gesture
@@ -1773,6 +1815,11 @@ export function ProcessingDialog({
                         : undefined
                     }
                     drawingMapExtent={drawing}
+                    onPopulateFromLayer={
+                      isSubsetUrlParameter(selectedTool, param)
+                        ? handlePopulateSubsetUrl
+                        : undefined
+                    }
                   />
                 ))
               )}
@@ -1890,6 +1937,9 @@ interface ParameterFieldProps {
   onDrawMapExtent?: () => void;
   /** Whether a draw is currently in progress (toggles the button's label/state). */
   drawingMapExtent?: boolean;
+  /** When set, renders a "From layer" picker on this (`url`) field that fills it
+   * (and any companion fields) from a compatible loaded raster layer. */
+  onPopulateFromLayer?: (layer: GeoLibreLayer) => void;
   toolId: string;
   runLocal: boolean;
   value: unknown;
@@ -1903,6 +1953,7 @@ function ParameterField({
   onUseMapExtent,
   onDrawMapExtent,
   drawingMapExtent,
+  onPopulateFromLayer,
   toolId,
   runLocal,
   value,
@@ -1912,6 +1963,11 @@ function ParameterField({
   const availableLayers = layers.filter((layer) =>
     canUseLayerForParameter(layer, param),
   );
+  // Loaded layers that can fill this subset `url` field, only computed for the
+  // url param the dialog wired `onPopulateFromLayer` to.
+  const subsetUrlLayers = onPopulateFromLayer
+    ? layersForSubsetUrl(toolId, layers)
+    : [];
   const label = parameterLabel(param);
   const valueText = value === undefined || value === null ? "" : String(value);
 
@@ -2049,6 +2105,37 @@ function ParameterField({
           value={valueText}
           onChange={onChange}
         />
+      ) : onPopulateFromLayer && subsetUrlLayers.length > 0 ? (
+        // A subset extractor's `url`, with loaded layers that can supply it: a
+        // "From layer" picker fills the url (and companion fields) from a
+        // COG/WMS/XYZ layer, while the field stays freely typeable.
+        <div className="grid grid-cols-[minmax(150px,200px)_minmax(0,1fr)] gap-2">
+          <Select
+            aria-label={t("processing.whitebox.fromLayer")}
+            value=""
+            onChange={(event) => {
+              const layer = subsetUrlLayers.find(
+                (item) => item.id === event.target.value,
+              );
+              if (layer) onPopulateFromLayer(layer);
+            }}
+          >
+            <option value="">{t("processing.whitebox.fromLayer")}</option>
+            {subsetUrlLayers.map((layer) => (
+              <option key={layer.id} value={layer.id}>
+                {layer.name}
+              </option>
+            ))}
+          </Select>
+          <Input
+            id={`whitebox-${param.name}`}
+            type="text"
+            value={valueText}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onChange(event.target.value)
+            }
+          />
+        </div>
       ) : (
         <Input
           id={`whitebox-${param.name}`}

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1082,12 +1082,29 @@ export function ProcessingDialog({
     if (!selectedTool) return;
     const fields = subsetUrlFieldValues(selectedTool.id, layer);
     if (!fields) return;
+    // Reset every companion field this populate can set back to the tool
+    // default first, so a previously picked layer's optional values (a WMS
+    // `styles`, an XYZ `subdomains`/`tile_size`) don't linger when the new layer
+    // omits them and skew the extraction. `fields` is spread after, so the new
+    // layer's present values win.
+    const defaults = createDefaultValues(selectedTool);
+    const kind = subsetUrlToolKind(selectedTool.id);
+    const companionReset: ParameterValues =
+      kind === "wms"
+        ? { styles: defaults.styles }
+        : kind === "xyz"
+          ? { tile_size: defaults.tile_size, subdomains: defaults.subdomains }
+          : {};
     const hasInput = selectedTool.params?.some((param) => param.name === "input");
     setValues((prev) => ({
       ...prev,
       ...(hasInput ? { input: "" } : {}),
+      ...companionReset,
       ...fields,
     }));
+    for (const name of Object.keys(companionReset)) {
+      browsedInputsRef.current.delete(name);
+    }
     for (const name of Object.keys(fields)) browsedInputsRef.current.delete(name);
     if (hasInput) browsedInputsRef.current.delete("input");
     setError(null);
@@ -2050,6 +2067,41 @@ function ParameterField({
             </p>
           ) : null}
         </div>
+      ) : onPopulateFromLayer && subsetUrlLayers.length > 0 ? (
+        // A subset extractor's `url`, with loaded layers that can supply it: a
+        // "From layer" picker fills the url (and companion fields) from a
+        // COG/WMS/XYZ layer, while the field stays freely typeable. Placed
+        // before the path/data-input branches (like the "Use map extent" one
+        // above) so a `url` description that happens to contain a word
+        // isPathParameter matches (path/file/…) can't shadow this picker into a
+        // local file-browse control.
+        <div className="grid grid-cols-[minmax(150px,200px)_minmax(0,1fr)] gap-2">
+          <Select
+            aria-label={t("processing.whitebox.fromLayer")}
+            value=""
+            onChange={(event) => {
+              const layer = subsetUrlLayers.find(
+                (item) => item.id === event.target.value,
+              );
+              if (layer) onPopulateFromLayer(layer);
+            }}
+          >
+            <option value="">{t("processing.whitebox.fromLayer")}</option>
+            {subsetUrlLayers.map((layer) => (
+              <option key={layer.id} value={layer.id}>
+                {layer.name}
+              </option>
+            ))}
+          </Select>
+          <Input
+            id={`whitebox-${param.name}`}
+            type="text"
+            value={valueText}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onChange(event.target.value)
+            }
+          />
+        </div>
       ) : isDataInputParameter(param) && availableLayers.length > 0 ? (
         <LayerOrPathInput
           id={`whitebox-${param.name}`}
@@ -2105,37 +2157,6 @@ function ParameterField({
           value={valueText}
           onChange={onChange}
         />
-      ) : onPopulateFromLayer && subsetUrlLayers.length > 0 ? (
-        // A subset extractor's `url`, with loaded layers that can supply it: a
-        // "From layer" picker fills the url (and companion fields) from a
-        // COG/WMS/XYZ layer, while the field stays freely typeable.
-        <div className="grid grid-cols-[minmax(150px,200px)_minmax(0,1fr)] gap-2">
-          <Select
-            aria-label={t("processing.whitebox.fromLayer")}
-            value=""
-            onChange={(event) => {
-              const layer = subsetUrlLayers.find(
-                (item) => item.id === event.target.value,
-              );
-              if (layer) onPopulateFromLayer(layer);
-            }}
-          >
-            <option value="">{t("processing.whitebox.fromLayer")}</option>
-            {subsetUrlLayers.map((layer) => (
-              <option key={layer.id} value={layer.id}>
-                {layer.name}
-              </option>
-            ))}
-          </Select>
-          <Input
-            id={`whitebox-${param.name}`}
-            type="text"
-            value={valueText}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              onChange(event.target.value)
-            }
-          />
-        </div>
       ) : (
         <Input
           id={`whitebox-${param.name}`}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2712,6 +2712,7 @@
       "toolsAvailable_other": "{{count}} tools available.",
       "runtimeUnavailable": "Whitebox runtime is unavailable.",
       "useMapExtent": "Use map extent",
+      "fromLayer": "From layer",
       "drawBbox": "Draw on map",
       "drawingBbox": "Drawing…",
       "drawBboxHint": "Drag a box on the map to set the bounding box. Press Esc to cancel.",

--- a/apps/geolibre-desktop/src/lib/raster-subset-export.ts
+++ b/apps/geolibre-desktop/src/lib/raster-subset-export.ts
@@ -5,11 +5,23 @@ import {
   extractXyzTileSubset,
 } from "@geolibre/processing";
 
+import {
+  normalizeSubdomains,
+  rasterSubsetKind,
+  type RasterSubsetKind,
+} from "./raster-subset-kind";
 import { saveBinaryFileWithFallback } from "./tauri-io";
 import { fetchableUrl } from "./url-utils";
 
-/** Raster layer families that support in-browser bounding-box subset export. */
-export type RasterSubsetKind = "cog" | "wms" | "xyz";
+// Classification helpers live in the dependency-light `raster-subset-kind`
+// module (importable from Node tests); re-exported here so existing importers
+// of this module keep working.
+export {
+  canExtractRasterSubset,
+  normalizeSubdomains,
+  rasterSubsetKind,
+  type RasterSubsetKind,
+} from "./raster-subset-kind";
 
 /**
  * A user-confirmed extraction request. The bounding box is always in WGS84
@@ -42,40 +54,6 @@ export interface RasterSubsetRequest {
    * the UI stuck on "Extracting...".
    */
   signal?: AbortSignal;
-}
-
-/**
- * The subset-extraction family a layer belongs to, or `null` when the layer's
- * type or source can't be extracted. A COG needs a fetchable file (an HTTP COG
- * or a File-loaded one); a WMS needs its endpoint and layer names; an XYZ needs
- * a tile-URL template.
- *
- * @param layer - The store layer to classify.
- * @returns The subset kind, or `null` if the layer can't be subset-extracted.
- */
-export function rasterSubsetKind(layer: GeoLibreLayer): RasterSubsetKind | null {
-  const source = layer.source as Record<string, unknown>;
-  if (layer.type === "cog") {
-    const url =
-      fetchableUrl(layer.metadata.localBytesUrl) ?? fetchableUrl(source.url);
-    return url ? "cog" : null;
-  }
-  if (layer.type === "wms") {
-    const url = typeof source.url === "string" ? source.url.trim() : "";
-    const layers = typeof source.layers === "string" ? source.layers.trim() : "";
-    return url && layers ? "wms" : null;
-  }
-  if (layer.type === "xyz") {
-    const tiles = Array.isArray(source.tiles) ? source.tiles : [];
-    const template = typeof tiles[0] === "string" ? tiles[0] : "";
-    return template ? "xyz" : null;
-  }
-  return null;
-}
-
-/** Whether a layer can be exported as a bounding-box raster subset. */
-export function canExtractRasterSubset(layer: GeoLibreLayer): boolean {
-  return rasterSubsetKind(layer) !== null;
 }
 
 /**
@@ -147,32 +125,6 @@ async function resolveCogSource(
     offset += chunk.byteLength;
   }
   return bytes;
-}
-
-/**
- * Coerce a tile source's `subdomains` into the string of letters the WASM XYZ
- * extractor expects (it rotates `{s}` by indexing into the string per tile). A
- * plain string is passed through; a MapLibre/Leaflet-style `string[]` of single
- * letters (as offline-tiles.ts models it) is joined so the rotation is
- * preserved. Anything else yields `undefined` (no `{s}` rotation).
- *
- * @param value - The source's `subdomains` field, of unknown shape.
- * @returns The subdomain letters as a string, or `undefined`.
- */
-function normalizeSubdomains(value: unknown): string | undefined {
-  if (typeof value === "string") return value || undefined;
-  if (Array.isArray(value)) {
-    // Only single-letter entries map onto the extractor's per-letter string
-    // form. Concatenating multi-character subdomains (e.g. ["mt0","mt1"]) would
-    // produce a garbage rotation string, so in that case drop rotation instead.
-    const letters = value.filter(
-      (v): v is string => typeof v === "string" && v.length === 1,
-    );
-    return letters.length > 0 && letters.length === value.length
-      ? letters.join("")
-      : undefined;
-  }
-  return undefined;
 }
 
 /** WGS84 bounding box EPSG code; the panel always draws/edits in lng/lat. */

--- a/apps/geolibre-desktop/src/lib/raster-subset-kind.ts
+++ b/apps/geolibre-desktop/src/lib/raster-subset-kind.ts
@@ -1,0 +1,73 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+
+import { fetchableUrl } from "./url-utils";
+
+/**
+ * Pure (browser/Node-safe) classification helpers for the raster subset
+ * extractors. Kept separate from `raster-subset-export.ts` so they can be
+ * imported without pulling in that module's heavy, browser-only dependencies
+ * (the WASM extractors and the Tauri save path).
+ */
+
+/** Raster layer families that support in-browser bounding-box subset export. */
+export type RasterSubsetKind = "cog" | "wms" | "xyz";
+
+/**
+ * The subset-extraction family a layer belongs to, or `null` when the layer's
+ * type or source can't be extracted. A COG needs a fetchable file (an HTTP COG
+ * or a File-loaded one); a WMS needs its endpoint and layer names; an XYZ needs
+ * a tile-URL template.
+ *
+ * @param layer - The store layer to classify.
+ * @returns The subset kind, or `null` if the layer can't be subset-extracted.
+ */
+export function rasterSubsetKind(layer: GeoLibreLayer): RasterSubsetKind | null {
+  const source = layer.source as Record<string, unknown>;
+  if (layer.type === "cog") {
+    const url =
+      fetchableUrl(layer.metadata.localBytesUrl) ?? fetchableUrl(source.url);
+    return url ? "cog" : null;
+  }
+  if (layer.type === "wms") {
+    const url = typeof source.url === "string" ? source.url.trim() : "";
+    const layers = typeof source.layers === "string" ? source.layers.trim() : "";
+    return url && layers ? "wms" : null;
+  }
+  if (layer.type === "xyz") {
+    const tiles = Array.isArray(source.tiles) ? source.tiles : [];
+    const template = typeof tiles[0] === "string" ? tiles[0] : "";
+    return template ? "xyz" : null;
+  }
+  return null;
+}
+
+/** Whether a layer can be exported as a bounding-box raster subset. */
+export function canExtractRasterSubset(layer: GeoLibreLayer): boolean {
+  return rasterSubsetKind(layer) !== null;
+}
+
+/**
+ * Coerce a tile source's `subdomains` into the string of letters the WASM XYZ
+ * extractor expects (it rotates `{s}` by indexing into the string per tile). A
+ * plain string is passed through; a MapLibre/Leaflet-style `string[]` of single
+ * letters (as offline-tiles.ts models it) is joined so the rotation is
+ * preserved. Anything else yields `undefined` (no `{s}` rotation).
+ *
+ * @param value - The source's `subdomains` field, of unknown shape.
+ * @returns The subdomain letters as a string, or `undefined`.
+ */
+export function normalizeSubdomains(value: unknown): string | undefined {
+  if (typeof value === "string") return value || undefined;
+  if (Array.isArray(value)) {
+    // Only single-letter entries map onto the extractor's per-letter string
+    // form. Concatenating multi-character subdomains (e.g. ["mt0","mt1"]) would
+    // produce a garbage rotation string, so in that case drop rotation instead.
+    const letters = value.filter(
+      (v): v is string => typeof v === "string" && v.length === 1,
+    );
+    return letters.length > 0 && letters.length === value.length
+      ? letters.join("")
+      : undefined;
+  }
+  return undefined;
+}

--- a/apps/geolibre-desktop/src/lib/subset-tool-url.ts
+++ b/apps/geolibre-desktop/src/lib/subset-tool-url.ts
@@ -1,0 +1,121 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+
+import {
+  normalizeSubdomains,
+  rasterSubsetKind,
+  type RasterSubsetKind,
+} from "./raster-subset-kind";
+import { fetchableUrl } from "./url-utils";
+
+/**
+ * The GeoLibre-authored subset extractors whose `url` parameter can be filled
+ * from a compatible raster layer already loaded in the map (GeoLibre#1271).
+ * Each tool maps to the raster family whose layers can supply its `url`: the COG
+ * extractor reads an HTTP COG by byte range, the WMS extractor calls an endpoint,
+ * and the XYZ extractor walks a tile template. Matching by kind keeps a picked
+ * layer from populating the wrong tool (e.g. an XYZ template into the COG url).
+ */
+const SUBSET_URL_TOOL_KIND: Record<string, RasterSubsetKind> = {
+  extract_cog_subset: "cog",
+  extract_wms_subset: "wms",
+  extract_xyz_tile_subset: "xyz",
+};
+
+/**
+ * The raster family whose loaded layers can populate the given subset tool's
+ * `url` field, or `null` when the tool is not a url-populatable subset extractor.
+ *
+ * @param toolId - The Whitebox/GeoLibre tool id.
+ * @returns The matching {@link RasterSubsetKind}, or `null`.
+ */
+export function subsetUrlToolKind(toolId: string): RasterSubsetKind | null {
+  return SUBSET_URL_TOOL_KIND[toolId] ?? null;
+}
+
+/**
+ * An HTTP(S) url usable as a subset extractor's `url` string, or `null`. A blob
+ * url (a File-loaded raster's retained bytes) is rejected: the `url` code path
+ * does byte-range reads a blob url cannot serve, and such a layer is better used
+ * through the tool's `input` field, which reads its bytes directly.
+ *
+ * @param value - A candidate url value of unknown shape.
+ * @returns The http(s) url, or `null`.
+ */
+function httpUrl(value: unknown): string | null {
+  const url = fetchableUrl(value);
+  return url && /^https?:/i.test(url) ? url : null;
+}
+
+/**
+ * Loaded layers that can populate the given subset tool's `url` field, matched
+ * by raster family. The COG tool additionally requires a remote (http) source so
+ * the populated url is byte-range readable; WMS/XYZ layers always carry a
+ * usable url/template once {@link rasterSubsetKind} has classified them.
+ *
+ * @param toolId - The subset tool id.
+ * @param layers - The store's current layers.
+ * @returns The subset of `layers` that can fill this tool's `url` field.
+ */
+export function layersForSubsetUrl(
+  toolId: string,
+  layers: GeoLibreLayer[],
+): GeoLibreLayer[] {
+  const kind = subsetUrlToolKind(toolId);
+  if (!kind) return [];
+  return layers.filter((layer) => {
+    if (rasterSubsetKind(layer) !== kind) return false;
+    if (kind === "cog") {
+      return httpUrl((layer.source as Record<string, unknown>).url) != null;
+    }
+    return true;
+  });
+}
+
+/**
+ * Derive the field values that populating the given subset tool's inputs from a
+ * layer should set. Beyond the `url` itself this fills the companion fields the
+ * extractor needs to run against that source: the WMS `layers` (and `styles`
+ * when present), and the XYZ `tile_size`/`subdomains`. The extractors' own
+ * defaults (WMS version 1.1.1, GeoTIFF format) are left untouched, matching the
+ * layer-context-menu "Extract subset" path. Values are strings, matching the
+ * dialog's convention that every parameter value is stored as a string.
+ *
+ * @param toolId - The subset tool id.
+ * @param layer - The layer to populate from.
+ * @returns A parameter-name to value map, or `null` when the layer can't supply
+ *   a usable url for this tool.
+ */
+export function subsetUrlFieldValues(
+  toolId: string,
+  layer: GeoLibreLayer,
+): Record<string, string> | null {
+  const kind = subsetUrlToolKind(toolId);
+  const source = layer.source as Record<string, unknown>;
+  if (kind === "cog") {
+    const url = httpUrl(source.url);
+    return url ? { url } : null;
+  }
+  if (kind === "wms") {
+    const url = typeof source.url === "string" ? source.url.trim() : "";
+    const layers = typeof source.layers === "string" ? source.layers.trim() : "";
+    if (!url || !layers) return null;
+    const values: Record<string, string> = { url, layers };
+    if (typeof source.styles === "string" && source.styles.trim()) {
+      values.styles = source.styles.trim();
+    }
+    return values;
+  }
+  if (kind === "xyz") {
+    const tiles = Array.isArray(source.tiles) ? source.tiles : [];
+    const template = typeof tiles[0] === "string" ? tiles[0] : "";
+    if (!template) return null;
+    const values: Record<string, string> = { url: template };
+    if (typeof source.tileSize === "number") {
+      values.tile_size = String(source.tileSize);
+    }
+    const subdomains = normalizeSubdomains(source.subdomains);
+    if (subdomains) values.subdomains = subdomains;
+    return values;
+  }
+  return null;
+}

--- a/apps/geolibre-desktop/src/lib/subset-tool-url.ts
+++ b/apps/geolibre-desktop/src/lib/subset-tool-url.ts
@@ -48,9 +48,11 @@ function httpUrl(value: unknown): string | null {
 
 /**
  * Loaded layers that can populate the given subset tool's `url` field, matched
- * by raster family. The COG tool additionally requires a remote (http) source so
- * the populated url is byte-range readable; WMS/XYZ layers always carry a
- * usable url/template once {@link rasterSubsetKind} has classified them.
+ * by raster family. A layer qualifies only when {@link subsetUrlFieldValues}
+ * can actually derive field values for it, so the "From layer" list and the
+ * click handler share one source of truth: a layer never appears in the list
+ * yet silently no-op when picked. The family gate (`rasterSubsetKind`) also
+ * keeps, say, a plain remote raster tile layer out of the COG tool.
  *
  * @param toolId - The subset tool id.
  * @param layers - The store's current layers.
@@ -62,13 +64,11 @@ export function layersForSubsetUrl(
 ): GeoLibreLayer[] {
   const kind = subsetUrlToolKind(toolId);
   if (!kind) return [];
-  return layers.filter((layer) => {
-    if (rasterSubsetKind(layer) !== kind) return false;
-    if (kind === "cog") {
-      return httpUrl((layer.source as Record<string, unknown>).url) != null;
-    }
-    return true;
-  });
+  return layers.filter(
+    (layer) =>
+      rasterSubsetKind(layer) === kind &&
+      subsetUrlFieldValues(toolId, layer) !== null,
+  );
 }
 
 /**

--- a/tests/subset-tool-url.test.ts
+++ b/tests/subset-tool-url.test.ts
@@ -1,0 +1,150 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  layersForSubsetUrl,
+  subsetUrlFieldValues,
+  subsetUrlToolKind,
+} from "../apps/geolibre-desktop/src/lib/subset-tool-url";
+
+function layer(partial: Partial<GeoLibreLayer>): GeoLibreLayer {
+  return {
+    id: "l1",
+    name: "layer",
+    type: "cog",
+    source: {},
+    visible: true,
+    opacity: 1,
+    style: {} as GeoLibreLayer["style"],
+    metadata: {},
+    ...partial,
+  };
+}
+
+describe("subsetUrlToolKind", () => {
+  it("maps each subset extractor to its raster family", () => {
+    assert.equal(subsetUrlToolKind("extract_cog_subset"), "cog");
+    assert.equal(subsetUrlToolKind("extract_wms_subset"), "wms");
+    assert.equal(subsetUrlToolKind("extract_xyz_tile_subset"), "xyz");
+  });
+
+  it("returns null for non-subset tools", () => {
+    assert.equal(subsetUrlToolKind("slope"), null);
+    assert.equal(subsetUrlToolKind(""), null);
+  });
+});
+
+describe("layersForSubsetUrl", () => {
+  const cogRemote = layer({
+    id: "cog-remote",
+    type: "cog",
+    source: { url: "https://example.com/dem.tif" },
+  });
+  const cogLocal = layer({
+    id: "cog-local",
+    type: "cog",
+    source: {},
+    metadata: { localBytesUrl: "blob:abc" },
+  });
+  const wms = layer({
+    id: "wms",
+    type: "wms",
+    source: { url: "https://example.com/wms", layers: "topo" },
+  });
+  const xyz = layer({
+    id: "xyz",
+    type: "xyz",
+    source: { tiles: ["https://example.com/{z}/{x}/{y}.png"] },
+  });
+  const all = [cogRemote, cogLocal, wms, xyz];
+
+  it("offers only remote COGs to the COG extractor (a blob COG is excluded)", () => {
+    assert.deepEqual(
+      layersForSubsetUrl("extract_cog_subset", all).map((l) => l.id),
+      ["cog-remote"],
+    );
+  });
+
+  it("offers WMS layers to the WMS extractor and XYZ to the XYZ extractor", () => {
+    assert.deepEqual(
+      layersForSubsetUrl("extract_wms_subset", all).map((l) => l.id),
+      ["wms"],
+    );
+    assert.deepEqual(
+      layersForSubsetUrl("extract_xyz_tile_subset", all).map((l) => l.id),
+      ["xyz"],
+    );
+  });
+
+  it("returns nothing for a non-subset tool", () => {
+    assert.deepEqual(layersForSubsetUrl("slope", all), []);
+  });
+});
+
+describe("subsetUrlFieldValues", () => {
+  it("fills the COG url from a remote source, rejecting a blob-only COG", () => {
+    assert.deepEqual(
+      subsetUrlFieldValues(
+        "extract_cog_subset",
+        layer({ source: { url: "https://example.com/dem.tif" } }),
+      ),
+      { url: "https://example.com/dem.tif" },
+    );
+    assert.equal(
+      subsetUrlFieldValues(
+        "extract_cog_subset",
+        layer({ source: {}, metadata: { localBytesUrl: "blob:abc" } }),
+      ),
+      null,
+    );
+  });
+
+  it("fills WMS url plus layers, and styles when present", () => {
+    assert.deepEqual(
+      subsetUrlFieldValues(
+        "extract_wms_subset",
+        layer({
+          type: "wms",
+          source: {
+            url: "https://example.com/wms",
+            layers: "topo",
+            styles: "default",
+          },
+        }),
+      ),
+      { url: "https://example.com/wms", layers: "topo", styles: "default" },
+    );
+  });
+
+  it("requires both a url and layer name for WMS", () => {
+    assert.equal(
+      subsetUrlFieldValues(
+        "extract_wms_subset",
+        layer({ type: "wms", source: { url: "https://example.com/wms" } }),
+      ),
+      null,
+    );
+  });
+
+  it("fills the XYZ template plus tile size and normalized subdomains", () => {
+    assert.deepEqual(
+      subsetUrlFieldValues(
+        "extract_xyz_tile_subset",
+        layer({
+          type: "xyz",
+          source: {
+            tiles: ["https://{s}.example.com/{z}/{x}/{y}.png"],
+            tileSize: 512,
+            subdomains: ["a", "b", "c"],
+          },
+        }),
+      ),
+      {
+        url: "https://{s}.example.com/{z}/{x}/{y}.png",
+        tile_size: "512",
+        subdomains: "abc",
+      },
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1271

## Problem

The **Extract COG Subset**, **Extract WMS Subset**, and **Extract XYZ Tile Subset** tools required typing a URL by hand. A COG/WMS/XYZ layer already added to the map could not be used as the input without retyping its source. Selecting the loaded layer as the COG tool's `input` field also forced a full download of the file, defeating the whole point of a COG's byte-range reads.

## Change

Each subset extractor's `url` field now shows a **From layer** picker listing the compatible loaded raster layers. Selecting one fills the `url` (and the companion fields the tool needs to run): WMS `layers`/`styles`, XYZ `tile_size`/`subdomains`. The field stays freely typeable.

- The COG tool offers only **remote (HTTP) COGs**, so the populated URL is byte-range readable, and clears the local `input` in the same gesture since the extractor takes exactly one source.
- Layer eligibility and URL derivation reuse the same classification the layer-context-menu "Extract subset" path already relies on (`rasterSubsetKind`), factored into a dependency-light `raster-subset-kind.ts` module so it is unit-testable.

## Verification

Drove the real app with a remote COG (`data.geo.admin.ch` Swiss S2 mosaic) and an OSM XYZ layer:

- Extract COG Subset: the picker lists only the remote COG and fills the `url`; verified in both light and dark themes.
- Extract XYZ Tile Subset: the picker lists only the XYZ layer (correctly excludes the COG) and fills the tile template.
- WMS derivation (url + layers + styles) and all field mappings are covered by `tests/subset-tool-url.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “From layer” option to subset extraction tools, letting compatible loaded rasters automatically populate URL-related parameters.
  * Populated fields are derived from the selected layer, while the URL input remains editable after auto-fill.
* **Bug Fixes**
  * Improved compatibility/validation for COG, WMS, and XYZ sources when selecting a “From layer” candidate.
* **Localization**
  * Added the new “fromLayer” UI label for the subset extraction dialog.
* **Tests**
  * Added automated coverage for layer compatibility filtering and URL/metadata population behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->