### PR TITLE
feat(record-video): burn an optional title/source caption into recordings

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
@@ -1,5 +1,5 @@
 import type { MapController } from "@geolibre/map";
-import { Button, cn, Input, Label } from "@geolibre/ui";
+import { Button, cn, Input, Label, Select } from "@geolibre/ui";
 import {
   Circle,
   Crop,
@@ -15,7 +15,11 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
 import {
+  CAPTION_POSITIONS,
+  type CaptionPosition,
+  DEFAULT_CAPTION_POSITION,
   DEFAULT_FPS,
+  hasCaptionText,
   isMapRecordingSupported,
   MapRecordingUnsupportedError,
   MAX_FPS,
@@ -73,7 +77,10 @@ function formatElapsed(totalSeconds: number): string {
  * Renders as a non-modal, draggable floating panel (mirroring
  * {@link RecordTourDialog}) so the map stays fully interactive while recording:
  * the user pans and zooms and the movement is captured. HTML overlays like this
- * panel and the selection frame are not part of the recorded canvas.
+ * panel and the selection frame are not part of the recorded canvas, but an
+ * optional title/source caption is burned into every frame (see the caption
+ * fields and {@link recordMapCanvas}), letting the user annotate the video
+ * itself the way the on-map HTML control cannot be.
  */
 export function RecordVideoDialog({
   open,
@@ -86,6 +93,12 @@ export function RecordVideoDialog({
   const [selecting, setSelecting] = useState(false);
   const [fps, setFps] = useState(DEFAULT_FPS);
   const [fpsText, setFpsText] = useState(String(DEFAULT_FPS));
+  // Optional title/source caption burned into every frame (see recordMapCanvas).
+  const [captionTitle, setCaptionTitle] = useState("");
+  const [captionText, setCaptionText] = useState("");
+  const [captionPosition, setCaptionPosition] = useState<CaptionPosition>(
+    DEFAULT_CAPTION_POSITION,
+  );
   const [status, setStatus] = useState<Status>("idle");
   const [elapsed, setElapsed] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -191,10 +204,17 @@ export function RecordVideoDialog({
     setStatus("recording");
     const controller = new AbortController();
     abortRef.current = controller;
+    // Snapshot the caption text at record start; blank fields draw nothing.
+    const captionOptions = {
+      title: captionTitle,
+      caption: captionText,
+      position: captionPosition,
+    };
     try {
       const rec = await recordMapCanvas({
         map,
         region: mode === "region" ? region : null,
+        caption: hasCaptionText(captionOptions) ? captionOptions : null,
         fps,
         signal: controller.signal,
         onElapsed: setElapsed,
@@ -417,6 +437,49 @@ export function RecordVideoDialog({
                 setFpsText(String(next));
               }}
             />
+          </div>
+
+          {/* Caption burned into the video. DOM overlays (the HTML control, this
+              panel) can't be recorded, so this text is drawn onto the frames
+              directly, letting the user annotate the video itself. */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="record-video-caption-title">
+              {t("recordVideo.caption")}
+            </Label>
+            <Input
+              id="record-video-caption-title"
+              disabled={editingFrozen}
+              value={captionTitle}
+              onChange={(e) => setCaptionTitle(e.target.value)}
+              placeholder={t("recordVideo.captionTitlePlaceholder")}
+            />
+            <Input
+              id="record-video-caption-text"
+              disabled={editingFrozen}
+              value={captionText}
+              onChange={(e) => setCaptionText(e.target.value)}
+              placeholder={t("recordVideo.captionTextPlaceholder")}
+            />
+            {hasCaptionText({
+              title: captionTitle,
+              caption: captionText,
+              position: captionPosition,
+            }) && (
+              <Select
+                aria-label={t("recordVideo.captionPosition")}
+                disabled={editingFrozen}
+                value={captionPosition}
+                onChange={(e) =>
+                  setCaptionPosition(e.target.value as CaptionPosition)
+                }
+              >
+                {CAPTION_POSITIONS.map((position) => (
+                  <option key={position} value={position}>
+                    {t(`recordVideo.captionPos.${position}`)}
+                  </option>
+                ))}
+              </Select>
+            )}
           </div>
 
           {/* Record / Stop, then the save step. */}

--- a/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordVideoDialog.tsx
@@ -455,6 +455,7 @@ export function RecordVideoDialog({
             />
             <Input
               id="record-video-caption-text"
+              aria-label={t("recordVideo.captionTextLabel")}
               disabled={editingFrozen}
               value={captionText}
               onChange={(e) => setCaptionText(e.target.value)}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -716,6 +716,7 @@
     "fps": "Frames per second",
     "caption": "Caption (burned into video)",
     "captionTitlePlaceholder": "Title (optional)",
+    "captionTextLabel": "Caption subtitle or data source",
     "captionTextPlaceholder": "Subtitle or data source (optional)",
     "captionPosition": "Caption position",
     "captionPos": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -714,6 +714,18 @@
     "noRegion": "Draw a rectangle on the map to choose the recording area.",
     "needRegion": "Select an area on the map first.",
     "fps": "Frames per second",
+    "caption": "Caption (burned into video)",
+    "captionTitlePlaceholder": "Title (optional)",
+    "captionTextPlaceholder": "Subtitle or data source (optional)",
+    "captionPosition": "Caption position",
+    "captionPos": {
+      "top-left": "Top left",
+      "top-center": "Top center",
+      "top-right": "Top right",
+      "bottom-left": "Bottom left",
+      "bottom-center": "Bottom center",
+      "bottom-right": "Bottom right"
+    },
     "record": "Record",
     "stop": "Stop",
     "savingStatus": "Saving video…",

--- a/apps/geolibre-desktop/src/lib/map-recorder.ts
+++ b/apps/geolibre-desktop/src/lib/map-recorder.ts
@@ -21,6 +21,12 @@ import { isFullViewportMapCanvas } from "./print-capture";
  * offscreen canvas via `captureStream`. Compositing into an intermediate canvas
  * is what makes the crop and the overlay possible: `captureStream` on the raw
  * WebGL canvas can neither crop nor pick up the deck.gl layer.
+ *
+ * An optional title/source **caption** ({@link CaptionOptions}) is drawn on top
+ * of the composited map with the 2D text API. DOM overlays (the HTML control,
+ * legends, the record panel) cannot be captured because they live outside the
+ * canvas, but a caption drawn straight onto the offscreen canvas records fine
+ * and keeps it origin-clean — letting the user annotate the video itself.
  */
 
 /**
@@ -188,10 +194,218 @@ export function computeCaptureRect(
   };
 }
 
+/**
+ * A text overlay ("title card") burned into every recorded frame.
+ *
+ * DOM overlays — the HTML control, legends, the record panel itself — live
+ * outside the canvas and so can never be captured (see the module doc). A
+ * caption sidesteps that: it is drawn straight onto the offscreen recording
+ * canvas with the 2D text API, so it needs no DOM-to-image rasterization and
+ * keeps the canvas origin-clean for `captureStream` (a tainted canvas cannot be
+ * recorded). This is how a user annotates the video itself — a title and a
+ * source line that are not tied to any map coordinate.
+ */
+
+/** Where the caption box is anchored within the recorded frame. */
+export type CaptionPosition =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
+
+/** The selectable caption positions, in menu order (top row then bottom row). */
+export const CAPTION_POSITIONS: readonly CaptionPosition[] = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+] as const;
+
+/** Default caption placement — a classic lower-left title card. */
+export const DEFAULT_CAPTION_POSITION: CaptionPosition = "bottom-left";
+
+/** Text to burn into the recording, plus where to place it. */
+export interface CaptionOptions {
+  /** Bold primary line (e.g. a video title). Blank/whitespace hides the line. */
+  title?: string;
+  /** Smaller secondary line (e.g. a data source). Blank hides the line. */
+  caption?: string;
+  /** Corner/edge the caption box is anchored to. */
+  position: CaptionPosition;
+}
+
+/** True when a caption has at least one non-blank line to draw. */
+export function hasCaptionText(
+  options: CaptionOptions | null | undefined,
+): boolean {
+  return Boolean(options && (options.title?.trim() || options.caption?.trim()));
+}
+
+/**
+ * Font sizes and paddings for a caption, in device pixels, scaled to the frame
+ * height so the overlay reads the same at any recording resolution. Pure, so the
+ * scaling can be unit tested without a canvas.
+ */
+export interface CaptionMetrics {
+  titlePx: number;
+  captionPx: number;
+  padX: number;
+  padY: number;
+  lineGap: number;
+  margin: number;
+  radius: number;
+}
+
+/** Derive caption {@link CaptionMetrics} from the output frame height. */
+export function captionMetrics(outputHeight: number): CaptionMetrics {
+  // Anchor the title height to a fraction of the frame, clamped so tiny frames
+  // stay legible and huge frames don't get a comically large title card.
+  const titlePx = Math.round(Math.min(48, Math.max(14, outputHeight * 0.034)));
+  return {
+    titlePx,
+    captionPx: Math.round(titlePx * 0.66),
+    padX: Math.round(titlePx * 0.6),
+    padY: Math.round(titlePx * 0.45),
+    lineGap: Math.round(titlePx * 0.28),
+    margin: Math.round(titlePx * 0.7),
+    radius: Math.round(titlePx * 0.3),
+  };
+}
+
+/**
+ * Top-left corner (device px) of a caption box of the given size, placed at
+ * `position` within a `canvasW`x`canvasH` frame with `margin` breathing room.
+ * The origin is clamped so the box never leaves the frame on the near edge (a
+ * very wide caption pins to the margin and overflows the far edge instead of
+ * floating off-canvas). Pure, so the placement math is unit tested without a
+ * canvas.
+ */
+export function captionBoxOrigin(
+  position: CaptionPosition,
+  boxW: number,
+  boxH: number,
+  canvasW: number,
+  canvasH: number,
+  margin: number,
+): { x: number; y: number } {
+  const [vert, horiz] = position.split("-") as [
+    "top" | "bottom",
+    "left" | "center" | "right",
+  ];
+  let x: number;
+  if (horiz === "left") x = margin;
+  else if (horiz === "right") x = canvasW - margin - boxW;
+  else x = (canvasW - boxW) / 2;
+  let y = vert === "top" ? margin : canvasH - margin - boxH;
+  // Clamp so the box stays on-canvas; the near-edge margin wins when the box is
+  // wider/taller than the frame allows.
+  x = Math.max(margin, Math.min(x, Math.max(margin, canvasW - margin - boxW)));
+  y = Math.max(margin, Math.min(y, Math.max(margin, canvasH - margin - boxH)));
+  return { x: Math.round(x), y: Math.round(y) };
+}
+
+/** Trace a rounded-rectangle path (fallback for contexts without `roundRect`). */
+function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const rr = Math.max(0, Math.min(r, w / 2, h / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.arcTo(x + w, y, x + w, y + h, rr);
+  ctx.arcTo(x + w, y + h, x, y + h, rr);
+  ctx.arcTo(x, y + h, x, y, rr);
+  ctx.arcTo(x, y, x + w, y, rr);
+  ctx.closePath();
+}
+
+const CAPTION_FONT_FAMILY =
+  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+
+/**
+ * Draw the caption overlay onto the recording context, sized to the frame. A
+ * no-op when there is no text or the frame is degenerate. Called once per frame
+ * from the compositor loop; it only measures and draws, so it stays cheap.
+ */
+export function drawCaptionOverlay(
+  ctx: CanvasRenderingContext2D,
+  options: CaptionOptions | null | undefined,
+  outW: number,
+  outH: number,
+): void {
+  if (!hasCaptionText(options) || outW < 2 || outH < 2) return;
+  const title = options?.title?.trim() ?? "";
+  const caption = options?.caption?.trim() ?? "";
+  const m = captionMetrics(outH);
+  const titleFont = `600 ${m.titlePx}px ${CAPTION_FONT_FAMILY}`;
+  const captionFont = `400 ${m.captionPx}px ${CAPTION_FONT_FAMILY}`;
+
+  // Measure both lines to size the background box around the widest one.
+  let textW = 0;
+  if (title) {
+    ctx.font = titleFont;
+    textW = Math.max(textW, ctx.measureText(title).width);
+  }
+  if (caption) {
+    ctx.font = captionFont;
+    textW = Math.max(textW, ctx.measureText(caption).width);
+  }
+  const lineH = (px: number) => Math.round(px * 1.2);
+  const titleLineH = title ? lineH(m.titlePx) : 0;
+  const captionLineH = caption ? lineH(m.captionPx) : 0;
+  const innerGap = title && caption ? m.lineGap : 0;
+  const boxW = Math.round(textW) + m.padX * 2;
+  const boxH = titleLineH + innerGap + captionLineH + m.padY * 2;
+  const { x, y } = captionBoxOrigin(
+    options?.position ?? DEFAULT_CAPTION_POSITION,
+    boxW,
+    boxH,
+    outW,
+    outH,
+    m.margin,
+  );
+
+  ctx.save();
+  // Semi-opaque rounded backing so the text stays legible over any basemap.
+  ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+  roundRectPath(ctx, x, y, boxW, boxH, m.radius);
+  ctx.fill();
+
+  ctx.textBaseline = "top";
+  ctx.textAlign = "left";
+  const tx = x + m.padX;
+  let ty = y + m.padY;
+  if (title) {
+    ctx.font = titleFont;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillText(title, tx, ty);
+    ty += titleLineH + innerGap;
+  }
+  if (caption) {
+    ctx.font = captionFont;
+    ctx.fillStyle = "rgba(255, 255, 255, 0.85)";
+    ctx.fillText(caption, tx, ty);
+  }
+  ctx.restore();
+}
+
 export interface RecordMapOptions {
   map: MapLibreMap;
   /** Screen rectangle to capture, or null/omitted for the whole viewport. */
   region?: RecordRegion | null;
+  /**
+   * A title/source caption burned into every frame, or null/omitted for none.
+   * Snapshotted at the start of the recording (see {@link recordMapCanvas}).
+   */
+  caption?: CaptionOptions | null;
   /** Frames per second sampled from the canvas. */
   fps: number;
   /**
@@ -226,6 +440,7 @@ export interface MapRecording {
 export async function recordMapCanvas({
   map,
   region,
+  caption,
   fps,
   signal,
   onElapsed,
@@ -355,6 +570,10 @@ export async function recordMapCanvas({
           }
         }
       });
+      // Draw the title/source caption on top of the composited map, in output
+      // space. Text drawn with the 2D API keeps the canvas origin-clean, so the
+      // caption records fine where a rasterized DOM overlay would taint it.
+      drawCaptionOverlay(ctx, caption, out.width, out.height);
     }
     // Stop scheduling frames once the recording has failed; the finally below
     // cancels the last pending frame and stops the recorder.

--- a/apps/geolibre-desktop/src/lib/map-recorder.ts
+++ b/apps/geolibre-desktop/src/lib/map-recorder.ts
@@ -308,7 +308,10 @@ export function captionBoxOrigin(
   return { x: Math.round(x), y: Math.round(y) };
 }
 
-/** Trace a rounded-rectangle path (fallback for contexts without `roundRect`). */
+/**
+ * Trace a rounded-rectangle path, preferring the native `roundRect` and falling
+ * back to `arcTo` for contexts that lack it (older Safari/Firefox).
+ */
 function roundRectPath(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -319,6 +322,10 @@ function roundRectPath(
 ): void {
   const rr = Math.max(0, Math.min(r, w / 2, h / 2));
   ctx.beginPath();
+  if (typeof ctx.roundRect === "function") {
+    ctx.roundRect(x, y, w, h, rr);
+    return;
+  }
   ctx.moveTo(x + rr, y);
   ctx.arcTo(x + w, y, x + w, y + h, rr);
   ctx.arcTo(x + w, y + h, x, y + h, rr);
@@ -362,7 +369,12 @@ export function drawCaptionOverlay(
   const titleLineH = title ? lineH(m.titlePx) : 0;
   const captionLineH = caption ? lineH(m.captionPx) : 0;
   const innerGap = title && caption ? m.lineGap : 0;
-  const boxW = Math.round(textW) + m.padX * 2;
+  // Cap the box to the frame (minus margins) so a very long caption can't run
+  // off the canvas with a hard mid-glyph cut-off; the text is then drawn with
+  // fillText's maxWidth so the browser compresses it to fit, matching how
+  // print-layout.ts burns a user-supplied title/subtitle onto a canvas.
+  const maxBoxW = Math.max(m.padX * 2 + 8, outW - m.margin * 2);
+  const boxW = Math.min(Math.round(textW) + m.padX * 2, maxBoxW);
   const boxH = titleLineH + innerGap + captionLineH + m.padY * 2;
   const { x, y } = captionBoxOrigin(
     options?.position ?? DEFAULT_CAPTION_POSITION,
@@ -383,16 +395,17 @@ export function drawCaptionOverlay(
   ctx.textAlign = "left";
   const tx = x + m.padX;
   let ty = y + m.padY;
+  const maxTextW = boxW - m.padX * 2;
   if (title) {
     ctx.font = titleFont;
     ctx.fillStyle = "#ffffff";
-    ctx.fillText(title, tx, ty);
+    ctx.fillText(title, tx, ty, maxTextW);
     ty += titleLineH + innerGap;
   }
   if (caption) {
     ctx.font = captionFont;
     ctx.fillStyle = "rgba(255, 255, 255, 0.85)";
-    ctx.fillText(caption, tx, ty);
+    ctx.fillText(caption, tx, ty, maxTextW);
   }
   ctx.restore();
 }

--- a/tests/map-recorder.test.ts
+++ b/tests/map-recorder.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  CAPTION_POSITIONS,
+  captionBoxOrigin,
+  captionMetrics,
   computeCaptureRect,
+  hasCaptionText,
   MAP_RECORD_MIME_CANDIDATES,
   pickSupportedMimeType,
   videoExtensionForMime,
@@ -133,5 +137,98 @@ describe("computeCaptureRect", () => {
     assert.equal(rect.sy, 20);
     assert.equal(rect.sw, 40);
     assert.equal(rect.sh, 30);
+  });
+});
+
+describe("hasCaptionText", () => {
+  it("is false for no options, blank, or whitespace-only text", () => {
+    assert.equal(hasCaptionText(null), false);
+    assert.equal(hasCaptionText(undefined), false);
+    assert.equal(
+      hasCaptionText({ title: "", caption: "", position: "bottom-left" }),
+      false,
+    );
+    assert.equal(
+      hasCaptionText({ title: "  ", caption: "\t", position: "bottom-left" }),
+      false,
+    );
+  });
+
+  it("is true when either the title or the caption has non-blank text", () => {
+    assert.equal(
+      hasCaptionText({ title: "Hello", caption: "", position: "top-left" }),
+      true,
+    );
+    assert.equal(
+      hasCaptionText({ title: " ", caption: "Source", position: "top-left" }),
+      true,
+    );
+  });
+});
+
+describe("captionMetrics", () => {
+  it("scales the title with the frame height", () => {
+    // ~1080p and ~2160p frames get proportionally larger, capped title text.
+    assert.ok(captionMetrics(2160).titlePx > captionMetrics(1080).titlePx);
+  });
+
+  it("clamps the title size for tiny and huge frames", () => {
+    assert.equal(captionMetrics(100).titlePx, 14); // floor
+    assert.equal(captionMetrics(100_000).titlePx, 48); // ceiling
+  });
+
+  it("derives paddings and the caption line from the title size", () => {
+    const m = captionMetrics(1000);
+    assert.ok(m.captionPx > 0 && m.captionPx < m.titlePx);
+    assert.ok(m.padX > 0 && m.padY > 0 && m.margin > 0);
+  });
+});
+
+describe("captionBoxOrigin", () => {
+  const W = 1920;
+  const H = 1080;
+  const box = { w: 400, h: 120 };
+  const margin = 24;
+
+  it("anchors each corner with the margin inset", () => {
+    assert.deepEqual(
+      captionBoxOrigin("top-left", box.w, box.h, W, H, margin),
+      { x: 24, y: 24 },
+    );
+    assert.deepEqual(
+      captionBoxOrigin("bottom-right", box.w, box.h, W, H, margin),
+      { x: W - margin - box.w, y: H - margin - box.h },
+    );
+  });
+
+  it("centers horizontally for the center positions", () => {
+    const top = captionBoxOrigin("top-center", box.w, box.h, W, H, margin);
+    assert.equal(top.x, Math.round((W - box.w) / 2));
+    assert.equal(top.y, margin);
+    const bottom = captionBoxOrigin(
+      "bottom-center",
+      box.w,
+      box.h,
+      W,
+      H,
+      margin,
+    );
+    assert.equal(bottom.x, Math.round((W - box.w) / 2));
+    assert.equal(bottom.y, H - margin - box.h);
+  });
+
+  it("pins an over-wide box to the near margin instead of off-canvas", () => {
+    // A box wider than the frame can't fit; it stays at the left margin rather
+    // than getting a negative x that would float it off-screen.
+    const origin = captionBoxOrigin("top-right", 5000, box.h, W, H, margin);
+    assert.equal(origin.x, margin);
+  });
+
+  it("covers every selectable position without going off-canvas", () => {
+    for (const position of CAPTION_POSITIONS) {
+      const { x, y } = captionBoxOrigin(position, box.w, box.h, W, H, margin);
+      assert.ok(x >= 0 && x + box.w <= W, `${position} x in bounds`);
+      assert.ok(y >= 0 && y + box.h <= H, `${position} y in bounds`);
+    }
   });
 });


### PR DESCRIPTION
Fixes #1276

## Problem

The Record Video feature captures only `<canvas>` pixels (the MapLibre base plus any full-viewport deck.gl overlay) into the offscreen canvas fed to `MediaRecorder`. DOM overlays that sit *on top of* the canvas — the on-map HTML control, legends, the record panel, the selection frame — are never in the buffer, so they can't be recorded. The reporter wanted a way to add information about the video itself (a title / data source) that isn't tied to a map coordinate.

Faithfully compositing the arbitrary-HTML control panel would need a heavy `html2canvas`-style dependency, and the native SVG `<foreignObject>` route taints the canvas, which breaks `captureStream` entirely.

## Fix

Let the user annotate the video with a **caption drawn straight onto the offscreen recording canvas with the Canvas 2D text API**. This needs no DOM rasterization and keeps the canvas origin-clean, so recording still works.

The Record Video dialog gains:
- an optional **title** line (bold),
- an optional **subtitle / data source** line,
- a **position** picker (6 corners/edges) that appears once there is text.

The text is snapshotted at record start and burned into every frame, with font size scaled to the output resolution and a legible semi-transparent rounded backing. Empty fields draw nothing.

## Notes
- No new dependencies. All logic lives in `map-recorder.ts` (pure helpers + a `drawCaptionOverlay`) and the `RecordVideoDialog` wiring, plus `en.json` strings.
- The placement/scaling math is covered by new unit tests in `tests/map-recorder.test.ts`.

## Verification

Driven end-to-end in the real app with Playwright against the live globe basemap:
- Set a title + source line, recorded a short clip, saved it. The recording reached the "ready" state and produced a valid MP4 — proving the caption compositing kept the canvas origin-clean (a taint would have failed the recording).
- Extracted a frame with ffmpeg and confirmed both caption lines are burned into the video, legible over the map.
- Confirmed the caption fields and position dropdown render correctly in both **light and dark** themes; the position picker has all 6 options and defaults to bottom-left.
- Full frontend test suite green (`npm run test:frontend`), `pre-commit` (incl. build) clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional burned-in captions to recorded videos.
  * Captions support a title and source/subtitle text, rendered into every frame.
  * Added configurable caption placement via a dropdown with multiple top/bottom/side/center positions.
  * Updated the recording dialog UI and labels to expose the new caption settings.

* **Tests**
  * Added caption validation, sizing, placement, and boundary-behavior test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->