### PR TITLE
feat(time-slider): mosaic (STAC/MosaicJSON) sources with GPU/WASM engine

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -79,7 +79,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.1.0",
+    "maplibre-gl-time-slider": "^1.3.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.9.2",
     "openai": "^6.46.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.1.0",
+        "maplibre-gl-time-slider": "^1.3.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.9.2",
         "openai": "^6.46.0",
@@ -17232,16 +17232,20 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.1.0.tgz",
-      "integrity": "sha512-x3NExYOo6UsDXRjmc4SUEjZj2YmcPtYasJ7D1wTQjVdFy+4lyTRkS6JLKcExqlPDHfM7CfqfNAaANbtgVy0tsw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.3.0.tgz",
+      "integrity": "sha512-uXgbYvYjA3zZNp/NqLltENQfnbiJUciWrRpmHiREd+U6w+jM1qNIywOHhiZ30HoOmDkTPNpDvM+fhi1rqqH/og==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
+        "maplibre-gl-raster": ">=0.12.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       },
       "peerDependenciesMeta": {
+        "maplibre-gl-raster": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -21885,7 +21889,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.1.0",
+        "maplibre-gl-time-slider": "^1.3.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.9.2",
         "netcdfjs": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12247,9 +12247,9 @@
       }
     },
     "node_modules/cog-tiler-wasm": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.2.6.tgz",
-      "integrity": "sha512-kg8x5I1vhzrpD+J/s3r1Df/jaGcCog65M1ll3DQ4TKSfkWEcgFETDhwky3yYPHX/QmeDlBTm7UbD0aRulrQkHg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.0.tgz",
+      "integrity": "sha512-wP+ogGdmhcIECpthCK6x7U75cc9yOfWT4+FEEpzPF0fNgEB2m7MId10wrXIAz1hi9zg0BkdjsXZ+IFP3TEhWdw==",
       "license": "MIT",
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
@@ -21864,7 +21864,7 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@turf/union": "^7.3.5",
-        "cog-tiler-wasm": "^0.2.6",
+        "cog-tiler-wasm": "^0.3.0",
         "geotiff": "^3.0.5",
         "h5wasm": "^0.10.3",
         "jspdf": "^4.2.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -28,7 +28,7 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@turf/union": "^7.3.5",
-    "cog-tiler-wasm": "^0.2.6",
+    "cog-tiler-wasm": "^0.3.0",
     "geotiff": "^3.0.5",
     "h5wasm": "^0.10.3",
     "jspdf": "^4.2.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -53,7 +53,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.1.0",
+    "maplibre-gl-time-slider": "^1.3.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.9.2",
     "netcdfjs": "^4.0.0",

--- a/tests/time-slider-config.test.ts
+++ b/tests/time-slider-config.test.ts
@@ -60,3 +60,35 @@ describe("Time Slider open-ended end date persistence", () => {
     assert.equal(apply(config), false);
   });
 });
+
+describe("Time Slider mosaic source persistence", () => {
+  const mosaicSource = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+    type: "mosaic",
+    id: "s2-mosaic",
+    name: "Sentinel-2 Monthly Mosaic",
+    url: "https://data.source.coop/giswqs/opengeos/s2_mosaic_ts/s2_{date:YYYY}_{date:MM}.json",
+    engine: "wasm",
+    ...overrides,
+  });
+
+  it("round-trips a mosaic source (url + engine) through a save", () => {
+    assert.equal(apply(baseConfig({ sources: [mosaicSource()] })), true);
+    const config = saved();
+    assert.ok(config);
+    const sources = config.sources as Record<string, unknown>[];
+    assert.equal(sources.length, 1);
+    assert.equal(sources[0].type, "mosaic");
+    assert.equal(sources[0].engine, "wasm");
+    assert.equal(
+      sources[0].url,
+      "https://data.source.coop/giswqs/opengeos/s2_mosaic_ts/s2_{date:YYYY}_{date:MM}.json",
+    );
+  });
+
+  it("rejects a mosaic source whose url is not a plain http(s) URL", () => {
+    assert.equal(
+      apply(baseConfig({ sources: [mosaicSource({ url: "javascript:alert(1)" })] })),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Consumes **maplibre-gl-time-slider@1.3.0** ([opengeos/maplibre-gl-time-slider#23](https://github.com/opengeos/maplibre-gl-time-slider/pull/23), [#24](https://github.com/opengeos/maplibre-gl-time-slider/pull/24)), which lets the Time Slider step through a series of **per-date mosaic manifests** — a MosaicJSON or STAC `FeatureCollection` of many COGs — each rendered as a full spatial mosaic (the same client-side deck.gl / `maplibre-gl-raster` engine the **Add Raster Layer** panel gained in #1344).

The dock's **Add data** form gains a **Mosaic** source type with a rendering-engine picker:

- **GPU** (deck.gl) — fast; forces a mercator projection (deck.gl can't render under the globe view, like the other deck.gl overlays).
- **WASM** (`cog-tiler-wasm`, already used by the Add Raster panel) — renders in **globe** as well as mercator.

So the Time Slider can now animate a stack of dated mosaic `.json` files, e.g. monthly Sentinel-2 composites.

## Changes

- Bump `maplibre-gl-time-slider` `^1.1.0` → `^1.3.0` (`packages/plugins` + `apps/geolibre-desktop`).
- Bump **`cog-tiler-wasm` `^0.2.6` → `^0.3.0`**: 0.3.0 generates all **107** colormaps from the sprite (up from 13 hand-written ramps), matching `maplibre-gl-raster`'s GPU renderer. The Time Slider's colormap picker now offers that full set, so the WASM engine needs 0.3.0 to render more than the old 13 correctly — this also widens the **Add Raster** panel's WASM-engine colormap support. Backward compatible.
- Add a config round-trip test for the `mosaic` source (`url` + `engine`, plus rejection of a non-http url).

No other GeoLibre source changes are needed: `isSafeSourceUrl` already validates the mosaic `url`, and `createStoreLayer` mirrors it as a `raster` store layer (so it appears in the Layers panel). The vite config for the WASM engine already exists.

## Testing

- `npm run test:frontend` → **3356 passing** (incl. the new mosaic-config test).
- `pre-commit run --files …` (json/eslint/oxfmt/**npm build**, with cog-tiler-wasm 0.3.0) → all pass.
- Verified end-to-end in the running app with Playwright against real data (5 monthly Sentinel-2 mosaics on source.coop) —
  - **GPU** renders and forces globe→mercator; stepping May→Sep swaps the mosaic (distinct imagery each month).
  - **WASM** renders in mercator **and** globe (0 `getBoundingVolume` errors).
  - Confirmed in light and dark themes; the mosaic mirrors into the Layers panel as a RASTER layer.

## Sample data

The engine picker's example points at `data.source.coop/giswqs/opengeos/s2_mosaic_ts/` (monthly Sentinel-2 true-color STAC mosaics over the French Alps), now hosted and public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the time slider experience with the latest improvements.
  * Time slider mosaic source settings now persist correctly when configurations are saved and reloaded.

* **Bug Fixes**
  * Added protection to reject unsafe mosaic source URLs, including non-HTTP(S) schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->