### PR TITLE
chore(deps): update maplibre-gl-time-slider to 1.7.1

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -80,7 +80,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.6.0",
+    "maplibre-gl-time-slider": "^1.7.1",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.0",
     "openai": "^6.48.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.6.0",
+        "maplibre-gl-time-slider": "^1.7.1",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.0",
         "openai": "^6.48.0",
@@ -17197,9 +17197,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.6.0.tgz",
-      "integrity": "sha512-L+yhgsFDZn+a7n0s+jn1x0vaCeJCbQ+iV3RX+x7fXuQ85FbnqWXizd0/Ho7GH1JxcZxVc+4Od6U5REvF87WjWQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.7.1.tgz",
+      "integrity": "sha512-8XyI76Wgtqd57VJq1nfcQYLylzILvmERzrzzOZb2iS4xef1eHOoq7+g+wJITXVB2rtPJ8OZ8TuN5vzK2I4AGMw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -21885,7 +21885,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.6.0",
+        "maplibre-gl-time-slider": "^1.7.1",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.0",
         "netcdfjs": "^4.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -54,7 +54,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.6.0",
+    "maplibre-gl-time-slider": "^1.7.1",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.0",
     "netcdfjs": "^4.0.0",


### PR DESCRIPTION
Bumps `maplibre-gl-time-slider` from `^1.6.0` to `^1.7.1` in `packages/plugins` and `apps/geolibre-desktop`. The lockfile was still resolving **1.5.0**, so this also brings the installed version back in line with `package.json`.

## Upstream changes since 1.5.0

- **1.6.0** — add-form no longer overwrites an existing timeline; Add data panel gains a resizable height, restored settings, and a no-data indicator ([#28](https://github.com/opengeos/maplibre-gl-time-slider/pull/28), [#30](https://github.com/opengeos/maplibre-gl-time-slider/pull/30))
- **1.7.0** — new `dates` option for irregularly spaced time series ([#32](https://github.com/opengeos/maplibre-gl-time-slider/pull/32))
- **1.7.1** — raises `cog-tiler-wasm` to 0.3.1 to drop the mosaic nodata border ([#33](https://github.com/opengeos/maplibre-gl-time-slider/pull/33))

No API changes were needed on the GeoLibre side.

## Verification

- `npm run build` — passes
- `npm run test:frontend` — 3758 passing, 0 failing
- `pre-commit run --files <changed>` — passes

## Follow-up

1.7.0's `dates` option (irregularly spaced time series) is not yet surfaced anywhere in GeoLibre's time-slider plugin. Worth a separate PR if we want to expose it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the map time slider component to improve compatibility and reliability across the application.
  * Applied the update consistently in both the desktop app and plugin functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->