### PR TITLE
feat(ios): scaffold Tauri iOS build (config, Info.plist, CI, docs)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -183,9 +183,11 @@ jobs:
           # signing secret rather than duplicating it.
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+          # Passed via env, not interpolated into the run script, so a workflow
+          # context expression can't be injected into the shell.
+          EXPORT_METHOD: ${{ github.event.inputs.export_method || 'app-store-connect' }}
         run: |
-          npx tauri ios build \
-            --export-method "${{ github.event.inputs.export_method || 'app-store-connect' }}"
+          npx tauri ios build --export-method "$EXPORT_METHOD"
 
       - name: Verify built bundle id
         if: steps.signing.outputs.present == 'true'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -102,18 +102,26 @@ jobs:
         # `secrets` can't be used in a step-level `if:`, so presence is turned
         # into an output and gated on below. All three are required to sign: a
         # partial set would spend the whole archive and only then fail.
+        #
+        # The iOS cert/profile use APPLE_IOS_* names, deliberately distinct from
+        # the release.yml macOS secrets (APPLE_CERTIFICATE / APPLE_CERTIFICATE_
+        # PASSWORD): that identity is a *Developer ID Application* cert for the
+        # notarized Homebrew build and cannot sign an iOS app — iOS needs its own
+        # Apple Distribution cert + provisioning profile. Reusing the name would
+        # feed the wrong cert/password in. APPLE_TEAM_ID *is* shared, though — the
+        # Team ID is account-wide, not per-certificate — so it is reused as-is.
         env:
-          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
-          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+          APPLE_IOS_CERTIFICATE_BASE64: ${{ secrets.APPLE_IOS_CERTIFICATE_BASE64 }}
+          APPLE_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_IOS_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if [ -n "${APPLE_CERTIFICATE_BASE64:-}" ] \
-            && [ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ] \
-            && [ -n "${APPLE_DEVELOPMENT_TEAM:-}" ]; then
+          if [ -n "${APPLE_IOS_CERTIFICATE_BASE64:-}" ] \
+            && [ -n "${APPLE_IOS_PROVISIONING_PROFILE_BASE64:-}" ] \
+            && [ -n "${APPLE_TEAM_ID:-}" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No complete Apple signing secret set — building an unsigned compile check only (no installable .ipa). Set APPLE_CERTIFICATE_BASE64, APPLE_CERTIFICATE_PASSWORD, APPLE_PROVISIONING_PROFILE_BASE64, and APPLE_DEVELOPMENT_TEAM to produce a signed build."
+            echo "::notice::No complete Apple iOS signing secret set — building an unsigned compile check only (no installable .ipa). Set APPLE_IOS_CERTIFICATE_BASE64, APPLE_IOS_CERTIFICATE_PASSWORD, APPLE_IOS_PROVISIONING_PROFILE_BASE64 (and reuse the existing APPLE_TEAM_ID) to produce a signed build."
           fi
 
       # ---- No-signing path: prove the iOS build compiles ---------------------
@@ -130,9 +138,9 @@ jobs:
       - name: Import signing identity
         if: steps.signing.outputs.present == 'true'
         env:
-          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_IOS_CERTIFICATE_BASE64: ${{ secrets.APPLE_IOS_CERTIFICATE_BASE64 }}
+          APPLE_IOS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_IOS_CERTIFICATE_PASSWORD }}
+          APPLE_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_IOS_PROVISIONING_PROFILE_BASE64 }}
         run: |
           set -euo pipefail
           # A dedicated, throwaway keychain (random password) rather than the
@@ -148,9 +156,9 @@ jobs:
           security unlock-keychain -p "$keychain_pass" "$keychain"
 
           cert="$RUNNER_TEMP/cert.p12"
-          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$cert"
+          echo "$APPLE_IOS_CERTIFICATE_BASE64" | base64 --decode > "$cert"
           security import "$cert" -k "$keychain" \
-            -P "${APPLE_CERTIFICATE_PASSWORD:-}" \
+            -P "${APPLE_IOS_CERTIFICATE_PASSWORD:-}" \
             -T /usr/bin/codesign -T /usr/bin/xcodebuild
           rm -f "$cert"
 
@@ -163,15 +171,17 @@ jobs:
           # Install the provisioning profile where Xcode looks for it.
           profiles="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$profiles"
-          echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode \
+          echo "$APPLE_IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode \
             > "$profiles/geolibre.mobileprovision"
 
       - name: Build signed IPA
         if: steps.signing.outputs.present == 'true'
         working-directory: apps/geolibre-desktop
         env:
-          # Tauri passes this through to the Xcode DEVELOPMENT_TEAM setting.
-          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+          # Tauri passes this through to the Xcode DEVELOPMENT_TEAM setting. The
+          # Team ID is account-wide, so this reuses the existing macOS/Homebrew
+          # signing secret rather than duplicating it.
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
         run: |
           npx tauri ios build \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,220 @@
+name: iOS
+
+# iOS builds run on published releases (matching release.yml / android.yml), not
+# on every PR — the Rust cross-compile + Xcode archive is slow and needs a macOS
+# runner. Use the manual "Run workflow" button (workflow_dispatch) to build on
+# demand from any branch.
+#
+# NOTE: iOS cannot be cross-compiled from Linux, so this runs on macOS. Unlike
+# Android — where a throwaway debug keystore makes every CI run installable — a
+# device/App Store build REQUIRES an Apple Developer account (signing certificate
+# + provisioning profile + team id). Without those secrets the job still runs a
+# no-signing compile check so CI catches iOS build breakage; it just can't
+# produce an installable .ipa.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      export_method:
+        description: "IPA export method (needs signing secrets)"
+        type: choice
+        default: app-store-connect
+        options:
+          - app-store-connect # TestFlight / App Store upload
+          - release-testing # ad-hoc: registered UDIDs only
+          - debugging # development devices
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The Apple bundle identifier, asserted after the build. Comes from
+  # `identifier` in src-tauri/tauri.ios.conf.json, which overrides the desktop
+  # `org.geolibre.desktop` for iOS only (same value Android uses — different
+  # stores, so the shared reverse-DNS id is fine). Burned permanently on first
+  # App Store Connect upload, so it is verified rather than trusted.
+  EXPECTED_BUNDLE_ID: "org.geolibre.app"
+
+jobs:
+  build:
+    name: Build iOS app
+    # Apple Silicon macOS image; ships a recent Xcode + CocoaPods. Pin the major
+    # image so a runner update can't silently change the Xcode/SDK under us.
+    runs-on: macos-14
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install Rust stable with iOS targets
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          # aarch64-apple-ios: real devices + the signed .ipa. The two simulator
+          # triples back the no-signing compile check (aarch64-sim on Apple
+          # Silicon runners; x86_64 kept for completeness).
+          targets: >-
+            aarch64-apple-ios,
+            aarch64-apple-ios-sim,
+            x86_64-apple-ios
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: apps/geolibre-desktop/src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build frontend
+        # tauri-build reads frontendDist (../dist) at compile time and errors if
+        # it's missing, so the web bundle must exist before `tauri ios` runs.
+        run: npm run build
+        env:
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+
+      - name: Generate iOS project
+        # gen/apple is not committed; regenerate it on the clean runner. The
+        # Tauri CLI is resolved through the geolibre-desktop workspace. This also
+        # merges src-tauri/tauri.ios.conf.json (bundle id, drops the Python
+        # backend) and src-tauri/Info.ios.plist (the NSLocation usage string) into
+        # the generated Xcode project.
+        working-directory: apps/geolibre-desktop
+        run: npx tauri ios init
+
+      - name: Check for Apple signing secrets
+        id: signing
+        # `secrets` can't be used in a step-level `if:`, so presence is turned
+        # into an output and gated on below. All three are required to sign: a
+        # partial set would spend the whole archive and only then fail.
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+        run: |
+          if [ -n "${APPLE_CERTIFICATE_BASE64:-}" ] \
+            && [ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ] \
+            && [ -n "${APPLE_DEVELOPMENT_TEAM:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No complete Apple signing secret set — building an unsigned compile check only (no installable .ipa). Set APPLE_CERTIFICATE_BASE64, APPLE_CERTIFICATE_PASSWORD, APPLE_PROVISIONING_PROFILE_BASE64, and APPLE_DEVELOPMENT_TEAM to produce a signed build."
+          fi
+
+      # ---- No-signing path: prove the iOS build compiles ---------------------
+      - name: Compile check (no signing)
+        if: steps.signing.outputs.present != 'true'
+        # Cross-compile the Tauri library for a real device target. This catches
+        # iOS-specific breakage (a dependency that won't build for aarch64-apple-
+        # ios, a bad cfg) without an Apple account. It deliberately stops short of
+        # the Xcode archive, which needs a signing identity.
+        working-directory: apps/geolibre-desktop/src-tauri
+        run: cargo build --lib --release --target aarch64-apple-ios
+
+      # ---- Signing path: import the identity, archive, export a signed .ipa ---
+      - name: Import signing identity
+        if: steps.signing.outputs.present == 'true'
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          # A dedicated, throwaway keychain (random password) rather than the
+          # login keychain, so the imported private key never lingers on the
+          # runner beyond this job.
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          keychain_pass="$(openssl rand -base64 24)"
+          echo "SIGNING_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+
+          security create-keychain -p "$keychain_pass" "$keychain"
+          # Auto-lock after 6h; keep unlocked for the archive.
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_pass" "$keychain"
+
+          cert="$RUNNER_TEMP/cert.p12"
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$cert"
+          security import "$cert" -k "$keychain" \
+            -P "${APPLE_CERTIFICATE_PASSWORD:-}" \
+            -T /usr/bin/codesign -T /usr/bin/xcodebuild
+          rm -f "$cert"
+
+          # Put the temp keychain on the search list so xcodebuild finds the
+          # identity, and grant codesign non-interactive access to the key.
+          security list-keychains -d user -s "$keychain" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$keychain_pass" "$keychain" >/dev/null
+
+          # Install the provisioning profile where Xcode looks for it.
+          profiles="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$profiles"
+          echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode \
+            > "$profiles/geolibre.mobileprovision"
+
+      - name: Build signed IPA
+        if: steps.signing.outputs.present == 'true'
+        working-directory: apps/geolibre-desktop
+        env:
+          # Tauri passes this through to the Xcode DEVELOPMENT_TEAM setting.
+          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_DEVELOPMENT_TEAM }}
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+        run: |
+          npx tauri ios build \
+            --export-method "${{ github.event.inputs.export_method || 'app-store-connect' }}"
+
+      - name: Verify built bundle id
+        if: steps.signing.outputs.present == 'true'
+        # Assert on the shipped bytes, not the config: the App Store burns the
+        # bundle id from the .ipa on first upload and it can never be changed, so
+        # it is checked rather than assumed (mirrors android.yml's package-id
+        # gate).
+        run: |
+          set -euo pipefail
+          ipa="$(find apps/geolibre-desktop/src-tauri/gen/apple -name '*.ipa' | head -1)"
+          if [ -z "$ipa" ]; then
+            echo "::error::No .ipa produced under gen/apple"
+            exit 1
+          fi
+          workdir="$(mktemp -d)"
+          unzip -o -q "$ipa" -d "$workdir"
+          plist="$(find "$workdir/Payload" -maxdepth 2 -name Info.plist | head -1)"
+          bid="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")"
+          if [ "$bid" != "$EXPECTED_BUNDLE_ID" ]; then
+            echo "::error::$ipa has bundle id '$bid', expected '$EXPECTED_BUNDLE_ID'"
+            exit 1
+          fi
+          echo "IPA $ipa reports bundle id $EXPECTED_BUNDLE_ID."
+          echo "IPA_PATH=$ipa" >> "$GITHUB_ENV"
+
+      - name: Clean up the signing keychain
+        # Runs even on failure so the imported key never outlives the job.
+        if: always() && steps.signing.outputs.present == 'true'
+        run: |
+          if [ -n "${SIGNING_KEYCHAIN:-}" ] && [ -f "$SIGNING_KEYCHAIN" ]; then
+            security delete-keychain "$SIGNING_KEYCHAIN" || true
+          fi
+          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/geolibre.mobileprovision" || true
+
+      - name: Upload signed IPA
+        if: steps.signing.outputs.present == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: geolibre-ios-ipa
+          path: ${{ env.IPA_PATH }}
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/geolibre-desktop/src-tauri/Info.ios.plist
+++ b/apps/geolibre-desktop/src-tauri/Info.ios.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  iOS-only Info.plist keys, merged into the generated
+  gen/apple/geolibre_iOS/Info.plist at build time (gen/apple is generated and
+  git-ignored, so per-key overrides must live here to survive regeneration).
+  Tauri v2 merges src-tauri/Info.plist (all Apple), Info.ios.plist (iOS), and
+  Info.macos.plist (macOS).
+
+  The location string is REQUIRED, not cosmetic: unlike Android — where the
+  geolocation plugin declares the runtime permission and the OS shows a generic
+  dialog — iOS *terminates the app* the instant it requests location if no
+  NSLocation*UsageDescription is present. This is the iOS analogue of the
+  AndroidManifest ACCESS_FINE/COARSE_LOCATION entries the plugin injects. It
+  covers all three location consumers: Field Collection, GPS Tracking, and the
+  Controls -> GeoLocate map control. "WhenInUse" (not "Always") because GeoLibre
+  only reads location while the app is foregrounded — there is no background
+  tracking.
+-->
+<plist version="1.0">
+  <dict>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>GeoLibre uses your location to center the map, capture GPS points during Field Collection, and record GPS tracks.</string>
+  </dict>
+</plist>

--- a/apps/geolibre-desktop/src-tauri/tauri.ios.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.ios.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "GeoLibre",
+  "identifier": "org.geolibre.app",
+  "bundle": {
+    "resources": []
+  }
+}

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -115,13 +115,27 @@ Linux, this is the only mobile workflow that needs a macOS runner.
 - **With Apple signing secrets set**, it imports the identity into a throwaway
   keychain, archives, exports a signed `.ipa`, verifies its bundle id, and
   uploads it as the `geolibre-ios-ipa` artifact:
-  - `APPLE_CERTIFICATE_BASE64` — `base64 -i dist.p12`
-  - `APPLE_CERTIFICATE_PASSWORD`
-  - `APPLE_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`
-  - `APPLE_DEVELOPMENT_TEAM` — your 10-char Team ID
+  - `APPLE_IOS_CERTIFICATE_BASE64` — `base64 -i dist.p12`
+  - `APPLE_IOS_CERTIFICATE_PASSWORD`
+  - `APPLE_IOS_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`
+  - `APPLE_TEAM_ID` — **reused** from the existing macOS/Homebrew signing
+    secrets; the Team ID is account-wide.
 - **Without them**, it falls back to a no-signing **compile check**
   (`cargo build --lib --target aarch64-apple-ios`) so CI still catches iOS build
   breakage; it just can't produce an installable `.ipa`.
+
+### Reusing the macOS/Homebrew signing secrets?
+
+Only the **Team ID**. The repo's release workflow already signs and notarizes the
+macOS build for the Homebrew cask, but its `APPLE_CERTIFICATE` is a **Developer ID
+Application** certificate — that type signs macOS apps distributed *outside* the
+App Store and **cannot sign an iOS app**. iOS needs its own **Apple Distribution**
+certificate and a **provisioning profile** (Developer ID distribution has
+neither), so those are the `APPLE_IOS_*` secrets above, deliberately named apart
+from the macOS ones to avoid feeding in the wrong cert/password. The good news:
+they're created under the **same paid Apple Developer account** at no extra cost —
+add an Apple Distribution certificate and an App Store provisioning profile for
+`org.geolibre.app` in the Developer portal, and reuse the existing `APPLE_TEAM_ID`.
 
 The `workflow_dispatch` `export_method` input picks the export path
 (`app-store-connect` for TestFlight/App Store, `release-testing` for ad-hoc

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -17,7 +17,7 @@ Vector tools (Turf.js / in-browser GeoPandas via Pyodide), the SQL Workspace
 (DuckDB-WASM and PGlite/PostGIS), the Python Console (Pyodide), geocoding,
 statistics, the AI assistant, story maps, and plugins.
 
-Tools that depend on a **local desktop process** are hidden on mobile, because
+Tools that depend on a **local desktop process** are hidden on mobile because
 iOS has no Python sidecar or local helper binaries and its sandbox forbids
 spawning subprocesses:
 
@@ -86,6 +86,7 @@ npx tauri ios build                    # release archive → signed .ipa (needs 
   Android (`identifier` in `tauri.conf.json` stays `org.geolibre.desktop` so it
   keeps keying desktop settings and the Linux/macOS packaging).
 - Verify the location string landed after a build:
+
   ```bash
   /usr/libexec/PlistBuddy -c 'Print :NSLocationWhenInUseUsageDescription' \
     src-tauri/gen/apple/geolibre_iOS/Info.plist

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -1,0 +1,179 @@
+# iOS
+
+GeoLibre runs as a native iOS app built from the same React codebase via **Tauri
+v2 mobile** — no separate app. The webview UI (WKWebView) is bundled in the app,
+so the shell works offline; map tiles and the heavier engines are fetched on
+demand (same as the desktop and Android builds).
+
+> **Status: scaffolding.** The iOS config, `Info.ios.plist`, and CI workflow are
+> in place, but — unlike Android — no iOS build has been shipped yet. Everything
+> below has to be run and verified on a Mac (iOS cannot be cross-compiled from
+> Linux). Treat the first `tauri ios build` as a bring-up, not a routine build.
+
+## What works on iOS vs desktop
+
+Same split as Android. The iOS build ships the full map workspace, Add Data, the
+Vector tools (Turf.js / in-browser GeoPandas via Pyodide), the SQL Workspace
+(DuckDB-WASM and PGlite/PostGIS), the Python Console (Pyodide), geocoding,
+statistics, the AI assistant, story maps, and plugins.
+
+Tools that depend on a **local desktop process** are hidden on mobile, because
+iOS has no Python sidecar or local helper binaries and its sandbox forbids
+spawning subprocesses:
+
+- Processing → **Whitebox**, **Raster**, **Conversion**, **AI Segmentation**
+  (all need the Python sidecar)
+- Add Data → **PostgreSQL** (served by the local Martin tile server)
+
+These are gated by a user-agent `isMobile()` check (which already matches
+iPhone/iPad) so they never appear and then fail. Everything else runs
+client-side.
+
+## Location permission (required)
+
+This is the one place iOS differs sharply from Android. Android's geolocation
+plugin declares the runtime permission and the OS shows a generic dialog; **iOS
+terminates the app the instant it requests location if no usage-description
+string is present.** GeoLibre supplies it in
+`src-tauri/Info.ios.plist`:
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>GeoLibre uses your location to center the map, capture GPS points during Field Collection, and record GPS tracks.</string>
+```
+
+Tauri merges `Info.ios.plist` into the generated
+`gen/apple/geolibre_iOS/Info.plist` at build time. `gen/apple` is git-ignored, so
+this file is the durable home for the string — the same reason Android's manifest
+permissions come from the plugin rather than a hand-edited, regenerated manifest.
+It covers all three location consumers: Field Collection, GPS Tracking, and the
+Controls → GeoLocate map control. After a build, confirm the key survived the
+merge (see *Build* below).
+
+## Toolchain setup (one time)
+
+You need a **Mac** with **Xcode** (from the App Store; open it once to accept the
+license and install the iOS platform), the command-line tools, CocoaPods, and the
+Rust iOS targets.
+
+```bash
+xcode-select --install                 # command-line tools (if not already)
+sudo xcodebuild -license accept
+brew install cocoapods                 # or `gem install cocoapods`
+
+# Rust device + simulator targets (install rustup first if needed)
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+```
+
+`aarch64-apple-ios` is real devices and the App Store `.ipa`;
+`aarch64-apple-ios-sim` is the simulator on Apple Silicon Macs.
+
+## Build
+
+```bash
+cd apps/geolibre-desktop
+npx tauri ios init                     # generate src-tauri/gen/apple (once)
+npx tauri ios dev                      # run in the simulator / on a tethered device
+npx tauri ios build                    # release archive → signed .ipa (needs signing, below)
+```
+
+- `gen/apple` is generated (git-ignored) and regenerated on demand. `init` also
+  merges `tauri.ios.conf.json` (bundle id, drops the Python backend) and
+  `Info.ios.plist` (the location string).
+- The app is named **GeoLibre** on iOS (the desktop build is "GeoLibre Desktop")
+  and uses the bundle id **`org.geolibre.app`**, both set via
+  `src-tauri/tauri.ios.conf.json` — the same override pattern and reasoning as
+  Android (`identifier` in `tauri.conf.json` stays `org.geolibre.desktop` so it
+  keeps keying desktop settings and the Linux/macOS packaging).
+- Verify the location string landed after a build:
+  ```bash
+  /usr/libexec/PlistBuddy -c 'Print :NSLocationWhenInUseUsageDescription' \
+    src-tauri/gen/apple/geolibre_iOS/Info.plist
+  ```
+
+## Signing
+
+Every build that runs on a real device or reaches the App Store must be signed —
+there is no debug-keystore shortcut like Android's. You need:
+
+1. An **Apple Developer Program** membership ($99/year).
+2. A **signing certificate** (Apple Distribution for App Store; Apple Development
+   for device testing), exported from Keychain as a `.p12`.
+3. A **provisioning profile** for the `org.geolibre.app` app id.
+4. Your **Team ID** (App Store Connect → Membership).
+
+Locally, opening `gen/apple/geolibre.xcodeproj` in Xcode once and enabling
+"Automatically manage signing" with your team is the simplest path. For CI, the
+identity is imported from secrets (below).
+
+## Continuous integration
+
+`.github/workflows/ios.yml` runs on `macos-14` on each published GitHub release
+(and on demand via "Run workflow"). Because iOS can't be cross-compiled from
+Linux, this is the only mobile workflow that needs a macOS runner.
+
+- **With Apple signing secrets set**, it imports the identity into a throwaway
+  keychain, archives, exports a signed `.ipa`, verifies its bundle id, and
+  uploads it as the `geolibre-ios-ipa` artifact:
+  - `APPLE_CERTIFICATE_BASE64` — `base64 -i dist.p12`
+  - `APPLE_CERTIFICATE_PASSWORD`
+  - `APPLE_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`
+  - `APPLE_DEVELOPMENT_TEAM` — your 10-char Team ID
+- **Without them**, it falls back to a no-signing **compile check**
+  (`cargo build --lib --target aarch64-apple-ios`) so CI still catches iOS build
+  breakage; it just can't produce an installable `.ipa`.
+
+The `workflow_dispatch` `export_method` input picks the export path
+(`app-store-connect` for TestFlight/App Store, `release-testing` for ad-hoc
+registered devices, `debugging` for development).
+
+## Install / test
+
+- **Simulator:** `npx tauri ios dev` and pick a simulator, or open the Xcode
+  project and Run. No paid account needed for the simulator.
+- **Your own device:** tether it, open `gen/apple/geolibre.xcodeproj` in Xcode,
+  select the device, and Run (a free Apple ID allows 7-day device signing).
+- **Testers:** distribute a signed build through **TestFlight** (upload the `.ipa`
+  via Xcode Organizer or Transporter, then invite testers in App Store Connect).
+
+## Publishing to the App Store
+
+The build side is covered by the CI workflow; the rest is App Store Connect
+onboarding.
+
+1. **App record.** In App Store Connect, create a new app with the bundle id
+   `org.geolibre.app` (register the app id in the Developer portal first).
+2. **Minimum Functionality (Guideline 4.2).** Apple rejects apps that are "a
+   repackaged website." GeoLibre passes because it's a bundled native app with
+   real device integration — GPS, offline-capable map workspace, local file
+   handling — not a wrapper that loads a remote URL. Keep it that way: ship the
+   web assets in the binary (the default here), don't point the webview at
+   `geolibre.app`.
+3. **Upload** the `.ipa` from the `geolibre-ios-ipa` CI artifact (or Xcode) to a
+   TestFlight build, then submit that build for App Store review. The build
+   number (`CFBundleVersion`) is derived from the version in `tauri.conf.json`
+   and must increase on every upload.
+4. **Store listing:** icon (already generated under `src-tauri/icons/ios`),
+   screenshots for the required device sizes (6.7" and 6.5" iPhone, plus 12.9"
+   iPad — a GIS workspace is genuinely iPad-appropriate), description, keywords.
+5. **Privacy.** Fill the **App Privacy** questionnaire honestly — declare each
+   network destination (geocoding, the AI assistant, basemap/tile fetches, Google
+   OAuth for Earth Engine) and that location is used *when in use* and not
+   collected by a backend. Point the privacy policy URL at the published
+   [privacy policy](privacy.md).
+6. **Age rating** questionnaire and category (Navigation or Productivity).
+
+## Known limitations / follow-ups
+
+Most mirror Android:
+
+- Local-file sources (MBTiles, local rasters, project files) assume real
+  filesystem paths; iOS hands apps sandboxed URLs via the document picker, so
+  those flows need adapting before they work natively.
+- The **Download Offline Area** tool relies on a service worker, which the Tauri
+  builds don't use — it's a PWA feature. Native offline basemap caching is future
+  work.
+- Earth Engine OAuth uses a desktop loopback/multi-window flow; a mobile
+  deep-link redirect (an iOS URL scheme / universal link) is future work.
+- iPadOS multitasking (Split View / Stage Manager) hasn't been tuned; the
+  responsive layout should adapt, but verify on a real iPad before release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
   - Reference:
       - Architecture: architecture.md
       - Android: android.md
+      - iOS: ios.md
       - Project Format: project-format.md
       - Plugin API: plugin-api.md
       - UI Profiles: ui-profiles.md


### PR DESCRIPTION
Scaffolds an iOS build of GeoLibre, mirroring the existing Android mobile setup. Follow-up to the mobile GPS work (#1373).

## No Rust changes needed
The app already builds for mobile via the existing `#[cfg(mobile)]` / `#[cfg(desktop)]` split (added for Android). The one thing that *looked* like it might need the Android treatment — the `native-tls` mTLS path, which Android excludes because `openssl-sys` can't cross-compile for the NDK — **works as-is on iOS**: `native-tls` uses Apple's Secure Transport (not openssl) on Apple platforms, identical to the shipping macOS build. So this PR is config + Info.plist + CI + docs only.

## What's here
- **`tauri.ios.conf.json`** — name `GeoLibre`, bundle id `org.geolibre.app`, drops the Python backend from the bundle (iOS can't run the sidecar). Same override pattern as `tauri.android.conf.json`; Tauri auto-merges it for iOS builds.
- **`Info.ios.plist`** — `NSLocationWhenInUseUsageDescription`. **Required, not cosmetic:** iOS *terminates the app* on a location request if it's missing — the iOS analogue of the Android manifest `ACCESS_*_LOCATION` entries the geolocation plugin injects. Merged into the generated (git-ignored) `gen/apple` Info.plist at build time, so it's the durable home for the string. Covers Field Collection, GPS Tracking, and the Controls → GeoLocate control.
- **`.github/workflows/ios.yml`** — `macos-14` runner (iOS can't cross-compile from Linux). With Apple signing secrets it imports the identity into a throwaway keychain, archives, exports a verified `.ipa`, and uploads it; **without** them it falls back to a no-signing `cargo build --target aarch64-apple-ios` compile check so CI still catches iOS breakage. Inline keychain handling (no unpinned third-party actions), mirroring `android.yml`'s style.
- **`docs/ios.md`** (+ mkdocs nav) — toolchain, build, signing, CI secrets, TestFlight, and App Store publishing including Guideline 4.2 (minimum functionality).

## ⚠️ This is bring-up, not a proven build
I authored this from Linux, where the Tauri CLI's `ios` subcommand is compiled out — so **none of the iOS build path has actually run**. CI on this PR exercises only the no-signing compile check. Everything below has to happen on a Mac. It can merge as scaffolding, but don't treat iOS as shippable until Phase 1–3 pass.

---

## Follow-up steps

### Phase 1 — Local bring-up on a Mac (no signing needed)
Proves the project generates and compiles; catches anything I couldn't see from Linux.

- [ ] Install the toolchain (see `docs/ios.md`): Xcode + `sudo xcodebuild -license accept`, `brew install cocoapods`, and `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios`.
- [ ] `npm ci && npm run build` (the web bundle must exist before `tauri ios`).
- [ ] `cd apps/geolibre-desktop && npx tauri ios init` — confirm `src-tauri/gen/apple` generates cleanly and picks up `tauri.ios.conf.json` (name **GeoLibre**, bundle id **org.geolibre.app**).
- [ ] **Verify the `Info.ios.plist` merge actually happened** (the highest-risk unknown — I couldn't confirm the merge filename/mechanism from Linux):
      `` /usr/libexec/PlistBuddy -c 'Print :NSLocationWhenInUseUsageDescription' src-tauri/gen/apple/geolibre_iOS/Info.plist ``
      If the key is missing, the merge file isn't wired the way I assumed — fix before anything else, or a location request will crash the app.
- [ ] `npx tauri ios dev` in the Simulator: confirm the app boots, the map renders, and the sidecar-only tools are hidden (`isMobile()` already matches iPhone/iPad).
- [ ] On a real device (free Apple ID signing is fine here): tap **Controls → GeoLocate**, **Field Collection → Use GPS**, and start a **GPS Tracking** session — confirm the iOS location prompt appears once and fixes come back (this is #1373 carrying over to iOS).

### Phase 2 — Create iOS signing artifacts (under the existing Apple Developer account)
The Homebrew/macOS `APPLE_CERTIFICATE` is a **Developer ID Application** cert and **cannot sign iOS** — but it proves a paid membership exists, so these are created under the same account at **no extra cost**. Only the **Team ID is reusable**.

- [ ] Register the App ID **`org.geolibre.app`** in the Apple Developer portal (Certificates, IDs & Profiles → Identifiers).
- [ ] Create an **Apple Distribution** certificate; export it from Keychain as a `.p12` with a password.
- [ ] Create an **App Store** provisioning profile for `org.geolibre.app` using that certificate; download the `.mobileprovision`.
- [ ] Grab the **Team ID** (App Store Connect → Membership) — already in the repo as `APPLE_TEAM_ID`.

### Phase 3 — Wire CI secrets and produce a signed IPA
Add these repository secrets (named `APPLE_IOS_*` on purpose, so they can't collide with the macOS `APPLE_CERTIFICATE*` secrets):

- [ ] `APPLE_IOS_CERTIFICATE_BASE64` — `base64 -i dist.p12`
- [ ] `APPLE_IOS_CERTIFICATE_PASSWORD` — the `.p12` export password
- [ ] `APPLE_IOS_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`
- [ ] `APPLE_TEAM_ID` — **already set**; reused as-is (no new secret)
- [ ] Run the **iOS** workflow via *Actions → iOS → Run workflow* (`export_method: app-store-connect`). Confirm the signing path runs (not the compile-check fallback), the bundle-id verification passes, and the `geolibre-ios-ipa` artifact uploads.
- [ ] **Validate the parts I wrote blind against a real run** and fix if Tauri/Xcode disagree: the `--export-method` value names (`app-store-connect` / `release-testing` / `debugging`), the `security import` / `set-key-partition-list` keychain steps, and whether Tauri reads the team from the `APPLE_DEVELOPMENT_TEAM` env var vs `bundle.iOS.developmentTeam`.

### Phase 4 — TestFlight and App Store submission
- [ ] Create the app record in App Store Connect (bundle id `org.geolibre.app`).
- [ ] Upload the `.ipa` (Xcode Organizer / Transporter — the existing `APPLE_ID` + `APPLE_PASSWORD` app-specific password can drive this) to a TestFlight build; smoke-test with internal testers.
- [ ] Fill **App Privacy** (declare geocoding, AI assistant, tile/basemap fetches, Earth Engine OAuth; location = *when in use*, not collected) and point the privacy URL at `docs/privacy.md`.
- [ ] Add store assets (icon set already exists under `src-tauri/icons/ios`; screenshots for 6.7"/6.5" iPhone + 12.9" iPad), category, age rating.
- [ ] Submit for review — keep the web assets **bundled** (don't point the webview at `geolibre.app`) so it clears Guideline 4.2 minimum-functionality.

### Phase 5 — Follow-up code work (separate PRs, post-merge)
Known iOS gaps, mirroring the Android limitations in `docs/ios.md`:
- [ ] Document-picker / scoped-storage adaptation for local-file sources (MBTiles, local rasters, project files).
- [ ] Earth Engine OAuth mobile redirect (iOS URL scheme / universal link) instead of the desktop loopback flow.
- [ ] iPadOS layout pass (Split View / Stage Manager).
- [ ] Optionally extend `ios.yml` with an automated TestFlight upload step once the manual flow is proven.

---

## Reviewer note
This can merge as scaffolding without a green signed build — the compile-check keeps `main` honest, and nothing here affects the desktop/Android/web builds. Phases 1–3 are the gate before advertising iOS as available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native iOS app support, including configuration for the iOS bundle and a dedicated iOS app Info plist with location permission messaging.
  * Added CI automation to build and produce a signed iOS IPA for release workflows when signing credentials are available.
* **Documentation**
  * Added a comprehensive iOS guide covering setup, build/test steps, signing requirements, and iOS-specific limitations.
  * Linked the new iOS documentation in the reference navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
