### PR TITLE
chore(deps): bump maplibre-gl-time-slider to 1.5.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -79,7 +79,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.4.0",
+    "maplibre-gl-time-slider": "^1.5.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.9.2",
     "openai": "^6.46.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.4.0",
+        "maplibre-gl-time-slider": "^1.5.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.9.2",
         "openai": "^6.46.0",
@@ -591,7 +591,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2727,7 +2726,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.6.tgz",
       "integrity": "sha512-shHIzD1fzPXYNqT5MvCW++3LMUA/odF25eWrjwQ6mRwPjwty9jUOEg5UoRYmNUN0fiE00vnc5kzMQVL7T/jDKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
@@ -2967,7 +2965,6 @@
       "resolved": "https://registry.npmjs.org/@developmentseed/morecantile/-/morecantile-0.7.0.tgz",
       "integrity": "sha512-m9tWDase9COlP/EZ2KK/ydraRU/5yfwvmF/y/2g/iFMFW1vYHQTW/8JYjmo84SiJXUifDDY2xoA3ErYlcWJctg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@developmentseed/affine": "^0.7.0"
       }
@@ -3096,8 +3093,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.4.tgz",
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-postgis": {
       "version": "0.2.4",
@@ -3724,7 +3720,6 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.10.3.tgz",
       "integrity": "sha512-o5iwxSDS2M8lwLkNtaJTKqyN3NHv2Ne5bL+7tfdcmmHukcGMuuSroRG/+IT3CXOS7gk9sYVdR0cMEPHs1lTWNQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3740,7 +3735,6 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.10.3.tgz",
       "integrity": "sha512-gBKSRC7L3cD1KX4fIleRiEKtzlvKjuDW5cYpDcDyQCn/Bw7bJzlGrlaMw87FQ+ReTZp9vlTYFXyrGMuUtR0dKw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.10.3",
         "@esri/arcgis-rest-form-data": "^4.10.3",
@@ -3869,7 +3863,6 @@
       "resolved": "https://registry.npmjs.org/@geoman-io/maplibre-geoman-free/-/maplibre-geoman-free-0.8.4.tgz",
       "integrity": "sha512-nOLEpMtORSR0XceXfOHc0RGqrkCQo3719o1d1Bp64xzijxn37KvkxB7S3dwOFV+i3Z3MleaSGAcIjvszil2D3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@turf/area": "^7.3.5",
         "@turf/bbox": "^7.3.5",
@@ -5445,7 +5438,6 @@
       "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
       "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@math.gl/core": "4.1.0"
       }
@@ -5476,7 +5468,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5605,7 +5596,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -10597,7 +10587,6 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -11279,7 +11268,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11412,7 +11400,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
       "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
@@ -11832,7 +11819,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -12110,7 +12096,6 @@
       "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.1.tgz",
       "integrity": "sha512-5mH36bBRrArqeCeCW3Gl2IhlWcU5g64eQRIfIsyo+XQwaBYfmjzuHJ36nbS7fCLUNk9khNUdgVWTU9C1zS33iw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
@@ -12990,7 +12975,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13061,7 +13045,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -13332,7 +13315,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14101,7 +14083,6 @@
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
       "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.9.3",
         "lerc": "^3.0.0",
@@ -14120,8 +14101,7 @@
       "version": "2024.4.13",
       "resolved": "https://registry.npmjs.org/geotiff-geokeys-to-proj4/-/geotiff-geokeys-to-proj4-2024.4.13.tgz",
       "integrity": "sha512-Jgtm/lcPkgB44wCqQHaVQx5/fyhmiVDRUKQcI/vMolsED8/GRWBnn5qkQo/CgutQg9xkGzig21DY9Px9mFRdvg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/geotiff/node_modules/lerc": {
       "version": "3.0.0",
@@ -14904,7 +14884,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
       "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15013,7 +14992,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6 || ^7"
       },
@@ -17087,9 +17065,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.4.0.tgz",
-      "integrity": "sha512-sge0jN3HHNSJ1aM+cCF7zaNMJQBBMRxMkkWlG0QB+EM+HmVsGv6i+1bSw4AdzOza5kXCWGyaNd4r+6KTJdgXUw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.5.0.tgz",
+      "integrity": "sha512-3ZQUvXRCbKLkb1KVbegLMs5Mjb1XjcnK5crwfA+vqgA1LOX51fA2tJe+4zA+pZnSRaXOKP0opD3dnLQa7Uo6VA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -18110,7 +18088,6 @@
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -18289,7 +18266,6 @@
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
       "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.5.5"
@@ -18501,7 +18477,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18511,7 +18486,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18912,7 +18886,6 @@
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -19907,7 +19880,6 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20097,7 +20069,6 @@
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -20361,7 +20332,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -20634,7 +20604,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -21038,7 +21007,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21253,7 +21221,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -21426,7 +21393,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -21504,7 +21470,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -21567,7 +21532,6 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -21758,7 +21722,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.4.0",
+        "maplibre-gl-time-slider": "^1.5.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.9.2",
         "netcdfjs": "^4.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -53,7 +53,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.4.0",
+    "maplibre-gl-time-slider": "^1.5.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.9.2",
     "netcdfjs": "^4.0.0",


### PR DESCRIPTION
## Summary
- Bump `maplibre-gl-time-slider` from `^1.4.0` to `^1.5.0` in `apps/geolibre-desktop` and `packages/plugins`.
- 1.5.0 changes the add-data panel so it no longer closes on click-outside; `+ Add data` is now the only control that opens or closes it. This is a deliberate UX change upstream, since panning the map to inspect a new layer was dismissing half-filled forms.
- Also adds a NAIP annual imagery example and repoints the built-in mosaic example at it with bands prefilled to 1,2,3. No API break: `destroy()` stays exported and callable, now a no-op.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run test:frontend` passes (3357 passed, 1 pre-existing skip)
- [x] `pre-commit run --files <changed>` clean, including the npm build hook
- [ ] Open the time slider dock and confirm the add-data panel stays open while panning and zooming the map
- [ ] Load the built-in mosaic example and confirm the NAIP layer renders in true color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the map time slider component to version 1.5.0, providing the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->