### PR TITLE
fix(share): record only plugin URLs a project uses, revalidate on load

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -10,7 +10,7 @@ import type { FeatureCollection } from "geojson";
 import { type FormEvent, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getPluginManager } from "./usePlugins";
-import { useDesktopSettingsStore } from "./useDesktopSettings";
+import { pluginManifestUrlsForIds } from "../lib/external-plugins";
 import {
   browserSaveFallsBackToDownload,
   isAbsoluteLocalPath,
@@ -294,9 +294,26 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     const state = useAppStore.getState();
     const defaultProjectName =
       nameOverride?.trim() || state.projectName.trim() || DEFAULT_PROJECT_NAME;
+    const pluginProjectState = getPluginManager().getProjectState();
+    // Record only the plugin URLs this project actually needs: the ones it
+    // already declared, plus the manifest URLs behind the plugins it uses. A
+    // plugin counts as used when it is active or has stored project state --
+    // `mapControlPositions` is written for every plugin that reports a position,
+    // so it says nothing about use.
+    //
+    // The author's remaining installed URLs are deliberately NOT merged in.
+    // Doing so stamped every share with the full list, so recipients were
+    // prompted to trust and execute third-party code the project never runs
+    // (the prompt is scary by design, and firing it on irrelevant URLs trains
+    // people to click through it), and the shared file disclosed exactly which
+    // plugins the author had installed.
+    const usedPluginIds = new Set([
+      ...pluginProjectState.activePluginIds,
+      ...Object.keys(pluginProjectState.settings ?? {}),
+    ]);
     const pluginManifestUrls = mergeStringLists(
       state.projectPlugins?.manifestUrls ?? [],
-      useDesktopSettingsStore.getState().desktopSettings.pluginManifestUrls,
+      pluginManifestUrlsForIds(usedPluginIds),
     );
     const project = projectFromStore({
       projectName: defaultProjectName,
@@ -309,7 +326,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       layerGroups: state.layerGroups,
       preferences: state.preferences,
       plugins: {
-        ...getPluginManager().getProjectState(),
+        ...pluginProjectState,
         manifestUrls: pluginManifestUrls,
       },
       legend: state.legend,

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -19,6 +19,7 @@ import {
 } from "./plugin-archive-unpack";
 import {
   isManagedUrlSource,
+  managedUrlSourcesForIds,
   pluginAssetUrlFromSource,
   resolvePluginAssetUrl,
 } from "./plugin-asset-url";
@@ -181,6 +182,25 @@ export async function loadExternalPlugins(
  */
 export function isExternalPluginId(pluginId: string): boolean {
   return externallyLoadedPluginSources.has(pluginId);
+}
+
+/**
+ * The manifest URLs backing the given loaded plugin ids, in the order the ids
+ * are supplied and de-duplicated.
+ *
+ * Only managed URL sources qualify. A filesystem source is a path, and a web
+ * archive source is a synthetic id (see `webPluginSource`) - neither is
+ * something a recipient could fetch, so recording either in a project would
+ * only produce a trust prompt that can never be satisfied. Built-in plugins are
+ * not tracked in the source map at all and contribute nothing.
+ *
+ * Used when serializing a project to record just the plugins that project
+ * actually needs, rather than everything the author happens to have installed.
+ */
+export function pluginManifestUrlsForIds(pluginIds: Iterable<string>): string[] {
+  return managedUrlSourcesForIds(pluginIds, (pluginId) =>
+    externallyLoadedPluginSources.get(pluginId),
+  );
 }
 
 async function loadFilesystemPluginBundles(

--- a/apps/geolibre-desktop/src/lib/plugin-asset-url.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-asset-url.ts
@@ -9,6 +9,31 @@ export function isManagedUrlSource(source: string): boolean {
   return /^(https?|tauri):\/\//.test(source);
 }
 
+/**
+ * The manifest URLs backing `pluginIds`, in the order given and de-duplicated.
+ *
+ * `sourceOf` maps a loaded plugin id to the source it was loaded from; ids it
+ * does not know (built-in plugins) contribute nothing. Only managed URL sources
+ * qualify: a filesystem source is a local path and a web archive source is a
+ * synthetic id, so neither is something a recipient of a shared project could
+ * fetch -- recording one would only produce a trust prompt that can never be
+ * satisfied.
+ */
+export function managedUrlSourcesForIds(
+  pluginIds: Iterable<string>,
+  sourceOf: (pluginId: string) => string | undefined,
+): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const pluginId of pluginIds) {
+    const source = sourceOf(pluginId);
+    if (source === undefined || !isManagedUrlSource(source) || seen.has(source)) continue;
+    seen.add(source);
+    urls.push(source);
+  }
+  return urls;
+}
+
 // Resolve `path` against a plugin manifest URL, rejecting anything absolute,
 // scheme-qualified, or that escapes the manifest's own directory. Mirrors the
 // safety checks GeoLibre applies to a manifest's `entry`/`style` paths so a

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -84,6 +84,18 @@ export async function fetchProjectFromUrl(
   try {
     response = await fetchImpl(projectUrl, {
       headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
+      // Always revalidate. A share host may serve the project with a long
+      // freshness lifetime (share.geolibre.app sends `max-age=3600`), and a
+      // shared URL is a *mutable* document: re-sharing overwrites it in place.
+      // With the default cache mode the browser answers from its own copy for
+      // the rest of that window, so recipients keep loading a superseded
+      // project with nothing in the UI to explain it -- and because the body
+      // feeds the plugin trust prompt, a stale copy can keep prompting for a
+      // plugin URL the current project no longer carries. `no-cache` (not
+      // `no-store`) still uses the cache; it just forces a conditional request
+      // first, so an unchanged project comes back as a 304 rather than a
+      // re-download.
+      cache: "no-cache",
       signal,
     });
   } catch (error) {

--- a/tests/external-plugin-assets.test.ts
+++ b/tests/external-plugin-assets.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { pluginAssetUrlFromSource } from "../apps/geolibre-desktop/src/lib/plugin-asset-url";
+import {
+  managedUrlSourcesForIds,
+  pluginAssetUrlFromSource,
+} from "../apps/geolibre-desktop/src/lib/plugin-asset-url";
 
 describe("pluginAssetUrlFromSource", () => {
   it("resolves an asset against a bundled plugin's manifest URL", () => {
@@ -66,5 +69,55 @@ describe("pluginAssetUrlFromSource", () => {
       pluginAssetUrlFromSource("https://geolibre.app/plugins/x/plugin.json", "%2e%2e/secrets"),
       null,
     );
+  });
+});
+
+describe("managedUrlSourcesForIds", () => {
+  // A plugin id -> loaded-source map covering every source kind the loader
+  // records: a manifest-URL install, a desktop bundled drop-in, a desktop
+  // filesystem plugin, and a web "install from file" archive.
+  const SOURCES: Record<string, string> = {
+    "url-plugin": "https://data.example.com/url-plugin/plugin.json",
+    "bundled-plugin": "tauri://localhost/plugins/bundled-plugin/plugin.json",
+    "filesystem-plugin": "/home/user/.local/share/org.geolibre.desktop/plugins/fs-plugin",
+    "web-archive-plugin": "web-archive:web-archive-plugin",
+  };
+  const sourceOf = (pluginId: string) => SOURCES[pluginId];
+
+  it("returns the manifest URL for a plugin installed from a URL", () => {
+    assert.deepEqual(managedUrlSourcesForIds(["url-plugin"], sourceOf), [
+      "https://data.example.com/url-plugin/plugin.json",
+    ]);
+  });
+
+  it("ignores built-in plugins, which have no recorded source", () => {
+    assert.deepEqual(managedUrlSourcesForIds(["maplibre-3d-tiles"], sourceOf), []);
+  });
+
+  it("skips sources a recipient could never fetch", () => {
+    // A filesystem path is local to the author's machine and a web archive
+    // source is a synthetic id; recording either in a shared project would
+    // raise a trust prompt that can never be satisfied.
+    assert.deepEqual(
+      managedUrlSourcesForIds(["filesystem-plugin", "web-archive-plugin"], sourceOf),
+      [],
+    );
+  });
+
+  it("preserves order and de-duplicates repeated ids", () => {
+    assert.deepEqual(
+      managedUrlSourcesForIds(
+        ["bundled-plugin", "url-plugin", "bundled-plugin", "filesystem-plugin"],
+        sourceOf,
+      ),
+      [
+        "tauri://localhost/plugins/bundled-plugin/plugin.json",
+        "https://data.example.com/url-plugin/plugin.json",
+      ],
+    );
+  });
+
+  it("returns nothing when the project uses no plugins", () => {
+    assert.deepEqual(managedUrlSourcesForIds([], sourceOf), []);
   });
 });

--- a/tests/project-url.test.ts
+++ b/tests/project-url.test.ts
@@ -26,6 +26,26 @@ describe("fetchProjectFromUrl", () => {
     assert.equal(project.name, "Test");
   });
 
+  it("revalidates instead of trusting the browser cache", async () => {
+    // A shared project URL is mutable: re-sharing overwrites it in place. Share
+    // hosts serve it with a long freshness lifetime (share.geolibre.app sends
+    // `max-age=3600`), so under the default cache mode the browser would keep
+    // answering from its own copy and recipients would silently load a
+    // superseded project -- including a stale `plugins.manifestUrls`, which
+    // drives the trust prompt.
+    let init: RequestInit | undefined;
+    const fetchImpl = (async (_url: string, requestInit?: RequestInit) => {
+      init = requestInit;
+      return new Response(VALID_PROJECT_JSON, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await fetchProjectFromUrl(PROJECT_URL, { fetchImpl });
+
+    // `no-cache`, not `no-store`: the cache is still used, it just has to
+    // revalidate, so an unchanged project comes back as a 304.
+    assert.equal(init?.cache, "no-cache");
+  });
+
   it("turns a rejected fetch (network/CORS) into a message naming the URL and CORS", async () => {
     // Mimic the bare TypeError a browser throws on a network or CORS failure
     // ("Failed to fetch" / "Load failed") rather than leaking it verbatim.


### PR DESCRIPTION
## Summary

Two bugs behind a spurious "Load plugins from this project?" prompt on a shared 3D Tiles project whose only layer is rendered by a built-in plugin.

**1. Sharing stamped the author's whole installed plugin list into the file.** `buildCurrentProject` unioned `desktopSettings.pluginManifestUrls` into every save and share, regardless of what the project used. Recipients were prompted to trust and execute third-party code the project never runs. The prompt is deliberately alarming, so firing it on irrelevant URLs teaches people to click through it, and the shared file also disclosed exactly which plugins the author had installed. Now only the URLs behind plugins the project actually uses are recorded: active, or holding project state. `mapControlPositions` is written for every plugin that reports a position, so it is not a usage signal. URLs the project already declared are kept, so a project that legitimately needs a plugin still round-trips.

**2. Project URLs were fetched with default cache semantics.** A shared URL is a mutable document that re-sharing overwrites in place, and share hosts serve it with a long freshness lifetime (`share.geolibre.app` sends `max-age=3600`), so for an hour after any load the browser answered from its own copy without revalidating. Recipients kept loading a superseded project with nothing in the UI to explain it. Because the body feeds the trust prompt, a stale copy kept prompting for a plugin URL the current project no longer carried, which made the first bug look permanent and untraceable: a fresh fetch in the console returned the corrected file while the app kept parsing the cached one. `cache: "no-cache"` (not `no-store`) forces a conditional request, so an unchanged project still comes back as a 304 rather than a re-download.

The URL-selection logic lives in `plugin-asset-url.ts` as a pure `managedUrlSourcesForIds`, since `external-plugins.ts` pulls in Tauri and cannot be imported from the Node test suite. It drops filesystem and web-archive sources: those are a local path and a synthetic id, so recording either would raise a trust prompt a recipient could never satisfy.

## Test plan

- [x] `npm run test:frontend` (3528 pass, 0 fail; 6 new tests)
- [x] New unit tests for `managedUrlSourcesForIds`: URL installs are kept, built-ins yield nothing, filesystem and web-archive sources are skipped, order preserved and de-duplicated
- [x] New unit test asserting the project fetch is issued with `cache: "no-cache"`
- [x] Verified in a real browser against the production build and the live share URL: the project request now carries `Cache-Control: max-age=0` and hits the network on a second load, where the previous behavior was served from disk cache inside the freshness window
- [x] `npm run build`, and `pre-commit run --files` on the changed paths
- [ ] Share a project while an unrelated URL plugin is installed and confirm the recipient gets no prompt

Note the second fix changes what is written on save, not what is read. A project file that already carries a stray URL keeps it, since declared URLs are preserved for round-trip fidelity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project files now record only the external plugin sources actually used by the project.
  * Project URLs are revalidated to prevent stale cached content from being loaded.

* **Tests**
  * Added coverage for plugin source filtering, ordering, deduplication, and unsupported sources.
  * Added coverage confirming project requests bypass stale browser cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->