### PR TITLE
docs: add Danish Datafordeler site-planning workflow

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -64,6 +64,13 @@ export const DEFAULT_WMS_LAYERS = "USGSNAIPImagery:FalseColorComposite";
 // attribution and must not be used for navigation. See gebco.net/data-products.
 export const GEBCO_WMS_ENDPOINT = "https://wms.gebco.net/mapserv";
 export const GEBCO_WMS_LAYERS = "GEBCO_LATEST";
+// Denmark's Datafordeler publishes its current spring orthophoto as a WMS.
+// Access uses an API key supplied as an `apikey` URL parameter. The placeholder
+// deliberately keeps credentials out of the shipped preset; replace it locally
+// before retrieving layers, and do not share a project containing the live URL.
+export const DATAFORDELER_ORTO_WMS_ENDPOINT =
+  "https://wms.datafordeler.dk/GeoDanmarkOrto/orto_foraar/1.0.0/WMS?apikey=<YOUR_API_KEY>";
+export const DATAFORDELER_ORTO_WMS_LAYERS = "orto_foraar";
 // GEBCO's license requires its imagery credit the source. `attributionForTileUrl`
 // (helpers) attaches this to any GEBCO WMS layer, however it was added (the sample
 // below or a hand-pasted wms.gebco.net URL).

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -14,6 +14,8 @@
 
 import {
   DEFAULT_ARCGIS_FEATURE_URL,
+  DATAFORDELER_ORTO_WMS_ENDPOINT,
+  DATAFORDELER_ORTO_WMS_LAYERS,
   DEFAULT_WFS_ENDPOINT,
   DEFAULT_WFS_TYPE_NAME,
   DEFAULT_WMS_ENDPOINT,
@@ -308,6 +310,24 @@ export const BUILTIN_SERVICES: readonly ServiceLibraryEntry[] = [
       tileSize: "256",
       // GEBCO serves the latest grid over WMS 1.3.0; pin it so the saved
       // service does not fall back to 1.1.1's flipped-axis GetMap.
+      version: "1.3.0",
+    },
+  },
+  {
+    id: "builtin-wms-datafordeler-ortofoto",
+    name: "Datafordeler Ortofoto (Denmark; API key required)",
+    category: "Denmark",
+    kind: "wms",
+    builtin: true,
+    fields: {
+      endpoint: DATAFORDELER_ORTO_WMS_ENDPOINT,
+      layers: DATAFORDELER_ORTO_WMS_LAYERS,
+      styles: "",
+      format: "image/jpeg",
+      transparent: false,
+      tileSize: "256",
+      // Datafordeler supports Web Mercator and WMS 1.3.0; pin the version so
+      // the built-in MapLibre WMS request uses the service's current contract.
       version: "1.3.0",
     },
   },

--- a/docs/tutorials/danish-site-planning.md
+++ b/docs/tutorials/danish-site-planning.md
@@ -1,0 +1,70 @@
+# Danish site-planning data: Datafordeler, current imagery, and historic plans
+
+This desktop workflow combines current official Danish map data with historic plan scans without confusing either for a survey. It is useful for an early courtyard, streetscape, landscape, or mobility study.
+
+You need a Datafordeler API key with access to GeoDanmark Ortofoto and Matriklen2. Keep the key in a secret manager or local password store. Never put it in a shared `.geolibre.json` file or a public project.
+
+## 1. Add the current official orthophoto
+
+Datafordeler's spring orthophoto is updated annually and supports WMS 1.3.0 and Web Mercator, so it can be displayed as a live GeoLibre WMS layer.
+
+1. Open **Add Data → WMS Layer**.
+2. In the service library, choose **Datafordeler Ortofoto (Denmark; API key required)**.
+3. Replace `<YOUR_API_KEY>` in the service URL with your own local API key, then click **Retrieve layers**.
+4. Select `orto_foraar`, keep WMS version `1.3.0`, and add it.
+
+The preset contains no credential. It uses:
+
+```text
+https://wms.datafordeler.dk/GeoDanmarkOrto/orto_foraar/1.0.0/WMS?apikey=<YOUR_API_KEY>
+```
+
+!!! warning "Do not share a live keyed layer"
+    A WMS URL is saved with a project. Before saving or sharing a project, remove the live keyed WMS layer and replace it with a local orthophoto export such as a GeoTIFF/COG. Store the API key only in your local secret manager.
+
+## 2. Add current cadastral reference geometry
+
+Datafordeler's Matriklen2 WFS returns GML. Download a small area as GML, then use **Add Data → Vector Layer** to load the local file; GeoLibre reprojects vector input to its map coordinate system.
+
+For example, set an API-key environment variable in a terminal and make a bounded request:
+
+```sh
+export DATAFORDELER_API_KEY='…'
+
+curl --get 'https://wfs.datafordeler.dk/MATRIKLEN2/MatGaeldendeOgForeloebigWFS/1.0.0/WFS' \
+  --data-urlencode "apikey=$DATAFORDELER_API_KEY" \
+  --data-urlencode 'service=WFS' \
+  --data-urlencode 'version=2.0.0' \
+  --data-urlencode 'request=GetFeature' \
+  --data-urlencode 'typenames=mat:Jordstykke_Gaeldende' \
+  --data-urlencode 'srsName=EPSG:25832' \
+  --data-urlencode 'bbox=<min-easting>,<min-northing>,<max-easting>,<max-northing>,EPSG:25832' \
+  --output parcels.gml
+```
+
+Also request `mat:Matrikelskel_Gaeldende` when you need visible boundary lines. Use **ETRS89 / UTM zone 32N (`EPSG:25832`)** for Datafordeler requests. Cadastral geometry is an authoritative reference map, but construction boundaries and registered rights still require the relevant authority or surveyor.
+
+## 3. Make an offline working base
+
+For a design workshop, use local files rather than live credentials:
+
+- a georeferenced current orthophoto as GeoTIFF/COG;
+- the downloaded parcel/boundary GML, or an exported GeoPackage;
+- GeoPackage layers for `historic`, `existing`, `rights/constraints`, and `proposal` geometry.
+
+Lock the current imagery and cadastral layers. Draw site observations and design alternatives in separate editable layers.
+
+## 4. Register historical drawings as evidence
+
+Use **Processing → Georeferencing** to add a scanned PDF page exported as PNG/JPG. First register the historic garage or site plan to the orthophoto using at least four unchanged facade or ramp corners. Then register a drainage plan to that already-registered plan, recording every ground-control point and residual.
+
+The tool uses an affine fit. A historic plan that needs a visibly non-uniform stretch is evidence of an older condition, not a current-survey base—keep it labelled as such rather than forcing it to match. Use a surveyor and engineer for construction levels, deck structure, drainage falls, utilities and set-out.
+
+## 5. Use AI only as a drafting accelerator
+
+After the orthophoto is georeferenced, **Processing → AI Segmentation** can create candidate polygons for paving, planting, roofs or cars. Review and correct every result before writing it to an `existing` or `proposal` layer. It cannot establish legal boundaries, parking rights, underground structure, drains or levels.
+
+## Sources
+
+- [Datafordeler: Ortofoto forår WMS](https://datafordeler.dk/dataoversigt/geodanmark-ortofoto/ortofoto-foraar-wms/)
+- [Datafordeler: Matriklen2 gældende og foreløbig WFS](https://datafordeler.dk/dataoversigt/matriklen-mat/matriklen2-gaeldende-og-foreloebig-wfs/)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -14,6 +14,7 @@ These tutorials walk through common GeoLibre workflows end to end. Each one is s
 | --- | --- |
 | [Your First Map](first-map.md) | Add a layer, style it, inspect attributes, and save. |
 | [Cloud-Native Data](cloud-native-data.md) | Load remote GeoParquet, FlatGeobuf, and COG, and convert local data. |
+| [Danish Site Planning](danish-site-planning.md) | Combine Datafordeler imagery and cadastral reference data with historic plans. |
 | [Vector Analysis](vector-analysis.md) | Buffer and overlay layers, then export the result. |
 | [Terrain Analysis](terrain-analysis.md) | Derive hillshade, slope, and contours from a DEM. |
 | [Spatial SQL](spatial-sql.md) | Query data with DuckDB Spatial and map the results. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Overview: tutorials/index.md
       - Your First Map: tutorials/first-map.md
       - Cloud-Native Data: tutorials/cloud-native-data.md
+      - Danish Site Planning: tutorials/danish-site-planning.md
       - Vector Analysis: tutorials/vector-analysis.md
       - Terrain Analysis: tutorials/terrain-analysis.md
       - Spatial SQL: tutorials/spatial-sql.md

--- a/tests/service-library.test.ts
+++ b/tests/service-library.test.ts
@@ -152,6 +152,19 @@ describe("serviceCategories", () => {
   });
 });
 
+describe("Danish Datafordeler starter service", () => {
+  it("ships an imagery preset with a credential placeholder, never a key", () => {
+    const service = BUILTIN_SERVICES.find(
+      (entry) => entry.id === "builtin-wms-datafordeler-ortofoto",
+    );
+    assert.ok(service);
+    assert.equal(service.kind, "wms");
+    assert.equal(service.fields.layers, "orto_foraar");
+    assert.match(String(service.fields.endpoint), /wms\.datafordeler\.dk/);
+    assert.match(String(service.fields.endpoint), /<YOUR_API_KEY>/);
+  });
+});
+
 describe("import / export round-trip", () => {
   it("serializes user entries (without builtin flag) and re-parses them", () => {
     const entry = createServiceEntry({


### PR DESCRIPTION
## Summary
- add a built-in Datafordeler spring-orthophoto WMS preset using a credential placeholder only
- document a Danish workflow for orthophotos, Matriklen2 GML, offline GeoTIFF/GeoPackage working bases, and historic-plan registration
- explain the limits of AI segmentation and add coverage for the preset

## Verification
- `node --import tsx --test tests/service-library.test.ts`
- `npm run lint -- --quiet`
- `npm run build`
- manually verified a Datafordeler WMS 1.3.0 / EPSG:3857 GetMap response

`npm test` has one unrelated failure: `render-linux-metainfo.sh` rejects this machine date (`DATE is not a valid calendar date`); 3,466 tests pass, 1 is skipped.

## Security
No Datafordeler credential is included. The built-in endpoint uses `<YOUR_API_KEY>` and the documentation explains how to keep keys local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a built-in Denmark Datafordeler spring orthophoto WMS service.
  * The service includes secure API key placeholder configuration and standard display settings.

* **Documentation**
  * Added a Danish site-planning tutorial covering imagery, cadastral data, historic plans, offline workflows, and georeferencing.
  * Added the tutorial to the documentation index and navigation.

* **Tests**
  * Added coverage verifying the service configuration and credential placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->