### PR TITLE
fix(storymap): keep cloud raster layers in HTML export and change views in the PDF handout

### DIFF
--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -355,11 +355,17 @@ export function StoryMapHandoutDialog({
     // chapter being left, enter+exit each skipped chapter, then enter the
     // target. Duration 0 makes each change instant so the capture never grabs
     // a mid-fade frame.
-    let effectsApplied = false;
+    const effectsApplied = chapters.some(
+      (chapter) =>
+        chapter.onChapterEnter.length > 0 || chapter.onChapterExit.length > 0,
+    );
+    // Reset to the store-backed layer styles first so the replay starts from
+    // the same baseline as a fresh presentation, not whatever opacities a
+    // prior preview or presentation left on the live map.
+    if (effectsApplied) controller.restoreLayerStyles();
     const applyEffects = (changes: StoryChapter["onChapterEnter"]) => {
       for (const change of changes) {
         controller.setStoryLayerOpacity(change.layerId, change.opacity, 0);
-        effectsApplied = true;
       }
     };
     let lastChapterIndex = -1;

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapHandoutDialog.tsx
@@ -324,8 +324,9 @@ export function StoryMapHandoutDialog({
   const handleGenerate = useCallback(async () => {
     setError(null);
     setNotice(null);
-    const map = mapControllerRef.current?.getMap();
-    if (!map) {
+    const controller = mapControllerRef.current;
+    const map = controller?.getMap();
+    if (!controller || !map) {
       setError(t("storymap.handout.noMap"));
       return;
     }
@@ -347,6 +348,21 @@ export function StoryMapHandoutDialog({
     const original = mapControllerRef.current?.readView();
     abortRef.current = false;
     setGenerating(true);
+    // Replay chapter layer-opacity effects so each captured page shows the
+    // same "change view" (e.g. a before/after imagery fade) the reader sees at
+    // that chapter, instead of freezing every page at the live map's current
+    // opacities (#1272). Mirrors the presenter's enterChapter replay: exit the
+    // chapter being left, enter+exit each skipped chapter, then enter the
+    // target. Duration 0 makes each change instant so the capture never grabs
+    // a mid-fade frame.
+    let effectsApplied = false;
+    const applyEffects = (changes: StoryChapter["onChapterEnter"]) => {
+      for (const change of changes) {
+        controller.setStoryLayerOpacity(change.layerId, change.opacity, 0);
+        effectsApplied = true;
+      }
+    };
+    let lastChapterIndex = -1;
     try {
       const captures: HandoutChapter[] = [];
       for (let i = 0; i < chosen.length; i++) {
@@ -388,6 +404,17 @@ export function StoryMapHandoutDialog({
         }
 
         const chapter = screen.chapter;
+        if (lastChapterIndex !== screen.index) {
+          if (lastChapterIndex >= 0) {
+            applyEffects(chapters[lastChapterIndex]?.onChapterExit ?? []);
+          }
+          for (let k = lastChapterIndex + 1; k < screen.index; k++) {
+            applyEffects(chapters[k]?.onChapterEnter ?? []);
+            applyEffects(chapters[k]?.onChapterExit ?? []);
+          }
+          applyEffects(chapter.onChapterEnter);
+          lastChapterIndex = screen.index;
+        }
         await jumpAndWaitIdle(map, chapter.location, () => abortRef.current);
         if (abortRef.current) break;
         const shot = captureMapImage(map);
@@ -432,7 +459,9 @@ export function StoryMapHandoutDialog({
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      // Always return the map to where the user left it, even on failure.
+      // Undo the replayed opacity effects (like the presenter does on exit) and
+      // return the map to where the user left it, even on failure.
+      if (effectsApplied) controller.restoreLayerStyles();
       if (original) {
         map.jumpTo({
           center: original.center,

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -346,17 +346,17 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
                 layer.type === "wms" ||
                 layer.type === "wmts"
               ) {
-                // Match buildRasterTileSource's string filter so a malformed
-                // tiles array still falls through to the live-source recovery.
+                // Match buildRasterTileSource's embeddable-source filters so a
+                // record it would drop (app-protocol tiles, non-http url, a
+                // wms/wmts service endpoint in url) still falls through to the
+                // live-source recovery instead of short-circuiting here.
+                const isHttpUrl = (value: unknown): value is string =>
+                  typeof value === "string" && /^https?:\/\//i.test(value);
                 const hasTiles =
                   Array.isArray(layer.source.tiles) &&
-                  layer.source.tiles.some((tile) => typeof tile === "string");
-                // Match buildRasterTileSource's embeddable-URL filter: a
-                // non-http url (blob:, geolibre://) cannot load standalone, so
-                // still try to recover a live source for it.
+                  layer.source.tiles.some(isHttpUrl);
                 const hasEmbeddableUrl =
-                  typeof layer.source.url === "string" &&
-                  /^https?:\/\//i.test(layer.source.url);
+                  layer.type === "raster" && isHttpUrl(layer.source.url);
                 if (hasTiles || hasEmbeddableUrl) {
                   return layer;
                 }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -346,9 +346,11 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
                 layer.type === "wms" ||
                 layer.type === "wmts"
               ) {
+                // Match buildRasterTileSource's string filter so a malformed
+                // tiles array still falls through to the live-source recovery.
                 const hasTiles =
                   Array.isArray(layer.source.tiles) &&
-                  layer.source.tiles.length > 0;
+                  layer.source.tiles.some((tile) => typeof tile === "string");
                 // Match buildRasterTileSource's embeddable-URL filter: a
                 // non-http url (blob:, geolibre://) cannot load standalone, so
                 // still try to recover a live source for it.

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -326,14 +326,38 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
       // URL-backed GeoJSON layers (remote GeoJSON, in-browser Parquet/Shapefile
       // conversion) keep their features only in the live MapLibre source, not in
       // the store record, so read them back so the export inlines the same data
-      // the map shows instead of dropping the layer (#936).
+      // the map shows instead of dropping the layer (#936). Service-backed
+      // raster layers (e.g. Planetary Computer scenes) likewise carry no tile
+      // or TileJSON URL in the store — their plugin registers the source on the
+      // map directly — so read the live raster source back too, or the export
+      // drops the imagery a chapter fades between (#1272).
       const controller = mapControllerRef.current;
       const layersForExport = controller
         ? await Promise.all(
             layers.map(async (layer) => {
-              if (layer.type !== "geojson" || layer.geojson) return layer;
-              const geojson = await controller.getLayerGeoJson(layer.id);
-              return geojson ? { ...layer, geojson } : layer;
+              if (layer.type === "geojson") {
+                if (layer.geojson) return layer;
+                const geojson = await controller.getLayerGeoJson(layer.id);
+                return geojson ? { ...layer, geojson } : layer;
+              }
+              if (
+                layer.type === "raster" ||
+                layer.type === "xyz" ||
+                layer.type === "wms" ||
+                layer.type === "wmts"
+              ) {
+                const hasTiles =
+                  Array.isArray(layer.source.tiles) &&
+                  layer.source.tiles.length > 0;
+                if (hasTiles || typeof layer.source.url === "string") {
+                  return layer;
+                }
+                const liveSource = controller.getLayerRasterSource(layer.id);
+                return liveSource
+                  ? { ...layer, source: { ...layer.source, ...liveSource } }
+                  : layer;
+              }
+              return layer;
             }),
           )
         : layers;

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -349,7 +349,13 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
                 const hasTiles =
                   Array.isArray(layer.source.tiles) &&
                   layer.source.tiles.length > 0;
-                if (hasTiles || typeof layer.source.url === "string") {
+                // Match buildRasterTileSource's embeddable-URL filter: a
+                // non-http url (blob:, geolibre://) cannot load standalone, so
+                // still try to recover a live source for it.
+                const hasEmbeddableUrl =
+                  typeof layer.source.url === "string" &&
+                  /^https?:\/\//i.test(layer.source.url);
+                if (hasTiles || hasEmbeddableUrl) {
                   return layer;
                 }
                 const liveSource = controller.getLayerRasterSource(layer.id);

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -5,7 +5,10 @@ import DOMPurify from "dompurify";
 // add `rel`, so enforce it ourselves. The flag lives on the DOMPurify singleton
 // so a re-evaluated module (HMR, dynamic import) cannot register it twice.
 const purify = DOMPurify as typeof DOMPurify & { __glRelHook?: boolean };
-if (!purify.__glRelHook) {
+// Without a DOM (Node tests), DOMPurify exports a bare factory with no
+// addHook/sanitize; skip the hook there and let sanitizeStoryHtml fall back to
+// escaping below.
+if (!purify.__glRelHook && typeof purify.addHook === "function") {
   purify.addHook("afterSanitizeAttributes", (node) => {
     if (node.tagName === "A" && node.getAttribute("target") === "_blank") {
       node.setAttribute("rel", "noopener noreferrer");
@@ -32,6 +35,15 @@ if (!purify.__glRelHook) {
  * @returns A sanitized HTML string safe for `dangerouslySetInnerHTML`.
  */
 export function sanitizeStoryHtml(html: string): string {
+  // DOMPurify needs a live DOM; in environments without one (Node tests) it is
+  // not supported. Fall back to escaping the markup wholesale — strictly more
+  // conservative than sanitizing, and those environments never render it.
+  if (!DOMPurify.isSupported) {
+    return html
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
   // Story text is prose with links and light formatting, so allow only that set
   // of tags rather than the full HTML profile. This excludes forms, tables,
   // media, and other structural elements by construction.

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -339,17 +339,20 @@ function buildRasterTileSource(
   ) {
     return null;
   }
+  // Only http(s) tile templates and TileJSON URLs can load in a standalone
+  // page; app-internal protocols (blob:, pmtiles:, geolibre:, …) have no
+  // handler there.
+  const isHttpUrl = (value: unknown): value is string =>
+    typeof value === "string" && /^https?:\/\//i.test(value);
   const tiles = Array.isArray(layer.source.tiles)
-    ? layer.source.tiles.filter((tile): tile is string => typeof tile === "string")
+    ? layer.source.tiles.filter(isHttpUrl)
     : [];
-  // Only an http(s) TileJSON URL can load in a standalone page; app-internal
-  // protocols (blob:, pmtiles:, geolibre:, …) have no handler there. Tiles win
-  // over the URL below because store records are not MapLibre source specs:
-  // WMS layers carry the raw service endpoint in `url` (not a TileJSON)
-  // alongside their GetMap tile template.
+  // The TileJSON `url` fallback is scoped to plain raster layers: wms/wmts
+  // records keep the raw service endpoint (not a TileJSON) in `url` — their
+  // loadable template lives in `tiles` — so embedding it would produce a
+  // source MapLibre cannot parse instead of just omitting the layer.
   const url =
-    typeof layer.source.url === "string" &&
-    /^https?:\/\//i.test(layer.source.url)
+    layer.type === "raster" && isHttpUrl(layer.source.url)
       ? layer.source.url
       : null;
   if (tiles.length === 0 && !url) return null;

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -319,8 +319,12 @@ function buildInlineLayer(
 
 /**
  * Build a MapLibre raster tile source from a raster/XYZ/WMS/WMTS layer, or
- * `null` when the layer carries no tile URL template. Mirrors the live app's
- * external raster tile sync so basemaps and tile services render in the export.
+ * `null` when the layer carries no tile URL template or TileJSON URL. Mirrors
+ * the live app's external raster tile sync so basemaps and tile services
+ * render in the export. A TileJSON `url` covers service-backed rasters such as
+ * Planetary Computer scenes, whose tiler resolves and signs the actual tile
+ * URLs server-side at load time — so the export never embeds an expiring
+ * token (#1272).
  */
 function buildRasterTileSource(
   layer: GeoLibreLayer,
@@ -336,10 +340,17 @@ function buildRasterTileSource(
   const tiles = Array.isArray(layer.source.tiles)
     ? layer.source.tiles.filter((tile): tile is string => typeof tile === "string")
     : [];
-  if (tiles.length === 0) return null;
+  // Only an http(s) TileJSON URL can load in a standalone page; app-internal
+  // protocols (blob:, pmtiles:, geolibre:, …) have no handler there.
+  const url =
+    typeof layer.source.url === "string" &&
+    /^https?:\/\//i.test(layer.source.url)
+      ? layer.source.url
+      : null;
+  if (tiles.length === 0 && !url) return null;
   const source: Record<string, unknown> = {
     type: "raster",
-    tiles,
+    ...(tiles.length > 0 ? { tiles } : { url }),
     tileSize:
       typeof layer.source.tileSize === "number" ? layer.source.tileSize : 256,
   };

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -323,8 +323,10 @@ function buildInlineLayer(
  * the live app's external raster tile sync so basemaps and tile services
  * render in the export. A TileJSON `url` covers service-backed rasters such as
  * Planetary Computer scenes, whose tiler resolves and signs the actual tile
- * URLs server-side at load time — so the export never embeds an expiring
- * token (#1272).
+ * URLs server-side at load time, so for such resolver-backed services the
+ * export embeds a stable endpoint instead of an expiring token (#1272). A
+ * provider whose url or tile template is itself pre-signed still expires with
+ * its credential — the export can only embed what the source exposes.
  */
 function buildRasterTileSource(
   layer: GeoLibreLayer,

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -341,7 +341,10 @@ function buildRasterTileSource(
     ? layer.source.tiles.filter((tile): tile is string => typeof tile === "string")
     : [];
   // Only an http(s) TileJSON URL can load in a standalone page; app-internal
-  // protocols (blob:, pmtiles:, geolibre:, …) have no handler there.
+  // protocols (blob:, pmtiles:, geolibre:, …) have no handler there. Tiles win
+  // over the URL below because store records are not MapLibre source specs:
+  // WMS layers carry the raw service endpoint in `url` (not a TileJSON)
+  // alongside their GetMap tile template.
   const url =
     typeof layer.source.url === "string" &&
     /^https?:\/\//i.test(layer.source.url)

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -556,6 +556,51 @@ export class MapController {
   }
 
   /**
+   * Read the live MapLibre raster source spec backing a project layer.
+   *
+   * Service-backed raster layers registered by plugins (e.g. Planetary
+   * Computer scenes) carry no tile or TileJSON URL in their store record — the
+   * plugin builds the source directly on the map. Reading the live source back
+   * lets the story-map HTML export inline those layers instead of silently
+   * dropping them (#1272). Only http(s) URLs are returned; a source backed by
+   * an app-internal protocol (blob:, pmtiles:, geolibre:, …) cannot load in a
+   * standalone page.
+   *
+   * @param layerId GeoLibre store layer id.
+   * @returns The serialized raster source spec, or null when the layer has no
+   *   embeddable raster source.
+   */
+  getLayerRasterSource(layerId: string): Record<string, unknown> | null {
+    if (!this.map) return null;
+    const map = this.map;
+    for (const nativeId of this.getNativeLayerIdsByLayerId(layerId)) {
+      const styleLayer = map.getLayer(nativeId);
+      const sourceId =
+        styleLayer && "source" in styleLayer
+          ? (styleLayer as { source?: unknown }).source
+          : undefined;
+      if (typeof sourceId !== "string") continue;
+      const source = map.getSource(sourceId);
+      if (source?.type !== "raster") continue;
+      const spec = (source as maplibregl.RasterTileSource).serialize() as
+        | Record<string, unknown>
+        | undefined;
+      if (!spec || typeof spec !== "object") continue;
+      const httpUrl = (value: unknown): value is string =>
+        typeof value === "string" && /^https?:\/\//i.test(value);
+      const tiles = Array.isArray(spec.tiles)
+        ? spec.tiles.filter(httpUrl)
+        : [];
+      if (tiles.length > 0) return { ...spec, tiles };
+      if (httpUrl(spec.url)) {
+        const { tiles: _tiles, ...rest } = spec;
+        return rest;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Fade a project layer in or out for story-map playback.
    *
    * Story chapters change layer opacity as the reader scrolls. This writes the
@@ -565,7 +610,9 @@ export class MapController {
    *
    * @param layerId GeoLibre store layer id to fade.
    * @param opacity Target opacity, clamped to the 0-1 range.
-   * @param durationMs Optional transition duration in milliseconds.
+   * @param durationMs Optional transition duration in milliseconds. Pass 0 for
+   *   an instant change (overriding MapLibre's default 300 ms paint
+   *   transition); leave undefined to keep the default fade.
    */
   setStoryLayerOpacity(
     layerId: string,
@@ -579,7 +626,7 @@ export class MapController {
       if (!styleLayer) continue;
       const props = OPACITY_PAINT_PROPERTIES[styleLayer.type] ?? [];
       for (const prop of props) {
-        if (durationMs && durationMs > 0) {
+        if (typeof durationMs === "number" && durationMs >= 0) {
           this.map.setPaintProperty(nativeId, `${prop}-transition`, {
             duration: durationMs,
           });

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -588,13 +588,22 @@ export class MapController {
       if (!spec || typeof spec !== "object") continue;
       const httpUrl = (value: unknown): value is string =>
         typeof value === "string" && /^https?:\/\//i.test(value);
-      const tiles = Array.isArray(spec.tiles)
-        ? spec.tiles.filter(httpUrl)
-        : [];
-      if (tiles.length > 0) return { ...spec, tiles };
+      // Prefer the TileJSON `url` over `tiles`, mirroring MapLibre's own
+      // precedence when a raster source carries both. serialize() returns the
+      // constructor options (load() extends the instance, not _options), but
+      // if that ever changes, url-first also keeps the export pointing at the
+      // stable TileJSON endpoint rather than a resolved tile template that
+      // could embed a time-limited token.
       if (httpUrl(spec.url)) {
         const { tiles: _tiles, ...rest } = spec;
         return rest;
+      }
+      const tiles = Array.isArray(spec.tiles)
+        ? spec.tiles.filter(httpUrl)
+        : [];
+      if (tiles.length > 0) {
+        const { url: _url, ...rest } = spec;
+        return { ...rest, tiles };
       }
     }
     return null;

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -974,6 +974,11 @@ describe("MapController story-map layer helpers", () => {
     const { controller } = externalRasterSetup({
       type: "raster",
       url: tilejson,
+      // A resolved tile template alongside the TileJSON url (the shape a
+      // loaded source would have if serialize() ever returned merged state).
+      // The url must win so the export embeds the stable TileJSON endpoint,
+      // never a resolved template that could carry a time-limited token.
+      tiles: ["https://example.com/signed/{z}/{x}/{y}.png?token=abc"],
       tileSize: 256,
       bounds: [76.8, 12.5, 77.9, 13.6],
       attribution: "Microsoft Planetary Computer",
@@ -982,6 +987,7 @@ describe("MapController story-map layer helpers", () => {
     const spec = controller.getLayerRasterSource("pc-1");
     assert.ok(spec, "returns the live source spec");
     assert.equal(spec.url, tilejson);
+    assert.equal(spec.tiles, undefined, "resolved tiles are not embedded");
     assert.equal(spec.tileSize, 256);
     assert.deepEqual(spec.bounds, [76.8, 12.5, 77.9, 13.6]);
   });

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -76,6 +76,9 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
         ? {
             type: (sources.get(id)?.type as string) ?? "geojson",
             bounds: sources.get(id)?.bounds,
+            // Mirrors RasterTileSource.serialize(): a copy of the original
+            // source spec, used by getLayerRasterSource.
+            serialize: () => ({ ...sources.get(id) }),
             setData: (data: unknown) => {
               const spec = sources.get(id);
               if (spec) spec.data = data;
@@ -931,5 +934,106 @@ describe("MapController base-layer label", () => {
       controller.destroy();
       assert.deepEqual(win.__GEOLIBRE_LAYER_LABELS__, {});
     });
+  });
+});
+
+describe("MapController story-map layer helpers", () => {
+  /**
+   * Register a plugin-owned native raster layer + source on the fake map, the
+   * way the Planetary Computer control does (outside syncLayers), and inject
+   * the matching store layer so getNativeLayerIdsByLayerId resolves it.
+   */
+  function externalRasterSetup(sourceSpec: Record<string, unknown>) {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    fake.sources.set("pc-1-source", sourceSpec);
+    fake.layers.set("pc-1", {
+      id: "pc-1",
+      type: "raster",
+      source: "pc-1-source",
+      paint: {},
+    });
+    fake.order.push("pc-1");
+    const layer = rasterLayer("pc-1", {
+      // Planetary Computer store records carry no tiles/url; the live source
+      // is the only place the TileJSON URL exists.
+      source: { type: "raster" },
+      metadata: {
+        externalNativeLayer: true,
+        nativeLayerIds: ["pc-1"],
+        sourceId: "pc-1-source",
+      },
+    });
+    internals(controller).syncedLayers = [layer];
+    return { controller, fake };
+  }
+
+  it("reads a live TileJSON raster source back for the HTML export (#1272)", () => {
+    const tilejson =
+      "https://planetarycomputer.microsoft.com/api/data/v1/item/tilejson.json?collection=sentinel-2-l2a&item=S2A&assets=visual";
+    const { controller } = externalRasterSetup({
+      type: "raster",
+      url: tilejson,
+      tileSize: 256,
+      bounds: [76.8, 12.5, 77.9, 13.6],
+      attribution: "Microsoft Planetary Computer",
+    });
+
+    const spec = controller.getLayerRasterSource("pc-1");
+    assert.ok(spec, "returns the live source spec");
+    assert.equal(spec.url, tilejson);
+    assert.equal(spec.tileSize, 256);
+    assert.deepEqual(spec.bounds, [76.8, 12.5, 77.9, 13.6]);
+  });
+
+  it("keeps only http(s) tile templates and drops non-embeddable urls", () => {
+    const { controller } = externalRasterSetup({
+      type: "raster",
+      tiles: [
+        "https://tiles.example.com/{z}/{x}/{y}.png",
+        "geolibre://local/{z}/{x}/{y}.png",
+      ],
+      tileSize: 256,
+    });
+    const spec = controller.getLayerRasterSource("pc-1");
+    assert.ok(spec);
+    assert.deepEqual(spec.tiles, ["https://tiles.example.com/{z}/{x}/{y}.png"]);
+
+    const blobBacked = externalRasterSetup({
+      type: "raster",
+      url: "blob:https://app.example/1234",
+    });
+    assert.equal(blobBacked.controller.getLayerRasterSource("pc-1"), null);
+  });
+
+  it("returns null for layers without a live raster source", () => {
+    const { map } = makeFakeMap();
+    const controller = controllerWith(map);
+    const layer = pointLayer("a");
+    internals(controller).syncedLayers = [layer];
+    assert.equal(controller.getLayerRasterSource("a"), null);
+    assert.equal(controller.getLayerRasterSource("missing"), null);
+  });
+
+  it("setStoryLayerOpacity applies an explicit 0 duration as an instant change", () => {
+    const { controller, fake } = externalRasterSetup({ type: "raster" });
+
+    controller.setStoryLayerOpacity("pc-1", 0.4, 0);
+
+    const paint = fake.layers.get("pc-1")?.paint as Record<string, unknown>;
+    assert.equal(paint["raster-opacity"], 0.4);
+    // The explicit 0 must override MapLibre's default 300 ms paint transition,
+    // or the handout capture grabs a mid-fade frame.
+    assert.deepEqual(paint["raster-opacity-transition"], { duration: 0 });
+  });
+
+  it("setStoryLayerOpacity leaves the default transition when no duration is given", () => {
+    const { controller, fake } = externalRasterSetup({ type: "raster" });
+
+    controller.setStoryLayerOpacity("pc-1", 0.4);
+
+    const paint = fake.layers.get("pc-1")?.paint as Record<string, unknown>;
+    assert.equal(paint["raster-opacity"], 0.4);
+    assert.equal(paint["raster-opacity-transition"], undefined);
   });
 });

--- a/tests/storymap-html-export.test.ts
+++ b/tests/storymap-html-export.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  DEFAULT_STORY_MAP,
+  type GeoLibreLayer,
+  type StoryMap,
+} from "@geolibre/core";
+import { buildStoryMapHtml } from "../apps/geolibre-desktop/src/lib/storymap-export";
+
+function story(overrides: Partial<StoryMap> = {}): StoryMap {
+  return {
+    ...DEFAULT_STORY_MAP,
+    title: "Change",
+    chapters: [
+      {
+        id: "chapter-1",
+        title: "Before",
+        description: "",
+        alignment: "center",
+        hidden: false,
+        location: { center: [77.3, 13.0], zoom: 12, pitch: 0, bearing: 0 },
+        mapAnimation: "flyTo",
+        rotateAnimation: false,
+        onChapterEnter: [{ layerId: "scene-a", opacity: 1, duration: 1000 }],
+        onChapterExit: [],
+      },
+      {
+        id: "chapter-2",
+        title: "After",
+        description: "",
+        alignment: "center",
+        hidden: false,
+        location: { center: [77.3, 13.0], zoom: 12, pitch: 0, bearing: 0 },
+        mapAnimation: "flyTo",
+        rotateAnimation: false,
+        onChapterEnter: [{ layerId: "scene-a", opacity: 0, duration: 1000 }],
+        onChapterExit: [],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function rasterLayer(
+  id: string,
+  source: Record<string, unknown>,
+  patch: Partial<GeoLibreLayer> = {},
+): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "raster",
+    source,
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    ...patch,
+  };
+}
+
+const TILEJSON_URL =
+  "https://planetarycomputer.microsoft.com/api/data/v1/item/tilejson.json?collection=sentinel-2-l2a&item=S2A&assets=visual";
+
+describe("buildStoryMapHtml raster sources", () => {
+  it("inlines a raster layer whose source is a TileJSON url (#1272)", () => {
+    const html = buildStoryMapHtml({
+      storymap: story(),
+      basemapStyleUrl: "https://tiles.example.com/style.json",
+      layers: [
+        rasterLayer("scene-a", {
+          type: "raster",
+          url: TILEJSON_URL,
+          tileSize: 256,
+          bounds: [76.8, 12.5, 77.9, 13.6],
+          attribution: "Microsoft Planetary Computer",
+        }),
+      ],
+    });
+    assert.ok(html.includes("scene-a-source"), "adds the raster source");
+    assert.ok(
+      html.includes(JSON.stringify(TILEJSON_URL)),
+      "embeds the TileJSON url",
+    );
+    // The chapter opacity effects survive because the layer was inlined.
+    assert.ok(
+      html.includes('"layer": "scene-a"'),
+      "keeps the chapter opacity effects targeting the layer",
+    );
+    assert.ok(
+      html.includes('"bounds"'),
+      "carries the source bounds so tiles stay inside the scene",
+    );
+  });
+
+  it("still inlines tile-template raster layers, preferring tiles over url", () => {
+    const html = buildStoryMapHtml({
+      storymap: story(),
+      basemapStyleUrl: "https://tiles.example.com/style.json",
+      layers: [
+        rasterLayer("scene-a", {
+          type: "raster",
+          tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
+          url: TILEJSON_URL,
+        }),
+      ],
+    });
+    assert.ok(html.includes("scene-a-source"));
+    assert.ok(html.includes("https://tiles.example.com/{z}/{x}/{y}.png"));
+    assert.ok(
+      !html.includes(JSON.stringify(TILEJSON_URL)),
+      "does not also embed the TileJSON url",
+    );
+  });
+
+  it("drops raster layers whose url is not http(s)", () => {
+    for (const url of [
+      "blob:https://app.example/1234",
+      "pmtiles://https://example.com/a.pmtiles",
+      "geolibre://offline-basemap",
+    ]) {
+      const html = buildStoryMapHtml({
+        storymap: story(),
+        basemapStyleUrl: "https://tiles.example.com/style.json",
+        layers: [rasterLayer("scene-a", { type: "raster", url })],
+      });
+      assert.ok(
+        !html.includes("scene-a-source"),
+        `does not inline a source for ${url}`,
+      );
+      assert.ok(
+        !html.includes('"layer": "scene-a"'),
+        `filters the chapter effects for ${url}`,
+      );
+    }
+  });
+
+  it("drops raster layers with neither tiles nor url", () => {
+    const html = buildStoryMapHtml({
+      storymap: story(),
+      basemapStyleUrl: "https://tiles.example.com/style.json",
+      layers: [
+        rasterLayer("scene-a", {
+          type: "raster",
+          collectionId: "sentinel-2-l2a",
+        }),
+      ],
+    });
+    assert.ok(!html.includes("scene-a-source"));
+  });
+});

--- a/tests/storymap-html-export.test.ts
+++ b/tests/storymap-html-export.test.ts
@@ -136,6 +136,47 @@ describe("buildStoryMapHtml raster sources", () => {
     }
   });
 
+  it("drops tile templates that are not http(s)", () => {
+    for (const tile of [
+      "blob:https://app.example/1234",
+      "pmtiles://https://example.com/a.pmtiles/{z}/{x}/{y}",
+      "geolibre://local/{z}/{x}/{y}.png",
+    ]) {
+      const html = buildStoryMapHtml({
+        storymap: story(),
+        basemapStyleUrl: "https://tiles.example.com/style.json",
+        layers: [rasterLayer("scene-a", { type: "raster", tiles: [tile] })],
+      });
+      assert.ok(
+        !html.includes("scene-a-source"),
+        `does not inline a source for ${tile}`,
+      );
+      assert.ok(
+        !html.includes('"layer": "scene-a"'),
+        `filters the chapter effects for ${tile}`,
+      );
+    }
+  });
+
+  it("does not embed a wms/wmts service endpoint as a TileJSON url", () => {
+    // WMS/WMTS records carry the raw service endpoint in `url` (not a
+    // TileJSON); with no usable tiles the layer must be omitted, not exported
+    // as a source MapLibre cannot parse.
+    const html = buildStoryMapHtml({
+      storymap: story(),
+      basemapStyleUrl: "https://tiles.example.com/style.json",
+      layers: [
+        rasterLayer(
+          "scene-a",
+          { type: "raster", url: "https://example.com/wms", tiles: [] },
+          { type: "wms" },
+        ),
+      ],
+    });
+    assert.ok(!html.includes("scene-a-source"));
+    assert.ok(!html.includes("https://example.com/wms"));
+  });
+
   it("drops raster layers with neither tiles nor url", () => {
     const html = buildStoryMapHtml({
       storymap: story(),


### PR DESCRIPTION
Fixes #1272

## Problem

Cloud-hosted imagery layers (e.g. Sentinel-2 scenes added from Microsoft Planetary Computer, as in the reporter's [example project](https://share.geolibre.app/spatialthoughts/cog-storymap)) worked in the in-app story map but broke in both exports:

- **HTML export**: `buildRasterTileSource` only inlined raster layers carrying a `tiles` array. Planetary Computer layers register their MapLibre source directly on the map (a TileJSON `url`), and their store record carries neither `tiles` nor `url`, so the export silently dropped the imagery and, with it, the chapter opacity effects that fade between scenes. The exported story was a bare basemap.
- **PDF Handout**: the capture loop flew to each chapter but never applied `onChapterEnter`/`onChapterExit` opacity effects, so a before/after change view produced identical pages.

## Fix

**HTML export**
- New `MapController.getLayerRasterSource(layerId)` reads the live MapLibre raster source spec back (mirroring the existing `getLayerGeoJson` precedent), keeping only http(s) URLs since app-internal protocols cannot load in a standalone page.
- `StoryMapPanel.handleExport` patches raster-family layers that have no tiles/URL in the store with the live source before building the HTML.
- `buildRasterTileSource` now accepts a TileJSON `url` in addition to a `tiles` array.
- Token expiry (the concern raised in the issue): for Planetary Computer this embeds the anonymous `tilejson.json` endpoint, which resolves and signs the actual asset URLs server-side on every load, so the exported page never contains an expiring token and keeps working indefinitely.

**PDF Handout**
- Before capturing each chapter, the dialog now replays the chapter opacity effects cumulatively (exit the chapter being left, enter+exit each skipped chapter, enter the target), mirroring the presenter's replay semantics, so each page shows the same change view the reader sees at that chapter. Effects apply with an instant transition so the capture never grabs a mid-fade frame, and `restoreLayerStyles()` undoes everything afterwards.
- `setStoryLayerOpacity` now honors an explicit duration of `0` as an instant change instead of silently falling back to MapLibre's default 300 ms paint transition.

**Testability**
- `sanitize-html` now degrades safely in DOM-less environments (DOMPurify hook registration guarded; wholesale escaping fallback when DOMPurify is unsupported), so the story map exporter can be tested under Node.

## Verification

- Loaded the reporter's shared project in the real app (Playwright) and confirmed the repro: exported HTML had zero sources and empty chapter effects; handout pages 2 and 3 were identical.
- After the fix, re-exported: the standalone HTML renders both Sentinel-2 scenes from the Planetary Computer TileJSON endpoints and scroll-driving from "Before" to "After" fades between the 2019 and 2026 scenes.
- Regenerated the handout: the "Before" page now shows the 2019 scene and the "After" page the 2026 scene, and layer opacities are restored in the app afterwards. Verified UI in dark and light themes.
- `npm run test:frontend:coverage` (2,845 tests, coverage above the floors), `npm run build`, and pre-commit all pass. New unit tests cover the TileJSON path, non-embeddable URL filtering, and the instant-transition behavior.

## Known limitation (follow-up)

Deck.gl-rendered COG layers (`type: "cog"`, added from a direct COG URL) are still not included in the HTML export. They render through a deck.gl overlay with no native MapLibre layer, so chapter opacity effects do not reach them in the in-app presenter either; supporting them end to end (export + presenter) is a separate, larger piece of work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved StoryMap PDF exports so each chapter page matches the presenter’s layer opacity transitions, and map styling is fully restored even if export is interrupted or fails.
  - Enhanced StoryMap HTML exports for raster layers by recovering missing live layer data and inlining only embeddable HTTP(S) TileJSON/tile sources (with correct chapter opacity effects).
- **Bug Fixes**
  - Strengthened HTML sanitization to safely handle non-browser environments and ensure `target="_blank"` links include safer attributes.
  - Story layer transition timing now supports a zero-duration update for instant opacity changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->