### PR TITLE
docs: point the NYC demo at a GIF small enough for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Manhattan building footprints extruded in 3D and colored by construction era, wi
 
 The animation below runs the Time Slider along the buildings' construction year, from 1850 to 2025, so Manhattan fills in era by era. Click it to play the full-quality video.
 
-[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://files.opengeos.org/nyc-buildings.gif)](https://files.opengeos.org/nyc-buildings.webm)
+[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://files.opengeos.org/nyc-buildings-gif.gif)](https://files.opengeos.org/nyc-buildings.webm)
 
 [Open the live project](https://share.geolibre.app/giswqs/nyc-buildings-and-subways)
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -28,7 +28,7 @@ buildings' construction year, from 1850 to 2025, so Manhattan fills in era by
 era — the camera stays put and the data moves. Click it to play the
 full-quality video.
 
-[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://files.opengeos.org/nyc-buildings.gif)](https://files.opengeos.org/nyc-buildings.webm)
+[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://files.opengeos.org/nyc-buildings-gif.gif)](https://files.opengeos.org/nyc-buildings.webm)
 
 [Open the live project](https://share.geolibre.app/giswqs/nyc-buildings-and-subways){ .md-button .md-button--primary }
 


### PR DESCRIPTION
## Summary

- Swap the NYC buildings animation to `nyc-buildings-gif.gif` in `README.md` and `docs/demos.md`. The previous file was 9.00 MiB, above the 5 MiB ceiling on GitHub's camo image proxy, so it returned 404 and showed as a broken image in the README. The replacement is 4.21 MiB.
- Only the animated GIF URL changes. The static WebP still shown above it, and the WebM the animation links to, are untouched.

## Test plan

- [x] `https://files.opengeos.org/nyc-buildings-gif.gif` returns 200 with `content-type: image/gif`
- [x] File is 4.21 MiB, under the 5 MiB proxy limit
- [x] `pre-commit run --files README.md docs/demos.md` passes, including the build hook
- [ ] After merge, confirm the animation renders on the repository front page rather than showing a broken image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the NYC buildings and subways demo image reference in the README and demos documentation.
  * Preserved the existing link destination and descriptive text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->