### PR TITLE
fix(time-slider): identify COG/mosaic pixels and restore the saved date list

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2414,8 +2414,10 @@ export function LayerPanel({
               hasNativeIdentifyLayers(layer);
             const identifyActive = identifyLayerId === layer.id;
             // COGs inspect raw pixel/band values rather than vector features, so
-            // the icon's tooltip reflects that distinct action.
-            const isPixelIdentify = layer.type === "cog";
+            // the icon's tooltip reflects that distinct action. Time Slider COG
+            // and mosaic sources read the same way, at the current timeline
+            // date, and mark themselves with `pixelIdentify`.
+            const isPixelIdentify = layer.type === "cog" || layer.metadata.pixelIdentify === true;
             // Shared by the button's title and aria-label so they can't diverge.
             const identifyLabel = canIdentify
               ? identifyActive

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -68,6 +68,29 @@ interface GeoLibreDuckDBBridge {
   setSelectedFeature?: (layerId: string, featureId: string | null) => void;
 }
 
+/** One band's value at an identified pixel, from the Time Slider bridge. */
+interface TimeSliderBandReading {
+  index: number;
+  name: string | null;
+  value: number;
+  isNodata: boolean;
+}
+
+interface TimeSliderPixelIdentifyBridgeResult {
+  sourceId: string;
+  date: string;
+  url: string;
+  bands: TimeSliderBandReading[];
+}
+
+interface GeoLibreTimeSliderBridge {
+  identifyPixelAt?: (
+    sourceId: string,
+    lngLat: [number, number],
+    options?: { signal?: AbortSignal },
+  ) => Promise<TimeSliderPixelIdentifyBridgeResult | null>;
+}
+
 function stringifyIdentifyValue(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "object") return JSON.stringify(value);
@@ -547,6 +570,50 @@ function duckDBBridge(): GeoLibreDuckDBBridge | undefined {
   return typeof window === "undefined"
     ? undefined
     : (window as Window & { __GEOLIBRE_DUCKDB__?: GeoLibreDuckDBBridge }).__GEOLIBRE_DUCKDB__;
+}
+
+function timeSliderBridge(): GeoLibreTimeSliderBridge | undefined {
+  return typeof window === "undefined"
+    ? undefined
+    : (window as Window & { __GEOLIBRE_TIME_SLIDER__?: GeoLibreTimeSliderBridge })
+        .__GEOLIBRE_TIME_SLIDER__;
+}
+
+/**
+ * Whether Identify should read source pixel values for this layer rather than
+ * query vector features. Set by the Time Slider for its COG/mosaic sources,
+ * which resolve to a different file per timeline date.
+ */
+function isPixelIdentifyLayer(layer: GeoLibreLayer): boolean {
+  return layer.metadata.pixelIdentify === true;
+}
+
+/**
+ * Trim a float sample to something readable. A 32-bit raster value decoded to a
+ * JS double prints all 17 digits of its binary representation
+ * (`48.11851119995117`), which is noise past the sensor's precision — six
+ * significant digits is more than any COG carries. Integers are left alone so a
+ * classification code is never shown in exponential form.
+ */
+function formatPixelValue(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  if (Number.isInteger(value)) return String(value);
+  return String(Number(value.toPrecision(6)));
+}
+
+/** Turn a pixel reading into the flat key/value rows the identify popup shows. */
+function pixelIdentifyProperties(
+  result: TimeSliderPixelIdentifyBridgeResult,
+): Record<string, unknown> {
+  const properties: Record<string, unknown> = { Date: result.date };
+  for (const band of result.bands) {
+    // Prefer the COG's own band name, falling back to the 1-based index so
+    // unnamed bands still get a stable, distinct row label.
+    const key = band.name ?? `Band ${band.index}`;
+    const formatted = formatPixelValue(band.value);
+    properties[key] = band.isNodata ? `${formatted} (nodata)` : formatted;
+  }
+  return properties;
 }
 
 function stringSource(value: unknown): string | undefined {
@@ -1154,6 +1221,7 @@ export const MapCanvas = memo(function MapCanvas({
     map.getCanvas().style.cursor = "crosshair";
 
     let wmsIdentifyAbortController: AbortController | null = null;
+    let pixelIdentifyAbortController: AbortController | null = null;
 
     const handleIdentifyClick = (event: maplibregl.MapMouseEvent) => {
       const clearIdentifyResult = () => {
@@ -1175,6 +1243,58 @@ export const MapCanvas = memo(function MapCanvas({
           .setDOMContent(content)
           .addTo(map);
       };
+
+      if (isPixelIdentifyLayer(layer)) {
+        const identifyPixelAt = timeSliderBridge()?.identifyPixelAt;
+        if (!identifyPixelAt) {
+          clearIdentifyResult();
+          return;
+        }
+        pixelIdentifyAbortController?.abort();
+        const abortController = new AbortController();
+        pixelIdentifyAbortController = abortController;
+        selectFeature(null);
+        showIdentifyPopup(createIdentifyMessagePopupElement(layer.name, "Loading..."));
+        // Same dismissal dance as the WMS branch: the × on the loading popup
+        // must cancel the read, but the programmatic swap to the result popup
+        // also fires "close", so track user dismissal with a flag rather than
+        // treating every close as a cancel.
+        let userDismissed = false;
+        const loadingPopup = identifyPopup.current;
+        const onLoadingClose = () => {
+          userDismissed = true;
+          abortController.abort();
+          if (pixelIdentifyAbortController === abortController) {
+            pixelIdentifyAbortController = null;
+          }
+        };
+        loadingPopup!.once("close", onLoadingClose);
+
+        void identifyPixelAt(layer.id, [event.lngLat.lng, event.lngLat.lat], {
+          signal: abortController.signal,
+        })
+          .then((result) => {
+            if (userDismissed || abortController.signal.aborted) return;
+            pixelIdentifyAbortController = null;
+            loadingPopup?.off("close", onLoadingClose);
+            // A null result means the click landed off the image grid, which is
+            // an ordinary miss rather than a failure.
+            showIdentifyPopup(
+              result
+                ? createIdentifyPopupElement(layer.name, pixelIdentifyProperties(result))
+                : createIdentifyMessagePopupElement(layer.name, "No data at this location."),
+            );
+          })
+          .catch((error: unknown) => {
+            if (userDismissed || isAbortError(error) || abortController.signal.aborted) return;
+            pixelIdentifyAbortController = null;
+            loadingPopup?.off("close", onLoadingClose);
+            const message =
+              error instanceof Error ? error.message : "The pixel value could not be read.";
+            showIdentifyPopup(createIdentifyMessagePopupElement(layer.name, message));
+          });
+        return;
+      }
 
       if (isWmsLayer(layer)) {
         wmsIdentifyAbortController?.abort();
@@ -1265,6 +1385,7 @@ export const MapCanvas = memo(function MapCanvas({
 
     return () => {
       wmsIdentifyAbortController?.abort();
+      pixelIdentifyAbortController?.abort();
       map.off("click", handleIdentifyClick);
       identifyPopup.current?.remove();
       identifyPopup.current = null;

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -503,6 +503,14 @@ export {
   type PixelTimeSeriesResult,
 } from "./plugins/time-slider-pixel-series";
 export {
+  getPixelIdentifiableSource,
+  identifyTimeSliderPixel,
+  isPixelIdentifiableSourceType,
+  PixelOutsideCoverageError,
+  type PixelIdentifiableSpec,
+  type TimeSliderPixelIdentifyResult,
+} from "./plugins/time-slider-pixel-identify";
+export {
   buildTimeBinding,
   buildTimeBindingFromRecords,
   buildTimeFilter,

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -138,9 +138,9 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
   restoresPanelCollapseState: true,
   activate: (app: GeoLibreAppAPI) => {
     if (timeSliderControl) return;
-    const control = new TimeSliderControl(
-      savedConfig ? configToOptions(savedConfig) : buildDefaultOptions(),
-    );
+    const control = savedConfig
+      ? controlFromConfig(savedConfig)
+      : new TimeSliderControl(buildDefaultOptions());
     timeSliderControl = control;
     attachStoreSync(control);
 
@@ -173,7 +173,7 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     const config = timeSliderControl.getConfig();
     detachStoreSync?.();
     app.removeMapControl(timeSliderControl);
-    const control = new TimeSliderControl(configToOptions(config));
+    const control = controlFromConfig(config);
     timeSliderControl = control;
     attachStoreSync(control);
     const added = app.addMapControl(control, timeSliderPosition);
@@ -234,13 +234,36 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
  * Builds constructor options from a serialized config so a fresh control
  * restores the full timeline state and all of its sources.
  *
+ * Exported so the restore contract can be asserted directly: every path that
+ * rebuilds the control (activate from a saved project, and moving the dock)
+ * goes through here, and a field missing from it is silently dropped rather
+ * than failing a type check, since `TimeSliderOptions` keys are all optional.
+ *
  * @param config - A config produced by `TimeSliderControl.getConfig()`.
  * @returns Options for a new `TimeSliderControl`.
  */
-function configToOptions(config: TimeSliderConfig): TimeSliderOptions {
+export function controlFromConfig(config: TimeSliderConfig): TimeSliderControl {
+  const control = new TimeSliderControl(configToOptions(config));
+  // `TimeSliderOptions` cannot express every `TimeSliderConfig` field: datesUrl
+  // — the URL an ordinal date list was loaded from, which the dock echoes back
+  // in its Dates box — has no option equivalent. setConfig does carry it and is
+  // safe on a control that has not been added to a map yet: without a map it
+  // creates no adapters and stashes the sources for onAdd instead, and every
+  // view/container touch it makes is null-guarded. Replay it only when there is
+  // something to recover, so the ordinary restore stays a single pass.
+  if (config.datesUrl) control.setConfig(config);
+  return control;
+}
+
+export function configToOptions(config: TimeSliderConfig): TimeSliderOptions {
   return {
     startDate: config.startDate,
     endDate: config.endDate,
+    // An ordinal timeline steps through this explicit list instead of the
+    // start/end/interval range. Dropping it silently turned a restored project's
+    // irregular date list back into a continuous range, so the slider stepped
+    // over dates that have no data.
+    dates: config.dates,
     interval: config.interval,
     granularity: config.granularity,
     granularities: config.granularities,
@@ -290,6 +313,16 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
     (candidate.endDate != null && typeof candidate.endDate !== "string") ||
     typeof candidate.granularity !== "string" ||
     (candidate.currentDate !== undefined && typeof candidate.currentDate !== "string") ||
+    // An ordinal timeline's explicit date list. Optional (a continuous timeline
+    // omits it), but when present it must be a list of date strings — it is fed
+    // straight to the library as the steps the slider walks.
+    (candidate.dates !== undefined &&
+      (!Array.isArray(candidate.dates) ||
+        (candidate.dates as unknown[]).some((date) => typeof date !== "string"))) ||
+    // Display-only, but it is rendered into the dock's Dates box, so hold it to
+    // the same http(s)-only rule as the source URLs.
+    (candidate.datesUrl !== undefined &&
+      (typeof candidate.datesUrl !== "string" || !isSafeSourceUrl(candidate.datesUrl))) ||
     !Array.isArray(candidate.sources) ||
     (candidate.sources as unknown[]).some((source) => {
       if (!source || typeof source !== "object") return true;
@@ -730,9 +763,25 @@ function shouldUpdateStoreLayer(existingLayer: GeoLibreLayer, nextLayer: GeoLibr
   );
 }
 
-function createStoreLayer(spec: SourceSpec): GeoLibreLayer {
+/**
+ * Mirrors one dock source into the store as an external-native layer.
+ *
+ * Exported so the metadata contract with the Layers panel can be asserted: the
+ * `identifiable`/`pixelIdentify` pair is what decides whether the panel's
+ * Identify icon is enabled and whether it reads pixels or queries features.
+ *
+ * @param spec - The dock source to mirror.
+ * @returns The store layer representing it.
+ */
+export function createStoreLayer(spec: SourceSpec): GeoLibreLayer {
   const sourceId = spec.id as string;
   const layerType = spec.type === "geojson" ? "geojson" : "raster";
+  // COG and mosaic sources carry real source values, so Identify reads their
+  // bands at the timeline's current date (see time-slider-pixel-identify) the
+  // same way it reads a COG added through Add Raster Layer. XYZ/WMS sources are
+  // pre-rendered picture tiles with nothing to recover, and a GeoJSON source is
+  // mirrored as a vector layer that identifies through the normal map query.
+  const pixelIdentify = spec.type === "cog" || spec.type === "mosaic";
   return {
     id: sourceId,
     name: spec.name ?? sourceId,
@@ -743,7 +792,8 @@ function createStoreLayer(spec: SourceSpec): GeoLibreLayer {
     style: { ...DEFAULT_LAYER_STYLE },
     metadata: {
       externalNativeLayer: true,
-      identifiable: false,
+      identifiable: pixelIdentify,
+      ...(pixelIdentify ? { pixelIdentify: true } : {}),
       nativeLayerIds: [sourceId],
       sourceId,
       sourceIds: [sourceId],

--- a/packages/plugins/src/plugins/time-slider-pixel-identify.ts
+++ b/packages/plugins/src/plugins/time-slider-pixel-identify.ts
@@ -1,0 +1,193 @@
+import { type CogSourceSpec, type MosaicSourceSpec, resolveUrl } from "maplibre-gl-time-slider";
+import {
+  type BandReading,
+  loadGeoTIFF,
+  loadMosaic,
+  readBandNames,
+  readPixelValues,
+} from "maplibre-gl-raster";
+import { getActiveTimeSliderControl } from "./maplibre-time-slider";
+
+/**
+ * Single-pixel Identify for the Time Slider's raster sources.
+ *
+ * The Layers-panel Identify icon reads band values under the cursor for a COG
+ * layer added through Add Raster Layer. A Time Slider COG or mosaic source is
+ * the same kind of data — it just resolves to a *different* file per timeline
+ * date — so Identify reads it at whichever date the timeline currently sits on.
+ *
+ * This is deliberately the one-date sibling of `time-slider-pixel-series`: that
+ * module walks the whole stack to chart a value over time, this one answers
+ * "what is under my cursor right now". Both reuse `maplibre-gl-raster`'s
+ * `loadGeoTIFF`/`readPixelValues`, so a read is an HTTP range request for the
+ * single tile containing the pixel — no sidecar and no full-file download.
+ *
+ * Only `cog` and `mosaic` sources are readable. `xyz`/`wms` sources are
+ * pre-rendered picture tiles with no source values to recover, and `geojson`
+ * sources identify as vector features through the normal map query.
+ */
+
+/** A Time Slider source whose pixels can be read. */
+export type PixelIdentifiableSpec = CogSourceSpec | MosaicSourceSpec;
+
+/** The band values under one clicked point, at one timeline date. */
+export interface TimeSliderPixelIdentifyResult {
+  /** Source id (matches the mirrored store layer id). */
+  sourceId: string;
+  /** ISO date (`YYYY-MM-DD`) of the timeline position that was read. */
+  date: string;
+  /**
+   * The COG the value came from. For a mosaic this is the individual asset
+   * covering the click, not the manifest, so the reading is attributable.
+   */
+  url: string;
+  /** Every band's reading at the clicked pixel. Empty is never returned — a
+   * pixel with no readable bands resolves to null instead. */
+  bands: BandReading[];
+}
+
+/** Raised when the click falls outside the data rather than failing to read it.
+ * The caller reports "no data here" instead of an error. */
+export class PixelOutsideCoverageError extends Error {
+  constructor(message = "The clicked point is outside this layer's coverage.") {
+    super(message);
+    this.name = "PixelOutsideCoverageError";
+  }
+}
+
+/**
+ * Whether a Time Slider source spec exposes readable source pixels.
+ *
+ * @param type - The spec's `type` discriminant.
+ * @returns True for `cog` and `mosaic` sources.
+ */
+export function isPixelIdentifiableSourceType(type: string | undefined): boolean {
+  return type === "cog" || type === "mosaic";
+}
+
+/**
+ * Look up a Time Slider source by id, when it is pixel-readable.
+ *
+ * @param sourceId - The source id (equals the mirrored store layer id).
+ * @returns The COG or mosaic spec, or null when the dock is closed, the id is
+ *   unknown, or the source is an XYZ/WMS/GeoJSON one.
+ */
+export function getPixelIdentifiableSource(sourceId: string): PixelIdentifiableSpec | null {
+  const control = getActiveTimeSliderControl();
+  if (!control) return null;
+  const spec = control.getSources().find((candidate) => candidate.id === sourceId);
+  if (!spec || !isPixelIdentifiableSourceType(spec.type)) return null;
+  return spec as PixelIdentifiableSpec;
+}
+
+/** Format a date as `YYYY-MM-DD` in UTC, matching the pixel-series module. */
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Whether a WGS84 point falls inside a `[minX, minY, maxX, maxY]` bbox. */
+function bboxContains(bbox: [number, number, number, number], lng: number, lat: number): boolean {
+  return lng >= bbox[0] && lng <= bbox[2] && lat >= bbox[1] && lat <= bbox[3];
+}
+
+/**
+ * Pick the mosaic asset to read a point from.
+ *
+ * Mosaic assets overlap at their seams, so a point can fall inside several
+ * bboxes. Prefer the smallest matching asset: overlapping tiles in a mosaic are
+ * conventionally ordered coarse-to-fine, and the tighter bbox is the one whose
+ * centre the point is nearest, so it is the least likely to be reading the
+ * feathered edge of a neighbouring scene.
+ *
+ * @param assets - The parsed mosaic's assets.
+ * @param lngLat - The clicked location, `[lng, lat]` in WGS84.
+ * @returns The asset URL to read, or null when no asset covers the point.
+ */
+export function pickMosaicAsset(
+  assets: { url: string; bbox: [number, number, number, number] }[],
+  lngLat: [number, number],
+): string | null {
+  const [lng, lat] = lngLat;
+  let best: { url: string; area: number } | null = null;
+  for (const asset of assets) {
+    if (!bboxContains(asset.bbox, lng, lat)) continue;
+    const area = (asset.bbox[2] - asset.bbox[0]) * (asset.bbox[3] - asset.bbox[1]);
+    if (!best || area < best.area) best = { url: asset.url, area };
+  }
+  return best?.url ?? null;
+}
+
+/**
+ * Read every band value at one point for a Time Slider COG or mosaic source, at
+ * the timeline's current date.
+ *
+ * @param sourceId - The source id (equals the mirrored store layer id).
+ * @param lngLat - The clicked location, `[lng, lat]` in WGS84.
+ * @param options - Optional abort signal.
+ * @returns The reading, or null when the pixel falls outside the image grid.
+ * @throws {PixelOutsideCoverageError} When a mosaic has no asset covering the
+ *   point — a miss in space rather than a failed read.
+ * @throws When the source is unknown/not pixel-readable, or the COG cannot be
+ *   opened (network, CORS, or a missing file for this date).
+ */
+export async function identifyTimeSliderPixel(
+  sourceId: string,
+  lngLat: [number, number],
+  options: { signal?: AbortSignal } = {},
+): Promise<TimeSliderPixelIdentifyResult | null> {
+  const { signal } = options;
+  const control = getActiveTimeSliderControl();
+  const spec = getPixelIdentifiableSource(sourceId);
+  if (!control || !spec) {
+    throw new Error("This Time Slider source has no readable pixels.");
+  }
+
+  const date = control.getCurrentDate();
+  const resolved = await resolveUrl(spec.url, date);
+  if (signal?.aborted) return null;
+
+  // A COG source resolves straight to the file; a mosaic resolves to a manifest
+  // listing many COGs, so the covering asset has to be found first.
+  let url = resolved;
+  if (spec.type === "mosaic") {
+    const mosaic = await loadMosaic(resolved, signal);
+    if (signal?.aborted) return null;
+    const assetUrl = pickMosaicAsset(mosaic.assets, lngLat);
+    if (!assetUrl) throw new PixelOutsideCoverageError();
+    url = assetUrl;
+  }
+
+  const tiff = await loadGeoTIFF(url);
+  // loadGeoTIFF does not accept the abort signal, so once its header fetch
+  // resolves, skip the pixel read if the identify was cancelled meanwhile.
+  if (signal?.aborted) return null;
+  const reading = await readPixelValues(tiff, lngLat, {
+    signal,
+    bandNames: readBandNames(tiff),
+  });
+  if (!reading || reading.bands.length === 0) return null;
+
+  return { sourceId, date: isoDate(date), url, bands: reading.bands };
+}
+
+/**
+ * The bridge shape consumed by `@geolibre/map` (MapCanvas), which cannot import
+ * this package directly.
+ */
+export interface TimeSliderGlobalBridge {
+  identifyPixelAt: typeof identifyTimeSliderPixel;
+}
+
+declare global {
+  interface Window {
+    __GEOLIBRE_TIME_SLIDER__?: TimeSliderGlobalBridge;
+  }
+}
+
+if (typeof window !== "undefined") {
+  // Frozen so its members cannot be swapped out by other scripts after
+  // construction, mirroring the DuckDB bridge. Do not widen this API.
+  window.__GEOLIBRE_TIME_SLIDER__ = Object.freeze({
+    identifyPixelAt: identifyTimeSliderPixel,
+  });
+}

--- a/tests/time-slider-config.test.ts
+++ b/tests/time-slider-config.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import {
+  configToOptions,
+  createStoreLayer,
   isTimeSliderIdle,
   maplibreTimeSliderPlugin,
 } from "../packages/plugins/src/plugins/maplibre-time-slider";
+import type { SourceSpec } from "maplibre-gl-time-slider";
 
 // applyProjectState / getProjectState touch no app methods while no control is
 // active (the plugin is never activated here), so a bare stub satisfies the type.
@@ -94,6 +97,115 @@ describe("Time Slider mosaic source persistence", () => {
       apply(baseConfig({ sources: [mosaicSource({ url: "javascript:alert(1)" })] })),
       false,
     );
+  });
+});
+
+describe("Time Slider ordinal dates persistence", () => {
+  const DATES = ["2023-01-28", "2023-02-20", "2023-03-27", "2025-10-03"];
+
+  it("round-trips an explicit date list through a save", () => {
+    assert.equal(apply(baseConfig({ dates: DATES })), true);
+    assert.deepEqual(saved()?.dates, DATES);
+  });
+
+  it("round-trips the URL the dates were loaded from", () => {
+    const datesUrl = "https://example.com/dates.json";
+    assert.equal(apply(baseConfig({ dates: DATES, datesUrl })), true);
+    assert.equal(saved()?.datesUrl, datesUrl);
+  });
+
+  it("omits dates for a continuous timeline", () => {
+    assert.equal(apply(baseConfig()), true);
+    const config = saved();
+    assert.ok(config);
+    assert.equal("dates" in config, false);
+  });
+
+  it("rejects a dates value that is not a list of strings", () => {
+    assert.equal(apply(baseConfig({ dates: "2023-01-28" })), false);
+    assert.equal(apply(baseConfig({ dates: [2023] })), false);
+  });
+
+  it("rejects a datesUrl that is not a plain http(s) URL", () => {
+    assert.equal(apply(baseConfig({ dates: DATES, datesUrl: "javascript:alert(1)" })), false);
+  });
+
+  // The restore path builds a fresh control from options, so a `dates` list the
+  // config carries but the options drop leaves the rebuilt timeline continuous.
+  it("carries the date list into the options a rebuilt control is built from", () => {
+    const options = configToOptions({
+      startDate: "2023-01-01T00:00:00.000Z",
+      interval: 1,
+      granularity: "day",
+      currentDate: "2023-01-28T00:00:00.000Z",
+      speed: 800,
+      loop: true,
+      sources: [],
+      dates: DATES,
+    });
+    assert.deepEqual(options.dates, DATES);
+  });
+
+  it("leaves the options without dates for a continuous timeline", () => {
+    const options = configToOptions({
+      startDate: "2023-01-01T00:00:00.000Z",
+      interval: 1,
+      granularity: "day",
+      currentDate: "2023-01-28T00:00:00.000Z",
+      speed: 800,
+      loop: true,
+      sources: [],
+    });
+    assert.equal(options.dates, undefined);
+  });
+});
+
+describe("Time Slider store layer identify metadata", () => {
+  it("marks a COG source for pixel identify", () => {
+    const layer = createStoreLayer({
+      type: "cog",
+      id: "landsat",
+      url: "https://example.com/{date:YYYY}.tif",
+    } as SourceSpec);
+    assert.equal(layer.type, "raster");
+    assert.equal(layer.metadata.identifiable, true);
+    assert.equal(layer.metadata.pixelIdentify, true);
+  });
+
+  it("marks a mosaic source for pixel identify", () => {
+    const layer = createStoreLayer({
+      type: "mosaic",
+      id: "s2",
+      url: "https://example.com/{date:YYYY}.json",
+    } as SourceSpec);
+    assert.equal(layer.metadata.identifiable, true);
+    assert.equal(layer.metadata.pixelIdentify, true);
+  });
+
+  it("leaves pre-rendered tile sources unidentifiable", () => {
+    // An XYZ/WMS source is a picture; there are no source values to report, so
+    // the Identify icon stays disabled rather than opening an empty popup.
+    for (const type of ["xyz", "wms"]) {
+      const layer = createStoreLayer({
+        type,
+        id: `${type}-source`,
+        tiles: "https://example.com/{z}/{x}/{y}.png",
+        baseUrl: "https://example.com/wms",
+      } as unknown as SourceSpec);
+      assert.equal(layer.metadata.identifiable, false, type);
+      assert.equal("pixelIdentify" in layer.metadata, false, type);
+    }
+  });
+
+  it("leaves a GeoJSON source to the normal vector feature query", () => {
+    const layer = createStoreLayer({
+      type: "geojson",
+      id: "quakes",
+      data: "https://example.com/quakes.geojson",
+      timeProperty: "time",
+    } as SourceSpec);
+    assert.equal(layer.type, "geojson");
+    assert.equal("pixelIdentify" in layer.metadata, false);
   });
 });
 

--- a/tests/time-slider-pixel-identify.test.ts
+++ b/tests/time-slider-pixel-identify.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isPixelIdentifiableSourceType,
+  pickMosaicAsset,
+} from "../packages/plugins/src/plugins/time-slider-pixel-identify";
+
+describe("isPixelIdentifiableSourceType", () => {
+  it("accepts the source types that carry readable source values", () => {
+    assert.equal(isPixelIdentifiableSourceType("cog"), true);
+    assert.equal(isPixelIdentifiableSourceType("mosaic"), true);
+  });
+
+  it("rejects pre-rendered tile sources and vector sources", () => {
+    // xyz/wms are pictures with no source values to recover; a geojson source
+    // identifies as vector features through the normal map query instead.
+    assert.equal(isPixelIdentifiableSourceType("xyz"), false);
+    assert.equal(isPixelIdentifiableSourceType("wms"), false);
+    assert.equal(isPixelIdentifiableSourceType("geojson"), false);
+    assert.equal(isPixelIdentifiableSourceType("custom"), false);
+    assert.equal(isPixelIdentifiableSourceType(undefined), false);
+  });
+});
+
+describe("pickMosaicAsset", () => {
+  const asset = (url: string, bbox: [number, number, number, number]) => ({ url, bbox });
+
+  it("returns the asset whose bbox contains the point", () => {
+    const assets = [
+      asset("a.tif", [0, 0, 10, 10]),
+      asset("b.tif", [10, 10, 20, 20]),
+      asset("c.tif", [20, 20, 30, 30]),
+    ];
+    assert.equal(pickMosaicAsset(assets, [15, 15]), "b.tif");
+  });
+
+  it("returns null when no asset covers the point", () => {
+    const assets = [asset("a.tif", [0, 0, 10, 10])];
+    assert.equal(pickMosaicAsset(assets, [50, 50]), null);
+  });
+
+  it("returns null for an empty mosaic", () => {
+    assert.equal(pickMosaicAsset([], [0, 0]), null);
+  });
+
+  it("prefers the smallest of several overlapping assets", () => {
+    // Seams overlap, and a coarse asset covering the whole mosaic would
+    // otherwise win by being first. The tighter bbox is the nearer scene.
+    const assets = [
+      asset("coarse.tif", [0, 0, 100, 100]),
+      asset("fine.tif", [40, 40, 50, 50]),
+      asset("medium.tif", [20, 20, 60, 60]),
+    ];
+    assert.equal(pickMosaicAsset(assets, [45, 45]), "fine.tif");
+  });
+
+  it("treats bbox edges as inside so a click on a seam still reads", () => {
+    const assets = [asset("a.tif", [0, 0, 10, 10])];
+    assert.equal(pickMosaicAsset(assets, [10, 10]), "a.tif");
+    assert.equal(pickMosaicAsset(assets, [0, 0]), "a.tif");
+  });
+});


### PR DESCRIPTION
Two Time Slider bugs, both reproduced against `https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/apalachicola-bay-emit-chla-v3.geolibre.json`.

## 1. Identify did nothing for a Time Slider COG or mosaic

It worked for a COG added through **Add Raster Layer**. The dock mirrors its sources into the store as `type: "raster"` layers marked `identifiable: false`, so the Layers-panel Identify icon was **disabled** — the pixel path keys off `type === "cog"`, which these layers are not.

COG and mosaic sources now mark themselves `pixelIdentify`, and Identify reads their bands **at whichever date the timeline currently sits on**:

- New `time-slider-pixel-identify.ts` resolves the source URL for the current date and range-reads the pixel with `maplibre-gl-raster`'s `loadGeoTIFF`/`readPixelValues` — the same reader the single-COG Identify uses, so no sidecar and no full-file download. A mosaic resolves to a manifest, so the covering asset is located first (smallest bbox wins, since seams overlap coarse-to-fine).
- `MapCanvas` gains a pixel-identify branch alongside the WMS one, sharing its loading-popup and abort-on-dismiss handling, reached through a frozen `__GEOLIBRE_TIME_SLIDER__` window bridge (`@geolibre/map` cannot import `@geolibre/plugins`). Float samples are trimmed to six significant digits so a 32-bit value does not print all 17 digits of its double.
- XYZ/WMS sources stay unidentifiable (pre-rendered pictures, no source values); GeoJSON sources keep identifying as vector features.

## 2. The Dates list was saved but not restored

`configToOptions` never copied `dates`, so every path that rebuilds the control from a saved config — opening a shared project, and moving the dock — fell back to the continuous `startDate`/`endDate`/`interval` range. The linked project turned its **16 irregular EMIT acquisition dates into a daily timeline** stepping over dates that have no data.

- `dates` is now carried through.
- `normalizeConfig` validates `dates` and `datesUrl` (held to the same http(s)-only rule as source URLs).
- `controlFromConfig` replays the config when it carries a `datesUrl`, which `TimeSliderOptions` cannot express. Safe before the control is added to a map: `setConfig` creates no adapters without a map and every view/container touch it makes is null-guarded.

## Verification

Driven in a real browser (Playwright) against the linked shared project, light and dark:

| | Before | After |
|---|---|---|
| Timeline | daily range 2023-01-28 → 2025-10-03 | the 16 saved dates (`Jan 28, Feb 20, Mar 27, May 27, …`) |
| Identify icon | disabled, "Identify is only available for…" | enabled, "Inspect pixel values" |
| Click a pixel | nothing | `Chlorophyll-a / Date 2023-02-20 / Band 1 48.1185` |
| Step to next date | — | re-reads that date's COG → `2023-03-27 / 10.7763` |

`npm run build`, `npm run test:frontend` (3776 passing), and `pre-commit run --files <changed>` all pass. `configToOptions`, `createStoreLayer`, and `pickMosaicAsset` are exported so the restore contract and identify metadata are asserted directly (12 new tests).

## Note

`layers.identifyUnavailable` still reads "…vector, WMS, and COG layers". It only shows on layers that *cannot* identify, so it is not wrong in practice — left alone rather than re-translating every locale for a disabled-state tooltip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pixel identification for Time Slider raster layers, including COG and mosaic sources.
  * Identify controls now support pixel-readable layers and display band values for the selected location and date.
  * Added loading, no-data, error, and cancellation handling for pixel identification.
  * Improved persistence and restoration of ordinal Time Slider dates.
* **Bug Fixes**
  * Restored Time Slider configurations now retain date lists and safely validate date URLs.
  * Mosaic identification selects the most appropriate covering asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->