### PR TITLE
feat(layers): report raster CRS and pixel size in the metadata dialog

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -152,7 +152,8 @@ import {
   refreshSqlQueryLayer,
 } from "../../lib/sql-query-layer";
 import { requestSqlWorkspaceQuery } from "../../lib/sql-workspace-prefill";
-import { canExportRasterLayer, exportRasterLayer } from "../../lib/raster-export";
+import { canExportRasterLayer, exportRasterLayer, rasterExportUrl } from "../../lib/raster-export";
+import { readRasterInfo, type RasterInfo } from "../../lib/raster-info";
 import { canExtractRasterSubset } from "../../lib/raster-subset-export";
 import {
   exportVectorLayer,
@@ -312,9 +313,44 @@ function canWriteEditsToSource(layer: GeoLibreLayer): boolean {
   return ext ? WRITEBACK_EXTENSIONS.includes(ext) : false;
 }
 
-function layerMetadataPayload(layer: GeoLibreLayer): Record<string, unknown> {
+/**
+ * Async state of the GeoTIFF header read that backs the raster section of the
+ * metadata dialog.
+ */
+type RasterInfoState =
+  | { status: "loading" }
+  | { status: "ready"; info: RasterInfo }
+  | { status: "error" };
+
+/**
+ * Whether a layer's metadata can be enriched with GeoTIFF header facts: a
+ * raster layer whose bytes are reachable as a single file (a remote COG or a
+ * retained local-bytes blob). Tile-template rasters have no such file.
+ *
+ * @param layer - The layer whose metadata dialog is open.
+ * @returns A fetchable GeoTIFF URL, or null.
+ */
+function rasterInfoUrl(layer: GeoLibreLayer): string | null {
+  if (layer.type !== "cog" && layer.type !== "raster") return null;
+  return rasterExportUrl(layer);
+}
+
+/**
+ * Builds the JSON payload shown in the layer metadata dialog. Raster header
+ * facts (CRS, pixel size, storage) lead when they have been read, since the
+ * store metadata below them only knows the WGS84 bounds and band count.
+ *
+ * @param layer - The layer whose metadata is shown.
+ * @param rasterInfo - GeoTIFF header facts, when read for this layer.
+ * @returns The payload to serialize into the dialog.
+ */
+function layerMetadataPayload(
+  layer: GeoLibreLayer,
+  rasterInfo?: RasterInfo | null,
+): Record<string, unknown> {
   const videoSourceUrls = sourceUrlsFromLayer(layer);
   return {
+    ...(rasterInfo ? { raster: rasterInfo } : {}),
     ...layer.metadata,
     layerName: layer.name,
     layerType: layer.type,
@@ -545,6 +581,11 @@ export function LayerPanel({
   const [editingName, setEditingName] = useState("");
   const [basemapPickerOpen, setBasemapPickerOpen] = useState(false);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(null);
+  // GeoTIFF header facts (CRS, pixel size, storage) for the raster whose
+  // metadata dialog is open. The store layer does not carry them, so they are
+  // read from the file on open (#1420): "loading" while the header is being
+  // fetched, "error" when it cannot be read.
+  const [rasterInfoState, setRasterInfoState] = useState<RasterInfoState | null>(null);
   const [layerPendingRemoval, setLayerPendingRemoval] = useState<GeoLibreLayer | null>(null);
   const [refreshSettingsLayerId, setRefreshSettingsLayerId] = useState<string | null>(null);
   const [refreshStatuses, setRefreshStatuses] = useState<Record<string, LayerRefreshStatus>>({});
@@ -1619,6 +1660,34 @@ export function LayerPanel({
         : "",
     );
   }, [refreshSettingsLayerId, refreshSettingsIntervalMs]);
+
+  // Read the GeoTIFF header behind an open raster metadata dialog so it can
+  // report the native CRS and pixel size the store layer never captured
+  // (#1420). Only the header is fetched, and the result is dropped when the
+  // dialog closes or moves to another layer while the read is in flight.
+  useEffect(() => {
+    const url = metadataLayer ? rasterInfoUrl(metadataLayer) : null;
+    if (!url) {
+      setRasterInfoState(null);
+      return;
+    }
+
+    let cancelled = false;
+    setRasterInfoState({ status: "loading" });
+    void readRasterInfo(url)
+      .then((info) => {
+        if (!cancelled) setRasterInfoState({ status: "ready", info });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        console.warn("[GeoLibre] Failed to read raster metadata", error);
+        setRasterInfoState({ status: "error" });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [metadataLayer]);
 
   useEffect(() => {
     const activeLayerIds = new Set<string>();
@@ -3251,9 +3320,24 @@ export function LayerPanel({
             </DialogTitle>
             <DialogDescription>{t("layers.metadataDialogDescription")}</DialogDescription>
           </DialogHeader>
+          {rasterInfoState && rasterInfoState.status !== "ready" && (
+            <p className="text-xs text-muted-foreground">
+              {rasterInfoState.status === "loading"
+                ? t("layers.metadataRasterLoading")
+                : t("layers.metadataRasterError")}
+            </p>
+          )}
           <ScrollArea className="max-h-80">
             <pre className="whitespace-pre-wrap break-all text-xs">
-              {metadataLayer && JSON.stringify(layerMetadataPayload(metadataLayer), null, 2)}
+              {metadataLayer &&
+                JSON.stringify(
+                  layerMetadataPayload(
+                    metadataLayer,
+                    rasterInfoState?.status === "ready" ? rasterInfoState.info : null,
+                  ),
+                  null,
+                  2,
+                )}
             </pre>
           </ScrollArea>
         </DialogContent>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -315,12 +315,16 @@ function canWriteEditsToSource(layer: GeoLibreLayer): boolean {
 
 /**
  * Async state of the GeoTIFF header read that backs the raster section of the
- * metadata dialog.
+ * metadata dialog. `layerId` scopes the state to the layer it was read for:
+ * the dialog re-renders for a newly opened layer before the effect below can
+ * restart the read, so without it the previous layer's header would show for a
+ * frame under the new layer's name.
  */
-type RasterInfoState =
+type RasterInfoState = { layerId: string } & (
   | { status: "loading" }
   | { status: "ready"; info: RasterInfo }
-  | { status: "error" };
+  | { status: "error" }
+);
 
 /**
  * Whether a layer's metadata can be enriched with GeoTIFF header facts: a
@@ -691,6 +695,11 @@ export function LayerPanel({
     () => layerGroups.filter((g) => !firstMemberIdByGroup.has(g.id)),
     [layerGroups, firstMemberIdByGroup],
   );
+  // The header read scoped to the layer whose metadata dialog is open. A state
+  // left over from a previously inspected layer is ignored rather than shown
+  // under the new layer's name.
+  const metadataRasterInfo =
+    rasterInfoState && rasterInfoState.layerId === metadataLayer?.id ? rasterInfoState : null;
   const refreshSettingsLayer = refreshSettingsLayerId
     ? (layers.find((layer) => layer.id === refreshSettingsLayerId) ?? null)
     : null;
@@ -1667,21 +1676,22 @@ export function LayerPanel({
   // dialog closes or moves to another layer while the read is in flight.
   useEffect(() => {
     const url = metadataLayer ? rasterInfoUrl(metadataLayer) : null;
-    if (!url) {
+    if (!metadataLayer || !url) {
       setRasterInfoState(null);
       return;
     }
 
+    const layerId = metadataLayer.id;
     let cancelled = false;
-    setRasterInfoState({ status: "loading" });
+    setRasterInfoState({ layerId, status: "loading" });
     void readRasterInfo(url)
       .then((info) => {
-        if (!cancelled) setRasterInfoState({ status: "ready", info });
+        if (!cancelled) setRasterInfoState({ layerId, status: "ready", info });
       })
       .catch((error: unknown) => {
         if (cancelled) return;
         console.warn("[GeoLibre] Failed to read raster metadata", error);
-        setRasterInfoState({ status: "error" });
+        setRasterInfoState({ layerId, status: "error" });
       });
 
     return () => {
@@ -3320,9 +3330,9 @@ export function LayerPanel({
             </DialogTitle>
             <DialogDescription>{t("layers.metadataDialogDescription")}</DialogDescription>
           </DialogHeader>
-          {rasterInfoState && rasterInfoState.status !== "ready" && (
+          {metadataRasterInfo && metadataRasterInfo.status !== "ready" && (
             <p className="text-xs text-muted-foreground">
-              {rasterInfoState.status === "loading"
+              {metadataRasterInfo.status === "loading"
                 ? t("layers.metadataRasterLoading")
                 : t("layers.metadataRasterError")}
             </p>
@@ -3333,7 +3343,7 @@ export function LayerPanel({
                 JSON.stringify(
                   layerMetadataPayload(
                     metadataLayer,
-                    rasterInfoState?.status === "ready" ? rasterInfoState.info : null,
+                    metadataRasterInfo?.status === "ready" ? metadataRasterInfo.info : null,
                   ),
                   null,
                   2,

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -590,6 +590,18 @@ export function LayerPanel({
   // read from the file on open (#1420): "loading" while the header is being
   // fetched, "error" when it cannot be read.
   const [rasterInfoState, setRasterInfoState] = useState<RasterInfoState | null>(null);
+  // Explicit metadata dialog size once the user drags the corner grip (null =
+  // the default responsive size). Kept across open/close so a size chosen for
+  // one layer still applies to the next. `metadataDialogRef` reads the live
+  // element size at the start of a drag; `metadataResizeCleanupRef` tears down
+  // the listeners on unmount.
+  const metadataDialogRef = useRef<HTMLDivElement>(null);
+  const [metadataDialogSize, setMetadataDialogSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  const metadataResizeCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => metadataResizeCleanupRef.current?.(), []);
   const [layerPendingRemoval, setLayerPendingRemoval] = useState<GeoLibreLayer | null>(null);
   const [refreshSettingsLayerId, setRefreshSettingsLayerId] = useState<string | null>(null);
   const [refreshStatuses, setRefreshStatuses] = useState<Record<string, LayerRefreshStatus>>({});
@@ -695,6 +707,58 @@ export function LayerPanel({
     () => layerGroups.filter((g) => !firstMemberIdByGroup.has(g.id)),
     [layerGroups, firstMemberIdByGroup],
   );
+  // Resize the metadata dialog from its bottom-right grip. The dialog is
+  // centred via a -50% transform, so each edge moves by half the size change;
+  // growing by 2x the pointer delta keeps the grip under the cursor (mirrors
+  // the Project Gallery dialog's resize idiom).
+  const startMetadataResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    const el = metadataDialogRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startW = rect.width;
+    const startH = rect.height;
+    let next = { width: startW, height: startH };
+    let frame: number | null = null;
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = "nwse-resize";
+    document.body.style.userSelect = "none";
+
+    const onMove = (e: PointerEvent) => {
+      next = {
+        width: Math.max(320, Math.min(window.innerWidth - 16, startW + (e.clientX - startX) * 2)),
+        height: Math.max(240, Math.min(window.innerHeight - 16, startH + (e.clientY - startY) * 2)),
+      };
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        setMetadataDialogSize(next);
+      });
+    };
+    const cleanup = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      metadataResizeCleanupRef.current = null;
+    };
+    const onUp = () => {
+      cleanup();
+      setMetadataDialogSize(next);
+    };
+    metadataResizeCleanupRef.current = cleanup;
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  }, []);
+
   // The header read scoped to the layer whose metadata dialog is open. A state
   // left over from a previously inspected layer is ignored rather than shown
   // under the new layer's name.
@@ -3323,7 +3387,41 @@ export function LayerPanel({
           if (!open) setMetadataLayer(null);
         }}
       >
-        <DialogContent>
+        <DialogContent
+          ref={metadataDialogRef}
+          style={
+            metadataDialogSize
+              ? {
+                  width: metadataDialogSize.width,
+                  height: metadataDialogSize.height,
+                  maxWidth: "none",
+                  maxHeight: "none",
+                }
+              : undefined
+          }
+          bodyClassName="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4 sm:p-6"
+          resizeHandle={
+            // Physical bottom-right (not logical `end-0`): the drag math grows
+            // the dialog with a positive x delta, so the grip stays on the
+            // right edge in right-to-left locales too.
+            <div
+              role="separator"
+              aria-label={t("layers.resizeMetadataDialog")}
+              title={t("layers.resizeMetadataDialog")}
+              onPointerDown={startMetadataResize}
+              className="absolute bottom-0 right-0 z-10 hidden h-5 w-5 cursor-nwse-resize touch-none select-none text-muted-foreground hover:text-foreground md:block"
+            >
+              <svg viewBox="0 0 16 16" className="h-full w-full" aria-hidden="true">
+                <path
+                  d="M11 15L15 11M6 15L15 6"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </div>
+          }
+        >
           <DialogHeader>
             <DialogTitle>
               {t("layers.metadataDialogTitle", { name: metadataLayer?.name })}
@@ -3337,7 +3435,9 @@ export function LayerPanel({
                 : t("layers.metadataRasterError")}
             </p>
           )}
-          <ScrollArea className="max-h-80">
+          {/* Capped at a readable height until the user resizes the dialog,
+              after which the payload fills whatever height they chose. */}
+          <ScrollArea className={cn("min-h-0", metadataDialogSize ? "flex-1" : "max-h-80")}>
             <pre className="whitespace-pre-wrap break-all text-xs">
               {metadataLayer &&
                 JSON.stringify(

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -707,10 +707,11 @@ export function LayerPanel({
     () => layerGroups.filter((g) => !firstMemberIdByGroup.has(g.id)),
     [layerGroups, firstMemberIdByGroup],
   );
-  // Resize the metadata dialog from its bottom-right grip. The dialog is
-  // centred via a -50% transform, so each edge moves by half the size change;
-  // growing by 2x the pointer delta keeps the grip under the cursor (mirrors
-  // the Project Gallery dialog's resize idiom).
+  // Resize the metadata dialog from its bottom-end grip. The dialog is centred
+  // via a -50% transform, so each edge moves by half the size change; growing
+  // by 2x the pointer delta keeps the grip under the cursor. In an RTL layout
+  // the grip renders on the physical left, so the horizontal delta is inverted
+  // (the same idiom as the Basemap Extract panel's grip).
   const startMetadataResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -718,6 +719,7 @@ export function LayerPanel({
     const el = metadataDialogRef.current;
     if (!el) return;
     const rect = el.getBoundingClientRect();
+    const isRtl = document.documentElement.dir === "rtl";
     const startX = event.clientX;
     const startY = event.clientY;
     const startW = rect.width;
@@ -726,12 +728,13 @@ export function LayerPanel({
     let frame: number | null = null;
     const prevCursor = document.body.style.cursor;
     const prevSelect = document.body.style.userSelect;
-    document.body.style.cursor = "nwse-resize";
+    document.body.style.cursor = isRtl ? "nesw-resize" : "nwse-resize";
     document.body.style.userSelect = "none";
 
     const onMove = (e: PointerEvent) => {
+      const deltaX = (e.clientX - startX) * (isRtl ? -1 : 1);
       next = {
-        width: Math.max(320, Math.min(window.innerWidth - 16, startW + (e.clientX - startX) * 2)),
+        width: Math.max(320, Math.min(window.innerWidth - 16, startW + deltaX * 2)),
         height: Math.max(240, Math.min(window.innerHeight - 16, startH + (e.clientY - startY) * 2)),
       };
       if (frame !== null) return;
@@ -3394,24 +3397,28 @@ export function LayerPanel({
               ? {
                   width: metadataDialogSize.width,
                   height: metadataDialogSize.height,
-                  maxWidth: "none",
-                  maxHeight: "none",
+                  // Only the width cap is lifted (to the viewport, not to
+                  // `none`): a size chosen on a wide window must not leave the
+                  // dialog clipped once the window narrows. The height keeps
+                  // DialogContent's own viewport cap.
+                  maxWidth: "calc(100vw - 1rem)",
                 }
               : undefined
           }
           bodyClassName="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-4 sm:p-6"
           resizeHandle={
-            // Physical bottom-right (not logical `end-0`): the drag math grows
-            // the dialog with a positive x delta, so the grip stays on the
-            // right edge in right-to-left locales too.
             <div
               role="separator"
               aria-label={t("layers.resizeMetadataDialog")}
               title={t("layers.resizeMetadataDialog")}
               onPointerDown={startMetadataResize}
-              className="absolute bottom-0 right-0 z-10 hidden h-5 w-5 cursor-nwse-resize touch-none select-none text-muted-foreground hover:text-foreground md:block"
+              className="absolute bottom-0 end-0 z-10 hidden h-5 w-5 cursor-nwse-resize touch-none select-none text-muted-foreground hover:text-foreground md:block rtl:cursor-nesw-resize"
             >
-              <svg viewBox="0 0 16 16" className="h-full w-full" aria-hidden="true">
+              <svg
+                viewBox="0 0 16 16"
+                className="h-full w-full rtl:scale-x-[-1]"
+                aria-hidden="true"
+              >
                 <path
                   d="M11 15L15 11M6 15L15 6"
                   stroke="currentColor"

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -4065,6 +4065,7 @@
     "metadataDialogDescription": "البيانات الوصفية للطبقة ومعلومات المصدر",
     "metadataRasterLoading": "جارٍ قراءة البيانات الوصفية للراستر…",
     "metadataRasterError": "تعذّرت قراءة البيانات الوصفية لهذا الراستر.",
+    "resizeMetadataDialog": "تغيير حجم مربع حوار البيانات الوصفية",
     "removeLayerConfirmTitle": "هل تريد إزالة الطبقة؟",
     "removeLayerConfirmBody": "يؤدي هذا إلى إزالة {{name}} من المشروع والخريطة.",
     "thisLayerFallback": "هذه الطبقة",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -4063,6 +4063,8 @@
     "enterPositiveSeconds": "أدخل عددًا موجبًا من الثواني.",
     "metadataDialogTitle": "البيانات الوصفية لـ {{name}}",
     "metadataDialogDescription": "البيانات الوصفية للطبقة ومعلومات المصدر",
+    "metadataRasterLoading": "جارٍ قراءة البيانات الوصفية للراستر…",
+    "metadataRasterError": "تعذّرت قراءة البيانات الوصفية لهذا الراستر.",
     "removeLayerConfirmTitle": "هل تريد إزالة الطبقة؟",
     "removeLayerConfirmBody": "يؤدي هذا إلى إزالة {{name}} من المشروع والخريطة.",
     "thisLayerFallback": "هذه الطبقة",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Ebenenmetadaten und Quelleninformationen",
     "metadataRasterLoading": "Rastermetadaten werden gelesen…",
     "metadataRasterError": "Die Metadaten dieses Rasters konnten nicht gelesen werden.",
+    "resizeMetadataDialog": "Metadaten-Dialog skalieren",
     "removeLayerConfirmTitle": "Ebene entfernen?",
     "removeLayerConfirmBody": "Dadurch wird {{name}} aus dem Projekt und der Karte entfernt.",
     "thisLayerFallback": "diese Ebene",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Geben Sie eine positive Anzahl von Sekunden ein.",
     "metadataDialogTitle": "Metadaten von {{name}}",
     "metadataDialogDescription": "Ebenenmetadaten und Quelleninformationen",
+    "metadataRasterLoading": "Rastermetadaten werden gelesen…",
+    "metadataRasterError": "Die Metadaten dieses Rasters konnten nicht gelesen werden.",
     "removeLayerConfirmTitle": "Ebene entfernen?",
     "removeLayerConfirmBody": "Dadurch wird {{name}} aus dem Projekt und der Karte entfernt.",
     "thisLayerFallback": "diese Ebene",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3870,6 +3870,8 @@
     "enterPositiveSeconds": "Enter a positive number of seconds.",
     "metadataDialogTitle": "{{name}} Metadata",
     "metadataDialogDescription": "Layer metadata and source information",
+    "metadataRasterLoading": "Reading raster metadata…",
+    "metadataRasterError": "Could not read this raster's metadata.",
     "removeLayerConfirmTitle": "Remove layer?",
     "removeLayerConfirmBody": "This removes {{name}} from the project and map.",
     "thisLayerFallback": "this layer",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3872,6 +3872,7 @@
     "metadataDialogDescription": "Layer metadata and source information",
     "metadataRasterLoading": "Reading raster metadata…",
     "metadataRasterError": "Could not read this raster's metadata.",
+    "resizeMetadataDialog": "Resize metadata dialog",
     "removeLayerConfirmTitle": "Remove layer?",
     "removeLayerConfirmBody": "This removes {{name}} from the project and map.",
     "thisLayerFallback": "this layer",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Introduzca un número positivo de segundos.",
     "metadataDialogTitle": "Metadatos de {{name}}",
     "metadataDialogDescription": "Metadatos de la capa e información de origen",
+    "metadataRasterLoading": "Leyendo los metadatos del ráster…",
+    "metadataRasterError": "No se pudieron leer los metadatos de este ráster.",
     "removeLayerConfirmTitle": "¿Quitar capa?",
     "removeLayerConfirmBody": "Esto quita {{name}} del proyecto y del mapa.",
     "thisLayerFallback": "esta capa",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Metadatos de la capa e información de origen",
     "metadataRasterLoading": "Leyendo los metadatos del ráster…",
     "metadataRasterError": "No se pudieron leer los metadatos de este ráster.",
+    "resizeMetadataDialog": "Redimensionar el diálogo de metadatos",
     "removeLayerConfirmTitle": "¿Quitar capa?",
     "removeLayerConfirmBody": "Esto quita {{name}} del proyecto y del mapa.",
     "thisLayerFallback": "esta capa",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Entrez un nombre de secondes positif.",
     "metadataDialogTitle": "Métadonnées de {{name}}",
     "metadataDialogDescription": "Métadonnées de la couche et informations sur la source",
+    "metadataRasterLoading": "Lecture des métadonnées du raster…",
+    "metadataRasterError": "Impossible de lire les métadonnées de ce raster.",
     "removeLayerConfirmTitle": "Supprimer la couche ?",
     "removeLayerConfirmBody": "Cela supprime {{name}} du projet et de la carte.",
     "thisLayerFallback": "cette couche",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Métadonnées de la couche et informations sur la source",
     "metadataRasterLoading": "Lecture des métadonnées du raster…",
     "metadataRasterError": "Impossible de lire les métadonnées de ce raster.",
+    "resizeMetadataDialog": "Redimensionner la boîte de dialogue des métadonnées",
     "removeLayerConfirmTitle": "Supprimer la couche ?",
     "removeLayerConfirmBody": "Cela supprime {{name}} du projet et de la carte.",
     "thisLayerFallback": "cette couche",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "लेयर मेटाडेटा और स्रोत जानकारी",
     "metadataRasterLoading": "रास्टर मेटाडेटा पढ़ा जा रहा है…",
     "metadataRasterError": "इस रास्टर का मेटाडेटा नहीं पढ़ा जा सका।",
+    "resizeMetadataDialog": "मेटाडेटा संवाद का आकार बदलें",
     "removeLayerConfirmTitle": "लेयर हटाएं?",
     "removeLayerConfirmBody": "यह {{name}} को प्रोजेक्ट और मानचित्र से हटा देता है।",
     "thisLayerFallback": "यह लेयर",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "सेकंड की एक धनात्मक संख्या दर्ज करें।",
     "metadataDialogTitle": "{{name}} मेटाडेटा",
     "metadataDialogDescription": "लेयर मेटाडेटा और स्रोत जानकारी",
+    "metadataRasterLoading": "रास्टर मेटाडेटा पढ़ा जा रहा है…",
+    "metadataRasterError": "इस रास्टर का मेटाडेटा नहीं पढ़ा जा सका।",
     "removeLayerConfirmTitle": "लेयर हटाएं?",
     "removeLayerConfirmBody": "यह {{name}} को प्रोजेक्ट और मानचित्र से हटा देता है।",
     "thisLayerFallback": "यह लेयर",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -3779,6 +3779,8 @@
     "enterPositiveSeconds": "Masukkan jumlah detik yang positif.",
     "metadataDialogTitle": "Metadata {{name}}",
     "metadataDialogDescription": "Metadata layer dan informasi sumber",
+    "metadataRasterLoading": "Membaca metadata raster…",
+    "metadataRasterError": "Tidak dapat membaca metadata raster ini.",
     "removeLayerConfirmTitle": "Hapus layer?",
     "removeLayerConfirmBody": "Ini menghapus {{name}} dari proyek dan peta.",
     "thisLayerFallback": "layer ini",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -3781,6 +3781,7 @@
     "metadataDialogDescription": "Metadata layer dan informasi sumber",
     "metadataRasterLoading": "Membaca metadata raster…",
     "metadataRasterError": "Tidak dapat membaca metadata raster ini.",
+    "resizeMetadataDialog": "Ubah ukuran dialog metadata",
     "removeLayerConfirmTitle": "Hapus layer?",
     "removeLayerConfirmBody": "Ini menghapus {{name}} dari proyek dan peta.",
     "thisLayerFallback": "layer ini",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Inserisci un numero positivo di secondi.",
     "metadataDialogTitle": "Metadati di {{name}}",
     "metadataDialogDescription": "Metadati del livello e informazioni sulla sorgente",
+    "metadataRasterLoading": "Lettura dei metadati del raster…",
+    "metadataRasterError": "Impossibile leggere i metadati di questo raster.",
     "removeLayerConfirmTitle": "Rimuovere il livello?",
     "removeLayerConfirmBody": "Questa operazione rimuove {{name}} dal progetto e dalla mappa.",
     "thisLayerFallback": "questo livello",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Metadati del livello e informazioni sulla sorgente",
     "metadataRasterLoading": "Lettura dei metadati del raster…",
     "metadataRasterError": "Impossibile leggere i metadati di questo raster.",
+    "resizeMetadataDialog": "Ridimensiona la finestra dei metadati",
     "removeLayerConfirmTitle": "Rimuovere il livello?",
     "removeLayerConfirmBody": "Questa operazione rimuove {{name}} dal progetto e dalla mappa.",
     "thisLayerFallback": "questo livello",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -3781,6 +3781,7 @@
     "metadataDialogDescription": "レイヤーのメタデータとソース情報",
     "metadataRasterLoading": "ラスターのメタデータを読み込んでいます…",
     "metadataRasterError": "このラスターのメタデータを読み取れませんでした。",
+    "resizeMetadataDialog": "メタデータダイアログのサイズを変更",
     "removeLayerConfirmTitle": "レイヤーを削除しますか?",
     "removeLayerConfirmBody": "{{name}}をプロジェクトと地図から削除します。",
     "thisLayerFallback": "このレイヤー",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -3779,6 +3779,8 @@
     "enterPositiveSeconds": "正の秒数を入力してください。",
     "metadataDialogTitle": "{{name}}のメタデータ",
     "metadataDialogDescription": "レイヤーのメタデータとソース情報",
+    "metadataRasterLoading": "ラスターのメタデータを読み込んでいます…",
+    "metadataRasterError": "このラスターのメタデータを読み取れませんでした。",
     "removeLayerConfirmTitle": "レイヤーを削除しますか?",
     "removeLayerConfirmBody": "{{name}}をプロジェクトと地図から削除します。",
     "thisLayerFallback": "このレイヤー",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "შრის მეტამონაცემები და წყაროს ინფორმაცია",
     "metadataRasterLoading": "რასტრის მეტამონაცემები იკითხება…",
     "metadataRasterError": "ამ რასტრის მეტამონაცემების წაკითხვა ვერ მოხერხდა.",
+    "resizeMetadataDialog": "მეტამონაცემების დიალოგის ზომის შეცვლა",
     "removeLayerConfirmTitle": "მოვაშოროთ შრე?",
     "removeLayerConfirmBody": "ეს მოაშორებს {{name}}-ს პროექტიდან და რუკიდან.",
     "thisLayerFallback": "ეს შრე",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "შეიყვანეთ დადებითი წამების რაოდენობა.",
     "metadataDialogTitle": "{{name}} — მეტამონაცემები",
     "metadataDialogDescription": "შრის მეტამონაცემები და წყაროს ინფორმაცია",
+    "metadataRasterLoading": "რასტრის მეტამონაცემები იკითხება…",
+    "metadataRasterError": "ამ რასტრის მეტამონაცემების წაკითხვა ვერ მოხერხდა.",
     "removeLayerConfirmTitle": "მოვაშოროთ შრე?",
     "removeLayerConfirmBody": "ეს მოაშორებს {{name}}-ს პროექტიდან და რუკიდან.",
     "thisLayerFallback": "ეს შრე",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -3779,6 +3779,8 @@
     "enterPositiveSeconds": "양수의 초를 입력하세요.",
     "metadataDialogTitle": "{{name}} 메타데이터",
     "metadataDialogDescription": "레이어 메타데이터 및 소스 정보",
+    "metadataRasterLoading": "래스터 메타데이터를 읽는 중…",
+    "metadataRasterError": "이 래스터의 메타데이터를 읽을 수 없습니다.",
     "removeLayerConfirmTitle": "레이어를 제거하시겠습니까?",
     "removeLayerConfirmBody": "{{name}}을(를) 프로젝트와 지도에서 제거합니다.",
     "thisLayerFallback": "이 레이어",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -3781,6 +3781,7 @@
     "metadataDialogDescription": "레이어 메타데이터 및 소스 정보",
     "metadataRasterLoading": "래스터 메타데이터를 읽는 중…",
     "metadataRasterError": "이 래스터의 메타데이터를 읽을 수 없습니다.",
+    "resizeMetadataDialog": "메타데이터 대화 상자 크기 조정",
     "removeLayerConfirmTitle": "레이어를 제거하시겠습니까?",
     "removeLayerConfirmBody": "{{name}}을(를) 프로젝트와 지도에서 제거합니다.",
     "thisLayerFallback": "이 레이어",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Laagmetadata en broninformatie",
     "metadataRasterLoading": "Rastermetadata worden gelezen…",
     "metadataRasterError": "Kan de metadata van dit raster niet lezen.",
+    "resizeMetadataDialog": "Formaat van metadatavenster wijzigen",
     "removeLayerConfirmTitle": "Laag verwijderen?",
     "removeLayerConfirmBody": "Hiermee wordt {{name}} verwijderd uit het project en de kaart.",
     "thisLayerFallback": "deze laag",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -3837,7 +3837,7 @@
     "metadataDialogTitle": "Metadata van {{name}}",
     "metadataDialogDescription": "Laagmetadata en broninformatie",
     "metadataRasterLoading": "Rastermetadata worden gelezen…",
-    "metadataRasterError": "Kan de metadata van deze raster niet lezen.",
+    "metadataRasterError": "Kan de metadata van dit raster niet lezen.",
     "removeLayerConfirmTitle": "Laag verwijderen?",
     "removeLayerConfirmBody": "Hiermee wordt {{name}} verwijderd uit het project en de kaart.",
     "thisLayerFallback": "deze laag",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Voer een positief aantal seconden in.",
     "metadataDialogTitle": "Metadata van {{name}}",
     "metadataDialogDescription": "Laagmetadata en broninformatie",
+    "metadataRasterLoading": "Rastermetadata worden gelezen…",
+    "metadataRasterError": "Kan de metadata van deze raster niet lezen.",
     "removeLayerConfirmTitle": "Laag verwijderen?",
     "removeLayerConfirmBody": "Hiermee wordt {{name}} verwijderd uit het project en de kaart.",
     "thisLayerFallback": "deze laag",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Metadados da camada e informações da fonte",
     "metadataRasterLoading": "Lendo os metadados do raster…",
     "metadataRasterError": "Não foi possível ler os metadados deste raster.",
+    "resizeMetadataDialog": "Redimensionar a caixa de diálogo de metadados",
     "removeLayerConfirmTitle": "Remover camada?",
     "removeLayerConfirmBody": "Isso remove {{name}} do projeto e do mapa.",
     "thisLayerFallback": "esta camada",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Digite um número positivo de segundos.",
     "metadataDialogTitle": "Metadados de {{name}}",
     "metadataDialogDescription": "Metadados da camada e informações da fonte",
+    "metadataRasterLoading": "Lendo os metadados do raster…",
+    "metadataRasterError": "Não foi possível ler os metadados deste raster.",
     "removeLayerConfirmTitle": "Remover camada?",
     "removeLayerConfirmBody": "Isso remove {{name}} do projeto e do mapa.",
     "thisLayerFallback": "esta camada",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -3950,6 +3950,8 @@
     "enterPositiveSeconds": "Введите положительное число секунд.",
     "metadataDialogTitle": "Метаданные {{name}}",
     "metadataDialogDescription": "Метаданные слоя и сведения об источнике",
+    "metadataRasterLoading": "Чтение метаданных растра…",
+    "metadataRasterError": "Не удалось прочитать метаданные этого растра.",
     "removeLayerConfirmTitle": "Удалить слой?",
     "removeLayerConfirmBody": "Это действие удаляет {{name}} из проекта и с карты.",
     "thisLayerFallback": "этот слой",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -3952,6 +3952,7 @@
     "metadataDialogDescription": "Метаданные слоя и сведения об источнике",
     "metadataRasterLoading": "Чтение метаданных растра…",
     "metadataRasterError": "Не удалось прочитать метаданные этого растра.",
+    "resizeMetadataDialog": "Изменить размер окна метаданных",
     "removeLayerConfirmTitle": "Удалить слой?",
     "removeLayerConfirmBody": "Это действие удаляет {{name}} из проекта и с карты.",
     "thisLayerFallback": "этот слой",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -3836,6 +3836,8 @@
     "enterPositiveSeconds": "Pozitif bir saniye sayısı girin.",
     "metadataDialogTitle": "{{name}} Meta Verileri",
     "metadataDialogDescription": "Katman meta verileri ve kaynak bilgileri",
+    "metadataRasterLoading": "Raster meta verileri okunuyor…",
+    "metadataRasterError": "Bu rasterin meta verileri okunamadı.",
     "removeLayerConfirmTitle": "Katman kaldırılsın mı?",
     "removeLayerConfirmBody": "Bu işlem {{name}} öğesini projeden ve haritadan kaldırır.",
     "thisLayerFallback": "bu katman",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -3838,6 +3838,7 @@
     "metadataDialogDescription": "Katman meta verileri ve kaynak bilgileri",
     "metadataRasterLoading": "Raster meta verileri okunuyor…",
     "metadataRasterError": "Bu rasterin meta verileri okunamadı.",
+    "resizeMetadataDialog": "Meta veri iletişim kutusunu yeniden boyutlandır",
     "removeLayerConfirmTitle": "Katman kaldırılsın mı?",
     "removeLayerConfirmBody": "Bu işlem {{name}} öğesini projeden ve haritadan kaldırır.",
     "thisLayerFallback": "bu katman",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -3781,6 +3781,7 @@
     "metadataDialogDescription": "图层元数据和数据源信息",
     "metadataRasterLoading": "正在读取栅格元数据…",
     "metadataRasterError": "无法读取该栅格的元数据。",
+    "resizeMetadataDialog": "调整元数据对话框大小",
     "removeLayerConfirmTitle": "是否移除图层？",
     "removeLayerConfirmBody": "此操作会从项目和地图中移除 {{name}}。",
     "thisLayerFallback": "此图层",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -3779,6 +3779,8 @@
     "enterPositiveSeconds": "请输入正的秒数。",
     "metadataDialogTitle": "{{name}} 元数据",
     "metadataDialogDescription": "图层元数据和数据源信息",
+    "metadataRasterLoading": "正在读取栅格元数据…",
+    "metadataRasterError": "无法读取该栅格的元数据。",
     "removeLayerConfirmTitle": "是否移除图层？",
     "removeLayerConfirmBody": "此操作会从项目和地图中移除 {{name}}。",
     "thisLayerFallback": "此图层",

--- a/apps/geolibre-desktop/src/lib/raster-info.ts
+++ b/apps/geolibre-desktop/src/lib/raster-info.ts
@@ -1,0 +1,92 @@
+import { loadGeoTIFF, summarizeGeoTIFF, type MetadataSummary } from "maplibre-gl-raster";
+
+/**
+ * The `gdalinfo`-style facts about a raster that the store layer does not
+ * carry: the native CRS, the pixel size and extent in that CRS, the pixel grid
+ * dimensions, and the storage details (data type, compression, tiling,
+ * overviews). The store's raster metadata only knows the WGS84 bounds and the
+ * band count, so these are read back from the GeoTIFF header on demand (#1420).
+ */
+export type RasterInfo = {
+  /** CRS label, e.g. `"EPSG:32643"` or `"User-defined: World_Mollweide"`. */
+  crs: string;
+  /** EPSG code when the file declares one; null for a user-defined CRS. */
+  epsg: number | null;
+  /** CRS citation from the geo keys, when the file carries one. */
+  crsCitation?: string;
+  /**
+   * Pixel size `[x, y]` in CRS units (degrees for a geographic CRS), from
+   * `ModelPixelScale`. Both values are positive magnitudes, so the y size is
+   * unsigned here where `gdalinfo` prints it negative. Omitted when the file
+   * has no pixel scale (e.g. it is georeferenced by tie points alone).
+   */
+  pixelSize?: [number, number];
+  /** Extent `[minX, minY, maxX, maxY]` in CRS units. */
+  extent?: [number, number, number, number];
+  /** Pixel grid width (columns). */
+  width: number;
+  /** Pixel grid height (rows). */
+  height: number;
+  bandCount: number;
+  /** Sample data type, e.g. `"uint8"` or `"float32"`. */
+  dataType: string;
+  /**
+   * Dataset nodata value, or null when the file declares none. A NaN nodata
+   * (common in float rasters) is reported as the string `"nan"`, since
+   * `JSON.stringify` turns NaN into `null` and would read as "no nodata".
+   */
+  nodata: number | "nan" | null;
+  /** Compression label, e.g. `"Deflate"` or `"none"`. */
+  compression: string;
+  /** Internal tile size `[width, height]`. */
+  tileSize: [number, number];
+  /** Number of overview (reduced-resolution) levels. */
+  overviewCount: number;
+};
+
+/**
+ * Derives the reported raster facts from an already-parsed GeoTIFF summary.
+ * Pure, so it is unit-testable without a network fetch.
+ *
+ * @param summary - A `summarizeGeoTIFF` result.
+ * @returns The raster facts shown in the layer metadata dialog.
+ */
+export function rasterInfoFromSummary(summary: MetadataSummary): RasterInfo {
+  const { crs, image, overviews } = summary;
+  const scale = crs.pixelScale;
+  const pixelSize: [number, number] | null = scale
+    ? [Math.abs(scale[0]), Math.abs(scale[1])]
+    : null;
+  const bbox = crs.bbox;
+  const extent: [number, number, number, number] | null =
+    Array.isArray(bbox) && bbox.length === 4 ? [bbox[0], bbox[1], bbox[2], bbox[3]] : null;
+  return {
+    crs: crs.label,
+    epsg: crs.code,
+    ...(crs.citation ? { crsCitation: crs.citation } : {}),
+    ...(pixelSize ? { pixelSize } : {}),
+    ...(extent ? { extent } : {}),
+    width: image.width,
+    height: image.height,
+    bandCount: image.bandCount,
+    dataType: image.dtype,
+    nodata: typeof image.nodata === "number" && Number.isNaN(image.nodata) ? "nan" : image.nodata,
+    compression: image.compression,
+    tileSize: [image.tileWidth, image.tileHeight],
+    overviewCount: overviews.length,
+  };
+}
+
+/**
+ * Reads a raster's CRS, pixel size, and storage details straight from its
+ * GeoTIFF header. Only the header (and the COG's tag pages) is fetched, not the
+ * pixel data, so this stays cheap for large remote rasters.
+ *
+ * @param url - A fetchable URL for the GeoTIFF/COG bytes (see `rasterExportUrl`).
+ * @returns The raster facts for the layer metadata dialog.
+ * @throws If the URL cannot be fetched or is not a readable GeoTIFF.
+ */
+export async function readRasterInfo(url: string): Promise<RasterInfo> {
+  const tiff = await loadGeoTIFF(url);
+  return rasterInfoFromSummary(summarizeGeoTIFF(tiff));
+}

--- a/tests/raster-info.test.ts
+++ b/tests/raster-info.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { MetadataSummary } from "maplibre-gl-raster";
+import { rasterInfoFromSummary } from "../apps/geolibre-desktop/src/lib/raster-info";
+
+function summaryWith(overrides: {
+  crs?: Partial<MetadataSummary["crs"]>;
+  image?: Partial<MetadataSummary["image"]>;
+  overviews?: MetadataSummary["overviews"];
+}): MetadataSummary {
+  return {
+    image: {
+      width: 8192,
+      height: 4096,
+      bandCount: 3,
+      dtype: "uint8",
+      photometric: "RGB",
+      compression: "Deflate",
+      predictor: null,
+      planarConfig: "chunky (interleaved)",
+      tileWidth: 512,
+      tileHeight: 512,
+      nodata: null,
+      ...overrides.image,
+    },
+    crs: {
+      code: 32643,
+      label: "EPSG:32643",
+      citation: "WGS 84 / UTM zone 43N",
+      bbox: [736000, 1802000, 736409.6, 1802204.8],
+      pixelScale: [0.05, 0.05],
+      ...overrides.crs,
+    },
+    overviews: overrides.overviews ?? [],
+    bands: [],
+    gdalItems: [],
+    rawGdalXml: null,
+  };
+}
+
+describe("rasterInfoFromSummary", () => {
+  it("reports the CRS, pixel size, and storage details a raster layer omits", () => {
+    const info = rasterInfoFromSummary(
+      summaryWith({
+        overviews: [
+          { width: 4096, height: 2048, tileWidth: 512, tileHeight: 512, tileCount: { x: 8, y: 4 } },
+          { width: 2048, height: 1024, tileWidth: 512, tileHeight: 512, tileCount: { x: 4, y: 2 } },
+        ],
+      }),
+    );
+
+    assert.deepEqual(info, {
+      crs: "EPSG:32643",
+      epsg: 32643,
+      crsCitation: "WGS 84 / UTM zone 43N",
+      pixelSize: [0.05, 0.05],
+      extent: [736000, 1802000, 736409.6, 1802204.8],
+      width: 8192,
+      height: 4096,
+      bandCount: 3,
+      dataType: "uint8",
+      nodata: null,
+      compression: "Deflate",
+      tileSize: [512, 512],
+      overviewCount: 2,
+    });
+  });
+
+  it("reports the pixel size as positive magnitudes", () => {
+    // GDAL prints the y size negative (north-up geotransforms count rows
+    // downward); ModelPixelScale itself is unsigned, but a file written with a
+    // signed scale must not surface as a negative pixel size.
+    const info = rasterInfoFromSummary(summaryWith({ crs: { pixelScale: [30, -30] } }));
+
+    assert.deepEqual(info.pixelSize, [30, 30]);
+  });
+
+  it("omits the pixel size and citation a file does not carry", () => {
+    const info = rasterInfoFromSummary(summaryWith({ crs: { pixelScale: null, citation: null } }));
+
+    assert.equal("pixelSize" in info, false);
+    assert.equal("crsCitation" in info, false);
+    assert.equal(info.crs, "EPSG:32643");
+  });
+
+  it('reports a NaN nodata as "nan" so it is not serialized as null', () => {
+    // JSON.stringify(NaN) is `null`, which in the metadata dialog would be
+    // indistinguishable from a file that declares no nodata at all.
+    const info = rasterInfoFromSummary(summaryWith({ image: { nodata: Number.NaN } }));
+
+    assert.equal(info.nodata, "nan");
+    assert.equal(rasterInfoFromSummary(summaryWith({ image: { nodata: 0 } })).nodata, 0);
+    assert.equal(rasterInfoFromSummary(summaryWith({})).nodata, null);
+  });
+
+  it("keeps a user-defined CRS label with no EPSG code", () => {
+    const info = rasterInfoFromSummary(
+      summaryWith({ crs: { code: null, label: "User-defined: World_Mollweide" } }),
+    );
+
+    assert.equal(info.crs, "User-defined: World_Mollweide");
+    assert.equal(info.epsg, null);
+  });
+});


### PR DESCRIPTION
Fixes #1420

## What

The layer Metadata dialog showed only the store layer's metadata. For a raster that means the WGS84 bounds and band count, but nothing about the file's own georeferencing, so there was no way to see the projection or ground resolution of a loaded raster without leaving the app.

The dialog now reads those facts back from the GeoTIFF header on demand (via `maplibre-gl-raster`'s already-exported `summarizeGeoTIFF`) and leads the payload with them:

```json
{
  "raster": {
    "crs": "EPSG:4326",
    "epsg": 4326,
    "crsCitation": "WGS 84",
    "pixelSize": [2.796960705804071e-7, 2.796960705804071e-7],
    "extent": [76.76500591806808, 16.30574356474106, 76.76780287877389, 16.308540525446865],
    "width": 10000,
    "height": 10000,
    "bandCount": 3,
    "dataType": "uint8",
    "nodata": null,
    "compression": "JPEG",
    "tileSize": [512, 512],
    "overviewCount": 5
  },
  ...
}
```

Notes:

- Only the header (and the COG's tag pages) is fetched, not pixel data, so it stays cheap for large remote rasters. A read still in flight when the dialog closes or moves to another layer is dropped.
- Works for both remote COGs and File-loaded rasters (the retained local-bytes blob URL). Non-raster layers are untouched; tile-template rasters have no single file, so nothing is added for them.
- A status line reports the read while it is in flight, and if it fails the dialog still shows the store metadata.
- A NaN nodata is reported as `"nan"`, since `JSON.stringify(NaN)` is `null` and would read as "no nodata declared".

## Verification

Driven in the real app (web build) with Playwright, in both light and dark themes:

- The reporter's dataset, `https://storage.googleapis.com/spatialthoughts-public-data/temp/drone_image.tif`: EPSG:4326, pixel size 2.796960705804071e-7, 10000x10000, 3 bands uint8, JPEG, 512x512 tiles, 5 overviews, extent as above.
- A local `dem.tif` loaded from disk (blob-backed, projected CRS): EPSG:3857, pixel size 33.23912532662325, 2880x1773, float64, `"nodata": "nan"`, Deflate, 2 overviews.
- Both cross-checked against `rasterio`/`gdalinfo` on the same files: every reported value matches.
- A vector layer's dialog is unchanged (no `raster` section, no status line), and a deliberately broken read renders the error line with the store metadata still shown.

`npm run build`, the full frontend suite (3536 tests, including the new `tests/raster-info.test.ts`), and pre-commit on the changed files all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layer metadata dialogs for eligible raster/COG layers now fetch GeoTIFF-derived details (e.g., CRS, pixel size, extent, dimensions, data type, compression, nodata, tile size, overviews).
  * Added raster metadata loading, error, and resize messaging in the metadata UI, localized across supported languages.
* **Tests**
  * Added unit tests for raster metadata extraction, including value normalization (e.g., pixel size sign, NaN nodata), handling missing CRS fields, and CRS EPSG/label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->