### PR TITLE
fix(style-manager): read the project-id snapshot fresh after the import file picker

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StyleManagerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StyleManagerPanel.tsx
@@ -444,7 +444,12 @@ export function StyleManagerPanel() {
       // exported bundle updates entries instead of duplicating them. Merge
       // into one setStyleLibrary call so the whole import costs a single
       // store update and a single IndexedDB flush.
-      const projectIds = new Set(projectStyleLibrary.map((e) => e.id));
+      // Read both lists fresh from the store: the file-picker await above can
+      // block while the store changes, and a render-time snapshot could miss a
+      // project-scoped id created meanwhile.
+      const projectIds = new Set(
+        useAppStore.getState().projectStyleLibrary.map((e) => e.id),
+      );
       const next = [...useAppStore.getState().styleLibrary];
       for (const entry of entries) {
         const imported = {

--- a/apps/geolibre-desktop/src/components/panels/StyleManagerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StyleManagerPanel.tsx
@@ -444,13 +444,12 @@ export function StyleManagerPanel() {
       // exported bundle updates entries instead of duplicating them. Merge
       // into one setStyleLibrary call so the whole import costs a single
       // store update and a single IndexedDB flush.
-      // Read both lists fresh from the store: the file-picker await above can
-      // block while the store changes, and a render-time snapshot could miss a
-      // project-scoped id created meanwhile.
-      const projectIds = new Set(
-        useAppStore.getState().projectStyleLibrary.map((e) => e.id),
-      );
-      const next = [...useAppStore.getState().styleLibrary];
+      // Read both lists fresh from one store snapshot: the file-picker await
+      // above can block while the store changes, and a render-time snapshot
+      // could miss a project-scoped id created meanwhile.
+      const state = useAppStore.getState();
+      const projectIds = new Set(state.projectStyleLibrary.map((e) => e.id));
+      const next = [...state.styleLibrary];
       for (const entry of entries) {
         const imported = {
           ...entry,


### PR DESCRIPTION
Follow-up to #1299 (merged while this last review fix was in flight): the bundle import's project-scoped id collision guard read `projectStyleLibrary` from the render-time closure, while the app library was read fresh from the store after the file-picker await. A project-scoped entry created while the picker was open could therefore defeat the guard. Both lists are now read from `useAppStore.getState()` after the picker resolves.

Addresses the last CodeRabbit review thread on #1299.