### PR TITLE
fix(raster): honor internal COG mask band (PER_DATASET) as nodata

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.10.1",
+    "maplibre-gl-raster": "^0.11.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.10.1",
+        "maplibre-gl-raster": "^0.11.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
@@ -17094,9 +17094,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.10.1.tgz",
-      "integrity": "sha512-rgyYRelIHh/VwAaY2tyuOMUXqPrkXTv0LjKIY5t64iYrrILTzopRD6mToCE5lCsO0MVpkz9Uc4dE5n5Y6BruLA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.11.0.tgz",
+      "integrity": "sha512-ohi9LGdZ6u4Qvu/cTlm2bRPRzm9wWnFwKTT6kUESPM3SnJMpQlw/AoOoYoV18HKv6Ba/76cprYCrdGd7Ov4WLg==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21865,7 +21865,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.10.1",
+        "maplibre-gl-raster": "^0.11.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,7 +49,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.10.1",
+    "maplibre-gl-raster": "^0.11.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",


### PR DESCRIPTION
## Summary

Fixes #1275. COG rasters whose validity is an internal **`PER_DATASET` mask band** (a mask IFD) rather than a scalar pixel value rendered their nodata border as **opaque black** on the default `maplibre-gl-raster (GPU)` engine.

This is exactly the case in the report: a lossy JPEG/YCbCr mosaic where a true black source pixel is not guaranteed to decode to `(0,0,0)` and some genuinely dark data pixels (shadow, water, canopy) decode close to it, so **no scalar `nodata`** can separate the border from valid data. The authoritative validity signal is the internal mask band, which the renderer ignored.

## What changed

Bump `maplibre-gl-raster` `^0.10.1 → ^0.11.0` in `apps/geolibre-desktop` and `packages/plugins` (+ lockfile).

The upstream release (opengeos/maplibre-gl-raster#41) uploads the tile's internal mask band as a single-channel texture and discards masked fragments via `deck.gl-raster`'s `MaskTexture` module, across rgb / single / index / palette modes and **independent of the scalar `nodata` setting** (including `nodata: 'off'`) — matching how GDAL/QGIS/titiler honor the mask by default. No GeoLibre-side wiring changes were needed.

## Verification

Drove the real app (`npm run dev`) with the reporter's swisstopo COG (`swisseo_s2-sr_v200 ... tci_10m.tif`, Byte/YCbCr JPEG, `Mask Flags: PER_DATASET`) on the `maplibre-gl-raster (GPU)` engine, using the published `maplibre-gl-raster@0.11.0`:

**Before** (`^0.10.1`): opaque black nodata border around the valid imagery.

**After** (`^0.11.0`): the border is transparent (basemap shows through) and valid data renders correctly. Confirmed in:
- Light theme
- Dark theme
- **No data = "Render all pixels" (off)** — the exact config from the report, proving the mask is applied regardless of the scalar nodata field.

`npm run build` and `npm run test:frontend` (2831 pass) both green; pre-commit clean.

## Scope note

This fixes the default `maplibre-gl-raster (GPU)` engine (the one the reporter used). The optional `cog-tiler-wasm` engine also does not read internal mask bands; that is tracked separately as a follow-up in the `cog-tiler-wasm` package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying raster map rendering components to the latest compatible version.
  * Improved the foundation for displaying raster-based map layers across the desktop app and plugin features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->