### PR TITLE
fix(layers): correct raster style paste for index mode and stop copying opacity

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2808,9 +2808,13 @@ export function LayerPanel({
                           )}
                           {/* Copy/paste symbology between layers (issue #1339),
                           for vector-styled layers and deck.gl rasters. Paste is
-                          disabled until a same-family style is on the clipboard. */}
+                          disabled until a same-family style is on the clipboard;
+                          its tooltip explains the enabled and both disabled
+                          cases. Separated from the neighbouring action groups to
+                          match the rest of the menu. */}
                           {copyStyleKind && (
                             <>
+                              <DropdownMenuSeparator />
                               <DropdownMenuItem
                                 onSelect={() => {
                                   handleCopyStyle(layer);
@@ -2826,7 +2830,9 @@ export function LayerPanel({
                                     ? t("layers.pasteStyleFrom", {
                                         name: copiedLayerStyle.sourceName,
                                       })
-                                    : undefined
+                                    : copiedLayerStyle
+                                      ? t("layers.pasteStyleMismatch")
+                                      : t("layers.pasteStyleEmpty")
                                 }
                                 onSelect={() => {
                                   handlePasteStyle(layer);

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3752,6 +3752,8 @@
     "copyStyle": "Copy style",
     "pasteStyle": "Paste style",
     "pasteStyleFrom": "Paste style from \"{{name}}\"",
+    "pasteStyleEmpty": "Copy a layer's style first",
+    "pasteStyleMismatch": "The copied style is for a different layer type",
     "styleCopied": "Copied style from \"{{name}}\".",
     "stylePasted": "Pasted style from \"{{name}}\".",
     "bindToTimeSlider": "Bind to Time Slider…",

--- a/packages/core/src/layer-style-clipboard.ts
+++ b/packages/core/src/layer-style-clipboard.ts
@@ -42,12 +42,15 @@ export const RASTER_APPEARANCE_STATE_KEYS = [
   "gamma",
 ] as const;
 
-/** Fields every clipboard entry carries, regardless of style family. */
+/**
+ * Fields every clipboard entry carries, regardless of style family. Layer
+ * `opacity` is deliberately excluded: like QGIS "Paste Style" and GeoLibre's
+ * own Style Manager, copy/paste transfers symbology only and leaves the
+ * target's opacity alone (opacity is a per-layer render setting, not style).
+ */
 interface CopiedLayerStyleBase {
   /** Source layer name, surfaced in the paste tooltip and status message. */
   sourceName: string;
-  /** Source layer opacity in [0, 1]. */
-  opacity: number;
 }
 
 /** A copied vector layer style: the whole {@link LayerStyle} bag. */
@@ -113,7 +116,6 @@ export function extractCopiedLayerStyle(layer: GeoLibreLayer): CopiedLayerStyle 
     return {
       kind,
       sourceName: layer.name,
-      opacity: layer.opacity,
       style: structuredClone({ ...DEFAULT_LAYER_STYLE, ...layer.style }),
     };
   }
@@ -121,13 +123,17 @@ export function extractCopiedLayerStyle(layer: GeoLibreLayer): CopiedLayerStyle 
   // clone is skipped here.
   const rasterState = layer.metadata.rasterState;
   const rasterSymbology = layer.metadata.rasterSymbology;
+  // Only a real symbology object counts as "has symbology". A missing or null
+  // value (the latter only reachable via a hand-edited project file) both mean
+  // "none", so the paste clears the target's symbology rather than writing a
+  // literal null onto it — symmetric with the delete path in applyCopiedLayerStyle.
+  const hasRasterSymbology = isPlainObject(rasterSymbology);
   return {
     kind,
     sourceName: layer.name,
-    opacity: layer.opacity,
     rasterState: isPlainObject(rasterState) ? structuredClone(rasterState) : undefined,
-    hasRasterSymbology: rasterSymbology !== undefined,
-    ...(rasterSymbology !== undefined ? { rasterSymbology: structuredClone(rasterSymbology) } : {}),
+    hasRasterSymbology,
+    ...(hasRasterSymbology ? { rasterSymbology: structuredClone(rasterSymbology) } : {}),
   };
 }
 
@@ -153,28 +159,29 @@ export function applyCopiedLayerStyle(
     // Manager's full-"style" preset: a target lacking those attributes just
     // renders that facet inert (no classification / labels), which the user
     // re-points, rather than the paste silently dropping parts of the style.
-    return { style: structuredClone(copied.style), opacity: copied.opacity };
+    return { style: structuredClone(copied.style) };
   }
   // Merge the appearance keys onto the target's existing rasterState, keeping
   // its own `mode`/`bands`/`index` so the paste restyles the layer without
   // repointing it at the source's band selection.
   const targetState = isPlainObject(target.metadata.rasterState) ? target.metadata.rasterState : {};
   const source = copied.rasterState ?? {};
-  const targetBandCount = Array.isArray(targetState.bands) ? targetState.bands.length : 1;
+  const expectedRescaleLength = rescaleEntryCount(targetState);
   const mergedState: Record<string, unknown> = { ...targetState };
   for (const key of RASTER_APPEARANCE_STATE_KEYS) {
     if (!(key in source)) continue;
-    // `rescale` is a per-band min/max array sized to the source's band count.
-    // Copying it onto a target with a different band count (e.g. an RGB source
-    // onto a single-band target) would leave a rescale whose length disagrees
-    // with the preserved `bands` — the same "band it does not have" hazard the
-    // mode/bands preservation above avoids, one level down. Skip it then and
-    // let the target keep its own stretch. A null source rescale (auto) is safe
-    // to carry over regardless.
+    // `rescale` is a per-channel min/max array whose length is set by the
+    // render mode (one entry for single/index, one per band for rgb), not by
+    // `bands.length` (index mode holds two operand bands but a single-entry
+    // rescale). Copying a rescale whose length disagrees with the target's mode
+    // — e.g. an RGB source's 3 entries onto a single-band target — would leave a
+    // rescale that no longer matches the preserved render mode, the same "band
+    // it does not have" hazard one level down. Skip it then and let the target
+    // keep its own stretch. A null source rescale (auto) is safe to carry over.
     if (
       key === "rescale" &&
       Array.isArray(source.rescale) &&
-      source.rescale.length !== targetBandCount
+      source.rescale.length !== expectedRescaleLength
     ) {
       continue;
     }
@@ -186,5 +193,15 @@ export function applyCopiedLayerStyle(
   } else {
     delete metadata.rasterSymbology;
   }
-  return { metadata, opacity: copied.opacity };
+  return { metadata };
+}
+
+/**
+ * Number of `rescale` entries a rasterState of this render mode expects: one
+ * per band for `"rgb"`, a single entry for `"single"` and `"index"` (the
+ * latter stretches one derived index even though it reads two operand bands).
+ */
+function rescaleEntryCount(state: Record<string, unknown>): number {
+  if (state.mode === "rgb") return Array.isArray(state.bands) ? state.bands.length : 3;
+  return 1;
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1423,10 +1423,10 @@ export const useAppStore = create<AppState>()(
         if (!layer) return false;
         const patch = applyCopiedLayerStyle(layer, copied);
         if (!patch) return false;
-        set({
-          layers: s.layers.map((l) => (l.id === id ? { ...l, ...patch } : l)),
-          isDirty: true,
-        });
+        // Go through updateLayer so the paste picks up any cross-cutting layer
+        // update logic (it also sets isDirty); the patch never carries geojson,
+        // so the join-cascade branch is a no-op.
+        get().updateLayer(id, patch);
         return true;
       },
 

--- a/tests/layer-style-clipboard.test.ts
+++ b/tests/layer-style-clipboard.test.ts
@@ -73,17 +73,16 @@ describe("copyableLayerStyleKind", () => {
 });
 
 describe("extractCopiedLayerStyle", () => {
-  it("captures the full style and opacity for a vector layer", () => {
+  it("captures the full style for a vector layer", () => {
     const source = vectorLayer({
-      opacity: 0.5,
       style: { ...DEFAULT_LAYER_STYLE, fillColor: "#ff0000", strokeWidth: 5 },
     });
     const copied = extractCopiedLayerStyle(source);
-    assert.ok(copied);
-    assert.equal(copied.kind, "vector");
-    assert.equal(copied.opacity, 0.5);
+    assert.ok(copied && copied.kind === "vector");
     assert.equal(copied.style.fillColor, "#ff0000");
     assert.equal(copied.style.strokeWidth, 5);
+    // Opacity is a per-layer render setting, not symbology, so it is not copied.
+    assert.equal("opacity" in copied, false);
   });
 
   it("deep-clones so later edits to the source do not mutate the clipboard", () => {
@@ -96,7 +95,6 @@ describe("extractCopiedLayerStyle", () => {
 
   it("captures rasterState and symbology for a raster layer", () => {
     const source = rasterLayer({
-      opacity: 0.8,
       metadata: {
         sourceKind: RASTER_SOURCE_KIND,
         rasterState: { mode: "single", bands: [1], colormap: "magma", rescale: [[10, 90]] },
@@ -109,16 +107,29 @@ describe("extractCopiedLayerStyle", () => {
       },
     });
     const copied = extractCopiedLayerStyle(source);
-    assert.ok(copied);
-    assert.equal(copied.kind, "raster");
-    assert.equal(copied.opacity, 0.8);
+    assert.ok(copied && copied.kind === "raster");
     assert.equal((copied.rasterState as Record<string, unknown>).colormap, "magma");
     assert.equal(copied.hasRasterSymbology, true);
+    assert.equal("opacity" in copied, false);
   });
 
   it("records that a raster source had no symbology", () => {
     const copied = extractCopiedLayerStyle(rasterLayer());
-    assert.ok(copied);
+    assert.ok(copied && copied.kind === "raster");
+    assert.equal(copied.hasRasterSymbology, false);
+  });
+
+  it("treats an explicit null rasterSymbology as no symbology", () => {
+    const copied = extractCopiedLayerStyle(
+      rasterLayer({
+        metadata: {
+          sourceKind: RASTER_SOURCE_KIND,
+          rasterState: { mode: "single", bands: [1], colormap: "gray" },
+          rasterSymbology: null,
+        },
+      }),
+    );
+    assert.ok(copied && copied.kind === "raster");
     assert.equal(copied.hasRasterSymbology, false);
   });
 
@@ -128,15 +139,16 @@ describe("extractCopiedLayerStyle", () => {
 });
 
 describe("applyCopiedLayerStyle", () => {
-  it("returns the full style and opacity when pasting vector onto vector", () => {
+  it("returns the full style (but not opacity) when pasting vector onto vector", () => {
     const copied = extractCopiedLayerStyle(
       vectorLayer({ opacity: 0.4, style: { ...DEFAULT_LAYER_STYLE, fillColor: "#123456" } }),
     );
     assert.ok(copied);
     const patch = applyCopiedLayerStyle(vectorLayer({ id: "target" }), copied);
     assert.ok(patch);
-    assert.equal(patch.opacity, 0.4);
     assert.equal(patch.style?.fillColor, "#123456");
+    // Opacity is left to the target.
+    assert.equal("opacity" in patch, false);
   });
 
   it("refuses to paste across style families", () => {
@@ -152,7 +164,6 @@ describe("applyCopiedLayerStyle", () => {
   it("merges raster appearance keys but preserves the target's band selection", () => {
     const copied = extractCopiedLayerStyle(
       rasterLayer({
-        opacity: 0.7,
         metadata: {
           sourceKind: RASTER_SOURCE_KIND,
           rasterState: {
@@ -191,7 +202,8 @@ describe("applyCopiedLayerStyle", () => {
     assert.deepEqual(state.rescale, [[5, 50]]);
     // Data selection stays with the target.
     assert.deepEqual(state.bands, [1]);
-    assert.equal(patch.opacity, 0.7);
+    // Opacity is left to the target.
+    assert.equal("opacity" in patch, false);
   });
 
   it("clears a stale symbology when the copied raster had none", () => {
@@ -248,6 +260,50 @@ describe("applyCopiedLayerStyle", () => {
     assert.equal(state.colormap, "gray");
     assert.deepEqual(state.rescale, [[10, 90]]);
     assert.deepEqual(state.bands, [1]);
+  });
+
+  it("copies rescale for an index-mode paste (two operand bands, single-entry rescale)", () => {
+    // Index mode reads two operand bands but stretches one derived index, so
+    // its rescale is a single entry even though bands.length is 2. The guard
+    // must not mistake that for a shape mismatch.
+    const copied = extractCopiedLayerStyle(
+      rasterLayer({
+        metadata: {
+          sourceKind: RASTER_SOURCE_KIND,
+          rasterState: {
+            mode: "index",
+            bands: [4, 3],
+            index: "ndvi",
+            colormap: "rdylgn",
+            rescale: [[-1, 1]],
+          },
+        },
+      }),
+    );
+    assert.ok(copied);
+    const target = rasterLayer({
+      id: "target",
+      metadata: {
+        sourceKind: RASTER_SOURCE_KIND,
+        rasterState: {
+          mode: "index",
+          bands: [8, 4],
+          index: "ndvi",
+          colormap: "viridis",
+          rescale: [[0, 1]],
+        },
+      },
+    });
+    const patch = applyCopiedLayerStyle(target, copied);
+    assert.ok(patch);
+    const state = (patch.metadata as Record<string, unknown>).rasterState as Record<
+      string,
+      unknown
+    >;
+    assert.equal(state.colormap, "rdylgn");
+    assert.deepEqual(state.rescale, [[-1, 1]]);
+    // The target keeps its own operand bands.
+    assert.deepEqual(state.bands, [8, 4]);
   });
 });
 


### PR DESCRIPTION
Follow-up to #1342 (copy/paste layer styles), addressing review feedback that landed after that PR was merged.

## Fixes

- **Raster style paste bug in index mode.** The `rescale` band-count guard added in #1342 derived the expected `rescale` length from `bands.length`. That is right for `single` (1 band, 1 entry) and `rgb` (N bands, N entries), but wrong for `index` mode, which reads two operand bands (`bands.length === 2`) yet stretches a single derived index (`rescale` is one entry). The guard therefore skipped `rescale` on a valid index-to-index paste. The expected length is now derived from the render mode (`rescaleEntryCount`), and an index-mode test covers it.
- **Stop copying layer opacity.** Like QGIS "Paste Style" and GeoLibre's own Style Manager, copy/paste now transfers symbology only and leaves the target's opacity alone (opacity is a per-layer render setting, not style). Removed from the clipboard, the paste patch, and the tests.

## Quality

- `pasteLayerStyle` applies its patch through `updateLayer` instead of re-implementing the merge + `isDirty` inline, so future cross-cutting layer-update logic reaches a style paste too.
- Harden the "has symbology" check: an explicit `null` `rasterSymbology` (only reachable via a hand-edited project) now counts as "none" and is cleared on paste rather than written as a literal `null`.
- Menu polish: a separator before the Copy/Paste style group, and an explanatory tooltip on the disabled Paste item (empty clipboard vs style-family mismatch).

## Verification

- `tests/layer-style-clipboard.test.ts` (21 tests) covers the index-mode paste, the cross-mode skip, the null-symbology case, and that opacity is no longer copied.
- `npm run build` and `pre-commit` pass.

Refs #1339, #1342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer feedback when pasting a layer style with no copied style or an incompatible style.
  * Improved separation of style-copying actions in the layer menu.

* **Bug Fixes**
  * Pasting a style now preserves the target layer’s opacity.
  * Improved raster style pasting, including safer rescale handling and preservation of target band settings.
  * Layer updates now consistently retain existing change tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->