### PR TITLE
fix(symbology): graduated classes are discrete, with correct class breaks

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -6,6 +6,7 @@ import {
   type ExpressionVariable,
   type FillPattern,
   type GeometryGeneratorType,
+  type GraduatedClassificationScheme,
   type LabelStyle,
   type LayerType,
   type LineDecoration,
@@ -17,8 +18,7 @@ import {
   type VectorStyleMode,
   type VectorStyleStop,
   collectDiagramData,
-  createEqualIntervalBreaks,
-  createQuantileBreaks,
+  createGraduatedClassBreaks,
   geojsonHasZCoordinates,
   interpolateRampColors,
   isStyleLibraryTargetLayer,
@@ -549,15 +549,19 @@ export function createGraduatedStops(
   const max = Math.max(...values);
   if (min === max) return [{ value: min, color: colors.at(-1) ?? "#2563eb" }];
 
-  const breaks =
-    classificationScheme === "quantile"
-      ? createQuantileBreaks(values, count)
-      : classificationScheme === "natural-breaks"
-        ? createNaturalBreaks(values, count)
-        : createEqualIntervalBreaks(min, max, count);
+  // The breaks are class lower bounds, so `count` classes give `count` stops
+  // and the top class is open-ended above (see createGraduatedClassBreaks).
+  // normalizeClassificationScheme keeps the scheme to the three known values;
+  // anything else classifies as equal interval, as it did before.
+  const breaks = createGraduatedClassBreaks(
+    values,
+    count,
+    classificationScheme as GraduatedClassificationScheme,
+  );
 
-  // Natural breaks can yield fewer breaks than the requested count when the
-  // layer has fewer unique values; align the color count so none are dropped.
+  // Any scheme can yield fewer breaks than the requested count when the layer
+  // has few unique values (duplicate breaks collapse); align the color count so
+  // none are dropped.
   const stopColors =
     breaks.length === count ? colors : interpolateRampColors(colorRamp, breaks.length);
 
@@ -640,76 +644,6 @@ function normalizeClassificationScheme(mode: VectorStyleMode, scheme: string): s
   return options.some((option) => option.value === scheme)
     ? scheme
     : defaultClassificationScheme(mode);
-}
-
-const MAX_NATURAL_BREAK_SAMPLES = 1000;
-
-function downsampleSortedValues(values: number[], maxSamples: number): number[] {
-  if (values.length <= maxSamples) return values;
-  const result: number[] = [];
-  const step = (values.length - 1) / (maxSamples - 1);
-  for (let index = 0; index < maxSamples; index += 1) {
-    result.push(values[Math.round(index * step)]);
-  }
-  return result;
-}
-
-function createNaturalBreaks(values: number[], count: number): number[] {
-  const unique = Array.from(new Set(values)).sort((a, b) => a - b);
-  // The Jenks DP below is roughly O(n^2 * k); cap the input so large layers
-  // do not freeze the Style panel on the UI thread.
-  const sorted = downsampleSortedValues(unique, MAX_NATURAL_BREAK_SAMPLES);
-  if (sorted.length <= count) return sorted;
-
-  const lowerClassLimits = Array.from({ length: sorted.length + 1 }, () =>
-    Array(count + 1).fill(0),
-  );
-  const varianceCombinations = Array.from({ length: sorted.length + 1 }, () =>
-    Array(count + 1).fill(Number.POSITIVE_INFINITY),
-  );
-
-  for (let classIndex = 1; classIndex <= count; classIndex += 1) {
-    lowerClassLimits[1][classIndex] = 1;
-    varianceCombinations[1][classIndex] = 0;
-  }
-
-  for (let valueIndex = 2; valueIndex <= sorted.length; valueIndex += 1) {
-    let sum = 0;
-    let sumSquares = 0;
-    let weight = 0;
-
-    for (let lowerIndex = 1; lowerIndex <= valueIndex; lowerIndex += 1) {
-      const currentIndex = valueIndex - lowerIndex + 1;
-      const value = sorted[currentIndex - 1];
-      weight += 1;
-      sum += value;
-      sumSquares += value * value;
-      const variance = sumSquares - (sum * sum) / weight;
-      const previousIndex = currentIndex - 1;
-      if (previousIndex === 0) continue;
-
-      for (let classIndex = 2; classIndex <= count; classIndex += 1) {
-        const candidate = variance + varianceCombinations[previousIndex][classIndex - 1];
-        if (varianceCombinations[valueIndex][classIndex] >= candidate) {
-          lowerClassLimits[valueIndex][classIndex] = currentIndex;
-          varianceCombinations[valueIndex][classIndex] = candidate;
-        }
-      }
-    }
-
-    lowerClassLimits[valueIndex][1] = 1;
-    varianceCombinations[valueIndex][1] = sumSquares - (sum * sum) / Math.max(1, weight);
-  }
-
-  const breaks = Array(count).fill(sorted[0]) as number[];
-  breaks[count - 1] = sorted[sorted.length - 1];
-  let valueIndex = sorted.length;
-  for (let classIndex = count; classIndex >= 2; classIndex -= 1) {
-    const lowerClassLimit = lowerClassLimits[valueIndex][classIndex] - 1;
-    breaks[classIndex - 2] = sorted[Math.max(0, lowerClassLimit)];
-    valueIndex = lowerClassLimit;
-  }
-  return breaks;
 }
 
 function chooseDefaultStyleProperty(

--- a/apps/geolibre-desktop/src/lib/assistant/symbology.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/symbology.ts
@@ -1,6 +1,5 @@
 import {
-  createEqualIntervalBreaks,
-  createQuantileBreaks,
+  createGraduatedClassBreaks,
   interpolateRampColors,
   type GeoLibreLayer,
   type LayerStyle,
@@ -41,10 +40,10 @@ function graduatedStops(
   scheme: "equal-interval" | "quantile",
   colorRamp: string,
 ): VectorStyleStop[] {
-  const breaks =
-    scheme === "quantile"
-      ? createQuantileBreaks(values, classCount)
-      : createEqualIntervalBreaks(Math.min(...values), Math.max(...values), classCount);
+  // Class lower bounds, matching the Style panel: the top class is open-ended
+  // above rather than ending at the maximum (see createGraduatedClassBreaks).
+  // Duplicate breaks collapse, so size the ramp off the breaks, not the count.
+  const breaks = createGraduatedClassBreaks(values, classCount, scheme);
   const colors = interpolateRampColors(colorRamp, breaks.length);
   return breaks.map((value, index) => ({
     value,

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -270,6 +270,11 @@ export function createEqualIntervalBreaks(min: number, max: number, count: numbe
 /**
  * Builds `count` quantile break values from a sample of numeric values.
  *
+ * These are ramp *edges* spanning the whole sample (the first break is the
+ * minimum, the last the maximum), matching {@link createEqualIntervalBreaks}.
+ * Graduated vector classes want class *lower bounds* instead; use
+ * {@link createGraduatedClassBreaks}.
+ *
  * @param values - The sample values.
  * @param count - Number of breaks to produce.
  * @returns The quantile break values.
@@ -282,9 +287,152 @@ export function createQuantileBreaks(values: number[], count: number): number[] 
   if (sorted.length === 0) return [];
   return Array.from({ length: count }, (_, index) => {
     const position = count === 1 ? 0 : (index / (count - 1)) * (sorted.length - 1);
-    const lowerIndex = Math.floor(position);
-    const upperIndex = Math.min(sorted.length - 1, Math.ceil(position));
-    const ratio = position - lowerIndex;
-    return sorted[lowerIndex] + (sorted[upperIndex] - sorted[lowerIndex]) * ratio;
+    return quantileAtPosition(sorted, position);
   });
+}
+
+/** Linearly interpolated order statistic at a fractional index into `sorted`. */
+function quantileAtPosition(sorted: number[], position: number): number {
+  const lowerIndex = Math.floor(position);
+  const upperIndex = Math.min(sorted.length - 1, Math.ceil(position));
+  const ratio = position - lowerIndex;
+  return sorted[lowerIndex] + (sorted[upperIndex] - sorted[lowerIndex]) * ratio;
+}
+
+/** The classification schemes the graduated vector renderer offers. */
+export type GraduatedClassificationScheme = "equal-interval" | "quantile" | "natural-breaks";
+
+/**
+ * Builds the class *lower bounds* for a graduated vector renderer.
+ *
+ * A graduated renderer's stops are lower bounds, not ramp edges: with N stops
+ * sorted ascending, class `i` covers `[stops[i], stops[i + 1])` and the last
+ * class is open-ended above. The legend (`≥ value`) and the QML/SLD exporters
+ * already read them that way, so the breaks must follow the same convention:
+ * `count` classes yield `count` breaks whose first entry is the sample minimum
+ * and whose last entry opens the top class. Producing edges instead (ending at
+ * the maximum) leaves the top class holding only the single largest feature and
+ * puts the interior breaks at the wrong percentiles.
+ *
+ * The result is strictly ascending: duplicate breaks (a skewed sample can push
+ * several quantiles onto the same value) are collapsed, so the caller may get
+ * fewer than `count` breaks and must size its colors off `breaks.length`.
+ * MapLibre rejects a `step` expression whose inputs are not strictly ascending,
+ * so this de-duplication is load-bearing, not cosmetic.
+ *
+ * @param values - The finite numeric values of the classified property.
+ * @param count - Number of classes requested.
+ * @param scheme - The classification scheme.
+ * @returns Up to `count` strictly ascending class lower bounds.
+ */
+export function createGraduatedClassBreaks(
+  values: number[],
+  count: number,
+  scheme: GraduatedClassificationScheme,
+): number[] {
+  if (count <= 0 || values.length === 0) return [];
+  if (scheme === "natural-breaks") return ascendingUnique(naturalClassBreaks(values, count));
+  const sorted = [...values].sort((a, b) => a - b);
+  if (scheme === "quantile") {
+    return ascendingUnique(
+      Array.from({ length: count }, (_, index) =>
+        quantileAtPosition(sorted, (index / count) * (sorted.length - 1)),
+      ),
+    );
+  }
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  return ascendingUnique(
+    Array.from({ length: count }, (_, index) => min + ((max - min) * index) / count),
+  );
+}
+
+/** Drops non-finite breaks and collapses repeats, keeping ascending order. */
+function ascendingUnique(breaks: number[]): number[] {
+  const out: number[] = [];
+  for (const value of breaks) {
+    if (!Number.isFinite(value)) continue;
+    if (out.length > 0 && value <= out[out.length - 1]) continue;
+    out.push(value);
+  }
+  return out;
+}
+
+/** Cap on the Jenks input size; the DP below is roughly O(n^2 * k). */
+const MAX_NATURAL_BREAK_SAMPLES = 1000;
+
+/** Evenly thins a sorted array down to at most `maxSamples` entries. */
+function downsampleSortedValues(values: number[], maxSamples: number): number[] {
+  if (values.length <= maxSamples) return values;
+  const result: number[] = [];
+  const step = (values.length - 1) / (maxSamples - 1);
+  for (let index = 0; index < maxSamples; index += 1) {
+    result.push(values[Math.round(index * step)]);
+  }
+  return result;
+}
+
+/**
+ * Jenks natural breaks: the class lower bounds that minimize the summed
+ * within-class variance. Returns the sample minimum first, then the first value
+ * of each subsequent class.
+ */
+function naturalClassBreaks(values: number[], count: number): number[] {
+  const unique = Array.from(new Set(values)).sort((a, b) => a - b);
+  // Cap the input so a large layer does not freeze the Style panel's UI thread.
+  const sorted = downsampleSortedValues(unique, MAX_NATURAL_BREAK_SAMPLES);
+  if (sorted.length <= count) return sorted;
+
+  const lowerClassLimits = Array.from({ length: sorted.length + 1 }, () =>
+    Array(count + 1).fill(0),
+  );
+  const varianceCombinations = Array.from({ length: sorted.length + 1 }, () =>
+    Array(count + 1).fill(Number.POSITIVE_INFINITY),
+  );
+
+  for (let classIndex = 1; classIndex <= count; classIndex += 1) {
+    lowerClassLimits[1][classIndex] = 1;
+    varianceCombinations[1][classIndex] = 0;
+  }
+
+  for (let valueIndex = 2; valueIndex <= sorted.length; valueIndex += 1) {
+    let sum = 0;
+    let sumSquares = 0;
+    let weight = 0;
+
+    for (let lowerIndex = 1; lowerIndex <= valueIndex; lowerIndex += 1) {
+      const currentIndex = valueIndex - lowerIndex + 1;
+      const value = sorted[currentIndex - 1];
+      weight += 1;
+      sum += value;
+      sumSquares += value * value;
+      const variance = sumSquares - (sum * sum) / weight;
+      const previousIndex = currentIndex - 1;
+      if (previousIndex === 0) continue;
+
+      for (let classIndex = 2; classIndex <= count; classIndex += 1) {
+        const candidate = variance + varianceCombinations[previousIndex][classIndex - 1];
+        if (varianceCombinations[valueIndex][classIndex] >= candidate) {
+          lowerClassLimits[valueIndex][classIndex] = currentIndex;
+          varianceCombinations[valueIndex][classIndex] = candidate;
+        }
+      }
+    }
+
+    lowerClassLimits[valueIndex][1] = 1;
+    varianceCombinations[valueIndex][1] = sumSquares - (sum * sum) / Math.max(1, weight);
+  }
+
+  // Walk the DP table back from the top class: `lowerClassLimits[i][k]` is the
+  // 1-based index in `sorted` where class `k` starts, which is exactly that
+  // class's lower bound. Class 1 always starts at the sample minimum.
+  const breaks = Array(count).fill(sorted[0]) as number[];
+  let valueIndex = sorted.length;
+  for (let classIndex = count; classIndex >= 2; classIndex -= 1) {
+    const lowerClassLimit = Math.max(1, lowerClassLimits[valueIndex][classIndex]);
+    breaks[classIndex - 1] = sorted[lowerClassLimit - 1];
+    valueIndex = lowerClassLimit - 1;
+  }
+  breaks[0] = sorted[0];
+  return breaks;
 }

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -276,7 +276,14 @@ export function parseJsonExpression(expression: string): unknown[] | null {
  * Builds the data-driven color value for a vector layer's current style mode.
  * `single` (or any mode that cannot produce a valid expression) returns the
  * flat fallback color; `categorized` returns a `match` expression, `graduated`
- * an `interpolate` expression, and `expression` the parsed user expression.
+ * a `step` expression, and `expression` the parsed user expression.
+ *
+ * Graduated stops are class lower bounds (see
+ * {@link createGraduatedClassBreaks}), so the classes are discrete: the map
+ * paints exactly one color per class, which is what the legend (`≥ value`) and
+ * the QML/SLD exporters already describe. Rendering them as a continuous
+ * `interpolate` instead blends a shade per feature, so a 4-class layer draws in
+ * many more than 4 colors and stops matching its own legend (#1384).
  *
  * @param style - The layer style.
  * @param fallbackColor - The flat color used for `single` mode and as the
@@ -312,21 +319,37 @@ export function vectorColorExpression(style: LayerStyle, fallbackColor: string):
     ];
   }
 
-  const stops = styleValue(style, "vectorStyleStops")
+  const stops = graduatedStops(style);
+  if (stops.length < 2) return fallbackColor;
+
+  // `step` outputs the base color below the first break, then switches at each
+  // subsequent break, so every feature lands in exactly one class and features
+  // under the lowest break keep the first class's color (matching how the SLD
+  // exporter writes its leading `< first` rule).
+  return [
+    "step",
+    ["to-number", ["get", property], stops[0].value],
+    stops[0].color,
+    ...stops.slice(1).flatMap((stop) => [stop.value, stop.color]),
+  ];
+}
+
+/**
+ * The graduated stops of a style, cleaned for rendering: non-numeric values and
+ * invalid colors dropped, sorted ascending, and de-duplicated. MapLibre rejects
+ * a `step` expression whose inputs are not strictly ascending, and stops reach
+ * here from hand-edited projects and style imports as well as the Style panel,
+ * so repeats are dropped rather than trusted away.
+ */
+function graduatedStops(style: LayerStyle): { color: string; value: number }[] {
+  const sorted = styleValue(style, "vectorStyleStops")
     .map((stop) => ({
       color: stop.color,
       value: typeof stop.value === "number" ? stop.value : Number.parseFloat(stop.value),
     }))
     .filter((stop) => Number.isFinite(stop.value) && isHexColor(stop.color))
     .sort((a, b) => a.value - b.value);
-  if (stops.length < 2) return fallbackColor;
-
-  return [
-    "interpolate",
-    ["linear"],
-    ["to-number", ["get", property], stops[0].value],
-    ...stops.flatMap((stop) => [stop.value, stop.color]),
-  ];
+  return sorted.filter((stop, index) => index === 0 || stop.value > sorted[index - 1].value);
 }
 
 /**

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -136,9 +136,11 @@ function wrappedProperty(node: unknown): string | null {
 /**
  * Reverse a color paint value (string or MapLibre expression) back into a
  * GeoLibre renderer. Recognizes the exact shapes the exporter produces:
- * `match` (categorized), `interpolate`/`linear` over a numeric field
- * (graduated), and `case` (rule-based); any other expression is preserved as an
- * `expression` renderer. A `coalesce` simplestyle wrapper is unwrapped first.
+ * `match` (categorized), `step` over a numeric field (graduated), and `case`
+ * (rule-based); any other expression is preserved as an `expression` renderer.
+ * A `coalesce` simplestyle wrapper is unwrapped first. `interpolate` over a
+ * numeric field is also read as graduated, for styles GeoLibre exported before
+ * the graduated renderer became discrete and for hand-written styles.
  */
 function parseColorValue(value: unknown, warnings: string[]): ParsedColor {
   const flat = asString(value);
@@ -165,6 +167,7 @@ function parseColorValue(value: unknown, warnings: string[]): ParsedColor {
   }
 
   if (array[0] === "match") return parseMatch(array, warnings);
+  if (array[0] === "step") return parseStepColor(array, warnings);
   if (array[0] === "interpolate") return parseInterpolateColor(array, warnings);
   if (array[0] === "case") return parseCase(array);
 
@@ -221,10 +224,50 @@ function parseMatch(array: unknown[], warnings: string[]): ParsedColor {
 }
 
 /**
+ * Parse `["step", ["to-number", ["get", p], v1], c1, v2, c2, ...]` as a
+ * graduated color renderer, the shape the exporter writes. The base output is
+ * the first class's color and the input's `to-number` fallback is that class's
+ * lower bound, so the leading stop is recovered from the input rather than the
+ * pairs. A `step` over a different input (`zoom`) is not graduated color, so it
+ * is preserved as an expression.
+ */
+function parseStepColor(array: unknown[], warnings: string[]): ParsedColor {
+  const property = wrappedProperty(array[1]);
+  const firstValue = asFiniteNumber(asArray(array[1])?.[2]);
+  const firstColor = asString(array[2]);
+  if (!property || firstValue === null || firstColor === null) {
+    return { mode: "expression", expression: JSON.stringify(array) };
+  }
+  const body = array.slice(3);
+  const stops: VectorStyleStop[] = [{ value: firstValue, color: firstColor }];
+  let droppedStop = false;
+  for (let index = 0; index + 1 < body.length; index += 2) {
+    const value = asFiniteNumber(body[index]);
+    const color = asString(body[index + 1]);
+    if (value === null || color === null) {
+      droppedStop = true;
+      continue;
+    }
+    stops.push({ value, color });
+  }
+  if (droppedStop && stops.length >= 2) {
+    warnings.push("Some graduated stops used a non-flat color and were skipped.");
+  }
+  if (stops.length < 2) {
+    warnings.push(
+      "A `step` color expression had too few classes to read as a graduated renderer; kept it as a raw expression.",
+    );
+    return { mode: "expression", expression: JSON.stringify(array) };
+  }
+  return { mode: "graduated", property, stops };
+}
+
+/**
  * Parse `["interpolate", ["linear"], ["to-number", ["get", p], x], v1, c1, ...]`
- * as a graduated color renderer. A different interpolation input (`zoom`,
- * `heatmap-density`) is not graduated color, so it is preserved as an
- * expression.
+ * as a graduated color renderer. Retained for styles GeoLibre exported before
+ * its graduated renderer became discrete, and for hand-written continuous
+ * ramps. A different interpolation input (`zoom`, `heatmap-density`) is not
+ * graduated color, so it is preserved as an expression.
  */
 function parseInterpolateColor(array: unknown[], warnings: string[]): ParsedColor {
   const property = wrappedProperty(array[2]);

--- a/packages/map/src/qml-export.ts
+++ b/packages/map/src/qml-export.ts
@@ -432,7 +432,7 @@ function graduatedRenderer(
   }
 
   warnings.push(
-    "The graduated color ramp was written as discrete QML class ranges (QGIS graduated convention); the continuous interpolation is approximated and features below the lowest class are left unclassified.",
+    "The graduated classes were written as QML class ranges (QGIS graduated convention); features below the lowest class are left unclassified rather than taking the first class's color.",
   );
 
   const ranges: string[] = [];

--- a/packages/map/src/sld-export.ts
+++ b/packages/map/src/sld-export.ts
@@ -549,15 +549,13 @@ function graduatedRules(
     .filter((stop) => Number.isFinite(stop.value) && isHexColor(stop.color))
     .sort((a, b) => a.value - b.value);
 
-  warnings.push(
-    "The graduated color ramp was written as discrete SLD class breaks; the continuous interpolation is approximated.",
-  );
+  warnings.push("The graduated classes were written as SLD class breaks, one rule per class.");
 
   const rules: string[] = [];
-  // Values below the first break clamp to the first stop's color on the live
-  // map (the interpolate expression clamps out-of-range inputs), so emit a
-  // leading `< first` rule to reproduce that in SLD consumers. The importer
-  // recognizes and skips this guard so the stop values still round-trip exactly.
+  // Values below the first break take the first stop's color on the live map
+  // (the `step` expression's base output covers everything under the first
+  // break), so emit a leading `< first` rule to reproduce that in SLD consumers.
+  // The importer recognizes and skips this guard so the stops round-trip exactly.
   if (numeric.length > 0) {
     rules.push(
       rule(

--- a/tests/color-ramp.test.ts
+++ b/tests/color-ramp.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  createGraduatedClassBreaks,
   interpolateColors,
   normalizeHexColor,
   parseHexColorList,
@@ -55,5 +56,53 @@ describe("interpolateColors", () => {
 
   it("repeats a single anchor color across the requested count", () => {
     assert.deepEqual(interpolateColors(["#abcdef"], 3), ["#abcdef", "#abcdef", "#abcdef"]);
+  });
+});
+
+describe("createGraduatedClassBreaks", () => {
+  // The 13 `nb_dentist` values from the layer reported in discussion #1384.
+  const DENTISTS = [262, 1157, 1331, 1404, 1977, 2040, 2815, 3621, 3643, 4166, 4409, 4983, 9133];
+
+  it("puts quantile breaks at the class boundaries, not the ramp edges", () => {
+    // 4 classes cut the sorted sample at the 0/25/50/75th percentiles. Breaks
+    // spanning min..max instead (262, 1977, 3643, 9133) leave the top class
+    // holding only the single largest feature.
+    assert.deepEqual(createGraduatedClassBreaks(DENTISTS, 4, "quantile"), [262, 1404, 2815, 4166]);
+  });
+
+  it("splits the value range evenly for equal interval, leaving the top class open", () => {
+    assert.deepEqual(createGraduatedClassBreaks([0, 100], 4, "equal-interval"), [0, 25, 50, 75]);
+  });
+
+  it("starts every scheme at the sample minimum", () => {
+    for (const scheme of ["equal-interval", "quantile", "natural-breaks"] as const) {
+      assert.equal(createGraduatedClassBreaks(DENTISTS, 5, scheme)[0], 262, scheme);
+    }
+  });
+
+  it("groups natural breaks around the gaps in the data", () => {
+    // Jenks isolates the 9133 outlier and keeps the three dense runs together.
+    assert.deepEqual(
+      createGraduatedClassBreaks(DENTISTS, 4, "natural-breaks"),
+      [262, 1977, 3621, 9133],
+    );
+  });
+
+  it("returns strictly ascending breaks so MapLibre accepts the step expression", () => {
+    // A sample with fewer distinct values than classes would otherwise repeat a
+    // break, which MapLibre rejects ("input values in strictly ascending order").
+    for (const scheme of ["equal-interval", "quantile", "natural-breaks"] as const) {
+      const breaks = createGraduatedClassBreaks([1, 1, 1, 5, 5], 6, scheme);
+      assert.ok(breaks.length > 0, scheme);
+      assert.ok(
+        breaks.every((value, index) => index === 0 || value > breaks[index - 1]),
+        `${scheme}: ${breaks.join(", ")}`,
+      );
+    }
+  });
+
+  it("returns nothing for an empty sample or a non-positive class count", () => {
+    assert.deepEqual(createGraduatedClassBreaks([], 4, "quantile"), []);
+    assert.deepEqual(createGraduatedClassBreaks([1, 2, 3], 0, "quantile"), []);
   });
 });

--- a/tests/mapbox-style-export.test.ts
+++ b/tests/mapbox-style-export.test.ts
@@ -124,7 +124,7 @@ describe("data-driven renderers", () => {
     assert.equal((color as unknown[])[0], "match");
   });
 
-  it("graduated maps to an interpolate expression", () => {
+  it("graduated maps to a discrete step expression", () => {
     const { style: doc } = buildMapboxStyle(
       layer({
         style: style({
@@ -141,8 +141,7 @@ describe("data-driven renderers", () => {
     const color = (layerById(doc, "my-layer-circle") as { paint: Record<string, unknown> }).paint[
       "circle-color"
     ];
-    assert.ok(Array.isArray(color));
-    assert.equal((color as unknown[])[0], "interpolate");
+    assert.deepEqual(color, ["step", ["to-number", ["get", "value"], 0], "#111111", 50, "#222222"]);
   });
 
   it("rule-based maps to a case expression", () => {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -178,6 +178,41 @@ describe("parseMapboxStyle round-trips exported symbology", () => {
     ]);
   });
 
+  it("reads a property-driven step color as a graduated renderer", () => {
+    // The lowest class is not one of the step's pairs: it is the base output,
+    // and its lower bound rides along as the input's `to-number` fallback.
+    const external = {
+      version: 8,
+      sources: {},
+      layers: [
+        {
+          id: "poly",
+          type: "fill",
+          source: "s",
+          paint: {
+            "fill-color": [
+              "step",
+              ["to-number", ["get", "value"], 10],
+              "#dbeafe",
+              50,
+              "#93c5fd",
+              90,
+              "#2563eb",
+            ],
+          },
+        },
+      ],
+    };
+    const result = parseMapboxStyle(external);
+    assert.equal(result.style.vectorStyleMode, "graduated");
+    assert.equal(result.style.vectorStyleProperty, "value");
+    assert.deepEqual(result.style.vectorStyleStops, [
+      { value: 10, color: "#dbeafe" },
+      { value: 50, color: "#93c5fd" },
+      { value: 90, color: "#2563eb" },
+    ]);
+  });
+
   it("still reads a legacy interpolate color as a graduated renderer", () => {
     // GeoLibre exported graduated layers as a continuous `interpolate` before
     // the renderer became discrete; those projects must keep their classes.

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -178,6 +178,59 @@ describe("parseMapboxStyle round-trips exported symbology", () => {
     ]);
   });
 
+  it("still reads a legacy interpolate color as a graduated renderer", () => {
+    // GeoLibre exported graduated layers as a continuous `interpolate` before
+    // the renderer became discrete; those projects must keep their classes.
+    const external = {
+      version: 8,
+      sources: {},
+      layers: [
+        {
+          id: "poly",
+          type: "fill",
+          source: "s",
+          paint: {
+            "fill-color": [
+              "interpolate",
+              ["linear"],
+              ["to-number", ["get", "value"], 0],
+              0,
+              "#dbeafe",
+              50,
+              "#2563eb",
+            ],
+          },
+        },
+      ],
+    };
+    const result = parseMapboxStyle(external);
+    assert.equal(result.style.vectorStyleMode, "graduated");
+    assert.equal(result.style.vectorStyleProperty, "value");
+    assert.deepEqual(result.style.vectorStyleStops, [
+      { value: 0, color: "#dbeafe" },
+      { value: 50, color: "#2563eb" },
+    ]);
+  });
+
+  it("keeps a zoom-driven step color as a raw expression", () => {
+    // `step` only means graduated when it steps over a feature property.
+    const external = {
+      version: 8,
+      sources: {},
+      layers: [
+        {
+          id: "poly",
+          type: "fill",
+          source: "s",
+          paint: { "fill-color": ["step", ["zoom"], "#111111", 8, "#222222"] },
+        },
+      ],
+    };
+    const result = parseMapboxStyle(external);
+    assert.equal(result.style.vectorStyleMode, "expression");
+    assert.equal(result.style.vectorStyleStops, undefined);
+  });
+
   it("recovers a rule-based renderer's filters, colors, and else", () => {
     const original = style({
       vectorStyleMode: "rule-based",

--- a/tests/qml-export.test.ts
+++ b/tests/qml-export.test.ts
@@ -132,7 +132,7 @@ describe("buildQml", () => {
     );
     assert.match(compact(qml), /<renderer-v2 type="graduatedSymbol" attr="pop"/);
     assert.match(compact(qml), /<range lower="0" upper="100" symbol="0"/);
-    assert.ok(warnings.some((w) => /discrete QML class ranges/.test(w)));
+    assert.ok(warnings.some((w) => /QML class ranges/.test(w)));
   });
 
   it("maps a rule-based renderer to QGIS-expression rules and an ELSE", () => {

--- a/tests/sld-export.test.ts
+++ b/tests/sld-export.test.ts
@@ -375,7 +375,7 @@ describe("buildSld", () => {
       compact(sld),
       /<ogc:PropertyIsLessThan><ogc:PropertyName>pop<\/ogc:PropertyName><ogc:Literal>100<\/ogc:Literal>/,
     );
-    assert.ok(warnings.some((w) => /discrete SLD class breaks/.test(w)));
+    assert.ok(warnings.some((w) => /SLD class breaks/.test(w)));
   });
 
   it("translates a rule-based renderer's filters to ogc:Filter", () => {

--- a/tests/vector-symbology.test.ts
+++ b/tests/vector-symbology.test.ts
@@ -87,6 +87,79 @@ describe("ruleBasedColorExpression", () => {
   });
 });
 
+describe("vectorColorExpression graduated mode", () => {
+  function graduated(patch: Partial<LayerStyle> = {}): LayerStyle {
+    return style({
+      vectorStyleMode: "graduated",
+      vectorStyleProperty: "pop",
+      vectorStyleStops: [
+        { value: 0, color: "#111111" },
+        { value: 10, color: "#222222" },
+        { value: 20, color: "#333333" },
+      ],
+      ...patch,
+    });
+  }
+
+  it("paints one flat color per class with a step expression", () => {
+    // Discrete, not `interpolate`: the stops are class lower bounds, so the map
+    // must draw exactly as many colors as the legend lists (#1384).
+    assert.deepEqual(vectorColorExpression(graduated(), "#000000"), [
+      "step",
+      ["to-number", ["get", "pop"], 0],
+      "#111111",
+      10,
+      "#222222",
+      20,
+      "#333333",
+    ]);
+  });
+
+  it("gives features below the lowest break the first class's color", () => {
+    const expression = vectorColorExpression(graduated(), "#000000") as unknown[];
+    // The step base output (index 2) covers everything under the first break,
+    // matching the SLD exporter's leading `< first` rule.
+    assert.equal(expression[2], "#111111");
+  });
+
+  it("sorts and de-duplicates stops so the step inputs strictly ascend", () => {
+    // MapLibre rejects a step whose inputs repeat; stops reach here from
+    // hand-edited projects and style imports, not only the Style panel.
+    const expression = vectorColorExpression(
+      graduated({
+        vectorStyleStops: [
+          { value: 20, color: "#333333" },
+          { value: 0, color: "#111111" },
+          { value: 20, color: "#444444" },
+        ],
+      }),
+      "#000000",
+    );
+    assert.deepEqual(expression, [
+      "step",
+      ["to-number", ["get", "pop"], 0],
+      "#111111",
+      20,
+      "#333333",
+    ]);
+  });
+
+  it("falls back to the flat color when fewer than two stops survive", () => {
+    assert.equal(
+      vectorColorExpression(
+        graduated({
+          vectorStyleStops: [
+            { value: 0, color: "#111111" },
+            { value: 10, color: "not-a-color" },
+          ],
+        }),
+        "#abcdef",
+      ),
+      "#abcdef",
+    );
+  });
+});
+
 describe("vectorColorExpression rule-based mode", () => {
   it("routes rule-based mode through the case compiler", () => {
     const rules: VectorRule[] = [


### PR DESCRIPTION
Reported in discussion #1384. The reporter classified `nb_dentist` (13 values, 262..9133) into 4 quantile classes and got the thresholds 262 / 1977 / 3643 / 9133 instead of the expected 262 / 1404 / 2815 / 4166, and the map drew 6-7 shades of blue for a legend that listed 4 classes.

## Root cause

A graduated renderer's stops have always been **class lower bounds**: the legend labels them `≥ value`, and the QML and SLD exporters write them as class ranges with the top class open-ended. Two places disagreed with that.

**The break generators built ramp edges, not class bounds.** They returned `count` values spanning `min..max`, so the top class held only the single largest feature and the interior breaks landed at the wrong positions. A 4-class quantile cut the sorted sample at the 0/33/67th percentiles instead of the 0/25/50/75th, which is exactly the reported numbers. Natural breaks was worse: an off-by-one in the Jenks backtrack shifted every class onto the next one's lower bound and repeated the maximum twice, so 4 classes on the reporter's layer produced `[1977, 3621, 9133, 9133]`.

**The map painted the stops with `interpolate`.** That blends a distinct shade per feature, so a 4-class layer drew in far more than 4 colors and stopped matching its own legend and its own exports.

## The fix

- All three schemes (equal interval, quantile, natural breaks) now build class lower bounds through one shared `createGraduatedClassBreaks` in `@geolibre/core`. The Style panel and the assistant used to classify separately, with the panel keeping its own copy of Jenks; they now share one implementation.
- The breaks are de-duplicated. A skewed sample can push several quantiles onto the same value, and MapLibre rejects a `step` whose inputs are not strictly ascending.
- The map paints graduated layers with `step`, so each class gets exactly one flat color and features below the lowest break take the first class's color (matching the SLD exporter's leading `< first` rule).
- The Mapbox style importer learns to read `step` back as graduated, and still reads `interpolate`, so projects and styles exported before this keep recovering their classes.
- `createEqualIntervalBreaks` / `createQuantileBreaks` keep their edge semantics untouched; the raster symbology panel builds colormap edges with them.

## Verification

Loaded the reporter's `Dentistes_regions.geojson` in the running app and classified `nb_dentist` into 4 classes:

| Scheme | Before | After |
| --- | --- | --- |
| Quantile | 262, 1977, 3643, 9133 | 262, 1404, 2815, 4166 |
| Natural breaks | 1977, 3621, 9133, 9133 | 262, 1977, 3621, 9133 |
| Equal interval | 262, 3219.7, 6176.3, 9133 | 262, 2479.75, 4697.5, 6915.25 |

The quantile row now matches the thresholds the reporter computed outside GeoLibre. Sampling the map canvas with the basemap hidden and full fill opacity returns exactly the four Viridis anchors (`#440154`, `#31688e`, `#35b779`, `#fde725`) as the only fill colors, so the map draws one color per legend class. Checked in both light and dark themes, with no console errors on any scheme.

`npm run build`, `npm run lint`, and the frontend suite (3464 tests) pass. New tests cover the class breaks for all three schemes, the strictly-ascending guarantee, the `step` paint expression, and the importer's `step` and legacy `interpolate` paths.

Fixes #1384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graduated styling now renders as discrete, `step`-based class colors.
  * Added a single graduated class-break generator supporting equal-interval, quantile, and natural-breaks.
  * Import/export updates: recognize Mapbox/MapLibre `step` graduated colors and round-trip them as graduated renders.

* **Bug Fixes**
  * Improved break generation robustness: filters invalid/non-finite stops, enforces strictly ascending breaks, and avoids ramp mis-sizing from duplicates.
  * Refined graduated export warnings for QML and SLD to reflect class-break output.

* **Tests**
  * Expanded tests for all classification schemes, `step` expression generation, and step/interpolate import scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->