### PR TITLE
fix(plugins): keep globe projection when adding a Zarr layer via addZarrLayer

### DIFF
--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -2281,9 +2281,9 @@ async function addZarrLayerExclusively(
     zarrControl.hide();
   }
 
-  // The untiled Zarr renderer draws in Web Mercator; switch off globe first
-  // (matching the COG raster flow) so the layer paints.
-  ensureMercatorProjection(app.getMap?.());
+  // Zarr renders correctly in globe (proj4js reprojects on the GPU), so — unlike the
+  // COG/deck.gl path — do not force Mercator here. This keeps addZarrLayer consistent
+  // with the Add Data → Zarr panel, which never switched projection. See #1466.
 
   const control = zarrControl;
   const headers = options.headers;


### PR DESCRIPTION
## What

`addZarrLayerExclusively` (the code path behind the `addZarrLayer` plugin API added in #1447) called `ensureMercatorProjection(app.getMap?.())`, which snapped the map out of **globe** and pinned it in Web Mercator whenever a plugin added a Zarr layer. This PR removes that call.

## Why

The **Add Data → Zarr panel** renders through the same `ZarrLayerControl` and never switches projection — so a projected Zarr renders fine in globe there. `@carbonplan/zarr-layer` reprojects on the GPU (via proj4js), and it renders projected data correctly in globe. So forcing Mercator on the `addZarrLayer` path was both unnecessary and **inconsistent** with the panel: the same store rendered in globe via Add Data but snapped to Mercator via a plugin.

The old comment ("the untiled Zarr renderer draws in Web Mercator") is disproven by the panel path and by external use of the same stack (`@carbonplan/zarr-layer` + MapLibre 6 in globe, rendering `EPSG:32633` data via proj4).

## Scope

- Only the Zarr `addZarrLayer` path changes. The **COG / cloud-NetCDF / LiDAR** deck.gl paths keep their own `ensureMercatorProjection` calls (deck.gl genuinely needs Mercator), so the import stays in use.
- No test referenced the removed call.

## Validation

Tested locally against a projected Zarr (seNorge, `EPSG:32633`, via proj4) added through a plugin while the map was in globe: it now **renders in globe and stays there**, matching the Add Data → Zarr panel. No regression on the other raster paths.

Fixes #1466 (as discussed there — thanks for the go-ahead 🙌).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zarr layer behavior in globe view by preserving the selected map projection.
  * Ensured Zarr layers remain consistent with the Add Data → Zarr panel across projection modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->