### PR TITLE
feat(print): attribute-table and chart blocks in the Print Layout

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -356,6 +356,14 @@ export function PrintLayoutDialog({
   // Set when the last atlas capture had to clamp a fixed scale to the map's
   // zoom limits, mirroring the manual scale flow's out-of-range notice.
   const [atlasScaleNotice, setAtlasScaleNotice] = useState<string | null>(null);
+  // The map's actual visible bounds after the last atlas capture, keyed by
+  // page index. The data blocks' page-extent filter prefers this over the
+  // page's nominal bounds: in fixed-scale mode the zoom correction changes
+  // the rendered extent away from the fitted feature box (GH #1324).
+  const [atlasViewBounds, setAtlasViewBounds] = useState<{
+    index: number;
+    bounds: AtlasBounds;
+  } | null>(null);
   // Mirror of atlasActive (derived further down) for the dialog-open effect,
   // which is declared before those derivations exist.
   const atlasActiveRef = useRef(false);
@@ -946,6 +954,10 @@ export function PrintLayoutDialog({
       chartLayer?.geojson ? listAtlasFields(chartLayer.geojson.features) : [],
     [chartLayer],
   );
+  const tableAllRows = useMemo(
+    () => (tableLayer?.geojson ? layerRows(tableLayer.geojson) : []),
+    [tableLayer],
+  );
   const chartAllRows = useMemo(
     () => (chartLayer?.geojson ? layerRows(chartLayer.geojson) : []),
     [chartLayer],
@@ -982,8 +994,12 @@ export function PrintLayoutDialog({
   }, [tableColumns, tableFields]);
 
   // The extent a data block's "only features on the page" filter tests
-  // against: the atlas page's fitted bounds, or the drawn print extent when
-  // that is what the capture clips to. Plain viewport captures don't filter.
+  // against, before the page's real capture is available: the atlas page's
+  // fitted bounds, or the drawn print extent when that is what the capture
+  // clips to. Plain viewport captures don't filter. Once a page has actually
+  // been captured, the map's true visible bounds override this approximation
+  // (see buildDataBlocksFor's viewBounds) — the fit expands the box on one
+  // axis for the page aspect, and fixed-scale mode re-zooms after fitting.
   const dataFilterBounds = useCallback(
     (page: AtlasPage | null): AtlasBounds | null => {
       if (page) {
@@ -1001,15 +1017,22 @@ export function PrintLayoutDialog({
   // Resolve both data blocks for one atlas page (or the non-atlas layout when
   // null). Used for the live preview/current page and again per page during
   // an atlas export, so each page's table/chart reflects its own extent.
+  // `viewBounds` is the map's actual visible extent from that page's capture;
+  // when provided it replaces the nominal page-bounds approximation.
   const buildDataBlocksFor = useCallback(
-    (page: AtlasPage | null): Pick<LayoutOptions, "dataTable" | "dataChart"> => {
+    (
+      page: AtlasPage | null,
+      viewBounds?: AtlasBounds | null,
+    ): Pick<LayoutOptions, "dataTable" | "dataChart"> => {
       let dataTable: LayoutOptions["dataTable"] = null;
       let dataChart: LayoutOptions["dataChart"] = null;
+      const filterBounds = () =>
+        (page && viewBounds) || dataFilterBounds(page);
       if (showDataTable && tableLayer?.geojson) {
-        const bounds = tableFilterToPage ? dataFilterBounds(page) : null;
+        const bounds = tableFilterToPage ? filterBounds() : null;
         const rows = bounds
           ? rowsWithinBounds(tableLayer.geojson, bounds)
-          : layerRows(tableLayer.geojson);
+          : tableAllRows;
         const data = buildTableBlock(rows, {
           columns: effectiveTableColumns,
           sortField: tableSortField || undefined,
@@ -1032,7 +1055,7 @@ export function PrintLayoutDialog({
         }
       }
       if (showDataChart && chartLayer?.geojson) {
-        const bounds = chartFilterToPage ? dataFilterBounds(page) : null;
+        const bounds = chartFilterToPage ? filterBounds() : null;
         const rows = bounds
           ? rowsWithinBounds(chartLayer.geojson, bounds)
           : chartAllRows;
@@ -1055,6 +1078,7 @@ export function PrintLayoutDialog({
     [
       showDataTable,
       tableLayer,
+      tableAllRows,
       tableFilterToPage,
       dataFilterBounds,
       effectiveTableColumns,
@@ -1077,8 +1101,17 @@ export function PrintLayoutDialog({
     ],
   );
   const displayDataBlocks = useMemo(
-    () => buildDataBlocksFor(currentAtlasPage),
-    [buildDataBlocksFor, currentAtlasPage],
+    () =>
+      buildDataBlocksFor(
+        currentAtlasPage,
+        // The captured view bounds only apply to the page they were taken on;
+        // while a newly selected page is still capturing, fall back to its
+        // nominal bounds until the auto-drive refresh lands.
+        atlasViewBounds && atlasViewBounds.index === clampedAtlasIndex
+          ? atlasViewBounds.bounds
+          : null,
+      ),
+    [buildDataBlocksFor, currentAtlasPage, atlasViewBounds, clampedAtlasIndex],
   );
 
   // Options with this page's atlas tokens resolved, fed to the preview, the
@@ -1121,9 +1154,12 @@ export function PrintLayoutDialog({
   // Drive the live map to one atlas page's extent and capture it. Margin mode
   // grows the feature's box before fitting; fixed-scale mode fits first, then
   // corrects the zoom by the log2 ratio difference (like applyScale) and
-  // recaptures.
+  // recaptures. Returns the capture plus the map's final visible bounds, so
+  // the data blocks can filter to what the page actually shows.
   const captureAtlasPage = useCallback(
-    async (page: AtlasPage): Promise<CapturedMap> => {
+    async (
+      page: AtlasPage,
+    ): Promise<{ cap: CapturedMap; viewBounds: AtlasBounds }> => {
       const map = mapControllerRef.current?.getMap();
       if (!map) throw new Error("Map is not ready");
       const [w, s, e, n] = expandBounds(
@@ -1199,7 +1235,11 @@ export function PrintLayoutDialog({
       } else {
         setAtlasScaleNotice(null);
       }
-      return cap;
+      const b = map.getBounds();
+      return {
+        cap,
+        viewBounds: [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()],
+      };
     },
     [
       mapControllerRef,
@@ -1220,8 +1260,9 @@ export function PrintLayoutDialog({
       setAtlasBusy(true);
       setError(null);
       try {
-        const cap = await captureAtlasPage(page);
+        const { cap, viewBounds } = await captureAtlasPage(page);
         setCaptured(cap);
+        setAtlasViewBounds({ index, bounds: viewBounds });
         setAtlasIndex(index);
       } catch {
         setError(t("printLayout.errors.captureFailed"));
@@ -1594,15 +1635,17 @@ export function PrintLayoutDialog({
         onProgress: (current: number, totalPages: number) =>
           setAtlasProgress({ current, total: totalPages }),
         optionsForPage: async (i: number): Promise<LayoutOptions> => {
-          const cap = await captureAtlasPage(pages[i]);
+          const { cap, viewBounds } = await captureAtlasPage(pages[i]);
           // Mirror progress into the dialog preview as pages are produced.
           setCaptured(cap);
+          setAtlasViewBounds({ index: i, bounds: viewBounds });
           setAtlasIndex(i);
           const ctx = ctxFor(i);
           return {
             ...options,
-            // Each page's table/chart re-filters to that page's own extent.
-            ...buildDataBlocksFor(pages[i]),
+            // Each page's table/chart re-filters to the extent the page's
+            // capture actually shows (not just the nominal feature bounds).
+            ...buildDataBlocksFor(pages[i], viewBounds),
             title: substituteAtlasTokens(options.title, ctx),
             subtitle: substituteAtlasTokens(options.subtitle, ctx),
             footerText: substituteAtlasTokens(options.footerText, ctx),

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -109,6 +109,7 @@ import {
   stripAtlasTokens,
   substituteAtlasTokens,
   type AtlasBounds,
+  type AtlasFeatureInfo,
   type AtlasPage,
   type AtlasTokenContext,
 } from "../../lib/print-atlas";
@@ -963,6 +964,19 @@ export function PrintLayoutDialog({
     () => (chartLayer?.geojson ? layerRows(chartLayer.geojson) : []),
     [chartLayer],
   );
+  // Per-feature bounds for the page-extent filter, walked once per layer so
+  // stepping/exporting an N-page atlas does not redo the vertex walk N times
+  // (the same precompute pattern the atlas page builder uses).
+  const tableFeatureInfos = useMemo(
+    () =>
+      tableLayer?.geojson ? collectAtlasFeatures(tableLayer.geojson) : [],
+    [tableLayer],
+  );
+  const chartFeatureInfos = useMemo(
+    () =>
+      chartLayer?.geojson ? collectAtlasFeatures(chartLayer.geojson) : [],
+    [chartLayer],
+  );
   const chartCategoricalFields = useMemo(
     () => categoricalColumns(chartAllRows, chartFields),
     [chartAllRows, chartFields],
@@ -1020,16 +1034,12 @@ export function PrintLayoutDialog({
   // it only re-runs when the layer, filter toggle, or bounds change.
   const rowsForBlock = useCallback(
     (
-      layer: (typeof atlasLayers)[number] | null,
+      features: readonly AtlasFeatureInfo[],
       allRows: ChartRow[],
       filterOn: boolean,
       bounds: AtlasBounds | null,
-    ): ChartRow[] => {
-      if (!layer?.geojson) return [];
-      return filterOn && bounds
-        ? rowsWithinBounds(layer.geojson, bounds)
-        : allRows;
-    },
+    ): ChartRow[] =>
+      filterOn && bounds ? rowsWithinBounds(features, bounds) : allRows,
     [],
   );
 
@@ -1076,6 +1086,9 @@ export function PrintLayoutDialog({
             title: chartTitle.trim() || undefined,
             position: chartPosition,
             data,
+            // Translated "+N more" for bar categories past the top-N cap.
+            formatNote: (count) =>
+              t("printLayout.dataTable.moreRows", { count }),
           };
         }
       }
@@ -1115,7 +1128,7 @@ export function PrintLayoutDialog({
     () =>
       showDataTable
         ? rowsForBlock(
-            tableLayer,
+            tableFeatureInfos,
             tableAllRows,
             tableFilterToPage,
             displayFilterBounds,
@@ -1124,7 +1137,7 @@ export function PrintLayoutDialog({
     [
       showDataTable,
       rowsForBlock,
-      tableLayer,
+      tableFeatureInfos,
       tableAllRows,
       tableFilterToPage,
       displayFilterBounds,
@@ -1134,7 +1147,7 @@ export function PrintLayoutDialog({
     () =>
       showDataChart
         ? rowsForBlock(
-            chartLayer,
+            chartFeatureInfos,
             chartAllRows,
             chartFilterToPage,
             displayFilterBounds,
@@ -1143,7 +1156,7 @@ export function PrintLayoutDialog({
     [
       showDataChart,
       rowsForBlock,
-      chartLayer,
+      chartFeatureInfos,
       chartAllRows,
       chartFilterToPage,
       displayFilterBounds,
@@ -1687,13 +1700,13 @@ export function PrintLayoutDialog({
             // capture actually shows (not just the nominal feature bounds).
             ...buildBlocksFromRows(
               rowsForBlock(
-                tableLayer,
+                tableFeatureInfos,
                 tableAllRows,
                 tableFilterToPage,
                 viewBounds,
               ),
               rowsForBlock(
-                chartLayer,
+                chartFeatureInfos,
                 chartAllRows,
                 chartFilterToPage,
                 viewBounds,

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1050,6 +1050,7 @@ export function PrintLayoutDialog({
                     count: data.truncated,
                   })
                 : undefined,
+            truncated: data.truncated,
             position: tablePosition,
           };
         }

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1044,13 +1044,11 @@ export function PrintLayoutDialog({
             title: tableTitle.trim() || undefined,
             columns: data.columns,
             rows: data.rows,
-            note:
-              data.truncated > 0
-                ? t("printLayout.dataTable.moreRows", {
-                    count: data.truncated,
-                  })
-                : undefined,
             truncated: data.truncated,
+            // The final hidden-row count depends on how many rows fit the
+            // page, which only the renderer knows; hand it the translation.
+            formatNote: (count) =>
+              t("printLayout.dataTable.moreRows", { count }),
             position: tablePosition,
           };
         }

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1008,25 +1008,27 @@ export function PrintLayoutDialog({
       : tableFields.slice(0, DEFAULT_TABLE_COLUMNS);
   }, [tableColumns, tableFields]);
 
+  // Margin applied when fitting an atlas page's bounds, shared by the real
+  // fit in captureAtlasPage and the pre-capture approximation below so the
+  // two can never desync (fixed-scale mode fits tight and re-zooms after).
+  const atlasFitMarginPct =
+    atlasExtentMode === "margin" ? atlasMarginPct : 0;
+
   // The extent a data block's "only features on the page" filter tests
   // against, before the page's real capture is available: the atlas page's
   // fitted bounds, or the drawn print extent when that is what the capture
   // clips to. Plain viewport captures don't filter. Once a page has actually
   // been captured, the map's true visible bounds override this approximation
-  // (see buildDataBlocksFor's viewBounds) — the fit expands the box on one
-  // axis for the page aspect, and fixed-scale mode re-zooms after fitting.
+  // (the viewBounds handed to rowsForBlock/buildBlocksFromRows) — the fit
+  // expands the box on one axis for the page aspect, and fixed-scale mode
+  // re-zooms after fitting.
   const dataFilterBounds = useCallback(
     (page: AtlasPage | null): AtlasBounds | null => {
-      if (page) {
-        return expandBounds(
-          page.bounds,
-          atlasExtentMode === "margin" ? atlasMarginPct : 0,
-        );
-      }
+      if (page) return expandBounds(page.bounds, atlasFitMarginPct);
       if (captureMode === "extent" && extentBbox) return extentBbox;
       return null;
     },
-    [atlasExtentMode, atlasMarginPct, captureMode, extentBbox],
+    [atlasFitMarginPct, captureMode, extentBbox],
   );
 
   // One block's rows after the optional page-extent filter. This is the
@@ -1215,10 +1217,7 @@ export function PrintLayoutDialog({
     ): Promise<{ cap: CapturedMap; viewBounds: AtlasBounds }> => {
       const map = mapControllerRef.current?.getMap();
       if (!map) throw new Error("Map is not ready");
-      const [w, s, e, n] = expandBounds(
-        page.bounds,
-        atlasExtentMode === "margin" ? atlasMarginPct : 0,
-      );
+      const [w, s, e, n] = expandBounds(page.bounds, atlasFitMarginPct);
       map.fitBounds(
         [
           [w, s],
@@ -1297,7 +1296,7 @@ export function PrintLayoutDialog({
     [
       mapControllerRef,
       atlasExtentMode,
-      atlasMarginPct,
+      atlasFitMarginPct,
       atlasScale,
       atlasPageCount,
       waitForAtlasSettle,

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -72,6 +72,7 @@ import {
   categoricalColumns,
   numericColumns,
   type BarAggregation,
+  type ChartRow,
 } from "../../lib/attribute-charts";
 import {
   clearPrintExtent,
@@ -1014,26 +1015,36 @@ export function PrintLayoutDialog({
     [atlasExtentMode, atlasMarginPct, captureMode, extentBbox],
   );
 
-  // Resolve both data blocks for one atlas page (or the non-atlas layout when
-  // null). Used for the live preview/current page and again per page during
-  // an atlas export, so each page's table/chart reflects its own extent.
-  // `viewBounds` is the map's actual visible extent from that page's capture;
-  // when provided it replaces the nominal page-bounds approximation.
-  const buildDataBlocksFor = useCallback(
+  // One block's rows after the optional page-extent filter. This is the
+  // O(features) geometry walk, kept apart from the formatting step below so
+  // it only re-runs when the layer, filter toggle, or bounds change.
+  const rowsForBlock = useCallback(
     (
-      page: AtlasPage | null,
-      viewBounds?: AtlasBounds | null,
+      layer: (typeof atlasLayers)[number] | null,
+      allRows: ChartRow[],
+      filterOn: boolean,
+      bounds: AtlasBounds | null,
+    ): ChartRow[] => {
+      if (!layer?.geojson) return [];
+      return filterOn && bounds
+        ? rowsWithinBounds(layer.geojson, bounds)
+        : allRows;
+    },
+    [],
+  );
+
+  // Formatting-only step: turn already-filtered rows into the drawable specs.
+  // Cosmetic inputs (headings, positions, sort, chart type) only invalidate
+  // this cheap step, not the extent scans above (per-keystroke lag review).
+  const buildBlocksFromRows = useCallback(
+    (
+      tableRows: ChartRow[],
+      chartRows: ChartRow[],
     ): Pick<LayoutOptions, "dataTable" | "dataChart"> => {
       let dataTable: LayoutOptions["dataTable"] = null;
       let dataChart: LayoutOptions["dataChart"] = null;
-      const filterBounds = () =>
-        (page && viewBounds) || dataFilterBounds(page);
-      if (showDataTable && tableLayer?.geojson) {
-        const bounds = tableFilterToPage ? filterBounds() : null;
-        const rows = bounds
-          ? rowsWithinBounds(tableLayer.geojson, bounds)
-          : tableAllRows;
-        const data = buildTableBlock(rows, {
+      if (showDataTable) {
+        const data = buildTableBlock(tableRows, {
           columns: effectiveTableColumns,
           sortField: tableSortField || undefined,
           sortDescending: tableSortDesc,
@@ -1053,12 +1064,8 @@ export function PrintLayoutDialog({
           };
         }
       }
-      if (showDataChart && chartLayer?.geojson) {
-        const bounds = chartFilterToPage ? filterBounds() : null;
-        const rows = bounds
-          ? rowsWithinBounds(chartLayer.geojson, bounds)
-          : chartAllRows;
-        const data = buildChartBlock(rows, {
+      if (showDataChart) {
+        const data = buildChartBlock(chartRows, {
           type: chartType,
           categoryField: effectiveCategoryField || undefined,
           aggregation: chartAggregation,
@@ -1076,10 +1083,6 @@ export function PrintLayoutDialog({
     },
     [
       showDataTable,
-      tableLayer,
-      tableAllRows,
-      tableFilterToPage,
-      dataFilterBounds,
       effectiveTableColumns,
       tableSortField,
       tableSortDesc,
@@ -1087,9 +1090,6 @@ export function PrintLayoutDialog({
       tableTitle,
       tablePosition,
       showDataChart,
-      chartLayer,
-      chartFilterToPage,
-      chartAllRows,
       chartType,
       effectiveCategoryField,
       chartAggregation,
@@ -1099,18 +1099,59 @@ export function PrintLayoutDialog({
       t,
     ],
   );
-  const displayDataBlocks = useMemo(
+
+  // Bounds the display path filters against: the current page's captured view
+  // bounds when they belong to it (while a newly selected page is still
+  // capturing, fall back to its nominal bounds until the auto-drive refresh
+  // lands), or the drawn print extent outside atlas mode.
+  const displayFilterBounds = useMemo<AtlasBounds | null>(() => {
+    const vb =
+      atlasViewBounds && atlasViewBounds.index === clampedAtlasIndex
+        ? atlasViewBounds.bounds
+        : null;
+    return (currentAtlasPage && vb) || dataFilterBounds(currentAtlasPage);
+  }, [atlasViewBounds, clampedAtlasIndex, currentAtlasPage, dataFilterBounds]);
+  const displayTableRows = useMemo(
     () =>
-      buildDataBlocksFor(
-        currentAtlasPage,
-        // The captured view bounds only apply to the page they were taken on;
-        // while a newly selected page is still capturing, fall back to its
-        // nominal bounds until the auto-drive refresh lands.
-        atlasViewBounds && atlasViewBounds.index === clampedAtlasIndex
-          ? atlasViewBounds.bounds
-          : null,
-      ),
-    [buildDataBlocksFor, currentAtlasPage, atlasViewBounds, clampedAtlasIndex],
+      showDataTable
+        ? rowsForBlock(
+            tableLayer,
+            tableAllRows,
+            tableFilterToPage,
+            displayFilterBounds,
+          )
+        : [],
+    [
+      showDataTable,
+      rowsForBlock,
+      tableLayer,
+      tableAllRows,
+      tableFilterToPage,
+      displayFilterBounds,
+    ],
+  );
+  const displayChartRows = useMemo(
+    () =>
+      showDataChart
+        ? rowsForBlock(
+            chartLayer,
+            chartAllRows,
+            chartFilterToPage,
+            displayFilterBounds,
+          )
+        : [],
+    [
+      showDataChart,
+      rowsForBlock,
+      chartLayer,
+      chartAllRows,
+      chartFilterToPage,
+      displayFilterBounds,
+    ],
+  );
+  const displayDataBlocks = useMemo(
+    () => buildBlocksFromRows(displayTableRows, displayChartRows),
+    [buildBlocksFromRows, displayTableRows, displayChartRows],
   );
 
   // Options with this page's atlas tokens resolved, fed to the preview, the
@@ -1644,7 +1685,20 @@ export function PrintLayoutDialog({
             ...options,
             // Each page's table/chart re-filters to the extent the page's
             // capture actually shows (not just the nominal feature bounds).
-            ...buildDataBlocksFor(pages[i], viewBounds),
+            ...buildBlocksFromRows(
+              rowsForBlock(
+                tableLayer,
+                tableAllRows,
+                tableFilterToPage,
+                viewBounds,
+              ),
+              rowsForBlock(
+                chartLayer,
+                chartAllRows,
+                chartFilterToPage,
+                viewBounds,
+              ),
+            ),
             title: substituteAtlasTokens(options.title, ctx),
             subtitle: substituteAtlasTokens(options.subtitle, ctx),
             footerText: substituteAtlasTokens(options.footerText, ctx),

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -51,12 +51,28 @@ import {
   drawLayout,
   PAPER_SIZES,
   resolvePageSize,
+  type BodyCorner,
   type CustomSize,
   type LayoutOptions,
   type Orientation,
   type PaperSizeId,
   type SizeUnit,
 } from "../../lib/print-layout";
+import {
+  buildChartBlock,
+  buildTableBlock,
+  DEFAULT_TABLE_COLUMNS,
+  DEFAULT_TABLE_ROWS,
+  layerRows,
+  MAX_TABLE_ROWS,
+  rowsWithinBounds,
+  type ChartBlockType,
+} from "../../lib/print-data-blocks";
+import {
+  categoricalColumns,
+  numericColumns,
+  type BarAggregation,
+} from "../../lib/attribute-charts";
 import {
   clearPrintExtent,
   drawPrintExtent,
@@ -91,6 +107,7 @@ import {
   parseAtlasFilter,
   stripAtlasTokens,
   substituteAtlasTokens,
+  type AtlasBounds,
   type AtlasPage,
   type AtlasTokenContext,
 } from "../../lib/print-atlas";
@@ -272,6 +289,29 @@ export function PrintLayoutDialog({
   const [colorbarPosition, setColorbarPosition] = useState<
     "top-left" | "top-right" | "bottom-left" | "bottom-right"
   >("top-right");
+  // Data blocks: attribute table + chart composed on the page (GH #1324).
+  const [showDataTable, setShowDataTable] = useState(false);
+  const [tableLayerId, setTableLayerId] = useState("");
+  const [tableTitle, setTableTitle] = useState("");
+  // Explicitly checked columns; empty = the layer's first few fields.
+  const [tableColumns, setTableColumns] = useState<string[]>([]);
+  const [tableSortField, setTableSortField] = useState("");
+  const [tableSortDesc, setTableSortDesc] = useState(false);
+  const [tableMaxRows, setTableMaxRows] = useState(DEFAULT_TABLE_ROWS);
+  const [tablePosition, setTablePosition] = useState<BodyCorner>("bottom-left");
+  const [tableFilterToPage, setTableFilterToPage] = useState(true);
+  const [showDataChart, setShowDataChart] = useState(false);
+  const [chartLayerId, setChartLayerId] = useState("");
+  const [chartTitle, setChartTitle] = useState("");
+  const [chartType, setChartType] = useState<ChartBlockType>("bar");
+  const [chartCategoryField, setChartCategoryField] = useState("");
+  const [chartAggregation, setChartAggregation] =
+    useState<BarAggregation>("count");
+  const [chartValueField, setChartValueField] = useState("");
+  // Top-right by default: the scale bar + north arrow duo occupies the
+  // bottom-right corner out of the box.
+  const [chartPosition, setChartPosition] = useState<BodyCorner>("top-right");
+  const [chartFilterToPage, setChartFilterToPage] = useState(true);
   // Cartographic title block ("stempel") fields (GH #522).
   const [showInfoBlock, setShowInfoBlock] = useState(false);
   const [author, setAuthor] = useState("");
@@ -885,24 +925,176 @@ export function PrintLayoutDialog({
         : null,
     [currentAtlasPage, clampedAtlasIndex, atlasPageCount],
   );
+  // ---- Data blocks: attribute table + chart on the page (GH #1324) ----
+  // Any layer with loaded features qualifies (the same eligibility as an atlas
+  // coverage layer: the extent filter needs per-feature geometry).
+  const tableLayer = useMemo(
+    () => atlasLayers.find((l) => l.id === tableLayerId) ?? null,
+    [atlasLayers, tableLayerId],
+  );
+  const chartLayer = useMemo(
+    () => atlasLayers.find((l) => l.id === chartLayerId) ?? null,
+    [atlasLayers, chartLayerId],
+  );
+  const tableFields = useMemo(
+    () =>
+      tableLayer?.geojson ? listAtlasFields(tableLayer.geojson.features) : [],
+    [tableLayer],
+  );
+  const chartFields = useMemo(
+    () =>
+      chartLayer?.geojson ? listAtlasFields(chartLayer.geojson.features) : [],
+    [chartLayer],
+  );
+  const chartAllRows = useMemo(
+    () => (chartLayer?.geojson ? layerRows(chartLayer.geojson) : []),
+    [chartLayer],
+  );
+  const chartCategoricalFields = useMemo(
+    () => categoricalColumns(chartAllRows, chartFields),
+    [chartAllRows, chartFields],
+  );
+  const chartNumericFields = useMemo(
+    () => numericColumns(chartAllRows, chartFields),
+    [chartAllRows, chartFields],
+  );
+  // Category options prefer detected low-cardinality fields but fall back to
+  // every field, so an unusual layer can still be charted.
+  const chartCategoryOptions =
+    chartCategoricalFields.length > 0 ? chartCategoricalFields : chartFields;
+  // Effective selections: the first suitable field stands in until the user
+  // picks one, so enabling a block gives instant feedback.
+  const effectiveCategoryField =
+    chartCategoryField && chartFields.includes(chartCategoryField)
+      ? chartCategoryField
+      : (chartCategoryOptions[0] ?? "");
+  const effectiveValueField =
+    chartValueField && chartNumericFields.includes(chartValueField)
+      ? chartValueField
+      : (chartNumericFields[0] ?? "");
+  const chartNeedsValueField =
+    chartType === "line" || chartAggregation !== "count";
+  const effectiveTableColumns = useMemo(() => {
+    const chosen = tableColumns.filter((c) => tableFields.includes(c));
+    return chosen.length > 0
+      ? chosen
+      : tableFields.slice(0, DEFAULT_TABLE_COLUMNS);
+  }, [tableColumns, tableFields]);
+
+  // The extent a data block's "only features on the page" filter tests
+  // against: the atlas page's fitted bounds, or the drawn print extent when
+  // that is what the capture clips to. Plain viewport captures don't filter.
+  const dataFilterBounds = useCallback(
+    (page: AtlasPage | null): AtlasBounds | null => {
+      if (page) {
+        return expandBounds(
+          page.bounds,
+          atlasExtentMode === "margin" ? atlasMarginPct : 0,
+        );
+      }
+      if (captureMode === "extent" && extentBbox) return extentBbox;
+      return null;
+    },
+    [atlasExtentMode, atlasMarginPct, captureMode, extentBbox],
+  );
+
+  // Resolve both data blocks for one atlas page (or the non-atlas layout when
+  // null). Used for the live preview/current page and again per page during
+  // an atlas export, so each page's table/chart reflects its own extent.
+  const buildDataBlocksFor = useCallback(
+    (page: AtlasPage | null): Pick<LayoutOptions, "dataTable" | "dataChart"> => {
+      let dataTable: LayoutOptions["dataTable"] = null;
+      let dataChart: LayoutOptions["dataChart"] = null;
+      if (showDataTable && tableLayer?.geojson) {
+        const bounds = tableFilterToPage ? dataFilterBounds(page) : null;
+        const rows = bounds
+          ? rowsWithinBounds(tableLayer.geojson, bounds)
+          : layerRows(tableLayer.geojson);
+        const data = buildTableBlock(rows, {
+          columns: effectiveTableColumns,
+          sortField: tableSortField || undefined,
+          sortDescending: tableSortDesc,
+          maxRows: tableMaxRows,
+        });
+        if (data) {
+          dataTable = {
+            title: tableTitle.trim() || undefined,
+            columns: data.columns,
+            rows: data.rows,
+            note:
+              data.truncated > 0
+                ? t("printLayout.dataTable.moreRows", {
+                    count: data.truncated,
+                  })
+                : undefined,
+            position: tablePosition,
+          };
+        }
+      }
+      if (showDataChart && chartLayer?.geojson) {
+        const bounds = chartFilterToPage ? dataFilterBounds(page) : null;
+        const rows = bounds
+          ? rowsWithinBounds(chartLayer.geojson, bounds)
+          : chartAllRows;
+        const data = buildChartBlock(rows, {
+          type: chartType,
+          categoryField: effectiveCategoryField || undefined,
+          aggregation: chartAggregation,
+          valueField: effectiveValueField || undefined,
+        });
+        if (data) {
+          dataChart = {
+            title: chartTitle.trim() || undefined,
+            position: chartPosition,
+            data,
+          };
+        }
+      }
+      return { dataTable, dataChart };
+    },
+    [
+      showDataTable,
+      tableLayer,
+      tableFilterToPage,
+      dataFilterBounds,
+      effectiveTableColumns,
+      tableSortField,
+      tableSortDesc,
+      tableMaxRows,
+      tableTitle,
+      tablePosition,
+      showDataChart,
+      chartLayer,
+      chartFilterToPage,
+      chartAllRows,
+      chartType,
+      effectiveCategoryField,
+      chartAggregation,
+      effectiveValueField,
+      chartTitle,
+      chartPosition,
+      t,
+    ],
+  );
+  const displayDataBlocks = useMemo(
+    () => buildDataBlocksFor(currentAtlasPage),
+    [buildDataBlocksFor, currentAtlasPage],
+  );
+
   // Options with this page's atlas tokens resolved, fed to the preview, the
   // clipboard copy, and the single-page exports; the inputs keep the raw
   // template so the tokens stay editable.
-  const displayOptions = useMemo<LayoutOptions>(
-    () =>
-      atlasTokenCtx
-        ? {
-            ...options,
-            title: substituteAtlasTokens(options.title, atlasTokenCtx),
-            subtitle: substituteAtlasTokens(options.subtitle, atlasTokenCtx),
-            footerText: substituteAtlasTokens(
-              options.footerText,
-              atlasTokenCtx,
-            ),
-          }
-        : options,
-    [options, atlasTokenCtx],
-  );
+  const displayOptions = useMemo<LayoutOptions>(() => {
+    const withBlocks = { ...options, ...displayDataBlocks };
+    return atlasTokenCtx
+      ? {
+          ...withBlocks,
+          title: substituteAtlasTokens(options.title, atlasTokenCtx),
+          subtitle: substituteAtlasTokens(options.subtitle, atlasTokenCtx),
+          footerText: substituteAtlasTokens(options.footerText, atlasTokenCtx),
+        }
+      : withBlocks;
+  }, [options, displayDataBlocks, atlasTokenCtx]);
 
   /** Resolve once the map goes idle after an atlas camera move, with a grace
    * timeout because browsers may throttle the occluded canvas behind the
@@ -1057,6 +1249,26 @@ export function PrintLayoutDialog({
       setAtlasIndex(0);
     }
   }, [atlasEnabled, atlasLayerId, atlasLayers]);
+
+  // Same defaulting for the data blocks' layers (GH #1324): fill in the first
+  // eligible layer when a block is enabled without one, or when its selected
+  // layer disappears; the field choices belong to the old layer, so drop them.
+  useEffect(() => {
+    if (!showDataTable || atlasLayers.length === 0) return;
+    if (!atlasLayers.some((l) => l.id === tableLayerId)) {
+      setTableLayerId(atlasLayers[0].id);
+      setTableColumns([]);
+      setTableSortField("");
+    }
+  }, [showDataTable, tableLayerId, atlasLayers]);
+  useEffect(() => {
+    if (!showDataChart || atlasLayers.length === 0) return;
+    if (!atlasLayers.some((l) => l.id === chartLayerId)) {
+      setChartLayerId(atlasLayers[0].id);
+      setChartCategoryField("");
+      setChartValueField("");
+    }
+  }, [showDataChart, chartLayerId, atlasLayers]);
 
   // Latest page index for the auto-drive effect below, so stepping (which
   // sets the index) does not itself re-trigger a capture.
@@ -1389,6 +1601,8 @@ export function PrintLayoutDialog({
           const ctx = ctxFor(i);
           return {
             ...options,
+            // Each page's table/chart re-filters to that page's own extent.
+            ...buildDataBlocksFor(pages[i]),
             title: substituteAtlasTokens(options.title, ctx),
             subtitle: substituteAtlasTokens(options.subtitle, ctx),
             footerText: substituteAtlasTokens(options.footerText, ctx),
@@ -2234,6 +2448,18 @@ export function PrintLayoutDialog({
                 checked={showCustomLegend}
                 onChange={setShowCustomLegend}
               />
+              <ToggleField
+                id="el-data-table"
+                label={t("printLayout.element.dataTable")}
+                checked={showDataTable}
+                onChange={setShowDataTable}
+              />
+              <ToggleField
+                id="el-data-chart"
+                label={t("printLayout.element.dataChart")}
+                checked={showDataChart}
+                onChange={setShowDataChart}
+              />
             </div>
 
             {showCustomLegend && (
@@ -2492,6 +2718,369 @@ export function PrintLayoutDialog({
                     onValueChange={(v: number[]) => setColorbarLength(v[0])}
                   />
                 </div>
+              </div>
+            )}
+
+            {/* Attribute-table block settings (GH #1324). */}
+            {showDataTable && (
+              <div className="space-y-3 rounded-md border p-3">
+                {atlasLayers.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {t("printLayout.atlas.noLayers")}
+                  </p>
+                ) : (
+                  <>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="dt-layer">
+                        {t("printLayout.dataBlocks.layer")}
+                      </Label>
+                      <Select
+                        id="dt-layer"
+                        value={tableLayerId}
+                        onChange={(e) => {
+                          setTableLayerId(e.target.value);
+                          // Column/sort choices belong to the previous layer.
+                          setTableColumns([]);
+                          setTableSortField("");
+                        }}
+                      >
+                        {atlasLayers.map((l) => (
+                          <option key={l.id} value={l.id}>
+                            {l.name}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="dt-title">
+                        {t("printLayout.dataBlocks.titleLabel")}
+                      </Label>
+                      <Input
+                        id="dt-title"
+                        value={tableTitle}
+                        placeholder={tableLayer?.name ?? ""}
+                        onChange={(e) => setTableTitle(e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label>{t("printLayout.dataTable.columns")}</Label>
+                      <div className="max-h-40 space-y-1 overflow-auto rounded-md border p-2">
+                        {tableFields.map((f) => (
+                          <label
+                            key={f}
+                            className="flex cursor-pointer items-center gap-2 text-sm"
+                          >
+                            <input
+                              type="checkbox"
+                              className="h-4 w-4 accent-primary"
+                              checked={effectiveTableColumns.includes(f)}
+                              onChange={(e) => {
+                                const next = new Set(effectiveTableColumns);
+                                if (e.target.checked) next.add(f);
+                                else next.delete(f);
+                                // Normalize to the layer's field order so the
+                                // printed column order is stable.
+                                setTableColumns(
+                                  tableFields.filter((c) => next.has(c)),
+                                );
+                              }}
+                            />
+                            {f}
+                          </label>
+                        ))}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        {t("printLayout.dataTable.columnsHint", {
+                          count: DEFAULT_TABLE_COLUMNS,
+                        })}
+                      </p>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dt-sort">
+                          {t("printLayout.atlas.sortField")}
+                        </Label>
+                        <Select
+                          id="dt-sort"
+                          value={tableSortField}
+                          onChange={(e) => setTableSortField(e.target.value)}
+                        >
+                          <option value="">
+                            {t("printLayout.atlas.sortNone")}
+                          </option>
+                          {tableFields.map((f) => (
+                            <option key={f} value={f}>
+                              {f}
+                            </option>
+                          ))}
+                        </Select>
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dt-sort-dir">
+                          {t("printLayout.atlas.sortOrder")}
+                        </Label>
+                        <Select
+                          id="dt-sort-dir"
+                          value={tableSortDesc ? "desc" : "asc"}
+                          disabled={!tableSortField}
+                          onChange={(e) =>
+                            setTableSortDesc(e.target.value === "desc")
+                          }
+                        >
+                          <option value="asc">
+                            {t("printLayout.atlas.sortAsc")}
+                          </option>
+                          <option value="desc">
+                            {t("printLayout.atlas.sortDesc")}
+                          </option>
+                        </Select>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dt-max-rows">
+                          {t("printLayout.dataTable.maxRows")}
+                        </Label>
+                        <Input
+                          id="dt-max-rows"
+                          type="number"
+                          min={1}
+                          max={MAX_TABLE_ROWS}
+                          value={tableMaxRows}
+                          onChange={(e) =>
+                            setTableMaxRows(
+                              Math.max(
+                                1,
+                                Math.min(
+                                  MAX_TABLE_ROWS,
+                                  Number(e.target.value) || 1,
+                                ),
+                              ),
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dt-position">
+                          {t("printLayout.dataBlocks.position")}
+                        </Label>
+                        <Select
+                          id="dt-position"
+                          value={tablePosition}
+                          onChange={(e) =>
+                            setTablePosition(e.target.value as BodyCorner)
+                          }
+                        >
+                          <option value="top-left">
+                            {t("printLayout.position.topLeft")}
+                          </option>
+                          <option value="top-right">
+                            {t("printLayout.position.topRight")}
+                          </option>
+                          <option value="bottom-left">
+                            {t("printLayout.position.bottomLeft")}
+                          </option>
+                          <option value="bottom-right">
+                            {t("printLayout.position.bottomRight")}
+                          </option>
+                        </Select>
+                      </div>
+                    </div>
+                    <ToggleField
+                      id="dt-filter-page"
+                      label={t("printLayout.dataBlocks.filterToPage")}
+                      checked={tableFilterToPage}
+                      onChange={setTableFilterToPage}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      {t("printLayout.dataBlocks.filterToPageHint")}
+                    </p>
+                    {!displayDataBlocks.dataTable && (
+                      <p className="text-xs text-muted-foreground">
+                        {t("printLayout.dataTable.noRows")}
+                      </p>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Chart block settings (GH #1324). */}
+            {showDataChart && (
+              <div className="space-y-3 rounded-md border p-3">
+                {atlasLayers.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {t("printLayout.atlas.noLayers")}
+                  </p>
+                ) : (
+                  <>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="dc-layer">
+                        {t("printLayout.dataBlocks.layer")}
+                      </Label>
+                      <Select
+                        id="dc-layer"
+                        value={chartLayerId}
+                        onChange={(e) => {
+                          setChartLayerId(e.target.value);
+                          // Field choices belong to the previous layer.
+                          setChartCategoryField("");
+                          setChartValueField("");
+                        }}
+                      >
+                        {atlasLayers.map((l) => (
+                          <option key={l.id} value={l.id}>
+                            {l.name}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dc-type">
+                          {t("printLayout.dataChart.type")}
+                        </Label>
+                        <Select
+                          id="dc-type"
+                          value={chartType}
+                          onChange={(e) =>
+                            setChartType(e.target.value as ChartBlockType)
+                          }
+                        >
+                          <option value="bar">
+                            {t("printLayout.dataChart.typeBar")}
+                          </option>
+                          <option value="pie">
+                            {t("printLayout.dataChart.typePie")}
+                          </option>
+                          <option value="line">
+                            {t("printLayout.dataChart.typeLine")}
+                          </option>
+                        </Select>
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dc-position">
+                          {t("printLayout.dataBlocks.position")}
+                        </Label>
+                        <Select
+                          id="dc-position"
+                          value={chartPosition}
+                          onChange={(e) =>
+                            setChartPosition(e.target.value as BodyCorner)
+                          }
+                        >
+                          <option value="top-left">
+                            {t("printLayout.position.topLeft")}
+                          </option>
+                          <option value="top-right">
+                            {t("printLayout.position.topRight")}
+                          </option>
+                          <option value="bottom-left">
+                            {t("printLayout.position.bottomLeft")}
+                          </option>
+                          <option value="bottom-right">
+                            {t("printLayout.position.bottomRight")}
+                          </option>
+                        </Select>
+                      </div>
+                    </div>
+                    {chartType !== "line" && (
+                      <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                          <Label htmlFor="dc-category">
+                            {t("printLayout.dataChart.categoryField")}
+                          </Label>
+                          <Select
+                            id="dc-category"
+                            value={effectiveCategoryField}
+                            onChange={(e) =>
+                              setChartCategoryField(e.target.value)
+                            }
+                          >
+                            {chartCategoryOptions.map((f) => (
+                              <option key={f} value={f}>
+                                {f}
+                              </option>
+                            ))}
+                          </Select>
+                        </div>
+                        <div className="space-y-1.5">
+                          <Label htmlFor="dc-aggregation">
+                            {t("printLayout.dataChart.aggregation")}
+                          </Label>
+                          <Select
+                            id="dc-aggregation"
+                            value={chartAggregation}
+                            onChange={(e) =>
+                              setChartAggregation(
+                                e.target.value as BarAggregation,
+                              )
+                            }
+                          >
+                            <option value="count">
+                              {t("printLayout.dataChart.aggCount")}
+                            </option>
+                            <option value="sum">
+                              {t("printLayout.dataChart.aggSum")}
+                            </option>
+                            <option value="mean">
+                              {t("printLayout.dataChart.aggMean")}
+                            </option>
+                          </Select>
+                        </div>
+                      </div>
+                    )}
+                    {chartNeedsValueField && (
+                      <div className="space-y-1.5">
+                        <Label htmlFor="dc-value">
+                          {t("printLayout.dataChart.valueField")}
+                        </Label>
+                        <Select
+                          id="dc-value"
+                          value={effectiveValueField}
+                          disabled={chartNumericFields.length === 0}
+                          onChange={(e) => setChartValueField(e.target.value)}
+                        >
+                          {chartNumericFields.map((f) => (
+                            <option key={f} value={f}>
+                              {f}
+                            </option>
+                          ))}
+                        </Select>
+                        {chartNumericFields.length === 0 && (
+                          <p className="text-xs text-destructive">
+                            {t("printLayout.dataChart.noNumericFields")}
+                          </p>
+                        )}
+                      </div>
+                    )}
+                    <div className="space-y-1.5">
+                      <Label htmlFor="dc-title">
+                        {t("printLayout.dataBlocks.titleLabel")}
+                      </Label>
+                      <Input
+                        id="dc-title"
+                        value={chartTitle}
+                        placeholder={chartLayer?.name ?? ""}
+                        onChange={(e) => setChartTitle(e.target.value)}
+                      />
+                    </div>
+                    <ToggleField
+                      id="dc-filter-page"
+                      label={t("printLayout.dataBlocks.filterToPage")}
+                      checked={chartFilterToPage}
+                      onChange={setChartFilterToPage}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      {t("printLayout.dataBlocks.filterToPageHint")}
+                    </p>
+                    {!displayDataBlocks.dataChart && (
+                      <p className="text-xs text-muted-foreground">
+                        {t("printLayout.dataChart.noData")}
+                      </p>
+                    )}
+                  </>
+                )}
               </div>
             )}
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1114,7 +1114,7 @@
     },
     "dataTable": {
       "columns": "Columns",
-      "columnsHint": "Leave all unchecked to show the layer's first {{count}} fields.",
+      "columnsHint": "The first {{count}} fields are selected by default. Check columns to customize.",
       "maxRows": "Max rows",
       "moreRows_one": "+{{count}} more",
       "moreRows_other": "+{{count}} more",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1101,7 +1101,38 @@
       "pageBorder": "Page border",
       "infoBlock": "Info block (title block)",
       "colorbar": "Colorbar",
-      "customLegend": "Custom legend"
+      "customLegend": "Custom legend",
+      "dataTable": "Attribute table",
+      "dataChart": "Chart"
+    },
+    "dataBlocks": {
+      "layer": "Layer",
+      "titleLabel": "Heading",
+      "position": "Position",
+      "filterToPage": "Only features in the page extent",
+      "filterToPageHint": "Applies to atlas pages and a drawn print extent; otherwise the whole layer is used."
+    },
+    "dataTable": {
+      "columns": "Columns",
+      "columnsHint": "Leave all unchecked to show the layer's first {{count}} fields.",
+      "maxRows": "Max rows",
+      "moreRows_one": "+{{count}} more",
+      "moreRows_other": "+{{count}} more",
+      "noRows": "No rows to show with the current settings."
+    },
+    "dataChart": {
+      "type": "Chart type",
+      "typeBar": "Bar",
+      "typePie": "Pie",
+      "typeLine": "Line",
+      "categoryField": "Category field",
+      "aggregation": "Aggregate",
+      "aggCount": "Count",
+      "aggSum": "Sum",
+      "aggMean": "Mean",
+      "valueField": "Value field",
+      "noNumericFields": "This layer has no numeric field to aggregate.",
+      "noData": "No chart data with the current settings."
     },
     "customLegend": {
       "title": "Legend title",

--- a/apps/geolibre-desktop/src/lib/print-data-blocks.ts
+++ b/apps/geolibre-desktop/src/lib/print-data-blocks.ts
@@ -15,7 +15,7 @@ import {
   type BarAggregation,
   type ChartRow,
 } from "./attribute-charts";
-import { geometryBounds, type AtlasBounds } from "./print-atlas";
+import { type AtlasBounds, type AtlasFeatureInfo } from "./print-atlas";
 import { paletteColor } from "../components/panels/charts/chart-colors";
 import type { DataChartData } from "./print-layout";
 
@@ -54,21 +54,21 @@ export function boundsIntersect(a: AtlasBounds, b: AtlasBounds): boolean {
 
 /**
  * The rows of the features whose geometry bounding box intersects `bounds` —
- * the per-page filter for atlas data blocks. A bbox test (not an exact
- * intersection) matches how atlas pages themselves are framed, and features
- * without a usable geometry are excluded (they are nowhere on the page).
+ * the per-page filter for atlas data blocks. Takes {@link AtlasFeatureInfo}s
+ * (from `collectAtlasFeatures`) rather than raw features so the per-vertex
+ * geometry walk runs once per layer, not once per atlas page; features
+ * without a usable geometry were already dropped there (they are nowhere on
+ * the page). A bbox test (not an exact intersection) matches how atlas pages
+ * themselves are framed.
  */
 export function rowsWithinBounds(
-  collection: Pick<FeatureCollection, "features">,
+  features: readonly AtlasFeatureInfo[],
   bounds: AtlasBounds,
 ): ChartRow[] {
   const rows: ChartRow[] = [];
-  for (const feature of collection.features) {
-    const b = geometryBounds(feature.geometry);
-    if (!b || !boundsIntersect(b, bounds)) continue;
-    rows.push({
-      properties: (feature.properties ?? {}) as Record<string, unknown>,
-    });
+  for (const info of features) {
+    if (!boundsIntersect(info.bounds, bounds)) continue;
+    rows.push({ properties: info.properties });
   }
   return rows;
 }
@@ -211,5 +211,6 @@ export function buildChartBlock(
     })),
     maxValue: bar.maxValue,
     minValue: bar.minValue,
+    truncated: bar.truncated,
   };
 }

--- a/apps/geolibre-desktop/src/lib/print-data-blocks.ts
+++ b/apps/geolibre-desktop/src/lib/print-data-blocks.ts
@@ -67,10 +67,15 @@ function cellText(value: unknown): string {
   return String(value);
 }
 
+/** Whether an attribute value counts as missing for sorting purposes. */
+function isMissing(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
 /** Numeric-aware attribute comparison; missing values sort last. */
 function compareCells(a: unknown, b: unknown): number {
-  const aMissing = a === null || a === undefined || a === "";
-  const bMissing = b === null || b === undefined || b === "";
+  const aMissing = isMissing(a);
+  const bMissing = isMissing(b);
   if (aMissing && bMissing) return 0;
   if (aMissing) return 1;
   if (bMissing) return -1;
@@ -114,22 +119,12 @@ export function buildTableBlock(
   if (sortField) {
     const sign = config.sortDescending ? -1 : 1;
     ordered = [...rows].sort((a, b) => {
-      const cmp = compareCells(
-        a.properties[sortField],
-        b.properties[sortField],
-      );
+      const av = a.properties[sortField];
+      const bv = b.properties[sortField];
+      const cmp = compareCells(av, bv);
       // Missing values stay last in both directions (same convention as the
-      // atlas page sort).
-      const aMissing =
-        a.properties[sortField] === null ||
-        a.properties[sortField] === undefined ||
-        a.properties[sortField] === "";
-      const bMissing =
-        b.properties[sortField] === null ||
-        b.properties[sortField] === undefined ||
-        b.properties[sortField] === "";
-      if (aMissing || bMissing) return cmp;
-      return cmp * sign;
+      // atlas page sort), so only present-vs-present flips with the sign.
+      return isMissing(av) || isMissing(bv) ? cmp : cmp * sign;
     });
   }
   const requested = Math.trunc(config.maxRows ?? DEFAULT_TABLE_ROWS);

--- a/apps/geolibre-desktop/src/lib/print-data-blocks.ts
+++ b/apps/geolibre-desktop/src/lib/print-data-blocks.ts
@@ -1,0 +1,208 @@
+/**
+ * Data-driven Print Layout blocks (GH #1324): pure builders that turn a vector
+ * layer's attribute rows into the drawable attribute-table and chart specs of
+ * {@link LayoutOptions}. Row aggregation reuses the attribute Charts panel's
+ * compute helpers, and the atlas page-extent filter reuses the atlas bounds
+ * walk, so the page shows exactly what those features hold. Framework-free and
+ * unit-testable; the canvas drawing lives in `print-layout.ts`.
+ */
+import type { FeatureCollection } from "geojson";
+import {
+  computeBar,
+  computeLine,
+  computePie,
+  toFiniteNumber,
+  type BarAggregation,
+  type ChartRow,
+} from "./attribute-charts";
+import { geometryBounds, type AtlasBounds } from "./print-atlas";
+import { paletteColor } from "../components/panels/charts/chart-colors";
+import type { DataChartData } from "./print-layout";
+
+/** Hard ceiling on table rows drawn on the page. */
+export const MAX_TABLE_ROWS = 50;
+/** Default table row limit offered by the dialog. */
+export const DEFAULT_TABLE_ROWS = 10;
+/** Columns shown when the user has not picked any explicitly. */
+export const DEFAULT_TABLE_COLUMNS = 4;
+
+/** Reduce a feature collection to the property-bag rows the builders consume. */
+export function layerRows(
+  collection: Pick<FeatureCollection, "features">,
+): ChartRow[] {
+  return collection.features.map((feature) => ({
+    properties: (feature.properties ?? {}) as Record<string, unknown>,
+  }));
+}
+
+/** Whether two `[west, south, east, north]` boxes overlap (touching counts). */
+export function boundsIntersect(a: AtlasBounds, b: AtlasBounds): boolean {
+  return a[0] <= b[2] && b[0] <= a[2] && a[1] <= b[3] && b[1] <= a[3];
+}
+
+/**
+ * The rows of the features whose geometry bounding box intersects `bounds` —
+ * the per-page filter for atlas data blocks. A bbox test (not an exact
+ * intersection) matches how atlas pages themselves are framed, and features
+ * without a usable geometry are excluded (they are nowhere on the page).
+ */
+export function rowsWithinBounds(
+  collection: Pick<FeatureCollection, "features">,
+  bounds: AtlasBounds,
+): ChartRow[] {
+  const rows: ChartRow[] = [];
+  for (const feature of collection.features) {
+    const b = geometryBounds(feature.geometry);
+    if (!b || !boundsIntersect(b, bounds)) continue;
+    rows.push({
+      properties: (feature.properties ?? {}) as Record<string, unknown>,
+    });
+  }
+  return rows;
+}
+
+/** Format one attribute value for a table cell (blank for null/undefined). */
+function cellText(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value);
+}
+
+/** Numeric-aware attribute comparison; missing values sort last. */
+function compareCells(a: unknown, b: unknown): number {
+  const aMissing = a === null || a === undefined || a === "";
+  const bMissing = b === null || b === undefined || b === "";
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+  const an = toFiniteNumber(a);
+  const bn = toFiniteNumber(b);
+  if (an !== null && bn !== null) return an === bn ? 0 : an < bn ? -1 : 1;
+  return String(a).localeCompare(String(b), undefined, { numeric: true });
+}
+
+export interface TableBlockConfig {
+  /** Columns to show, in order. */
+  columns: string[];
+  /** Attribute to order rows by; blank keeps the source row order. */
+  sortField?: string;
+  /** Reverse the sort (missing values always sort last). */
+  sortDescending?: boolean;
+  /** Row limit (clamped to 1..{@link MAX_TABLE_ROWS}). */
+  maxRows?: number;
+}
+
+export interface TableBlockData {
+  columns: string[];
+  /** Cell display strings, aligned with {@link columns}. */
+  rows: string[][];
+  /** Source rows beyond the limit (0 when everything fit). */
+  truncated: number;
+}
+
+/**
+ * Build the table block's display data: sort, cap to the row limit, and
+ * stringify cells. Returns null when there are no rows or no columns, so the
+ * dialog can skip the block entirely instead of drawing an empty panel.
+ */
+export function buildTableBlock(
+  rows: ChartRow[],
+  config: TableBlockConfig,
+): TableBlockData | null {
+  if (rows.length === 0 || config.columns.length === 0) return null;
+  let ordered = rows;
+  const { sortField } = config;
+  if (sortField) {
+    const sign = config.sortDescending ? -1 : 1;
+    ordered = [...rows].sort((a, b) => {
+      const cmp = compareCells(
+        a.properties[sortField],
+        b.properties[sortField],
+      );
+      // Missing values stay last in both directions (same convention as the
+      // atlas page sort).
+      const aMissing =
+        a.properties[sortField] === null ||
+        a.properties[sortField] === undefined ||
+        a.properties[sortField] === "";
+      const bMissing =
+        b.properties[sortField] === null ||
+        b.properties[sortField] === undefined ||
+        b.properties[sortField] === "";
+      if (aMissing || bMissing) return cmp;
+      return cmp * sign;
+    });
+  }
+  const requested = Math.trunc(config.maxRows ?? DEFAULT_TABLE_ROWS);
+  const limit = Number.isFinite(requested)
+    ? Math.max(1, Math.min(MAX_TABLE_ROWS, requested))
+    : DEFAULT_TABLE_ROWS;
+  const shown = ordered.slice(0, limit);
+  return {
+    columns: config.columns,
+    rows: shown.map((row) =>
+      config.columns.map((column) => cellText(row.properties[column])),
+    ),
+    truncated: Math.max(0, ordered.length - shown.length),
+  };
+}
+
+export type ChartBlockType = "bar" | "pie" | "line";
+
+export interface ChartBlockConfig {
+  type: ChartBlockType;
+  /** Grouping field (bar/pie). */
+  categoryField?: string;
+  /** How bar/pie values reduce their groups. */
+  aggregation?: BarAggregation;
+  /** Numeric field summed/averaged (bar/pie) or plotted (line). */
+  valueField?: string;
+}
+
+/**
+ * Build the chart block's drawable data from attribute rows, reusing the
+ * Charts panel's aggregation helpers (top-N capping and the "(other)" fold
+ * included) and its categorical palette. Returns null when the configuration
+ * is incomplete or no chartable data survives, so nothing is drawn.
+ */
+export function buildChartBlock(
+  rows: ChartRow[],
+  config: ChartBlockConfig,
+): DataChartData | null {
+  if (rows.length === 0) return null;
+  if (config.type === "line") {
+    if (!config.valueField) return null;
+    const line = computeLine(rows, config.valueField);
+    if (!line) return null;
+    return { kind: "line", ...line, color: paletteColor(0) };
+  }
+  if (!config.categoryField) return null;
+  const aggregation = config.aggregation ?? "count";
+  const valueField =
+    aggregation === "count" ? null : (config.valueField ?? null);
+  if (aggregation !== "count" && !valueField) return null;
+  if (config.type === "pie") {
+    const pie = computePie(rows, config.categoryField, aggregation, valueField);
+    if (!pie) return null;
+    return {
+      kind: "pie",
+      slices: pie.slices.map((slice, i) => ({
+        label: slice.label,
+        value: slice.value,
+        color: paletteColor(i),
+      })),
+      total: pie.total,
+    };
+  }
+  const bar = computeBar(rows, config.categoryField, aggregation, valueField);
+  if (!bar) return null;
+  return {
+    kind: "bar",
+    bars: bar.bars.map((datum, i) => ({
+      label: datum.label,
+      value: datum.value,
+      color: paletteColor(i),
+    })),
+    maxValue: bar.maxValue,
+    minValue: bar.minValue,
+  };
+}

--- a/apps/geolibre-desktop/src/lib/print-data-blocks.ts
+++ b/apps/geolibre-desktop/src/lib/print-data-blocks.ts
@@ -35,9 +35,21 @@ export function layerRows(
   }));
 }
 
-/** Whether two `[west, south, east, north]` boxes overlap (touching counts). */
+/**
+ * Whether two `[west, south, east, north]` boxes overlap (touching counts).
+ * The two boxes need not share a longitude convention: `geometryBounds`
+ * returns shifted boxes (east > 180) for antimeridian-crossing features, and
+ * `map.getBounds()` can return unwrapped longitudes near the dateline, so the
+ * test also tries `b` shifted by ±360° — the same ground box, one world copy
+ * over. (A box that is degenerate `west > east` without being unwrapped is
+ * not supported, matching the print-extent tool's documented limitation.)
+ */
 export function boundsIntersect(a: AtlasBounds, b: AtlasBounds): boolean {
-  return a[0] <= b[2] && b[0] <= a[2] && a[1] <= b[3] && b[1] <= a[3];
+  if (a[1] > b[3] || b[1] > a[3]) return false;
+  for (const offset of [0, -360, 360]) {
+    if (a[0] <= b[2] + offset && b[0] + offset <= a[2]) return true;
+  }
+  return false;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -166,6 +166,12 @@ export type DataChartData =
       maxValue: number;
       /** Smallest bar value; negative when sum/mean produce negatives. */
       minValue: number;
+      /**
+       * Categories dropped past the top-N cap, drawn as a "+N more" note so
+       * the chart is never silently incomplete (the pie folds its remainder
+       * into an "(other)" slice instead).
+       */
+      truncated?: number;
     }
   | {
       kind: "pie";
@@ -338,6 +344,11 @@ export interface LayoutOptions {
     title?: string;
     position: BodyCorner;
     data: DataChartData;
+    /**
+     * Translated formatter for the bar chart's "+N more" truncation note;
+     * falls back to English when omitted (like the table's formatter).
+     */
+    formatNote?: (count: number) => string;
   } | null;
   legend: LegendEntry[];
   /** Heading drawn above the legend entries. */
@@ -1698,6 +1709,13 @@ function drawDataChart(
   if (data.kind === "bar") {
     const labelCap = unit * 18;
     const barAreaW = unit * 20;
+    // Categories the top-N cap dropped are surfaced as a note row, so the
+    // chart is never silently incomplete.
+    const barNote =
+      (data.truncated ?? 0) > 0
+        ? (chart.formatNote?.(data.truncated ?? 0) ??
+          `+${data.truncated} more`)
+        : "";
     let labelW = 0;
     let valueW = 0;
     for (const bar of data.bars) {
@@ -1711,7 +1729,7 @@ function drawDataChart(
       );
     }
     contentW = labelW + gap + barAreaW + gap + valueW;
-    contentH = data.bars.length * rowH;
+    contentH = (data.bars.length + (barNote ? 1 : 0)) * rowH;
     drawContent = (cx0, cy0) => {
       // Scale across the full value range so negative sums/means keep a truthful
       // zero baseline (bars extend left of it).
@@ -1735,6 +1753,12 @@ function drawDataChart(
           cx0 + labelW + gap + barAreaW + gap,
           cy,
         );
+      }
+      if (barNote) {
+        cy += rowH;
+        ctx.fillStyle = MUTED;
+        ctx.textAlign = "left";
+        ctx.fillText(truncateToWidth(ctx, barNote, contentW), cx0, cy);
       }
     };
   } else if (data.kind === "pie") {

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -315,17 +315,18 @@ export interface LayoutOptions {
     /** Row cells as display strings, aligned with {@link columns}. */
     rows: string[][];
     /**
-     * Note drawn under the rows (e.g. "+12 more"), supplied translated by the
-     * dialog when the row limit truncated the source rows.
-     */
-    note?: string;
-    /**
-     * How many source rows the dialog's row limit already dropped. When the
-     * body height forces the renderer to hide further rows, they are added to
-     * this count in an English fallback note replacing {@link note} (the
-     * translated text cannot be recomputed here).
+     * How many source rows the dialog's row limit already dropped. Rows the
+     * renderer additionally hides to fit the body height are added to this
+     * count in a "+N more" note under the table.
      */
     truncated?: number;
+    /**
+     * Translated formatter for the note (e.g. `(n) => t("moreRows", {count:
+     * n})`). A function rather than preformatted text because the final count
+     * depends on the canvas geometry; falls back to English "+N more" when
+     * omitted, like the drawing code's other i18n fallbacks.
+     */
+    formatNote?: (count: number) => string;
     position: BodyCorner;
   } | null;
   /**
@@ -1543,22 +1544,21 @@ function drawDataTable(
 
   // Fit the rows to the body height remaining below/above the stack offset:
   // a 50-row table on a small page would otherwise clip its title or note
-  // away silently. Rows hidden here join the dialog's own truncation count in
-  // a fallback note (the dialog's translated note text cannot be recomputed).
-  const availH = bodyH - inset * 2 - stackOffset;
-  const chromeH = pad * 2 + titleBlockH + rowH; // padding + title + header row
-  const fitWithoutNote = Math.floor((availH - chromeH) / rowH);
+  // away silently. The note row is part of the same budget, so a table whose
+  // rows exactly fill the space still has room for a dialog-truncation note.
+  const budget = bodyH - inset * 2 - stackOffset - (pad * 2 + titleBlockH + rowH);
   let rows = table.rows;
-  let hiddenByHeight = 0;
-  if (rows.length > fitWithoutNote) {
-    const fitWithNote = Math.max(1, fitWithoutNote - 1);
-    rows = rows.slice(0, fitWithNote);
-    hiddenByHeight = table.rows.length - rows.length;
+  let hidden = table.truncated ?? 0;
+  if (rows.length * rowH + (hidden > 0 ? rowH : 0) > budget) {
+    // Reserve one row of the budget for the note the truncation produces.
+    const fitRows = Math.max(1, Math.floor((budget - rowH) / rowH));
+    if (fitRows < rows.length) {
+      hidden += rows.length - fitRows;
+      rows = rows.slice(0, fitRows);
+    }
   }
   const note =
-    hiddenByHeight > 0
-      ? `+${hiddenByHeight + (table.truncated ?? 0)} more`
-      : (table.note ?? "").trim();
+    hidden > 0 ? (table.formatNote?.(hidden) ?? `+${hidden} more`) : "";
   const hasNote = note.length > 0;
 
   ctx.save();

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -810,63 +810,101 @@ export function drawLayout(
     ctx.restore();
   }
 
-  // --- Colorbar (user-chosen corner inside the map) ---------------------
+  // --- Corner panels (colorbar, custom legend, table, chart) ------------
+  // Panels sharing a corner stack toward the body centre instead of drawing
+  // on top of each other (e.g. colorbar + chart, both defaulting top-right).
+  // The ledger tracks the vertical space already claimed per corner; the info
+  // block still owns the bottom-right, so panels aimed there relocate to the
+  // top-right first (the original colorbar rule, GH #522).
+  const cornerUsed: Record<BodyCorner, number> = {
+    "top-left": 0,
+    "top-right": 0,
+    "bottom-left": 0,
+    "bottom-right": 0,
+  };
+  const stackGap = unit * 1.2;
+  const resolveCorner = (position: BodyCorner): BodyCorner =>
+    hasInfoBlock && position === "bottom-right" ? "top-right" : position;
+  const drawCornerPanel = (
+    position: BodyCorner,
+    draw: (corner: BodyCorner, stackOffset: number) => number,
+  ) => {
+    const corner = resolveCorner(position);
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(bodyX, bodyY, bodyW, bodyH);
+    ctx.clip();
+    const height = draw(corner, cornerUsed[corner]);
+    ctx.restore();
+    cornerUsed[corner] += height + stackGap;
+  };
+
   if (opts.colorbar && opts.colorbar.colors.length >= 2) {
-    // The info block ("stempel") always occupies the bottom-right corner; move a
-    // bottom-right colorbar to the top-right so the two never overlap.
-    const colorbar =
-      hasInfoBlock && opts.colorbar.position === "bottom-right"
-        ? { ...opts.colorbar, position: "top-right" as const }
-        : opts.colorbar;
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(bodyX, bodyY, bodyW, bodyH);
-    ctx.clip();
-    drawColorbar(ctx, colorbar, bodyX, bodyY, bodyW, bodyH, unit);
-    ctx.restore();
+    const colorbar = opts.colorbar;
+    drawCornerPanel(colorbar.position, (corner, stackOffset) =>
+      drawColorbar(
+        ctx,
+        { ...colorbar, position: corner },
+        bodyX,
+        bodyY,
+        bodyW,
+        bodyH,
+        unit,
+        stackOffset,
+      ),
+    );
   }
 
-  // --- Custom legend (user-chosen corner inside the map) ----------------
   if (opts.customLegend && opts.customLegend.entries.length > 0) {
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(bodyX, bodyY, bodyW, bodyH);
-    ctx.clip();
-    drawCustomLegend(ctx, opts.customLegend, bodyX, bodyY, bodyW, bodyH, unit);
-    ctx.restore();
+    const customLegend = opts.customLegend;
+    drawCornerPanel(customLegend.position, (corner, stackOffset) =>
+      drawCustomLegend(
+        ctx,
+        { ...customLegend, position: corner },
+        bodyX,
+        bodyY,
+        bodyW,
+        bodyH,
+        unit,
+        stackOffset,
+      ),
+    );
   }
 
-  // --- Attribute table block (user-chosen corner inside the map) --------
   if (
     opts.dataTable &&
     opts.dataTable.columns.length > 0 &&
     opts.dataTable.rows.length > 0
   ) {
-    // The info block owns the bottom-right corner; relocate like the colorbar.
-    const table =
-      hasInfoBlock && opts.dataTable.position === "bottom-right"
-        ? { ...opts.dataTable, position: "top-right" as const }
-        : opts.dataTable;
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(bodyX, bodyY, bodyW, bodyH);
-    ctx.clip();
-    drawDataTable(ctx, table, bodyX, bodyY, bodyW, bodyH, unit);
-    ctx.restore();
+    const table = opts.dataTable;
+    drawCornerPanel(table.position, (corner, stackOffset) =>
+      drawDataTable(
+        ctx,
+        { ...table, position: corner },
+        bodyX,
+        bodyY,
+        bodyW,
+        bodyH,
+        unit,
+        stackOffset,
+      ),
+    );
   }
 
-  // --- Chart block (user-chosen corner inside the map) ------------------
   if (opts.dataChart) {
-    const chart =
-      hasInfoBlock && opts.dataChart.position === "bottom-right"
-        ? { ...opts.dataChart, position: "top-right" as const }
-        : opts.dataChart;
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(bodyX, bodyY, bodyW, bodyH);
-    ctx.clip();
-    drawDataChart(ctx, chart, bodyX, bodyY, bodyW, bodyH, unit);
-    ctx.restore();
+    const chart = opts.dataChart;
+    drawCornerPanel(chart.position, (corner, stackOffset) =>
+      drawDataChart(
+        ctx,
+        { ...chart, position: corner },
+        bodyX,
+        bodyY,
+        bodyW,
+        bodyH,
+        unit,
+        stackOffset,
+      ),
+    );
   }
 
   // --- Page border -------------------------------------------------------
@@ -1150,6 +1188,9 @@ type ColorbarSpec = NonNullable<LayoutOptions["colorbar"]>;
  * panel anchored at one of the four body corners. Rendered with the canvas at
  * full output resolution, so it stays crisp in the export (unlike a rasterized
  * on-map control).
+ *
+ * @returns The drawn panel's height, so a later panel sharing the corner can
+ *   stack below/above it instead of overlapping.
  */
 function drawColorbar(
   ctx: CanvasRenderingContext2D,
@@ -1159,7 +1200,8 @@ function drawColorbar(
   bodyW: number,
   bodyH: number,
   unit: number,
-): void {
+  stackOffset = 0,
+): number {
   const vertical = cb.orientation === "vertical";
   const pad = unit * 1.4;
   const barThick = unit * 2.2;
@@ -1217,12 +1259,17 @@ function drawColorbar(
     panelH = pad * 2 + titleStrip + barThick + tickLen + tickGap + labelSize;
   }
 
-  const px = cb.position.endsWith("left")
-    ? bodyX + inset
-    : bodyX + bodyW - inset - panelW;
-  const py = cb.position.startsWith("top")
-    ? bodyY + inset
-    : bodyY + bodyH - inset - panelH;
+  const { x: px, y: py } = panelOrigin(
+    cb.position,
+    bodyX,
+    bodyY,
+    bodyW,
+    bodyH,
+    inset,
+    panelW,
+    panelH,
+    stackOffset,
+  );
 
   ctx.fillStyle = "rgba(255,255,255,0.85)";
   ctx.strokeStyle = BORDER;
@@ -1311,6 +1358,7 @@ function drawColorbar(
     }
   }
   ctx.restore();
+  return panelH;
 }
 
 type CustomLegendSpec = NonNullable<LayoutOptions["customLegend"]>;
@@ -1319,6 +1367,8 @@ type CustomLegendSpec = NonNullable<LayoutOptions["customLegend"]>;
  * Draw a user-defined legend (title + colour/label rows) as a bordered panel
  * anchored at one of the four body corners. Crisp at export resolution, the
  * native equivalent of a Controls -> Legend control.
+ *
+ * @returns The drawn panel's height, for corner stacking.
  */
 function drawCustomLegend(
   ctx: CanvasRenderingContext2D,
@@ -1328,7 +1378,8 @@ function drawCustomLegend(
   bodyW: number,
   bodyH: number,
   unit: number,
-): void {
+  stackOffset = 0,
+): number {
   const pad = unit * 1.4;
   const rowH = unit * 2.6;
   const swatch = unit * 2;
@@ -1351,12 +1402,17 @@ function drawCustomLegend(
   const titleBlock = hasTitle ? titleSize + unit : 0;
   const boxW = pad * 2 + maxText;
   const boxH = pad * 2 + titleBlock + cl.entries.length * rowH;
-  const x = cl.position.endsWith("left")
-    ? bodyX + inset
-    : bodyX + bodyW - inset - boxW;
-  const y = cl.position.startsWith("top")
-    ? bodyY + inset
-    : bodyY + bodyH - inset - boxH;
+  const { x, y } = panelOrigin(
+    cl.position,
+    bodyX,
+    bodyY,
+    bodyW,
+    bodyH,
+    inset,
+    boxW,
+    boxH,
+    stackOffset,
+  );
 
   ctx.fillStyle = "rgba(255,255,255,0.85)";
   ctx.strokeStyle = BORDER;
@@ -1387,9 +1443,15 @@ function drawCustomLegend(
     ctx.fillText(e.label, x + pad + swatch + gap, cy, boxW - pad * 2 - swatch - gap);
   }
   ctx.restore();
+  return boxH;
 }
 
-/** Top-left origin of a panel of `boxW`×`boxH` anchored at a body corner. */
+/**
+ * Top-left origin of a panel of `boxW`×`boxH` anchored at a body corner.
+ * `stackOffset` shifts the panel toward the body centre (down from a top
+ * corner, up from a bottom one) past panels already drawn in that corner, so
+ * two panels sharing a corner stack instead of overlapping.
+ */
 function panelOrigin(
   position: BodyCorner,
   bodyX: number,
@@ -1399,10 +1461,13 @@ function panelOrigin(
   inset: number,
   boxW: number,
   boxH: number,
+  stackOffset = 0,
 ): { x: number; y: number } {
   return {
     x: position.endsWith("left") ? bodyX + inset : bodyX + bodyW - inset - boxW,
-    y: position.startsWith("top") ? bodyY + inset : bodyY + bodyH - inset - boxH,
+    y: position.startsWith("top")
+      ? bodyY + inset + stackOffset
+      : bodyY + bodyH - inset - boxH - stackOffset,
   };
 }
 
@@ -1435,6 +1500,8 @@ type DataTableSpec = NonNullable<LayoutOptions["dataTable"]>;
  * row per feature, and an optional "+N more" note. Column widths come from the
  * widest cell, capped per column and scaled down together when the full table
  * would overrun the body width. GH #1324.
+ *
+ * @returns The drawn panel's height, for corner stacking.
  */
 function drawDataTable(
   ctx: CanvasRenderingContext2D,
@@ -1444,7 +1511,8 @@ function drawDataTable(
   bodyW: number,
   bodyH: number,
   unit: number,
-): void {
+  stackOffset = 0,
+): number {
   const pad = unit * 1.4;
   const rowH = unit * 2.4;
   const labelSize = unit * 1.7;
@@ -1498,6 +1566,7 @@ function drawDataTable(
     inset,
     boxW,
     boxH,
+    stackOffset,
   );
 
   ctx.fillStyle = "rgba(255,255,255,0.85)";
@@ -1551,6 +1620,7 @@ function drawDataTable(
     ctx.fillText(truncateToWidth(ctx, note, boxW - pad * 2), x + pad, cy);
   }
   ctx.restore();
+  return boxH;
 }
 
 type DataChartSpec = NonNullable<LayoutOptions["dataChart"]>;
@@ -1560,6 +1630,8 @@ type DataChartSpec = NonNullable<LayoutOptions["dataChart"]>;
  * corners. Bars render horizontally (label, bar, value per row — long category
  * names stay readable), the pie renders as a disc with a swatch legend, and the
  * line renders as a framed sparkline with min/max labels. GH #1324.
+ *
+ * @returns The drawn panel's height, for corner stacking.
  */
 function drawDataChart(
   ctx: CanvasRenderingContext2D,
@@ -1569,7 +1641,8 @@ function drawDataChart(
   bodyW: number,
   bodyH: number,
   unit: number,
-): void {
+  stackOffset = 0,
+): number {
   const pad = unit * 1.4;
   const rowH = unit * 2.4;
   const labelSize = unit * 1.7;
@@ -1764,6 +1837,7 @@ function drawDataChart(
     inset,
     boxW,
     boxH,
+    stackOffset,
   );
 
   ctx.fillStyle = "rgba(255,255,255,0.85)";
@@ -1789,6 +1863,7 @@ function drawDataChart(
   ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
   drawContent(x + pad, topY);
   ctx.restore();
+  return boxH;
 }
 
 /** Draw a legend box anchored at its top-left corner. */

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -146,6 +146,44 @@ export interface LegendEntry {
   swatches: LegendSwatch[];
 }
 
+/** Corner of the map body a composed panel is anchored to. */
+export type BodyCorner =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+/**
+ * Resolved, drawable data for the chart block (GH #1324). Like the colorbar's
+ * `colors`, everything here is already computed by the dialog (aggregation,
+ * top-N capping, colors) so this drawing code stays data-only.
+ */
+export type DataChartData =
+  | {
+      kind: "bar";
+      bars: { label: string; value: number; color: string }[];
+      /** Largest bar value (>= 0), for scaling. */
+      maxValue: number;
+      /** Smallest bar value; negative when sum/mean produce negatives. */
+      minValue: number;
+    }
+  | {
+      kind: "pie";
+      slices: { label: string; value: number; color: string }[];
+      /** Sum of every slice value (> 0). */
+      total: number;
+    }
+  | {
+      kind: "line";
+      /** Finite values plotted against original row order (gaps skipped). */
+      points: { index: number; value: number }[];
+      min: number;
+      max: number;
+      /** Total row count, so x spans the full feature order. */
+      length: number;
+      color: string;
+    };
+
 export interface LayoutOptions {
   title: string;
   subtitle: string;
@@ -262,6 +300,36 @@ export interface LayoutOptions {
     title?: string;
     entries: { label: string; color: string }[];
     position: "top-left" | "top-right" | "bottom-left" | "bottom-right";
+  } | null;
+  /**
+   * An attribute-table block composed in the Print Layout (GH #1324): rows of a
+   * vector layer's attributes drawn as a bordered panel at the chosen corner.
+   * Cell text is already resolved to display strings (and, for an atlas page,
+   * already filtered to the page extent) by the dialog, so this drawing code
+   * stays data-only.
+   */
+  dataTable?: {
+    title?: string;
+    /** Column headers, in display order. */
+    columns: string[];
+    /** Row cells as display strings, aligned with {@link columns}. */
+    rows: string[][];
+    /**
+     * Note drawn under the rows (e.g. "+12 more"), supplied translated by the
+     * dialog when the row limit truncated the source rows.
+     */
+    note?: string;
+    position: BodyCorner;
+  } | null;
+  /**
+   * A chart block composed in the Print Layout (GH #1324): a bar, pie, or line
+   * chart of a vector layer's attributes, drawn crisply at export resolution
+   * at the chosen corner.
+   */
+  dataChart?: {
+    title?: string;
+    position: BodyCorner;
+    data: DataChartData;
   } | null;
   legend: LegendEntry[];
   /** Heading drawn above the legend entries. */
@@ -765,6 +833,39 @@ export function drawLayout(
     ctx.rect(bodyX, bodyY, bodyW, bodyH);
     ctx.clip();
     drawCustomLegend(ctx, opts.customLegend, bodyX, bodyY, bodyW, bodyH, unit);
+    ctx.restore();
+  }
+
+  // --- Attribute table block (user-chosen corner inside the map) --------
+  if (
+    opts.dataTable &&
+    opts.dataTable.columns.length > 0 &&
+    opts.dataTable.rows.length > 0
+  ) {
+    // The info block owns the bottom-right corner; relocate like the colorbar.
+    const table =
+      hasInfoBlock && opts.dataTable.position === "bottom-right"
+        ? { ...opts.dataTable, position: "top-right" as const }
+        : opts.dataTable;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(bodyX, bodyY, bodyW, bodyH);
+    ctx.clip();
+    drawDataTable(ctx, table, bodyX, bodyY, bodyW, bodyH, unit);
+    ctx.restore();
+  }
+
+  // --- Chart block (user-chosen corner inside the map) ------------------
+  if (opts.dataChart) {
+    const chart =
+      hasInfoBlock && opts.dataChart.position === "bottom-right"
+        ? { ...opts.dataChart, position: "top-right" as const }
+        : opts.dataChart;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(bodyX, bodyY, bodyW, bodyH);
+    ctx.clip();
+    drawDataChart(ctx, chart, bodyX, bodyY, bodyW, bodyH, unit);
     ctx.restore();
   }
 
@@ -1285,6 +1386,408 @@ function drawCustomLegend(
     ctx.fillStyle = INK;
     ctx.fillText(e.label, x + pad + swatch + gap, cy, boxW - pad * 2 - swatch - gap);
   }
+  ctx.restore();
+}
+
+/** Top-left origin of a panel of `boxW`×`boxH` anchored at a body corner. */
+function panelOrigin(
+  position: BodyCorner,
+  bodyX: number,
+  bodyY: number,
+  bodyW: number,
+  bodyH: number,
+  inset: number,
+  boxW: number,
+  boxH: number,
+): { x: number; y: number } {
+  return {
+    x: position.endsWith("left") ? bodyX + inset : bodyX + bodyW - inset - boxW,
+    y: position.startsWith("top") ? bodyY + inset : bodyY + bodyH - inset - boxH,
+  };
+}
+
+/**
+ * Truncate text to fit `maxWidth` with a trailing ellipsis, using the context's
+ * current font. Returns the text unchanged when it already fits.
+ */
+function truncateToWidth(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  let lo = 0;
+  let hi = text.length;
+  // Largest prefix whose "prefix…" still fits (binary search on length).
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (ctx.measureText(`${text.slice(0, mid)}…`).width <= maxWidth) lo = mid;
+    else hi = mid - 1;
+  }
+  return `${text.slice(0, lo)}…`;
+}
+
+type DataTableSpec = NonNullable<LayoutOptions["dataTable"]>;
+
+/**
+ * Draw the attribute-table block as a bordered panel anchored at one of the
+ * four body corners: an optional title, a bold header row over a hairline, one
+ * row per feature, and an optional "+N more" note. Column widths come from the
+ * widest cell, capped per column and scaled down together when the full table
+ * would overrun the body width. GH #1324.
+ */
+function drawDataTable(
+  ctx: CanvasRenderingContext2D,
+  table: DataTableSpec,
+  bodyX: number,
+  bodyY: number,
+  bodyW: number,
+  bodyH: number,
+  unit: number,
+): void {
+  const pad = unit * 1.4;
+  const rowH = unit * 2.4;
+  const labelSize = unit * 1.7;
+  const titleSize = unit * 2;
+  const colGap = unit * 1.6;
+  const maxColW = unit * 26;
+  const inset = unit * 2; // matches the info block/legend corner inset
+  const title = (table.title ?? "").trim();
+  const hasTitle = title.length > 0;
+  const note = (table.note ?? "").trim();
+  const hasNote = note.length > 0;
+
+  ctx.save();
+  // Measure each column: the widest of its header (bold) and cells (regular),
+  // capped so one long text field cannot swallow the page.
+  const colW = table.columns.map((header, i) => {
+    ctx.font = `600 ${labelSize}px system-ui, sans-serif`;
+    let w = ctx.measureText(header).width;
+    ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+    for (const row of table.rows) {
+      w = Math.max(w, ctx.measureText(row[i] ?? "").width);
+    }
+    return Math.min(w, maxColW);
+  });
+  let contentW =
+    colW.reduce((sum, w) => sum + w, 0) + colGap * (table.columns.length - 1);
+  // Shrink every column proportionally if the table would overrun the body;
+  // cell text is ellipsis-truncated to its final column width below.
+  const availW = bodyW - inset * 2 - pad * 2;
+  if (contentW > availW && contentW > 0) {
+    const scale = availW / contentW;
+    for (let i = 0; i < colW.length; i++) colW[i] *= scale;
+    contentW = availW;
+  }
+  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+  const titleW = hasTitle ? ctx.measureText(title).width : 0;
+
+  const titleBlock = hasTitle ? titleSize + unit : 0;
+  const boxW = pad * 2 + Math.max(contentW, Math.min(titleW, availW));
+  const boxH =
+    pad * 2 +
+    titleBlock +
+    (1 + table.rows.length) * rowH +
+    (hasNote ? rowH : 0);
+  const { x, y } = panelOrigin(
+    table.position,
+    bodyX,
+    bodyY,
+    bodyW,
+    bodyH,
+    inset,
+    boxW,
+    boxH,
+  );
+
+  ctx.fillStyle = "rgba(255,255,255,0.85)";
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = Math.max(1, unit * 0.15);
+  roundRect(ctx, x, y, boxW, boxH, unit);
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
+  let cy = y + pad;
+  if (hasTitle) {
+    cy += titleSize;
+    ctx.fillStyle = INK;
+    ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+    ctx.fillText(truncateToWidth(ctx, title, boxW - pad * 2), x + pad, cy);
+    cy += unit;
+  }
+
+  // Header row, with a hairline separating it from the data rows.
+  cy += rowH;
+  ctx.fillStyle = INK;
+  ctx.font = `600 ${labelSize}px system-ui, sans-serif`;
+  let cx = x + pad;
+  table.columns.forEach((header, i) => {
+    ctx.fillText(truncateToWidth(ctx, header, colW[i]), cx, cy);
+    cx += colW[i] + colGap;
+  });
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = Math.max(1, unit * 0.12);
+  ctx.beginPath();
+  ctx.moveTo(x + pad, cy + unit * 0.7);
+  ctx.lineTo(x + boxW - pad, cy + unit * 0.7);
+  ctx.stroke();
+
+  ctx.fillStyle = INK;
+  ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+  for (const row of table.rows) {
+    cy += rowH;
+    cx = x + pad;
+    table.columns.forEach((_, i) => {
+      ctx.fillText(truncateToWidth(ctx, row[i] ?? "", colW[i]), cx, cy);
+      cx += colW[i] + colGap;
+    });
+  }
+
+  if (hasNote) {
+    cy += rowH;
+    ctx.fillStyle = MUTED;
+    ctx.fillText(truncateToWidth(ctx, note, boxW - pad * 2), x + pad, cy);
+  }
+  ctx.restore();
+}
+
+type DataChartSpec = NonNullable<LayoutOptions["dataChart"]>;
+
+/**
+ * Draw the chart block as a bordered panel anchored at one of the four body
+ * corners. Bars render horizontally (label, bar, value per row — long category
+ * names stay readable), the pie renders as a disc with a swatch legend, and the
+ * line renders as a framed sparkline with min/max labels. GH #1324.
+ */
+function drawDataChart(
+  ctx: CanvasRenderingContext2D,
+  chart: DataChartSpec,
+  bodyX: number,
+  bodyY: number,
+  bodyW: number,
+  bodyH: number,
+  unit: number,
+): void {
+  const pad = unit * 1.4;
+  const rowH = unit * 2.4;
+  const labelSize = unit * 1.7;
+  const titleSize = unit * 2;
+  const gap = unit;
+  const inset = unit * 2; // matches the info block/legend corner inset
+  const title = (chart.title ?? "").trim();
+  const hasTitle = title.length > 0;
+  const titleBlock = hasTitle ? titleSize + unit : 0;
+  const data = chart.data;
+
+  ctx.save();
+  ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+
+  // Content size + a deferred content draw at (cx0, cy0), so panel sizing and
+  // anchoring are computed once for all three chart kinds.
+  let contentW = 0;
+  let contentH = 0;
+  let drawContent: (cx0: number, cy0: number) => void = () => {};
+
+  if (data.kind === "bar") {
+    const labelCap = unit * 18;
+    const barAreaW = unit * 20;
+    let labelW = 0;
+    let valueW = 0;
+    for (const bar of data.bars) {
+      labelW = Math.max(
+        labelW,
+        Math.min(ctx.measureText(bar.label).width, labelCap),
+      );
+      valueW = Math.max(
+        valueW,
+        ctx.measureText(formatColorbarTick(bar.value)).width,
+      );
+    }
+    contentW = labelW + gap + barAreaW + gap + valueW;
+    contentH = data.bars.length * rowH;
+    drawContent = (cx0, cy0) => {
+      // Scale across the full value range so negative sums/means keep a truthful
+      // zero baseline (bars extend left of it).
+      const lo = Math.min(0, data.minValue);
+      const hi = Math.max(0, data.maxValue);
+      const span = hi - lo || 1;
+      const zeroX = cx0 + labelW + gap + ((0 - lo) / span) * barAreaW;
+      let cy = cy0;
+      for (const bar of data.bars) {
+        cy += rowH;
+        ctx.fillStyle = INK;
+        ctx.textAlign = "left";
+        ctx.fillText(truncateToWidth(ctx, bar.label, labelCap), cx0, cy);
+        const barW = (Math.abs(bar.value) / span) * barAreaW;
+        const barX = bar.value < 0 ? zeroX - barW : zeroX;
+        ctx.fillStyle = bar.color;
+        ctx.fillRect(barX, cy - labelSize * 0.85, barW, labelSize);
+        ctx.fillStyle = INK;
+        ctx.fillText(
+          formatColorbarTick(bar.value),
+          cx0 + labelW + gap + barAreaW + gap,
+          cy,
+        );
+      }
+    };
+  } else if (data.kind === "pie") {
+    const diameter = unit * 14;
+    const swatch = unit * 2;
+    let legendW = 0;
+    for (const slice of data.slices) {
+      const pct = Math.round((slice.value / data.total) * 100);
+      legendW = Math.max(
+        legendW,
+        swatch +
+          gap +
+          Math.min(
+            ctx.measureText(`${slice.label} (${pct}%)`).width,
+            unit * 22,
+          ),
+      );
+    }
+    contentW = diameter + gap * 2 + legendW;
+    contentH = Math.max(diameter, data.slices.length * rowH);
+    drawContent = (cx0, cy0) => {
+      const cx = cx0 + diameter / 2;
+      const cyMid = cy0 + contentH / 2;
+      const r = diameter / 2;
+      let angle = -Math.PI / 2;
+      for (const slice of data.slices) {
+        const sweep = (slice.value / data.total) * Math.PI * 2;
+        ctx.fillStyle = slice.color;
+        ctx.beginPath();
+        ctx.moveTo(cx, cyMid);
+        ctx.arc(cx, cyMid, r, angle, angle + sweep);
+        ctx.closePath();
+        ctx.fill();
+        angle += sweep;
+      }
+      ctx.strokeStyle = BORDER;
+      ctx.lineWidth = Math.max(1, unit * 0.12);
+      ctx.beginPath();
+      ctx.arc(cx, cyMid, r, 0, Math.PI * 2);
+      ctx.stroke();
+      // Swatch legend, vertically centred beside the disc.
+      let cy = cy0 + (contentH - data.slices.length * rowH) / 2;
+      ctx.textAlign = "left";
+      for (const slice of data.slices) {
+        cy += rowH;
+        ctx.fillStyle = slice.color;
+        ctx.fillRect(
+          cx0 + diameter + gap * 2,
+          cy - swatch * 0.85,
+          swatch,
+          swatch,
+        );
+        ctx.strokeStyle = BORDER;
+        ctx.strokeRect(
+          cx0 + diameter + gap * 2,
+          cy - swatch * 0.85,
+          swatch,
+          swatch,
+        );
+        const pct = Math.round((slice.value / data.total) * 100);
+        ctx.fillStyle = INK;
+        ctx.fillText(
+          truncateToWidth(ctx, `${slice.label} (${pct}%)`, unit * 22),
+          cx0 + diameter + gap * 2 + swatch + gap,
+          cy,
+        );
+      }
+    };
+  } else {
+    const plotW = unit * 24;
+    const plotH = unit * 12;
+    const maxLabel = formatColorbarTick(data.max);
+    const minLabel = formatColorbarTick(data.min);
+    const axisW = Math.max(
+      ctx.measureText(maxLabel).width,
+      ctx.measureText(minLabel).width,
+    );
+    contentW = axisW + gap + plotW;
+    contentH = plotH;
+    drawContent = (cx0, cy0) => {
+      const plotX = cx0 + axisW + gap;
+      ctx.strokeStyle = BORDER;
+      ctx.lineWidth = Math.max(1, unit * 0.12);
+      ctx.strokeRect(plotX, cy0, plotW, plotH);
+      ctx.fillStyle = MUTED;
+      ctx.textAlign = "right";
+      ctx.textBaseline = "top";
+      ctx.fillText(maxLabel, plotX - gap * 0.6, cy0);
+      ctx.textBaseline = "bottom";
+      ctx.fillText(minLabel, plotX - gap * 0.6, cy0 + plotH);
+      ctx.textBaseline = "alphabetic";
+      const spanY = data.max - data.min || 1;
+      const spanX = Math.max(1, data.length - 1);
+      const px = (index: number) => plotX + (index / spanX) * plotW;
+      const py = (value: number) =>
+        cy0 + plotH - ((value - data.min) / spanY) * plotH;
+      ctx.strokeStyle = data.color;
+      ctx.lineWidth = Math.max(1, unit * 0.25);
+      if (data.points.length === 1) {
+        // A single sample has no path to stroke; mark it with a dot instead.
+        ctx.fillStyle = data.color;
+        ctx.beginPath();
+        ctx.arc(
+          px(data.points[0].index),
+          py(data.points[0].value),
+          unit * 0.5,
+          0,
+          Math.PI * 2,
+        );
+        ctx.fill();
+      } else if (data.points.length > 1) {
+        ctx.beginPath();
+        data.points.forEach((p, i) => {
+          if (i === 0) ctx.moveTo(px(p.index), py(p.value));
+          else ctx.lineTo(px(p.index), py(p.value));
+        });
+        ctx.stroke();
+      }
+    };
+  }
+
+  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+  const titleW = hasTitle ? ctx.measureText(title).width : 0;
+  const boxW = pad * 2 + Math.max(contentW, Math.min(titleW, unit * 40));
+  const boxH = pad * 2 + titleBlock + contentH;
+  const { x, y } = panelOrigin(
+    chart.position,
+    bodyX,
+    bodyY,
+    bodyW,
+    bodyH,
+    inset,
+    boxW,
+    boxH,
+  );
+
+  ctx.fillStyle = "rgba(255,255,255,0.85)";
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = Math.max(1, unit * 0.15);
+  roundRect(ctx, x, y, boxW, boxH, unit);
+  ctx.fill();
+  ctx.stroke();
+
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
+  let topY = y + pad;
+  if (hasTitle) {
+    ctx.fillStyle = INK;
+    ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+    ctx.fillText(
+      truncateToWidth(ctx, title, boxW - pad * 2),
+      x + pad,
+      topY + titleSize,
+    );
+    topY += titleBlock;
+  }
+  ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+  drawContent(x + pad, topY);
   ctx.restore();
 }
 

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -1562,7 +1562,10 @@ function drawDataTable(
   let hidden = table.truncated ?? 0;
   if (rows.length * rowH + (hidden > 0 ? rowH : 0) > budget) {
     // Reserve one row of the budget for the note the truncation produces.
-    const fitRows = Math.max(1, Math.floor((budget - rowH) / rowH));
+    // When even a single row cannot fit (several panels already stacked in
+    // this corner on a small page), degrade to header + note only rather
+    // than forcing a row that would overlap the neighbouring panel.
+    const fitRows = Math.max(0, Math.floor((budget - rowH) / rowH));
     if (fitRows < rows.length) {
       hidden += rows.length - fitRows;
       rows = rows.slice(0, fitRows);

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -319,6 +319,13 @@ export interface LayoutOptions {
      * dialog when the row limit truncated the source rows.
      */
     note?: string;
+    /**
+     * How many source rows the dialog's row limit already dropped. When the
+     * body height forces the renderer to hide further rows, they are added to
+     * this count in an English fallback note replacing {@link note} (the
+     * translated text cannot be recomputed here).
+     */
+    truncated?: number;
     position: BodyCorner;
   } | null;
   /**
@@ -795,18 +802,26 @@ export function drawLayout(
     }
   }
 
-  // --- Legend (bottom-left inside the map) ------------------------------
+  // --- Legend (top-left inside the map) ---------------------------------
   // Clip to the map body so a legend with many layers cannot overflow onto the
   // footer or off the page.
+  let legendHeight = 0;
   if (opts.showLegend && opts.legend.length > 0) {
     ctx.save();
     ctx.beginPath();
     ctx.rect(bodyX, bodyY, bodyW, bodyH);
     ctx.clip();
-    drawLegend(ctx, bodyX + inset, bodyY + inset, opts.legend, unit, {
-      title: opts.legendTitle,
-      groupByLayer: opts.legendGroupByLayer,
-    });
+    legendHeight = drawLegend(
+      ctx,
+      bodyX + inset,
+      bodyY + inset,
+      opts.legend,
+      unit,
+      {
+        title: opts.legendTitle,
+        groupByLayer: opts.legendGroupByLayer,
+      },
+    );
     ctx.restore();
   }
 
@@ -816,13 +831,15 @@ export function drawLayout(
   // The ledger tracks the vertical space already claimed per corner; the info
   // block still owns the bottom-right, so panels aimed there relocate to the
   // top-right first (the original colorbar rule, GH #522).
+  const stackGap = unit * 1.2;
   const cornerUsed: Record<BodyCorner, number> = {
-    "top-left": 0,
+    // The layer-derived legend always occupies the top-left corner when shown;
+    // seed the ledger so a panel aimed there stacks below it.
+    "top-left": legendHeight > 0 ? legendHeight + stackGap : 0,
     "top-right": 0,
     "bottom-left": 0,
     "bottom-right": 0,
   };
-  const stackGap = unit * 1.2;
   const resolveCorner = (position: BodyCorner): BodyCorner =>
     hasInfoBlock && position === "bottom-right" ? "top-right" : position;
   const drawCornerPanel = (
@@ -1522,7 +1539,26 @@ function drawDataTable(
   const inset = unit * 2; // matches the info block/legend corner inset
   const title = (table.title ?? "").trim();
   const hasTitle = title.length > 0;
-  const note = (table.note ?? "").trim();
+  const titleBlockH = hasTitle ? titleSize + unit : 0;
+
+  // Fit the rows to the body height remaining below/above the stack offset:
+  // a 50-row table on a small page would otherwise clip its title or note
+  // away silently. Rows hidden here join the dialog's own truncation count in
+  // a fallback note (the dialog's translated note text cannot be recomputed).
+  const availH = bodyH - inset * 2 - stackOffset;
+  const chromeH = pad * 2 + titleBlockH + rowH; // padding + title + header row
+  const fitWithoutNote = Math.floor((availH - chromeH) / rowH);
+  let rows = table.rows;
+  let hiddenByHeight = 0;
+  if (rows.length > fitWithoutNote) {
+    const fitWithNote = Math.max(1, fitWithoutNote - 1);
+    rows = rows.slice(0, fitWithNote);
+    hiddenByHeight = table.rows.length - rows.length;
+  }
+  const note =
+    hiddenByHeight > 0
+      ? `+${hiddenByHeight + (table.truncated ?? 0)} more`
+      : (table.note ?? "").trim();
   const hasNote = note.length > 0;
 
   ctx.save();
@@ -1532,7 +1568,7 @@ function drawDataTable(
     ctx.font = `600 ${labelSize}px system-ui, sans-serif`;
     let w = ctx.measureText(header).width;
     ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
-    for (const row of table.rows) {
+    for (const row of rows) {
       w = Math.max(w, ctx.measureText(row[i] ?? "").width);
     }
     return Math.min(w, maxColW);
@@ -1550,13 +1586,9 @@ function drawDataTable(
   ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
   const titleW = hasTitle ? ctx.measureText(title).width : 0;
 
-  const titleBlock = hasTitle ? titleSize + unit : 0;
   const boxW = pad * 2 + Math.max(contentW, Math.min(titleW, availW));
   const boxH =
-    pad * 2 +
-    titleBlock +
-    (1 + table.rows.length) * rowH +
-    (hasNote ? rowH : 0);
+    pad * 2 + titleBlockH + (1 + rows.length) * rowH + (hasNote ? rowH : 0);
   const { x, y } = panelOrigin(
     table.position,
     bodyX,
@@ -1605,7 +1637,7 @@ function drawDataTable(
 
   ctx.fillStyle = INK;
   ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
-  for (const row of table.rows) {
+  for (const row of rows) {
     cy += rowH;
     cx = x + pad;
     table.columns.forEach((_, i) => {
@@ -1866,7 +1898,11 @@ function drawDataChart(
   return boxH;
 }
 
-/** Draw a legend box anchored at its top-left corner. */
+/**
+ * Draw a legend box anchored at its top-left corner.
+ *
+ * @returns The drawn box's height, so corner panels can stack below it.
+ */
 function drawLegend(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -1874,7 +1910,7 @@ function drawLegend(
   entries: LegendEntry[],
   unit: number,
   opts: { title: string; groupByLayer: boolean },
-): void {
+): number {
   const pad = unit * 1.4;
   const rowH = unit * 2.6;
   const swatch = unit * 2;
@@ -1957,6 +1993,7 @@ function drawLegend(
     ctx.fillText(r.text, textX, cy);
   }
   ctx.restore();
+  return boxH;
 }
 
 function roundRect(

--- a/tests/print-data-blocks.test.ts
+++ b/tests/print-data-blocks.test.ts
@@ -39,7 +39,17 @@ describe("boundsIntersect", () => {
 
   it("rejects disjoint boxes on either axis", () => {
     assert.equal(boundsIntersect([0, 0, 10, 10], [11, 0, 20, 10]), false);
-    assert.equal(boundsIntersect([0, 0, 10, 10], [0, 11, 10, 20], ), false);
+    assert.equal(boundsIntersect([0, 0, 10, 10], [0, 11, 10, 20]), false);
+  });
+
+  it("matches across the antimeridian's differing longitude conventions", () => {
+    // An unwrapped dateline view (east > 180, à la map.getBounds()) against a
+    // normalized feature box on the far side of the wrap.
+    assert.equal(boundsIntersect([170, -10, 190, 10], [-178, -5, -176, 5]), true);
+    // And the mirror case: a shifted feature box against a normalized view.
+    assert.equal(boundsIntersect([-180, -10, -170, 10], [178, -5, 185, 5]), true);
+    // Genuinely far apart boxes still do not match.
+    assert.equal(boundsIntersect([170, -10, 190, 10], [-10, -5, 0, 5]), false);
   });
 });
 

--- a/tests/print-data-blocks.test.ts
+++ b/tests/print-data-blocks.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_TABLE_ROWS,
   rowsWithinBounds,
 } from "../apps/geolibre-desktop/src/lib/print-data-blocks";
+import { collectAtlasFeatures } from "../apps/geolibre-desktop/src/lib/print-atlas";
 import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
 
 function point(
@@ -67,8 +68,12 @@ describe("rowsWithinBounds", () => {
     ],
   };
 
+  // The dialog precomputes per-feature bounds once per layer (the atlas
+  // pattern) and hands those to the filter.
+  const infos = collectAtlasFeatures(collection);
+
   it("keeps only features whose bounds intersect the extent", () => {
-    const result = rowsWithinBounds(collection, [0, 0, 10, 10]);
+    const result = rowsWithinBounds(infos, [0, 0, 10, 10]);
     assert.deepEqual(
       result.map((r) => r.properties.name),
       ["inside"],
@@ -76,7 +81,7 @@ describe("rowsWithinBounds", () => {
   });
 
   it("returns no rows for a fully disjoint extent", () => {
-    assert.equal(rowsWithinBounds(collection, [-30, -30, -20, -20]).length, 0);
+    assert.equal(rowsWithinBounds(infos, [-30, -30, -20, -20]).length, 0);
   });
 });
 
@@ -199,6 +204,20 @@ describe("buildChartBlock", () => {
     );
     assert.equal(chart.maxValue, 2);
     assert.ok(chart.bars.every((b) => /^#/.test(b.color)));
+  });
+
+  it("reports bar categories dropped past the top-N cap", () => {
+    const many = rows(
+      ...Array.from({ length: 25 }, (_, i) => ({ kind: `k${i}` })),
+    );
+    const chart = buildChartBlock(many, {
+      type: "bar",
+      categoryField: "kind",
+      aggregation: "count",
+    });
+    assert.ok(chart && chart.kind === "bar");
+    assert.equal(chart.bars.length, 20);
+    assert.equal(chart.truncated, 5);
   });
 
   it("builds a sum-aggregated pie whose slices carry the total", () => {

--- a/tests/print-data-blocks.test.ts
+++ b/tests/print-data-blocks.test.ts
@@ -1,0 +1,229 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { FeatureCollection } from "geojson";
+import {
+  boundsIntersect,
+  buildChartBlock,
+  buildTableBlock,
+  DEFAULT_TABLE_ROWS,
+  layerRows,
+  MAX_TABLE_ROWS,
+  rowsWithinBounds,
+} from "../apps/geolibre-desktop/src/lib/print-data-blocks";
+import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
+
+function point(
+  lng: number,
+  lat: number,
+  properties: Record<string, unknown>,
+): GeoJSON.Feature {
+  return {
+    type: "Feature",
+    properties,
+    geometry: { type: "Point", coordinates: [lng, lat] },
+  };
+}
+
+function rows(...props: Record<string, unknown>[]): ChartRow[] {
+  return props.map((properties) => ({ properties }));
+}
+
+describe("boundsIntersect", () => {
+  it("detects overlap, touching edges, and containment", () => {
+    assert.equal(boundsIntersect([0, 0, 10, 10], [5, 5, 15, 15]), true);
+    // Touching along an edge counts as intersecting.
+    assert.equal(boundsIntersect([0, 0, 10, 10], [10, 0, 20, 10]), true);
+    // One box fully inside the other.
+    assert.equal(boundsIntersect([0, 0, 10, 10], [2, 2, 3, 3]), true);
+  });
+
+  it("rejects disjoint boxes on either axis", () => {
+    assert.equal(boundsIntersect([0, 0, 10, 10], [11, 0, 20, 10]), false);
+    assert.equal(boundsIntersect([0, 0, 10, 10], [0, 11, 10, 20], ), false);
+  });
+});
+
+describe("rowsWithinBounds", () => {
+  const collection: Pick<FeatureCollection, "features"> = {
+    features: [
+      point(1, 1, { name: "inside" }),
+      point(50, 50, { name: "outside" }),
+      // No geometry: nowhere on the page, so never included.
+      {
+        type: "Feature",
+        properties: { name: "no-geometry" },
+        geometry: null as unknown as GeoJSON.Geometry,
+      },
+    ],
+  };
+
+  it("keeps only features whose bounds intersect the extent", () => {
+    const result = rowsWithinBounds(collection, [0, 0, 10, 10]);
+    assert.deepEqual(
+      result.map((r) => r.properties.name),
+      ["inside"],
+    );
+  });
+
+  it("returns no rows for a fully disjoint extent", () => {
+    assert.equal(rowsWithinBounds(collection, [-30, -30, -20, -20]).length, 0);
+  });
+});
+
+describe("layerRows", () => {
+  it("maps features to property bags, defaulting missing properties", () => {
+    const result = layerRows({
+      features: [
+        point(0, 0, { a: 1 }),
+        {
+          type: "Feature",
+          properties: null,
+          geometry: { type: "Point", coordinates: [0, 0] },
+        },
+      ],
+    });
+    assert.deepEqual(result, [{ properties: { a: 1 } }, { properties: {} }]);
+  });
+});
+
+describe("buildTableBlock", () => {
+  const source = rows(
+    { name: "b-town", pop: 200 },
+    { name: "a-town", pop: 300 },
+    { name: "c-town", pop: null },
+  );
+
+  it("returns null without rows or without columns", () => {
+    assert.equal(buildTableBlock([], { columns: ["name"] }), null);
+    assert.equal(buildTableBlock(source, { columns: [] }), null);
+  });
+
+  it("stringifies cells and blanks null/undefined values", () => {
+    const table = buildTableBlock(source, { columns: ["name", "pop", "nope"] });
+    assert.ok(table);
+    assert.deepEqual(table.columns, ["name", "pop", "nope"]);
+    assert.deepEqual(table.rows[0], ["b-town", "200", ""]);
+    assert.deepEqual(table.rows[2], ["c-town", "", ""]);
+    assert.equal(table.truncated, 0);
+  });
+
+  it("sorts numerically with missing values last, both directions", () => {
+    const asc = buildTableBlock(source, {
+      columns: ["name"],
+      sortField: "pop",
+    });
+    assert.deepEqual(
+      asc?.rows.map((r) => r[0]),
+      ["b-town", "a-town", "c-town"],
+    );
+    const desc = buildTableBlock(source, {
+      columns: ["name"],
+      sortField: "pop",
+      sortDescending: true,
+    });
+    assert.deepEqual(
+      desc?.rows.map((r) => r[0]),
+      ["a-town", "b-town", "c-town"],
+    );
+  });
+
+  it("caps rows at the limit and reports the truncated count", () => {
+    const many = rows(
+      ...Array.from({ length: 30 }, (_, i) => ({ id: i })),
+    );
+    const table = buildTableBlock(many, { columns: ["id"], maxRows: 5 });
+    assert.equal(table?.rows.length, 5);
+    assert.equal(table?.truncated, 25);
+    // Clamped into 1..MAX_TABLE_ROWS; non-finite falls back to the default.
+    assert.equal(
+      buildTableBlock(many, { columns: ["id"], maxRows: 0 })?.rows.length,
+      1,
+    );
+    assert.equal(
+      buildTableBlock(many, { columns: ["id"], maxRows: 999 })?.rows.length,
+      Math.min(30, MAX_TABLE_ROWS),
+    );
+    assert.equal(
+      buildTableBlock(many, { columns: ["id"], maxRows: Number.NaN })?.rows
+        .length,
+      DEFAULT_TABLE_ROWS,
+    );
+  });
+});
+
+describe("buildChartBlock", () => {
+  const source = rows(
+    { kind: "a", v: 10 },
+    { kind: "a", v: 30 },
+    { kind: "b", v: 5 },
+  );
+
+  it("returns null for empty rows or incomplete configuration", () => {
+    assert.equal(buildChartBlock([], { type: "bar", categoryField: "kind" }), null);
+    assert.equal(buildChartBlock(source, { type: "bar" }), null);
+    assert.equal(buildChartBlock(source, { type: "line" }), null);
+    // sum/mean without a value field cannot aggregate.
+    assert.equal(
+      buildChartBlock(source, {
+        type: "bar",
+        categoryField: "kind",
+        aggregation: "sum",
+      }),
+      null,
+    );
+  });
+
+  it("builds a bar chart with counts, sorted descending, colored", () => {
+    const chart = buildChartBlock(source, {
+      type: "bar",
+      categoryField: "kind",
+      aggregation: "count",
+    });
+    assert.ok(chart && chart.kind === "bar");
+    assert.deepEqual(
+      chart.bars.map((b) => [b.label, b.value]),
+      [
+        ["a", 2],
+        ["b", 1],
+      ],
+    );
+    assert.equal(chart.maxValue, 2);
+    assert.ok(chart.bars.every((b) => /^#/.test(b.color)));
+  });
+
+  it("builds a sum-aggregated pie whose slices carry the total", () => {
+    const chart = buildChartBlock(source, {
+      type: "pie",
+      categoryField: "kind",
+      aggregation: "sum",
+      valueField: "v",
+    });
+    assert.ok(chart && chart.kind === "pie");
+    assert.equal(chart.total, 45);
+    assert.deepEqual(
+      chart.slices.map((s) => [s.label, s.value]),
+      [
+        ["a", 40],
+        ["b", 5],
+      ],
+    );
+  });
+
+  it("builds a line chart over row order, skipping non-numeric rows", () => {
+    const chart = buildChartBlock(
+      rows({ v: 1 }, { v: "x" }, { v: 3 }),
+      { type: "line", valueField: "v" },
+    );
+    assert.ok(chart && chart.kind === "line");
+    assert.deepEqual(
+      chart.points.map((p) => [p.index, p.value]),
+      [
+        [0, 1],
+        [2, 3],
+      ],
+    );
+    assert.equal(chart.min, 1);
+    assert.equal(chart.max, 3);
+    assert.equal(chart.length, 3);
+  });
+});

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -19,8 +19,17 @@ import {
 function recordingCanvas(): {
   canvas: HTMLCanvasElement;
   fills: { text: string; textAlign: string; textBaseline: string }[];
+  fillRects: { w: number; h: number; fillStyle: string }[];
+  arcs: number;
+  polylines: number[];
 } {
   const fills: { text: string; textAlign: string; textBaseline: string }[] = [];
+  // Filled rectangles (swatches, chart bars), with the fill colour in effect.
+  const fillRects: { w: number; h: number; fillStyle: string }[] = [];
+  // Stroked polylines: one entry per beginPath..stroke sequence that used
+  // lineTo, holding the segment count (the line chart's path).
+  const polylines: number[] = [];
+  const counters = { arcs: 0, pendingLines: 0 };
   const state: Record<string, unknown> = {
     textAlign: "start",
     textBaseline: "alphabetic",
@@ -36,8 +45,33 @@ function recordingCanvas(): {
             textBaseline: String(target.textBaseline),
           });
       }
+      if (prop === "fillRect") {
+        return (_x: number, _y: number, w: number, h: number) =>
+          fillRects.push({ w, h, fillStyle: String(target.fillStyle) });
+      }
+      if (prop === "arc") {
+        return () => {
+          counters.arcs += 1;
+        };
+      }
+      if (prop === "beginPath") {
+        return () => {
+          counters.pendingLines = 0;
+        };
+      }
+      if (prop === "lineTo") {
+        return () => {
+          counters.pendingLines += 1;
+        };
+      }
+      if (prop === "stroke") {
+        return () => {
+          if (counters.pendingLines > 0) polylines.push(counters.pendingLines);
+          counters.pendingLines = 0;
+        };
+      }
       if (prop in target) return target[prop as string];
-      // Any other method (save, restore, fillRect, beginPath, clip, ...) is a no-op.
+      // Any other method (save, restore, clip, ...) is a no-op.
       return () => {};
     },
     set(target, prop, value) {
@@ -50,7 +84,15 @@ function recordingCanvas(): {
     height: 400,
     getContext: () => ctx,
   } as unknown as HTMLCanvasElement;
-  return { canvas, fills };
+  return {
+    canvas,
+    fills,
+    fillRects,
+    get arcs() {
+      return counters.arcs;
+    },
+    polylines,
+  };
 }
 
 function baseOptions(overrides: Partial<LayoutOptions> = {}): LayoutOptions {
@@ -501,6 +543,31 @@ describe("drawLayout data blocks (GH #1324)", () => {
     }
   });
 
+  it("drops rows that cannot fit the body height and folds them into the note", () => {
+    const rows = Array.from({ length: 50 }, (_, i) => [`row${i}`]);
+    const rec = recordingCanvas();
+    drawLayout(
+      rec.canvas,
+      baseOptions({
+        dataTable: {
+          columns: ["name"],
+          rows,
+          note: "+5 more",
+          truncated: 5,
+          position: "bottom-left",
+        },
+      }),
+    );
+    // 50 rows cannot fit a 400px page body; the tail rows must be dropped...
+    assert.ok(rec.fills.some((f) => f.text === "row0"));
+    assert.ok(!rec.fills.some((f) => f.text === "row49"));
+    // ...and the note must count both the dialog-truncated and height-hidden
+    // rows (so it reads "+N more" with N > the dialog's own 5).
+    const note = rec.fills.find((f) => /^\+\d+ more$/.test(f.text));
+    assert.ok(note, "expected a truncation note to be drawn");
+    assert.ok(Number(note.text.match(/\d+/)?.[0]) > 5);
+  });
+
   it("skips a table with no rows or no columns", () => {
     const { canvas, fills } = recordingCanvas();
     drawLayout(
@@ -516,10 +583,10 @@ describe("drawLayout data blocks (GH #1324)", () => {
     assert.ok(!fills.some((f) => f.text === "name"));
   });
 
-  it("renders bar chart labels and values", () => {
-    const { canvas, fills } = recordingCanvas();
+  it("renders bar chart labels, values, and one bar rect per category", () => {
+    const rec = recordingCanvas();
     drawLayout(
-      canvas,
+      rec.canvas,
       baseOptions({
         dataChart: {
           title: "Population",
@@ -538,16 +605,23 @@ describe("drawLayout data blocks (GH #1324)", () => {
     );
     for (const text of ["Population", "CA", "OR", "12", "4"]) {
       assert.ok(
-        fills.some((f) => f.text === text),
+        rec.fills.some((f) => f.text === text),
         `expected "${text}" to be drawn`,
       );
     }
+    // The bars themselves must be filled in each category's colour, with the
+    // larger value producing the wider rect.
+    const ca = rec.fillRects.find((r) => r.fillStyle === "#111111");
+    const or = rec.fillRects.find((r) => r.fillStyle === "#222222");
+    assert.ok(ca && or, "expected one filled bar rect per category");
+    assert.ok(ca.w > or.w, "expected the larger value to draw a wider bar");
   });
 
-  it("renders pie slice labels with their percentage share", () => {
-    const { canvas, fills } = recordingCanvas();
+  it("renders pie slice labels, percentages, and slice arcs", () => {
+    const rec = recordingCanvas();
+    const before = rec.arcs;
     drawLayout(
-      canvas,
+      rec.canvas,
       baseOptions({
         dataChart: {
           position: "bottom-right",
@@ -562,14 +636,23 @@ describe("drawLayout data blocks (GH #1324)", () => {
         },
       }),
     );
-    assert.ok(fills.some((f) => f.text === "a (75%)"));
-    assert.ok(fills.some((f) => f.text === "b (25%)"));
+    assert.ok(rec.fills.some((f) => f.text === "a (75%)"));
+    assert.ok(rec.fills.some((f) => f.text === "b (25%)"));
+    // One arc per slice plus the outline circle (the north arrow's backing
+    // disc also uses arc, so require at least that many new arcs).
+    assert.ok(
+      rec.arcs - before >= 3,
+      "expected slice arcs and the outline circle to be drawn",
+    );
+    // Slice colours are also used for the legend swatch rects.
+    assert.ok(rec.fillRects.some((r) => r.fillStyle === "#111111"));
+    assert.ok(rec.fillRects.some((r) => r.fillStyle === "#222222"));
   });
 
-  it("renders the line chart's min/max axis labels", () => {
-    const { canvas, fills } = recordingCanvas();
+  it("renders the line chart's axis labels and polyline path", () => {
+    const rec = recordingCanvas();
     drawLayout(
-      canvas,
+      rec.canvas,
       baseOptions({
         dataChart: {
           position: "top-left",
@@ -577,6 +660,7 @@ describe("drawLayout data blocks (GH #1324)", () => {
             kind: "line",
             points: [
               { index: 0, value: 5 },
+              { index: 1, value: 7 },
               { index: 2, value: 9 },
             ],
             min: 5,
@@ -587,7 +671,12 @@ describe("drawLayout data blocks (GH #1324)", () => {
         },
       }),
     );
-    assert.ok(fills.some((f) => f.text === "9" && f.textAlign === "right"));
-    assert.ok(fills.some((f) => f.text === "5" && f.textAlign === "right"));
+    assert.ok(rec.fills.some((f) => f.text === "9" && f.textAlign === "right"));
+    assert.ok(rec.fills.some((f) => f.text === "5" && f.textAlign === "right"));
+    // The path itself: one stroked polyline with a segment per point pair.
+    assert.ok(
+      rec.polylines.includes(2),
+      "expected a stroked 2-segment polyline for the 3 points",
+    );
   });
 });

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -617,6 +617,30 @@ describe("drawLayout data blocks (GH #1324)", () => {
     assert.ok(ca.w > or.w, "expected the larger value to draw a wider bar");
   });
 
+  it("draws a truncation note for bar categories past the top-N cap", () => {
+    const rec = recordingCanvas();
+    drawLayout(
+      rec.canvas,
+      baseOptions({
+        dataChart: {
+          position: "top-right",
+          data: {
+            kind: "bar",
+            bars: [{ label: "CA", value: 12, color: "#111111" }],
+            maxValue: 12,
+            minValue: 0,
+            truncated: 7,
+          },
+          formatNote: (count) => `+${count} more`,
+        },
+      }),
+    );
+    assert.ok(
+      rec.fills.some((f) => f.text === "+7 more"),
+      "expected the dropped-category note to be drawn",
+    );
+  });
+
   it("renders pie slice labels, percentages, and slice arcs", () => {
     const rec = recordingCanvas();
     const before = rec.arcs;

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -524,7 +524,8 @@ describe("drawLayout data blocks (GH #1324)", () => {
             ["Springfield", "42000"],
             ["Shelbyville", "39000"],
           ],
-          note: "+3 more",
+          truncated: 3,
+          formatNote: (count) => `+${count} more`,
           position: "bottom-left",
         },
       }),
@@ -552,7 +553,6 @@ describe("drawLayout data blocks (GH #1324)", () => {
         dataTable: {
           columns: ["name"],
           rows,
-          note: "+5 more",
           truncated: 5,
           position: "bottom-left",
         },

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -468,3 +468,126 @@ describe("drawLayout map frame border (GH #749)", () => {
     );
   });
 });
+
+describe("drawLayout data blocks (GH #1324)", () => {
+  it("renders the table title, headers, cells, and truncation note", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        dataTable: {
+          title: "Cities",
+          columns: ["name", "pop"],
+          rows: [
+            ["Springfield", "42000"],
+            ["Shelbyville", "39000"],
+          ],
+          note: "+3 more",
+          position: "bottom-left",
+        },
+      }),
+    );
+    for (const text of [
+      "Cities",
+      "name",
+      "pop",
+      "Springfield",
+      "42000",
+      "+3 more",
+    ]) {
+      const fill = fills.find((f) => f.text === text);
+      assert.ok(fill, `expected "${text}" to be drawn`);
+      assert.equal(fill.textAlign, "left");
+    }
+  });
+
+  it("skips a table with no rows or no columns", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        dataTable: {
+          columns: ["name"],
+          rows: [],
+          position: "bottom-left",
+        },
+      }),
+    );
+    assert.ok(!fills.some((f) => f.text === "name"));
+  });
+
+  it("renders bar chart labels and values", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        dataChart: {
+          title: "Population",
+          position: "top-right",
+          data: {
+            kind: "bar",
+            bars: [
+              { label: "CA", value: 12, color: "#111111" },
+              { label: "OR", value: 4, color: "#222222" },
+            ],
+            maxValue: 12,
+            minValue: 0,
+          },
+        },
+      }),
+    );
+    for (const text of ["Population", "CA", "OR", "12", "4"]) {
+      assert.ok(
+        fills.some((f) => f.text === text),
+        `expected "${text}" to be drawn`,
+      );
+    }
+  });
+
+  it("renders pie slice labels with their percentage share", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        dataChart: {
+          position: "bottom-right",
+          data: {
+            kind: "pie",
+            slices: [
+              { label: "a", value: 3, color: "#111111" },
+              { label: "b", value: 1, color: "#222222" },
+            ],
+            total: 4,
+          },
+        },
+      }),
+    );
+    assert.ok(fills.some((f) => f.text === "a (75%)"));
+    assert.ok(fills.some((f) => f.text === "b (25%)"));
+  });
+
+  it("renders the line chart's min/max axis labels", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        dataChart: {
+          position: "top-left",
+          data: {
+            kind: "line",
+            points: [
+              { index: 0, value: 5 },
+              { index: 2, value: 9 },
+            ],
+            min: 5,
+            max: 9,
+            length: 3,
+            color: "#111111",
+          },
+        },
+      }),
+    );
+    assert.ok(fills.some((f) => f.text === "9" && f.textAlign === "right"));
+    assert.ok(fills.some((f) => f.text === "5" && f.textAlign === "right"));
+  });
+});


### PR DESCRIPTION
Fixes #1324

## Summary

Adds the two data-driven page elements requested in #1324 to the Print Layout composer:

- **Attribute table block**: rows of a vector layer drawn as a bordered corner panel, with a column picker, sort field/order, row limit (1-50), optional heading, and a "+N more" note when the limit truncates the rows.
- **Chart block**: bar / pie / line charts of a layer's attributes. Bar and pie group by a category field with count/sum/mean aggregation, reusing the attribute Charts panel's compute helpers (`computeBar`/`computePie`/`computeLine`), including top-N capping and the "(other)" fold, plus its categorical palette. Line plots a numeric field against feature order.

Both blocks are drawn directly on the layout canvas (`drawLayout`), so they render crisply in the on-screen preview, PNG/PDF export, Copy to Clipboard, and on every Atlas page.

**Atlas integration**: each block has an "Only features in the page extent" option (on by default). During an Atlas series it re-filters the rows per page against that page's fitted bounds (bbox test, matching how pages are framed), so each page's table/chart summarizes the features on that page - per-page report generation. Outside Atlas mode the option applies to a drawn print extent; plain viewport captures use the whole layer.

Details:

- Pure builders live in `apps/geolibre-desktop/src/lib/print-data-blocks.ts` (row extraction, bbox filtering via the atlas `geometryBounds` walk, table sorting/truncation, chart spec building); drawing helpers in `print-layout.ts` follow the existing colorbar/custom-legend panel idiom (corner anchoring, unit-scaled fonts, body clipping).
- A bottom-right table/chart relocates to the top-right when the info block is shown, matching the colorbar's existing collision rule. The chart defaults to top-right since the scale-bar/north-arrow duo owns the bottom-right corner by default.
- New UI strings are translatable via `en.json` (`printLayout.dataBlocks/dataTable/dataChart`); the canvas code stays i18n-agnostic (the translated "+N more" note is passed in as data).

## Testing

- New unit tests: `tests/print-data-blocks.test.ts` (bounds intersection, extent filtering, table sort/truncation/stringification, bar/pie/line spec building) and recording-canvas rendering tests in `tests/print-layout.test.ts` (table headers/cells/note, bar labels/values, pie percentages, line axis labels). Full frontend suite passes (3267 tests).
- Verified in the browser with Playwright against real datasets (`us_cities.geojson` + `us_regions.geojson`): enabled both blocks, confirmed the preview draws the table (with "+99 more" note) and a region bar chart; enabled an Atlas over `us_regions` and confirmed page 1 (Northeast) and page 2 (Midwest) each show only their own cities and per-page chart counts; checked both dark and light themes.
- `npm run build` and pre-commit pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable print “data blocks” for attribute tables and statistics charts, including enablement, layer/field selection, titles, positions, sizing, row limits, and “no data”/empty-state messaging.
  * Added chart rendering for bar/pie/line with aggregation, sorting/numeric handling, truncation, and value/percentage display.
  * Added per-atlas-page data blocks that can filter results to the current page’s visible extent for more accurate atlas preview and export.
  * Improved print corner-panel stacking so data blocks don’t overlap existing legend/cartographic info elements.
* **Tests**
  * Added unit tests and rendering checks for extent filtering, truncation behavior, empty-state skipping, and table/chart visuals across positions and chart types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->