### PR TITLE
feat(style): proportional (data-driven) size for marker icons

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2122,15 +2122,12 @@ export function StylePanel({
   const showProportionalControls =
     hasVectorPaintControls &&
     pointRenderer !== "heatmap" &&
-    // A marker symbol layer uses a baked icon (icon-size 1), so proportional
-    // circle-radius sizing would not apply; hide it for points to avoid a silent
-    // no-op. The marker gate stays inside the point branch so that proportional
-    // line-width controls remain available on layers that carry lines (markers
-    // never affect line rendering, even if markerEnabled is set on a mixed
-    // point+line layer via a hand-edited project file).
-    ((geometryFlags.hasPoint &&
-      pointRenderer === "single" &&
-      !styleValue(style, "markerEnabled")) ||
+    // Proportional sizing drives circle-radius, marker icon-size (the
+    // interpolate scales the baked sprite, see markerIconSizeValue in
+    // @geolibre/map), and line-width, so it applies to any single-renderer
+    // point layer (with or without a marker icon) and to layers that carry
+    // lines.
+    ((geometryFlags.hasPoint && pointRenderer === "single") ||
       geometryFlags.hasLine);
   const showFillPatternControls =
     hasVectorPaintControls && !extrusionEnabled && geometryFlags.hasPolygon;

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1,4 +1,5 @@
 import {
+  circleRadiusValue,
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
   geojsonHasZCoordinates,
@@ -438,6 +439,7 @@ function syncExternalNativeLayer(
         applyExternalNativeFeatureFilters(map, nativeLayerId, layer);
       }
     }
+    syncVectorControlPointSymbology(map, layer, beforeId);
     // A deck.gl raster has no real MapLibre style layer to move (it renders in a
     // `deck-layer-group-*` keyed by its beforeId prop), so forward the computed
     // beforeId to the control that owns it.
@@ -1449,6 +1451,117 @@ function isFillStyleLayerSpec(
 
 export function externalExtrusionLayerId(nativeLayerId: string): string {
   return `${nativeLayerId}-geolibre-extrusion`;
+}
+
+/**
+ * Marker-icon and proportional-size rendering for a point layer owned by the
+ * Add Vector Layer control (maplibre-gl-vector). The control's VectorLayerStyle
+ * carries no marker or data-driven-radius concept, so those Style-panel
+ * options would otherwise silently no-op on control-managed layers. Following
+ * the synthetic-extrusion pattern in {@link syncExternalNativeLayer}, GeoLibre
+ * renders them itself on top of the control's own source:
+ *
+ * - Marker enabled: the control's circle layer is hidden and a GeoLibre-owned
+ *   symbol layer ({@link markerLayerId}) draws the baked sprite per point,
+ *   honoring proportional sizing through its `icon-size` interpolate.
+ * - Proportional size without a marker: the control circle's `circle-radius`
+ *   is overridden with the shared interpolate; when proportional sizing turns
+ *   off the flat radius is restored and the control owns the paint again.
+ *
+ * Scoped to the control's single-point render (GeoLibre's "single" renderer /
+ * the control's "circle" pointMode); the cluster and heatmap renderers keep
+ * the control's own layers untouched.
+ */
+function syncVectorControlPointSymbology(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  if (layer.metadata.sourceKind !== "maplibre-gl-vector") return;
+  const syntheticMarkerId = markerLayerId(layer.id);
+  const singleRenderer = styleValue(layer.style, "pointRenderer") === "single";
+  const circleNativeId = getExternalNativeLayerIds(layer).find(
+    (id) => map.getLayer(id)?.type === "circle",
+  );
+  if (!singleRenderer || !circleNativeId) {
+    // Cluster/heatmap modes rebuild the control's native layers, so the old
+    // overlay (if any) just needs dropping.
+    removeIfExists(map, syntheticMarkerId);
+    return;
+  }
+
+  const circleSpec = getStyleLayerSpec(map, circleNativeId);
+  ensureGeneratedImageHandler(map);
+  const markerImageId = prepareMarker(layer.style);
+
+  if (markerImageId && circleSpec) {
+    // Reuse the control's own base filter (the tracked base when Time-Slider /
+    // rule extras are active, so they never nest) combined with the current
+    // extras, mirroring applyExternalNativeFeatureFilters.
+    const tracked = nativeFilterStatesFor(map).get(circleNativeId);
+    const base = tracked
+      ? tracked.base
+      : (("filter" in circleSpec
+          ? (circleSpec.filter as maplibregl.FilterSpecification)
+          : null) ?? null);
+    const filter = combineExternalFilters(
+      base,
+      externalFeatureFilterExtras(layer),
+    );
+    const sourceLayer =
+      "source-layer" in circleSpec ? circleSpec["source-layer"] : undefined;
+    ensureLayer(
+      map,
+      syntheticMarkerId,
+      {
+        id: syntheticMarkerId,
+        type: "symbol",
+        source: (circleSpec as { source: string }).source,
+        ...(sourceLayer ? { "source-layer": sourceLayer } : {}),
+        ...styleLayerZoomRange(layer.style),
+        // Always present so clearing the extras also clears the layer filter
+        // on the update path (ensureLayer only diffs keys that exist).
+        filter: filter ?? undefined,
+        layout: {
+          "icon-image": markerImageId,
+          "icon-size": markerIconSizeValue(
+            layer.style,
+          ) as PropertyValueSpecification<number>,
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+          visibility: layer.visible ? "visible" : "none",
+        },
+        paint: { "icon-opacity": layer.opacity },
+      },
+      beforeId,
+    );
+    // The control keeps managing its circle's visibility (and re-shows it on
+    // its own toggles), but every sync re-hides it while the marker overlay is
+    // active, so the points never render twice.
+    setNativeLayerVisibility(map, circleNativeId, "none");
+    return;
+  }
+
+  // No marker: drop the overlay and hand the point render back to the control.
+  if (map.getLayer(syntheticMarkerId)) {
+    removeIfExists(map, syntheticMarkerId);
+    setNativeLayerVisibility(
+      map,
+      circleNativeId,
+      layer.visible ? "visible" : "none",
+    );
+  }
+
+  // Proportional size on the control's flat circle: hold the override while
+  // active; once off, restore the flat radius if (and only if) an expression
+  // from a previous override is still applied, then leave the paint to the
+  // control again.
+  const radius = circleRadiusValue(layer.style);
+  if (Array.isArray(radius)) {
+    map.setPaintProperty(circleNativeId, "circle-radius", radius);
+  } else if (Array.isArray(map.getPaintProperty(circleNativeId, "circle-radius"))) {
+    map.setPaintProperty(circleNativeId, "circle-radius", radius);
+  }
 }
 
 function setExternalNativeLayerPaint(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -9,6 +9,7 @@ import {
 } from "@geolibre/core";
 import { addProtocol, config } from "maplibre-gl";
 import type maplibregl from "maplibre-gl";
+import type { PropertyValueSpecification } from "maplibre-gl";
 import { FileSource, PMTiles, Protocol } from "pmtiles";
 import {
   ensureGeoJsonVtProtocol,
@@ -37,7 +38,7 @@ import {
 import { buildDedupedLabelFeatures } from "./label-dedup";
 import { ensureGeneratedImageHandler } from "./generated-images";
 import { prepareFillPattern } from "./fill-patterns";
-import { prepareMarker } from "./markers";
+import { markerIconSizeValue, prepareMarker } from "./markers";
 import { isPlaceholderLayer } from "./placeholders";
 import {
   circlePaint,
@@ -1858,8 +1859,11 @@ function applyVectorDataRenderLayers(
           filter: pointFilter,
           layout: {
             "icon-image": markerImageId,
-            // The sprite is baked at its display size, so keep icon-size at 1.
-            "icon-size": 1,
+            // The sprite is baked at its display size, so icon-size stays 1
+            // unless proportional sizing scales it per feature.
+            "icon-size": markerIconSizeValue(
+              layer.style,
+            ) as PropertyValueSpecification<number>,
             "icon-allow-overlap": true,
             "icon-ignore-placement": true,
             visibility,

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -179,41 +179,79 @@ function loadSvgMarker(
 }
 
 /**
+ * The proportional-size radius range for a marker layer, or `null` when
+ * proportional sizing does not apply (disabled, no field chosen, degenerate or
+ * non-finite value range, non-finite radii). The guards mirror the layer-level
+ * base of `circleRadiusValue` in `@geolibre/core` (`baseCircleRadiusValue`) so
+ * a configuration that leaves circles at their constant radius also leaves
+ * markers unscaled. Shared by {@link prepareMarker} (bake size) and
+ * {@link markerIconSizeValue} (scale expression) so both always agree on
+ * whether proportional sizing is active.
+ */
+function proportionalRadiusRange(
+  style: LayerStyle,
+): { property: string; minValue: number; maxValue: number; minRadius: number; maxRadius: number } | null {
+  if (!styleValue(style, "proportionalSizeEnabled")) return null;
+  const property = styleValue(style, "proportionalSizeProperty").trim();
+  if (!property) return null;
+  const minValue = styleValue(style, "proportionalSizeMinValue");
+  const maxValue = styleValue(style, "proportionalSizeMaxValue");
+  if (!(Number.isFinite(minValue) && Number.isFinite(maxValue))) return null;
+  if (maxValue <= minValue) return null;
+  const minRadius = styleValue(style, "proportionalSizeMinRadius");
+  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
+  if (!(Number.isFinite(minRadius) && Number.isFinite(maxRadius))) return null;
+  return { property, minValue, maxValue, minRadius, maxRadius };
+}
+
+/**
+ * The pixel size the marker sprite is baked at. Normally the configured
+ * `markerSize`, but with proportional sizing active the bake grows to cover
+ * the largest proportional diameter (clamped to the canvas-safety maximum), so
+ * `icon-size` mostly scales the sprite *down* instead of blowing a small bake
+ * up ~10x into a blurry icon. Downscaling stays crisp; the residual upscale
+ * past the 96 px clamp is at most ~2x, which the 2x bake pixel ratio absorbs
+ * on standard-DPI displays.
+ */
+function markerBakedSize(style: LayerStyle): number {
+  const base = markerSize(style);
+  const range = proportionalRadiusRange(style);
+  if (!range) return base;
+  const maxDiameter = 2 * Math.max(range.minRadius, range.maxRadius);
+  if (maxDiameter <= base) return base;
+  return Math.min(MAX_MARKER_SIZE, Math.round(maxDiameter));
+}
+
+/**
  * Builds the `icon-size` layout value for a marker symbol layer, honoring
- * proportional (graduated) symbol sizing. The marker sprite is baked at its
- * display size (see {@link prepareMarker}), so the constant value is `1`; when
- * {@link LayerStyle.proportionalSizeEnabled} is set with a chosen numeric field
- * and a valid value range, returns an `interpolate` whose outputs scale the
- * sprite so its on-screen width matches the diameter a proportional circle of
- * the same radius would span (`2 * radius / bakedSize`). The guards mirror
- * `circleRadiusValue` in `@geolibre/core` so a configuration that leaves
- * circles at their constant radius also leaves markers unscaled.
+ * proportional (graduated) symbol sizing. The marker sprite is baked at
+ * {@link markerBakedSize}, so the constant value is `1`; when proportional
+ * sizing applies (see {@link proportionalRadiusRange}), returns an
+ * `interpolate` whose outputs scale the sprite so its on-screen width matches
+ * the diameter a proportional circle of the same radius would span
+ * (`2 * radius / bakedSize`).
+ *
+ * Note: per-rule symbol-size overrides (rule-based mode) apply only to circle
+ * rendering (`circleRadiusValue`'s `ruleOverrideValue` wrapper); marker
+ * icon-size deliberately uses the layer-level proportional base only.
  *
  * @param style - The layer style.
  * @returns `1`, or a MapLibre `interpolate` expression for `icon-size`.
  */
 export function markerIconSizeValue(style: LayerStyle): number | unknown[] {
-  if (!styleValue(style, "proportionalSizeEnabled")) return 1;
-  const property = styleValue(style, "proportionalSizeProperty").trim();
-  if (!property) return 1;
-  const minValue = styleValue(style, "proportionalSizeMinValue");
-  const maxValue = styleValue(style, "proportionalSizeMaxValue");
-  if (!(Number.isFinite(minValue) && Number.isFinite(maxValue))) return 1;
-  if (maxValue <= minValue) return 1;
-  const minRadius = styleValue(style, "proportionalSizeMinRadius");
-  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
-  if (!(Number.isFinite(minRadius) && Number.isFinite(maxRadius))) return 1;
-  const size = markerSize(style);
+  const range = proportionalRadiusRange(style);
+  if (!range) return 1;
+  const size = markerBakedSize(style);
   // icon-size must not go negative; clamp so a hand-edited project with a
   // negative radius degrades to an invisible marker instead of a style error.
   return [
     "interpolate",
     ["linear"],
-    ["to-number", ["get", property], minValue],
-    minValue,
-    Math.max(0, (2 * minRadius) / size),
-    maxValue,
-    Math.max(0, (2 * maxRadius) / size),
+    ["to-number", ["get", range.property], range.minValue],
+    range.minValue,
+    Math.max(0, (2 * range.minRadius) / size),
+    range.maxValue,
+    Math.max(0, (2 * range.maxRadius) / size),
   ];
 }
 
@@ -224,8 +262,10 @@ export function markerIconSizeValue(style: LayerStyle): number | unknown[] {
  * instead.
  *
  * The id encodes shape, color, and size so a recolor or resize produces a
- * distinct image; the marker is baked at its display size with `icon-size` left
- * at `1`. See {@link ensureGeneratedImageHandler} for materialization.
+ * distinct image; the marker is baked at {@link markerBakedSize} with
+ * `icon-size` left at `1` (or scaled down per feature by
+ * {@link markerIconSizeValue} when proportional sizing applies). See
+ * {@link ensureGeneratedImageHandler} for materialization.
  *
  * @param style - The layer style.
  * @returns The image id, or `null` when no marker applies.
@@ -233,7 +273,7 @@ export function markerIconSizeValue(style: LayerStyle): number | unknown[] {
 export function prepareMarker(style: LayerStyle): string | null {
   if (!styleValue(style, "markerEnabled")) return null;
   const shape = styleValue(style, "markerShape");
-  const size = markerSize(style);
+  const size = markerBakedSize(style);
 
   if (shape === "custom") {
     const markup = styleValue(style, "markerSvg").trim();

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -179,6 +179,45 @@ function loadSvgMarker(
 }
 
 /**
+ * Builds the `icon-size` layout value for a marker symbol layer, honoring
+ * proportional (graduated) symbol sizing. The marker sprite is baked at its
+ * display size (see {@link prepareMarker}), so the constant value is `1`; when
+ * {@link LayerStyle.proportionalSizeEnabled} is set with a chosen numeric field
+ * and a valid value range, returns an `interpolate` whose outputs scale the
+ * sprite so its on-screen width matches the diameter a proportional circle of
+ * the same radius would span (`2 * radius / bakedSize`). The guards mirror
+ * `circleRadiusValue` in `@geolibre/core` so a configuration that leaves
+ * circles at their constant radius also leaves markers unscaled.
+ *
+ * @param style - The layer style.
+ * @returns `1`, or a MapLibre `interpolate` expression for `icon-size`.
+ */
+export function markerIconSizeValue(style: LayerStyle): number | unknown[] {
+  if (!styleValue(style, "proportionalSizeEnabled")) return 1;
+  const property = styleValue(style, "proportionalSizeProperty").trim();
+  if (!property) return 1;
+  const minValue = styleValue(style, "proportionalSizeMinValue");
+  const maxValue = styleValue(style, "proportionalSizeMaxValue");
+  if (!(Number.isFinite(minValue) && Number.isFinite(maxValue))) return 1;
+  if (maxValue <= minValue) return 1;
+  const minRadius = styleValue(style, "proportionalSizeMinRadius");
+  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
+  if (!(Number.isFinite(minRadius) && Number.isFinite(maxRadius))) return 1;
+  const size = markerSize(style);
+  // icon-size must not go negative; clamp so a hand-edited project with a
+  // negative radius degrades to an invisible marker instead of a style error.
+  return [
+    "interpolate",
+    ["linear"],
+    ["to-number", ["get", property], minValue],
+    minValue,
+    Math.max(0, (2 * minRadius) / size),
+    maxValue,
+    Math.max(0, (2 * maxRadius) / size),
+  ];
+}
+
+/**
  * Resolve the `icon-image` id for a point layer's marker, registering the lazy
  * factory that draws it. Returns `null` when markers are disabled or a custom
  * SVG marker has no markup, in which case the caller renders a plain circle

--- a/tests/vector-control-symbology.test.ts
+++ b/tests/vector-control-symbology.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import { syncLayer } from "../packages/map/src/layer-sync";
+
+// Records the maplibre calls a layer sync makes so a test can assert which
+// native operations ran. Mirrors the stub in control-owns-paint.test.ts, plus
+// the style/paint getters the vector-control symbology overlay reads.
+interface MapCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeVectorControlMapStub(
+  options: { circleRadiusPaint?: unknown } = {},
+) {
+  const calls: MapCall[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const circleSpec = {
+    id: "vec1-circle",
+    type: "circle",
+    source: "vec1-source",
+    filter: ["==", ["geometry-type"], "Point"],
+  };
+  const map = {
+    getStyle: () => ({ layers: [circleSpec] }),
+    getLayer: (id: string) =>
+      id === "vec1-circle" ? { id, type: "circle" } : undefined,
+    getSource: () => undefined,
+    getFilter: () => circleSpec.filter,
+    getPaintProperty: (_id: string, _prop: string) =>
+      options.circleRadiusPaint,
+    setLayoutProperty: record("setLayoutProperty"),
+    setPaintProperty: record("setPaintProperty"),
+    setFilter: record("setFilter"),
+    setLayerZoomRange: record("setLayerZoomRange"),
+    moveLayer: record("moveLayer"),
+    removeLayer: record("removeLayer"),
+    addLayer: record("addLayer"),
+    addSource: record("addSource"),
+  };
+  return { map, calls };
+}
+
+function vectorControlLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id: "vec1",
+    name: "us_cities",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      customLayerType: "circle",
+      externalNativeLayer: true,
+      controlOwnsPaint: true,
+      sourceKind: "maplibre-gl-vector",
+      nativeLayerIds: ["vec1-circle"],
+      sourceIds: ["vec1-source"],
+    },
+    ...patch,
+  };
+}
+
+const proportionalStyle = {
+  proportionalSizeEnabled: true,
+  proportionalSizeProperty: "pop_max",
+  proportionalSizeMinValue: 20000,
+  proportionalSizeMaxValue: 8000000,
+  proportionalSizeMinRadius: 4,
+  proportionalSizeMaxRadius: 24,
+} as const;
+
+describe("vector-control point symbology overlay (#1311)", () => {
+  it("renders a GeoLibre marker symbol layer and hides the control's circle", () => {
+    const { map, calls } = makeVectorControlMapStub();
+    const layer = vectorControlLayer({
+      style: { ...DEFAULT_LAYER_STYLE, markerEnabled: true },
+    });
+
+    syncLayer(map as never, layer);
+
+    const added = calls.find((c) => c.method === "addLayer");
+    assert.ok(added, "expected the marker overlay layer to be added");
+    const spec = added.args[0] as {
+      id: string;
+      type: string;
+      source: string;
+      layout: Record<string, unknown>;
+    };
+    assert.equal(spec.id, "layer-vec1-marker");
+    assert.equal(spec.type, "symbol");
+    assert.equal(spec.source, "vec1-source");
+    assert.match(String(spec.layout["icon-image"]), /^geolibre-marker-/);
+
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.method === "setLayoutProperty" &&
+          c.args[0] === "vec1-circle" &&
+          c.args[1] === "visibility" &&
+          c.args[2] === "none",
+      ),
+      "expected the control's circle layer to be hidden under the marker",
+    );
+  });
+
+  it("drives the marker overlay's icon-size from proportional sizing", () => {
+    const { map, calls } = makeVectorControlMapStub();
+    const layer = vectorControlLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        markerEnabled: true,
+        ...proportionalStyle,
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    const added = calls.find((c) => c.method === "addLayer");
+    assert.ok(added, "expected the marker overlay layer to be added");
+    const layout = (added.args[0] as { layout: Record<string, unknown> })
+      .layout;
+    assert.ok(
+      Array.isArray(layout["icon-size"]),
+      "expected a data-driven icon-size expression",
+    );
+  });
+
+  it("overrides the control circle's radius while proportional sizing is on", () => {
+    const { map, calls } = makeVectorControlMapStub();
+    const layer = vectorControlLayer({
+      style: { ...DEFAULT_LAYER_STYLE, ...proportionalStyle },
+    });
+
+    syncLayer(map as never, layer);
+
+    const radius = calls.find(
+      (c) =>
+        c.method === "setPaintProperty" &&
+        c.args[0] === "vec1-circle" &&
+        c.args[1] === "circle-radius",
+    );
+    assert.ok(radius, "expected circle-radius to be overridden");
+    assert.ok(Array.isArray(radius.args[2]), "expected an interpolate");
+  });
+
+  it("restores the flat radius when proportional sizing turns off", () => {
+    // The map still carries a stale expression from a previous override.
+    const { map, calls } = makeVectorControlMapStub({
+      circleRadiusPaint: ["interpolate", ["linear"], ["get", "pop_max"]],
+    });
+
+    syncLayer(map as never, vectorControlLayer());
+
+    const radius = calls.find(
+      (c) =>
+        c.method === "setPaintProperty" &&
+        c.args[0] === "vec1-circle" &&
+        c.args[1] === "circle-radius",
+    );
+    assert.ok(radius, "expected the stale expression to be replaced");
+    assert.equal(typeof radius.args[2], "number");
+  });
+
+  it("leaves the control's paint alone when neither option is active", () => {
+    const { map, calls } = makeVectorControlMapStub();
+
+    syncLayer(map as never, vectorControlLayer());
+
+    assert.ok(
+      !calls.some((c) => c.method === "setPaintProperty"),
+      "expected paint to be left to the control",
+    );
+    assert.ok(
+      !calls.some((c) => c.method === "addLayer"),
+      "expected no overlay layer",
+    );
+  });
+
+  it("keeps the cluster renderer untouched", () => {
+    const { map, calls } = makeVectorControlMapStub();
+    const layer = vectorControlLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        markerEnabled: true,
+        ...proportionalStyle,
+        pointRenderer: "cluster",
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    assert.ok(
+      !calls.some((c) => c.method === "addLayer"),
+      "expected no overlay layer in cluster mode",
+    );
+    assert.ok(
+      !calls.some(
+        (c) =>
+          c.method === "setPaintProperty" && c.args[1] === "circle-radius",
+      ),
+      "expected the cluster radius paint to be left alone",
+    );
+  });
+});

--- a/tests/vector-symbology.test.ts
+++ b/tests/vector-symbology.test.ts
@@ -261,15 +261,43 @@ describe("markerIconSizeValue proportional sizing", () => {
         proportionalSizeMaxRadius: 24,
       }),
     );
-    // Outputs are 2 * radius / markerSize: 8/18 and 48/18.
+    // The sprite bakes at the largest proportional diameter (48 px, above the
+    // 18 px markerSize), so outputs are 2 * radius / 48: the max value maps to
+    // exactly 1 (no upscaling) and the min value scales down.
     assert.deepEqual(result, [
       "interpolate",
       ["linear"],
       ["to-number", ["get", "pop"], 0],
       0,
-      8 / 18,
+      8 / 48,
       100,
-      48 / 18,
+      1,
+    ]);
+  });
+
+  it("clamps the grown bake at the canvas-safety maximum (96 px)", () => {
+    const result = markerIconSizeValue(
+      style({
+        markerEnabled: true,
+        markerSize: 18,
+        proportionalSizeEnabled: true,
+        proportionalSizeProperty: "pop",
+        proportionalSizeMinValue: 0,
+        proportionalSizeMaxValue: 100,
+        proportionalSizeMinRadius: 4,
+        proportionalSizeMaxRadius: 100,
+      }),
+    );
+    // 2 * 100 = 200 px diameter clamps to a 96 px bake, so the max output is a
+    // mild ~2x upscale instead of ~11x on the raw 18 px sprite.
+    assert.deepEqual(result, [
+      "interpolate",
+      ["linear"],
+      ["to-number", ["get", "pop"], 0],
+      0,
+      8 / 96,
+      100,
+      200 / 96,
     ]);
   });
 

--- a/tests/vector-symbology.test.ts
+++ b/tests/vector-symbology.test.ts
@@ -17,6 +17,7 @@ import {
   type LayerStyle,
   type VectorRule,
 } from "@geolibre/core";
+import { markerIconSizeValue } from "../packages/map/src/markers";
 
 function style(patch: Partial<LayerStyle> = {}): LayerStyle {
   return { ...DEFAULT_LAYER_STYLE, ...patch };
@@ -239,6 +240,100 @@ describe("lineWidthValue proportional sizing", () => {
 
   it("keeps the constant pixel width when proportional is off", () => {
     assert.equal(lineWidthValue(style({ strokeWidth: 3 })), 3);
+  });
+});
+
+describe("markerIconSizeValue proportional sizing", () => {
+  it("returns 1 when proportional sizing is disabled", () => {
+    assert.equal(markerIconSizeValue(style({ markerEnabled: true })), 1);
+  });
+
+  it("scales the baked sprite so the icon width matches the circle diameter", () => {
+    const result = markerIconSizeValue(
+      style({
+        markerEnabled: true,
+        markerSize: 18,
+        proportionalSizeEnabled: true,
+        proportionalSizeProperty: "pop",
+        proportionalSizeMinValue: 0,
+        proportionalSizeMaxValue: 100,
+        proportionalSizeMinRadius: 4,
+        proportionalSizeMaxRadius: 24,
+      }),
+    );
+    // Outputs are 2 * radius / markerSize: 8/18 and 48/18.
+    assert.deepEqual(result, [
+      "interpolate",
+      ["linear"],
+      ["to-number", ["get", "pop"], 0],
+      0,
+      8 / 18,
+      100,
+      48 / 18,
+    ]);
+  });
+
+  it("returns 1 when the value range is degenerate", () => {
+    const result = markerIconSizeValue(
+      style({
+        markerEnabled: true,
+        proportionalSizeEnabled: true,
+        proportionalSizeProperty: "pop",
+        proportionalSizeMinValue: 50,
+        proportionalSizeMaxValue: 50,
+      }),
+    );
+    assert.equal(result, 1);
+  });
+
+  it("returns 1 when no field is chosen", () => {
+    const result = markerIconSizeValue(
+      style({
+        markerEnabled: true,
+        proportionalSizeEnabled: true,
+        proportionalSizeProperty: "  ",
+      }),
+    );
+    assert.equal(result, 1);
+  });
+
+  it("returns 1 when a radius output is non-finite", () => {
+    const result = markerIconSizeValue(
+      style({
+        markerEnabled: true,
+        proportionalSizeEnabled: true,
+        proportionalSizeProperty: "pop",
+        proportionalSizeMinValue: 0,
+        proportionalSizeMaxValue: 100,
+        proportionalSizeMinRadius: Number.NaN,
+        proportionalSizeMaxRadius: 24,
+      }),
+    );
+    assert.equal(result, 1);
+  });
+
+  it("clamps negative radii to zero instead of emitting a negative icon-size", () => {
+    const result = markerIconSizeValue(
+      style({
+        markerEnabled: true,
+        markerSize: 20,
+        proportionalSizeEnabled: true,
+        proportionalSizeProperty: "pop",
+        proportionalSizeMinValue: 0,
+        proportionalSizeMaxValue: 100,
+        proportionalSizeMinRadius: -5,
+        proportionalSizeMaxRadius: 10,
+      }),
+    );
+    assert.deepEqual(result, [
+      "interpolate",
+      ["linear"],
+      ["to-number", ["get", "pop"], 0],
+      0,
+      0,
+      100,
+      1,
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to discussion #1311 (https://github.com/opengeos/GeoLibre/discussions/1311#discussioncomment-17682199): marker icons could not be sized by a data value, and on layers added through the Add Vector Layer dialog both "Use marker icon" and "Size by value" silently did nothing.

### Proportional (data-driven) size for marker icons

- Add `markerIconSizeValue` (`packages/map/src/markers.ts`): builds the `icon-size` layout value for the marker symbol layer. When proportional sizing is enabled with a valid field and range, it returns an `interpolate` whose outputs scale the baked sprite so the marker's on-screen width matches the diameter a proportional circle of the same radius would span. Guards mirror the layer-level base of `circleRadiusValue`; negative radii clamp to 0.
- The sprite bakes at the largest proportional diameter (clamped at the 96 px canvas-safety maximum) so large size ranges scale the sprite down instead of blowing a small bake up into a blurry icon.
- Wire it into the marker symbol layer in `layer-sync.ts` (previously hard-coded `icon-size: 1`) and show the Proportional size controls for marker-enabled point layers in `StylePanel.tsx`.

### Marker icons and proportional size on Add Vector Layer control layers

The Add Vector Layer control (maplibre-gl-vector) renders its own native layers and owns their paint, so these Style panel options were silent no-ops there. Following the existing synthetic-extrusion pattern, GeoLibre now:

- overlays its own marker symbol layer on the control's source (hiding the control's circle while the marker is active), honoring the control's base filter plus Time Slider / rule filters, visibility, opacity, and zoom range;
- overrides the control circle's `circle-radius` with the shared proportional interpolate while "Size by value" is on, restoring the flat radius when it turns off;
- leaves the control's cluster and heatmap renderers untouched.

## Testing

- New unit tests: `markerIconSizeValue` (interpolate output, sprite-size scaling and 96 px clamp, degenerate ranges, missing field, non-finite and negative radii) in `tests/vector-symbology.test.ts`, and the control-layer overlay behavior (marker overlay added and circle hidden, data-driven icon-size, radius override on/off, cluster mode untouched, no paint touched when idle) in `tests/vector-control-symbology.test.ts`.
- Verified in the browser with Playwright against a real point dataset (US cities, sized by `pop_max`) on both data paths (drag-and-drop store layers and Add Vector Layer control layers), in light and dark themes, across marker shapes, including toggling the options off to confirm the control's circles come back.
- `npm run build`, frontend tests, and pre-commit pass.

Closes the request in discussion #1311.
