### PR TITLE
fix(sidecar): serialize lifecycle and reclaim orphaned port 8765

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -82,6 +82,10 @@ struct MartinServerState {
 
 struct SidecarServerState {
     process: Mutex<Option<SidecarProcess>>,
+    // Serialize start/stop across every UI surface that can request the shared
+    // sidecar. Without this, two callers can both pass the reuse check and race
+    // to bind the fixed port, or a restart can overlap the previous teardown.
+    lifecycle: Mutex<()>,
 }
 
 struct JupyterServerState {
@@ -204,6 +208,7 @@ pub fn run() {
         })
         .manage(SidecarServerState {
             process: Mutex::new(None),
+            lifecycle: Mutex::new(()),
         })
         .manage(JupyterServerState {
             process: Mutex::new(None),
@@ -1584,6 +1589,10 @@ async fn start_geolibre_sidecar(app: tauri::AppHandle) -> Result<SidecarServerIn
 fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServerInfo, String> {
     let base_url = sidecar_base_url();
     let state = app.state::<SidecarServerState>();
+    let _lifecycle = state
+        .lifecycle
+        .lock()
+        .map_err(|_| "Could not lock sidecar lifecycle.".to_string())?;
     {
         let mut process = state
             .process
@@ -1614,16 +1623,21 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
                 token: sidecar_token().to_string(),
             });
         }
-        // A sidecar is listening but rejects this session's token — an orphan
-        // from a previous launch still holding the port. We can't reclaim it
-        // (no child handle here, and /shutdown is token-protected), so fail with
-        // a clear message rather than handing back a token that 401s every call.
-        return Err(
-            "A GeoLibre processing server from a previous session is still \
-             running on port 8765 but does not accept this session's token. \
-             Quit any stray GeoLibre processes and try again."
-                .to_string(),
-        );
+        // A sidecar is listening but rejects this session's token — usually an
+        // orphan from a previous app launch. Reclaim it when the OS-specific
+        // listener inspection can prove it is one of our sidecars. The process
+        // identity guard prevents terminating an unrelated service that happens
+        // to use the same port.
+        terminate_sidecar_listeners_on_port(SIDECAR_PORT)?;
+        wait_for_port_free(SIDECAR_PORT);
+        if sidecar_health_is_ready(&base_url) {
+            return Err(
+                "A GeoLibre processing server from a previous session is still \
+                 running on port 8765 but does not accept this session's token. \
+                 Quit any stray GeoLibre processes and try again."
+                    .to_string(),
+            );
+        }
     }
 
     let uv = ensure_managed_uv(&app)?;
@@ -1708,6 +1722,10 @@ async fn stop_geolibre_sidecar(app: tauri::AppHandle) -> Result<(), String> {
 
 fn stop_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<(), String> {
     let state = app.state::<SidecarServerState>();
+    let _lifecycle = state
+        .lifecycle
+        .lock()
+        .map_err(|_| "Could not lock sidecar lifecycle.".to_string())?;
     {
         let mut process = state
             .process

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1629,8 +1629,11 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
         // identity guard prevents terminating an unrelated service that happens
         // to use the same port.
         terminate_sidecar_listeners_on_port(SIDECAR_PORT)?;
-        wait_for_port_free(SIDECAR_PORT);
-        if sidecar_health_is_ready(&base_url) {
+        // Bind-testing the port is the authoritative check that the reclaim
+        // worked: a listener we could not terminate may also have stopped
+        // answering /health, and falling through to spawn would then surface as
+        // an opaque uvicorn "address already in use" instead of this message.
+        if !wait_for_port_free(SIDECAR_PORT) {
             return Err(
                 "A GeoLibre processing server from a previous session is still \
                  running on port 8765 but does not accept this session's token. \
@@ -1809,7 +1812,9 @@ fn start_jupyter_server_blocking(app: tauri::AppHandle) -> Result<JupyterServerI
     // and exit 1 ("exited before it was ready") while the orphan lingers. Clear
     // any stale listener and wait for the port to free before spawning.
     let _ = terminate_jupyter_listeners_on_port(JUPYTER_PORT);
-    wait_for_port_free(JUPYTER_PORT);
+    // Best-effort here: if the port never frees, the spawn below fails with
+    // Jupyter's own bind error, which is already reported to the user.
+    let _ = wait_for_port_free(JUPYTER_PORT);
 
     let uv = ensure_managed_uv(&app)?;
     let project_dir = sidecar_project_dir(&app)?;
@@ -1962,13 +1967,16 @@ fn jupyter_base_url() -> String {
 // Wait (briefly) until `port` can be bound, i.e. a just-terminated listener has
 // fully released it. Binding then dropping leaves a small race window, but it is
 // enough to avoid a `--port-retries=0` bind failure right after killing an orphan.
-fn wait_for_port_free(port: u16) {
+// Returns whether the port actually came free within the timeout, so a caller
+// that can report a better error than the failed spawn is able to bail out.
+fn wait_for_port_free(port: u16) -> bool {
     for _ in 0..20 {
         if TcpListener::bind(("127.0.0.1", port)).is_ok() {
-            return;
+            return true;
         }
         thread::sleep(Duration::from_millis(100));
     }
+    false
 }
 
 // Prepend `dir` to any inherited PYTHONPATH (platform separator), so a user's


### PR DESCRIPTION
## Summary
- Add a lifecycle mutex to `SidecarServerState` so start and stop of the shared Python sidecar are serialized. Without it, two callers could both pass the reuse check and race to bind the fixed port 8765, or a restart could overlap the previous teardown.
- When a listener on 8765 rejects this session's token (typically an orphan from a previous app launch), attempt to terminate it through the existing process-identity guard and wait for the port to free, instead of failing immediately. The hard error is now only returned if the stray server is still healthy after the reclaim attempt, so an unrelated service on the same port is never terminated.

## Test plan
- [x] `npm run check:rust`
- [x] `pre-commit run --files apps/geolibre-desktop/src-tauri/src/lib.rs`
- [ ] `npm run tauri:dev`, open a Processing tool that needs the sidecar, confirm it starts once
- [ ] Trigger two sidecar-backed tools in quick succession and confirm only one server starts
- [ ] Leave a sidecar running, force-quit the app, relaunch and confirm the new session reclaims port 8765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidecar startup and shutdown reliability by ensuring lifecycle actions don’t conflict and reducing port/process reuse races.
  * When an existing listener won’t match the current session token, the app now clears known stale listeners and waits briefly for the port to become available.
  * Refined startup cleanup behavior to be more resilient during Jupyter startup.
  * Provides more consistent, clearer early-failure messaging when a previous instance is still running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->