### PR TITLE
fix(overture): render 3D extrusion for Overture Maps polygon layers

### DIFF
--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -423,6 +423,18 @@ function syncExternalNativeLayer(
   // visibility/paint/zoom-range sync below must be skipped — only ordering is
   // handled here.
   if (isExternalCustomLayer(layer)) {
+    // Controls whose native fills are ordinary vector polygons (e.g. Overture
+    // Maps buildings) opt into GeoLibre-owned 3D extrusion. The Style panel
+    // offers the 3D mode to these layers, so without this the toggle would
+    // silently no-op on the ordering-only path below.
+    if (
+      supportsNativeFillExtrusion(layer) &&
+      syncExternalNativeExtrusion(map, layer, nativeLayerIds, beforeId)
+    ) {
+      return;
+    }
+    clearExternalNativeExtrusion(map, layer, nativeLayerIds);
+
     for (const nativeLayerId of nativeLayerIds) {
       moveLayer(map, nativeLayerId, beforeId);
       // Control-painted vector layers (e.g. Add Vector Layer's circle/fill/line
@@ -475,50 +487,14 @@ function syncExternalNativeLayer(
 
   ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
 
-  const nativeFillLayerSpecs = nativeLayerIds
-    .map((nativeLayerId) => getStyleLayerSpec(map, nativeLayerId))
-    .filter(isFillStyleLayerSpec);
-
-  if (layer.style.extrusionEnabled && nativeFillLayerSpecs.length > 0 && !controlOwnsPaint(layer)) {
-    for (const nativeLayerId of nativeLayerIds) {
-      setNativeLayerVisibility(map, nativeLayerId, "none");
-    }
-
-    for (const fillLayerSpec of nativeFillLayerSpecs) {
-      const extrusionLayerId = externalExtrusionLayerId(fillLayerSpec.id);
-      // The synthetic extrusion layer must honor the same per-feature filters
-      // (Time Slider window, rule-based hide-unmatched) as the fill it
-      // replaces. The copied fill filter may still carry a previously pushed
-      // combined filter, so prefer the tracked base — the fill's own filter —
-      // and re-apply the current extras on top so they never compound or go
-      // stale.
-      const tracked = nativeFilterStatesFor(map).get(fillLayerSpec.id);
-      const baseFilter = tracked
-        ? tracked.base
-        : ((fillLayerSpec.filter as maplibregl.FilterSpecification) ?? null);
-      const filter = combineExternalFilters(baseFilter, externalFeatureFilterExtras(layer));
-      ensureLayer(
-        map,
-        extrusionLayerId,
-        {
-          id: extrusionLayerId,
-          type: "fill-extrusion",
-          source: fillLayerSpec.source,
-          "source-layer": fillLayerSpec["source-layer"],
-          filter: filter ?? undefined,
-          ...intersectZoomRange(fillLayerSpec, layer.style),
-          paint: fillExtrusionPaint(layer.style, layer.opacity),
-          layout: { visibility: layer.visible ? "visible" : "none" },
-        },
-        beforeId,
-      );
-    }
+  if (
+    !controlOwnsPaint(layer) &&
+    syncExternalNativeExtrusion(map, layer, nativeLayerIds, beforeId)
+  ) {
     return;
   }
 
-  for (const nativeLayerId of nativeLayerIds) {
-    removeIfExists(map, externalExtrusionLayerId(nativeLayerId));
-  }
+  clearExternalNativeExtrusion(map, layer, nativeLayerIds);
 
   for (const nativeLayerId of nativeLayerIds) {
     const nativeLayer = map.getLayer(nativeLayerId);
@@ -690,6 +666,15 @@ function isPMTilesExternalLayer(layer: GeoLibreLayer): boolean {
 
 function isExternalCustomLayer(layer: GeoLibreLayer): boolean {
   return typeof layer.metadata.customLayerType === "string";
+}
+
+// Opt-in for control-managed layers (`customLayerType`, the ordering-only path)
+// whose native fill layers are plain vector polygons GeoLibre can re-render as
+// fill-extrusions. Controls that implement extrusion themselves — Add Vector
+// Layer and DuckDB push `extrusionEnabled` into their own control style — must
+// leave this unset, or both would extrude the same features.
+function supportsNativeFillExtrusion(layer: GeoLibreLayer): boolean {
+  return layer.metadata.nativeFillExtrusion === true;
 }
 
 // External controls that paint their native layers with data-driven MapLibre
@@ -1401,6 +1386,97 @@ function isFillStyleLayerSpec(
 
 export function externalExtrusionLayerId(nativeLayerId: string): string {
   return `${nativeLayerId}-geolibre-extrusion`;
+}
+
+// Native layers hidden to make room for a synthetic fill-extrusion layer.
+// Tracked so switching 3D extrusion back off can restore them on the
+// control-managed path, which otherwise never writes visibility (the control
+// owns it) and would leave the layer invisible.
+const extrusionHiddenNativeLayerIds = new Set<string>();
+
+/**
+ * Render an external control's native `fill` layers as GeoLibre-owned
+ * `fill-extrusion` layers built from the same source and source layer.
+ *
+ * The natives are hidden rather than restyled, so the control keeps owning
+ * them and a later toggle back to 2D restores its rendering untouched.
+ *
+ * @param map: The MapLibre map to reconcile against.
+ * @param layer: The store layer whose style drives the extrusion paint.
+ * @param nativeLayerIds: Native layer ids registered by the control.
+ * @param beforeId: Layer id the extrusion layers are inserted before.
+ * @returns True when extrusion layers were applied, false when the layer is
+ *     not extruded or exposes no native fill layer to extrude.
+ */
+function syncExternalNativeExtrusion(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  nativeLayerIds: string[],
+  beforeId?: string,
+): boolean {
+  if (!layer.style.extrusionEnabled) return false;
+
+  const nativeFillLayerSpecs = nativeLayerIds
+    .map((nativeLayerId) => getStyleLayerSpec(map, nativeLayerId))
+    .filter(isFillStyleLayerSpec);
+  if (nativeFillLayerSpecs.length === 0) return false;
+
+  for (const nativeLayerId of nativeLayerIds) {
+    setNativeLayerVisibility(map, nativeLayerId, "none");
+    extrusionHiddenNativeLayerIds.add(nativeLayerId);
+  }
+
+  for (const fillLayerSpec of nativeFillLayerSpecs) {
+    const extrusionLayerId = externalExtrusionLayerId(fillLayerSpec.id);
+    // The synthetic extrusion layer must honor the same per-feature filters
+    // (Time Slider window, rule-based hide-unmatched) as the fill it
+    // replaces. The copied fill filter may still carry a previously pushed
+    // combined filter, so prefer the tracked base — the fill's own filter —
+    // and re-apply the current extras on top so they never compound or go
+    // stale.
+    const tracked = nativeFilterStatesFor(map).get(fillLayerSpec.id);
+    const baseFilter = tracked
+      ? tracked.base
+      : ((fillLayerSpec.filter as maplibregl.FilterSpecification) ?? null);
+    const filter = combineExternalFilters(baseFilter, externalFeatureFilterExtras(layer));
+    ensureLayer(
+      map,
+      extrusionLayerId,
+      {
+        id: extrusionLayerId,
+        type: "fill-extrusion",
+        source: fillLayerSpec.source,
+        "source-layer": fillLayerSpec["source-layer"],
+        filter: filter ?? undefined,
+        ...intersectZoomRange(fillLayerSpec, layer.style),
+        paint: fillExtrusionPaint(layer.style, layer.opacity),
+        layout: { visibility: layer.visible ? "visible" : "none" },
+      },
+      beforeId,
+    );
+  }
+  return true;
+}
+
+/**
+ * Drop the synthetic extrusion layers for `nativeLayerIds` and un-hide any
+ * native layer {@link syncExternalNativeExtrusion} hid for them.
+ *
+ * @param map: The MapLibre map to reconcile against.
+ * @param layer: The store layer, read for its current visibility.
+ * @param nativeLayerIds: Native layer ids registered by the control.
+ */
+function clearExternalNativeExtrusion(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  nativeLayerIds: string[],
+): void {
+  for (const nativeLayerId of nativeLayerIds) {
+    removeIfExists(map, externalExtrusionLayerId(nativeLayerId));
+    if (extrusionHiddenNativeLayerIds.delete(nativeLayerId)) {
+      setNativeLayerVisibility(map, nativeLayerId, layer.visible ? "visible" : "none");
+    }
+  }
 }
 
 /**
@@ -3260,6 +3336,17 @@ function ensureLayer(
           ...(strippedLayout ? { layout: strippedLayout } : {}),
         }
       : spec;
+  // An explicit `filter: undefined` key fails MapLibre's add-time validation
+  // ("array expected, undefined found") and the layer is dropped without
+  // throwing — only an `error` event reports it. Callers that compute an
+  // optional filter still need the key present on the update branch above, so
+  // it is dropped here, on first add, where "no filter" must mean "absent".
+  const hasUndefinedFilter = "filter" in addSpec && addSpec.filter === undefined;
+  if (hasUndefinedFilter) {
+    const { filter: _filter, ...withoutFilter } = addSpec;
+    map.addLayer(withoutFilter as typeof addSpec, validBeforeId);
+    return;
+  }
   map.addLayer(addSpec, validBeforeId);
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1391,8 +1391,20 @@ export function externalExtrusionLayerId(nativeLayerId: string): string {
 // Native layers hidden to make room for a synthetic fill-extrusion layer.
 // Tracked so switching 3D extrusion back off can restore them on the
 // control-managed path, which otherwise never writes visibility (the control
-// owns it) and would leave the layer invisible.
-const extrusionHiddenNativeLayerIds = new Set<string>();
+// owns it) and would leave the layer invisible. Keyed per map (like
+// `nativeFilterStatesFor`) because native layer ids are only unique within one
+// map: two live maps showing the same control would otherwise share entries,
+// and one clearing extrusion would strand the other's fill hidden.
+const extrusionHiddenNativeLayerIdsByMap = new WeakMap<maplibregl.Map, Set<string>>();
+
+function extrusionHiddenNativeLayerIdsFor(map: maplibregl.Map): Set<string> {
+  let ids = extrusionHiddenNativeLayerIdsByMap.get(map);
+  if (!ids) {
+    ids = new Set();
+    extrusionHiddenNativeLayerIdsByMap.set(map, ids);
+  }
+  return ids;
+}
 
 /**
  * Render an external control's native `fill` layers as GeoLibre-owned
@@ -1421,9 +1433,10 @@ function syncExternalNativeExtrusion(
     .filter(isFillStyleLayerSpec);
   if (nativeFillLayerSpecs.length === 0) return false;
 
+  const hiddenNativeLayerIds = extrusionHiddenNativeLayerIdsFor(map);
   for (const nativeLayerId of nativeLayerIds) {
     setNativeLayerVisibility(map, nativeLayerId, "none");
-    extrusionHiddenNativeLayerIds.add(nativeLayerId);
+    hiddenNativeLayerIds.add(nativeLayerId);
   }
 
   for (const fillLayerSpec of nativeFillLayerSpecs) {
@@ -1471,9 +1484,10 @@ function clearExternalNativeExtrusion(
   layer: GeoLibreLayer,
   nativeLayerIds: string[],
 ): void {
+  const hiddenNativeLayerIds = extrusionHiddenNativeLayerIdsFor(map);
   for (const nativeLayerId of nativeLayerIds) {
     removeIfExists(map, externalExtrusionLayerId(nativeLayerId));
-    if (extrusionHiddenNativeLayerIds.delete(nativeLayerId)) {
+    if (hiddenNativeLayerIds.delete(nativeLayerId)) {
       setNativeLayerVisibility(map, nativeLayerId, layer.visible ? "visible" : "none");
     }
   }

--- a/packages/plugins/src/plugins/maplibre-overture-maps.ts
+++ b/packages/plugins/src/plugins/maplibre-overture-maps.ts
@@ -7,6 +7,7 @@ import {
   THEME_IDS,
   THEMES,
   tileUrlForTheme,
+  type OvertureGeometry,
   type OvertureMapsControlOptions,
   type OvertureMapsEventHandler,
   type OvertureMapsState,
@@ -145,6 +146,7 @@ export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
 interface OvertureUnit {
   theme: OvertureTheme;
   sourceLayer: string;
+  geometry: OvertureGeometry;
 }
 
 let storeUnsubscribe: (() => void) | null = null;
@@ -159,8 +161,17 @@ const OVERTURE_UNITS: OvertureUnit[] = THEME_IDS.flatMap((theme) =>
   THEMES[theme].layers.map((layer) => ({
     theme,
     sourceLayer: layer.sourceLayer,
+    geometry: layer.geometry,
   })),
 );
+
+// Numeric Overture schema fields worth extruding by, offered as the Style
+// panel's height-attribute options. The tiles carry no field listing, so
+// without these the picker has nothing to choose from and the user is stuck on
+// the default. Only the buildings theme defines height in the Overture schema.
+const BUILDING_HEIGHT_FIELDS: Partial<Record<OvertureTheme, string[]>> = {
+  buildings: ["height", "min_height", "num_floors", "min_floor", "roof_height"],
+};
 
 function unitKey(unit: OvertureUnit): string {
   return `${unit.theme}/${unit.sourceLayer}`;
@@ -335,6 +346,12 @@ function createOvertureStoreLayer(
       sourceId,
       sourceIds: [sourceId],
       sourceKind: SOURCE_KIND,
+      // The control has no extrusion concept, so polygon themes hand 3D
+      // extrusion back to GeoLibre's layer sync, which re-renders the control's
+      // native fill as a fill-extrusion. Without this the Style panel's 3D mode
+      // is offered but never takes effect.
+      ...(unit.geometry === "polygon" ? { nativeFillExtrusion: true } : {}),
+      ...(BUILDING_HEIGHT_FIELDS[unit.theme] ? { fields: BUILDING_HEIGHT_FIELDS[unit.theme] } : {}),
     },
     sourcePath: tileUrl,
   };

--- a/tests/native-fill-extrusion.test.ts
+++ b/tests/native-fill-extrusion.test.ts
@@ -14,7 +14,7 @@ interface MapCall {
   args: unknown[];
 }
 
-function makeMapStub(fillLayerId: string) {
+function makeMapStub(fillLayerId: string, baseFilter?: unknown) {
   const calls: MapCall[] = [];
   const present = new Set<string>([fillLayerId]);
   const record =
@@ -22,22 +22,32 @@ function makeMapStub(fillLayerId: string) {
     (...args: unknown[]) => {
       calls.push({ method, args });
     };
-  const fillSpec = {
+  const fillSpec: Record<string, unknown> = {
     id: fillLayerId,
     type: "fill",
     source: "overture-buildings",
     "source-layer": "building",
+    ...(baseFilter ? { filter: baseFilter } : {}),
   };
+  // Filters are read back the way MapLibre does, so a sync that pushes a
+  // combined filter onto the native layer is visible to the next sync.
+  const filters = new Map<string, unknown>();
+  if (baseFilter) filters.set(fillLayerId, baseFilter);
   const map = {
     getStyle: () => ({ layers: [fillSpec] }),
     getLayer: (id: string) =>
       present.has(id) ? { id, type: id === fillLayerId ? "fill" : "fill-extrusion" } : undefined,
     getSource: () => ({}),
-    getFilter: () => undefined,
+    getFilter: (id: string) => filters.get(id),
     getPaintProperty: () => undefined,
     setLayoutProperty: record("setLayoutProperty"),
     setPaintProperty: record("setPaintProperty"),
-    setFilter: record("setFilter"),
+    setFilter: (...args: unknown[]) => {
+      const [id, filter] = args as [string, unknown];
+      filters.set(id, filter);
+      if (id === fillLayerId) fillSpec.filter = filter;
+      calls.push({ method: "setFilter", args });
+    },
     setLayerZoomRange: record("setLayerZoomRange"),
     moveLayer: record("moveLayer"),
     addSource: record("addSource"),
@@ -127,11 +137,63 @@ describe("3D extrusion on control-managed native fill layers", () => {
       }),
     );
 
-    const added = calls.find((c) => c.method === "addLayer");
+    const added = calls.find(
+      (c) =>
+        c.method === "addLayer" &&
+        (c.args[0] as { id: string }).id === externalExtrusionLayerId(nativeId),
+    );
     assert.ok(added, "expected the extrusion layer to be added");
     assert.ok(
       !("filter" in (added.args[0] as Record<string, unknown>)),
       "expected no filter key so MapLibre does not reject the layer",
+    );
+  });
+
+  it("combines the native fill's own filter with the Time Slider window without compounding", () => {
+    const nativeId = "filtered-fill";
+    const baseFilter = ["==", ["get", "class"], "building"];
+    const timeFilter = ["<=", ["get", "year"], 2000];
+    const { map, calls } = makeMapStub(nativeId, baseFilter);
+    const metadata = {
+      customLayerType: "overture-maps",
+      externalNativeLayer: true,
+      nativeLayerIds: [nativeId],
+      sourceIds: ["overture-buildings"],
+      nativeFillExtrusion: true,
+    };
+
+    // First sync in 2D with a Time Slider window: the ordering-only path pushes
+    // a combined filter onto the native fill and records its base.
+    syncLayer(map as never, overtureLayer("filtered", { metadata, timeFilter }));
+    assert.deepEqual(
+      calls.find((c) => c.method === "setFilter")?.args[1],
+      ["all", baseFilter, timeFilter],
+      "expected the native fill to be narrowed to the time window",
+    );
+
+    // Switching to 3D must rebuild from the tracked base, not from the combined
+    // filter already sitting on the fill — otherwise the window nests deeper on
+    // every toggle.
+    calls.length = 0;
+    syncLayer(
+      map as never,
+      overtureLayer("filtered", {
+        metadata,
+        timeFilter,
+        style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      }),
+    );
+
+    const added = calls.find(
+      (c) =>
+        c.method === "addLayer" &&
+        (c.args[0] as { id: string }).id === externalExtrusionLayerId(nativeId),
+    );
+    assert.ok(added, "expected the extrusion layer to be added");
+    assert.deepEqual(
+      (added.args[0] as { filter: unknown }).filter,
+      ["all", baseFilter, timeFilter],
+      "expected the extrusion filter to combine the base once, not the combined filter again",
     );
   });
 

--- a/tests/native-fill-extrusion.test.ts
+++ b/tests/native-fill-extrusion.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import { externalExtrusionLayerId, syncLayer } from "../packages/map/src/layer-sync";
+
+// Control-managed layers (`customLayerType`) take layer-sync's ordering-only
+// path, which deliberately leaves the control's rendering alone. Polygon
+// sources whose control has no extrusion concept — Overture Maps buildings —
+// opt back in with `nativeFillExtrusion` so the Style panel's 3D extrusion mode
+// actually renders. Mirrors the stub in control-owns-paint.test.ts, plus the
+// getters the synthetic extrusion layer reads.
+interface MapCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeMapStub(fillLayerId: string) {
+  const calls: MapCall[] = [];
+  const present = new Set<string>([fillLayerId]);
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const fillSpec = {
+    id: fillLayerId,
+    type: "fill",
+    source: "overture-buildings",
+    "source-layer": "building",
+  };
+  const map = {
+    getStyle: () => ({ layers: [fillSpec] }),
+    getLayer: (id: string) =>
+      present.has(id) ? { id, type: id === fillLayerId ? "fill" : "fill-extrusion" } : undefined,
+    getSource: () => ({}),
+    getFilter: () => undefined,
+    getPaintProperty: () => undefined,
+    setLayoutProperty: record("setLayoutProperty"),
+    setPaintProperty: record("setPaintProperty"),
+    setFilter: record("setFilter"),
+    setLayerZoomRange: record("setLayerZoomRange"),
+    moveLayer: record("moveLayer"),
+    addSource: record("addSource"),
+    addLayer: (...args: unknown[]) => {
+      const spec = args[0] as { id: string };
+      present.add(spec.id);
+      calls.push({ method: "addLayer", args });
+    },
+    removeLayer: (...args: unknown[]) => {
+      present.delete(args[0] as string);
+      calls.push({ method: "removeLayer", args });
+    },
+  };
+  return { map, calls, present };
+}
+
+function overtureLayer(id: string, patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id,
+    name: "Overture Building",
+    type: "vector-tiles",
+    source: { type: "vector", sourceId: "overture-buildings" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      customLayerType: "overture-maps",
+      externalNativeLayer: true,
+      nativeLayerIds: [`${id}-fill`],
+      sourceIds: ["overture-buildings"],
+      nativeFillExtrusion: true,
+    },
+    ...patch,
+  };
+}
+
+describe("3D extrusion on control-managed native fill layers", () => {
+  it("extrudes an opted-in control layer instead of only reordering it", () => {
+    const nativeId = "opt-in-fill";
+    const { map, calls } = makeMapStub(nativeId);
+    const layer = overtureLayer("opt-in", {
+      style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+    });
+
+    syncLayer(map as never, layer);
+
+    const added = calls.find(
+      (c) =>
+        c.method === "addLayer" &&
+        (c.args[0] as { id: string }).id === `${nativeId}-geolibre-extrusion`,
+    );
+    assert.ok(added, "expected a synthetic fill-extrusion layer to be added");
+    const spec = added.args[0] as Record<string, unknown>;
+    assert.equal(spec.type, "fill-extrusion");
+    // Built from the control's own source so the extrusion covers the same
+    // tiles the flat fill did.
+    assert.equal(spec.source, "overture-buildings");
+    assert.equal(spec["source-layer"], "building");
+
+    // The flat fill is hidden rather than restyled, leaving it to the control.
+    const hidden = calls.find(
+      (c) => c.method === "setLayoutProperty" && c.args[0] === nativeId && c.args[2] === "none",
+    );
+    assert.ok(hidden, "expected the native fill to be hidden behind the extrusion");
+  });
+
+  it("omits the filter key entirely when the native fill carries no filter", () => {
+    // MapLibre validates the spec on first add and rejects an explicit
+    // `filter: undefined` ("array expected, undefined found") by dropping the
+    // layer without throwing — only an `error` event reports it. Overture's
+    // native fills carry no filter, so passing the key through meant the
+    // extrusion layer never reached the map.
+    const nativeId = "unfiltered-fill";
+    const { map, calls } = makeMapStub(nativeId);
+
+    syncLayer(
+      map as never,
+      overtureLayer("unfiltered", {
+        metadata: {
+          customLayerType: "overture-maps",
+          externalNativeLayer: true,
+          nativeLayerIds: [nativeId],
+          sourceIds: ["overture-buildings"],
+          nativeFillExtrusion: true,
+        },
+        style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      }),
+    );
+
+    const added = calls.find((c) => c.method === "addLayer");
+    assert.ok(added, "expected the extrusion layer to be added");
+    assert.ok(
+      !("filter" in (added.args[0] as Record<string, unknown>)),
+      "expected no filter key so MapLibre does not reject the layer",
+    );
+  });
+
+  it("leaves a control layer that has not opted in on the ordering-only path", () => {
+    const nativeId = "opt-out-fill";
+    const { map, calls } = makeMapStub(nativeId);
+    const layer = overtureLayer("opt-out", {
+      style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      metadata: {
+        customLayerType: "overture-maps",
+        externalNativeLayer: true,
+        nativeLayerIds: [nativeId],
+        sourceIds: ["overture-buildings"],
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    assert.ok(
+      !calls.some((c) => c.method === "addLayer"),
+      "expected no extrusion layer for a control that renders extrusions itself",
+    );
+    assert.ok(
+      calls.some((c) => c.method === "moveLayer"),
+      "expected ordering to still be synced",
+    );
+  });
+
+  it("restores the control's flat fill when extrusion is switched back off", () => {
+    const nativeId = "toggle-fill";
+    const { map, calls, present } = makeMapStub(nativeId);
+
+    syncLayer(
+      map as never,
+      overtureLayer("toggle", {
+        metadata: {
+          customLayerType: "overture-maps",
+          externalNativeLayer: true,
+          nativeLayerIds: [nativeId],
+          sourceIds: ["overture-buildings"],
+          nativeFillExtrusion: true,
+        },
+        style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      }),
+    );
+    assert.ok(present.has(externalExtrusionLayerId(nativeId)), "expected the extrusion layer");
+
+    calls.length = 0;
+    syncLayer(
+      map as never,
+      overtureLayer("toggle", {
+        metadata: {
+          customLayerType: "overture-maps",
+          externalNativeLayer: true,
+          nativeLayerIds: [nativeId],
+          sourceIds: ["overture-buildings"],
+          nativeFillExtrusion: true,
+        },
+      }),
+    );
+
+    assert.ok(
+      !present.has(externalExtrusionLayerId(nativeId)),
+      "expected the synthetic extrusion layer to be removed",
+    );
+    // Without this the control-managed path never writes visibility, so the
+    // fill would stay hidden and the layer would vanish on the way back to 2D.
+    const restored = calls.find(
+      (c) => c.method === "setLayoutProperty" && c.args[0] === nativeId && c.args[2] === "visible",
+    );
+    assert.ok(restored, "expected the native fill to be made visible again");
+  });
+
+  it("keeps a hidden layer hidden when extrusion is switched off", () => {
+    const nativeId = "hidden-fill";
+    const { map, calls } = makeMapStub(nativeId);
+    const metadata = {
+      customLayerType: "overture-maps",
+      externalNativeLayer: true,
+      nativeLayerIds: [nativeId],
+      sourceIds: ["overture-buildings"],
+      nativeFillExtrusion: true,
+    };
+
+    syncLayer(
+      map as never,
+      overtureLayer("hidden", {
+        metadata,
+        style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      }),
+    );
+
+    calls.length = 0;
+    syncLayer(map as never, overtureLayer("hidden", { metadata, visible: false }));
+
+    const restored = calls.find((c) => c.method === "setLayoutProperty" && c.args[0] === nativeId);
+    assert.ok(restored, "expected visibility to be written back");
+    assert.equal(restored.args[2], "none", "expected a hidden layer to stay hidden");
+  });
+});


### PR DESCRIPTION
## Problem

Buildings added via the **Overture Maps plugin** don't respond to the Style panel's **3D extrusion** toggle. The same buildings added via **Add Data → PMTiles Layer** extrude fine.

## Root cause

The plugin mirrors its layers into the store with `metadata.customLayerType`, which puts them on `layer-sync`'s **ordering-only** path — GeoLibre reorders them and leaves rendering entirely to the control, returning before the extrusion block ever runs:

```ts
if (isExternalCustomLayer(layer)) {
  for (const nativeLayerId of nativeLayerIds) { moveLayer(...) }
  ...
  return;   // <- extrusion handling lives below this
}
```

The Style panel still *offers* 3D extrusion, because `supportsExtrusionControls()` returns true for any `vector-tiles` layer. So the radio switched, the store updated, and nothing rendered.

Add PMTiles Layer builds a `type: "pmtiles"` / `sourceKind: "pmtiles-url"` record with no `customLayerType`, so it falls through to the extrusion path — hence the difference.

## Fix

Polygon Overture layers opt back in with `metadata.nativeFillExtrusion`, and layer-sync re-renders the control's native `fill` as a GeoLibre-owned `fill-extrusion` built from the same source and source layer. The natives are **hidden rather than restyled**, so toggling back to 2D restores the control's own rendering untouched.

Controls that already implement extrusion themselves (Add Vector Layer, DuckDB — both push `extrusionEnabled` into their own control style) leave the flag unset, so nothing double-extrudes.

### Two supporting fixes found while verifying

- **`ensureLayer` passed an explicit `filter: undefined` on first add.** MapLibre rejects that in style validation (`filter: array expected, undefined found`) and **discards the layer without throwing** — it only fires an `error` event. Overture's native fills carry no filter, so the extrusion layer was built correctly and then silently dropped. The PMTiles path was unaffected because its fills *do* carry a filter. The key is now omitted on add only; the update branch still needs it present to clear a stale filter.
- **Buildings layers publish their Overture schema height fields** (`height`, `min_height`, `num_floors`, `min_floor`, `roof_height`), so the height-attribute picker is populated instead of empty and disabled.

## Verification

Driven in a real browser against **live Overture PMTiles** over downtown Chicago (z16, pitch 60).

Extruded heights match published figures exactly:

| Building | Rendered | Actual |
|---|---|---|
| Franklin Center North Tower | 306.9 m | 306.9 m |
| Chase Tower | 260 m | 259.4 m |
| Salesforce Tower Chicago | 255 m | 255 m |
| 110 North Wacker | 249 m | 250 m |
| 150 N Riverside | 229 m | 228.6 m |
| River Point | 222 m | 222 m |

Round-trip is clean: switching back to 2D removes the synthetic layer, restores both natives to visible, and renders **556** flat fills — exactly the pre-extrusion baseline. No MapLibre `error` events in either direction.

## Tests

New `tests/native-fill-extrusion.test.ts` (5 cases): extrusion applied for opted-in layers, `filter` key omitted when the native fill has none, opted-out layers left on the ordering-only path, natives restored on toggle-off, and a hidden layer staying hidden. Three of the five fail without the fix.

Full frontend suite passes (3781/3782, 1 pre-existing skip); `npm run typecheck` and scoped `pre-commit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in 3D building extrusion for supported polygon layers.
  * Preserves filters and time-slider/rule behavior when switching between flat and extruded views.
  * Exposed building height attribute options for applicable map layers.
* **Bug Fixes**
  * Prevented failures when optional layer filters are missing during layer creation.
  * Correctly restores native layer visibility when extrusion is toggled off (including when the layer was previously hidden).
* **Tests**
  * Added coverage for native fill extrusion toggling, ordering, and filter/visibility handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->