### PR TITLE
fix(raster): apply min/max zoom constraint to COG layers

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.13.0",
+    "maplibre-gl-raster": "^0.14.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.13.0",
+        "maplibre-gl-raster": "^0.14.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
@@ -3128,17 +3128,6 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.5.4"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -17001,9 +16990,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.13.0.tgz",
-      "integrity": "sha512-fB/bNpeq8BJjy67tA70+sXpHYhxLxxw9NhTyJXUO9e9aSAL17IzTWmICjQm57Ji+4xC6BiTTtUMW+FAZ6utHUg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.0.tgz",
+      "integrity": "sha512-lslg2Gl4q7QhALWNAzYgDSd0P10v9n0Mb2bBSGFqTa2A6BO9be+dGrWIX0/+IRP58tDhSSYYwieW2Meu8td1Jg==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21825,7 +21814,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.13.0",
+        "maplibre-gl-raster": "^0.14.0",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,7 +49,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.13.0",
+    "maplibre-gl-raster": "^0.14.0",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from "@geolibre/core";
+import { styleValue, useAppStore } from "@geolibre/core";
 import type { Layer } from "@deck.gl/core";
 import type {
   RasterControl,
@@ -411,6 +411,11 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
                 ...savedRasterState(layer),
                 opacity: layer.opacity,
                 visible: layer.visible,
+                // The zoom range lives on layer.style (the shared Style-panel
+                // control), not in metadata.rasterState, so it is replayed here
+                // to survive a project reload / map reinitialisation.
+                minZoom: styleValue(layer.style, "minZoom"),
+                maxZoom: styleValue(layer.style, "maxZoom"),
               },
               zoomTo: false,
             })

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, useAppStore } from "@geolibre/core";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, styleValue, useAppStore } from "@geolibre/core";
 import type { RasterLayerInfo, RasterLayerState } from "maplibre-gl-raster";
 
 export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
@@ -259,6 +259,8 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
         }
         const patch = rasterStatePatch(layer, current);
         if (patch) activeControl.setRasterState(layer.id, patch);
+        const zoomPatch = zoomRangePatch(layer, current);
+        if (zoomPatch) activeControl.setRasterState(layer.id, zoomPatch);
       }
     });
   });
@@ -303,6 +305,32 @@ function rasterStatePatch(
     }
   }
   return changed ? (patch as Partial<RasterLayerState>) : null;
+}
+
+/**
+ * Diffs a raster layer's min/max zoom between two store snapshots and returns
+ * the range to push through setRasterState, or null when unchanged.
+ *
+ * The zoom-range control lives on `layer.style` (the shared Style-panel widget),
+ * not in `metadata.rasterState`, so it is diffed separately from the symbology
+ * fields. A control-managed COG is an external custom layer, so layer-sync skips
+ * the native `map.setLayerZoomRange` path for it; the range reaches the raster
+ * only through this bridge.
+ *
+ * @param previous - The prior store layer.
+ * @param current - The current store layer.
+ * @returns A `{ minZoom, maxZoom }` patch, or null.
+ */
+function zoomRangePatch(
+  previous: GeoLibreLayer,
+  current: GeoLibreLayer,
+): Partial<RasterLayerState> | null {
+  const beforeMin = styleValue(previous.style, "minZoom");
+  const beforeMax = styleValue(previous.style, "maxZoom");
+  const afterMin = styleValue(current.style, "minZoom");
+  const afterMax = styleValue(current.style, "maxZoom");
+  if (beforeMin === afterMin && beforeMax === afterMax) return null;
+  return { minZoom: afterMin, maxZoom: afterMax };
 }
 
 function rasterStateRecord(layer: GeoLibreLayer): Record<string, unknown> {

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -459,6 +459,35 @@ describe("wireRasterStoreSync", () => {
 
     assert.deepEqual(calls, []);
   });
+
+  it("pushes the min/max zoom range through setRasterState when the style changes", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const layer = useAppStore.getState().layers[0];
+    useAppStore.getState().updateLayer("raster-1", {
+      style: { ...layer.style, minZoom: 6, maxZoom: 12 },
+    });
+
+    assert.deepEqual(calls, [
+      { method: "setRasterState", args: ["raster-1", { minZoom: 6, maxZoom: 12 }] },
+    ]);
+  });
+
+  it("does not push a zoom range when the style zoom bounds are unchanged", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const layer = useAppStore.getState().layers[0];
+    // A style edit that leaves minZoom/maxZoom untouched must not push a range.
+    useAppStore.getState().updateLayer("raster-1", {
+      style: { ...layer.style, fillOpacity: 0.5 },
+    });
+
+    assert.deepEqual(calls, []);
+  });
 });
 
 describe("removeRasterStoreLayers", () => {


### PR DESCRIPTION
## Summary

Fixes #1375. The min/max zoom constraint set in the Style panel had no effect on COG (Cloud Optimized GeoTIFF) layers, even the built-in sample COGs, while it works for every other layer type.

**Root cause.** A COG renders through the `maplibre-gl-raster` deck.gl overlay as an *external custom layer*, so `MapController.syncLayers` deliberately skips the native `map.setLayerZoomRange` path for it (custom layers manage their own visibility). The store-to-control bridge (`raster-layer-sync`) only forwarded visibility and opacity, never the zoom range, and the deck.gl `RasterControl` had no zoom-range concept at all, so the constraint was silently dropped.

## Changes

- **Bump `maplibre-gl-raster` 0.13.0 -> 0.14.0** (opengeos/maplibre-gl-raster#55, released as [v0.14.0](https://github.com/opengeos/maplibre-gl-raster/releases/tag/v0.14.0)). That release adds optional per-layer `minZoom`/`maxZoom` to the raster layer state, honored by all three of its render engines (deck.gl filters + a `zoom` listener; cog-tiler-wasm / titiler set the range on the native MapLibre raster layer).
- **Forward the zoom range** from `style.minZoom` / `style.maxZoom` to the control via `setRasterState` in the raster store-sync bridge. The range lives on `layer.style` (the shared Style-panel widget), not in `metadata.rasterState`, so it is diffed separately from the symbology fields.
- **Replay the saved range on project restore / map reinitialisation**, since the zoom range is persisted on the layer style rather than in the raster-state metadata.

## Tests

- New `raster-layer-sync` tests: the zoom range is pushed through `setRasterState` when the style's zoom bounds change, and is not pushed when an unrelated style field changes.
- Upstream `maplibre-gl-raster` ships its own zoom-range suite (deck.gl filtering + zoom listener + both native engines).

## Verification

Driven in the real desktop app with Playwright against the production build using the published `maplibre-gl-raster@0.14.0`, with a local tiled COG (`dem.tif`). At map zoom 8.72 the raster is visible with max zoom 24, disappears when max zoom is set to 4 or min zoom to 10, and returns when the constraint is relaxed. Verified in both light and dark UI themes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Raster layer minimum and maximum zoom settings now persist when projects are reloaded or maps are reinitialized.
  - Changes to raster layer zoom ranges now stay synchronized with the map.
  - Unrelated style changes no longer trigger unnecessary raster state updates.

- **Tests**
  - Added coverage for zoom-range synchronization and unrelated style updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->