### PR TITLE
feat(processing): add Random extract vector tool

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -290,6 +290,9 @@ export function ProcessingMenu({
                     <DropdownMenuItem onSelect={() => setVectorToolOpen("select-by-location")}>
                       {t("toolbar.vectorTool.selectByLocation")}
                     </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setVectorToolOpen("random-extract")}>
+                      {t("toolbar.vectorTool.randomExtract")}
+                    </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuLabel className="text-xs text-muted-foreground">
                       {t("toolbar.item.subGroupH3")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1937,6 +1937,7 @@
       "attributeJoin": "Attribute join",
       "selectByValue": "Select by value",
       "selectByLocation": "Select by location",
+      "randomExtract": "Random extract",
       "reproject": "Reproject",
       "explode": "Explode",
       "aggregate": "Aggregate by attribute",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -101,6 +101,7 @@ export type VectorToolKind =
   | "attribute-join"
   | "select-by-value"
   | "select-by-location"
+  | "random-extract"
   | "reproject"
   | "explode"
   | "aggregate"

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1200,6 +1200,79 @@ export const selectByLocationTool: ProcessingAlgorithm = {
   },
 };
 
+export const randomExtractTool: ProcessingAlgorithm = {
+  id: "random-extract",
+  name: "Random extract",
+  description:
+    "Extract a random subset of features into a new layer, sized by a feature count or a percentage of the input.",
+  group: "Select",
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+    {
+      id: "method",
+      label: "Method",
+      type: "select",
+      default: "count",
+      options: [
+        { value: "count", label: "Number of features" },
+        { value: "percentage", label: "Percentage of features" },
+      ],
+    },
+    {
+      id: "count",
+      label: "Number of features",
+      type: "number",
+      default: 10,
+      min: 0,
+      step: 1,
+      description: "Clamped to the number of input features when larger.",
+      visibleWhen: { param: "method", in: ["count"] },
+    },
+    {
+      id: "percentage",
+      label: "Percentage of features",
+      type: "number",
+      default: 10,
+      min: 0,
+      max: 100,
+      step: 1,
+      visibleWhen: { param: "method", in: ["percentage"] },
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx, "layer");
+    if (!fc) return;
+    const total = fc.features.length;
+    const method = (ctx.parameters.method as string) || "count";
+
+    // Resolve the requested sample size, then clamp to [0, total] so an
+    // oversized count or a >100 percentage yields every feature rather than
+    // erroring, and a negative value yields none.
+    let requested: number;
+    if (method === "percentage") {
+      const pct = numberParam(ctx, "percentage", 10);
+      requested = Math.round((pct / 100) * total);
+    } else {
+      requested = Math.round(numberParam(ctx, "count", 10));
+    }
+    const sampleSize = Math.max(0, Math.min(total, requested));
+
+    // Partial Fisher-Yates: draw `sampleSize` distinct indices uniformly
+    // without replacement, without shuffling the whole array.
+    const indices = Array.from({ length: total }, (_, i) => i);
+    for (let i = 0; i < sampleSize; i += 1) {
+      const j = i + Math.floor(Math.random() * (total - i));
+      [indices[i], indices[j]] = [indices[j], indices[i]];
+    }
+    // Sort the chosen indices so the output keeps the input's feature order.
+    const chosen = indices.slice(0, sampleSize).sort((a, b) => a - b);
+    const selected = chosen.map((i) => fc.features[i]);
+
+    ctx.log(`Random extract: selected ${selected.length} of ${total} feature(s)`);
+    ctx.addResultLayer?.("Random extract", featureCollection(selected));
+  },
+};
+
 export const reprojectTool: ProcessingAlgorithm = {
   id: "reproject",
   name: "Reproject",
@@ -2610,6 +2683,7 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   attributeJoinTool,
   selectByValueTool,
   selectByLocationTool,
+  randomExtractTool,
   reprojectTool,
   explodeTool,
   aggregateTool,

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -492,6 +492,59 @@ describe("processing registry", () => {
     assert.equal(runHex({ operator: "eq", value: "0x10" }), 1);
   });
 
+  it("extracts a random subset of features", () => {
+    const tool = getVectorTool("random-extract");
+    assert.ok(tool);
+    // 10 features with distinct, ordered ids so we can check membership + order.
+    const many: GeoLibreLayer = {
+      ...layer,
+      id: "many",
+      name: "Many",
+      geojson: {
+        type: "FeatureCollection",
+        features: Array.from({ length: 10 }, (_, i) => ({
+          type: "Feature" as const,
+          properties: { idx: i },
+          geometry: { type: "Point" as const, coordinates: [i, 0] },
+        })),
+      },
+    };
+    const run = (parameters: Record<string, unknown>): FeatureCollection => {
+      let out: FeatureCollection = { type: "FeatureCollection", features: [] };
+      tool.run({
+        layers: [many],
+        parameters: { layer: "many", ...parameters },
+        log: () => {},
+        addResultLayer: (_n, g) => {
+          out = g;
+        },
+      });
+      return out;
+    };
+
+    // By count: exactly N features, all drawn from the input, no duplicates,
+    // and the input's feature order is preserved in the output.
+    const byCount = run({ method: "count", count: 3 });
+    assert.equal(byCount.features.length, 3);
+    const idxs = byCount.features.map((f) => f.properties?.idx as number);
+    assert.ok(idxs.every((i) => i >= 0 && i < 10));
+    assert.equal(new Set(idxs).size, 3);
+    assert.deepEqual(
+      idxs,
+      [...idxs].sort((a, b) => a - b),
+    );
+
+    // By percentage: 40% of 10 → 4 features.
+    assert.equal(run({ method: "percentage", percentage: 40 }).features.length, 4);
+    // 0% (and a count of 0) select nothing.
+    assert.equal(run({ method: "percentage", percentage: 0 }).features.length, 0);
+    assert.equal(run({ method: "count", count: 0 }).features.length, 0);
+    // A count larger than the input is clamped to every feature, not an error.
+    assert.equal(run({ method: "count", count: 999 }).features.length, 10);
+    // Likewise a percentage above 100 clamps to the full input.
+    assert.equal(run({ method: "percentage", percentage: 150 }).features.length, 10);
+  });
+
   it("selects features by location, including disjoint", () => {
     const tool = getVectorTool("select-by-location");
     assert.ok(tool);


### PR DESCRIPTION
## Summary

Adds a **Random extract** algorithm to Processing → Vector (Select group) that
extracts a random subset of features from a vector layer into a new layer.

The subset size is chosen one of two ways:

- **Number of features** — draw exactly N features.
- **Percentage of features** — draw `round(percentage / 100 * total)` features.

Oversized inputs clamp to the full input rather than erroring (a count larger
than the layer, or a percentage above 100, selects every feature; a count/
percentage of 0 selects none). Selection is uniform and without replacement
(a partial Fisher-Yates draw), and the output preserves the input's feature
order.

Runs entirely client-side (no sidecar dependency).

## Changes

- `packages/processing/src/vector-tools.ts` — new `randomExtractTool`, registered in `VECTOR_TOOLS`.
- `packages/core/src/store.ts` — add `"random-extract"` to `VectorToolKind`.
- `apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx` — menu entry under the Select group.
- `apps/geolibre-desktop/src/i18n/locales/en.json` — `toolbar.vectorTool.randomExtract`.
- `tests/processing.test.ts` — unit test covering count, percentage, zero, and clamping.

## Verification

- `npm run test:frontend` (3365 pass), `npm run build`, pre-commit all green.
- Drove the real web app with Playwright using a 24-feature point layer: ran
  both methods (count 5 → 5 of 24; percentage 25 → 6 of 24), confirmed the new
  result layer is added, and verified the dialog renders correctly in both
  light and dark themes.

Fixes #1351


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Random extract” vector processing tool.
  * Create a new layer containing a random subset of features by count or percentage.
  * Supports limits from zero to the total number of available features while preserving input order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->