### PR TITLE
fix(processing): restore parameters for WASM tools whose manifest declares none

### DIFF
--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -186,7 +186,9 @@ export async function listWasmToolManifests(): Promise<WhiteboxTool[]> {
  *
  * Every catalog tool that the WASM binary also implements keeps its catalog
  * metadata but takes the manifest's parameters; the GeoLibre-authored tools that
- * never appear in the catalog are appended.
+ * never appear in the catalog are appended. A manifest that declares *no*
+ * parameters at all is treated as missing metadata rather than as a
+ * parameterless tool — see {@link mergeWasmToolManifests}.
  *
  * @param catalogTools - Tools from the Whitebox catalog snapshot.
  * @param wasmTools - Every WASM tool manifest ({@link listWasmToolManifests}).
@@ -239,13 +241,26 @@ function shouldPreferCatalogKind(
  * Reconcile one tool's WASM manifest params against the catalog's. The WASM
  * params win (names and set), but a same-named catalog param corrects a WASM
  * kind that mislabels a scalar as a dataset/bool (see {@link shouldPreferCatalogKind}).
+ *
+ * A manifest that declares **no** params is a metadata gap, not a parameterless
+ * tool, so the catalog's params are kept instead. geolibre-wasm ships 138 such
+ * manifests (`d8_pointer`, `fill_depressions`, `aspect`, `basins`, every
+ * Hydrology → Flow Routing tool, …) whose `params` array is empty while the
+ * binary still validates and requires them — running one with no arguments
+ * fails with `validation error: missing required parameter '…'` for all 138.
+ * Trusting the empty set rendered "This tool has no parameters." in the
+ * Processing dialog and left the tool impossible to run in local (WASM) mode.
+ * The sidecar path already restores catalog params the same way
+ * (`mergeCatalogParameterFallbacks` in ProcessingDialog), which is why the bug
+ * only ever showed with "Run locally (WASM)" on.
  */
 function reconcileToolParams(
   catalogParams: WhiteboxToolParameter[] | undefined,
   wasmParams: WhiteboxToolParameter[] | undefined,
 ): WhiteboxToolParameter[] {
+  if (!wasmParams?.length) return catalogParams ?? [];
   const catalogByName = new Map((catalogParams ?? []).map((param) => [param.name, param] as const));
-  return (wasmParams ?? []).map((param) => {
+  return wasmParams.map((param) => {
     const catalogParam = catalogByName.get(param.name);
     if (!catalogParam) return param;
     const catalogKind = paramKind(catalogParam);
@@ -267,12 +282,14 @@ export function mergeWasmToolManifests(
     // Consume the match so a WASM-only-appended tool (below) can never duplicate
     // a catalog tool's id.
     wasmById.delete(tool.id);
-    // The WASM binary is authoritative for the parameters (even an empty set)
-    // and for the tool's provenance; keep only the catalog's display metadata
-    // (name, category, …). Preserving `source` matters so a GeoLibre-authored
-    // tool that also has a catalog stub keeps its "geolibre" marker for the
-    // source filter. A same-named catalog param still corrects a WASM kind that
-    // mislabels a scalar expression as a dataset/bool (GeoLibre#1073).
+    // The WASM binary is authoritative for the parameters it declares, and for
+    // the tool's provenance; keep only the catalog's display metadata (name,
+    // category, …). A manifest that declares no params at all keeps the
+    // catalog's instead — see {@link reconcileToolParams}. Preserving `source`
+    // matters so a GeoLibre-authored tool that also has a catalog stub keeps its
+    // "geolibre" marker for the source filter. A same-named catalog param still
+    // corrects a WASM kind that mislabels a scalar expression as a dataset/bool
+    // (GeoLibre#1073).
     return {
       ...tool,
       params: reconcileToolParams(tool.params, wasm.params),

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -282,10 +282,10 @@ describe("mergeWasmToolManifests", () => {
       params: [],
     };
     const [tool] = mergeWasmToolManifests([catalogD8Pointer], [wasmD8Pointer]);
-    assert.deepEqual(
-      tool.params?.map((param) => param.name),
-      ["dem", "esri_pntr", "output"],
-    );
+    // Compare the whole params, not just the names: `kind` decides how the
+    // dialog renders each field (a dropped one turns a raster picker into a
+    // text box), and `required`/`default` seed createDefaultValues and gate Run.
+    assert.deepEqual(tool.params, catalogD8Pointer.params);
     // Still a catalog merge, not a passthrough: display metadata is the catalog's.
     assert.equal(tool.category, "Hydrology - Flow Routing");
   });

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -255,6 +255,47 @@ describe("mergeWasmToolManifests", () => {
       ["some_wasm_only_whitebox_tool"],
     );
   });
+
+  it("keeps catalog params when the WASM manifest declares none", () => {
+    // geolibre-wasm ships 138 manifests with an empty `params` array — every
+    // Hydrology → Flow Routing tool among them (d8_pointer, fill_depressions,
+    // aspect, basins, …) — while the binary still requires those parameters:
+    // running any of the 138 with no arguments fails with "validation error:
+    // missing required parameter '…'". Trusting the empty set showed "This tool
+    // has no parameters." in the Processing dialog and left the tool unrunnable
+    // in local (WASM) mode. The catalog's params are the fallback, exactly as
+    // the sidecar path does via mergeCatalogParameterFallbacks.
+    const catalogD8Pointer: WhiteboxTool = {
+      id: "d8_pointer",
+      display_name: "D8 Pointer",
+      category: "Hydrology - Flow Routing",
+      params: [
+        { name: "dem", kind: "raster_in", required: true },
+        { name: "esri_pntr", kind: "bool", required: false, default: false },
+        { name: "output", kind: "raster_out", required: true },
+      ],
+    };
+    const wasmD8Pointer: WhiteboxTool = {
+      id: "d8_pointer",
+      display_name: "D8 Pointer",
+      category: "Raster",
+      params: [],
+    };
+    const [tool] = mergeWasmToolManifests([catalogD8Pointer], [wasmD8Pointer]);
+    assert.deepEqual(
+      tool.params?.map((param) => param.name),
+      ["dem", "esri_pntr", "output"],
+    );
+    // Still a catalog merge, not a passthrough: display metadata is the catalog's.
+    assert.equal(tool.category, "Hydrology - Flow Routing");
+  });
+
+  it("leaves a WASM-only tool with no params alone", () => {
+    // Nothing to fall back to when the catalog does not list the tool at all;
+    // it must still be listed rather than dropped.
+    const merged = mergeWasmToolManifests([], [{ id: "some_tool", params: [] }]);
+    assert.deepEqual(merged[0].params, []);
+  });
 });
 
 describe("normalizeVectorOutputFormat", () => {


### PR DESCRIPTION
## The bug

In local (WASM) mode the Processing dialog shows **"This tool has no parameters."** for **138 of the 881** Whitebox tools — every tool under **Hydrology → Flow Routing** (D8 Pointer, D8 Flow Accum, Rho8 Pointer, Dinf Pointer, …), plus Fill Depressions, Aspect, Basins, Sink, Sky View Factor and more. With no parameters rendered there is nothing to configure and nothing to run: Run sends no arguments and the tool exits with `validation error: missing required parameter '…'`.

## Cause

`geolibre-wasm` ships those 138 manifests with an **empty `params` array** while the binary still requires the parameters. Probing every one of the 138 with no arguments produces `validation error: missing required parameter '…'` for **all 138** — so an empty manifest is a metadata gap, not a parameterless tool.

`mergeWasmToolManifests` treated the WASM manifest as authoritative *"even an empty set"*, so that empty array overwrote the catalog snapshot's parameters for every tool present in both sources.

This only ever showed with **Run locally (WASM)** on: the sidecar path already restores catalog parameters for a live tool that reports none, via `mergeCatalogParameterFallbacks` in `ProcessingDialog`.

Not a regression from #1386 — the merged output is byte-identical under geolibre-wasm 0.9.0, 0.10.0, 0.11.0 and 1.0.0 (all four ship the same 138 empty manifests), so the tools have been unconfigurable in WASM mode since the merge was introduced.

## Fix

An **empty** manifest param list falls back to the catalog's parameters, mirroring the sidecar path. A manifest that *declares* params stays authoritative, so #1047 (`reproject_vector`'s `epsg` vs the catalog's `dst_epsg`) and #1073 (scalar-kind corrections for `statement`/`expression`) are untouched.

## Result

All **881** tools now render their parameters — **0** left showing "This tool has no parameters."

Probing the binary with the catalog's parameter names: **129 of 138** accept them as-is. The remaining **9** name their input differently in the binary than in the catalog and still need an upstream manifest fix in `geolibre-rust` (they were unrunnable before this change too):

| tool | catalog input | binary requires |
| --- | --- | --- |
| `average_horizon_distance` | `input` | `dem` |
| `horizon_area` | `input` | `dem` |
| `sky_view_factor` | `input` | `dem` |
| `visibility_index` | `input` | `dem` |
| `distance_to_outlet` | `d8_pointer` | `d8_pntr` |
| `farthest_channel_head` | `d8_pointer` | `d8_pntr` |
| `find_main_stem` | `d8_pointer` | `d8_pntr` |
| `max_branch_length` | `dem` | `input` |
| `minimal_dispersion_flow_algorithm` | `raster` | `input` |

The real upstream fix is for geolibre-rust to emit `params` in these 138 manifests.

## Verification

- Real browser, real data: loaded the source.coop `giswqs/opengeos/dem.tif` COG, opened **Processing → Hydrology → Flow Routing → D8 Pointer** with **Run locally (WASM)** on. It renders `Dem` / `Esri Pntr` / `Output`, runs in the WASM engine and adds **D8 Pointer Output** to the map (`{"path":"/work/d8_pointer_output.tif"}`, status `succeeded`). Fill Depressions, Aspect and Basins render their parameters too.
- Two new unit tests: catalog params are kept when the manifest declares none; a WASM-only tool with no params is still listed (nothing to fall back to).
- 3454 frontend tests pass; `pre-commit` (oxfmt, eslint, npm build) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed merged local WASM tools with empty `params` being treated as parameterless.
  * When WASM manifest parameter details are missing (empty `params`), the merged result now preserves the catalog’s full parameter definitions and related display metadata.
  * Continued to honor WASM-provided parameter details when present, and kept WASM-only tools with truly empty parameter lists available.
* **Tests**
  * Added coverage for the “empty params” merge edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->