### PR TITLE
fix(print-layout): draw point markers in the legend

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -3020,7 +3020,11 @@ export function PrintLayoutDialog({
                                 return (
                                   <span
                                     className="h-3.5 w-3.5 shrink-0 rounded-sm border bg-contain bg-center bg-no-repeat"
-                                    style={{ backgroundImage: `url(${svgSrc})` }}
+                                    // Quote the url(): resolveSvgSource encodes markup with
+                                    // encodeURIComponent, which leaves ( ) unescaped, and an
+                                    // unquoted ) (common in SVG: translate(), rgba(), url(#id))
+                                    // would prematurely close the CSS url() token.
+                                    style={{ backgroundImage: `url("${svgSrc}")` }}
                                   />
                                 );
                               }

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -7,6 +7,7 @@ import {
   VECTOR_COLOR_RAMPS,
 } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
+import { loadMarkerSvgImage } from "@geolibre/map";
 import { GRATICULE_LABEL_LAYER_ID } from "@geolibre/plugins";
 import {
   Button,
@@ -508,6 +509,42 @@ export function PrintLayoutDialog({
     () => legendEditorRows(baseLegend, legendConfig),
     [baseLegend, legendConfig],
   );
+
+  // Custom SVG markers must be drawn into legend swatches, but drawLayout is
+  // synchronous while decoding an SVG is not, so preload them here (keyed by the
+  // swatch marker's svg string) and hand drawLayout the ready images -- like the
+  // captured map image. A stable joined key avoids reloading on unrelated legend
+  // edits (labels, hidden flags); the NUL separator never occurs in SVG markup
+  // or a URL, so splitting it back into sources in the effect is lossless.
+  const markerSvgKey = useMemo(() => {
+    const sources = new Set<string>();
+    for (const entry of baseLegend) {
+      for (const sw of entry.swatches) {
+        if (sw.marker?.shape === "custom" && sw.marker.svg) sources.add(sw.marker.svg);
+      }
+    }
+    return Array.from(sources).sort().join(" ");
+  }, [baseLegend]);
+  const [markerIcons, setMarkerIcons] = useState<Map<string, HTMLImageElement>>(new Map());
+  useEffect(() => {
+    const sources = markerSvgKey ? markerSvgKey.split(" ") : [];
+    if (sources.length === 0) {
+      setMarkerIcons((prev) => (prev.size === 0 ? prev : new Map()));
+      return;
+    }
+    let cancelled = false;
+    void Promise.all(
+      sources.map(async (src) => [src, await loadMarkerSvgImage(src)] as const),
+    ).then((pairs) => {
+      if (cancelled) return;
+      const next = new Map<string, HTMLImageElement>();
+      for (const [src, img] of pairs) if (img) next.set(src, img);
+      setMarkerIcons(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [markerSvgKey]);
   const entryIdsInOrder = useMemo(
     () => editorRows.filter((r) => r.kind === "entry").map((r) => r.layerId),
     [editorRows],
@@ -696,6 +733,7 @@ export function PrintLayoutDialog({
       legend,
       legendTitle: legendConfig.title,
       legendGroupByLayer: legendConfig.groupByLayer,
+      markerIcons,
       metersPerPixel: captured?.metersPerPixel ?? 0,
       bearingDeg: captured?.bearingDeg ?? 0,
       mapImage: captured?.image ?? null,
@@ -749,6 +787,7 @@ export function PrintLayoutDialog({
       revision,
       legend,
       legendConfig,
+      markerIcons,
       captured,
       mapFit,
       t,
@@ -2972,14 +3011,29 @@ export function PrintLayoutDialog({
                             ) : (
                               <span className="w-3 shrink-0" />
                             )}
-                            {row.color ? (
-                              <span
-                                className="h-3.5 w-3.5 shrink-0 rounded-sm border"
-                                style={{ backgroundColor: row.color }}
-                              />
-                            ) : (
-                              <span className="w-3.5 shrink-0" />
-                            )}
+                            {(() => {
+                              const svgSrc =
+                                row.marker?.shape === "custom" && row.marker.svg
+                                  ? markerIcons.get(row.marker.svg)?.src
+                                  : undefined;
+                              if (svgSrc) {
+                                return (
+                                  <span
+                                    className="h-3.5 w-3.5 shrink-0 rounded-sm border bg-contain bg-center bg-no-repeat"
+                                    style={{ backgroundImage: `url(${svgSrc})` }}
+                                  />
+                                );
+                              }
+                              if (row.color) {
+                                return (
+                                  <span
+                                    className="h-3.5 w-3.5 shrink-0 rounded-sm border"
+                                    style={{ backgroundColor: row.color }}
+                                  />
+                                );
+                              }
+                              return <span className="w-3.5 shrink-0" />;
+                            })()}
                             <Input
                               className="h-7 flex-1 text-sm"
                               value={row.label}

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -513,9 +513,10 @@ export function PrintLayoutDialog({
   // Custom SVG markers must be drawn into legend swatches, but drawLayout is
   // synchronous while decoding an SVG is not, so preload them here (keyed by the
   // swatch marker's svg string) and hand drawLayout the ready images -- like the
-  // captured map image. A stable joined key avoids reloading on unrelated legend
-  // edits (labels, hidden flags); the NUL separator never occurs in SVG markup
-  // or a URL, so splitting it back into sources in the effect is lossless.
+  // captured map image. The key is a JSON array of the sorted sources: it
+  // round-trips losslessly (SVG markup and URLs contain spaces/newlines) and,
+  // being stable, avoids reloading on unrelated legend edits (labels, hidden
+  // flags).
   const markerSvgKey = useMemo(() => {
     const sources = new Set<string>();
     for (const entry of baseLegend) {
@@ -523,11 +524,11 @@ export function PrintLayoutDialog({
         if (sw.marker?.shape === "custom" && sw.marker.svg) sources.add(sw.marker.svg);
       }
     }
-    return Array.from(sources).sort().join(" ");
+    return JSON.stringify(Array.from(sources).sort());
   }, [baseLegend]);
   const [markerIcons, setMarkerIcons] = useState<Map<string, HTMLImageElement>>(new Map());
   useEffect(() => {
-    const sources = markerSvgKey ? markerSvgKey.split(" ") : [];
+    const sources = JSON.parse(markerSvgKey) as string[];
     if (sources.length === 0) {
       setMarkerIcons((prev) => (prev.size === 0 ? prev : new Map()));
       return;

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -6,8 +6,7 @@ import {
   useAppStore,
   VECTOR_COLOR_RAMPS,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
-import { loadMarkerSvgImage } from "@geolibre/map";
+import { loadMarkerSvgImage, type MapController } from "@geolibre/map";
 import { GRATICULE_LABEL_LAYER_ID } from "@geolibre/plugins";
 import {
   Button,

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -2001,7 +2001,9 @@ function drawLegend(
     } else {
       if (opts.groupByLayer) rows.push({ color: "", text: entry.name });
       for (const sw of entry.swatches) {
-        rows.push({ color: sw.color, text: sw.label ?? "" });
+        // Carry the marker so a marker + diagram layer (a multi-swatch entry
+        // whose primary swatch is the marker) draws its marker, not a square.
+        rows.push({ color: sw.color, text: sw.label ?? "", marker: sw.marker });
       }
     }
   }

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -8,7 +8,14 @@
  * (PNG / PDF), so the preview is faithful to the output.
  */
 
-import { formatRoundNum, getRoundNum, scaleDenomination, type MapScaleUnit } from "@geolibre/core";
+import {
+  drawMarkerPath,
+  formatRoundNum,
+  getRoundNum,
+  scaleDenomination,
+  type MapScaleUnit,
+  type MarkerShape,
+} from "@geolibre/core";
 
 export type PaperSizeId =
   | "a4"
@@ -167,10 +174,34 @@ export function pagePx(size: ResolvedPageSize, dpi: number): { width: number; he
   };
 }
 
+/**
+ * A point layer's marker, carried on its legend swatch so the legend can draw
+ * the actual marker (a built-in shape recolored, or a custom SVG icon) instead
+ * of a plain color square. Mirrors the map's marker sprite (`prepareMarker` in
+ * `@geolibre/map`).
+ */
+export interface LegendMarker {
+  /** Built-in shape, or `"custom"` for an SVG icon in {@link svg}. */
+  shape: MarkerShape;
+  /** Fill color for a built-in shape (ignored for `"custom"`). */
+  color: string;
+  /**
+   * Raw SVG markup or a URL, set only when {@link shape} is `"custom"`. Doubles
+   * as the lookup key into {@link LayoutOptions.markerIcons}.
+   */
+  svg?: string;
+}
+
 /** A single swatch in a legend entry (one color, with an optional label). */
 export interface LegendSwatch {
   color: string;
   label?: string;
+  /**
+   * When set, the swatch represents a point marker: the legend draws the marker
+   * (see {@link LegendMarker}) in place of the {@link color} square, falling
+   * back to the square if a custom SVG icon has not been preloaded.
+   */
+  marker?: LegendMarker;
 }
 
 export interface LegendEntry {
@@ -388,6 +419,14 @@ export interface LayoutOptions {
    * classes; when false, classes are listed flat without the layer heading.
    */
   legendGroupByLayer: boolean;
+  /**
+   * Preloaded custom-SVG marker icons for legend swatches, keyed by the
+   * swatch marker's `svg` string ({@link LegendMarker.svg}). Loading SVGs is
+   * async, but {@link drawLayout} is synchronous, so the caller resolves them
+   * up front (like {@link mapImage}) and passes them here; a marker whose icon
+   * is missing falls back to a plain color square.
+   */
+  markerIcons?: ReadonlyMap<string, CanvasImageSource>;
   /** Ground metres per source-image pixel at the map centre. */
   metersPerPixel: number;
   /** Map bearing in degrees clockwise from north. */
@@ -836,6 +875,7 @@ export function drawLayout(canvas: HTMLCanvasElement, opts: LayoutOptions): void
     legendHeight = drawLegend(ctx, bodyX + inset, bodyY + inset, opts.legend, unit, {
       title: opts.legendTitle,
       groupByLayer: opts.legendGroupByLayer,
+      markerIcons: opts.markerIcons,
     });
     ctx.restore();
   }
@@ -1876,6 +1916,47 @@ function drawDataChart(
 }
 
 /**
+ * Draw a point layer's marker into a `size`×`size` legend swatch box at
+ * (`sx`, `sy`): a custom SVG icon (from the preloaded {@link markerIcons}) or a
+ * built-in shape recolored to the marker color. Falls back to a plain
+ * `fallbackColor` square when a custom SVG has not been (or could not be)
+ * preloaded, so the swatch is never blank.
+ */
+function drawLegendMarker(
+  ctx: CanvasRenderingContext2D,
+  marker: LegendMarker,
+  sx: number,
+  sy: number,
+  size: number,
+  fallbackColor: string,
+  markerIcons?: ReadonlyMap<string, CanvasImageSource>,
+): void {
+  if (marker.shape === "custom") {
+    const icon = marker.svg ? markerIcons?.get(marker.svg) : undefined;
+    if (icon) {
+      ctx.drawImage(icon, sx, sy, size, size);
+      return;
+    }
+    // SVG not available: fall back to a neutral color square.
+    ctx.fillStyle = fallbackColor || "#999999";
+    ctx.fillRect(sx, sy, size, size);
+    ctx.strokeStyle = BORDER;
+    ctx.strokeRect(sx, sy, size, size);
+    return;
+  }
+  ctx.save();
+  ctx.translate(sx, sy);
+  ctx.fillStyle = marker.color;
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = Math.max(1, size * 0.06);
+  ctx.lineJoin = "round";
+  drawMarkerPath(ctx, marker.shape, size);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+/**
  * Draw a legend box anchored at its top-left corner.
  *
  * @returns The drawn box's height, so corner panels can stack below it.
@@ -1886,7 +1967,11 @@ function drawLegend(
   y: number,
   entries: LegendEntry[],
   unit: number,
-  opts: { title: string; groupByLayer: boolean },
+  opts: {
+    title: string;
+    groupByLayer: boolean;
+    markerIcons?: ReadonlyMap<string, CanvasImageSource>;
+  },
 ): number {
   const pad = unit * 1.4;
   const rowH = unit * 2.6;
@@ -1898,8 +1983,9 @@ function drawLegend(
 
   // Flatten entries into drawable rows. Single-swatch entries render inline; a
   // multi-class entry renders a layer heading (when groupByLayer is on) above
-  // its class swatches, or just the flat class swatches when it is off.
-  const rows: { color: string; text: string }[] = [];
+  // its class swatches, or just the flat class swatches when it is off. A row
+  // draws a swatch when it has a color or a marker; a group heading has neither.
+  const rows: { color: string; text: string; marker?: LegendMarker }[] = [];
   for (const entry of entries) {
     if (entry.swatches.length <= 1) {
       // Prefer the swatch's own label so a multi-class entry collapsed to one
@@ -1910,6 +1996,7 @@ function drawLegend(
       rows.push({
         color: swatch?.color ?? "#999999",
         text: swatch?.label ?? entry.name,
+        marker: swatch?.marker,
       });
     } else {
       if (opts.groupByLayer) rows.push({ color: "", text: entry.name });
@@ -1919,13 +2006,16 @@ function drawLegend(
     }
   }
 
+  const rowHasSwatch = (r: { color: string; marker?: LegendMarker }): boolean =>
+    Boolean(r.color) || Boolean(r.marker);
+
   // Measure required width.
   ctx.save();
   ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
   let maxText = hasTitle ? ctx.measureText(title).width : 0;
   ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
   for (const r of rows) {
-    const w = ctx.measureText(r.text).width + (r.color ? swatch + unit : 0);
+    const w = ctx.measureText(r.text).width + (rowHasSwatch(r) ? swatch + unit : 0);
     if (w > maxText) maxText = w;
   }
 
@@ -1958,15 +2048,20 @@ function drawLegend(
 
   for (const r of rows) {
     cy += rowH;
-    const textX = r.color ? x + pad + swatch + unit : x + pad;
-    if (r.color) {
+    const hasSwatch = rowHasSwatch(r);
+    const textX = hasSwatch ? x + pad + swatch + unit : x + pad;
+    const sx = x + pad;
+    const sy = cy - swatch * 0.85;
+    if (r.marker) {
+      drawLegendMarker(ctx, r.marker, sx, sy, swatch, r.color, opts.markerIcons);
+    } else if (r.color) {
       ctx.fillStyle = r.color;
-      ctx.fillRect(x + pad, cy - swatch * 0.85, swatch, swatch);
+      ctx.fillRect(sx, sy, swatch, swatch);
       ctx.strokeStyle = BORDER;
-      ctx.strokeRect(x + pad, cy - swatch * 0.85, swatch, swatch);
+      ctx.strokeRect(sx, sy, swatch, swatch);
     }
-    ctx.fillStyle = r.color ? INK : MUTED;
-    ctx.font = `${r.color ? 400 : 600} ${labelSize}px system-ui, sans-serif`;
+    ctx.fillStyle = hasSwatch ? INK : MUTED;
+    ctx.font = `${hasSwatch ? 400 : 600} ${labelSize}px system-ui, sans-serif`;
     ctx.fillText(r.text, textX, cy);
   }
   ctx.restore();

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -1935,6 +1935,11 @@ function drawLegendMarker(
     const icon = marker.svg ? markerIcons?.get(marker.svg) : undefined;
     if (icon) {
       ctx.drawImage(icon, sx, sy, size, size);
+      // Border for parity with every other swatch (built-in shapes, the
+      // fallback square, fill/ramp squares), so a light or transparent-edged
+      // SVG still reads as a bounded swatch.
+      ctx.strokeStyle = BORDER;
+      ctx.strokeRect(sx, sy, size, size);
       return;
     }
     // SVG not available: fall back to a neutral color square.

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -6,14 +6,17 @@ import {
   diagramsSuppressedByPointRenderer,
   effectiveVectorRules,
   isHexColor,
+  normalizeHexColor,
   styleValue,
   type GeoLibreLayer,
+  type LayerStyle,
   type LayerType,
   type LegendConfig,
   type LegendItemOverride,
+  type MarkerShape,
   type VectorStyleStop,
 } from "@geolibre/core";
-import type { LegendEntry, LegendSwatch } from "./print-layout";
+import type { LegendEntry, LegendMarker, LegendSwatch } from "./print-layout";
 
 /** Layer types styled as vectors (colored fills the legend can represent). */
 const VECTOR_TYPES: ReadonlySet<LayerType> = new Set<LayerType>([
@@ -91,10 +94,13 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
           continue;
         }
       }
+      const primary = pointMarkerSwatch(layer.style) ?? {
+        color: styleValue(layer.style, "fillColor"),
+      };
       entries.push({
         id: layer.id,
         name: layer.name,
-        swatches: [{ color: styleValue(layer.style, "fillColor") }, ...diagrams],
+        swatches: [primary, ...diagrams],
       });
       continue;
     }
@@ -107,6 +113,28 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
     });
   }
   return entries;
+}
+
+/**
+ * The primary legend swatch for a single-symbol point layer that renders a
+ * marker icon, carrying the marker so the legend draws the actual shape / SVG
+ * instead of a plain fill square. Mirrors `prepareMarker` (`@geolibre/map`):
+ * enabled only when `markerEnabled` is on, and a `"custom"` marker with no SVG
+ * markup falls through (returns null) to the plain fill swatch. Returns null
+ * for layers with no marker, so the caller keeps the existing fill swatch.
+ */
+function pointMarkerSwatch(style: LayerStyle): LegendSwatch | null {
+  if (styleValue(style, "markerEnabled") !== true) return null;
+  const shape = styleValue(style, "markerShape") as MarkerShape;
+  const color = normalizeHexColor(styleValue(style, "markerColor")) ?? "#3b82f6";
+  if (shape === "custom") {
+    const svg = styleValue(style, "markerSvg").trim();
+    if (!svg) return null;
+    const marker: LegendMarker = { shape, color, svg };
+    return { color, marker };
+  }
+  const marker: LegendMarker = { shape, color };
+  return { color, marker };
 }
 
 /** Stable key for an individual class swatch within an entry. */
@@ -268,6 +296,8 @@ export interface LegendEditorRow {
   kind: "entry" | "class";
   /** Swatch color, when the row has one (entries always do; class rows do too). */
   color?: string;
+  /** Point marker for a single-symbol entry row, so the editor previews it. */
+  marker?: LegendMarker;
   /** The auto-generated label. */
   defaultLabel: string;
   /** Effective label after applying any override. */
@@ -298,6 +328,7 @@ export function legendEditorRows(base: LegendEntry[], config: LegendConfig): Leg
       layerId: entry.id,
       kind: "entry",
       color: single ? entry.swatches[0]?.color : undefined,
+      marker: single ? entry.swatches[0]?.marker : undefined,
       defaultLabel: entry.name,
       // Show the raw override (so the input can hold spaces mid-edit) but fall
       // back to the default when it is blank, matching what applyLegendConfig

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -215,6 +215,10 @@ export function applyLegendConfig(base: LegendEntry[], config: LegendConfig): Le
         label: hasLabelOverride(override?.label)
           ? renderedLabel(override?.label, swatch.label ?? "")
           : swatch.label,
+        // Preserve the marker so a point layer with both a marker icon and
+        // diagram symbology (a multi-swatch entry: [marker primary, ...diagrams])
+        // still draws its marker rather than regressing to a color square.
+        marker: swatch.marker,
       });
     });
     // Every class hidden: drop the whole entry rather than render an empty box.
@@ -347,6 +351,7 @@ export function legendEditorRows(base: LegendEntry[], config: LegendConfig): Leg
         layerId: entry.id,
         kind: "class",
         color: swatch.color,
+        marker: swatch.marker,
         defaultLabel,
         label: hasLabelOverride(override?.label) ? (override?.label as string) : defaultLabel,
         hidden: Boolean(override?.hidden),

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -125,6 +125,11 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
  */
 function pointMarkerSwatch(style: LayerStyle): LegendSwatch | null {
   if (styleValue(style, "markerEnabled") !== true) return null;
+  // Mirror the map (layer-sync gates the marker overlay on the "single" point
+  // renderer): cluster/heatmap draw clustered circles or a density surface with
+  // no individual markers, so the legend must not advertise a marker the map
+  // isn't drawing. Sibling guard to diagramsSuppressedByPointRenderer.
+  if (styleValue(style, "pointRenderer") !== "single") return null;
   const shape = styleValue(style, "markerShape") as MarkerShape;
   const color = normalizeHexColor(styleValue(style, "markerColor")) ?? "#3b82f6";
   if (shape === "custom") {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./diagram";
+export * from "./marker-shape";
 export * from "./photo";
 export * from "./ellipsoids";
 export * from "./geojson-z";

--- a/packages/core/src/marker-shape.ts
+++ b/packages/core/src/marker-shape.ts
@@ -1,0 +1,92 @@
+import type { MarkerShape } from "./types";
+
+/**
+ * Trace the outline of a built-in marker {@link MarkerShape} onto a 2D canvas
+ * path, centered in a `size`×`size` box. The caller supplies the fill/stroke;
+ * this only builds the path (via `beginPath`/`closePath`), so it stays free of
+ * any DOM other than the passed context and can be shared by the map's sprite
+ * baker (`@geolibre/map`) and the Print Layout legend renderer.
+ *
+ * `"custom"` (SVG) markers have no built-in path and are handled by the caller
+ * (rasterized separately); passing one draws the default circle so the marker
+ * never vanishes silently.
+ *
+ * @param ctx - Any 2D path-drawing context (a real `CanvasRenderingContext2D`
+ *   satisfies this structurally).
+ * @param shape - The built-in marker shape to trace.
+ * @param size - The box edge length in pixels; the shape is inset slightly so a
+ *   stroke is not clipped at the edge.
+ */
+export function drawMarkerPath(
+  ctx: CanvasRenderingContext2D,
+  shape: MarkerShape,
+  size: number,
+): void {
+  const c = size / 2;
+  // Leave a small inset so the stroke is not clipped at the tile edge.
+  const r = c * 0.82;
+  ctx.beginPath();
+  switch (shape) {
+    case "square":
+      ctx.rect(c - r, c - r, r * 2, r * 2);
+      break;
+    case "triangle":
+      ctx.moveTo(c, c - r);
+      ctx.lineTo(c + r, c + r);
+      ctx.lineTo(c - r, c + r);
+      ctx.closePath();
+      break;
+    case "diamond":
+      ctx.moveTo(c, c - r);
+      ctx.lineTo(c + r, c);
+      ctx.lineTo(c, c + r);
+      ctx.lineTo(c - r, c);
+      ctx.closePath();
+      break;
+    case "star": {
+      const outer = r;
+      const inner = r * 0.42;
+      for (let point = 0; point < 10; point += 1) {
+        const radius = point % 2 === 0 ? outer : inner;
+        const angle = (Math.PI / 5) * point - Math.PI / 2;
+        const x = c + radius * Math.cos(angle);
+        const y = c + radius * Math.sin(angle);
+        if (point === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+      break;
+    }
+    case "cross": {
+      const arm = r * 0.42;
+      ctx.moveTo(c - arm, c - r);
+      ctx.lineTo(c + arm, c - r);
+      ctx.lineTo(c + arm, c - arm);
+      ctx.lineTo(c + r, c - arm);
+      ctx.lineTo(c + r, c + arm);
+      ctx.lineTo(c + arm, c + arm);
+      ctx.lineTo(c + arm, c + r);
+      ctx.lineTo(c - arm, c + r);
+      ctx.lineTo(c - arm, c + arm);
+      ctx.lineTo(c - r, c + arm);
+      ctx.lineTo(c - r, c - arm);
+      ctx.lineTo(c - arm, c - arm);
+      ctx.closePath();
+      break;
+    }
+    case "pin": {
+      // A teardrop: a circle bowl with a point at the bottom.
+      const bowlR = r * 0.7;
+      const bowlY = c - r * 0.2;
+      ctx.moveTo(c, c + r);
+      ctx.quadraticCurveTo(c - bowlR, bowlY + bowlR * 0.4, c - bowlR, bowlY);
+      ctx.arc(c, bowlY, bowlR, Math.PI, Math.PI * 2);
+      ctx.quadraticCurveTo(c + bowlR, bowlY + bowlR * 0.4, c, c + r);
+      ctx.closePath();
+      break;
+    }
+    case "circle":
+    default:
+      ctx.arc(c, c, r, 0, Math.PI * 2);
+  }
+}

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -89,3 +89,4 @@ export {
   type QmlExportResult,
 } from "./qml-export";
 export { applyQmlImport, parseQml, type QmlImportResult } from "./qml-import";
+export { loadMarkerSvgImage } from "./markers";

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -1,4 +1,5 @@
 import {
+  drawMarkerPath,
   normalizeHexColor,
   proportionalSizeRange,
   styleValue,
@@ -38,78 +39,6 @@ function markerSize(style: LayerStyle): number {
   return Math.min(MAX_MARKER_SIZE, Math.max(MIN_MARKER_SIZE, Math.round(size)));
 }
 
-function drawShape(ctx: CanvasRenderingContext2D, shape: MarkerShape, size: number): void {
-  const c = size / 2;
-  // Leave a small inset so the stroke is not clipped at the tile edge.
-  const r = c * 0.82;
-  ctx.beginPath();
-  switch (shape) {
-    case "circle":
-      ctx.arc(c, c, r, 0, Math.PI * 2);
-      break;
-    case "square":
-      ctx.rect(c - r, c - r, r * 2, r * 2);
-      break;
-    case "triangle":
-      ctx.moveTo(c, c - r);
-      ctx.lineTo(c + r, c + r);
-      ctx.lineTo(c - r, c + r);
-      ctx.closePath();
-      break;
-    case "diamond":
-      ctx.moveTo(c, c - r);
-      ctx.lineTo(c + r, c);
-      ctx.lineTo(c, c + r);
-      ctx.lineTo(c - r, c);
-      ctx.closePath();
-      break;
-    case "star": {
-      const outer = r;
-      const inner = r * 0.42;
-      for (let point = 0; point < 10; point += 1) {
-        const radius = point % 2 === 0 ? outer : inner;
-        const angle = (Math.PI / 5) * point - Math.PI / 2;
-        const x = c + radius * Math.cos(angle);
-        const y = c + radius * Math.sin(angle);
-        if (point === 0) ctx.moveTo(x, y);
-        else ctx.lineTo(x, y);
-      }
-      ctx.closePath();
-      break;
-    }
-    case "cross": {
-      const arm = r * 0.42;
-      ctx.moveTo(c - arm, c - r);
-      ctx.lineTo(c + arm, c - r);
-      ctx.lineTo(c + arm, c - arm);
-      ctx.lineTo(c + r, c - arm);
-      ctx.lineTo(c + r, c + arm);
-      ctx.lineTo(c + arm, c + arm);
-      ctx.lineTo(c + arm, c + r);
-      ctx.lineTo(c - arm, c + r);
-      ctx.lineTo(c - arm, c + arm);
-      ctx.lineTo(c - r, c + arm);
-      ctx.lineTo(c - r, c - arm);
-      ctx.lineTo(c - arm, c - arm);
-      ctx.closePath();
-      break;
-    }
-    case "pin": {
-      // A teardrop: a circle bowl with a point at the bottom.
-      const bowlR = r * 0.7;
-      const bowlY = c - r * 0.2;
-      ctx.moveTo(c, c + r);
-      ctx.quadraticCurveTo(c - bowlR, bowlY + bowlR * 0.4, c - bowlR, bowlY);
-      ctx.arc(c, bowlY, bowlR, Math.PI, Math.PI * 2);
-      ctx.quadraticCurveTo(c + bowlR, bowlY + bowlR * 0.4, c, c + r);
-      ctx.closePath();
-      break;
-    }
-    default:
-      ctx.arc(c, c, r, 0, Math.PI * 2);
-  }
-}
-
 function drawBuiltinMarker(
   shape: MarkerShape,
   color: string,
@@ -129,10 +58,33 @@ function drawBuiltinMarker(
   ctx.strokeStyle = "rgba(255,255,255,0.9)";
   ctx.lineWidth = Math.max(1, ratio);
   ctx.lineJoin = "round";
-  drawShape(ctx, shape, px);
+  drawMarkerPath(ctx, shape, px);
   ctx.fill();
   ctx.stroke();
   return { image: ctx.getImageData(0, 0, px, px), pixelRatio: ratio };
+}
+
+/**
+ * Load a custom SVG marker as a decoded `HTMLImageElement` for the Print Layout
+ * legend, which draws it into a small swatch at an arbitrary size (unlike the
+ * map's {@link loadSvgMarker}, which rasterizes to fixed-size sprite pixels).
+ * Resolves `null` when the markup is empty/unsupported or the image fails to
+ * load, so the caller falls back to a plain color swatch.
+ *
+ * @param markup - Raw SVG markup, a `data:` URL, or an `http(s)` URL.
+ * @returns The decoded image, or `null`.
+ */
+export function loadMarkerSvgImage(markup: string): Promise<HTMLImageElement | null> {
+  const src = resolveSvgSource(markup.trim());
+  if (!src) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.decoding = "async";
+    image.crossOrigin = "anonymous";
+    image.onload = () => resolve(image);
+    image.onerror = () => resolve(null);
+    image.src = src;
+  });
 }
 
 function loadSvgMarker(markup: string, size: number): Promise<GeneratedImageResult | null> {

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -29,7 +29,7 @@ function recordingCanvas(): {
   // Stroked polylines: one entry per beginPath..stroke sequence that used
   // lineTo, holding the segment count (the line chart's path).
   const polylines: number[] = [];
-  const counters = { arcs: 0, pendingLines: 0 };
+  const counters = { arcs: 0, pendingLines: 0, drawImages: 0 };
   const state: Record<string, unknown> = {
     textAlign: "start",
     textBaseline: "alphabetic",
@@ -52,6 +52,11 @@ function recordingCanvas(): {
       if (prop === "arc") {
         return () => {
           counters.arcs += 1;
+        };
+      }
+      if (prop === "drawImage") {
+        return () => {
+          counters.drawImages += 1;
         };
       }
       if (prop === "beginPath") {
@@ -90,6 +95,9 @@ function recordingCanvas(): {
     fillRects,
     get arcs() {
       return counters.arcs;
+    },
+    get drawImages() {
+      return counters.drawImages;
     },
     polylines,
   };
@@ -165,6 +173,78 @@ describe("drawLayout legend rendering", () => {
       }),
     );
     assert.ok(fills.some((f) => f.text === "Roads"));
+  });
+
+  it("draws a built-in point marker as its shape (not a color square)", () => {
+    const { canvas, polylines, fillRects } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "pts",
+            name: "Sites",
+            swatches: [{ color: "#00aa55", marker: { shape: "triangle", color: "#00aa55" } }],
+          },
+        ],
+      }),
+    );
+    // The triangle is a stroked/filled path, so a polyline is recorded and no
+    // swatch-sized color square is filled for the marker.
+    assert.ok(polylines.length > 0, "expected the marker shape path to be drawn");
+    assert.ok(
+      !fillRects.some((r) => r.fillStyle === "#00aa55" && r.w === r.h),
+      "expected no plain color square for a shape marker",
+    );
+  });
+
+  it("draws a preloaded custom SVG marker as an image", () => {
+    const svg = "<svg/>";
+    const image = {} as unknown as CanvasImageSource;
+    // `drawImages` is a live getter, so read it off `rec` after the draw rather
+    // than destructuring (which would capture its pre-draw value of 0).
+    const rec = recordingCanvas();
+    drawLayout(
+      rec.canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "bees",
+            name: "Bees",
+            swatches: [{ color: "#3b82f6", marker: { shape: "custom", color: "#3b82f6", svg } }],
+          },
+        ],
+        markerIcons: new Map([[svg, image]]),
+      }),
+    );
+    assert.equal(rec.drawImages, 1, "expected the SVG icon to be drawn as an image");
+    assert.ok(
+      !rec.fillRects.some((r) => r.fillStyle === "#3b82f6" && r.w === r.h),
+      "expected no fallback color square when the icon is available",
+    );
+  });
+
+  it("falls back to a color square when a custom SVG marker icon is not preloaded", () => {
+    const svg = "<svg/>";
+    const rec = recordingCanvas();
+    drawLayout(
+      rec.canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "bees",
+            name: "Bees",
+            swatches: [{ color: "#3b82f6", marker: { shape: "custom", color: "#3b82f6", svg } }],
+          },
+        ],
+        // No markerIcons: the icon is unavailable.
+      }),
+    );
+    assert.equal(rec.drawImages, 0);
+    assert.ok(
+      rec.fillRects.some((r) => r.fillStyle === "#3b82f6" && r.w === r.h),
+      "expected a fallback color square when the icon is missing",
+    );
   });
 
   it("left-aligns legend rows when a legend title is present", () => {

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -247,6 +247,32 @@ describe("drawLayout legend rendering", () => {
     );
   });
 
+  it("draws the marker of a multi-swatch entry's primary swatch as a shape", () => {
+    const { canvas, polylines, fillRects } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "md",
+            name: "Marker+Diagram",
+            swatches: [
+              { color: "#00aa55", marker: { shape: "triangle", color: "#00aa55" } },
+              { color: "#111111", label: "votes" },
+            ],
+          },
+        ],
+      }),
+    );
+    // The primary swatch's marker is a triangle path; the diagram swatch is a
+    // plain color square.
+    assert.ok(polylines.length > 0, "expected the primary marker shape to be drawn");
+    assert.ok(
+      fillRects.some((r) => r.fillStyle === "#111111" && r.w === r.h),
+      "expected the diagram class swatch to still be a color square",
+    );
+  });
+
   it("left-aligns legend rows when a legend title is present", () => {
     const { canvas, fills } = recordingCanvas();
     drawLayout(canvas, baseOptions({ legendTitle: "Key" }));

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -213,6 +213,40 @@ describe("buildLegend", () => {
     assert.equal(legend[0].swatches[0].marker, undefined);
   });
 
+  it("keeps the marker on the primary swatch of a marker + diagram multi-swatch entry", () => {
+    const pointGeojson = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [0, 0] },
+          properties: { votes_a: 1 },
+        },
+      ],
+    } as GeoJSON.FeatureCollection;
+    const style = {
+      vectorStyleMode: "single",
+      markerEnabled: true,
+      markerShape: "star",
+      markerColor: "#ff8800",
+      diagramType: "pie",
+      diagramFields: [{ property: "votes_a", color: "#111111" }],
+    } as unknown as LayerStyle;
+    const base = buildLegend([
+      makeLayer({ id: "m", name: "Marker+Diagram", geojson: pointGeojson, style }),
+    ]);
+    // Multi-swatch entry: marker primary + one diagram swatch.
+    assert.equal(base[0].swatches.length, 2);
+    assert.deepEqual(base[0].swatches[0].marker, { shape: "star", color: "#ff8800" });
+    // applyLegendConfig's multi-swatch rebuild must not drop the marker.
+    const applied = applyLegendConfig(base, config());
+    assert.deepEqual(applied[0].swatches[0].marker, { shape: "star", color: "#ff8800" });
+    // The editor's per-class row must preview the marker too.
+    const rows = legendEditorRows(base, config());
+    const primaryClass = rows.find((r) => r.kind === "class");
+    assert.deepEqual(primaryClass?.marker, { shape: "star", color: "#ff8800" });
+  });
+
   it("surfaces the entry marker on the editor row for a single-symbol point layer", () => {
     const base = buildLegend([
       makeLayer({

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -140,6 +140,96 @@ describe("buildLegend", () => {
     assert.equal(legend[0].swatches[0].color, "#ff0000");
   });
 
+  it("carries a built-in marker (in its marker color) for a marker-enabled point layer", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Stations",
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#ffffff",
+          markerEnabled: true,
+          markerShape: "star",
+          markerColor: "#ff8800",
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 1);
+    // The swatch uses the marker color (not the white fill) and carries the shape.
+    assert.equal(legend[0].swatches[0].color, "#ff8800");
+    assert.deepEqual(legend[0].swatches[0].marker, { shape: "star", color: "#ff8800" });
+  });
+
+  it("carries the SVG on a custom marker so the legend can draw the icon", () => {
+    const svg = "<svg><circle r='4'/></svg>";
+    const legend = buildLegend([
+      makeLayer({
+        name: "Bees",
+        style: {
+          vectorStyleMode: "single",
+          markerEnabled: true,
+          markerShape: "custom",
+          markerColor: "#3b82f6",
+          markerSvg: svg,
+        } as LayerStyle,
+      }),
+    ]);
+    assert.deepEqual(legend[0].swatches[0].marker, {
+      shape: "custom",
+      color: "#3b82f6",
+      svg,
+    });
+  });
+
+  it("falls back to the fill swatch when a custom marker has no SVG markup", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Empty",
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#112233",
+          markerEnabled: true,
+          markerShape: "custom",
+          markerSvg: "   ",
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches[0].color, "#112233");
+    assert.equal(legend[0].swatches[0].marker, undefined);
+  });
+
+  it("leaves non-marker layers with a plain fill swatch and no marker", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Plain",
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#123456",
+          markerEnabled: false,
+          markerShape: "star",
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches[0].color, "#123456");
+    assert.equal(legend[0].swatches[0].marker, undefined);
+  });
+
+  it("surfaces the entry marker on the editor row for a single-symbol point layer", () => {
+    const base = buildLegend([
+      makeLayer({
+        id: "pts",
+        name: "Points",
+        style: {
+          vectorStyleMode: "single",
+          markerEnabled: true,
+          markerShape: "triangle",
+          markerColor: "#00aa55",
+        } as LayerStyle,
+      }),
+    ]);
+    const rows = legendEditorRows(base, config());
+    assert.deepEqual(rows[0].marker, { shape: "triangle", color: "#00aa55" });
+  });
+
   it("expands graduated symbology into ramp swatches with labels", () => {
     const legend = buildLegend([
       makeLayer({

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -213,6 +213,26 @@ describe("buildLegend", () => {
     assert.equal(legend[0].swatches[0].marker, undefined);
   });
 
+  it("suppresses the marker when the point renderer is not single (cluster/heatmap)", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Clustered",
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#123456",
+          markerEnabled: true,
+          markerShape: "star",
+          markerColor: "#ff8800",
+          pointRenderer: "cluster",
+        } as unknown as LayerStyle,
+      }),
+    ]);
+    // The map draws clustered circles, not markers, so the legend falls back to
+    // the fill swatch with no marker (mirrors the layer-sync render gate).
+    assert.equal(legend[0].swatches[0].color, "#123456");
+    assert.equal(legend[0].swatches[0].marker, undefined);
+  });
+
   it("keeps the marker on the primary swatch of a marker + diagram multi-swatch entry", () => {
     const pointGeojson = {
       type: "FeatureCollection",


### PR DESCRIPTION
## Summary

Follow-up to discussion [#1311](https://github.com/opengeos/GeoLibre/discussions/1311#discussioncomment-17696781): after the marker-sizing work in #1325, a point layer styled with a **custom SVG marker** renders correctly on the map but shows up as an **empty/white swatch** in the Print Layout legend, while a plain colored marker looks fine.

**Root cause:** the auto-generated legend represented every point layer by a plain `fillColor` square (`buildLegend` → `drawLegend`), with no awareness of marker icons. A custom-SVG marker layer keeps `fillColor` at its default (near-white) while its real symbol is the SVG, so the swatch looked blank. It also used `fillColor` rather than `markerColor` even for built-in shapes.

## What changed

The legend now mirrors the map's marker sprite (`prepareMarker` in `@geolibre/map`):

- **`print-legend.ts`** — `buildLegend` attaches a marker descriptor (shape + marker color, plus the raw SVG for `custom`) to a single-symbol point layer's swatch, and uses the **marker color** as the fallback swatch color. `legendEditorRows` carries it so the editor previews the marker.
- **`print-layout.ts`** — `drawLegend` draws the actual marker into the swatch: a built-in shape recolored to the marker color, or the preloaded custom SVG icon, falling back to a color square when a custom SVG hasn't decoded. New `LegendMarker` type + `LegendSwatch.marker` + `LayoutOptions.markerIcons`.
- **`PrintLayoutDialog.tsx`** — SVG decoding is async but `drawLayout` is synchronous, so the dialog **preloads** the custom-SVG icons (like the captured map image) and passes them via `markerIcons`. The editor rows also preview the SVG.
- **`@geolibre/core`** — the built-in shape geometry moves to a new DOM-free `drawMarkerPath`, reused by both the map's sprite baker (`markers.ts`) and the legend renderer (de-duplicated).

## Testing

- New unit tests in `tests/print-legend.test.ts` (marker descriptors: built-in in marker color, custom SVG carried, empty-SVG fallback, non-marker layers untouched, editor-row marker) and `tests/print-layout.test.ts` (built-in shape drawn as a path, preloaded SVG drawn as an image, fallback square when the icon is missing).
- Full frontend suite (3374 tests), `npm run build`, and pre-commit pass.
- **Verified in a real browser (Playwright)** with a US-cities point layer: enabled a custom SVG marker (red star) and a built-in Star, opened Print Layout in **light and dark** themes — the legend now shows the actual marker next to the layer name, and Export PNG runs with no canvas-taint error.

Addresses the report in discussion #1311.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Print layout legends now render point marker swatches, including built-in shapes and custom SVG markers, with proper preview in the legend editor.
  - Legend swatches and editor rows now carry marker metadata (marker shape and color) alongside standard legend styling.
- **Bug Fixes**
  - Improved behavior when custom SVG marker artwork can’t be loaded: the legend reliably falls back to the standard swatch rendering.
- **Tests**
  - Added/expanded coverage for built-in markers, custom SVG markers (including preloaded vs. missing icons), and marker preservation in multi-swatch legends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->