### PR TITLE
fix(time-slider): offer bare-year columns in the Bind to Time Slider dialog

### DIFF
--- a/packages/plugins/src/plugins/time-slider-binding.ts
+++ b/packages/plugins/src/plugins/time-slider-binding.ts
@@ -18,8 +18,11 @@ export type TimeGranularity = "hour" | "day" | "month" | "year";
  *   compared lexicographically, which equals chronological order for ISO-8601.
  * - `isoDate`: date-only ISO strings (`YYYY-MM-DD`), compared against date-only
  *   bounds so a feature on the boundary day is not dropped.
+ * - `year`: bare calendar years (`1958`, `"2015"`), the common vintage column in
+ *   GIS data (construction year, survey year). Compared numerically against
+ *   year bounds; each year is anchored at Jan 1 UTC on the timeline.
  */
-export type TimeValueKind = "epochMs" | "epochS" | "isoDateTime" | "isoDate";
+export type TimeValueKind = "epochMs" | "epochS" | "isoDateTime" | "isoDate" | "year";
 
 /**
  * A sliding window of time placed around the timeline's current date. Features
@@ -64,10 +67,19 @@ export interface TimePropertyCandidate {
 const EPOCH_MS_THRESHOLD = 1e11;
 /**
  * Smallest magnitude accepted as an epoch-second timestamp (~1973-03). Numbers
- * below this are not treated as timestamps, so bare-year columns (2015, 2016,
- * ...) and small counts are not misclassified as epoch seconds near 1970.
+ * between the year range and this are not treated as timestamps, so counts and
+ * ids are not misclassified as epoch seconds near 1970.
  */
 const EPOCH_SECONDS_MIN = 1e8;
+/**
+ * Integers in `[YEAR_MIN, YEAR_MAX]` are read as bare calendar years — the
+ * common vintage column in GIS data (construction year, survey year). Kept to
+ * four digits so counts and codes outside the range stay rejected; a four-digit
+ * count column can still slip in as a low-ranked candidate, which is why
+ * {@link detectTimeProperties} breaks coverage ties by distinct-value count.
+ */
+const YEAR_MIN = 1000;
+const YEAR_MAX = 9999;
 /** How many features to inspect when detecting candidate columns / value kind. */
 const SAMPLE_LIMIT = 500;
 const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
@@ -77,9 +89,10 @@ const NUMERIC_STRING = /^-?\d+(\.\d+)?$/;
  * Parse a raw property value into an epoch-millisecond timestamp.
  *
  * Numbers (and all-numeric strings) are treated as epoch seconds or
- * milliseconds by magnitude; other strings are parsed as dates (ISO and any
- * format `Date.parse` accepts). Numbers too small to be a plausible epoch (a
- * bare year or a count) are rejected rather than read as seconds near 1970.
+ * milliseconds by magnitude; four-digit integers are read as bare calendar
+ * years anchored at Jan 1 UTC; other strings are parsed as dates (ISO and any
+ * format `Date.parse` accepts). Remaining numbers (counts, ids) are rejected
+ * rather than read as seconds near 1970.
  *
  * @param value - A raw feature-property value.
  * @returns Epoch milliseconds, or `null` when the value is not a timestamp.
@@ -90,6 +103,9 @@ export function parseTimeValue(value: unknown): number | null {
     const magnitude = Math.abs(value);
     if (magnitude >= EPOCH_MS_THRESHOLD) return value;
     if (magnitude >= EPOCH_SECONDS_MIN) return value * 1000;
+    if (Number.isInteger(value) && value >= YEAR_MIN && value <= YEAR_MAX) {
+      return Date.UTC(value, 0, 1);
+    }
     return null;
   }
   if (typeof value === "string") {
@@ -106,8 +122,12 @@ export function parseTimeValue(value: unknown): number | null {
 
 /**
  * Inspect a feature collection and return the properties that look like
- * timestamps, most-covered first. A property qualifies when at least 60% of the
- * inspected features carry a parseable value.
+ * timestamps, best first. A property qualifies when at least 60% of the
+ * inspected features carry a parseable value. Candidates are ordered by
+ * coverage, and ties by how many distinct timestamps they hold: a real time
+ * column varies across features, while a constant code that happens to parse
+ * (e.g. a `feature_code` of `2100` on every row) collapses to one value and
+ * sinks below it.
  *
  * @param geojson - The layer's feature collection.
  * @returns Candidate timestamp properties for the bind dialog.
@@ -121,6 +141,7 @@ export function detectTimeProperties(
   const total = new Map<string, number>();
   const parsed = new Map<string, number>();
   const sample = new Map<string, unknown>();
+  const distinct = new Map<string, Set<number>>();
   const inspected = Math.min(features.length, SAMPLE_LIMIT);
 
   for (let i = 0; i < inspected; i += 1) {
@@ -129,9 +150,13 @@ export function detectTimeProperties(
     for (const [key, value] of Object.entries(props)) {
       if (value === null || value === undefined || value === "") continue;
       total.set(key, (total.get(key) ?? 0) + 1);
-      if (parseTimeValue(value) !== null) {
+      const ms = parseTimeValue(value);
+      if (ms !== null) {
         parsed.set(key, (parsed.get(key) ?? 0) + 1);
         if (!sample.has(key)) sample.set(key, value);
+        let seen = distinct.get(key);
+        if (!seen) distinct.set(key, (seen = new Set()));
+        seen.add(ms);
       }
     }
   }
@@ -144,7 +169,11 @@ export function detectTimeProperties(
       candidates.push({ property: key, coverage, sample: sample.get(key) });
     }
   }
-  candidates.sort((a, b) => b.coverage - a.coverage);
+  candidates.sort(
+    (a, b) =>
+      b.coverage - a.coverage ||
+      (distinct.get(b.property)?.size ?? 0) - (distinct.get(a.property)?.size ?? 0),
+  );
   return candidates;
 }
 
@@ -156,19 +185,24 @@ export function detectTimeProperties(
  */
 export function detectValueKind(values: unknown[]): TimeValueKind {
   let numeric = 0;
+  let years = 0;
   let isoDateOnly = 0;
   let strings = 0;
   let maxMagnitude = 0;
 
+  const countNumber = (n: number): void => {
+    numeric += 1;
+    maxMagnitude = Math.max(maxMagnitude, Math.abs(n));
+    if (Number.isInteger(n) && n >= YEAR_MIN && n <= YEAR_MAX) years += 1;
+  };
+
   for (const value of values) {
     if (typeof value === "number") {
-      numeric += 1;
-      maxMagnitude = Math.max(maxMagnitude, Math.abs(value));
+      countNumber(value);
     } else if (typeof value === "string") {
       const trimmed = value.trim();
       if (NUMERIC_STRING.test(trimmed)) {
-        numeric += 1;
-        maxMagnitude = Math.max(maxMagnitude, Math.abs(Number(trimmed)));
+        countNumber(Number(trimmed));
       } else {
         strings += 1;
         if (ISO_DATE_ONLY.test(trimmed)) isoDateOnly += 1;
@@ -176,11 +210,13 @@ export function detectValueKind(values: unknown[]): TimeValueKind {
     }
   }
 
-  // Only a purely numeric column is treated as epoch. If any date strings are
-  // present the column is compared as ISO text, so a mixed (or exactly 50/50)
-  // sample is never misclassified as epoch — which would coerce the ISO strings
-  // to NaN and silently drop them. Magnitude tells milliseconds from seconds.
+  // Only a purely numeric column is treated as epoch or year. If any date
+  // strings are present the column is compared as ISO text, so a mixed (or
+  // exactly 50/50) sample is never misclassified as epoch — which would coerce
+  // the ISO strings to NaN and silently drop them. An all-years sample is a
+  // vintage column; otherwise magnitude tells milliseconds from seconds.
   if (numeric > 0 && strings === 0) {
+    if (years === numeric) return "year";
     return maxMagnitude >= EPOCH_MS_THRESHOLD ? "epochMs" : "epochS";
   }
   // Bare calendar dates compare date-only; otherwise (datetimes, or an empty /
@@ -299,6 +335,25 @@ export function buildTimeFilter(binding: TimeBinding, date: Date): unknown[] {
     const scale = valueKind === "epochS" ? 0.001 : 1;
     const value = ["to-number", ["get", property]];
     return ["all", [">=", value, lowerMs * scale], ["<", value, upperMs * scale]];
+  }
+
+  if (valueKind === "year") {
+    // A year Y is in the window iff its Jan 1 UTC anchor falls in
+    // [lowerMs, upperMs), i.e. Y lies in [firstYearAtOrAfter(lowerMs),
+    // firstYearAtOrAfter(upperMs)). Comparing the year numbers directly keeps
+    // the filter a plain numeric comparison on the raw property value.
+    // `to-number` coerces a missing property to 0, below YEAR_MIN, so undated
+    // features fall outside every window.
+    const firstYearAtOrAfter = (ms: number): number => {
+      const y = new Date(ms).getUTCFullYear();
+      return Date.UTC(y, 0, 1) >= ms ? y : y + 1;
+    };
+    const value = ["to-number", ["get", property]];
+    return [
+      "all",
+      [">=", value, firstYearAtOrAfter(lowerMs)],
+      ["<", value, firstYearAtOrAfter(upperMs)],
+    ];
   }
 
   // Compare a fixed-length leading slice of the ISO text on both sides so a

--- a/packages/plugins/src/plugins/time-slider-binding.ts
+++ b/packages/plugins/src/plugins/time-slider-binding.ts
@@ -343,7 +343,9 @@ export function buildTimeFilter(binding: TimeBinding, date: Date): unknown[] {
     // firstYearAtOrAfter(upperMs)). Comparing the year numbers directly keeps
     // the filter a plain numeric comparison on the raw property value.
     // `to-number` coerces a missing property to 0, below YEAR_MIN, so undated
-    // features fall outside every window.
+    // features fall outside every window. The floor check mirrors
+    // parseTimeValue's integer requirement, so a fractional value (1958.5)
+    // that never parsed as a year cannot slip through the window bounds.
     const firstYearAtOrAfter = (ms: number): number => {
       const y = new Date(ms).getUTCFullYear();
       return Date.UTC(y, 0, 1) >= ms ? y : y + 1;
@@ -351,6 +353,7 @@ export function buildTimeFilter(binding: TimeBinding, date: Date): unknown[] {
     const value = ["to-number", ["get", property]];
     return [
       "all",
+      ["==", value, ["floor", value]],
       [">=", value, firstYearAtOrAfter(lowerMs)],
       ["<", value, firstYearAtOrAfter(upperMs)],
     ];

--- a/tests/time-slider-binding.test.ts
+++ b/tests/time-slider-binding.test.ts
@@ -42,15 +42,22 @@ describe("parseTimeValue", () => {
     assert.equal(parseTimeValue(null), null);
   });
 
-  it("rejects bare years and small integers instead of reading them as 1970", () => {
-    assert.equal(parseTimeValue(2015), null);
-    assert.equal(parseTimeValue("2016"), null);
+  it("reads four-digit integers as bare calendar years anchored at Jan 1 UTC", () => {
+    assert.equal(parseTimeValue(2015), Date.UTC(2015, 0, 1));
+    assert.equal(parseTimeValue("2016"), Date.UTC(2016, 0, 1));
+    assert.equal(parseTimeValue(1819), Date.UTC(1819, 0, 1));
+  });
+
+  it("rejects small integers, fractions, and mid-range ids instead of misreading them", () => {
     assert.equal(parseTimeValue(42), null);
+    assert.equal(parseTimeValue(999), null);
+    assert.equal(parseTimeValue(1958.5), null);
+    assert.equal(parseTimeValue(12_345), null); // five digits: not a year, too small for epoch
   });
 });
 
 describe("detectTimeProperties", () => {
-  it("does not offer a bare-year integer column as a timestamp", () => {
+  it("offers a bare-year integer column as a timestamp", () => {
     const fc = pointFeatures([
       { date: "2015-06-01", label: "a" },
       { date: "2016-06-01", label: "b" },
@@ -62,8 +69,23 @@ describe("detectTimeProperties", () => {
       type: "FeatureCollection",
       features: fc,
     });
-    assert.ok(!candidates.some((c) => c.property === "year"));
+    assert.ok(candidates.some((c) => c.property === "year"));
     assert.ok(candidates.some((c) => c.property === "date"));
+  });
+
+  it("ranks a varied year column above a constant code with equal coverage", () => {
+    // Manhattan Building Heights shape: `construction_year` varies per
+    // building while `feature_code` is the same four-digit code on every row.
+    // Both parse on 100% of features; the distinct-value tiebreak must put the
+    // real vintage column first so the bind dialog defaults to it.
+    const features = [1819, 1886, 1930, 1958, 2015].map((year, i) => ({
+      type: "Feature" as const,
+      properties: { construction_year: year, feature_code: "2100" },
+      geometry: { type: "Point" as const, coordinates: [i, i] },
+    }));
+    const candidates = detectTimeProperties({ type: "FeatureCollection", features });
+    assert.equal(candidates[0]?.property, "construction_year");
+    assert.ok(candidates.some((c) => c.property === "feature_code"));
   });
 });
 
@@ -82,6 +104,66 @@ describe("detectValueKind", () => {
     assert.equal(detectValueKind([1_600_000_000, "2016-06-01"]), "isoDate");
     // An empty / unknown sample falls back to the safe string comparison.
     assert.equal(detectValueKind([]), "isoDateTime");
+  });
+
+  it("classifies an all-years numeric sample as year, but not a mixed one", () => {
+    assert.equal(detectValueKind([1819, 1958, 2015]), "year");
+    assert.equal(detectValueKind(["1819", 1958]), "year");
+    // One epoch-magnitude value means the column is epoch, not vintage years.
+    assert.equal(detectValueKind([1958, 1_600_000_000]), "epochS");
+  });
+});
+
+describe("buildTimeFilter (year)", () => {
+  it("compares the raw year number against year bounds", () => {
+    const binding: TimeBinding = {
+      property: "construction_year",
+      valueKind: "year",
+      min: Date.UTC(1819, 0, 1),
+      max: Date.UTC(2015, 0, 1),
+      granularity: "year",
+      window: { unit: "year", before: 0, after: 1 },
+    };
+    const filter = buildTimeFilter(binding, new Date(Date.UTC(1958, 0, 1)));
+    assert.deepEqual(filter, [
+      "all",
+      [">=", ["to-number", ["get", "construction_year"]], 1958],
+      ["<", ["to-number", ["get", "construction_year"]], 1959],
+    ]);
+  });
+
+  it("only includes years whose Jan 1 anchor falls inside a mid-year window", () => {
+    const binding: TimeBinding = {
+      property: "construction_year",
+      valueKind: "year",
+      min: Date.UTC(1819, 0, 1),
+      max: Date.UTC(2015, 0, 1),
+      granularity: "year",
+      window: { unit: "year", before: 0, after: 1 },
+    };
+    // Window [1958-07-01, 1959-07-01): only 1959's Jan 1 anchor is inside.
+    const filter = buildTimeFilter(binding, new Date(Date.UTC(1958, 6, 1)));
+    assert.deepEqual(filter, [
+      "all",
+      [">=", ["to-number", ["get", "construction_year"]], 1959],
+      ["<", ["to-number", ["get", "construction_year"]], 1960],
+    ]);
+  });
+});
+
+describe("buildTimeBinding (year column)", () => {
+  it("builds a year binding spanning the data extent", () => {
+    const features = [1819, 1886, 1958].map((year, i) => ({
+      type: "Feature" as const,
+      properties: { construction_year: year },
+      geometry: { type: "Point" as const, coordinates: [i, i] },
+    }));
+    const binding = buildTimeBinding({ type: "FeatureCollection", features }, "construction_year");
+    assert.ok(binding);
+    assert.equal(binding.valueKind, "year");
+    assert.equal(binding.min, Date.UTC(1819, 0, 1));
+    assert.equal(binding.max, Date.UTC(1958, 0, 1));
+    assert.equal(binding.granularity, "year");
   });
 });
 

--- a/tests/time-slider-binding.test.ts
+++ b/tests/time-slider-binding.test.ts
@@ -127,6 +127,14 @@ describe("buildTimeFilter (year)", () => {
     const filter = buildTimeFilter(binding, new Date(Date.UTC(1958, 0, 1)));
     assert.deepEqual(filter, [
       "all",
+      // Integer guard: a fractional value like 1958.5 never parses as a year
+      // (parseTimeValue rejects it), so the filter must reject it too rather
+      // than let it slip inside the [1958, 1959) window.
+      [
+        "==",
+        ["to-number", ["get", "construction_year"]],
+        ["floor", ["to-number", ["get", "construction_year"]]],
+      ],
       [">=", ["to-number", ["get", "construction_year"]], 1958],
       ["<", ["to-number", ["get", "construction_year"]], 1959],
     ]);
@@ -145,6 +153,11 @@ describe("buildTimeFilter (year)", () => {
     const filter = buildTimeFilter(binding, new Date(Date.UTC(1958, 6, 1)));
     assert.deepEqual(filter, [
       "all",
+      [
+        "==",
+        ["to-number", ["get", "construction_year"]],
+        ["floor", ["to-number", ["get", "construction_year"]]],
+      ],
       [">=", ["to-number", ["get", "construction_year"]], 1959],
       ["<", ["to-number", ["get", "construction_year"]], 1960],
     ]);


### PR DESCRIPTION
## Summary

Binding a GeoJSON layer like **Manhattan Building Heights** (via GeoLens) to the Time Slider showed only `title (97%)` in the Time property dropdown instead of the real time column. Two things conspired:

- The dataset's actual vintage column, `construction_year`, holds bare years (`1958`), which `parseTimeValue` deliberately rejected so year numbers would not be misread as epoch seconds near 1970 — so it never became a candidate.
- The `title` column holds strings like `"Built 1958"`, which V8's lenient `Date.parse` happily reads as a date, so the junk column was the only thing left to offer.

## Changes

- **Bare years are a first-class time kind.** Four-digit integers (and numeric strings) parse as Jan 1 UTC of that year; an all-years column binds with a new `year` value kind; its MapLibre filter compares the raw year number against year bounds (`to-number` coerces undated features to 0, below any year, so they fall outside every window).
- **Candidate ranking breaks coverage ties by distinct-value count.** A constant code that happens to parse (`feature_code` is `2100` on every Manhattan row) collapses to one distinct value and sinks below a genuinely varying year column, so the dialog defaults to the right property.

## Verification

- Drove the real app against the GeoLens Manhattan dataset: the dropdown now offers `construction_year` (selected by default), `feature_code`, and `title (97%)` in that order. After binding, the timeline spans the construction years and scrubbing filters buildings by year — zero buildings at 1719, a sparse correct set at 1984.
- New tests: year parsing bounds (accepts 1000-9999 integers, rejects fractions/counts/five-digit ids), `year` kind detection, year filter expressions incl. mid-year window anchoring, year binding extent, and the distinct-value ranking tiebreak.
- `npm run test:frontend` — full suite passes; `pre-commit` on changed files passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for four-digit calendar years in time-based data.
  * Year values are interpreted as January 1 (UTC) and can be used with time sliders, filters, and bindings.
  * Enhanced timestamp candidate detection to better rank columns containing year values.
* **Bug Fixes**
  * Improved classification and validation of numeric date inputs, rejecting fractional and out-of-range values for year handling.
* **Tests**
  * Updated and expanded the time-slider binding test coverage for year parsing and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->