### PR TITLE
fix(whitebox): hide WASM-absent catalog tools in local mode (#1355)

### DIFF
--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -188,9 +188,20 @@ export async function listWasmToolManifests(): Promise<WhiteboxTool[]> {
  * metadata but takes the manifest's parameters; the GeoLibre-authored tools that
  * never appear in the catalog are appended.
  *
+ * When the WASM manifests loaded, the binary's tool set is the ground truth for
+ * what can actually run locally, so a catalog tool the binary does **not**
+ * implement is dropped: it cannot run in WASM mode and would otherwise render as
+ * a dead-end form (the `assign_projection_*` tools carry no catalog params, so
+ * the dialog just says "This tool has no parameters", GeoLibre#1355) or, for
+ * ones the catalog does parameterize (`reproject_lidar`, the colour composites),
+ * fail on Run with "tool not found". This mirrors how locked "pro" tools that
+ * cannot run are hidden entirely. When manifest enumeration failed (an empty
+ * `wasmTools`), the whole catalog is kept as a display-only fallback rather than
+ * emptying the toolbox.
+ *
  * @param catalogTools - Tools from the Whitebox catalog snapshot.
  * @param wasmTools - Every WASM tool manifest ({@link listWasmToolManifests}).
- * @returns Catalog tools with WASM parameters, plus WASM-only GeoLibre tools.
+ * @returns Runnable catalog tools with WASM parameters, plus WASM-only GeoLibre tools.
  */
 /** Scalar catalog kinds trusted to correct a mislabeled WASM manifest param. */
 const CATALOG_SCALAR_KINDS = new Set(["string", "int", "double"]);
@@ -261,9 +272,12 @@ export function mergeWasmToolManifests(
   wasmTools: WhiteboxTool[],
 ): WhiteboxTool[] {
   const wasmById = new Map(wasmTools.map((tool) => [tool.id, tool] as const));
-  const merged = catalogTools.map((tool) => {
+  // With manifests loaded, drop a catalog tool the binary lacks (it can't run
+  // locally); with none loaded, keep the catalog as a display-only fallback.
+  const haveWasmManifests = wasmTools.length > 0;
+  const merged = catalogTools.flatMap((tool) => {
     const wasm = wasmById.get(tool.id);
-    if (!wasm) return tool;
+    if (!wasm) return haveWasmManifests ? [] : [tool];
     // Consume the match so a WASM-only-appended tool (below) can never duplicate
     // a catalog tool's id.
     wasmById.delete(tool.id);
@@ -273,11 +287,13 @@ export function mergeWasmToolManifests(
     // tool that also has a catalog stub keeps its "geolibre" marker for the
     // source filter. A same-named catalog param still corrects a WASM kind that
     // mislabels a scalar expression as a dataset/bool (GeoLibre#1073).
-    return {
-      ...tool,
-      params: reconcileToolParams(tool.params, wasm.params),
-      source: wasm.source ?? tool.source,
-    };
+    return [
+      {
+        ...tool,
+        params: reconcileToolParams(tool.params, wasm.params),
+        source: wasm.source ?? tool.source,
+      },
+    ];
   });
   const geolibreOnly = [...wasmById.values()].filter((tool) => tool.source === "geolibre");
   return [...merged, ...geolibreOnly];

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -56,7 +56,11 @@ describe("mergeWasmToolManifests", () => {
     assert.equal(tool.category, "Projection and Georeferencing");
   });
 
-  it("keeps catalog params when the WASM binary lacks the tool", () => {
+  it("keeps the whole catalog as a fallback when no manifests loaded", () => {
+    // An empty wasmTools means the manifest enumeration failed, not that the
+    // binary lacks every tool: keep the catalog (with its own params) as a
+    // display-only fallback rather than emptying the toolbox. Contrast with the
+    // #1355 case below, where a loaded manifest set does drop WASM-absent tools.
     const merged = mergeWasmToolManifests([catalogReprojectVector], []);
     const tool = merged.find((item) => item.id === "reproject_vector");
     assert.deepEqual(
@@ -212,6 +216,28 @@ describe("mergeWasmToolManifests", () => {
     const [tool] = mergeWasmToolManifests([catalog], [wasm]);
     // Kind stays unset so parameterKind resolves the WASM vector_out.
     assert.equal(tool.params?.[0]?.kind, undefined);
+  });
+
+  it("drops a catalog tool the WASM binary lacks once manifests loaded (#1355)", () => {
+    // assign_projection_* ship in the catalog with no params and are absent from
+    // the WASM binary, so in local mode they render a dead-end "no parameters"
+    // form and fail on Run with "tool not found". Once the manifests loaded (a
+    // non-empty wasmTools), such catalog-only tools are hidden, like locked ones.
+    const assignProjectionVector: WhiteboxTool = {
+      id: "assign_projection_vector",
+      display_name: "Assign Projection Vector",
+      category: "Projection and Georeferencing",
+      params: [],
+    };
+    const merged = mergeWasmToolManifests(
+      [catalogReprojectVector, assignProjectionVector],
+      [wasmReprojectVector],
+    );
+    assert.deepEqual(
+      merged.map((tool) => tool.id),
+      ["reproject_vector"],
+      "the WASM-absent catalog tool should be dropped",
+    );
   });
 
   it("does not append WASM-only Whitebox tools missing from the catalog", () => {


### PR DESCRIPTION
## Summary

In the Whitebox toolbox's local (Run locally / WASM) mode, opening **Assign Projection Vector / Raster / Lidar** showed only "This tool has no parameters" with no input or projection fields (#1355).

**Root cause:** these three tools ship in the Whitebox catalog snapshot with an empty parameter list, and they are **not present in the `geolibre-wasm` binary** at all. The local-mode merge kept catalog tools even when the binary did not implement them, so they rendered a dead-end form and, if Run, failed with `tool not found`. Six catalog tools total are absent from the WASM binary (`assign_projection_{vector,raster,lidar}`, `reproject_lidar`, `false_colour_composite`, `true_colour_composite`); the three `assign_projection_*` ones have no params, which is the reported dead-end.

## Fix

When the WASM manifests load, the binary's tool set is the ground truth for what can run locally, so `mergeWasmToolManifests` now drops catalog tools the binary lacks, exactly as locked "pro" tools that cannot run are already hidden. When manifest enumeration fails (an empty manifest list), the whole catalog is kept as a display-only fallback so the toolbox is not emptied.

This is a GeoLibre-only change; no upstream package or release was needed. Only the local-mode merge path is affected (sidecar mode, where these tools do run and report live parameters, is untouched).

## Verification

Drove the real web build with Playwright in both light and dark themes:

- Searching "assign" no longer lists the three `assign_projection_*` dead-end tools.
- The "Projection and Georeferencing" list keeps the WASM-runnable tools (Reproject Raster/Vector, Georeference Raster From Control Points) and no longer shows the WASM-absent Reproject Lidar.
- Tool count drops from 755 to 749 (exactly the six WASM-absent tools), and runnable tools still render their parameters.

Also added a `mergeWasmToolManifests` unit test for the drop, clarified the existing empty-manifest fallback test, and ran the full frontend suite (green).

Fixes #1355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WASM tool availability handling.
  * Retained catalog tools as a display-only fallback when manifest loading returns no tools.
  * Removed catalog tools that are not implemented by a successfully loaded WASM binary.
  * Preserved tool parameter reconciliation and source information during merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->