### PR TITLE
fix: Raster Calculator equality operations match nothing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -613,7 +613,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2749,7 +2748,6 @@
       "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.7.tgz",
       "integrity": "sha512-eRzddMlHuBBFeSfhBig5V/32psav5JLvRYjuMqHgcwWXKfanAcxsKBfDSA4tzwWpnDU4id9sfdGW1RDzbVgY5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@luma.gl/shadertools": "^9.3.3",
         "@math.gl/core": "^4.1.0",
@@ -2989,7 +2987,6 @@
       "resolved": "https://registry.npmjs.org/@developmentseed/morecantile/-/morecantile-0.7.0.tgz",
       "integrity": "sha512-m9tWDase9COlP/EZ2KK/ydraRU/5yfwvmF/y/2g/iFMFW1vYHQTW/8JYjmo84SiJXUifDDY2xoA3ErYlcWJctg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@developmentseed/affine": "^0.7.0"
       }
@@ -3118,8 +3115,7 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.4.tgz",
       "integrity": "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-postgis": {
       "version": "0.2.4",
@@ -3769,7 +3765,6 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.10.3.tgz",
       "integrity": "sha512-o5iwxSDS2M8lwLkNtaJTKqyN3NHv2Ne5bL+7tfdcmmHukcGMuuSroRG/+IT3CXOS7gk9sYVdR0cMEPHs1lTWNQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3785,7 +3780,6 @@
       "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.10.3.tgz",
       "integrity": "sha512-gBKSRC7L3cD1KX4fIleRiEKtzlvKjuDW5cYpDcDyQCn/Bw7bJzlGrlaMw87FQ+ReTZp9vlTYFXyrGMuUtR0dKw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@esri/arcgis-rest-fetch": "^4.10.3",
         "@esri/arcgis-rest-form-data": "^4.10.3",
@@ -3914,7 +3908,6 @@
       "resolved": "https://registry.npmjs.org/@geoman-io/maplibre-geoman-free/-/maplibre-geoman-free-0.8.4.tgz",
       "integrity": "sha512-nOLEpMtORSR0XceXfOHc0RGqrkCQo3719o1d1Bp64xzijxn37KvkxB7S3dwOFV+i3Z3MleaSGAcIjvszil2D3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@turf/area": "^7.3.5",
         "@turf/bbox": "^7.3.5",
@@ -5575,7 +5568,6 @@
       "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.1.0.tgz",
       "integrity": "sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@math.gl/core": "4.1.0"
       }
@@ -5606,7 +5598,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -5735,7 +5726,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -10795,7 +10785,6 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -11477,7 +11466,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11610,7 +11598,6 @@
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.2.0.tgz",
       "integrity": "sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^25.2.0",
         "flatbuffers": "^25.1.24",
@@ -12025,7 +12012,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -12303,7 +12289,6 @@
       "resolved": "https://registry.npmjs.org/cog-tiler-wasm/-/cog-tiler-wasm-0.3.1.tgz",
       "integrity": "sha512-5mH36bBRrArqeCeCW3Gl2IhlWcU5g64eQRIfIsyo+XQwaBYfmjzuHJ36nbS7fCLUNk9khNUdgVWTU9C1zS33iw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "geotiff": "^2.1.0 || ^3.0.0",
         "geotiff-geokeys-to-proj4": "^2024.4.13",
@@ -13160,7 +13145,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -13231,7 +13215,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -13502,7 +13485,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -14214,9 +14196,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.2.0.tgz",
-      "integrity": "sha512-TnWs2X6SHT+jv3yvNICkPiiPdxJKTb+hg8PHDuhrIjelzLOwClASdvTS4m5e8PRsbCDikRSBx6lXE4XGiP/FFg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.2.1.tgz",
+      "integrity": "sha512-s/XzE2uDwoJOcXx4tUXIj7qSsfzqLcUpxib/p+Knjsr4cbM3JE0bBbiK4nKtUUZR1KNPUaLeowpMSKgzPWeqAg==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -14227,7 +14209,6 @@
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
       "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.9.3",
         "lerc": "^3.0.0",
@@ -14246,8 +14227,7 @@
       "version": "2024.4.13",
       "resolved": "https://registry.npmjs.org/geotiff-geokeys-to-proj4/-/geotiff-geokeys-to-proj4-2024.4.13.tgz",
       "integrity": "sha512-Jgtm/lcPkgB44wCqQHaVQx5/fyhmiVDRUKQcI/vMolsED8/GRWBnn5qkQo/CgutQg9xkGzig21DY9Px9mFRdvg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/geotiff/node_modules/lerc": {
       "version": "3.0.0",
@@ -15030,7 +15010,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
       "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -15139,7 +15118,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6 || ^7"
       },
@@ -18242,7 +18220,6 @@
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -18421,7 +18398,6 @@
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.9.tgz",
       "integrity": "sha512-GLBGqXaTcdWnppre3o1sMmy4DcMGSGq/ng+9k2MTNddarRK6SveINqlqYzi3xEXuy06ljY1TTrC6H9C4f360IQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.5.5"
@@ -18633,7 +18609,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18643,7 +18618,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19044,7 +19018,6 @@
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -20039,7 +20012,6 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20229,7 +20201,6 @@
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -20493,7 +20464,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -20766,7 +20736,6 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -21170,7 +21139,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21385,7 +21353,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -21558,7 +21525,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -21636,7 +21602,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -21699,7 +21664,6 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
       "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -22003,7 +21967,7 @@
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^1.2.0",
+        "geolibre-wasm": "^1.2.1",
         "geotiff": "^3.0.5",
         "onnxruntime-web": "1.27.0"
       },

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -33,7 +33,7 @@
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^1.2.0",
+    "geolibre-wasm": "^1.2.1",
     "geotiff": "^3.0.5",
     "onnxruntime-web": "1.27.0"
   },


### PR DESCRIPTION
## Summary

Fixes #1419.

The Whitebox toolbox Raster Calculator (and Conditional Evaluation) never matched equality tests: `"clusters" == 1` produced an all-zero raster, `"clusters" != 1` matched every cell, and `"clusters" = 1` produced an all-nodata raster.

Root cause is in the WASM Whitebox engine (whitebox-wasm, consumed via geolibre-wasm): raster cell values are bound into the evalexpr context as `Float`, and evalexpr never considers values of different types equal, so comparing against an integer literal like `1` was always false. A lone `=` parsed as an evalexpr assignment, which fails against the immutable context and mapped every cell to nodata.

## Changes

- Bump `geolibre-wasm` to 1.2.1 (opengeos/whitebox-wasm#12, released through opengeos/geolibre-rust#445 and v1.2.1). The expression normalizer now promotes standalone integer literals to floats (`1` -> `1.0`) and rewrites SQL/QGIS-style `=` to `==`, both quote- and exponent-aware.
- Regenerated the Whitebox menu catalog per the bump checklist; output is byte-identical, so no catalog changes ship. `MAX_VECTOR_PMTILES_ZOOM` is unaffected (no tiler changes in this release; the mirror test in the frontend suite passes).

## Verification

Reproduced and verified in the running web app with the reporter's `clusters.tif` (float32 cells with exact values 0-3, NaN nodata), in both dark and light themes. At a fixed coordinate deep inside a `clusters == 1` region, and a second coordinate where `clusters == 0`:

| Expression | Before | After |
| --- | --- | --- |
| `"clusters" == 1` | 0 everywhere | 1 / 0 binary mask |
| `"clusters" = 1` | all nodata | 1 / 0 binary mask |
| `"clusters" > 0 && "clusters" < 2` | correct | still correct |

Engine-level regression tests for `== 1`, `= 1`, and `!= 1` live upstream in whitebox-wasm.

## Local gates

- `npm run test:frontend`: 3530 pass, 0 fail
- `npm run build`: clean
- pre-commit on changed files: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the geospatial processing component to a newer patch version for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->