### PR TITLE
ci(review): skip Claude review runs initiated by bot actors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,8 +44,15 @@ jobs:
     #      path for first-time-contributor PRs).
     # author_association on the comment gates (b): only OWNER/MEMBER/COLLABORATOR
     # accounts — i.e. people with write/admin on the repo — can trigger a review.
+    #
+    # sender.type gates out bot-initiated events (e.g. a pre-commit.ci autofix
+    # push firing `synchronize`): claude-code-action hard-fails on non-human
+    # actors not in its allowed_bots list, and an autofix formatting commit does
+    # not need a fresh (paid) review anyway. Skipping here shows the run as
+    # skipped instead of failed; a maintainer can still `/claude-review`.
     if: >
       (github.event_name == 'pull_request_target' &&
+        github.event.sender.type != 'Bot' &&
         (github.event.pull_request.author_association == 'OWNER' ||
          github.event.pull_request.author_association == 'MEMBER' ||
          github.event.pull_request.author_association == 'COLLABORATOR' ||


### PR DESCRIPTION
## Summary

The Claude Code Review workflow failed on #1327 when a pre-commit.ci autofix push fired `pull_request_target: synchronize`:

```
Error: Action failed with error: Workflow initiated by non-human actor: pre-commit-ci (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

`anthropics/claude-code-action` hard-fails when the initiating actor is a bot that is not allowlisted, so every bot push to a PR shows up as a red X.

## Fix

Gate the `pull_request_target` path of the job `if:` on `github.event.sender.type != 'Bot'`. Bot-initiated runs (pre-commit.ci autofix pushes, or PRs opened by bots) are now cleanly skipped instead of failing, and no review credits are spent re-reviewing an autofix formatting commit. The `/claude-review` maintainer opt-in path is unchanged, so a maintainer can still request a review on any PR.

Skipping was chosen over `allowed_bots` because an autofix push is a trivial formatting commit that does not need a fresh (paid) review, consistent with the workflow's existing cost controls (first-timer gating, concurrency dedupe).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated review workflows from failing on bot-generated pull request updates.
  * Bot-triggered updates are now skipped automatically, while manual review requests remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->