### PR TITLE
docs: change heading 'Set up' to 'Setup' in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,7 +31,7 @@ before you invest time in a pull request.
   commit hooks below) and, if you work on the backend, the conversion sidecar
   and its tests
 
-## Set up
+## Setup
 
 ```bash
 git clone https://github.com/opengeos/GeoLibre.git


### PR DESCRIPTION
## Description
This PR fixes section heading typography in `docs/contributing.md`.

## Details
Updated heading `## Set up` -> `## Setup` to match noun section header conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributing guide’s subsection heading from “Set up” to “Setup” for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->