### PR TITLE
docs: fix Title Case section headings and clone URL placeholder in docs/contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,10 @@ pull request workflow, lives in the documentation:
 
 **<https://geolibre.app/contributing/>** (source: [`docs/contributing.md`](docs/contributing.md))
 
-## Quick start
+## Quick Start
 
 ```bash
-git clone https://github.com/opengeos/GeoLibre.git
+git clone https://github.com/<your-username>/GeoLibre.git
 cd GeoLibre
 npm install
 npm run dev          # web build at http://localhost:5173

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,7 @@ typo to adding a new processing tool or plugin.
 
 By participating, you agree to keep interactions respectful and constructive.
 
-## Ways to contribute
+## Ways to Contribute
 
 - **Report a bug or request a feature** by opening an
   [issue](https://github.com/opengeos/GeoLibre/issues). Include steps to
@@ -34,7 +34,7 @@ before you invest time in a pull request.
 ## Setup
 
 ```bash
-git clone https://github.com/opengeos/GeoLibre.git
+git clone https://github.com/<your-username>/GeoLibre.git
 cd GeoLibre
 npm install
 ```


### PR DESCRIPTION
## Description
This PR updates section heading Title Case capitalization and fixes the git clone URL placeholder in `docs/contributing.md`.

## Details
1. Updated section header (`## Ways to contribute` $\to$ `## Ways to Contribute`).
2. Replaced upstream repository URL with user fork placeholder (`opengeos` $\to$ `<your-username>`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor setup materials with clearer “Quick Start” wording and improved formatting.
  * Capitalized the “Ways to Contribute” heading for consistency.
  * Refined cloning instructions to use a user-specific placeholder (e.g., `YOUR_GITHUB_USERNAME`) and clearer step-by-step phrasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->