### PR TITLE
feat(map): auto-enable terrain when the Terrain control is turned on

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -94,6 +94,9 @@ export interface GeoLibreAppAPI {
     position?: GeoLibreMapControlPosition,
   ) => boolean;
   removeMapControl: (control: IControl) => void;
+  // Note: showing the "terrain" control (visible: true) also switches 3D
+  // terrain on, mirroring the Controls menu so the user doesn't have to click
+  // the control button as a second step. Hiding it turns terrain back off.
   setBuiltInMapControlVisible: (
     control: GeoLibreBuiltInMapControl,
     visible: boolean,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -356,6 +356,11 @@ export class MapController {
   // Undefined until the React layer supplies a translated label; the control
   // falls back to its own default in the meantime (single source for the string).
   private terrainLabel: string | undefined;
+  // Set when the Terrain control is switched on before the basemap style is
+  // ready (no DEM source yet, so setEnabled would have nothing to point at).
+  // handleStyleReady reconciles it once the source lands so the toggle isn't
+  // silently dropped; cleared whenever terrain is turned off.
+  private terrainEnablePending = false;
   private scaleControl: PlanetaryScaleControl | null = null;
   private attributionControl: maplibregl.AttributionControl | null = null;
   private logoControl: maplibregl.LogoControl | null = null;
@@ -442,6 +447,10 @@ export class MapController {
       this.styleReady = true;
       this.enforceProjection();
       this.addTerrainSource();
+      // If the Terrain control was switched on before the style finished
+      // loading, the DEM source didn't exist yet and auto-enable was deferred;
+      // now that the source is in, turn terrain on so the toggle isn't dropped.
+      if (this.terrainEnablePending) this.autoEnableTerrain();
       this.applyBasemapVisibility();
       this.applyBasemapOpacity();
       this.addLayerControl();
@@ -787,12 +796,8 @@ export class MapController {
       if (control === "terrain") {
         const added = this.addTerrainControl();
         // Turning the Terrain control on should show 3D relief immediately, so
-        // users don't have to click the control button as a second step. Guard
-        // on the DEM source being present (added by addTerrainControl once the
-        // style is ready) so setEnabled has a source to point setTerrain at.
-        if (this.map?.getSource(TERRAIN_SOURCE_ID)) {
-          this.terrainControl?.setEnabled(true);
-        }
+        // users don't have to click the control button as a second step.
+        this.autoEnableTerrain();
         return added;
       }
       if (control === "scale") return this.addScaleControl();
@@ -2264,7 +2269,26 @@ export class MapController {
     return true;
   }
 
+  /**
+   * Turn 3D terrain on for the current control, deferring until the DEM source
+   * exists when the style is still loading. Called when the Terrain control is
+   * switched on so relief appears without a second click; the pending flag is
+   * reconciled by handleStyleReady once the source lands.
+   */
+  private autoEnableTerrain(): void {
+    if (!this.terrainControl) return;
+    if (this.map?.getSource(TERRAIN_SOURCE_ID)) {
+      this.terrainControl.setEnabled(true);
+      this.terrainEnablePending = false;
+    } else {
+      this.terrainEnablePending = true;
+    }
+  }
+
   private removeTerrainControl(): void {
+    // Any deferred auto-enable is void once terrain is being turned off, so a
+    // late style load can't re-enable a control the user just hid.
+    this.terrainEnablePending = false;
     if (this.map?.getTerrain()?.source === TERRAIN_SOURCE_ID) {
       this.map.setTerrain(null);
       // Mirror TerrainControl.setEnabled(false): restore MapLibre's default

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -784,7 +784,17 @@ export class MapController {
       if (control === "compass") return this.addCompassControl();
       if (control === "geolocate") return this.addGeolocateControl();
       if (control === "globe") return this.addGlobeControl();
-      if (control === "terrain") return this.addTerrainControl();
+      if (control === "terrain") {
+        const added = this.addTerrainControl();
+        // Turning the Terrain control on should show 3D relief immediately, so
+        // users don't have to click the control button as a second step. Guard
+        // on the DEM source being present (added by addTerrainControl once the
+        // style is ready) so setEnabled has a source to point setTerrain at.
+        if (this.map?.getSource(TERRAIN_SOURCE_ID)) {
+          this.terrainControl?.setEnabled(true);
+        }
+        return added;
+      }
       if (control === "scale") return this.addScaleControl();
       if (control === "attribution") return this.addAttributionControl();
       if (control === "logo") return this.addLogoControl();

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1086,7 +1086,7 @@ describe("MapController terrain auto-enable", () => {
     }
   });
 
-  it("does not enable terrain when the style (and DEM source) is not ready", () => {
+  it("defers the enable while the style loads, then turns terrain on once ready", () => {
     const prevDoc = (globalThis as { document?: unknown }).document;
     (globalThis as { document?: unknown }).document = makeTerrainDomStub();
     try {
@@ -1109,15 +1109,31 @@ describe("MapController terrain auto-enable", () => {
         off() {},
       };
       const controller = createMapController();
-      const internal = controller as unknown as { map: unknown; styleReady: boolean };
+      const internal = controller as unknown as {
+        map: unknown;
+        styleReady: boolean;
+        terrainEnablePending: boolean;
+        addTerrainSource(): boolean;
+        autoEnableTerrain(): void;
+      };
       internal.map = map;
-      // Style not ready: addTerrainSource no-ops, so there is no source for
-      // setTerrain to point at and auto-enable must be skipped rather than throw.
+      // Style not ready: addTerrainSource no-ops, so there is no source yet for
+      // setTerrain to point at. Auto-enable must be deferred, not dropped.
       internal.styleReady = false;
 
       controller.setBuiltInControlVisible("terrain", true);
 
       assert.equal(terrain, null);
+      assert.equal(internal.terrainEnablePending, true);
+
+      // Emulate handleStyleReady: the DEM source lands, and the deferred enable
+      // is reconciled so terrain turns on without the user re-toggling.
+      internal.styleReady = true;
+      internal.addTerrainSource();
+      if (internal.terrainEnablePending) internal.autoEnableTerrain();
+
+      assert.equal(terrain?.source, "geolibre-terrain-dem");
+      assert.equal(internal.terrainEnablePending, false);
     } finally {
       if (prevDoc === undefined) delete (globalThis as { document?: unknown }).document;
       else (globalThis as { document?: unknown }).document = prevDoc;

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1017,3 +1017,110 @@ describe("MapController story-map layer helpers", () => {
     assert.equal(paint["raster-opacity-transition"], undefined);
   });
 });
+
+// A DOM stub just rich enough for TerrainControl.onAdd, which the fake map's
+// addControl invokes below so the control has a live map to enable terrain on.
+function makeTerrainDomStub(): { createElement: () => unknown } {
+  return {
+    createElement: () => {
+      const classes = new Set<string>();
+      return {
+        className: "",
+        type: "",
+        title: "",
+        setAttribute() {},
+        appendChild: (child: unknown) => child,
+        addEventListener() {},
+        remove() {},
+        classList: {
+          toggle: (name: string, force?: boolean) => {
+            const next = force ?? !classes.has(name);
+            if (next) classes.add(name);
+            else classes.delete(name);
+            return next;
+          },
+        },
+      };
+    },
+  };
+}
+
+describe("MapController terrain auto-enable", () => {
+  it("enables terrain when the Terrain control is turned on, without a click", () => {
+    const prevDoc = (globalThis as { document?: unknown }).document;
+    (globalThis as { document?: unknown }).document = makeTerrainDomStub();
+    try {
+      let terrain: maplibregl.TerrainSpecification | null = null;
+      const sources = new Set<string>();
+      const map = {
+        // addControl mirrors MapLibre: it runs the control's onAdd so the
+        // control captures the map and can toggle terrain.
+        addControl: (control: maplibregl.IControl) =>
+          control.onAdd(map as unknown as maplibregl.Map),
+        removeControl() {},
+        getSource: (id: string) => (sources.has(id) ? {} : undefined),
+        addSource: (id: string) => {
+          sources.add(id);
+        },
+        getTerrain: () => terrain,
+        setTerrain: (spec: maplibregl.TerrainSpecification | null) => {
+          terrain = spec;
+        },
+        setCenterClampedToGround() {},
+        on() {},
+        off() {},
+      };
+      const controller = createMapController();
+      const internal = controller as unknown as { map: unknown; styleReady: boolean };
+      internal.map = map;
+      internal.styleReady = true;
+
+      const ok = controller.setBuiltInControlVisible("terrain", true);
+
+      assert.equal(ok, true);
+      // Terrain is active immediately — the user never had to click the button.
+      assert.equal(terrain?.source, "geolibre-terrain-dem");
+    } finally {
+      if (prevDoc === undefined) delete (globalThis as { document?: unknown }).document;
+      else (globalThis as { document?: unknown }).document = prevDoc;
+    }
+  });
+
+  it("does not enable terrain when the style (and DEM source) is not ready", () => {
+    const prevDoc = (globalThis as { document?: unknown }).document;
+    (globalThis as { document?: unknown }).document = makeTerrainDomStub();
+    try {
+      let terrain: maplibregl.TerrainSpecification | null = null;
+      const sources = new Set<string>();
+      const map = {
+        addControl: (control: maplibregl.IControl) =>
+          control.onAdd(map as unknown as maplibregl.Map),
+        removeControl() {},
+        getSource: (id: string) => (sources.has(id) ? {} : undefined),
+        addSource: (id: string) => {
+          sources.add(id);
+        },
+        getTerrain: () => terrain,
+        setTerrain: (spec: maplibregl.TerrainSpecification | null) => {
+          terrain = spec;
+        },
+        setCenterClampedToGround() {},
+        on() {},
+        off() {},
+      };
+      const controller = createMapController();
+      const internal = controller as unknown as { map: unknown; styleReady: boolean };
+      internal.map = map;
+      // Style not ready: addTerrainSource no-ops, so there is no source for
+      // setTerrain to point at and auto-enable must be skipped rather than throw.
+      internal.styleReady = false;
+
+      controller.setBuiltInControlVisible("terrain", true);
+
+      assert.equal(terrain, null);
+    } finally {
+      if (prevDoc === undefined) delete (globalThis as { document?: unknown }).document;
+      else (globalThis as { document?: unknown }).document = prevDoc;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- When the Terrain control is turned on (Controls menu or project restore), 3D terrain now activates automatically so users no longer have to click the control button as a second step.
- The auto-enable is guarded on the DEM source being present (style ready), and it only runs on the control-activation path, so merely repositioning the control does not toggle terrain.

## Test plan
- [ ] `node --import tsx --test tests/map-controller.test.ts` passes (new "terrain auto-enable" cases)
- [ ] `node --import tsx --test tests/terrain-control.test.ts tests/terrain-exaggeration.test.ts` pass
- [ ] In the app, toggle Controls > Terrain on and confirm 3D relief appears without clicking the mountain icon
- [ ] Toggle Terrain off and confirm terrain is removed and the map re-clamps to ground