### PR TITLE
fix(vector): load KMZ from a URL in Add Data → Vector Layer

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -82,7 +82,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.8.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.0",
+    "maplibre-gl-vector": "^0.10.1",
     "openai": "^6.48.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.8.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.0",
+        "maplibre-gl-vector": "^0.10.1",
         "openai": "^6.48.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17244,9 +17244,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.0.tgz",
-      "integrity": "sha512-EpOg8iVi6/j8XiJ7qM2E24rmM9oHGkzPmnPaoNdP5l2SDPYdxkF0rg/dUSdB496dfARIDxV2jd0/0v2zAXwEqw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.1.tgz",
+      "integrity": "sha512-1LZa8jGJ449gw6iaNX6J6y+apAUaerZtbWflGevmjNWIi0wBSJHM2sZV2L55F+30oakAL8JBOnS07G3YMDDoOw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21887,7 +21887,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.8.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.0",
+        "maplibre-gl-vector": "^0.10.1",
         "netcdfjs": "^4.0.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -56,7 +56,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.8.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.0",
+    "maplibre-gl-vector": "^0.10.1",
     "netcdfjs": "^4.0.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",


### PR DESCRIPTION
Fixes #1440

## Problem

Pasting a KMZ URL into **Add Data → Vector Layer** failed with an opaque error, e.g. for NASA FIRMS live fire footprints:

```
Invalid Error: NetworkError: Failed to execute 'send' on 'XMLHttpRequest':
Failed to load 'https://firms.modaps.eosdis.nasa.gov/.../FirespotArea_russia_asia_c6.1_24h.*'
```

Downloading the same file and importing it from disk worked, which made this look like a network or CORS problem.

## Root cause

Not CORS: the FIRMS URL serves `access-control-allow-origin: *`.

A KMZ is a zip holding a KML document, and GDAL can only open one through its `/vsizip` handler. That handler reads through GDAL's own virtual filesystem, so it could reach neither a DuckDB-WASM registered buffer nor the bare URL that `maplibre-gl-vector` was handing to `ST_Read`. The trailing `.*` in the error was GDAL probing for sibling files.

A plain remote `.kml` already loaded fine, which is what isolated the failure to the zip container specifically.

## Fix

Bump `maplibre-gl-vector` to **0.10.1** (opengeos/maplibre-gl-vector#46), which unzips the archive and registers the KML inside it, the same approach already used for zipped shapefiles. No GeoLibre code changes are needed.

This also fixes a second bug found while investigating: loading a **local** `.kmz` through that same panel in the **web** build, which failed with `GDAL Error (4): not recognized as a supported file format`. The desktop file picker was never affected, since it is routed through GeoLibre's own KML reader; that is why importing a downloaded KMZ already worked.

## Verification

Drove the real app in a browser against the reporter's exact URL (3,820 placemarks in a 4 MB KML), using the published 0.10.1 from npm:

- The KMZ URL now opens the layer picker with all 6 FIRMS layers (centroids and footprints for the 0-6h, 6-12h and 12-24h buckets) and renders on the map.
- Verified in both light and dark themes.
- The local-KMZ-in-web case is fixed too.

`npm run build` and `npm run test:frontend` (3,815 tests) pass; pre-commit clean on the changed files.

## Note on scope

A KMZ loaded this way goes through the generic GDAL path, so it does not carry the embedded KML symbology that GeoLibre's own desktop KML reader preserves (#407). Routing remote KMZ through that richer reader is a larger change than this fix, so it is left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the map rendering component to a newer patch release, improving stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->