### PR TITLE
feat(vector): pick which GeoPackage layers to load in the Add Vector panel

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -82,7 +82,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.5.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.9.3",
+    "maplibre-gl-vector": "^0.10.0",
     "openai": "^6.48.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2654,11 +2654,16 @@ body,
    selectors outrank the upstream prefers-color-scheme block regardless of
    stylesheet order. The attribute picker popup is themed through the same
    variables; it mounts in MapLibre's popup container without a hook for a
-   custom class, so it is keyed off html:not(.dark)/.dark instead. */
+   custom class, so it is keyed off html:not(.dark)/.dark instead. The
+   multi-layer picker modal mounts straight into the map container (so it
+   stays visible while the panel is hidden), which has no custom-class hook
+   either, so it is keyed the same way. */
 .vector-control.geolibre-vector-control,
 .vector-control-panel.geolibre-vector-panel,
 html:not(.dark) .vector-control-popup,
-.dark .vector-control-popup {
+html:not(.dark) .vector-control-layer-picker,
+.dark .vector-control-popup,
+.dark .vector-control-layer-picker {
   --vc-bg: hsl(var(--popover));
   --vc-text: hsl(var(--popover-foreground));
   --vc-text-strong: hsl(var(--foreground));
@@ -2684,7 +2689,8 @@ html:not(.dark) .vector-control-popup,
 
 .dark .vector-control.geolibre-vector-control,
 .dark .vector-control-panel.geolibre-vector-panel,
-.dark .vector-control-popup {
+.dark .vector-control-popup,
+.dark .vector-control-layer-picker {
   --vc-shadow: 0 0 0 2px hsl(0 0% 0% / 0.4);
 
   color-scheme: dark;

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.5.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.9.3",
+        "maplibre-gl-vector": "^0.10.0",
         "openai": "^6.48.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17163,9 +17163,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.9.3.tgz",
-      "integrity": "sha512-2kqPNmhHV3WkD9jokOkemS5qXE57WTDO3eOPVxFBJrqnyebBa3KMHfBOD5TiaTMxGfe9OpP0eP8CStDLYpqmVA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.0.tgz",
+      "integrity": "sha512-EpOg8iVi6/j8XiJ7qM2E24rmM9oHGkzPmnPaoNdP5l2SDPYdxkF0rg/dUSdB496dfARIDxV2jd0/0v2zAXwEqw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21820,7 +21820,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.5.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.9.3",
+        "maplibre-gl-vector": "^0.10.0",
         "netcdfjs": "^4.0.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -55,7 +55,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.5.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.9.3",
+    "maplibre-gl-vector": "^0.10.0",
     "netcdfjs": "^4.0.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",

--- a/packages/plugins/src/plugins/maplibre-source-coop.ts
+++ b/packages/plugins/src/plugins/maplibre-source-coop.ts
@@ -26,6 +26,7 @@
 
 import { useAppStore } from "@geolibre/core";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+import { isVectorLayerSelectionCancelled } from "maplibre-gl-vector/errors";
 import { addPMTilesLayerFromUrl } from "./maplibre-components";
 import { addVectorLayerFromUrl } from "./maplibre-vector";
 import {
@@ -697,7 +698,12 @@ function buildPanel(
       const added = await addObjectToMap(app, object, mode);
       if (!added) error = labels.addError(labels.unsupportedTitle);
     } catch (caught) {
-      error = labels.addError(errorMessage(caught));
+      // Dismissing the vector control's multi-layer picker rejects the add, but
+      // the user chose to load nothing: leave the card as it was instead of
+      // reporting a failure.
+      if (!isVectorLayerSelectionCancelled(caught)) {
+        error = labels.addError(errorMessage(caught));
+      }
     } finally {
       addInFlight.delete(object.key);
       render();

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -1,5 +1,10 @@
 import { getSpatialExtensionPath, hasPathTraversal, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
+// Imported from the `/errors` subpath, a standalone entry point holding just
+// these helpers. The package root re-exports VectorControl, so importing from
+// there would statically pull the control's module graph in and undo the
+// deliberate lazy `import("maplibre-gl-vector")` in getVectorControlClass.
+import { isVectorLayerSelectionCancelled } from "maplibre-gl-vector/errors";
 import type {
   VectorControl,
   VectorControlEventHandler,
@@ -708,6 +713,11 @@ export type VectorDataSink = Pick<VectorControl, "addData">;
  * loose `.shp` loads as a single layer. Each file is added independently; an
  * empty list (e.g. a cancelled dialog) loads nothing.
  *
+ * A multi-layer container (a GeoPackage with several feature tables) opens the
+ * control's layer picker. Dismissing it rejects that file's load as a
+ * cancellation, which is skipped here rather than aborting the files behind it:
+ * declining one container must not silently drop the rest of the selection.
+ *
  * @param control - The vector control (or anything with `addData`).
  * @param picked - The picked files (empty when the dialog was cancelled).
  */
@@ -717,11 +727,17 @@ export async function addPickedVectorFiles(
 ): Promise<void> {
   for (const { file, companionFiles, sourcePath, nativeData } of picked) {
     const source = nativeData ? nativeGeoJsonFile(file, nativeData) : file;
-    await control.addData(source, {
-      ...(nativeData ? { name: file.name } : {}),
-      ...(!nativeData && companionFiles.length > 0 ? { companionFiles } : {}),
-      ...(sourcePath ? { sourcePath } : {}),
-    });
+    try {
+      await control.addData(source, {
+        ...(nativeData ? { name: file.name } : {}),
+        ...(!nativeData && companionFiles.length > 0 ? { companionFiles } : {}),
+        ...(sourcePath ? { sourcePath } : {}),
+      });
+    } catch (error) {
+      // A real load failure still propagates (the caller logs it, and the
+      // control already surfaced it through its 'error' event).
+      if (!isVectorLayerSelectionCancelled(error)) throw error;
+    }
   }
 }
 

--- a/tests/vector-desktop-picker.test.ts
+++ b/tests/vector-desktop-picker.test.ts
@@ -100,4 +100,37 @@ describe("addPickedVectorFiles", () => {
 
     assert.equal(calls.length, 0);
   });
+
+  it("keeps loading the rest when a multi-layer picker is dismissed", async () => {
+    const { sink, calls } = createSink();
+    const cancelled = new Error("No layers were selected from city.");
+    cancelled.name = "VectorLayerSelectionCancelledError";
+    const inner = sink.addData;
+    sink.addData = (async (source: File, options?: never) => {
+      if (source.name === "city.gpkg") throw cancelled;
+      return inner(source, options);
+    }) as typeof sink.addData;
+
+    await addPickedVectorFiles(sink, [
+      { file: new File(["x"], "city.gpkg"), companionFiles: [] },
+      { file: new File(["x"], "after.geojson"), companionFiles: [] },
+    ]);
+
+    assert.deepEqual(
+      calls.map((call) => call.name),
+      ["after.geojson"],
+    );
+  });
+
+  it("still propagates a real load failure", async () => {
+    const { sink } = createSink();
+    sink.addData = (async () => {
+      throw new Error("boom");
+    }) as typeof sink.addData;
+
+    await assert.rejects(
+      addPickedVectorFiles(sink, [{ file: new File(["x"], "a.geojson"), companionFiles: [] }]),
+      /boom/,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #1380

## Problem

Add Data → Vector Layer added **every** layer of a multi-layer GeoPackage at once. A container with many feature tables filled the layer stack with layers the user never asked for and paid the load cost for each, with no way to choose a subset.

Reproduced before fixing with a three-layer GeoPackage (`us_states`, `us_cities`, `us_regions`, built from real US census-style data): dropping it into the panel silently added all three.

## Root cause

Not in GeoLibre. The Add Vector Layer panel is `maplibre-gl-vector`, and the auto-expansion lives in its `LayerManager._maybeExpandLayers`, which loaded every layer `listLayers` reported.

## Upstream fix

opengeos/maplibre-gl-vector#45, released as **v0.10.0**.

Multi-layer expansion now runs through a layer selector. By default that is a modal picker over the map listing every layer with a checkbox, all preselected — so confirming reproduces the previous result, and unchecking loads a subset. Dismissing it loads nothing and rejects with a `VectorLayerSelectionCancelledError` (deliberately not an `'error'` event, since nothing failed). Hosts can replace the picker via `VectorControlOptions.selectLayers`, disable the prompt with `selectLayers: false`, or name a subset up front with the new per-load `sourceLayers`.

## GeoLibre side

- Bump `maplibre-gl-vector` to `^0.10.0` in both `package.json`s that declare it.
- `addPickedVectorFiles` skips a dismissed container and keeps loading the files behind it, instead of aborting the rest of the selection. A real load failure still propagates.
- The Source Cooperative browser leaves the card as it was on a dismissed picker rather than reporting an add failure.
- The picker mounts in the map container (so it shows while the control is hidden), which has no custom-class hook, so its `--vc-*` variables are keyed off `html:not(.dark)` / `.dark` in `index.css` — the same pattern the attribute popup already uses.
- `isVectorLayerSelectionCancelled` is imported from the package's new `/errors` subpath, a standalone entry point, so the helper does not statically pull the control's module graph in and undo the deliberate lazy `import("maplibre-gl-vector")`.

Project restore is unaffected: replayed layers carry their `sourceLayer`, which skips the prompt.

## Verification

Driven in the real app (dev server) with a three-layer GeoPackage built from real US states/cities/regions data, against the **published** 0.10.0:

- **Light theme**: picker opens above the Add Vector Layer panel with all three layers checked; unchecking `us_cities` and confirming loads exactly `us_states` and `us_regions` — the Layers panel shows those two and nothing else. Unchecking two and confirming loads the single remaining layer (the button reads "Load 1 layer").
- **Dark theme**: the dialog picks up the app's dark tokens; Escape dismisses it with the layer list unchanged and no console errors.
- Cancel leaves no status line, no error, and no new layers.

Also: `npm run build`, `npm run test:frontend` (3450 passing, including 2 new `addPickedVectorFiles` cases covering the cancellation skip and that a real failure still propagates), and `pre-commit run --files <changed>` all clean.

## Known limitations (worth follow-ups, not in scope here)

- The picker's strings are English-only, like the rest of the upstream panel's chrome ("Drop file or click to browse", "Load", "Layers"), so they do not go through GeoLibre's i18n catalogs.
- The Browser panel and drag-and-drop use GeoLibre's own loader (`gpkg-reader.ts`), not the vector control. That path has the opposite defect: it reads only the **first** feature layer of a GeoPackage and silently ignores the rest. The issue lists the Browser panel under optional implementation notes; fixing it means threading a selection through `loadDroppedVectorPaths` and the native Tauri reader as well, so it is better as its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when dismissing multi-layer vector selections, allowing other selected layers to continue loading.
  - Prevented cancellation actions from appearing as errors while preserving reporting for genuine loading failures.
  - Updated vector controls so layer pickers follow the app’s light and dark theme styling consistently.

- **Tests**
  - Added coverage for cancelled layer selections and genuine loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->