### PR TITLE
fix(core): adapt to createExpression rootKey arg in style-spec 26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21596,7 +21596,7 @@
       "name": "@geolibre/core",
       "version": "2.2.0",
       "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "^24.10.0",
+        "@maplibre/maplibre-gl-style-spec": "^26.1.0",
         "uuid": "^14.0.1",
         "zundo": "^2.3.0",
         "zustand": "^5.0.14"
@@ -21605,6 +21605,37 @@
         "@types/geojson": "^7946.0.16",
         "typescript": "^7.0.2"
       }
+    },
+    "packages/core/node_modules/@mapbox/unitbezier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
+      "license": "BSD-2-Clause"
+    },
+    "packages/core/node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.1.0.tgz",
+      "integrity": "sha512-JaVj0XqDWFb2xfaRFCvF2Gi7qSpCYXXJlVghDDfRUV2dks61YsQKDjlZKT3H+oVwFBxX7CjErz9zjdGTEP/Lug==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
+        "@mapbox/unitbezier": "^1.0.0",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "packages/core/node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "packages/core/node_modules/typescript": {
       "version": "7.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@maplibre/maplibre-gl-style-spec": "^24.10.0",
+    "@maplibre/maplibre-gl-style-spec": "^26.1.0",
     "uuid": "^14.0.1",
     "zundo": "^2.3.0",
     "zustand": "^5.0.14"

--- a/packages/core/src/expressions.ts
+++ b/packages/core/src/expressions.ts
@@ -198,6 +198,15 @@ export interface ValidateMapExpressionOptions {
 }
 
 /**
+ * The `rootKey` `createExpression` (style-spec v26+) requires as its second
+ * argument — a location label it only surfaces when attaching a runtime
+ * warning to `console.warn` during evaluation. These expressions come from the
+ * Expression Builder dialog, not a style JSON layer, so a generic label is the
+ * honest value; it never appears in the parsing errors we report.
+ */
+const EXPRESSION_ROOT_KEY = "expression";
+
+/**
  * Builds the minimal property spec that makes `createExpression` enforce a
  * result type while still allowing zoom- and feature-dependent input.
  *
@@ -205,16 +214,17 @@ export interface ValidateMapExpressionOptions {
  * `@maplibre/maplibre-gl-style-spec` expects — the cast below means the
  * compiler cannot catch a change to that contract, so whenever the
  * style-spec package is bumped (including Dependabot PRs) re-check that
- * expected-type enforcement still works. The "enforces an expected result
- * type" test in `tests/expressions.test.ts` fails if this shape stops
- * being honored.
+ * expected-type enforcement still works, and that the property spec is still
+ * `createExpression`'s third parameter (v26 inserted a `rootKey` at index 1,
+ * shifting it from `[1]` to `[2]`). The "enforces an expected result type"
+ * test in `tests/expressions.test.ts` fails if this shape stops being honored.
  */
 function propertySpecFor(expectedType: ExpressionExpectedType) {
   return {
     type: expectedType,
     "property-type": "data-driven",
     expression: { parameters: ["zoom", "feature"] },
-  } as unknown as Parameters<typeof createExpression>[1];
+  } as unknown as NonNullable<Parameters<typeof createExpression>[2]>;
 }
 
 /** Outcome of validating an expression source string. */
@@ -286,6 +296,7 @@ function compileMapExpression(
   const substituted = substituteExpressionVariables(parsed, options.variables ?? []) as unknown[];
   const compiled = createExpression(
     substituted,
+    EXPRESSION_ROOT_KEY,
     options.expectedType ? propertySpecFor(options.expectedType) : undefined,
   );
   if (compiled.result === "error") {


### PR DESCRIPTION
## Problem

The Dependabot PR #1370 bumps `@maplibre/maplibre-gl-style-spec` from 24.10.0 to 26.1.0, and every build/deploy job on it fails:

```
../../packages/core/src/expressions.ts(289,5): error TS2345:
Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

Dependabot only edits the manifest, so it can never make the accompanying code change the new major version requires.

## Root cause

style-spec v26 inserted a required `rootKey: string` as `createExpression`'s **second** parameter, pushing the optional property spec from index `[1]` to `[2]`:

- v24: `createExpression(expression, propertySpec?, globalState?)`
- v26: `createExpression(expression, rootKey, propertySpec?, globalState?)`

`packages/core/src/expressions.ts` is the only consumer of this API. Both its `propertySpecFor` cast (to `Parameters<...>[1]`, now the `rootKey` string) and the `createExpression` call (no `rootKey` passed) broke against the new signature. This is exactly the contract drift the mirror-warning comment in that file (and CLAUDE.md) flags for this package.

## Fix

- Bump `@maplibre/maplibre-gl-style-spec` to `^26.1.0` in `@geolibre/core` and update the lockfile. `maplibre-gl` still pins `^24.8.1`, so npm nests both copies; core's compiled expressions stay inside core, so the two versions coexist cleanly.
- Pass a `rootKey` (`"expression"`) to `createExpression`. `rootKey` is only surfaced as a `console.warn` location label at evaluation time (these expressions come from the Expression Builder dialog, not a style JSON layer), so it never appears in the parsing errors we report.
- Move the `propertySpecFor` cast to `Parameters<...>[2]`.
- Refresh the mirror-warning comments to record the new parameter order.

Supersedes the plain bump in #1370.

## Verification

- `npm run build` (the failing CI step) now passes.
- Full frontend suite green (3409 pass). The 24 `tests/expressions.test.ts` cases, including the "enforces an expected result type" canary, run against the newly nested v26.1.0 copy, so they exercise the changed path against the real new runtime.
- Drove the real app with Playwright, both light and dark themes: loaded a remote GeoJSON, opened the Expression Builder, confirmed a valid color/numeric expression previews correctly against real features and an invalid expression (unknown operator, wrong arity) is caught with the right message. 0 console errors throughout.

Fixes #1370


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression compilation compatibility with the latest style specification version.
  * Preserved expected type validation when compiling map expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->