### PR TITLE
feat: persist the active layer and lift the GeoLens feature cap

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -305,6 +305,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       basemapVisible: state.basemapVisible,
       basemapOpacity: state.basemapOpacity,
       layers: layersOverride ?? state.layers,
+      selectedLayerId: state.selectedLayerId,
       layerGroups: state.layerGroups,
       preferences: state.preferences,
       plugins: {

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -27,6 +27,7 @@ export function buildProjectSnapshot(
     basemapVisible: state.basemapVisible,
     basemapOpacity: state.basemapOpacity,
     layers: state.layers,
+    selectedLayerId: state.selectedLayerId,
     layerGroups: state.layerGroups,
     preferences: state.preferences,
     plugins: {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -110,6 +110,13 @@ export function parseProject(json: string): GeoLibreProject {
     .map((layer) =>
       layer.groupId && !validGroupIds.has(layer.groupId) ? { ...layer, groupId: undefined } : layer,
     );
+  const selectedLayerId =
+    data.selectedLayerId === null
+      ? null
+      : typeof data.selectedLayerId === "string" &&
+          layers.some((layer) => layer.id === data.selectedLayerId)
+        ? data.selectedLayerId
+        : undefined;
   const basemapStyleUrl = data.basemapStyleUrl ?? DEFAULT_BASEMAP;
   const basemapVisible = data.basemapVisible ?? true;
   const basemapOpacity = data.basemapOpacity ?? 1;
@@ -127,6 +134,7 @@ export function parseProject(json: string): GeoLibreProject {
     basemapVisible,
     basemapOpacity,
     layers,
+    ...(selectedLayerId !== undefined ? { selectedLayerId } : {}),
     ...(layerGroups.length > 0 ? { layerGroups } : {}),
     styles: data.styles ?? {},
     preferences: normalizeProjectPreferences(data.preferences),
@@ -1061,6 +1069,7 @@ export function projectFromStore(state: {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  selectedLayerId?: string | null;
   layerGroups?: LayerGroup[];
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState | null;
@@ -1107,6 +1116,13 @@ export function projectFromStore(state: {
   );
   const persistGrid = mapLayout.rows * mapLayout.cols > 1;
   const styleLibrary = normalizeStyleLibraryEntries(state.styleLibrary);
+  const selectedLayerId =
+    state.selectedLayerId === null
+      ? null
+      : typeof state.selectedLayerId === "string" &&
+          state.layers.some((layer) => layer.id === state.selectedLayerId)
+        ? state.selectedLayerId
+        : undefined;
   return {
     version: PROJECT_VERSION,
     name: state.projectName,
@@ -1115,6 +1131,7 @@ export function projectFromStore(state: {
     basemapVisible: state.basemapVisible,
     basemapOpacity: state.basemapOpacity,
     layers: state.layers.map(prepareLayerForSave),
+    ...(selectedLayerId !== undefined ? { selectedLayerId } : {}),
     ...(layerGroups.length > 0 ? { layerGroups } : {}),
     styles,
     preferences: state.preferences,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1731,12 +1731,19 @@ export const useAppStore = create<AppState>()(
         // (or with an empty one) open normally. Callers that open a project for
         // authoring rather than viewing can pass `presenting: false` to override.
         const presentStory = options.presenting ?? (applied.storymap?.chapters.length ?? 0) > 0;
+        const selectedLayerId =
+          project.selectedLayerId === null
+            ? null
+            : typeof project.selectedLayerId === "string" &&
+                applied.layers.some((layer) => layer.id === project.selectedLayerId)
+              ? project.selectedLayerId
+              : (applied.layers[0]?.id ?? null);
         set((s) => ({
           ...applied,
           projectPath: path,
           projectGeneration: s.projectGeneration + 1,
           isDirty: false,
-          selectedLayerId: applied.layers[0]?.id ?? null,
+          selectedLayerId,
           selectedFeatureId: null,
           selectedFeatureIds: [],
           identifyLayerId: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1591,6 +1591,11 @@ export interface GeoLibreProject {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  /**
+   * Layer selected in the Layers panel when the project was saved. Omitted by
+   * legacy projects; `null` deliberately restores no active layer.
+   */
+  selectedLayerId?: string | null;
   /** Named folders that organize the flat `layers` list in the layer panel. */
   layerGroups?: LayerGroup[];
   styles: Record<string, LayerStyle>;

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -360,8 +360,10 @@ export {
 } from "./plugins/maplibre-source-coop";
 export {
   DEFAULT_GEOLENS_LABELS,
+  DEFAULT_GEOLENS_FEATURE_LIMIT,
   GEOLENS_PLUGIN_ID,
   maplibreGeoLensPlugin,
+  normalizeGeoLensFeatureLimit,
   setGeoLensLabels,
   type GeoLensLabels,
 } from "./plugins/maplibre-geolens";

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -366,7 +366,12 @@ export async function fetchDatasetFeatures(
     if (!Array.isArray(body.features)) {
       throw new Error("GeoLens items response contained no features");
     }
-    features.push(...(body.features as import("geojson").Feature[]));
+    // Appended one at a time, not spread: a page can hold more features than
+    // the engine accepts as call arguments, and `push(...page)` would throw.
+    for (const feature of body.features as import("geojson").Feature[]) {
+      if (features.length >= limit) break;
+      features.push(feature);
+    }
 
     const links = Array.isArray(body.links) ? body.links : [];
     const next = links.find(
@@ -393,7 +398,7 @@ export async function fetchDatasetFeatures(
   return {
     ...(firstPage ?? {}),
     type: "FeatureCollection",
-    features: features.slice(0, limit),
+    features,
   } as import("geojson").FeatureCollection;
 }
 

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -15,7 +15,7 @@
  *    URL is not enough; the caller must re-mint before `expires_in` elapses.
  *  - **OGC API Features** — `GET /api/collections/{id}/items` is a plain
  *    (paginated) GeoJSON `FeatureCollection`, the fallback for a full-feature
- *    load. GeoLens caps `limit` (300 → 400), so this reads one page.
+ *    load.
  *  - **STAC 1.0** — `/api/stac` catalog + `/api/stac/collections`, the natural
  *    path for raster/COG datasets.
  *
@@ -338,6 +338,63 @@ export async function resolveRasterTiles(
 /** OGC API Features items URL (one GeoJSON page) for a dataset. */
 export function itemsUrl(options: GeoLensClientOptions, datasetId: string, limit: number): string {
   return `${options.baseUrl}/api/collections/${encodeURIComponent(datasetId)}/items?limit=${limit}`;
+}
+
+/**
+ * Load up to `limit` features, following OGC API Features `rel=next` links.
+ * GeoLens deployments may cap each response below the requested page size, so
+ * requesting a large limit alone is not sufficient to avoid silent truncation.
+ */
+export async function fetchDatasetFeatures(
+  options: GeoLensClientOptions,
+  datasetId: string,
+  limit: number,
+  fetchImpl: GeoLensFetch = defaultGeoLensFetch,
+  signal?: AbortSignal,
+): Promise<import("geojson").FeatureCollection> {
+  const features: import("geojson").Feature[] = [];
+  const visited = new Set<string>();
+  let nextUrl: string | null = itemsUrl(options, datasetId, limit);
+  let firstPage: Record<string, unknown> | null = null;
+
+  while (nextUrl && features.length < limit && !visited.has(nextUrl)) {
+    visited.add(nextUrl);
+    const res = await fetchImpl(nextUrl, { headers: authHeaders(options), signal });
+    if (!res.ok) throw new Error(`GeoLens items request failed (HTTP ${res.status})`);
+    const body = (await res.json()) as Record<string, unknown>;
+    if (!firstPage) firstPage = body;
+    if (!Array.isArray(body.features)) {
+      throw new Error("GeoLens items response contained no features");
+    }
+    features.push(...(body.features as import("geojson").Feature[]));
+
+    const links = Array.isArray(body.links) ? body.links : [];
+    const next = links.find(
+      (link): link is { rel: string; href: string } =>
+        !!link &&
+        typeof link === "object" &&
+        (link as { rel?: unknown }).rel === "next" &&
+        typeof (link as { href?: unknown }).href === "string",
+    );
+    if (next) {
+      const resolvedUrl: URL = new URL(next.href, nextUrl);
+      if (
+        !HTTP_URL_RE.test(resolvedUrl.href) ||
+        resolvedUrl.origin !== new URL(options.baseUrl).origin
+      ) {
+        throw new Error("GeoLens pagination returned an unsafe next-page URL");
+      }
+      nextUrl = resolvedUrl.href;
+    } else {
+      nextUrl = null;
+    }
+  }
+
+  return {
+    ...(firstPage ?? {}),
+    type: "FeatureCollection",
+    features: features.slice(0, limit),
+  } as import("geojson").FeatureCollection;
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -21,15 +21,13 @@
  */
 
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
-import type { FeatureCollection } from "geojson";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 import {
-  authHeaders,
   datasetPageUrl,
   defaultGeoLensFetch,
+  fetchDatasetFeatures,
   fetchDatasetFields,
   geometryKind,
-  itemsUrl,
   mintTileToken,
   normalizeBaseUrl,
   resolveRasterTiles,
@@ -44,8 +42,10 @@ export const GEOLENS_PLUGIN_ID = "maplibre-gl-geolens";
 
 /** Number of datasets requested per catalog search. */
 const SEARCH_LIMIT = 50;
-/** OGC Features page size (GeoLens caps `limit`, so this reads one page). */
-const FEATURES_LIMIT = 100;
+/** Default maximum number of editable GeoJSON features loaded per dataset. */
+export const DEFAULT_GEOLENS_FEATURE_LIMIT = 10_000;
+const MAX_GEOLENS_FEATURE_LIMIT = 1_000_000;
+const FEATURE_LIMIT_STORAGE_KEY = "geolibre.geolens.featureLimit";
 /** Re-mint the tile token this many seconds before it expires. */
 const TOKEN_REFRESH_LEAD_SECONDS = 30;
 /** Floor on the refresh delay, so a tiny/expired TTL cannot busy-loop. */
@@ -83,6 +83,9 @@ export interface GeoLensLabels {
   addGeoJsonTitle: string;
   metadata: string;
   metadataTitle: string;
+  settings: string;
+  featureLimit: string;
+  featureLimitHelp: string;
   addError: (message: string) => string;
   features: (count: number) => string;
 }
@@ -108,15 +111,44 @@ export const DEFAULT_GEOLENS_LABELS: GeoLensLabels = {
   adding: "Adding…",
   added: "Added",
   addGeoJson: "Add GeoJSON",
-  addGeoJsonTitle:
-    "Load features as editable GeoJSON (first 100) for the attribute table and export",
+  addGeoJsonTitle: "Load features as editable GeoJSON for the attribute table and export",
   metadata: "Metadata",
   metadataTitle: "Open this dataset's page on the GeoLens server in a new tab",
+  settings: "Settings",
+  featureLimit: "Default GeoJSON feature limit",
+  featureLimitHelp: "The loader follows paginated responses until this many features are loaded.",
   addError: (message) => `Could not add layer: ${message}`,
   features: (count) => `${count.toLocaleString()} features`,
 };
 
 let labels: GeoLensLabels = { ...DEFAULT_GEOLENS_LABELS };
+
+export function normalizeGeoLensFeatureLimit(value: unknown): number {
+  if (value === null || value === undefined || value === "") {
+    return DEFAULT_GEOLENS_FEATURE_LIMIT;
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_GEOLENS_FEATURE_LIMIT;
+  return Math.min(MAX_GEOLENS_FEATURE_LIMIT, Math.max(1, Math.floor(parsed)));
+}
+
+function readFeatureLimit(): number {
+  if (typeof localStorage === "undefined") return DEFAULT_GEOLENS_FEATURE_LIMIT;
+  try {
+    return normalizeGeoLensFeatureLimit(localStorage.getItem(FEATURE_LIMIT_STORAGE_KEY));
+  } catch {
+    return DEFAULT_GEOLENS_FEATURE_LIMIT;
+  }
+}
+
+function writeFeatureLimit(value: number): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(FEATURE_LIMIT_STORAGE_KEY, String(value));
+  } catch {
+    // Storage can be unavailable in privacy-restricted webviews.
+  }
+}
 
 /** Panels currently mounted, so a language change can repaint them in place. */
 const mountedPanels = new Set<() => void>();
@@ -174,6 +206,9 @@ const CSS = {
     "padding:2px 8px;font-size:11px;border-radius:4px;cursor:pointer;" +
     "border:1px solid hsl(var(--border));background:hsl(var(--background));" +
     "color:hsl(var(--foreground));",
+  settings:
+    "display:none;flex-direction:column;gap:5px;padding:7px;border-radius:6px;" +
+    "border:1px solid hsl(var(--border));background:hsl(var(--muted));",
 } as const;
 
 function el<K extends keyof HTMLElementTagNameMap>(
@@ -451,12 +486,10 @@ async function addFeaturesLayer(
   app: GeoLibreAppAPI,
   client: GeoLensClientOptions,
   dataset: GeoLensDataset,
+  featureLimit: number,
   fetchImpl: GeoLensFetch,
 ): Promise<void> {
-  const url = itemsUrl(client, dataset.id, FEATURES_LIMIT);
-  const res = await fetchImpl(url, { headers: authHeaders(client) });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = (await res.json()) as FeatureCollection;
+  const data = await fetchDatasetFeatures(client, dataset.id, featureLimit, fetchImpl);
   app.addGeoJsonLayer(dataset.title, data, `${sourcePathFor(client, dataset)}#items`);
   if (dataset.bbox) app.fitBounds?.(dataset.bbox);
 }
@@ -471,6 +504,7 @@ interface PanelState {
   /** Monotonic token to ignore superseded in-flight requests. */
   generation: number;
   controller: AbortController | null;
+  featureLimit: number;
 }
 
 /**
@@ -488,10 +522,28 @@ function buildPanel(
     datasets: [],
     generation: 0,
     controller: null,
+    featureLimit: readFeatureLimit(),
   };
 
   const panel = el("div", CSS.panel);
-  const hint = el("div", CSS.hint, labels.hint);
+  const hintRow = el("div", "display:flex;align-items:flex-start;gap:8px;");
+  const hint = el("div", `${CSS.hint}flex:1 1 auto;`, labels.hint);
+  const settingsButton = button("⚙", CSS.action, labels.settings);
+  settingsButton.setAttribute("aria-label", labels.settings);
+  hintRow.append(hint, settingsButton);
+
+  const settingsPanel = el("div", CSS.settings);
+  const featureLimitLabel = el("label", "font-size:11px;font-weight:600;", labels.featureLimit);
+  const featureLimitInput = el("input", CSS.input) as HTMLInputElement;
+  featureLimitInput.type = "number";
+  featureLimitInput.min = "1";
+  featureLimitInput.max = String(MAX_GEOLENS_FEATURE_LIMIT);
+  featureLimitInput.step = "1";
+  featureLimitInput.value = String(state.featureLimit);
+  featureLimitInput.style.display = "block";
+  featureLimitInput.style.marginTop = "4px";
+  featureLimitLabel.append(featureLimitInput);
+  settingsPanel.append(featureLimitLabel, el("div", CSS.hint, labels.featureLimitHelp));
 
   const baseUrlInput = el("input", CSS.input) as HTMLInputElement;
   baseUrlInput.placeholder = labels.baseUrlPlaceholder;
@@ -521,7 +573,17 @@ function buildPanel(
   errorLine.style.display = "none";
   const list = el("div", CSS.list);
 
-  panel.append(hint, baseUrlInput, apiKeyInput, connectRow, searchRow, status, errorLine, list);
+  panel.append(
+    hintRow,
+    settingsPanel,
+    baseUrlInput,
+    apiKeyInput,
+    connectRow,
+    searchRow,
+    status,
+    errorLine,
+    list,
+  );
   container.replaceChildren(panel);
 
   const showError = (message: string): void => {
@@ -634,7 +696,7 @@ function buildPanel(
       syncGeoJson();
       geoJsonButton.addEventListener("click", () => {
         void handleAdd(geoJsonButton, syncGeoJson, () =>
-          addFeaturesLayer(app!, state.client!, dataset, fetchImpl),
+          addFeaturesLayer(app!, state.client!, dataset, state.featureLimit, fetchImpl),
         );
       });
       actions.append(geoJsonButton);
@@ -696,6 +758,17 @@ function buildPanel(
   };
 
   connectButton.addEventListener("click", () => void connect());
+  settingsButton.addEventListener("click", () => {
+    const open = settingsPanel.style.display !== "flex";
+    settingsPanel.style.display = open ? "flex" : "none";
+    settingsButton.setAttribute("aria-expanded", String(open));
+  });
+  settingsButton.setAttribute("aria-expanded", "false");
+  featureLimitInput.addEventListener("change", () => {
+    state.featureLimit = normalizeGeoLensFeatureLimit(featureLimitInput.value);
+    featureLimitInput.value = String(state.featureLimit);
+    writeFeatureLimit(state.featureLimit);
+  });
   baseUrlInput.addEventListener("keydown", (event) => {
     if (event.key === "Enter") void connect();
   });

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -47,6 +47,32 @@ describe("project parsing", () => {
     assert.equal(dangling.selectedLayerId, undefined);
   });
 
+  it("normalizes the selected layer on save as well as on load", () => {
+    const layer = geojsonLayer({ id: "chosen" });
+    const save = (selectedLayerId: string | null | undefined) =>
+      parseProject(
+        serializeProject(
+          projectFromStore({
+            projectName: "Selection",
+            mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+            basemapStyleUrl: DEFAULT_BASEMAP,
+            basemapVisible: true,
+            basemapOpacity: 1,
+            layers: [layer],
+            selectedLayerId,
+            preferences: createEmptyProject().preferences,
+            metadata: {},
+          }),
+        ),
+      );
+
+    assert.equal(save("chosen").selectedLayerId, "chosen");
+    assert.equal(save("missing").selectedLayerId, undefined);
+    assert.equal(save(undefined).selectedLayerId, undefined);
+    // An explicit null is a saved "nothing active", so it must survive the trip.
+    assert.equal(save(null).selectedLayerId, null);
+  });
+
   it("fills defaults while preserving valid project fields", () => {
     const project = parseProject(
       JSON.stringify({

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -33,6 +33,20 @@ function geojsonLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
 }
 
 describe("project parsing", () => {
+  it("preserves a valid selected layer and drops a dangling selection", () => {
+    const base = createEmptyProject("Selection");
+    const layer = geojsonLayer({ id: "chosen" });
+    const selected = parseProject(
+      serializeProject({ ...base, layers: [layer], selectedLayerId: "chosen" }),
+    );
+    assert.equal(selected.selectedLayerId, "chosen");
+
+    const dangling = parseProject(
+      serializeProject({ ...base, layers: [layer], selectedLayerId: "missing" }),
+    );
+    assert.equal(dangling.selectedLayerId, undefined);
+  });
+
   it("fills defaults while preserving valid project fields", () => {
     const project = parseProject(
       JSON.stringify({
@@ -663,6 +677,29 @@ describe("app store", () => {
     useAppStore.getState().selectLayer(first);
     useAppStore.getState().removeLayer(first);
     assert.equal(useAppStore.getState().selectedLayerId, second);
+  });
+
+  it("restores the saved active layer and keeps the legacy first-layer fallback", () => {
+    const first = geojsonLayer({ id: "first", name: "First" });
+    const second = geojsonLayer({ id: "second", name: "Second" });
+    const base = createEmptyProject("Selection");
+
+    useAppStore.getState().loadProject({
+      ...base,
+      layers: [first, second],
+      selectedLayerId: "second",
+    });
+    assert.equal(useAppStore.getState().selectedLayerId, "second");
+
+    useAppStore.getState().loadProject({ ...base, layers: [first, second] });
+    assert.equal(useAppStore.getState().selectedLayerId, "first");
+
+    useAppStore.getState().loadProject({
+      ...base,
+      layers: [first, second],
+      selectedLayerId: null,
+    });
+    assert.equal(useAppStore.getState().selectedLayerId, null);
   });
 
   it("renames a layer without changing its id (keeps MapLibre sync stable)", () => {

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -4,6 +4,7 @@ import {
   authHeaders,
   bboxFromGeometry,
   datasetPageUrl,
+  fetchDatasetFeatures,
   fetchDatasetFields,
   geometryKind,
   itemsUrl,
@@ -147,6 +148,46 @@ describe("itemsUrl / stac URLs", () => {
     );
     assert.equal(stacCatalogUrl(opts), "http://localhost:8080/api/stac");
     assert.equal(stacCollectionsUrl(opts), "http://localhost:8080/api/stac/collections");
+  });
+});
+
+describe("fetchDatasetFeatures", () => {
+  it("follows pagination and stops at the requested feature limit", async () => {
+    const calls: string[] = [];
+    const fetchImpl: GeoLensFetch = async (url) => {
+      calls.push(url);
+      const second = url.includes("offset=2");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: "FeatureCollection",
+          features: second
+            ? [{ type: "Feature", geometry: null, properties: { id: 3 } }]
+            : [
+                { type: "Feature", geometry: null, properties: { id: 1 } },
+                { type: "Feature", geometry: null, properties: { id: 2 } },
+              ],
+          links: second ? [] : [{ rel: "next", href: "?limit=3&offset=2" }],
+        }),
+      };
+    };
+    const result = await fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 3, fetchImpl);
+    assert.equal(result.features.length, 3);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1], "http://h/api/collections/d/items?limit=3&offset=2");
+  });
+
+  it("truncates an oversized response to the requested limit", async () => {
+    const { fetchImpl } = stubFetch({
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", geometry: null, properties: { id: 1 } },
+        { type: "Feature", geometry: null, properties: { id: 2 } },
+      ],
+    });
+    const result = await fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 1, fetchImpl);
+    assert.equal(result.features.length, 1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Persist `selectedLayerId` in the `.geolibre.json` project format so reopening a project restores the layer that was active in the Layers panel. A dangling id is dropped on both save and load, `null` deliberately restores no active layer, and projects saved before this change keep the old first-layer fallback.
- Replace the GeoLens GeoJSON loader's single 100-feature page with a paginated fetch that follows OGC API Features `rel=next` links until the requested feature limit is reached. Next-page URLs are validated as same-origin http(s) before they are followed.
- Add a settings toggle to the GeoLens panel for the feature limit, defaulting to 10,000 and remembered in local storage.

## Test plan
- [x] `npm run test:frontend` passes, including new cases for project selection round-tripping and for `fetchDatasetFeatures` pagination and truncation.
- [x] `npm run build` passes.
- [ ] Save a project with a non-first layer selected, reopen it, and confirm that layer is active in the Layers panel.
- [ ] Open a project saved before this change and confirm the first layer is selected as before.
- [ ] Connect the GeoLens panel to a server, raise the feature limit in Settings, and add a dataset larger than one page as GeoJSON. Confirm the attribute table shows more than one page worth of features and that the limit survives a reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoLens now lets you set a per-dataset maximum number of features to load (saved for future sessions), using capped OGC pagination.
  * Added support for intentionally restoring “no active layer” when reopening projects.
* **Bug Fixes**
  * Project loading and saving now preserve the currently selected layer when valid, normalize invalid selections, and fall back safely when needed.
* **Tests**
  * Added coverage for `selectedLayerId` persistence/normalization and GeoLens pagination/limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->