### PR TITLE
fix(legend): merge graduated color and size into one legend block

### DIFF
--- a/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
+++ b/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
@@ -15,20 +15,39 @@ import type { LegendMarker } from "../../lib/print-layout";
 /** Neutral outline that reads on both light and dark themes. */
 const OUTLINE = "rgba(107,114,128,0.6)";
 
+/** Largest radius / stroke width a proportional legend symbol is drawn at (px). */
+const MAX_SWATCH_RADIUS = 12;
+const MAX_SWATCH_STROKE = 8;
+
+/**
+ * The scale that fits an entry's largest proportional symbol into the legend.
+ * Applied to EVERY row of that entry so the drawn symbols keep the map's true
+ * size ratios; clamping each radius on its own instead would flatten a 4 → 24px
+ * ramp into 4 → 12 and make the classes look far closer in size than they are.
+ */
+function swatchScale(largest: number | undefined, size: number, cap: number): number {
+  const reference = Math.max(largest ?? size, size);
+  return reference > cap ? cap / reference : 1;
+}
+
 /**
  * A small geometry-aware swatch: point → filled circle, line → rounded stroke,
  * polygon → filled square, raster → image glyph. `size` overrides the symbol
- * size for proportional-symbol rows (circle radius / line width in px).
+ * size for proportional-symbol rows (circle radius / line width in px), and
+ * `maxSize` is the largest `size` in the same entry so the whole set scales by
+ * one factor and shares one box width (keeping the labels aligned).
  */
 export function GeometrySwatch({
   shape,
   color,
   size,
+  maxSize,
   opacity = 1,
 }: {
   shape: LayerSwatchShape;
   color: string;
   size?: number;
+  maxSize?: number;
   opacity?: number;
 }) {
   const style = opacity < 1 ? { opacity } : undefined;
@@ -43,9 +62,15 @@ export function GeometrySwatch({
     );
   }
   if (shape === "circle") {
-    // Proportional rows pass a radius; cap it so the largest class still fits.
-    const r = Math.max(2, Math.min(size ?? 5, 11));
-    const box = size !== undefined ? 24 : 14;
+    const scale = size !== undefined ? swatchScale(maxSize, size, MAX_SWATCH_RADIUS) : 1;
+    // Proportional rows pass a radius; keep the smallest visible without
+    // disturbing the shared scale of the rest.
+    const r = size !== undefined ? Math.max(1.5, size * scale) : 5;
+    // One box per entry: derived from the entry's largest symbol, not this row's.
+    const box =
+      size !== undefined
+        ? Math.ceil(Math.max(r, Math.max(maxSize ?? size, size) * scale) * 2) + 2
+        : 14;
     return (
       <svg
         width={box}
@@ -60,7 +85,8 @@ export function GeometrySwatch({
     );
   }
   if (shape === "line") {
-    const width = Math.max(1.5, Math.min(size ?? 2.5, 8));
+    const scale = size !== undefined ? swatchScale(maxSize, size, MAX_SWATCH_STROKE) : 1;
+    const width = size !== undefined ? Math.max(1, size * scale) : 2.5;
     const box = size !== undefined ? 24 : 14;
     return (
       <svg width={box} height={14} className="shrink-0" style={style} aria-hidden="true">

--- a/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
+++ b/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
@@ -297,6 +297,9 @@ export function MapLegendPanel({
             label: row.label,
             color: normalizeHexColor(row.color) ?? row.color,
             ...(row.shape === "circle" || row.shape === "line" ? { shape: row.shape } : {}),
+            // Carry proportional sizes so customizing a graduated-size entry
+            // renames/reorders its rows without flattening every symbol.
+            ...(row.size !== undefined ? { size: row.size } : {}),
           }))
         : [
             {
@@ -704,6 +707,13 @@ function LegendEntryRow({
   const { t } = useTranslation();
   const index = entryIds.indexOf(entry.id);
   const visibleRows = editing ? entry.rows : entry.rows.filter((row) => !row.hidden);
+  // The entry's largest proportional symbol, so every row scales by one factor
+  // (see GeometrySwatch). Taken over all rows, not just the visible ones, so
+  // hiding a class does not resize the ones left behind.
+  const maxRowSize = entry.rows.reduce(
+    (largest, row) => (row.size !== undefined && row.size > largest ? row.size : largest),
+    0,
+  );
   const editingCustom = editing && entry.custom && customEntry;
   const hasBody = Boolean(
     entry.fieldLabel || entry.gradient || editingCustom || visibleRows.length > 0,
@@ -870,6 +880,7 @@ function LegendEntryRow({
                 key={row.key}
                 row={row}
                 entry={entry}
+                maxRowSize={maxRowSize}
                 editing={editing && !entry.custom}
                 legend={legend}
                 onCommit={onCommit}
@@ -896,51 +907,63 @@ function LegendEntryRow({
 function LegendClassRow({
   row,
   entry,
+  maxRowSize,
   editing,
   legend,
   onCommit,
 }: {
   row: AutoLegendRow;
   entry: AutoLegendEntry;
+  maxRowSize: number;
   editing: boolean;
   legend: LegendConfig;
   onCommit: (next: LegendConfig) => void;
 }) {
   const { t } = useTranslation();
   return (
-    <li className={cn("flex items-center gap-1.5", row.hidden && "opacity-40")}>
-      {row.marker ? (
-        <MarkerSwatch marker={row.marker} opacity={entry.opacity} />
-      ) : (
-        <GeometrySwatch
-          shape={row.shape}
-          color={row.color}
-          size={row.size}
-          opacity={entry.opacity}
-        />
+    <li className={cn(row.hidden && "opacity-40")}>
+      {/* Names the field this and the following rows describe, when it is not
+          the entry's classified field (a size ramp on a second attribute). */}
+      {row.caption && (
+        <div className="mb-0.5 mt-1 truncate text-[10px] font-medium text-muted-foreground">
+          {row.caption}
+        </div>
       )}
-      {editing ? (
-        <>
-          <InlineEdit
-            value={row.label}
-            ariaLabel={t("legendPanel.renameItem", { name: row.label })}
-            className="text-xs text-foreground/80"
-            onCommit={(next) =>
-              onCommit(setLegendItemLabel(legend, row.key, next, row.defaultLabel))
-            }
+      <div className="flex items-center gap-1.5">
+        {row.marker ? (
+          <MarkerSwatch marker={row.marker} opacity={entry.opacity} />
+        ) : (
+          <GeometrySwatch
+            shape={row.shape}
+            color={row.color}
+            size={row.size}
+            maxSize={maxRowSize > 0 ? maxRowSize : undefined}
+            opacity={entry.opacity}
           />
-          <IconButton
-            label={row.hidden ? t("legendPanel.showItem") : t("legendPanel.hideItem")}
-            onClick={() => onCommit(toggleLegendItemHidden(legend, row.key))}
-          >
-            {row.hidden ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-          </IconButton>
-        </>
-      ) : (
-        <span className="min-w-0 flex-1 truncate text-xs text-foreground/80" title={row.label}>
-          {row.label}
-        </span>
-      )}
+        )}
+        {editing ? (
+          <>
+            <InlineEdit
+              value={row.label}
+              ariaLabel={t("legendPanel.renameItem", { name: row.label })}
+              className="text-xs text-foreground/80"
+              onCommit={(next) =>
+                onCommit(setLegendItemLabel(legend, row.key, next, row.defaultLabel))
+              }
+            />
+            <IconButton
+              label={row.hidden ? t("legendPanel.showItem") : t("legendPanel.hideItem")}
+              onClick={() => onCommit(toggleLegendItemHidden(legend, row.key))}
+            >
+              {row.hidden ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+            </IconButton>
+          </>
+        ) : (
+          <span className="min-w-0 flex-1 truncate text-xs text-foreground/80" title={row.label}>
+            {row.label}
+          </span>
+        )}
+      </div>
     </li>
   );
 }

--- a/apps/geolibre-desktop/src/lib/auto-legend.ts
+++ b/apps/geolibre-desktop/src/lib/auto-legend.ts
@@ -16,12 +16,15 @@
 import {
   effectiveVectorRules,
   isHexColor,
+  proportionalSizeRange,
   styleValue,
   type GeoLibreLayer,
+  type LayerStyle,
   type LegendConfig,
   type LegendCustomEntry,
   type LegendCustomItem,
   type LegendItemOverride,
+  type ProportionalSizeRange,
   type VectorStyleStop,
 } from "@geolibre/core";
 import { isRasterLike, layerSwatchShape, type LayerSwatchShape } from "./layer-swatch";
@@ -63,6 +66,12 @@ export const HEATMAP_RAMP_COLORS: readonly string[] = [
 export interface AutoLegendRow {
   /** Stable override key (`<entryId>::p:<index>` in the panel namespace). */
   key: string;
+  /**
+   * Caption naming the field the rows from here down describe. Set on the first
+   * row of a size ramp that reads a different field than the colors classify,
+   * so the two blocks are not both read as the entry's `fieldLabel`.
+   */
+  caption?: string;
   /** Effective label after applying any user override. */
   label: string;
   /** The auto-generated label (for the rename editor's clear-to-default). */
@@ -173,6 +182,7 @@ interface RawRow {
   shape: LayerSwatchShape;
   marker?: LegendMarker;
   size?: number;
+  caption?: string;
 }
 
 /** Vector class rows (graduated ranges / categorized values). */
@@ -436,26 +446,72 @@ export function expressionLegendParts(
 /**
  * Proportional-symbol size rows: min / middle / max symbol sizes with their
  * data values, mirroring the interpolate the map renders. Circles for points,
- * line strokes for lines.
+ * line strokes for lines. Only used when the size field is NOT the field the
+ * colors classify — otherwise the sizes are merged into the class rows by
+ * {@link sizeClassRows} so one field yields one legend block.
  */
 function proportionalSizeRows(
-  layer: GeoLibreLayer,
+  range: ProportionalSizeRange,
+  color: string,
   shape: LayerSwatchShape,
-  locale?: string,
+  locale: string | undefined,
+  /** Field caption for the block, when the entry's own caption names another. */
+  caption?: string,
 ): RawRow[] {
-  const style = layer.style;
-  const color = styleValue(style, "fillColor") || NEUTRAL;
-  const minValue = styleValue(style, "proportionalSizeMinValue");
-  const maxValue = styleValue(style, "proportionalSizeMaxValue");
-  const minRadius = styleValue(style, "proportionalSizeMinRadius");
-  const maxRadius = styleValue(style, "proportionalSizeMaxRadius");
   const rowShape: LayerSwatchShape = shape === "line" ? "line" : "circle";
-  return [0, 0.5, 1].map((ratio) => ({
-    label: formatLegendNumber(lerp(minValue, maxValue, ratio), locale),
+  return [0, 0.5, 1].map((ratio, index) => ({
+    label: formatLegendNumber(lerp(range.minValue, range.maxValue, ratio), locale),
     color,
     shape: rowShape,
-    size: lerp(minRadius, maxRadius, ratio),
+    size: lerp(range.minRadius, range.maxRadius, ratio),
+    ...(index === 0 && caption ? { caption } : {}),
   }));
+}
+
+/**
+ * The symbol size the map draws for `value`, clamping outside the configured
+ * value range exactly as the `interpolate` in `proportionalRadiusExpression`
+ * does, so a legend symbol can never claim a size the map does not render.
+ */
+function proportionalSize(range: ProportionalSizeRange, value: number): number {
+  const ratio = (value - range.minValue) / (range.maxValue - range.minValue);
+  return lerp(range.minRadius, range.maxRadius, Math.min(1, Math.max(0, ratio)));
+}
+
+/**
+ * Size each graduated class row at the symbol the map draws for that class —
+ * the midpoint of the class range, or the lower bound for the open-ended top
+ * class. Applied when the color classification and the proportional sizing read
+ * the same field, so the legend shows ONE block of correctly-sized,
+ * correctly-colored symbols instead of the class rows plus a second,
+ * differently-colored size ramp describing the very same field.
+ *
+ * Rows whose stop value is not numeric keep their default size.
+ */
+function sizeClassRows(
+  rows: RawRow[],
+  stops: VectorStyleStop[],
+  range: ProportionalSizeRange,
+): RawRow[] {
+  return rows.map((row, index) => {
+    const from = Number(stops[index]?.value);
+    const to = Number(stops[index + 1]?.value);
+    // The top class has no upper bound ("≥ x"): represent it at its lower bound.
+    const representative = Number.isFinite(to) ? (from + to) / 2 : from;
+    if (!Number.isFinite(representative)) return row;
+    return { ...row, size: proportionalSize(range, representative) };
+  });
+}
+
+/**
+ * Fill color for a standalone size ramp. A class-colored layer paints no single
+ * `fillColor` — using it there is what made the size swatches show an unrelated
+ * default blue next to the layer's actual ramp — so sample the middle class
+ * color instead; single-symbol layers keep their fill.
+ */
+function sizeRampColor(classRows: RawRow[], style: LayerStyle): string {
+  if (classRows.length > 0) return classRows[Math.floor(classRows.length / 2)].color;
+  return styleValue(style, "fillColor") || NEUTRAL;
 }
 
 /** Grayscale fallback when a named colormap has not been sampled yet. */
@@ -613,26 +669,56 @@ function vectorParts(
     };
   }
 
-  const sizeRows =
-    styleValue(style, "proportionalSizeEnabled") &&
-    styleValue(style, "proportionalSizeProperty") !== "" &&
-    (shape === "circle" || shape === "line")
-      ? proportionalSizeRows(layer, shape, locale)
-      : [];
+  // The shared guard from @geolibre/core, so the legend advertises proportional
+  // sizing on exactly the layers the map actually sizes. Only circles and line
+  // strokes carry a size; polygon fills ignore it.
+  const sizeRange = shape === "circle" || shape === "line" ? proportionalSizeRange(style) : null;
 
   if ((mode === "graduated" || mode === "categorized") && stops.length > 0) {
+    const classProperty = styleValue(style, "vectorStyleProperty");
+    const classRows = stopRows(stops, mode, shape, locale);
+    // Same field classified and sized: one merged block. Categorized values are
+    // not numeric ranges, so they can only carry a separate ramp.
+    const merged =
+      sizeRange !== null && mode === "graduated" && sizeRange.property === classProperty;
     return {
-      rows: [...stopRows(stops, mode, shape, locale), ...sizeRows, ...diagrams],
+      rows: [
+        ...(merged && sizeRange ? sizeClassRows(classRows, stops, sizeRange) : classRows),
+        ...(sizeRange && !merged
+          ? proportionalSizeRows(
+              sizeRange,
+              sizeRampColor(classRows, style),
+              shape,
+              locale,
+              // The entry caption already names the classified field; say which
+              // field this second block sizes by so the two are not confused.
+              sizeRange.property === classProperty ? undefined : sizeRange.property,
+            )
+          : []),
+        ...diagrams,
+      ],
       gradient: null,
       headerSwatch: null,
-      fieldLabel: styleValue(style, "vectorStyleProperty") || undefined,
+      fieldLabel: classProperty || undefined,
     };
   }
   if (mode === "rule-based") {
     const rows = ruleRows(layer, shape);
     if (rows.length > 0) {
       return {
-        rows: [...rows, ...sizeRows, ...diagrams],
+        rows: [
+          ...rows,
+          ...(sizeRange
+            ? proportionalSizeRows(
+                sizeRange,
+                sizeRampColor(rows, style),
+                shape,
+                locale,
+                sizeRange.property,
+              )
+            : []),
+          ...diagrams,
+        ],
         gradient: null,
         headerSwatch: null,
       };
@@ -642,7 +728,19 @@ function vectorParts(
     const parts = expressionLegendParts(styleValue(style, "vectorStyleExpression"), shape, locale);
     if (parts) {
       return {
-        rows: [...parts.rows, ...sizeRows, ...diagrams],
+        rows: [
+          ...parts.rows,
+          ...(sizeRange
+            ? proportionalSizeRows(
+                sizeRange,
+                sizeRampColor(parts.rows, style),
+                shape,
+                locale,
+                sizeRange.property === parts.fieldLabel ? undefined : sizeRange.property,
+              )
+            : []),
+          ...diagrams,
+        ],
         gradient: parts.gradient,
         headerSwatch: null,
         fieldLabel: parts.fieldLabel,
@@ -650,21 +748,29 @@ function vectorParts(
     }
   }
 
+  // Single symbology: the size ramp IS the classification, so it carries the
+  // field caption and replaces the single-swatch heading chip.
+  const sizeRows = sizeRange
+    ? proportionalSizeRows(sizeRange, styleValue(style, "fillColor") || NEUTRAL, shape, locale)
+    : [];
   const marker = pointMarkerSwatch(style);
   const headerSwatch = marker
     ? { color: marker.color, marker: marker.marker }
     : { color: styleValue(style, "fillColor") || NEUTRAL };
-  const fieldLabel =
-    sizeRows.length > 0 ? styleValue(style, "proportionalSizeProperty") || undefined : undefined;
+  const fieldLabel = sizeRange ? sizeRange.property : undefined;
   return { rows: [...sizeRows, ...diagrams], gradient: null, headerSwatch, fieldLabel };
 }
 
-/** Rows for a hand-authored entry. */
+/**
+ * Rows for a hand-authored entry. Item sizes carry through so customizing a
+ * proportional-symbol entry keeps the graduated symbol sizes it was seeded from.
+ */
 function customRows(entry: LegendCustomEntry): RawRow[] {
   return entry.items.slice(0, MAX_LEGEND_ROWS).map((item) => ({
     label: item.label,
     color: item.color,
     shape: item.shape ?? ("square" as const),
+    ...(typeof item.size === "number" && Number.isFinite(item.size) ? { size: item.size } : {}),
   }));
 }
 
@@ -802,6 +908,7 @@ function finishEntry(
       const override = config.overrides[key];
       return {
         key,
+        ...(row.caption ? { caption: row.caption } : {}),
         label: effectiveLabel(override, row.label),
         defaultLabel: row.label,
         color: row.color,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -250,7 +250,18 @@ function normalizeLegendConfig(legend: unknown): LegendConfig | undefined {
           row.shape === "circle" || row.shape === "line" || row.shape === "square"
             ? row.shape
             : undefined;
-        items.push({ label: row.label, color: row.color, ...(shape ? { shape } : {}) });
+        // Proportional symbol size in map pixels; bounded so a hand-edited file
+        // cannot ask the panel for an absurd swatch.
+        const size =
+          typeof row.size === "number" && Number.isFinite(row.size) && row.size > 0
+            ? Math.min(row.size, 1000)
+            : undefined;
+        items.push({
+          label: row.label,
+          color: row.color,
+          ...(shape ? { shape } : {}),
+          ...(size !== undefined ? { size } : {}),
+        });
       }
       if (items.length === 0) continue;
       customEntries[key.trim()] = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1226,6 +1226,12 @@ export interface LegendCustomItem {
   color: string;
   /** Swatch shape; defaults to `"square"`. */
   shape?: LegendCustomShape;
+  /**
+   * Symbol size in map pixels (circle radius / line width). Carried so that
+   * customizing a proportional-symbol entry keeps the graduated sizes it was
+   * seeded from instead of flattening every symbol to one size.
+   */
+  size?: number;
 }
 
 /**

--- a/tests/auto-legend.test.ts
+++ b/tests/auto-legend.test.ts
@@ -200,6 +200,136 @@ describe("buildAutoLegend — vector layers", () => {
     );
     assert.ok(entry.rows.every((row) => row.shape === "circle"));
   });
+
+  it("sizes graduated class rows instead of repeating the field as a size ramp", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "sized",
+          metadata: { geometryType: "point" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            vectorStyleMode: "graduated",
+            vectorStyleProperty: "pop_max",
+            vectorStyleStops: [
+              { value: 0, color: "#440154" },
+              { value: 100, color: "#31688e" },
+              { value: 200, color: "#fde725" },
+            ],
+            proportionalSizeEnabled: true,
+            proportionalSizeProperty: "pop_max",
+            proportionalSizeMinValue: 0,
+            proportionalSizeMaxValue: 200,
+            proportionalSizeMinRadius: 4,
+            proportionalSizeMaxRadius: 24,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    const [entry] = entries;
+    // One row per class, each keeping its class color and carrying the size the
+    // map draws at the class midpoint (the open-ended top class at its bound).
+    assert.deepEqual(
+      entry.rows.map((row) => [row.label, row.color, row.size]),
+      [
+        ["0 – 100", "#440154", 9],
+        ["100 – 200", "#31688e", 19],
+        ["≥ 200", "#fde725", 24],
+      ],
+    );
+  });
+
+  it("keeps a separate size ramp for a different field, colored from the classes", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "two-fields",
+          metadata: { geometryType: "point" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            fillColor: "#3388ff",
+            vectorStyleMode: "categorized",
+            vectorStyleProperty: "region",
+            vectorStyleStops: [
+              { value: "north", color: "#440154" },
+              { value: "south", color: "#31688e" },
+              { value: "east", color: "#fde725" },
+            ],
+            proportionalSizeEnabled: true,
+            proportionalSizeProperty: "pop_max",
+            proportionalSizeMinValue: 0,
+            proportionalSizeMaxValue: 100,
+            proportionalSizeMinRadius: 4,
+            proportionalSizeMaxRadius: 12,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    const [entry] = entries;
+    assert.equal(entry.rows.length, 6);
+    assert.equal(entry.fieldLabel, "region");
+    // The size swatches sample the middle class, never the unused layer fill,
+    // and the block is captioned with the field it actually sizes by.
+    assert.deepEqual(
+      entry.rows.slice(3).map((row) => [row.label, row.color, row.size, row.caption]),
+      [
+        ["0", "#31688e", 4, "pop_max"],
+        ["50", "#31688e", 8, undefined],
+        ["100", "#31688e", 12, undefined],
+      ],
+    );
+  });
+
+  it("omits size rows when the proportional range is degenerate", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "degenerate",
+          metadata: { geometryType: "point" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            proportionalSizeEnabled: true,
+            proportionalSizeProperty: "magnitude",
+            proportionalSizeMinValue: 100,
+            proportionalSizeMaxValue: 100,
+            proportionalSizeMinRadius: 4,
+            proportionalSizeMaxRadius: 12,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    const [entry] = entries;
+    assert.equal(entry.rows.length, 0);
+    assert.equal(entry.fieldLabel, undefined);
+    assert.ok(entry.headerSwatch);
+  });
+
+  it("carries item sizes through a hand-authored custom entry", () => {
+    const entries = buildAutoLegend(
+      [layer({ id: "c", metadata: { geometryType: "point" } })],
+      config({
+        customEntries: {
+          c: {
+            items: [
+              { label: "Small", color: "#440154", shape: "circle", size: 4 },
+              { label: "Large", color: "#fde725", shape: "circle", size: 24 },
+            ],
+          },
+        },
+      }),
+      EN,
+    );
+    assert.deepEqual(
+      entries[0].rows.map((row) => row.size),
+      [4, 24],
+    );
+  });
 });
 
 describe("expressionLegendParts — advanced expression styles", () => {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -211,6 +211,38 @@ describe("project parsing", () => {
     assert.deepEqual(project.legend?.overrides, { a: { label: "Renamed", hidden: true } });
   });
 
+  it("keeps hand-authored legend item sizes and drops nonsensical ones", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Legend",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        legend: {
+          title: "Legend",
+          groupByLayer: true,
+          order: [],
+          overrides: {},
+          customEntries: {
+            a: {
+              items: [
+                { label: "Small", color: "#440154", shape: "circle", size: 4 },
+                { label: "Huge", color: "#fde725", shape: "circle", size: 9e9 },
+                { label: "Bad", color: "#000000", size: "big" },
+                { label: "None", color: "#111111", size: 0 },
+              ],
+            },
+          },
+        },
+      }),
+    );
+    assert.deepEqual(project.legend?.customEntries?.a.items, [
+      { label: "Small", color: "#440154", shape: "circle", size: 4 },
+      { label: "Huge", color: "#fde725", shape: "circle", size: 1000 },
+      { label: "Bad", color: "#000000" },
+      { label: "None", color: "#111111" },
+    ]);
+  });
+
   it("round-trips a legend config through projectFromStore", () => {
     const legend = {
       title: "Custom",


### PR DESCRIPTION
Fixes #1412

## The bug

A point layer classified by a field **and** sized proportionally by the *same* field produced two legend blocks for one classification:

1. The class rows, all drawn at the same dot size.
2. A second min/mid/max size ramp painted in the layer's `fillColor` — a value the map does not use in graduated mode, so it showed up as a generic blue next to the layer's actual ramp.

The sizes in that second block were also clamped row by row, so a 4 → 24px ramp was flattened to 4 → 11 and never matched the circles on the map. Clicking the pencil to customize the entry then dropped the sizes entirely, collapsing every symbol to one size.

Reproduced with `us_cities.geojson`: Graduated on `pop_max` (5 equal-interval classes, Viridis) + Proportional size on `pop_max`, 0 – 15,232,040 → 4 – 24px.

| Before | After |
| --- | --- |
| 5 class rows as identical dots, then 3 blue circles labelled 0 / 7.6M / 15.2M | one block: 5 class rows in their class colors, each sized as the map draws it |

## The fix

- **Derivation** (`auto-legend.ts`): when the color classification and the proportional sizing read the same field, size each class row at the symbol the map draws for that class — the class midpoint, or the lower bound for the open-ended top class — instead of appending a separate ramp. Sizing now goes through the shared `proportionalSizeRange` guard from `@geolibre/core`, so the legend advertises it on exactly the layers the map actually sizes (a degenerate range no longer produces rows).
- **Different fields**: a size ramp that genuinely reads another attribute is still shown, but sampled from the middle class color rather than the unused fill, and captioned with the field it sizes by so it is not read as the classified one.
- **Swatches** (`LegendSwatch.tsx`): proportional symbols scale by one factor per entry, preserving the map's true size ratios and sharing one box width so labels stay aligned.
- **Customize items**: `LegendCustomItem` carries an optional `size` (validated on project load), so converting an entry to hand-authored keeps the graduated sizes it was seeded from.

## Verification

- Driven in the real app with Playwright against `us_cities.geojson`, in **both light and dark themes**: merged same-field case, separate-field case with its caption, and the Customize items round trip.
- `npm run test:frontend` — 3523 passing, including 5 new cases in `tests/auto-legend.test.ts` and 1 in `tests/core-project.test.ts`.
- `npm run build` clean; `pre-commit run --files <changed>` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proportional sizing support for legend symbols, preserving relative sizes across rows.
  * Legend entries can now retain custom symbol sizes.
  * Added captions for size-ramp legend sections, including when sizing and coloring use different fields.
  * Improved graduated legends when rows are hidden or customized.

* **Bug Fixes**
  * Corrected proportional symbol scaling, color handling, and invalid size normalization.
  * Prevented degenerate size ranges from producing misleading legend rows.

* **Tests**
  * Added coverage for proportional sizing, custom entries, captions, and size validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->