### PR TITLE
ci(preview): split PR preview into build + deploy so fork PRs get previews

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,243 @@
+name: PR preview deploy
+
+# Stage 2 of 2: PUBLISH ONLY. Holds the deploy secrets; runs no contributor code.
+#
+# Triggered by `workflow_run` on .github/workflows/pr-preview.yml, which builds
+# the site from the PR's tree with no secrets in scope. Because `workflow_run`
+# always executes the workflow definition from the DEFAULT BRANCH, a pull
+# request cannot alter what this file does, and repository secrets are
+# available even when the PR came from a fork -- which is the entire reason the
+# preview is split in two.
+#
+# The invariant that makes that safe: this job must never execute anything from
+# the pull request. It downloads an artifact and copies files. Specifically:
+#
+#   * The checkout below takes the default branch. It must never be given
+#     `ref: ...head.sha` or anything else derived from the PR.
+#   * No `npm ci`, no build, no `npm run`, no running a script out of `site/`.
+#     The artifact is inert data here -- static files pushed to a host.
+#   * Nothing from the artifact may be interpolated into a `run:` block.
+#
+# The PR number is NOT taken from the artifact, which a fork controls and could
+# use to overwrite an unrelated PR's preview and comment on it. It is looked up
+# from the API using the head repo and branch recorded in the trusted
+# `workflow_run` payload, so a run can only ever address its own PR.
+#
+# Required repository secrets:
+#   CLOUDFLARE_API_TOKEN   - needs the "Cloudflare Pages: Edit" permission
+#   CLOUDFLARE_ACCOUNT_ID
+#   PREVIEW_DEPLOY_TOKEN   - fine-grained PAT scoped to opengeos/pages-preview
+#                            only, with Contents: Read and write + Pages: Read.
+#                            Pages read is required by wait-for-pages-deployment
+#                            below; without it the poll never sees a build and
+#                            the job times out with a misleading error.
+
+on:
+  workflow_run:
+    workflows: ["PR preview"]
+    types: [completed]
+
+permissions:
+  contents: read
+  # Download the build artifact from the triggering run.
+  actions: read
+  # The sticky preview comment. The deploy to opengeos/pages-preview does not
+  # use this token -- it uses PREVIEW_DEPLOY_TOKEN, which has no access to this
+  # repository.
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-deploy-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  # NOT cancel-in-progress: unlike the build, this job pushes commits to
+  # opengeos/pages-preview. Queue overlapping runs instead of killing one
+  # mid-push.
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy preview
+    runs-on: ubuntu-latest
+    # Only for builds that came from a pull request and actually succeeded. A
+    # `workflow_dispatch` build of pr-preview.yml is a build smoke test and
+    # publishes nothing, matching the behaviour before the split.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      # Resolve the PR from trusted event data only. `workflow_run.pull_requests`
+      # is empty for fork PRs, so query by head instead: the (fork, branch) pair
+      # is recorded by GitHub, not by the build, and an attacker cannot push to
+      # someone else's fork -- so this can only resolve to the PR that triggered
+      # the run.
+      - name: Resolve the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          # Highest number wins if a branch has been reused across PRs; that is
+          # the current one.
+          # No --paginate: the head filter cannot return anywhere near 100 PRs,
+          # and per-page --jq would mangle the max_by below.
+          #
+          # `// empty` matters: max_by on an empty array yields null, and piping
+          # null into the object constructor would produce {"number":null} --
+          # a truthy string that sails past the emptiness check below.
+          pr=$(gh api \
+            "repos/${REPO}/pulls?state=all&per_page=100&head=${HEAD_OWNER}:${HEAD_BRANCH}" \
+            --jq 'max_by(.number) // empty | {number, state}' || true)
+          if [ -z "$pr" ]; then
+            echo "::notice::No pull request found for ${HEAD_OWNER}:${HEAD_BRANCH} -- nothing to publish."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          number=$(echo "$pr" | jq -r .number)
+          state=$(echo "$pr" | jq -r .state)
+          case "$number" in
+            ''|*[!0-9]*) echo "::error::Unexpected PR number: $number"; exit 1 ;;
+          esac
+          echo "PR #${number} is ${state}"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+          # Drive deploy-vs-remove off the PR's live state rather than off the
+          # build job, so a preview is never published for a closed PR.
+          if [ "$state" = "closed" ]; then
+            echo "action=remove" >> "$GITHUB_OUTPUT"
+          else
+            echo "action=deploy" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The Pages deploy action needs a git repository in the workspace. This
+      # is the DEFAULT BRANCH -- never the PR head. Do not add a `ref:` here.
+      - name: Checkout repository
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Download the built site
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.action == 'deploy'
+        uses: actions/download-artifact@v7
+        with:
+          name: pr-preview-site
+          path: site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # ------------------------------------------------------- GitHub Pages
+      # Runs BEFORE the DuckDB deletion below: Pages allows 100 MB per file and
+      # ignores the `_redirects` file stage 1 wrote, so it serves those modules
+      # locally and needs them present.
+      - name: Deploy preview to GitHub Pages
+        id: pages
+        if: steps.pr.outputs.found == 'true'
+        # A Pages problem (bad deploy token, Pages size limit) would otherwise
+        # take the Cloudflare preview and the PR comment down with it. Let the
+        # job carry on; the comment says which target failed.
+        #
+        # Deploy runs only. On a removal this step IS the job -- everything
+        # after it is skipped -- so swallowing a failed removal would report
+        # success while the preview stayed published.
+        continue-on-error: ${{ steps.pr.outputs.action == 'deploy' }}
+        # Pinned rather than tracking the v1 tag: this is a third-party action
+        # and it receives PREVIEW_DEPLOY_TOKEN.
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: site
+          deploy-repository: opengeos/pages-preview
+          token: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
+          pages-base-url: opengeos.org/pages-preview
+          preview-branch: gh-pages
+          # pages-preview is shared across opengeos repositories and the action
+          # composes the path as "<umbrella-dir>/pr-<number>", so this namespaces
+          # our previews against every other repository's.
+          umbrella-dir: GeoLibre
+          # There is no pull_request payload under `workflow_run`, so the PR
+          # number and the deploy/remove decision have to be passed explicitly;
+          # the action would otherwise read them off the event and do nothing.
+          pr-number: ${{ steps.pr.outputs.number }}
+          action: ${{ steps.pr.outputs.action }}
+          # Same reason: the default messages interpolate `github.event.number`,
+          # which is empty here.
+          deploy-commit-message: Deploy preview for PR ${{ steps.pr.outputs.number }} 🛫
+          remove-commit-message: Remove preview for PR ${{ steps.pr.outputs.number }} 🛬
+          wait-for-pages-deployment: true
+          # Both URLs go in one comment, posted below.
+          comment: false
+
+      # --------------------------------------------------------- Cloudflare
+      - name: Drop the CDN-redirected DuckDB WASM
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.action == 'deploy'
+        # Cloudflare Pages rejects any single file > 25 MiB. Stage 1 already
+        # wrote site/_redirects pointing every such file at jsDelivr and failed
+        # the build on any it could not map, so deleting by size alone here is
+        # safe: anything left over 25 MiB is already redirected.
+        run: |
+          set -euo pipefail
+          find site -type f -size +26214400c -printf 'dropping %p (%s bytes)\n' -delete
+          echo "----- site/_redirects -----"
+          cat site/_redirects || echo "(none)"
+
+      - name: Create a scratch directory for wrangler
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.action == 'deploy'
+        run: mkdir -p .wrangler-deploy
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.action == 'deploy'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # wrangler-action installs wrangler with npm into its working
+          # directory. Point it at an empty scratch dir so it does not resolve
+          # against this monorepo's package.json / workspaces, and give the
+          # payload an absolute path.
+          workingDirectory: .wrangler-deploy
+          # --branch is anything other than the project's production branch, so
+          # every run here is a preview deployment with its own URL.
+          command: >-
+            pages deploy ${{ github.workspace }}/site
+            --project-name=geolibre-preview
+            --branch="${{ github.event.workflow_run.head_branch }}"
+            --commit-dirty=true
+
+      - name: Comment preview URLs on PR
+        if: steps.pr.outputs.found == 'true' && steps.pr.outputs.action == 'deploy'
+        uses: actions/github-script@v9
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
+          PAGES_URL: ${{ steps.pages.outputs.preview-url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const url = process.env.DEPLOY_URL;
+            const pagesUrl = process.env.PAGES_URL;
+            if (!url && !pagesUrl) return;
+            const marker = '<!-- cloudflare-preview -->';
+            const rows = [];
+            if (pagesUrl) {
+              rows.push(`| GitHub Pages | ${pagesUrl} |`);
+              rows.push(`| Demo app | ${pagesUrl}demo/ |`);
+            } else {
+              rows.push(`| GitHub Pages | deploy failed — see the job log |`);
+            }
+            if (url) {
+              rows.push(`| Cloudflare | ${url} |`);
+              rows.push(`| Demo app | ${url}/demo/ |`);
+            }
+            rows.push(`| Commit | \`${process.env.HEAD_SHA.slice(0, 7)}\` |`);
+            const body = `${marker}\n### 🔍 PR preview\n\n| Item | Value |\n| --- | --- |\n${rows.join('\n')}`;
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,40 +1,55 @@
 name: PR preview
 
-# Builds the docs site + web demo for every pull request and publishes it to
-# two places from a single build:
+# Stage 1 of 2: BUILD ONLY. No secrets are available to this workflow.
 #
-#   GitHub Pages  https://opengeos.org/pages-preview/GeoLibre/pr-<N>/
-#   Cloudflare    a per-branch *.pages.dev preview deployment
+# This job runs `npm ci` and a full Vite build from the pull request's own
+# tree, so on a fork PR it executes code written by an outside contributor.
+# That is why it holds nothing worth stealing: `permissions` is read-only and
+# no `secrets.*` is referenced anywhere below. It produces a `pr-preview-site`
+# artifact and stops.
 #
-# Both URLs land in one sticky comment on the PR. The Pages copy is removed
-# automatically when the PR closes.
+# Stage 2 (.github/workflows/pr-preview-deploy.yml) picks that artifact up on
+# `workflow_run` and publishes it. That job DOES hold PREVIEW_DEPLOY_TOKEN and
+# CLOUDFLARE_API_TOKEN, but it only moves static files -- it never runs
+# contributor code. Splitting it this way is what lets previews work for fork
+# PRs at all: the `pull_request` event withholds repository secrets from forks,
+# and `workflow_run` runs from the default branch with them restored.
+#
+# Do NOT "fix" anything here by switching to pull_request_target: that would
+# put the secrets back into the same job as the contributor's build script,
+# which is the exact arrangement this split exists to avoid.
+#
+# The build-time `secrets.*` still referenced below are the exception that
+# proves the rule. On a fork-triggered `pull_request` run GitHub resolves every
+# one of them to an empty string, so a fork build never sees them; on a
+# maintainer's same-repo branch they resolve normally, exactly as before. The
+# practical effect is that fork previews build without the Google Maps /
+# Protomaps / GEE keys and those basemaps are absent from the preview, while
+# maintainer previews are unchanged. That asymmetry is the point -- do not
+# "fix" it by moving the keys somewhere a fork run can read.
+#
+# Do NOT add any secret here whose absence a fork build cannot tolerate, and
+# never the deploy tokens: those live in stage 2 only.
+#
+# Publishing fork-authored HTML/JS under opengeos.org/pages-preview/ puts it on
+# a real origin the project owns. That is inherent to previewing a fork, but it
+# means the repository's "Require approval for all external contributors"
+# setting is load-bearing: stage 1 will not run until a maintainer approves the
+# run, and stage 2 only fires after stage 1 succeeds, so that approval gates
+# the publish too. Keep it on.
 #
 # The build mirrors .github/workflows/pages.yml (the GitHub Pages production
 # deploy) so previews match what ships:
 #   docs deps -> jupyterlite deps -> npm ci -> web demo build -> docs build ->
 #   bundle demo into site/demo.
 #
-# NOTE on fork PRs: the `pull_request` event does NOT expose repository secrets
-# to PRs opened from forks, so previews only run for branches pushed to this
-# repo (maintainers and collaborators). External fork PRs are skipped — the job
-# guard below short-circuits them instead of failing with a missing token.
-# Do NOT "fix" this by switching to pull_request_target: this job runs `npm ci`
-# and a full build from the PR's own tree, so it executes contributor code, and
-# under pull_request_target that code would run with this repo's secrets in
-# scope. (opengeos/geolibre-plugins can use pull_request_target for its plugin
-# previews only because it never executes the submitted code.)
-#
-# Required repository secrets (already present for the Workers deploys):
-#   CLOUDFLARE_API_TOKEN   - needs the "Cloudflare Pages: Edit" permission
-#   CLOUDFLARE_ACCOUNT_ID
-#   PREVIEW_DEPLOY_TOKEN   - fine-grained PAT scoped to opengeos/pages-preview
-#                            only, with Contents: Read and write + Pages: Read.
-#                            Pages read is required by wait-for-pages-deployment
-#                            below; without it the poll never sees a build and
-#                            the job times out with a misleading error.
-# Optional (baked into the client bundle, same as pages.yml):
+# Optional build-time values, baked into the client bundle, same as pages.yml:
 #   VITE_GEE_OAUTH_CLIENT_ID, VITE_PROTOMAPS_API_KEY,
-#   VITE_GOOGLE_MAPS_API_KEY or GOOGLE_MAPS_API_KEY
+#   VITE_GOOGLE_MAPS_API_KEY or GOOGLE_MAPS_API_KEY, VITE_MAPILLARY_ACCESS_TOKEN
+# Empty on fork runs, per the note above.
+#
+# The deploy secrets that used to live here (PREVIEW_DEPLOY_TOKEN,
+# CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID) moved to stage 2.
 
 on:
   pull_request:
@@ -42,27 +57,31 @@ on:
     types: [opened, reopened, synchronize, closed]
   workflow_dispatch:
 
+# Read-only, and deliberately so -- see the header. The PR comment is posted by
+# stage 2, which has `pull-requests: write`.
 permissions:
   contents: read
-  # For the sticky preview comment. The deploy to opengeos/pages-preview does
-  # not use this token -- it uses PREVIEW_DEPLOY_TOKEN, which has no access to
-  # this repository.
-  pull-requests: write
 
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  preview:
-    name: Build and deploy preview
+  build:
+    name: Build preview
     runs-on: ubuntu-latest
-    # Skip fork PRs: secrets are unavailable there, so the deploy would fail.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      # Unconditional: on `closed` there is nothing to build, but the preview
-      # removal below still needs a git repository in the workspace.
+      # On `closed` there is nothing to build, but the job still has to run and
+      # succeed: it is what triggers stage 2, which removes the published
+      # preview. Every build step below is skipped and no artifact is uploaded;
+      # stage 2 reads the PR's state from the API rather than from anything
+      # this job hands it.
+      - name: Note the removal trigger
+        if: github.event.action == 'closed'
+        run: echo "PR closed -- stage 2 will remove the preview."
+
       - name: Checkout repository
+        if: github.event.action != 'closed'
         uses: actions/checkout@v7
         with:
           # Match ci.yml: don't leave the GITHUB_TOKEN in .git/config where an
@@ -104,6 +123,9 @@ jobs:
         run: npm run build -w geolibre-desktop
         env:
           GEOLIBRE_APP_BASE: ./
+          # All empty on a fork run -- see the header. Mapillary additionally
+          # falls back to a public repository variable, so that one basemap
+          # does survive into fork previews.
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
           VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
@@ -123,14 +145,8 @@ jobs:
           test -f site/demo/index.html
           test -f site/demo/jupyterlite/lab/index.html
 
-      # ------------------------------------------------------- GitHub Pages
-      # Deployed BEFORE the DuckDB offload below, which deletes those modules
-      # and replaces them with site/_redirects. `_redirects` is a Cloudflare
-      # Pages feature that GitHub Pages ignores, so a Pages copy taken after
-      # that step would 404 on DuckDB. Pages allows 100 MB per file, so the
-      # ~40 MiB modules are fine to serve directly here.
       - name: Check the site fits GitHub Pages
-        if: github.event.action != 'closed' && github.event_name == 'pull_request'
+        if: github.event.action != 'closed'
         run: |
           set -euo pipefail
           echo "preview size: $(du -sh site | cut -f1)"
@@ -142,59 +158,28 @@ jobs:
             exit 1
           fi
 
-      # Publishing happens via `git add`, which honors any .gitignore inside the
-      # payload and would silently drop those files from the commit while the
-      # build still reports success.
-      - name: Strip .gitignore files from the site
-        if: github.event.action != 'closed' && github.event_name == 'pull_request'
-        run: find site -name .gitignore -print -delete
-
-      - name: Deploy preview to GitHub Pages
-        id: pages
-        if: github.event_name == 'pull_request'
-        # This step has to run before the DuckDB offload below, which means a
-        # Pages problem (bad deploy token, Pages size limit) would otherwise
-        # take the Cloudflare preview and the PR comment down with it. Let the
-        # job carry on instead; the comment says which target failed.
-        #
-        # Deploy runs only. On `closed` this step IS the job -- everything after
-        # it is skipped -- so swallowing a failed removal would report success
-        # while the preview stayed published.
-        continue-on-error: ${{ github.event.action != 'closed' }}
-        # Pinned rather than tracking the v1 tag: this is a third-party action
-        # and it receives PREVIEW_DEPLOY_TOKEN.
-        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
-        with:
-          source-dir: site
-          deploy-repository: opengeos/pages-preview
-          token: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
-          pages-base-url: opengeos.org/pages-preview
-          preview-branch: gh-pages
-          # pages-preview is shared across opengeos repositories and the action
-          # composes the path as "<umbrella-dir>/pr-<number>", so this namespaces
-          # our previews against every other repository's.
-          umbrella-dir: GeoLibre
-          action: ${{ github.event.action == 'closed' && 'remove' || 'deploy' }}
-          wait-for-pages-deployment: true
-          # Both URLs go in one comment, posted below.
-          comment: false
-
-      # --------------------------------------------------------- Cloudflare
-      - name: Offload oversized DuckDB WASM to CDN
+      - name: Map oversized DuckDB WASM to a CDN redirect
         if: github.event.action != 'closed'
         # Cloudflare Pages rejects any single file > 25 MiB. The bundled DuckDB
-        # WASM modules (duckdb-eh ~35 MiB, duckdb-mvp ~40 MiB) exceed that, so we
-        # drop the local copies and redirect their hashed URLs to jsDelivr at the
-        # exact pinned version (byte-identical to the bundled file). This only
-        # affects the Cloudflare preview; GitHub Pages still serves them locally.
-        # Any OTHER oversized file is a hard error so we never ship a broken site.
+        # WASM modules (duckdb-eh ~35 MiB, duckdb-mvp ~40 MiB) exceed that, so
+        # we point their hashed URLs at jsDelivr at the exact pinned version
+        # (byte-identical to the bundled file).
+        #
+        # This step only WRITES site/_redirects; it does not delete anything.
+        # GitHub Pages allows 100 MB per file and ignores `_redirects`, so the
+        # Pages copy keeps serving the modules locally. Stage 2 deletes them
+        # right before the Cloudflare deploy, once Pages has had the full set.
+        #
+        # Any OTHER oversized file is a hard error here, which is also what
+        # lets stage 2 delete by size alone: if this step passed, every file
+        # over 25 MiB has a redirect.
         run: |
           set -euo pipefail
           version=$(node -e "console.log(require('./node_modules/@duckdb/duckdb-wasm/package.json').version)")
           echo "duckdb-wasm version: $version"
           redirects=site/_redirects
           touch "$redirects"
-          moved=0
+          mapped=0
           # 26214400 bytes = 25 MiB, Cloudflare Pages' exact per-file limit.
           while IFS= read -r -d '' f; do
             rel=${f#site}
@@ -208,64 +193,33 @@ jobs:
                 exit 1 ;;
             esac
             echo "$rel https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@${version}/dist/${cdn} 302" >> "$redirects"
-            rm "$f"
             echo "redirect: $rel -> $cdn"
-            moved=$((moved + 1))
+            mapped=$((mapped + 1))
           done < <(find site -type f -size +26214400c -print0)
-          echo "offloaded $moved oversized file(s)"
+          echo "mapped $mapped oversized file(s)"
           echo "----- site/_redirects -----"
           cat "$redirects"
 
-      - name: Deploy to Cloudflare Pages
-        id: deploy
-        # pull_request only, like the Pages deploy above. --branch falls back to
-        # github.ref_name, so a manual run from the production branch would
-        # publish a *production* deployment to the preview project instead of a
-        # preview one.
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        uses: cloudflare/wrangler-action@v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # --branch is anything other than the project's production branch, so
-          # every run here is a preview deployment with its own URL.
-          command: >-
-            pages deploy site
-            --project-name=geolibre-preview
-            --branch="${{ github.head_ref || github.ref_name }}"
-            --commit-dirty=true
+      # The Pages publish in stage 2 happens via `git add`, which honors any
+      # .gitignore inside the payload and would silently drop those files from
+      # the commit while the build still reports success.
+      - name: Strip .gitignore files from the site
+        if: github.event.action != 'closed'
+        run: find site -name .gitignore -print -delete
 
-      - name: Comment preview URLs on PR
-        if: github.event_name == 'pull_request' && github.event.action != 'closed'
-        uses: actions/github-script@v9
-        env:
-          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
-          PAGES_URL: ${{ steps.pages.outputs.preview-url }}
+      - name: Upload the built site
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const url = process.env.DEPLOY_URL;
-            const pagesUrl = process.env.PAGES_URL;
-            if (!url && !pagesUrl) return;
-            const marker = '<!-- cloudflare-preview -->';
-            const rows = [];
-            if (pagesUrl) {
-              rows.push(`| GitHub Pages | ${pagesUrl} |`);
-              rows.push(`| Demo app | ${pagesUrl}demo/ |`);
-            } else {
-              rows.push(`| GitHub Pages | deploy failed — see the job log |`);
-            }
-            if (url) {
-              rows.push(`| Cloudflare | ${url} |`);
-              rows.push(`| Demo app | ${url}/demo/ |`);
-            }
-            rows.push(`| Commit | \`${context.sha.slice(0, 7)}\` |`);
-            const body = `${marker}\n### 🔍 PR preview\n\n| Item | Value |\n| --- | --- |\n${rows.join('\n')}`;
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          name: pr-preview-site
+          path: site
+          # upload-artifact drops dotfiles by default, which would quietly gut
+          # parts of the JupyterLite build. The .gitignore strip above already
+          # ran, so nothing unwanted comes back with them.
+          include-hidden-files: true
+          if-no-files-found: error
+          # The payload is a few hundred MB and is consumed minutes later.
+          retention-days: 1
+          # Mostly pre-compressed wasm/js; level 6 costs minutes for almost no
+          # size win on this payload.
+          compression-level: 1


### PR DESCRIPTION
## Why

PR previews were skipped for every fork PR (e.g. #1428). The `pull_request` event withholds repository secrets from forks, so `PREVIEW_DEPLOY_TOKEN` and `CLOUDFLARE_API_TOKEN` were empty and the job guarded itself off rather than failing. External contributors got no preview.

## What

Split the workflow so the secrets never share a job with contributor code:

| file | event | secrets | runs contributor code |
| --- | --- | --- | --- |
| `pr-preview.yml` | `pull_request` | no deploy tokens | yes — `npm ci` + Vite build |
| `pr-preview-deploy.yml` | `workflow_run` | deploy tokens | **no** — downloads an artifact and copies files |

`workflow_run` always executes the **default branch's** workflow definition, so a PR cannot alter what the deploying job does, and repository secrets are available there even for forks. Same reasoning that lets `opengeos/geolibre-plugins` use `pull_request_target` for plugin previews — it never executes the submitted code. The build half still must **not** become `pull_request_target`; the header comments say so.

### PR number resolution

`workflow_run.pull_requests` is empty for fork PRs, and the artifact is fork-controlled — trusting a PR number from it would let a fork overwrite an unrelated PR's preview and comment on it. Instead the deploy job queries `GET /pulls?head=<head_repo_owner>:<head_branch>` using values from the trusted `workflow_run` payload. Nobody can push to someone else's fork, so a run can only ever resolve to its own PR. Deploy-vs-remove comes from the PR's live `state`, so a preview is never published for a closed PR.

### DuckDB WASM offload

Also split. The build writes `site/_redirects` but **keeps** the >25 MiB modules, so GitHub Pages still serves them locally (Pages allows 100 MB/file and ignores `_redirects`); the deploy job deletes them right before the Cloudflare upload. Deleting by size alone is safe there because the build hard-fails on any oversized file it could not map.

### Build-time keys

`VITE_GEE_OAUTH_CLIENT_ID`, `VITE_PROTOMAPS_API_KEY`, `VITE_GOOGLE_MAPS_API_KEY`/`GOOGLE_MAPS_API_KEY`, `VITE_MAPILLARY_ACCESS_TOKEN` stay in the build job. On a fork run GitHub resolves them to empty strings — no exposure — so **fork previews build without those basemaps** while maintainer previews are unchanged. Mapillary falls back to a public `vars.*` and does survive.

## Behaviour changes

- Fork PRs now get both preview URLs.
- Build and deploy are two runs; the sticky comment arrives a few minutes later than before (artifact round-trip of the few-hundred-MB site).
- The build job is now `permissions: contents: read` only; the comment is posted by the deploy job.
- Fork previews are missing the Google Maps / Protomaps / GEE basemaps.

## Security note

This publishes fork-authored HTML/JS under `opengeos.org/pages-preview/`, a real origin the project owns. That is inherent to previewing a fork, but it makes the repo's **"Require approval for all external contributors"** setting load-bearing: stage 1 does not run until a maintainer approves, and stage 2 only fires after stage 1 succeeds, so that approval gates the publish too. Keep it enabled.

## Verification

- `actionlint` clean on both files.
- `pre-commit run --files` on both — passed (including the `npm build` hook).
- Both shell blocks extracted and executed locally: the redirect mapping produces the right `_redirects` and leaves files in place, the deploy-side delete removes only the mapped modules, and an unmapped oversized file still hard-errors.
- PR resolution exercised against live data — open fork PR #1428 → `deploy`, merged #1425 → `remove`, nonexistent branch → graceful skip. That last case caught a bug: `max_by` on an empty array yields `{"number":null}`, not `null`, so the guard needed `// empty`.

**Not verifiable before merge:** `workflow_run` only fires from a workflow file present on the default branch, so the deploy half cannot run on this PR. First real exercise is the next PR after merge — retrigger #1428 with an empty commit to confirm the fork path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated preview deployments for pull requests to GitHub Pages and Cloudflare Pages.
  * Preview links are posted or updated in a single pull request comment.
  * Closed pull requests automatically remove their deployed previews.

* **Improvements**
  * Preview builds and deployments now run as separate stages.
  * Build artifacts are retained temporarily for deployment.
  * Large DuckDB WASM files are handled through redirects to support preview publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->