### PR TITLE
fix(map): collapse the attribution control after the map loads

### DIFF
--- a/packages/map/src/collapsed-attribution-control.ts
+++ b/packages/map/src/collapsed-attribution-control.ts
@@ -1,0 +1,75 @@
+import maplibregl from "maplibre-gl";
+
+/** Set by MapLibre once the control is in compact (collapsible) mode. */
+const COMPACT_CLASS = "maplibregl-compact";
+/** Set alongside it while the attribution text is expanded. */
+const SHOW_CLASS = "maplibregl-compact-show";
+
+/** The slice of an element the collapse helpers touch (kept small for tests). */
+type ClassListElement = Pick<HTMLElement, "classList">;
+
+/**
+ * Collapse a compact attribution control once MapLibre has expanded it.
+ *
+ * @returns True once compact mode is on — the moment after which MapLibre never
+ *   expands the control on its own again, so a caller watching for it can stop.
+ *   False while the control has yet to enter compact mode.
+ */
+export function collapseCompactAttribution(container: ClassListElement): boolean {
+  if (!container.classList.contains(COMPACT_CLASS)) return false;
+  container.classList.remove(SHOW_CLASS);
+  return true;
+}
+
+/**
+ * Collapse the control as soon as MapLibre expands it, then stop watching.
+ *
+ * Attribution arrives asynchronously — with the first tiles, and again as
+ * layers are added — so the expansion cannot be caught at `onAdd` time. Watching
+ * the class list catches it whenever it lands, and giving up straight afterwards
+ * leaves the user's own toggling of the control alone.
+ *
+ * @returns A function that stops the watch early (on control removal), or null
+ *   when the control was already expanded or no `MutationObserver` exists.
+ */
+export function watchForCompactAttribution(container: HTMLElement): (() => void) | null {
+  if (collapseCompactAttribution(container)) return null;
+  if (typeof MutationObserver === "undefined") return null;
+  const observer = new MutationObserver(() => {
+    if (collapseCompactAttribution(container)) observer.disconnect();
+  });
+  observer.observe(container, { attributes: true, attributeFilter: ["class"] });
+  return () => observer.disconnect();
+}
+
+/**
+ * A compact attribution control that starts collapsed.
+ *
+ * MapLibre's compact mode expands itself the first time the style reports an
+ * attribution: `_updateCompact` adds `maplibregl-compact` and
+ * `maplibregl-compact-show` in the same breath, and the only things that take
+ * `maplibregl-compact-show` back off are a map drag or a click on the toggle.
+ * A freshly loaded map therefore sits with its full attribution text spread
+ * across the corner until the user touches the map. Collapsing it ourselves the
+ * moment that expansion lands gives the map the tidy corner badge that compact
+ * mode was asked for in the first place.
+ */
+export class CollapsedAttributionControl extends maplibregl.AttributionControl {
+  private unwatch: (() => void) | null = null;
+
+  constructor() {
+    super({ compact: true });
+  }
+
+  override onAdd(map: maplibregl.Map): HTMLElement {
+    const container = super.onAdd(map);
+    this.unwatch = watchForCompactAttribution(container);
+    return container;
+  }
+
+  override onRemove(): void {
+    this.unwatch?.();
+    this.unwatch = null;
+    super.onRemove();
+  }
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -20,6 +20,7 @@ import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import maplibregl from "maplibre-gl";
 import { LayerControl, type CustomLayerAdapter, type LayerState } from "maplibre-gl-layer-control";
+import { CollapsedAttributionControl } from "./collapsed-attribution-control";
 import {
   circleLayerId,
   fillExtrusionLayerId,
@@ -2322,9 +2323,7 @@ export class MapController {
     if (!this.map || this.attributionControl || !this.controlVisibility.attribution) {
       return false;
     }
-    this.attributionControl = new maplibregl.AttributionControl({
-      compact: true,
-    });
+    this.attributionControl = new CollapsedAttributionControl();
     this.map.addControl(this.attributionControl, this.controlPositions.attribution);
     return true;
   }

--- a/tests/collapsed-attribution-control.test.ts
+++ b/tests/collapsed-attribution-control.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  collapseCompactAttribution,
+  watchForCompactAttribution,
+} from "../packages/map/src/collapsed-attribution-control";
+
+/** Minimal stand-in for the control's container: node:test has no DOM. */
+function makeContainer(...initial: string[]) {
+  const classes = new Set(initial);
+  return {
+    classes,
+    element: {
+      classList: {
+        contains: (name: string) => classes.has(name),
+        remove: (name: string) => classes.delete(name),
+        add: (...names: string[]) => names.forEach((n) => classes.add(n)),
+      },
+    } as unknown as HTMLElement,
+  };
+}
+
+/**
+ * Install a fake MutationObserver that hands the test the callback, so it can
+ * replay MapLibre mutating the container's class list.
+ */
+function withFakeObserver() {
+  let callback = () => {};
+  let connected = false;
+  const state = {
+    // A disconnected observer never fires again, so model that rather than
+    // letting a test drive a callback the browser would no longer call.
+    fire: () => {
+      if (connected) callback();
+    },
+    disconnects: 0,
+    observed: 0,
+  };
+  class FakeMutationObserver {
+    constructor(cb: () => void) {
+      callback = cb;
+    }
+    observe() {
+      state.observed += 1;
+      connected = true;
+    }
+    disconnect() {
+      state.disconnects += 1;
+      connected = false;
+    }
+  }
+  (globalThis as Record<string, unknown>).MutationObserver = FakeMutationObserver;
+  return state;
+}
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).MutationObserver;
+});
+
+describe("collapseCompactAttribution", () => {
+  it("does nothing while MapLibre has yet to switch to compact mode", () => {
+    const { element, classes } = makeContainer("maplibregl-ctrl-attrib");
+    assert.equal(collapseCompactAttribution(element), false);
+    assert.deepEqual([...classes], ["maplibregl-ctrl-attrib"]);
+  });
+
+  it("collapses the control once MapLibre expands it", () => {
+    const { element, classes } = makeContainer("maplibregl-compact", "maplibregl-compact-show");
+    assert.equal(collapseCompactAttribution(element), true);
+    assert.equal(classes.has("maplibregl-compact-show"), false);
+    // Compact mode itself stays on — that is what renders the toggle button.
+    assert.equal(classes.has("maplibregl-compact"), true);
+  });
+
+  it("reports done for an already-collapsed compact control", () => {
+    const { element } = makeContainer("maplibregl-compact");
+    assert.equal(collapseCompactAttribution(element), true);
+  });
+});
+
+describe("watchForCompactAttribution", () => {
+  it("collapses the expansion that arrives with the first attribution", () => {
+    const observer = withFakeObserver();
+    const { element, classes } = makeContainer();
+
+    const unwatch = watchForCompactAttribution(element);
+    assert.ok(unwatch, "watches a control that is not yet compact");
+    assert.equal(observer.observed, 1);
+
+    // MapLibre adds both classes together once a source reports attribution.
+    element.classList.add("maplibregl-compact", "maplibregl-compact-show");
+    observer.fire();
+
+    assert.equal(classes.has("maplibregl-compact-show"), false);
+    assert.equal(observer.disconnects, 1, "stops watching after the one expansion");
+  });
+
+  it("leaves a later user expansion alone", () => {
+    const observer = withFakeObserver();
+    const { element, classes } = makeContainer();
+
+    watchForCompactAttribution(element);
+    element.classList.add("maplibregl-compact", "maplibregl-compact-show");
+    observer.fire();
+
+    // The user clicks the toggle; the watch is over, so it stays open.
+    element.classList.add("maplibregl-compact-show");
+    observer.fire();
+    assert.equal(classes.has("maplibregl-compact-show"), true);
+  });
+
+  it("skips the watch when the control is already compact", () => {
+    const observer = withFakeObserver();
+    const { element } = makeContainer("maplibregl-compact", "maplibregl-compact-show");
+    assert.equal(watchForCompactAttribution(element), null);
+    assert.equal(observer.observed, 0);
+  });
+
+  it("degrades gracefully where MutationObserver is unavailable", () => {
+    const { element } = makeContainer();
+    assert.equal(watchForCompactAttribution(element), null);
+  });
+});


### PR DESCRIPTION
## Summary
- MapLibre's compact attribution control enters compact mode already expanded: `_updateCompact` adds `maplibregl-compact` and `maplibregl-compact-show` in the same breath, and the only things that remove the show class are a map `drag` or a click on the toggle. Compact mode is entered when the first source reports an attribution, which arrives asynchronously with the first tiles, so the map loaded with its full attribution text spread across the corner until the user touched it.
- Adds `CollapsedAttributionControl`, a subclass that watches the container's class list with a `MutationObserver`, strips `maplibregl-compact-show` the moment that one expansion lands, and then disconnects. Since `_updateCompact` never re-adds the show class once `maplibregl-compact` is present, a single collapse is enough and the user's own toggling is left alone afterwards.
- `MapController.addAttributionControl` now constructs the subclass instead of `new maplibregl.AttributionControl({ compact: true })`.

## Test plan
- [x] `npm run test:frontend` (3364 passed, 0 failed), including the new `tests/collapsed-attribution-control.test.ts`
- [x] `npx tsc -b` clean
- [x] `pre-commit run --files <changed paths>` clean
- [x] Verified in a real browser with Playwright against the dev server at 1400x900: before the fix the container carried `maplibregl-compact maplibregl-compact-show` with the inner text visible on load; after the fix it loads as `maplibregl-compact` with the inner text hidden
- [x] Clicking the toggle after load still expands the control, confirming the watch does not fight the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact attribution control that automatically returns to its collapsed state when expanded.
  * Map attribution now remains unobtrusive while still allowing initial access to attribution details.

* **Bug Fixes**
  * Prevented the attribution control from staying expanded after it is opened.

* **Tests**
  * Added coverage for compact-state behavior, automatic collapsing, cleanup, and unsupported browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->