### PR TITLE
fix(android): drop native-tls/openssl-sys from Android build; bump setup-android to v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,9 +53,10 @@ jobs:
           java-version: "21"
 
       - name: Set up Android SDK
-        # Third-party action pinned to a full commit SHA (v3 tag head) per the
-        # repo's policy for non-official actions; a tag could be re-pointed.
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+        # Third-party action pinned to a full commit SHA (v4.0.1) per the repo's
+        # policy for non-official actions; a tag could be re-pointed. v4 runs on
+        # Node.js 24 (v3 targeted the now-deprecated Node.js 20).
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
       - name: Install Android NDK, platform, and build-tools
         run: |

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -40,13 +40,15 @@ tauri-plugin-persisted-scope = "2"
 duckdb = { version = "1.10504.0", features = ["bundled", "parquet"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 # rustls-tls stays the default backend for every request. rustls-tls-native-roots
-# also trusts the OS/system certificate store (enterprise CAs), and native-tls is
-# used only on the opt-in mTLS path for PKCS#12 client certificates (issue #1220).
+# also trusts the OS/system certificate store (enterprise CAs). native-tls (which
+# drags in openssl-sys) is used only on the opt-in mTLS path for PKCS#12 client
+# certificates (issue #1220), so it is added per-target below — everywhere except
+# Android, where there is no such path and openssl-sys cannot cross-compile for
+# the NDK.
 reqwest = { version = "0.12", default-features = false, features = [
   "blocking",
   "rustls-tls",
   "rustls-tls-native-roots",
-  "native-tls",
 ] }
 flate2 = "1"
 tar = "0.4"
@@ -56,6 +58,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # OS CSPRNG for the per-launch Jupyter token (already an indirect dep).
 getrandom = "0.4"
+
+# native-tls backs only the desktop mTLS PKCS#12 path (issue #1220). It pulls in
+# openssl-sys, which has no vendored/cross build for the Android NDK, so the
+# feature is added on every target except Android (the code that uses it is
+# likewise cfg'd out in src/lib.rs).
+[target.'cfg(not(target_os = "android"))'.dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
 
 # Runtime WebKitGTK version check (already an indirect dep via tauri/wry).
 [target."cfg(target_os = \"linux\")".dependencies]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -735,7 +735,9 @@ impl reqwest::dns::Resolve for GuardedDnsResolver {
 enum ClientIdentity {
     /// PEM identity (certificate chain plus an unencrypted PKCS#8 key), rustls.
     Pem(reqwest::Identity),
-    /// PKCS#12 identity, native-tls.
+    /// PKCS#12 identity, native-tls. Not available on Android, which does not
+    /// ship the native-tls backend (openssl-sys has no NDK cross build).
+    #[cfg(not(target_os = "android"))]
     Pkcs12(reqwest::Identity),
 }
 
@@ -811,14 +813,27 @@ fn client_identity() -> Result<Option<ClientIdentity>, String> {
         )
     })?;
     if client_cert_is_pkcs12(&path, password.is_some()) {
-        let identity = reqwest::Identity::from_pkcs12_der(&bytes, password.as_deref().unwrap_or(""))
-            .map_err(|error| {
-                format!(
-                    "Could not load PKCS#12 client certificate {}: {error}",
-                    path.display()
-                )
-            })?;
-        Ok(Some(ClientIdentity::Pkcs12(identity)))
+        #[cfg(not(target_os = "android"))]
+        {
+            let identity =
+                reqwest::Identity::from_pkcs12_der(&bytes, password.as_deref().unwrap_or(""))
+                    .map_err(|error| {
+                        format!(
+                            "Could not load PKCS#12 client certificate {}: {error}",
+                            path.display()
+                        )
+                    })?;
+            Ok(Some(ClientIdentity::Pkcs12(identity)))
+        }
+        // Android lacks the native-tls backend that parses PKCS#12, so surface a
+        // clear error rather than silently misreading the bundle as PEM.
+        #[cfg(target_os = "android")]
+        {
+            Err(format!(
+                "PKCS#12 client certificates are not supported on this platform: {}",
+                path.display()
+            ))
+        }
     } else {
         let identity = reqwest::Identity::from_pem(&bytes).map_err(|error| {
             format!(
@@ -867,6 +882,8 @@ fn build_guarded_http_client() -> Result<reqwest::blocking::Client, String> {
     builder = match client_identity()? {
         // PKCS#12 identities are only understood by native-tls, which also reads
         // the OS trust store on every platform; switch this one client over.
+        // (Not reachable on Android — client_identity errors out there.)
+        #[cfg(not(target_os = "android"))]
         Some(ClientIdentity::Pkcs12(identity)) => builder.use_native_tls().identity(identity),
         Some(ClientIdentity::Pem(identity)) => builder.use_rustls_tls().identity(identity),
         None => builder.use_rustls_tls(),


### PR DESCRIPTION
## Problem

The **v2.2.0 Android** release build ([run 29668727337](https://github.com/opengeos/GeoLibre/actions/runs/29668727337)) failed while cross-compiling `openssl-sys` for `aarch64-linux-android`:

```
error: failed to run custom build command for `openssl-sys v0.9.117`
  Could not find directory of OpenSSL installation, and this `-sys` crate
  cannot proceed without this knowledge.
```

`openssl-sys` is pulled in **only** by `reqwest`'s `native-tls` feature, which was added for the desktop mutual-TLS PKCS#12 client-certificate path (#1220). Android has no such path, and `openssl-sys` has no vendored NDK cross build — so the whole toolchain has nothing to link against.

The run also emitted a deprecation warning: `android-actions/setup-android@…` (v3) targets the now-removed Node.js 20.

## Fix

- **Gate `native-tls` off Android.** Moved the `native-tls` feature from the shared `reqwest` dependency to a `cfg(not(target_os = "android"))` target dependency, and `cfg`-gated the code that uses it (`ClientIdentity::Pkcs12` + the `use_native_tls()` builder arm). Android now returns a clear "PKCS#12 client certificates are not supported on this platform" error instead of silently misreading the bundle as PEM. **Desktop builds are unchanged** — `openssl-sys` stays in their dependency tree.
- **Bump `android-actions/setup-android` v3 → v4.0.1**, which runs on Node.js 24.

## Verification

- `cargo tree -i openssl-sys` for `--target aarch64-linux-android` → *nothing to print* (removed); host target still shows it via `native-tls → reqwest`.
- `cargo check --lib` and the `client_cert` unit tests pass on the host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build reliability by updating the Android SDK setup process.
  * Prevented unsupported PKCS#12 client certificates from being used on Android and added clearer error handling.
  * Preserved PKCS#12 client-certificate support on supported desktop platforms.
  * Improved TLS and certificate compatibility across desktop and Android builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->