### PR TITLE
Expose bounded Overture queries to cooperating plugins

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -36,6 +36,7 @@ import {
   maplibreHuggingFacePlugin,
   maplibreGeoLensPlugin,
   maplibreOvertureMapsPlugin,
+  queryOvertureFeatures,
   maplibreGraticulePlugin,
   maplibreCloudsPlugin,
   maplibrePrecipitationPlugin,
@@ -723,7 +724,9 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
         (typeof version !== "string" || !/^1\.\d/.test(version.trim()))
       ) {
         console.warn(
-          `[GeoLibre] addWmsLayer: unsupported WMS version "${String(version)}"; using "${resolvedVersion}".`,
+          `[GeoLibre] addWmsLayer: unsupported WMS version "${String(
+            version,
+          )}"; using "${resolvedVersion}".`,
         );
       }
       const tileUrl = createWmsTileUrl({
@@ -826,6 +829,12 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       }),
     fetchArrayBuffer: fetchRemoteArrayBuffer,
     resolvePluginAssetUrl: resolvePluginAssetUrlForLoadedPlugin,
+    activatePlugin: (pluginId: string, state?: unknown) => {
+      manager.activate(pluginId, api);
+      if (!manager.isActive(pluginId)) return false;
+      return state === undefined ? true : manager.applyPluginState(pluginId, api, state);
+    },
+    queryOvertureFeatures,
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,
@@ -960,7 +969,9 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       // forever.
       if (projection !== "globe" && projection !== "mercator") {
         console.warn(
-          `[GeoLibre] setMapProjection: ignoring unknown projection "${String(projection)}" (expected "globe" or "mercator").`,
+          `[GeoLibre] setMapProjection: ignoring unknown projection "${String(
+            projection,
+          )}" (expected "globe" or "mercator").`,
         );
         return;
       }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -829,9 +829,9 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       }),
     fetchArrayBuffer: fetchRemoteArrayBuffer,
     resolvePluginAssetUrl: resolvePluginAssetUrlForLoadedPlugin,
-    activatePlugin: (pluginId: string, state?: unknown) => {
-      manager.activate(pluginId, api);
-      if (!manager.isActive(pluginId)) return false;
+    activatePlugin: async (pluginId: string, state?: unknown) => {
+      const activated = await manager.activate(pluginId, api);
+      if (!activated || !manager.isActive(pluginId)) return false;
       return state === undefined ? true : manager.applyPluginState(pluginId, api, state);
     },
     queryOvertureFeatures,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21860,6 +21860,7 @@
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.8.4",
         "@loaders.gl/i3s": "^4.4.3",
+        "@mapbox/vector-tile": "^2.0.5",
         "@maplibre/maplibre-gl-directions": "^0.9.1",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-opener": "^2.5.4",
@@ -21893,6 +21894,8 @@
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.1",
         "netcdfjs": "^4.0.0",
+        "pbf": "^4.0.2",
+        "pmtiles": "^4.4.1",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.185.1"
@@ -21900,6 +21903,23 @@
       "devDependencies": {
         "@types/geojson": "^7946.0.16",
         "typescript": "^7.0.2"
+      }
+    },
+    "packages/plugins/node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "packages/plugins/node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
       }
     },
     "packages/plugins/node_modules/three": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -25,6 +25,7 @@
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.8.4",
     "@loaders.gl/i3s": "^4.4.3",
+    "@mapbox/vector-tile": "^2.0.5",
     "@maplibre/maplibre-gl-directions": "^0.9.1",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-opener": "^2.5.4",
@@ -58,6 +59,8 @@
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.1",
     "netcdfjs": "^4.0.0",
+    "pbf": "^4.0.2",
+    "pmtiles": "^4.4.1",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.185.1"

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -151,6 +151,11 @@ export {
   type DuckDBIdentifyResult,
 } from "./plugins/maplibre-duckdb";
 export {
+  queryOvertureFeatures,
+  overtureFeatureMatchesFilter,
+  overtureTilesForBBox,
+} from "./plugins/overture-query";
+export {
   closePlanetaryComputerPanel,
   openPlanetaryComputerPanel,
   restorePlanetaryComputerLayers,

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -17,6 +17,7 @@ export class PluginManager {
   private urlParameterNamesById = new Map<string, string[]>();
   private listeners = new Set<() => void>();
   private activationGenerations = new Map<string, number>();
+  private activating = new Set<string>();
   private version = 0;
 
   register(plugin: GeoLibrePlugin): void {
@@ -85,6 +86,7 @@ export class PluginManager {
     this.defaultMapControlPositions.delete(id);
     this.urlParameterNamesById.delete(id);
     this.activationGenerations.delete(id);
+    this.activating.delete(id);
     for (const handled of this.handledUrlParametersByContext.values()) {
       handled.delete(id);
     }
@@ -135,9 +137,15 @@ export class PluginManager {
 
   activate(id: string, app: GeoLibreAppAPI): void {
     const plugin = this.plugins.get(id);
-    if (!plugin || this.active.has(id)) return;
+    if (!plugin || this.active.has(id) || this.activating.has(id)) return;
     const scopedApp = scopeAppToPlugin(app, id);
-    const activated = plugin.activate(scopedApp);
+    this.activating.add(id);
+    let activated: ReturnType<GeoLibrePlugin["activate"]>;
+    try {
+      activated = plugin.activate(scopedApp);
+    } finally {
+      this.activating.delete(id);
+    }
     if (activated === false) return;
     const generation = this.nextActivationGeneration(id);
     this.active.add(id);
@@ -221,6 +229,19 @@ export class PluginManager {
   toggle(id: string, app: GeoLibreAppAPI): void {
     if (this.active.has(id)) this.deactivate(id, app);
     else this.activate(id, app);
+  }
+
+  /**
+   * Apply a state patch to one registered plugin without restoring the whole
+   * project. Used by cooperating plugins after the target is active.
+   */
+  applyPluginState(id: string, app: GeoLibreAppAPI, state: unknown): boolean {
+    const plugin = this.plugins.get(id);
+    if (!plugin?.applyProjectState) return false;
+    const updated = plugin.applyProjectState(scopeAppToPlugin(app, id), state);
+    if (updated === false) return false;
+    this.notify();
+    return true;
   }
 
   async handleUrlParameters(
@@ -410,9 +431,15 @@ export class PluginManager {
     for (const id of targetActive) {
       if (this.active.has(id)) continue;
       const plugin = this.plugins.get(id);
-      if (!plugin) continue;
+      if (!plugin || this.activating.has(id)) continue;
       const scopedApp = scopeForRestore(id);
-      const activated = plugin.activate(scopedApp);
+      this.activating.add(id);
+      let activated: ReturnType<GeoLibrePlugin["activate"]>;
+      try {
+        activated = plugin.activate(scopedApp);
+      } finally {
+        this.activating.delete(id);
+      }
       if (activated === false) continue;
       const generation = this.nextActivationGeneration(id);
       this.active.add(id);
@@ -471,7 +498,8 @@ function scopeAppToPlugin(
 ): GeoLibreAppAPI {
   const { onControlAdded } = options;
   const register = app.registerToolbarMenu;
-  if (!register && !onControlAdded) return app;
+  const activatePlugin = app.activatePlugin;
+  if (!register && !onControlAdded && !activatePlugin) return app;
 
   const scoped: GeoLibreAppAPI = { ...app };
 
@@ -493,6 +521,11 @@ function scopeAppToPlugin(
       if (added !== false) onControlAdded(control);
       return added;
     };
+  }
+
+  if (activatePlugin) {
+    scoped.activatePlugin = (targetPluginId, state) =>
+      targetPluginId === pluginId ? false : activatePlugin(targetPluginId, state);
   }
 
   return scoped;

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -86,7 +86,10 @@ export class PluginManager {
     this.defaultActive.delete(id);
     this.defaultMapControlPositions.delete(id);
     this.urlParameterNamesById.delete(id);
-    this.activationGenerations.delete(id);
+    // Invalidate any watcher retained by an activation Promise from the old
+    // plugin instance. Keep the counter monotonic so a re-registered plugin
+    // cannot reuse the same generation identity.
+    this.nextActivationGeneration(id);
     this.activationResults.delete(id);
     this.activating.delete(id);
     for (const handled of this.handledUrlParametersByContext.values()) {
@@ -421,6 +424,7 @@ export class PluginManager {
       if (!plugin) continue;
       plugin.deactivate(scopeAppToPlugin(app, id));
       this.active.delete(id);
+      this.activationResults.delete(id);
       changed = true;
     }
 

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -17,6 +17,7 @@ export class PluginManager {
   private urlParameterNamesById = new Map<string, string[]>();
   private listeners = new Set<() => void>();
   private activationGenerations = new Map<string, number>();
+  private activationResults = new Map<string, Promise<boolean>>();
   private activating = new Set<string>();
   private version = 0;
 
@@ -86,6 +87,7 @@ export class PluginManager {
     this.defaultMapControlPositions.delete(id);
     this.urlParameterNamesById.delete(id);
     this.activationGenerations.delete(id);
+    this.activationResults.delete(id);
     this.activating.delete(id);
     for (const handled of this.handledUrlParametersByContext.values()) {
       handled.delete(id);
@@ -135,9 +137,12 @@ export class PluginManager {
     return () => this.listeners.delete(listener);
   }
 
-  activate(id: string, app: GeoLibreAppAPI): void {
+  activate(id: string, app: GeoLibreAppAPI): boolean | Promise<boolean> {
     const plugin = this.plugins.get(id);
-    if (!plugin || this.active.has(id) || this.activating.has(id)) return;
+    if (!plugin || this.activating.has(id)) return false;
+    const pendingResult = this.activationResults.get(id);
+    if (pendingResult) return pendingResult;
+    if (this.active.has(id)) return true;
     const scopedApp = scopeAppToPlugin(app, id);
     this.activating.add(id);
     let activated: ReturnType<GeoLibrePlugin["activate"]>;
@@ -146,11 +151,14 @@ export class PluginManager {
     } finally {
       this.activating.delete(id);
     }
-    if (activated === false) return;
+    if (activated === false) return false;
     const generation = this.nextActivationGeneration(id);
     this.active.add(id);
     this.notify();
-    this.watchAsyncActivation(id, activated, scopedApp, generation);
+    const result = this.watchAsyncActivation(id, activated, scopedApp, generation);
+    if (!result) return true;
+    this.trackActivationResult(id, result);
+    return result;
   }
 
   /**
@@ -169,19 +177,24 @@ export class PluginManager {
     activated: boolean | void | PromiseLike<boolean | void>,
     app: GeoLibreAppAPI,
     generation: number,
-  ): void {
+  ): Promise<boolean> | null {
     // An async plugin (e.g. one mounted behind a dynamic import) reports
     // failure after the fact by resolving false or rejecting. Roll back so the
     // Plugins menu does not show a plugin that never mounted (e.g. when its
     // chunk fails to load after a web redeploy).
-    if (!isThenable(activated)) return;
-    void Promise.resolve(activated).then(
+    if (!isThenable(activated)) return null;
+    return Promise.resolve(activated).then(
       (result) => {
         if (result === false) {
           this.rollbackFailedActivation(id, app, generation);
+          return false;
         }
+        return this.active.has(id) && this.activationGenerations.get(id) === generation;
       },
-      (error) => this.rollbackFailedActivation(id, app, generation, error),
+      (error) => {
+        this.rollbackFailedActivation(id, app, generation, error);
+        return false;
+      },
     );
   }
 
@@ -218,11 +231,19 @@ export class PluginManager {
     this.notify();
   }
 
+  private trackActivationResult(id: string, result: Promise<boolean>): void {
+    this.activationResults.set(id, result);
+    void result.then(() => {
+      if (this.activationResults.get(id) === result) this.activationResults.delete(id);
+    });
+  }
+
   deactivate(id: string, app: GeoLibreAppAPI): void {
     const plugin = this.plugins.get(id);
     if (!plugin || !this.active.has(id)) return;
     plugin.deactivate(scopeAppToPlugin(app, id));
     this.active.delete(id);
+    this.activationResults.delete(id);
     this.notify();
   }
 
@@ -305,7 +326,11 @@ export class PluginManager {
         // failure to this plugin instead of aborting the whole loop.
         if (!this.active.has(id)) {
           try {
-            this.activate(id, app);
+            const activated = await this.activate(id, app);
+            if (!activated) {
+              handledPluginIds.delete(id);
+              continue;
+            }
           } catch (error) {
             handledPluginIds.delete(id);
             console.warn(
@@ -447,7 +472,8 @@ export class PluginManager {
       // Restoring a saved project re-activates plugins the same way the user
       // would, so an async mount that later fails (e.g. a stale chunk after a
       // redeploy) must roll back here too, not just from activate().
-      this.watchAsyncActivation(id, activated, scopedApp, generation);
+      const result = this.watchAsyncActivation(id, activated, scopedApp, generation);
+      if (result) this.trackActivationResult(id, result);
     }
 
     if (changed) this.notify();
@@ -524,7 +550,7 @@ function scopeAppToPlugin(
   }
 
   if (activatePlugin) {
-    scoped.activatePlugin = (targetPluginId, state) =>
+    scoped.activatePlugin = async (targetPluginId, state) =>
       targetPluginId === pluginId ? false : activatePlugin(targetPluginId, state);
   }
 

--- a/packages/plugins/src/plugins/maplibre-overture-maps.ts
+++ b/packages/plugins/src/plugins/maplibre-overture-maps.ts
@@ -11,6 +11,8 @@ import {
   type OvertureMapsControlOptions,
   type OvertureMapsEventHandler,
   type OvertureMapsState,
+  type OvertureLayerState,
+  type OvertureThemeState,
   type OvertureTheme,
 } from "maplibre-gl-overture-maps";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
@@ -69,6 +71,104 @@ function isOvertureMapsState(value: unknown): value is Partial<OvertureMapsState
   return "themes" in value || "release" in value || "collapsed" in value;
 }
 
+type OvertureStatePatch = Omit<Partial<OvertureMapsState>, "themes"> & {
+  themes?: Partial<
+    Record<
+      OvertureTheme,
+      Partial<Omit<OvertureThemeState, "layers">> & {
+        layers?: Record<string, Partial<OvertureLayerState>>;
+      }
+    >
+  >;
+};
+
+function defaultOvertureState(): OvertureMapsState {
+  return new OvertureMapsControl({
+    ...OVERTURE_OPTIONS,
+    position: overturePosition,
+  }).getState();
+}
+
+/** Deep-merge a partial Overture state patch without dropping other themes. */
+export function mergeOvertureMapsState(
+  base: OvertureMapsState,
+  patch: OvertureStatePatch,
+): OvertureMapsState {
+  const themes = Object.fromEntries(
+    Object.entries(base.themes).map(([theme, state]) => [
+      theme,
+      {
+        ...state,
+        layers: Object.fromEntries(
+          Object.entries(state.layers).map(([sourceLayer, layer]) => [sourceLayer, { ...layer }]),
+        ),
+      },
+    ]),
+  ) as OvertureMapsState["themes"];
+
+  for (const [theme, themePatch] of Object.entries(patch.themes ?? {}) as Array<
+    [OvertureTheme, NonNullable<OvertureStatePatch["themes"]>[OvertureTheme]]
+  >) {
+    const currentTheme = themes[theme];
+    if (!currentTheme || !themePatch) continue;
+    const layers = { ...currentTheme.layers };
+    for (const [sourceLayer, layerPatch] of Object.entries(themePatch.layers ?? {})) {
+      if (!layers[sourceLayer]) continue;
+      layers[sourceLayer] = { ...layers[sourceLayer], ...layerPatch };
+    }
+    themes[theme] = { ...currentTheme, ...themePatch, layers };
+  }
+
+  return { ...base, ...patch, themes };
+}
+
+function applyOvertureMapsState(control: OvertureMapsControl, patch: OvertureStatePatch): void {
+  const current = control.getState();
+  const next = mergeOvertureMapsState(current, patch);
+
+  if (next.release && next.release !== current.release) {
+    control.setRelease(next.release);
+  }
+  if (patch.inspect !== undefined && next.inspect !== current.inspect) {
+    control.setInspect(next.inspect);
+  }
+  for (const [theme, themePatch] of Object.entries(patch.themes ?? {}) as Array<
+    [OvertureTheme, NonNullable<OvertureStatePatch["themes"]>[OvertureTheme]]
+  >) {
+    if (!themePatch) continue;
+    if (
+      themePatch.expanded !== undefined &&
+      next.themes[theme].expanded !== current.themes[theme].expanded
+    ) {
+      control.setThemeExpanded(theme, next.themes[theme].expanded);
+    }
+    for (const [sourceLayer, layerPatch] of Object.entries(themePatch.layers ?? {})) {
+      const before = current.themes[theme].layers[sourceLayer];
+      const after = next.themes[theme].layers[sourceLayer];
+      if (!before || !after) continue;
+      if (layerPatch.visible !== undefined && after.visible !== before.visible) {
+        control.setLayerVisible(theme, sourceLayer, after.visible);
+      }
+      if (layerPatch.opacity !== undefined && after.opacity !== before.opacity) {
+        control.setLayerOpacity(theme, sourceLayer, after.opacity);
+      }
+      if (layerPatch.color !== undefined && after.color !== before.color) {
+        control.setLayerColor(theme, sourceLayer, after.color);
+      }
+      if (layerPatch.size !== undefined && after.size !== before.size) {
+        control.setLayerSize(theme, sourceLayer, after.size);
+      }
+    }
+  }
+  if (patch.panelWidth !== undefined) {
+    control.setState({ panelWidth: next.panelWidth });
+  }
+  if (patch.collapsed !== undefined && next.collapsed !== current.collapsed) {
+    if (next.collapsed) control.collapse();
+    else control.expand();
+  }
+}
+
 export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-overture-maps",
   name: "Overture Maps",
@@ -115,8 +215,16 @@ export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
   getProjectState: () => overtureControl?.getState() ?? pendingState ?? undefined,
   applyProjectState: (_app: GeoLibreAppAPI, state: unknown) => {
     if (!isOvertureMapsState(state)) return false;
-    pendingState = state;
-    overtureControl?.setState(state);
+    const patch = state as OvertureStatePatch;
+    if (overtureControl) {
+      applyOvertureMapsState(overtureControl, patch);
+      pendingState = overtureControl.getState();
+    } else {
+      pendingState = mergeOvertureMapsState(
+        mergeOvertureMapsState(defaultOvertureState(), pendingState ?? {}),
+        patch,
+      );
+    }
   },
 };
 

--- a/packages/plugins/src/plugins/maplibre-overture-maps.ts
+++ b/packages/plugins/src/plugins/maplibre-overture-maps.ts
@@ -38,7 +38,7 @@ const SOURCE_KIND = "overture-maps";
 let overtureControl: OvertureMapsControl | null = null;
 // Holds the panel state while the control is detached so re-activating or
 // repositioning it restores the user's release, visibility, and opacity.
-let pendingState: OvertureMapsState | null = null;
+let pendingState: RestorableOvertureState | null = null;
 
 function createOvertureControl(app: GeoLibreAppAPI): OvertureMapsControl {
   // Construct with the static defaults, then let setState restore the full
@@ -75,6 +75,12 @@ type OvertureStatePatch = Partial<
       }
     >
   >;
+};
+
+type RestorableOvertureState = Partial<
+  Pick<OvertureMapsState, "collapsed" | "inspect" | "panelWidth" | "release">
+> & {
+  themes: OvertureMapsState["themes"];
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -148,6 +154,16 @@ function defaultOvertureState(): OvertureMapsState {
     themes,
     inspect: OVERTURE_OPTIONS.inspect,
     error: null,
+  };
+}
+
+function restorableOvertureState(state: OvertureMapsState): RestorableOvertureState {
+  return {
+    collapsed: state.collapsed,
+    panelWidth: state.panelWidth,
+    inspect: state.inspect,
+    ...(state.release ? { release: state.release } : {}),
+    themes: state.themes,
   };
 }
 
@@ -305,7 +321,7 @@ export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     if (!overtureControl) return;
     detachStoreSync();
-    pendingState = overtureControl.getState();
+    pendingState = restorableOvertureState(overtureControl.getState());
     app.removeMapControl(overtureControl);
     overtureControl = null;
   },
@@ -315,7 +331,7 @@ export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
     if (!overtureControl) return;
     // Snapshot before detaching from the map so a failed re-add still keeps
     // the latest state, mirroring the ordering used in deactivate.
-    pendingState = overtureControl.getState();
+    pendingState = restorableOvertureState(overtureControl.getState());
     app.removeMapControl(overtureControl);
     const added = app.addMapControl(overtureControl, overturePosition);
     if (!added) {
@@ -330,14 +346,14 @@ export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
     if (!isOvertureMapsState(state)) return false;
     if (overtureControl) {
       if (!applyOvertureMapsState(overtureControl, state)) return false;
-      pendingState = overtureControl.getState();
+      pendingState = restorableOvertureState(overtureControl.getState());
     } else {
-      const { state: next, applied } = mergeOvertureMapsStateWithResult(
-        pendingState ?? defaultOvertureState(),
-        state,
-      );
+      const base = pendingState
+        ? mergeOvertureMapsStateWithResult(defaultOvertureState(), pendingState).state
+        : defaultOvertureState();
+      const { state: next, applied } = mergeOvertureMapsStateWithResult(base, state);
       if (!applied) return false;
-      pendingState = next;
+      pendingState = restorableOvertureState(next);
     }
     return true;
   },

--- a/packages/plugins/src/plugins/maplibre-overture-maps.ts
+++ b/packages/plugins/src/plugins/maplibre-overture-maps.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import {
   DEFAULT_TILES_BASE_URL,
+  defaultSizeForGeometry,
   layerIdsForSourceLayer,
   OvertureMapsControl,
   sourceIdForTheme,
@@ -23,6 +24,7 @@ const OVERTURE_OPTIONS = {
   collapsed: false,
   title: "Overture Maps",
   panelWidth: 340,
+  inspect: true,
   className: "geolibre-overture-control",
   // Start with only the buildings theme (its "building" and "building_part"
   // source layers) shown, instead of the upstream default that also enables
@@ -36,7 +38,7 @@ const SOURCE_KIND = "overture-maps";
 let overtureControl: OvertureMapsControl | null = null;
 // Holds the panel state while the control is detached so re-activating or
 // repositioning it restores the user's release, visibility, and opacity.
-let pendingState: Partial<OvertureMapsState> | null = null;
+let pendingState: OvertureMapsState | null = null;
 
 function createOvertureControl(app: GeoLibreAppAPI): OvertureMapsControl {
   // Construct with the static defaults, then let setState restore the full
@@ -62,16 +64,9 @@ function createOvertureControl(app: GeoLibreAppAPI): OvertureMapsControl {
   return control;
 }
 
-function isOvertureMapsState(value: unknown): value is Partial<OvertureMapsState> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  // Require at least one distinctive OvertureMapsState field so an unrelated
-  // object stored under this plugin's key is not forwarded to setState.
-  return "themes" in value || "release" in value || "collapsed" in value;
-}
-
-type OvertureStatePatch = Omit<Partial<OvertureMapsState>, "themes"> & {
+type OvertureStatePatch = Partial<
+  Pick<OvertureMapsState, "collapsed" | "inspect" | "panelWidth" | "release">
+> & {
   themes?: Partial<
     Record<
       OvertureTheme,
@@ -82,18 +77,89 @@ type OvertureStatePatch = Omit<Partial<OvertureMapsState>, "themes"> & {
   >;
 };
 
-function defaultOvertureState(): OvertureMapsState {
-  return new OvertureMapsControl({
-    ...OVERTURE_OPTIONS,
-    position: overturePosition,
-  }).getState();
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-/** Deep-merge a partial Overture state patch without dropping other themes. */
-export function mergeOvertureMapsState(
+function isLayerStatePatch(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    (value.visible === undefined || typeof value.visible === "boolean") &&
+    (value.opacity === undefined ||
+      (typeof value.opacity === "number" && Number.isFinite(value.opacity))) &&
+    (value.color === undefined || typeof value.color === "string") &&
+    (value.size === undefined || (typeof value.size === "number" && Number.isFinite(value.size)))
+  );
+}
+
+function isThemeStatePatch(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.expanded !== undefined && typeof value.expanded !== "boolean") return false;
+  if (value.layers === undefined) return true;
+  if (!isRecord(value.layers)) return false;
+  return Object.values(value.layers).every(isLayerStatePatch);
+}
+
+function isOvertureMapsState(value: unknown): value is OvertureStatePatch {
+  if (!isRecord(value)) return false;
+  if (!["collapsed", "inspect", "panelWidth", "release", "themes"].some((key) => key in value)) {
+    return false;
+  }
+  if (value.collapsed !== undefined && typeof value.collapsed !== "boolean") return false;
+  if (value.inspect !== undefined && typeof value.inspect !== "boolean") return false;
+  if (
+    value.panelWidth !== undefined &&
+    (typeof value.panelWidth !== "number" || !Number.isFinite(value.panelWidth))
+  ) {
+    return false;
+  }
+  if (value.release !== undefined && typeof value.release !== "string") return false;
+  if (value.themes === undefined) return true;
+  if (!isRecord(value.themes)) return false;
+  return Object.values(value.themes).every(isThemeStatePatch);
+}
+
+function defaultOvertureState(): OvertureMapsState {
+  const visibleThemes = new Set<OvertureTheme>(OVERTURE_OPTIONS.visibleThemes);
+  const themes = Object.fromEntries(
+    THEME_IDS.map((theme) => [
+      theme,
+      {
+        expanded: false,
+        layers: Object.fromEntries(
+          THEMES[theme].layers.map((layer) => [
+            layer.sourceLayer,
+            {
+              visible: visibleThemes.has(theme),
+              opacity: 0.8,
+              color: THEMES[theme].color,
+              size: defaultSizeForGeometry(layer.geometry),
+            },
+          ]),
+        ),
+      },
+    ]),
+  ) as OvertureMapsState["themes"];
+  return {
+    collapsed: OVERTURE_OPTIONS.collapsed,
+    panelWidth: OVERTURE_OPTIONS.panelWidth,
+    release: "",
+    releases: [],
+    themes,
+    inspect: OVERTURE_OPTIONS.inspect,
+    error: null,
+  };
+}
+
+interface OvertureStateMergeResult {
+  state: OvertureMapsState;
+  applied: boolean;
+}
+
+function mergeOvertureMapsStateWithResult(
   base: OvertureMapsState,
   patch: OvertureStatePatch,
-): OvertureMapsState {
+): OvertureStateMergeResult {
   const themes = Object.fromEntries(
     Object.entries(base.themes).map(([theme, state]) => [
       theme,
@@ -105,28 +171,74 @@ export function mergeOvertureMapsState(
       },
     ]),
   ) as OvertureMapsState["themes"];
+  const state: OvertureMapsState = { ...base, themes };
+  let applied = false;
+
+  if (patch.collapsed !== undefined && patch.collapsed !== state.collapsed) {
+    state.collapsed = patch.collapsed;
+    applied = true;
+  }
+  if (patch.inspect !== undefined && patch.inspect !== state.inspect) {
+    state.inspect = patch.inspect;
+    applied = true;
+  }
+  if (patch.panelWidth !== undefined && patch.panelWidth !== state.panelWidth) {
+    state.panelWidth = patch.panelWidth;
+    applied = true;
+  }
+  if (patch.release && patch.release !== state.release) {
+    state.release = patch.release;
+    applied = true;
+  }
 
   for (const [theme, themePatch] of Object.entries(patch.themes ?? {}) as Array<
     [OvertureTheme, NonNullable<OvertureStatePatch["themes"]>[OvertureTheme]]
   >) {
-    const currentTheme = themes[theme];
+    const currentTheme = state.themes[theme];
     if (!currentTheme || !themePatch) continue;
-    const layers = { ...currentTheme.layers };
-    for (const [sourceLayer, layerPatch] of Object.entries(themePatch.layers ?? {})) {
-      if (!layers[sourceLayer]) continue;
-      layers[sourceLayer] = { ...layers[sourceLayer], ...layerPatch };
+    if (themePatch.expanded !== undefined && themePatch.expanded !== currentTheme.expanded) {
+      currentTheme.expanded = themePatch.expanded;
+      applied = true;
     }
-    themes[theme] = { ...currentTheme, ...themePatch, layers };
+    for (const [sourceLayer, layerPatch] of Object.entries(themePatch.layers ?? {})) {
+      const layer = currentTheme.layers[sourceLayer];
+      if (!layer) continue;
+      if (layerPatch.visible !== undefined && layerPatch.visible !== layer.visible) {
+        layer.visible = layerPatch.visible;
+        applied = true;
+      }
+      if (layerPatch.opacity !== undefined && layerPatch.opacity !== layer.opacity) {
+        layer.opacity = layerPatch.opacity;
+        applied = true;
+      }
+      if (layerPatch.color !== undefined && layerPatch.color !== layer.color) {
+        layer.color = layerPatch.color;
+        applied = true;
+      }
+      if (layerPatch.size !== undefined && layerPatch.size !== layer.size) {
+        layer.size = layerPatch.size;
+        applied = true;
+      }
+    }
   }
 
-  return { ...base, ...patch, themes };
+  return { state, applied };
 }
 
-function applyOvertureMapsState(control: OvertureMapsControl, patch: OvertureStatePatch): void {
-  const current = control.getState();
-  const next = mergeOvertureMapsState(current, patch);
+/** Deep-merge a partial Overture state patch without dropping other themes. */
+export function mergeOvertureMapsState(
+  base: OvertureMapsState,
+  patch: OvertureStatePatch,
+): OvertureMapsState {
+  return mergeOvertureMapsStateWithResult(base, patch).state;
+}
 
-  if (next.release && next.release !== current.release) {
+function applyOvertureMapsState(control: OvertureMapsControl, patch: OvertureStatePatch): boolean {
+  const current = control.getState();
+  const { state: next, applied } = mergeOvertureMapsStateWithResult(current, patch);
+  if (!applied) return false;
+
+  if (next.release !== current.release) {
     control.setRelease(next.release);
   }
   if (patch.inspect !== undefined && next.inspect !== current.inspect) {
@@ -136,15 +248,15 @@ function applyOvertureMapsState(control: OvertureMapsControl, patch: OvertureSta
     [OvertureTheme, NonNullable<OvertureStatePatch["themes"]>[OvertureTheme]]
   >) {
     if (!themePatch) continue;
-    if (
-      themePatch.expanded !== undefined &&
-      next.themes[theme].expanded !== current.themes[theme].expanded
-    ) {
-      control.setThemeExpanded(theme, next.themes[theme].expanded);
+    const currentTheme = current.themes[theme];
+    const nextTheme = next.themes[theme];
+    if (!currentTheme || !nextTheme) continue;
+    if (themePatch.expanded !== undefined && nextTheme.expanded !== currentTheme.expanded) {
+      control.setThemeExpanded(theme, nextTheme.expanded);
     }
     for (const [sourceLayer, layerPatch] of Object.entries(themePatch.layers ?? {})) {
-      const before = current.themes[theme].layers[sourceLayer];
-      const after = next.themes[theme].layers[sourceLayer];
+      const before = currentTheme.layers[sourceLayer];
+      const after = nextTheme.layers[sourceLayer];
       if (!before || !after) continue;
       if (layerPatch.visible !== undefined && after.visible !== before.visible) {
         control.setLayerVisible(theme, sourceLayer, after.visible);
@@ -167,6 +279,7 @@ function applyOvertureMapsState(control: OvertureMapsControl, patch: OvertureSta
     if (next.collapsed) control.collapse();
     else control.expand();
   }
+  return true;
 }
 
 export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
@@ -215,16 +328,18 @@ export const maplibreOvertureMapsPlugin: GeoLibrePlugin = {
   getProjectState: () => overtureControl?.getState() ?? pendingState ?? undefined,
   applyProjectState: (_app: GeoLibreAppAPI, state: unknown) => {
     if (!isOvertureMapsState(state)) return false;
-    const patch = state as OvertureStatePatch;
     if (overtureControl) {
-      applyOvertureMapsState(overtureControl, patch);
+      if (!applyOvertureMapsState(overtureControl, state)) return false;
       pendingState = overtureControl.getState();
     } else {
-      pendingState = mergeOvertureMapsState(
-        mergeOvertureMapsState(defaultOvertureState(), pendingState ?? {}),
-        patch,
+      const { state: next, applied } = mergeOvertureMapsStateWithResult(
+        pendingState ?? defaultOvertureState(),
+        state,
       );
+      if (!applied) return false;
+      pendingState = next;
     }
+    return true;
   },
 };
 

--- a/packages/plugins/src/plugins/overture-query.ts
+++ b/packages/plugins/src/plugins/overture-query.ts
@@ -1,0 +1,416 @@
+import { VectorTile } from "@mapbox/vector-tile";
+import type { Feature, FeatureCollection, Geometry, Position } from "geojson";
+import {
+  DEFAULT_TILES_BASE_URL,
+  fetchReleases,
+  type OvertureTheme,
+} from "maplibre-gl-overture-maps";
+import Pbf from "pbf";
+import { PMTiles } from "pmtiles";
+import type {
+  GeoLibreOvertureQuery,
+  GeoLibreOvertureQueryResult,
+} from "../types";
+
+const WEB_MERCATOR_MAX_LAT = 85.05112878;
+const DEFAULT_ZOOM = 12;
+const DEFAULT_MAX_TILES = 512;
+const DEFAULT_MAX_FEATURES = 50_000;
+const DEFAULT_CONCURRENCY = 8;
+const MAX_TILES = 1024;
+const MAX_FEATURES = 250_000;
+
+type BBox = [number, number, number, number];
+type AreaGeometry = Extract<Geometry, { type: "Polygon" | "MultiPolygon" }>;
+
+interface TileCoordinate {
+  x: number;
+  y: number;
+  z: number;
+}
+
+function assertBBox(value: BBox): void {
+  const [west, south, east, north] = value;
+  if (
+    !value.every(Number.isFinite) ||
+    west >= east ||
+    south >= north ||
+    west < -180 ||
+    east > 180 ||
+    south < -90 ||
+    north > 90
+  ) {
+    throw new Error(
+      "Overture query bbox must be a valid [west, south, east, north] extent."
+    );
+  }
+}
+
+function clampLatitude(value: number): number {
+  return Math.max(-WEB_MERCATOR_MAX_LAT, Math.min(WEB_MERCATOR_MAX_LAT, value));
+}
+
+function longitudeTileX(longitude: number, zoom: number): number {
+  const scale = 2 ** zoom;
+  return Math.max(
+    0,
+    Math.min(scale - 1, Math.floor(((longitude + 180) / 360) * scale))
+  );
+}
+
+function latitudeTileY(latitude: number, zoom: number): number {
+  const radians = (clampLatitude(latitude) * Math.PI) / 180;
+  const scale = 2 ** zoom;
+  const y = Math.floor(
+    ((1 - Math.asinh(Math.tan(radians)) / Math.PI) / 2) * scale
+  );
+  return Math.max(0, Math.min(scale - 1, y));
+}
+
+/** Enumerate XYZ tiles covering a WGS84 bbox at a fixed zoom. */
+export function overtureTilesForBBox(
+  bbox: BBox,
+  zoom: number
+): TileCoordinate[] {
+  assertBBox(bbox);
+  const [west, south, east, north] = bbox;
+  const minX = longitudeTileX(west, zoom);
+  const maxX = longitudeTileX(east, zoom);
+  const minY = latitudeTileY(north, zoom);
+  const maxY = latitudeTileY(south, zoom);
+  const tiles: TileCoordinate[] = [];
+  for (let x = minX; x <= maxX; x += 1) {
+    for (let y = minY; y <= maxY; y += 1) {
+      tiles.push({ x, y, z: zoom });
+    }
+  }
+  return tiles;
+}
+
+function collectPositions(geometry: Geometry, sink: Position[]): void {
+  if (geometry.type === "GeometryCollection") {
+    for (const child of geometry.geometries) collectPositions(child, sink);
+    return;
+  }
+  const visit = (value: unknown): void => {
+    if (
+      Array.isArray(value) &&
+      value.length >= 2 &&
+      typeof value[0] === "number" &&
+      typeof value[1] === "number"
+    ) {
+      sink.push(value as Position);
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) visit(child);
+    }
+  };
+  visit(geometry.coordinates);
+}
+
+function geometryBBox(geometry: Geometry): BBox | null {
+  const positions: Position[] = [];
+  collectPositions(geometry, positions);
+  if (!positions.length) return null;
+  let west = Infinity;
+  let south = Infinity;
+  let east = -Infinity;
+  let north = -Infinity;
+  for (const [longitude, latitude] of positions) {
+    west = Math.min(west, longitude);
+    south = Math.min(south, latitude);
+    east = Math.max(east, longitude);
+    north = Math.max(north, latitude);
+  }
+  return [west, south, east, north];
+}
+
+function bboxesIntersect(first: BBox, second: BBox): boolean {
+  return !(
+    first[2] < second[0] ||
+    first[0] > second[2] ||
+    first[3] < second[1] ||
+    first[1] > second[3]
+  );
+}
+
+function pointInRing(point: Position, ring: Position[]): boolean {
+  const [x, y] = point;
+  let inside = false;
+  for (
+    let index = 0, previous = ring.length - 1;
+    index < ring.length;
+    previous = index++
+  ) {
+    const [xi, yi] = ring[index];
+    const [xj, yj] = ring[previous];
+    if (
+      yi > y !== yj > y &&
+      x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function pointInArea(point: Position, geometry: AreaGeometry): boolean {
+  const polygons =
+    geometry.type === "Polygon" ? [geometry.coordinates] : geometry.coordinates;
+  return polygons.some(([outer, ...holes]) => {
+    if (!outer || !pointInRing(point, outer)) return false;
+    return !holes.some((hole) => pointInRing(point, hole));
+  });
+}
+
+function cross(first: Position, second: Position, third: Position): number {
+  return (
+    (second[0] - first[0]) * (third[1] - first[1]) -
+    (second[1] - first[1]) * (third[0] - first[0])
+  );
+}
+
+function onSegment(
+  first: Position,
+  second: Position,
+  point: Position
+): boolean {
+  return (
+    Math.abs(cross(first, second, point)) < 1e-12 &&
+    point[0] >= Math.min(first[0], second[0]) &&
+    point[0] <= Math.max(first[0], second[0]) &&
+    point[1] >= Math.min(first[1], second[1]) &&
+    point[1] <= Math.max(first[1], second[1])
+  );
+}
+
+function segmentsIntersect(
+  firstStart: Position,
+  firstEnd: Position,
+  secondStart: Position,
+  secondEnd: Position
+): boolean {
+  const d1 = cross(firstStart, firstEnd, secondStart);
+  const d2 = cross(firstStart, firstEnd, secondEnd);
+  const d3 = cross(secondStart, secondEnd, firstStart);
+  const d4 = cross(secondStart, secondEnd, firstEnd);
+  if (
+    ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+    ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))
+  ) {
+    return true;
+  }
+  return (
+    onSegment(firstStart, firstEnd, secondStart) ||
+    onSegment(firstStart, firstEnd, secondEnd) ||
+    onSegment(secondStart, secondEnd, firstStart) ||
+    onSegment(secondStart, secondEnd, firstEnd)
+  );
+}
+
+function areaRings(areas: AreaGeometry[]): Position[][] {
+  return areas.flatMap((area) =>
+    area.type === "Polygon" ? area.coordinates : area.coordinates.flat()
+  );
+}
+
+function lineIntersectsAreas(line: Position[], areas: AreaGeometry[]): boolean {
+  if (line.some((point) => areas.some((area) => pointInArea(point, area)))) {
+    return true;
+  }
+  const rings = areaRings(areas);
+  for (let index = 1; index < line.length; index += 1) {
+    for (const ring of rings) {
+      for (let edge = 1; edge < ring.length; edge += 1) {
+        if (
+          segmentsIntersect(
+            line[index - 1],
+            line[index],
+            ring[edge - 1],
+            ring[edge]
+          )
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function areaGeometries(filter?: Geometry | FeatureCollection): AreaGeometry[] {
+  if (!filter) return [];
+  if (filter.type === "FeatureCollection") {
+    return filter.features
+      .map((feature) => feature.geometry)
+      .filter(
+        (geometry): geometry is AreaGeometry =>
+          geometry?.type === "Polygon" || geometry?.type === "MultiPolygon"
+      );
+  }
+  return filter.type === "Polygon" || filter.type === "MultiPolygon"
+    ? [filter]
+    : [];
+}
+
+function geometryCentroid(geometry: Geometry): Position | null {
+  const positions: Position[] = [];
+  collectPositions(geometry, positions);
+  if (!positions.length) return null;
+  const sum = positions.reduce(
+    (current, [longitude, latitude]) =>
+      [current[0] + longitude, current[1] + latitude] as Position,
+    [0, 0] as Position
+  );
+  return [sum[0] / positions.length, sum[1] / positions.length];
+}
+
+/** Test a feature against an optional polygon filter. */
+export function overtureFeatureMatchesFilter(
+  feature: Feature,
+  filter: Geometry | FeatureCollection | undefined,
+  mode: "centroid-within" | "intersects" = "intersects"
+): boolean {
+  if (!feature.geometry || !filter) return true;
+  const areas = areaGeometries(filter);
+  if (!areas.length) return true;
+  if (mode === "centroid-within") {
+    const center = geometryCentroid(feature.geometry);
+    return !!center && areas.some((area) => pointInArea(center, area));
+  }
+  const geometry = feature.geometry;
+  if (geometry.type === "Point") {
+    return areas.some((area) => pointInArea(geometry.coordinates, area));
+  }
+  if (geometry.type === "MultiPoint") {
+    return geometry.coordinates.some((point) =>
+      areas.some((area) => pointInArea(point, area))
+    );
+  }
+  if (geometry.type === "LineString") {
+    return lineIntersectsAreas(geometry.coordinates, areas);
+  }
+  if (geometry.type === "MultiLineString") {
+    return geometry.coordinates.some((line) =>
+      lineIntersectsAreas(line, areas)
+    );
+  }
+  const center = geometryCentroid(geometry);
+  return !!center && areas.some((area) => pointInArea(center, area));
+}
+
+function overtureArchiveUrl(release: string, theme: OvertureTheme): string {
+  return `${DEFAULT_TILES_BASE_URL.replace(
+    /\/+$/,
+    ""
+  )}/${release}/${theme}.pmtiles`;
+}
+
+/**
+ * Query official Overture PMTiles for a bounded set of MVT features.
+ *
+ * The preferred zoom is lowered until the tile cap is satisfied. Every matching
+ * feature fragment is preserved because long transportation segments and large
+ * polygons can span tile boundaries.
+ */
+export async function queryOvertureFeatures(
+  query: GeoLibreOvertureQuery
+): Promise<GeoLibreOvertureQueryResult> {
+  assertBBox(query.bbox);
+  const maxTiles = Math.min(
+    MAX_TILES,
+    Math.max(1, Math.floor(query.maxTiles ?? DEFAULT_MAX_TILES))
+  );
+  const maxFeatures = Math.min(
+    MAX_FEATURES,
+    Math.max(1, Math.floor(query.maxFeatures ?? DEFAULT_MAX_FEATURES))
+  );
+  let zoom = Math.max(0, Math.min(14, Math.floor(query.zoom ?? DEFAULT_ZOOM)));
+  let tiles = overtureTilesForBBox(query.bbox, zoom);
+  while (tiles.length > maxTiles && zoom > 0) {
+    zoom -= 1;
+    tiles = overtureTilesForBBox(query.bbox, zoom);
+  }
+  if (tiles.length > maxTiles) {
+    throw new Error(
+      `Overture query covers ${tiles.length} tiles, above the ${maxTiles}-tile limit.`
+    );
+  }
+
+  const { latest: release } = await fetchReleases();
+  const archive = new PMTiles(overtureArchiveUrl(release, query.theme));
+  const features: Feature[] = [];
+  let matchedFeatureCount = 0;
+  let truncated = false;
+  let nextTile = 0;
+
+  const workers = Array.from(
+    { length: Math.min(DEFAULT_CONCURRENCY, tiles.length) },
+    async () => {
+      while (nextTile < tiles.length && !truncated) {
+        if (query.signal?.aborted)
+          throw new DOMException("Aborted", "AbortError");
+        const tile = tiles[nextTile];
+        nextTile += 1;
+        const response = await archive.getZxy(
+          tile.z,
+          tile.x,
+          tile.y,
+          query.signal
+        );
+        if (!response) continue;
+        if (truncated) return;
+        const vectorTile = new VectorTile(new Pbf(response.data));
+        const source = vectorTile.layers[query.sourceLayer];
+        if (!source) continue;
+        for (let index = 0; index < source.length; index += 1) {
+          const vectorFeature = source.feature(index);
+          const feature = vectorFeature.toGeoJSON(
+            tile.x,
+            tile.y,
+            tile.z
+          ) as Feature;
+          if (!feature.geometry) continue;
+          const featureBox = geometryBBox(feature.geometry);
+          if (!featureBox || !bboxesIntersect(featureBox, query.bbox)) continue;
+          if (
+            !overtureFeatureMatchesFilter(
+              feature,
+              query.filterGeometry,
+              query.filterMode
+            )
+          ) {
+            continue;
+          }
+          matchedFeatureCount += 1;
+          if (features.length >= maxFeatures) {
+            truncated = true;
+            break;
+          }
+          feature.properties = {
+            ...(feature.properties ?? {}),
+            _overture_id:
+              vectorFeature.id === undefined ? null : String(vectorFeature.id),
+            _overture_release: release,
+            _overture_theme: query.theme,
+            _overture_source_layer: query.sourceLayer,
+          };
+          features.push(feature);
+        }
+      }
+    }
+  );
+  await Promise.all(workers);
+
+  return {
+    data: { type: "FeatureCollection", features },
+    release,
+    theme: query.theme,
+    sourceLayer: query.sourceLayer,
+    zoom,
+    tilesRead: tiles.length,
+    matchedFeatureCount,
+    truncated,
+  };
+}

--- a/packages/plugins/src/plugins/overture-query.ts
+++ b/packages/plugins/src/plugins/overture-query.ts
@@ -7,10 +7,7 @@ import {
 } from "maplibre-gl-overture-maps";
 import Pbf from "pbf";
 import { PMTiles } from "pmtiles";
-import type {
-  GeoLibreOvertureQuery,
-  GeoLibreOvertureQueryResult,
-} from "../types";
+import type { GeoLibreOvertureQuery, GeoLibreOvertureQueryResult } from "../types";
 
 const WEB_MERCATOR_MAX_LAT = 85.05112878;
 const DEFAULT_ZOOM = 12;
@@ -40,9 +37,7 @@ function assertBBox(value: BBox): void {
     south < -90 ||
     north > 90
   ) {
-    throw new Error(
-      "Overture query bbox must be a valid [west, south, east, north] extent."
-    );
+    throw new Error("Overture query bbox must be a valid [west, south, east, north] extent.");
   }
 }
 
@@ -52,26 +47,18 @@ function clampLatitude(value: number): number {
 
 function longitudeTileX(longitude: number, zoom: number): number {
   const scale = 2 ** zoom;
-  return Math.max(
-    0,
-    Math.min(scale - 1, Math.floor(((longitude + 180) / 360) * scale))
-  );
+  return Math.max(0, Math.min(scale - 1, Math.floor(((longitude + 180) / 360) * scale)));
 }
 
 function latitudeTileY(latitude: number, zoom: number): number {
   const radians = (clampLatitude(latitude) * Math.PI) / 180;
   const scale = 2 ** zoom;
-  const y = Math.floor(
-    ((1 - Math.asinh(Math.tan(radians)) / Math.PI) / 2) * scale
-  );
+  const y = Math.floor(((1 - Math.asinh(Math.tan(radians)) / Math.PI) / 2) * scale);
   return Math.max(0, Math.min(scale - 1, y));
 }
 
 /** Enumerate XYZ tiles covering a WGS84 bbox at a fixed zoom. */
-export function overtureTilesForBBox(
-  bbox: BBox,
-  zoom: number
-): TileCoordinate[] {
+export function overtureTilesForBBox(bbox: BBox, zoom: number): TileCoordinate[] {
   assertBBox(bbox);
   const [west, south, east, north] = bbox;
   const minX = longitudeTileX(west, zoom);
@@ -138,17 +125,10 @@ function bboxesIntersect(first: BBox, second: BBox): boolean {
 function pointInRing(point: Position, ring: Position[]): boolean {
   const [x, y] = point;
   let inside = false;
-  for (
-    let index = 0, previous = ring.length - 1;
-    index < ring.length;
-    previous = index++
-  ) {
+  for (let index = 0, previous = ring.length - 1; index < ring.length; previous = index++) {
     const [xi, yi] = ring[index];
     const [xj, yj] = ring[previous];
-    if (
-      yi > y !== yj > y &&
-      x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi
-    ) {
+    if (yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi) {
       inside = !inside;
     }
   }
@@ -156,8 +136,7 @@ function pointInRing(point: Position, ring: Position[]): boolean {
 }
 
 function pointInArea(point: Position, geometry: AreaGeometry): boolean {
-  const polygons =
-    geometry.type === "Polygon" ? [geometry.coordinates] : geometry.coordinates;
+  const polygons = geometry.type === "Polygon" ? [geometry.coordinates] : geometry.coordinates;
   return polygons.some(([outer, ...holes]) => {
     if (!outer || !pointInRing(point, outer)) return false;
     return !holes.some((hole) => pointInRing(point, hole));
@@ -166,16 +145,11 @@ function pointInArea(point: Position, geometry: AreaGeometry): boolean {
 
 function cross(first: Position, second: Position, third: Position): number {
   return (
-    (second[0] - first[0]) * (third[1] - first[1]) -
-    (second[1] - first[1]) * (third[0] - first[0])
+    (second[0] - first[0]) * (third[1] - first[1]) - (second[1] - first[1]) * (third[0] - first[0])
   );
 }
 
-function onSegment(
-  first: Position,
-  second: Position,
-  point: Position
-): boolean {
+function onSegment(first: Position, second: Position, point: Position): boolean {
   return (
     Math.abs(cross(first, second, point)) < 1e-12 &&
     point[0] >= Math.min(first[0], second[0]) &&
@@ -189,16 +163,13 @@ function segmentsIntersect(
   firstStart: Position,
   firstEnd: Position,
   secondStart: Position,
-  secondEnd: Position
+  secondEnd: Position,
 ): boolean {
   const d1 = cross(firstStart, firstEnd, secondStart);
   const d2 = cross(firstStart, firstEnd, secondEnd);
   const d3 = cross(secondStart, secondEnd, firstStart);
   const d4 = cross(secondStart, secondEnd, firstEnd);
-  if (
-    ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
-    ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))
-  ) {
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
     return true;
   }
   return (
@@ -211,7 +182,7 @@ function segmentsIntersect(
 
 function areaRings(areas: AreaGeometry[]): Position[][] {
   return areas.flatMap((area) =>
-    area.type === "Polygon" ? area.coordinates : area.coordinates.flat()
+    area.type === "Polygon" ? area.coordinates : area.coordinates.flat(),
   );
 }
 
@@ -223,14 +194,7 @@ function lineIntersectsAreas(line: Position[], areas: AreaGeometry[]): boolean {
   for (let index = 1; index < line.length; index += 1) {
     for (const ring of rings) {
       for (let edge = 1; edge < ring.length; edge += 1) {
-        if (
-          segmentsIntersect(
-            line[index - 1],
-            line[index],
-            ring[edge - 1],
-            ring[edge]
-          )
-        ) {
+        if (segmentsIntersect(line[index - 1], line[index], ring[edge - 1], ring[edge])) {
           return true;
         }
       }
@@ -246,12 +210,10 @@ function areaGeometries(filter?: Geometry | FeatureCollection): AreaGeometry[] {
       .map((feature) => feature.geometry)
       .filter(
         (geometry): geometry is AreaGeometry =>
-          geometry?.type === "Polygon" || geometry?.type === "MultiPolygon"
+          geometry?.type === "Polygon" || geometry?.type === "MultiPolygon",
       );
   }
-  return filter.type === "Polygon" || filter.type === "MultiPolygon"
-    ? [filter]
-    : [];
+  return filter.type === "Polygon" || filter.type === "MultiPolygon" ? [filter] : [];
 }
 
 function geometryCentroid(geometry: Geometry): Position | null {
@@ -259,9 +221,8 @@ function geometryCentroid(geometry: Geometry): Position | null {
   collectPositions(geometry, positions);
   if (!positions.length) return null;
   const sum = positions.reduce(
-    (current, [longitude, latitude]) =>
-      [current[0] + longitude, current[1] + latitude] as Position,
-    [0, 0] as Position
+    (current, [longitude, latitude]) => [current[0] + longitude, current[1] + latitude] as Position,
+    [0, 0] as Position,
   );
   return [sum[0] / positions.length, sum[1] / positions.length];
 }
@@ -270,7 +231,7 @@ function geometryCentroid(geometry: Geometry): Position | null {
 export function overtureFeatureMatchesFilter(
   feature: Feature,
   filter: Geometry | FeatureCollection | undefined,
-  mode: "centroid-within" | "intersects" = "intersects"
+  mode: "centroid-within" | "intersects" = "intersects",
 ): boolean {
   if (!feature.geometry || !filter) return true;
   const areas = areaGeometries(filter);
@@ -284,27 +245,20 @@ export function overtureFeatureMatchesFilter(
     return areas.some((area) => pointInArea(geometry.coordinates, area));
   }
   if (geometry.type === "MultiPoint") {
-    return geometry.coordinates.some((point) =>
-      areas.some((area) => pointInArea(point, area))
-    );
+    return geometry.coordinates.some((point) => areas.some((area) => pointInArea(point, area)));
   }
   if (geometry.type === "LineString") {
     return lineIntersectsAreas(geometry.coordinates, areas);
   }
   if (geometry.type === "MultiLineString") {
-    return geometry.coordinates.some((line) =>
-      lineIntersectsAreas(line, areas)
-    );
+    return geometry.coordinates.some((line) => lineIntersectsAreas(line, areas));
   }
   const center = geometryCentroid(geometry);
   return !!center && areas.some((area) => pointInArea(center, area));
 }
 
 function overtureArchiveUrl(release: string, theme: OvertureTheme): string {
-  return `${DEFAULT_TILES_BASE_URL.replace(
-    /\/+$/,
-    ""
-  )}/${release}/${theme}.pmtiles`;
+  return `${DEFAULT_TILES_BASE_URL.replace(/\/+$/, "")}/${release}/${theme}.pmtiles`;
 }
 
 /**
@@ -315,16 +269,16 @@ function overtureArchiveUrl(release: string, theme: OvertureTheme): string {
  * polygons can span tile boundaries.
  */
 export async function queryOvertureFeatures(
-  query: GeoLibreOvertureQuery
+  query: GeoLibreOvertureQuery,
 ): Promise<GeoLibreOvertureQueryResult> {
   assertBBox(query.bbox);
   const maxTiles = Math.min(
     MAX_TILES,
-    Math.max(1, Math.floor(query.maxTiles ?? DEFAULT_MAX_TILES))
+    Math.max(1, Math.floor(query.maxTiles ?? DEFAULT_MAX_TILES)),
   );
   const maxFeatures = Math.min(
     MAX_FEATURES,
-    Math.max(1, Math.floor(query.maxFeatures ?? DEFAULT_MAX_FEATURES))
+    Math.max(1, Math.floor(query.maxFeatures ?? DEFAULT_MAX_FEATURES)),
   );
   let zoom = Math.max(0, Math.min(14, Math.floor(query.zoom ?? DEFAULT_ZOOM)));
   let tiles = overtureTilesForBBox(query.bbox, zoom);
@@ -334,7 +288,7 @@ export async function queryOvertureFeatures(
   }
   if (tiles.length > maxTiles) {
     throw new Error(
-      `Overture query covers ${tiles.length} tiles, above the ${maxTiles}-tile limit.`
+      `Overture query covers ${tiles.length} tiles, above the ${maxTiles}-tile limit.`,
     );
   }
 
@@ -345,62 +299,42 @@ export async function queryOvertureFeatures(
   let truncated = false;
   let nextTile = 0;
 
-  const workers = Array.from(
-    { length: Math.min(DEFAULT_CONCURRENCY, tiles.length) },
-    async () => {
-      while (nextTile < tiles.length && !truncated) {
-        if (query.signal?.aborted)
-          throw new DOMException("Aborted", "AbortError");
-        const tile = tiles[nextTile];
-        nextTile += 1;
-        const response = await archive.getZxy(
-          tile.z,
-          tile.x,
-          tile.y,
-          query.signal
-        );
-        if (!response) continue;
-        if (truncated) return;
-        const vectorTile = new VectorTile(new Pbf(response.data));
-        const source = vectorTile.layers[query.sourceLayer];
-        if (!source) continue;
-        for (let index = 0; index < source.length; index += 1) {
-          const vectorFeature = source.feature(index);
-          const feature = vectorFeature.toGeoJSON(
-            tile.x,
-            tile.y,
-            tile.z
-          ) as Feature;
-          if (!feature.geometry) continue;
-          const featureBox = geometryBBox(feature.geometry);
-          if (!featureBox || !bboxesIntersect(featureBox, query.bbox)) continue;
-          if (
-            !overtureFeatureMatchesFilter(
-              feature,
-              query.filterGeometry,
-              query.filterMode
-            )
-          ) {
-            continue;
-          }
-          matchedFeatureCount += 1;
-          if (features.length >= maxFeatures) {
-            truncated = true;
-            break;
-          }
-          feature.properties = {
-            ...(feature.properties ?? {}),
-            _overture_id:
-              vectorFeature.id === undefined ? null : String(vectorFeature.id),
-            _overture_release: release,
-            _overture_theme: query.theme,
-            _overture_source_layer: query.sourceLayer,
-          };
-          features.push(feature);
+  const workers = Array.from({ length: Math.min(DEFAULT_CONCURRENCY, tiles.length) }, async () => {
+    while (nextTile < tiles.length && !truncated) {
+      if (query.signal?.aborted) throw new DOMException("Aborted", "AbortError");
+      const tile = tiles[nextTile];
+      nextTile += 1;
+      const response = await archive.getZxy(tile.z, tile.x, tile.y, query.signal);
+      if (!response) continue;
+      if (truncated) return;
+      const vectorTile = new VectorTile(new Pbf(response.data));
+      const source = vectorTile.layers[query.sourceLayer];
+      if (!source) continue;
+      for (let index = 0; index < source.length; index += 1) {
+        const vectorFeature = source.feature(index);
+        const feature = vectorFeature.toGeoJSON(tile.x, tile.y, tile.z) as Feature;
+        if (!feature.geometry) continue;
+        const featureBox = geometryBBox(feature.geometry);
+        if (!featureBox || !bboxesIntersect(featureBox, query.bbox)) continue;
+        if (!overtureFeatureMatchesFilter(feature, query.filterGeometry, query.filterMode)) {
+          continue;
         }
+        matchedFeatureCount += 1;
+        if (features.length >= maxFeatures) {
+          truncated = true;
+          break;
+        }
+        feature.properties = {
+          ...(feature.properties ?? {}),
+          _overture_id: vectorFeature.id === undefined ? null : String(vectorFeature.id),
+          _overture_release: release,
+          _overture_theme: query.theme,
+          _overture_source_layer: query.sourceLayer,
+        };
+        features.push(feature);
       }
     }
-  );
+  });
   await Promise.all(workers);
 
   return {

--- a/packages/plugins/src/plugins/overture-query.ts
+++ b/packages/plugins/src/plugins/overture-query.ts
@@ -26,6 +26,13 @@ interface TileCoordinate {
   z: number;
 }
 
+interface TileRange {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
 function assertBBox(value: BBox): void {
   const [west, south, east, north] = value;
   if (
@@ -57,14 +64,26 @@ function latitudeTileY(latitude: number, zoom: number): number {
   return Math.max(0, Math.min(scale - 1, y));
 }
 
-/** Enumerate XYZ tiles covering a WGS84 bbox at a fixed zoom. */
-export function overtureTilesForBBox(bbox: BBox, zoom: number): TileCoordinate[] {
+function overtureTileRangeForBBox(bbox: BBox, zoom: number): TileRange {
   assertBBox(bbox);
   const [west, south, east, north] = bbox;
-  const minX = longitudeTileX(west, zoom);
-  const maxX = longitudeTileX(east, zoom);
-  const minY = latitudeTileY(north, zoom);
-  const maxY = latitudeTileY(south, zoom);
+  return {
+    minX: longitudeTileX(west, zoom),
+    maxX: longitudeTileX(east, zoom),
+    minY: latitudeTileY(north, zoom),
+    maxY: latitudeTileY(south, zoom),
+  };
+}
+
+/** Count XYZ tiles covering a WGS84 bbox without allocating tile objects. */
+export function overtureTileCountForBBox(bbox: BBox, zoom: number): number {
+  const { minX, maxX, minY, maxY } = overtureTileRangeForBBox(bbox, zoom);
+  return (maxX - minX + 1) * (maxY - minY + 1);
+}
+
+/** Enumerate XYZ tiles covering a WGS84 bbox at a fixed zoom. */
+export function overtureTilesForBBox(bbox: BBox, zoom: number): TileCoordinate[] {
+  const { minX, maxX, minY, maxY } = overtureTileRangeForBBox(bbox, zoom);
   const tiles: TileCoordinate[] = [];
   for (let x = minX; x <= maxX; x += 1) {
     for (let y = minY; y <= maxY; y += 1) {
@@ -186,11 +205,21 @@ function areaRings(areas: AreaGeometry[]): Position[][] {
   );
 }
 
-function lineIntersectsAreas(line: Position[], areas: AreaGeometry[]): boolean {
+function areaOuterRings(areas: AreaGeometry[]): Position[][] {
+  return areas.flatMap((area) => {
+    const polygons = area.type === "Polygon" ? [area.coordinates] : area.coordinates;
+    return polygons.flatMap((polygon) => (polygon[0] ? [polygon[0]] : []));
+  });
+}
+
+function lineIntersectsAreas(
+  line: Position[],
+  areas: AreaGeometry[],
+  rings: Position[][],
+): boolean {
   if (line.some((point) => areas.some((area) => pointInArea(point, area)))) {
     return true;
   }
-  const rings = areaRings(areas);
   for (let index = 1; index < line.length; index += 1) {
     for (const ring of rings) {
       for (let edge = 1; edge < ring.length; edge += 1) {
@@ -203,17 +232,60 @@ function lineIntersectsAreas(line: Position[], areas: AreaGeometry[]): boolean {
   return false;
 }
 
-function areaGeometries(filter?: Geometry | FeatureCollection): AreaGeometry[] {
-  if (!filter) return [];
-  if (filter.type === "FeatureCollection") {
-    return filter.features
-      .map((feature) => feature.geometry)
-      .filter(
-        (geometry): geometry is AreaGeometry =>
-          geometry?.type === "Polygon" || geometry?.type === "MultiPolygon",
-      );
+function collectAreaGeometries(geometry: Geometry | null, sink: AreaGeometry[]): void {
+  if (!geometry) return;
+  if (geometry.type === "Polygon" || geometry.type === "MultiPolygon") {
+    const polygons = geometry.type === "Polygon" ? [geometry.coordinates] : geometry.coordinates;
+    if (polygons.some((polygon) => (polygon[0]?.length ?? 0) >= 4)) {
+      sink.push(geometry);
+    }
+    return;
   }
-  return filter.type === "Polygon" || filter.type === "MultiPolygon" ? [filter] : [];
+  if (geometry.type === "GeometryCollection") {
+    for (const child of geometry.geometries) collectAreaGeometries(child, sink);
+  }
+}
+
+function areaGeometries(filter?: Geometry | FeatureCollection): AreaGeometry[] {
+  const areas: AreaGeometry[] = [];
+  if (!filter) return areas;
+  if (filter.type === "FeatureCollection") {
+    for (const feature of filter.features) collectAreaGeometries(feature.geometry, areas);
+  } else {
+    collectAreaGeometries(filter, areas);
+  }
+  return areas;
+}
+
+interface PreparedAreaFilter {
+  areas: AreaGeometry[];
+  rings: Position[][];
+  outerRings: Position[][];
+  bbox: BBox;
+}
+
+function prepareAreaFilter(
+  filter: Geometry | FeatureCollection | undefined,
+): PreparedAreaFilter | null {
+  if (!filter) return null;
+  const areas = areaGeometries(filter);
+  const boxes = areas
+    .map((area) => geometryBBox(area))
+    .filter((box): box is BBox => box !== null && box[0] < box[2] && box[1] < box[3]);
+  if (!areas.length || boxes.length !== areas.length) {
+    throw new Error("Overture query filterGeometry must contain a usable Polygon or MultiPolygon.");
+  }
+  return {
+    areas,
+    rings: areaRings(areas),
+    outerRings: areaOuterRings(areas),
+    bbox: [
+      Math.min(...boxes.map((box) => box[0])),
+      Math.min(...boxes.map((box) => box[1])),
+      Math.max(...boxes.map((box) => box[2])),
+      Math.max(...boxes.map((box) => box[3])),
+    ],
+  };
 }
 
 function geometryCentroid(geometry: Geometry): Position | null {
@@ -227,38 +299,87 @@ function geometryCentroid(geometry: Geometry): Position | null {
   return [sum[0] / positions.length, sum[1] / positions.length];
 }
 
+function geometryIntersectsFilter(geometry: Geometry, filter: PreparedAreaFilter): boolean {
+  if (geometry.type === "Point") {
+    return filter.areas.some((area) => pointInArea(geometry.coordinates, area));
+  }
+  if (geometry.type === "MultiPoint") {
+    return geometry.coordinates.some((point) =>
+      filter.areas.some((area) => pointInArea(point, area)),
+    );
+  }
+  if (geometry.type === "LineString") {
+    return lineIntersectsAreas(geometry.coordinates, filter.areas, filter.rings);
+  }
+  if (geometry.type === "MultiLineString") {
+    return geometry.coordinates.some((line) =>
+      lineIntersectsAreas(line, filter.areas, filter.rings),
+    );
+  }
+  if (geometry.type === "Polygon" || geometry.type === "MultiPolygon") {
+    const featureAreas: AreaGeometry[] = [geometry];
+    const featureRings = areaRings(featureAreas);
+    if (featureRings.some((ring) => lineIntersectsAreas(ring, filter.areas, filter.rings))) {
+      return true;
+    }
+    return filter.outerRings.some(
+      (ring) => ring.length > 0 && featureAreas.some((area) => pointInArea(ring[0], area)),
+    );
+  }
+  return geometry.geometries.some((child) => geometryIntersectsFilter(child, filter));
+}
+
+function featureMatchesPreparedFilter(
+  feature: Feature,
+  filter: PreparedAreaFilter | null,
+  mode: "centroid-within" | "intersects" = "intersects",
+  featureBBox?: BBox,
+): boolean {
+  if (!filter) return true;
+  if (!feature.geometry) return false;
+  const bounds = featureBBox ?? geometryBBox(feature.geometry);
+  if (!bounds || !bboxesIntersect(bounds, filter.bbox)) return false;
+  if (mode === "centroid-within") {
+    const center = geometryCentroid(feature.geometry);
+    return !!center && filter.areas.some((area) => pointInArea(center, area));
+  }
+  return geometryIntersectsFilter(feature.geometry, filter);
+}
+
 /** Test a feature against an optional polygon filter. */
 export function overtureFeatureMatchesFilter(
   feature: Feature,
   filter: Geometry | FeatureCollection | undefined,
   mode: "centroid-within" | "intersects" = "intersects",
 ): boolean {
-  if (!feature.geometry || !filter) return true;
-  const areas = areaGeometries(filter);
-  if (!areas.length) return true;
-  if (mode === "centroid-within") {
-    const center = geometryCentroid(feature.geometry);
-    return !!center && areas.some((area) => pointInArea(center, area));
-  }
-  const geometry = feature.geometry;
-  if (geometry.type === "Point") {
-    return areas.some((area) => pointInArea(geometry.coordinates, area));
-  }
-  if (geometry.type === "MultiPoint") {
-    return geometry.coordinates.some((point) => areas.some((area) => pointInArea(point, area)));
-  }
-  if (geometry.type === "LineString") {
-    return lineIntersectsAreas(geometry.coordinates, areas);
-  }
-  if (geometry.type === "MultiLineString") {
-    return geometry.coordinates.some((line) => lineIntersectsAreas(line, areas));
-  }
-  const center = geometryCentroid(geometry);
-  return !!center && areas.some((area) => pointInArea(center, area));
+  return featureMatchesPreparedFilter(feature, prepareAreaFilter(filter), mode);
 }
 
 function overtureArchiveUrl(release: string, theme: OvertureTheme): string {
   return `${DEFAULT_TILES_BASE_URL.replace(/\/+$/, "")}/${release}/${theme}.pmtiles`;
+}
+
+function boundedPositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const candidate = Number.isFinite(value) ? Math.floor(value as number) : fallback;
+  return Math.min(maximum, Math.max(1, candidate));
+}
+
+/** Select the highest zoom whose bbox tile count fits the requested cap. */
+export function overtureZoomForBBox(bbox: BBox, preferredZoom: number, maxTiles: number): number {
+  let zoom = preferredZoom;
+  let tileCount = overtureTileCountForBBox(bbox, zoom);
+  while (tileCount > maxTiles && zoom > 0) {
+    zoom -= 1;
+    tileCount = overtureTileCountForBBox(bbox, zoom);
+  }
+  if (tileCount > maxTiles) {
+    throw new Error(`Overture query covers ${tileCount} tiles, above the ${maxTiles}-tile limit.`);
+  }
+  return zoom;
 }
 
 /**
@@ -272,30 +393,20 @@ export async function queryOvertureFeatures(
   query: GeoLibreOvertureQuery,
 ): Promise<GeoLibreOvertureQueryResult> {
   assertBBox(query.bbox);
-  const maxTiles = Math.min(
-    MAX_TILES,
-    Math.max(1, Math.floor(query.maxTiles ?? DEFAULT_MAX_TILES)),
-  );
-  const maxFeatures = Math.min(
-    MAX_FEATURES,
-    Math.max(1, Math.floor(query.maxFeatures ?? DEFAULT_MAX_FEATURES)),
-  );
-  let zoom = Math.max(0, Math.min(14, Math.floor(query.zoom ?? DEFAULT_ZOOM)));
-  let tiles = overtureTilesForBBox(query.bbox, zoom);
-  while (tiles.length > maxTiles && zoom > 0) {
-    zoom -= 1;
-    tiles = overtureTilesForBBox(query.bbox, zoom);
-  }
-  if (tiles.length > maxTiles) {
-    throw new Error(
-      `Overture query covers ${tiles.length} tiles, above the ${maxTiles}-tile limit.`,
-    );
-  }
+  const maxTiles = boundedPositiveInteger(query.maxTiles, DEFAULT_MAX_TILES, MAX_TILES);
+  const maxFeatures = boundedPositiveInteger(query.maxFeatures, DEFAULT_MAX_FEATURES, MAX_FEATURES);
+  const requestedZoom = Number.isFinite(query.zoom)
+    ? Math.floor(query.zoom as number)
+    : DEFAULT_ZOOM;
+  const zoom = overtureZoomForBBox(query.bbox, Math.max(0, Math.min(14, requestedZoom)), maxTiles);
+  const tiles = overtureTilesForBBox(query.bbox, zoom);
+  const preparedFilter = prepareAreaFilter(query.filterGeometry);
 
   const { latest: release } = await fetchReleases();
   const archive = new PMTiles(overtureArchiveUrl(release, query.theme));
   const features: Feature[] = [];
   let matchedFeatureCount = 0;
+  let tilesRead = 0;
   let truncated = false;
   let nextTile = 0;
 
@@ -305,6 +416,7 @@ export async function queryOvertureFeatures(
       const tile = tiles[nextTile];
       nextTile += 1;
       const response = await archive.getZxy(tile.z, tile.x, tile.y, query.signal);
+      tilesRead += 1;
       if (!response) continue;
       if (truncated) return;
       const vectorTile = new VectorTile(new Pbf(response.data));
@@ -316,10 +428,9 @@ export async function queryOvertureFeatures(
         if (!feature.geometry) continue;
         const featureBox = geometryBBox(feature.geometry);
         if (!featureBox || !bboxesIntersect(featureBox, query.bbox)) continue;
-        if (!overtureFeatureMatchesFilter(feature, query.filterGeometry, query.filterMode)) {
+        if (!featureMatchesPreparedFilter(feature, preparedFilter, query.filterMode, featureBox)) {
           continue;
         }
-        matchedFeatureCount += 1;
         if (features.length >= maxFeatures) {
           truncated = true;
           break;
@@ -332,6 +443,7 @@ export async function queryOvertureFeatures(
           _overture_source_layer: query.sourceLayer,
         };
         features.push(feature);
+        matchedFeatureCount += 1;
       }
     }
   });
@@ -343,7 +455,7 @@ export async function queryOvertureFeatures(
     theme: query.theme,
     sourceLayer: query.sourceLayer,
     zoom,
-    tilesRead: tiles.length,
+    tilesRead,
     matchedFeatureCount,
     truncated,
   };

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -4,7 +4,7 @@ import type {
   GeoLibreLayer,
   LayerStyle,
 } from "@geolibre/core";
-import type { FeatureCollection } from "geojson";
+import type { FeatureCollection, Geometry } from "geojson";
 import type { TemporalLayerAdapter } from "./plugins/temporal-layers";
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 
@@ -115,6 +115,49 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
    * sends `CRS` instead of `SRS`; some servers accept only one version.
    */
   version?: string;
+}
+
+/** Overture Maps themes available through the host's official PMTiles source. */
+export type GeoLibreOvertureTheme =
+  | "addresses"
+  | "base"
+  | "buildings"
+  | "divisions"
+  | "places"
+  | "transportation";
+
+/** Parameters for a bounded Overture Maps feature query. */
+export interface GeoLibreOvertureQuery {
+  /** Overture theme archive to query. */
+  theme: GeoLibreOvertureTheme;
+  /** MVT source layer inside the theme, e.g. `building` or `segment`. */
+  sourceLayer: string;
+  /** Query bounds as `[west, south, east, north]` in WGS84 degrees. */
+  bbox: [number, number, number, number];
+  /** Preferred MVT zoom. Defaults to 12 and decreases when the tile cap requires it. */
+  zoom?: number;
+  /** Maximum PMTiles tiles to inspect. Defaults to 512. */
+  maxTiles?: number;
+  /** Maximum matching features returned. Defaults to 50,000. */
+  maxFeatures?: number;
+  /** Optional polygon filter applied before features are returned. */
+  filterGeometry?: Geometry | FeatureCollection;
+  /** Spatial predicate for `filterGeometry`. Defaults to `intersects`. */
+  filterMode?: "centroid-within" | "intersects";
+  /** Optional request cancellation signal. */
+  signal?: AbortSignal;
+}
+
+/** Result of a bounded Overture Maps PMTiles feature query. */
+export interface GeoLibreOvertureQueryResult {
+  data: FeatureCollection;
+  release: string;
+  theme: GeoLibreOvertureTheme;
+  sourceLayer: string;
+  zoom: number;
+  tilesRead: number;
+  matchedFeatureCount: number;
+  truncated: boolean;
 }
 
 /**
@@ -372,6 +415,17 @@ export interface GeoLibreAppAPI {
    * since any plugin can fetch any same-origin URL directly.
    */
   resolvePluginAssetUrl?: (pluginId: string, relativePath: string) => string | null;
+  /**
+   * Activate an installed plugin and optionally apply a partial project-state
+   * patch after activation. Returns false when the plugin is unavailable,
+   * refuses activation, or rejects the state.
+   */
+  activatePlugin?: (pluginId: string, state?: unknown) => boolean;
+  /**
+   * Query a bounded set of features from GeoLibre's official Overture Maps
+   * PMTiles integration. The host enforces tile and feature limits.
+   */
+  queryOvertureFeatures?: (query: GeoLibreOvertureQuery) => Promise<GeoLibreOvertureQueryResult>;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => MapLibreMap | null;
   /**

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -5,8 +5,9 @@ import type {
   LayerStyle,
 } from "@geolibre/core";
 import type { FeatureCollection, Geometry } from "geojson";
-import type { TemporalLayerAdapter } from "./plugins/temporal-layers";
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
+import type { OvertureTheme } from "maplibre-gl-overture-maps";
+import type { TemporalLayerAdapter } from "./plugins/temporal-layers";
 
 export type GeoLibreMapControlPosition = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
@@ -118,13 +119,7 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
 }
 
 /** Overture Maps themes available through the host's official PMTiles source. */
-export type GeoLibreOvertureTheme =
-  | "addresses"
-  | "base"
-  | "buildings"
-  | "divisions"
-  | "places"
-  | "transportation";
+export type GeoLibreOvertureTheme = OvertureTheme;
 
 /** Parameters for a bounded Overture Maps feature query. */
 export interface GeoLibreOvertureQuery {
@@ -142,7 +137,10 @@ export interface GeoLibreOvertureQuery {
   maxFeatures?: number;
   /** Optional polygon filter applied before features are returned. */
   filterGeometry?: Geometry | FeatureCollection;
-  /** Spatial predicate for `filterGeometry`. Defaults to `intersects`. */
+  /**
+   * Spatial predicate for `filterGeometry`. Defaults to `intersects`.
+   * `centroid-within` uses the arithmetic mean of geometry vertices.
+   */
   filterMode?: "centroid-within" | "intersects";
   /** Optional request cancellation signal. */
   signal?: AbortSignal;
@@ -155,8 +153,11 @@ export interface GeoLibreOvertureQueryResult {
   theme: GeoLibreOvertureTheme;
   sourceLayer: string;
   zoom: number;
+  /** Number of PMTiles tile lookups completed before the query stopped. */
   tilesRead: number;
+  /** Number of matching features included in `data`. */
   matchedFeatureCount: number;
+  /** Whether at least one additional match was excluded by `maxFeatures`. */
   truncated: boolean;
 }
 
@@ -420,7 +421,7 @@ export interface GeoLibreAppAPI {
    * patch after activation. Returns false when the plugin is unavailable,
    * refuses activation, or rejects the state.
    */
-  activatePlugin?: (pluginId: string, state?: unknown) => boolean;
+  activatePlugin?: (pluginId: string, state?: unknown) => Promise<boolean>;
   /**
    * Query a bounded set of features from GeoLibre's official Overture Maps
    * PMTiles integration. The host enforces tile and feature limits.

--- a/tests/overture-query.test.ts
+++ b/tests/overture-query.test.ts
@@ -1,12 +1,24 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { Feature, FeatureCollection, Polygon } from "geojson";
+import type {
+  Feature,
+  FeatureCollection,
+  GeometryCollection,
+  MultiPolygon,
+  Polygon,
+} from "geojson";
 import type { OvertureMapsState, OvertureTheme } from "maplibre-gl-overture-maps";
-import { mergeOvertureMapsState } from "../packages/plugins/src/plugins/maplibre-overture-maps";
+import {
+  maplibreOvertureMapsPlugin,
+  mergeOvertureMapsState,
+} from "../packages/plugins/src/plugins/maplibre-overture-maps";
 import {
   overtureFeatureMatchesFilter,
+  overtureTileCountForBBox,
   overtureTilesForBBox,
+  overtureZoomForBBox,
 } from "../packages/plugins/src/plugins/overture-query";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 
 const flood: FeatureCollection<Polygon> = {
   type: "FeatureCollection",
@@ -34,7 +46,18 @@ describe("Overture PMTiles query helpers", () => {
   it("enumerates bounded XYZ tile ranges", () => {
     const tiles = overtureTilesForBBox([-0.9, 38.8, 0.2, 39.9], 12);
     assert.equal(tiles.length, 238);
+    assert.equal(overtureTileCountForBBox([-0.9, 38.8, 0.2, 39.9], 12), tiles.length);
     assert.deepEqual(tiles[0], { x: 2037, y: 1552, z: 12 });
+  });
+
+  it("backs off zoom before materializing a tile range above the cap", () => {
+    const bbox: [number, number, number, number] = [-0.9, 38.8, 0.2, 39.9];
+    const zoom = overtureZoomForBBox(bbox, 12, 50);
+
+    assert.ok(zoom < 12);
+    assert.ok(overtureTileCountForBBox(bbox, zoom) <= 50);
+    assert.ok(overtureTileCountForBBox(bbox, zoom + 1) > 50);
+    assert.equal(overtureTilesForBBox(bbox, zoom).length, overtureTileCountForBBox(bbox, zoom));
   });
 
   it("supports centroid and line-intersection polygon filters", () => {
@@ -80,6 +103,125 @@ describe("Overture PMTiles query helpers", () => {
     assert.equal(overtureFeatureMatchesFilter(building, flood, "centroid-within"), true);
     assert.equal(overtureFeatureMatchesFilter(road, flood, "intersects"), true);
     assert.equal(overtureFeatureMatchesFilter(outside, flood, "intersects"), false);
+  });
+
+  it("detects polygon overlap when the vertex mean is outside the filter", () => {
+    const overlapping: Feature<Polygon> = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-2, 0.4],
+            [0.2, 0.4],
+            [0.2, 0.6],
+            [-2, 0.6],
+            [-2, 0.4],
+          ],
+        ],
+      },
+    };
+
+    assert.equal(overtureFeatureMatchesFilter(overlapping, flood, "centroid-within"), false);
+    assert.equal(overtureFeatureMatchesFilter(overlapping, flood, "intersects"), true);
+  });
+
+  it("rejects filters that contain no usable area geometry", () => {
+    const building = flood.features[0];
+
+    assert.throws(
+      () =>
+        overtureFeatureMatchesFilter(building, {
+          type: "Point",
+          coordinates: [0.5, 0.5],
+        }),
+      /must contain a usable Polygon or MultiPolygon/,
+    );
+    assert.throws(
+      () =>
+        overtureFeatureMatchesFilter(building, {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [1, 1],
+          ],
+        }),
+      /must contain a usable Polygon or MultiPolygon/,
+    );
+    assert.throws(
+      () =>
+        overtureFeatureMatchesFilter(building, {
+          type: "GeometryCollection",
+          geometries: [],
+        }),
+      /must contain a usable Polygon or MultiPolygon/,
+    );
+  });
+
+  it("collects area filters recursively from GeometryCollections", () => {
+    const filter: GeometryCollection = {
+      type: "GeometryCollection",
+      geometries: [{ type: "Point", coordinates: [10, 10] }, flood.features[0].geometry],
+    };
+
+    assert.equal(overtureFeatureMatchesFilter(flood.features[0], filter), true);
+  });
+
+  it("respects polygon holes and MultiPolygon components", () => {
+    const withHole: Polygon = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [4, 0],
+          [4, 4],
+          [0, 4],
+          [0, 0],
+        ],
+        [
+          [1, 1],
+          [3, 1],
+          [3, 3],
+          [1, 3],
+          [1, 1],
+        ],
+      ],
+    };
+    const separateAreas: MultiPolygon = {
+      type: "MultiPolygon",
+      coordinates: [
+        flood.features[0].geometry.coordinates,
+        [
+          [
+            [3, 0],
+            [4, 0],
+            [4, 1],
+            [3, 1],
+            [3, 0],
+          ],
+        ],
+      ],
+    };
+    const pointInHole: Feature = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Point", coordinates: [2, 2] },
+    };
+    const pointInOuter: Feature = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Point", coordinates: [0.5, 0.5] },
+    };
+    const pointInSecondPolygon: Feature = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Point", coordinates: [3.5, 0.5] },
+    };
+
+    assert.equal(overtureFeatureMatchesFilter(pointInHole, withHole), false);
+    assert.equal(overtureFeatureMatchesFilter(pointInOuter, withHole), true);
+    assert.equal(overtureFeatureMatchesFilter(pointInSecondPolygon, separateAreas), true);
   });
 });
 
@@ -142,5 +284,55 @@ describe("Overture plugin state coordination", () => {
     });
     assert.equal(merged.themes.transportation.layers.segment.visible, false);
     assert.equal(merged.themes.places.expanded, false);
+  });
+
+  it("drops unknown state keys and rejects invalid or no-op patches", () => {
+    const base = maplibreOvertureMapsPlugin.getProjectState?.() as OvertureMapsState | undefined;
+    const invalid = maplibreOvertureMapsPlugin.applyProjectState?.({} as GeoLibreAppAPI, {
+      themes: "buildings",
+    });
+    const unknown = maplibreOvertureMapsPlugin.applyProjectState?.({} as GeoLibreAppAPI, {
+      themes: { future_theme: { expanded: true } },
+    });
+    const unchanged = maplibreOvertureMapsPlugin.applyProjectState?.({} as GeoLibreAppAPI, {
+      collapsed: false,
+    });
+
+    assert.equal(base, undefined);
+    assert.equal(invalid, false);
+    assert.equal(unknown, false);
+    assert.equal(unchanged, false);
+
+    const themeIds: OvertureTheme[] = [
+      "addresses",
+      "base",
+      "buildings",
+      "divisions",
+      "places",
+      "transportation",
+    ];
+    const state: OvertureMapsState = {
+      collapsed: false,
+      panelWidth: 340,
+      release: "",
+      releases: [],
+      inspect: true,
+      themes: Object.fromEntries(
+        themeIds.map((theme) => [
+          theme,
+          {
+            expanded: false,
+            layers: {},
+          },
+        ]),
+      ) as OvertureMapsState["themes"],
+    };
+    const merged = mergeOvertureMapsState(state, {
+      inspect: false,
+      unexpected: "ignored",
+    } as Parameters<typeof mergeOvertureMapsState>[1] & { unexpected: string });
+
+    assert.equal(merged.inspect, false);
+    assert.equal("unexpected" in merged, false);
   });
 });

--- a/tests/overture-query.test.ts
+++ b/tests/overture-query.test.ts
@@ -1,10 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { Feature, FeatureCollection, Polygon } from "geojson";
-import type {
-  OvertureMapsState,
-  OvertureTheme,
-} from "maplibre-gl-overture-maps";
+import type { OvertureMapsState, OvertureTheme } from "maplibre-gl-overture-maps";
 import { mergeOvertureMapsState } from "../packages/plugins/src/plugins/maplibre-overture-maps";
 import {
   overtureFeatureMatchesFilter,
@@ -80,15 +77,9 @@ describe("Overture PMTiles query helpers", () => {
       },
     };
 
-    assert.equal(
-      overtureFeatureMatchesFilter(building, flood, "centroid-within"),
-      true
-    );
+    assert.equal(overtureFeatureMatchesFilter(building, flood, "centroid-within"), true);
     assert.equal(overtureFeatureMatchesFilter(road, flood, "intersects"), true);
-    assert.equal(
-      overtureFeatureMatchesFilter(outside, flood, "intersects"),
-      false
-    );
+    assert.equal(overtureFeatureMatchesFilter(outside, flood, "intersects"), false);
   });
 });
 

--- a/tests/overture-query.test.ts
+++ b/tests/overture-query.test.ts
@@ -335,4 +335,16 @@ describe("Overture plugin state coordination", () => {
     assert.equal(merged.inspect, false);
     assert.equal("unexpected" in merged, false);
   });
+
+  it("does not persist an empty release or fetched release list while detached", () => {
+    const applied = maplibreOvertureMapsPlugin.applyProjectState?.({} as GeoLibreAppAPI, {
+      collapsed: true,
+    });
+    const pending = maplibreOvertureMapsPlugin.getProjectState?.() as Record<string, unknown>;
+
+    assert.equal(applied, true);
+    assert.equal(pending.collapsed, true);
+    assert.equal("release" in pending, false);
+    assert.equal("releases" in pending, false);
+  });
 });

--- a/tests/overture-query.test.ts
+++ b/tests/overture-query.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Feature, FeatureCollection, Polygon } from "geojson";
+import type {
+  OvertureMapsState,
+  OvertureTheme,
+} from "maplibre-gl-overture-maps";
+import { mergeOvertureMapsState } from "../packages/plugins/src/plugins/maplibre-overture-maps";
+import {
+  overtureFeatureMatchesFilter,
+  overtureTilesForBBox,
+} from "../packages/plugins/src/plugins/overture-query";
+
+const flood: FeatureCollection<Polygon> = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 1],
+            [0, 0],
+          ],
+        ],
+      },
+    },
+  ],
+};
+
+describe("Overture PMTiles query helpers", () => {
+  it("enumerates bounded XYZ tile ranges", () => {
+    const tiles = overtureTilesForBBox([-0.9, 38.8, 0.2, 39.9], 12);
+    assert.equal(tiles.length, 238);
+    assert.deepEqual(tiles[0], { x: 2037, y: 1552, z: 12 });
+  });
+
+  it("supports centroid and line-intersection polygon filters", () => {
+    const building: Feature<Polygon> = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0.2, 0.2],
+            [0.4, 0.2],
+            [0.4, 0.4],
+            [0.2, 0.4],
+            [0.2, 0.2],
+          ],
+        ],
+      },
+    };
+    const road: Feature = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-1, 0.5],
+          [2, 0.5],
+        ],
+      },
+    };
+    const outside: Feature = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [-1, 2],
+          [2, 2],
+        ],
+      },
+    };
+
+    assert.equal(
+      overtureFeatureMatchesFilter(building, flood, "centroid-within"),
+      true
+    );
+    assert.equal(overtureFeatureMatchesFilter(road, flood, "intersects"), true);
+    assert.equal(
+      overtureFeatureMatchesFilter(outside, flood, "intersects"),
+      false
+    );
+  });
+});
+
+describe("Overture plugin state coordination", () => {
+  it("deep-merges a disaster style patch without dropping other themes", () => {
+    const themeIds: OvertureTheme[] = [
+      "addresses",
+      "base",
+      "buildings",
+      "divisions",
+      "places",
+      "transportation",
+    ];
+    const base: OvertureMapsState = {
+      collapsed: false,
+      panelWidth: 340,
+      release: "2026-07-22.0",
+      releases: ["2026-07-22.0"],
+      inspect: false,
+      themes: Object.fromEntries(
+        themeIds.map((theme) => [
+          theme,
+          {
+            expanded: false,
+            layers: {
+              [theme === "transportation" ? "segment" : "building"]: {
+                visible: false,
+                opacity: 1,
+                color: "#000000",
+                size: 1,
+              },
+            },
+          },
+        ]),
+      ) as OvertureMapsState["themes"],
+    };
+
+    const merged = mergeOvertureMapsState(base, {
+      inspect: true,
+      themes: {
+        buildings: {
+          expanded: true,
+          layers: {
+            building: {
+              visible: true,
+              opacity: 0.4,
+              color: "#64748b",
+            },
+          },
+        },
+      },
+    });
+
+    assert.equal(merged.inspect, true);
+    assert.deepEqual(merged.themes.buildings.layers.building, {
+      visible: true,
+      opacity: 0.4,
+      color: "#64748b",
+      size: 1,
+    });
+    assert.equal(merged.themes.transportation.layers.segment.visible, false);
+    assert.equal(merged.themes.places.expanded, false);
+  });
+});

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -537,6 +537,75 @@ describe("PluginManager async activation", () => {
     await Promise.resolve();
     assert.equal(manager.isActive("reactivated-plugin"), true);
   });
+
+  it("does not let an unregistered plugin's activation revert its replacement", async () => {
+    const manager = new PluginManager();
+    let resolveOldMount: (value: boolean) => void = () => {};
+    let replacementDeactivations = 0;
+
+    manager.register(
+      testPlugin({
+        id: "replaceable-plugin",
+        activate: () =>
+          new Promise<boolean>((resolve) => {
+            resolveOldMount = resolve;
+          }),
+      }),
+    );
+    const oldActivation = manager.activate("replaceable-plugin", app);
+    manager.unregister("replaceable-plugin", app);
+    manager.register(
+      testPlugin({
+        id: "replaceable-plugin",
+        deactivate: () => {
+          replacementDeactivations += 1;
+        },
+      }),
+    );
+
+    assert.equal(await manager.activate("replaceable-plugin", app), true);
+    resolveOldMount(false);
+    assert.equal(await oldActivation, false);
+    assert.equal(manager.isActive("replaceable-plugin"), true);
+    assert.equal(replacementDeactivations, 0);
+  });
+
+  it("starts a fresh activation after project restore deactivates a pending mount", async () => {
+    const manager = new PluginManager();
+    const resolvers: Array<(value: boolean) => void> = [];
+    let activationCalls = 0;
+
+    manager.register(
+      testPlugin({
+        id: "restore-race-plugin",
+        activate: () => {
+          activationCalls += 1;
+          return new Promise<boolean>((resolve) => {
+            resolvers.push(resolve);
+          });
+        },
+      }),
+    );
+    const firstActivation = manager.activate("restore-race-plugin", app);
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: [],
+        mapControlPositions: {},
+        settings: {},
+      },
+      app,
+    );
+    const secondActivation = manager.activate("restore-race-plugin", app);
+
+    assert.equal(activationCalls, 2);
+    assert.notEqual(secondActivation, firstActivation);
+    resolvers[0](true);
+    resolvers[1](true);
+    assert.equal(await firstActivation, false);
+    assert.equal(await secondActivation, true);
+    assert.equal(manager.isActive("restore-race-plugin"), true);
+  });
 });
 
 describe("PluginManager toolbar menu scoping", () => {

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -911,7 +911,12 @@ describe("PluginManager markDefaultActive", () => {
     manager.markDefaultActive("bundled-drop-in");
 
     manager.restoreProjectState(
-      { manifestUrls: [], activePluginIds: [], mapControlPositions: {}, settings: {} },
+      {
+        manifestUrls: [],
+        activePluginIds: [],
+        mapControlPositions: {},
+        settings: {},
+      },
       app,
     );
     assert.equal(manager.isActive("bundled-drop-in"), false);
@@ -933,5 +938,61 @@ describe("PluginManager markDefaultActive", () => {
 
     manager.restoreProjectState(null, app);
     assert.equal(manager.isActive("bundled-drop-in"), false);
+  });
+});
+
+describe("PluginManager plugin coordination", () => {
+  it("applies a state patch to one registered plugin", () => {
+    const manager = new PluginManager();
+    const states: unknown[] = [];
+    manager.register(
+      testPlugin({
+        id: "target",
+        applyProjectState: (_app, state) => {
+          states.push(state);
+        },
+      }),
+    );
+
+    assert.equal(manager.applyPluginState("target", app, { visible: true }), true);
+    assert.deepEqual(states, [{ visible: true }]);
+    assert.equal(manager.applyPluginState("missing", app, {}), false);
+  });
+
+  it("prevents recursive activation across coordinating plugins", () => {
+    const manager = new PluginManager();
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const coordinatingApp = {
+      ...app,
+      activatePlugin: (id: string) => {
+        manager.activate(id, coordinatingApp);
+        return manager.isActive(id);
+      },
+    } as GeoLibreAppAPI;
+    manager.register(
+      testPlugin({
+        id: "first",
+        activate: (scopedApp) => {
+          firstCalls += 1;
+          scopedApp.activatePlugin?.("second");
+        },
+      }),
+    );
+    manager.register(
+      testPlugin({
+        id: "second",
+        activate: (scopedApp) => {
+          secondCalls += 1;
+          scopedApp.activatePlugin?.("first");
+        },
+      }),
+    );
+
+    manager.activate("first", coordinatingApp);
+    assert.equal(firstCalls, 1);
+    assert.equal(secondCalls, 1);
+    assert.equal(manager.isActive("first"), true);
+    assert.equal(manager.isActive("second"), true);
   });
 });

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -397,16 +397,14 @@ describe("PluginManager async activation", () => {
       }),
     );
 
-    manager.activate("async-plugin", app);
+    const activation = manager.activate("async-plugin", app);
+    const repeatedActivation = manager.activate("async-plugin", app);
     // Optimistically active while the mount is in flight.
     assert.equal(manager.isActive("async-plugin"), true);
+    assert.equal(repeatedActivation, activation);
 
     resolveMount(false);
-    // watchAsyncActivation wraps the plugin promise in Promise.resolve().then(),
-    // so two microtask ticks are needed: one for the wrapper, one for the
-    // callback. (The other async tests below flush twice for the same reason.)
-    await Promise.resolve();
-    await Promise.resolve();
+    assert.equal(await activation, false);
 
     // A failed mount reverts the menu and tears down the partial activation.
     assert.equal(manager.isActive("async-plugin"), false);
@@ -423,9 +421,8 @@ describe("PluginManager async activation", () => {
       }),
     );
 
-    manager.activate("rejecting-plugin", app);
-    await Promise.resolve();
-    await Promise.resolve();
+    const activation = manager.activate("rejecting-plugin", app);
+    assert.equal(await activation, false);
 
     assert.equal(manager.isActive("rejecting-plugin"), false);
   });
@@ -440,9 +437,8 @@ describe("PluginManager async activation", () => {
       }),
     );
 
-    manager.activate("ok-plugin", app);
-    await Promise.resolve();
-    await Promise.resolve();
+    const activation = manager.activate("ok-plugin", app);
+    assert.equal(await activation, true);
 
     assert.equal(manager.isActive("ok-plugin"), true);
   });
@@ -959,16 +955,13 @@ describe("PluginManager plugin coordination", () => {
     assert.equal(manager.applyPluginState("missing", app, {}), false);
   });
 
-  it("prevents recursive activation across coordinating plugins", () => {
+  it("prevents recursive activation across coordinating plugins", async () => {
     const manager = new PluginManager();
     let firstCalls = 0;
     let secondCalls = 0;
     const coordinatingApp = {
       ...app,
-      activatePlugin: (id: string) => {
-        manager.activate(id, coordinatingApp);
-        return manager.isActive(id);
-      },
+      activatePlugin: async (id: string) => Boolean(await manager.activate(id, coordinatingApp)),
     } as GeoLibreAppAPI;
     manager.register(
       testPlugin({
@@ -989,7 +982,7 @@ describe("PluginManager plugin coordination", () => {
       }),
     );
 
-    manager.activate("first", coordinatingApp);
+    await manager.activate("first", coordinatingApp);
     assert.equal(firstCalls, 1);
     assert.equal(secondCalls, 1);
     assert.equal(manager.isActive("first"), true);


### PR DESCRIPTION
## Summary

- add host APIs for safe cross-plugin activation and partial state application
- expose bounded, cancellable Overture PMTiles feature queries with hard tile and feature limits
- let cooperating plugins style the existing Overture control without dropping user state
- add coverage for query geometry, state merging, and activation cycles

## Validation

- `npm test`
- `npm run build`
- `pre-commit run --all-files`
- live Overture PMTiles query against release `2026-07-22.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Overture Maps feature querying within a WGS84 bbox with optional geometry filtering and configurable zoom/tile/feature caps.
  * Exposed Overture query utilities from the plugins package.
  * Added desktop app API support for `activatePlugin` (with optional plugin state) and `queryOvertureFeatures`.
  * Introduced validated, deep-mergeable Overture map state patches for per-plugin updates.
* **Bug Fixes**
  * Prevented duplicate/re-entrant plugin activation during URL dispatch and project restore; improved activation rollback and coordination behavior.
* **Tests**
  * Added/expanded unit tests for Overture querying, state merging, and plugin activation/state coordination.
* **Chores**
  * Added runtime dependencies to support additional tile/data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->