### PR TITLE
Expose layer groups to external plugins

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -835,6 +835,9 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       return state === undefined ? true : manager.applyPluginState(pluginId, api, state);
     },
     queryOvertureFeatures,
+    addLayerGroup: (name?: string, layerIds?: string[]) =>
+      useAppStore.getState().addLayerGroup(name, layerIds),
+    removeLayerGroup: (id: string) => useAppStore.getState().removeLayerGroup(id),
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,

--- a/apps/geolibre-desktop/src/lib/external-native-layer.ts
+++ b/apps/geolibre-desktop/src/lib/external-native-layer.ts
@@ -76,5 +76,6 @@ export function createExternalNativeStoreLayer(
     beforeId: registration.beforeId ?? existing?.beforeId,
     geojson: registration.geojson ?? existing?.geojson,
     sourcePath: registration.sourcePath ?? existing?.sourcePath,
+    groupId: registration.groupId ?? existing?.groupId,
   };
 }

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -26,6 +26,8 @@ export type GeoLibreBuiltInMapControl =
 export interface GeoLibreExternalNativeLayerRegistration {
   id: string;
   name: string;
+  /** Optional host layer-group id that should contain this layer. */
+  groupId?: string;
   type?: GeoLibreLayer["type"];
   source?: Record<string, unknown>;
   geojson?: FeatureCollection;
@@ -427,6 +429,13 @@ export interface GeoLibreAppAPI {
    * PMTiles integration. The host enforces tile and feature limits.
    */
   queryOvertureFeatures?: (query: GeoLibreOvertureQuery) => Promise<GeoLibreOvertureQueryResult>;
+  /**
+   * Create a named Layers-panel group, optionally assigning existing layer ids
+   * to it, and return the new group id.
+   */
+  addLayerGroup?: (name?: string, layerIds?: string[]) => string;
+  /** Remove a Layers-panel group without removing its child layers. */
+  removeLayerGroup?: (id: string) => void;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => MapLibreMap | null;
   /**

--- a/tests/external-native-layer.test.ts
+++ b/tests/external-native-layer.test.ts
@@ -159,4 +159,15 @@ describe("createExternalNativeStoreLayer", () => {
 
     assert.equal(layer.visible, false);
   });
+
+  it("assigns and preserves the requested host layer group", () => {
+    const grouped = createExternalNativeStoreLayer(baseRegistration({ groupId: "event-imagery" }));
+    assert.equal(grouped.groupId, "event-imagery");
+
+    const updated = createExternalNativeStoreLayer(
+      baseRegistration({ name: "Updated Plugin Layer" }),
+      grouped,
+    );
+    assert.equal(updated.groupId, "event-imagery");
+  });
 });


### PR DESCRIPTION
## Summary

- expose host layer-group creation and removal through the external plugin API
- preserve requested group IDs when external native layers are registered or updated
- add coverage for external native layer group assignment

## Testing

- `npm run lint`
- `npm run build -w geolibre-desktop`
- `npm test`
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins can now create and remove layer groups.
  * External layers can be assigned to existing layer groups.
  * Layer group assignments are preserved when external layer details are updated.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->