### PR TITLE
feat(processing): deep-link Whitebox tools via ?tool= URL param

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -15,6 +15,7 @@ import { useThemeMode } from "./hooks/useThemeMode";
 import { useThemeScheme } from "./hooks/useThemeScheme";
 import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts";
+import { useWhiteboxToolUrl } from "./hooks/useWhiteboxToolUrl";
 import { languageDirection } from "./i18n/languages";
 
 export default function App() {
@@ -34,6 +35,7 @@ export default function App() {
   useRuntimeEnvironmentVariables();
   useUndoRedoShortcuts();
   useBeforeUnloadGuard();
+  useWhiteboxToolUrl();
   return (
     <DirectionProvider dir={languageDirection(i18n.language)}>
       <DesktopShell

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -697,8 +697,14 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
 
   const handleCopyLink = useCallback(() => {
     if (!shareUrl) return;
+    // The Clipboard API is absent in insecure contexts (HTTP over a LAN) or when
+    // blocked; surface a failure message instead of silently doing nothing.
+    if (!navigator.clipboard) {
+      setError(t("processing.whitebox.copyLinkFailed"));
+      return;
+    }
     void navigator.clipboard
-      ?.writeText(shareUrl)
+      .writeText(shareUrl)
       .then(() => {
         if (linkCopyTimer.current !== null) window.clearTimeout(linkCopyTimer.current);
         setLinkCopied(true);

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -24,11 +24,13 @@ import { Button, Input, Label, ScrollArea, Select, cn } from "@geolibre/ui";
 import type { FeatureCollection } from "geojson";
 import {
   AlertCircle,
+  Check,
   CheckCircle2,
   ChevronDown,
   ChevronUp,
   FolderOpen,
   GripHorizontal,
+  Link2,
   Loader2,
   Play,
   RefreshCw,
@@ -57,6 +59,7 @@ import {
   subsetUrlFieldValues,
   subsetUrlToolKind,
 } from "../../lib/subset-tool-url";
+import { buildWhiteboxToolShareUrl, whiteboxToolShareBase } from "../../lib/whitebox-tool-url";
 import { clearPrintExtent, drawPrintExtent } from "../../lib/print-extent";
 import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
 import {
@@ -426,6 +429,9 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
   // terminal job (never "pending"/"running"), so without this flag the Run
   // button would stay enabled mid-execution and allow concurrent runs.
   const [runningLocal, setRunningLocal] = useState(false);
+  // Transient "Copied!" state for the share-link button, cleared after 2s.
+  const [linkCopied, setLinkCopied] = useState(false);
+  const linkCopyTimer = useRef<number | null>(null);
 
   // Floating, non-modal panel (GH: whitebox modal -> floating panel). Rendered
   // as a draggable `fixed` window instead of a Radix modal so the map stays
@@ -664,6 +670,49 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
   // Whether any GeoLibre-authored tools are present (WASM mode), gating the
   // source filter — pointless when every tool is from Whitebox.
   const hasGeolibreTools = useMemo(() => tools.some((tool) => tool.source === "geolibre"), [tools]);
+
+  // A shareable `?tool=` deep link for the selected tool: the tool id plus the
+  // parameters the user changed from their defaults. Local file paths
+  // (`*_in`/`*_out`) are excluded — they are machine-specific and either useless
+  // or leaky to a recipient — while an HTTP `url` (a `string` param) is kept. The
+  // web build links to its own origin; the desktop build, whose window origin is
+  // a non-shareable `tauri://…`, links to the hosted web app.
+  const shareUrl = useMemo(() => {
+    if (!selectedTool) return "";
+    const defaults = createDefaultValues(selectedTool);
+    const asString = (value: unknown) =>
+      typeof value === "string" ? value : value == null ? "" : String(value);
+    const parameters: Record<string, string> = {};
+    for (const param of selectedTool.params ?? []) {
+      const name = param.name;
+      if (!name) continue;
+      const kind = parameterKind(param);
+      if (kind.endsWith("_in") || kind.endsWith("_out")) continue;
+      const value = asString(values[name]);
+      if (!value.trim() || value === asString(defaults[name])) continue;
+      parameters[name] = value;
+    }
+    return buildWhiteboxToolShareUrl(selectedTool.id, parameters, whiteboxToolShareBase(desktop));
+  }, [selectedTool, values, desktop]);
+
+  const handleCopyLink = useCallback(() => {
+    if (!shareUrl) return;
+    void navigator.clipboard
+      ?.writeText(shareUrl)
+      .then(() => {
+        if (linkCopyTimer.current !== null) window.clearTimeout(linkCopyTimer.current);
+        setLinkCopied(true);
+        linkCopyTimer.current = window.setTimeout(() => setLinkCopied(false), 2000);
+      })
+      .catch(() => setError(t("processing.whitebox.copyLinkFailed")));
+  }, [shareUrl, t]);
+
+  useEffect(
+    () => () => {
+      if (linkCopyTimer.current !== null) window.clearTimeout(linkCopyTimer.current);
+    },
+    [],
+  );
 
   // Ignore the source filter when no GeoLibre tools are present (e.g. sidecar
   // mode), so a stale "geolibre" selection can't empty the whole list.
@@ -1674,6 +1723,19 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
                 />
                 {t("processing.whitebox.runLocal")}
               </label>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleCopyLink}
+                disabled={!selectedTool}
+                title={t("processing.whitebox.copyLinkHint")}
+                aria-label={t("processing.whitebox.copyLink")}
+              >
+                {linkCopied ? <Check className="h-4 w-4" /> : <Link2 className="h-4 w-4" />}
+                {linkCopied
+                  ? t("processing.whitebox.copyLinkCopied")
+                  : t("processing.whitebox.copyLink")}
+              </Button>
               <Button
                 type="button"
                 onClick={runSelectedTool}

--- a/apps/geolibre-desktop/src/hooks/useWhiteboxToolUrl.ts
+++ b/apps/geolibre-desktop/src/hooks/useWhiteboxToolUrl.ts
@@ -1,0 +1,57 @@
+import { useAppStore } from "@geolibre/core";
+import { useEffect, useMemo } from "react";
+
+import { whiteboxToolFromLocation } from "../lib/whitebox-tool-url";
+
+/**
+ * Opens the Processing (Whitebox toolbox) dialog on a specific tool when the app
+ * is loaded with a `?tool=<id>` deep link, optionally pre-filling the tool's
+ * parameters from the remaining query params, e.g.
+ * `…/?tool=extract_cog_subset&url=https%3A%2F%2F…%2Fdem.tif&bbox_crs=4326`.
+ *
+ * The id is validated against the checked-in menu catalog
+ * ({@link whiteboxToolFromLocation}). A **known** id preselects the tool — and,
+ * when the URL carries parameters, dispatches a re-run-style request so the
+ * dialog overlays those values on the tool's defaults once its catalog finishes
+ * loading, exactly like the History "re-run" path (`ProcessingDialog` consumes
+ * `ui.processingRerun` + `ui.processingInitialTool`). A present-but-**unknown**
+ * id still opens the dialog with no preselection rather than silently doing
+ * nothing; its parameters can't be mapped without a tool, so they are dropped.
+ *
+ * The query string is read once on mount (`useMemo` with no deps), so later
+ * in-app state changes never re-trigger it. Works identically in the web and
+ * desktop builds: it touches only `window.location.search` and the shared store.
+ */
+export function useWhiteboxToolUrl(): void {
+  const setProcessingOpen = useAppStore((state) => state.setProcessingOpen);
+  const setProcessingInitialTool = useAppStore((state) => state.setProcessingInitialTool);
+  const setProcessingRerun = useAppStore((state) => state.setProcessingRerun);
+  const target = useMemo(() => whiteboxToolFromLocation(), []);
+
+  useEffect(() => {
+    if (!target) return;
+
+    if (!target.known) {
+      // Unknown id: open Processing without preselecting a tool. Clear any stale
+      // pending id so the dialog lands on its default tool rather than a leftover.
+      setProcessingInitialTool(null);
+      setProcessingOpen(true);
+      return;
+    }
+
+    // Known id. When the URL carries tool parameters, queue a re-run-style
+    // request that pre-fills the form (the rerun effect overlays the values on
+    // the tool's defaults once the catalog is loaded). Pair it with the
+    // initial-tool stash, which clears the list filters and selects the tool —
+    // exactly how the History panel opens a whitebox re-run.
+    if (Object.keys(target.parameters).length > 0) {
+      setProcessingRerun({
+        kind: "whitebox",
+        toolId: target.toolId,
+        parameters: target.parameters,
+      });
+    }
+    setProcessingInitialTool(target.toolId);
+    setProcessingOpen(true);
+  }, [target, setProcessingInitialTool, setProcessingRerun, setProcessingOpen]);
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2916,6 +2916,10 @@
       "runLocal": "Run locally (WASM)",
       "runLocalHint": "Run locally in WebAssembly (no Python sidecar)",
       "runningLocally": "Running locally with WebAssembly. No sidecar required.",
+      "copyLink": "Copy link",
+      "copyLinkCopied": "Copied!",
+      "copyLinkHint": "Copy a shareable link that opens this tool with the current settings",
+      "copyLinkFailed": "Could not copy the link to the clipboard.",
       "catalogSnapshotError": "Could not load Whitebox catalog snapshot.",
       "localRunnerError": "Could not load the local (WASM) tool runner. Refresh and try again, or use the sidecar if it is available.",
       "output": {

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -1,5 +1,6 @@
 import { parseProject, type GeoLibreProject } from "@geolibre/core";
 import { normalizeProjectUrl } from "./urls";
+import { WHITEBOX_TOOL_PARAM } from "./whitebox-tool-url";
 
 // Query parameters that carry a `.geolibre.json` project URL deep link. A bare
 // `?https://...` query (no key) is also accepted by `projectUrlFromLocation`.
@@ -24,7 +25,7 @@ export function projectUrlFromLocation(): string | null {
   // `whitebox-tool-url.ts`). Suppress the project loader so the two features
   // don't both claim `url` — otherwise the loader would try to parse a raster as
   // a `.geolibre.json` project and surface an error.
-  if (params.get("tool")?.trim()) return null;
+  if (params.get(WHITEBOX_TOOL_PARAM)?.trim()) return null;
   for (const key of PROJECT_URL_PARAMS) {
     const value = params.get(key);
     const url = normalizeProjectUrl(value);

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -19,6 +19,12 @@ export function projectUrlFromLocation(): string | null {
 
   const search = window.location.search;
   const params = new URLSearchParams(search);
+  // A `?tool=` deep link puts the app in Whitebox tool mode, where `url` names a
+  // tool input (e.g. a COG to subset), not a project to load (see
+  // `whitebox-tool-url.ts`). Suppress the project loader so the two features
+  // don't both claim `url` — otherwise the loader would try to parse a raster as
+  // a `.geolibre.json` project and surface an error.
+  if (params.get("tool")?.trim()) return null;
   for (const key of PROJECT_URL_PARAMS) {
     const value = params.get(key);
     const url = normalizeProjectUrl(value);

--- a/apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts
@@ -31,7 +31,7 @@ export interface WhiteboxMenuCategory {
   subcategories: WhiteboxMenuSubcategory[];
 }
 
-/** 755 tools across 9 categories. */
+/** 757 tools across 9 categories. */
 export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
   {
     key: "conversion",
@@ -955,7 +955,9 @@ export const WHITEBOX_MENU_CATALOG: WhiteboxMenuCategory[] = [
         label: "GeoLibre",
         tools: [
           { id: "assign_projection_vector", name: "Assign Projection Vector" },
+          { id: "regularize_building_footprints", name: "Regularize Building Footprints" },
           { id: "render_vector_png", name: "Render Vector to PNG" },
+          { id: "smooth_natural_features", name: "Smooth Natural Features" },
         ],
       },
       {

--- a/apps/geolibre-desktop/src/lib/whitebox-tool-url.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-tool-url.ts
@@ -1,0 +1,114 @@
+import { WHITEBOX_MENU_CATALOG } from "./whitebox-menu-catalog";
+
+/**
+ * Query parameter that deep-links to a single Whitebox/Processing tool, e.g.
+ * `…/?tool=adaptive_filter`. Opening the app with it preselects that tool in the
+ * Processing (Whitebox toolbox) dialog. Mirrors the tool ids the Processing menu
+ * uses (`ProcessingMenu.openWhiteboxTool`).
+ */
+export const WHITEBOX_TOOL_PARAM = "tool";
+
+/**
+ * App-level query parameters that keep their own meaning even when a `?tool=`
+ * deep link is present, so they are **not** forwarded to the tool's parameter
+ * form. Every other query parameter — including `url` — becomes a tool
+ * parameter (the "tool mode wins" rule: with `?tool=` present, `url` names a
+ * tool input, and the project-URL loader is suppressed; see
+ * `projectUrlFromLocation`). Keep this list in sync with the embed/layout params
+ * documented in `docs/user-guide/embedding.md`.
+ */
+const RESERVED_PARAMS: ReadonlySet<string> = new Set([
+  WHITEBOX_TOOL_PARAM,
+  // Embed chrome / layout.
+  "layout",
+  "embed",
+  "iframe",
+  "toolbar",
+  "panels",
+  "hidePanels",
+  "maponly",
+  "theme",
+  "welcome",
+  // i18n + collaboration.
+  "locale",
+  "lang",
+  "collab",
+]);
+
+/**
+ * Every tool id present in the checked-in Whitebox menu catalog — the Whitebox
+ * catalog snapshot tools plus the GeoLibre-authored WASM tools. Built once at
+ * module load and used to validate a `?tool=` deep link before it opens the
+ * dialog. This is the union across engines; a given runtime (WASM in the
+ * browser, the Python sidecar under Tauri) may not expose every one, which the
+ * dialog's own async guard handles by ignoring an id absent from the *loaded*
+ * tool list.
+ */
+const KNOWN_TOOL_IDS: ReadonlySet<string> = new Set(
+  WHITEBOX_MENU_CATALOG.flatMap((category) =>
+    category.subcategories.flatMap((subcategory) => subcategory.tools.map((tool) => tool.id)),
+  ),
+);
+
+/**
+ * Whether `toolId` matches a tool id in the Processing menu catalog.
+ *
+ * @param toolId - A candidate tool id.
+ * @returns `true` when the catalog contains the id.
+ */
+export function isKnownWhiteboxToolId(toolId: string): boolean {
+  return KNOWN_TOOL_IDS.has(toolId);
+}
+
+/** A `?tool=` deep-link target parsed from a query string. */
+export interface WhiteboxToolUrlTarget {
+  /** The trimmed `?tool=` value. */
+  toolId: string;
+  /** Whether {@link toolId} matches a catalog tool id. */
+  known: boolean;
+  /**
+   * Tool parameter values parsed from the remaining (non-reserved) query
+   * params, each kept as a string (the dialog stores every parameter value as a
+   * string). First value wins for a repeated key. Empty when the deep link
+   * carries no tool parameters. Only applied when {@link known} is `true`.
+   */
+  parameters: Record<string, string>;
+}
+
+/**
+ * Parses a `?tool=` deep link from a raw query string.
+ *
+ * @param search - A `window.location.search`-style query string (leading `?`
+ *   optional).
+ * @returns The target, or `null` when the `tool` parameter is absent or empty.
+ *   A present-but-unknown id is returned with `known: false` (and no
+ *   parameters) rather than dropped, so the caller can still open the dialog and
+ *   let the user pick.
+ */
+export function whiteboxToolFromSearch(search: string): WhiteboxToolUrlTarget | null {
+  const params = new URLSearchParams(search);
+  const toolId = params.get(WHITEBOX_TOOL_PARAM)?.trim() ?? "";
+  if (!toolId) return null;
+
+  const parameters: Record<string, string> = {};
+  for (const [key, value] of params) {
+    // First value wins for a repeated key; skip app-level params so, e.g.,
+    // `theme` styles the app rather than becoming a phantom tool input.
+    if (RESERVED_PARAMS.has(key) || key in parameters) continue;
+    parameters[key] = value;
+  }
+
+  return { toolId, known: isKnownWhiteboxToolId(toolId), parameters };
+}
+
+/**
+ * Reads a `?tool=` deep link from the current `window.location`, if one is
+ * present. Returns `null` outside a browser (SSR/tests without a window) or
+ * when the parameter is absent.
+ *
+ * @returns The parsed target, or `null`.
+ */
+export function whiteboxToolFromLocation(): WhiteboxToolUrlTarget | null {
+  if (typeof window === "undefined") return null;
+  return whiteboxToolFromSearch(window.location.search);
+}

--- a/apps/geolibre-desktop/src/lib/whitebox-tool-url.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-tool-url.ts
@@ -112,3 +112,52 @@ export function whiteboxToolFromLocation(): WhiteboxToolUrlTarget | null {
   if (typeof window === "undefined") return null;
   return whiteboxToolFromSearch(window.location.search);
 }
+
+/**
+ * Canonical public URL of the hosted web app, used as the base for a shareable
+ * tool link from the **desktop** build — there `window.location` is a
+ * `tauri://…` origin that recipients can't open. The web build shares its own
+ * origin instead (see `whiteboxToolShareBase`).
+ */
+export const GEOLIBRE_WEB_APP_URL = "https://web.geolibre.app/";
+
+/**
+ * The base URL a "Copy link" share should build on.
+ *
+ * @param desktop - Whether the app is the desktop (Tauri) build, whose
+ *   `window.location` is not shareable.
+ * @returns `GEOLIBRE_WEB_APP_URL` on desktop; otherwise the current app's
+ *   origin + path (so a self-hosted web deployment links to itself), falling
+ *   back to the canonical URL when there is no window.
+ */
+export function whiteboxToolShareBase(desktop: boolean): string {
+  if (desktop || typeof window === "undefined") return GEOLIBRE_WEB_APP_URL;
+  return `${window.location.origin}${window.location.pathname}`;
+}
+
+/**
+ * Builds a shareable `?tool=` deep link, the inverse of
+ * {@link whiteboxToolFromSearch}: `<base>?tool=<toolId>` plus one query
+ * parameter per entry in `parameters`. Any query string already on `base` is
+ * dropped so the link is deterministic. The caller decides which parameters to
+ * include (the dialog omits local file paths and values left at their default).
+ *
+ * @param toolId - The tool id to preselect.
+ * @param parameters - Tool parameter values to prefill, each a string.
+ * @param base - The base URL (see {@link whiteboxToolShareBase}).
+ * @returns The absolute share URL.
+ */
+export function buildWhiteboxToolShareUrl(
+  toolId: string,
+  parameters: Record<string, string>,
+  base: string,
+): string {
+  const url = new URL(base);
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set(WHITEBOX_TOOL_PARAM, toolId);
+  for (const [key, value] of Object.entries(parameters)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -20,22 +20,41 @@ A chrome-free `maponly` embed shows only the map, as in this shared 3D Tiles pro
 
 ## URL parameters
 
-| Parameter | Example | Description |
-| --- | --- | --- |
-| `url` | `url=https://share.geolibre.app/you/project.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
-| `layout` | `layout=compact` | Compact embed layout: icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
-| `toolbar` | `toolbar=icons` | Icon-only toolbar buttons without the full compact layout. `icon` and `icon-only` are aliases. |
-| `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
-| `hidePanels` | `hidePanels=true` | Alternative way to hide those panels. |
-| `maponly` | `maponly` | Hides all chrome (toolbar, panels, and status bar), leaving only the map. The bare flag or `true`, `1`, `yes`, `on` enable it. |
-| `welcome` | `welcome=0` | Hides the first-launch welcome wizard. Accepts `0`, `false`, `off`, or `no`. A `url=` deep link already suppresses it automatically. |
-| `theme` | `theme=dark` | Sets the initial color theme, overriding the OS preference. Accepts `dark` or `light`; the in-app toggle still works afterward. |
+| Parameter    | Example                                                    | Description                                                                                                                           |
+| ------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`        | `url=https://share.geolibre.app/you/project.geolibre.json` | Loads a `.geolibre.json` project from a public URL.                                                                                   |
+| `layout`     | `layout=compact`                                           | Compact embed layout: icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases.                        |
+| `toolbar`    | `toolbar=icons`                                            | Icon-only toolbar buttons without the full compact layout. `icon` and `icon-only` are aliases.                                        |
+| `panels`     | `panels=none`                                              | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases.                                         |
+| `hidePanels` | `hidePanels=true`                                          | Alternative way to hide those panels.                                                                                                 |
+| `maponly`    | `maponly`                                                  | Hides all chrome (toolbar, panels, and status bar), leaving only the map. The bare flag or `true`, `1`, `yes`, `on` enable it.        |
+| `welcome`    | `welcome=0`                                                | Hides the first-launch welcome wizard. Accepts `0`, `false`, `off`, or `no`. A `url=` deep link already suppresses it automatically.  |
+| `theme`      | `theme=dark`                                               | Sets the initial color theme, overriding the OS preference. Accepts `dark` or `light`; the in-app toggle still works afterward.       |
+| `tool`       | `tool=adaptive_filter`                                     | Opens the Processing (Whitebox toolbox) dialog on a specific tool by its id. Unknown ids open the dialog without preselecting a tool. |
 
 Parameters combine. For a narrow, chrome-free, dark embed of a shared project:
 
 ```text
 https://web.geolibre.app/?url=https://share.geolibre.app/you/project.geolibre.json&maponly&theme=dark
 ```
+
+### Deep-linking a Processing tool
+
+`tool=<id>` opens the Processing (Whitebox toolbox) dialog preselected to a tool.
+Any **additional** query parameters pre-fill that tool's form, using the tool's
+own parameter names, so a link can arrive ready to run:
+
+```text
+https://web.geolibre.app/?tool=extract_cog_subset&url=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fdem.tif&bbox_crs=4326
+```
+
+When `tool=` is present the app is in **tool mode**: `url` names a tool input
+(here, the COG to subset) rather than a project to load, so the project loader
+stands down. App/embed parameters above (`theme`, `layout`, `panels`, `maponly`,
+`locale`, …) keep their own meaning and are never passed to the tool. An id the
+current engine doesn't expose (WASM in the browser, the Python sidecar on
+desktop) simply isn't preselected. Tool ids match the Processing menu — the same
+ids used across the [Whitebox toolbox](processing.md).
 
 ## Embedding in a page
 

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -51,10 +51,13 @@ https://web.geolibre.app/?tool=extract_cog_subset&url=https%3A%2F%2Fdata.source.
 When `tool=` is present the app is in **tool mode**: `url` names a tool input
 (here, the COG to subset) rather than a project to load, so the project loader
 stands down. App/embed parameters above (`theme`, `layout`, `panels`, `maponly`,
-`locale`, …) keep their own meaning and are never passed to the tool. An id the
-current engine doesn't expose (WASM in the browser, the Python sidecar on
-desktop) simply isn't preselected. Tool ids match the Processing menu — the same
-ids used across the [Whitebox toolbox](processing.md).
+`locale`, …) keep their own meaning and are never passed to the tool.
+Preselection and parameter prefilling apply only to an id that matches the
+Processing menu: an id not in the menu still opens the dialog, but without
+preselecting a tool or applying any parameters. A known id the current engine
+doesn't expose (WASM in the browser, the Python sidecar on desktop) likewise
+isn't preselected. Tool ids match the Processing menu — the same ids used across
+the [Whitebox toolbox](processing.md).
 
 ## Embedding in a page
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -591,6 +591,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2726,6 +2727,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.6.tgz",
       "integrity": "sha512-shHIzD1fzPXYNqT5MvCW++3LMUA/odF25eWrjwQ6mRwPjwty9jUOEg5UoRYmNUN0fiE00vnc5kzMQVL7T/jDKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
@@ -2965,6 +2967,7 @@
       "resolved": "https://registry.npmjs.org/@developmentseed/morecantile/-/morecantile-0.7.0.tgz",
       "integrity": "sha512-m9tWDase9COlP/EZ2KK/ydraRU/5yfwvmF/y/2g/iFMFW1vYHQTW/8JYjmo84SiJXUifDDY2xoA3ErYlcWJctg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@developmentseed/affine": "^0.7.0"
       }
@@ -3093,7 +3096,8 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.4.tgz",
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-postgis": {
       "version": "0.2.4",
@@ -3720,6 +3724,7 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.10.3.tgz",
       "integrity": "sha512-o5iwxSDS2M8lwLkNtaJTKqyN3NHv2Ne5bL+7tfdcmmHukcGMuuSroRG/+IT3CXOS7gk9sYVdR0cMEPHs1lTWNQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3735,6 +3740,7 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.10.3.tgz",
       "integrity": "sha512-gBKSRC7L3cD1KX4fIleRiEKtzlvKjuDW5cYpDcDyQCn/Bw7bJzlGrlaMw87FQ+ReTZp9vlTYFXyrGMuUtR0dKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.10.3",
         "@esri/arcgis-rest-form-data": "^4.10.3",
@@ -3863,6 +3869,7 @@
       "resolved": "https://registry.npmjs.org/@geoman-io/maplibre-geoman-free/-/maplibre-geoman-free-0.8.4.tgz",
       "integrity": "sha512-nOLEpMtORSR0XceXfOHc0RGqrkCQo3719o1d1Bp64xzijxn37KvkxB7S3dwOFV+i3Z3MleaSGAcIjvszil2D3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/area": "^7.3.5",
         "@turf/bbox": "^7.3.5",
@@ -5438,6 +5445,7 @@
       "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
       "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/core": "4.1.0"
       }
@@ -5468,6 +5476,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5596,6 +5605,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -10587,6 +10597,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -11268,6 +11279,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11400,6 +11412,7 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
       "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/command-line-args": "^5.2.3",
@@ -11819,6 +11832,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -12096,6 +12110,7 @@
       "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.1.tgz",
       "integrity": "sha512-5mH36bBRrArqeCeCW3Gl2IhlWcU5g64eQRIfIsyo+XQwaBYfmjzuHJ36nbS7fCLUNk9khNUdgVWTU9C1zS33iw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
@@ -12975,6 +12990,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13045,6 +13061,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -13315,6 +13332,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14070,9 +14088,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.10.0.tgz",
-      "integrity": "sha512-PTF89futCYwxDxbI6HBUTviQ0N5aNGTQHJdfgVAUf21HGY0/7fMnhmtmfKfadSuFCZ3F54famEWC35oCmAh4lA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.11.0.tgz",
+      "integrity": "sha512-vm2JxUCOLPC9a+9DSEg3GP+11ktHXP8DeCxwymlCSi2ce2lJuuVSuk6jY8RKbvvl0MA6q8Uze8+kS8VJOmu59A==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -14083,6 +14101,7 @@
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
       "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.9.3",
         "lerc": "^3.0.0",
@@ -14101,7 +14120,8 @@
       "version": "2024.4.13",
       "resolved": "https://registry.npmjs.org/geotiff-geokeys-to-proj4/-/geotiff-geokeys-to-proj4-2024.4.13.tgz",
       "integrity": "sha512-Jgtm/lcPkgB44wCqQHaVQx5/fyhmiVDRUKQcI/vMolsED8/GRWBnn5qkQo/CgutQg9xkGzig21DY9Px9mFRdvg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/geotiff/node_modules/lerc": {
       "version": "3.0.0",
@@ -14884,6 +14904,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
       "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -14992,6 +15013,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6 || ^7"
       },
@@ -18088,6 +18110,7 @@
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -18266,6 +18289,7 @@
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
       "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.5.5"
@@ -18477,6 +18501,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18486,6 +18511,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18886,6 +18912,7 @@
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -19880,6 +19907,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20069,6 +20097,7 @@
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -20332,6 +20361,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -20604,6 +20634,7 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -21007,6 +21038,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21221,6 +21253,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -21393,6 +21426,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -21470,6 +21504,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -21532,6 +21567,7 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -21804,7 +21840,7 @@
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^0.10.0",
+        "geolibre-wasm": "^0.11.0",
         "geotiff": "^3.0.5",
         "onnxruntime-web": "1.27.0"
       },

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -33,7 +33,7 @@
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^0.10.0",
+    "geolibre-wasm": "^0.11.0",
     "geotiff": "^3.0.5",
     "onnxruntime-web": "1.27.0"
   },

--- a/tests/whitebox-tool-url.test.ts
+++ b/tests/whitebox-tool-url.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  isKnownWhiteboxToolId,
+  WHITEBOX_TOOL_PARAM,
+  whiteboxToolFromSearch,
+} from "../apps/geolibre-desktop/src/lib/whitebox-tool-url";
+
+describe("isKnownWhiteboxToolId", () => {
+  it("accepts ids present in the checked-in menu catalog", () => {
+    // A Whitebox catalog tool, a terrain tool, and a GeoLibre-authored WASM
+    // tool — all three families the catalog merges.
+    assert.equal(isKnownWhiteboxToolId("adaptive_filter"), true);
+    assert.equal(isKnownWhiteboxToolId("slope"), true);
+    assert.equal(isKnownWhiteboxToolId("write_geoparquet"), true);
+  });
+
+  it("rejects ids not in the catalog", () => {
+    assert.equal(isKnownWhiteboxToolId("not_a_real_tool"), false);
+    assert.equal(isKnownWhiteboxToolId(""), false);
+    // Case-sensitive: catalog ids are lowercase snake_case.
+    assert.equal(isKnownWhiteboxToolId("Adaptive_Filter"), false);
+  });
+});
+
+describe("whiteboxToolFromSearch", () => {
+  it("parses a known tool id and marks it known with no parameters", () => {
+    assert.deepEqual(whiteboxToolFromSearch("?tool=adaptive_filter"), {
+      toolId: "adaptive_filter",
+      known: true,
+      parameters: {},
+    });
+  });
+
+  it("returns a present-but-unknown id with known=false rather than dropping it", () => {
+    assert.deepEqual(whiteboxToolFromSearch("?tool=not_a_real_tool"), {
+      toolId: "not_a_real_tool",
+      known: false,
+      parameters: {},
+    });
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    assert.deepEqual(whiteboxToolFromSearch("?tool=%20adaptive_filter%20"), {
+      toolId: "adaptive_filter",
+      known: true,
+      parameters: {},
+    });
+  });
+
+  it("returns null when the tool parameter is absent or empty", () => {
+    assert.equal(whiteboxToolFromSearch(""), null);
+    assert.equal(whiteboxToolFromSearch("?foo=bar"), null);
+    assert.equal(whiteboxToolFromSearch("?tool="), null);
+    assert.equal(whiteboxToolFromSearch("?tool=%20%20"), null);
+  });
+
+  it("reads the parameter with or without a leading question mark", () => {
+    assert.equal(whiteboxToolFromSearch(`${WHITEBOX_TOOL_PARAM}=slope`)?.toolId, "slope");
+    assert.equal(whiteboxToolFromSearch(`?${WHITEBOX_TOOL_PARAM}=slope`)?.toolId, "slope");
+  });
+
+  it("uses the first value when the tool parameter is repeated", () => {
+    assert.equal(whiteboxToolFromSearch("?tool=slope&tool=aspect")?.toolId, "slope");
+  });
+
+  it("collects remaining query params as tool parameters, including url", () => {
+    // The geolibre-rust-style deep link: url + a decoded value + a plain param.
+    const target = whiteboxToolFromSearch(
+      "?tool=extract_cog_subset&url=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fdem.tif&bbox_crs=4326",
+    );
+    assert.deepEqual(target, {
+      toolId: "extract_cog_subset",
+      known: true,
+      parameters: {
+        url: "https://data.source.coop/giswqs/opengeos/dem.tif",
+        bbox_crs: "4326",
+      },
+    });
+  });
+
+  it("excludes app/embed params from the tool parameters", () => {
+    const target = whiteboxToolFromSearch(
+      "?tool=slope&theme=dark&maponly=1&locale=fr&panels=none&z_factor=2",
+    );
+    // Only the genuine tool parameter survives; app chrome keeps its own meaning.
+    assert.deepEqual(target?.parameters, { z_factor: "2" });
+  });
+
+  it("uses the first value when a tool parameter is repeated", () => {
+    assert.equal(
+      whiteboxToolFromSearch("?tool=extract_cog_subset&url=a&url=b")?.parameters.url,
+      "a",
+    );
+  });
+});

--- a/tests/whitebox-tool-url.test.ts
+++ b/tests/whitebox-tool-url.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  buildWhiteboxToolShareUrl,
+  GEOLIBRE_WEB_APP_URL,
   isKnownWhiteboxToolId,
   WHITEBOX_TOOL_PARAM,
   whiteboxToolFromSearch,
+  whiteboxToolShareBase,
 } from "../apps/geolibre-desktop/src/lib/whitebox-tool-url";
 
 describe("isKnownWhiteboxToolId", () => {
@@ -93,5 +96,54 @@ describe("whiteboxToolFromSearch", () => {
       whiteboxToolFromSearch("?tool=extract_cog_subset&url=a&url=b")?.parameters.url,
       "a",
     );
+  });
+});
+
+describe("buildWhiteboxToolShareUrl", () => {
+  const BASE = "https://web.geolibre.app/";
+
+  it("builds a ?tool= link with the tool id and each parameter", () => {
+    const url = buildWhiteboxToolShareUrl(
+      "extract_cog_subset",
+      { url: "https://data.source.coop/giswqs/opengeos/dem.tif", bbox_crs: "4326" },
+      BASE,
+    );
+    const params = new URLSearchParams(new URL(url).search);
+    assert.equal(params.get("tool"), "extract_cog_subset");
+    assert.equal(params.get("url"), "https://data.source.coop/giswqs/opengeos/dem.tif");
+    assert.equal(params.get("bbox_crs"), "4326");
+  });
+
+  it("round-trips through whiteboxToolFromSearch", () => {
+    const parameters = {
+      url: "https://data.source.coop/giswqs/opengeos/dem.tif",
+      bbox_crs: "4326",
+    };
+    const url = buildWhiteboxToolShareUrl("extract_cog_subset", parameters, BASE);
+    const parsed = whiteboxToolFromSearch(new URL(url).search);
+    assert.deepEqual(parsed, { toolId: "extract_cog_subset", known: true, parameters });
+  });
+
+  it("emits just ?tool= when there are no parameters", () => {
+    assert.equal(
+      buildWhiteboxToolShareUrl("slope", {}, BASE),
+      "https://web.geolibre.app/?tool=slope",
+    );
+  });
+
+  it("drops any query and hash already on the base so the link is deterministic", () => {
+    const url = buildWhiteboxToolShareUrl("slope", { z_factor: "2" }, `${BASE}?tool=old&x=1#frag`);
+    assert.equal(url, "https://web.geolibre.app/?tool=slope&z_factor=2");
+  });
+});
+
+describe("whiteboxToolShareBase", () => {
+  it("uses the hosted web app URL for the desktop build", () => {
+    assert.equal(whiteboxToolShareBase(true), GEOLIBRE_WEB_APP_URL);
+  });
+
+  it("falls back to the hosted web app URL when there is no window (web build, no DOM)", () => {
+    // node:test runs without a `window`, standing in for the SSR/no-DOM case.
+    assert.equal(whiteboxToolShareBase(false), GEOLIBRE_WEB_APP_URL);
   });
 });


### PR DESCRIPTION
## Summary

Adds **deep-linking to Whitebox/Processing tools** via a `?tool=` URL parameter, matching the [geolibre-rust](https://opengeos.org/geolibre-rust/?tool=adaptive_filter) scheme, and bumps `geolibre-wasm` to 0.11.0 (which adds two menu tools).

### `?tool=` deep link

- `?tool=adaptive_filter` opens the Processing (Whitebox toolbox) dialog preselected to that tool.
- **Additional query params pre-fill the tool's form** using its own parameter names, reusing the History "re-run" injection path (`processingRerun` + `processingInitialTool`), so a link can arrive ready to run:
  ```
  ?tool=extract_cog_subset&url=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fdem.tif&bbox_crs=4326
  ```
- **Tool mode wins:** when `?tool=` is present, `url` names a tool input (not a project), so the project-URL loader stands down — otherwise it would try to parse the raster as a `.geolibre.json` and error.
- App/embed params (`theme`, `layout`, `panels`, `maponly`, `locale`, `collab`, …) keep their own meaning and are never forwarded to the tool.
- Tool ids are validated against the checked-in menu catalog; an **unknown** id opens the dialog without preselecting rather than silently no-op'ing.
- Works identically in the **web** and desktop builds (touches only `window.location.search` + the shared store).
- Documented under **docs/user-guide/embedding.md → Deep-linking a Processing tool**.

Note: no auto-run flag — the Whitebox dialog doesn't consume `autoRun`, so a `?run=` would be a broken promise. The link pre-fills the form; the user clicks **Run**.

### `geolibre-wasm` 0.11.0

- Regenerated the menu catalog (`scripts/gen-whitebox-menu-catalog.mjs`), adding **`regularize_building_footprints`** and **`smooth_natural_features`** under **Vector → GeoLibre**.
- The `wasm-convert` drift test still passes, so `MAX_VECTOR_PMTILES_ZOOM` (18) is unchanged.

## Testing

- **New unit tests** (`tests/whitebox-tool-url.test.ts`, 11 cases): catalog validation, parameter parsing (incl. the full `extract_cog_subset` URL, `url`→tool, reserved-key exclusion, repeated keys, trimming).
- **Full frontend suite:** 3403 pass / 0 fail.
- **Real-browser verification (Playwright):** loaded `?tool=extract_cog_subset&url=…/dem.tif&bbox_crs=4326` against the running web app — the Whitebox toolbox opened on **Extract COG Subset** (WASM mode) with the COG URL and `bbox_crs=4326` pre-filled, no project-load error.
- `oxfmt`, `eslint`, `npm build` (pre-commit) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Processing/Whitebox tool deep-linking via `?tool=<id>`, with support for prefilled parameters.
  * Processing dialog now includes a “Copy” button to share the current tool configuration.
  * Extended the Whitebox catalog with 2 additional tools.
* **Bug Fixes**
  * Prevented `?tool=` links from being mistaken for project URLs.
* **Documentation**
  * Updated embedding docs with `tool=<id>` and guidance on combining parameters.
* **Tests**
  * Added coverage for tool-id validation, deep-link parsing, and share-link URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update: Copy link button

Added a **Copy link** button to the Whitebox tool panel (next to Run) that copies a shareable `?tool=` deep link for the current tool, with a transient "Copied!" state.

- The link carries the tool id + the parameters the user changed from defaults, **excluding local file paths** (input/output paths are machine-specific), while keeping an HTTP `url`. Round-trips with `whiteboxToolFromSearch`.
- Base URL: the **web** build links to its own origin (self-hosted deploys link to themselves); the **desktop** build (whose origin is `tauri://…`) links to the hosted web app.
- New `buildWhiteboxToolShareUrl` / `whiteboxToolShareBase` helpers + round-trip tests; new i18n strings.
- **Playwright-verified:** clicking Copy link on the `extract_cog_subset` deep link copied `…/?tool=extract_cog_subset&url=…dem.tif&bbox_crs=4326` to the clipboard and showed "Copied!".