### PR TITLE
fix(whitebox): implement Assign Projection tools in the WASM engine (#1355)

### DIFF
--- a/apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts
@@ -248,6 +248,12 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
     labelKey: "toolbar.item.lidar",
     subcategories: [
       {
+        label: "GeoLibre",
+        tools: [
+          { id: "assign_projection_lidar", name: "Assign Projection Lidar" },
+        ],
+      },
+      {
         label: "Analysis Metrics",
         tools: [
           { id: "colourize_based_on_class", name: "Colourize Based On Class" },
@@ -377,9 +383,6 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
       {
         label: "General",
         tools: [
-          { id: "assign_projection_lidar", name: "Assign Projection Lidar" },
-          { id: "assign_projection_raster", name: "Assign Projection Raster" },
-          { id: "assign_projection_vector", name: "Assign Projection Vector" },
           { id: "georeference_raster_from_control_points", name: "Georeference Raster From Control Points" },
           { id: "orthorectification", name: "Orthorectification" },
           { id: "reproject_lidar", name: "Reproject Lidar" },
@@ -395,6 +398,7 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
       {
         label: "GeoLibre",
         tools: [
+          { id: "assign_projection_raster", name: "Assign Projection Raster" },
           { id: "dem_filter", name: "DEM Filter" },
           { id: "extract_cog_subset", name: "Extract COG Subset" },
           { id: "extract_wms_subset", name: "Extract WMS Subset" },
@@ -950,6 +954,7 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
       {
         label: "GeoLibre",
         tools: [
+          { id: "assign_projection_vector", name: "Assign Projection Vector" },
           { id: "render_vector_png", name: "Render Vector to PNG" },
         ],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14070,9 +14070,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.9.0.tgz",
-      "integrity": "sha512-n75ogoH8p8ygS0zEYxljuV6p9TIAWUSEPV2ZM91tHKB1bG3NNdk2dlirvBO1bx0IGkBDwGqBMib86WI+6twOxw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.10.0.tgz",
+      "integrity": "sha512-PTF89futCYwxDxbI6HBUTviQ0N5aNGTQHJdfgVAUf21HGY0/7fMnhmtmfKfadSuFCZ3F54famEWC35oCmAh4lA==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -21804,7 +21804,7 @@
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^0.9.0",
+        "geolibre-wasm": "^0.10.0",
         "geotiff": "^3.0.5",
         "onnxruntime-web": "1.27.0"
       },

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -33,7 +33,7 @@
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^0.9.0",
+    "geolibre-wasm": "^0.10.0",
     "geotiff": "^3.0.5",
     "onnxruntime-web": "1.27.0"
   },

--- a/scripts/gen-whitebox-menu-catalog.mjs
+++ b/scripts/gen-whitebox-menu-catalog.mjs
@@ -42,7 +42,10 @@ const SNAPSHOT_OUT = resolve(
 const GROUPS = [
   ["conversion", "toolbar.item.conversion", (c) => c.startsWith("Conversion")],
   ["hydrology", "toolbar.item.hydrology", (c) => c.startsWith("Hydrology")],
-  ["lidar", "toolbar.item.lidar", (c) => c.startsWith("LiDAR")],
+  // Whitebox catalog tools use "LiDAR"; GeoLibre-authored WASM tools carry the
+  // bare `ToolCategory::Lidar` form "Lidar" (e.g. assign_projection_lidar), so
+  // match both or the geolibre-authored LiDAR tools drop out of the menu.
+  ["lidar", "toolbar.item.lidar", (c) => c.startsWith("LiDAR") || c === "Lidar"],
   ["network", "toolbar.item.network", (c) => c === "Vector - Network Analysis"],
   ["projection", "toolbar.item.projection", (c) => c.startsWith("Projection")],
   ["raster", "toolbar.item.raster", (c) => c === "Raster" || c.startsWith("Raster -")],


### PR DESCRIPTION
## Summary

In the Whitebox toolbox's local (WASM) mode, opening **Assign Projection Raster / Vector / Lidar** showed only "This tool has no parameters", and running one failed with `tool not found` (#1355).

**Root cause:** these three tools exist only in the `whitebox_next_gen` catalog (with empty params) and were **never implemented in the `whitebox-wasm` engine** that compiles into `geolibre-wasm` (confirmed: zero source matches for `assign_projection` anywhere in whitebox-wasm). The catalog advertised tools the engine couldn't run.

## Fix

Rather than hide the tools, the fix implements them upstream so they actually work:

- **opengeos/geolibre-rust#43** (released as `geolibre-wasm@0.10.0`) adds `assign_projection_{raster,vector,lidar}` as GeoLibre-authored WASM tools, the same way `geolibre-tools` already fills gaps the whitebox suite leaves (e.g. `reproject_raster`). Each assigns an EPSG CRS to the dataset **without transforming coordinates** (for data whose coordinates are already in that CRS but carry a missing/wrong projection tag).
- This PR bumps `geolibre-wasm` to `^0.10.0` so the toolbox picks up the real tools with `input` / `epsg` / `output` parameters.
- Regenerates the Processing menu catalog. The new tools are GeoLibre-authored, so they group under each data type's **GeoLibre** submenu. `assign_projection_lidar` carries the bare `ToolCategory::Lidar` category string `"Lidar"`, which the menu generator's lidar predicate (`startsWith("LiDAR")`) did not match and so dropped it from the menu; the predicate is widened to accept both forms.

## Verification

Drove the real web build with Playwright against the published `geolibre-wasm@0.10.0`, in **light and dark themes**, using real data:

- All three tools now render `input` / `EPSG code` / `output` fields (no more "This tool has no parameters").
- Loaded a real vector layer and a real raster; ran **Assign Projection Vector** (EPSG:3857) and **Assign Projection Raster** (EPSG:32610) end to end — both reached **succeeded** and added an output layer.
- Upstream unit tests cover all three, including a LAS CRS write/read roundtrip and a UTM→WGS84 GeoJSON reprojection check.
- Full frontend suite green (incl. the `MAX_VECTOR_PMTILES_ZOOM` mirror test); the whole app builds via pre-commit.

Fixes #1355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer GeoLibre subcategories for projection tools across LiDAR, raster, and vector workflows.
  * Ensured GeoLibre LiDAR tools appear in the Processing menu.

* **Bug Fixes**
  * Improved tool categorization so projection and LiDAR tools are displayed in the appropriate menu sections.
  * Updated processing support for the latest geospatial capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->