### PR TITLE
fix(shell): only surface project URL load failures on the map

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -2233,14 +2233,12 @@ export function DesktopShell({
           </div>
         </div>
       ) : null}
-      {projectUrlLoadState?.message || projectUrlLoadState?.error ? (
+      {projectUrlLoadState?.error ? (
         <div
-          aria-live="polite"
-          className={`pointer-events-none absolute left-1/2 top-14 z-50 max-w-[min(90vw,32rem)] -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-center text-sm shadow-lg ${
-            projectUrlLoadState.error ? "text-destructive" : "text-foreground"
-          }`}
+          aria-live="assertive"
+          className="pointer-events-none absolute left-1/2 top-14 z-50 max-w-[min(90vw,32rem)] -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-center text-sm text-destructive shadow-lg"
         >
-          {projectUrlLoadState.error ?? projectUrlLoadState.message}
+          {projectUrlLoadState.error}
         </div>
       ) : null}
       {dropMessage || dropError ? (


### PR DESCRIPTION
## Summary
- Drop the on-map status banner for the loading and loaded states of a `?project=` URL load, so it no longer covers the map while the project the user is watching arrive is being fetched.
- Keep the banner for the error case only, and promote it to `aria-live="assertive"` since it is now the sole signal that the load failed.

## Test plan
- [ ] Open the app with `?project=<url>` pointing at a valid project: no banner appears, the project loads.
- [ ] Open the app with `?project=<url>` pointing at a missing or malformed file: the error banner appears in destructive styling and is announced by a screen reader.
- [ ] `npm run build` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status notifications by displaying only critical errors.
  * Ensured error messages are announced immediately for better accessibility.
  * Simplified error styling for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->