### PR TITLE
feat(raster): add NAIP VRT mosaic to the Add Raster Layer sample datasets

### DIFF
--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -66,6 +66,14 @@ const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
     url: "https://data.source.coop/opengeos/geoai/S2C-MSIL2A-20250920T162001-subset.tif",
     attribution: "Copernicus Sentinel data (ESA)",
   },
+  {
+    // A gdalbuildvrt mosaic of six NAIP COG tiles (4-band RGB+NIR), read
+    // straight from the .vrt: exercises maplibre-gl-raster's VRT support
+    // (v0.11.0+), which renders a plain COG mosaic in the browser without GDAL.
+    label: "NAIP mosaic (VRT)",
+    url: "https://data.source.coop/giswqs/opengeos/naip_water_train.vrt",
+    attribution: "USDA Farm Service Agency (NAIP)",
+  },
 ];
 
 // This type mirrors undocumented private members of RasterControl from

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -72,7 +72,7 @@ const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
     // (v0.11.0+), which renders a plain COG mosaic in the browser without GDAL.
     label: "NAIP mosaic (VRT)",
     url: "https://data.source.coop/giswqs/opengeos/naip_water_train.vrt",
-    attribution: "USDA Farm Service Agency (NAIP)",
+    attribution: "USDA Farm Service Agency (FSA)",
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds `https://data.source.coop/giswqs/opengeos/naip_water_train.vrt` to the **Add Raster Layer** panel's "Load sample data…" dropdown as **"NAIP mosaic (VRT)"**.

`maplibre-gl-raster` 0.11.0 (already the pinned/latest version) renders a plain `gdalbuildvrt` mosaic of COGs directly in the browser — no GDAL required — by loading each member COG as its own tiled layer under one shared visualization state. This sample exercises that VRT path: a 4-band RGB+NIR NAIP mosaic assembled from six `/vsicurl/https://` COG tiles on Source Cooperative, at natural placement with no GDAL-only transforms (exactly the supported subset).

No dependency bump was needed — `maplibre-gl-raster` is already at `0.11.0`, npm's latest.

## Verification

Drove the real app (Vite dev server + Playwright), not mocks:
- "NAIP mosaic (VRT)" appears in the sample dropdown.
- Selecting it adds `naip_water_train.vrt` as a COG layer and renders the NAIP RGB composite on the map at BBox ~-99.2/47.0 — North Dakota, matching the VRT's NAD83 / UTM zone 14N SRS.
- "USDA Farm Service Agency (NAIP)" attribution shows in the map's attribution control.
- No console errors, no `VrtUnsupportedError`.

`pre-commit run --files` (including the full `npm build`) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new one-click **“NAIP mosaic (VRT)”** option to the raster control’s **“Load sample data”** menu.
  * Displays the sample dataset’s **source attribution** alongside the entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->