### PR TITLE
fix(mobile): request Android/iOS location permission for GPS capture

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -48,6 +48,7 @@
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-fs": "^2.5.1",
+    "@tauri-apps/plugin-geolocation": "^2.3.2",
     "@tauri-apps/plugin-http": "^2.5.2",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "apache-arrow": "^21.2.0",

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-geolocation",
  "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-persisted-scope",
@@ -4911,6 +4912,20 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-geolocation"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0366e51823ad001ff1a47f116cd34ddfea3d94ebeb2309caf42e290dec27e0a6"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -32,6 +32,11 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = { version = "2", features = ["watch"] }
+# Native geolocation on Android/iOS: ships the location manifest permissions and
+# drives the OS permission dialog for Field Collection / GPS Tracking, which the
+# WebView's navigator.geolocation cannot do on Android. On desktop it is inert
+# (the frontend only invokes it on mobile).
+tauri-plugin-geolocation = "2"
 tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 # Persists the fs scope the folder picker grants, so Browser-panel pinned

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -14,6 +14,11 @@
     "fs:allow-write-text-file",
     "fs:allow-watch",
     "fs:allow-unwatch",
+    "geolocation:allow-check-permissions",
+    "geolocation:allow-request-permissions",
+    "geolocation:allow-get-current-position",
+    "geolocation:allow-watch-position",
+    "geolocation:allow-clear-watch",
     {
       "comment": "Cleanup of the temporary GeoJSON the sidecar writes when a File Geodatabase layer is added (GdbSource); scoped to exactly that filename pattern so nothing else becomes deletable.",
       "identifier": "fs:allow-remove",

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -194,6 +194,7 @@ pub fn run() {
         // not revoke its (persisted) read scope. Accepted for durable pins;
         // revisit if a narrower per-source scope or a revoke path is wanted.
         .plugin(tauri_plugin_persisted_scope::init())
+        .plugin(tauri_plugin_geolocation::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
         .manage(EarthEngineOAuthState::default())

--- a/apps/geolibre-desktop/src/components/layout/FieldCollectionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/FieldCollectionDialog.tsx
@@ -60,6 +60,7 @@ import {
   type Vertex,
 } from "../../lib/field-collection";
 import { attributeFormErrorMessage } from "../../lib/attribute-form-messages";
+import { getCurrentPosition } from "../../lib/geolocation";
 import { releaseBodyPointerEvents } from "../../lib/radix-compat";
 
 interface FieldCollectionDialogProps {
@@ -466,18 +467,17 @@ export function FieldCollectionDialog({
 
   const handleUseGps = useCallback(
     (asVertex: boolean) => {
-      if (!("geolocation" in navigator)) {
-        setNotice(t("fieldCollection.noGeolocation"));
-        return;
-      }
       setLocating(true);
       setNotice(null);
       const seq = (gpsSeqRef.current += 1);
       // Ignore a fix that resolves after the tool was dismissed or superseded by
       // a newer capture (e.g. the user picked/drew a point while GPS was pending).
       const stale = () => !activeRef.current || seq !== gpsSeqRef.current;
-      navigator.geolocation.getCurrentPosition(
-        (pos) => {
+      // On Tauri mobile this routes through the native geolocation plugin, which
+      // requests the OS location permission first; elsewhere it wraps
+      // navigator.geolocation. See lib/geolocation.ts.
+      getCurrentPosition({ enableHighAccuracy: true, timeout: 15000, maximumAge: 0 })
+        .then((pos) => {
           if (stale()) return;
           setLocating(false);
           const { longitude, latitude } = pos.coords;
@@ -488,14 +488,18 @@ export function FieldCollectionDialog({
             // capturePoint(..., true) already recenters the map.
             capturePoint(longitude, latitude, true);
           }
-        },
-        () => {
+        })
+        .catch((err) => {
           if (stale()) return;
           setLocating(false);
-          setNotice(t("fieldCollection.geolocationDenied"));
-        },
-        { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 },
-      );
+          setNotice(
+            t(
+              err?.unavailable
+                ? "fieldCollection.noGeolocation"
+                : "fieldCollection.geolocationDenied",
+            ),
+          );
+        });
     },
     [t, pushVertex, capturePoint, recenter],
   );

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -51,6 +51,7 @@ import {
   trackPreview,
   trackStats,
 } from "../../lib/gps-tracking";
+import { watchPosition } from "../../lib/geolocation";
 import { saveTextFileWithFallback } from "../../lib/tauri-io";
 
 interface GpsTrackingDialogProps {
@@ -304,19 +305,20 @@ export function GpsTrackingDialog({
     [getMap, setGpsStatus],
   );
 
-  // The watchPosition subscription follows `tracking`.
+  // The watchPosition subscription follows `tracking`. On Tauri mobile this
+  // routes through the native geolocation plugin (which requests the OS location
+  // permission first); elsewhere it wraps navigator.geolocation. Starting a
+  // native watch is async, so the effect tracks cancellation and unsubscribes
+  // once the watch resolves. See lib/geolocation.ts.
   useEffect(() => {
     if (!tracking) return;
-    if (!("geolocation" in navigator)) {
-      setError(t("gps.noGeolocation"));
-      setTracking(false);
-      return;
-    }
     zoomedRef.current = false;
-    const id = navigator.geolocation.watchPosition(
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+    watchPosition(
       (pos) => handleFix(fixFromPosition(pos)),
       (err) => {
-        if (err.code === err.PERMISSION_DENIED) {
+        if (err.permissionDenied) {
           setError(t("gps.permissionDenied"));
           setTracking(false);
         } else {
@@ -325,8 +327,19 @@ export function GpsTrackingDialog({
         }
       },
       { enableHighAccuracy: true, maximumAge: 0 },
-    );
-    return () => navigator.geolocation.clearWatch(id);
+    )
+      .then((unsub) => {
+        if (cancelled) unsub();
+        else unsubscribe = unsub;
+      })
+      .catch((err) => {
+        setError(t(err?.permissionDenied ? "gps.permissionDenied" : "gps.noGeolocation"));
+        setTracking(false);
+      });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [tracking, handleFix, t]);
 
   // Map subscriptions while tracking. Manual panning turns follow mode off,

--- a/apps/geolibre-desktop/src/lib/geolocation.ts
+++ b/apps/geolibre-desktop/src/lib/geolocation.ts
@@ -75,9 +75,7 @@ function toPluginOptions(o?: PositionOptions): PluginPositionOptions {
  * Throws {@link GeolocationError} (permissionDenied) if the user refuses.
  */
 async function ensureNativePermission(): Promise<void> {
-  const { checkPermissions, requestPermissions } = await import(
-    "@tauri-apps/plugin-geolocation"
-  );
+  const { checkPermissions, requestPermissions } = await import("@tauri-apps/plugin-geolocation");
   let status = await checkPermissions();
   const undecided = (s: string) => s === "prompt" || s === "prompt-with-rationale";
   if (undecided(status.location) || undecided(status.coarseLocation)) {
@@ -93,14 +91,10 @@ async function ensureNativePermission(): Promise<void> {
  * Native mobile requests OS permission first; elsewhere this wraps
  * `navigator.geolocation.getCurrentPosition`.
  */
-export async function getCurrentPosition(
-  options?: PositionOptions,
-): Promise<GeolocationPosition> {
+export async function getCurrentPosition(options?: PositionOptions): Promise<GeolocationPosition> {
   if (useNativeGeolocation()) {
     await ensureNativePermission();
-    const { getCurrentPosition: nativeGet } = await import(
-      "@tauri-apps/plugin-geolocation"
-    );
+    const { getCurrentPosition: nativeGet } = await import("@tauri-apps/plugin-geolocation");
     return fromPlugin(await nativeGet(toPluginOptions(options)));
   }
   if (!("geolocation" in navigator)) {
@@ -109,10 +103,7 @@ export async function getCurrentPosition(
   return new Promise((resolve, reject) => {
     navigator.geolocation.getCurrentPosition(
       resolve,
-      (err) =>
-        reject(
-          new GeolocationError(err.message, err.code === err.PERMISSION_DENIED),
-        ),
+      (err) => reject(new GeolocationError(err.message, err.code === err.PERMISSION_DENIED)),
       options,
     );
   });
@@ -131,9 +122,8 @@ export async function watchPosition(
 ): Promise<() => void> {
   if (useNativeGeolocation()) {
     await ensureNativePermission();
-    const { watchPosition: nativeWatch, clearWatch } = await import(
-      "@tauri-apps/plugin-geolocation"
-    );
+    const { watchPosition: nativeWatch, clearWatch } =
+      await import("@tauri-apps/plugin-geolocation");
     const id = await nativeWatch(toPluginOptions(options), (pos, err) => {
       if (pos) onFix(fromPlugin(pos));
       // A watch error after start is treated as transient (signal loss): keep
@@ -149,8 +139,7 @@ export async function watchPosition(
   }
   const id = navigator.geolocation.watchPosition(
     onFix,
-    (err) =>
-      onError(new GeolocationError(err.message, err.code === err.PERMISSION_DENIED)),
+    (err) => onError(new GeolocationError(err.message, err.code === err.PERMISSION_DENIED)),
     options,
   );
   return () => navigator.geolocation.clearWatch(id);

--- a/apps/geolibre-desktop/src/lib/geolocation.ts
+++ b/apps/geolibre-desktop/src/lib/geolocation.ts
@@ -27,7 +27,7 @@ import { isTauri } from "./is-tauri";
  * WebView. Only the packaged mobile app: a phone browser matches `isMobile()`
  * but isn't Tauri (no plugin), so it correctly stays on `navigator.geolocation`.
  */
-export function useNativeGeolocation(): boolean {
+export function nativeGeolocationAvailable(): boolean {
   return isTauri() && isMobile();
 }
 
@@ -92,7 +92,7 @@ async function ensureNativePermission(): Promise<void> {
  * `navigator.geolocation.getCurrentPosition`.
  */
 export async function getCurrentPosition(options?: PositionOptions): Promise<GeolocationPosition> {
-  if (useNativeGeolocation()) {
+  if (nativeGeolocationAvailable()) {
     await ensureNativePermission();
     const { getCurrentPosition: nativeGet } = await import("@tauri-apps/plugin-geolocation");
     return fromPlugin(await nativeGet(toPluginOptions(options)));
@@ -120,7 +120,7 @@ export async function watchPosition(
   onError: (err: GeolocationError) => void,
   options?: PositionOptions,
 ): Promise<() => void> {
-  if (useNativeGeolocation()) {
+  if (nativeGeolocationAvailable()) {
     await ensureNativePermission();
     const { watchPosition: nativeWatch, clearWatch } =
       await import("@tauri-apps/plugin-geolocation");

--- a/apps/geolibre-desktop/src/lib/geolocation.ts
+++ b/apps/geolibre-desktop/src/lib/geolocation.ts
@@ -1,0 +1,157 @@
+/**
+ * Cross-platform geolocation for the Field Collection and GPS Tracking tools.
+ *
+ * On desktop and in the browser we read position through the WebView's
+ * `navigator.geolocation`. That path is broken inside the packaged Android/iOS
+ * app: on Android the WebView tries to request `ACCESS_FINE/COARSE_LOCATION` at
+ * runtime, but those permissions aren't declared in the (generated, gitignored)
+ * AndroidManifest, so Android auto-denies the request without ever showing the
+ * system dialog — the user "is never asked for GPS" and the failing request path
+ * crashes the app (reported on a Galaxy S25 Ultra).
+ *
+ * So on Tauri **mobile** we go through the official `@tauri-apps/plugin-
+ * geolocation` instead: its Android/iOS library ships the location
+ * `<uses-permission>` manifest entries and drives the OS permission dialog, and
+ * it reads position natively rather than via the fragile WebView bridge. The
+ * plugin is loaded lazily so it never enters the web bundle.
+ */
+import type {
+  Position as PluginPosition,
+  PositionOptions as PluginPositionOptions,
+} from "@tauri-apps/plugin-geolocation";
+import { isMobile } from "./is-mobile";
+import { isTauri } from "./is-tauri";
+
+/**
+ * True when geolocation must go through the native Tauri plugin rather than the
+ * WebView. Only the packaged mobile app: a phone browser matches `isMobile()`
+ * but isn't Tauri (no plugin), so it correctly stays on `navigator.geolocation`.
+ */
+export function useNativeGeolocation(): boolean {
+  return isTauri() && isMobile();
+}
+
+/** Why a geolocation request failed, so callers can pick the right message. */
+export class GeolocationError extends Error {
+  constructor(
+    message: string,
+    /** The user (or OS) refused location access. */
+    readonly permissionDenied: boolean,
+    /** No geolocation source at all (no `navigator.geolocation`, unsupported). */
+    readonly unavailable: boolean = false,
+  ) {
+    super(message);
+    this.name = "GeolocationError";
+  }
+}
+
+/**
+ * The plugin's `Position` is structurally the subset of `GeolocationPosition`
+ * that both tools read (`coords.{longitude,latitude,accuracy,heading,speed}` and
+ * `timestamp`), so callers keep using the browser type. The prototype (`toJSON`,
+ * `GeolocationCoordinates`) is absent, but nothing reads it — hence the cast.
+ */
+function fromPlugin(p: PluginPosition): GeolocationPosition {
+  return p as unknown as GeolocationPosition;
+}
+
+/**
+ * The browser's `PositionOptions` are all optional; the plugin's require every
+ * field. Fill in browser-equivalent defaults (accuracy off, no cached fix). The
+ * `timeout` default is finite because the plugin can't take the browser's
+ * `Infinity`; it's ignored on Android for a one-shot read and only bounds the
+ * per-update wait for a watch.
+ */
+function toPluginOptions(o?: PositionOptions): PluginPositionOptions {
+  return {
+    enableHighAccuracy: o?.enableHighAccuracy ?? false,
+    timeout: o?.timeout ?? 30000,
+    maximumAge: o?.maximumAge ?? 0,
+  };
+}
+
+/**
+ * Ensure native location permission, prompting once if it hasn't been decided.
+ * Throws {@link GeolocationError} (permissionDenied) if the user refuses.
+ */
+async function ensureNativePermission(): Promise<void> {
+  const { checkPermissions, requestPermissions } = await import(
+    "@tauri-apps/plugin-geolocation"
+  );
+  let status = await checkPermissions();
+  const undecided = (s: string) => s === "prompt" || s === "prompt-with-rationale";
+  if (undecided(status.location) || undecided(status.coarseLocation)) {
+    status = await requestPermissions(["location", "coarseLocation"]);
+  }
+  if (status.location !== "granted" && status.coarseLocation !== "granted") {
+    throw new GeolocationError("Location permission denied", true);
+  }
+}
+
+/**
+ * A single position fix. Rejects with {@link GeolocationError} on failure.
+ * Native mobile requests OS permission first; elsewhere this wraps
+ * `navigator.geolocation.getCurrentPosition`.
+ */
+export async function getCurrentPosition(
+  options?: PositionOptions,
+): Promise<GeolocationPosition> {
+  if (useNativeGeolocation()) {
+    await ensureNativePermission();
+    const { getCurrentPosition: nativeGet } = await import(
+      "@tauri-apps/plugin-geolocation"
+    );
+    return fromPlugin(await nativeGet(toPluginOptions(options)));
+  }
+  if (!("geolocation" in navigator)) {
+    throw new GeolocationError("Geolocation unavailable", false, true);
+  }
+  return new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(
+      resolve,
+      (err) =>
+        reject(
+          new GeolocationError(err.message, err.code === err.PERMISSION_DENIED),
+        ),
+      options,
+    );
+  });
+}
+
+/**
+ * Continuously watch position. Fixes go to `onFix`; recoverable problems (denied
+ * permission, transient signal loss) go to `onError`. Resolves to an unsubscribe
+ * function; rejects with {@link GeolocationError} only when a watch can't start
+ * at all (no geolocation source, native permission refused up front).
+ */
+export async function watchPosition(
+  onFix: (pos: GeolocationPosition) => void,
+  onError: (err: GeolocationError) => void,
+  options?: PositionOptions,
+): Promise<() => void> {
+  if (useNativeGeolocation()) {
+    await ensureNativePermission();
+    const { watchPosition: nativeWatch, clearWatch } = await import(
+      "@tauri-apps/plugin-geolocation"
+    );
+    const id = await nativeWatch(toPluginOptions(options), (pos, err) => {
+      if (pos) onFix(fromPlugin(pos));
+      // A watch error after start is treated as transient (signal loss): keep
+      // watching. Up-front permission refusal already rejected above.
+      else if (err) onError(new GeolocationError(err, false));
+    });
+    return () => {
+      void clearWatch(id);
+    };
+  }
+  if (!("geolocation" in navigator)) {
+    throw new GeolocationError("Geolocation unavailable", false, true);
+  }
+  const id = navigator.geolocation.watchPosition(
+    onFix,
+    (err) =>
+      onError(new GeolocationError(err.message, err.code === err.PERMISSION_DENIED)),
+    options,
+  );
+  return () => navigator.geolocation.clearWatch(id);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
         "@tauri-apps/plugin-fs": "^2.5.1",
+        "@tauri-apps/plugin-geolocation": "^2.3.2",
         "@tauri-apps/plugin-http": "^2.5.2",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "apache-arrow": "^21.2.0",
@@ -612,6 +613,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2747,6 +2749,7 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.7.tgz",
       "integrity": "sha512-eRzddMlHuBBFeSfhBig5V/32psav5JLvRYjuMqHgcwWXKfanAcxsKBfDSA4tzwWpnDU4id9sfdGW1RDzbVgY5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
@@ -2986,6 +2989,7 @@
       "resolved": "https://registry.npmjs.org/@developmentseed/morecantile/-/morecantile-0.7.0.tgz",
       "integrity": "sha512-m9tWDase9COlP/EZ2KK/ydraRU/5yfwvmF/y/2g/iFMFW1vYHQTW/8JYjmo84SiJXUifDDY2xoA3ErYlcWJctg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@developmentseed/affine": "^0.7.0"
       }
@@ -3114,7 +3118,8 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.4.tgz",
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-postgis": {
       "version": "0.2.4",
@@ -3123,29 +3128,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.5.4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3764,6 +3746,7 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.10.3.tgz",
       "integrity": "sha512-o5iwxSDS2M8lwLkNtaJTKqyN3NHv2Ne5bL+7tfdcmmHukcGMuuSroRG/+IT3CXOS7gk9sYVdR0cMEPHs1lTWNQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3779,6 +3762,7 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.10.3.tgz",
       "integrity": "sha512-gBKSRC7L3cD1KX4fIleRiEKtzlvKjuDW5cYpDcDyQCn/Bw7bJzlGrlaMw87FQ+ReTZp9vlTYFXyrGMuUtR0dKw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.10.3",
         "@esri/arcgis-rest-form-data": "^4.10.3",
@@ -3907,6 +3891,7 @@
       "resolved": "https://registry.npmjs.org/@geoman-io/maplibre-geoman-free/-/maplibre-geoman-free-0.8.4.tgz",
       "integrity": "sha512-nOLEpMtORSR0XceXfOHc0RGqrkCQo3719o1d1Bp64xzijxn37KvkxB7S3dwOFV+i3Z3MleaSGAcIjvszil2D3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/area": "^7.3.5",
         "@turf/bbox": "^7.3.5",
@@ -4157,9 +4142,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4177,9 +4159,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4197,9 +4176,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4217,9 +4193,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4237,9 +4210,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4257,9 +4227,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4277,9 +4244,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4297,9 +4261,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4317,9 +4278,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4343,9 +4301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4369,9 +4324,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4395,9 +4347,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4421,9 +4370,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4447,9 +4393,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4473,9 +4416,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4499,9 +4439,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5530,6 +5467,7 @@
       "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
       "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@math.gl/core": "4.1.0"
       }
@@ -5560,6 +5498,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5688,6 +5627,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6903,9 +6843,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6923,9 +6860,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6943,9 +6877,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6963,9 +6894,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6983,9 +6911,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7003,9 +6928,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7928,9 +7850,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7948,9 +7867,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7968,9 +7884,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7988,9 +7901,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8028,27 +7938,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -8414,6 +8303,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-geolocation": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-geolocation/-/plugin-geolocation-2.3.2.tgz",
+      "integrity": "sha512-ONCwav1monafjeO8/JdXtRlbhZ3xgAdBYxo/62qgw99u9+y6xGsohy3avZgFZsBHA0JVNe1uJnMi+vfT5ZSFUA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-http": {
@@ -10778,6 +10676,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -11459,6 +11358,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11591,6 +11491,7 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.2.0.tgz",
       "integrity": "sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^25.2.0",
         "flatbuffers": "^25.1.24",
@@ -12005,6 +11906,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -12282,6 +12184,7 @@
       "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.1.tgz",
       "integrity": "sha512-5mH36bBRrArqeCeCW3Gl2IhlWcU5g64eQRIfIsyo+XQwaBYfmjzuHJ36nbS7fCLUNk9khNUdgVWTU9C1zS33iw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
@@ -13138,6 +13041,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13208,6 +13112,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -13478,6 +13383,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14229,6 +14135,7 @@
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
       "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.9.3",
         "lerc": "^3.0.0",
@@ -14247,7 +14154,8 @@
       "version": "2024.4.13",
       "resolved": "https://registry.npmjs.org/geotiff-geokeys-to-proj4/-/geotiff-geokeys-to-proj4-2024.4.13.tgz",
       "integrity": "sha512-Jgtm/lcPkgB44wCqQHaVQx5/fyhmiVDRUKQcI/vMolsED8/GRWBnn5qkQo/CgutQg9xkGzig21DY9Px9mFRdvg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/geotiff/node_modules/lerc": {
       "version": "3.0.0",
@@ -15030,6 +14938,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
       "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15138,6 +15047,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6 || ^7"
       },
@@ -18240,6 +18150,7 @@
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -18418,6 +18329,7 @@
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
       "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.5.5"
@@ -18629,6 +18541,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18638,6 +18551,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19038,6 +18952,7 @@
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -20032,6 +19947,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20221,6 +20137,7 @@
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -20484,6 +20401,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -20756,6 +20674,7 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -21159,6 +21078,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21373,6 +21293,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -21545,6 +21466,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -21622,6 +21544,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -21684,6 +21607,7 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/tests/geolocation.test.ts
+++ b/tests/geolocation.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  GeolocationError,
+  getCurrentPosition,
+  useNativeGeolocation,
+  watchPosition,
+} from "../apps/geolibre-desktop/src/lib/geolocation";
+
+// These cover the browser/desktop path (navigator.geolocation). The native Tauri
+// mobile path is gated behind useNativeGeolocation() (isTauri && isMobile) and
+// dynamically imports @tauri-apps/plugin-geolocation, which can't run under
+// node --test — it's exercised on-device instead.
+
+type GeolocationLike = {
+  getCurrentPosition: Geolocation["getCurrentPosition"];
+  watchPosition: Geolocation["watchPosition"];
+  clearWatch: Geolocation["clearWatch"];
+};
+
+function setNavigator(geolocation?: GeolocationLike, userAgent = "node-test") {
+  const nav = geolocation ? { userAgent, maxTouchPoints: 0, geolocation } : { userAgent, maxTouchPoints: 0 };
+  Object.defineProperty(globalThis, "navigator", {
+    value: nav,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function setWindow(tauri: boolean) {
+  Object.defineProperty(globalThis, "window", {
+    value: tauri ? { __TAURI_INTERNALS__: {} } : {},
+    configurable: true,
+    writable: true,
+  });
+}
+
+const okPosition = {
+  coords: { longitude: -122.4, latitude: 37.8, accuracy: 5 },
+  timestamp: 1000,
+} as unknown as GeolocationPosition;
+
+// A GeolocationPositionError with the PERMISSION_DENIED discriminant the wrapper reads.
+function positionError(code: number): GeolocationPositionError {
+  return { code, message: "err", PERMISSION_DENIED: 1, POSITION_UNAVAILABLE: 2, TIMEOUT: 3 } as GeolocationPositionError;
+}
+
+afterEach(() => {
+  setWindow(false);
+  setNavigator();
+});
+
+describe("useNativeGeolocation", () => {
+  it("is false outside Tauri even on a mobile user agent", () => {
+    setWindow(false);
+    setNavigator(undefined, "Mozilla/5.0 (Linux; Android 14; Pixel 8) Mobile");
+    assert.equal(useNativeGeolocation(), false);
+  });
+
+  it("is false in Tauri on a desktop user agent", () => {
+    setWindow(true);
+    setNavigator(undefined, "Mozilla/5.0 (X11; Linux x86_64)");
+    assert.equal(useNativeGeolocation(), false);
+  });
+});
+
+describe("getCurrentPosition (browser path)", () => {
+  it("resolves with the fix from navigator.geolocation", async () => {
+    setWindow(false);
+    setNavigator({
+      getCurrentPosition: (ok) => ok(okPosition),
+      watchPosition: () => 0,
+      clearWatch: () => {},
+    });
+    const pos = await getCurrentPosition({ enableHighAccuracy: true });
+    assert.equal(pos.coords.longitude, -122.4);
+  });
+
+  it("rejects with permissionDenied when the user refuses", async () => {
+    setWindow(false);
+    setNavigator({
+      getCurrentPosition: (_ok, err) => err?.(positionError(1)),
+      watchPosition: () => 0,
+      clearWatch: () => {},
+    });
+    await assert.rejects(getCurrentPosition(), (e: GeolocationError) => {
+      assert.equal(e instanceof GeolocationError, true);
+      assert.equal(e.permissionDenied, true);
+      return true;
+    });
+  });
+
+  it("rejects as unavailable when the device has no geolocation", async () => {
+    setWindow(false);
+    setNavigator(); // no geolocation
+    await assert.rejects(getCurrentPosition(), (e: GeolocationError) => {
+      assert.equal(e.unavailable, true);
+      assert.equal(e.permissionDenied, false);
+      return true;
+    });
+  });
+});
+
+describe("watchPosition (browser path)", () => {
+  it("delivers fixes and unsubscribes via clearWatch", async () => {
+    setWindow(false);
+    const fixes: GeolocationPosition[] = [];
+    let cleared: number | undefined;
+    setNavigator({
+      getCurrentPosition: () => {},
+      watchPosition: (ok) => {
+        ok(okPosition);
+        return 42;
+      },
+      clearWatch: (id) => {
+        cleared = id;
+      },
+    });
+    const unsubscribe = await watchPosition(
+      (p) => fixes.push(p),
+      () => {},
+    );
+    assert.equal(fixes.length, 1);
+    unsubscribe();
+    assert.equal(cleared, 42);
+  });
+
+  it("reports a denied permission through onError as transient/denied", async () => {
+    setWindow(false);
+    let denied = false;
+    setNavigator({
+      getCurrentPosition: () => {},
+      watchPosition: (_ok, err) => {
+        err?.(positionError(1));
+        return 1;
+      },
+      clearWatch: () => {},
+    });
+    await watchPosition(
+      () => {},
+      (e) => {
+        denied = e.permissionDenied;
+      },
+    );
+    assert.equal(denied, true);
+  });
+
+  it("rejects when starting a watch with no geolocation source", async () => {
+    setWindow(false);
+    setNavigator();
+    await assert.rejects(
+      watchPosition(
+        () => {},
+        () => {},
+      ),
+      (e: GeolocationError) => {
+        assert.equal(e.unavailable, true);
+        return true;
+      },
+    );
+  });
+});

--- a/tests/geolocation.test.ts
+++ b/tests/geolocation.test.ts
@@ -19,7 +19,9 @@ type GeolocationLike = {
 };
 
 function setNavigator(geolocation?: GeolocationLike, userAgent = "node-test") {
-  const nav = geolocation ? { userAgent, maxTouchPoints: 0, geolocation } : { userAgent, maxTouchPoints: 0 };
+  const nav = geolocation
+    ? { userAgent, maxTouchPoints: 0, geolocation }
+    : { userAgent, maxTouchPoints: 0 };
   Object.defineProperty(globalThis, "navigator", {
     value: nav,
     configurable: true,
@@ -42,7 +44,13 @@ const okPosition = {
 
 // A GeolocationPositionError with the PERMISSION_DENIED discriminant the wrapper reads.
 function positionError(code: number): GeolocationPositionError {
-  return { code, message: "err", PERMISSION_DENIED: 1, POSITION_UNAVAILABLE: 2, TIMEOUT: 3 } as GeolocationPositionError;
+  return {
+    code,
+    message: "err",
+    PERMISSION_DENIED: 1,
+    POSITION_UNAVAILABLE: 2,
+    TIMEOUT: 3,
+  } as GeolocationPositionError;
 }
 
 afterEach(() => {

--- a/tests/geolocation.test.ts
+++ b/tests/geolocation.test.ts
@@ -3,12 +3,12 @@ import { afterEach, describe, it } from "node:test";
 import {
   GeolocationError,
   getCurrentPosition,
-  useNativeGeolocation,
+  nativeGeolocationAvailable,
   watchPosition,
 } from "../apps/geolibre-desktop/src/lib/geolocation";
 
 // These cover the browser/desktop path (navigator.geolocation). The native Tauri
-// mobile path is gated behind useNativeGeolocation() (isTauri && isMobile) and
+// mobile path is gated behind nativeGeolocationAvailable() (isTauri && isMobile) and
 // dynamically imports @tauri-apps/plugin-geolocation, which can't run under
 // node --test — it's exercised on-device instead.
 
@@ -58,17 +58,17 @@ afterEach(() => {
   setNavigator();
 });
 
-describe("useNativeGeolocation", () => {
+describe("nativeGeolocationAvailable", () => {
   it("is false outside Tauri even on a mobile user agent", () => {
     setWindow(false);
     setNavigator(undefined, "Mozilla/5.0 (Linux; Android 14; Pixel 8) Mobile");
-    assert.equal(useNativeGeolocation(), false);
+    assert.equal(nativeGeolocationAvailable(), false);
   });
 
   it("is false in Tauri on a desktop user agent", () => {
     setWindow(true);
     setNavigator(undefined, "Mozilla/5.0 (X11; Linux x86_64)");
-    assert.equal(useNativeGeolocation(), false);
+    assert.equal(nativeGeolocationAvailable(), false);
   });
 });
 


### PR DESCRIPTION
## Problem

User feedback (Samsung Galaxy S25 Ultra, Android APK):

> The app currently fails to request system Location/GPS permissions. As a result, tapping the GPS location button during Field Collection causes the app to crash immediately. Digitizing manually on the map works, but GPS-based field capture is currently blocked.

**Root cause:** Field Collection's GPS button (`FieldCollectionDialog.tsx`) and the GPS Tracking tool (`GpsTrackingDialog.tsx`) read location via the WebView's `navigator.geolocation`. On Android the WebView tries to request `ACCESS_FINE/COARSE_LOCATION` at runtime, but those permissions are never declared in the generated `AndroidManifest.xml` — and that file lives under `gen/android/`, which is **gitignored**, so a manual manifest edit wouldn't survive regeneration. Android auto-denies a runtime request for an undeclared dangerous permission *without showing a dialog*, so the user is never prompted and the failing request path crashes the app.

## Fix

Route mobile GPS through the official [`@tauri-apps/plugin-geolocation`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/geolocation), whose Android/iOS library ships the location `<uses-permission>` manifest entries and drives the OS permission dialog, and reads position natively instead of via the fragile WebView bridge. Desktop and browser builds keep `navigator.geolocation` unchanged.

- **`src/lib/geolocation.ts`** (new) — cross-platform wrapper. On Tauri **mobile** (`isTauri() && isMobile()`): `checkPermissions` → `requestPermissions` → native `getCurrentPosition`/`watchPosition`. Everywhere else: `navigator.geolocation`. The plugin is lazily imported so it never enters the web bundle.
- **`FieldCollectionDialog.tsx`** / **`GpsTrackingDialog.tsx`** — use the wrapper (stale-fix guard and error→notice mapping preserved).
- **Rust** — `tauri-plugin-geolocation = "2"` added and registered in `lib.rs`.
- **`capabilities/default.json`** — the five `geolocation:allow-*` command permissions (this plugin ships no `default` permission set, so `geolocation:default` would be invalid — verified against its permission schema).
- **`tests/geolocation.test.ts`** (new) — 8 tests over the browser path (resolve / permission-denied / unavailable / watch + unsubscribe).

## Verification

- `tsc -b` ✓ · `cargo check` ✓ · full frontend suite (**3417 pass**) ✓ · `npm run build` ✓

⚠️ **Not verified from CI/dev machine:** the actual on-device Android permission prompt requires an `npm run tauri android build` / emulator run. The wrapper matches the plugin's documented `.d.ts` API and permission schema, but a real APK test on a device is recommended before the next mobile release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native GPS access on supported mobile devices with unified location permission handling across desktop, browser, and mobile.
  * Preflight location permission request is now performed when enabling the on-map geolocate control.
* **Bug Fixes**
  * Prevented late GPS fixes from updating dismissed or superseded dialogs.
  * Improved error handling by distinguishing between denied vs unavailable location services.
  * Ensured GPS tracking subscriptions are properly cleaned up.
* **Tests**
  * Added automated coverage for permission checks, position retrieval, tracking, error cases, and unsubscription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->