### PR TITLE
fix(geolens): page the GeoJSON loader instead of passing the feature limit through

### DIFF
--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -341,9 +341,19 @@ export function itemsUrl(options: GeoLensClientOptions, datasetId: string, limit
 }
 
 /**
+ * Features requested per items page. GeoLens caps the `limit` query param and
+ * **rejects** anything above the cap with HTTP 400 rather than clamping (the
+ * reference deployment caps it at 200), so the total feature limit must never
+ * be passed through as the page size — pagination accumulates the rest.
+ */
+export const GEOLENS_PAGE_LIMIT = 100;
+
+/**
  * Load up to `limit` features, following OGC API Features `rel=next` links.
- * GeoLens deployments may cap each response below the requested page size, so
- * requesting a large limit alone is not sufficient to avoid silent truncation.
+ * Each page requests at most {@link GEOLENS_PAGE_LIMIT} features, because
+ * GeoLens rejects (HTTP 400) a `limit` above its per-page cap instead of
+ * clamping it, and deployments may cap each response below the requested page
+ * size anyway.
  */
 export async function fetchDatasetFeatures(
   options: GeoLensClientOptions,
@@ -352,9 +362,12 @@ export async function fetchDatasetFeatures(
   fetchImpl: GeoLensFetch = defaultGeoLensFetch,
   signal?: AbortSignal,
 ): Promise<import("geojson").FeatureCollection> {
+  if (!HTTP_URL_RE.test(options.baseUrl)) throw new Error("GeoLens URL must be http(s)");
+  const base = new URL(options.baseUrl);
+  const pageLimit = Math.min(Math.max(1, Math.floor(limit)), GEOLENS_PAGE_LIMIT);
   const features: import("geojson").Feature[] = [];
   const visited = new Set<string>();
-  let nextUrl: string | null = itemsUrl(options, datasetId, limit);
+  let nextUrl: string | null = itemsUrl(options, datasetId, pageLimit);
   let firstPage: Record<string, unknown> | null = null;
 
   while (nextUrl && features.length < limit && !visited.has(nextUrl)) {
@@ -382,14 +395,14 @@ export async function fetchDatasetFeatures(
         typeof (link as { href?: unknown }).href === "string",
     );
     if (next) {
+      // A deployment behind a reverse proxy may advertise its *internal*
+      // origin in link hrefs (datasets.geolibre.app returns
+      // `http://localhost:8080/...` next links), so the href's path + query
+      // are rebased onto the configured base URL rather than trusted verbatim.
+      // This also keeps every paginated request (and its auth header) on the
+      // origin the user connected to.
       const resolvedUrl: URL = new URL(next.href, nextUrl);
-      if (
-        !HTTP_URL_RE.test(resolvedUrl.href) ||
-        resolvedUrl.origin !== new URL(options.baseUrl).origin
-      ) {
-        throw new Error("GeoLens pagination returned an unsafe next-page URL");
-      }
-      nextUrl = resolvedUrl.href;
+      nextUrl = `${base.origin}${resolvedUrl.pathname}${resolvedUrl.search}`;
     } else {
       nextUrl = null;
     }

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -341,19 +341,30 @@ export function itemsUrl(options: GeoLensClientOptions, datasetId: string, limit
 }
 
 /**
- * Features requested per items page. GeoLens caps the `limit` query param and
- * **rejects** anything above the cap with HTTP 400 rather than clamping (the
- * reference deployment caps it at 200), so the total feature limit must never
- * be passed through as the page size — pagination accumulates the rest.
+ * The known-safe items page size, used as the last rung of
+ * {@link GEOLENS_PAGE_SIZE_LADDER}. GeoLens caps the `limit` query param and
+ * **rejects** anything above the cap with HTTP 400 rather than clamping, and
+ * the cap is not advertised anywhere a client can read, so the loader probes
+ * downward instead of assuming.
  */
 export const GEOLENS_PAGE_LIMIT = 100;
 
 /**
+ * Page sizes retried, in order, after a server rejects the full requested
+ * limit with HTTP 400: GeoLens's OGC items cap (10,000), then the
+ * conservative floor every deployment accepts.
+ */
+const GEOLENS_PAGE_SIZE_LADDER = [10_000, GEOLENS_PAGE_LIMIT];
+
+/**
  * Load up to `limit` features, following OGC API Features `rel=next` links.
- * Each page requests at most {@link GEOLENS_PAGE_LIMIT} features, because
- * GeoLens rejects (HTTP 400) a `limit` above its per-page cap instead of
- * clamping it, and deployments may cap each response below the requested page
- * size anyway.
+ *
+ * The first request asks for all `limit` features at once, so a server whose
+ * page cap allows it answers in a single round trip. A server that caps the
+ * page size responds one of two ways: clamping servers return a shorter first
+ * page plus a `next` link, which the pagination loop follows as usual; GeoLens
+ * instead rejects the request with HTTP 400, in which case the loader retries
+ * down {@link GEOLENS_PAGE_SIZE_LADDER} until a page size is accepted.
  */
 export async function fetchDatasetFeatures(
   options: GeoLensClientOptions,
@@ -364,55 +375,73 @@ export async function fetchDatasetFeatures(
 ): Promise<import("geojson").FeatureCollection> {
   if (!HTTP_URL_RE.test(options.baseUrl)) throw new Error("GeoLens URL must be http(s)");
   const base = new URL(options.baseUrl);
-  const pageLimit = Math.min(Math.max(1, Math.floor(limit)), GEOLENS_PAGE_LIMIT);
-  const features: import("geojson").Feature[] = [];
-  const visited = new Set<string>();
-  let nextUrl: string | null = itemsUrl(options, datasetId, pageLimit);
-  let firstPage: Record<string, unknown> | null = null;
+  const requested = Math.max(1, Math.floor(limit));
+  const pageSizes = [requested, ...GEOLENS_PAGE_SIZE_LADDER.filter((n) => n < requested)];
 
-  while (nextUrl && features.length < limit && !visited.has(nextUrl)) {
-    visited.add(nextUrl);
-    const res = await fetchImpl(nextUrl, { headers: authHeaders(options), signal });
-    if (!res.ok) throw new Error(`GeoLens items request failed (HTTP ${res.status})`);
-    const body = (await res.json()) as Record<string, unknown>;
-    if (!firstPage) firstPage = body;
-    if (!Array.isArray(body.features)) {
-      throw new Error("GeoLens items response contained no features");
-    }
-    // Appended one at a time, not spread: a page can hold more features than
-    // the engine accepts as call arguments, and `push(...page)` would throw.
-    for (const feature of body.features as import("geojson").Feature[]) {
-      if (features.length >= limit) break;
-      features.push(feature);
+  for (let attempt = 0; attempt < pageSizes.length; attempt++) {
+    const features: import("geojson").Feature[] = [];
+    const visited = new Set<string>();
+    let nextUrl: string | null = itemsUrl(options, datasetId, pageSizes[attempt]);
+    let firstPage: Record<string, unknown> | null = null;
+    let pageSizeRejected = false;
+
+    while (nextUrl && features.length < requested && !visited.has(nextUrl)) {
+      visited.add(nextUrl);
+      const res = await fetchImpl(nextUrl, { headers: authHeaders(options), signal });
+      if (!res.ok) {
+        // Only a 400 on the *first* request means the page size was refused;
+        // one mid-pagination is a real error and must surface, not silently
+        // restart the whole download.
+        if (res.status === 400 && firstPage === null && attempt < pageSizes.length - 1) {
+          pageSizeRejected = true;
+          break;
+        }
+        throw new Error(`GeoLens items request failed (HTTP ${res.status})`);
+      }
+      const body = (await res.json()) as Record<string, unknown>;
+      if (!firstPage) firstPage = body;
+      if (!Array.isArray(body.features)) {
+        throw new Error("GeoLens items response contained no features");
+      }
+      // Appended one at a time, not spread: a page can hold more features than
+      // the engine accepts as call arguments, and `push(...page)` would throw.
+      for (const feature of body.features as import("geojson").Feature[]) {
+        if (features.length >= requested) break;
+        features.push(feature);
+      }
+
+      const links = Array.isArray(body.links) ? body.links : [];
+      const next = links.find(
+        (link): link is { rel: string; href: string } =>
+          !!link &&
+          typeof link === "object" &&
+          (link as { rel?: unknown }).rel === "next" &&
+          typeof (link as { href?: unknown }).href === "string",
+      );
+      if (next) {
+        // A deployment behind a reverse proxy may advertise its *internal*
+        // origin in link hrefs (datasets.geolibre.app returns
+        // `http://localhost:8080/...` next links), so the href's path + query
+        // are rebased onto the configured base URL rather than trusted
+        // verbatim. This also keeps every paginated request (and its auth
+        // header) on the origin the user connected to.
+        const resolvedUrl: URL = new URL(next.href, nextUrl);
+        nextUrl = `${base.origin}${resolvedUrl.pathname}${resolvedUrl.search}`;
+      } else {
+        nextUrl = null;
+      }
     }
 
-    const links = Array.isArray(body.links) ? body.links : [];
-    const next = links.find(
-      (link): link is { rel: string; href: string } =>
-        !!link &&
-        typeof link === "object" &&
-        (link as { rel?: unknown }).rel === "next" &&
-        typeof (link as { href?: unknown }).href === "string",
-    );
-    if (next) {
-      // A deployment behind a reverse proxy may advertise its *internal*
-      // origin in link hrefs (datasets.geolibre.app returns
-      // `http://localhost:8080/...` next links), so the href's path + query
-      // are rebased onto the configured base URL rather than trusted verbatim.
-      // This also keeps every paginated request (and its auth header) on the
-      // origin the user connected to.
-      const resolvedUrl: URL = new URL(next.href, nextUrl);
-      nextUrl = `${base.origin}${resolvedUrl.pathname}${resolvedUrl.search}`;
-    } else {
-      nextUrl = null;
-    }
+    if (pageSizeRejected) continue;
+    return {
+      ...(firstPage ?? {}),
+      type: "FeatureCollection",
+      features,
+    } as import("geojson").FeatureCollection;
   }
 
-  return {
-    ...(firstPage ?? {}),
-    type: "FeatureCollection",
-    features,
-  } as import("geojson").FeatureCollection;
+  // Unreachable: the final ladder rung either returns or throws above.
+  throw new Error("GeoLens items request failed");
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -478,9 +478,10 @@ async function addRasterTilesLayer(
 }
 
 /**
- * Add a vector dataset as GeoJSON via OGC API Features. Reads one page (GeoLens
- * caps `limit`); the vector-tile path is preferred for large datasets. Uses the
- * host GeoJSON layer so styling/attribute-table/export all apply.
+ * Add a vector dataset as GeoJSON via OGC API Features. Follows `rel=next`
+ * pages until `featureLimit` features are loaded; the vector-tile path is
+ * preferred for large datasets. Uses the host GeoJSON layer so
+ * styling/attribute-table/export all apply.
  */
 async function addFeaturesLayer(
   app: GeoLibreAppAPI,

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -179,13 +179,38 @@ describe("fetchDatasetFeatures", () => {
     assert.equal(calls[1], "http://h/api/collections/d/items?limit=3&offset=2");
   });
 
-  it("caps the per-page limit even when the total limit is larger", async () => {
-    // GeoLens rejects (HTTP 400) a `limit` query param above its per-page cap
-    // instead of clamping, so a 10,000-feature request must page, not pass
-    // 10000 through.
+  it("loads everything in one request when the server accepts the full limit", async () => {
     const calls: string[] = [];
     const fetchImpl: GeoLensFetch = async (url) => {
       calls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: "FeatureCollection",
+          features: Array.from({ length: 500 }, (_, i) => ({
+            type: "Feature",
+            geometry: null,
+            properties: { id: i },
+          })),
+          links: [],
+        }),
+      };
+    };
+    const result = await fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 10_000, fetchImpl);
+    assert.equal(result.features.length, 500);
+    assert.deepEqual(calls, ["http://h/api/collections/d/items?limit=10000"]);
+  });
+
+  it("falls back down the page-size ladder when the server rejects the limit", async () => {
+    // GeoLens rejects (HTTP 400) a `limit` query param above its per-page cap
+    // instead of clamping. A 25,000-feature request should try 25000, then
+    // 10000, then the conservative floor — stopping at the first accepted size.
+    const calls: string[] = [];
+    const fetchImpl: GeoLensFetch = async (url) => {
+      calls.push(url);
+      const rejected = /limit=(25000|10000)/.test(url);
+      if (rejected) return { ok: false, status: 400, json: async () => ({}) };
       return {
         ok: true,
         status: 200,
@@ -196,8 +221,32 @@ describe("fetchDatasetFeatures", () => {
         }),
       };
     };
-    await fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 10_000, fetchImpl);
-    assert.equal(calls[0], `http://h/api/collections/d/items?limit=${GEOLENS_PAGE_LIMIT}`);
+    const result = await fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 25_000, fetchImpl);
+    assert.equal(result.features.length, 1);
+    assert.deepEqual(calls, [
+      "http://h/api/collections/d/items?limit=25000",
+      "http://h/api/collections/d/items?limit=10000",
+      `http://h/api/collections/d/items?limit=${GEOLENS_PAGE_LIMIT}`,
+    ]);
+  });
+
+  it("surfaces a mid-pagination 400 instead of silently restarting", async () => {
+    const fetchImpl: GeoLensFetch = async (url) => {
+      if (url.includes("page=2")) return { ok: false, status: 400, json: async () => ({}) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: "FeatureCollection",
+          features: [{ type: "Feature", geometry: null, properties: { id: 1 } }],
+          links: [{ rel: "next", href: "?page=2" }],
+        }),
+      };
+    };
+    await assert.rejects(
+      () => fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 10_000, fetchImpl),
+      /HTTP 400/,
+    );
   });
 
   it("rebases a next link advertising an internal origin onto the base URL", async () => {

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -6,6 +6,7 @@ import {
   datasetPageUrl,
   fetchDatasetFeatures,
   fetchDatasetFields,
+  GEOLENS_PAGE_LIMIT,
   geometryKind,
   itemsUrl,
   mintTileToken,
@@ -176,6 +177,57 @@ describe("fetchDatasetFeatures", () => {
     assert.equal(result.features.length, 3);
     assert.equal(calls.length, 2);
     assert.equal(calls[1], "http://h/api/collections/d/items?limit=3&offset=2");
+  });
+
+  it("caps the per-page limit even when the total limit is larger", async () => {
+    // GeoLens rejects (HTTP 400) a `limit` query param above its per-page cap
+    // instead of clamping, so a 10,000-feature request must page, not pass
+    // 10000 through.
+    const calls: string[] = [];
+    const fetchImpl: GeoLensFetch = async (url) => {
+      calls.push(url);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: "FeatureCollection",
+          features: [{ type: "Feature", geometry: null, properties: { id: 1 } }],
+          links: [],
+        }),
+      };
+    };
+    await fetchDatasetFeatures({ baseUrl: "http://h" }, "d", 10_000, fetchImpl);
+    assert.equal(calls[0], `http://h/api/collections/d/items?limit=${GEOLENS_PAGE_LIMIT}`);
+  });
+
+  it("rebases a next link advertising an internal origin onto the base URL", async () => {
+    // datasets.geolibre.app sits behind a reverse proxy and returns
+    // `http://localhost:8080/...` next hrefs; the path + query must be
+    // followed on the public origin the user connected to.
+    const calls: string[] = [];
+    const fetchImpl: GeoLensFetch = async (url) => {
+      calls.push(url);
+      const second = url.includes("after_gid=1");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: "FeatureCollection",
+          features: [{ type: "Feature", geometry: null, properties: { id: second ? 2 : 1 } }],
+          links: second
+            ? []
+            : [{ rel: "next", href: "http://localhost:8080/api/collections/d/items?after_gid=1" }],
+        }),
+      };
+    };
+    const result = await fetchDatasetFeatures(
+      { baseUrl: "https://public.example" },
+      "d",
+      2,
+      fetchImpl,
+    );
+    assert.equal(result.features.length, 2);
+    assert.equal(calls[1], "https://public.example/api/collections/d/items?after_gid=1");
   });
 
   it("truncates an oversized response to the requested limit", async () => {


### PR DESCRIPTION
## Summary

#1400 made the GeoLens GeoJSON loader configurable up to a default limit of 10,000 features, but passed that limit straight through as the OGC API Features `limit` query param. GeoLens rejects a `limit` above its per-page cap with HTTP 400 instead of clamping it, so every **Add GeoJSON** failed with:

> Could not add layer: GeoLens items request failed (HTTP 400)

Three changes:

- **Adaptive page size.** `fetchDatasetFeatures` first asks for the full requested limit in one request, so a server whose cap allows it answers in a single round trip. When the server rejects the page size with HTTP 400, the loader retries down a ladder (10,000 — GeoLens's raised OGC items cap per geolens-io/geolens#665 — then a conservative 100 every deployment accepts). Servers that clamp silently keep working through the normal `rel=next` pagination, and a 400 raised mid-pagination still surfaces as an error instead of silently restarting the download.
- **Rebase next links onto the base URL.** A deployment behind a reverse proxy advertises its internal origin in link hrefs (datasets.geolibre.app returns `http://localhost:8080/...` next links), which the previous same-origin check rejected as unsafe after the first page. The next href's path and query are now rebased onto the configured base URL, which follows those links correctly and keeps every paginated request (and its `X-Api-Key` header) on the origin the user connected to.
- **Pagination accumulates up to the configured feature limit** in all cases, so the setting from #1400 now actually works.

## Verification

- Drove the real app against `https://datasets.geolibre.app`: connected, searched, and added **Manhattan Building Heights** (22,324 features) as GeoJSON with no error; the layer renders on the map.
- Live loader checks: `limit=10000` loads 10,000 features in **1 request (~2.5 s)** — previously 100 requests (~9 s); `limit=25000` ladders down to 10,000-feature pages and loads all 22,324 features in 4 requests (~5.5 s).
- Regression tests: single-request fast path, ladder fallback on 400, mid-pagination 400 surfaces, internal-origin next link rebased, truncation at the limit.
- `npm run test:frontend` — 3,509 pass / 0 fail; `pre-commit` on changed files passes.