### PR TITLE
feat(geolens): render private rasters by attaching the API key via transformRequest

### DIFF
--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -130,9 +130,43 @@ export function normalizeBaseUrl(raw: string): string {
 }
 
 /** Auth headers for a request — an API key becomes `X-Api-Key`. */
+/** GeoLens accepts the API key in this header (it also honors `Authorization`). */
+export const GEOLENS_API_KEY_HEADER = "X-Api-Key";
+
 export function authHeaders(options: GeoLensClientOptions): Record<string, string> {
   const key = options.apiKey?.trim();
-  return key ? { "X-Api-Key": key } : {};
+  return key ? { [GEOLENS_API_KEY_HEADER]: key } : {};
+}
+
+/**
+ * The prefix of a tile URL template: everything before the first `{z}`/`{x}`/`{y}`
+ * placeholder.
+ *
+ * Used as the match key when attaching credentials to MapLibre-issued raster
+ * tile requests, so a key is scoped to the exact endpoint that produced it
+ * rather than to a whole origin.
+ */
+export function tileUrlPrefix(template: string): string {
+  const brace = template.indexOf("{");
+  return brace === -1 ? template : template.slice(0, brace);
+}
+
+/**
+ * Auth headers for a raster tile URL, or `null` to leave the request untouched.
+ *
+ * `keysByPrefix` maps a {@link tileUrlPrefix} to the API key that endpoint needs.
+ * A request only ever gets a key when its URL starts with that exact prefix, so
+ * basemaps, other plugins' tiles, and a second GeoLens server on the same origin
+ * are all unaffected.
+ */
+export function rasterTileAuthHeaders(
+  url: string,
+  keysByPrefix: ReadonlyMap<string, string>,
+): Record<string, string> | null {
+  for (const [prefix, apiKey] of keysByPrefix) {
+    if (url.startsWith(prefix)) return { [GEOLENS_API_KEY_HEADER]: apiKey };
+  }
+  return null;
 }
 
 /**

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -151,6 +151,39 @@ export function tileUrlPrefix(template: string): string {
   return brace === -1 ? template : template.slice(0, brace);
 }
 
+/** The store-layer fields needed to re-key restored GeoLens raster layers. */
+export interface GeoLensRasterLayerLike {
+  metadata?: Record<string, unknown> | null;
+  source?: { tiles?: unknown } | null;
+}
+
+/**
+ * Tile templates of GeoLens raster layers already on the map that belong to
+ * `baseUrl`.
+ *
+ * API keys are held in memory only, so a restored project (or a
+ * deactivate/reactivate cycle) leaves private raster layers in the store with
+ * no registered credential, and the Add button is disabled for them because
+ * they are already present. Re-registering these templates at connect time is
+ * what lets the key the user just entered reach those layers' tile requests.
+ */
+export function rasterTemplatesForServer(
+  layers: readonly GeoLensRasterLayerLike[],
+  baseUrl: string,
+): string[] {
+  const out: string[] = [];
+  for (const layer of layers) {
+    const md = layer.metadata;
+    if (!md || md.sourceKind !== "geolens-raster-tiles" || md.geolensBaseUrl !== baseUrl) {
+      continue;
+    }
+    const tiles = layer.source?.tiles;
+    const first = Array.isArray(tiles) ? tiles[0] : undefined;
+    if (typeof first === "string" && first) out.push(first);
+  }
+  return out;
+}
+
 /**
  * Auth headers for a raster tile URL, or `null` to leave the request untouched.
  *

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -21,6 +21,7 @@
  */
 
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import type { Map as MapLibreMap, RequestParameters, ResourceType } from "maplibre-gl";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 import {
   datasetPageUrl,
@@ -30,8 +31,10 @@ import {
   geometryKind,
   mintTileToken,
   normalizeBaseUrl,
+  rasterTileAuthHeaders,
   resolveRasterTiles,
   searchDatasets,
+  tileUrlPrefix,
   vectorTileTemplate,
   type GeoLensClientOptions,
   type GeoLensDataset,
@@ -269,6 +272,66 @@ function clearAllRefreshTimers(): void {
   refreshTimers.clear();
 }
 
+/**
+ * Raster tile URL prefixes that need an `X-Api-Key` header, mapped to the key.
+ *
+ * MapLibre issues raster tile requests itself, so an API-key-only private raster
+ * cannot carry the key the way the fetch calls in `./geolens-api` do.
+ * `transformRequest` is the supported hook: `RasterTileSource` routes every tile
+ * URL through it, and supplying any header other than `accept` moves the request
+ * off `HTMLImageElement` onto fetch, which sends headers. (Verified against
+ * maplibre-gl 5.24: `ImageRequest.doImageRequest` only takes the
+ * `HTMLImageElement` path when `requestParameters.headers` is empty or
+ * `accept`-only.)
+ *
+ * Keyed by tile-URL prefix (everything before the `{z}` placeholder) rather than
+ * by origin, so a key is only ever attached to the exact GeoLens raster endpoint
+ * that issued it. A basemap, another plugin's tiles, or a second GeoLens server
+ * reachable on the same origin never sees it.
+ */
+const rasterApiKeys = new Map<string, string>();
+
+let installedOnMap: MapLibreMap | null = null;
+
+function geolensTransformRequest(
+  url: string,
+  resourceType?: ResourceType,
+): RequestParameters | undefined {
+  if (resourceType !== "Tile" || rasterApiKeys.size === 0) return undefined;
+  const headers = rasterTileAuthHeaders(url, rasterApiKeys);
+  return headers ? { url, headers } : undefined;
+}
+
+/**
+ * Register a private raster's tile URL so its requests carry the API key.
+ *
+ * Installs the transform on first use only. GeoLibre sets no `transformRequest`
+ * of its own, and `Map` exposes no getter for an existing one, so this
+ * deliberately does not try to chain: it returns `undefined` for anything it
+ * does not recognize, which is the documented "leave this request alone" answer
+ * and keeps the hook cheap to hand over if the host ever wants to own it.
+ */
+function registerRasterApiKey(app: GeoLibreAppAPI, tiles: string, apiKey: string): void {
+  rasterApiKeys.set(tileUrlPrefix(tiles), apiKey);
+  const map = app.getMap?.();
+  if (!map || installedOnMap === map) return;
+  map.setTransformRequest(geolensTransformRequest);
+  installedOnMap = map;
+}
+
+/**
+ * Drop every registered key and uninstall the hook (plugin deactivation).
+ *
+ * Raster layers the user added stay on the map, but a private one stops
+ * rendering once its key is gone. That is deliberate: the credential was
+ * entered into the plugin panel, so it should not outlive the plugin.
+ */
+function clearRasterApiKeys(): void {
+  rasterApiKeys.clear();
+  installedOnMap?.setTransformRequest(null);
+  installedOnMap = null;
+}
+
 /** True when the layer's signed tile URL carries an expired (or near-expiry) token. */
 function tileTokenExpired(layer: GeoLibreLayer): boolean {
   const tiles = layer.source.tiles;
@@ -450,6 +513,8 @@ async function addRasterTilesLayer(
   fetchImpl: GeoLensFetch,
 ): Promise<void> {
   const raster = await resolveRasterTiles(client, dataset.id, fetchImpl);
+  // A public raster renders anonymously; only a keyed client needs the header.
+  if (client.apiKey) registerRasterApiKey(app, raster.tiles, client.apiKey);
   const layer: GeoLibreLayer = {
     id: createLayerId(),
     name: dataset.title,
@@ -849,8 +914,10 @@ function createGeoLensPlugin(config: GeoLensPluginConfig): GeoLibrePlugin {
       unregisterPanel = null;
       mountedPanels.delete(remount);
       // Layers the user added stay on the map (ordinary GeoLibre layers now),
-      // but the token-refresh timers we own must not outlive the plugin.
+      // but the token-refresh timers and the raster API keys we own must not
+      // outlive the plugin.
       clearAllRefreshTimers();
+      clearRasterApiKeys();
       appRef = null;
     },
   };

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -31,6 +31,7 @@ import {
   geometryKind,
   mintTileToken,
   normalizeBaseUrl,
+  rasterTemplatesForServer,
   rasterTileAuthHeaders,
   resolveRasterTiles,
   searchDatasets,
@@ -324,7 +325,9 @@ function registerRasterApiKey(app: GeoLibreAppAPI, tiles: string, apiKey: string
  *
  * Raster layers the user added stay on the map, but a private one stops
  * rendering once its key is gone. That is deliberate: the credential was
- * entered into the plugin panel, so it should not outlive the plugin.
+ * entered into the plugin panel, so it should not outlive the plugin. The way
+ * back is the connect handler, which re-registers templates for restored
+ * layers when the user reconnects with a key.
  */
 function clearRasterApiKeys(): void {
   rasterApiKeys.clear();
@@ -821,6 +824,16 @@ function buildPanel(
     // display to "" would wipe the inline `display:flex` and collapse to block.
     if (!connected) state.client = null;
     searchRow.style.display = connected ? "flex" : "none";
+    // Restored private rasters (project reopen, plugin reactivation) are in the
+    // store but hold no registered key — and their Add button is disabled, so
+    // re-adding is not a path back. The key entered here is the one credential
+    // they can get; register their templates so their tiles authenticate again.
+    if (connected && app && state.client?.apiKey) {
+      const layers = useAppStore.getState().layers;
+      for (const template of rasterTemplatesForServer(layers, state.client.baseUrl)) {
+        registerRasterApiKey(app, template, state.client.apiKey);
+      }
+    }
   };
 
   connectButton.addEventListener("click", () => void connect());

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -12,10 +12,12 @@ import {
   mintTileToken,
   normalizeBaseUrl,
   parseDataset,
+  rasterTileAuthHeaders,
   resolveRasterTiles,
   searchDatasets,
   stacCatalogUrl,
   stacCollectionsUrl,
+  tileUrlPrefix,
   vectorTileTemplate,
   type GeoLensFetch,
   type GeoLensHttpResponse,
@@ -414,5 +416,55 @@ describe("resolveRasterTiles", () => {
       () => resolveRasterTiles({ baseUrl: "http://h" }, "id", fetchImpl),
       /not a raster/,
     );
+  });
+});
+
+describe("tileUrlPrefix", () => {
+  it("keeps everything before the first placeholder", () => {
+    assert.equal(
+      tileUrlPrefix("https://demo.example.com/raster-tiles/abc/tiles/{z}/{x}/{y}.png"),
+      "https://demo.example.com/raster-tiles/abc/tiles/",
+    );
+  });
+
+  it("returns a template without placeholders unchanged", () => {
+    assert.equal(tileUrlPrefix("https://h/tiles.png"), "https://h/tiles.png");
+  });
+});
+
+describe("rasterTileAuthHeaders", () => {
+  const keys = new Map([
+    ["https://demo.example.com/raster-tiles/abc/tiles/", "key-abc"],
+    ["https://other.example.com/raster-tiles/xyz/tiles/", "key-xyz"],
+  ]);
+
+  it("attaches the key registered for that tile endpoint", () => {
+    assert.deepEqual(
+      rasterTileAuthHeaders("https://demo.example.com/raster-tiles/abc/tiles/3/2/1.png", keys),
+      { "X-Api-Key": "key-abc" },
+    );
+  });
+
+  it("picks the matching server when several are registered", () => {
+    assert.deepEqual(
+      rasterTileAuthHeaders("https://other.example.com/raster-tiles/xyz/tiles/0/0/0.png", keys),
+      { "X-Api-Key": "key-xyz" },
+    );
+  });
+
+  it("does not leak the key to a basemap or another host", () => {
+    assert.equal(rasterTileAuthHeaders("https://tiles.openfreemap.org/1/2/3.pbf", keys), null);
+    assert.equal(rasterTileAuthHeaders("https://demo.example.com.evil.test/x", keys), null);
+  });
+
+  it("does not attach a key to a different dataset on the same server", () => {
+    assert.equal(
+      rasterTileAuthHeaders("https://demo.example.com/raster-tiles/zzz/tiles/1/1/1.png", keys),
+      null,
+    );
+  });
+
+  it("returns null when nothing is registered", () => {
+    assert.equal(rasterTileAuthHeaders("https://demo.example.com/x", new Map()), null);
   });
 });

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -12,6 +12,7 @@ import {
   mintTileToken,
   normalizeBaseUrl,
   parseDataset,
+  rasterTemplatesForServer,
   rasterTileAuthHeaders,
   resolveRasterTiles,
   searchDatasets,
@@ -466,5 +467,49 @@ describe("rasterTileAuthHeaders", () => {
 
   it("returns null when nothing is registered", () => {
     assert.equal(rasterTileAuthHeaders("https://demo.example.com/x", new Map()), null);
+  });
+});
+
+describe("rasterTemplatesForServer", () => {
+  const base = "https://demo.example.com";
+  const layers = [
+    {
+      metadata: {
+        sourceKind: "geolens-raster-tiles",
+        geolensBaseUrl: base,
+        geolensDatasetId: "abc",
+      },
+      source: { tiles: [`${base}/raster-tiles/abc/tiles/{z}/{x}/{y}.png`] },
+    },
+    {
+      metadata: { sourceKind: "geolens-raster-tiles", geolensBaseUrl: "https://other.example.com" },
+      source: { tiles: ["https://other.example.com/raster-tiles/xyz/tiles/{z}/{x}/{y}.png"] },
+    },
+    {
+      metadata: { sourceKind: "geolens-vector-tiles", geolensBaseUrl: base },
+      source: { tiles: [`${base}/api/tiles/t/{z}/{x}/{y}.pbf?sig=s`] },
+    },
+    { metadata: null, source: { tiles: [`${base}/raster-tiles/zzz/tiles/{z}/{x}/{y}.png`] } },
+    {
+      metadata: { sourceKind: "geolens-raster-tiles", geolensBaseUrl: base },
+      source: { tiles: [] },
+    },
+    { metadata: { sourceKind: "geolens-raster-tiles", geolensBaseUrl: base }, source: null },
+  ];
+
+  it("returns only this server's raster templates", () => {
+    assert.deepEqual(rasterTemplatesForServer(layers, base), [
+      `${base}/raster-tiles/abc/tiles/{z}/{x}/{y}.png`,
+    ]);
+  });
+
+  it("returns the other server's template for its own base URL", () => {
+    assert.deepEqual(rasterTemplatesForServer(layers, "https://other.example.com"), [
+      "https://other.example.com/raster-tiles/xyz/tiles/{z}/{x}/{y}.png",
+    ]);
+  });
+
+  it("returns nothing when no GeoLens raster layers are present", () => {
+    assert.deepEqual(rasterTemplatesForServer([], base), []);
   });
 });


### PR DESCRIPTION
Follows up on #1427. `geolens-api.ts` noted that an API-key-only private raster cannot render because MapLibre issues the tile image requests and does not attach `X-Api-Key`. This wires up `transformRequest` so it does.

## How it works

`RasterTileSource.loadTile` routes every tile URL through `map._requestManager.transformRequest(url, "Tile")`, and `ImageRequest.doImageRequest` only takes the `HTMLImageElement` path when `requestParameters.headers` is empty or `accept`-only. Supplying any other header moves the request onto fetch, which sends it. So returning `{ url, headers }` from a `transformRequest` is enough to authenticate a raster tile.

When a raster layer is added from a client that has an API key, the plugin registers that layer's tile-URL prefix and installs the hook on first use.

On the server side this is a real authorization path, not just a CORS allowance: the `/raster-tiles/` location proxies to the GeoLens API, which resolves `X-Api-Key` into a user and then applies dataset RBAC. Private responses come back `no-store`, so the tile cache in front of it does not serve them across users.

## This is the interim path, not the end state

As I mentioned in #1427, the better answer is for GeoLens to hand you a signed raster template the way it already does for vector tiles, so no key rides on the request at all. That is tracked as geolens-io/geolens#688. When it ships you should be able to delete this and treat rasters like the vector path.

Merging this in the meantime seems worth it: it unblocks private rasters on every GeoLens deployment that exists today, including older servers that will not get the signed-template change for a while.

## Scoping

The key is matched by **tile-URL prefix** (everything before the `{z}` placeholder), not by origin. A request only gets a key when its URL starts with that exact prefix, so a basemap, another plugin's tiles, a different dataset, or a second GeoLens server on the same origin never see it. That felt worth being strict about, since a leaked key here would be the user's catalog credential.

Public rasters are untouched: they render anonymously and no key is registered.

## Lifecycle

`deactivate` clears the registry and uninstalls the hook, alongside the existing `clearAllRefreshTimers()`. Layers stay on the map as ordinary GeoLibre layers, but a private raster stops rendering once the plugin is off. That seemed right given the credential was entered into the plugin panel, though say the word if you would rather it persist for the session.

The way back in (from the Codex P1): a successful keyed connect re-registers templates for this server's raster layers already in the store, so a reopened project or a reactivated plugin recovers as soon as the user reconnects, without deleting and re-adding the layer.

Known limitation (from the Codex P2): only the primary map gets the transform, because plugins can only reach `getMap()`; split-view panes are host-internal. Options and a proposal are in the review thread.

The hook returns `undefined` for anything it does not recognize, which is the documented "leave this request alone" answer, so it stays cheap to hand over if the host ever wants to own `transformRequest` itself. GeoLibre sets none today and `Map` exposes no getter for an existing one, so this deliberately does not try to chain.

## Verification

- `pre-commit run --files` on the three changed files: oxfmt, eslint and npm build all pass. Scoped rather than `--all-files` per the note in `CLAUDE.md` about the build hook.
- `npm run lint`: 0 errors (35 pre-existing warnings, none in the touched files).
- `npm run build`: clean.
- `npm run test:frontend:coverage`: 3579 pass. Totals 84.06% lines / 84.29% branches / 70.95% functions, above the 78/78/63 floors. `geolens-api.ts` is at 98.13% lines from the 7 new tests, which cover prefix parsing and the scoping rules including the lookalike-host and wrong-dataset cases.
- The header/fetch behavior is confirmed by reading maplibre-gl 5.24.0, the version this repo resolves, rather than only from the docs.

Three things worth naming rather than leaving you to find:

- I did not run `test:worker`, `test:backend:coverage` or `check:rust` from `npm run ci`. This change touches no worker, Python or Rust code, and I do not have those toolchains set up here.
- The server half is measured, not assumed: against a real private raster through the public edge, an anonymous request and an invalid-key request both get 401 while a valid `X-Api-Key` gets 200 (and 200 with `Origin: https://web.geolibre.app`). Numbers in the thread below. Not verified: watching a GeoLibre instance paint the tile, since I have no private raster registered in one.
- `tests/metainfo-generated.test.ts` fails for me on macOS on a clean checkout too, `render-linux-metainfo.sh` giving "DATE is not a valid calendar date" (BSD `date`). Untouched here, just flagging it.
