### PR TITLE
fix(measure): show a real total in the Measure panel

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -64,7 +64,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
     "maplibre-gl-basemap-control": "^0.13.0",
-    "maplibre-gl-components": "^0.28.0",
+    "maplibre-gl-components": "^0.28.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
         "maplibre-gl-basemap-control": "^0.13.0",
-        "maplibre-gl-components": "^0.28.0",
+        "maplibre-gl-components": "^0.28.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -16653,9 +16653,9 @@
       }
     },
     "node_modules/maplibre-gl-components": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.28.0.tgz",
-      "integrity": "sha512-9Q+wTBSKfvb3uKG1tGUbvbAIQDcSDwmR02dHdo+hkuoqeITPrTvE8fp0lNeKKccAkQ1K5mNdwISXsIoteNQlmw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.28.1.tgz",
+      "integrity": "sha512-Anwmv3GrfZXfKfRS5XI6dUg78NKjHIIlNInXMSYmcawftgEkcJHKdjTjI23W2AWugKdRoTe58gX5j7+Yq7HfWA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -21873,7 +21873,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.4",
         "maplibre-gl-basemap-control": "^0.13.0",
-        "maplibre-gl-components": "^0.28.0",
+        "maplibre-gl-components": "^0.28.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.4",
     "maplibre-gl-basemap-control": "^0.13.0",
-    "maplibre-gl-components": "^0.28.0",
+    "maplibre-gl-components": "^0.28.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",


### PR DESCRIPTION
Fixes #1460

## Problem

Controls -> Measure showed **Total Distance** / **Total Area** as `0.00` no matter how much the user measured. The reporter's screenshot captures it exactly: a completed polygon of `1324428.31 Square Kilometers` sits in the results list while the readout above reads `0.00`.

## Root cause

Upstream, in `maplibre-gl-components`' `MeasureControl`. The readout rendered only `state.currentValue` (the drawing in progress). Finishing a measurement re-arms the tool for the next one, and re-arming resets `currentValue` to zero, so the number labelled "Total" collapsed to `0.00` the instant a measurement completed.

## Fix

Bumps `maplibre-gl-components` to **0.28.1** (opengeos/maplibre-gl-components#124), where the readout now:

- sums every completed measurement of the active mode plus the one being drawn, so it matches its "Total" label. Measurements from the other mode are excluded, so switching Distance/Area does not mix square kilometers into a distance total.
- refreshes when a measurement is deleted from the list.
- stays on screen after Escape while saved measurements remain (including legitimately zero-valued ones); `Clear All` still hides it.
- follows the panel's unit selector, which now also re-renders the saved measurements list in the new unit instead of leaving the previous unit's numbers.

No GeoLibre-side wiring changes were needed. `main` already tracked `^0.28.0`, so this is the patch bump plus the lockfile.

## Verification

Driven in a browser against the published 0.28.1, in **light and dark** themes:

| Step | Result |
| --- | --- |
| Draw a distance, finish with Enter | total holds at `4300.03 Kilometers`, matching the list entry |
| Add a second measurement | total sums to the two entries |
| Switch unit km -> miles | total **and** both list entries convert |
| Delete the first entry | total drops to the remaining measurement |
| Escape mid-draw with a saved measurement | total stays visible |
| Escape mid-draw with nothing saved | readout hides |
| Area mode | label switches to Total Area, resets per mode, holds after finish; the terrain panel's surface area agrees |
| Clear All | readout and list hide |

Gate: `npm run build` clean, `npm run test:frontend` 3951 passing, `npm run test:worker` clean, `pre-commit run --files <changed>` passing. Upstream: 247 tests passing (7 new `MeasureControl` cases), lint and build clean, CodeRabbit approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the mapping components to a newer patch version, providing the latest available fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->