### PR TITLE
chore(deps): bump maplibre-gl-raster to 0.11.1

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.11.0",
+    "maplibre-gl-raster": "^0.11.1",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12247,15 +12247,15 @@
       }
     },
     "node_modules/cog-tiler-wasm": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.2.5.tgz",
-      "integrity": "sha512-9nX2dXmKwM6y6b6JrqiXpL2gCPvF3oKlrC7/j3+gwI/EBxbh1O1quP7c5k70OvqjV99jbLIf3b6n81EHx6WPBg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.2.6.tgz",
+      "integrity": "sha512-kg8x5I1vhzrpD+J/s3r1Df/jaGcCog65M1ll3DQ4TKSfkWEcgFETDhwky3yYPHX/QmeDlBTm7UbD0aRulrQkHg==",
       "license": "MIT",
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
         "proj4": "^2.15.0",
-        "whitebox-wasm": "^0.4.0"
+        "whitebox-wasm": "^0.4.1"
       }
     },
     "node_modules/color-convert": {
@@ -21030,9 +21030,9 @@
       }
     },
     "node_modules/whitebox-wasm": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/whitebox-wasm/-/whitebox-wasm-0.4.0.tgz",
-      "integrity": "sha512-MGtesUVK4au7C+11Vb/v/HNA1vl/vU4t29mzsoTosySSkDZoGyTtjQkug7lDcB6tNvxRShpV7iY3cHXrTcqXuA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/whitebox-wasm/-/whitebox-wasm-0.4.1.tgz",
+      "integrity": "sha512-9UO5LXdThXsthy19JG27u1IjK4Tal2IGgTnvq61uNiv3Wta9yVDy81B/qhQLu8UyTJ0mmG8bP/e+uVJm5xm4Rw==",
       "license": "MIT OR Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -21844,7 +21844,7 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@turf/union": "^7.3.5",
-        "cog-tiler-wasm": "^0.2.5",
+        "cog-tiler-wasm": "^0.2.6",
         "geotiff": "^3.0.5",
         "h5wasm": "^0.10.3",
         "jspdf": "^4.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.11.0",
+        "maplibre-gl-raster": "^0.11.1",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
@@ -17094,9 +17094,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.11.0.tgz",
-      "integrity": "sha512-ohi9LGdZ6u4Qvu/cTlm2bRPRzm9wWnFwKTT6kUESPM3SnJMpQlw/AoOoYoV18HKv6Ba/76cprYCrdGd7Ov4WLg==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.11.1.tgz",
+      "integrity": "sha512-jqSblsYDdwlOaOY7vQRp7JJkfvimuaADYwN6SHjhzhXZk/5UCoYGvdWcojrk9VCW0Y2YxfzWyCw4K7/rx4+Pug==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21865,7 +21865,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.11.0",
+        "maplibre-gl-raster": "^0.11.1",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,7 +49,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.11.0",
+    "maplibre-gl-raster": "^0.11.1",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -28,7 +28,7 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@turf/union": "^7.3.5",
-    "cog-tiler-wasm": "^0.2.5",
+    "cog-tiler-wasm": "^0.2.6",
     "geotiff": "^3.0.5",
     "h5wasm": "^0.10.3",
     "jspdf": "^4.2.1",

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -77,7 +77,7 @@ const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
 ];
 
 // This type mirrors undocumented private members of RasterControl from
-// maplibre-gl-raster (re-verified against v0.11.0). All access is optional (?.)
+// maplibre-gl-raster (re-verified against v0.11.1). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.
@@ -200,7 +200,7 @@ export function setNonTiledRasterHandler(
 }
 
 /** Whether a raster load error is the upstream "striped, not tiled" failure.
- * maplibre-gl-raster (re-verified against v0.11.0) rejects non-tiled GeoTIFFs with a message
+ * maplibre-gl-raster (re-verified against v0.11.1) rejects non-tiled GeoTIFFs with a message
  * containing "not tiled"; this is the only signal it exposes, so the match is
  * coupled to that wording. Re-verify it (and broaden if needed) when bumping the
  * dependency -- a reworded message degrades to the plain error, not a crash. */
@@ -629,7 +629,7 @@ function createRasterControl(
   });
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
-  // _state.collapsed BEFORE emitting the event (re-verified against v0.11.0) --
+  // _state.collapsed BEFORE emitting the event (re-verified against v0.11.1) --
   // re-verify that ordering when bumping the dependency.
   const panelStateSyncHandler: RasterControlEventHandler = () =>
     syncRasterLayersToStoreForRuntime(control);
@@ -731,7 +731,7 @@ function patchWebRasterOverlayFactory(
     };
   };
 
-  // maplibre-gl-raster (re-verified against v0.11.0) calls `_deps.removeOverlay(this._map, this._overlay)`
+  // maplibre-gl-raster (re-verified against v0.11.1) calls `_deps.removeOverlay(this._map, this._overlay)`
   // from its LayerManager teardown (after the last raster is removed / the
   // control is destroyed); re-verify this hook exists when bumping the
   // dependency. Even if a future version stopped calling it, the control still

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -22,7 +22,7 @@ import {
 import { colormapColors, warmColormapColors } from "./colormap-colors";
 
 // These types mirror undocumented private members of the maplibre-gl-raster
-// LayerManager (re-verified against v0.11.0) and the deck.gl-raster Colormap
+// LayerManager (re-verified against v0.11.1) and the deck.gl-raster Colormap
 // module name (deck.gl-raster v0.7.0). Access is feature-detected and falls
 // back to a no-op rather than throwing -- re-verify these names AND the
 // "colormap" module name when bumping either dependency.


### PR DESCRIPTION
## Summary
- Bump maplibre-gl-raster from 0.11.0 to 0.11.1 (patch release) in the plugins package and the desktop app
- Update package-lock.json to resolve the new version

## Test plan
- [ ] npm install resolves maplibre-gl-raster@0.11.1
- [ ] npm run build succeeds
- [ ] Raster plugin loads and renders in the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the map raster rendering dependency to **0.11.1** for the latest fixes and improvements.
  * Applied the same update consistently across both desktop and plugin builds.
  * Updated the CO G tiling dependency to **0.2.6** as part of the same set of improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->