### PR TITLE
fix(vector): reproject GeoJSON declaring a non-WGS84 crs member

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -81,7 +81,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.5.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.9.2",
+    "maplibre-gl-vector": "^0.9.3",
     "openai": "^6.46.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -10,6 +10,7 @@ import maplibregl from "maplibre-gl";
 import { tool } from "@strands-agents/sdk";
 import type { FeatureCollection } from "geojson";
 import { z } from "zod";
+import { projectedGeoJsonCrs } from "../crs-utils";
 import { inferPropertyColumns } from "../pglite-sql";
 import { consoleDeps, runConsoleCode } from "../pyodide/pyodide-console";
 import { cleanStatement, maskSqlLiterals, previewLayerTables, runSqlQuery } from "../sql-workspace";
@@ -364,7 +365,15 @@ export function createAssistantTools(deps: AssistantToolDeps): InvokableTool<unk
         if (length && Number(length) > MAX_BYTES) {
           throw new Error(`Response too large (${length} bytes).`);
         }
-        const geojson = asFeatureCollection(JSON.parse(await readTextCapped(response, MAX_BYTES)));
+        const parsed = asFeatureCollection(JSON.parse(await readTextCapped(response, MAX_BYTES)));
+        // A projected GeoJSON declares a non-WGS84 CRS via a legacy top-level
+        // `crs` member; reproject to WGS84 so MapLibre receives lon/lat. The
+        // DuckDB loader is pulled in only when such a member is present.
+        const geojson = projectedGeoJsonCrs(parsed)
+          ? await (
+              await import("../duckdb-vector-loader")
+            ).reprojectFeatureCollectionToWgs84(parsed)
+          : parsed;
         const name =
           input.name?.trim() || input.url.split("/").pop()?.split("?")[0] || "Remote layer";
         const id = store().addGeoJsonLayer(name, geojson, input.url);

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -369,10 +369,11 @@ export function createAssistantTools(deps: AssistantToolDeps): InvokableTool<unk
         // A projected GeoJSON declares a non-WGS84 CRS via a legacy top-level
         // `crs` member; reproject to WGS84 so MapLibre receives lon/lat. The
         // DuckDB loader is pulled in only when such a member is present.
-        const geojson = projectedGeoJsonCrs(parsed)
+        const sourceCrs = projectedGeoJsonCrs(parsed);
+        const geojson = sourceCrs
           ? await (
               await import("../duckdb-vector-loader")
-            ).reprojectFeatureCollectionToWgs84(parsed)
+            ).reprojectFeatureCollectionToWgs84(parsed, sourceCrs)
           : parsed;
         const name =
           input.name?.trim() || input.url.split("/").pop()?.split("?")[0] || "Remote layer";

--- a/apps/geolibre-desktop/src/lib/crs-utils.ts
+++ b/apps/geolibre-desktop/src/lib/crs-utils.ts
@@ -27,24 +27,31 @@ export function isGeographicCrs(crs: string | undefined): boolean {
 }
 
 /**
- * Reads the name of a legacy top-level GeoJSON `crs` member when it declares a
- * projected (non-WGS84) CRS, or null otherwise.
+ * Reads a legacy top-level GeoJSON `crs` member and, when it names a projected
+ * (non-WGS84) EPSG CRS, returns it as the canonical `EPSG:<code>` string to
+ * reproject from. Returns null otherwise.
  *
  * RFC 7946 mandates WGS84 for GeoJSON, but GDAL/QGIS still emit the pre-RFC form
  * with a `"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::26911" } }`
  * member and coordinates in the projected CRS. Such coordinates (metres) cannot
- * be rendered by MapLibre and must be reprojected to WGS84 first. A member that
- * is absent, malformed, or already WGS84/CRS84 returns null so the caller keeps
- * the cheap, DuckDB-free path.
+ * be rendered by MapLibre and must be reprojected to WGS84 first. The `EPSG:+`
+ * pattern accepts both the URN form (`urn:ogc:def:crs:EPSG::26911`) and the
+ * short form (`EPSG:26911`), normalizing either to `EPSG:26911`. A member that
+ * is absent, malformed, already WGS84/CRS84, or not an EPSG code returns null so
+ * the caller keeps the cheap, DuckDB-free path.
  *
- * The returned name is handed as-is to `reprojectFeatureCollectionToWgs84`,
- * which parses the EPSG code from it, so both the URN and short forms work.
+ * The returned value is passed as the explicit source CRS to
+ * `reprojectFeatureCollectionToWgs84`, so it is already in the `AUTHORITY:CODE`
+ * form `ST_Transform` expects.
  *
  * @param value - A parsed GeoJSON object that may carry a `crs` member
- * @returns The projected CRS name to reproject from, or null when none is needed
+ * @returns The source CRS as `EPSG:<code>`, or null when no reprojection is needed
  */
 export function projectedGeoJsonCrs(value: unknown): string | null {
   const name = (value as { crs?: { properties?: { name?: unknown } } })?.crs?.properties?.name;
-  if (typeof name !== "string") return null;
-  return isGeographicCrs(name) ? null : name;
+  if (typeof name !== "string" || isGeographicCrs(name)) return null;
+  // Extract the trailing EPSG code from either the URN (`EPSG::26911`) or short
+  // (`EPSG:26911`) form; `:+` tolerates the URN's double colon.
+  const match = name.toUpperCase().match(/EPSG:+(\d+)/);
+  return match ? `EPSG:${match[1]}` : null;
 }

--- a/apps/geolibre-desktop/src/lib/crs-utils.ts
+++ b/apps/geolibre-desktop/src/lib/crs-utils.ts
@@ -25,3 +25,26 @@ export function isGeographicCrs(crs: string | undefined): boolean {
   if (!value) return true;
   return value.includes("CRS84") || /EPSG:+4326\b/.test(value);
 }
+
+/**
+ * Reads the name of a legacy top-level GeoJSON `crs` member when it declares a
+ * projected (non-WGS84) CRS, or null otherwise.
+ *
+ * RFC 7946 mandates WGS84 for GeoJSON, but GDAL/QGIS still emit the pre-RFC form
+ * with a `"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::26911" } }`
+ * member and coordinates in the projected CRS. Such coordinates (metres) cannot
+ * be rendered by MapLibre and must be reprojected to WGS84 first. A member that
+ * is absent, malformed, or already WGS84/CRS84 returns null so the caller keeps
+ * the cheap, DuckDB-free path.
+ *
+ * The returned name is handed as-is to `reprojectFeatureCollectionToWgs84`,
+ * which parses the EPSG code from it, so both the URN and short forms work.
+ *
+ * @param value - A parsed GeoJSON object that may carry a `crs` member
+ * @returns The projected CRS name to reproject from, or null when none is needed
+ */
+export function projectedGeoJsonCrs(value: unknown): string | null {
+  const name = (value as { crs?: { properties?: { name?: unknown } } })?.crs?.properties?.name;
+  if (typeof name !== "string") return null;
+  return isGeographicCrs(name) ? null : name;
+}

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -29,6 +29,7 @@ import {
 } from "./duckdb-vector-guard";
 import type { GeotaggedPhotoResult } from "./geotagged-photos";
 import { PHOTO_IMAGE_EXTENSIONS, isPhotoDropFileName, isPhotoFileName } from "./geotagged-photos";
+import { projectedGeoJsonCrs } from "./crs-utils";
 import { parseGpxLayer } from "./gpx";
 import { isTauri } from "./is-tauri";
 import {
@@ -415,7 +416,20 @@ function normalizeShapefileResult(value: unknown): FeatureCollection {
 }
 
 async function parseGeoJsonText(text: string): Promise<FeatureCollection> {
-  return assertFeatureCollection(JSON.parse(text));
+  const fc = assertFeatureCollection(JSON.parse(text));
+  // A projected GeoJSON declares a non-WGS84 CRS via a legacy top-level `crs`
+  // member and carries raw projected coordinates MapLibre cannot render. When
+  // one is present, reproject to WGS84 (the heavy DuckDB loader is pulled in
+  // only then). A blank/WGS84 member takes the cheap path below and never loads
+  // DuckDB, keeping the common case light.
+  if (projectedGeoJsonCrs(fc)) {
+    const { reprojectFeatureCollectionToWgs84 } = await import("./duckdb-vector-loader");
+    return reprojectFeatureCollectionToWgs84(fc);
+  }
+  // Drop the deprecated `crs` member (RFC 7946 mandates WGS84) so it does not
+  // linger on an already-WGS84 collection.
+  const { crs: _deprecatedCrs, ...stripped } = fc as FeatureCollection & { crs?: unknown };
+  return stripped as FeatureCollection;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -422,9 +422,10 @@ async function parseGeoJsonText(text: string): Promise<FeatureCollection> {
   // one is present, reproject to WGS84 (the heavy DuckDB loader is pulled in
   // only then). A blank/WGS84 member takes the cheap path below and never loads
   // DuckDB, keeping the common case light.
-  if (projectedGeoJsonCrs(fc)) {
+  const sourceCrs = projectedGeoJsonCrs(fc);
+  if (sourceCrs) {
     const { reprojectFeatureCollectionToWgs84 } = await import("./duckdb-vector-loader");
-    return reprojectFeatureCollectionToWgs84(fc);
+    return reprojectFeatureCollectionToWgs84(fc, sourceCrs);
   }
   // Drop the deprecated `crs` member (RFC 7946 mandates WGS84) so it does not
   // linger on an already-WGS84 collection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.5.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.9.2",
+        "maplibre-gl-vector": "^0.9.3",
         "openai": "^6.46.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17112,9 +17112,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.9.2.tgz",
-      "integrity": "sha512-VxOuUwRllS5Oz3fl1IPW73DxMJ09eJugGm6kUBAOV7ldozq9h301EYuFdy0FcyUV/OTCzULs1z0ak3M5dVBWQw==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.9.3.tgz",
+      "integrity": "sha512-2kqPNmhHV3WkD9jokOkemS5qXE57WTDO3eOPVxFBJrqnyebBa3KMHfBOD5TiaTMxGfe9OpP0eP8CStDLYpqmVA==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21724,7 +21724,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.5.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.9.2",
+        "maplibre-gl-vector": "^0.9.3",
         "netcdfjs": "^4.0.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13642,9 +13642,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
     "typescript-eslint": "^8.64.0"
   },
   "overrides": {
+    "filelist": {
+      "minimatch": {
+        "brace-expansion": "^2.1.2"
+      }
+    },
     "sweepline-intersections": "^1.5.0",
     "uuid": "^14.0.0"
   },

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -55,7 +55,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.5.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.9.2",
+    "maplibre-gl-vector": "^0.9.3",
     "netcdfjs": "^4.0.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { isGeographicCrs } from "../apps/geolibre-desktop/src/lib/crs-utils";
+import { isGeographicCrs, projectedGeoJsonCrs } from "../apps/geolibre-desktop/src/lib/crs-utils";
 import {
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
@@ -202,6 +202,35 @@ describe("isGeographicCrs", () => {
     assert.equal(isGeographicCrs("EPSG:32643"), false);
     assert.equal(isGeographicCrs("EPSG:3857"), false);
     assert.equal(isGeographicCrs("ESRI:102100"), false);
+  });
+});
+
+describe("projectedGeoJsonCrs", () => {
+  const withCrs = (name: string) => ({
+    type: "FeatureCollection",
+    crs: { type: "name", properties: { name } },
+    features: [],
+  });
+
+  it("returns the projected CRS name from a legacy crs member (URN and short form)", () => {
+    assert.equal(
+      projectedGeoJsonCrs(withCrs("urn:ogc:def:crs:EPSG::26911")),
+      "urn:ogc:def:crs:EPSG::26911",
+    );
+    assert.equal(projectedGeoJsonCrs(withCrs("EPSG:3857")), "EPSG:3857");
+  });
+
+  it("returns null for a WGS84/CRS84 member", () => {
+    assert.equal(projectedGeoJsonCrs(withCrs("urn:ogc:def:crs:EPSG::4326")), null);
+    assert.equal(projectedGeoJsonCrs(withCrs("EPSG:4326")), null);
+    assert.equal(projectedGeoJsonCrs(withCrs("urn:ogc:def:crs:OGC:1.3:CRS84")), null);
+  });
+
+  it("returns null when the crs member is absent or malformed", () => {
+    assert.equal(projectedGeoJsonCrs({ type: "FeatureCollection", features: [] }), null);
+    assert.equal(projectedGeoJsonCrs({ crs: { properties: {} } }), null);
+    assert.equal(projectedGeoJsonCrs(null), null);
+    assert.equal(projectedGeoJsonCrs("not an object"), null);
   });
 });
 

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -212,12 +212,10 @@ describe("projectedGeoJsonCrs", () => {
     features: [],
   });
 
-  it("returns the projected CRS name from a legacy crs member (URN and short form)", () => {
-    assert.equal(
-      projectedGeoJsonCrs(withCrs("urn:ogc:def:crs:EPSG::26911")),
-      "urn:ogc:def:crs:EPSG::26911",
-    );
+  it("normalizes the projected CRS to EPSG:<code> from the URN and short forms", () => {
+    assert.equal(projectedGeoJsonCrs(withCrs("urn:ogc:def:crs:EPSG::26911")), "EPSG:26911");
     assert.equal(projectedGeoJsonCrs(withCrs("EPSG:3857")), "EPSG:3857");
+    assert.equal(projectedGeoJsonCrs(withCrs("epsg:32617")), "EPSG:32617");
   });
 
   it("returns null for a WGS84/CRS84 member", () => {
@@ -226,9 +224,10 @@ describe("projectedGeoJsonCrs", () => {
     assert.equal(projectedGeoJsonCrs(withCrs("urn:ogc:def:crs:OGC:1.3:CRS84")), null);
   });
 
-  it("returns null when the crs member is absent or malformed", () => {
+  it("returns null when the crs member is absent, malformed, or not an EPSG code", () => {
     assert.equal(projectedGeoJsonCrs({ type: "FeatureCollection", features: [] }), null);
     assert.equal(projectedGeoJsonCrs({ crs: { properties: {} } }), null);
+    assert.equal(projectedGeoJsonCrs(withCrs("ESRI:102100")), null);
     assert.equal(projectedGeoJsonCrs(null), null);
     assert.equal(projectedGeoJsonCrs("not an object"), null);
   });


### PR DESCRIPTION
## Problem

A GeoJSON that declares a non-WGS84 CRS via a legacy top-level `crs` member could not be rendered. For example:

```
https://data.source.coop/giswqs/opengeos/naip_building_masks_utm.geojson
```

carries `"crs": { ... "name": "urn:ogc:def:crs:EPSG::26911" }` with coordinates in UTM metres. RFC 7946 mandates WGS84, but GDAL/QGIS still export this pre-RFC form. MapLibre only understands WGS84 lon/lat, so the raw metre coordinates:

- **Drag-and-drop / file picker** rendered off-map (near [0,0]).
- **Add Vector Layer panel** got stuck at "loading" (the out-of-range latitude threw `Invalid LngLat` in the panel's `fitBounds`).

## Fix

Two ingest paths ignored the `crs` member; both now reproject to WGS84 through the existing DuckDB Spatial PROJ path, which already parses the member:

- `parseGeoJsonText` (the chokepoint for drag-and-drop, the file picker, and local-path loads) reprojects via `reprojectFeatureCollectionToWgs84` when a projected `crs` member is present, and otherwise strips the deprecated member on the cheap, DuckDB-free path. The heavy loader is dynamically imported only when a projected member is actually seen, so the common WGS84 case stays light.
- The AI assistant `add_layer_from_url` tool gets the same treatment.
- A shared, unit-tested helper `projectedGeoJsonCrs` (in `crs-utils.ts`) centralizes the detection so both call sites agree.

The **Add Vector Layer panel** is the upstream `maplibre-gl-vector` control, whose GeoJSON fast path bypassed its own DuckDB engine. That was fixed upstream in opengeos/maplibre-gl-vector#44 and released as **v0.9.3**; this PR bumps the dependency to `^0.9.3`.

## Tests

- `projectedGeoJsonCrs` unit tests (`tests/data-parsing.test.ts`): URN and short forms return the projected name; WGS84/CRS84 and absent/malformed members return null.
- Full frontend suite passes (3392 tests); `npm run build` clean; `pre-commit` clean on the changed files.

## Verification

Verified in the real app with the UTM (EPSG:26911) file above, in both light and dark themes, with zero console errors:

- **Drag-and-drop**: the layer renders correctly over Spokane / Airway Heights, WA (bbox `-117.60, 47.64`).
- **Add Vector Layer panel** (with the published 0.9.3): loads without hanging and renders at the same location.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing GeoJSON with legacy/projected coordinate reference systems, with automatic reprojection to WGS84 for correct map display.

- **Bug Fixes**
  - Improved CRS detection and normalization to reliably determine whether reprojection is needed.
  - Removed deprecated top-level CRS metadata from stored/processed GeoJSON to keep it standards-compliant.

- **Tests**
  - Added unit tests for projected CRS detection and edge cases.

- **Chores**
  - Updated the vector integration dependency to `^0.9.3`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->