### PR TITLE
fix(huggingface): keep the file list in place when adding a dataset

### DIFF
--- a/packages/plugins/src/plugins/maplibre-huggingface.ts
+++ b/packages/plugins/src/plugins/maplibre-huggingface.ts
@@ -622,6 +622,25 @@ function field(
 }
 
 /**
+ * Repaints a scrolling list without losing the user's place in it.
+ *
+ * `replaceChildren` empties the container before refilling it, and while it is
+ * empty the browser clamps `scrollTop` to 0 — so any repaint of a long listing
+ * silently scrolls back to the top. Capturing the offset first and restoring it
+ * after the rebuild keeps the row the user was looking at under their cursor.
+ *
+ * @param list - The scrolling container
+ * @param paint - Fills it with the new children
+ */
+export function repaintPreservingScroll(list: HTMLElement, paint: () => void): void {
+  const { scrollTop } = list;
+  paint();
+  // The rebuilt content is the same listing with one card restyled, so the
+  // offset is still meaningful; the browser clamps it if the list did shrink.
+  list.scrollTop = scrollTop;
+}
+
+/**
  * Finds the store layer backing a file, if it is already on the map. Derived
  * from the store rather than remembered in module state so the Add/Remove
  * button stays correct across a project reload, and after the user removes the
@@ -1166,12 +1185,15 @@ function buildPanel(container: HTMLElement, app: GeoLibreAppAPI | null): () => v
     const existing = findAddedLayer(file);
     if (existing) {
       useAppStore.getState().removeLayer(existing.id);
-      render();
+      renderCurrentView();
       return;
     }
     addInFlight.set(file.path, mode);
     error = "";
-    render();
+    // Deliberately not render(): a full repaint rebuilds the scrolling list
+    // element itself, so the user's place in a long file listing is lost the
+    // moment they press Add. Only the cards need to change here.
+    renderCurrentView();
     try {
       const added = await addFileToMap(app, file, mode, rasterDefaults);
       if (!added) error = labels.addError(labels.unsupportedTitle);
@@ -1183,7 +1205,7 @@ function buildPanel(container: HTMLElement, app: GeoLibreAppAPI | null): () => v
       }
     } finally {
       addInFlight.delete(file.path);
-      render();
+      renderCurrentView();
     }
   }
 
@@ -1249,6 +1271,10 @@ function buildPanel(container: HTMLElement, app: GeoLibreAppAPI | null): () => v
     root.appendChild(list);
 
     function renderResults(): void {
+      repaintPreservingScroll(list, () => paintResults());
+    }
+
+    function paintResults(): void {
       list.replaceChildren();
       statusNode.textContent = busy
         ? status || labels.searching
@@ -1427,6 +1453,10 @@ function buildPanel(container: HTMLElement, app: GeoLibreAppAPI | null): () => v
     root.appendChild(list);
 
     function renderFiles(): void {
+      repaintPreservingScroll(list, () => paintFiles());
+    }
+
+    function paintFiles(): void {
       list.replaceChildren();
       errorNode.textContent = error;
       errorNode.style.display = error ? "" : "none";

--- a/tests/huggingface-plugin.test.ts
+++ b/tests/huggingface-plugin.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   layerFileName,
   rasterFileName,
+  repaintPreservingScroll,
 } from "../packages/plugins/src/plugins/maplibre-huggingface";
 
 describe("layerFileName", () => {
@@ -67,5 +68,51 @@ describe("rasterFileName", () => {
 
   it("preserves a non-tif raster extension", () => {
     assert.equal(rasterFileName("scene.tiff", "S"), "scene.tiff");
+  });
+});
+
+describe("repaintPreservingScroll", () => {
+  /** Stands in for a scroll container; only `scrollTop` is touched. */
+  function fakeList(scrollTop: number) {
+    return { scrollTop } as unknown as HTMLElement;
+  }
+
+  it("keeps the user's place when the repaint resets the offset", () => {
+    // What `replaceChildren` does: the container is momentarily empty, so the
+    // browser clamps scrollTop to 0. Pressing Add in a long file listing used
+    // to jump back to the top for exactly this reason.
+    const list = fakeList(700);
+    repaintPreservingScroll(list, () => {
+      list.scrollTop = 0;
+    });
+    assert.equal(list.scrollTop, 700);
+  });
+
+  it("still runs the repaint", () => {
+    let painted = 0;
+    const list = fakeList(0);
+    repaintPreservingScroll(list, () => {
+      painted += 1;
+    });
+    assert.equal(painted, 1);
+  });
+
+  it("leaves a list that was already at the top alone", () => {
+    const list = fakeList(0);
+    repaintPreservingScroll(list, () => {
+      list.scrollTop = 0;
+    });
+    assert.equal(list.scrollTop, 0);
+  });
+
+  it("restores after the paint, not before, so the paint cannot win", () => {
+    const seen: number[] = [];
+    const list = fakeList(120);
+    repaintPreservingScroll(list, () => {
+      seen.push(list.scrollTop);
+      list.scrollTop = 0;
+    });
+    assert.deepEqual(seen, [120]);
+    assert.equal(list.scrollTop, 120);
   });
 });


### PR DESCRIPTION
Pressing **Add** on a file scrolled the dataset's file listing back to the top, losing the user's place. Adding several files from one folder meant scrolling back down after every single click.

## Cause

Two separate resets, both on the Add path:

1. **`handleAdd` called the full `render()`** — three times per add (pending, and again on settle/failure). That does `root.replaceChildren()` and rebuilds the entire panel, *including the scrolling list element itself*. Once the container is a new node there is no scroll offset left to restore.

2. **The in-place repaint reset it too.** `replaceChildren()` empties the container before refilling it, and while it is empty the browser clamps `scrollTop` to 0. So even repainting just the list scrolled to the top — which is why this also affected the store-subscription repaint (removing the layer from the Layers panel).

## Fix

- `handleAdd` now calls `renderCurrentView()` instead of `render()`. Only the list actually changes on an add — one card's button label and the error line — so rebuilding the header, search box and breadcrumb was never needed.
- Both list repaints (`renderFiles`, `renderResults`) go through a small `repaintPreservingScroll` helper that captures the offset and restores it after the rebuild.

## Verification

Driven in a real browser against a live repo listing (`giswqs/geospatial` → `landsat/`, 40+ files):

| | before Add | mid-add | after Add |
| --- | --- | --- | --- |
| **with fix** | 700 | 700 | 700 ✅ |
| **fix reverted** | 700 | 0 | 0 ❌ |

The reverted run was done deliberately (`git stash`) to confirm the reproduction is real and that the check isn't vacuously passing.

Unit tests cover the helper directly, including that it restores *after* the paint so a paint that zeroes the offset cannot win.

Full frontend suite green, pre-commit and build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved users’ scroll position when browsing or updating dataset and file lists.
  * Prevented unnecessary full-panel refreshes during file add and remove actions.
  * Improved continuity by updating only the currently visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->