### PR TITLE
feat(notebook): drive the map from external Jupyter clients (VS Code)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -114,6 +114,7 @@ import { KnowledgeCardConsentDialog } from "./KnowledgeCardConsentDialog";
 import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
+import { useJupyterRelay } from "../../hooks/useJupyterRelay";
 import { appendDiagnostic, useDiagnosticsSnapshot } from "../../lib/diagnostics";
 import { SectionErrorBoundary, SilentErrorBoundary } from "../common/error-boundaries";
 import { AttributeTable } from "../panels/AttributeTable";
@@ -747,6 +748,10 @@ export function DesktopShell({
   // Request/reply + event channel backing the Python scripting API (live
   // queries, processing, map events). Also inert when not embedded.
   useCommandBridge(mapControllerRef);
+  // Same scripting surface, reached over the desktop Jupyter server's relay, so
+  // a kernel driven from an EXTERNAL client (VS Code's Jupyter extension) can
+  // control the map too. Inert until that server is running.
+  useJupyterRelay(mapControllerRef);
   // Routes the Layers-panel Identify action to the raster pixel inspector for
   // COG layers (read band values on click). Inert until a COG is identified.
   useRasterIdentify();

--- a/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
@@ -181,7 +181,13 @@ export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: No
                   onClick={() => {
                     void navigator.clipboard
                       ?.writeText(externalClientUrl(server))
-                      .then(() => setCopied(true));
+                      .then(() => setCopied(true))
+                      .catch((error: unknown) => {
+                        // Clipboard access can be denied; never leave the button
+                        // claiming a copy that did not happen.
+                        setCopied(false);
+                        console.error("Could not copy the Jupyter server URL", error);
+                      });
                   }}
                 >
                   {copied ? (

--- a/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx
@@ -1,6 +1,14 @@
 import { useAppStore } from "@geolibre/core";
 import { Button } from "@geolibre/ui";
-import { Loader2, NotebookPen, PanelRightClose, PanelRightOpen, X } from "lucide-react";
+import {
+  Check,
+  Link2,
+  Loader2,
+  NotebookPen,
+  PanelRightClose,
+  PanelRightOpen,
+  X,
+} from "lucide-react";
 import {
   type PointerEvent as ReactPointerEvent,
   type RefObject,
@@ -15,7 +23,7 @@ import { useNotebookBridge } from "../../hooks/useNotebookBridge";
 import { useNotebookThemeSync } from "../../hooks/useNotebookThemeSync";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/is-tauri";
-import { startJupyterServer } from "../../lib/jupyter";
+import { type JupyterServerInfo, startJupyterServer } from "../../lib/jupyter";
 
 /**
  * Resolve the notebook iframe URL for the current environment:
@@ -24,13 +32,24 @@ import { startJupyterServer } from "../../lib/jupyter";
  *   embed its token-authenticated `/lab` URL.
  * - **Web:** load the self-hosted JupyterLite site (in-browser Pyodide kernel)
  *   built by `npm run build:jupyterlite` into `public/jupyterlite/`.
+ *
+ * @returns The iframe `src`, plus the desktop server it belongs to (null on web,
+ *   where there is no server an external client could attach to).
  */
-async function resolveNotebookUrl(): Promise<string> {
+async function resolveNotebook(): Promise<{ src: string; server: JupyterServerInfo | null }> {
   if (isTauri()) {
     const info = await startJupyterServer();
-    return `${info.url}/lab?token=${encodeURIComponent(info.token)}`;
+    return {
+      src: `${info.url}/lab?token=${encodeURIComponent(info.token)}`,
+      server: info,
+    };
   }
-  return `${import.meta.env.BASE_URL}jupyterlite/lab/index.html`;
+  return { src: `${import.meta.env.BASE_URL}jupyterlite/lab/index.html`, server: null };
+}
+
+/** The URL an external Jupyter client (VS Code…) attaches to this server with. */
+function externalClientUrl(server: JupyterServerInfo): string {
+  return `${server.url}/?token=${encodeURIComponent(server.token)}`;
 }
 
 interface NotebookPanelProps {
@@ -62,6 +81,8 @@ export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: No
   const [isCollapsed, setIsCollapsed] = useState(getIsMobileViewport);
   const [loaded, setLoaded] = useState(false);
   const [src, setSrc] = useState<string | null>(null);
+  const [server, setServer] = useState<JupyterServerInfo | null>(null);
+  const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -74,9 +95,11 @@ export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: No
   // which can take a moment on first run while uv syncs the environment).
   useEffect(() => {
     let cancelled = false;
-    resolveNotebookUrl()
-      .then((url) => {
-        if (!cancelled) setSrc(url);
+    resolveNotebook()
+      .then(({ src: url, server: info }) => {
+        if (cancelled) return;
+        setSrc(url);
+        setServer(info);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -95,6 +118,13 @@ export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: No
       cancelled = true;
     };
   }, [t]);
+
+  // Revert the copy button's confirmation so it reads as reusable.
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
 
   return (
     <aside
@@ -137,6 +167,30 @@ export function NotebookPanel({ onResizeStart, mapControllerRef, themeMode }: No
             <NotebookPen className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-semibold">{t("notebook.title")}</span>
             <div className="ms-auto flex items-center gap-1">
+              {/* Desktop only: the loopback server URL + token an external
+                  Jupyter client (VS Code's Jupyter extension, `jupyter
+                  console`) attaches to. Such a client drives the map through the
+                  relay (useJupyterRelay), not through this iframe. */}
+              {server ? (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  title={copied ? t("notebook.serverUrlCopied") : t("notebook.copyServerUrl")}
+                  aria-label={t("notebook.copyServerUrl")}
+                  onClick={() => {
+                    void navigator.clipboard
+                      ?.writeText(externalClientUrl(server))
+                      .then(() => setCopied(true));
+                  }}
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-primary" />
+                  ) : (
+                    <Link2 className="h-4 w-4" />
+                  )}
+                </Button>
+              ) : null}
               <Button
                 variant="ghost"
                 size="icon"

--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -1,0 +1,120 @@
+import { type RefObject, useEffect } from "react";
+import type { MapController } from "@geolibre/map";
+import { subscribeJupyterServer } from "../lib/jupyter";
+import {
+  type RelayCommand,
+  parseRelayMessage,
+  relayReconnectDelay,
+  relaySocketUrl,
+} from "../lib/jupyter-relay";
+import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
+
+// The app side of the desktop Jupyter map-command relay. This is the SIBLING of
+// useNotebookBridge: that one receives commands over postMessage from the
+// notebook iframe the app embeds, which only works while the notebook is
+// rendered inside the Notebook panel. This one subscribes to a loopback
+// WebSocket on the Jupyter server itself, so a kernel driven by ANY frontend —
+// notably VS Code's Jupyter extension attached to the same server — reaches the
+// same map (issue #1442).
+//
+// Both feed the SAME createScriptingHandlers surface used by the in-app Python
+// console and the Jupyter widget, so behaviour cannot drift between transports.
+
+/**
+ * Subscribe to the desktop Jupyter server's map-command relay for the app's
+ * lifetime, running each relayed command against the live map.
+ *
+ * Connects whenever a Jupyter server is running (started by the Notebook panel)
+ * and reconnects with backoff if the socket drops. Inert on web and on desktop
+ * until a server has been started.
+ *
+ * @param mapControllerRef - Ref to the live map controller, read lazily by the
+ *   command handlers.
+ */
+export function useJupyterRelay(mapControllerRef: RefObject<MapController | null>): void {
+  useEffect(() => {
+    const handlers = createScriptingHandlers({
+      getController: () => mapControllerRef.current,
+    });
+
+    let socket: WebSocket | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+    // Bumped on every server change/unmount so a socket opened for a previous
+    // server can never resurrect the reconnect loop after we moved on.
+    let generation = 0;
+
+    const run = async (command: RelayCommand) => {
+      // Own-property only, so an inherited member ("constructor", …) can never be
+      // invoked as a command.
+      if (!Object.hasOwn(handlers, command.method)) {
+        console.warn(`Jupyter relay: unknown command "${command.method}"`);
+        return;
+      }
+      try {
+        await handlers[command.method](command.params);
+      } catch (error) {
+        console.error(`Jupyter relay: command "${command.method}" failed`, error);
+      }
+    };
+
+    const close = () => {
+      generation += 1;
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      // Drop the handlers first: onclose must not schedule a reconnect for a
+      // socket we are deliberately tearing down.
+      if (socket) {
+        socket.onclose = null;
+        socket.onerror = null;
+        socket.onmessage = null;
+        socket.close();
+        socket = null;
+      }
+    };
+
+    const unsubscribe = subscribeJupyterServer((info) => {
+      close();
+      if (!info) return;
+      const mine = generation;
+      attempt = 0;
+
+      const connect = () => {
+        if (generation !== mine) return;
+        let next: WebSocket;
+        try {
+          next = new WebSocket(relaySocketUrl(info));
+        } catch (error) {
+          console.warn("Jupyter relay: could not open the command socket", error);
+          return;
+        }
+        socket = next;
+        next.onopen = () => {
+          attempt = 0;
+        };
+        next.onmessage = (event: MessageEvent) => {
+          const command = parseRelayMessage(event.data);
+          if (command) void run(command);
+        };
+        next.onclose = () => {
+          if (generation !== mine) return;
+          socket = null;
+          // The server outlives a dropped socket (it runs for the app's
+          // lifetime), so keep retrying rather than giving up on the channel.
+          retryTimer = setTimeout(connect, relayReconnectDelay(attempt));
+          attempt += 1;
+        };
+      };
+
+      connect();
+    });
+
+    return () => {
+      unsubscribe();
+      close();
+    };
+    // Mount-only: the ref is stable and read lazily inside the handlers.
+  }, [mapControllerRef]);
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2882,6 +2882,8 @@
     "collapse": "Collapse notebook",
     "expand": "Expand notebook",
     "close": "Close notebook",
+    "copyServerUrl": "Copy the server URL for external clients (VS Code…)",
+    "serverUrlCopied": "Server URL copied",
     "loading": "Loading notebook…",
     "loadFailed": "Failed to load the notebook."
   },

--- a/apps/geolibre-desktop/src/lib/jupyter-relay.ts
+++ b/apps/geolibre-desktop/src/lib/jupyter-relay.ts
@@ -1,0 +1,77 @@
+import type { JupyterServerInfo } from "./jupyter";
+
+// Wire format for the desktop Jupyter map-command relay
+// (backend/geolibre_server/geolibre_server/jupyter_relay.py). The relay lets a
+// kernel drive the map regardless of which *frontend* is running the cell — the
+// embedded Notebook panel, or an external client such as VS Code's Jupyter
+// extension (issue #1442) — where the postMessage transport in useNotebookBridge
+// only reaches the map from inside the app's own iframe.
+//
+// Pure helpers live here (not in the hook) so the protocol is unit-testable.
+
+/** One scripting command relayed from a kernel, in the shared bridge envelope. */
+export interface RelayCommand {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+/** URL path the relay's endpoints are mounted under, mirroring `RELAY_PATH`. */
+const RELAY_PATH = "geolibre/relay";
+
+/**
+ * Build the app-side WebSocket URL for a running Jupyter server.
+ *
+ * The token rides in the query string because a WebSocket handshake cannot carry
+ * an `Authorization` header, and the server's session cookie is unavailable to
+ * us (the app is a different origin than the loopback server).
+ *
+ * @param info - The running server's connection details.
+ * @returns A `ws://` URL for the relay socket.
+ */
+export function relaySocketUrl(info: JupyterServerInfo): string {
+  const url = new URL(`${info.url.replace(/\/+$/, "")}/${RELAY_PATH}/socket`);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  if (info.token) url.searchParams.set("token", info.token);
+  return url.toString();
+}
+
+/**
+ * Parse one relay frame into a command, rejecting anything malformed.
+ *
+ * @param data - The raw WebSocket payload.
+ * @returns The command, or null for a non-command frame (e.g. the relay's
+ *   `geolibre:relay-ready` greeting) or an unparseable one.
+ */
+export function parseRelayMessage(data: unknown): RelayCommand | null {
+  if (typeof data !== "string") return null;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== "object") return null;
+  const message = payload as { type?: unknown; method?: unknown; params?: unknown };
+  if (message.type !== "geolibre:command") return null;
+  if (typeof message.method !== "string" || !message.method) return null;
+  const params =
+    message.params && typeof message.params === "object" && !Array.isArray(message.params)
+      ? (message.params as Record<string, unknown>)
+      : {};
+  return { method: message.method, params };
+}
+
+/** Reconnect backoff (ms) after a dropped socket, capped so it stays responsive. */
+export const RELAY_RECONNECT_MIN_MS = 1_000;
+export const RELAY_RECONNECT_MAX_MS = 15_000;
+
+/**
+ * Next reconnect delay for a given consecutive-failure count (exponential).
+ *
+ * @param attempt - How many reconnects have already failed (0 for the first).
+ * @returns The delay in milliseconds, capped at {@link RELAY_RECONNECT_MAX_MS}.
+ */
+export function relayReconnectDelay(attempt: number): number {
+  const delay = RELAY_RECONNECT_MIN_MS * 2 ** Math.max(0, attempt);
+  return Math.min(delay, RELAY_RECONNECT_MAX_MS);
+}

--- a/apps/geolibre-desktop/src/lib/jupyter.ts
+++ b/apps/geolibre-desktop/src/lib/jupyter.ts
@@ -14,19 +14,55 @@ export interface JupyterServerInfo {
   token: string;
 }
 
+// The live server, published so app-level consumers (the map-command relay in
+// useJupyterRelay) can reach it without depending on the Notebook panel, which
+// owns the *starting* of the server but may be closed while it keeps running.
+let liveServer: JupyterServerInfo | null = null;
+const serverListeners = new Set<(info: JupyterServerInfo | null) => void>();
+
+/** The running desktop JupyterLab server, or null when none has been started. */
+export function getJupyterServer(): JupyterServerInfo | null {
+  return liveServer;
+}
+
+/**
+ * Observe the desktop JupyterLab server's lifecycle.
+ *
+ * @param listener - Called with the current server (or null) immediately, then
+ *   on every start/stop.
+ * @returns An unsubscribe function.
+ */
+export function subscribeJupyterServer(
+  listener: (info: JupyterServerInfo | null) => void,
+): () => void {
+  serverListeners.add(listener);
+  listener(liveServer);
+  return () => {
+    serverListeners.delete(listener);
+  };
+}
+
+function setJupyterServer(info: JupyterServerInfo | null): void {
+  liveServer = info;
+  for (const listener of serverListeners) listener(info);
+}
+
 /**
  * Start (or reuse) the desktop JupyterLab server. Desktop-only — the web build
  * embeds the self-hosted JupyterLite site instead.
  */
 export async function startJupyterServer(): Promise<JupyterServerInfo> {
   assertTauri();
-  return invoke<JupyterServerInfo>("start_jupyter_server");
+  const info = await invoke<JupyterServerInfo>("start_jupyter_server");
+  setJupyterServer(info);
+  return info;
 }
 
 /** Stop the desktop JupyterLab server if it is running. */
 export async function stopJupyterServer(): Promise<void> {
   assertTauri();
   await invoke("stop_jupyter_server");
+  setJupyterServer(null);
 }
 
 function assertTauri(): void {

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -1,0 +1,256 @@
+"""Jupyter Server extension: relay map commands from ANY kernel to the app.
+
+The kernel-side ``geolibre`` client (``notebook_client.py``) drives the live
+GeoLibre map. Its original transport was ``display(Javascript(...))`` posting to
+``window.parent``, which only works when the notebook is rendered *inside* the
+app's Notebook-panel ``<iframe>``. Connect an external Jupyter frontend to the
+same server — VS Code's Jupyter extension, ``jupyter console``, nbclient — and
+that output is never executed in a window the app can see, so every map command
+silently did nothing (issue #1442).
+
+This extension adds a transport that does not depend on how the notebook is
+being *displayed*, only on which server the kernel belongs to:
+
+``POST {base_url}geolibre/relay/command``
+    Send one scripting command (the kernel side). Responds with
+    ``{"delivered": n}`` — the number of connected app windows it reached, so the
+    client can warn instead of failing silently.
+``GET {base_url}geolibre/relay/socket`` (WebSocket)
+    Subscribe to commands (the app side). Every posted command is broadcast to
+    all open sockets.
+``GET {base_url}geolibre/relay/status``
+    ``{"listeners": n}`` — whether any app window is currently subscribed.
+
+Kernels find the relay through two environment variables exported here at
+extension load; kernels the server spawns inherit them, which is what lets an
+externally driven kernel reach the map with no extra setup:
+
+- ``GEOLIBRE_RELAY_URL`` — the ``…/geolibre/relay`` base URL
+- ``GEOLIBRE_RELAY_TOKEN`` — the server's auth token (may be empty)
+
+Security: the server binds loopback and every endpoint here requires the same
+per-launch token as the rest of the Jupyter API, so a command can only be
+injected by something that already has full kernel-execution rights on this
+server. WebSocket origins are restricted to the app's own origins (the same set
+``jupyter_server_config.py`` allows to frame the server).
+
+Enabled from ``jupyter_server_config.py``; the app side is
+``apps/geolibre-desktop/src/hooks/useJupyterRelay.ts``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+from jupyter_server.base.handlers import APIHandler, JupyterHandler
+from jupyter_server.base.websocket import WebSocketMixin
+from jupyter_server.utils import url_path_join
+from tornado import web, websocket
+
+__all__ = [
+    "ENV_RELAY_TOKEN",
+    "ENV_RELAY_URL",
+    "RELAY_PATH",
+    "is_allowed_origin",
+    "normalize_command",
+    "relay_base_url",
+]
+
+#: URL segment the relay endpoints live under, relative to the server's base_url.
+RELAY_PATH = "geolibre/relay"
+
+#: Environment variables kernels read to find the relay (see module docstring).
+ENV_RELAY_URL = "GEOLIBRE_RELAY_URL"
+ENV_RELAY_TOKEN = "GEOLIBRE_RELAY_TOKEN"
+
+#: Message envelope the scripting bridge speaks, shared with the postMessage
+#: transport (``useNotebookBridge``) so the app dispatches both identically.
+COMMAND_TYPE = "geolibre:command"
+
+# Origins allowed to open the relay WebSocket: the Tauri webview (tauri:// on
+# macOS/Linux, https://tauri.localhost on Windows) and any loopback dev origin.
+# This mirrors the `frame-ancestors` list in jupyter_server_config.py — the app
+# that may embed this server is exactly the app that may drive the map.
+_ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "tauri.localhost"})
+_ALLOWED_ORIGIN_SCHEMES = frozenset({"http", "https", "tauri"})
+
+# Open app-side sockets. Module level (not per-handler) because every handler
+# instance is created per request: the POST handler needs the set the WebSocket
+# handlers registered themselves in.
+_listeners: set[GeoLibreRelaySocket] = set()
+
+
+def is_allowed_origin(origin: str | None) -> bool:
+    """Return whether ``origin`` may open the relay WebSocket.
+
+    Args:
+        origin: The request's ``Origin`` header, or None when absent (a non-browser
+            client such as a test harness, which is not subject to the same-origin
+            policy and is already token-gated).
+
+    Returns:
+        True when the origin is one of the GeoLibre app origins (Tauri webview or
+        loopback), or when no origin was sent.
+    """
+    if not origin:
+        return True
+    parsed = urlparse(origin)
+    if parsed.scheme not in _ALLOWED_ORIGIN_SCHEMES:
+        return False
+    return (parsed.hostname or "") in _ALLOWED_ORIGIN_HOSTS
+
+
+def normalize_command(payload: Any) -> dict[str, Any]:
+    """Validate a posted command and return the envelope to broadcast.
+
+    Args:
+        payload: The decoded JSON request body.
+
+    Returns:
+        A ``{"type", "requestId", "method", "params"}`` envelope.
+
+    Raises:
+        ValueError: If the payload is not a command envelope with a method name.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("Expected a JSON object.")
+    method = payload.get("method")
+    if not isinstance(method, str) or not method:
+        raise ValueError("Missing a non-empty 'method'.")
+    params = payload.get("params") or {}
+    if not isinstance(params, dict):
+        raise ValueError("'params' must be an object.")
+    request_id = payload.get("requestId")
+    return {
+        "type": COMMAND_TYPE,
+        "requestId": request_id if isinstance(request_id, str) else "",
+        "method": method,
+        "params": params,
+    }
+
+
+def relay_base_url(host: str, port: int, base_url: str) -> str:
+    """Build the ``…/geolibre/relay`` URL kernels post commands to.
+
+    Args:
+        host: The server's bind address; a wildcard or empty value becomes
+            ``127.0.0.1`` (the relay is only ever reached over loopback).
+        port: The server's port.
+        base_url: The server's ``base_url`` prefix (usually ``/``).
+
+    Returns:
+        An absolute ``http://`` URL with no trailing slash.
+    """
+    if host in {"", "0.0.0.0", "::"}:  # noqa: S104 - matched, not bound
+        host = "127.0.0.1"
+    return f"http://{host}:{port}" + url_path_join(base_url, RELAY_PATH)
+
+
+def _broadcast(message: dict[str, Any]) -> int:
+    """Send ``message`` to every open app socket; return how many received it."""
+    encoded = json.dumps(message)
+    delivered = 0
+    # Copy: write_message on a closed socket raises and we drop it from the set.
+    for socket in list(_listeners):
+        try:
+            socket.write_message(encoded)
+        except Exception:  # noqa: BLE001 - a dead peer must not fail the request
+            _listeners.discard(socket)
+            continue
+        delivered += 1
+    return delivered
+
+
+class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHandler):
+    """The app side: subscribes to every command posted to the relay."""
+
+    def check_origin(self, origin: str | None = None) -> bool:
+        """Allow the GeoLibre app's origins (see :func:`is_allowed_origin`)."""
+        return is_allowed_origin(origin or self.request.headers.get("Origin"))
+
+    async def pre_get(self) -> None:
+        """Reject an unauthenticated upgrade before the WebSocket handshake."""
+        if self.current_user is None:
+            raise web.HTTPError(403)
+
+    async def get(self, *args: Any, **kwargs: Any) -> None:
+        """Authenticate, then complete the WebSocket handshake."""
+        await self.pre_get()
+        await super().get(*args, **kwargs)
+
+    def open(self, *args: Any, **kwargs: Any) -> None:
+        """Register this app window as a command listener."""
+        _listeners.add(self)
+        self.write_message(json.dumps({"type": "geolibre:relay-ready"}))
+
+    def on_message(self, message: str) -> None:
+        """Ignore app→relay traffic: commands are fire-and-forget today."""
+
+    def on_close(self) -> None:
+        """Unregister this app window."""
+        _listeners.discard(self)
+
+
+class GeoLibreRelayCommandHandler(APIHandler):
+    """The kernel side: posts one command to every connected app window."""
+
+    @web.authenticated
+    def post(self) -> None:
+        """Relay the posted command and report how many windows received it."""
+        try:
+            message = normalize_command(json.loads(self.request.body or b"{}"))
+        except (ValueError, json.JSONDecodeError) as error:
+            raise web.HTTPError(400, str(error)) from error
+        self.finish(json.dumps({"delivered": _broadcast(message)}))
+
+
+class GeoLibreRelayStatusHandler(APIHandler):
+    """Report whether any app window is listening, without sending a command."""
+
+    @web.authenticated
+    def get(self) -> None:
+        """Return the number of connected app windows."""
+        self.finish(json.dumps({"listeners": len(_listeners)}))
+
+
+def _jupyter_server_extension_points() -> list[dict[str, str]]:
+    """Declare this module as the extension entry point (Jupyter Server API)."""
+    return [{"module": "geolibre_server.jupyter_relay"}]
+
+
+def _load_jupyter_server_extension(serverapp: Any) -> None:
+    """Register the relay endpoints and publish them to future kernels.
+
+    Args:
+        serverapp: The running ``ServerApp``, supplied by Jupyter Server.
+    """
+    web_app = serverapp.web_app
+    base_url = web_app.settings["base_url"]
+    prefix = url_path_join(base_url, RELAY_PATH)
+    web_app.add_handlers(
+        ".*$",
+        [
+            (url_path_join(prefix, "socket"), GeoLibreRelaySocket),
+            (url_path_join(prefix, "command"), GeoLibreRelayCommandHandler),
+            (url_path_join(prefix, "status"), GeoLibreRelayStatusHandler),
+        ],
+    )
+
+    # Kernels inherit the server process environment at spawn time, so exporting
+    # here (startup, before any kernel exists) is what makes `import geolibre`
+    # work from an externally driven kernel with no configuration.
+    os.environ[ENV_RELAY_URL] = relay_base_url(serverapp.ip, serverapp.port, base_url)
+    os.environ[ENV_RELAY_TOKEN] = _server_token(serverapp)
+    serverapp.log.info("GeoLibre map-command relay listening at %s", prefix)
+
+
+def _server_token(serverapp: Any) -> str:
+    """Best-effort read of the server's auth token across Jupyter Server versions."""
+    identity_provider = getattr(serverapp, "identity_provider", None)
+    token = getattr(identity_provider, "token", None)
+    if not isinstance(token, str):
+        token = getattr(serverapp, "token", None)
+    return token if isinstance(token, str) else ""

--- a/backend/geolibre_server/jupyter_server_config.py
+++ b/backend/geolibre_server/jupyter_server_config.py
@@ -27,6 +27,13 @@ _FRAME_ANCESTORS = (
 
 c = get_config()  # noqa: F821  (provided by the Jupyter config loader)
 
+# The map-command relay (geolibre_server/jupyter_relay.py). It lets ANY client of
+# this server — the embedded Notebook panel, but also an external frontend such
+# as VS Code's Jupyter extension — drive the live map, because commands travel
+# over a loopback endpoint instead of depending on the notebook being rendered
+# inside the app's iframe. See docs/notebook.md.
+c.ServerApp.jpserver_extensions = {"geolibre_server.jupyter_relay": True}
+
 c.ServerApp.tornado_settings = {
     "headers": {
         "Content-Security-Policy": _FRAME_ANCESTORS,

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -1,9 +1,10 @@
 """``geolibre`` — drive the host GeoLibre map from a notebook cell.
 
 This module is made importable inside GeoLibre's **Notebook panel** (both the
-in-browser JupyterLite kernel on web and the JupyterLab server on desktop). It
-is the kernel side of the notebook scripting bridge: it forwards commands to the
-GeoLibre app that embeds this notebook (the parent window).
+in-browser JupyterLite kernel on web and the JupyterLab server on desktop), and
+in any kernel of the desktop app's Jupyter server — including one driven from an
+external client such as VS Code's Jupyter extension. It is the kernel side of the
+notebook scripting bridge: it forwards commands to the running GeoLibre app.
 
 Scope: this client speaks GeoLibre's **scripting bridge** (the same
 ``createScriptingHandlers`` surface used by the in-app Python console). That is a
@@ -19,6 +20,23 @@ browser/WebAssembly kernel) and a real JupyterLab server, with no
 ``anywidget``/comm dependency. Consequently *read-back* queries (``get_view``,
 ``identify``, ``list_layers``, …) are not available here — they need the blocking
 request/reply path the ``geolibre`` widget uses.
+
+Two transports carry those commands, picked per call:
+
+1. **The relay** (``geolibre_server/jupyter_relay.py``), when the kernel belongs
+   to a GeoLibre desktop Jupyter server. Commands are POSTed to a loopback
+   endpoint the app subscribes to, so they arrive no matter which *frontend* is
+   driving the kernel — the Notebook panel, or an external client such as VS
+   Code's Jupyter extension (issue #1442).
+2. **``display(Javascript(...))`` → ``window.parent.postMessage``**, the fallback.
+   This only reaches the map when the notebook is rendered inside the app's own
+   iframe, which is exactly the case on web (JupyterLite).
+
+When neither can deliver, the call emits a :class:`GeoLibreNotConnectedWarning`
+rather than doing nothing at all. Turn it into an error with::
+
+    import warnings, geolibre
+    warnings.simplefilter("error", geolibre.GeoLibreNotConnectedWarning)
 
 Usage::
 
@@ -38,26 +56,97 @@ and the desktop launcher copies it onto the kernel's import path
 from __future__ import annotations
 
 import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import warnings
 from typing import Any, Iterable, Sequence
 
 from IPython.display import Javascript, display
 
-__all__ = ["HostMap", "Map", "connect"]
+__all__ = [
+    "GeoLibreNotConnectedWarning",
+    "HostMap",
+    "Map",
+    "connect",
+    "is_connected",
+]
+
+# Published by the relay extension into the Jupyter server's environment, which
+# every kernel it spawns inherits. See geolibre_server/jupyter_relay.py.
+_RELAY_URL_ENV = "GEOLIBRE_RELAY_URL"
+_RELAY_TOKEN_ENV = "GEOLIBRE_RELAY_TOKEN"
+
+# Loopback round-trip to the local app. Short: a hung relay must not stall a
+# notebook, and the caller only loses a fire-and-forget command.
+_RELAY_TIMEOUT_SECONDS = 5.0
+
+_NOT_CONNECTED_HINT = (
+    "The command was not delivered to a GeoLibre map. Open GeoLibre Desktop and "
+    "its Notebook panel (Processing -> Jupyter Notebook) so the app is running "
+    "and connected to this Jupyter server, then run the cell again."
+)
 
 
-def _send(method: str, params: dict[str, Any] | None = None) -> None:
-    """Post one scripting command up to the host GeoLibre app window.
+class GeoLibreNotConnectedWarning(UserWarning):
+    """Warned when a map command could not be delivered to a GeoLibre window."""
 
-    The notebook document is itself an iframe inside the app, so
-    ``window.parent`` is the app. An empty ``requestId`` marks a fire-and-forget
-    call (the host still replies; we just don't await it).
+
+def _relay_url() -> str | None:
+    """Return the relay base URL for this kernel, or None when there is none."""
+    url = os.environ.get(_RELAY_URL_ENV, "").strip()
+    return url.rstrip("/") or None
+
+
+def _is_browser_kernel() -> bool:
+    """Whether this kernel runs in the browser (JupyterLite / Pyodide).
+
+    There the notebook page is itself the app's iframe, so the ``postMessage``
+    transport is the right (and only) one, and a missing relay is expected.
     """
-    message = {
-        "type": "geolibre:command",
-        "requestId": "",
-        "method": method,
-        "params": params or {},
-    }
+    return sys.platform == "emscripten"
+
+
+def _post_to_relay(url: str, message: dict[str, Any]) -> tuple[int, str | None]:
+    """POST one command to the relay.
+
+    Args:
+        url: The relay base URL (no trailing slash).
+        message: The command envelope to deliver.
+
+    Returns:
+        ``(delivered, error)`` — how many app windows received the command, and a
+        human-readable reason when the relay itself could not be reached.
+    """
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get(_RELAY_TOKEN_ENV, "").strip()
+    if token:
+        headers["Authorization"] = f"token {token}"
+    request = urllib.request.Request(  # noqa: S310 - fixed http:// loopback URL
+        f"{url}/command",
+        data=json.dumps(message).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - see above
+            request, timeout=_RELAY_TIMEOUT_SECONDS
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as error:
+        return 0, f"the local GeoLibre relay could not be reached ({error})"
+    delivered = payload.get("delivered")
+    return (delivered if isinstance(delivered, int) else 0), None
+
+
+def _post_message_via_display(message: dict[str, Any]) -> None:
+    """Emit the ``window.parent.postMessage`` transport as a display output.
+
+    The notebook document is an iframe inside the app, so ``window.parent`` is
+    the app. Inert in a frontend that does not execute JavaScript output (which
+    is why the relay is tried first).
+    """
     # json.dumps leaves "<" and ">" unescaped; escape them so a value containing
     # "</script>" (e.g. a layer name) can't break out of the <script> block that
     # IPython's Javascript() display wraps this code in. The \uXXXX escapes are
@@ -76,6 +165,82 @@ def _send(method: str, params: dict[str, Any] | None = None) -> None:
             "}"
         )
     )
+
+
+def is_connected() -> bool:
+    """Whether a GeoLibre window is currently listening for map commands.
+
+    Only the relay transport can answer this. On the in-browser kernel
+    (JupyterLite) commands travel through the notebook's own iframe and there is
+    nothing to ask, so this reports True.
+
+    Returns:
+        True when at least one GeoLibre window would receive a command now.
+    """
+    url = _relay_url()
+    if url is None:
+        return _is_browser_kernel()
+    headers = {}
+    token = os.environ.get(_RELAY_TOKEN_ENV, "").strip()
+    if token:
+        headers["Authorization"] = f"token {token}"
+    request = urllib.request.Request(  # noqa: S310 - fixed http:// loopback URL
+        f"{url}/status", headers=headers
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - see above
+            request, timeout=_RELAY_TIMEOUT_SECONDS
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+    return bool(payload.get("listeners"))
+
+
+def _send(method: str, params: dict[str, Any] | None = None) -> None:
+    """Post one scripting command to the host GeoLibre app.
+
+    Prefers the relay (works from any Jupyter frontend, and reports delivery);
+    falls back to the ``postMessage`` display transport (the embedded panel and
+    JupyterLite). An empty ``requestId`` marks a fire-and-forget call (the host
+    still replies; we just don't await it).
+
+    Warns with :class:`GeoLibreNotConnectedWarning` when the command provably did
+    not reach a map, so a disconnected setup never looks like a silent success.
+    """
+    message = {
+        "type": "geolibre:command",
+        "requestId": "",
+        "method": method,
+        "params": params or {},
+    }
+    url = _relay_url()
+    if url is not None:
+        delivered, error = _post_to_relay(url, message)
+        if delivered:
+            return
+        # Last-ditch: an app old enough to lack the relay socket still listens on
+        # postMessage, and this notebook may be embedded in its Notebook panel.
+        _post_message_via_display(message)
+        reason = error or "no GeoLibre window is connected to this Jupyter server"
+        # stacklevel=3: HostMap method -> _send -> the user's cell, so the warning
+        # points at their code (and repeats in each new cell rather than once).
+        warnings.warn(
+            f"GeoLibre: {reason}. {_NOT_CONNECTED_HINT}",
+            GeoLibreNotConnectedWarning,
+            stacklevel=3,
+        )
+        return
+
+    _post_message_via_display(message)
+    if not _is_browser_kernel():
+        warnings.warn(
+            "GeoLibre: this kernel is not running on a GeoLibre Jupyter server, "
+            "so map commands can only be delivered when the notebook is rendered "
+            f"inside the app's Notebook panel. {_NOT_CONNECTED_HINT}",
+            GeoLibreNotConnectedWarning,
+            stacklevel=3,
+        )
 
 
 def _to_featurecollection(data: Any) -> dict[str, Any]:
@@ -144,7 +309,7 @@ class HostMap:
     """A handle to the live map in the surrounding GeoLibre app."""
 
     def __repr__(self) -> str:
-        return "<GeoLibre map (live, connected to the app)>"
+        return "<GeoLibre map (commands are sent to the live app)>"
 
     # -- camera ---------------------------------------------------------------
 
@@ -257,7 +422,19 @@ class HostMap:
 
 
 def connect() -> HostMap:
-    """Return a handle to the live map in the surrounding GeoLibre app."""
+    """Return a handle to the live map in the surrounding GeoLibre app.
+
+    Warns with :class:`GeoLibreNotConnectedWarning` when no GeoLibre window is
+    listening, so a misconfigured session says so up front instead of at the
+    first command that quietly goes nowhere.
+    """
+    if _relay_url() is not None and not is_connected():
+        warnings.warn(
+            f"GeoLibre: no GeoLibre window is connected to this Jupyter server. "
+            f"{_NOT_CONNECTED_HINT}",
+            GeoLibreNotConnectedWarning,
+            stacklevel=2,
+        )
     return HostMap()
 
 

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -61,7 +61,8 @@ import sys
 import urllib.error
 import urllib.request
 import warnings
-from typing import Any, Iterable, Sequence
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 from IPython.display import Javascript, display
 

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -12,7 +12,7 @@ dev = ["pytest>=8.0.0", "pytest-cov>=5.0.0"]
 # the vector/raster/SQL/ML tests skip themselves (via skipif/importorskip), so a
 # `[dev]`-only install reports a misleadingly green, near-empty run. CI installs
 # this group; run it locally with `pip install -e "backend/geolibre_server[test]"`.
-test = ["geolibre-server[dev,vector,raster,conversion,ml,sedona,postgis]"]
+test = ["geolibre-server[dev,vector,raster,conversion,ml,sedona,postgis,notebook]"]
 whitebox = ["whitebox-workflows>=2.0.2"]
 conversion = ["duckdb>=1.1.0", "rio-cogeo>=5.0.0", "freestiler>=0.1.0"]
 # Optional GeoPandas engine for the Vector processing tools. Not installed by

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -1,0 +1,231 @@
+"""Tests for the Jupyter map-command relay (issue #1442).
+
+The relay is what lets a kernel driven by an EXTERNAL Jupyter frontend (VS
+Code's Jupyter extension) control the live map, so the cases that matter are:
+the command envelope it will broadcast, who may open the socket, the URL and
+environment it publishes to kernels, and the broadcast bookkeeping itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+jupyter_relay = pytest.importorskip(
+    "geolibre_server.jupyter_relay",
+    reason="needs the `notebook` extra (jupyter-server)",
+)
+
+
+class FakeSocket:
+    """Stands in for a connected app window."""
+
+    def __init__(self, *, fails: bool = False) -> None:
+        self.received: list[str] = []
+        self.fails = fails
+
+    def write_message(self, message: str) -> None:
+        if self.fails:
+            raise RuntimeError("socket is closed")
+        self.received.append(message)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_listeners():
+    """Keep each test's listener set independent of the module-level one."""
+    saved = set(jupyter_relay._listeners)
+    jupyter_relay._listeners.clear()
+    yield
+    jupyter_relay._listeners.clear()
+    jupyter_relay._listeners.update(saved)
+
+
+# -- the command envelope ----------------------------------------------------
+
+
+def test_normalize_command_fills_in_the_bridge_envelope():
+    message = jupyter_relay.normalize_command({"method": "flyTo", "params": {"zoom": 4}})
+    assert message == {
+        "type": "geolibre:command",
+        "requestId": "",
+        "method": "flyTo",
+        "params": {"zoom": 4},
+    }
+
+
+def test_normalize_command_keeps_a_string_request_id():
+    message = jupyter_relay.normalize_command({"method": "flyTo", "requestId": "abc"})
+    assert message["requestId"] == "abc"
+
+
+def test_normalize_command_defaults_missing_params_to_an_empty_object():
+    assert jupyter_relay.normalize_command({"method": "getView"})["params"] == {}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ["not", "an", "object"],
+        {},
+        {"method": ""},
+        {"method": 42},
+        {"method": "flyTo", "params": [1, 2]},
+    ],
+)
+def test_normalize_command_rejects_malformed_payloads(payload):
+    with pytest.raises(ValueError):
+        jupyter_relay.normalize_command(payload)
+
+
+# -- who may drive the map ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        None,
+        "",
+        "tauri://localhost",
+        "https://tauri.localhost",
+        "http://localhost:5173",
+        "http://127.0.0.1:8766",
+    ],
+)
+def test_allows_the_app_origins(origin):
+    assert jupyter_relay.is_allowed_origin(origin) is True
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://evil.example.com",
+        "http://localhost.evil.example.com",
+        "file://",
+        "ftp://127.0.0.1",
+    ],
+)
+def test_rejects_foreign_origins(origin):
+    assert jupyter_relay.is_allowed_origin(origin) is False
+
+
+# -- what kernels are told ---------------------------------------------------
+
+
+def test_relay_base_url_joins_the_server_base_url():
+    assert (
+        jupyter_relay.relay_base_url("127.0.0.1", 8766, "/")
+        == "http://127.0.0.1:8766/geolibre/relay"
+    )
+
+
+def test_relay_base_url_honors_a_prefixed_server():
+    assert (
+        jupyter_relay.relay_base_url("127.0.0.1", 8766, "/jupyter/")
+        == "http://127.0.0.1:8766/jupyter/geolibre/relay"
+    )
+
+
+@pytest.mark.parametrize("host", ["", "0.0.0.0", "::"])
+def test_relay_base_url_falls_back_to_loopback(host):
+    # A wildcard bind is not an address a kernel can POST to.
+    assert jupyter_relay.relay_base_url(host, 8766, "/").startswith("http://127.0.0.1:8766")
+
+
+# -- broadcasting ------------------------------------------------------------
+
+
+def test_broadcast_reaches_every_listener_and_counts_them():
+    first, second = FakeSocket(), FakeSocket()
+    jupyter_relay._listeners.update({first, second})
+
+    delivered = jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"})
+
+    assert delivered == 2
+    assert json.loads(first.received[0])["method"] == "flyTo"
+    assert json.loads(second.received[0])["method"] == "flyTo"
+
+
+def test_broadcast_drops_a_dead_listener_instead_of_failing():
+    alive, dead = FakeSocket(), FakeSocket(fails=True)
+    jupyter_relay._listeners.update({alive, dead})
+
+    delivered = jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"})
+
+    assert delivered == 1
+    assert dead not in jupyter_relay._listeners
+    assert alive in jupyter_relay._listeners
+
+
+def test_broadcast_with_no_listeners_reports_zero():
+    # This zero is what the kernel client turns into a "nothing is listening"
+    # warning rather than a silent no-op.
+    assert jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"}) == 0
+
+
+# -- extension load ----------------------------------------------------------
+
+
+class FakeWebApp:
+    def __init__(self) -> None:
+        self.settings = {"base_url": "/"}
+        self.added: list[tuple[str, object]] = []
+
+    def add_handlers(self, host_pattern, handlers):  # noqa: ARG002 - signature parity
+        self.added.extend(handlers)
+
+
+class FakeLog:
+    def info(self, *args, **kwargs) -> None:
+        """Swallow the startup log line."""
+
+
+class FakeIdentityProvider:
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+
+class FakeServerApp:
+    def __init__(self, token: str = "s3cret") -> None:
+        self.web_app = FakeWebApp()
+        self.ip = "127.0.0.1"
+        self.port = 8766
+        self.log = FakeLog()
+        self.identity_provider = FakeIdentityProvider(token)
+
+
+def test_load_registers_the_endpoints_and_publishes_them_to_kernels(monkeypatch):
+    monkeypatch.delenv(jupyter_relay.ENV_RELAY_URL, raising=False)
+    monkeypatch.delenv(jupyter_relay.ENV_RELAY_TOKEN, raising=False)
+    serverapp = FakeServerApp()
+
+    jupyter_relay._load_jupyter_server_extension(serverapp)
+
+    routes = [route for route, _ in serverapp.web_app.added]
+    assert routes == [
+        "/geolibre/relay/socket",
+        "/geolibre/relay/command",
+        "/geolibre/relay/status",
+    ]
+    # Kernels the server spawns inherit these, which is what makes an externally
+    # driven kernel able to find the map with no configuration.
+    assert os.environ[jupyter_relay.ENV_RELAY_URL] == "http://127.0.0.1:8766/geolibre/relay"
+    assert os.environ[jupyter_relay.ENV_RELAY_TOKEN] == "s3cret"
+
+
+def test_load_tolerates_a_tokenless_server(monkeypatch):
+    monkeypatch.delenv(jupyter_relay.ENV_RELAY_TOKEN, raising=False)
+    serverapp = FakeServerApp()
+    serverapp.identity_provider = FakeIdentityProvider(None)  # type: ignore[arg-type]
+    serverapp.token = None
+
+    jupyter_relay._load_jupyter_server_extension(serverapp)
+
+    assert os.environ[jupyter_relay.ENV_RELAY_TOKEN] == ""
+
+
+def test_extension_points_declare_this_module():
+    assert jupyter_relay._jupyter_server_extension_points() == [
+        {"module": "geolibre_server.jupyter_relay"}
+    ]

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -1,0 +1,188 @@
+"""Tests for the kernel-side ``geolibre`` client's transport choice (issue #1442).
+
+``notebook_client.py`` has to reach the live map from three very different
+kernels: the desktop Notebook panel, an external frontend attached to the same
+Jupyter server (VS Code), and JupyterLite in the browser. What it must never do
+again is quietly do nothing, so every path here is checked for *which* transport
+it used and whether it warned.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+pytest.importorskip("IPython", reason="the notebook client renders IPython displays")
+
+import notebook_client  # noqa: E402
+
+
+class FakeResponse(io.BytesIO):
+    """Minimal ``urlopen`` result: a context manager exposing ``read()``."""
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+
+@pytest.fixture
+def relay(monkeypatch):
+    """Point the client at a relay and record what it posts."""
+    monkeypatch.setenv(notebook_client._RELAY_URL_ENV, "http://127.0.0.1:8766/geolibre/relay")
+    monkeypatch.setenv(notebook_client._RELAY_TOKEN_ENV, "s3cret")
+
+    class Relay:
+        listeners = 1
+        error: Exception | None = None
+        calls: list[object] = []
+
+    def fake_urlopen(request, timeout=None):  # noqa: ARG001 - signature parity
+        Relay.calls.append(request)
+        if Relay.error is not None:
+            raise Relay.error
+        body = (
+            {"listeners": Relay.listeners}
+            if request.full_url.endswith("/status")
+            else {"delivered": Relay.listeners}
+        )
+        return FakeResponse(json.dumps(body).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    return Relay
+
+
+@pytest.fixture
+def displays(monkeypatch):
+    """Capture the ``display(Javascript(...))`` fallback transport."""
+    captured: list[object] = []
+    monkeypatch.setattr(notebook_client, "display", captured.append)
+    return captured
+
+
+# -- the relay transport (any Jupyter frontend, including VS Code) -----------
+
+
+def test_uses_the_relay_and_stays_quiet_when_a_window_receives_it(relay, displays, recwarn):
+    notebook_client.HostMap().fly_to(-122.4, 37.8, zoom=11)
+
+    assert len(relay.calls) == 1
+    request = relay.calls[0]
+    assert request.full_url == "http://127.0.0.1:8766/geolibre/relay/command"
+    assert json.loads(request.data) == {
+        "type": "geolibre:command",
+        "requestId": "",
+        "method": "flyTo",
+        "params": {"center": [-122.4, 37.8], "zoom": 11.0},
+    }
+    # Delivered, so no postMessage output and nothing to warn about.
+    assert displays == []
+    assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+
+def test_authenticates_with_the_server_token(relay, displays):
+    notebook_client.HostMap().fly_to(0, 0)
+
+    assert relay.calls[0].get_header("Authorization") == "token s3cret"
+
+
+def test_warns_when_no_window_is_listening(relay, displays):
+    relay.listeners = 0
+
+    with pytest.warns(notebook_client.GeoLibreNotConnectedWarning, match="no GeoLibre window"):
+        notebook_client.HostMap().fly_to(0, 0)
+
+    # Still tries the embedded-panel transport rather than dropping the command.
+    assert len(displays) == 1
+
+
+def test_warns_when_the_relay_cannot_be_reached(relay, displays):
+    relay.error = urllib.error.URLError("connection refused")
+
+    with pytest.warns(notebook_client.GeoLibreNotConnectedWarning, match="could not be reached"):
+        notebook_client.HostMap().fly_to(0, 0)
+
+    assert len(displays) == 1
+
+
+def test_connect_warns_up_front_when_nothing_is_listening(relay):
+    relay.listeners = 0
+
+    with pytest.warns(notebook_client.GeoLibreNotConnectedWarning):
+        notebook_client.connect()
+
+
+def test_connect_is_quiet_when_a_window_is_listening(relay, recwarn):
+    notebook_client.connect()
+
+    assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+
+def test_is_connected_reports_the_relay_status(relay):
+    assert notebook_client.is_connected() is True
+    relay.listeners = 0
+    assert notebook_client.is_connected() is False
+
+
+def test_is_connected_is_false_when_the_relay_is_unreachable(relay):
+    relay.error = OSError("boom")
+
+    assert notebook_client.is_connected() is False
+
+
+# -- the postMessage transport (embedded panel / JupyterLite) ----------------
+
+
+def test_falls_back_to_post_message_without_a_relay(monkeypatch, displays):
+    monkeypatch.delenv(notebook_client._RELAY_URL_ENV, raising=False)
+    monkeypatch.setattr(notebook_client.sys, "platform", "emscripten")
+
+    notebook_client.HostMap().fly_to(0, 0)
+
+    # JupyterLite: the notebook page IS the app's iframe, so this is the right
+    # transport and there is nothing to warn about.
+    assert len(displays) == 1
+
+
+def test_warns_on_a_plain_kernel_with_no_relay(monkeypatch, displays):
+    monkeypatch.delenv(notebook_client._RELAY_URL_ENV, raising=False)
+    monkeypatch.setattr(notebook_client.sys, "platform", "linux")
+
+    with pytest.warns(
+        notebook_client.GeoLibreNotConnectedWarning, match="not running on a GeoLibre Jupyter"
+    ):
+        notebook_client.HostMap().fly_to(0, 0)
+
+    assert len(displays) == 1
+
+
+def test_is_connected_without_a_relay_follows_the_kernel_kind(monkeypatch):
+    monkeypatch.delenv(notebook_client._RELAY_URL_ENV, raising=False)
+    monkeypatch.setattr(notebook_client.sys, "platform", "emscripten")
+    assert notebook_client.is_connected() is True
+
+    monkeypatch.setattr(notebook_client.sys, "platform", "linux")
+    assert notebook_client.is_connected() is False
+
+
+# -- payloads ----------------------------------------------------------------
+
+
+def test_add_geojson_wraps_a_bare_geometry(relay, displays):
+    notebook_client.HostMap().add_geojson({"type": "Point", "coordinates": [1, 2]}, name="Pin")
+
+    params = json.loads(relay.calls[0].data)["params"]
+    assert params["name"] == "Pin"
+    assert params["geojson"]["features"][0]["geometry"]["coordinates"] == [1, 2]
+
+
+def test_add_markers_builds_a_point_collection(relay, displays):
+    notebook_client.HostMap().add_markers([(-122.4, 37.8), {"lng": 1, "lat": 2, "kind": "x"}])
+
+    features = json.loads(relay.calls[0].data)["params"]["geojson"]["features"]
+    assert [f["geometry"]["coordinates"] for f in features] == [[-122.4, 37.8], [1.0, 2.0]]
+    assert features[1]["properties"] == {"kind": "x"}

--- a/backend/geolibre_server/uv.lock
+++ b/backend/geolibre_server/uv.lock
@@ -522,7 +522,7 @@ name = "click-plugins"
 version = "1.1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
+    { name = "click", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
 wheels = [
@@ -567,7 +567,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -645,7 +645,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -920,7 +920,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1140,9 +1140,12 @@ test = [
     { name = "freestiler" },
     { name = "geopandas" },
     { name = "httpx" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pip" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1167,7 +1170,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'conversion'", specifier = ">=1.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "freestiler", marker = "extra == 'conversion'", specifier = ">=0.1.0" },
-    { name = "geolibre-server", extras = ["dev", "vector", "raster", "conversion", "ml", "sedona", "postgis"], marker = "extra == 'test'" },
+    { name = "geolibre-server", extras = ["dev", "vector", "raster", "conversion", "ml", "sedona", "postgis", "notebook"], marker = "extra == 'test'" },
     { name = "geopandas", marker = "extra == 'sedona'", specifier = ">=1.0" },
     { name = "geopandas", marker = "extra == 'vector'", specifier = ">=1.0" },
     { name = "httpx", marker = "extra == 'ml'", specifier = ">=0.27" },
@@ -1346,17 +1349,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1379,18 +1382,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -1402,7 +1405,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1800,9 +1803,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "pydantic" },
-    { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version < '3.11'" },
+    { name = "pydantic", marker = "python_full_version < '3.11'" },
+    { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/72/2d0e1f1e936538004581f792f8a2377831761fd12e4ed0a665abf768fc60/morecantile-6.2.0.tar.gz", hash = "sha256:65c7150ea68bbe16ee6f75f3f171ac1ae51ab26e7a77c92a768048f40f916412", size = 46317, upload-time = "2024-12-19T15:35:47.233Z" }
 wheels = [
@@ -1825,10 +1828,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "click" },
-    { name = "pydantic" },
-    { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version >= '3.11'" },
+    { name = "click", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/44/fa4f0685481b51e5ce33089ca84e821453593d34f306738515a937934751/morecantile-7.0.3.tar.gz", hash = "sha256:b44419c83f310b411b1f547df2d07c115dc6d194ab7c8a4c318a154490e938c1", size = 43104, upload-time = "2026-02-04T23:03:26.423Z" }
 wheels = [
@@ -2145,10 +2148,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2217,10 +2220,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2296,7 +2299,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2726,7 +2729,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/10/a8480ea27ea4bbe896c168808854d00f2a9b49f95c0319ddcbba693c8a90/pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47", size = 226339, upload-time = "2025-02-16T04:28:46.621Z" }
 wheels = [
@@ -2780,7 +2783,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "certifi" },
+    { name = "certifi", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
 wheels = [
@@ -3081,15 +3084,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "affine" },
-    { name = "attrs" },
-    { name = "certifi" },
-    { name = "click" },
-    { name = "click-plugins" },
-    { name = "cligj" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
+    { name = "affine", marker = "python_full_version < '3.12'" },
+    { name = "attrs", marker = "python_full_version < '3.12'" },
+    { name = "certifi", marker = "python_full_version < '3.12'" },
+    { name = "click", marker = "python_full_version < '3.12'" },
+    { name = "click-plugins", marker = "python_full_version < '3.12'" },
+    { name = "cligj", marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "pyparsing" },
+    { name = "pyparsing", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fa/fce8dc9f09e5bc6520b6fc1b4ecfa510af9ca06eb42ad7bdff9c9b8989d0/rasterio-1.4.4.tar.gz", hash = "sha256:c95424e2c7f009b8f7df1095d645c52895cd332c0c2e1b4c2e073ea28b930320", size = 445004, upload-time = "2025-12-12T18:01:08.971Z" }
 wheels = [
@@ -3149,13 +3152,13 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "affine" },
-    { name = "attrs" },
-    { name = "certifi" },
-    { name = "click" },
-    { name = "cligj" },
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
+    { name = "affine", marker = "python_full_version >= '3.12'" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "certifi", marker = "python_full_version >= '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.12'" },
+    { name = "cligj", marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/88/edb4b66b6cb2c13f123af5a3896bf70c0cbe73ab3cd4243cb4eb0212a0f6/rasterio-1.5.0.tar.gz", hash = "sha256:1e0ea56b02eea4989b36edf8e58a5a3ef40e1b7edcb04def2603accd5ab3ee7b", size = 452184, upload-time = "2026-01-05T16:06:47.169Z" }
 wheels = [
@@ -3262,10 +3265,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "click" },
-    { name = "morecantile", version = "6.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydantic" },
-    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "click", marker = "python_full_version < '3.11'" },
+    { name = "morecantile", version = "6.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pydantic", marker = "python_full_version < '3.11'" },
+    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/14/1c00dc4795ac3ee6a040d79e215ad9f84e14ef04d04fd592fdd0f62504bb/rio_cogeo-6.0.0.tar.gz", hash = "sha256:d215904c3b348edda1e38340f0dfdda5ffdf865ab9871df1fc55b6142dd58bb3", size = 21189, upload-time = "2025-11-05T10:37:21.794Z" }
 wheels = [
@@ -3288,10 +3291,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "click" },
-    { name = "morecantile", version = "7.0.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydantic" },
-    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "click", marker = "python_full_version >= '3.11'" },
+    { name = "morecantile", version = "7.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "rasterio", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/01/3b88154233db4cb29cc54df64006537fadb8d7c2ace872af985dac972fd3/rio_cogeo-7.0.2.tar.gz", hash = "sha256:1454ff94dca8652db68862d667bf47e54ecabfe8872c939f2c16ebb62d432f69", size = 19282, upload-time = "2026-03-27T08:25:27.554Z" }

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -38,13 +38,54 @@ m.remove_layer(layer_id)
 Calls are **fire-and-forget**: each posts a command to the host app over the
 shared scripting protocol (the same `createScriptingHandlers` surface used by the
 in-app Python console and the Jupyter widget) and returns immediately, so the
-client behaves identically on the in-browser kernel and a real server. The
-app-side endpoint is `useNotebookBridge` in
-`apps/geolibre-desktop/src/hooks/`. Canonical client source:
-`backend/geolibre_server/notebook_client.py`.
+client behaves identically on the in-browser kernel and a real server. Canonical
+client source: `backend/geolibre_server/notebook_client.py`.
 
 > Read-back queries (e.g. `get_center`) are not exposed by this fire-and-forget
 > client; they need the blocking request/reply path the `geolibre` widget uses.
+
+## Driving the map from an external client (VS Code, …)
+
+The desktop app's JupyterLab server is a normal, token-authenticated Jupyter
+server, so you can attach any Jupyter client to it and keep your own editor —
+and the map commands above still work. Open the Notebook panel once (that is
+what starts the server), then use its **link button** in the panel header to copy
+the connection URL and paste it into your client (in VS Code: *Jupyter: Specify
+Jupyter Server for Connections* → *Existing*).
+
+This works because commands travel over a **relay** on the Jupyter server rather
+than depending on how the notebook is being *displayed*:
+
+- `backend/geolibre_server/geolibre_server/jupyter_relay.py` is a Jupyter Server
+  extension (enabled from `jupyter_server_config.py`) exposing
+  `POST …/geolibre/relay/command`, a `…/geolibre/relay/socket` WebSocket, and
+  `GET …/geolibre/relay/status`. At load it publishes `GEOLIBRE_RELAY_URL` and
+  `GEOLIBRE_RELAY_TOKEN` into the server's environment, which **kernels inherit**
+  — that is how `import geolibre` finds the map with no configuration.
+- The app subscribes to that socket for its whole lifetime
+  (`useJupyterRelay`), reconnecting with backoff, and runs each command against
+  the same `createScriptingHandlers` surface.
+- `useNotebookBridge` remains the postMessage path for the **embedded** panel and
+  for web (JupyterLite), where the notebook page really is the app's iframe.
+
+The POST answers with how many app windows received the command, so a
+disconnected session is reported instead of silently doing nothing:
+
+```python
+geolibre.is_connected()   # False -> no GeoLibre window is listening
+```
+
+When a command cannot be delivered the client raises a
+`GeoLibreNotConnectedWarning` pointing at your own line. Promote it to an error
+with:
+
+```python
+import warnings, geolibre
+warnings.simplefilter("error", geolibre.GeoLibreNotConnectedWarning)
+```
+
+Only the desktop server has the relay: on web (JupyterLite) there is no server to
+attach an external client to.
 
 ## Theme
 
@@ -99,3 +140,7 @@ precache (see `pwaPlugin` in `apps/geolibre-desktop/vite.config.ts`).
   `Content-Security-Policy: frame-ancestors` to the Tauri webview / loopback
   origins so the app can embed the server; the Tauri CSP (`tauri.conf.json`)
   adds the loopback origins to `frame-src`/`child-src`.
+- Map-command relay: the same config enables the `geolibre_server.jupyter_relay`
+  server extension (see above). Its WebSocket accepts only the app's own origins
+  and every endpoint requires the server's per-launch token, so a command can
+  only come from something that already has kernel-execution rights there.

--- a/tests/jupyter-relay.test.ts
+++ b/tests/jupyter-relay.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  RELAY_RECONNECT_MAX_MS,
+  RELAY_RECONNECT_MIN_MS,
+  parseRelayMessage,
+  relayReconnectDelay,
+  relaySocketUrl,
+} from "../apps/geolibre-desktop/src/lib/jupyter-relay";
+
+// The wire format the app shares with the desktop Jupyter map-command relay
+// (backend/geolibre_server/geolibre_server/jupyter_relay.py), which is what lets
+// an external Jupyter client (VS Code) drive the map — issue #1442.
+
+const SERVER = { url: "http://127.0.0.1:8766", port: 8766, token: "s3cret" };
+
+describe("relaySocketUrl", () => {
+  it("points at the relay socket with the server token", () => {
+    assert.equal(relaySocketUrl(SERVER), "ws://127.0.0.1:8766/geolibre/relay/socket?token=s3cret");
+  });
+
+  it("upgrades an https server to wss", () => {
+    assert.equal(
+      relaySocketUrl({ ...SERVER, url: "https://127.0.0.1:8766" }),
+      "wss://127.0.0.1:8766/geolibre/relay/socket?token=s3cret",
+    );
+  });
+
+  it("does not double up the path separator", () => {
+    assert.equal(
+      relaySocketUrl({ ...SERVER, url: "http://127.0.0.1:8766/" }),
+      "ws://127.0.0.1:8766/geolibre/relay/socket?token=s3cret",
+    );
+  });
+
+  it("escapes a token with URL-significant characters", () => {
+    const url = new URL(relaySocketUrl({ ...SERVER, token: "a b&c=d" }));
+    assert.equal(url.searchParams.get("token"), "a b&c=d");
+  });
+
+  it("omits the token when the server has none", () => {
+    assert.equal(
+      relaySocketUrl({ ...SERVER, token: "" }),
+      "ws://127.0.0.1:8766/geolibre/relay/socket",
+    );
+  });
+});
+
+describe("parseRelayMessage", () => {
+  it("accepts a command envelope", () => {
+    const command = parseRelayMessage(
+      JSON.stringify({
+        type: "geolibre:command",
+        requestId: "",
+        method: "flyTo",
+        params: { zoom: 4 },
+      }),
+    );
+    assert.deepEqual(command, { method: "flyTo", params: { zoom: 4 } });
+  });
+
+  it("defaults missing or non-object params to an empty object", () => {
+    for (const params of [undefined, null, "nope", [1, 2]]) {
+      const command = parseRelayMessage(
+        JSON.stringify({ type: "geolibre:command", method: "x", params }),
+      );
+      assert.deepEqual(command?.params, {});
+    }
+  });
+
+  it("ignores the relay's ready greeting", () => {
+    assert.equal(parseRelayMessage(JSON.stringify({ type: "geolibre:relay-ready" })), null);
+  });
+
+  it("rejects anything that is not a command", () => {
+    // A frame that is not ours must never be dispatched as a map command.
+    assert.equal(parseRelayMessage(JSON.stringify({ type: "other", method: "flyTo" })), null);
+    assert.equal(parseRelayMessage(JSON.stringify({ type: "geolibre:command" })), null);
+    assert.equal(parseRelayMessage(JSON.stringify({ type: "geolibre:command", method: "" })), null);
+    assert.equal(parseRelayMessage(JSON.stringify({ type: "geolibre:command", method: 7 })), null);
+    assert.equal(parseRelayMessage(JSON.stringify(["geolibre:command"])), null);
+    assert.equal(parseRelayMessage("not json"), null);
+    assert.equal(parseRelayMessage(new ArrayBuffer(4)), null);
+    assert.equal(parseRelayMessage(null), null);
+  });
+});
+
+describe("relayReconnectDelay", () => {
+  it("starts at the minimum and backs off exponentially", () => {
+    assert.equal(relayReconnectDelay(0), RELAY_RECONNECT_MIN_MS);
+    assert.equal(relayReconnectDelay(1), RELAY_RECONNECT_MIN_MS * 2);
+    assert.equal(relayReconnectDelay(2), RELAY_RECONNECT_MIN_MS * 4);
+  });
+
+  it("caps the delay so a restarted server is picked up promptly", () => {
+    assert.equal(relayReconnectDelay(50), RELAY_RECONNECT_MAX_MS);
+  });
+
+  it("treats a negative attempt count as the first one", () => {
+    assert.equal(relayReconnectDelay(-3), RELAY_RECONNECT_MIN_MS);
+  });
+});


### PR DESCRIPTION
Fixes #1442

## The problem

`geolibre.connect()` delivered every map command as a `display(Javascript(...))`
output that calls `window.parent.postMessage(...)`. That reaches the map only
when the notebook is rendered *inside* the app's own Notebook-panel iframe.
Attach an external Jupyter frontend to the desktop app's Jupyter server (VS
Code's Jupyter extension, `jupyter console`, nbclient) and cell execution works
but `fly_to()` / `add_geojson()` silently do nothing, with no error to explain it.

Reproduced against a real kernel started through the server's REST API (exactly
what VS Code does): the command left the kernel only as an inert
`application/javascript` display payload.

## The fix

A transport that depends on which **server** the kernel belongs to, not on how
the notebook is being displayed.

**`geolibre_server/jupyter_relay.py`** - a Jupyter Server extension enabled from
`jupyter_server_config.py`:

| Endpoint | Who calls it |
| --- | --- |
| `POST .../geolibre/relay/command` | the kernel; answers `{"delivered": n}` |
| `GET .../geolibre/relay/socket` (WebSocket) | the app; receives the broadcast |
| `GET .../geolibre/relay/status` | `{"listeners": n}` |

At load it exports `GEOLIBRE_RELAY_URL` / `GEOLIBRE_RELAY_TOKEN` into the server
process environment, which kernels inherit at spawn. That is what makes an
externally driven kernel work with **no configuration and no launcher change**
(no Rust edit was needed).

**`useJupyterRelay`** subscribes the app to that socket for its whole lifetime
(reconnecting with capped backoff) and runs each command through the same
`createScriptingHandlers` surface as `useNotebookBridge`, the in-app console and
the Jupyter widget, so the transports cannot drift.

**The kernel client** prefers the relay and keeps `postMessage` as the fallback
for the embedded panel and JupyterLite (where the notebook page really is the
app's iframe). Because the POST reports how many windows received the command,
issue point 2 comes for free: an undeliverable call now warns instead of quietly
succeeding.

```python
geolibre.is_connected()   # False -> nothing is listening

import warnings, geolibre
warnings.simplefilter("error", geolibre.GeoLibreNotConnectedWarning)
```

The warning points at the user's own line, and `connect()` warns up front.

**Discoverability:** the Notebook panel header gains a link button that copies
the server URL an external client attaches to, which is the only setup step left.

## Security

Every relay endpoint requires the server's per-launch token, and the WebSocket
accepts only the app's own origins (the same set `jupyter_server_config.py`
already allows to frame the server). The server binds loopback, so a command can
only come from something that already has full kernel-execution rights there.

## Verification

Real JupyterLab server with this config, real kernels started over its REST API,
and the real app in a browser - not mocks:

- **External kernel drives the map**: added `us_cities.geojson` (109 features)
  and `las-vegas-buildings.geojson` (540 features) as layers, flew the camera,
  and switched the basemap; all landed. Verified in **both light and dark**
  themes.
- **Nothing listening**: `is_connected() -> False` and a
  `GeoLibreNotConnectedWarning` quoting the user's own line, where the old client
  returned silently.
- **Resilience**: killing and restarting the Jupyter server; the app reconnected
  on its own and `listeners` returned to 1.
- `npm run build`, `npm run test:frontend` (3827 pass), backend pytest, and
  `pre-commit run --files ...` all clean. The one pre-existing local failure
  (`test_conversion_gdb.py`) reproduces on a clean `main`.

## Notes

- `backend/geolibre_server/uv.lock` is refreshed for the `test` extra, which now
  includes `notebook` so the new backend tests actually run in CI instead of
  skipping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop Jupyter relay to drive the live map from external notebook clients.
  * Notebook panel now provides a token-authenticated server URL with a one-click copy action.
  * Added connection-aware delivery with clear warnings when commands can’t be delivered, including fallback behavior when the relay isn’t available.
* **Documentation**
  * Expanded notebook documentation with desktop relay behavior, token usage, and troubleshooting.
* **Tests**
  * Added/extended coverage for relay URL construction, message parsing/validation, reconnect timing, delivery/broadcast behavior, authentication, and fallback delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->