### PR TITLE
docs: fix Title Case section heading and fork clone URL placeholder in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,10 @@ pull request workflow, lives in the documentation:
 
 **<https://geolibre.app/contributing/>** (source: [`docs/contributing.md`](docs/contributing.md))
 
-## Quick start
+## Quick Start
 
 ```bash
-git clone https://github.com/opengeos/GeoLibre.git
+git clone https://github.com/<your-username>/GeoLibre.git
 cd GeoLibre
 npm install
 npm run dev          # web build at http://localhost:5173

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,11 @@ pull request workflow, lives in the documentation:
 
 ## Quick Start
 
+Fork the repository, then clone your fork — replace `YOUR_GITHUB_USERNAME` with
+your GitHub username:
+
 ```bash
-git clone https://github.com/<your-username>/GeoLibre.git
+git clone https://github.com/YOUR_GITHUB_USERNAME/GeoLibre.git
 cd GeoLibre
 npm install
 npm run dev          # web build at http://localhost:5173

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,8 +33,11 @@ before you invest time in a pull request.
 
 ## Setup
 
+Fork the repository, then clone your fork — replace `YOUR_GITHUB_USERNAME` with
+your GitHub username:
+
 ```bash
-git clone https://github.com/opengeos/GeoLibre.git
+git clone https://github.com/YOUR_GITHUB_USERNAME/GeoLibre.git
 cd GeoLibre
 npm install
 ```


### PR DESCRIPTION
## Description
This PR updates section heading Title Case formatting and fixes the git clone URL placeholder in `CONTRIBUTING.md`.

## Details
1. Updated section header (`## Quick start` $\to$ `## Quick Start`).
2. Replaced upstream repository URL with user fork placeholder (`opengeos` $\to$ `<your-username>`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworded the “Quick Start” section heading for consistent capitalization.
  * Updated repository cloning steps to fork first, then clone using a `YOUR_GITHUB_USERNAME` placeholder.
  * Left the remaining Quick Start and “Before opening a pull request” instructions unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->