### PR TITLE
feat(processing): add Processing History panel with re-run and Copy as Python

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -271,6 +271,20 @@ const StatisticsToolsDialog = lazy(() =>
     }),
 );
 
+const ProcessingHistoryDialog = lazy(() =>
+  import("../processing/ProcessingHistoryDialog")
+    .then((module) => ({
+      default: module.ProcessingHistoryDialog,
+    }))
+    .catch((error) => {
+      // Same chunk-load fallback rationale as ProcessingDialog above.
+      console.error("Failed to load ProcessingHistoryDialog", error);
+      const Fallback = (() =>
+        null) as unknown as typeof import("../processing/ProcessingHistoryDialog").ProcessingHistoryDialog;
+      return { default: Fallback };
+    }),
+);
+
 const GeocodeDialog = lazy(() =>
   import("../processing/GeocodeDialog")
     .then((module) => ({
@@ -2293,6 +2307,9 @@ export function DesktopShell({
       </Suspense>
       <Suspense fallback={null}>
         <GeocodeDialog mapControllerRef={mapControllerRef} />
+      </Suspense>
+      <Suspense fallback={null}>
+        <ProcessingHistoryDialog />
       </Suspense>
       <Suspense fallback={null}>
         <RasterToolsDialog mapControllerRef={mapControllerRef} />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -58,6 +58,9 @@ export function ProcessingMenu({
   const setNotebookOpen = useAppStore((s) => s.setNotebookOpen);
   const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
   const setDashboardOpen = useAppStore((s) => s.setDashboardOpen);
+  const setProcessingHistoryOpen = useAppStore(
+    (s) => s.setProcessingHistoryOpen,
+  );
 
   // Format Conversion, Raster tools, and AI Segmentation require the Python
   // sidecar, which cannot run on Android/iOS — hide them on mobile so they don't
@@ -97,6 +100,7 @@ export function ProcessingMenu({
     show("processing.segmentEverything");
   const showGeolibre = showGeolibreTools || showGeolibreActions;
   const showWorkspacesOrServices =
+    show("processing.history") ||
     show("processing.sqlWorkspace") ||
     show("processing.pythonConsole") ||
     show("processing.notebook") ||
@@ -560,6 +564,11 @@ export function ProcessingMenu({
         {show("processing.dashboard") && (
           <DropdownMenuItem onSelect={() => setDashboardOpen(true)}>
             {t("toolbar.command.dashboard")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.history") && (
+          <DropdownMenuItem onSelect={() => setProcessingHistoryOpen(true)}>
+            {t("toolbar.item.processingHistory")}
           </DropdownMenuItem>
         )}
         {show("processing.planetaryComputer") && (

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -1341,45 +1341,57 @@ export function ConversionDialog() {
   const dispatchConversion = async () => {
     if (!kind) return;
     setError(null);
-    // Track the run for the Processing History panel (#1292). Only the
+    // History tracker for this run (#1292), built lazily so a submit that
+    // fails the validation checks below is never recorded (matching the other
+    // processing dialogs) and never occupies the pending slot. Only the
     // parameters that apply to the selected conversion kind are recorded.
-    const browserInputName = usesBrowserRuntime
-      ? (splitBrowserSelection(browserFiles).mainFile?.name ?? "")
-      : "";
-    pendingTrackerRef.current = beginProcessingRun(
-      {
-        kind: "conversion",
-        toolId: kind,
-        toolName: TOOL_CONFIGS[kind].titleKey
-          ? t(TOOL_CONFIGS[kind].titleKey)
-          : TOOL_CONFIGS[kind].title,
-        engine: usesBrowserRuntime ? "browser" : "sidecar",
-        parameters: {
-          ...(compression ? { compression } : {}),
-          ...(kind === "vector-to-geoparquet" || kind === "csv-to-geoparquet"
-            ? { rowGroupSize }
-            : {}),
-          ...(kind === "csv-to-geoparquet" ? { lonColumn, latColumn } : {}),
-          ...(kind === "vector-to-pmtiles"
-            ? { layerName, minZoom, maxZoom }
-            : {}),
-          ...(kind === "raster-to-pmtiles"
-            ? {
-                ...(band ? { band } : {}),
-                ...(colormap ? { colormap } : {}),
-                resampling,
-                minZoom,
-                maxZoom,
-              }
-            : {}),
+    const makeTracker = () =>
+      beginProcessingRun(
+        {
+          kind: "conversion",
+          toolId: kind,
+          toolName: TOOL_CONFIGS[kind].titleKey
+            ? t(TOOL_CONFIGS[kind].titleKey)
+            : TOOL_CONFIGS[kind].title,
+          engine: usesBrowserRuntime ? "browser" : "sidecar",
+          parameters: {
+            ...(compression ? { compression } : {}),
+            ...(kind === "vector-to-geoparquet" || kind === "csv-to-geoparquet"
+              ? { rowGroupSize }
+              : {}),
+            ...(kind === "csv-to-geoparquet" ? { lonColumn, latColumn } : {}),
+            ...(kind === "vector-to-pmtiles"
+              ? { layerName, minZoom, maxZoom }
+              : {}),
+            ...(kind === "raster-to-pmtiles"
+              ? {
+                  ...(band ? { band } : {}),
+                  ...(colormap ? { colormap } : {}),
+                  resampling,
+                  minZoom,
+                  maxZoom,
+                }
+              : {}),
+          },
         },
-      },
-      {
-        inputPath: usesBrowserRuntime ? browserInputName : inputPath.trim(),
-        outputPath: outputPath.trim(),
-      },
-    );
+        {
+          inputPath: usesBrowserRuntime
+            ? (splitBrowserSelection(browserFiles).mainFile?.name ?? "")
+            : inputPath.trim(),
+          outputPath: outputPath.trim(),
+        },
+      );
     if (usesBrowserRuntime) {
+      // Mirror runBrowserConversion's own input check before creating the
+      // tracker. Deeper per-kind validations inside the browser sub-runners
+      // return before any job is dispatched, so a tracker they strand is
+      // never finished nor misattributed (the terminal-status effect only
+      // fires on job transitions, and each dispatch overwrites the slot).
+      if (!splitBrowserSelection(browserFiles).mainFile) {
+        setError("Choose an input file.");
+        return;
+      }
+      pendingTrackerRef.current = makeTracker();
       await runBrowserConversion();
       return;
     }
@@ -1396,16 +1408,48 @@ export function ConversionDialog() {
     const parsedRowGroupSize = Number.parseInt(rowGroupSize, 10);
     const rowGroupValid =
       Number.isFinite(parsedRowGroupSize) && parsedRowGroupSize > 0;
+    // Per-kind parameter validation, before the tracker exists so an invalid
+    // submit is not recorded and cannot strand a pending tracker.
+    if (
+      (kind === "vector-to-geoparquet" || kind === "csv-to-geoparquet") &&
+      !rowGroupValid
+    ) {
+      setError("Row group size must be a positive integer.");
+      return;
+    }
+    if (
+      kind === "csv-to-geoparquet" &&
+      (!lonColumn.trim() || !latColumn.trim())
+    ) {
+      setError("Longitude and latitude column names are required.");
+      return;
+    }
+    // Unlike Raster to PMTiles, the sidecar requires both bounds, so a blank
+    // (undefined) one is an error rather than a "let the engine decide".
+    let pmtilesZoomRange: { minZoom: number; maxZoom: number } | null = null;
+    if (kind === "vector-to-pmtiles") {
+      const zooms = parseZoomRange(minZoom, maxZoom, MAX_PMTILES_ZOOM);
+      if (
+        !zooms ||
+        zooms.minZoom === undefined ||
+        zooms.maxZoom === undefined
+      ) {
+        setError(
+          i18n.t("toolbar.conversion.zoomRangeError", {
+            max: MAX_PMTILES_ZOOM,
+          }),
+        );
+        return;
+      }
+      pmtilesZoomRange = { minZoom: zooms.minZoom, maxZoom: zooms.maxZoom };
+    }
+    pendingTrackerRef.current = makeTracker();
     try {
       if (kind === "vector-to-vector") {
         // The backend resolves the output format from the output extension, so
         // the input/output paths are all it needs.
         setJob(await runVectorToVector({ input_path, output_path }));
       } else if (kind === "vector-to-geoparquet") {
-        if (!rowGroupValid) {
-          setError("Row group size must be a positive integer.");
-          return;
-        }
         setJob(
           await runVectorToGeoParquet({
             input_path,
@@ -1421,14 +1465,6 @@ export function ConversionDialog() {
       } else if (kind === "vector-to-geopackage") {
         setJob(await runVectorToGeoPackage({ input_path, output_path }));
       } else if (kind === "csv-to-geoparquet") {
-        if (!rowGroupValid) {
-          setError("Row group size must be a positive integer.");
-          return;
-        }
-        if (!lonColumn.trim() || !latColumn.trim()) {
-          setError("Longitude and latitude column names are required.");
-          return;
-        }
         setJob(
           await runCsvToGeoParquet({
             input_path,
@@ -1439,29 +1475,14 @@ export function ConversionDialog() {
             row_group_size: parsedRowGroupSize,
           }),
         );
-      } else if (kind === "vector-to-pmtiles") {
-        // Unlike Raster to PMTiles, the sidecar requires both bounds, so a blank
-        // (undefined) one is an error rather than a "let the engine decide".
-        const zooms = parseZoomRange(minZoom, maxZoom, MAX_PMTILES_ZOOM);
-        if (
-          !zooms ||
-          zooms.minZoom === undefined ||
-          zooms.maxZoom === undefined
-        ) {
-          setError(
-            i18n.t("toolbar.conversion.zoomRangeError", {
-              max: MAX_PMTILES_ZOOM,
-            }),
-          );
-          return;
-        }
+      } else if (kind === "vector-to-pmtiles" && pmtilesZoomRange) {
         setJob(
           await runVectorToPmtiles({
             input_path,
             output_path,
             layer_name: layerName.trim() || "data",
-            min_zoom: zooms.minZoom,
-            max_zoom: zooms.maxZoom,
+            min_zoom: pmtilesZoomRange.minZoom,
+            max_zoom: pmtilesZoomRange.maxZoom,
           }),
         );
       } else if (kind === "raster-to-cog") {

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -584,8 +584,10 @@ export function ConversionDialog() {
   const [job, setJob] = useState<ConversionJob | null>(null);
   // History tracker for the conversion dispatched last (#1292). Sidecar and
   // browser runs both settle through `job`, so one pending slot suffices;
-  // `finish` is idempotent.
+  // `finish` is idempotent. Overlapping dispatches (which would cross-wire
+  // trackers) are prevented by the synchronous guard in runConversion.
   const pendingTrackerRef = useRef<ProcessingRunTracker | null>(null);
+  const dispatchGuardRef = useRef(false);
   const logEndRef = useRef<HTMLDivElement | null>(null);
 
   const config = kind ? TOOL_CONFIGS[kind] : null;
@@ -1323,6 +1325,20 @@ export function ConversionDialog() {
   };
 
   const runConversion = async () => {
+    // Serialize dispatches. `running` derives from job state, which is not yet
+    // set while the initial sidecar request is in flight, so rapid clicks
+    // could otherwise dispatch overlapping jobs and cross-wire their history
+    // trackers (#1292 review).
+    if (dispatchGuardRef.current) return;
+    dispatchGuardRef.current = true;
+    try {
+      await dispatchConversion();
+    } finally {
+      dispatchGuardRef.current = false;
+    }
+  };
+
+  const dispatchConversion = async () => {
     if (!kind) return;
     setError(null);
     // Track the run for the Processing History panel (#1292). Only the
@@ -1334,7 +1350,9 @@ export function ConversionDialog() {
       {
         kind: "conversion",
         toolId: kind,
-        toolName: TOOL_CONFIGS[kind].title,
+        toolName: TOOL_CONFIGS[kind].titleKey
+          ? t(TOOL_CONFIGS[kind].titleKey)
+          : TOOL_CONFIGS[kind].title,
         engine: usesBrowserRuntime ? "browser" : "sidecar",
         parameters: {
           ...(compression ? { compression } : {}),

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -1491,7 +1491,13 @@ export function ConversionDialog() {
         // raster-to-pmtiles is the only remaining kind and has no sidecar
         // endpoint; conversionUsesBrowserRuntime always routes it to the WASM
         // path above, so reaching here means those two have drifted apart.
-        setError(i18n.t("toolbar.conversion.noSidecarConversion", { kind }));
+        const message = i18n.t("toolbar.conversion.noSidecarConversion", {
+          kind,
+        });
+        // No job will ever settle this dispatch, so finish the tracker here
+        // rather than stranding it in the pending slot.
+        pendingTrackerRef.current?.finish("error", message);
+        setError(message);
       }
     } catch (err) {
       const message =

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -54,6 +54,10 @@ import {
 } from "../../lib/tauri-io";
 import type { LargeVectorDataset } from "../../lib/duckdb-vector-guard";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
+import {
+  beginProcessingRun,
+  type ProcessingRunTracker,
+} from "../../lib/processing-history";
 import i18n from "../../i18n";
 
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
@@ -578,6 +582,10 @@ export function ConversionDialog() {
   const [startingServer, setStartingServer] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [job, setJob] = useState<ConversionJob | null>(null);
+  // History tracker for the conversion dispatched last (#1292). Sidecar and
+  // browser runs both settle through `job`, so one pending slot suffices;
+  // `finish` is idempotent.
+  const pendingTrackerRef = useRef<ProcessingRunTracker | null>(null);
   const logEndRef = useRef<HTMLDivElement | null>(null);
 
   const config = kind ? TOOL_CONFIGS[kind] : null;
@@ -686,6 +694,17 @@ export function ConversionDialog() {
       cancelled = true;
       window.clearTimeout(timer);
     };
+  }, [job]);
+
+  // Record a History entry once a conversion reaches a terminal status (#1292).
+  // Covers sidecar jobs (via polling) and browser runs (synthetic jobs that
+  // arrive terminal). `finish` is idempotent across re-renders.
+  useEffect(() => {
+    if (!job || RUNNING_JOB_STATUSES.has(job.status)) return;
+    pendingTrackerRef.current?.finish(
+      job.status === "succeeded" ? "success" : "error",
+      job.error ?? undefined,
+    );
   }, [job]);
 
   // Keep the newest log lines in view as messages stream in.
@@ -1306,6 +1325,42 @@ export function ConversionDialog() {
   const runConversion = async () => {
     if (!kind) return;
     setError(null);
+    // Track the run for the Processing History panel (#1292). Only the
+    // parameters that apply to the selected conversion kind are recorded.
+    const browserInputName = usesBrowserRuntime
+      ? (splitBrowserSelection(browserFiles).mainFile?.name ?? "")
+      : "";
+    pendingTrackerRef.current = beginProcessingRun(
+      {
+        kind: "conversion",
+        toolId: kind,
+        toolName: TOOL_CONFIGS[kind].title,
+        engine: usesBrowserRuntime ? "browser" : "sidecar",
+        parameters: {
+          ...(compression ? { compression } : {}),
+          ...(kind === "vector-to-geoparquet" || kind === "csv-to-geoparquet"
+            ? { rowGroupSize }
+            : {}),
+          ...(kind === "csv-to-geoparquet" ? { lonColumn, latColumn } : {}),
+          ...(kind === "vector-to-pmtiles"
+            ? { layerName, minZoom, maxZoom }
+            : {}),
+          ...(kind === "raster-to-pmtiles"
+            ? {
+                ...(band ? { band } : {}),
+                ...(colormap ? { colormap } : {}),
+                resampling,
+                minZoom,
+                maxZoom,
+              }
+            : {}),
+        },
+      },
+      {
+        inputPath: usesBrowserRuntime ? browserInputName : inputPath.trim(),
+        outputPath: outputPath.trim(),
+      },
+    );
     if (usesBrowserRuntime) {
       await runBrowserConversion();
       return;
@@ -1400,9 +1455,10 @@ export function ConversionDialog() {
         setError(i18n.t("toolbar.conversion.noSidecarConversion", { kind }));
       }
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Could not start conversion.",
-      );
+      const message =
+        err instanceof Error ? err.message : "Could not start conversion.";
+      pendingTrackerRef.current?.finish("error", message);
+      setError(message);
     }
   };
 

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -105,7 +105,7 @@ export function NetworkToolsDialog({
     if (!getNetworkTool(rerun.toolId)) {
       setLog((prev) => [
         ...prev,
-        `Error: tool "${rerun.toolId}" is no longer available`,
+        `Error: ${t("processing.history.toolUnavailable", { toolId: rerun.toolId })}`,
       ]);
       setProcessingRerun(null);
       return;
@@ -114,17 +114,23 @@ export function NetworkToolsDialog({
     setParams({ ...rerun.parameters });
     setProcessingRerun(null);
     if (rerun.autoRun) setAutoRunPending(true);
-  }, [open, rerun, tool, setProcessingRerun]);
+  }, [open, rerun, tool, setProcessingRerun, t]);
 
   // Keep the newest log lines in view as they stream in.
   useEffect(() => {
     logEndRef.current?.scrollIntoView({ block: "end" });
   }, [log]);
 
-  const appendLog = useCallback(
-    (message: string) => setLog((prev) => [...prev, message]),
-    [],
-  );
+  // Client tools report validation failures via ctx.log("Error: ...") plus a
+  // plain return rather than throwing; capture the last such line so the run
+  // is recorded as failed in the Processing History (#1292). Reset per run.
+  const softErrorRef = useRef<string | null>(null);
+  const appendLog = useCallback((message: string) => {
+    if (message.startsWith("Error:")) {
+      softErrorRef.current = message.slice("Error:".length).trim();
+    }
+    setLog((prev) => [...prev, message]);
+  }, []);
 
   const layerOptions = useCallback(
     (filter?: GeometryFamily[]) =>
@@ -208,6 +214,7 @@ export function NetworkToolsDialog({
 
   const handleRun = useCallback(async () => {
     setLog([]);
+    softErrorRef.current = null;
     for (const param of tool.parameters) {
       if (!param.required) continue;
       const value = params[param.id];
@@ -246,7 +253,10 @@ export function NetworkToolsDialog({
         signal: controller.signal,
       };
       await tool.run(ctx);
-      tracker.finish("success");
+      // A logged "Error: ..." line marks a soft failure (the client tools
+      // bail out without throwing); don't record those as successes.
+      if (softErrorRef.current) tracker.finish("error", softErrorRef.current);
+      else tracker.finish("success");
     } catch (error) {
       // A user-initiated cancel (closing the dialog or starting a new run)
       // rejects with an AbortError; that is not a failed run, so don't log it

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -238,6 +238,10 @@ export function NetworkToolsDialog({
       await tool.run(ctx);
       tracker.finish("success");
     } catch (error) {
+      // A user-initiated cancel (closing the dialog or starting a new run)
+      // rejects with an AbortError; that is not a failed run, so don't log it
+      // or record it in the Processing History.
+      if (controller.signal.aborted) return;
       appendLog(`Error: ${(error as Error).message}`);
       tracker.finish("error", (error as Error).message);
     } finally {

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -28,6 +28,10 @@ import {
   type ReactElement,
 } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  beginProcessingRun,
+  type ProcessingRunTracker,
+} from "../../lib/processing-history";
 import { ParameterField } from "./ParameterField";
 
 interface NetworkToolsDialogProps {
@@ -50,6 +54,8 @@ export function NetworkToolsDialog({
   const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
   const layers = useAppStore((s) => s.layers);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const rerun = useAppStore((s) => s.ui.processingRerun);
+  const setProcessingRerun = useAppStore((s) => s.setProcessingRerun);
 
   const open = openTool !== null;
   const [selectedId, setSelectedId] = useState<string>(
@@ -58,6 +64,8 @@ export function NetworkToolsDialog({
   const [params, setParams] = useState<Record<string, unknown>>({});
   const [log, setLog] = useState<string[]>([]);
   const [running, setRunning] = useState(false);
+  const [autoRunPending, setAutoRunPending] = useState(false);
+  const runTrackerRef = useRef<ProcessingRunTracker | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
   // Cancels the in-flight run (and any pending routing requests) when the
   // dialog closes or a new run starts, so closing the dialog mid-batch does not
@@ -86,6 +94,17 @@ export function NetworkToolsDialog({
     setParams(defaults);
     setLog([]);
   }, [tool]);
+
+  // Pre-fill from a pending History re-run once the requested tool is selected.
+  // Declared after the defaults-reset effect above so the recorded parameters
+  // win over the defaults when both effects fire in the same commit.
+  useEffect(() => {
+    if (!open || !rerun || rerun.kind !== "network") return;
+    if (rerun.toolId !== tool.id) return;
+    setParams({ ...rerun.parameters });
+    setProcessingRerun(null);
+    if (rerun.autoRun) setAutoRunPending(true);
+  }, [open, rerun, tool, setProcessingRerun]);
 
   // Keep the newest log lines in view as they stream in.
   useEffect(() => {
@@ -150,6 +169,7 @@ export function NetworkToolsDialog({
         return;
       }
       const layerId = addGeoJsonLayer(name, fc);
+      runTrackerRef.current?.addOutputLayer(name);
       const layer = useAppStore
         .getState()
         .layers.find((item) => item.id === layerId);
@@ -197,6 +217,14 @@ export function NetworkToolsDialog({
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    const tracker = beginProcessingRun({
+      kind: "network",
+      toolId: tool.id,
+      toolName: tool.name,
+      engine: "client",
+      parameters: params,
+    });
+    runTrackerRef.current = tracker;
     setRunning(true);
     try {
       const ctx: ProcessingContext = {
@@ -208,13 +236,28 @@ export function NetworkToolsDialog({
         signal: controller.signal,
       };
       await tool.run(ctx);
+      tracker.finish("success");
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);
+      tracker.finish("error", (error as Error).message);
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
       setRunning(false);
     }
   }, [tool, params, layers, appendLog, addResultLayer, mapControllerRef]);
+
+  // Auto-run for a History "Re-run": kick off handleRun on the render after the
+  // pre-fill effect committed the recorded parameters. The ref always points at
+  // the latest handleRun closure, so the run sees the pre-filled state.
+  const handleRunRef = useRef(handleRun);
+  useEffect(() => {
+    handleRunRef.current = handleRun;
+  });
+  useEffect(() => {
+    if (!autoRunPending) return;
+    setAutoRunPending(false);
+    void handleRunRef.current();
+  }, [autoRunPending]);
 
   const endpoint = (params.endpoint as string) || getRoutingConfig().endpoint;
 

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -100,6 +100,16 @@ export function NetworkToolsDialog({
   // win over the defaults when both effects fire in the same commit.
   useEffect(() => {
     if (!open || !rerun || rerun.kind !== "network") return;
+    // A saved-project history entry can reference a tool that was renamed or
+    // removed since; drop the request instead of leaving it pending forever.
+    if (!getNetworkTool(rerun.toolId)) {
+      setLog((prev) => [
+        ...prev,
+        `Error: tool "${rerun.toolId}" is no longer available`,
+      ]);
+      setProcessingRerun(null);
+      return;
+    }
     if (rerun.toolId !== tool.id) return;
     setParams({ ...rerun.parameters });
     setProcessingRerun(null);

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1070,7 +1070,7 @@ export function ProcessingDialog({
           // Whitebox catalog no longer ships (e.g. after a geolibre-wasm
           // rename); drop the request instead of leaving it pending forever.
           setError(
-            `Tool "${rerun.toolId}" is no longer in the Whitebox catalog.`,
+            t("processing.history.toolUnavailable", { toolId: rerun.toolId }),
           );
           setProcessingRerun(null);
         }
@@ -1082,7 +1082,7 @@ export function ProcessingDialog({
       ...(rerun.parameters as ParameterValues),
     });
     setProcessingRerun(null);
-  }, [open, rerun, selectedTool, loadingTools, tools, setProcessingRerun]);
+  }, [open, rerun, selectedTool, loadingTools, tools, setProcessingRerun, t]);
 
   useEffect(() => {
     if (!job || !RUNNING_JOB_STATUSES.has(job.status)) return;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -73,6 +73,10 @@ import {
 } from "../../lib/subset-tool-url";
 import { clearPrintExtent, drawPrintExtent } from "../../lib/print-extent";
 import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
+import {
+  beginProcessingRun,
+  type ProcessingRunTracker,
+} from "../../lib/processing-history";
 import { SidecarHelpBanner } from "./SidecarHelpBanner";
 
 interface ProcessingDialogProps {
@@ -451,6 +455,8 @@ export function ProcessingDialog({
   );
   const layers = useAppStore((s) => s.layers);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const rerun = useAppStore((s) => s.ui.processingRerun);
+  const setProcessingRerun = useAppStore((s) => s.setProcessingRerun);
 
   const [tools, setTools] = useState<WhiteboxTool[]>([]);
   const [selectedToolId, setSelectedToolId] = useState("");
@@ -710,6 +716,11 @@ export function ProcessingDialog({
   // has actually started, so the apply only fires on a true -> false transition.
   const pendingInitialToolRef = useRef<string | null>(null);
   const wasLoadingRef = useRef(false);
+  // History trackers per dispatched job id (#1292). Entries stay after finish
+  // (finish is idempotent) so async output imports can still report layers.
+  const historyTrackersRef = useRef<Map<string, ProcessingRunTracker>>(
+    new Map(),
+  );
   // Bytes of input files the user browsed from disk (web build, where the
   // browser cannot expose a real path). Keyed by parameter name; consumed by
   // the in-browser WASM runner. GeoJSON files are parsed up front so vector
@@ -1038,6 +1049,26 @@ export function ProcessingDialog({
     importedJobIdRef.current = null;
   }, [selectedTool?.id]);
 
+  // Pre-fill from a pending History re-run (#1292). If the requested tool is
+  // not selected yet, select it once the catalog holds it (the initial-tool
+  // stash above covers the not-yet-loaded case); once selected, overlay the
+  // recorded values on the tool's defaults. Declared after the values-reset
+  // effect above so the recorded values win when both fire in the same commit.
+  useEffect(() => {
+    if (!open || !rerun || rerun.kind !== "whitebox") return;
+    if (selectedTool?.id !== rerun.toolId) {
+      if (!loadingTools && tools.some((tool) => tool.id === rerun.toolId)) {
+        setSelectedToolId(rerun.toolId);
+      }
+      return;
+    }
+    setValues({
+      ...createDefaultValues(selectedTool),
+      ...(rerun.parameters as ParameterValues),
+    });
+    setProcessingRerun(null);
+  }, [open, rerun, selectedTool, loadingTools, tools, setProcessingRerun]);
+
   useEffect(() => {
     if (!job || !RUNNING_JOB_STATUSES.has(job.status)) return;
     // Schedule the next poll only after the current request resolves so a slow
@@ -1063,6 +1094,19 @@ export function ProcessingDialog({
       cancelled = true;
       window.clearTimeout(timer);
     };
+  }, [job]);
+
+  // Record a History entry once a job reaches a terminal status (#1292). WASM
+  // jobs arrive terminal on dispatch; sidecar jobs get here via polling.
+  // `finish` is idempotent, so re-renders with the same terminal job are no-ops.
+  useEffect(() => {
+    if (!job || RUNNING_JOB_STATUSES.has(job.status)) return;
+    historyTrackersRef.current
+      .get(job.id)
+      ?.finish(
+        job.status === "succeeded" ? "success" : "error",
+        job.error ?? undefined,
+      );
   }, [job]);
 
   const updateValue = (name: string, value: unknown) => {
@@ -1302,11 +1346,9 @@ export function ProcessingDialog({
           ? value
           : await fetchWhiteboxJsonOutput(path);
         if (!isFeatureCollection(data)) continue;
-        const layerId = addGeoJsonLayer(
-          `${jobToolLabel} ${humanize(name)}`,
-          data,
-          path || undefined,
-        );
+        const layerName = `${jobToolLabel} ${humanize(name)}`;
+        const layerId = addGeoJsonLayer(layerName, data, path || undefined);
+        historyTrackersRef.current.get(nextJob.id)?.addOutputLayer(layerName);
         const layer = useAppStore
           .getState()
           .layers.find((item) => item.id === layerId);
@@ -1342,11 +1384,13 @@ export function ProcessingDialog({
           // Display name stays human-readable; the file name matches the actual
           // WASM output path (e.g. fill_depressions_wang_and_liu_output.tif), so
           // the layer's sourcePath lines up with the path shown in the panel.
+          const rasterName = `${jobToolLabel} ${humanize(name)}`;
           await onAddRaster(
             value,
-            `${jobToolLabel} ${humanize(name)}`,
+            rasterName,
             `${outputBaseName(nextJob.tool_id, name)}.tif`,
           );
+          historyTrackersRef.current.get(nextJob.id)?.addOutputLayer(rasterName);
         }
       }
     },
@@ -1441,6 +1485,16 @@ export function ProcessingDialog({
     // cast to a bogus format and produce a `..._output.undefined` filename.
     const vectorOutputFormat = normalizeVectorOutputFormat(vectorOutValue);
 
+    // Track the run for the Processing History panel (#1292). The raw form
+    // values (with `layer:` tokens) are recorded, not the resolved request
+    // parameters, so Edit & re-run can restore the form exactly.
+    const tracker = beginProcessingRun({
+      kind: "whitebox",
+      toolId: selectedTool.id,
+      toolName: toolLabel(selectedTool),
+      engine: runLocal ? "wasm" : "sidecar",
+      parameters: { ...values },
+    });
     try {
       const request = {
         tool_id: selectedTool.id,
@@ -1470,11 +1524,13 @@ export function ProcessingDialog({
       if (runLocal && nextJob.status === "succeeded") {
         runParametersByJobRef.current.set(nextJob.id, parameters);
       }
+      historyTrackersRef.current.set(nextJob.id, tracker);
       setJob(nextJob);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Could not start Whitebox tool.",
-      );
+      const message =
+        err instanceof Error ? err.message : "Could not start Whitebox tool.";
+      tracker.finish("error", message);
+      setError(message);
     } finally {
       setRunningLocal(false);
     }

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -75,6 +75,7 @@ import { clearPrintExtent, drawPrintExtent } from "../../lib/print-extent";
 import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
 import {
   beginProcessingRun,
+  MAX_TRACKED_HISTORY_JOBS,
   type ProcessingRunTracker,
 } from "../../lib/processing-history";
 import { SidecarHelpBanner } from "./SidecarHelpBanner";
@@ -95,9 +96,6 @@ type ParameterValues = Record<string, unknown>;
 
 const LAYER_TOKEN_PREFIX = "layer:";
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
-
-/** Cap on retained per-job history trackers (#1292); oldest are evicted. */
-const MAX_TRACKED_HISTORY_JOBS = 50;
 
 // Smallest the floating panel can be resized to, so the two-column tool browser
 // stays usable (left list + a readable parameter form).
@@ -1083,6 +1081,16 @@ export function ProcessingDialog({
     });
     setProcessingRerun(null);
   }, [open, rerun, selectedTool, loadingTools, tools, setProcessingRerun, t]);
+
+  // Drop an unconsumed whitebox re-run when the dialog closes (e.g. the
+  // catalog failed to load, so the effect above never matched), so a stale
+  // pre-fill cannot suddenly apply on a later open.
+  useEffect(() => {
+    if (open) return;
+    if (useAppStore.getState().ui.processingRerun?.kind === "whitebox") {
+      setProcessingRerun(null);
+    }
+  }, [open, setProcessingRerun]);
 
   useEffect(() => {
     if (!job || !RUNNING_JOB_STATUSES.has(job.status)) return;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -96,6 +96,9 @@ type ParameterValues = Record<string, unknown>;
 const LAYER_TOKEN_PREFIX = "layer:";
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
 
+/** Cap on retained per-job history trackers (#1292); oldest are evicted. */
+const MAX_TRACKED_HISTORY_JOBS = 50;
+
 // Smallest the floating panel can be resized to, so the two-column tool browser
 // stays usable (left list + a readable parameter form).
 const PANEL_MIN_W = 560;
@@ -717,7 +720,9 @@ export function ProcessingDialog({
   const pendingInitialToolRef = useRef<string | null>(null);
   const wasLoadingRef = useRef(false);
   // History trackers per dispatched job id (#1292). Entries stay after finish
-  // (finish is idempotent) so async output imports can still report layers.
+  // (finish is idempotent) so async output imports can still report layers;
+  // the map is capped (oldest evicted, Map preserves insertion order) so a
+  // long batch session cannot grow it without bound.
   const historyTrackersRef = useRef<Map<string, ProcessingRunTracker>>(
     new Map(),
   );
@@ -1057,8 +1062,18 @@ export function ProcessingDialog({
   useEffect(() => {
     if (!open || !rerun || rerun.kind !== "whitebox") return;
     if (selectedTool?.id !== rerun.toolId) {
-      if (!loadingTools && tools.some((tool) => tool.id === rerun.toolId)) {
-        setSelectedToolId(rerun.toolId);
+      if (!loadingTools && tools.length > 0) {
+        if (tools.some((tool) => tool.id === rerun.toolId)) {
+          setSelectedToolId(rerun.toolId);
+        } else {
+          // A saved-project history entry can reference a tool the current
+          // Whitebox catalog no longer ships (e.g. after a geolibre-wasm
+          // rename); drop the request instead of leaving it pending forever.
+          setError(
+            `Tool "${rerun.toolId}" is no longer in the Whitebox catalog.`,
+          );
+          setProcessingRerun(null);
+        }
       }
       return;
     }
@@ -1525,6 +1540,11 @@ export function ProcessingDialog({
         runParametersByJobRef.current.set(nextJob.id, parameters);
       }
       historyTrackersRef.current.set(nextJob.id, tracker);
+      while (historyTrackersRef.current.size > MAX_TRACKED_HISTORY_JOBS) {
+        const oldest = historyTrackersRef.current.keys().next().value;
+        if (oldest === undefined) break;
+        historyTrackersRef.current.delete(oldest);
+      }
       setJob(nextJob);
     } catch (err) {
       const message =

--- a/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
@@ -41,6 +41,13 @@ const PYTHON_TOOL_IDS = new Set(
     (tool) => tool.id,
   ),
 );
+/**
+ * Run kinds whose tool ids resolve against those registries. Ids are not
+ * disjoint across engines (e.g. Whitebox and raster both have "clip"/
+ * "reproject"), so a bare id match would offer a Python snippet that silently
+ * invokes the client vector tool with foreign parameters.
+ */
+const PYTHON_ELIGIBLE_KINDS = new Set(["vector", "statistics", "algorithm"]);
 
 /** Dialog families whose History "Re-run" can auto-start the run. */
 const AUTO_RERUN_KINDS = new Set(["vector", "statistics", "network"]);
@@ -312,7 +319,8 @@ export function ProcessingHistoryDialog(): ReactElement {
                           ? t("processing.history.copied")
                           : t("processing.history.copyJson")}
                       </Button>
-                      {PYTHON_TOOL_IDS.has(run.toolId) ? (
+                      {PYTHON_ELIGIBLE_KINDS.has(run.kind) &&
+                      PYTHON_TOOL_IDS.has(run.toolId) ? (
                         <Button
                           variant="ghost"
                           size="sm"

--- a/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
@@ -1,0 +1,338 @@
+import {
+  useAppStore,
+  type NetworkToolKind,
+  type ProcessingRun,
+  type RasterToolKind,
+  type StatisticsToolKind,
+  type VectorToolKind,
+} from "@geolibre/core";
+import {
+  ALGORITHMS,
+  H3_TOOLS,
+  STATISTICS_TOOLS,
+  VECTOR_TOOLS,
+} from "@geolibre/processing";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  cn,
+} from "@geolibre/ui";
+import {
+  Braces,
+  CheckCircle2,
+  FileCode2,
+  Pencil,
+  Play,
+  Trash2,
+  XCircle,
+} from "lucide-react";
+import { useCallback, useMemo, useRef, useState, type ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+
+/** Tool ids reachable from the Python API (`m.run_algorithm`), i.e. the client
+ * registries the scripting bridge spans. Only these get "Copy as Python". */
+const PYTHON_TOOL_IDS = new Set(
+  [...ALGORITHMS, ...VECTOR_TOOLS, ...H3_TOOLS, ...STATISTICS_TOOLS].map(
+    (tool) => tool.id,
+  ),
+);
+
+/** Dialog families whose History "Re-run" can auto-start the run. */
+const AUTO_RERUN_KINDS = new Set(["vector", "statistics", "network"]);
+/** Dialog families that support "Edit & re-run" (pre-filled dialog). */
+const EDIT_RERUN_KINDS = new Set([
+  "vector",
+  "statistics",
+  "network",
+  "whitebox",
+  "raster",
+]);
+
+/**
+ * Render a value as a Python literal (`true` → `True`, `null` → `None`), for
+ * the "Copy as Python" action. Strings use JSON quoting, which Python accepts.
+ */
+function toPythonLiteral(value: unknown): string {
+  if (value === null || value === undefined) return "None";
+  if (typeof value === "boolean") return value ? "True" : "False";
+  if (typeof value === "number")
+    return Number.isFinite(value) ? String(value) : "None";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value))
+    return `[${value.map((item) => toPythonLiteral(item)).join(", ")}]`;
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => `${JSON.stringify(key)}: ${toPythonLiteral(item)}`);
+    return `{${entries.join(", ")}}`;
+  }
+  return "None";
+}
+
+/** The `m.run_algorithm(...)` call equivalent to a recorded run. */
+function pythonSnippet(run: ProcessingRun): string {
+  return `m.run_algorithm(${JSON.stringify(run.toolId)}, ${toPythonLiteral(
+    run.parameters,
+  )})`;
+}
+
+/** Compact duration label: sub-second in ms, else one-decimal seconds. */
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)} ms` : `${(ms / 1000).toFixed(1)} s`;
+}
+
+/**
+ * Processing → History dialog (issue #1292): every processing run recorded by
+ * the tool dialogs and the scripting bridge, newest first. Each entry offers
+ * Re-run (client tools, runs immediately), Edit & re-run (reopens the tool
+ * dialog pre-filled), Copy parameters as JSON, and Copy as Python for tools
+ * reachable from the `geolibre` Python API. History persists in the project
+ * file, so a saved project documents how its derived layers were produced.
+ */
+export function ProcessingHistoryDialog(): ReactElement {
+  const { t } = useTranslation();
+  const open = useAppStore((s) => s.ui.processingHistoryOpen);
+  const setProcessingHistoryOpen = useAppStore(
+    (s) => s.setProcessingHistoryOpen,
+  );
+  const history = useAppStore((s) => s.processingHistory);
+  const clearProcessingHistory = useAppStore((s) => s.clearProcessingHistory);
+  const setProcessingRerun = useAppStore((s) => s.setProcessingRerun);
+  const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
+  const setStatisticsToolOpen = useAppStore((s) => s.setStatisticsToolOpen);
+  const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
+  const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
+  const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
+  const setProcessingInitialTool = useAppStore(
+    (s) => s.setProcessingInitialTool,
+  );
+
+  // Newest first for display; the store keeps runs oldest first.
+  const entries = useMemo(() => [...history].reverse(), [history]);
+
+  // Transient "Copied" feedback per entry+action, reset shortly after.
+  const [copied, setCopied] = useState<string | null>(null);
+  const copyTimerRef = useRef<number | null>(null);
+  const copyText = useCallback((key: string, text: string) => {
+    void navigator.clipboard?.writeText(text).then(() => {
+      setCopied(key);
+      if (copyTimerRef.current) window.clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = window.setTimeout(() => setCopied(null), 1500);
+    });
+  }, []);
+
+  // Route a re-run to the dialog family that recorded the run: queue the
+  // payload, open the dialog (pre-selecting the tool), and close History so
+  // the reopened dialog is visible.
+  const openForRun = useCallback(
+    (run: ProcessingRun, autoRun: boolean) => {
+      setProcessingRerun({
+        kind: run.kind,
+        toolId: run.toolId,
+        parameters: run.parameters,
+        engine: run.engine,
+        autoRun,
+      });
+      switch (run.kind) {
+        case "vector":
+          setVectorToolOpen(run.toolId as VectorToolKind);
+          break;
+        case "statistics":
+          setStatisticsToolOpen(run.toolId as StatisticsToolKind);
+          break;
+        case "network":
+          setNetworkToolOpen(run.toolId as NetworkToolKind);
+          break;
+        case "raster":
+          setRasterToolOpen(run.toolId as RasterToolKind);
+          break;
+        case "whitebox":
+          setProcessingInitialTool(run.toolId);
+          setProcessingOpen(true);
+          break;
+        default:
+          return;
+      }
+      setProcessingHistoryOpen(false);
+    },
+    [
+      setProcessingRerun,
+      setVectorToolOpen,
+      setStatisticsToolOpen,
+      setNetworkToolOpen,
+      setRasterToolOpen,
+      setProcessingInitialTool,
+      setProcessingOpen,
+      setProcessingHistoryOpen,
+    ],
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next: boolean) => {
+        if (!next) setProcessingHistoryOpen(false);
+      }}
+    >
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t("processing.history.title")}</DialogTitle>
+          <DialogDescription>
+            {t("processing.history.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="h-[24rem] rounded-md border">
+          {entries.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">
+              {t("processing.history.empty")}
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1 p-2">
+              {entries.map((run) => {
+                const inputs = Object.values(run.inputLayerNames ?? {});
+                return (
+                  <div
+                    key={run.id}
+                    className="rounded-md border bg-muted/20 px-3 py-2"
+                  >
+                    <div className="flex items-center gap-2">
+                      {run.status === "success" ? (
+                        <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-600" />
+                      ) : (
+                        <XCircle className="h-4 w-4 shrink-0 text-destructive" />
+                      )}
+                      <span className="truncate text-sm font-medium">
+                        {run.toolName}
+                      </span>
+                      <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                        {run.engine}
+                      </span>
+                      <span className="ms-auto shrink-0 text-xs text-muted-foreground">
+                        {run.startedAt
+                          ? new Date(run.startedAt).toLocaleString()
+                          : ""}
+                        {run.durationMs !== undefined
+                          ? ` · ${formatDuration(run.durationMs)}`
+                          : ""}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-center gap-1">
+                      <p
+                        className={cn(
+                          "min-w-0 flex-1 truncate text-xs text-muted-foreground",
+                          run.status === "error" && "text-destructive",
+                        )}
+                      >
+                        {run.status === "error" && run.error
+                          ? run.error
+                          : [
+                              inputs.length > 0
+                                ? `${inputs.join(", ")}`
+                                : (run.inputPath ?? ""),
+                              (run.outputLayerNames?.length ?? 0) > 0
+                                ? `→ ${run.outputLayerNames?.join(", ")}`
+                                : run.outputPath
+                                  ? `→ ${run.outputPath}`
+                                  : "",
+                            ]
+                              .filter(Boolean)
+                              .join(" ")}
+                      </p>
+                      {AUTO_RERUN_KINDS.has(run.kind) ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 px-2 text-xs"
+                          title={t("processing.history.rerun")}
+                          onClick={() => openForRun(run, true)}
+                        >
+                          <Play className="h-3.5 w-3.5" />
+                          {t("processing.history.rerun")}
+                        </Button>
+                      ) : null}
+                      {EDIT_RERUN_KINDS.has(run.kind) ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 px-2 text-xs"
+                          title={t("processing.history.editRerun")}
+                          onClick={() => openForRun(run, false)}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                          {t("processing.history.editRerun")}
+                        </Button>
+                      ) : null}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 gap-1 px-2 text-xs"
+                        title={t("processing.history.copyJson")}
+                        onClick={() =>
+                          copyText(
+                            `${run.id}:json`,
+                            JSON.stringify(
+                              {
+                                tool: run.toolId,
+                                engine: run.engine,
+                                parameters: run.parameters,
+                              },
+                              null,
+                              2,
+                            ),
+                          )
+                        }
+                      >
+                        <Braces className="h-3.5 w-3.5" />
+                        {copied === `${run.id}:json`
+                          ? t("processing.history.copied")
+                          : t("processing.history.copyJson")}
+                      </Button>
+                      {PYTHON_TOOL_IDS.has(run.toolId) ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 px-2 text-xs"
+                          title={t("processing.history.copyPython")}
+                          onClick={() =>
+                            copyText(`${run.id}:py`, pythonSnippet(run))
+                          }
+                        >
+                          <FileCode2 className="h-3.5 w-3.5" />
+                          {copied === `${run.id}:py`
+                            ? t("processing.history.copied")
+                            : t("processing.history.copyPython")}
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </ScrollArea>
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {t("processing.history.count", { count: history.length })}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            disabled={history.length === 0}
+            onClick={clearProcessingHistory}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            {t("processing.history.clear")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
@@ -6,12 +6,7 @@ import {
   type StatisticsToolKind,
   type VectorToolKind,
 } from "@geolibre/core";
-import {
-  ALGORITHMS,
-  H3_TOOLS,
-  STATISTICS_TOOLS,
-  VECTOR_TOOLS,
-} from "@geolibre/processing";
+import { allAlgorithms } from "../../lib/scripting/scriptingApi";
 import {
   Button,
   Dialog,
@@ -34,13 +29,10 @@ import {
 import { useCallback, useMemo, useRef, useState, type ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
-/** Tool ids reachable from the Python API (`m.run_algorithm`), i.e. the client
- * registries the scripting bridge spans. Only these get "Copy as Python". */
-const PYTHON_TOOL_IDS = new Set(
-  [...ALGORITHMS, ...VECTOR_TOOLS, ...H3_TOOLS, ...STATISTICS_TOOLS].map(
-    (tool) => tool.id,
-  ),
-);
+/** Tool ids reachable from the Python API (`m.run_algorithm`): the scripting
+ * bridge's own registry list, so "Copy as Python" eligibility cannot drift
+ * from what `run_algorithm` actually resolves. */
+const PYTHON_TOOL_IDS = new Set(allAlgorithms().map((tool) => tool.id));
 /**
  * Run kinds whose tool ids resolve against those registries. Ids are not
  * disjoint across engines (e.g. Whitebox and raster both have "clip"/

--- a/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingHistoryDialog.tsx
@@ -115,15 +115,34 @@ export function ProcessingHistoryDialog(): ReactElement {
   // Newest first for display; the store keeps runs oldest first.
   const entries = useMemo(() => [...history].reverse(), [history]);
 
-  // Transient "Copied" feedback per entry+action, reset shortly after.
+  // Transient "Copied" feedback per entry+action, reset shortly after. Only
+  // shown once a copy actually succeeded.
   const [copied, setCopied] = useState<string | null>(null);
   const copyTimerRef = useRef<number | null>(null);
-  const copyText = useCallback((key: string, text: string) => {
-    void navigator.clipboard?.writeText(text).then(() => {
-      setCopied(key);
-      if (copyTimerRef.current) window.clearTimeout(copyTimerRef.current);
-      copyTimerRef.current = window.setTimeout(() => setCopied(null), 1500);
-    });
+  const copyText = useCallback(async (key: string, text: string) => {
+    let ok = false;
+    try {
+      await navigator.clipboard.writeText(text);
+      ok = true;
+    } catch {
+      // Clipboard access can be denied (insecure context, permissions). Fall
+      // back to a transient textarea + execCommand, like MapContextMenu.
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      try {
+        ok = document.execCommand("copy");
+      } finally {
+        document.body.removeChild(textarea);
+      }
+    }
+    if (!ok) return;
+    setCopied(key);
+    if (copyTimerRef.current) window.clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = window.setTimeout(() => setCopied(null), 1500);
   }, []);
 
   // Route a re-run to the dialog family that recorded the run: queue the
@@ -274,7 +293,7 @@ export function ProcessingHistoryDialog(): ReactElement {
                         className="h-7 gap-1 px-2 text-xs"
                         title={t("processing.history.copyJson")}
                         onClick={() =>
-                          copyText(
+                          void copyText(
                             `${run.id}:json`,
                             JSON.stringify(
                               {
@@ -300,7 +319,7 @@ export function ProcessingHistoryDialog(): ReactElement {
                           className="h-7 gap-1 px-2 text-xs"
                           title={t("processing.history.copyPython")}
                           onClick={() =>
-                            copyText(`${run.id}:py`, pythonSnippet(run))
+                            void copyText(`${run.id}:py`, pythonSnippet(run))
                           }
                         >
                           <FileCode2 className="h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -57,6 +57,10 @@ import {
   saveBinaryFileWithFallback,
 } from "../../lib/tauri-io";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
+import {
+  beginProcessingRun,
+  type ProcessingRunTracker,
+} from "../../lib/processing-history";
 import { createAppAPI } from "../../hooks/usePlugins";
 import { canExportRasterLayer, rasterExportUrl } from "../../lib/raster-export";
 import { fetchableUrl } from "../../lib/url-utils";
@@ -115,6 +119,8 @@ export function RasterToolsDialog({
   const openTool = useAppStore((s) => s.ui.rasterToolOpen);
   const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
   const layers = useAppStore((s) => s.layers);
+  const rerun = useAppStore((s) => s.ui.processingRerun);
+  const setProcessingRerun = useAppStore((s) => s.setProcessingRerun);
 
   const open = openTool !== null;
   const desktop = isTauri();
@@ -137,6 +143,11 @@ export function RasterToolsDialog({
   // Aborts an in-flight layer-bytes fetch when the dialog closes/unmounts or a
   // new pick supersedes it, so its state setters never fire on a dead component.
   const layerFetchAbortRef = useRef<AbortController | null>(null);
+  // History trackers per dispatched sidecar job id (#1292). Entries stay after
+  // finish (finish is idempotent).
+  const historyTrackersRef = useRef<Map<string, ProcessingRunTracker>>(
+    new Map(),
+  );
 
   // Client-engine state. The browser fallback reads a GeoTIFF into memory,
   // computes a new raster, adds it to the map, and offers a download.
@@ -208,6 +219,17 @@ export function RasterToolsDialog({
     setEngine(tool.supportsClient && !desktop ? "client" : "sidecar");
   }, [open, tool, desktop]);
 
+  // Pre-fill from a pending History re-run once the requested tool is selected.
+  // Declared after the reset effect above so the recorded parameters win over
+  // the defaults when both effects fire in the same commit. Input/output paths
+  // are not restored: the user re-picks files.
+  useEffect(() => {
+    if (!open || !rerun || rerun.kind !== "raster") return;
+    if (rerun.toolId !== tool.id) return;
+    setParams({ ...toolDefaults(tool), ...rerun.parameters });
+    setProcessingRerun(null);
+  }, [open, rerun, tool, setProcessingRerun]);
+
   // Probe the runtime only when the dialog opens, not on every tool switch
   // (each probe spawns a sidecar subprocess import check).
   useEffect(() => {
@@ -240,6 +262,18 @@ export function RasterToolsDialog({
       cancelled = true;
       window.clearTimeout(timer);
     };
+  }, [job]);
+
+  // Record a History entry once a sidecar job reaches a terminal status
+  // (#1292). `finish` is idempotent, so re-renders with the same job are no-ops.
+  useEffect(() => {
+    if (!job || RUNNING_JOB_STATUSES.has(job.status)) return;
+    historyTrackersRef.current
+      .get(job.id)
+      ?.finish(
+        job.status === "succeeded" ? "success" : "error",
+        job.error ?? undefined,
+      );
   }, [job]);
 
   // Keep the newest log lines in view as messages stream in. One effect per log
@@ -453,19 +487,32 @@ export function RasterToolsDialog({
         return;
       }
     }
+    // Record the raw form params (not the injected sidecar expression) so
+    // Edit & re-run restores the form exactly (#1292).
+    const tracker = beginProcessingRun(
+      {
+        kind: "raster",
+        toolId: tool.id,
+        toolName: tool.name,
+        engine: "sidecar",
+        parameters: params,
+      },
+      { inputPath: inputPath.trim(), outputPath: outputPath.trim() },
+    );
     try {
-      setJob(
-        await runRasterTool({
-          tool_id: tool.id,
-          input_path: inputPath.trim(),
-          output_path: outputPath.trim(),
-          parameters: sidecarParams,
-        }),
-      );
+      const nextJob = await runRasterTool({
+        tool_id: tool.id,
+        input_path: inputPath.trim(),
+        output_path: outputPath.trim(),
+        parameters: sidecarParams,
+      });
+      historyTrackersRef.current.set(nextJob.id, tracker);
+      setJob(nextJob);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Could not start raster tool.",
-      );
+      const message =
+        err instanceof Error ? err.message : "Could not start raster tool.";
+      tracker.finish("error", message);
+      setError(message);
     }
   }, [tool, inputPath, outputPath, params, validateParams, t]);
 
@@ -483,6 +530,16 @@ export function RasterToolsDialog({
     }
     setClientRunning(true);
     setClientLog([t("toolbar.rasterTool.runningInBrowser", { tool: tool.name })]);
+    const tracker = beginProcessingRun(
+      {
+        kind: "raster",
+        toolId: tool.id,
+        toolName: tool.name,
+        engine: "client",
+        parameters: params,
+      },
+      { inputPath: clientInput.name },
+    );
     try {
       const raster = await readRasterData(clientInput.bytes);
       setClientLog((prev) => [
@@ -534,6 +591,7 @@ export function RasterToolsDialog({
           ...prev,
           t("toolbar.rasterTool.addedToMap", { name: outName }),
         ]);
+        tracker.addOutputLayer(outName);
       } catch (mapError) {
         const mapMessage =
           mapError instanceof Error
@@ -545,9 +603,11 @@ export function RasterToolsDialog({
           t("toolbar.rasterTool.mapAddFailed", { message: mapMessage }),
         ]);
       }
+      tracker.finish("success");
     } catch (err) {
       const message =
         err instanceof Error ? err.message : t("toolbar.rasterTool.runError");
+      tracker.finish("error", message);
       setError(message);
       setClientLog((prev) => [...prev, message]);
     } finally {

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -232,14 +232,16 @@ export function RasterToolsDialog({
     // A saved-project history entry can reference a tool that was renamed or
     // removed since; drop the request instead of leaving it pending forever.
     if (!getRasterTool(rerun.toolId)) {
-      setError(`Tool "${rerun.toolId}" is no longer available.`);
+      setError(
+        t("processing.history.toolUnavailable", { toolId: rerun.toolId }),
+      );
       setProcessingRerun(null);
       return;
     }
     if (rerun.toolId !== tool.id) return;
     setParams({ ...toolDefaults(tool), ...rerun.parameters });
     setProcessingRerun(null);
-  }, [open, rerun, tool, setProcessingRerun]);
+  }, [open, rerun, tool, setProcessingRerun, t]);
 
   // Probe the runtime only when the dialog opens, not on every tool switch
   // (each probe spawns a sidecar subprocess import check).

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -59,6 +59,7 @@ import {
 import { startGeoLibreSidecar } from "../../lib/sidecar";
 import {
   beginProcessingRun,
+  MAX_TRACKED_HISTORY_JOBS,
   type ProcessingRunTracker,
 } from "../../lib/processing-history";
 import { createAppAPI } from "../../hooks/usePlugins";
@@ -84,9 +85,6 @@ function sidecarRasterUrl(layer: GeoLibreLayer): string | null {
 type RasterEngine = "sidecar" | "client";
 
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
-
-/** Cap on retained per-job history trackers (#1292); oldest are evicted. */
-const MAX_TRACKED_HISTORY_JOBS = 50;
 
 /** Tools grouped by their `group` label, preserving registry order. */
 function groupedTools(): { group: string; tools: RasterTool[] }[] {

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -85,6 +85,9 @@ type RasterEngine = "sidecar" | "client";
 
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
 
+/** Cap on retained per-job history trackers (#1292); oldest are evicted. */
+const MAX_TRACKED_HISTORY_JOBS = 50;
+
 /** Tools grouped by their `group` label, preserving registry order. */
 function groupedTools(): { group: string; tools: RasterTool[] }[] {
   const groups: { group: string; tools: RasterTool[] }[] = [];
@@ -144,7 +147,8 @@ export function RasterToolsDialog({
   // new pick supersedes it, so its state setters never fire on a dead component.
   const layerFetchAbortRef = useRef<AbortController | null>(null);
   // History trackers per dispatched sidecar job id (#1292). Entries stay after
-  // finish (finish is idempotent).
+  // finish (finish is idempotent); the map is capped (oldest evicted) so a
+  // long session cannot grow it without bound.
   const historyTrackersRef = useRef<Map<string, ProcessingRunTracker>>(
     new Map(),
   );
@@ -225,6 +229,13 @@ export function RasterToolsDialog({
   // are not restored: the user re-picks files.
   useEffect(() => {
     if (!open || !rerun || rerun.kind !== "raster") return;
+    // A saved-project history entry can reference a tool that was renamed or
+    // removed since; drop the request instead of leaving it pending forever.
+    if (!getRasterTool(rerun.toolId)) {
+      setError(`Tool "${rerun.toolId}" is no longer available.`);
+      setProcessingRerun(null);
+      return;
+    }
     if (rerun.toolId !== tool.id) return;
     setParams({ ...toolDefaults(tool), ...rerun.parameters });
     setProcessingRerun(null);
@@ -507,6 +518,11 @@ export function RasterToolsDialog({
         parameters: sidecarParams,
       });
       historyTrackersRef.current.set(nextJob.id, tracker);
+      while (historyTrackersRef.current.size > MAX_TRACKED_HISTORY_JOBS) {
+        const oldest = historyTrackersRef.current.keys().next().value;
+        if (oldest === undefined) break;
+        historyTrackersRef.current.delete(oldest);
+      }
       setJob(nextJob);
     } catch (err) {
       const message =
@@ -605,6 +621,7 @@ export function RasterToolsDialog({
         // The compute succeeded but the result never made it onto the map, so
         // record the run as failed rather than a green no-output "success".
         tracker.finish("error", mapMessage);
+        return;
       }
       tracker.finish("success");
     } catch (err) {

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -602,6 +602,9 @@ export function RasterToolsDialog({
           ...prev,
           t("toolbar.rasterTool.mapAddFailed", { message: mapMessage }),
         ]);
+        // The compute succeeded but the result never made it onto the map, so
+        // record the run as failed rather than a green no-output "success".
+        tracker.finish("error", mapMessage);
       }
       tracker.finish("success");
     } catch (err) {

--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -118,7 +118,7 @@ export function StatisticsToolsDialog({
     if (!getStatisticsTool(rerun.toolId)) {
       setLog((prev) => [
         ...prev,
-        `Error: tool "${rerun.toolId}" is no longer available`,
+        `Error: ${t("processing.history.toolUnavailable", { toolId: rerun.toolId })}`,
       ]);
       setProcessingRerun(null);
       return;
@@ -127,17 +127,23 @@ export function StatisticsToolsDialog({
     setParams({ ...rerun.parameters });
     setProcessingRerun(null);
     if (rerun.autoRun) setAutoRunPending(true);
-  }, [open, rerun, tool, setProcessingRerun]);
+  }, [open, rerun, tool, setProcessingRerun, t]);
 
   // Keep the newest log lines in view as they stream in.
   useEffect(() => {
     logEndRef.current?.scrollIntoView({ block: "end" });
   }, [log]);
 
-  const appendLog = useCallback(
-    (message: string) => setLog((prev) => [...prev, message]),
-    [],
-  );
+  // Client tools report validation failures via ctx.log("Error: ...") plus a
+  // plain return rather than throwing; capture the last such line so the run
+  // is recorded as failed in the Processing History (#1292). Reset per run.
+  const softErrorRef = useRef<string | null>(null);
+  const appendLog = useCallback((message: string) => {
+    if (message.startsWith("Error:")) {
+      softErrorRef.current = message.slice("Error:".length).trim();
+    }
+    setLog((prev) => [...prev, message]);
+  }, []);
 
   const layerOptions = useCallback(
     (filter?: GeometryFamily[]) =>
@@ -243,6 +249,7 @@ export function StatisticsToolsDialog({
 
   const handleRun = useCallback(async () => {
     setLog([]);
+    softErrorRef.current = null;
     for (const param of tool.parameters) {
       if (!param.required || !isParamVisible(param)) continue;
       if (isValueEmpty(param, params[param.id])) {
@@ -275,7 +282,10 @@ export function StatisticsToolsDialog({
         },
       };
       await tool.run(ctx);
-      tracker.finish("success");
+      // A logged "Error: ..." line marks a soft failure (the client tools
+      // bail out without throwing); don't record those as successes.
+      if (softErrorRef.current) tracker.finish("error", softErrorRef.current);
+      else tracker.finish("success");
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);
       tracker.finish("error", (error as Error).message);

--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -113,6 +113,16 @@ export function StatisticsToolsDialog({
   // win over the defaults when both effects fire in the same commit.
   useEffect(() => {
     if (!open || !rerun || rerun.kind !== "statistics") return;
+    // A saved-project history entry can reference a tool that was renamed or
+    // removed since; drop the request instead of leaving it pending forever.
+    if (!getStatisticsTool(rerun.toolId)) {
+      setLog((prev) => [
+        ...prev,
+        `Error: tool "${rerun.toolId}" is no longer available`,
+      ]);
+      setProcessingRerun(null);
+      return;
+    }
     if (rerun.toolId !== tool.id) return;
     setParams({ ...rerun.parameters });
     setProcessingRerun(null);

--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -28,6 +28,10 @@ import {
   type ReactElement,
 } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  beginProcessingRun,
+  type ProcessingRunTracker,
+} from "../../lib/processing-history";
 import { ParameterField } from "./ParameterField";
 
 interface StatisticsToolsDialogProps {
@@ -70,6 +74,8 @@ export function StatisticsToolsDialog({
   const setStatisticsToolOpen = useAppStore((s) => s.setStatisticsToolOpen);
   const layers = useAppStore((s) => s.layers);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const rerun = useAppStore((s) => s.ui.processingRerun);
+  const setProcessingRerun = useAppStore((s) => s.setProcessingRerun);
 
   const open = openTool !== null;
   const [selectedId, setSelectedId] = useState<string>(
@@ -78,7 +84,9 @@ export function StatisticsToolsDialog({
   const [params, setParams] = useState<Record<string, unknown>>({});
   const [log, setLog] = useState<string[]>([]);
   const [running, setRunning] = useState(false);
+  const [autoRunPending, setAutoRunPending] = useState(false);
   const logEndRef = useRef<HTMLDivElement>(null);
+  const runTrackerRef = useRef<ProcessingRunTracker | null>(null);
 
   const tool = useMemo(
     () => getStatisticsTool(selectedId) ?? STATISTICS_TOOLS[0],
@@ -99,6 +107,17 @@ export function StatisticsToolsDialog({
     setParams(defaults);
     setLog([]);
   }, [tool]);
+
+  // Pre-fill from a pending History re-run once the requested tool is selected.
+  // Declared after the defaults-reset effect above so the recorded parameters
+  // win over the defaults when both effects fire in the same commit.
+  useEffect(() => {
+    if (!open || !rerun || rerun.kind !== "statistics") return;
+    if (rerun.toolId !== tool.id) return;
+    setParams({ ...rerun.parameters });
+    setProcessingRerun(null);
+    if (rerun.autoRun) setAutoRunPending(true);
+  }, [open, rerun, tool, setProcessingRerun]);
 
   // Keep the newest log lines in view as they stream in.
   useEffect(() => {
@@ -160,6 +179,7 @@ export function StatisticsToolsDialog({
         return;
       }
       const layerId = addGeoJsonLayer(name, fc);
+      runTrackerRef.current?.addOutputLayer(name);
       const layer = useAppStore
         .getState()
         .layers.find((item) => item.id === layerId);
@@ -221,6 +241,14 @@ export function StatisticsToolsDialog({
       }
     }
 
+    const tracker = beginProcessingRun({
+      kind: "statistics",
+      toolId: tool.id,
+      toolName: tool.name,
+      engine: "client",
+      parameters: params,
+    });
+    runTrackerRef.current = tracker;
     setRunning(true);
     try {
       const ctx: ProcessingContext = {
@@ -237,8 +265,10 @@ export function StatisticsToolsDialog({
         },
       };
       await tool.run(ctx);
+      tracker.finish("success");
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);
+      tracker.finish("error", (error as Error).message);
     } finally {
       setRunning(false);
     }
@@ -251,6 +281,19 @@ export function StatisticsToolsDialog({
     mapControllerRef,
     isParamVisible,
   ]);
+
+  // Auto-run for a History "Re-run": kick off handleRun on the render after the
+  // pre-fill effect committed the recorded parameters. The ref always points at
+  // the latest handleRun closure, so the run sees the pre-filled state.
+  const handleRunRef = useRef(handleRun);
+  useEffect(() => {
+    handleRunRef.current = handleRun;
+  });
+  useEffect(() => {
+    if (!autoRunPending) return;
+    setAutoRunPending(false);
+    void handleRunRef.current();
+  }, [autoRunPending]);
 
   return (
     <Dialog

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -44,6 +44,7 @@ import {
   useState,
   type ReactElement,
 } from "react";
+import { useTranslation } from "react-i18next";
 
 interface VectorToolsDialogProps {
   mapControllerRef: React.RefObject<MapController | null>;
@@ -69,6 +70,7 @@ function groupedTools(): { group: string; tools: ProcessingAlgorithm[] }[] {
 export function VectorToolsDialog({
   mapControllerRef,
 }: VectorToolsDialogProps): ReactElement {
+  const { t } = useTranslation();
   const openTool = useAppStore((s) => s.ui.vectorToolOpen);
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
   const layers = useAppStore((s) => s.layers);
@@ -129,7 +131,7 @@ export function VectorToolsDialog({
     if (!getVectorTool(rerun.toolId)) {
       setLog((prev) => [
         ...prev,
-        `Error: tool "${rerun.toolId}" is no longer available`,
+        `Error: ${t("processing.history.toolUnavailable", { toolId: rerun.toolId })}`,
       ]);
       setProcessingRerun(null);
       return;
@@ -145,7 +147,7 @@ export function VectorToolsDialog({
     }
     setProcessingRerun(null);
     if (rerun.autoRun) setAutoRunPending(true);
-  }, [open, rerun, tool, setProcessingRerun]);
+  }, [open, rerun, tool, setProcessingRerun, t]);
 
   // Prefill the H3 grid's manual bounding-box fields from the current map
   // viewport when the user first switches to that source, so they can tweak the
@@ -197,10 +199,16 @@ export function VectorToolsDialog({
     logEndRef.current?.scrollIntoView({ block: "end" });
   }, [log]);
 
-  const appendLog = useCallback(
-    (message: string) => setLog((prev) => [...prev, message]),
-    [],
-  );
+  // Client tools report validation failures via ctx.log("Error: ...") plus a
+  // plain return rather than throwing; capture the last such line so the run
+  // is recorded as failed in the Processing History (#1292). Reset per run.
+  const softErrorRef = useRef<string | null>(null);
+  const appendLog = useCallback((message: string) => {
+    if (message.startsWith("Error:")) {
+      softErrorRef.current = message.slice("Error:".length).trim();
+    }
+    setLog((prev) => [...prev, message]);
+  }, []);
 
   const layerOptions = useCallback(
     (filter?: GeometryFamily[]) =>
@@ -352,6 +360,7 @@ export function VectorToolsDialog({
 
   const handleRun = useCallback(async () => {
     setLog([]);
+    softErrorRef.current = null;
     // Validate required parameters before doing any work.
     for (const param of tool.parameters) {
       if (!param.required || !isParamVisible(param)) continue;
@@ -414,7 +423,10 @@ export function VectorToolsDialog({
         };
         await tool.run(ctx);
       }
-      if (failure) tracker.finish("error", failure);
+      // A logged "Error: ..." line marks a soft failure (the client tools
+      // bail out without throwing); don't record those as successes.
+      const softError = failure ?? softErrorRef.current;
+      if (softError) tracker.finish("error", softError);
       else tracker.finish("success");
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -291,23 +291,27 @@ export function VectorToolsDialog({
   // Shared tail for the two Python engines (sidecar and Pyodide): both take the
   // same {tool_id, geojson, overlay, parameters} request and return
   // {geojson, messages}. Resolve the layers, invoke, then validate and add the
-  // result. `label` describes where it ran, for the log line.
+  // result. `label` describes where it ran, for the log line. Returns the
+  // failure message when the run bailed out (so the caller records the run as
+  // failed in the Processing History), or null on success.
   const runRemoteEngine = useCallback(
     async (
       label: string,
       invoke: (request: VectorToolRequest) => Promise<VectorToolResult>,
-    ) => {
+    ): Promise<string | null> => {
       const inputLayer = layers.find((l) => l.id === params.layer);
       const overlayLayer = layers.find((l) => l.id === params.overlay);
       // A layer may have been removed from the project after the dialog opened;
       // bail out with a clear message instead of sending null GeoJSON.
       if (!inputLayer?.geojson) {
-        appendLog("Error: input layer no longer exists in the project");
-        return;
+        const message = "input layer no longer exists in the project";
+        appendLog(`Error: ${message}`);
+        return message;
       }
       if (params.overlay && !overlayLayer?.geojson) {
-        appendLog("Error: overlay layer no longer exists in the project");
-        return;
+        const message = "overlay layer no longer exists in the project";
+        appendLog(`Error: ${message}`);
+        return message;
       }
       appendLog(`Running "${tool.name}" ${label}...`);
       const result = await invoke({
@@ -327,9 +331,11 @@ export function VectorToolsDialog({
         Array.isArray(remoteResult.features)
       ) {
         addResultLayer(tool.name, remoteResult as unknown as FeatureCollection);
-      } else {
-        appendLog("Error: engine returned invalid GeoJSON");
+        return null;
       }
+      const message = "engine returned invalid GeoJSON";
+      appendLog(`Error: ${message}`);
+      return message;
     },
     [layers, params, tool, appendLog, addResultLayer],
   );
@@ -361,8 +367,12 @@ export function VectorToolsDialog({
     runTrackerRef.current = tracker;
     setRunning(true);
     try {
+      // A remote engine can bail out without throwing (missing layer, invalid
+      // response); its returned failure message keeps the run from being
+      // recorded as a green no-output success.
+      let failure: string | null = null;
       if (engine === "sidecar") {
-        await runRemoteEngine("on the Python sidecar", runVectorTool);
+        failure = await runRemoteEngine("on the Python sidecar", runVectorTool);
       } else if (engine === "pyodide") {
         // Progress phases (one-time runtime + GeoPandas download) stream into
         // the log; the subscription is dropped once the run finishes.
@@ -370,7 +380,7 @@ export function VectorToolsDialog({
           appendLog(`${phase}...`),
         );
         try {
-          await runRemoteEngine(
+          failure = await runRemoteEngine(
             "in your browser (Pyodide)",
             runVectorToolInPyodide,
           );
@@ -394,7 +404,8 @@ export function VectorToolsDialog({
         };
         await tool.run(ctx);
       }
-      tracker.finish("success");
+      if (failure) tracker.finish("error", failure);
+      else tracker.finish("success");
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);
       tracker.finish("error", (error as Error).message);

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -124,6 +124,16 @@ export function VectorToolsDialog({
   // win over the defaults when both effects fire in the same commit.
   useEffect(() => {
     if (!open || !rerun || rerun.kind !== "vector") return;
+    // A saved-project history entry can reference a tool that was renamed or
+    // removed since; drop the request instead of leaving it pending forever.
+    if (!getVectorTool(rerun.toolId)) {
+      setLog((prev) => [
+        ...prev,
+        `Error: tool "${rerun.toolId}" is no longer available`,
+      ]);
+      setProcessingRerun(null);
+      return;
+    }
     if (rerun.toolId !== tool.id) return;
     setParams({ ...rerun.parameters });
     if (

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -18,6 +18,10 @@ import {
 } from "../../lib/pyodide/pyodide-vector-loader";
 import { createDuckDbCapability } from "../../lib/duckdb-processing";
 import {
+  beginProcessingRun,
+  type ProcessingRunTracker,
+} from "../../lib/processing-history";
+import {
   Button,
   Dialog,
   DialogContent,
@@ -69,6 +73,8 @@ export function VectorToolsDialog({
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
   const layers = useAppStore((s) => s.layers);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const rerun = useAppStore((s) => s.ui.processingRerun);
+  const setProcessingRerun = useAppStore((s) => s.setProcessingRerun);
 
   const open = openTool !== null;
   const [selectedId, setSelectedId] = useState<string>(
@@ -79,7 +85,9 @@ export function VectorToolsDialog({
   const [log, setLog] = useState<string[]>([]);
   const [running, setRunning] = useState(false);
   const [sidecarAvailable, setSidecarAvailable] = useState<boolean | null>(null);
+  const [autoRunPending, setAutoRunPending] = useState(false);
   const logEndRef = useRef<HTMLDivElement>(null);
+  const runTrackerRef = useRef<ProcessingRunTracker | null>(null);
 
   const tool = useMemo(
     () => getVectorTool(selectedId) ?? VECTOR_TOOLS[0],
@@ -110,6 +118,24 @@ export function VectorToolsDialog({
     if (tool.requiresSidecar) setEngine("sidecar");
     else if (!tool.supportsSidecar) setEngine("client");
   }, [tool]);
+
+  // Pre-fill from a pending History re-run once the requested tool is selected.
+  // Declared after the defaults-reset effect above so the recorded parameters
+  // win over the defaults when both effects fire in the same commit.
+  useEffect(() => {
+    if (!open || !rerun || rerun.kind !== "vector") return;
+    if (rerun.toolId !== tool.id) return;
+    setParams({ ...rerun.parameters });
+    if (
+      rerun.engine === "client" ||
+      rerun.engine === "sidecar" ||
+      rerun.engine === "pyodide"
+    ) {
+      setEngine(rerun.engine);
+    }
+    setProcessingRerun(null);
+    if (rerun.autoRun) setAutoRunPending(true);
+  }, [open, rerun, tool, setProcessingRerun]);
 
   // Prefill the H3 grid's manual bounding-box fields from the current map
   // viewport when the user first switches to that source, so they can tweak the
@@ -253,6 +279,7 @@ export function VectorToolsDialog({
         return;
       }
       const layerId = addGeoJsonLayer(name, fc);
+      runTrackerRef.current?.addOutputLayer(name);
       const layer = useAppStore
         .getState()
         .layers.find((item) => item.id === layerId);
@@ -324,6 +351,14 @@ export function VectorToolsDialog({
       }
     }
 
+    const tracker = beginProcessingRun({
+      kind: "vector",
+      toolId: tool.id,
+      toolName: tool.name,
+      engine,
+      parameters: params,
+    });
+    runTrackerRef.current = tracker;
     setRunning(true);
     try {
       if (engine === "sidecar") {
@@ -359,8 +394,10 @@ export function VectorToolsDialog({
         };
         await tool.run(ctx);
       }
+      tracker.finish("success");
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);
+      tracker.finish("error", (error as Error).message);
     } finally {
       setRunning(false);
     }
@@ -376,6 +413,19 @@ export function VectorToolsDialog({
     isParamVisible,
     duckdb,
   ]);
+
+  // Auto-run for a History "Re-run": kick off handleRun on the render after the
+  // pre-fill effect committed the recorded parameters. The ref always points at
+  // the latest handleRun closure, so the run sees the pre-filled state.
+  const handleRunRef = useRef(handleRun);
+  useEffect(() => {
+    handleRunRef.current = handleRun;
+  });
+  useEffect(() => {
+    if (!autoRunPending) return;
+    setAutoRunPending(false);
+    void handleRunRef.current();
+  }, [autoRunPending]);
 
   const groups = useMemo(groupedTools, []);
 

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -348,6 +348,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       legend: state.legend,
       storymap: state.storymap,
       models: state.models,
+      processingHistory: state.processingHistory,
       widgets: state.widgets,
       dashboardColumns: state.dashboardColumns,
       mapLayout: state.mapLayout,

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2731,7 +2731,8 @@
       "copied": "Copied",
       "clear": "Clear history",
       "count_one": "{{count}} run recorded",
-      "count_other": "{{count}} runs recorded"
+      "count_other": "{{count}} runs recorded",
+      "toolUnavailable": "Tool \"{{toolId}}\" is no longer available"
     },
     "modelBuilder": {
       "moveStepUp": "Move step up",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1970,6 +1970,7 @@
       "whitebox": "Whitebox",
       "geocode": "Geocode Addresses",
       "modelBuilder": "Batch & Models",
+      "processingHistory": "History",
       "conversion": "Conversion",
       "vector": "Vector",
       "network": "Network",
@@ -2719,6 +2720,19 @@
     "refreshCatalog": "Refresh catalog",
     "increaseValue": "Increase value",
     "decreaseValue": "Decrease value",
+    "history": {
+      "title": "Processing History",
+      "description": "Every processing run in this project, newest first. Re-run a tool, reopen it with the same parameters, or copy the run as JSON or Python.",
+      "empty": "No processing runs recorded yet. Run a tool from the Processing menu and it will appear here.",
+      "rerun": "Re-run",
+      "editRerun": "Edit & re-run",
+      "copyJson": "Copy JSON",
+      "copyPython": "Copy Python",
+      "copied": "Copied",
+      "clear": "Clear history",
+      "count_one": "{{count}} run recorded",
+      "count_other": "{{count}} runs recorded"
+    },
     "modelBuilder": {
       "moveStepUp": "Move step up",
       "moveStepDown": "Move step down",

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -40,6 +40,7 @@ export function buildProjectSnapshot(
     legend: state.legend,
     storymap: state.storymap,
     models: state.models,
+    processingHistory: state.processingHistory,
     widgets: state.widgets,
     dashboardColumns: state.dashboardColumns,
     mapLayout: state.mapLayout,

--- a/apps/geolibre-desktop/src/lib/processing-history.ts
+++ b/apps/geolibre-desktop/src/lib/processing-history.ts
@@ -1,0 +1,113 @@
+import {
+  useAppStore,
+  type ProcessingRunKind,
+  type ProcessingRunStatus,
+} from "@geolibre/core";
+
+/** Prefix the Whitebox dialog uses for layer-reference parameter values. */
+const LAYER_TOKEN_PREFIX = "layer:";
+
+/**
+ * Tracks one in-flight processing run for the Processing History panel
+ * (issue #1292). Created by {@link beginProcessingRun} when a dialog dispatches
+ * a tool; the dialog reports produced layers via `addOutputLayer` and seals the
+ * record with `finish`. Layers reported after `finish` (e.g. a sidecar job's
+ * outputs imported asynchronously) are patched into the already-recorded entry.
+ */
+export interface ProcessingRunTracker {
+  /** Id of the history entry this tracker writes. */
+  id: string;
+  /** Report a layer the run added to the map. Safe to call after `finish`. */
+  addOutputLayer: (name: string) => void;
+  /** Record the run. Idempotent: only the first call writes the entry. */
+  finish: (status: ProcessingRunStatus, error?: string) => void;
+}
+
+function makeRunId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `run-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+}
+
+/**
+ * Snapshot the names of layers referenced by parameter values. Parameter values
+ * reference layers by id (the Whitebox dialog prefixes them with `layer:`), and
+ * a layer can be renamed or removed before the History panel renders, so the
+ * names are captured at run time.
+ */
+function snapshotInputLayerNames(
+  parameters: Record<string, unknown>,
+): Record<string, string> | undefined {
+  const layers = useAppStore.getState().layers;
+  const names: Record<string, string> = {};
+  for (const value of Object.values(parameters)) {
+    if (typeof value !== "string" || !value) continue;
+    const layerId = value.startsWith(LAYER_TOKEN_PREFIX)
+      ? value.slice(LAYER_TOKEN_PREFIX.length)
+      : value;
+    const layer = layers.find((item) => item.id === layerId);
+    if (layer) names[layerId] = layer.name;
+  }
+  return Object.keys(names).length > 0 ? names : undefined;
+}
+
+/**
+ * Start tracking a processing run for the History panel.
+ *
+ * @param entry - The run's identity: dialog family, tool, engine, and the
+ *   parameter values exactly as dispatched (layer parameters hold layer ids).
+ * @param paths - Optional input/output file paths for file-based tools.
+ * @returns A tracker the caller finishes when the run completes.
+ */
+export function beginProcessingRun(
+  entry: {
+    kind: ProcessingRunKind;
+    toolId: string;
+    toolName: string;
+    engine: string;
+    parameters: Record<string, unknown>;
+  },
+  paths?: { inputPath?: string; outputPath?: string },
+): ProcessingRunTracker {
+  const startedAt = Date.now();
+  const id = makeRunId();
+  const outputs: string[] = [];
+  let finished = false;
+  const inputLayerNames = snapshotInputLayerNames(entry.parameters);
+
+  return {
+    id,
+    addOutputLayer: (name) => {
+      if (!finished) {
+        outputs.push(name);
+        return;
+      }
+      // The run is already recorded (e.g. an async job import): patch the entry.
+      const state = useAppStore.getState();
+      const run = state.processingHistory.find((item) => item.id === id);
+      state.updateProcessingRun(id, {
+        outputLayerNames: [...(run?.outputLayerNames ?? []), name],
+      });
+    },
+    finish: (status, error) => {
+      if (finished) return;
+      finished = true;
+      useAppStore.getState().addProcessingRun({
+        id,
+        kind: entry.kind,
+        toolId: entry.toolId,
+        toolName: entry.toolName,
+        engine: entry.engine,
+        parameters: { ...entry.parameters },
+        ...(inputLayerNames ? { inputLayerNames } : {}),
+        ...(outputs.length > 0 ? { outputLayerNames: [...outputs] } : {}),
+        ...(paths?.inputPath ? { inputPath: paths.inputPath } : {}),
+        ...(paths?.outputPath ? { outputPath: paths.outputPath } : {}),
+        startedAt: new Date(startedAt).toISOString(),
+        durationMs: Date.now() - startedAt,
+        status,
+        ...(error ? { error } : {}),
+      });
+    },
+  };
+}

--- a/apps/geolibre-desktop/src/lib/processing-history.ts
+++ b/apps/geolibre-desktop/src/lib/processing-history.ts
@@ -8,6 +8,13 @@ import {
 const LAYER_TOKEN_PREFIX = "layer:";
 
 /**
+ * Cap on per-job history trackers the job-based dialogs (Whitebox, Raster)
+ * retain; oldest entries are evicted once exceeded. Shared here so the two
+ * dialogs cannot drift apart.
+ */
+export const MAX_TRACKED_HISTORY_JOBS = 50;
+
+/**
  * Tracks one in-flight processing run for the Processing History panel
  * (issue #1292). Created by {@link beginProcessingRun} when a dialog dispatches
  * a tool; the dialog reports produced layers via `addOutputLayer` and seals the

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -31,8 +31,13 @@ export interface ScriptingDeps {
   getController: () => MapController | null;
 }
 
-/** Combined client-side algorithm registry, matching the in-app dialogs. */
-function allAlgorithms(): ProcessingAlgorithm[] {
+/**
+ * Combined client-side algorithm registry, matching the in-app dialogs. This
+ * is the list `runAlgorithm` (and thus the Python API's `m.run_algorithm`)
+ * resolves tool ids against; the Processing History panel imports it so its
+ * "Copy as Python" eligibility can never drift from what actually runs.
+ */
+export function allAlgorithms(): ProcessingAlgorithm[] {
   return [...ALGORITHMS, ...VECTOR_TOOLS, ...H3_TOOLS, ...STATISTICS_TOOLS];
 }
 

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -213,39 +213,45 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
         engine: "client",
         parameters: (params.params as Record<string, unknown>) ?? {},
       });
-      // duckdb-wasm is browser-only and heavy; import it only when an algorithm
-      // actually runs (also keeps this module importable in plain Node tests).
-      const { createDuckDbCapability } = await import("../duckdb-processing");
-      const ctx: ProcessingContext = {
-        layers: useAppStore.getState().layers,
-        parameters: (params.params as Record<string, unknown>) ?? {},
-        log: (message) => logs.push(message),
-        fitBounds: (bounds) => getController()?.fitBounds(bounds),
-        addResultLayer: (name: string, fc: FeatureCollection) => {
-          if (!fc.features.length) {
-            logs.push(`No features produced for "${name}"`);
-            return;
-          }
-          const layerId = useAppStore.getState().addGeoJsonLayer(name, fc);
-          tracker.addOutputLayer(name);
-          resultLayerIds.push(layerId);
-          const layer = useAppStore
-            .getState()
-            .layers.find((item) => item.id === layerId);
-          if (layer) getController()?.fitLayer(layer);
-        },
-        duckdb: createDuckDbCapability(),
-        viewportBounds: () => {
-          const map = getController()?.getMap();
-          if (!map) return null;
-          const b = map.getBounds();
-          return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
-        },
-      };
+      // Everything after beginProcessingRun runs inside one try so setup
+      // failures (the lazy import, DuckDB capability) are recorded too.
       try {
+        // duckdb-wasm is browser-only and heavy; import it only when an
+        // algorithm actually runs (also keeps this module importable in plain
+        // Node tests).
+        const { createDuckDbCapability } = await import("../duckdb-processing");
+        const ctx: ProcessingContext = {
+          layers: useAppStore.getState().layers,
+          parameters: (params.params as Record<string, unknown>) ?? {},
+          log: (message) => logs.push(message),
+          fitBounds: (bounds) => getController()?.fitBounds(bounds),
+          addResultLayer: (name: string, fc: FeatureCollection) => {
+            if (!fc.features.length) {
+              logs.push(`No features produced for "${name}"`);
+              return;
+            }
+            const layerId = useAppStore.getState().addGeoJsonLayer(name, fc);
+            tracker.addOutputLayer(name);
+            resultLayerIds.push(layerId);
+            const layer = useAppStore
+              .getState()
+              .layers.find((item) => item.id === layerId);
+            if (layer) getController()?.fitLayer(layer);
+          },
+          duckdb: createDuckDbCapability(),
+          viewportBounds: () => {
+            const map = getController()?.getMap();
+            if (!map) return null;
+            const b = map.getBounds();
+            return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
+          },
+        };
         await algo.run(ctx);
       } catch (error) {
-        tracker.finish("error", (error as Error).message);
+        tracker.finish(
+          "error",
+          error instanceof Error ? error.message : String(error),
+        );
         throw error;
       }
       tracker.finish("success");

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -213,6 +213,10 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
         engine: "client",
         parameters: (params.params as Record<string, unknown>) ?? {},
       });
+      // Registry tools report validation failures via ctx.log("Error: ...")
+      // plus a plain return rather than throwing; capture the last such line
+      // so the run is recorded as failed in the Processing History.
+      let softError: string | null = null;
       // Everything after beginProcessingRun runs inside one try so setup
       // failures (the lazy import, DuckDB capability) are recorded too.
       try {
@@ -223,7 +227,12 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
         const ctx: ProcessingContext = {
           layers: useAppStore.getState().layers,
           parameters: (params.params as Record<string, unknown>) ?? {},
-          log: (message) => logs.push(message),
+          log: (message) => {
+            if (message.startsWith("Error:")) {
+              softError = message.slice("Error:".length).trim();
+            }
+            logs.push(message);
+          },
           fitBounds: (bounds) => getController()?.fitBounds(bounds),
           addResultLayer: (name: string, fc: FeatureCollection) => {
             if (!fc.features.length) {
@@ -254,7 +263,8 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
         );
         throw error;
       }
-      tracker.finish("success");
+      if (softError) tracker.finish("error", softError);
+      else tracker.finish("success");
       return { logs, resultLayerIds };
     },
 

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -10,6 +10,7 @@ import {
 import { SKETCHES_SOURCE_KIND } from "@geolibre/plugins";
 import type { Feature, FeatureCollection } from "geojson";
 import type { MapController } from "@geolibre/map";
+import { beginProcessingRun } from "../processing-history";
 import { captureMapImage } from "../print-layout-export";
 
 // The scripting command surface, shared by every programmatic entry point: the
@@ -203,6 +204,15 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
       if (!algo) throw new Error(`Unknown algorithm "${id}"`);
       const logs: string[] = [];
       const resultLayerIds: string[] = [];
+      // Track the run for the Processing History panel (#1292), so notebook /
+      // console runs document themselves alongside dialog runs.
+      const tracker = beginProcessingRun({
+        kind: "algorithm",
+        toolId: algo.id,
+        toolName: algo.name,
+        engine: "client",
+        parameters: (params.params as Record<string, unknown>) ?? {},
+      });
       // duckdb-wasm is browser-only and heavy; import it only when an algorithm
       // actually runs (also keeps this module importable in plain Node tests).
       const { createDuckDbCapability } = await import("../duckdb-processing");
@@ -217,6 +227,7 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
             return;
           }
           const layerId = useAppStore.getState().addGeoJsonLayer(name, fc);
+          tracker.addOutputLayer(name);
           resultLayerIds.push(layerId);
           const layer = useAppStore
             .getState()
@@ -231,7 +242,13 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
           return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
         },
       };
-      await algo.run(ctx);
+      try {
+        await algo.run(ctx);
+      } catch (error) {
+        tracker.finish("error", (error as Error).message);
+        throw error;
+      }
+      tracker.finish("success");
       return { logs, resultLayerIds };
     },
 

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -254,6 +254,7 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "processing.pythonConsole", menuId: "processing", labelKey: "toolbar.command.pythonConsole", tier: "advanced" },
   { id: "processing.notebook", menuId: "processing", labelKey: "toolbar.command.notebook", tier: "advanced" },
   { id: "processing.dashboard", menuId: "processing", labelKey: "toolbar.command.dashboard", tier: "intermediate" },
+  { id: "processing.history", menuId: "processing", labelKey: "toolbar.item.processingHistory", tier: "intermediate" },
   { id: "processing.planetaryComputer", menuId: "processing", labelKey: "toolbar.command.planetaryComputer", tier: "advanced" },
   { id: "processing.earthEngine", menuId: "processing", labelKey: "toolbar.command.earthEngine", tier: "advanced" },
   // Controls — built-in map controls

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -22,7 +22,10 @@ import {
   type MapGridLayout,
   type MapScaleUnit,
   type MapViewState,
+  MAX_PROCESSING_HISTORY,
   type ProcessingModel,
+  type ProcessingRun,
+  type ProcessingRunKind,
   type SecondaryMapView,
   type ProcessingModelStep,
   type ProjectPluginControlPosition,
@@ -131,6 +134,8 @@ export function parseProject(json: string): GeoLibreProject {
     legend: normalizeLegendConfig(data.legend),
     storymap: normalizeStoryMap(data.storymap) ?? undefined,
     models: normalizeModels(data.models) ?? undefined,
+    processingHistory:
+      normalizeProcessingHistory(data.processingHistory) ?? undefined,
     widgets: normalizeWidgets(data.widgets) ?? undefined,
     ...(data.dashboardColumns === undefined
       ? {}
@@ -454,6 +459,89 @@ export function normalizeModels(value: unknown): ProcessingModel[] | null {
     models.push({ id, name: normalizeString(candidate.name), steps });
   }
   return models.length > 0 ? models : null;
+}
+
+const PROCESSING_RUN_KINDS = new Set<ProcessingRunKind>([
+  "vector",
+  "statistics",
+  "network",
+  "whitebox",
+  "raster",
+  "conversion",
+  "algorithm",
+]);
+
+/**
+ * Coerce an untrusted (possibly hand-edited) `processingHistory` array into
+ * valid {@link ProcessingRun} records. Drops entries without a usable id, tool
+ * id, or known kind, de-duplicates by id, keeps `parameters` as a plain object,
+ * and caps the list at {@link MAX_PROCESSING_HISTORY} (keeping the newest,
+ * i.e. last, entries). Returns `null` when nothing survives, so a history-less
+ * project stays free of the key.
+ *
+ * @param value Raw `processingHistory` value from the project JSON.
+ * @returns Normalized runs, or `null` when none survive.
+ */
+export function normalizeProcessingHistory(
+  value: unknown,
+): ProcessingRun[] | null {
+  if (!Array.isArray(value)) return null;
+  const runs: ProcessingRun[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as Partial<ProcessingRun>;
+    const id = normalizeString(candidate.id).trim();
+    const toolId = normalizeString(candidate.toolId).trim();
+    const kind = candidate.kind;
+    if (!id || !toolId || seen.has(id)) continue;
+    if (!kind || !PROCESSING_RUN_KINDS.has(kind)) continue;
+    seen.add(id);
+    const inputLayerNames =
+      candidate.inputLayerNames && typeof candidate.inputLayerNames === "object"
+        ? Object.fromEntries(
+            Object.entries(candidate.inputLayerNames).filter(
+              ([, name]) => typeof name === "string",
+            ),
+          )
+        : undefined;
+    const outputLayerNames = Array.isArray(candidate.outputLayerNames)
+      ? candidate.outputLayerNames.filter(
+          (name): name is string => typeof name === "string",
+        )
+      : undefined;
+    runs.push({
+      id,
+      kind,
+      toolId,
+      toolName: normalizeString(candidate.toolName) || toolId,
+      engine: normalizeString(candidate.engine),
+      parameters:
+        candidate.parameters && typeof candidate.parameters === "object"
+          ? (candidate.parameters as Record<string, unknown>)
+          : {},
+      ...(inputLayerNames && Object.keys(inputLayerNames).length > 0
+        ? { inputLayerNames }
+        : {}),
+      ...(outputLayerNames?.length ? { outputLayerNames } : {}),
+      ...(normalizeString(candidate.inputPath)
+        ? { inputPath: normalizeString(candidate.inputPath) }
+        : {}),
+      ...(normalizeString(candidate.outputPath)
+        ? { outputPath: normalizeString(candidate.outputPath) }
+        : {}),
+      startedAt: normalizeString(candidate.startedAt),
+      ...(Number.isFinite(candidate.durationMs)
+        ? { durationMs: Math.max(0, Number(candidate.durationMs)) }
+        : {}),
+      status: candidate.status === "error" ? "error" : "success",
+      ...(normalizeString(candidate.error)
+        ? { error: normalizeString(candidate.error) }
+        : {}),
+    });
+  }
+  if (runs.length === 0) return null;
+  return runs.slice(-MAX_PROCESSING_HISTORY);
 }
 
 /**
@@ -997,6 +1085,7 @@ export function projectFromStore(state: {
   legend?: LegendConfig | null;
   storymap?: StoryMap | null;
   models?: ProcessingModel[] | null;
+  processingHistory?: ProcessingRun[] | null;
   widgets?: DashboardWidget[] | null;
   dashboardColumns?: number;
   mapLayout?: MapGridLayout;
@@ -1012,6 +1101,7 @@ export function projectFromStore(state: {
   const legend = normalizeLegendConfig(state.legend);
   const storymap = normalizeStoryMap(state.storymap);
   const models = normalizeModels(state.models);
+  const processingHistory = normalizeProcessingHistory(state.processingHistory);
   const widgets = normalizeWidgets(state.widgets);
   // Persist a non-default column count only; a default-layout dashboard (or a
   // widget-less project) stays free of the key for legacy readers.
@@ -1047,6 +1137,7 @@ export function projectFromStore(state: {
     ...(legend ? { legend } : {}),
     ...(storymap ? { storymap } : {}),
     ...(models ? { models } : {}),
+    ...(processingHistory ? { processingHistory } : {}),
     ...(widgets ? { widgets } : {}),
     ...(dashboardColumns !== DEFAULT_DASHBOARD_COLUMNS ? { dashboardColumns } : {}),
     ...(persistGrid
@@ -1160,6 +1251,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   legend: LegendConfig;
   storymap: StoryMap | null;
   models: ProcessingModel[];
+  processingHistory: ProcessingRun[];
   widgets: DashboardWidget[];
   dashboardColumns: number;
   mapLayout: MapGridLayout;
@@ -1213,6 +1305,8 @@ export function applyProjectToStore(project: GeoLibreProject): {
     legend: normalizeLegendConfig(project.legend) ?? { ...DEFAULT_LEGEND_CONFIG },
     storymap: normalizeStoryMap(project.storymap),
     models: normalizeModels(project.models) ?? [],
+    processingHistory:
+      normalizeProcessingHistory(project.processingHistory) ?? [],
     widgets: normalizeWidgets(project.widgets) ?? [],
     dashboardColumns: normalizeDashboardColumns(project.dashboardColumns),
     mapLayout,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -534,7 +534,10 @@ export function normalizeProcessingHistory(
       ...(Number.isFinite(candidate.durationMs)
         ? { durationMs: Math.max(0, Number(candidate.durationMs)) }
         : {}),
-      status: candidate.status === "error" ? "error" : "success",
+      // Only an explicit "success" earns the green checkmark; a missing or
+      // corrupted status from hand-edited JSON degrades to "error" rather than
+      // presenting an indeterminate run as having succeeded.
+      status: candidate.status === "success" ? "success" : "error",
       ...(normalizeString(candidate.error)
         ? { error: normalizeString(candidate.error) }
         : {}),

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -486,9 +486,16 @@ export function normalizeProcessingHistory(
   value: unknown,
 ): ProcessingRun[] | null {
   if (!Array.isArray(value)) return null;
+  // Bound the work for a crafted or corrupted file (shared/collaboration
+  // projects reach this path too): only the newest entries can survive the
+  // cap anyway, so ignore all but a generous tail up front.
+  const source =
+    value.length > MAX_PROCESSING_HISTORY * 10
+      ? value.slice(-MAX_PROCESSING_HISTORY * 10)
+      : value;
   const runs: ProcessingRun[] = [];
   const seen = new Set<string>();
-  for (const entry of value) {
+  for (const entry of source) {
     if (!entry || typeof entry !== "object") continue;
     const candidate = entry as Partial<ProcessingRun>;
     const id = normalizeString(candidate.id).trim();

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -30,6 +30,7 @@ import {
   MAX_MAP_GRID_DIM,
   DEFAULT_STORY_MAP,
   MAX_DASHBOARD_COLUMNS,
+  MAX_PROCESSING_HISTORY,
   MIN_DASHBOARD_COLUMNS,
   type AddTileLayerOptions,
   type CollaborationChatMessage,
@@ -45,6 +46,8 @@ import {
   type MapGridLayout,
   type MapViewState,
   type ProcessingModel,
+  type ProcessingRerunRequest,
+  type ProcessingRun,
   type SecondaryMapView,
   type ProjectPluginState,
   type ProjectPreferences,
@@ -155,6 +158,8 @@ export interface AppState {
   storymap: StoryMap | null;
   /** Saved processing pipelines (batch/model chaining; issue #344). */
   models: ProcessingModel[];
+  /** Recorded processing tool runs, oldest first (Processing History; #1292). */
+  processingHistory: ProcessingRun[];
   /** Saved Dashboard panel chart widgets (issue #401). */
   widgets: DashboardWidget[];
   /** Number of columns in the Dashboard widget grid. */
@@ -229,6 +234,14 @@ export interface AppState {
     // save the resulting camera back into this chapter (issue #775).
     storymapComposingId: string | null;
     modelBuilderOpen: boolean;
+    /** Processing History panel visibility (#1292). */
+    processingHistoryOpen: boolean;
+    /**
+     * Pending "re-run from History" request. Written by the History panel just
+     * before it opens the target processing dialog; consumed and cleared by
+     * that dialog once it has pre-filled its parameter form. Null when idle.
+     */
+    processingRerun: ProcessingRerunRequest | null;
     zoomToSelectedFeature: boolean;
     // Live-collaboration dialog visibility. Lifted into the store (rather than
     // local toolbar state) so the on-canvas session-status badge can reopen the
@@ -340,6 +353,8 @@ export interface AppState {
   ) => void;
   setStorymapComposing: (chapterId: string | null) => void;
   setModelBuilderOpen: (open: boolean) => void;
+  setProcessingHistoryOpen: (open: boolean) => void;
+  setProcessingRerun: (request: ProcessingRerunRequest | null) => void;
   setCollaborateDialogOpen: (open: boolean) => void;
   setZoomToSelectedFeature: (enabled: boolean) => void;
 
@@ -347,6 +362,16 @@ export interface AppState {
   saveModel: (model: ProcessingModel) => void;
   /** Remove a saved model by id. */
   deleteModel: (id: string) => void;
+
+  /** Append a processing run to the history (bounded, de-duped by id; #1292). */
+  addProcessingRun: (run: ProcessingRun) => void;
+  /** Patch a recorded run by id (no-op if absent), e.g. to add output layers. */
+  updateProcessingRun: (
+    id: string,
+    patch: Partial<Omit<ProcessingRun, "id">>
+  ) => void;
+  /** Drop all recorded processing runs. */
+  clearProcessingHistory: () => void;
 
   /** Append a new dashboard widget. */
   addWidget: (widget: DashboardWidget) => void;
@@ -641,6 +666,7 @@ export const useAppStore = create<AppState>()(
       legend: { ...DEFAULT_LEGEND_CONFIG },
       storymap: null,
       models: [],
+      processingHistory: [],
       widgets: [],
       dashboardColumns: DEFAULT_DASHBOARD_COLUMNS,
       mapLayout: { ...DEFAULT_MAP_GRID_LAYOUT },
@@ -680,6 +706,8 @@ export const useAppStore = create<AppState>()(
         storymapReturnToEditor: false,
         storymapComposingId: null,
         modelBuilderOpen: false,
+        processingHistoryOpen: false,
+        processingRerun: null,
         zoomToSelectedFeature: false,
         collaborateDialogOpen: false,
       },
@@ -968,6 +996,10 @@ export const useAppStore = create<AppState>()(
         set((s) => ({ ui: { ...s.ui, storymapComposingId: chapterId } })),
       setModelBuilderOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, modelBuilderOpen: open } })),
+      setProcessingHistoryOpen: (open) =>
+        set((s) => ({ ui: { ...s.ui, processingHistoryOpen: open } })),
+      setProcessingRerun: (request) =>
+        set((s) => ({ ui: { ...s.ui, processingRerun: request } })),
       setCollaborateDialogOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, collaborateDialogOpen: open } })),
       setZoomToSelectedFeature: (enabled) =>
@@ -986,6 +1018,32 @@ export const useAppStore = create<AppState>()(
           models: s.models.filter((m) => m.id !== id),
           isDirty: true,
         })),
+
+      addProcessingRun: (run) =>
+        set((s) => {
+          // Ignore a duplicate id so updateProcessingRun stays unambiguous.
+          if (s.processingHistory.some((r) => r.id === run.id)) return s;
+          const processingHistory = [...s.processingHistory, run].slice(
+            -MAX_PROCESSING_HISTORY,
+          );
+          return { processingHistory, isDirty: true };
+        }),
+      updateProcessingRun: (id, patch) =>
+        set((s) => {
+          if (!s.processingHistory.some((r) => r.id === id)) return s;
+          return {
+            processingHistory: s.processingHistory.map((r) =>
+              r.id === id ? { ...r, ...patch, id: r.id } : r,
+            ),
+            isDirty: true,
+          };
+        }),
+      clearProcessingHistory: () =>
+        set((s) =>
+          s.processingHistory.length === 0
+            ? s
+            : { processingHistory: [], isDirty: true },
+        ),
 
       addWidget: (widget) =>
         set((s) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -986,6 +986,76 @@ export interface ProcessingModel {
   steps: ProcessingModelStep[];
 }
 
+/**
+ * Which dialog family executed a {@link ProcessingRun}. Drives the History
+ * panel's re-run routing: each kind maps to the dialog (and store open-flag)
+ * that can be reopened pre-filled with the run's parameters.
+ */
+export type ProcessingRunKind =
+  | "vector"
+  | "statistics"
+  | "network"
+  | "whitebox"
+  | "raster"
+  | "conversion"
+  | "algorithm";
+
+export type ProcessingRunStatus = "success" | "error";
+
+/** Upper bound on persisted processing-history entries (oldest are dropped). */
+export const MAX_PROCESSING_HISTORY = 100;
+
+/**
+ * One recorded processing tool run (issue #1292). Appended by every processing
+ * dialog when a run finishes and persisted in the project file, so a saved
+ * project documents how its derived layers were produced. Parameter values are
+ * stored exactly as the dialog dispatched them (layer parameters hold layer
+ * ids), which is what re-run pre-fills and "Copy as Python" emit.
+ */
+export interface ProcessingRun {
+  /** Stable id, unique within the project (React key and update key). */
+  id: string;
+  kind: ProcessingRunKind;
+  /** The tool's registry id (e.g. `"buffer"`, `"slope"`). */
+  toolId: string;
+  /** Human-readable tool name captured at run time. */
+  toolName: string;
+  /** Engine that executed the run: `client`, `wasm`, `sidecar`, `pyodide`, `browser`. */
+  engine: string;
+  /** Parameter values keyed by the tool's parameter ids. */
+  parameters: Record<string, unknown>;
+  /** Names of input layers referenced by layer parameters, keyed by layer id. */
+  inputLayerNames?: Record<string, string>;
+  /** Names of layers the run added to the map. */
+  outputLayerNames?: string[];
+  /** Input file path/name, for file-based tools (raster/conversion). */
+  inputPath?: string;
+  /** Output file path/name, for file-based tools (raster/conversion). */
+  outputPath?: string;
+  /** ISO timestamp of when the run started. */
+  startedAt: string;
+  /** Wall-clock duration of the run in milliseconds. */
+  durationMs?: number;
+  status: ProcessingRunStatus;
+  /** Error message when `status` is `"error"`. */
+  error?: string;
+}
+
+/**
+ * A pending "re-run from History" request. The History panel writes it to the
+ * store and opens the target dialog; the dialog consumes it (pre-filling its
+ * parameter form) and clears it. `autoRun` asks the dialog to start the run
+ * immediately after pre-filling (plain Re-run vs Edit & re-run).
+ */
+export interface ProcessingRerunRequest {
+  kind: ProcessingRunKind;
+  toolId: string;
+  parameters: Record<string, unknown>;
+  /** Engine to preselect, when the dialog offers a choice. */
+  engine?: string;
+  autoRun?: boolean;
+}
+
 /** Column-count bounds for the Dashboard panel's widget grid. */
 export const MIN_DASHBOARD_COLUMNS = 1;
 export const MAX_DASHBOARD_COLUMNS = 6;
@@ -1059,6 +1129,8 @@ export interface GeoLibreProject {
   storymap?: StoryMap;
   /** Saved processing pipelines (batch/model chaining; issue #344). */
   models?: ProcessingModel[];
+  /** Recorded processing tool runs (Processing History; issue #1292). */
+  processingHistory?: ProcessingRun[];
   /** Saved Dashboard panel chart widgets (issue #401). */
   widgets?: DashboardWidget[];
   /** Number of columns in the Dashboard widget grid; omitted when default. */

--- a/tests/processing-history.test.ts
+++ b/tests/processing-history.test.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  MAX_PROCESSING_HISTORY,
+  normalizeProcessingHistory,
+  parseProject,
+  projectFromStore,
+  serializeProject,
+  useAppStore,
+  type ProcessingRun,
+} from "@geolibre/core";
+
+function makeRun(patch: Partial<ProcessingRun> = {}): ProcessingRun {
+  return {
+    id: "run-1",
+    kind: "vector",
+    toolId: "buffer",
+    toolName: "Buffer",
+    engine: "client",
+    parameters: { layer: "layer-a", distance: 10, units: "kilometers" },
+    startedAt: "2026-07-17T12:00:00.000Z",
+    durationMs: 42,
+    status: "success",
+    ...patch,
+  };
+}
+
+describe("processing history store actions", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject();
+  });
+
+  it("appends runs, de-dupes by id, and marks the project dirty", () => {
+    const store = useAppStore.getState();
+    store.addProcessingRun(makeRun());
+    store.addProcessingRun(makeRun({ toolName: "Duplicate id" }));
+    store.addProcessingRun(makeRun({ id: "run-2", toolId: "centroids" }));
+
+    const history = useAppStore.getState().processingHistory;
+    assert.equal(history.length, 2);
+    assert.equal(history[0].toolName, "Buffer");
+    assert.equal(history[1].toolId, "centroids");
+    assert.equal(useAppStore.getState().isDirty, true);
+  });
+
+  it("caps the history at MAX_PROCESSING_HISTORY, dropping the oldest", () => {
+    const store = useAppStore.getState();
+    for (let i = 0; i < MAX_PROCESSING_HISTORY + 5; i += 1) {
+      store.addProcessingRun(makeRun({ id: `run-${i}` }));
+    }
+    const history = useAppStore.getState().processingHistory;
+    assert.equal(history.length, MAX_PROCESSING_HISTORY);
+    assert.equal(history[0].id, "run-5");
+    assert.equal(history.at(-1)?.id, `run-${MAX_PROCESSING_HISTORY + 4}`);
+  });
+
+  it("patches a recorded run in place and ignores unknown ids", () => {
+    const store = useAppStore.getState();
+    store.addProcessingRun(makeRun());
+    store.updateProcessingRun("run-1", {
+      outputLayerNames: ["Buffer result"],
+    });
+    store.updateProcessingRun("missing", { toolName: "nope" });
+
+    const history = useAppStore.getState().processingHistory;
+    assert.equal(history.length, 1);
+    assert.deepEqual(history[0].outputLayerNames, ["Buffer result"]);
+  });
+
+  it("clears the history", () => {
+    const store = useAppStore.getState();
+    store.addProcessingRun(makeRun());
+    store.clearProcessingHistory();
+    assert.equal(useAppStore.getState().processingHistory.length, 0);
+  });
+
+  it("does not create undo entries when recording runs", () => {
+    const before = useAppStore.temporal.getState().pastStates.length;
+    useAppStore.getState().addProcessingRun(makeRun());
+    assert.equal(useAppStore.temporal.getState().pastStates.length, before);
+  });
+});
+
+describe("processing history persistence", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject();
+  });
+
+  it("round-trips through the project file", () => {
+    const store = useAppStore.getState();
+    store.addProcessingRun(makeRun());
+    store.addProcessingRun(
+      makeRun({
+        id: "run-2",
+        kind: "whitebox",
+        toolId: "slope",
+        toolName: "Slope",
+        engine: "wasm",
+        parameters: { dem: "layer:layer-b" },
+        inputLayerNames: { "layer-b": "DEM" },
+        outputLayerNames: ["Slope Output"],
+        status: "error",
+        error: "boom",
+      }),
+    );
+
+    const state = useAppStore.getState();
+    const project = projectFromStore({
+      projectName: state.projectName,
+      mapView: state.mapView,
+      basemapStyleUrl: state.basemapStyleUrl,
+      basemapVisible: state.basemapVisible,
+      basemapOpacity: state.basemapOpacity,
+      layers: state.layers,
+      preferences: state.preferences,
+      processingHistory: state.processingHistory,
+      metadata: state.metadata,
+    });
+    const reloaded = parseProject(serializeProject(project));
+    assert.equal(reloaded.processingHistory?.length, 2);
+    assert.deepEqual(reloaded.processingHistory?.[0], makeRun());
+    assert.equal(reloaded.processingHistory?.[1].status, "error");
+    assert.equal(reloaded.processingHistory?.[1].error, "boom");
+    assert.deepEqual(reloaded.processingHistory?.[1].inputLayerNames, {
+      "layer-b": "DEM",
+    });
+
+    useAppStore.getState().loadProject(reloaded);
+    assert.equal(useAppStore.getState().processingHistory.length, 2);
+    assert.equal(useAppStore.getState().processingHistory[1].toolId, "slope");
+  });
+
+  it("omits the key entirely for a history-less project", () => {
+    const state = useAppStore.getState();
+    const project = projectFromStore({
+      projectName: state.projectName,
+      mapView: state.mapView,
+      basemapStyleUrl: state.basemapStyleUrl,
+      basemapVisible: state.basemapVisible,
+      basemapOpacity: state.basemapOpacity,
+      layers: state.layers,
+      preferences: state.preferences,
+      processingHistory: state.processingHistory,
+      metadata: state.metadata,
+    });
+    assert.ok(!("processingHistory" in project));
+  });
+
+  it("resets the history when a new project is created", () => {
+    useAppStore.getState().addProcessingRun(makeRun());
+    useAppStore.getState().newProject();
+    assert.equal(useAppStore.getState().processingHistory.length, 0);
+  });
+});
+
+describe("normalizeProcessingHistory", () => {
+  it("drops invalid entries, de-dupes by id, and defaults fields", () => {
+    const runs = normalizeProcessingHistory([
+      makeRun(),
+      makeRun({ toolName: "duplicate" }),
+      { id: "", toolId: "buffer", kind: "vector" },
+      { id: "no-tool", toolId: "", kind: "vector" },
+      { id: "bad-kind", toolId: "buffer", kind: "nope" },
+      {
+        id: "sparse",
+        toolId: "centroids",
+        kind: "vector",
+        parameters: "not-an-object",
+        durationMs: "NaN",
+        status: "weird",
+      },
+      "not-an-object",
+    ]);
+    assert.equal(runs?.length, 2);
+    assert.equal(runs?.[0].toolName, "Buffer");
+    const sparse = runs?.[1];
+    assert.equal(sparse?.toolName, "centroids");
+    assert.deepEqual(sparse?.parameters, {});
+    assert.equal(sparse?.status, "success");
+    assert.equal(sparse?.durationMs, undefined);
+  });
+
+  it("returns null for absent or empty input", () => {
+    assert.equal(normalizeProcessingHistory(undefined), null);
+    assert.equal(normalizeProcessingHistory([]), null);
+    assert.equal(normalizeProcessingHistory([{}]), null);
+  });
+
+  it("caps a hand-edited list at MAX_PROCESSING_HISTORY keeping the newest", () => {
+    const runs = normalizeProcessingHistory(
+      Array.from({ length: MAX_PROCESSING_HISTORY + 10 }, (_, i) =>
+        makeRun({ id: `run-${i}` }),
+      ),
+    );
+    assert.equal(runs?.length, MAX_PROCESSING_HISTORY);
+    assert.equal(runs?.[0].id, "run-10");
+  });
+});

--- a/tests/processing-history.test.ts
+++ b/tests/processing-history.test.ts
@@ -176,7 +176,8 @@ describe("normalizeProcessingHistory", () => {
     const sparse = runs?.[1];
     assert.equal(sparse?.toolName, "centroids");
     assert.deepEqual(sparse?.parameters, {});
-    assert.equal(sparse?.status, "success");
+    // An unknown/missing status must not present as a green "success".
+    assert.equal(sparse?.status, "error");
     assert.equal(sparse?.durationMs, undefined);
   });
 


### PR DESCRIPTION
## Summary

Fixes #1292

Processing tool runs previously left no record, making interactive sessions non-reproducible. This PR persists every processing run and adds a **Processing -> History** panel, mirroring QGIS's Processing History with "Copy as Python command".

### What is recorded

Every run site is instrumented: the Vector, Spatial Statistics, Network, Whitebox (WASM + sidecar), Raster (client + sidecar), and Conversion (browser + sidecar) dialogs, plus the scripting bridge (`runAlgorithm` used by the Jupyter widget and the in-app Python console). Each `ProcessingRun` entry captures the tool id and name, engine (client/wasm/sidecar/pyodide/browser), parameter values exactly as dispatched, input layer names (snapshotted at run time), output layer names, input/output file paths for file-based tools, start timestamp, duration, and success/failure with the error message.

### History panel

- Entries listed newest first with status, engine badge, timing, and an inputs -> outputs summary.
- **Re-run**: client tools (vector/statistics/network) reopen their dialog pre-filled and start the run immediately.
- **Edit & re-run**: vector/statistics/network/Whitebox/raster reopen the tool dialog pre-filled with the recorded parameters (Whitebox overlays the recorded values on the tool's defaults; raster restores parameters but not file paths).
- **Copy parameters as JSON**: tool id + engine + parameters, pretty-printed.
- **Copy as Python**: emits the equivalent `m.run_algorithm("<tool>", {...})` call for tools reachable from the `geolibre` Python API (the client registries the scripting bridge spans), with Python literals (`True`/`None`).
- **Clear history** plus a run count; menu entry under Processing (UI-profile gated as `processing.history`, intermediate tier).

### Persistence

- `processingHistory` is stored in `@geolibre/core` next to `models`, capped at 100 entries (oldest dropped), excluded from undo history, and persisted in the `.geolibre.json` project file with a hardening `normalizeProcessingHistory` (invalid entries dropped, de-duped by id, capped). A history-less project stays byte-identical (the key is omitted).
- Wired through `projectFromStore`/`parseProject`/`applyProjectToStore`, the Save/Share path, and the embed/collaboration snapshot builder.

## Testing

- New `tests/processing-history.test.ts` (11 tests): store append/dedupe/cap/patch/clear, no undo entries, project round-trip, key omission for empty history, reset on new project, and normalization of hand-edited input.
- Full frontend suite: 2878 pass, 0 fail. `npm run build` clean. Pre-commit (eslint + npm build) clean.
- Verified end to end in the browser with Playwright against the real web app in **both dark and light themes**, using the US cities sample dataset: ran Buffer (client engine), confirmed the history entry (engine badge, duration, `us_cities -> Buffer`), Re-run auto-executed with the recorded parameters and appended a second entry, Edit & re-run pre-filled without running, Copy JSON / Copy Python produced correct clipboard content, and Clear history emptied the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Processing History panel to review past processing runs (status, duration, inputs/outputs, and errors).
  * Added a Processing History menu action and a desktop-shell dialog.
  * Enables “Re-run” / “Edit & re-run” with parameter prefill and optional auto-execution.
  * Automatically records conversions, vector/raster tools, statistics, network tools, and scripting runs, and persists history in saved/reopened projects.
* **Bug Fixes**
  * Improved resilience for failed/aborted runs and more accurate error capture in history.
* **Tests**
  * Added coverage for store behavior and project save/load normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->