### PR TITLE
docs(raster): bump 're-verified against' pins to v0.11.0

### DIFF
--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -69,7 +69,7 @@ const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
 ];
 
 // This type mirrors undocumented private members of RasterControl from
-// maplibre-gl-raster (re-verified against v0.10.1). All access is optional (?.)
+// maplibre-gl-raster (re-verified against v0.11.0). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.
@@ -192,7 +192,7 @@ export function setNonTiledRasterHandler(
 }
 
 /** Whether a raster load error is the upstream "striped, not tiled" failure.
- * maplibre-gl-raster (re-verified against v0.10.1) rejects non-tiled GeoTIFFs with a message
+ * maplibre-gl-raster (re-verified against v0.11.0) rejects non-tiled GeoTIFFs with a message
  * containing "not tiled"; this is the only signal it exposes, so the match is
  * coupled to that wording. Re-verify it (and broaden if needed) when bumping the
  * dependency -- a reworded message degrades to the plain error, not a crash. */
@@ -621,7 +621,7 @@ function createRasterControl(
   });
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
-  // _state.collapsed BEFORE emitting the event (re-verified against v0.10.1) --
+  // _state.collapsed BEFORE emitting the event (re-verified against v0.11.0) --
   // re-verify that ordering when bumping the dependency.
   const panelStateSyncHandler: RasterControlEventHandler = () =>
     syncRasterLayersToStoreForRuntime(control);
@@ -723,7 +723,7 @@ function patchWebRasterOverlayFactory(
     };
   };
 
-  // maplibre-gl-raster (re-verified against v0.10.1) calls `_deps.removeOverlay(this._map, this._overlay)`
+  // maplibre-gl-raster (re-verified against v0.11.0) calls `_deps.removeOverlay(this._map, this._overlay)`
   // from its LayerManager teardown (after the last raster is removed / the
   // control is destroyed); re-verify this hook exists when bumping the
   // dependency. Even if a future version stopped calling it, the control still

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -22,7 +22,7 @@ import {
 import { colormapColors, warmColormapColors } from "./colormap-colors";
 
 // These types mirror undocumented private members of the maplibre-gl-raster
-// LayerManager (re-verified against v0.10.1) and the deck.gl-raster Colormap
+// LayerManager (re-verified against v0.11.0) and the deck.gl-raster Colormap
 // module name (deck.gl-raster v0.7.0). Access is feature-detected and falls
 // back to a no-op rather than throwing -- re-verify these names AND the
 // "colormap" module name when bumping either dependency.


### PR DESCRIPTION
Follow-up to #1279.

#1279 bumped `maplibre-gl-raster` to 0.11.0 but merged before the version-pin comments in the raster plugin files were updated (they still read "re-verified against v0.10.1"). Per the convention those comments establish, this bumps each pin to v0.11.0.

The private `RasterControl` / `LayerManager` surfaces these files depend on are unchanged in v0.11.0:
- `src/lib/core/RasterControl.ts` is **byte-identical** between v0.10.1 and v0.11.0 (`_layerManager`, `_deps`, `_panel`, `.mlr-control-close`, toggle ordering, `_deps.removeOverlay` teardown).
- `LayerManager` still exposes `_renderTileFor` and the striped/"not tiled" message; the `deck.gl-raster` dependency version is unchanged, so the `"colormap"` render-pipeline module name is too.

Re-exercised in the running app against `maplibre-gl-raster@0.11.0` (0 console errors): single-band pseudocolor render + colormap swap (gray → terrain), discrete classification (`raster-symbology-texture.ts`), and raster panel open/close.

Comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal compatibility references to reflect version 0.11.0.
  * No changes to application functionality, public APIs, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->