### PR TITLE
feat(add-data): support delimited text layers in any CRS

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -134,11 +134,13 @@ export const MAX_SAVED_SERVICES = 200;
 // Last File Geodatabase (and feature class) added through the GDB source, so
 // reopening the panel restores the selection instead of starting blank.
 export const LAST_GEODATABASE_STORAGE_KEY = "geolibre.lastGeodatabase";
-// A short list of common coordinate systems offered as quick presets in the Add
-// CAD Layer dialog (CAD files carry no CRS of their own, so the user names one).
-// The labels are CRS proper names and stay untranslated; selecting one fills the
-// free-text EPSG field, which remains the source of truth.
-export const CAD_CRS_PRESETS: readonly { label: string; value: string }[] = [
+// A short list of common coordinate systems offered as quick presets wherever a
+// source CRS is named by hand: the Add CAD Layer dialog (CAD files carry no CRS
+// of their own) and the Add Delimited Text Layer dialog (a CSV's coordinate
+// columns may be in any CRS). The labels are CRS proper names and stay
+// untranslated; selecting one fills the free-text EPSG field, which remains the
+// source of truth.
+export const COMMON_CRS_PRESETS: readonly { label: string; value: string }[] = [
   { label: "WGS 84 (EPSG:4326)", value: "EPSG:4326" },
   { label: "Web Mercator (EPSG:3857)", value: "EPSG:3857" },
   { label: "NAD83 (EPSG:4269)", value: "EPSG:4269" },

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -36,10 +36,17 @@ export function layerNameFromPath(path: string, fallback: string): string {
  * Normalize a user-entered CRS into the `AUTHORITY:CODE` form `ST_Transform`
  * expects: a bare number becomes `EPSG:<n>`, an `epsg:4326` is upper-cased, and
  * an already-qualified `ESRI:102100` passes through. A blank stays blank (load
- * the data as-is). Shared by the CAD and File Geodatabase sources.
+ * the data as-is). Shared by the CAD, File Geodatabase, and Delimited Text
+ * sources.
+ *
+ * All whitespace is stripped, not just the edges, so a code pasted with a stray
+ * space (e.g. `EPSG: 32643`, common when copied from a site that renders it with
+ * a space) becomes `EPSG:32643` and is handed to PROJ in a form it accepts. This
+ * also keeps the normalized value in agreement with `isGeographicCrs`, which
+ * strips whitespace before classifying.
  */
 export function normalizeCrs(raw: string): string {
-  const value = raw.trim();
+  const value = raw.replace(/\s+/g, "");
   if (!value) return "";
   if (/^\d+$/.test(value)) return `EPSG:${value}`;
   return value.toUpperCase();

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -39,15 +39,23 @@ export function layerNameFromPath(path: string, fallback: string): string {
  * the data as-is). Shared by the CAD, File Geodatabase, and Delimited Text
  * sources.
  *
- * All whitespace is stripped, not just the edges, so a code pasted with a stray
- * space (e.g. `EPSG: 32643`, common when copied from a site that renders it with
- * a space) becomes `EPSG:32643` and is handed to PROJ in a form it accepts. This
- * also keeps the normalized value in agreement with `isGeographicCrs`, which
- * strips whitespace before classifying.
+ * For authority-code input, all whitespace is stripped, not just the edges, so a
+ * code pasted with a stray space (e.g. `EPSG: 32643`, common when copied from a
+ * site that renders it with a space) becomes `EPSG:32643` and is handed to PROJ
+ * in a form it accepts. This also keeps the normalized value in agreement with
+ * `isGeographicCrs`, which strips whitespace before classifying.
+ *
+ * A WKT definition (which `ST_Transform` also accepts) is passed through with
+ * only edge trimming: its internal whitespace and letter case are significant,
+ * so it is detected by its brackets/quotes and left untouched.
  */
 export function normalizeCrs(raw: string): string {
-  const value = raw.replace(/\s+/g, "");
-  if (!value) return "";
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  // A WKT string carries meaningful spaces and casing; compacting or upper-casing
+  // it would corrupt it, so return it as-is once edge-trimmed.
+  if (/[["]/.test(trimmed)) return trimmed;
+  const value = trimmed.replace(/\s+/g, "");
   if (/^\d+$/.test(value)) return `EPSG:${value}`;
   return value.toUpperCase();
 }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/CadSource.tsx
@@ -9,7 +9,7 @@ import {
   readCadLayers,
 } from "../../../../lib/duckdb-vector-loader";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
-import { CAD_CRS_PRESETS, CAD_SAMPLES } from "../constants";
+import { COMMON_CRS_PRESETS, CAD_SAMPLES } from "../constants";
 import {
   createBaseLayer,
   errorMessage,
@@ -273,7 +273,7 @@ export function CadSource() {
             <option value="" disabled>
               {t("addData.cad.crsPresetLabel")}
             </option>
-            {CAD_CRS_PRESETS.map((preset) => (
+            {COMMON_CRS_PRESETS.map((preset) => (
               <option key={preset.value} value={preset.value}>
                 {preset.label}
               </option>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -2,9 +2,9 @@ import { Button, Input, Label, Select } from "@geolibre/ui";
 import { Columns3, FileUp } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { isGeographicCrs } from "../../../../lib/crs-utils";
 import {
   detectCoordinateFields,
-  isGeographicCrs,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "../../../../lib/delimited-text";

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -11,7 +11,7 @@ import {
 import { reprojectFeatureCollectionToWgs84 } from "../../../../lib/duckdb-vector-loader";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
 import {
-  CAD_CRS_PRESETS,
+  COMMON_CRS_PRESETS,
   DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD,
   DEFAULT_DELIMITED_TEXT_LONGITUDE_FIELD,
   DEFAULT_DELIMITED_TEXT_URL,
@@ -412,7 +412,7 @@ export function DelimitedTextSource() {
             <option value="" disabled>
               {t("addData.delimitedText.crsPresetLabel")}
             </option>
-            {CAD_CRS_PRESETS.map((preset) => (
+            {COMMON_CRS_PRESETS.map((preset) => (
               <option key={preset.value} value={preset.value}>
                 {preset.label}
               </option>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -61,10 +61,21 @@ export function DelimitedTextSource() {
     setDelimitedTextColumnsStatus(null);
   };
 
+  // Clear the entered CRS whenever the underlying data source changes (new file,
+  // new URL, mode switch, sample). A projected CRS disables the lon/lat bounds
+  // check in parseDelimitedTextLayer, so a code left over from a previous file
+  // would silently reinterpret the next (possibly WGS84) file's coordinates as
+  // easting/northing and reproject them into nonsense with no validation error.
+  // Deliberately not called on a delimiter tweak, which keeps the same file.
+  const resetDelimitedTextCrs = () => {
+    setDelimitedTextCrs("");
+  };
+
   const handleDelimitedTextModeChange = (mode: DelimitedTextMode) => {
     setDelimitedTextMode(mode);
     setSelectedDelimitedText(null);
     resetDelimitedTextColumns();
+    resetDelimitedTextCrs();
   };
 
   const readDelimitedTextSource = async (): Promise<{
@@ -114,6 +125,7 @@ export function DelimitedTextSource() {
         text: result.text,
       });
       resetDelimitedTextColumns();
+      resetDelimitedTextCrs();
       source.setLayerName((current) =>
         current.trim() && current !== defaultName
           ? current
@@ -297,6 +309,7 @@ export function DelimitedTextSource() {
               onChange={(event) => {
                 setDelimitedTextUrl(event.target.value);
                 resetDelimitedTextColumns();
+                resetDelimitedTextCrs();
               }}
             />
           </div>
@@ -437,7 +450,7 @@ export function DelimitedTextSource() {
             setDelimitedTextCustomDelimiter("");
             // The sample is WGS84 lon/lat, so clear any projected CRS the user
             // may have entered; otherwise it would reproject correct coordinates.
-            setDelimitedTextCrs("");
+            resetDelimitedTextCrs();
             setDelimitedTextUrl(url);
           }}
         />

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -218,7 +218,9 @@ export function DelimitedTextSource() {
             latitudeField: delimitedTextLatitudeField.trim(),
             longitudeField: delimitedTextLongitudeField.trim(),
             skippedRows: result.skippedRows,
-            sourceCrs: sourceCrs || null,
+            // A non-spatial attribute table has no geometry, so a source CRS is
+            // meaningless there; only record it for point layers.
+            sourceCrs: result.isTable ? null : sourceCrs || null,
             sourceKind: "delimited-text",
             totalRows: result.totalRows,
           },

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -4,11 +4,14 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   detectCoordinateFields,
+  isGeographicCrs,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "../../../../lib/delimited-text";
+import { reprojectFeatureCollectionToWgs84 } from "../../../../lib/duckdb-vector-loader";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
 import {
+  CAD_CRS_PRESETS,
   DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD,
   DEFAULT_DELIMITED_TEXT_LONGITUDE_FIELD,
   DEFAULT_DELIMITED_TEXT_URL,
@@ -18,6 +21,7 @@ import {
   errorMessage,
   fileNameFromPath,
   layerNameFromPath,
+  normalizeCrs,
   resolveDelimitedTextDelimiter,
 } from "../helpers";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
@@ -40,6 +44,10 @@ export function DelimitedTextSource() {
   const [delimitedTextLongitudeField, setDelimitedTextLongitudeField] = useState(
     DEFAULT_DELIMITED_TEXT_LONGITUDE_FIELD,
   );
+  // Source CRS of the coordinate columns. Blank means WGS84 longitude/latitude
+  // (the historical behaviour); a projected EPSG code reprojects the points to
+  // WGS84 after parsing so CSVs in any CRS import in the right place (#1338).
+  const [delimitedTextCrs, setDelimitedTextCrs] = useState("");
   const [delimitedTextFields, setDelimitedTextFields] = useState<string[]>([]);
   const [delimitedTextColumnsStatus, setDelimitedTextColumnsStatus] = useState<string | null>(null);
   const [isRetrievingDelimitedTextColumns, setIsRetrievingDelimitedTextColumns] = useState(false);
@@ -179,11 +187,20 @@ export function DelimitedTextSource() {
     const { sourcePath, text } = await readDelimitedTextSource();
     if (!text) throw new Error(t("addData.delimitedText.errorDataMissing"));
 
+    const sourceCrs = normalizeCrs(delimitedTextCrs);
     const result = parseDelimitedTextLayer(text, {
       delimiter,
       latitudeField: delimitedTextLatitudeField,
       longitudeField: delimitedTextLongitudeField,
+      sourceCrs,
     });
+    // A projected source CRS leaves the parsed coordinates in their native units
+    // (e.g. UTM metres), so reproject them to WGS84 before the map renders them.
+    // Attribute tables (null geometry) have nothing to reproject.
+    const geojson =
+      result.isTable || isGeographicCrs(sourceCrs)
+        ? result.data
+        : await reprojectFeatureCollectionToWgs84(result.data, sourceCrs);
     source.addAndClose(
       {
         ...createBaseLayer(
@@ -195,17 +212,18 @@ export function DelimitedTextSource() {
           },
           {
             delimiter,
-            featureCount: result.data.features.length,
+            featureCount: geojson.features.length,
             fields: result.fields,
             isTable: result.isTable,
             latitudeField: delimitedTextLatitudeField.trim(),
             longitudeField: delimitedTextLongitudeField.trim(),
             skippedRows: result.skippedRows,
+            sourceCrs: sourceCrs || null,
             sourceKind: "delimited-text",
             totalRows: result.totalRows,
           },
         ),
-        geojson: result.data,
+        geojson,
         sourcePath,
       },
       // A non-spatial attribute table has no geometry to fit the map to.
@@ -375,6 +393,34 @@ export function DelimitedTextSource() {
           </div>
         </div>
         <p className="text-xs text-muted-foreground">{t("addData.delimitedText.tableHint")}</p>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="delimited-text-crs">{t("addData.delimitedText.crs")}</Label>
+          <Input
+            id="delimited-text-crs"
+            placeholder={t("addData.delimitedText.crsPlaceholder")}
+            value={delimitedTextCrs}
+            onChange={(event) => setDelimitedTextCrs(event.target.value)}
+          />
+          <Select
+            aria-label={t("addData.delimitedText.crsPresetLabel")}
+            value=""
+            onChange={(event) => {
+              if (event.target.value) setDelimitedTextCrs(event.target.value);
+            }}
+          >
+            <option value="" disabled>
+              {t("addData.delimitedText.crsPresetLabel")}
+            </option>
+            {CAD_CRS_PRESETS.map((preset) => (
+              <option key={preset.value} value={preset.value}>
+                {preset.label}
+              </option>
+            ))}
+          </Select>
+          <p className="text-xs text-muted-foreground">{t("addData.delimitedText.crsHelp")}</p>
+        </div>
+
         <SampleDataSelect
           samples={[
             { label: t("addData.delimitedText.sampleLabel"), value: DEFAULT_DELIMITED_TEXT_URL },
@@ -387,6 +433,9 @@ export function DelimitedTextSource() {
             // otherwise a previously chosen delimiter would misparse it.
             setDelimitedTextDelimiter("comma");
             setDelimitedTextCustomDelimiter("");
+            // The sample is WGS84 lon/lat, so clear any projected CRS the user
+            // may have entered; otherwise it would reproject correct coordinates.
+            setDelimitedTextCrs("");
             setDelimitedTextUrl(url);
           }}
         />

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -470,7 +470,11 @@
       "longitudeField": "Longitude field",
       "latitudeField": "Latitude field",
       "noneField": "None (attribute table)",
-      "tableHint": "Leave both coordinate fields as None to add the file as a non-spatial attribute table (for use in an attribute join)."
+      "tableHint": "Leave both coordinate fields as None to add the file as a non-spatial attribute table (for use in an attribute join).",
+      "crs": "Coordinate system",
+      "crsPlaceholder": "e.g. EPSG:32643",
+      "crsPresetLabel": "Common coordinate systems...",
+      "crsHelp": "Leave blank if the coordinates are already longitude/latitude (WGS84). Otherwise enter the EPSG code of the coordinate columns and the points will be reprojected to WGS84."
     },
     "photos": {
       "defaultName": "Photos",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -474,7 +474,7 @@
       "crs": "Coordinate system",
       "crsPlaceholder": "e.g. EPSG:32643",
       "crsPresetLabel": "Common coordinate systems...",
-      "crsHelp": "Leave blank if the coordinates are already longitude/latitude (WGS84). Otherwise enter the EPSG code of the coordinate columns and the points will be reprojected to WGS84."
+      "crsHelp": "Leave blank if the coordinates are already longitude/latitude (WGS84). Otherwise enter the EPSG code of the coordinate columns and the points will be reprojected to WGS84. For a projected CRS, the longitude and latitude fields select the X (easting) and Y (northing) columns."
     },
     "photos": {
       "defaultName": "Photos",

--- a/apps/geolibre-desktop/src/lib/crs-utils.ts
+++ b/apps/geolibre-desktop/src/lib/crs-utils.ts
@@ -1,0 +1,27 @@
+/**
+ * Small CRS helpers shared across data-loading modules. Kept in a neutral place
+ * (rather than in a feature-specific module like `delimited-text.ts`) so both
+ * the generic DuckDB vector loader and the delimited-text importer can depend on
+ * it without a backwards feature-to-generic dependency.
+ */
+
+/**
+ * True when `crs` denotes WGS84 longitude/latitude (or is blank), so the parsed
+ * coordinates are already in the +/-180 / +/-90 range MapLibre expects and need
+ * no reprojection. A projected CRS (e.g. `EPSG:32643`) returns `false`: its
+ * coordinates are metres, must skip the lon/lat bounds check, and are
+ * reprojected to WGS84 by the caller before the layer is added.
+ *
+ * @param crs - A CRS as `AUTHORITY:CODE` (e.g. `EPSG:4326`), a WGS84 alias
+ *   (`CRS84`), or blank.
+ * @returns `true` for a blank/WGS84 CRS, `false` for any other declared CRS.
+ */
+export function isGeographicCrs(crs: string | undefined): boolean {
+  // Strip all whitespace before matching so a free-text CRS with a stray space
+  // (e.g. `EPSG: 4326`) is still recognized as WGS84 rather than mistaken for a
+  // projected CRS, which would skip the lon/lat bounds check and trigger a
+  // needless reprojection round-trip.
+  const value = (crs ?? "").replace(/\s+/g, "").toUpperCase();
+  if (!value) return true;
+  return value.includes("CRS84") || /EPSG:+4326\b/.test(value);
+}

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -43,16 +43,45 @@ export function parseDelimitedTextFields(text: string, delimiter: string): strin
   return uniqueFieldNames(rows[0].map((field) => field.trim()));
 }
 
+/**
+ * True when `crs` denotes WGS84 longitude/latitude (or is blank), so the parsed
+ * coordinates are already in the +/-180 / +/-90 range MapLibre expects and need
+ * no reprojection. A projected CRS (e.g. `EPSG:32643`) returns `false`: its
+ * coordinates are metres, must skip the lon/lat bounds check, and are
+ * reprojected to WGS84 by the caller before the layer is added.
+ *
+ * @param crs - A CRS as `AUTHORITY:CODE` (e.g. `EPSG:4326`), a WGS84 alias
+ *   (`CRS84`), or blank.
+ * @returns `true` for a blank/WGS84 CRS, `false` for any other declared CRS.
+ */
+export function isGeographicCrs(crs: string | undefined): boolean {
+  const value = (crs ?? "").trim().toUpperCase();
+  if (!value) return true;
+  return value.includes("CRS84") || /EPSG:+4326\b/.test(value);
+}
+
 export function parseDelimitedTextLayer(
   text: string,
   options: {
     delimiter: string;
     latitudeField: string;
     longitudeField: string;
+    /**
+     * Source CRS of the coordinate columns as `AUTHORITY:CODE`, or blank for
+     * WGS84 longitude/latitude. When a projected CRS is given, coordinates are
+     * kept in their native units (skipping the lon/lat range check) so the
+     * caller can reproject them to WGS84; see {@link isGeographicCrs}.
+     */
+    sourceCrs?: string;
   },
 ): DelimitedTextLayerResult {
   const delimiter = options.delimiter;
   if (!delimiter) throw new Error("Enter a delimiter.");
+  // A projected source CRS carries coordinates in metres (or feet), which lie
+  // far outside the WGS84 +/-180 / +/-90 range, so the geographic bounds check
+  // below would reject every row. Skip it for projected CRSs and let the caller
+  // reproject the raw coordinates to WGS84.
+  const geographic = isGeographicCrs(options.sourceCrs);
 
   const rows = parseDelimitedRows(text, delimiter).filter((row) =>
     row.some((value) => value.trim()),
@@ -119,7 +148,7 @@ export function parseDelimitedTextLayer(
       skippedRows += 1;
       continue;
     }
-    if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    if (geographic && (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)) {
       skippedRows += 1;
       continue;
     }

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -55,7 +55,11 @@ export function parseDelimitedTextFields(text: string, delimiter: string): strin
  * @returns `true` for a blank/WGS84 CRS, `false` for any other declared CRS.
  */
 export function isGeographicCrs(crs: string | undefined): boolean {
-  const value = (crs ?? "").trim().toUpperCase();
+  // Strip all whitespace before matching so a free-text CRS with a stray space
+  // (e.g. `EPSG: 4326`) is still recognized as WGS84 rather than mistaken for a
+  // projected CRS, which would skip the lon/lat bounds check and trigger a
+  // needless reprojection round-trip.
+  const value = (crs ?? "").replace(/\s+/g, "").toUpperCase();
   if (!value) return true;
   return value.includes("CRS84") || /EPSG:+4326\b/.test(value);
 }

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -1,4 +1,5 @@
 import type { Feature, FeatureCollection, GeoJsonProperties, Geometry, Point } from "geojson";
+import { isGeographicCrs } from "./crs-utils";
 
 export interface DelimitedTextLayerResult {
   data: FeatureCollection;
@@ -41,27 +42,6 @@ export function parseDelimitedTextFields(text: string, delimiter: string): strin
   }
 
   return uniqueFieldNames(rows[0].map((field) => field.trim()));
-}
-
-/**
- * True when `crs` denotes WGS84 longitude/latitude (or is blank), so the parsed
- * coordinates are already in the +/-180 / +/-90 range MapLibre expects and need
- * no reprojection. A projected CRS (e.g. `EPSG:32643`) returns `false`: its
- * coordinates are metres, must skip the lon/lat bounds check, and are
- * reprojected to WGS84 by the caller before the layer is added.
- *
- * @param crs - A CRS as `AUTHORITY:CODE` (e.g. `EPSG:4326`), a WGS84 alias
- *   (`CRS84`), or blank.
- * @returns `true` for a blank/WGS84 CRS, `false` for any other declared CRS.
- */
-export function isGeographicCrs(crs: string | undefined): boolean {
-  // Strip all whitespace before matching so a free-text CRS with a stray space
-  // (e.g. `EPSG: 4326`) is still recognized as WGS84 rather than mistaken for a
-  // projected CRS, which would skip the lon/lat bounds check and trigger a
-  // needless reprojection round-trip.
-  const value = (crs ?? "").replace(/\s+/g, "").toUpperCase();
-  if (!value) return true;
-  return value.includes("CRS84") || /EPSG:+4326\b/.test(value);
 }
 
 export function parseDelimitedTextLayer(
@@ -328,6 +308,15 @@ function findFieldIndex(fields: string[], fieldName: string): number {
  * point) is stripped rather than read as a decimal. A comma that is *not* a
  * valid thousands group (e.g. `659319,6`, a European decimal) still falls
  * through to the decimal heuristic, so both conventions round-trip correctly.
+ *
+ * **Known limitation:** a single-group value with <=3 integer digits, e.g.
+ * `"45,123"`, is genuinely ambiguous from the string alone -- it could be the
+ * thousands-grouped `45123` or the European decimal `45.123`. In `grouped` mode
+ * it is read as `45123`. This is correct for the dominant projected cases
+ * (UTM/State-Plane eastings/northings are 6-7 digits, well clear of this range)
+ * but misreads a small-magnitude local/site grid coordinate written with a
+ * decimal comma. There is no way to disambiguate without knowing the locale, so
+ * the large-magnitude interpretation is chosen deliberately.
  *
  * @param value - The raw coordinate field (may include surrounding whitespace).
  * @param options - `grouped` marks the value as a projected coordinate, where a

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -146,8 +146,10 @@ export function parseDelimitedTextLayer(
   const features: Feature<Point, GeoJsonProperties>[] = [];
 
   for (const row of rows.slice(1)) {
-    const latitude = parseCoordinate(row[latitudeIndex]);
-    const longitude = parseCoordinate(row[longitudeIndex]);
+    // For a projected CRS, treat a bare comma as a thousands separator (large
+    // easting/northing) rather than a decimal point.
+    const latitude = parseCoordinate(row[latitudeIndex], { grouped: !geographic });
+    const longitude = parseCoordinate(row[longitudeIndex], { grouped: !geographic });
     if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
       skippedRows += 1;
       continue;
@@ -318,16 +320,38 @@ function findFieldIndex(fields: string[], fieldName: string): number {
  * parses to `1.234`); this is unambiguous for WGS84 coordinates, where a
  * thousands grouping never occurs within the valid +/-180 range.
  *
+ * That last assumption breaks for **projected** coordinates: a UTM easting is
+ * hundreds of thousands to millions of metres, exactly where thousands grouping
+ * occurs, so `"659,319"` means `659319`, not `659.319`. Pass `grouped: true`
+ * (the delimited-text importer sets it for a projected source CRS) so a bare
+ * comma laid out as a thousands group (e.g. `659,319` or `1,234,567`, no decimal
+ * point) is stripped rather than read as a decimal. A comma that is *not* a
+ * valid thousands group (e.g. `659319,6`, a European decimal) still falls
+ * through to the decimal heuristic, so both conventions round-trip correctly.
+ *
  * @param value - The raw coordinate field (may include surrounding whitespace).
+ * @param options - `grouped` marks the value as a projected coordinate, where a
+ *   bare comma is a thousands separator rather than a decimal point.
  * @returns The parsed number, or `NaN` when the value is empty or unparsable.
  */
-export function parseCoordinate(value: string | undefined): number {
+export function parseCoordinate(
+  value: string | undefined,
+  options?: { grouped?: boolean },
+): number {
   const trimmed = (value ?? "").trim();
   if (!trimmed) return Number.NaN;
 
   const lastComma = trimmed.lastIndexOf(",");
   const lastDot = trimmed.lastIndexOf(".");
   if (lastComma < 0 && lastDot < 0) return Number(trimmed);
+
+  // A projected coordinate written with comma thousands separators and no
+  // decimal point (`659,319`, `1,234,567`) is a whole number of metres; strip
+  // the commas. Only a strict thousands layout qualifies, so a European decimal
+  // like `659319,6` is left for the decimal heuristic below.
+  if (options?.grouped && lastDot < 0 && /^-?\d{1,3}(,\d{3})+$/.test(trimmed)) {
+    return Number(trimmed.replaceAll(",", ""));
+  }
 
   const decimalSeparator = lastComma > lastDot ? "," : ".";
   const groupingSeparator = decimalSeparator === "," ? "." : ",";

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -13,7 +13,7 @@ import {
   stripAutoFidColumn,
   wkbRowsToFeatureCollection,
 } from "./duckdb-geometry";
-import { isGeographicCrs } from "./delimited-text";
+import { isGeographicCrs } from "./crs-utils";
 import { confirmLargeDataset, type DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { isLikelyGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -1,5 +1,6 @@
 import * as duckdb from "@duckdb/duckdb-wasm";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
+import { isGeographicCrs } from "./crs-utils";
 import {
   detectGeometryColumn,
   geometryExpr,
@@ -13,7 +14,6 @@ import {
   stripAutoFidColumn,
   wkbRowsToFeatureCollection,
 } from "./duckdb-geometry";
-import { isGeographicCrs } from "./crs-utils";
 import { confirmLargeDataset, type DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { isLikelyGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -13,6 +13,7 @@ import {
   stripAutoFidColumn,
   wkbRowsToFeatureCollection,
 } from "./duckdb-geometry";
+import { isGeographicCrs } from "./delimited-text";
 import { confirmLargeDataset, type DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { isLikelyGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";
@@ -818,7 +819,9 @@ function sourceCrsFromGeoJson(fc: FeatureCollection): string | null {
   if (typeof name !== "string") return null;
   const upper = name.toUpperCase();
   // CRS84 and EPSG:4326 are both WGS84 lon/lat; no reprojection is required.
-  if (upper.includes("CRS84") || /EPSG:+4326\b/.test(upper)) return null;
+  // Shares the WGS84 test with the delimited-text importer so the rule lives in
+  // one place.
+  if (isGeographicCrs(name)) return null;
   const match = upper.match(/EPSG:+(\d+)/);
   return match ? `EPSG:${match[1]}` : null;
 }

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -17,6 +17,7 @@ import {
   wmsVersionFromEndpoint,
   geoJsonToPointRows,
   layerNameFromPath,
+  normalizeCrs,
   parseOptionalNumber,
   parseRequiredNumber,
   parseVideoCorner,
@@ -293,6 +294,24 @@ describe("resolveDelimitedTextDelimiter", () => {
     assert.equal(resolveDelimitedTextDelimiter("comma", ""), ",");
     assert.equal(resolveDelimitedTextDelimiter("tab", ""), "\t");
     assert.equal(resolveDelimitedTextDelimiter("custom", "~"), "~");
+  });
+});
+
+describe("normalizeCrs", () => {
+  it("qualifies a bare code and upper-cases an authority string", () => {
+    assert.equal(normalizeCrs("32643"), "EPSG:32643");
+    assert.equal(normalizeCrs("epsg:4326"), "EPSG:4326");
+    assert.equal(normalizeCrs("esri:102100"), "ESRI:102100");
+  });
+
+  it("returns blank for an empty or whitespace-only value", () => {
+    assert.equal(normalizeCrs(""), "");
+    assert.equal(normalizeCrs("   "), "");
+  });
+
+  it("strips internal whitespace so a pasted `EPSG: 32643` is valid for PROJ", () => {
+    assert.equal(normalizeCrs("EPSG: 32643"), "EPSG:32643");
+    assert.equal(normalizeCrs("  epsg : 4326 "), "EPSG:4326");
   });
 });
 

--- a/tests/add-data-helpers.test.ts
+++ b/tests/add-data-helpers.test.ts
@@ -313,6 +313,11 @@ describe("normalizeCrs", () => {
     assert.equal(normalizeCrs("EPSG: 32643"), "EPSG:32643");
     assert.equal(normalizeCrs("  epsg : 4326 "), "EPSG:4326");
   });
+
+  it("passes a WKT definition through untouched (apart from edge trimming)", () => {
+    const wkt = '  GEOGCS["WGS 84",DATUM["WGS_1984"]]  ';
+    assert.equal(normalizeCrs(wkt), 'GEOGCS["WGS 84",DATUM["WGS_1984"]]');
+  });
 });
 
 describe("savedPostgresConnectionLabel", () => {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -145,6 +145,41 @@ describe("delimited text parsing", () => {
     assert.equal(result.isTable, false);
     assert.equal(result.data.features.length, 1);
   });
+
+  it("keeps out-of-range coordinates when a projected source CRS is given", () => {
+    // UTM zone 43N (EPSG:32643) easting/northing lie far outside the WGS84
+    // +/-180 / +/-90 range; without a projected CRS every row would be skipped
+    // (issue #1338). The caller reprojects these native coordinates to WGS84.
+    const result = parseDelimitedTextLayer(
+      ["id,x,y", "1,659319.6360799533,3005510.000378756"].join("\n"),
+      {
+        delimiter: ",",
+        longitudeField: "x",
+        latitudeField: "y",
+        sourceCrs: "EPSG:32643",
+      },
+    );
+
+    assert.equal(result.isTable, false);
+    assert.equal(result.skippedRows, 0);
+    assert.equal(result.data.features.length, 1);
+    assert.deepEqual(
+      (result.data.features[0].geometry as { coordinates: number[] }).coordinates,
+      [659319.6360799533, 3005510.000378756],
+    );
+  });
+
+  it("still rejects out-of-range coordinates for a WGS84 (blank) CRS", () => {
+    assert.throws(
+      () =>
+        parseDelimitedTextLayer(["id,x,y", "1,659319.6,3005510.0"].join("\n"), {
+          delimiter: ",",
+          longitudeField: "x",
+          latitudeField: "y",
+        }),
+      /No rows contained valid longitude and latitude values\./,
+    );
+  });
 });
 
 describe("parseCoordinate", () => {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { isGeographicCrs } from "../apps/geolibre-desktop/src/lib/crs-utils";
 import {
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
-  isGeographicCrs,
   parseCoordinate,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
@@ -242,6 +242,15 @@ describe("parseCoordinate", () => {
     assert.equal(parseCoordinate("659319,6", { grouped: true }), 659319.6);
     assert.equal(parseCoordinate("659319.6", { grouped: true }), 659319.6);
     assert.equal(parseCoordinate("1,234.56", { grouped: true }), 1234.56);
+  });
+
+  it("resolves the ambiguous small-magnitude grouped value as thousands (documented)", () => {
+    // `45,123` could be 45123 (thousands) or 45.123 (European decimal); it is
+    // indistinguishable from the string alone. Grouped mode deliberately chooses
+    // the large-magnitude reading, which suits UTM/State-Plane coordinates. This
+    // test pins that documented behavior so a future change to the heuristic is
+    // a conscious one.
+    assert.equal(parseCoordinate("45,123", { grouped: true }), 45123);
   });
 });
 

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -226,6 +226,23 @@ describe("parseCoordinate", () => {
     assert.ok(Number.isNaN(parseCoordinate(undefined)));
     assert.ok(Number.isNaN(parseCoordinate("not-a-number")));
   });
+
+  it("reads a bare comma as thousands grouping for projected coordinates", () => {
+    // A UTM easting exported with a thousands separator and no decimal must not
+    // be mistaken for a decimal (659.319); grouped mode strips the commas.
+    assert.equal(parseCoordinate("659,319", { grouped: true }), 659319);
+    assert.equal(parseCoordinate("1,234,567", { grouped: true }), 1234567);
+    // Without grouped mode (WGS84) the historical decimal reading is preserved.
+    assert.equal(parseCoordinate("659,319"), 659.319);
+  });
+
+  it("still reads a European decimal comma for projected coordinates", () => {
+    // `659319,6` is not a valid thousands layout, so it stays a decimal even in
+    // grouped mode; a mixed grouping+decimal value resolves the same way.
+    assert.equal(parseCoordinate("659319,6", { grouped: true }), 659319.6);
+    assert.equal(parseCoordinate("659319.6", { grouped: true }), 659319.6);
+    assert.equal(parseCoordinate("1,234.56", { grouped: true }), 1234.56);
+  });
 });
 
 describe("delimited text auto-detection", () => {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
+  isGeographicCrs,
   parseCoordinate,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
@@ -179,6 +180,28 @@ describe("delimited text parsing", () => {
         }),
       /No rows contained valid longitude and latitude values\./,
     );
+  });
+});
+
+describe("isGeographicCrs", () => {
+  it("treats a blank or missing CRS as WGS84", () => {
+    assert.equal(isGeographicCrs(""), true);
+    assert.equal(isGeographicCrs("   "), true);
+    assert.equal(isGeographicCrs(undefined), true);
+  });
+
+  it("recognizes WGS84 aliases regardless of case or stray whitespace", () => {
+    assert.equal(isGeographicCrs("EPSG:4326"), true);
+    assert.equal(isGeographicCrs("epsg:4326"), true);
+    assert.equal(isGeographicCrs("EPSG: 4326"), true);
+    assert.equal(isGeographicCrs("OGC:CRS84"), true);
+    assert.equal(isGeographicCrs("urn:ogc:def:crs:OGC:1.3:CRS84"), true);
+  });
+
+  it("treats a projected CRS as non-geographic", () => {
+    assert.equal(isGeographicCrs("EPSG:32643"), false);
+    assert.equal(isGeographicCrs("EPSG:3857"), false);
+    assert.equal(isGeographicCrs("ESRI:102100"), false);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1338. The Add Delimited Text Layer dialog previously assumed coordinate columns were WGS84 longitude/latitude, so a CSV in a projected CRS (e.g. EPSG:32643 / UTM zone 43N) had every row rejected by the `+/-180 / +/-90` bounds check and could not be imported.

This adds a **Source CRS** field (free-text EPSG code plus a "Common coordinate systems…" preset dropdown) to the dialog:

- Leave it blank for the existing WGS84 longitude/latitude behaviour (unchanged).
- Enter a projected EPSG code and the points are reprojected to WGS84 after parsing.

## How it works

- `parseDelimitedTextLayer` takes an optional `sourceCrs`. When it denotes a projected CRS, the WGS84 lon/lat bounds check is skipped so the native easting/northing values are kept instead of being dropped as out-of-range.
- The dialog then reprojects the parsed points to WGS84 with the existing DuckDB-WASM Spatial (PROJ) `reprojectFeatureCollectionToWgs84` helper, which resolves any EPSG code, before the layer is added.
- A new `isGeographicCrs` helper centralises the WGS84/blank detection.

## Testing

- Added unit tests: projected-CRS coordinates are kept (not skipped), and out-of-range coordinates are still rejected for a blank/WGS84 CRS.
- Full frontend suite green (`npm run test:frontend`), `npm run build` green, pre-commit clean.
- Verified in the running app with the reporter's sample `point.csv` (`659319.636, 3005510.000` in EPSG:32643): with the CRS set to `EPSG:32643` the point lands at lon `76.6080`, lat `27.1630`, matching the expected WGS84 location. Confirmed the new field renders correctly in both light and dark themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Coordinate system” field and preset selector to Delimited Text import, with guidance for non-spatial attribute handling.
  * If you provide a projected CRS, coordinates are converted for correct map display, and layer metadata reflects the selected CRS.
  * Shared CRS presets are now used across relevant Add Data dialogs (e.g., CAD and Delimited Text).
* **Bug Fixes**
  * Fixed CRS-dependent coordinate validation so out-of-range checks apply only to geographic inputs.
  * Improved CRS normalization (whitespace removed) and enhanced parsing for projected numbers with grouped thousands separators.
* **Tests**
  * Expanded coverage for geographic vs. projected CRS behavior, CRS normalization, and grouped-coordinate parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->