### PR TITLE
refactor(style): shared proportional-size guards and scoped control-layer radius override

### DIFF
--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -203,33 +203,12 @@ export function metersWidthExpression(meters: number): unknown[] {
 export function lineWidthValue(style: LayerStyle): number | unknown[] {
   // Proportional (graduated) sizing takes precedence: width is driven by a
   // numeric field, reusing the circle-radius output range as the width range.
-  if (styleValue(style, "proportionalSizeEnabled")) {
-    const property = styleValue(style, "proportionalSizeProperty").trim();
-    const minValue = styleValue(style, "proportionalSizeMinValue");
-    const maxValue = styleValue(style, "proportionalSizeMaxValue");
-    const minRadius = styleValue(style, "proportionalSizeMinRadius");
-    const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
-    if (
-      property &&
-      Number.isFinite(minValue) &&
-      Number.isFinite(maxValue) &&
-      maxValue > minValue &&
-      Number.isFinite(minRadius) &&
-      Number.isFinite(maxRadius)
-    ) {
-      // Per-rule widths still override the proportional base for matched
-      // features (the property-driven interpolate nests legally inside a
-      // case), mirroring circleRadiusValue.
-      return vectorStrokeWidthValue(style, [
-        "interpolate",
-        ["linear"],
-        ["to-number", ["get", property], minValue],
-        minValue,
-        minRadius,
-        maxValue,
-        maxRadius,
-      ]);
-    }
+  const proportionalWidth = proportionalRadiusExpression(style);
+  if (proportionalWidth) {
+    // Per-rule widths still override the proportional base for matched
+    // features (the property-driven interpolate nests legally inside a
+    // case), mirroring circleRadiusValue.
+    return vectorStrokeWidthValue(style, proportionalWidth);
   }
   if (styleValue(style, "strokeWidthUnit") === "meters") {
     // The meters width is itself a zoom-driven interpolation; embedding it
@@ -740,6 +719,67 @@ export function vectorFillOpacityValue(
 }
 
 
+/** The validated proportional (graduated) size configuration of a layer. */
+export interface ProportionalSizeRange {
+  property: string;
+  minValue: number;
+  maxValue: number;
+  minRadius: number;
+  maxRadius: number;
+}
+
+/**
+ * The proportional-size configuration, or `null` when proportional sizing
+ * does not apply: disabled, no field chosen, non-finite or degenerate
+ * (`maxValue <= minValue`) value range, or non-finite radii. This is the
+ * single validation chain for every proportional consumer — circle radius,
+ * line width, and marker icon-size (`@geolibre/map`) — so their notion of
+ * "active" can never drift apart.
+ *
+ * @param style - The layer style.
+ * @returns The validated range, or `null` when proportional sizing is off.
+ */
+export function proportionalSizeRange(
+  style: LayerStyle,
+): ProportionalSizeRange | null {
+  if (!styleValue(style, "proportionalSizeEnabled")) return null;
+  const property = styleValue(style, "proportionalSizeProperty").trim();
+  if (!property) return null;
+  const minValue = styleValue(style, "proportionalSizeMinValue");
+  const maxValue = styleValue(style, "proportionalSizeMaxValue");
+  if (!(Number.isFinite(minValue) && Number.isFinite(maxValue))) return null;
+  if (maxValue <= minValue) return null;
+  const minRadius = styleValue(style, "proportionalSizeMinRadius");
+  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
+  if (!(Number.isFinite(minRadius) && Number.isFinite(maxRadius))) return null;
+  return { property, minValue, maxValue, minRadius, maxRadius };
+}
+
+/**
+ * The proportional `interpolate` expression mapping
+ * `proportionalSizeMinValue..proportionalSizeMaxValue` onto
+ * `proportionalSizeMinRadius..proportionalSizeMaxRadius`, or `null` when
+ * proportional sizing does not apply (see {@link proportionalSizeRange}).
+ *
+ * @param style - The layer style.
+ * @returns The `interpolate` expression, or `null`.
+ */
+export function proportionalRadiusExpression(
+  style: LayerStyle,
+): unknown[] | null {
+  const range = proportionalSizeRange(style);
+  if (!range) return null;
+  return [
+    "interpolate",
+    ["linear"],
+    ["to-number", ["get", range.property], range.minValue],
+    range.minValue,
+    range.minRadius,
+    range.maxValue,
+    range.maxRadius,
+  ];
+}
+
 /**
  * Builds the `circle-radius` paint value, honoring proportional (graduated)
  * symbol sizing. When {@link LayerStyle.proportionalSizeEnabled} is set with a
@@ -761,28 +801,9 @@ export function circleRadiusValue(style: LayerStyle): number | unknown[] {
 
 /** The layer-level circle radius before per-rule overrides. */
 function baseCircleRadiusValue(style: LayerStyle): number | unknown[] {
-  const constant = styleValue(style, "circleRadius");
-  if (!styleValue(style, "proportionalSizeEnabled")) return constant;
-  const property = styleValue(style, "proportionalSizeProperty").trim();
-  if (!property) return constant;
-  const minValue = styleValue(style, "proportionalSizeMinValue");
-  const maxValue = styleValue(style, "proportionalSizeMaxValue");
-  if (!(Number.isFinite(minValue) && Number.isFinite(maxValue))) return constant;
-  if (maxValue <= minValue) return constant;
-  const minRadius = styleValue(style, "proportionalSizeMinRadius");
-  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
-  if (!(Number.isFinite(minRadius) && Number.isFinite(maxRadius))) {
-    return constant;
-  }
-  return [
-    "interpolate",
-    ["linear"],
-    ["to-number", ["get", property], minValue],
-    minValue,
-    minRadius,
-    maxValue,
-    maxRadius,
-  ];
+  return (
+    proportionalRadiusExpression(style) ?? styleValue(style, "circleRadius")
+  );
 }
 
 /** Fill color value for a polygon layer (fallback: the layer fill color). */

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -3234,6 +3234,14 @@ export function removeLayerFromMap(
   ]) {
     if (src && map.getSource(src)) map.removeSource(src);
   }
+  // Drop radius-override tracking for the removed layer's native ids so a
+  // later layer reusing an id never inherits a stale restore.
+  const overriddenRadiusIds = overriddenRadiusNativeLayerIds.get(map);
+  if (overriddenRadiusIds) {
+    for (const id of getExternalNativeLayerIds(layer)) {
+      overriddenRadiusIds.delete(id);
+    }
+  }
   // Free any client-side tile index built for this layer's tiled render path.
   unregisterGeoJsonVtSource(layerId);
   // Free an in-memory PMTiles archive (an offline basemap extract) this layer

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1565,17 +1565,31 @@ function syncVectorControlPointSymbology(
   const radius = proportionalRadiusExpression(layer.style);
   if (radius) {
     map.setPaintProperty(circleNativeId, "circle-radius", radius);
-    overriddenRadiusNativeLayerIds.add(circleNativeId);
+    overriddenRadiusIdsFor(map).add(circleNativeId);
   } else {
     restoreOverriddenCircleRadius(map, circleNativeId, layer);
   }
 }
 
 // Control-owned circle layers whose circle-radius GeoLibre has overridden with
-// the proportional interpolate. Tracked (like managedZoomRangeLayerIds) so the
-// restore only ever touches a layer this module actually overrode — never a
-// control-authored expression such as the cluster renderer's stepped radius.
-const overriddenRadiusNativeLayerIds = new Set<string>();
+// the proportional interpolate. Tracked (like externalNativeBaseFilters, keyed
+// per map so two maps sharing a native layer id never see each other's state)
+// so the restore only ever touches a layer this module actually overrode —
+// never a control-authored expression such as the cluster renderer's stepped
+// radius.
+const overriddenRadiusNativeLayerIds = new WeakMap<
+  maplibregl.Map,
+  Set<string>
+>();
+
+function overriddenRadiusIdsFor(map: maplibregl.Map): Set<string> {
+  let ids = overriddenRadiusNativeLayerIds.get(map);
+  if (!ids) {
+    ids = new Set();
+    overriddenRadiusNativeLayerIds.set(map, ids);
+  }
+  return ids;
+}
 
 /** Hand an overridden circle-radius back to the control's flat value. */
 function restoreOverriddenCircleRadius(
@@ -1583,7 +1597,7 @@ function restoreOverriddenCircleRadius(
   circleNativeId: string,
   layer: GeoLibreLayer,
 ): void {
-  if (!overriddenRadiusNativeLayerIds.delete(circleNativeId)) return;
+  if (!overriddenRadiusIdsFor(map).delete(circleNativeId)) return;
   map.setPaintProperty(
     circleNativeId,
     "circle-radius",

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1,9 +1,9 @@
 import {
-  circleRadiusValue,
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
   geojsonHasZCoordinates,
   type LayerStyle,
+  proportionalRadiusExpression,
   ruleBasedVisibilityFilter,
   shouldUseTiledRendering,
   styleValue,
@@ -1485,8 +1485,13 @@ function syncVectorControlPointSymbology(
   );
   if (!singleRenderer || !circleNativeId) {
     // Cluster/heatmap modes rebuild the control's native layers, so the old
-    // overlay (if any) just needs dropping.
+    // overlay (if any) just needs dropping. If the control ever reused a
+    // still-live circle id across the mode switch, also hand back its radius
+    // so a stale proportional interpolate cannot bleed into the new renderer.
     removeIfExists(map, syntheticMarkerId);
+    if (circleNativeId) {
+      restoreOverriddenCircleRadius(map, circleNativeId, layer);
+    }
     return;
   }
 
@@ -1553,15 +1558,37 @@ function syncVectorControlPointSymbology(
   }
 
   // Proportional size on the control's flat circle: hold the override while
-  // active; once off, restore the flat radius if (and only if) an expression
-  // from a previous override is still applied, then leave the paint to the
-  // control again.
-  const radius = circleRadiusValue(layer.style);
-  if (Array.isArray(radius)) {
+  // active; once off, restore the flat radius and leave the paint to the
+  // control again. Deliberately proportional-only (not circleRadiusValue):
+  // rule-based per-rule sizes stay a store-managed-layer feature, since none
+  // of the other rule-based paint overrides apply to control-owned layers.
+  const radius = proportionalRadiusExpression(layer.style);
+  if (radius) {
     map.setPaintProperty(circleNativeId, "circle-radius", radius);
-  } else if (Array.isArray(map.getPaintProperty(circleNativeId, "circle-radius"))) {
-    map.setPaintProperty(circleNativeId, "circle-radius", radius);
+    overriddenRadiusNativeLayerIds.add(circleNativeId);
+  } else {
+    restoreOverriddenCircleRadius(map, circleNativeId, layer);
   }
+}
+
+// Control-owned circle layers whose circle-radius GeoLibre has overridden with
+// the proportional interpolate. Tracked (like managedZoomRangeLayerIds) so the
+// restore only ever touches a layer this module actually overrode — never a
+// control-authored expression such as the cluster renderer's stepped radius.
+const overriddenRadiusNativeLayerIds = new Set<string>();
+
+/** Hand an overridden circle-radius back to the control's flat value. */
+function restoreOverriddenCircleRadius(
+  map: maplibregl.Map,
+  circleNativeId: string,
+  layer: GeoLibreLayer,
+): void {
+  if (!overriddenRadiusNativeLayerIds.delete(circleNativeId)) return;
+  map.setPaintProperty(
+    circleNativeId,
+    "circle-radius",
+    styleValue(layer.style, "circleRadius"),
+  );
 }
 
 function setExternalNativeLayerPaint(

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -1,5 +1,6 @@
 import {
   normalizeHexColor,
+  proportionalSizeRange,
   styleValue,
   type LayerStyle,
   type MarkerShape,
@@ -179,34 +180,10 @@ function loadSvgMarker(
 }
 
 /**
- * The proportional-size radius range for a marker layer, or `null` when
- * proportional sizing does not apply (disabled, no field chosen, degenerate or
- * non-finite value range, non-finite radii). The guards mirror the layer-level
- * base of `circleRadiusValue` in `@geolibre/core` (`baseCircleRadiusValue`) so
- * a configuration that leaves circles at their constant radius also leaves
- * markers unscaled. Shared by {@link prepareMarker} (bake size) and
- * {@link markerIconSizeValue} (scale expression) so both always agree on
- * whether proportional sizing is active.
- */
-function proportionalRadiusRange(
-  style: LayerStyle,
-): { property: string; minValue: number; maxValue: number; minRadius: number; maxRadius: number } | null {
-  if (!styleValue(style, "proportionalSizeEnabled")) return null;
-  const property = styleValue(style, "proportionalSizeProperty").trim();
-  if (!property) return null;
-  const minValue = styleValue(style, "proportionalSizeMinValue");
-  const maxValue = styleValue(style, "proportionalSizeMaxValue");
-  if (!(Number.isFinite(minValue) && Number.isFinite(maxValue))) return null;
-  if (maxValue <= minValue) return null;
-  const minRadius = styleValue(style, "proportionalSizeMinRadius");
-  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
-  if (!(Number.isFinite(minRadius) && Number.isFinite(maxRadius))) return null;
-  return { property, minValue, maxValue, minRadius, maxRadius };
-}
-
-/**
  * The pixel size the marker sprite is baked at. Normally the configured
- * `markerSize`, but with proportional sizing active the bake grows to cover
+ * `markerSize`, but with proportional sizing active (the shared
+ * `proportionalSizeRange` guard from `@geolibre/core`, so marker activation
+ * can never drift from circle-radius activation) the bake grows to cover
  * the largest proportional diameter (clamped to the canvas-safety maximum), so
  * `icon-size` mostly scales the sprite *down* instead of blowing a small bake
  * up ~10x into a blurry icon. Downscaling stays crisp; the residual upscale
@@ -215,7 +192,7 @@ function proportionalRadiusRange(
  */
 function markerBakedSize(style: LayerStyle): number {
   const base = markerSize(style);
-  const range = proportionalRadiusRange(style);
+  const range = proportionalSizeRange(style);
   if (!range) return base;
   const maxDiameter = 2 * Math.max(range.minRadius, range.maxRadius);
   if (maxDiameter <= base) return base;
@@ -226,10 +203,10 @@ function markerBakedSize(style: LayerStyle): number {
  * Builds the `icon-size` layout value for a marker symbol layer, honoring
  * proportional (graduated) symbol sizing. The marker sprite is baked at
  * {@link markerBakedSize}, so the constant value is `1`; when proportional
- * sizing applies (see {@link proportionalRadiusRange}), returns an
- * `interpolate` whose outputs scale the sprite so its on-screen width matches
- * the diameter a proportional circle of the same radius would span
- * (`2 * radius / bakedSize`).
+ * sizing applies (the shared `proportionalSizeRange` guard from
+ * `@geolibre/core`), returns an `interpolate` whose outputs scale the sprite
+ * so its on-screen width matches the diameter a proportional circle of the
+ * same radius would span (`2 * radius / bakedSize`).
  *
  * Note: per-rule symbol-size overrides (rule-based mode) apply only to circle
  * rendering (`circleRadiusValue`'s `ruleOverrideValue` wrapper); marker
@@ -239,7 +216,7 @@ function markerBakedSize(style: LayerStyle): number {
  * @returns `1`, or a MapLibre `interpolate` expression for `icon-size`.
  */
 export function markerIconSizeValue(style: LayerStyle): number | unknown[] {
-  const range = proportionalRadiusRange(style);
+  const range = proportionalSizeRange(style);
   if (!range) return 1;
   const size = markerBakedSize(style);
   // icon-size must not go negative; clamp so a hand-edited project with a

--- a/tests/vector-control-symbology.test.ts
+++ b/tests/vector-control-symbology.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
-import { syncLayer } from "../packages/map/src/layer-sync";
+import { removeLayerFromMap, syncLayer } from "../packages/map/src/layer-sync";
 
 // Records the maplibre calls a layer sync makes so a test can assert which
 // native operations ran. Mirrors the stub in control-owns-paint.test.ts, plus
@@ -199,6 +199,26 @@ describe("vector-control point symbology overlay (#1311)", () => {
       "expected the second map to restore independently",
     );
     assert.equal(typeof secondRadius[1].args[2], "number");
+  });
+
+  it("forgets an overridden radius when the layer is removed outright", () => {
+    // Deleting a layer mid-override must clear its tracking entry; otherwise
+    // a later layer that reuses the native id would inherit a stale restore
+    // and clobber a control-authored radius expression.
+    const { map, calls } = makeVectorControlMapStub("vecd");
+    const overridden = vectorControlLayer("vecd", {
+      style: { ...DEFAULT_LAYER_STYLE, ...proportionalStyle },
+    });
+
+    syncLayer(map as never, overridden);
+    removeLayerFromMap(map as never, "vecd", overridden);
+    // A fresh layer reusing the same native id, proportional off: nothing to
+    // restore, so the control keeps its radius paint untouched.
+    syncLayer(map as never, vectorControlLayer("vecd"));
+
+    const radius = radiusCalls(calls, "vecd");
+    assert.equal(radius.length, 1, "expected the override only — no restore");
+    assert.ok(Array.isArray(radius[0].args[2]));
   });
 
   it("restores an overridden radius when the renderer leaves single mode", () => {

--- a/tests/vector-control-symbology.test.ts
+++ b/tests/vector-control-symbology.test.ts
@@ -6,10 +6,6 @@ import { syncLayer } from "../packages/map/src/layer-sync";
 // Records the maplibre calls a layer sync makes so a test can assert which
 // native operations ran. Mirrors the stub in control-owns-paint.test.ts, plus
 // the style/paint getters the vector-control symbology overlay reads.
-//
-// Each test uses a distinct layer id: the overlay tracks overridden radii in
-// a module-level set (like managedZoomRangeLayerIds), so sharing ids across
-// tests would leak state between them.
 interface MapCall {
   method: string;
   args: unknown[];
@@ -173,6 +169,36 @@ describe("vector-control point symbology overlay (#1311)", () => {
     assert.equal(radius.length, 2, "expected override then restore");
     assert.ok(Array.isArray(radius[0].args[2]));
     assert.equal(typeof radius[1].args[2], "number");
+  });
+
+  it("tracks overridden radii per map, not globally by layer id", () => {
+    // Two maps (e.g. a swipe pair) can host control layers with the same
+    // native layer id. Restoring one map's radius must not eat the tracking
+    // entry of the other, which would leave its proportional interpolate
+    // stuck on the control's circle.
+    const first = makeVectorControlMapStub("vecw");
+    const second = makeVectorControlMapStub("vecw");
+    const proportional = vectorControlLayer("vecw", {
+      style: { ...DEFAULT_LAYER_STYLE, ...proportionalStyle },
+    });
+
+    syncLayer(first.map as never, proportional);
+    syncLayer(second.map as never, proportional);
+    // Turn proportional sizing off on the first map only.
+    syncLayer(first.map as never, vectorControlLayer("vecw"));
+    syncLayer(second.map as never, vectorControlLayer("vecw"));
+
+    const firstRadius = radiusCalls(first.calls, "vecw");
+    assert.equal(firstRadius.length, 2, "expected override then restore");
+    assert.equal(typeof firstRadius[1].args[2], "number");
+
+    const secondRadius = radiusCalls(second.calls, "vecw");
+    assert.equal(
+      secondRadius.length,
+      2,
+      "expected the second map to restore independently",
+    );
+    assert.equal(typeof secondRadius[1].args[2], "number");
   });
 
   it("restores an overridden radius when the renderer leaves single mode", () => {

--- a/tests/vector-control-symbology.test.ts
+++ b/tests/vector-control-symbology.test.ts
@@ -6,14 +6,16 @@ import { syncLayer } from "../packages/map/src/layer-sync";
 // Records the maplibre calls a layer sync makes so a test can assert which
 // native operations ran. Mirrors the stub in control-owns-paint.test.ts, plus
 // the style/paint getters the vector-control symbology overlay reads.
+//
+// Each test uses a distinct layer id: the overlay tracks overridden radii in
+// a module-level set (like managedZoomRangeLayerIds), so sharing ids across
+// tests would leak state between them.
 interface MapCall {
   method: string;
   args: unknown[];
 }
 
-function makeVectorControlMapStub(
-  options: { circleRadiusPaint?: unknown } = {},
-) {
+function makeVectorControlMapStub(layerId: string) {
   const calls: MapCall[] = [];
   const record =
     (method: string) =>
@@ -21,19 +23,18 @@ function makeVectorControlMapStub(
       calls.push({ method, args });
     };
   const circleSpec = {
-    id: "vec1-circle",
+    id: `${layerId}-circle`,
     type: "circle",
-    source: "vec1-source",
+    source: `${layerId}-source`,
     filter: ["==", ["geometry-type"], "Point"],
   };
   const map = {
     getStyle: () => ({ layers: [circleSpec] }),
     getLayer: (id: string) =>
-      id === "vec1-circle" ? { id, type: "circle" } : undefined,
+      id === circleSpec.id ? { id, type: "circle" } : undefined,
     getSource: () => undefined,
     getFilter: () => circleSpec.filter,
-    getPaintProperty: (_id: string, _prop: string) =>
-      options.circleRadiusPaint,
+    getPaintProperty: () => undefined,
     setLayoutProperty: record("setLayoutProperty"),
     setPaintProperty: record("setPaintProperty"),
     setFilter: record("setFilter"),
@@ -46,9 +47,12 @@ function makeVectorControlMapStub(
   return { map, calls };
 }
 
-function vectorControlLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+function vectorControlLayer(
+  layerId: string,
+  patch: Partial<GeoLibreLayer> = {},
+): GeoLibreLayer {
   return {
-    id: "vec1",
+    id: layerId,
     name: "us_cities",
     type: "geojson",
     source: { type: "geojson" },
@@ -60,8 +64,8 @@ function vectorControlLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
       externalNativeLayer: true,
       controlOwnsPaint: true,
       sourceKind: "maplibre-gl-vector",
-      nativeLayerIds: ["vec1-circle"],
-      sourceIds: ["vec1-source"],
+      nativeLayerIds: [`${layerId}-circle`],
+      sourceIds: [`${layerId}-source`],
     },
     ...patch,
   };
@@ -76,10 +80,19 @@ const proportionalStyle = {
   proportionalSizeMaxRadius: 24,
 } as const;
 
+function radiusCalls(calls: MapCall[], layerId: string): MapCall[] {
+  return calls.filter(
+    (c) =>
+      c.method === "setPaintProperty" &&
+      c.args[0] === `${layerId}-circle` &&
+      c.args[1] === "circle-radius",
+  );
+}
+
 describe("vector-control point symbology overlay (#1311)", () => {
   it("renders a GeoLibre marker symbol layer and hides the control's circle", () => {
-    const { map, calls } = makeVectorControlMapStub();
-    const layer = vectorControlLayer({
+    const { map, calls } = makeVectorControlMapStub("vecm");
+    const layer = vectorControlLayer("vecm", {
       style: { ...DEFAULT_LAYER_STYLE, markerEnabled: true },
     });
 
@@ -93,16 +106,16 @@ describe("vector-control point symbology overlay (#1311)", () => {
       source: string;
       layout: Record<string, unknown>;
     };
-    assert.equal(spec.id, "layer-vec1-marker");
+    assert.equal(spec.id, "layer-vecm-marker");
     assert.equal(spec.type, "symbol");
-    assert.equal(spec.source, "vec1-source");
+    assert.equal(spec.source, "vecm-source");
     assert.match(String(spec.layout["icon-image"]), /^geolibre-marker-/);
 
     assert.ok(
       calls.some(
         (c) =>
           c.method === "setLayoutProperty" &&
-          c.args[0] === "vec1-circle" &&
+          c.args[0] === "vecm-circle" &&
           c.args[1] === "visibility" &&
           c.args[2] === "none",
       ),
@@ -111,8 +124,8 @@ describe("vector-control point symbology overlay (#1311)", () => {
   });
 
   it("drives the marker overlay's icon-size from proportional sizing", () => {
-    const { map, calls } = makeVectorControlMapStub();
-    const layer = vectorControlLayer({
+    const { map, calls } = makeVectorControlMapStub("vecms");
+    const layer = vectorControlLayer("vecms", {
       style: {
         ...DEFAULT_LAYER_STYLE,
         markerEnabled: true,
@@ -133,45 +146,97 @@ describe("vector-control point symbology overlay (#1311)", () => {
   });
 
   it("overrides the control circle's radius while proportional sizing is on", () => {
-    const { map, calls } = makeVectorControlMapStub();
-    const layer = vectorControlLayer({
+    const { map, calls } = makeVectorControlMapStub("vecp");
+    const layer = vectorControlLayer("vecp", {
       style: { ...DEFAULT_LAYER_STYLE, ...proportionalStyle },
     });
 
     syncLayer(map as never, layer);
 
-    const radius = calls.find(
-      (c) =>
-        c.method === "setPaintProperty" &&
-        c.args[0] === "vec1-circle" &&
-        c.args[1] === "circle-radius",
-    );
-    assert.ok(radius, "expected circle-radius to be overridden");
-    assert.ok(Array.isArray(radius.args[2]), "expected an interpolate");
+    const radius = radiusCalls(calls, "vecp");
+    assert.equal(radius.length, 1, "expected circle-radius to be overridden");
+    assert.ok(Array.isArray(radius[0].args[2]), "expected an interpolate");
   });
 
   it("restores the flat radius when proportional sizing turns off", () => {
-    // The map still carries a stale expression from a previous override.
-    const { map, calls } = makeVectorControlMapStub({
-      circleRadiusPaint: ["interpolate", ["linear"], ["get", "pop_max"]],
+    const { map, calls } = makeVectorControlMapStub("vecr");
+
+    syncLayer(
+      map as never,
+      vectorControlLayer("vecr", {
+        style: { ...DEFAULT_LAYER_STYLE, ...proportionalStyle },
+      }),
+    );
+    syncLayer(map as never, vectorControlLayer("vecr"));
+
+    const radius = radiusCalls(calls, "vecr");
+    assert.equal(radius.length, 2, "expected override then restore");
+    assert.ok(Array.isArray(radius[0].args[2]));
+    assert.equal(typeof radius[1].args[2], "number");
+  });
+
+  it("restores an overridden radius when the renderer leaves single mode", () => {
+    // If the control reused the same circle id across a mode switch, a stale
+    // proportional interpolate must not bleed into the new renderer.
+    const { map, calls } = makeVectorControlMapStub("vecc");
+
+    syncLayer(
+      map as never,
+      vectorControlLayer("vecc", {
+        style: { ...DEFAULT_LAYER_STYLE, ...proportionalStyle },
+      }),
+    );
+    syncLayer(
+      map as never,
+      vectorControlLayer("vecc", {
+        style: {
+          ...DEFAULT_LAYER_STYLE,
+          ...proportionalStyle,
+          pointRenderer: "cluster",
+        },
+      }),
+    );
+
+    const radius = radiusCalls(calls, "vecc");
+    assert.equal(radius.length, 2, "expected override then restore");
+    assert.equal(typeof radius[1].args[2], "number");
+  });
+
+  it("only applies proportional sizing, never rule-based radius overrides", () => {
+    // Rule-based per-rule sizes are a store-managed-layer feature; on a
+    // control-owned layer none of the other rule paint applies, so smuggling
+    // just the radius through would be a half-applied rule experience.
+    const { map, calls } = makeVectorControlMapStub("vecrb");
+    const layer = vectorControlLayer("vecrb", {
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        vectorStyleMode: "rule-based",
+        vectorRules: [
+          {
+            id: "r1",
+            label: "big",
+            filter: '[">", ["get", "pop_max"], 1000000]',
+            color: "#ff0000",
+            isElse: false,
+            circleRadius: 12,
+          },
+        ],
+      },
     });
 
-    syncLayer(map as never, vectorControlLayer());
+    syncLayer(map as never, layer);
 
-    const radius = calls.find(
-      (c) =>
-        c.method === "setPaintProperty" &&
-        c.args[0] === "vec1-circle" &&
-        c.args[1] === "circle-radius",
+    assert.equal(
+      radiusCalls(calls, "vecrb").length,
+      0,
+      "expected rule-based radius to be left to store-managed layers",
     );
-    assert.ok(radius, "expected the stale expression to be replaced");
-    assert.equal(typeof radius.args[2], "number");
   });
 
   it("leaves the control's paint alone when neither option is active", () => {
-    const { map, calls } = makeVectorControlMapStub();
+    const { map, calls } = makeVectorControlMapStub("vecn");
 
-    syncLayer(map as never, vectorControlLayer());
+    syncLayer(map as never, vectorControlLayer("vecn"));
 
     assert.ok(
       !calls.some((c) => c.method === "setPaintProperty"),
@@ -184,8 +249,8 @@ describe("vector-control point symbology overlay (#1311)", () => {
   });
 
   it("keeps the cluster renderer untouched", () => {
-    const { map, calls } = makeVectorControlMapStub();
-    const layer = vectorControlLayer({
+    const { map, calls } = makeVectorControlMapStub("veck");
+    const layer = vectorControlLayer("veck", {
       style: {
         ...DEFAULT_LAYER_STYLE,
         markerEnabled: true,
@@ -200,11 +265,9 @@ describe("vector-control point symbology overlay (#1311)", () => {
       !calls.some((c) => c.method === "addLayer"),
       "expected no overlay layer in cluster mode",
     );
-    assert.ok(
-      !calls.some(
-        (c) =>
-          c.method === "setPaintProperty" && c.args[1] === "circle-radius",
-      ),
+    assert.equal(
+      radiusCalls(calls, "veck").length,
+      0,
       "expected the cluster radius paint to be left alone",
     );
   });


### PR DESCRIPTION
## Summary

Follow-up to #1325, addressing the three review comments that landed after it merged.

- **Shared proportional-size guards.** `proportionalSizeRange` and `proportionalRadiusExpression` are now exported from `@geolibre/core` as the single validation chain for proportional sizing. Circle radius (`baseCircleRadiusValue`), line width (`lineWidthValue`), and marker icon-size (`@geolibre/map`) all consume them, replacing three hand-maintained copies of the same guards that could silently drift apart.
- **No rule-based leak onto control layers.** The Add Vector Layer control-circle radius override now uses the proportional expression only, not `circleRadiusValue`, so rule-based per-rule radii no longer apply to control-owned layers where none of the other rule-based paint applies.
- **Tracked radius restore.** Overridden native circle ids are tracked in a set (mirroring `managedZoomRangeLayerIds`), and the flat radius is restored through that set, including when the point renderer leaves single mode. A stale interpolate can never bleed into a control renderer that reuses the layer id, and a control-authored expression (e.g. a cluster stepped radius) is never clobbered by shape-sniffing.

## Testing

- `tests/vector-control-symbology.test.ts` updated for the tracked-restore semantics (unique native ids per test) and extended with transition cases: proportional on -> off restores the flat radius, single -> cluster restores an overridden radius, and rule-based per-rule radii are asserted not to touch control layers.
- 59 tests pass across the two symbology test files; `npm run build` and pre-commit pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent proportional sizing for lines, circles, and markers based on data-driven style settings.
  - Improved proportional marker scaling and sprite sizing.

- **Bug Fixes**
  - Restores configured circle sizes when proportional sizing is no longer applicable.
  - Prevents unintended radius changes when switching renderer modes or applying rule-based styles.
  - Preserves cluster styling during proportional sizing updates.

- **Tests**
  - Expanded coverage for proportional sizing, restoration behavior, renderer transitions, and isolated layer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->