### PR TITLE
fix(embed): hide the Browser rail (and all side panels) in maponly mode

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1829,7 +1829,7 @@ export function DesktopShell({
         {/* The Browser panel body is portaled into its dedicated content host
             (which the dock slots relocate between positions), so it shares the
             app's React context and the shell owns its dock chrome. */}
-        {activePanelId === BROWSER_PANEL_ID
+        {activePanelId === BROWSER_PANEL_ID && !layoutOptions.panelsHidden
           ? createPortal(
               <BrowserPanel
                 mapControllerRef={mapControllerRef}
@@ -1839,7 +1839,10 @@ export function DesktopShell({
               browserContentEl,
             )
           : null}
-        {replaceLayersPanelId ? (
+        {/* Map-only / hidden-panels embeds show nothing but the map: skip the
+            whole left side-dock (Layers, plugin panels, and the shared rail that
+            hosts the Browser entry), not just the built-in Layers panel. */}
+        {layoutOptions.panelsHidden ? null : replaceLayersPanelId ? (
           // Shared-rail mode on the Layers (left) side: the plugin panel shares
           // the Layers sidebar surface, so a single rail lists both the workbench
           // and Layers instead of the two positional plugin slots flanking it.
@@ -2024,7 +2027,9 @@ export function DesktopShell({
             />
           )}
         </main>
-        {replaceStylePanelId ? (
+        {/* Same as the left dock: a map-only / hidden-panels embed skips the
+            entire right side-dock (Style, plugin panels, and their shared rail). */}
+        {layoutOptions.panelsHidden ? null : replaceStylePanelId ? (
           // Shared-rail mode (issue #765): the plugin panel shares the Style
           // sidebar surface, so a single rail lists both the workbench and Style
           // instead of the two positional plugin slots flanking the Style panel.

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -6,6 +6,14 @@ export interface LayoutOptions {
   attributePanelVisible: boolean;
   compact: boolean;
   layerPanelVisible: boolean;
+  /**
+   * Whether the embed chrome hides every side panel (`?maponly`,
+   * `?panels=hidden`, `?hidePanels=true`). Unlike `layerPanelVisible` /
+   * `stylePanelVisible` (which the in-app settings also toggle), this gates the
+   * whole side-dock surface — including the plugin/Browser panels and their
+   * shared rail — so a map-only embed shows nothing but the map.
+   */
+  panelsHidden: boolean;
   showProjectInfo: boolean;
   statusBarVisible: boolean;
   stylePanelVisible: boolean;
@@ -30,6 +38,7 @@ export function layoutOptionsFromLocation(layoutSettings: DesktopLayoutSettings)
     return {
       attributePanelVisible: true,
       compact: false,
+      panelsHidden: false,
       statusBarVisible: true,
       toolbarVisible: true,
       ...layoutSettings,
@@ -68,6 +77,7 @@ export function layoutOptionsFromLocation(layoutSettings: DesktopLayoutSettings)
     attributePanelVisible,
     compact,
     layerPanelVisible,
+    panelsHidden,
     showProjectInfo,
     statusBarVisible: !mapOnly,
     stylePanelVisible,

--- a/tests/layout-options.test.ts
+++ b/tests/layout-options.test.ts
@@ -28,6 +28,7 @@ describe("layoutOptionsFromLocation", () => {
     assert.equal(options.layerPanelVisible, true);
     assert.equal(options.stylePanelVisible, true);
     assert.equal(options.attributePanelVisible, true);
+    assert.equal(options.panelsHidden, false);
   });
 
   it("hides every chrome element when maponly is set as a bare flag", () => {
@@ -38,6 +39,9 @@ describe("layoutOptionsFromLocation", () => {
     assert.equal(options.layerPanelVisible, false);
     assert.equal(options.stylePanelVisible, false);
     assert.equal(options.attributePanelVisible, false);
+    // Gates the whole side dock (plugin/Browser panels + shared rail), not just
+    // the built-in Layers/Style panels.
+    assert.equal(options.panelsHidden, true);
   });
 
   it("accepts truthy maponly values", () => {
@@ -61,6 +65,7 @@ describe("layoutOptionsFromLocation", () => {
     assert.equal(options.layerPanelVisible, true);
     assert.equal(options.stylePanelVisible, true);
     assert.equal(options.attributePanelVisible, true);
+    assert.equal(options.panelsHidden, false);
   });
 
   it("ignores maponly with a non-truthy value", () => {
@@ -69,6 +74,7 @@ describe("layoutOptionsFromLocation", () => {
     assert.equal(options.toolbarVisible, true);
     assert.equal(options.statusBarVisible, true);
     assert.equal(options.layerPanelVisible, true);
+    assert.equal(options.panelsHidden, false);
   });
 
   it("leaves the toolbar and status bar visible for panels=none", () => {
@@ -79,5 +85,6 @@ describe("layoutOptionsFromLocation", () => {
     assert.equal(options.layerPanelVisible, false);
     assert.equal(options.stylePanelVisible, false);
     assert.equal(options.attributePanelVisible, false);
+    assert.equal(options.panelsHidden, true);
   });
 });


### PR DESCRIPTION
## Problem

In `?maponly` mode (and `?panels=hidden` / `?hidePanels=true`), the left **BROWSER / LAYERS** vertical rail was still visible — the embed was supposed to show nothing but the map.

`useLayoutOptions` hid the built-in **Layers**, **Style**, and **attribute** panels, but the **plugin/Browser panels** and the **shared sidebar rail** that hosts them weren't gated. The Browser panel docks on the layers side by default (shared-rail mode), so `SharedSidebar` kept rendering; its `builtinVisible={layerPanelVisible}` only dropped the *Layers* entry, leaving the rail on screen with the Browser entry.

## Fix

- Expose the internal `panelsHidden` flag from `useLayoutOptions` (already computed from `maponly` / `panels=hidden` / `hidePanels`). Unlike `layerPanelVisible` / `stylePanelVisible` (which the in-app settings also toggle), it gates the **entire side-dock surface**.
- In `DesktopShell`, gate the whole **left** and **right** side-dock — `SharedSidebar` + every `PluginRightPanel` slot, plus the Browser content portal — on `!panelsHidden`. A hidden-panels embed now renders only the map.

## Testing

- `tests/layout-options.test.ts` — added `panelsHidden` assertions (`false` by default / SSR / `maponly=false`; `true` for `?maponly` and `?panels=none`).
- `npm run test:frontend` → **3357 passing**; `pre-commit` (eslint/oxfmt/**npm build**) → all pass; `tsc` → 0 errors.
- Verified in the running app with Playwright:
  - `?maponly` → no BROWSER/LAYERS rail, no toolbar/status bar; a full-viewport map only.
  - No param → the BROWSER/LAYERS rail and toolbar render as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fully hiding the desktop side-dock interface, including Layers, Style, Browser, plugin, and shared panels.
  - Embed and URL options can now display a map-only experience using `maponly` or `panels=none`.

- **Bug Fixes**
  - Ensured panel visibility settings work consistently across standard browser and server-rendered environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->