### PR TITLE
feat(add-data): add OGC API - Features collections as vector layers

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -14,6 +14,7 @@ import { GdbSource } from "./add-data/sources/GdbSource";
 import { GeoRssSource } from "./add-data/sources/GeoRssSource";
 import { GpxSource } from "./add-data/sources/GpxSource";
 import { MbtilesSource } from "./add-data/sources/MbtilesSource";
+import { OgcFeaturesSource } from "./add-data/sources/OgcFeaturesSource";
 import { OgcVectorTilesSource } from "./add-data/sources/OgcVectorTilesSource";
 import { PhotosSource } from "./add-data/sources/PhotosSource";
 import { PostgresSource } from "./add-data/sources/PostgresSource";
@@ -64,6 +65,8 @@ function renderSource(
       return <WfsSource />;
     case "wmts":
       return <WmtsSource />;
+    case "ogc-features":
+      return <OgcFeaturesSource />;
     case "ogc-vector-tiles":
       return <OgcVectorTilesSource />;
     case "gpx":

--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -26,6 +26,7 @@ import type { MapController } from "@geolibre/map";
 import type { ArcGISLayerType, ArcGISSourceType } from "@geolibre/plugins";
 import type { FeatureCollection } from "geojson";
 import type { RefObject } from "react";
+import { OGC_FEATURES_SOURCE_KIND } from "../../../lib/ogc-api-features";
 import type { ResolvedXyzTileUrl } from "../../../lib/xyz-url";
 import {
   attributionForTileUrl,
@@ -292,6 +293,63 @@ export function buildWfsGeoJsonLayer(params: WfsLayerParams): GeoLibreLayer {
     ),
     geojson: params.data,
     sourcePath: params.featureUrl,
+  };
+}
+
+// --- OGC API - Features ----------------------------------------------------
+
+export interface OgcFeaturesLayerParams {
+  name: string;
+  /** The first page's `/items` request URL, replayed on refresh. */
+  itemsUrl: string;
+  data: FeatureCollection;
+  baseUrl: string;
+  collectionId: string;
+  maxFeatures: number;
+  bbox?: string;
+  datetime?: string;
+  extraQuery?: string;
+  /** The server's `numberMatched`, when it advertised one. */
+  numberMatched?: number;
+  /** True when the collection holds more features than were loaded. */
+  truncated: boolean;
+}
+
+/**
+ * Builds a GeoJSON layer from fetched OGC API - Features items. The request
+ * parameters are persisted alongside the data so a refresh can replay the same
+ * paged walk rather than re-reading only the first page.
+ *
+ * @param params - The layer name, items URL, fetched data, and request metadata.
+ * @returns The constructed GeoJSON layer.
+ */
+export function buildOgcFeaturesLayer(params: OgcFeaturesLayerParams): GeoLibreLayer {
+  return {
+    ...createBaseLayer(
+      params.name,
+      "geojson",
+      {
+        type: "geojson",
+        url: params.itemsUrl,
+        service: "ogc-features",
+        baseUrl: params.baseUrl,
+        collectionId: params.collectionId,
+        maxFeatures: params.maxFeatures,
+        bbox: params.bbox || undefined,
+        datetime: params.datetime || undefined,
+        extraQuery: params.extraQuery || undefined,
+      },
+      {
+        featureCount: params.data.features.length,
+        service: "ogc-features",
+        sourceKind: OGC_FEATURES_SOURCE_KIND,
+        collectionId: params.collectionId,
+        ...(params.numberMatched !== undefined ? { numberMatched: params.numberMatched } : {}),
+        truncated: params.truncated,
+      },
+    ),
+    geojson: params.data,
+    sourcePath: params.itemsUrl,
   };
 }
 

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -16,6 +16,7 @@ export type KindI18nKey =
   | "wms"
   | "wfs"
   | "wmts"
+  | "ogcFeatures"
   | "ogcVectorTiles"
   | "gpx"
   | "georss"
@@ -39,6 +40,7 @@ export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
   wms: "wms",
   wfs: "wfs",
   wmts: "wmts",
+  "ogc-features": "ogcFeatures",
   "ogc-vector-tiles": "ogcVectorTiles",
   gpx: "gpx",
   georss: "georss",
@@ -87,6 +89,11 @@ export const DEFAULT_WMTS_URL =
 // this to any EOX tile layer, however it was added.
 export const EOX_S2CLOUDLESS_ATTRIBUTION =
   'Sentinel-2 cloudless 2025 by <a href="https://s2maps.eu" target="_blank" rel="noreferrer">EOX IT Services GmbH</a> (contains modified Copernicus Sentinel data 2025)';
+// pygeoapi's public demo, the reference OGC API - Features implementation. Its
+// `lakes` collection is a small global polygon set, and the server caps `limit`
+// at 10 per page, so the sample also exercises the `next`-link paging walk.
+export const DEFAULT_OGC_FEATURES_ENDPOINT = "https://demo.pygeoapi.io/master";
+export const DEFAULT_OGC_FEATURES_COLLECTION = "lakes";
 // PDOK BGT (Dutch large-scale base map) served as OGC API - Tiles vector tiles.
 // The style document carries the source-layer names the TileJSON omits; both
 // are prefilled so the sample works out of the box (zoom into the Netherlands).

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcFeaturesSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/OgcFeaturesSource.tsx
@@ -1,0 +1,365 @@
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import { ListTree, Loader2 } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DEFAULT_OGC_FEATURES_MAX_FEATURES,
+  fetchOgcFeatureCollections,
+  fetchOgcFeatureItems,
+  parseOgcFeaturesUrl,
+  type OgcFeaturesCollectionOption,
+} from "../../../../lib/ogc-api-features";
+import { buildOgcFeaturesLayer } from "../apply-service";
+import { DEFAULT_OGC_FEATURES_COLLECTION, DEFAULT_OGC_FEATURES_ENDPOINT } from "../constants";
+import { serviceRequestErrorMessage } from "../helpers";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
+
+/**
+ * Retains the form input across dialog close/reopen (in memory, for the
+ * session) so a user can add several collections from the same service without
+ * re-entering the URL or re-retrieving its collection list each time.
+ */
+interface OgcFeaturesFormCache {
+  endpoint: string;
+  collectionId: string;
+  maxFeatures: string;
+  bbox: string;
+  datetime: string;
+  options: OgcFeaturesCollectionOption[];
+}
+let ogcFeaturesFormCache: OgcFeaturesFormCache | null = null;
+
+interface OgcFeaturesSample {
+  endpoint: string;
+  collectionId: string;
+}
+
+/**
+ * Adds features from an **OGC API - Features** collection as a GeoJSON layer.
+ *
+ * The user points at a service (its landing page, or any `/collections/…` URL
+ * copied from the service's own HTML browser), retrieves its collections, and
+ * picks one. The fetch follows the service's `next` links until the requested
+ * feature count is reached, because a single `/items` request returns only one
+ * server-sized page.
+ */
+export function OgcFeaturesSource() {
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.ogcFeatures.defaultName"));
+  const [endpoint, setEndpoint] = useState(ogcFeaturesFormCache?.endpoint ?? "");
+  const [collectionId, setCollectionId] = useState(ogcFeaturesFormCache?.collectionId ?? "");
+  const [maxFeatures, setMaxFeatures] = useState(
+    ogcFeaturesFormCache?.maxFeatures ?? String(DEFAULT_OGC_FEATURES_MAX_FEATURES),
+  );
+  const [bbox, setBbox] = useState(ogcFeaturesFormCache?.bbox ?? "");
+  const [datetime, setDatetime] = useState(ogcFeaturesFormCache?.datetime ?? "");
+  const [collectionOptions, setCollectionOptions] = useState<OgcFeaturesCollectionOption[]>(
+    ogcFeaturesFormCache?.options ?? [],
+  );
+  const [isRetrieving, setIsRetrieving] = useState(false);
+  const [retrieveError, setRetrieveError] = useState<string | null>(null);
+  const collectionListId = useId();
+
+  // Persist the form input so reopening the dialog restores the URL, the
+  // fields, and the retrieved collection list.
+  useEffect(() => {
+    ogcFeaturesFormCache = {
+      endpoint,
+      collectionId,
+      maxFeatures,
+      bbox,
+      datetime,
+      options: collectionOptions,
+    };
+  }, [endpoint, collectionId, maxFeatures, bbox, datetime, collectionOptions]);
+
+  // See WfsSource: guards a stale in-flight retrieval from overwriting the form.
+  const retrieveTokenRef = useRef(0);
+  const retrieveAbortRef = useRef<AbortController | null>(null);
+  // Aborts an items fetch still running when the dialog closes, so a slow
+  // service cannot add a layer after the user has left.
+  const submitAbortRef = useRef<AbortController | null>(null);
+
+  const cancelRetrieve = () => {
+    retrieveAbortRef.current?.abort();
+    retrieveAbortRef.current = null;
+  };
+
+  // Abort anything in flight if the dialog closes mid-request, and advance the
+  // token so a finally block cannot set state after unmount.
+  useEffect(
+    () => () => {
+      retrieveTokenRef.current += 1;
+      retrieveAbortRef.current?.abort();
+      submitAbortRef.current?.abort();
+    },
+    [],
+  );
+
+  /** Drops a collection list that belongs to a previous service URL. */
+  const clearCollections = () => {
+    if (collectionOptions.length > 0 || isRetrieving) {
+      cancelRetrieve();
+      setCollectionOptions([]);
+      setIsRetrieving(false);
+    }
+    if (retrieveError) setRetrieveError(null);
+  };
+
+  const handleRetrieveCollections = async () => {
+    retrieveAbortRef.current?.abort();
+    const controller = new AbortController();
+    retrieveAbortRef.current = controller;
+    const token = ++retrieveTokenRef.current;
+    const isStale = () => token !== retrieveTokenRef.current || controller.signal.aborted;
+    setIsRetrieving(true);
+    setRetrieveError(null);
+    try {
+      const parsed = parseOgcFeaturesUrl(endpoint);
+      const options = await fetchOgcFeatureCollections(parsed, {
+        signal: controller.signal,
+      });
+      if (isStale()) return;
+      if (options.length === 0) {
+        setCollectionOptions([]);
+        setRetrieveError(t("addData.ogcFeatures.noCollectionsFound"));
+        return;
+      }
+      setCollectionOptions(options);
+      // A URL pasted from the service's own browser already names a collection;
+      // otherwise preselect the first so a single click leaves the form ready.
+      const pasted = parsed.collectionId;
+      if (pasted && options.some((option) => option.id === pasted)) {
+        setCollectionId(pasted);
+      } else if (!collectionId.trim()) {
+        setCollectionId(options[0].id);
+      }
+    } catch (error) {
+      if (isStale()) return;
+      setCollectionOptions([]);
+      setRetrieveError(
+        serviceRequestErrorMessage(error, t, t("addData.ogcFeatures.retrieveError")),
+      );
+    } finally {
+      if (token === retrieveTokenRef.current) setIsRetrieving(false);
+    }
+  };
+
+  const applySample = (sample: OgcFeaturesSample) => {
+    setEndpoint(sample.endpoint);
+    setCollectionId(sample.collectionId);
+    setBbox("");
+    setDatetime("");
+    setMaxFeatures(String(DEFAULT_OGC_FEATURES_MAX_FEATURES));
+    // The new service's collections must be re-retrieved.
+    cancelRetrieve();
+    setCollectionOptions([]);
+    setIsRetrieving(false);
+    setRetrieveError(null);
+  };
+
+  const handleSubmit = source.runSubmit(async () => {
+    // Throws a field-level message for an empty or non-absolute URL.
+    const parsed = parseOgcFeaturesUrl(endpoint);
+    // A URL pasted straight from the service's HTML browser already names the
+    // collection, so an empty field is only an error when neither carries one.
+    const collection = collectionId.trim() || parsed.collectionId;
+    if (!collection) {
+      throw new Error(t("addData.ogcFeatures.errorCollection"));
+    }
+    const requestedMax = Number(maxFeatures.trim());
+    if (!Number.isFinite(requestedMax) || requestedMax < 1) {
+      throw new Error(t("addData.ogcFeatures.errorMaxFeatures"));
+    }
+    const trimmedBbox = bbox.trim();
+    if (trimmedBbox) {
+      const parts = trimmedBbox.split(",").map((part) => part.trim());
+      // OGC API accepts a 4-value (2D) or 6-value (3D) bounding box.
+      if (
+        (parts.length !== 4 && parts.length !== 6) ||
+        parts.some((part) => part === "" || !Number.isFinite(Number(part)))
+      ) {
+        throw new Error(t("addData.ogcFeatures.errorBbox"));
+      }
+    }
+
+    submitAbortRef.current?.abort();
+    const controller = new AbortController();
+    submitAbortRef.current = controller;
+    const result = await fetchOgcFeatureItems(
+      {
+        baseUrl: parsed.baseUrl,
+        collectionId: collection,
+        extraQuery: parsed.extraQuery,
+        maxFeatures: Math.floor(requestedMax),
+        bbox: trimmedBbox || undefined,
+        datetime: datetime.trim() || undefined,
+      },
+      { signal: controller.signal },
+    );
+    // A superseded/cancelled request must not add a layer after the fact.
+    if (controller.signal.aborted) return;
+    if (result.data.features.length === 0) {
+      throw new Error(t("addData.ogcFeatures.errorNoFeatures"));
+    }
+    if (result.truncated) {
+      // Not an error: the layer holds the requested slice of a larger
+      // collection. Note it so a user comparing counts against the service is
+      // not left wondering where the rest went.
+      console.info(
+        `OGC API - Features: loaded ${result.data.features.length} of ${
+          result.numberMatched ?? "more"
+        } features from "${collection}". Raise "Max features" to load more.`,
+      );
+    }
+
+    const name = source.layerName.trim() || collection || t("addData.ogcFeatures.defaultName");
+    source.addAndClose(
+      buildOgcFeaturesLayer({
+        name,
+        itemsUrl: result.url,
+        data: result.data,
+        baseUrl: parsed.baseUrl,
+        collectionId: collection,
+        maxFeatures: Math.floor(requestedMax),
+        bbox: trimmedBbox || undefined,
+        datetime: datetime.trim() || undefined,
+        extraQuery: parsed.extraQuery || undefined,
+        numberMatched: result.numberMatched,
+        truncated: result.truncated,
+      }),
+      { fit: true },
+    );
+  });
+
+  return (
+    <AddDataSourceForm
+      layerName={source.layerName}
+      onLayerNameChange={source.setLayerName}
+      beforeLayerId={source.beforeLayerId}
+      onBeforeLayerIdChange={source.setBeforeLayerId}
+      onSubmit={handleSubmit}
+      error={source.error}
+      submitDisabled={source.isSubmitting}
+      useServiceIcon
+    >
+      <div className="space-y-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="ogc-features-endpoint">{t("addData.common.serviceUrl")}</Label>
+          <div className="flex gap-2">
+            <Input
+              id="ogc-features-endpoint"
+              placeholder={t("addData.ogcFeatures.urlPlaceholder")}
+              value={endpoint}
+              onChange={(event) => {
+                setEndpoint(event.target.value);
+                // Collections belong to the previous service; clear them (and
+                // cancel any retrieval in flight) so the list never reflects a
+                // different one.
+                clearCollections();
+              }}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleRetrieveCollections}
+              disabled={isRetrieving || !endpoint.trim()}
+              className="shrink-0"
+            >
+              {isRetrieving ? (
+                <Loader2 className="me-2 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <ListTree className="me-2 h-3.5 w-3.5" />
+              )}
+              {isRetrieving
+                ? t("addData.ogcFeatures.retrieving")
+                : t("addData.ogcFeatures.retrieveCollections")}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">{t("addData.ogcFeatures.urlHint")}</p>
+          {retrieveError ? <p className="text-xs text-destructive">{retrieveError}</p> : null}
+          {collectionOptions.length > 0 ? (
+            <div className="space-y-1.5">
+              <Label htmlFor={collectionListId}>
+                {t("addData.ogcFeatures.retrievedCollections")}
+              </Label>
+              {/* Picker listing every retrieved collection; fills the field
+                  below on select. Value stays empty (action menu), so it always
+                  shows the full list and can never mismatch the free-text field. */}
+              <Select
+                id={collectionListId}
+                value=""
+                onChange={(event) => {
+                  if (event.target.value) setCollectionId(event.target.value);
+                }}
+              >
+                <option value="" disabled>
+                  {t("addData.ogcFeatures.selectCollection", {
+                    count: collectionOptions.length,
+                  })}
+                </option>
+                {collectionOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.title === option.id ? option.id : `${option.title} (${option.id})`}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : null}
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="ogc-features-collection">{t("addData.ogcFeatures.collection")}</Label>
+            {/* Plain free-text field: holds the submitted collection id and
+                stays editable for manual entry. The picker above fills it. */}
+            <Input
+              id="ogc-features-collection"
+              placeholder={t("addData.ogcFeatures.collectionPlaceholder")}
+              value={collectionId}
+              onChange={(event) => setCollectionId(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="ogc-features-max">{t("addData.ogcFeatures.maxFeatures")}</Label>
+            <Input
+              id="ogc-features-max"
+              inputMode="numeric"
+              value={maxFeatures}
+              onChange={(event) => setMaxFeatures(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="ogc-features-bbox">{t("addData.ogcFeatures.bbox")}</Label>
+            <Input
+              id="ogc-features-bbox"
+              placeholder={t("addData.common.optional")}
+              value={bbox}
+              onChange={(event) => setBbox(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="ogc-features-datetime">{t("addData.ogcFeatures.datetime")}</Label>
+            <Input
+              id="ogc-features-datetime"
+              placeholder={t("addData.common.optional")}
+              value={datetime}
+              onChange={(event) => setDatetime(event.target.value)}
+            />
+          </div>
+        </div>
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.ogcFeatures.sampleLabel"),
+              value: {
+                endpoint: DEFAULT_OGC_FEATURES_ENDPOINT,
+                collectionId: DEFAULT_OGC_FEATURES_COLLECTION,
+              },
+            },
+          ]}
+          onSelect={applySample}
+        />
+      </div>
+    </AddDataSourceForm>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -7,6 +7,7 @@ export type AddDataKind =
   | "wms"
   | "wfs"
   | "wmts"
+  | "ogc-features"
   | "ogc-vector-tiles"
   | "gpx"
   | "georss"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -67,6 +67,7 @@ export function AddDataMenu({
     wms: { onSelect: () => onSetAddDataKind("wms") },
     wfs: { onSelect: () => onSetAddDataKind("wfs") },
     wmts: { onSelect: () => onSetAddDataKind("wmts") },
+    "ogc-features": { onSelect: () => onSetAddDataKind("ogc-features") },
     "ogc-vector-tiles": {
       onSelect: () => onSetAddDataKind("ogc-vector-tiles"),
     },

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1078,7 +1078,11 @@ export function LayerPanel({
           scheduleStatusClear(layer.id);
           return;
         }
-        const { geojson, featureCount } = await refreshGeoJsonLayer(layer);
+        const {
+          geojson,
+          featureCount,
+          metadata: refreshedMetadata,
+        } = await refreshGeoJsonLayer(layer);
         const latest = useAppStore.getState().layers.find((candidate) => candidate.id === layer.id);
         if (!latest) return;
 
@@ -1087,6 +1091,9 @@ export function LayerPanel({
           metadata: {
             ...latest.metadata,
             featureCount,
+            // Source kinds whose refresh recomputes more than the count (an OGC
+            // API - Features layer's numberMatched/truncated) patch it here.
+            ...refreshedMetadata,
           },
         });
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -398,7 +398,7 @@
       "urlPlaceholder": "https://example.com/wmts/{z}/{y}/{x}.png"
     },
     "ogcFeatures": {
-      "defaultName": "OGC API Features Layer",
+      "defaultName": "OGC API - Features Layer",
       "sampleLabel": "Global lakes (pygeoapi demo)",
       "urlPlaceholder": "https://example.com/ogcapi",
       "urlHint": "The service landing page, or any URL copied from it (a /collections or /collections/{id}/items URL also works).",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -235,6 +235,10 @@
         "label": "Add WMTS Layer",
         "description": "Add a WMTS tile URL template as a raster layer."
       },
+      "ogcFeatures": {
+        "label": "Add OGC API - Features Layer",
+        "description": "Add features from an OGC API - Features collection as a vector layer, following the service's paging links until the requested feature count is loaded."
+      },
       "ogcVectorTiles": {
         "label": "Add OGC Vector Tiles",
         "description": "Add an OGC API - Tiles (vector) service from a TileJSON or tile template, optionally reading its source layers from a style URL."
@@ -392,6 +396,28 @@
       "sampleLabel": "EOX World Imagery (Sentinel-2)",
       "errorUrl": "Enter a WMTS tile URL template.",
       "urlPlaceholder": "https://example.com/wmts/{z}/{y}/{x}.png"
+    },
+    "ogcFeatures": {
+      "defaultName": "OGC API Features Layer",
+      "sampleLabel": "Global lakes (pygeoapi demo)",
+      "urlPlaceholder": "https://example.com/ogcapi",
+      "urlHint": "The service landing page, or any URL copied from it (a /collections or /collections/{id}/items URL also works).",
+      "retrieveCollections": "Retrieve collections",
+      "retrieving": "Retrieving...",
+      "retrievedCollections": "Retrieved collections",
+      "selectCollection_one": "Select from {{count}} collection",
+      "selectCollection_other": "Select from {{count}} collections",
+      "noCollectionsFound": "No feature collections were found for this service.",
+      "retrieveError": "Could not retrieve collections from this service.",
+      "collection": "Collection",
+      "collectionPlaceholder": "collection-id",
+      "maxFeatures": "Max features",
+      "bbox": "Bounding box",
+      "datetime": "Date and time",
+      "errorCollection": "Enter an OGC API - Features collection id.",
+      "errorMaxFeatures": "Enter a max features value of 1 or more.",
+      "errorBbox": "Enter the bounding box as \"west,south,east,north\".",
+      "errorNoFeatures": "This collection returned no features."
     },
     "ogcVectorTiles": {
       "defaultName": "OGC Vector Tiles Layer",
@@ -1948,6 +1974,7 @@
       "wms": "WMS Layer",
       "wfs": "WFS Layer",
       "wmts": "WMTS Layer",
+      "ogcFeatures": "OGC API - Features",
       "ogcVectorTiles": "OGC Vector Tiles",
       "arcgis": "ArcGIS Layer",
       "georss": "GeoRSS Layer",

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -12,12 +12,21 @@ import { isSqlQueryLayer } from "./sql-query-layer";
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 const FETCH_TIMEOUT_MS = 30_000;
+// Feature cap for refreshing an OGC API - Features layer whose stored request
+// carries no `maxFeatures` (added before it was persisted, or hand-edited).
+// Mirrors DEFAULT_OGC_FEATURES_MAX_FEATURES in lib/ogc-api-features.ts.
+const DEFAULT_OGC_FEATURES_REFRESH_MAX = 1000;
 export const MIN_REFRESH_INTERVAL_MS = 1_000;
 const GEORSS_SOURCE_KIND = "georss";
+// Local copy of OGC_FEATURES_SOURCE_KIND (lib/ogc-api-features.ts), kept here so
+// this module's metadata checks stay free of that module's import graph; the
+// paged fetch itself is imported dynamically in the refresh branch below.
+const OGC_FEATURES_SOURCE_KIND = "ogc-features-items";
 const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   "wfs-getfeature",
   "geojson-url",
   GEORSS_SOURCE_KIND,
+  OGC_FEATURES_SOURCE_KIND,
 ]);
 
 // Add Vector Layer (maplibre-gl-vector) tags its store layers with this
@@ -240,6 +249,13 @@ export async function refreshGeoJsonLayer(
     return refreshGeoRssLayer(sourceUrl);
   }
 
+  // An OGC API - Features layer was loaded by walking the service's `next`
+  // links, so re-fetching the stored URL alone would silently shrink it to the
+  // first page. Replay the same paged request instead.
+  if (isOgcFeaturesLayer(layer)) {
+    return refreshOgcFeaturesLayer(layer);
+  }
+
   const data = await fetchGeoJsonFeatureCollection(sourceUrl, {
     useWfsProxy: isWfsLayer(layer),
   });
@@ -247,6 +263,59 @@ export async function refreshGeoJsonLayer(
   return {
     geojson: data,
     featureCount: data.features.length,
+  };
+}
+
+/**
+ * Re-runs an OGC API - Features layer's paged items request from the parameters
+ * stored on its source, so a refresh reloads the whole slice the layer was
+ * added with.
+ *
+ * A layer saved before these parameters existed (or hand-edited) may carry only
+ * the items URL; that case falls back to a plain single-page fetch of it, which
+ * is still better than failing the refresh outright.
+ *
+ * @param layer - The OGC API - Features layer to reload.
+ * @returns The reloaded features and their count.
+ */
+async function refreshOgcFeaturesLayer(
+  layer: GeoLibreLayer,
+): Promise<{ geojson: FeatureCollection; featureCount: number }> {
+  const source = layer.source as {
+    url?: unknown;
+    baseUrl?: unknown;
+    collectionId?: unknown;
+    maxFeatures?: unknown;
+    bbox?: unknown;
+    datetime?: unknown;
+    extraQuery?: unknown;
+  };
+  const baseUrl = typeof source.baseUrl === "string" ? source.baseUrl : "";
+  const collectionId = typeof source.collectionId === "string" ? source.collectionId : "";
+  if (!baseUrl || !collectionId) {
+    const url = layerHttpUrl(layer);
+    if (!url) throw new Error("This layer does not have a refreshable GeoJSON URL.");
+    const data = await fetchGeoJsonFeatureCollection(url);
+    return { geojson: data, featureCount: data.features.length };
+  }
+  // Imported here rather than at module scope so this module stays light for
+  // the callers that only read refresh metadata.
+  const { fetchOgcFeatureItems } = await import("./ogc-api-features");
+  const maxFeatures =
+    typeof source.maxFeatures === "number" && Number.isFinite(source.maxFeatures)
+      ? source.maxFeatures
+      : DEFAULT_OGC_FEATURES_REFRESH_MAX;
+  const result = await fetchOgcFeatureItems({
+    baseUrl,
+    collectionId,
+    extraQuery: typeof source.extraQuery === "string" ? source.extraQuery : undefined,
+    maxFeatures,
+    bbox: typeof source.bbox === "string" ? source.bbox : undefined,
+    datetime: typeof source.datetime === "string" ? source.datetime : undefined,
+  });
+  return {
+    geojson: result.data,
+    featureCount: result.data.features.length,
   };
 }
 
@@ -405,6 +474,14 @@ function isWfsLayer(layer: GeoLibreLayer): boolean {
 
 function isGeoRssLayer(layer: GeoLibreLayer): boolean {
   return layer.metadata.sourceKind === GEORSS_SOURCE_KIND;
+}
+
+function isOgcFeaturesLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.metadata.sourceKind === OGC_FEATURES_SOURCE_KIND ||
+    layer.metadata.service === "ogc-features" ||
+    layer.source.service === "ogc-features"
+  );
 }
 
 function isViteDevServer(): boolean {

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -235,9 +235,21 @@ export async function fetchWfsGeoJson(
   throw lastError instanceof Error ? lastError : new WfsXmlResponseError(false);
 }
 
-export async function refreshGeoJsonLayer(
-  layer: GeoLibreLayer,
-): Promise<{ geojson: FeatureCollection; featureCount: number }> {
+/** The reloaded features, plus any layer metadata the refresh itself updates. */
+export interface GeoJsonRefreshResult {
+  geojson: FeatureCollection;
+  featureCount: number;
+  /**
+   * Metadata keys the refresh recomputed, merged over the layer's existing
+   * metadata by the caller. Only the source kinds that carry request state
+   * beyond the feature count (currently OGC API - Features, whose
+   * `numberMatched`/`truncated` would otherwise stay at the values from when
+   * the layer was added) return anything here.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export async function refreshGeoJsonLayer(layer: GeoLibreLayer): Promise<GeoJsonRefreshResult> {
   const sourceUrl = refreshSourceUrl(layer);
   if (!sourceUrl) {
     throw new Error("This layer does not have a refreshable GeoJSON URL.");
@@ -276,11 +288,9 @@ export async function refreshGeoJsonLayer(
  * is still better than failing the refresh outright.
  *
  * @param layer - The OGC API - Features layer to reload.
- * @returns The reloaded features and their count.
+ * @returns The reloaded features, their count, and the refreshed paging metadata.
  */
-async function refreshOgcFeaturesLayer(
-  layer: GeoLibreLayer,
-): Promise<{ geojson: FeatureCollection; featureCount: number }> {
+async function refreshOgcFeaturesLayer(layer: GeoLibreLayer): Promise<GeoJsonRefreshResult> {
   const source = layer.source as {
     url?: unknown;
     baseUrl?: unknown;
@@ -296,6 +306,9 @@ async function refreshOgcFeaturesLayer(
     const url = layerHttpUrl(layer);
     if (!url) throw new Error("This layer does not have a refreshable GeoJSON URL.");
     const data = await fetchGeoJsonFeatureCollection(url);
+    // No metadata patch: this path reads a single page with no `numberMatched`
+    // to compare against, so it cannot say whether the collection is truncated.
+    // Leaving the stored values alone beats overwriting them with a guess.
     return { geojson: data, featureCount: data.features.length };
   }
   // Imported here rather than at module scope so this module stays light for
@@ -316,6 +329,10 @@ async function refreshOgcFeaturesLayer(
   return {
     geojson: result.data,
     featureCount: result.data.features.length,
+    // Both are always written, `numberMatched` even when the service stopped
+    // advertising one, so the layer reports this fetch rather than the counts
+    // it was originally added with.
+    metadata: { numberMatched: result.numberMatched, truncated: result.truncated },
   };
 }
 

--- a/apps/geolibre-desktop/src/lib/ogc-api-features.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-api-features.ts
@@ -1,0 +1,390 @@
+/**
+ * Client for **OGC API - Features** services (the successor to WFS).
+ *
+ * A service is a tree of JSON documents rooted at a landing page: `/collections`
+ * lists the feature collections, and `/collections/{id}/items` returns GeoJSON.
+ * Unlike WFS there is no capabilities document and no output-format negotiation
+ * to guess at — GeoJSON is the mandated encoding — but responses are **paged**:
+ * a server answers with at most its own page size and advertises a `next` link,
+ * so a naive single request commonly yields only the first 10 features.
+ *
+ * This module owns the three things the Add Data source needs:
+ *
+ * - {@link parseOgcFeaturesUrl}, which accepts whatever URL the user has in
+ *   hand (landing page, `/collections`, a collection, or a full `/items` URL,
+ *   which is what a service's HTML browser puts in the address bar) and splits
+ *   it into a base URL plus collection id.
+ * - {@link fetchOgcFeatureCollections}, the collection picker's list.
+ * - {@link fetchOgcFeatureItems}, which follows `next` links until the
+ *   requested feature count is reached and reports whether more remain.
+ */
+
+import type { Feature, FeatureCollection } from "geojson";
+import { fetchOgcJson } from "./ogc-json";
+
+/** Default number of features an Add OGC API - Features request asks for. */
+export const DEFAULT_OGC_FEATURES_MAX_FEATURES = 1000;
+
+/**
+ * `metadata.sourceKind` tag carried by layers added from an OGC API - Features
+ * collection. `layer-refresh` keys off it to replay the paged items walk instead
+ * of re-fetching only the stored first page.
+ */
+export const OGC_FEATURES_SOURCE_KIND = "ogc-features-items";
+
+/**
+ * Features requested per page. Servers clamp `limit` to their own maximum (and
+ * a few reject an oversized one outright), so ask for a conservative page and
+ * let the `next` links carry the rest rather than betting on a large limit.
+ */
+const OGC_FEATURES_PAGE_SIZE = 1000;
+
+/**
+ * Safety net for the paging loop: a server whose `next` link always points at
+ * another non-empty page (or at a page that never advances) cannot make this
+ * fetch run forever. At the page size above this still allows far more features
+ * than the max the dialog accepts.
+ */
+const MAX_ITEM_PAGES = 200;
+
+/** Overall deadline shared by every request of one fetch, in milliseconds. */
+const REQUEST_BUDGET_MS = 60_000;
+
+/**
+ * Query parameters this module sets itself. They are stripped from a pasted URL
+ * so a copied `…/items?f=html&limit=10` cannot fight the request built on top of
+ * it (which would otherwise return an HTML page, or silently cap the layer at
+ * the pasted limit). Any other parameter — an API key, a service-specific
+ * filter — is preserved and re-sent with every request.
+ */
+const OGC_ITEM_PARAMS: ReadonlySet<string> = new Set([
+  "f",
+  "limit",
+  "offset",
+  "startindex",
+  "bbox",
+  "datetime",
+]);
+
+/** A service URL split into the parts the requests are built from. */
+export interface OgcFeaturesEndpoint {
+  /** The service base URL (its landing page), without a query or trailing slash. */
+  baseUrl: string;
+  /** The collection id read from a `/collections/{id}` URL, or `""` if none. */
+  collectionId: string;
+  /** Non-OGC query parameters from the pasted URL, re-sent with every request. */
+  extraQuery: string;
+}
+
+/** A feature collection advertised by a service's `/collections` document. */
+export interface OgcFeaturesCollectionOption {
+  /** The collection `id` — the path segment used to request its items. */
+  id: string;
+  /** The collection's human-readable `title`; falls back to the id. */
+  title: string;
+}
+
+/** A resolved items request. */
+export interface OgcFeaturesRequest {
+  baseUrl: string;
+  collectionId: string;
+  extraQuery?: string;
+  /** Upper bound on features to load across all pages. */
+  maxFeatures: number;
+  /** Optional `west,south,east,north` filter (CRS84). */
+  bbox?: string;
+  /** Optional RFC 3339 instant or interval for the `datetime` filter. */
+  datetime?: string;
+}
+
+/** The outcome of an items fetch. */
+export interface OgcFeaturesResult {
+  /** The loaded features, capped at the request's `maxFeatures`. */
+  data: FeatureCollection;
+  /** The first page's request URL, persisted so the layer can be refreshed. */
+  url: string;
+  /** The server's `numberMatched` for the query, when it advertises one. */
+  numberMatched?: number;
+  /** True when the collection holds more features than were loaded. */
+  truncated: boolean;
+  /** How many pages were fetched (1 when the server returned everything). */
+  pages: number;
+}
+
+/**
+ * Appends query parameters to a URL that has none of its own, merging in the
+ * endpoint's preserved parameters. The built-in parameters win, so a stray
+ * `f=html` carried over from a pasted URL can never override `f=json`.
+ */
+function withQuery(url: string, extraQuery: string, params: Array<[string, string]>): string {
+  const search = new URLSearchParams(extraQuery);
+  for (const [key, value] of params) search.set(key, value);
+  const query = search.toString();
+  return query ? `${url}?${query}` : url;
+}
+
+/**
+ * Splits a user-entered OGC API - Features URL into a base URL and (when the
+ * URL points at one) a collection id.
+ *
+ * Everything from `https://example.com/ogcapi` down to
+ * `https://example.com/ogcapi/collections/parking/items?f=json&limit=10` is
+ * accepted, because all of them are URLs a user plausibly has in hand: the
+ * service's own HTML browser navigates to the deepest form. The path is cut at
+ * the last `collections` segment, so a service that happens to be mounted under
+ * a path containing that word still resolves against its real base.
+ *
+ * @param input - The service URL as entered.
+ * @returns The base URL, collection id (or `""`), and preserved query.
+ * @throws If the input is empty or is not an absolute http(s) URL.
+ */
+export function parseOgcFeaturesUrl(input: string): OgcFeaturesEndpoint {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("Enter an OGC API - Features service URL.");
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error(
+      "Enter an absolute OGC API - Features service URL, starting with http or https.",
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(
+      "Enter an absolute OGC API - Features service URL, starting with http or https.",
+    );
+  }
+
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (OGC_ITEM_PARAMS.has(key.toLowerCase())) url.searchParams.delete(key);
+  }
+
+  // Path segments stay percent-encoded here: they are re-joined into the base
+  // URL as-is, and only the collection id is decoded (it is shown in the form
+  // and re-encoded when the items URL is built).
+  const segments = url.pathname.split("/").filter(Boolean);
+  const index = segments.lastIndexOf("collections");
+  let collectionId = "";
+  if (index !== -1) {
+    const candidate = segments[index + 1];
+    // `/collections` alone lists them all; `/collections/{id}/items` names one.
+    if (candidate && candidate !== "items") {
+      try {
+        collectionId = decodeURIComponent(candidate);
+      } catch {
+        collectionId = candidate;
+      }
+    }
+    segments.length = index;
+  }
+
+  const path = segments.length > 0 ? `/${segments.join("/")}` : "";
+  return {
+    baseUrl: `${url.origin}${path}`,
+    collectionId,
+    extraQuery: url.searchParams.toString(),
+  };
+}
+
+/**
+ * Builds the `/collections` request URL for a service.
+ *
+ * @param endpoint - The parsed service endpoint.
+ * @returns The collections document URL.
+ */
+export function createOgcCollectionsUrl(
+  endpoint: Pick<OgcFeaturesEndpoint, "baseUrl" | "extraQuery">,
+): string {
+  return withQuery(`${endpoint.baseUrl}/collections`, endpoint.extraQuery ?? "", [["f", "json"]]);
+}
+
+/**
+ * Builds an `/items` request URL for one collection.
+ *
+ * @param request - The collection, page size, and optional bbox/datetime filters.
+ * @returns The items request URL.
+ */
+export function createOgcItemsUrl(request: {
+  baseUrl: string;
+  collectionId: string;
+  extraQuery?: string;
+  limit?: number;
+  bbox?: string;
+  datetime?: string;
+}): string {
+  const params: Array<[string, string]> = [["f", "json"]];
+  if (request.limit !== undefined) params.push(["limit", String(request.limit)]);
+  if (request.bbox) params.push(["bbox", request.bbox]);
+  if (request.datetime) params.push(["datetime", request.datetime]);
+  const path = `${request.baseUrl}/collections/${encodeURIComponent(request.collectionId)}/items`;
+  return withQuery(path, request.extraQuery ?? "", params);
+}
+
+/**
+ * Reads the feature collections from a `/collections` document, in document
+ * order and deduplicated by id.
+ *
+ * Collections whose `itemType` is present and not `"feature"` are skipped: a
+ * service can publish coverage or record collections alongside feature ones,
+ * and those have no `/items` GeoJSON to add as a layer. An absent `itemType`
+ * means `"feature"` per the specification, so it is kept.
+ *
+ * @param doc - The parsed `/collections` document.
+ * @returns The feature collections it advertises.
+ * @throws If the document has no `collections` array.
+ */
+export function parseOgcCollections(doc: unknown): OgcFeaturesCollectionOption[] {
+  const collections = (doc as { collections?: unknown } | null)?.collections;
+  if (!Array.isArray(collections)) {
+    throw new Error("The response is not an OGC API - Features collections document.");
+  }
+  const options: OgcFeaturesCollectionOption[] = [];
+  const seen = new Set<string>();
+  for (const entry of collections) {
+    if (!entry || typeof entry !== "object") continue;
+    const collection = entry as { id?: unknown; title?: unknown; itemType?: unknown };
+    const id = typeof collection.id === "string" ? collection.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    if (typeof collection.itemType === "string" && collection.itemType !== "feature") continue;
+    seen.add(id);
+    const title = typeof collection.title === "string" ? collection.title.trim() : "";
+    options.push({ id, title: title || id });
+  }
+  return options;
+}
+
+/**
+ * The `next` page URL advertised by an items response, resolved against the URL
+ * it came from.
+ *
+ * The link is only followed when it stays on the same origin as the request:
+ * `next` is server-controlled and this client reaches it through the desktop
+ * app's native HTTP path (which bypasses browser CORS), so a service must not
+ * be able to redirect the paging loop at an unrelated host. `f=json` is
+ * re-asserted for the few servers that emit a `next` without it.
+ *
+ * @param doc - The parsed items response.
+ * @param currentUrl - The URL the response was fetched from.
+ * @returns The next page URL, or null when there is none to follow.
+ */
+export function nextItemsPageUrl(doc: unknown, currentUrl: string): string | null {
+  const links = (doc as { links?: unknown } | null)?.links;
+  if (!Array.isArray(links)) return null;
+  for (const entry of links) {
+    if (!entry || typeof entry !== "object") continue;
+    const link = entry as { rel?: unknown; href?: unknown; type?: unknown };
+    if (link.rel !== "next" || typeof link.href !== "string" || !link.href.trim()) continue;
+    // An `alternate`-style next link for HTML/CSV is not a page of this
+    // response's encoding; only follow JSON (or an unlabelled) link.
+    if (typeof link.type === "string" && link.type && !/\bjson\b/i.test(link.type)) continue;
+    let next: URL;
+    try {
+      next = new URL(link.href, currentUrl);
+    } catch {
+      continue;
+    }
+    if (next.origin !== new URL(currentUrl).origin) continue;
+    if (!next.searchParams.has("f")) next.searchParams.set("f", "json");
+    return next.toString();
+  }
+  return null;
+}
+
+/** Narrows a parsed document to a GeoJSON FeatureCollection. */
+function asFeatureCollection(doc: unknown): FeatureCollection {
+  const value = doc as { type?: unknown; features?: unknown } | null;
+  if (!value || value.type !== "FeatureCollection" || !Array.isArray(value.features)) {
+    throw new Error("The response is not a GeoJSON FeatureCollection.");
+  }
+  return doc as FeatureCollection;
+}
+
+/**
+ * Lists a service's feature collections.
+ *
+ * @param endpoint - The parsed service endpoint.
+ * @param options - Optional abort signal.
+ * @returns The collections the service advertises.
+ */
+export async function fetchOgcFeatureCollections(
+  endpoint: Pick<OgcFeaturesEndpoint, "baseUrl" | "extraQuery">,
+  options: { signal?: AbortSignal } = {},
+): Promise<OgcFeaturesCollectionOption[]> {
+  const doc = await fetchOgcJson(createOgcCollectionsUrl(endpoint), {
+    signal: options.signal,
+    context: "OGC API - Features collections",
+  });
+  return parseOgcCollections(doc);
+}
+
+/**
+ * Fetches a collection's features, following the service's `next` links until
+ * `maxFeatures` is reached (or the collection is exhausted).
+ *
+ * Every page shares one {@link REQUEST_BUDGET_MS} deadline rather than each
+ * getting a fresh timeout, so a slow service cannot stack up N × 30s of hang
+ * before the error surfaces.
+ *
+ * @param request - The collection to load and how much of it to load.
+ * @param options - Optional abort signal.
+ * @returns The loaded features, the first page's URL, and whether more remain.
+ */
+export async function fetchOgcFeatureItems(
+  request: OgcFeaturesRequest,
+  options: { signal?: AbortSignal } = {},
+): Promise<OgcFeaturesResult> {
+  const maxFeatures = Math.max(1, Math.floor(request.maxFeatures));
+  const firstUrl = createOgcItemsUrl({
+    ...request,
+    limit: Math.min(maxFeatures, OGC_FEATURES_PAGE_SIZE),
+  });
+
+  const budget = AbortSignal.timeout(REQUEST_BUDGET_MS);
+  const signal = options.signal ? AbortSignal.any([options.signal, budget]) : budget;
+
+  const features: Feature[] = [];
+  // Guards a service whose `next` link points back at a page already read,
+  // which would otherwise cycle until the page cap.
+  const visited = new Set<string>();
+  let numberMatched: number | undefined;
+  let pages = 0;
+  let nextUrl: string | null = firstUrl;
+
+  while (nextUrl && features.length < maxFeatures && pages < MAX_ITEM_PAGES) {
+    if (visited.has(nextUrl)) {
+      nextUrl = null;
+      break;
+    }
+    visited.add(nextUrl);
+    const doc = await fetchOgcJson(nextUrl, {
+      signal,
+      context: "OGC API - Features items",
+    });
+    const page = asFeatureCollection(doc);
+    pages += 1;
+    if (numberMatched === undefined) {
+      const matched = (doc as { numberMatched?: unknown }).numberMatched;
+      if (typeof matched === "number" && Number.isFinite(matched)) numberMatched = matched;
+    }
+    features.push(...page.features);
+    // Many services advertise a `next` link even on the final page, so an empty
+    // page — not the absence of a link — is what ends the walk.
+    nextUrl = page.features.length === 0 ? null : nextItemsPageUrl(doc, nextUrl);
+  }
+
+  const loaded = features.length > maxFeatures ? features.slice(0, maxFeatures) : features;
+  return {
+    data: { type: "FeatureCollection", features: loaded },
+    url: firstUrl,
+    numberMatched,
+    // `numberMatched` is the authoritative count when advertised; otherwise fall
+    // back to "we stopped with a page still pending".
+    truncated:
+      numberMatched !== undefined
+        ? loaded.length < numberMatched
+        : features.length > maxFeatures || nextUrl !== null,
+    pages,
+  };
+}

--- a/apps/geolibre-desktop/src/lib/ogc-json.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-json.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared JSON fetch for the OGC API clients (Tiles, Features).
+ *
+ * An OGC API service is browsed by walking its JSON documents (landing page,
+ * `/collections`, TileJSON, `/items`), and those hosts frequently send no CORS
+ * headers. This module centralizes the three ways GeoLibre can reach them:
+ *
+ * - **Desktop (Tauri):** the Rust `fetch_url_bytes` command, which is not
+ *   subject to browser CORS, so any service works.
+ * - **Dev server (Vite):** the same-origin dev proxy.
+ * - **Hosted web build:** a direct fetch, which only succeeds when the service
+ *   sends `Access-Control-Allow-Origin`.
+ */
+
+import { isTauri } from "./is-tauri";
+
+/**
+ * Dev-server CORS proxy path. The proxy is a generic pass-through; the
+ * `GPX_PROXY_PATH` name it is bound under in vite.config.ts is historical.
+ */
+const OGC_PROXY_PATH = "/__geolibre_gpx_proxy";
+
+/** Default deadline for a single request when the caller supplies no signal. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * A promise that never resolves and rejects when the signal aborts, with its
+ * abort reason. Used to race an uncancellable Tauri invoke against the caller's
+ * abort and a timeout.
+ */
+export function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+  });
+}
+
+/**
+ * Converts opaque fetch/abort failures into a clear, user-facing Error so the
+ * Add Data dialogs surface the real cause instead of a generic fallback.
+ */
+export function normalizeFetchError(error: unknown): Error {
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return new Error("The request timed out.");
+  }
+  // A CORS/network rejection surfaces as a bare TypeError with no status.
+  if (error instanceof TypeError) {
+    return new Error(
+      "Could not reach the service. It may not allow cross-origin requests from the browser; try the desktop app.",
+    );
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+/**
+ * Builds the error for a non-2xx response. OGC APIs answer a bad request with a
+ * JSON problem document (`{ code, description }` or RFC 7807 `{ title, detail }`),
+ * which names the actual problem (an unsupported `limit`, an unknown collection);
+ * surface it alongside the status instead of the status alone. Only a JSON body
+ * is read, and only a short prefix of it, so an HTML error page or an oversized
+ * payload cannot end up rendered into the dialog.
+ */
+async function responseStatusError(response: Response): Promise<Error> {
+  const status = `Request failed with status ${response.status}`;
+  try {
+    if (!/\bjson\b/i.test(response.headers.get("content-type") ?? "")) {
+      return new Error(status);
+    }
+    const body = (await response.json()) as Record<string, unknown>;
+    const detail = [body?.description, body?.detail, body?.title].find(
+      (value): value is string => typeof value === "string" && value.trim() !== "",
+    );
+    return detail ? new Error(`${status}: ${detail.trim().slice(0, 300)}`) : new Error(status);
+  } catch {
+    return new Error(status);
+  }
+}
+
+/**
+ * Fetches and parses a remote JSON document, working around cross-origin limits
+ * (see the module comment). When the caller passes a `signal` it owns the
+ * deadline (callers that issue several requests share one across them);
+ * otherwise a {@link REQUEST_TIMEOUT_MS} timeout is applied so an unresponsive
+ * endpoint cannot hang forever.
+ *
+ * @param url - The absolute document URL.
+ * @param options - An optional abort signal and a diagnostics context label.
+ * @returns The parsed JSON document.
+ */
+export async function fetchOgcJson(
+  url: string,
+  options: { signal?: AbortSignal; context?: string } = {},
+): Promise<unknown> {
+  const abort = options.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  if (isTauri()) {
+    // `fetch_url_bytes` cannot be cancelled mid-flight, so race it against the
+    // abort/timeout to still return promptly on a slow or hung host.
+    const { fetchUrlBytes } = await import("./native-http");
+    const bytesPromise = fetchUrlBytes(url, { context: options.context ?? "OGC API" });
+    // If the abort/timeout wins the race, the invoke promise is left unobserved;
+    // swallow a later rejection so it does not surface as an unhandled rejection.
+    bytesPromise.catch(() => {});
+    try {
+      const bytes = await Promise.race([bytesPromise, rejectOnAbort(abort)]);
+      const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+      return JSON.parse(new TextDecoder().decode(array));
+    } catch (error) {
+      throw normalizeFetchError(error);
+    }
+  }
+  const isDev = Boolean((import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV);
+  const fetchUrl = isDev ? `${OGC_PROXY_PATH}?url=${encodeURIComponent(url)}` : url;
+  let response: Response;
+  try {
+    response = await fetch(fetchUrl, { signal: abort });
+  } catch (error) {
+    throw normalizeFetchError(error);
+  }
+  if (!response.ok) {
+    throw await responseStatusError(response);
+  }
+  return response.json();
+}

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -11,10 +11,12 @@
  * TileJSON's `vector_layers` ids.
  */
 
-import { isTauri } from "./is-tauri";
+import { fetchOgcJson as fetchOgcJsonDocument } from "./ogc-json";
 
-/** Dev-server CORS proxy path; kept in sync with GPX_PROXY_PATH in vite.config.ts. */
-const OGC_PROXY_PATH = "/__geolibre_gpx_proxy";
+/** Fetches an OGC API JSON document, tagged for the native-HTTP diagnostics log. */
+function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown> {
+  return fetchOgcJsonDocument(url, { signal, context: "OGC vector tiles" });
+}
 
 /** The resolved configuration for an OGC API vector tiles layer. */
 export interface OgcVectorTilesConfig {
@@ -259,73 +261,6 @@ export function tileJsonConfig(
  * verbatim and silently fail to load. */
 function normalizeTilePlaceholders(url: string): string {
   return url.replace(/\{z\}/gi, "{z}").replace(/\{x\}/gi, "{x}").replace(/\{y\}/gi, "{y}");
-}
-
-/** A promise that rejects when the signal aborts, with its abort reason. Used to
- * race an uncancellable Tauri invoke against the caller's abort and a timeout. */
-function rejectOnAbort(signal: AbortSignal): Promise<never> {
-  return new Promise((_, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason);
-      return;
-    }
-    signal.addEventListener("abort", () => reject(signal.reason), { once: true });
-  });
-}
-
-/** Converts opaque fetch/abort failures into a clear, user-facing Error so the
- * Add Data dialog surfaces the real cause instead of a generic fallback. */
-function normalizeFetchError(error: unknown): Error {
-  if (error instanceof DOMException && error.name === "TimeoutError") {
-    return new Error("The request timed out.");
-  }
-  // A CORS/network rejection surfaces as a bare TypeError with no status.
-  if (error instanceof TypeError) {
-    return new Error(
-      "Could not reach the service. It may not allow cross-origin requests from the browser; try the desktop app.",
-    );
-  }
-  return error instanceof Error ? error : new Error(String(error));
-}
-
-/**
- * Fetches and parses a remote JSON document, working around cross-origin limits.
- * The Tauri path uses the Rust `fetch_url_bytes` command (not subject to browser
- * CORS); the dev server routes through the same-origin proxy; the hosted web
- * build fetches directly. When the caller passes a `signal` it owns the deadline
- * (see `resolveOgcVectorTiles`, which shares one across its requests); otherwise
- * a 30s timeout is applied so an unresponsive endpoint cannot hang forever.
- */
-async function fetchOgcJson(url: string, signal?: AbortSignal): Promise<unknown> {
-  const abort = signal ?? AbortSignal.timeout(30_000);
-  if (isTauri()) {
-    // `fetch_url_bytes` cannot be cancelled mid-flight, so race it against the
-    // abort/timeout to still return promptly on a slow or hung host.
-    const { fetchUrlBytes } = await import("./native-http");
-    const bytesPromise = fetchUrlBytes(url, { context: "OGC vector tiles" });
-    // If the abort/timeout wins the race, the invoke promise is left unobserved;
-    // swallow a later rejection so it does not surface as an unhandled rejection.
-    bytesPromise.catch(() => {});
-    try {
-      const bytes = await Promise.race([bytesPromise, rejectOnAbort(abort)]);
-      const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-      return JSON.parse(new TextDecoder().decode(array));
-    } catch (error) {
-      throw normalizeFetchError(error);
-    }
-  }
-  const isDev = Boolean((import.meta as ImportMeta & { env?: { DEV?: boolean } }).env?.DEV);
-  const fetchUrl = isDev ? `${OGC_PROXY_PATH}?url=${encodeURIComponent(url)}` : url;
-  let response: Response;
-  try {
-    response = await fetch(fetchUrl, { signal: abort });
-  } catch (error) {
-    throw normalizeFetchError(error);
-  }
-  if (!response.ok) {
-    throw new Error(`Request failed with status ${response.status}`);
-  }
-  return response.json();
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -90,6 +90,12 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   { id: "wfs", section: "webServices", labelKey: "toolbar.layerType.wfs", tier: "intermediate" },
   { id: "wmts", section: "webServices", labelKey: "toolbar.layerType.wmts", tier: "intermediate" },
   {
+    id: "ogc-features",
+    section: "webServices",
+    labelKey: "toolbar.layerType.ogcFeatures",
+    tier: "intermediate",
+  },
+  {
     id: "ogc-vector-tiles",
     section: "webServices",
     labelKey: "toolbar.layerType.ogcVectorTiles",

--- a/tests/ogc-api-features.test.ts
+++ b/tests/ogc-api-features.test.ts
@@ -1,0 +1,376 @@
+import assert from "node:assert/strict";
+import type { Feature, FeatureCollection } from "geojson";
+import { describe, it } from "node:test";
+
+import {
+  createOgcCollectionsUrl,
+  createOgcItemsUrl,
+  fetchOgcFeatureItems,
+  nextItemsPageUrl,
+  parseOgcCollections,
+  parseOgcFeaturesUrl,
+} from "../apps/geolibre-desktop/src/lib/ogc-api-features";
+import { buildOgcFeaturesLayer } from "../apps/geolibre-desktop/src/components/layout/add-data/apply-service";
+
+/** A minimal point feature, numbered so pages can be told apart. */
+function feature(index: number): Feature {
+  return {
+    type: "Feature",
+    properties: { index },
+    geometry: { type: "Point", coordinates: [index, index] },
+  };
+}
+
+/** A page of features plus the links document an OGC API service returns. */
+function page(features: Feature[], next?: string, numberMatched?: number): unknown {
+  return {
+    type: "FeatureCollection",
+    features,
+    ...(numberMatched !== undefined ? { numberMatched } : {}),
+    links: [
+      { rel: "self", type: "application/geo+json", href: "https://ex.com/self" },
+      ...(next ? [{ rel: "next", type: "application/geo+json", href: next }] : []),
+    ],
+  };
+}
+
+/**
+ * Runs `body` with `globalThis.fetch` answering from a URL map, returning the
+ * URLs that were requested in order.
+ */
+async function withFetch(
+  responses: Record<string, unknown>,
+  body: () => Promise<void>,
+): Promise<string[]> {
+  const original = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    const document = responses[url];
+    return Promise.resolve({
+      ok: document !== undefined,
+      status: document !== undefined ? 200 : 404,
+      headers: new Headers({ "content-type": "application/geo+json" }),
+      json: async () => document ?? {},
+    } as Response);
+  }) as typeof fetch;
+  try {
+    await body();
+  } finally {
+    globalThis.fetch = original;
+  }
+  return calls;
+}
+
+describe("parseOgcFeaturesUrl", () => {
+  it("keeps a landing page URL as the base", () => {
+    assert.deepEqual(parseOgcFeaturesUrl("https://ex.com/ogcapi"), {
+      baseUrl: "https://ex.com/ogcapi",
+      collectionId: "",
+      extraQuery: "",
+    });
+  });
+
+  it("strips a trailing slash and the /collections segment", () => {
+    assert.equal(parseOgcFeaturesUrl("https://ex.com/ogcapi/").baseUrl, "https://ex.com/ogcapi");
+    assert.equal(
+      parseOgcFeaturesUrl("https://ex.com/ogcapi/collections").baseUrl,
+      "https://ex.com/ogcapi",
+    );
+  });
+
+  it("reads the collection id out of a collection or items URL", () => {
+    for (const url of [
+      "https://ex.com/ogcapi/collections/parking_live",
+      "https://ex.com/ogcapi/collections/parking_live/items",
+      "https://ex.com/ogcapi/collections/parking_live/items/",
+    ]) {
+      assert.deepEqual(
+        parseOgcFeaturesUrl(url),
+        { baseUrl: "https://ex.com/ogcapi", collectionId: "parking_live", extraQuery: "" },
+        url,
+      );
+    }
+  });
+
+  it("decodes a percent-encoded collection id", () => {
+    assert.equal(
+      parseOgcFeaturesUrl("https://ex.com/ogcapi/collections/road%20signs/items").collectionId,
+      "road signs",
+    );
+  });
+
+  it("handles a service mounted at the site root", () => {
+    assert.deepEqual(parseOgcFeaturesUrl("https://ex.com/collections/lakes/items"), {
+      baseUrl: "https://ex.com",
+      collectionId: "lakes",
+      extraQuery: "",
+    });
+  });
+
+  it("drops the request parameters it sets itself and keeps the rest", () => {
+    const parsed = parseOgcFeaturesUrl(
+      "https://ex.com/ogcapi/collections/lakes/items?f=html&limit=10&offset=20&bbox=1,2,3,4&apikey=abc",
+    );
+    assert.equal(parsed.baseUrl, "https://ex.com/ogcapi");
+    assert.equal(parsed.collectionId, "lakes");
+    assert.equal(parsed.extraQuery, "apikey=abc");
+  });
+
+  it("rejects an empty or non-absolute URL", () => {
+    assert.throws(() => parseOgcFeaturesUrl("   "), /Enter an OGC API - Features service URL/);
+    assert.throws(() => parseOgcFeaturesUrl("example.com/ogcapi"), /absolute/);
+    assert.throws(() => parseOgcFeaturesUrl("ftp://ex.com/ogcapi"), /absolute/);
+  });
+});
+
+describe("createOgcCollectionsUrl / createOgcItemsUrl", () => {
+  it("requests JSON and carries the preserved query", () => {
+    assert.equal(
+      createOgcCollectionsUrl({ baseUrl: "https://ex.com/ogcapi", extraQuery: "apikey=abc" }),
+      "https://ex.com/ogcapi/collections?apikey=abc&f=json",
+    );
+    assert.equal(
+      createOgcCollectionsUrl({ baseUrl: "https://ex.com/ogcapi", extraQuery: "" }),
+      "https://ex.com/ogcapi/collections?f=json",
+    );
+  });
+
+  it("builds an items URL with the optional filters", () => {
+    assert.equal(
+      createOgcItemsUrl({
+        baseUrl: "https://ex.com/ogcapi",
+        collectionId: "lakes",
+        limit: 500,
+        bbox: "1,2,3,4",
+        datetime: "2026-01-01/2026-02-01",
+      }),
+      "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=500&bbox=1%2C2%2C3%2C4&datetime=2026-01-01%2F2026-02-01",
+    );
+  });
+
+  it("percent-encodes a collection id with a space", () => {
+    assert.equal(
+      createOgcItemsUrl({ baseUrl: "https://ex.com/ogcapi", collectionId: "road signs" }),
+      "https://ex.com/ogcapi/collections/road%20signs/items?f=json",
+    );
+  });
+});
+
+describe("parseOgcCollections", () => {
+  it("reads ids and titles, deduplicating and defaulting the title", () => {
+    const options = parseOgcCollections({
+      collections: [
+        { id: "lakes", title: "Large Lakes" },
+        { id: "obs" },
+        { id: "lakes", title: "Duplicate" },
+        { id: "  " },
+        null,
+      ],
+    });
+    assert.deepEqual(options, [
+      { id: "lakes", title: "Large Lakes" },
+      { id: "obs", title: "obs" },
+    ]);
+  });
+
+  it("skips collections that are not feature collections", () => {
+    const options = parseOgcCollections({
+      collections: [
+        { id: "lakes", itemType: "feature" },
+        { id: "dem", itemType: "coverage" },
+        { id: "records", itemType: "record" },
+        { id: "legacy" },
+      ],
+    });
+    assert.deepEqual(
+      options.map((option) => option.id),
+      ["lakes", "legacy"],
+    );
+  });
+
+  it("throws when the document is not a collections response", () => {
+    assert.throws(
+      () => parseOgcCollections({ type: "FeatureCollection", features: [] }),
+      /not an OGC API - Features collections document/,
+    );
+  });
+});
+
+describe("nextItemsPageUrl", () => {
+  const current = "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=10";
+
+  it("resolves a relative next link and keeps f=json", () => {
+    const url = nextItemsPageUrl({ links: [{ rel: "next", href: "items?offset=10" }] }, current);
+    assert.equal(url, "https://ex.com/ogcapi/collections/lakes/items?offset=10&f=json");
+  });
+
+  it("ignores links that are not a JSON next page", () => {
+    assert.equal(nextItemsPageUrl({ links: [{ rel: "prev", href: "?offset=0" }] }, current), null);
+    assert.equal(
+      nextItemsPageUrl({ links: [{ rel: "next", type: "text/html", href: "?f=html" }] }, current),
+      null,
+    );
+    assert.equal(nextItemsPageUrl({}, current), null);
+  });
+
+  it("refuses a next link that leaves the service's origin", () => {
+    assert.equal(
+      nextItemsPageUrl({ links: [{ rel: "next", href: "https://evil.example/items" }] }, current),
+      null,
+    );
+  });
+});
+
+describe("fetchOgcFeatureItems", () => {
+  it("follows next links until maxFeatures is reached", async () => {
+    const first = "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=25";
+    const second = "https://ex.com/ogcapi/collections/lakes/items?offset=10&f=json";
+    const third = "https://ex.com/ogcapi/collections/lakes/items?offset=20&f=json";
+    let result: Awaited<ReturnType<typeof fetchOgcFeatureItems>> | undefined;
+    const calls = await withFetch(
+      {
+        [first]: page([feature(0), feature(1)], second, 5),
+        [second]: page([feature(2), feature(3)], third, 5),
+        [third]: page([feature(4)], undefined, 5),
+      },
+      async () => {
+        result = await fetchOgcFeatureItems({
+          baseUrl: "https://ex.com/ogcapi",
+          collectionId: "lakes",
+          maxFeatures: 25,
+        });
+      },
+    );
+    assert.equal(calls.length, 3);
+    assert.equal(result?.pages, 3);
+    assert.equal(result?.data.features.length, 5);
+    assert.equal(result?.numberMatched, 5);
+    assert.equal(result?.truncated, false);
+    assert.equal(result?.url, first);
+  });
+
+  it("stops at maxFeatures and reports the collection as truncated", async () => {
+    const first = "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=3";
+    const second = "https://ex.com/ogcapi/collections/lakes/items?offset=2&f=json";
+    let result: Awaited<ReturnType<typeof fetchOgcFeatureItems>> | undefined;
+    const calls = await withFetch(
+      {
+        [first]: page([feature(0), feature(1)], second, 100),
+        [second]: page([feature(2), feature(3)], second, 100),
+      },
+      async () => {
+        result = await fetchOgcFeatureItems({
+          baseUrl: "https://ex.com/ogcapi",
+          collectionId: "lakes",
+          maxFeatures: 3,
+        });
+      },
+    );
+    assert.equal(calls.length, 2);
+    assert.equal(result?.data.features.length, 3);
+    assert.equal(result?.truncated, true);
+  });
+
+  it("stops on an empty page even when the service still advertises next", async () => {
+    const first = "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=50";
+    const second = "https://ex.com/ogcapi/collections/lakes/items?offset=2&f=json";
+    let result: Awaited<ReturnType<typeof fetchOgcFeatureItems>> | undefined;
+    const calls = await withFetch(
+      {
+        [first]: page([feature(0), feature(1)], second),
+        // A last page that is empty but still links onward; without the
+        // empty-page stop this would page until the safety cap.
+        [second]: page([], "https://ex.com/ogcapi/collections/lakes/items?offset=4&f=json"),
+      },
+      async () => {
+        result = await fetchOgcFeatureItems({
+          baseUrl: "https://ex.com/ogcapi",
+          collectionId: "lakes",
+          maxFeatures: 50,
+        });
+      },
+    );
+    assert.equal(calls.length, 2);
+    assert.equal(result?.data.features.length, 2);
+    assert.equal(result?.truncated, false);
+  });
+
+  it("does not loop when next points back at a page already read", async () => {
+    const first = "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=50";
+    let result: Awaited<ReturnType<typeof fetchOgcFeatureItems>> | undefined;
+    const calls = await withFetch({ [first]: page([feature(0)], first) }, async () => {
+      result = await fetchOgcFeatureItems({
+        baseUrl: "https://ex.com/ogcapi",
+        collectionId: "lakes",
+        maxFeatures: 50,
+      });
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(result?.data.features.length, 1);
+  });
+
+  it("rejects a response that is not a FeatureCollection", async () => {
+    const first = "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=10";
+    await withFetch({ [first]: { code: "NotFound" } }, async () => {
+      await assert.rejects(
+        fetchOgcFeatureItems({
+          baseUrl: "https://ex.com/ogcapi",
+          collectionId: "lakes",
+          maxFeatures: 10,
+        }),
+        /not a GeoJSON FeatureCollection/,
+      );
+    });
+  });
+});
+
+describe("buildOgcFeaturesLayer", () => {
+  const data: FeatureCollection = {
+    type: "FeatureCollection",
+    features: [feature(0), feature(1)],
+  };
+
+  it("persists the request so the layer can replay its paged walk on refresh", () => {
+    const layer = buildOgcFeaturesLayer({
+      name: "Lakes",
+      itemsUrl: "https://ex.com/ogcapi/collections/lakes/items?f=json&limit=1000",
+      data,
+      baseUrl: "https://ex.com/ogcapi",
+      collectionId: "lakes",
+      maxFeatures: 1000,
+      numberMatched: 25,
+      truncated: false,
+    });
+    assert.equal(layer.type, "geojson");
+    assert.equal(layer.name, "Lakes");
+    assert.equal(layer.source.service, "ogc-features");
+    assert.equal(layer.source.baseUrl, "https://ex.com/ogcapi");
+    assert.equal(layer.source.collectionId, "lakes");
+    assert.equal(layer.source.maxFeatures, 1000);
+    assert.equal(layer.metadata.sourceKind, "ogc-features-items");
+    assert.equal(layer.metadata.featureCount, 2);
+    assert.equal(layer.metadata.numberMatched, 25);
+    assert.equal(layer.geojson, data);
+    assert.equal(layer.sourcePath, layer.source.url);
+  });
+
+  it("omits the optional filters that were not used", () => {
+    const layer = buildOgcFeaturesLayer({
+      name: "Lakes",
+      itemsUrl: "https://ex.com/ogcapi/collections/lakes/items?f=json",
+      data,
+      baseUrl: "https://ex.com/ogcapi",
+      collectionId: "lakes",
+      maxFeatures: 1000,
+      bbox: "",
+      truncated: true,
+    });
+    assert.equal(layer.source.bbox, undefined);
+    assert.equal(layer.source.datetime, undefined);
+    assert.equal(layer.source.extraQuery, undefined);
+    assert.equal(layer.metadata.numberMatched, undefined);
+    assert.equal(layer.metadata.truncated, true);
+  });
+});


### PR DESCRIPTION
Fixes #1446

GeoLibre could reach OGC feature services only through WFS. An **OGC API - Features** endpoint (the WFS successor: no capabilities document, JSON-native, paged) had no way in, even though it is what most new services publish.

## What this adds

A new **Add Data → OGC API - Features** source.

- **`lib/ogc-api-features.ts`** owns the client. `parseOgcFeaturesUrl` accepts whatever URL the user has in hand: a landing page, `/collections`, a collection, or the full `/collections/{id}/items` URL that a service's own HTML browser puts in the address bar (the exact form the issue links). It splits that into a base URL plus collection id, keeps non-OGC query parameters (an API key), and drops the request parameters the builder sets itself, so a pasted `?f=html&limit=10` cannot fight the request built on top of it.
- **Paging is the part a single request gets wrong.** A service answers `/items` with one server-sized page and advertises a `next` link; pygeoapi's demo caps `limit` at 10, so a naive fetch returns 10 of 25 features. The fetch walks `next` until the requested feature count is reached, stops on an empty page (many services advertise `next` even on the last one), refuses a `next` that leaves the service's origin, and shares one deadline across every page.
- **`OgcFeaturesSource`** retrieves the collection list, preselects the collection a pasted URL already named, and offers optional bounding-box and date/time filters. Collections whose `itemType` is not `feature` (coverage, record) are filtered out of the picker.
- **Refresh works properly.** The layer persists its request parameters, so `Refresh` / auto-refresh replays the same paged walk rather than silently shrinking the layer to the stored first page.

## Refactor carried along

The JSON fetch that works around missing CORS headers (Tauri native HTTP → dev proxy → direct) moves to **`lib/ogc-json.ts`** and is now shared with the OGC API - Tiles client, which held the only copy. It also now surfaces a service's JSON problem-document `description`/`detail` alongside the HTTP status on a failed request, instead of the bare status.

## Verification

Driven in the real app with Playwright, in **both dark and light themes**:

- **The issue's own service** — pasted `https://rast-monitor.de/ogcapi/collections/parking_live/items/` verbatim. The URL was split correctly, 3 collections were retrieved, `parking_live` was preselected, and the layer loaded **1000 of 1829** features (the requested cap) across pages, fitted to Germany, with every attribute (`name`, `road_identifier`, `total_spaces`, `occupancy_pct`, …) present in the attribute table.
- **Paging end to end** — the built-in pygeoapi sample (`lakes`, server page size 10) loaded all **25** features. `Refresh` on it returned 25 again, confirming the refresh path replays the paged walk (a single-page refresh would have returned 10).
- **Bounding box** — `5,40,30,60` on the same collection returned the single lake inside it (Vänern).
- **Error path** — a non-absolute URL surfaces a field-level message rather than an opaque fetch failure.

No console errors in any of the above.

`npm run build` passes; `tests/ogc-api-features.test.ts` adds 23 tests covering URL parsing, URL building, collection parsing, the four paging-termination cases, the cross-origin `next` guard, and the layer builder. The 7 pre-existing failures in the frontend suite (`label-sync`, `huggingface-plugin`, `vector-desktop-picker`) are unchanged from `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OGC API – Features support for adding web service layers, including endpoint/collection setup, max features, optional bounding box and date-time filters.
  - Added collection retrieval, sample presets, paginated feature loading with truncation feedback, and automatic map fitting.
  - Updated the data source catalog/menu and layer type labels, with new i18n strings.
- **Bug Fixes**
  - OGC API – Features layers refresh by replaying the original pagination/filters and updating returned layer metadata as well as feature counts.
  - Improved OGC service error and timeout handling across OGC JSON requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->