### PR TITLE
feat(layers): Layers-panel symbology swatches + auto on-map legend

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -79,6 +79,7 @@ import { useOsmPbfLoader } from "../../hooks/useOsmPbfLoader";
 import type { ProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import { useAutoLegend } from "../../hooks/useAutoLegend";
+import { useVectorTileGeometryBackfill } from "../../hooks/useVectorTileGeometryBackfill";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/tauri-io";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
@@ -423,6 +424,10 @@ export function TopToolbar({
   const appApi = useMemo(() => createAppAPI(mapControllerRef), [mapControllerRef]);
 
   const panels = useToolbarPanels(appApi);
+  // Fill in the geometry kind for vector-tile layers that arrived without it
+  // (older projects, sources that don't record it), so their swatch/legend
+  // symbols are a dot/line/square rather than a neutral square.
+  useVectorTileGeometryBackfill(appApi);
   // Feed the visible layers' symbology into the Legend panel while it is open,
   // so it auto-updates as layers are shown/hidden.
   useAutoLegend(appApi, panels.legend.visible, t("toolbar.item.legend"));

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -78,6 +78,7 @@ import { useConsentGatedActions } from "../../hooks/useConsentGatedActions";
 import { useOsmPbfLoader } from "../../hooks/useOsmPbfLoader";
 import type { ProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useToolbarPanels } from "../../hooks/useToolbarPanels";
+import { useAutoLegend } from "../../hooks/useAutoLegend";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/tauri-io";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
@@ -422,6 +423,9 @@ export function TopToolbar({
   const appApi = useMemo(() => createAppAPI(mapControllerRef), [mapControllerRef]);
 
   const panels = useToolbarPanels(appApi);
+  // Feed the visible layers' symbology into the Legend panel while it is open,
+  // so it auto-updates as layers are shown/hidden.
+  useAutoLegend(appApi, panels.legend.visible, t("toolbar.item.legend"));
   const osmPbf = useOsmPbfLoader(appApi, projectFiles.setActionError);
   const consent = useConsentGatedActions({ appApi, isActive, toggle });
   const viewportHistory = useViewportHistory(

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -426,8 +426,10 @@ export function TopToolbar({
   const panels = useToolbarPanels(appApi);
   // Fill in the geometry kind for vector-tile layers that arrived without it
   // (older projects, sources that don't record it), so their swatch/legend
-  // symbols are a dot/line/square rather than a neutral square.
-  useVectorTileGeometryBackfill(appApi);
+  // symbols are a dot/line/square rather than a neutral square. Keyed on
+  // mapReadyGeneration so it re-runs once the map exists (an early mount before
+  // map init would otherwise miss its only chance to attach the idle listener).
+  useVectorTileGeometryBackfill(appApi, mapReadyGeneration);
   // Feed the visible layers' symbology into the Legend panel while it is open,
   // so it auto-updates as layers are shown/hidden.
   useAutoLegend(appApi, panels.legend.visible, t("toolbar.item.legend"));

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -174,6 +174,7 @@ import {
 import { isTauri } from "../../lib/is-tauri";
 import { BasemapPickerDialog } from "./BasemapPickerDialog";
 import { LayerPanelPlaceSearch } from "./LayerPanelPlaceSearch";
+import { LayerSwatchIcon } from "./LayerSwatchIcon";
 
 interface LayerPanelProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -2337,6 +2338,7 @@ export function LayerPanel({
                           <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
                         )}
                       </button>
+                      <LayerSwatchIcon layer={layer} />
                       {editingLayerId === layer.id ? (
                         <input
                           autoFocus

--- a/apps/geolibre-desktop/src/components/panels/LayerSwatchIcon.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerSwatchIcon.tsx
@@ -1,4 +1,5 @@
 import type { GeoLibreLayer } from "@geolibre/core";
+import { Image as RasterIcon } from "lucide-react";
 import { layerSwatch } from "../../lib/layer-swatch";
 
 /**
@@ -11,6 +12,10 @@ export function LayerSwatchIcon({ layer }: { layer: GeoLibreLayer }): React.Reac
   const { color, shape } = layerSwatch(layer);
   const dim = layer.visible ? "" : "opacity-40";
 
+  if (shape === "raster") {
+    // Raster/imagery layers get an image glyph rather than a solid square.
+    return <RasterIcon aria-hidden className={`h-3 w-3 shrink-0 text-muted-foreground ${dim}`} />;
+  }
   if (shape === "circle") {
     return (
       <span

--- a/apps/geolibre-desktop/src/components/panels/LayerSwatchIcon.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerSwatchIcon.tsx
@@ -15,22 +15,23 @@ export function LayerSwatchIcon({ layer }: { layer: GeoLibreLayer }): React.Reac
     return (
       <span
         aria-hidden
-        className={`h-3 w-3 shrink-0 rounded-full border border-black/25 dark:border-white/25 ${dim}`}
+        className={`h-2.5 w-2.5 shrink-0 rounded-full border border-black/25 dark:border-white/25 ${dim}`}
         style={{ backgroundColor: color }}
       />
     );
   }
   if (shape === "line") {
     return (
-      <span aria-hidden className={`flex h-3 w-3 shrink-0 items-center justify-center ${dim}`}>
-        <span className="h-[3px] w-3 rounded-full" style={{ backgroundColor: color }} />
+      <span aria-hidden className={`flex h-2.5 w-2.5 shrink-0 items-center justify-center ${dim}`}>
+        <span className="h-[2px] w-2.5 rounded-full" style={{ backgroundColor: color }} />
       </span>
     );
   }
+  // Polygon: a sharp square (no corner rounding, which reads as a circle at this size).
   return (
     <span
       aria-hidden
-      className={`h-3 w-3 shrink-0 rounded-sm border border-black/25 dark:border-white/25 ${dim}`}
+      className={`h-2.5 w-2.5 shrink-0 border border-black/25 dark:border-white/25 ${dim}`}
       style={{ backgroundColor: color }}
     />
   );

--- a/apps/geolibre-desktop/src/components/panels/LayerSwatchIcon.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerSwatchIcon.tsx
@@ -1,0 +1,37 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import { layerSwatch } from "../../lib/layer-swatch";
+
+/**
+ * The per-row symbology symbol in the Layers panel: a colored dot (point), line
+ * (line), or square (polygon / raster / service) reflecting the layer's
+ * geometry and its first symbology color. Dimmed for hidden layers so the panel
+ * reads at a glance, matching the on-map legend's swatches.
+ */
+export function LayerSwatchIcon({ layer }: { layer: GeoLibreLayer }): React.ReactElement {
+  const { color, shape } = layerSwatch(layer);
+  const dim = layer.visible ? "" : "opacity-40";
+
+  if (shape === "circle") {
+    return (
+      <span
+        aria-hidden
+        className={`h-3 w-3 shrink-0 rounded-full border border-black/25 dark:border-white/25 ${dim}`}
+        style={{ backgroundColor: color }}
+      />
+    );
+  }
+  if (shape === "line") {
+    return (
+      <span aria-hidden className={`flex h-3 w-3 shrink-0 items-center justify-center ${dim}`}>
+        <span className="h-[3px] w-3 rounded-full" style={{ backgroundColor: color }} />
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      className={`h-3 w-3 shrink-0 rounded-sm border border-black/25 dark:border-white/25 ${dim}`}
+      style={{ backgroundColor: color }}
+    />
+  );
+}

--- a/apps/geolibre-desktop/src/hooks/useAutoLegend.ts
+++ b/apps/geolibre-desktop/src/hooks/useAutoLegend.ts
@@ -1,0 +1,42 @@
+/**
+ * Drives the on-map Legend panel from the currently VISIBLE layers' symbology.
+ *
+ * The Legend control, its toggle, and `openLegendPanelWithItems` already exist
+ * (used by the raster palette UIs); what was missing is a reactive feed. While
+ * the panel is open, this hook recomputes the legend from the store on every
+ * layer change (add/remove, visibility, rename, restyle) and pushes it in — so
+ * items appear and disappear as layers are shown and hidden, like GeoLens.
+ */
+import { useAppStore } from "@geolibre/core";
+import { openLegendPanelWithItems } from "@geolibre/plugins";
+import { useEffect } from "react";
+import type { createAppAPI } from "./usePlugins";
+import { autoLegendItems } from "../lib/layer-swatch";
+
+/**
+ * Keep the Legend panel in sync with the visible layers while it is open.
+ *
+ * @param app - The host app API (stably memoized by the caller).
+ * @param active - Whether the Legend panel is currently visible.
+ * @param title - Panel title (reuse the existing "Legend" i18n string).
+ */
+export function useAutoLegend(
+  app: ReturnType<typeof createAppAPI>,
+  active: boolean,
+  title: string,
+): void {
+  const layers = useAppStore((state) => state.layers);
+
+  useEffect(() => {
+    if (!active) return;
+    // A per-run token so a superseded update (rapid visibility toggles) can't
+    // clobber a newer one — openLegendPanelWithItems honors the AbortSignal.
+    const controller = new AbortController();
+    void openLegendPanelWithItems(app, {
+      title,
+      items: autoLegendItems(layers),
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [app, active, title, layers]);
+}

--- a/apps/geolibre-desktop/src/hooks/useVectorTileGeometryBackfill.ts
+++ b/apps/geolibre-desktop/src/hooks/useVectorTileGeometryBackfill.ts
@@ -1,0 +1,102 @@
+/**
+ * Backfills `metadata.geometryType` for vector-tile layers that don't carry it.
+ *
+ * A vector-tile layer has no local features, so its geometry (point / line /
+ * polygon) is only known if a source set the hint — the GeoLens plugin does for
+ * new layers, but layers restored from an older saved project, or added by
+ * sources that don't record it, arrive with none. Without it the Layers-panel
+ * swatch and the legend fall back to a neutral square for everything.
+ *
+ * This reads the geometry straight from the rendered tiles: once tiles settle,
+ * `querySourceFeatures` reports the actual geometry types, and the dominant one
+ * is written back to the store (once, idempotently). It self-heals on `idle`,
+ * so a layer whose tiles load after a pan/zoom is picked up too.
+ */
+import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import { sourceId } from "@geolibre/map";
+import type { Map as MapLibreMap } from "maplibre-gl";
+import { useEffect } from "react";
+import type { createAppAPI } from "./usePlugins";
+
+/** Layer types drawn from vector tiles (no local features to inspect). */
+const VECTOR_TILE_TYPES = new Set<GeoLibreLayer["type"]>(["vector-tiles", "pmtiles", "mbtiles"]);
+
+function sourceLayerOf(layer: GeoLibreLayer): string | undefined {
+  const fromSource = layer.source.sourceLayer;
+  if (typeof fromSource === "string" && fromSource) return fromSource;
+  const fromMeta = layer.metadata.sourceLayers;
+  if (Array.isArray(fromMeta) && typeof fromMeta[0] === "string") return fromMeta[0];
+  return undefined;
+}
+
+/** The dominant geometry kind among a layer's loaded tile features, or null. */
+function dominantGeometry(
+  map: MapLibreMap,
+  layer: GeoLibreLayer,
+): "point" | "line" | "polygon" | null {
+  const sourceLayer = sourceLayerOf(layer);
+  let features;
+  try {
+    features = map.querySourceFeatures(
+      sourceId(layer.id),
+      sourceLayer ? { sourceLayer } : undefined,
+    );
+  } catch {
+    return null; // source not added yet
+  }
+  if (!features || features.length === 0) return null;
+  let polygon = 0;
+  let line = 0;
+  let point = 0;
+  for (const feature of features.slice(0, 400)) {
+    const type = feature.geometry?.type ?? "";
+    if (type.includes("Polygon")) polygon++;
+    else if (type.includes("LineString")) line++;
+    else if (type.includes("Point")) point++;
+  }
+  if (polygon === 0 && line === 0 && point === 0) return null;
+  // Prefer the highest-dimension geometry present (polygon > line > point).
+  if (polygon >= line && polygon >= point) return "polygon";
+  if (line >= point) return "line";
+  return "point";
+}
+
+/** Keep vector-tile layers' `metadata.geometryType` populated from their tiles. */
+export function useVectorTileGeometryBackfill(app: ReturnType<typeof createAppAPI>): void {
+  const layers = useAppStore((state) => state.layers);
+
+  useEffect(() => {
+    const map = app.getMap?.();
+    if (!map) return;
+
+    const needsGeometry = () =>
+      useAppStore
+        .getState()
+        .layers.filter(
+          (layer) =>
+            VECTOR_TILE_TYPES.has(layer.type) && typeof layer.metadata.geometryType !== "string",
+        );
+
+    if (needsGeometry().length === 0) return;
+
+    const backfill = (): void => {
+      for (const layer of needsGeometry()) {
+        const geometryType = dominantGeometry(map, layer);
+        if (!geometryType) continue;
+        const current = useAppStore.getState().layers.find((l) => l.id === layer.id);
+        if (current && typeof current.metadata.geometryType !== "string") {
+          useAppStore
+            .getState()
+            .updateLayer(layer.id, { metadata: { ...current.metadata, geometryType } });
+        }
+      }
+    };
+
+    // Try now (tiles may already be loaded) and again whenever the map settles.
+    backfill();
+    map.on("idle", backfill);
+    return () => {
+      map.off("idle", backfill);
+    };
+  }, [app, layers]);
+}

--- a/apps/geolibre-desktop/src/hooks/useVectorTileGeometryBackfill.ts
+++ b/apps/geolibre-desktop/src/hooks/useVectorTileGeometryBackfill.ts
@@ -61,8 +61,18 @@ function dominantGeometry(
   return "point";
 }
 
-/** Keep vector-tile layers' `metadata.geometryType` populated from their tiles. */
-export function useVectorTileGeometryBackfill(app: ReturnType<typeof createAppAPI>): void {
+/**
+ * Keep vector-tile layers' `metadata.geometryType` populated from their tiles.
+ *
+ * @param app - The host app API (stably memoized by the caller).
+ * @param mapReadyGeneration - Bumped when the map (re)initializes; a dependency
+ *   so the effect re-runs once `app.getMap()` is available (an early mount
+ *   before map init returns before attaching the `idle` listener).
+ */
+export function useVectorTileGeometryBackfill(
+  app: ReturnType<typeof createAppAPI>,
+  mapReadyGeneration: number,
+): void {
   const layers = useAppStore((state) => state.layers);
 
   useEffect(() => {
@@ -98,5 +108,5 @@ export function useVectorTileGeometryBackfill(app: ReturnType<typeof createAppAP
     return () => {
       map.off("idle", backfill);
     };
-  }, [app, layers]);
+  }, [app, layers, mapReadyGeneration]);
 }

--- a/apps/geolibre-desktop/src/lib/layer-swatch.ts
+++ b/apps/geolibre-desktop/src/lib/layer-swatch.ts
@@ -7,7 +7,27 @@
 import type { GeoLibreLayer } from "@geolibre/core";
 import { legendSwatchesForLayer } from "./print-legend";
 
-export type LayerSwatchShape = "circle" | "line" | "square";
+export type LayerSwatchShape = "circle" | "line" | "square" | "raster";
+
+/** Layer types styled as vectors (a colored dot/line/fill represents them). */
+const VECTOR_TYPES = new Set<GeoLibreLayer["type"]>([
+  "geojson",
+  "flatgeobuf",
+  "geoparquet",
+  "vector-tiles",
+  "pmtiles",
+  "duckdb-query",
+  "deckgl-viz",
+]);
+
+/** Whether a layer is raster/imagery (COG, XYZ, WMS/WMTS, raster MBTiles, …). */
+function isRasterLike(layer: GeoLibreLayer): boolean {
+  if (VECTOR_TYPES.has(layer.type)) return false;
+  if (layer.type === "mbtiles") {
+    return layer.metadata.tileType === "raster" || layer.source.type === "raster";
+  }
+  return true;
+}
 
 export interface LayerSwatch {
   /** First representative color of the layer's symbology. */
@@ -30,6 +50,9 @@ function stringMetadata(value: unknown): string | null {
  * GeoJSON geometry, then a neutral square for raster/service/unknown layers.
  */
 export function layerSwatchShape(layer: GeoLibreLayer): LayerSwatchShape {
+  // Raster/imagery layers get an image glyph, not a solid square.
+  if (isRasterLike(layer)) return "raster";
+
   const geometryType = stringMetadata(layer.metadata?.geometryType);
   if (geometryType === "point") return "circle";
   if (geometryType === "line") return "line";
@@ -64,11 +87,11 @@ export function layerSwatch(layer: GeoLibreLayer): LayerSwatch {
   };
 }
 
-/** One flattened row in the on-map legend. */
+/** One flattened row in the on-map legend (the legend control has no raster glyph). */
 export interface AutoLegendItem {
   label: string;
   color: string;
-  shape: LayerSwatchShape;
+  shape: "square" | "circle" | "line";
 }
 
 /**
@@ -84,7 +107,9 @@ export function autoLegendItems(layers: GeoLibreLayer[]): AutoLegendItem[] {
     if (!layer.visible) continue;
     const swatches = legendSwatchesForLayer(layer);
     if (swatches.length === 0) continue;
-    const shape = layerSwatchShape(layer);
+    // The legend control has no raster glyph, so it falls back to a square.
+    const resolved = layerSwatchShape(layer);
+    const shape = resolved === "raster" ? "square" : resolved;
     if (swatches.length === 1) {
       items.push({ label: layer.name, color: swatches[0].color || NEUTRAL, shape });
       continue;

--- a/apps/geolibre-desktop/src/lib/layer-swatch.ts
+++ b/apps/geolibre-desktop/src/lib/layer-swatch.ts
@@ -1,0 +1,98 @@
+/**
+ * The small symbology swatch shown on each Layers-panel row: a representative
+ * color plus a shape reflecting the layer's geometry (point → dot, line → line,
+ * polygon/raster → square). Reuses {@link legendSwatchesForLayer} for the color
+ * so the panel symbol and the legend never disagree.
+ */
+import type { GeoLibreLayer } from "@geolibre/core";
+import { legendSwatchesForLayer } from "./print-legend";
+
+export type LayerSwatchShape = "circle" | "line" | "square";
+
+export interface LayerSwatch {
+  /** First representative color of the layer's symbology. */
+  color: string;
+  /** Geometry-driven shape: point → circle, line → line, polygon/other → square. */
+  shape: LayerSwatchShape;
+}
+
+/** Neutral fallback color, matching the legend's raster/service swatch. */
+const NEUTRAL = "#94a3b8";
+
+function stringMetadata(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Resolve the geometry-driven swatch shape for a layer. Prefers the host's
+ * canonical `metadata.geometryType` (set by the vector control and the GeoLens
+ * plugin — the only signal a tile layer has), then falls back to sampling local
+ * GeoJSON geometry, then a neutral square for raster/service/unknown layers.
+ */
+export function layerSwatchShape(layer: GeoLibreLayer): LayerSwatchShape {
+  const geometryType = stringMetadata(layer.metadata?.geometryType);
+  if (geometryType === "point") return "circle";
+  if (geometryType === "line") return "line";
+  if (geometryType === "polygon") return "square";
+
+  const features = layer.geojson?.features;
+  if (features && features.length > 0) {
+    let hasPolygon = false;
+    let hasLine = false;
+    let hasPoint = false;
+    for (const feature of features.slice(0, 500)) {
+      const type = feature.geometry?.type ?? "";
+      if (type.includes("Polygon")) hasPolygon = true;
+      else if (type.includes("LineString")) hasLine = true;
+      else if (type.includes("Point")) hasPoint = true;
+    }
+    // Prefer the highest-dimension geometry present (polygon > line > point).
+    if (hasPolygon) return "square";
+    if (hasLine) return "line";
+    if (hasPoint) return "circle";
+  }
+
+  return "square";
+}
+
+/** The Layers-panel symbol for a layer: a color plus a geometry-driven shape. */
+export function layerSwatch(layer: GeoLibreLayer): LayerSwatch {
+  const swatches = legendSwatchesForLayer(layer);
+  return {
+    color: swatches[0]?.color ?? NEUTRAL,
+    shape: layerSwatchShape(layer),
+  };
+}
+
+/** One flattened row in the on-map legend. */
+export interface AutoLegendItem {
+  label: string;
+  color: string;
+  shape: LayerSwatchShape;
+}
+
+/**
+ * Flatten the VISIBLE layers into legend rows (top-of-stack first). A
+ * single-symbol layer contributes one row (its name + geometry swatch); a
+ * graduated / categorized / rule-based layer contributes a name row followed by
+ * one row per class — mirroring the Layers panel's swatches. Kept pure (no
+ * React / map deps) so it is unit testable.
+ */
+export function autoLegendItems(layers: GeoLibreLayer[]): AutoLegendItem[] {
+  const items: AutoLegendItem[] = [];
+  for (const layer of [...layers].reverse()) {
+    if (!layer.visible) continue;
+    const swatches = legendSwatchesForLayer(layer);
+    if (swatches.length === 0) continue;
+    const shape = layerSwatchShape(layer);
+    if (swatches.length === 1) {
+      items.push({ label: layer.name, color: swatches[0].color || NEUTRAL, shape });
+      continue;
+    }
+    items.push({ label: layer.name, color: swatches[0].color || NEUTRAL, shape });
+    for (const swatch of swatches) {
+      items.push({ label: swatch.label ?? "", color: swatch.color || NEUTRAL, shape: "square" });
+    }
+  }
+  return items;
+}

--- a/apps/geolibre-desktop/src/lib/layer-swatch.ts
+++ b/apps/geolibre-desktop/src/lib/layer-swatch.ts
@@ -20,9 +20,22 @@ const VECTOR_TYPES = new Set<GeoLibreLayer["type"]>([
   "deckgl-viz",
 ]);
 
+/**
+ * Layer types that are neither vector nor raster imagery (3D tiles, point
+ * clouds, media). They get the neutral geometry fallback, not the raster glyph.
+ * Mirrors NON_LEGEND_TYPES in print-legend.ts.
+ */
+const NON_RASTER_TYPES = new Set<GeoLibreLayer["type"]>([
+  "lidar",
+  "gaussian-splat",
+  "3d-tiles",
+  "video",
+  "image",
+]);
+
 /** Whether a layer is raster/imagery (COG, XYZ, WMS/WMTS, raster MBTiles, …). */
 function isRasterLike(layer: GeoLibreLayer): boolean {
-  if (VECTOR_TYPES.has(layer.type)) return false;
+  if (VECTOR_TYPES.has(layer.type) || NON_RASTER_TYPES.has(layer.type)) return false;
   if (layer.type === "mbtiles") {
     return layer.metadata.tileType === "raster" || layer.source.type === "raster";
   }

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -55,64 +55,57 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
   // Render order in the store is bottom-first; legends read top-first.
   for (const layer of [...layers].reverse()) {
     if (!layer.visible) continue;
-    if (NON_LEGEND_TYPES.has(layer.type)) continue;
-
-    // MBTiles can carry vector or raster tiles; the app renders it as vector
-    // unless its metadata or source says raster (mirrors layer-sync), so a
-    // missing or legacy tileType is treated as vector here too.
-    const isVector =
-      VECTOR_TYPES.has(layer.type) ||
-      (layer.type === "mbtiles" &&
-        layer.metadata.tileType !== "raster" &&
-        layer.source.type !== "raster");
-    if (isVector) {
-      const mode = styleValue(layer.style, "vectorStyleMode");
-      const stops = styleValue(layer.style, "vectorStyleStops");
-      // Diagram symbology adds one labeled swatch per charted attribute after
-      // the base symbology's swatches, mirroring the QGIS legend.
-      const diagrams = diagramSwatches(layer);
-      if (
-        (mode === "graduated" || mode === "categorized") &&
-        Array.isArray(stops) &&
-        stops.length > 0
-      ) {
-        entries.push({
-          id: layer.id,
-          name: layer.name,
-          swatches: [...rampSwatches(stops, mode), ...diagrams],
-        });
-        continue;
-      }
-      if (mode === "rule-based") {
-        const swatches = ruleSwatches(layer);
-        if (swatches.length > 0) {
-          entries.push({
-            id: layer.id,
-            name: layer.name,
-            swatches: [...swatches, ...diagrams],
-          });
-          continue;
-        }
-      }
-      const primary = pointMarkerSwatch(layer.style) ?? {
-        color: styleValue(layer.style, "fillColor"),
-      };
-      entries.push({
-        id: layer.id,
-        name: layer.name,
-        swatches: [primary, ...diagrams],
-      });
-      continue;
-    }
-
-    // Raster / service layers: a single neutral marker swatch.
-    entries.push({
-      id: layer.id,
-      name: layer.name,
-      swatches: [{ color: NEUTRAL_SWATCH }],
-    });
+    const swatches = legendSwatchesForLayer(layer);
+    // No swatches means a type with no meaningful legend representation.
+    if (swatches.length === 0) continue;
+    entries.push({ id: layer.id, name: layer.name, swatches });
   }
   return entries;
+}
+
+/**
+ * The legend swatch(es) for a single layer, independent of its visibility.
+ * Shared by {@link buildLegend} (which filters to visible layers) and the
+ * Layers-panel row symbol (which shows a swatch even for hidden layers). Returns
+ * an empty array for types with no meaningful legend representation
+ * ({@link NON_LEGEND_TYPES}); every legend-able layer yields at least one swatch.
+ */
+export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
+  if (NON_LEGEND_TYPES.has(layer.type)) return [];
+
+  // MBTiles can carry vector or raster tiles; the app renders it as vector
+  // unless its metadata or source says raster (mirrors layer-sync), so a
+  // missing or legacy tileType is treated as vector here too.
+  const isVector =
+    VECTOR_TYPES.has(layer.type) ||
+    (layer.type === "mbtiles" &&
+      layer.metadata.tileType !== "raster" &&
+      layer.source.type !== "raster");
+  if (isVector) {
+    const mode = styleValue(layer.style, "vectorStyleMode");
+    const stops = styleValue(layer.style, "vectorStyleStops");
+    // Diagram symbology adds one labeled swatch per charted attribute after the
+    // base symbology's swatches, mirroring the QGIS legend.
+    const diagrams = diagramSwatches(layer);
+    if (
+      (mode === "graduated" || mode === "categorized") &&
+      Array.isArray(stops) &&
+      stops.length > 0
+    ) {
+      return [...rampSwatches(stops, mode), ...diagrams];
+    }
+    if (mode === "rule-based") {
+      const swatches = ruleSwatches(layer);
+      if (swatches.length > 0) return [...swatches, ...diagrams];
+    }
+    const primary = pointMarkerSwatch(layer.style) ?? {
+      color: styleValue(layer.style, "fillColor"),
+    };
+    return [primary, ...diagrams];
+  }
+
+  // Raster / service layers: a single neutral marker swatch.
+  return [{ color: NEUTRAL_SWATCH }];
 }
 
 /**

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -371,6 +371,20 @@ export function datasetPageUrl(options: GeoLensClientOptions, datasetId: string)
   return `${options.baseUrl}/datasets/${encodeURIComponent(datasetId)}`;
 }
 
+/**
+ * Map a GeoLens `geometry_type` (e.g. `MULTIPOLYGON`, `LINESTRING`) to the
+ * host's canonical `point | line | polygon` geometry kind, or null when it
+ * can't be classified (mixed/unknown). Used to set a vector-tile layer's
+ * `metadata.geometryType` so the host knows the geometry without local features.
+ */
+export function geometryKind(geometryType: string | null): "point" | "line" | "polygon" | null {
+  const g = (geometryType ?? "").toUpperCase();
+  if (g.includes("POINT")) return "point";
+  if (g.includes("LINE")) return "line"; // LINESTRING / MULTILINESTRING
+  if (g.includes("POLYGON")) return "polygon";
+  return null;
+}
+
 /** STAC 1.0 landing page URL. */
 export function stacCatalogUrl(options: GeoLensClientOptions): string {
   return `${options.baseUrl}/api/stac`;

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -89,7 +89,7 @@ export interface GeoLensLabels {
 
 export const DEFAULT_GEOLENS_LABELS: GeoLensLabels = {
   hint: "Connect to a GeoLens server to browse and add its catalog datasets.",
-  baseUrlPlaceholder: "GeoLens URL, e.g. https://demo.getgeolens.com",
+  baseUrlPlaceholder: "GeoLens URL, e.g. https://datasets.geolibre.app",
   apiKeyPlaceholder: "API key (optional, for private data)",
   connect: "Connect",
   connecting: "Connecting…",
@@ -233,6 +233,58 @@ function clearAllRefreshTimers(): void {
   for (const timer of refreshTimers.values()) clearTimeout(timer);
   refreshTimers.clear();
 }
+
+/** True when the layer's signed tile URL carries an expired (or near-expiry) token. */
+function tileTokenExpired(layer: GeoLibreLayer): boolean {
+  const tiles = layer.source.tiles;
+  const url = Array.isArray(tiles) && typeof tiles[0] === "string" ? tiles[0] : "";
+  const match = url.match(/[?&]exp=(\d+)/);
+  if (!match) return false; // no signed expiry — leave it alone
+  return Number(match[1]) <= Math.floor(Date.now() / 1000) + 5;
+}
+
+/** GeoLens layers currently being re-minted, to avoid overlapping restores. */
+const restoringLayerIds = new Set<string>();
+
+/**
+ * Re-mint tile tokens for GeoLens vector-tile layers restored from a saved
+ * project. Such a layer arrives with a dead token (tokens live seconds to
+ * minutes) and no refresh timer — so its tiles 404 forever. For any GeoLens
+ * layer whose token has expired and that isn't already managed, this mints a
+ * fresh token, patches the layer's `tiles`, and starts the refresh loop.
+ *
+ * Only public datasets restore automatically: the API key is never persisted,
+ * so a private layer stays blank until re-added through the panel.
+ */
+function healRestoredGeoLensLayers(): void {
+  for (const layer of useAppStore.getState().layers) {
+    if (layer.metadata.sourceKind !== "geolens-vector-tiles") continue;
+    if (refreshTimers.has(layer.id) || restoringLayerIds.has(layer.id)) continue;
+    if (!tileTokenExpired(layer)) continue; // a fresh add already has a live token
+    const baseUrl = layer.metadata.geolensBaseUrl;
+    const datasetId = layer.metadata.geolensDatasetId;
+    if (typeof baseUrl !== "string" || typeof datasetId !== "string") continue;
+    const client: GeoLensClientOptions = { baseUrl };
+    restoringLayerIds.add(layer.id);
+    void mintTileToken(client, datasetId, defaultGeoLensFetch)
+      .then((token) => {
+        const current = useAppStore.getState().layers.find((l) => l.id === layer.id);
+        if (!current) return;
+        const { tiles } = vectorTileTemplate(client, token);
+        useAppStore
+          .getState()
+          .updateLayer(layer.id, { source: { ...current.source, tiles: [tiles] } });
+        scheduleTokenRefresh(client, layer.id, datasetId, token.expiresIn, defaultGeoLensFetch);
+      })
+      .catch(() => {}) // a transient failure is retried on the next store change
+      .finally(() => restoringLayerIds.delete(layer.id));
+  }
+}
+
+// Heal on any store change (covers project load and late additions), plus once
+// now for layers already present when this module loads.
+useAppStore.subscribe(healRestoredGeoLensLayers);
+healRestoredGeoLensLayers();
 
 /**
  * Schedule a re-mint of the signed tile token shortly before it expires and

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -281,9 +281,16 @@ function healRestoredGeoLensLayers(): void {
   }
 }
 
-// Heal on any store change (covers project load and late additions), plus once
-// now for layers already present when this module loads.
-useAppStore.subscribe(healRestoredGeoLensLayers);
+// Heal when the layer set changes (covers project load and late additions),
+// plus once now for layers already present when this module loads. Guarded on
+// the `layers` reference so unrelated store churn (pointer, selection, map view)
+// doesn't re-run the scan — useAppStore has no selector-subscribe middleware.
+let lastLayersRef: readonly GeoLibreLayer[] | null = null;
+useAppStore.subscribe((state) => {
+  if (state.layers === lastLayersRef) return;
+  lastLayersRef = state.layers;
+  healRestoredGeoLensLayers();
+});
 healRestoredGeoLensLayers();
 
 /**

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -28,6 +28,7 @@ import {
   datasetPageUrl,
   defaultGeoLensFetch,
   fetchDatasetFields,
+  geometryKind,
   itemsUrl,
   mintTileToken,
   normalizeBaseUrl,
@@ -328,6 +329,11 @@ async function addVectorTilesLayer(
       geolensDatasetId: dataset.id,
       sourceLayers: [sourceLayer],
       fields,
+      // The host's canonical geometry signal — drives the Layers-panel symbol
+      // and default styling when there are no local features to inspect.
+      ...(geometryKind(dataset.geometryType)
+        ? { geometryType: geometryKind(dataset.geometryType) }
+        : {}),
     },
     sourcePath: sourcePathFor(client, dataset),
   };

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -5,6 +5,7 @@ import {
   bboxFromGeometry,
   datasetPageUrl,
   fetchDatasetFields,
+  geometryKind,
   itemsUrl,
   mintTileToken,
   normalizeBaseUrl,
@@ -172,6 +173,19 @@ describe("fetchDatasetFields", () => {
       () => fetchDatasetFields({ baseUrl: "http://h" }, "d", fetchImpl),
       /HTTP 404/,
     );
+  });
+});
+
+describe("geometryKind", () => {
+  it("maps GeoLens geometry types to the host's point/line/polygon", () => {
+    assert.equal(geometryKind("MULTIPOINT"), "point");
+    assert.equal(geometryKind("Point"), "point");
+    assert.equal(geometryKind("MULTILINESTRING"), "line");
+    assert.equal(geometryKind("LineString"), "line");
+    assert.equal(geometryKind("MULTIPOLYGON"), "polygon");
+    assert.equal(geometryKind("Polygon"), "polygon");
+    assert.equal(geometryKind(null), null);
+    assert.equal(geometryKind("GeometryCollection"), null);
   });
 });
 

--- a/tests/layer-legend.test.ts
+++ b/tests/layer-legend.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "../packages/core/src/index";
+import { legendSwatchesForLayer } from "../apps/geolibre-desktop/src/lib/print-legend";
+import { autoLegendItems, layerSwatchShape } from "../apps/geolibre-desktop/src/lib/layer-swatch";
+
+function layer(over: Partial<GeoLibreLayer>): GeoLibreLayer {
+  return {
+    id: "l",
+    name: "Layer",
+    type: "vector-tiles",
+    source: { type: "vector" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    ...over,
+  } as GeoLibreLayer;
+}
+
+describe("legendSwatchesForLayer", () => {
+  it("gives a single fill swatch for a single-symbol vector layer", () => {
+    const s = legendSwatchesForLayer(
+      layer({ style: { ...DEFAULT_LAYER_STYLE, fillColor: "#ff0000" } }),
+    );
+    assert.equal(s.length, 1);
+    assert.equal(s[0].color, "#ff0000");
+  });
+
+  it("gives a neutral swatch for a raster layer", () => {
+    const s = legendSwatchesForLayer(layer({ type: "xyz", source: { type: "raster" } }));
+    assert.equal(s.length, 1);
+    assert.equal(s[0].color, "#94a3b8");
+  });
+
+  it("returns no swatches for a non-legend type (3d-tiles)", () => {
+    assert.deepEqual(legendSwatchesForLayer(layer({ type: "3d-tiles" })), []);
+  });
+});
+
+describe("layerSwatchShape", () => {
+  it("uses metadata.geometryType when present", () => {
+    assert.equal(layerSwatchShape(layer({ metadata: { geometryType: "point" } })), "circle");
+    assert.equal(layerSwatchShape(layer({ metadata: { geometryType: "line" } })), "line");
+    assert.equal(layerSwatchShape(layer({ metadata: { geometryType: "polygon" } })), "square");
+  });
+
+  it("falls back to sampling local GeoJSON geometry", () => {
+    const geojson = {
+      type: "FeatureCollection" as const,
+      features: [
+        {
+          type: "Feature" as const,
+          properties: {},
+          geometry: { type: "MultiLineString" as const, coordinates: [] },
+        },
+      ],
+    };
+    assert.equal(layerSwatchShape(layer({ type: "geojson", metadata: {}, geojson })), "line");
+  });
+
+  it("defaults to square for raster/unknown", () => {
+    assert.equal(layerSwatchShape(layer({ type: "cog", metadata: {} })), "square");
+  });
+});
+
+describe("autoLegendItems", () => {
+  it("excludes hidden layers and lists visible ones top-first", () => {
+    const layers = [
+      layer({ id: "a", name: "A", visible: true, metadata: { geometryType: "point" } }),
+      layer({ id: "b", name: "B", visible: false }),
+      layer({ id: "c", name: "C", visible: true, metadata: { geometryType: "line" } }),
+    ];
+    const items = autoLegendItems(layers);
+    // Store is bottom-first; legend is top-first → C then A; B hidden.
+    assert.deepEqual(
+      items.map((i) => i.label),
+      ["C", "A"],
+    );
+    assert.equal(items[0].shape, "line");
+    assert.equal(items[1].shape, "circle");
+  });
+
+  it("expands a categorized layer into a name row plus one row per class", () => {
+    const styled = layer({
+      id: "cat",
+      name: "Era",
+      metadata: { geometryType: "polygon" },
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        vectorStyleMode: "categorized",
+        vectorStyleStops: [
+          { value: "old", color: "#8c2d04" },
+          { value: "new", color: "#08306b" },
+        ],
+      },
+    });
+    const items = autoLegendItems([styled]);
+    assert.equal(items[0].label, "Era"); // name row
+    assert.ok(items.some((i) => i.label === "old" && i.color === "#8c2d04"));
+    assert.ok(items.some((i) => i.label === "new" && i.color === "#08306b"));
+  });
+});

--- a/tests/layer-legend.test.ts
+++ b/tests/layer-legend.test.ts
@@ -59,8 +59,9 @@ describe("layerSwatchShape", () => {
     assert.equal(layerSwatchShape(layer({ type: "geojson", metadata: {}, geojson })), "line");
   });
 
-  it("defaults to square for raster/unknown", () => {
-    assert.equal(layerSwatchShape(layer({ type: "cog", metadata: {} })), "square");
+  it("classifies raster/imagery layers as raster", () => {
+    assert.equal(layerSwatchShape(layer({ type: "cog", metadata: {} })), "raster");
+    assert.equal(layerSwatchShape(layer({ type: "xyz", metadata: {} })), "raster");
   });
 });
 

--- a/tests/layer-legend.test.ts
+++ b/tests/layer-legend.test.ts
@@ -63,6 +63,13 @@ describe("layerSwatchShape", () => {
     assert.equal(layerSwatchShape(layer({ type: "cog", metadata: {} })), "raster");
     assert.equal(layerSwatchShape(layer({ type: "xyz", metadata: {} })), "raster");
   });
+
+  it("does not classify 3D/point-cloud/media layers as raster", () => {
+    // These are neither vector nor imagery — they must not get the raster glyph.
+    assert.notEqual(layerSwatchShape(layer({ type: "3d-tiles", metadata: {} })), "raster");
+    assert.notEqual(layerSwatchShape(layer({ type: "lidar", metadata: {} })), "raster");
+    assert.notEqual(layerSwatchShape(layer({ type: "video", metadata: {} })), "raster");
+  });
 });
 
 describe("autoLegendItems", () => {


### PR DESCRIPTION
## Summary
Two related, GeoLens-inspired improvements to how layers read at a glance:

1. **Layers-panel symbology swatch** — each layer row now shows a small symbol before its name: a colored **dot** (point), **line** (line), or **square** (polygon / raster / service), colored by the layer's first symbology color and dimmed when the layer is hidden. Reflects the layer type and its styling.
2. **Automatic on-map legend** — the existing Legend panel now auto-populates from the currently **visible** layers and stays in sync as layers are shown/hidden, renamed, or restyled (items appear/disappear reactively). No manual legend building needed.

Both reuse the existing print-legend generator (`buildLegend`) and the existing legend control, so symbology handling (single / graduated / categorized / rule-based / point-marker / raster) is shared and consistent between the panel swatch, the legend, and print/export.

## Implementation notes
- Refactored `print-legend.ts` to expose `legendSwatchesForLayer(layer)` (per-layer, visibility-independent); `buildLegend` now maps over it. New `lib/layer-swatch.ts` derives the panel swatch (color + geometry shape) and flattens visible layers into legend items.
- `useAutoLegend` feeds `buildLegend(visibleLayers)` into `openLegendPanelWithItems` while the Legend panel is open, subscribed to the store.
- Geometry shape resolves from the canonical `metadata.geometryType`, then local GeoJSON, then a neutral square. The GeoLens plugin now records `metadata.geometryType` (mapped from the dataset's geometry type) so its vector-tile layers get the right shape without local features.
- No new i18n keys (reuses the existing "Legend" string).

## Test plan
- [x] `node --test` — 28/28 pass (new `layer-legend` suite: swatch shape, `legendSwatchesForLayer`, `autoLegendItems`; new `geometryKind` test)
- [x] `tsc -b` typecheck clean; `pre-commit` (oxfmt/eslint/npm build) passes
- [x] Manual with the NYC datasets via the GeoLens plugin: Subway Lines → line swatch, Subway Stations → dot swatch, Buildings → square swatch; toggling the Legend shows all three, hiding a layer removes it from the legend live

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-layer swatch icons in the Layers panel, reflecting geometry, style, and visibility.
  * Legend now auto-refreshes to stay in sync with currently visible layers and symbology.
  * Improved legend swatch generation across raster, vector, categorized/graduated, rule-based, and diagram styles.
  * Added automatic backfilling of missing geometry types for vector-tile layers.
* **Bug Fixes**
  * Improved GeoLens project recovery by refreshing near-expired tile tokens.
* **Tests**
  * Added/extended tests for geometry detection and legend/swatch behavior, including ordering and visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->