### PR TITLE
feat(vector): Data quality tools — Check validity, Fix geometries, Check topology rules

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -362,6 +362,25 @@ export function ProcessingMenu({
             >
               {t("toolbar.vectorTool.spaceTimeProximity")}
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupDataQuality")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("check-validity")}
+            >
+              {t("toolbar.vectorTool.checkValidity")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("fix-geometries")}
+            >
+              {t("toolbar.vectorTool.fixGeometries")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("check-topology-rules")}
+            >
+              {t("toolbar.vectorTool.checkTopologyRules")}
+            </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         )}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1831,7 +1831,10 @@
       "h3BinPoints": "Bin points to H3",
       "trajectorySpeed": "Trajectory speed",
       "detectStops": "Detect stops",
-      "spaceTimeProximity": "Space-time proximity"
+      "spaceTimeProximity": "Space-time proximity",
+      "checkValidity": "Check validity",
+      "fixGeometries": "Fix geometries",
+      "checkTopologyRules": "Check topology rules"
     },
     "networkTool": {
       "isochrone": "Isochrone / service area",
@@ -1987,6 +1990,7 @@
       "subGroupSelect": "Select",
       "subGroupH3": "H3",
       "subGroupMovement": "Movement & time",
+      "subGroupDataQuality": "Data quality",
       "subGroupTerrain": "Terrain",
       "subGroupReproject": "Reproject",
       "subGroupClip": "Clip",

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -998,6 +998,143 @@ def _voronoi(
     return _to_feature_collection(result), [message]
 
 
+def _first_coordinate(geom: Any) -> Optional[tuple[float, float]]:
+    """Return the first (x, y) coordinate of a geometry, or None if empty.
+
+    Used to anchor a validity-error marker when :func:`explain_validity` does
+    not include a problem location. Works on invalid geometry (no GEOS
+    operations that require validity).
+
+    Args:
+        geom: Any Shapely geometry.
+
+    Returns:
+        The first coordinate as ``(x, y)``, or ``None`` for empty geometry.
+    """
+    if geom is None or geom.is_empty:
+        return None
+    if geom.geom_type == "Point":
+        return (geom.x, geom.y)
+    if geom.geom_type in ("LineString", "LinearRing"):
+        x, y = geom.coords[0][:2]
+        return (x, y)
+    if geom.geom_type == "Polygon":
+        x, y = geom.exterior.coords[0][:2]
+        return (x, y)
+    for part in getattr(geom, "geoms", []):
+        found = _first_coordinate(part)
+        if found is not None:
+            return found
+    return None
+
+
+def _validity_anchor(reason: str, geom: Any) -> Optional[tuple[float, float]]:
+    """Choose a marker location for an invalid geometry.
+
+    Prefers the ``[x y]`` location embedded in a GEOS
+    :func:`~shapely.validation.explain_validity` message (e.g.
+    ``"Self-intersection[2 2]"``); falls back to the geometry's first
+    coordinate.
+
+    Args:
+        reason: The ``explain_validity`` message.
+        geom: The invalid Shapely geometry.
+
+    Returns:
+        The marker ``(x, y)``, or ``None`` when no coordinate exists at all.
+    """
+    import re  # noqa: PLC0415 - tiny stdlib import, keep local like the engines
+
+    match = re.search(r"\[(-?[\d.eE+]+)\s+(-?[\d.eE+]+)\]", reason)
+    if match:
+        try:
+            return (float(match.group(1)), float(match.group(2)))
+        except ValueError:
+            pass
+    return _first_coordinate(geom)
+
+
+def _check_validity(
+    geojson: Optional[dict], overlay: Optional[dict], parameters: dict[str, Any]
+) -> tuple[dict, list[str]]:
+    """Report features with invalid geometry as a marker point layer.
+
+    Mirrors the client tool: each invalid feature produces one point feature
+    with ``feature_index`` and a ``detail`` message. Unlike the DuckDB client
+    engine (a bare valid/invalid verdict), Shapely's ``explain_validity``
+    supplies the reason and, when GEOS embeds one, the problem location.
+    """
+    from shapely.validation import explain_validity  # noqa: PLC0415
+
+    gdf = _load_gdf(geojson, "Input layer")
+    markers: list[dict] = []
+    missing = 0
+    for index, geom in enumerate(gdf.geometry):
+        if geom is None or geom.is_empty:
+            missing += 1
+            continue
+        if geom.is_valid:
+            continue
+        reason = explain_validity(geom)
+        anchor = _validity_anchor(reason, geom)
+        if anchor is None:
+            continue
+        markers.append(
+            {
+                "type": "Feature",
+                "properties": {"feature_index": index, "detail": reason},
+                "geometry": {"type": "Point", "coordinates": list(anchor)},
+            }
+        )
+    checked = len(gdf) - missing
+    message = f"Checked {checked} feature(s): {len(markers)} invalid"
+    if missing:
+        message += f", {missing} without geometry"
+    messages = [message]
+    if not markers:
+        messages.append("No invalid geometries found")
+    return {"type": "FeatureCollection", "features": markers}, messages
+
+
+def _fix_geometries(
+    geojson: Optional[dict], overlay: Optional[dict], parameters: dict[str, Any]
+) -> tuple[dict, list[str]]:
+    """Repair invalid geometries with ``make_valid``; valid features pass through.
+
+    A repair that raises or produces empty geometry leaves the original
+    geometry unchanged (and is counted), matching the client tool's behavior.
+    """
+    from shapely.validation import make_valid  # noqa: PLC0415
+
+    gdf = _load_gdf(geojson, "Input layer")
+    fixed = 0
+    unfixable = 0
+
+    def _repair(geom: Any) -> Any:
+        nonlocal fixed, unfixable
+        if geom is None or geom.is_empty or geom.is_valid:
+            return geom
+        try:
+            repaired = make_valid(geom)
+        except Exception:  # noqa: BLE001 - keep the original geometry
+            unfixable += 1
+            return geom
+        if repaired is None or repaired.is_empty:
+            unfixable += 1
+            return geom
+        fixed += 1
+        return repaired
+
+    gdf["geometry"] = gdf.geometry.apply(_repair)
+    if fixed == 0 and unfixable == 0:
+        message = "All geometries are already valid — nothing to fix"
+    else:
+        message = f"Fixed {fixed} invalid geometr{'y' if fixed == 1 else 'ies'}"
+        if unfixable:
+            message += f"; {unfixable} could not be repaired and were left unchanged"
+    return _to_feature_collection(gdf), [message]
+
+
 # tool_id -> handler(geojson, overlay, parameters) -> (feature_collection, messages)
 _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "buffer": _buffer,
@@ -1019,6 +1156,8 @@ _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "aggregate": _aggregate,
     "smooth": _smooth,
     "voronoi": _voronoi,
+    "check-validity": _check_validity,
+    "fix-geometries": _fix_geometries,
 }
 
 

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -1045,7 +1045,7 @@ def _validity_anchor(reason: str, geom: Any) -> Optional[tuple[float, float]]:
     """
     import re  # noqa: PLC0415 - tiny stdlib import, keep local like the engines
 
-    match = re.search(r"\[(-?[\d.eE+]+)\s+(-?[\d.eE+]+)\]", reason)
+    match = re.search(r"\[([-+0-9.eE]+)\s+([-+0-9.eE]+)\]", reason)
     if match:
         try:
             return (float(match.group(1)), float(match.group(2)))
@@ -1069,12 +1069,16 @@ def _check_validity(
     gdf = _load_gdf(geojson, "Input layer")
     markers: list[dict] = []
     missing = 0
+    invalid = 0
     for index, geom in enumerate(gdf.geometry):
         if geom is None or geom.is_empty:
             missing += 1
             continue
         if geom.is_valid:
             continue
+        # Count the feature as invalid even when no marker location can be
+        # resolved, so the summary never understates the problem.
+        invalid += 1
         reason = explain_validity(geom)
         anchor = _validity_anchor(reason, geom)
         if anchor is None:
@@ -1087,11 +1091,11 @@ def _check_validity(
             }
         )
     checked = len(gdf) - missing
-    message = f"Checked {checked} feature(s): {len(markers)} invalid"
+    message = f"Checked {checked} feature(s): {invalid} invalid"
     if missing:
         message += f", {missing} without geometry"
     messages = [message]
-    if not markers:
+    if invalid == 0:
         messages.append("No invalid geometries found")
     return {"type": "FeatureCollection", "features": markers}, messages
 

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -74,6 +74,8 @@ def test_dispatch_covers_all_tools() -> None:
         "aggregate",
         "smooth",
         "voronoi",
+        "check-validity",
+        "fix-geometries",
     }
     assert set(_DISPATCH) == expected
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -1219,3 +1219,29 @@ def test_fix_geometries_no_op_on_valid_layer() -> None:
     geojson, messages = run_vector_tool("fix-geometries", SQUARE)
     assert len(geojson["features"]) == 1
     assert any("already valid" in m for m in messages)
+
+
+@requires_geopandas
+def test_validity_anchor_parses_scientific_notation() -> None:
+    anchor = vector_ops._validity_anchor(
+        "Self-intersection[1.5e-10 -2.3e-05]", None
+    )
+    assert anchor == (1.5e-10, -2.3e-05)
+
+
+@requires_geopandas
+def test_check_validity_counts_empty_geometry_as_missing() -> None:
+    with_empty = {
+        "type": "FeatureCollection",
+        "features": [
+            SQUARE["features"][0],
+            {
+                "type": "Feature",
+                "properties": {"name": "empty"},
+                "geometry": {"type": "Polygon", "coordinates": []},
+            },
+        ],
+    }
+    _, messages = run_vector_tool("check-validity", with_empty)
+    assert any("1 without geometry" in m for m in messages)
+    assert any("Checked 1 feature(s)" in m for m in messages)

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -1151,3 +1151,71 @@ def test_json_wrapper_round_trips() -> None:
     assert set(result) == {"geojson", "messages"}
     assert result["geojson"]["type"] == "FeatureCollection"
     assert isinstance(result["messages"], list)
+
+
+BOWTIE = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"name": "bowtie"},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[0, 0], [2, 2], [2, 0], [0, 2], [0, 0]]],
+            },
+        },
+        {
+            "type": "Feature",
+            "properties": {"name": "ok"},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[10, 0], [14, 0], [14, 4], [10, 4], [10, 0]]
+                ],
+            },
+        },
+    ],
+}
+
+
+@requires_geopandas
+def test_check_validity_marks_invalid_features() -> None:
+    geojson, messages = run_vector_tool("check-validity", BOWTIE)
+    assert geojson["type"] == "FeatureCollection"
+    assert len(geojson["features"]) == 1
+    marker = geojson["features"][0]
+    assert marker["geometry"]["type"] == "Point"
+    assert marker["properties"]["feature_index"] == 0
+    # explain_validity names the problem (e.g. "Self-intersection[...]").
+    assert "intersection" in marker["properties"]["detail"].lower()
+    assert any("1 invalid" in m for m in messages)
+
+
+@requires_geopandas
+def test_check_validity_reports_clean_layer() -> None:
+    geojson, messages = run_vector_tool("check-validity", SQUARE)
+    assert geojson["features"] == []
+    assert any("No invalid geometries" in m for m in messages)
+
+
+@requires_geopandas
+def test_fix_geometries_repairs_only_invalid() -> None:
+    from shapely.geometry import shape
+
+    geojson, messages = run_vector_tool("fix-geometries", BOWTIE)
+    assert len(geojson["features"]) == 2
+    repaired = shape(geojson["features"][0]["geometry"])
+    assert repaired.is_valid
+    assert repaired.geom_type == "MultiPolygon"
+    assert geojson["features"][0]["properties"]["name"] == "bowtie"
+    # The already-valid square keeps its ring untouched.
+    untouched = shape(geojson["features"][1]["geometry"])
+    assert untouched.equals(shape(BOWTIE["features"][1]["geometry"]))
+    assert any("Fixed 1 invalid geometry" in m for m in messages)
+
+
+@requires_geopandas
+def test_fix_geometries_no_op_on_valid_layer() -> None:
+    geojson, messages = run_vector_tool("fix-geometries", SQUARE)
+    assert len(geojson["features"]) == 1
+    assert any("already valid" in m for m in messages)

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -102,7 +102,10 @@ export type VectorToolKind =
   | "h3-bin-points"
   | "trajectory-speed"
   | "detect-stops"
-  | "space-time-proximity";
+  | "space-time-proximity"
+  | "check-validity"
+  | "fix-geometries"
+  | "check-topology-rules";
 
 /** Identifiers of the network-analysis tools (`NETWORK_TOOLS` ids). */
 export type NetworkToolKind = "isochrone" | "od-matrix" | "sequential-route";

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -7,6 +7,16 @@ export {
 } from "./registry";
 export { VECTOR_TOOLS, getVectorTool } from "./vector-tools";
 export {
+  TOPOLOGY_TOOLS,
+  TOPOLOGY_RULES,
+  checkValidityTool,
+  fixGeometriesTool,
+  checkTopologyRulesTool,
+  setTopologyWasmRunner,
+  type WasmToolRunner,
+  type WasmToolRunResult,
+} from "./topology-tools";
+export {
   runAlgorithmCapture,
   runModel,
   type RunnerHost,

--- a/packages/processing/src/topology-tools.ts
+++ b/packages/processing/src/topology-tools.ts
@@ -1,0 +1,457 @@
+// Data-quality vector tools: geometry validity (DuckDB-WASM Spatial / GEOS)
+// and rule-based topology checking (the wbtopology engine inside
+// geolibre-wasm). See GeoLibre#1290.
+//
+// Engines:
+// - `check-validity` / `fix-geometries` run on DuckDB-WASM Spatial
+//   (`ST_IsValid` / `ST_MakeValid`, GEOS semantics) in the browser, and on
+//   GeoPandas/Shapely via the sidecar or Pyodide (`vector_ops.py` implements
+//   the same tool ids, with `explain_validity` reasons).
+// - `check-topology-rules` runs `topology_rule_validate` from the WASI tool
+//   runner (client-only): rule-set checks across features (overlaps, gaps,
+//   dangles, endpoint snapping) that SQL-per-row engines don't cover.
+//   `topology_rule_autofix` was evaluated and deliberately not exposed: of its
+//   four fixable rules only point-to-line projection demonstrably changed
+//   anything (dangle/gap/endpoint-snap probes all produced zero changes).
+import type {
+  Feature,
+  FeatureCollection,
+  Geometry,
+  Position,
+} from "geojson";
+import type { GeoLibreLayer } from "@geolibre/core";
+import type {
+  DuckDbCapability,
+  ProcessingAlgorithm,
+  ProcessingContext,
+} from "./types";
+
+// Mirrors the same helper in vector-tools.ts, h3-tools.ts and registry.ts;
+// intentionally duplicated because vector-tools.ts imports from this file, so
+// importing the other direction would create a cycle. Keep the copies in sync.
+function getLayer(
+  ctx: ProcessingContext,
+  paramId = "layer",
+): GeoLibreLayer | undefined {
+  const id = ctx.parameters[paramId] as string | undefined;
+  return ctx.layers.find((l) => l.id === id);
+}
+
+function requireFeatures(ctx: ProcessingContext): FeatureCollection | null {
+  const layer = getLayer(ctx);
+  if (!layer?.geojson) {
+    ctx.log("Error: select a vector layer with GeoJSON data");
+    return null;
+  }
+  if (!layer.geojson.features?.length) {
+    ctx.log("Error: the selected layer has no features");
+    return null;
+  }
+  return layer.geojson;
+}
+
+const NO_DUCKDB =
+  "This tool requires DuckDB-WASM, which is unavailable in this environment.";
+
+function requireDuckDb(ctx: ProcessingContext): DuckDbCapability {
+  if (!ctx.duckdb) throw new Error(NO_DUCKDB);
+  return ctx.duckdb;
+}
+
+/**
+ * Return the first coordinate found in a geometry, used to anchor an error
+ * marker on a feature whose exact problem location is unknown (GEOS validity
+ * is a per-geometry verdict, not a point).
+ *
+ * @param geometry - Any GeoJSON geometry, or null.
+ * @returns The first `[lng, lat]` position, or null for empty geometry.
+ */
+export function firstCoordinate(geometry: Geometry | null): Position | null {
+  if (!geometry) return null;
+  if (geometry.type === "GeometryCollection") {
+    for (const member of geometry.geometries) {
+      const found = firstCoordinate(member);
+      if (found) return found;
+    }
+    return null;
+  }
+  let cursor: unknown = geometry.coordinates;
+  while (Array.isArray(cursor) && Array.isArray(cursor[0])) cursor = cursor[0];
+  return Array.isArray(cursor) && typeof cursor[0] === "number"
+    ? (cursor as Position)
+    : null;
+}
+
+/**
+ * Property used to correlate DuckDB result rows back to input features.
+ * ST_Read does not guarantee row order, so each feature is tagged with its
+ * index before registration and the query selects the tag back out.
+ */
+export const IDX_PROPERTY = "__geolibre_topo_idx";
+
+/**
+ * Copy `fc` with each feature's index stored under {@link IDX_PROPERTY}.
+ * The copy is shallow per feature: geometry objects are shared, properties
+ * are re-created with the tag added.
+ */
+export function tagFeatureIndexes(fc: FeatureCollection): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: fc.features.map((feature, index) => ({
+      ...feature,
+      properties: { ...(feature.properties ?? {}), [IDX_PROPERTY]: index },
+    })),
+  };
+}
+
+/**
+ * Build the validity query for a registered source. Exported for tests.
+ *
+ * `fixInvalid` additionally computes `ST_MakeValid` GeoJSON for the invalid
+ * rows only, so Fix geometries never rewrites coordinates of already-valid
+ * features through a DuckDB round-trip.
+ */
+export function buildValiditySql(sourceSql: string, fixInvalid: boolean): string {
+  const fixed = fixInvalid
+    ? `CASE WHEN ST_IsValid(geom) THEN NULL ELSE ST_AsGeoJSON(ST_MakeValid(geom)) END AS fixed`
+    : "NULL AS fixed";
+  return (
+    `SELECT "${IDX_PROPERTY}" AS idx, ST_IsValid(geom) AS valid, ${fixed} ` +
+    `FROM ${sourceSql} WHERE geom IS NOT NULL`
+  );
+}
+
+interface ValidityRow {
+  idx: number;
+  valid: boolean;
+  fixed: Geometry | null;
+}
+
+/**
+ * Run the validity query and normalize row values (DuckDB may hand back
+ * BigInt indexes and JSON strings). Rows whose payload cannot be interpreted
+ * are dropped rather than crashing the tool.
+ */
+async function queryValidity(
+  ctx: ProcessingContext,
+  fc: FeatureCollection,
+  fixInvalid: boolean,
+): Promise<ValidityRow[]> {
+  const duckdb = requireDuckDb(ctx);
+  await duckdb.ensureExtensions(["spatial"]);
+  const registered = await duckdb.registerGeoJson(tagFeatureIndexes(fc));
+  try {
+    const rows = await duckdb.query(buildValiditySql(registered.sql, fixInvalid));
+    const result: ValidityRow[] = [];
+    for (const row of rows) {
+      const idx = Number(row.idx);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= fc.features.length) {
+        continue;
+      }
+      let fixed: Geometry | null = null;
+      if (typeof row.fixed === "string" && row.fixed.length > 0) {
+        try {
+          fixed = JSON.parse(row.fixed) as Geometry;
+        } catch {
+          fixed = null;
+        }
+      }
+      result.push({ idx, valid: Boolean(row.valid), fixed });
+    }
+    return result;
+  } finally {
+    await registered.release();
+  }
+}
+
+/** Whether a repaired geometry is usable (non-empty) as a replacement. */
+export function isUsableGeometry(geometry: Geometry | null): boolean {
+  if (!geometry) return false;
+  if (geometry.type === "GeometryCollection") {
+    return geometry.geometries.some((member) => isUsableGeometry(member));
+  }
+  return Array.isArray(geometry.coordinates) && geometry.coordinates.length > 0;
+}
+
+export const checkValidityTool: ProcessingAlgorithm = {
+  id: "check-validity",
+  name: "Check validity",
+  description:
+    "Find features with invalid geometry (GEOS rules: self-intersecting rings, holes outside shells, ...) and mark them on the map",
+  group: "Data quality",
+  supportsSidecar: true,
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+  ],
+  run: async (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const rows = await queryValidity(ctx, fc, false);
+    const missingGeometry = fc.features.filter((f) => !f.geometry).length;
+    const markers: Feature[] = [];
+    for (const row of rows) {
+      if (row.valid) continue;
+      const feature = fc.features[row.idx];
+      const anchor = firstCoordinate(feature.geometry);
+      if (!anchor) continue;
+      markers.push({
+        type: "Feature",
+        properties: {
+          feature_index: row.idx,
+          detail: "invalid geometry — run Fix geometries to repair",
+        },
+        geometry: { type: "Point", coordinates: anchor },
+      });
+    }
+    const checked = rows.length;
+    ctx.log(
+      `Checked ${checked} feature(s): ${markers.length} invalid` +
+        (missingGeometry ? `, ${missingGeometry} without geometry` : ""),
+    );
+    if (markers.length === 0) {
+      ctx.log("No invalid geometries found");
+      return;
+    }
+    ctx.addResultLayer?.("Validity errors", {
+      type: "FeatureCollection",
+      features: markers,
+    });
+  },
+};
+
+export const fixGeometriesTool: ProcessingAlgorithm = {
+  id: "fix-geometries",
+  name: "Fix geometries",
+  description:
+    "Repair invalid geometries with ST_MakeValid (GEOS); valid features pass through untouched",
+  group: "Data quality",
+  supportsSidecar: true,
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+  ],
+  run: async (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const rows = await queryValidity(ctx, fc, true);
+    let fixed = 0;
+    let unfixable = 0;
+    const features = fc.features.slice();
+    for (const row of rows) {
+      if (row.valid) continue;
+      if (!isUsableGeometry(row.fixed)) {
+        unfixable += 1;
+        continue;
+      }
+      const original = features[row.idx];
+      features[row.idx] = { ...original, geometry: row.fixed! };
+      fixed += 1;
+    }
+    if (fixed === 0 && unfixable === 0) {
+      ctx.log("All geometries are already valid — nothing to fix");
+      return;
+    }
+    ctx.log(
+      `Fixed ${fixed} invalid geometr${fixed === 1 ? "y" : "ies"}` +
+        (unfixable
+          ? `; ${unfixable} could not be repaired and were left unchanged`
+          : ""),
+    );
+    ctx.addResultLayer?.("Fixed geometries", {
+      type: "FeatureCollection",
+      features,
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Topology rules (wbtopology via the geolibre-wasm WASI runner)
+// ---------------------------------------------------------------------------
+
+/** Result of one WASI tool run (mirrors `geolibre-wasm/tools`). */
+export interface WasmToolRunResult {
+  exitCode: number;
+  stdout: string[];
+  files: Record<string, Uint8Array>;
+}
+
+export type WasmToolRunner = (
+  tool: string,
+  opts: { args?: string[]; input?: Record<string, Uint8Array> },
+) => Promise<WasmToolRunResult>;
+
+let wasmRunnerOverride: WasmToolRunner | null = null;
+
+/**
+ * Replace the WASI tool runner. Tests inject either a fake or the real
+ * geolibre-wasm module initialized from bytes (the default lazy import
+ * resolves the .wasm binary by URL, which only works in a bundler/browser).
+ *
+ * @param runner - The replacement runner, or null to restore the default.
+ */
+export function setTopologyWasmRunner(runner: WasmToolRunner | null): void {
+  wasmRunnerOverride = runner;
+}
+
+async function getWasmRunner(): Promise<WasmToolRunner> {
+  if (wasmRunnerOverride) return wasmRunnerOverride;
+  const module = (await import("geolibre-wasm/tools")) as unknown as {
+    runTool: WasmToolRunner;
+  };
+  return module.runTool;
+}
+
+/**
+ * The topology rules `topology_rule_validate` understands, in the order the
+ * dialog lists them. `default` reflects which checks make sense on an
+ * arbitrary layer: connectivity rules (dangles, endpoint snapping, point
+ * coverage) are opt-in because every free line end or standalone point would
+ * otherwise be flagged.
+ */
+export const TOPOLOGY_RULES = [
+  {
+    ruleId: "line_must_not_self_intersect",
+    paramId: "ruleSelfIntersect",
+    label: "Lines must not self-intersect",
+    default: true,
+  },
+  {
+    ruleId: "polygon_must_not_overlap",
+    paramId: "ruleOverlap",
+    label: "Polygons must not overlap",
+    default: true,
+  },
+  {
+    ruleId: "polygon_must_not_have_gaps",
+    paramId: "ruleGaps",
+    label: "Polygons must not have gaps",
+    default: true,
+  },
+  {
+    ruleId: "line_must_not_have_dangles",
+    paramId: "ruleDangles",
+    label: "Lines must not have dangles",
+    default: false,
+  },
+  {
+    ruleId: "point_must_be_covered_by_line",
+    paramId: "rulePointCovered",
+    label: "Points must be covered by a line",
+    default: false,
+  },
+  {
+    ruleId: "line_endpoints_must_snap_within_tolerance",
+    paramId: "ruleEndpointSnap",
+    label: "Line endpoints must connect within tolerance",
+    default: false,
+  },
+] as const;
+
+/** Summary report emitted by `topology_rule_validate` (--report). */
+interface TopologyRuleReport {
+  total_violations?: number;
+  violations_by_rule?: Record<string, number>;
+}
+
+/** Rule ids selected by the tool's boolean parameters. Exported for tests. */
+export function selectedRuleIds(parameters: Record<string, unknown>): string[] {
+  return TOPOLOGY_RULES.filter((rule) => {
+    const value = parameters[rule.paramId];
+    return value === undefined ? rule.default : Boolean(value);
+  }).map((rule) => rule.ruleId);
+}
+
+export const checkTopologyRulesTool: ProcessingAlgorithm = {
+  id: "check-topology-rules",
+  name: "Check topology rules",
+  description:
+    "Validate the layer against topology rules (overlaps, gaps, self-intersections, dangles) and mark each violation on the map",
+  group: "Data quality",
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+    ...TOPOLOGY_RULES.map((rule) => ({
+      id: rule.paramId,
+      label: rule.label,
+      type: "boolean" as const,
+      default: rule.default,
+    })),
+    {
+      id: "snapTolerance",
+      label: "Snap tolerance",
+      type: "number",
+      default: 0.0001,
+      min: 0,
+      step: 0.0001,
+      description:
+        "For the endpoint rule: how far apart (in layer coordinate units — degrees for WGS84) two line ends may be and still count as connected.",
+    },
+  ],
+  run: async (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const rules = selectedRuleIds(ctx.parameters);
+    if (rules.length === 0) {
+      ctx.log("Error: enable at least one topology rule");
+      return;
+    }
+    const snapTolerance = Number(ctx.parameters.snapTolerance ?? 0.0001);
+    const runTool = await getWasmRunner();
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const { exitCode, stdout, files } = await runTool("topology_rule_validate", {
+      args: [
+        "--input=/work/input.geojson",
+        "--output=/work/violations.geojson",
+        "--report=/work/report.json",
+        `--rule_set=${rules.join(",")}`,
+        `--snap_tolerance=${snapTolerance}`,
+      ],
+      input: { "input.geojson": encoder.encode(JSON.stringify(fc)) },
+    });
+    if (exitCode !== 0) {
+      ctx.log(
+        `Error: topology check failed — ${stdout.join(" ") || `exit code ${exitCode}`}`,
+      );
+      return;
+    }
+    let report: TopologyRuleReport = {};
+    try {
+      report = JSON.parse(decoder.decode(files["report.json"]));
+    } catch {
+      // Missing/malformed report: fall back to counting the output features.
+    }
+    let violations: FeatureCollection | null = null;
+    try {
+      const parsed: unknown = JSON.parse(decoder.decode(files["violations.geojson"]));
+      if (
+        (parsed as FeatureCollection)?.type === "FeatureCollection" &&
+        Array.isArray((parsed as FeatureCollection).features)
+      ) {
+        violations = parsed as FeatureCollection;
+      }
+    } catch {
+      // handled below
+    }
+    if (!violations) {
+      ctx.log("Error: topology check produced no readable violations output");
+      return;
+    }
+    const total = report.total_violations ?? violations.features.length;
+    ctx.log(
+      `Checked ${fc.features.length} feature(s) against ${rules.length} rule(s): ${total} violation(s)`,
+    );
+    for (const [rule, count] of Object.entries(report.violations_by_rule ?? {})) {
+      ctx.log(`  ${rule}: ${count}`);
+    }
+    if (violations.features.length === 0) {
+      ctx.log("No topology violations found");
+      return;
+    }
+    ctx.addResultLayer?.("Topology violations", violations);
+  },
+};
+
+export const TOPOLOGY_TOOLS: ProcessingAlgorithm[] = [
+  checkValidityTool,
+  fixGeometriesTool,
+  checkTopologyRulesTool,
+];

--- a/packages/processing/src/topology-tools.ts
+++ b/packages/processing/src/topology-tools.ts
@@ -187,11 +187,20 @@ export const checkValidityTool: ProcessingAlgorithm = {
     const fc = requireFeatures(ctx);
     if (!fc) return;
     const rows = await queryValidity(ctx, fc, false);
-    const missingGeometry = fc.features.filter((f) => !f.geometry).length;
+    // Mirror the sidecar's definition of "without geometry" (null OR empty),
+    // so the two engines report the same counts for the same layer.
+    const missingGeometry = fc.features.filter(
+      (f) => !isUsableGeometry(f.geometry),
+    ).length;
     const markers: Feature[] = [];
+    let invalid = 0;
     for (const row of rows) {
       if (row.valid) continue;
       const feature = fc.features[row.idx];
+      if (!isUsableGeometry(feature.geometry)) continue;
+      // Counted even if no marker location resolves, so the summary never
+      // understates the problem (matches the sidecar).
+      invalid += 1;
       const anchor = firstCoordinate(feature.geometry);
       if (!anchor) continue;
       markers.push({
@@ -203,15 +212,16 @@ export const checkValidityTool: ProcessingAlgorithm = {
         geometry: { type: "Point", coordinates: anchor },
       });
     }
-    const checked = rows.length;
+    const checked = fc.features.length - missingGeometry;
     ctx.log(
-      `Checked ${checked} feature(s): ${markers.length} invalid` +
+      `Checked ${checked} feature(s): ${invalid} invalid` +
         (missingGeometry ? `, ${missingGeometry} without geometry` : ""),
     );
-    if (markers.length === 0) {
+    if (invalid === 0) {
       ctx.log("No invalid geometries found");
       return;
     }
+    if (markers.length === 0) return;
     ctx.addResultLayer?.("Validity errors", {
       type: "FeatureCollection",
       features: markers,

--- a/packages/processing/src/topology-tools.ts
+++ b/packages/processing/src/topology-tools.ts
@@ -75,11 +75,22 @@ export function firstCoordinate(geometry: Geometry | null): Position | null {
     }
     return null;
   }
-  let cursor: unknown = geometry.coordinates;
-  while (Array.isArray(cursor) && Array.isArray(cursor[0])) cursor = cursor[0];
-  return Array.isArray(cursor) && typeof cursor[0] === "number"
-    ? (cursor as Position)
-    : null;
+  return firstPositionIn(geometry.coordinates);
+}
+
+/**
+ * Depth-first search for the first `[x, y]` leaf in a coordinates array.
+ * Unlike a naive "descend the first branch" walk, empty siblings are skipped,
+ * so `Polygon [[], [ring]]`-shaped nesting still yields a coordinate.
+ */
+function firstPositionIn(node: unknown): Position | null {
+  if (!Array.isArray(node)) return null;
+  if (typeof node[0] === "number") return node as Position;
+  for (const child of node) {
+    const found = firstPositionIn(child);
+    if (found) return found;
+  }
+  return null;
 }
 
 /**
@@ -164,13 +175,18 @@ async function queryValidity(
   }
 }
 
-/** Whether a repaired geometry is usable (non-empty) as a replacement. */
+/**
+ * Whether a geometry is usable (contains at least one actual coordinate).
+ * Recursive rather than a top-level length check so nested-empty shapes like
+ * `Polygon [[]]` count as empty — matching Shapely's `is_empty` on the
+ * sidecar, which this file's parity messaging depends on.
+ */
 export function isUsableGeometry(geometry: Geometry | null): boolean {
   if (!geometry) return false;
   if (geometry.type === "GeometryCollection") {
     return geometry.geometries.some((member) => isUsableGeometry(member));
   }
-  return Array.isArray(geometry.coordinates) && geometry.coordinates.length > 0;
+  return firstPositionIn(geometry.coordinates) !== null;
 }
 
 export const checkValidityTool: ProcessingAlgorithm = {
@@ -213,6 +229,16 @@ export const checkValidityTool: ProcessingAlgorithm = {
       });
     }
     const checked = fc.features.length - missingGeometry;
+    // Rows can be dropped by queryValidity (unparseable payloads) or omitted
+    // by the reader; surface the gap instead of silently understating counts.
+    const evaluated = rows.filter((row) =>
+      isUsableGeometry(fc.features[row.idx].geometry),
+    ).length;
+    if (evaluated < checked) {
+      ctx.log(
+        `Warning: ${checked - evaluated} feature(s) could not be evaluated and are not counted as invalid`,
+      );
+    }
     ctx.log(
       `Checked ${checked} feature(s): ${invalid} invalid` +
         (missingGeometry ? `, ${missingGeometry} without geometry` : ""),

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -33,6 +33,7 @@ import type {
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { GeometryFamily, ProcessingAlgorithm, ProcessingContext } from "./types";
 import { createH3GridTool, binPointsTool } from "./h3-tools";
+import { TOPOLOGY_TOOLS } from "./topology-tools";
 
 /** Upper bound on input×overlay pairs for the main-thread intersection loop. */
 const MAX_CLIENT_PAIRS = 250_000;
@@ -2739,6 +2740,8 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   trajectorySpeedTool,
   detectStopsTool,
   spaceTimeProximityTool,
+  // Data-quality tools (validity + topology rules) last, matching the menu.
+  ...TOPOLOGY_TOOLS,
 ];
 
 export function getVectorTool(id: string): ProcessingAlgorithm | undefined {

--- a/tests/fixtures/vector/SPEC.md
+++ b/tests/fixtures/vector/SPEC.md
@@ -11,8 +11,12 @@ and kept in sync by hand:
   auto-generated verbatim copy of this file, so it is the *same* engine — there
   are two implementations to keep aligned, not three.
 
-Both expose the same 19 tools and the **same canonical parameter names**, so a
-single set of language-neutral fixtures can drive both. These fixtures are the
+Both expose the same 21 tools and the **same canonical parameter names**, so a
+single set of language-neutral fixtures can drive both. (Exception: the two
+Data-quality tools, `check-validity` and `fix-geometries`, run on DuckDB-WASM
+Spatial client-side rather than Turf, so the TS golden harness cannot execute
+them; they are covered by `tests/topology-tools.test.ts` and
+`test_vector_ops.py` instead of golden cases.) These fixtures are the
 shared contract: each one is an `(input, parameters) → expected` case that both
 engines must satisfy. Drift between the two engines is then caught by CI instead
 of in the field. This directory is the "shared spec / golden fixtures" called

--- a/tests/topology-tools.test.ts
+++ b/tests/topology-tools.test.ts
@@ -230,12 +230,17 @@ describe("check-validity (fake DuckDB)", () => {
     assert.match(logs.join("\n"), /No invalid geometries found/);
   });
 
-  it("counts features without geometry", async () => {
+  it("counts null and empty geometry as missing, like the sidecar", async () => {
     const noGeom = { type: "Feature", properties: {}, geometry: null };
+    const emptyGeom = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Polygon", coordinates: [] },
+    };
     const duckdb = fakeDuckDb([{ idx: 0, valid: true, fixed: null }]);
-    const { ctx, logs } = makeCtx(fcOf(SQUARE, noGeom), {}, duckdb);
+    const { ctx, logs } = makeCtx(fcOf(SQUARE, noGeom, emptyGeom), {}, duckdb);
     await checkValidityTool.run(ctx);
-    assert.match(logs.join("\n"), /1 without geometry/);
+    assert.match(logs.join("\n"), /Checked 1 feature\(s\): 0 invalid, 2 without geometry/);
   });
 
   it("fails clearly without a DuckDB capability", async () => {

--- a/tests/topology-tools.test.ts
+++ b/tests/topology-tools.test.ts
@@ -1,0 +1,403 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { after, before, describe, it } from "node:test";
+import type { FeatureCollection } from "geojson";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type {
+  DuckDbCapability,
+  ProcessingContext,
+} from "../packages/processing/src/types";
+import {
+  IDX_PROPERTY,
+  TOPOLOGY_RULES,
+  buildValiditySql,
+  checkTopologyRulesTool,
+  checkValidityTool,
+  firstCoordinate,
+  fixGeometriesTool,
+  isUsableGeometry,
+  selectedRuleIds,
+  setTopologyWasmRunner,
+  tagFeatureIndexes,
+} from "../packages/processing/src/topology-tools";
+
+function layerOf(fc: FeatureCollection, id = "layer-1"): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: fc,
+  };
+}
+
+const BOWTIE = {
+  type: "Feature",
+  properties: { name: "bowtie" },
+  geometry: {
+    type: "Polygon",
+    coordinates: [[[0, 0], [2, 2], [2, 0], [0, 2], [0, 0]]],
+  },
+} as const;
+
+const SQUARE = {
+  type: "Feature",
+  properties: { name: "square" },
+  geometry: {
+    type: "Polygon",
+    coordinates: [[[10, 0], [14, 0], [14, 4], [10, 4], [10, 0]]],
+  },
+} as const;
+
+function fcOf(...features: unknown[]): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: features as FeatureCollection["features"],
+  };
+}
+
+/** Fake DuckDB capability returning canned validity rows. */
+function fakeDuckDb(rows: Record<string, unknown>[]): DuckDbCapability & {
+  queries: string[];
+  registered: FeatureCollection[];
+  released: number;
+} {
+  const state = {
+    queries: [] as string[],
+    registered: [] as FeatureCollection[],
+    released: 0,
+  };
+  return {
+    ...state,
+    ensureExtensions: async () => {},
+    async registerGeoJson(geojson: FeatureCollection) {
+      state.registered.push(geojson);
+      return {
+        sql: "ST_Read('fake.geojson')",
+        release: async () => {
+          state.released += 1;
+        },
+      };
+    },
+    async query(sql: string) {
+      state.queries.push(sql);
+      return rows;
+    },
+    get queries() {
+      return state.queries;
+    },
+    get registered() {
+      return state.registered;
+    },
+    get released() {
+      return state.released;
+    },
+  };
+}
+
+function makeCtx(
+  fc: FeatureCollection,
+  parameters: Record<string, unknown>,
+  duckdb?: DuckDbCapability,
+): {
+  ctx: ProcessingContext;
+  logs: string[];
+  added: { name: string; fc: FeatureCollection }[];
+} {
+  const logs: string[] = [];
+  const added: { name: string; fc: FeatureCollection }[] = [];
+  const ctx: ProcessingContext = {
+    layers: [layerOf(fc)],
+    parameters: { layer: "layer-1", ...parameters },
+    log: (message) => logs.push(message),
+    addResultLayer: (name, result) => added.push({ name, fc: result }),
+    duckdb,
+  };
+  return { ctx, logs, added };
+}
+
+describe("topology helper functions", () => {
+  it("finds the first coordinate of nested geometries", () => {
+    assert.deepEqual(
+      firstCoordinate({ type: "Point", coordinates: [1, 2] }),
+      [1, 2],
+    );
+    assert.deepEqual(firstCoordinate(BOWTIE.geometry), [0, 0]);
+    assert.deepEqual(
+      firstCoordinate({
+        type: "GeometryCollection",
+        geometries: [{ type: "Point", coordinates: [5, 6] }],
+      }),
+      [5, 6],
+    );
+    assert.equal(firstCoordinate(null), null);
+    assert.equal(
+      firstCoordinate({ type: "GeometryCollection", geometries: [] }),
+      null,
+    );
+  });
+
+  it("tags each feature with its index without mutating the input", () => {
+    const fc = fcOf(BOWTIE, SQUARE);
+    const tagged = tagFeatureIndexes(fc);
+    assert.equal(tagged.features[0].properties?.[IDX_PROPERTY], 0);
+    assert.equal(tagged.features[1].properties?.[IDX_PROPERTY], 1);
+    assert.equal(tagged.features[1].properties?.name, "square");
+    assert.equal(fc.features[0].properties && IDX_PROPERTY in fc.features[0].properties, false);
+  });
+
+  it("builds the validity SQL with and without repair", () => {
+    const check = buildValiditySql("ST_Read('x')", false);
+    assert.match(check, /ST_IsValid\(geom\)/);
+    assert.match(check, /NULL AS fixed/);
+    assert.match(check, /WHERE geom IS NOT NULL/);
+    const fix = buildValiditySql("ST_Read('x')", true);
+    assert.match(fix, /ST_MakeValid\(geom\)/);
+    assert.match(fix, /ST_AsGeoJSON/);
+  });
+
+  it("treats empty geometry as unusable", () => {
+    assert.equal(isUsableGeometry(null), false);
+    assert.equal(
+      isUsableGeometry({ type: "Polygon", coordinates: [] }),
+      false,
+    );
+    assert.equal(
+      isUsableGeometry({ type: "GeometryCollection", geometries: [] }),
+      false,
+    );
+    assert.equal(isUsableGeometry(BOWTIE.geometry), true);
+  });
+
+  it("selects rules from boolean params, honoring defaults", () => {
+    const defaults = selectedRuleIds({});
+    assert.deepEqual(defaults, [
+      "line_must_not_self_intersect",
+      "polygon_must_not_overlap",
+      "polygon_must_not_have_gaps",
+    ]);
+    const custom = selectedRuleIds({
+      ruleSelfIntersect: false,
+      ruleOverlap: false,
+      ruleGaps: false,
+      ruleDangles: true,
+    });
+    assert.deepEqual(custom, ["line_must_not_have_dangles"]);
+    // Every rule id maps to a distinct param id.
+    assert.equal(
+      new Set(TOPOLOGY_RULES.map((rule) => rule.paramId)).size,
+      TOPOLOGY_RULES.length,
+    );
+  });
+});
+
+describe("check-validity (fake DuckDB)", () => {
+  it("adds a marker layer anchored at the invalid feature", async () => {
+    const duckdb = fakeDuckDb([
+      { idx: 0, valid: false, fixed: null },
+      { idx: 1, valid: true, fixed: null },
+    ]);
+    const { ctx, logs, added } = makeCtx(fcOf(BOWTIE, SQUARE), {}, duckdb);
+    await checkValidityTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.equal(added[0].name, "Validity errors");
+    const marker = added[0].fc.features[0];
+    assert.equal(marker.properties?.feature_index, 0);
+    assert.deepEqual(
+      marker.geometry,
+      { type: "Point", coordinates: [0, 0] },
+    );
+    assert.match(logs.join("\n"), /Checked 2 feature\(s\): 1 invalid/);
+    // Input features were index-tagged for the query, then released.
+    assert.equal(
+      duckdb.registered[0].features[0].properties?.[IDX_PROPERTY],
+      0,
+    );
+    assert.equal(duckdb.released, 1);
+  });
+
+  it("adds no layer when everything is valid", async () => {
+    const duckdb = fakeDuckDb([{ idx: 0, valid: true, fixed: null }]);
+    const { ctx, logs, added } = makeCtx(fcOf(SQUARE), {}, duckdb);
+    await checkValidityTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.match(logs.join("\n"), /No invalid geometries found/);
+  });
+
+  it("counts features without geometry", async () => {
+    const noGeom = { type: "Feature", properties: {}, geometry: null };
+    const duckdb = fakeDuckDb([{ idx: 0, valid: true, fixed: null }]);
+    const { ctx, logs } = makeCtx(fcOf(SQUARE, noGeom), {}, duckdb);
+    await checkValidityTool.run(ctx);
+    assert.match(logs.join("\n"), /1 without geometry/);
+  });
+
+  it("fails clearly without a DuckDB capability", async () => {
+    const { ctx } = makeCtx(fcOf(SQUARE), {});
+    await assert.rejects(
+      async () => checkValidityTool.run(ctx),
+      /DuckDB-WASM/,
+    );
+  });
+});
+
+describe("fix-geometries (fake DuckDB)", () => {
+  const FIXED = JSON.stringify({
+    type: "MultiPolygon",
+    coordinates: [
+      [[[0, 2], [1, 1], [0, 0], [0, 2]]],
+      [[[2, 0], [1, 1], [2, 2], [2, 0]]],
+    ],
+  });
+
+  it("replaces only invalid geometries and keeps properties", async () => {
+    const duckdb = fakeDuckDb([
+      { idx: 0, valid: false, fixed: FIXED },
+      { idx: 1, valid: true, fixed: null },
+    ]);
+    const { ctx, logs, added } = makeCtx(fcOf(BOWTIE, SQUARE), {}, duckdb);
+    await fixGeometriesTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.equal(added[0].name, "Fixed geometries");
+    const [fixed, untouched] = added[0].fc.features;
+    assert.equal(fixed.geometry?.type, "MultiPolygon");
+    assert.equal(fixed.properties?.name, "bowtie");
+    assert.deepEqual(untouched.geometry, SQUARE.geometry);
+    assert.match(logs.join("\n"), /Fixed 1 invalid geometry/);
+  });
+
+  it("adds no layer when everything is already valid", async () => {
+    const duckdb = fakeDuckDb([{ idx: 0, valid: true, fixed: null }]);
+    const { ctx, logs, added } = makeCtx(fcOf(SQUARE), {}, duckdb);
+    await fixGeometriesTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.match(logs.join("\n"), /already valid/);
+  });
+
+  it("keeps the original geometry when the repair is empty", async () => {
+    const duckdb = fakeDuckDb([
+      {
+        idx: 0,
+        valid: false,
+        fixed: JSON.stringify({ type: "Polygon", coordinates: [] }),
+      },
+    ]);
+    const { ctx, logs, added } = makeCtx(fcOf(BOWTIE), {}, duckdb);
+    await fixGeometriesTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.deepEqual(added[0].fc.features[0].geometry, BOWTIE.geometry);
+    assert.match(logs.join("\n"), /could not be repaired/);
+  });
+});
+
+describe("check-topology-rules (real geolibre-wasm)", () => {
+  before(async () => {
+    // The default lazy import resolves the .wasm by URL, which requires a
+    // bundler; in Node we initialize the module from bytes and inject it.
+    const require = createRequire(import.meta.url);
+    const toolsPath = require.resolve("geolibre-wasm/tools");
+    const wasmPath = path.join(path.dirname(toolsPath), "geolibre-cli.wasm");
+    const wasm = (await import("geolibre-wasm/tools")) as unknown as {
+      initTools: (source: unknown) => Promise<unknown>;
+      runTool: Parameters<typeof setTopologyWasmRunner>[0];
+    };
+    await wasm.initTools(readFileSync(wasmPath));
+    setTopologyWasmRunner(wasm.runTool);
+  });
+
+  after(() => setTopologyWasmRunner(null));
+
+  it("finds overlapping polygons and adds a violations layer", async () => {
+    const overlapping = {
+      type: "Feature",
+      properties: { name: "overlaps-square" },
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[12, 2], [16, 2], [16, 6], [12, 6], [12, 2]]],
+      },
+    };
+    const { ctx, logs, added } = makeCtx(fcOf(SQUARE, overlapping), {});
+    await checkTopologyRulesTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.equal(added[0].name, "Topology violations");
+    // One violation per overlapping feature, anchored as points.
+    assert.equal(added[0].fc.features.length, 2);
+    for (const violation of added[0].fc.features) {
+      assert.equal(violation.geometry?.type, "Point");
+      assert.equal(
+        violation.properties?.RULE_TYPE,
+        "polygon_must_not_overlap",
+      );
+      assert.equal(typeof violation.properties?.DETAIL, "string");
+    }
+    assert.match(logs.join("\n"), /2 violation\(s\)/);
+    assert.match(logs.join("\n"), /polygon_must_not_overlap: 2/);
+  });
+
+  it("finds dangles and self-intersections in line layers", async () => {
+    const selfCrossing = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [[0, 0], [4, 4], [4, 0], [0, 4]],
+      },
+    };
+    const { ctx, added } = makeCtx(fcOf(selfCrossing), {
+      ruleOverlap: false,
+      ruleGaps: false,
+      ruleDangles: true,
+    });
+    await checkTopologyRulesTool.run(ctx);
+    assert.equal(added.length, 1);
+    const rules = new Set(
+      added[0].fc.features.map((f) => f.properties?.RULE_TYPE),
+    );
+    assert.ok(rules.has("line_must_not_self_intersect"));
+    assert.ok(rules.has("line_must_not_have_dangles"));
+  });
+
+  it("reports no violations for a clean layer without adding one", async () => {
+    const { ctx, logs, added } = makeCtx(fcOf(SQUARE), {});
+    await checkTopologyRulesTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.match(logs.join("\n"), /No topology violations found/);
+  });
+
+  it("requires at least one rule", async () => {
+    const { ctx, logs, added } = makeCtx(fcOf(SQUARE), {
+      ruleSelfIntersect: false,
+      ruleOverlap: false,
+      ruleGaps: false,
+    });
+    await checkTopologyRulesTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.match(logs.join("\n"), /enable at least one topology rule/);
+  });
+
+  it("surfaces a tool failure as an error log", async () => {
+    setTopologyWasmRunner(async () => ({
+      exitCode: 1,
+      stdout: ["boom"],
+      files: {},
+    }));
+    try {
+      const { ctx, logs, added } = makeCtx(fcOf(SQUARE), {});
+      await checkTopologyRulesTool.run(ctx);
+      assert.equal(added.length, 0);
+      assert.match(logs.join("\n"), /topology check failed — boom/);
+    } finally {
+      // Restore the real runner for any later test in this describe block.
+      const wasm = (await import("geolibre-wasm/tools")) as unknown as {
+        runTool: Parameters<typeof setTopologyWasmRunner>[0];
+      };
+      setTopologyWasmRunner(wasm.runTool);
+    }
+  });
+});

--- a/tests/topology-tools.test.ts
+++ b/tests/topology-tools.test.ts
@@ -172,6 +172,15 @@ describe("topology helper functions", () => {
       isUsableGeometry({ type: "GeometryCollection", geometries: [] }),
       false,
     );
+    // Nested-empty shapes must count as empty, matching Shapely's is_empty.
+    assert.equal(
+      isUsableGeometry({ type: "Polygon", coordinates: [[]] }),
+      false,
+    );
+    assert.equal(
+      isUsableGeometry({ type: "MultiPolygon", coordinates: [[[]]] }),
+      false,
+    );
     assert.equal(isUsableGeometry(BOWTIE.geometry), true);
   });
 


### PR DESCRIPTION
Implements the first half of #1290: **Check Validity / Fix Geometries** plus the core of the **Topology Checker** as a rules-based processing tool. All three ship as a new **Data quality** group under Processing → GeoLibre → Vector.

## What's included

**Check validity** (`check-validity`)
- Client engine: DuckDB-WASM Spatial `ST_IsValid` (GEOS semantics). Invalid features become a "Validity errors" marker point layer with `feature_index` + `detail`; features without geometry are counted separately.
- Sidecar / Pyodide engines: GeoPandas + Shapely `explain_validity`, which additionally reports the *reason* and, when GEOS embeds one (e.g. `Self-intersection[2 2]`), anchors the marker at the exact problem location.

**Fix geometries** (`fix-geometries`)
- Client: `ST_MakeValid`; sidecar/Pyodide: Shapely `make_valid`. Only invalid geometries are rewritten — valid features pass through byte-identical (no coordinate round-tripping), and a repair that comes back empty leaves the original untouched and is reported.

**Check topology rules** (`check-topology-rules`, client-only)
- Wraps `topology_rule_validate` from the **wbtopology** crate already shipped inside the `geolibre-wasm` WASI binary. Six rules with per-rule checkboxes (self-intersection, polygon overlap, gaps, dangles, point-covered-by-line, endpoint snap tolerance); violations arrive as a point layer with `RULE_TYPE`/`FEATURE_FID`/`RELATED_FID`/`DETAIL` and a per-rule summary in the log. Connectivity rules default off so arbitrary layers aren't flooded with free-end noise.

## wbtopology evaluation notes

- `topology_rule_validate` is solid and is what this PR exposes: correct results on overlaps, line self-intersections, dangles, and endpoint snapping, with GeoJSON in/out through the existing WASI runner.
- `topology_rule_autofix` was evaluated and **deliberately not exposed**: of its four fixable rules, only `point_must_be_covered_by_line` (project-to-line) produced changes in probes; dangle/gap/endpoint-snap fixes returned `total_changes: 0` on textbook cases. Worth revisiting after an upstream look.
- `topology_validation_report` flags every GeoJSON polygon as `polygon_exterior_unclosed` (reader artifact), so per-feature validity went to GEOS instead.

## Engine parity & plumbing

- Backend: `check-validity` / `fix-geometries` handlers in `vector_ops.py` (shared verbatim by the sidecar and Pyodide), registered in `_DISPATCH`; parity test updated.
- The two new tools can't run in the TS golden harness (client engine is DuckDB-WASM, not Turf) — noted in `tests/fixtures/vector/SPEC.md`; they're covered by dedicated tests on both sides instead.
- New `VectorToolKind` ids, menu items, and i18n keys (`en.json`).

## Testing

- `tests/topology-tools.test.ts` (17 tests): helper units, fake-DuckDB runs for both validity tools, and **real-WASM integration** — the topology tool runs the actual `geolibre-cli.wasm` from `node_modules` in Node and asserts violation counts/attributes.
- `test_vector_ops.py`: bowtie repair (→ valid MultiPolygon), marker/reason assertions, no-op on clean layers.
- Full suites green: frontend 2884 pass, backend 254 pass, `tsc -b && vite build` clean.
- Verified end-to-end in the running app with Playwright: a crafted QA layer (1 bowtie + 2 overlapping squares + 1 clean) produced exactly `1 invalid`, `Fixed 1 invalid geometry` (re-check: `0 invalid`), and `2 violation(s): polygon_must_not_overlap`. On the public `us-states` dataset the in-app result (`Checked 52 feature(s): 3 invalid` — Alaska, Maryland, Virginia) matches an independent Shapely ground-truth run exactly.

Closes the Check Validity / Fix Geometries scope of #1290; the follow-on dockable Topology Checker panel (persisted per-layer rules, zoom-to-error list) can build on `check-topology-rules`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Data Quality tools for checking geometry validity, repairing invalid geometries, and checking topology rules.
  * Added map result layers for validity errors, repaired geometries, and topology violations.
  * Added the new tools to the GeoLibre → Vector menu under Data Quality.
* **Bug Fixes**
  * Geometry repairs preserve valid features and report unfixable geometries.
* **Tests**
  * Added coverage for validity checks, geometry repairs, topology rules, and related error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->