### PR TITLE
fix(plugins): update Add PMTiles sample data URL to a reachable release

### DIFF
--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -139,7 +139,7 @@ const splattingControlPosition: GeoLibreMapControlPosition = "top-left";
 
 const FLATGEOBUF_SAMPLE_URL = "https://flatgeobuf.org/test/data/UScounties.fgb";
 const PMTILES_SAMPLE_URL =
-  "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-05-20.0/buildings.pmtiles";
+  "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-06-17.0/buildings.pmtiles";
 const ZARR_SAMPLE_URL =
   "https://carbonplan-maps.s3.us-west-2.amazonaws.com/v2/demo/4d/tavg-prec-month";
 const LIDAR_SAMPLE_URL = "https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz";


### PR DESCRIPTION
## Summary

The **Add PMTiles → Overture buildings** sample data URL pointed at the Overture Maps `2026-05-20.0` release, which is no longer accessible. This bumps it to the current `2026-06-17.0` release, keeping the same host and `buildings.pmtiles` path.

- `packages/plugins/src/plugins/maplibre-components.ts` — `PMTILES_SAMPLE_URL` now `.../tiles/2026-06-17.0/buildings.pmtiles`

## Test plan

- [ ] Add Data → PMTiles → load the "Overture buildings" sample and confirm the archive loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled sample map data to a newer PMTiles release for improved sample content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->