### PR TITLE
fix(assistant): make the Docker deployment AI proxy usable in the browser

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -32,7 +32,7 @@ import {
   ASSISTANT_PROVIDER_IDS,
   availableProviders,
   defaultModelFor,
-  hasDeploymentAssistantEnv,
+  hasManagedAssistantProxy,
   hasProviderKey,
   PROVIDER_MODELS,
   PROVIDER_LABELS,
@@ -189,7 +189,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     return storeSettings.aiProfiles.some((p) => p.id === stored) ? stored : null;
   });
 
-  const deploymentProxyConfigured = hasDeploymentAssistantEnv();
+  const deploymentProxyConfigured = hasManagedAssistantProxy();
 
   // The currently active profile: if the user hasn't explicitly chosen one,
   // follow the default. Otherwise respect their explicit selection.

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -26,11 +26,13 @@ import {
 import { useTranslation } from "react-i18next";
 import { AssistantSession } from "../../lib/assistant/agent";
 import { renderAssistantMarkdown } from "../../lib/assistant/markdown";
+import { selectActiveAssistantProfile } from "../../lib/assistant/profiles";
 import { openSettingsSection } from "../layout/SettingsDialog";
 import {
   ASSISTANT_PROVIDER_IDS,
   availableProviders,
   defaultModelFor,
+  hasDeploymentAssistantEnv,
   hasProviderKey,
   PROVIDER_MODELS,
   PROVIDER_LABELS,
@@ -187,22 +189,19 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     return storeSettings.aiProfiles.some((p) => p.id === stored) ? stored : null;
   });
 
+  const deploymentProxyConfigured = hasDeploymentAssistantEnv();
+
   // The currently active profile: if the user hasn't explicitly chosen one,
   // follow the default. Otherwise respect their explicit selection.
   const activeProfile: AssistantProfile | null = useMemo(() => {
-    // If the user explicitly chose a profile via the dropdown, use that.
-    if (userExplicitlyChoseProfile.current && selectedProfileId) {
-      const found = aiProfiles.find((p) => p.id === selectedProfileId);
-      if (found) return found;
-    }
-    // Fall back to the default profile.
-    if (defaultAiProfileId) {
-      const found = aiProfiles.find((p) => p.id === defaultAiProfileId);
-      if (found) return found;
-    }
-    // Fall back to the first profile.
-    return aiProfiles[0] ?? null;
-  }, [selectedProfileId, aiProfiles, defaultAiProfileId]);
+    return selectActiveAssistantProfile({
+      profiles: aiProfiles,
+      defaultProfileId: defaultAiProfileId,
+      selectedProfileId,
+      userExplicitlyChoseProfile: userExplicitlyChoseProfile.current,
+      deploymentProxyConfigured,
+    });
+  }, [selectedProfileId, aiProfiles, defaultAiProfileId, deploymentProxyConfigured]);
 
   // Queue of model-generated code snippets (run_python / run_maplibre_js)
   // awaiting the user's approval, each with the promise resolver its tool
@@ -597,6 +596,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
                 disabled={running}
                 onChange={(event) => onProfileChange(event.target.value)}
               >
+                {deploymentProxyConfigured ? (
+                  <option value="">{t("assistant.deploymentProxy")}</option>
+                ) : null}
                 {aiProfiles.map((profile) => (
                   <option key={profile.id} value={profile.id}>
                     {profile.name}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3009,6 +3009,7 @@
     "toolError": "failed",
     "provider": "LLM provider",
     "profile": "AI profile",
+    "deploymentProxy": "Deployment proxy",
     "model": "Model",
     "codeApprovalTitle": "Run assistant code?",
     "codeApprovalBody": "The assistant wants to run {{language}} code in the app. Review it first — it can change the map and access app data.",

--- a/apps/geolibre-desktop/src/lib/assistant/profiles.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/profiles.ts
@@ -15,6 +15,40 @@ function generateProfileId(): string {
   return `prof_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+export interface ActiveAssistantProfileOptions {
+  profiles: AssistantProfile[];
+  defaultProfileId: string | null;
+  selectedProfileId: string | null;
+  userExplicitlyChoseProfile: boolean;
+  deploymentProxyConfigured: boolean;
+}
+
+/**
+ * Choose the assistant profile that should pin the current session.
+ *
+ * @param options Profile state and deployment-proxy availability.
+ * @returns The active profile, or null to let provider auto-resolution choose.
+ */
+export function selectActiveAssistantProfile({
+  profiles,
+  defaultProfileId,
+  selectedProfileId,
+  userExplicitlyChoseProfile,
+  deploymentProxyConfigured,
+}: ActiveAssistantProfileOptions): AssistantProfile | null {
+  if (userExplicitlyChoseProfile) {
+    if (!selectedProfileId) return null;
+    const selected = profiles.find((profile) => profile.id === selectedProfileId);
+    if (selected) return selected;
+  }
+  if (defaultProfileId) {
+    const found = profiles.find((profile) => profile.id === defaultProfileId);
+    if (found) return found;
+  }
+  if (deploymentProxyConfigured) return null;
+  return profiles[0] ?? null;
+}
+
 /**
  * Migrate a legacy flat `aiProviderEnv` map to an array of {@link AssistantProfile}.
  * The legacy format stored every env var key/value in one flat map; we split it

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -63,6 +63,8 @@ export interface AssistantProviderConfig {
   apiKey?: string;
   /** OpenAI-compatible base URL (ollama, custom). */
   baseURL?: string;
+  /** Suppress Bearer auth for same-origin proxies protected by browser auth. */
+  suppressAuthorizationHeader?: boolean;
   /** AWS region (bedrock). */
   region?: string;
   /** AWS credentials (bedrock). */
@@ -259,17 +261,32 @@ export const PROVIDER_LABELS: Record<AssistantProviderId, string> = {
  */
 export type RuntimeEnv = Record<string, string>;
 
+function browserOrigin(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  const origin = window.location?.origin;
+  return origin && origin !== "null" ? origin : undefined;
+}
+
+function managedProxyBaseUrl(proxyUrl: string, baseOrigin?: string): string {
+  let normalized = proxyUrl.trim().replace(/\/+$/, "");
+  if (baseOrigin && normalized.startsWith("/")) {
+    normalized = new URL(normalized, baseOrigin).toString().replace(/\/+$/, "");
+  }
+  return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+}
+
 /** Public AI proxy configuration embedded by Vite for a managed build. */
 export function readBuildTimeAssistantEnv(
   viteEnv: Record<string, string | undefined> | undefined = (
     import.meta as ImportMeta & { env?: Record<string, string | undefined> }
   ).env,
+  baseOrigin?: string,
 ): RuntimeEnv {
   if (!viteEnv) return {};
   const result: RuntimeEnv = {};
   const proxyUrl = viteEnv.VITE_GEOLIBRE_AI_URL?.trim().replace(/\/+$/, "");
   if (proxyUrl) {
-    result.OPENAI_COMPATIBLE_BASE_URL = proxyUrl.endsWith("/v1") ? proxyUrl : `${proxyUrl}/v1`;
+    result.OPENAI_COMPATIBLE_BASE_URL = managedProxyBaseUrl(proxyUrl, baseOrigin);
     result.OPENAI_COMPATIBLE_MODEL =
       viteEnv.VITE_GEOLIBRE_AI_MODEL?.trim() || result.OPENAI_COMPATIBLE_MODEL || "openai/gpt-5.5";
   }
@@ -284,12 +301,22 @@ export function readDeploymentAssistantEnv(): RuntimeEnv {
       __GEOLIBRE_DEPLOYMENT_ENV__?: Record<string, string | undefined>;
     }
   ).__GEOLIBRE_DEPLOYMENT_ENV__;
-  return readBuildTimeAssistantEnv(deploymentEnv);
+  const result = readBuildTimeAssistantEnv(deploymentEnv, browserOrigin());
+  if (result.OPENAI_COMPATIBLE_BASE_URL) {
+    result.GEOLIBRE_AI_PROXY_BASE_URL = result.OPENAI_COMPATIBLE_BASE_URL;
+    result.GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION = "1";
+  }
+  return result;
+}
+
+/** True when a Docker deployment injected a managed AI proxy endpoint. */
+export function hasDeploymentAssistantEnv(): boolean {
+  return Boolean(readDeploymentAssistantEnv().OPENAI_COMPATIBLE_BASE_URL);
 }
 
 /** Read build-time credentials plus the live runtime environment map. */
 export function readRuntimeEnv(): RuntimeEnv {
-  const built = readBuildTimeAssistantEnv();
+  const built = readBuildTimeAssistantEnv(undefined, browserOrigin());
   if (typeof window === "undefined") return built;
   return {
     ...built,
@@ -390,11 +417,17 @@ export function configForProvider(
       const baseURL = firstValue(env, "OPENAI_COMPATIBLE_BASE_URL");
       if (!baseURL || !modelId) return null;
       const apiKey = firstValue(env, "OPENAI_COMPATIBLE_API_KEY") ?? "not-needed";
+      const normalizedBaseURL = baseURL.replace(/\/+$/, "");
+      const proxyBaseURL = firstValue(env, "GEOLIBRE_AI_PROXY_BASE_URL")?.replace(/\/+$/, "");
       return {
         provider,
         apiKey,
-        baseURL: baseURL.replace(/\/+$/, ""),
+        baseURL: normalizedBaseURL,
         modelId,
+        suppressAuthorizationHeader:
+          env.GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION === "1" &&
+          Boolean(proxyBaseURL) &&
+          normalizedBaseURL === proxyBaseURL,
       };
     }
     case "bedrock": {
@@ -496,6 +529,7 @@ export async function createModel(config: AssistantProviderConfig): Promise<Mode
         modelId: config.modelId,
         clientConfig: {
           baseURL: config.baseURL,
+          defaultHeaders: config.suppressAuthorizationHeader ? { Authorization: null } : undefined,
           dangerouslyAllowBrowser: true,
         },
       }) as unknown as Model;

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -309,9 +309,17 @@ export function readDeploymentAssistantEnv(): RuntimeEnv {
   return result;
 }
 
-/** True when a Docker deployment injected a managed AI proxy endpoint. */
-export function hasDeploymentAssistantEnv(): boolean {
-  return Boolean(readDeploymentAssistantEnv().OPENAI_COMPATIBLE_BASE_URL);
+/**
+ * True when the build or the Docker entrypoint supplied a managed AI proxy.
+ *
+ * Deliberately ignores `__GEOLIBRE_RUNTIME_ENV__`: an endpoint the user typed
+ * into Settings is their own custom provider, not an operator-managed proxy.
+ */
+export function hasManagedAssistantProxy(viteEnv?: Record<string, string | undefined>): boolean {
+  return Boolean(
+    readBuildTimeAssistantEnv(viteEnv, browserOrigin()).OPENAI_COMPATIBLE_BASE_URL ||
+    readDeploymentAssistantEnv().OPENAI_COMPATIBLE_BASE_URL,
+  );
 }
 
 /** Read build-time credentials plus the live runtime environment map. */

--- a/tests/assistant-provider-persistence.test.ts
+++ b/tests/assistant-provider-persistence.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { normalizeDesktopSettings } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+import { selectActiveAssistantProfile } from "../apps/geolibre-desktop/src/lib/assistant/profiles";
 import { mergeRuntimeEnv } from "../apps/geolibre-desktop/src/lib/assistant/provider";
+import type { AssistantProfile } from "../apps/geolibre-desktop/src/lib/assistant/provider";
 
 const NO_SOURCES = {
   osEnv: {},
@@ -127,6 +129,87 @@ describe("DesktopSettings.aiProfiles persistence and migration", () => {
     const result = normalizeDesktopSettings(stored);
     assert.equal(result.aiProfiles.length, 1);
     assert.deepEqual(result.aiProfiles[0].fieldValues, {});
+  });
+});
+
+describe("selectActiveAssistantProfile", () => {
+  const profiles: AssistantProfile[] = [
+    {
+      id: "prof_openai",
+      name: "OpenAI",
+      provider: "openai",
+      modelId: "gpt-5.6",
+      fieldValues: { OPENAI_API_KEY: "sk-openai" },
+    },
+    {
+      id: "prof_anthropic",
+      name: "Anthropic",
+      provider: "anthropic",
+      modelId: "claude-opus-5",
+      fieldValues: { ANTHROPIC_API_KEY: "sk-ant" },
+    },
+  ];
+
+  it("falls back to the first profile when no deployment proxy is injected", () => {
+    assert.equal(
+      selectActiveAssistantProfile({
+        profiles,
+        defaultProfileId: null,
+        selectedProfileId: null,
+        userExplicitlyChoseProfile: false,
+        deploymentProxyConfigured: false,
+      })?.id,
+      "prof_openai",
+    );
+  });
+
+  it("lets a Docker deployment proxy auto-resolve instead of pinning the first profile", () => {
+    assert.equal(
+      selectActiveAssistantProfile({
+        profiles,
+        defaultProfileId: null,
+        selectedProfileId: null,
+        userExplicitlyChoseProfile: false,
+        deploymentProxyConfigured: true,
+      }),
+      null,
+    );
+  });
+
+  it("honors explicit and default profiles over the deployment proxy", () => {
+    assert.equal(
+      selectActiveAssistantProfile({
+        profiles,
+        defaultProfileId: "prof_anthropic",
+        selectedProfileId: null,
+        userExplicitlyChoseProfile: false,
+        deploymentProxyConfigured: true,
+      })?.id,
+      "prof_anthropic",
+    );
+    assert.equal(
+      selectActiveAssistantProfile({
+        profiles,
+        defaultProfileId: "prof_openai",
+        selectedProfileId: "prof_anthropic",
+        userExplicitlyChoseProfile: true,
+        deploymentProxyConfigured: true,
+      })?.id,
+      "prof_anthropic",
+    );
+  });
+
+  it("lets an explicit empty selection use provider auto-resolution", () => {
+    assert.equal(
+      selectActiveAssistantProfile({
+        profiles,
+        defaultProfileId: "prof_openai",
+        selectedProfileId: "",
+        userExplicitlyChoseProfile: true,
+        deploymentProxyConfigured: true,
+      }),
+      null,
+    );
   });
 });
 

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -53,21 +53,41 @@ describe("build-time AI proxy", () => {
     );
   });
 
+  it("resolves a same-origin managed proxy path against the deployment origin", () => {
+    assert.deepEqual(
+      readBuildTimeAssistantEnv(
+        {
+          VITE_GEOLIBRE_AI_URL: "/ai",
+          VITE_GEOLIBRE_AI_MODEL: "openai/gpt-5.5",
+        },
+        "http://localhost:8081",
+      ),
+      {
+        OPENAI_COMPATIBLE_BASE_URL: "http://localhost:8081/ai/v1",
+        OPENAI_COMPATIBLE_MODEL: "openai/gpt-5.5",
+      },
+    );
+  });
+
   it("reads Docker deployment config only when the entrypoint injects a URL", () => {
     const originalWindow = globalThis.window;
     try {
       globalThis.window = {
+        location: { origin: "http://localhost:8081" },
         __GEOLIBRE_DEPLOYMENT_ENV__: {
           VITE_GEOLIBRE_AI_URL: "/ai",
           VITE_GEOLIBRE_AI_MODEL: "openai/gpt-5.5",
         },
       } as unknown as Window & typeof globalThis;
       assert.deepEqual(readDeploymentAssistantEnv(), {
-        OPENAI_COMPATIBLE_BASE_URL: "/ai/v1",
+        OPENAI_COMPATIBLE_BASE_URL: "http://localhost:8081/ai/v1",
         OPENAI_COMPATIBLE_MODEL: "openai/gpt-5.5",
+        GEOLIBRE_AI_PROXY_BASE_URL: "http://localhost:8081/ai/v1",
+        GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION: "1",
       });
 
       globalThis.window = {
+        location: { origin: "http://localhost:8081" },
         __GEOLIBRE_DEPLOYMENT_ENV__: {
           VITE_GEOLIBRE_AI_MODEL: "openai/gpt-5.5",
         },
@@ -82,6 +102,7 @@ describe("build-time AI proxy", () => {
     const originalWindow = globalThis.window;
     try {
       globalThis.window = {
+        location: { origin: "http://localhost:8081" },
         __GEOLIBRE_DEPLOYMENT_ENV__: {
           VITE_GEOLIBRE_AI_URL: "/ai",
           VITE_GEOLIBRE_AI_MODEL: "openai/gpt-5.5",
@@ -93,8 +114,9 @@ describe("build-time AI proxy", () => {
       const env = readRuntimeEnv();
       // The deployment supplies the endpoint, the user's own setting wins on
       // the model: runtime beats deployment, deployment beats build defaults.
-      assert.equal(env.OPENAI_COMPATIBLE_BASE_URL, "/ai/v1");
+      assert.equal(env.OPENAI_COMPATIBLE_BASE_URL, "http://localhost:8081/ai/v1");
       assert.equal(env.OPENAI_COMPATIBLE_MODEL, "anthropic/claude-opus-5");
+      assert.equal(env.GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION, "1");
     } finally {
       globalThis.window = originalWindow;
     }
@@ -210,7 +232,37 @@ describe("resolveProviderConfig", () => {
       apiKey: "k",
       baseURL: "https://api.example.com/v1",
       modelId: "my-model",
+      suppressAuthorizationHeader: false,
     });
+  });
+
+  it("suppresses Bearer auth only for the Docker-managed proxy endpoint", () => {
+    assert.deepEqual(
+      configForProvider("custom", undefined, {
+        OPENAI_COMPATIBLE_BASE_URL: "http://localhost:8081/ai/v1",
+        OPENAI_COMPATIBLE_MODEL: "openai/gpt-5.5",
+        GEOLIBRE_AI_PROXY_BASE_URL: "http://localhost:8081/ai/v1",
+        GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION: "1",
+      }),
+      {
+        provider: "custom",
+        apiKey: "not-needed",
+        baseURL: "http://localhost:8081/ai/v1",
+        modelId: "openai/gpt-5.5",
+        suppressAuthorizationHeader: true,
+      },
+    );
+
+    assert.equal(
+      configForProvider("custom", undefined, {
+        OPENAI_COMPATIBLE_BASE_URL: "https://api.example.com/v1",
+        OPENAI_COMPATIBLE_MODEL: "my-model",
+        OPENAI_COMPATIBLE_API_KEY: "k",
+        GEOLIBRE_AI_PROXY_BASE_URL: "http://localhost:8081/ai/v1",
+        GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION: "1",
+      })?.suppressAuthorizationHeader,
+      false,
+    );
   });
 });
 

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   availableProviders,
   configForProvider,
+  hasManagedAssistantProxy,
   readBuildTimeAssistantEnv,
   readDeploymentAssistantEnv,
   readRuntimeEnv,
@@ -117,6 +118,46 @@ describe("build-time AI proxy", () => {
       assert.equal(env.OPENAI_COMPATIBLE_BASE_URL, "http://localhost:8081/ai/v1");
       assert.equal(env.OPENAI_COMPATIBLE_MODEL, "anthropic/claude-opus-5");
       assert.equal(env.GEOLIBRE_AI_PROXY_OMIT_AUTHORIZATION, "1");
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+});
+
+describe("hasManagedAssistantProxy", () => {
+  it("recognizes a proxy baked in at build time, with no Docker injection", () => {
+    assert.equal(
+      hasManagedAssistantProxy({ VITE_GEOLIBRE_AI_URL: "https://ai.example.com" }),
+      true,
+    );
+    assert.equal(hasManagedAssistantProxy({ VITE_GEOLIBRE_AI_MODEL: "openai/gpt-5.5" }), false);
+  });
+
+  it("recognizes a proxy injected by the Docker entrypoint", () => {
+    const originalWindow = globalThis.window;
+    try {
+      globalThis.window = {
+        location: { origin: "http://localhost:8081" },
+        __GEOLIBRE_DEPLOYMENT_ENV__: { VITE_GEOLIBRE_AI_URL: "/ai" },
+      } as unknown as Window & typeof globalThis;
+      assert.equal(hasManagedAssistantProxy({}), true);
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("ignores an endpoint the user typed into Settings", () => {
+    const originalWindow = globalThis.window;
+    try {
+      // A custom OpenAI-compatible endpoint is the user's own provider, not an
+      // operator-managed proxy, so it must not take over profile selection.
+      globalThis.window = {
+        location: { origin: "http://localhost:8081" },
+        __GEOLIBRE_RUNTIME_ENV__: {
+          OPENAI_COMPATIBLE_BASE_URL: "https://api.example.com/v1",
+        },
+      } as unknown as Window & typeof globalThis;
+      assert.equal(hasManagedAssistantProxy({}), false);
     } finally {
       globalThis.window = originalWindow;
     }


### PR DESCRIPTION
## Summary
- Resolve a same-origin managed proxy path (`VITE_GEOLIBRE_AI_URL=/ai`) against the page origin so the SDK receives an absolute base URL instead of a relative one.
- Stop auto-pinning the first saved AI profile when a deployment injects a proxy, and surface the proxy as an explicit "Deployment proxy" choice in the profile dropdown; an explicit profile or a configured default still wins.
- Omit the `Authorization` header for that proxy endpoint only, since the proxy supplies the upstream key itself. Any other custom base URL keeps its Bearer auth.

## Test plan
- [x] `npm run test:frontend` (3934 passing) covering the new `selectActiveAssistantProfile`, origin resolution, and header-suppression cases
- [x] `pre-commit run --files <changed files>` (oxfmt, eslint, npm build)
- [ ] Docker web deployment with `VITE_GEOLIBRE_AI_URL` set: assistant answers a prompt through the proxy with no API key configured
- [ ] Desktop/web build with no proxy injected: profile selection and custom OpenAI-compatible endpoints behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deployment-proxy assistant configurations.
  * Added a “Deployment proxy” option to the assistant profile selector when available.
  * Improved resolution of relative proxy URLs and ensured OpenAI-compatible `/v1` endpoints.
  * For managed deployment proxies, Authorization headers are now automatically omitted.
* **Bug Fixes**
  * Assistant profile selection now consistently prioritizes an explicit choice or default profile, with correct fallback behavior when a deployment proxy is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->