### PR TITLE
fix(raster): keep local rasters in saved projects and under layer order

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.1",
+    "maplibre-gl-raster": "^0.14.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.2",
+    "maplibre-gl-raster": "^0.14.3",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.0",
+    "maplibre-gl-raster": "^0.14.1",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -2079,6 +2079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,6 +4764,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ panic = "abort"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = { version = "2", features = ["watch"] }
 # Native geolocation on Android/iOS: ships the location manifest permissions and
@@ -41,7 +41,7 @@ tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 # Persists the fs scope the folder picker grants, so Browser-panel pinned
 # folders stay readable across app restarts (no re-pick required).
-tauri-plugin-persisted-scope = "2"
+tauri-plugin-persisted-scope = { version = "2", features = ["protocol-asset"] }
 duckdb = { version = "1.10504.0", features = ["bundled", "parquet"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 # rustls-tls stays the default backend for every request. rustls-tls-native-roots

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 use tauri::Manager;
+use tauri_plugin_fs::FsExt;
 
 // OAuth popups are a desktop-only, multi-window concept; Android/iOS have no
 // equivalent, and `WebviewWindowBuilder::{on_new_window, window_features}` do
@@ -405,6 +406,11 @@ fn allow_raster_asset(app: tauri::AppHandle, path: String) -> Result<(), String>
     if !is_safe_absolute_path(&path) || !(lower.ends_with(".tif") || lower.ends_with(".tiff")) {
         return Err(format!(
             "Refusing to expose \"{path}\": not an absolute GeoTIFF path"
+        ));
+    }
+    if !app.fs_scope().is_allowed(&path) {
+        return Err(format!(
+            "Refusing to expose \"{path}\": the file was not selected or dropped by the user"
         ));
     }
     app.asset_protocol_scope()

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -225,6 +225,7 @@ pub fn run() {
             load_external_plugin_bundles,
             read_admin_profile,
             read_env_vars,
+            allow_raster_asset,
             read_local_file,
             read_project_file,
             read_shapefile_siblings,
@@ -393,6 +394,22 @@ fn read_local_file(path: String) -> Result<tauri::ipc::Response, String> {
     fs::read(&path)
         .map(tauri::ipc::Response::new)
         .map_err(|error| format!("Could not read local file: {error}"))
+}
+
+/// Add one user-selected GeoTIFF to the asset-protocol scope. The filesystem
+/// and asset scopes are separate in Tauri; dialogs and native drops grant the
+/// former, but maplibre-gl-raster fetches through the latter for range reads.
+#[tauri::command]
+fn allow_raster_asset(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let lower = path.to_ascii_lowercase();
+    if !is_safe_absolute_path(&path) || !(lower.ends_with(".tif") || lower.ends_with(".tiff")) {
+        return Err(format!(
+            "Refusing to expose \"{path}\": not an absolute GeoTIFF path"
+        ));
+    }
+    app.asset_protocol_scope()
+        .allow_file(&path)
+        .map_err(|error| format!("Could not authorize local raster: {error}"))
 }
 
 /// Shapefile sidecar extensions read alongside a `.shp` (lowercased, no dot).

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' blob: https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; frame-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; frame-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,11 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; frame-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' asset: data: blob: https: http://asset.localhost http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' asset: data: blob: https: http://asset.localhost; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; frame-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "assetProtocol": {
+        "enable": true,
+        "scope": []
+      },
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -26,6 +26,8 @@ import {
   restoreThreeDTilesLayers,
   restoreVectorLayers,
   setBookmarkLabels,
+  setLocalRasterFileReader,
+  setLocalRasterPicker,
   setNonTiledRasterHandler,
   setTerrainMeasureLabels,
   setViewStateLabels,
@@ -57,6 +59,8 @@ import {
   loadDroppedPhotoPaths,
   loadDroppedRasterFiles,
   loadDroppedRasterPaths,
+  pickLocalRasterFiles,
+  readRasterFileAtPath,
   isLoadedImageOverlay,
   isLoadedModel,
   loadDroppedVectorFiles,
@@ -931,6 +935,21 @@ export function DesktopShell({
     }
   }, []);
 
+  // Let the raster plugin reach the local filesystem on desktop: re-read a
+  // raster a saved project references by path, and open the native file dialog
+  // instead of the panel's own <input type="file"> (whose File carries no path,
+  // so the raster could never be restored). Both stay unregistered in the
+  // browser, where the plugin keeps its existing behavior. See issue #1463.
+  useEffect(() => {
+    if (!isTauri()) return;
+    setLocalRasterFileReader(readRasterFileAtPath);
+    setLocalRasterPicker(pickLocalRasterFiles);
+    return () => {
+      setLocalRasterFileReader(null);
+      setLocalRasterPicker(null);
+    };
+  }, []);
+
   // When a GeoTIFF fails to load because it is striped (not a tiled COG), offer
   // to convert it to a COG in the browser and load the result. Works for both a
   // local file and a remote URL (issue #916). The raster plugin detects the case
@@ -1241,7 +1260,12 @@ export function DesktopShell({
     if (!rasters.length) return 0;
     const appAPI = createAppAPI(mapControllerRef);
     for (const raster of rasters) {
-      await addRasterToMap(appAPI, raster.source, { name: raster.name });
+      // `path` is present only for a desktop pick/drop; it is what lets a saved
+      // project reload the raster instead of dropping it (issue #1463).
+      await addRasterToMap(appAPI, raster.source, {
+        name: raster.name,
+        ...(raster.path ? { localPath: raster.path } : {}),
+      });
     }
     return rasters.length;
   }, []);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -5,6 +5,7 @@ import { MapCanvas, setExternalDeckLayerOrderHandler } from "@geolibre/map";
 import { useTranslation } from "react-i18next";
 import {
   addRasterToMap,
+  prepareRasterControl,
   applyRasterLayerOrder,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
@@ -1363,6 +1364,15 @@ export function DesktopShell({
         .onDragDropEvent(async (event) => {
           if (event.payload.type === "enter" || event.payload.type === "over") {
             setIsDraggingFiles(true);
+            // Match the perceived speed of Add Raster Layer: that flow warms
+            // the lazy raster control while its native picker is open. A map
+            // drop otherwise starts all initialization only after release.
+            // Fire-and-forget here so drag feedback never waits on imports.
+            if (event.payload.type === "enter") {
+              void prepareRasterControl(createAppAPI(mapControllerRef)).catch((error) => {
+                console.warn("[GeoLibre] Could not prepare the raster drop handler", error);
+              });
+            }
             return;
           }
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4341,6 +4341,7 @@
     "rowLabel": "Label for value {{value}}"
   },
   "raster": {
+    "filePickerLabel": "Rasters",
     "cogConvertConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Convert it to a Cloud-Optimized GeoTIFF now and load that?",
     "cogConvertRemoteConfirm": "\"{{name}}\" is a plain (striped) GeoTIFF, which cannot be displayed directly. Displaying it means downloading the full file and converting it to a Cloud-Optimized GeoTIFF in the browser, which can be slow and memory-intensive for large files. Proceed?",
     "cogConvertLargeConfirm": "\"{{name}}\" is a large {{width}}×{{height}} GeoTIFF that is not a Cloud-Optimized GeoTIFF. Converting it in the browser may be slow and memory-intensive. Convert and load it anyway?",

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -2412,6 +2412,12 @@ export interface DroppedRaster {
    * manages its object URL, matching how the Add Raster panel loads local files.
    */
   source: File;
+  /**
+   * The absolute path the bytes were read from, when there is one (Tauri).
+   * Recorded on the layer so a saved project can reload the raster; absent for
+   * a browser drag-and-drop, which has no path.
+   */
+  path?: string;
 }
 
 function fileBaseName(path: string): string {
@@ -2439,9 +2445,52 @@ export async function loadDroppedRasterPaths(paths: string[]): Promise<DroppedRa
     rasters.push({
       name,
       source: new File([bytes], name, { type: "image/tiff" }),
+      path,
     });
   }
   return rasters;
+}
+
+/**
+ * Read one raster file off disk into a browser `File`, for reloading a raster a
+ * saved project references by path (issue #1463). Rejects when the file is
+ * gone; the caller then drops that layer with a notice.
+ *
+ * @param path - The absolute path recorded when the raster was first added.
+ * @returns The file, named after its basename.
+ */
+export async function readRasterFileAtPath(path: string): Promise<File> {
+  const bytes = await readFile(path);
+  return new File([bytes], fileBaseName(path), { type: "image/tiff" });
+}
+
+/**
+ * Open a native file dialog for raster files and read each pick, keeping the
+ * absolute path alongside the bytes. Used in place of the raster panel's own
+ * `<input type="file">`, whose `File` carries no path. Resolves to an empty
+ * array when the dialog is cancelled or the app is not running under Tauri.
+ *
+ * @returns The picked rasters, each with its file and path.
+ */
+export async function pickLocalRasterFiles(): Promise<{ file: File; path: string }[]> {
+  if (!isTauri()) return [];
+  const selected = await open({
+    multiple: true,
+    filters: [{ name: "Rasters", extensions: [...RASTER_DROP_EXTENSIONS] }],
+  });
+  if (!selected) return [];
+  const paths = (Array.isArray(selected) ? selected : [selected]).filter(isRasterFileName);
+  const picked: { file: File; path: string }[] = [];
+  for (const path of paths) {
+    // Read each pick independently so one unreadable file does not abandon the
+    // rest of the selection, matching pickImageFilesWithFallback.
+    try {
+      picked.push({ file: await readRasterFileAtPath(path), path });
+    } catch (error) {
+      console.warn(`Could not read the selected raster "${path}".`, error);
+    }
+  }
+  return picked;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1,5 +1,5 @@
 import { hasPathTraversal, parseProject, type GeoLibreProject } from "@geolibre/core";
-import { invoke } from "@tauri-apps/api/core";
+import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import {
   readDir,
@@ -2411,7 +2411,7 @@ export interface DroppedRaster {
    * The GeoTIFF/COG as a File. The raster control accepts a File directly and
    * manages its object URL, matching how the Add Raster panel loads local files.
    */
-  source: File;
+  source: File | string;
   /**
    * The absolute path the bytes were read from, when there is one (Tauri).
    * Recorded on the layer so a saved project can reload the raster; absent for
@@ -2432,23 +2432,18 @@ export function loadDroppedRasterFiles(droppedFiles: FileList | File[]): Dropped
 }
 
 /**
- * Read dropped raster file paths (Tauri) into File objects the control can load.
- * There is no asset-protocol scope configured, so the bytes are read and wrapped
- * in a File, matching how local vector files are loaded.
+ * Convert dropped raster paths (Tauri) to asset-protocol URLs. Tauri serves
+ * these with byte-range support, so a COG opens lazily instead of copying the
+ * entire file over IPC and then copying it again into a browser File.
  */
 export async function loadDroppedRasterPaths(paths: string[]): Promise<DroppedRaster[]> {
   const rasterPaths = paths.filter(isRasterFileName);
-  const rasters: DroppedRaster[] = [];
-  for (const path of rasterPaths) {
-    const bytes = await readFile(path);
-    const name = fileBaseName(path);
-    rasters.push({
-      name,
-      source: new File([bytes], name, { type: "image/tiff" }),
-      path,
-    });
-  }
-  return rasters;
+  await Promise.all(rasterPaths.map((path) => invoke("allow_raster_asset", { path })));
+  return rasterPaths.map((path) => ({
+    name: fileBaseName(path),
+    source: convertFileSrc(path),
+    path,
+  }));
 }
 
 /**
@@ -2459,9 +2454,9 @@ export async function loadDroppedRasterPaths(paths: string[]): Promise<DroppedRa
  * @param path - The absolute path recorded when the raster was first added.
  * @returns The file, named after its basename.
  */
-export async function readRasterFileAtPath(path: string): Promise<File> {
-  const bytes = await readFile(path);
-  return new File([bytes], fileBaseName(path), { type: "image/tiff" });
+export async function readRasterFileAtPath(path: string): Promise<string> {
+  await invoke("allow_raster_asset", { path });
+  return convertFileSrc(path);
 }
 
 /**
@@ -2472,7 +2467,7 @@ export async function readRasterFileAtPath(path: string): Promise<File> {
  *
  * @returns The picked rasters, each with its file and path.
  */
-export async function pickLocalRasterFiles(): Promise<{ file: File; path: string }[]> {
+export async function pickLocalRasterFiles(): Promise<{ file: File | string; path: string }[]> {
   if (!isTauri()) return [];
   const selected = await open({
     multiple: true,
@@ -2480,7 +2475,7 @@ export async function pickLocalRasterFiles(): Promise<{ file: File; path: string
   });
   if (!selected) return [];
   const paths = (Array.isArray(selected) ? selected : [selected]).filter(isRasterFileName);
-  const picked: { file: File; path: string }[] = [];
+  const picked: { file: File | string; path: string }[] = [];
   for (const path of paths) {
     // Read each pick independently so one unreadable file does not abandon the
     // rest of the selection, matching pickImageFilesWithFallback.

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -2471,7 +2471,9 @@ export async function pickLocalRasterFiles(): Promise<{ file: File | string; pat
   if (!isTauri()) return [];
   const selected = await open({
     multiple: true,
-    filters: [{ name: "Rasters", extensions: [...RASTER_DROP_EXTENSIONS] }],
+    filters: [
+      { name: i18next.t("raster.filePickerLabel"), extensions: [...RASTER_DROP_EXTENSIONS] },
+    ],
   });
   if (!selected) return [];
   const paths = (Array.isArray(selected) ? selected : [selected]).filter(isRasterFileName);

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -61,8 +61,7 @@ server {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        # Closely mirrors the Tauri desktop CSP (the browser build additionally
-        # permits data: URIs in connect-src). 'unsafe-eval' is required by the
+        # Closely mirrors the Tauri desktop CSP. 'unsafe-eval' is required by the
         # @google/earthengine and maplibre-gl-geoagent bundles; connect-src
         # stays broad because users connect to arbitrary tile/WMS endpoints.
         # The http://localhost:* / http://127.0.0.1:* (and ws:// equivalents)
@@ -83,8 +82,11 @@ server {
         # mirror the change in the Tauri CSP in
         # apps/geolibre-desktop/src-tauri/tauri.conf.json as well --
         # wss://collab.geolibre.app is an example of a host duplicated in both.
-        # (The browser build intentionally adds data: to connect-src; that
-        # difference is documented in the "Closely mirrors" note above.)
+        # `data:` must stay in connect-src in BOTH CSPs: MapLibre fetches an
+        # image source's URL (it does not assign it to an <img>), so a data:
+        # URI image -- a KML/KMZ <GroundOverlay>, a deck.gl icon atlas -- is
+        # matched against connect-src, not img-src. Dropping it makes those
+        # layers fail to load with an opaque "Load failed" (issue #1463).
         # The Tauri CSP additionally allows http://127.0.0.1:* / http://localhost:*
         # in frame-src/child-src so the desktop app can embed its locally
         # launched JupyterLab server in the Notebook panel. That is desktop-only

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.0",
+        "maplibre-gl-raster": "^0.14.1",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
@@ -17075,9 +17075,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.0.tgz",
-      "integrity": "sha512-lslg2Gl4q7QhALWNAzYgDSd0P10v9n0Mb2bBSGFqTa2A6BO9be+dGrWIX0/+IRP58tDhSSYYwieW2Meu8td1Jg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.1.tgz",
+      "integrity": "sha512-GgQthHH3rSsDPWK3BMkr0Rh9fp6nV0QtGB0NjEhTPOEwu5JtWBgpde+ZuLl5eDH6nYHftwILF2+h7+Lxie43LA==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21886,7 +21886,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.0",
+        "maplibre-gl-raster": "^0.14.1",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21017,7 +21017,6 @@
       "resolved": "https://registry.npmjs.org/whitebox-wasm/-/whitebox-wasm-0.4.1.tgz",
       "integrity": "sha512-9UO5LXdThXsthy19JG27u1IjK4Tal2IGgTnvq61uNiv3Wta9yVDy81B/qhQLu8UyTJ0mmG8bP/e+uVJm5xm4Rw==",
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
       }
@@ -21867,6 +21866,7 @@
         "@turf/union": "^7.3.5",
         "cog-tiler-wasm": "^0.3.1",
         "geotiff": "^3.0.5",
+        "geotiff-geokeys-to-proj4": "^2024.4.13",
         "h5wasm": "^0.10.3",
         "jspdf": "^4.2.1",
         "mapillary-js": "^4.1.2",
@@ -21898,7 +21898,8 @@
         "pmtiles": "^4.4.1",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
-        "three": "^0.185.1"
+        "three": "^0.185.1",
+        "whitebox-wasm": "^0.4.1"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.1",
+        "maplibre-gl-raster": "^0.14.2",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
@@ -17075,9 +17075,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.1.tgz",
-      "integrity": "sha512-GgQthHH3rSsDPWK3BMkr0Rh9fp6nV0QtGB0NjEhTPOEwu5JtWBgpde+ZuLl5eDH6nYHftwILF2+h7+Lxie43LA==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.2.tgz",
+      "integrity": "sha512-MQszsPz6iyUOjWulqwyRPuYWRPz99VH7yoBod7b8ok9fkFcwOXgC0wUwpXoMiLb5N/aIRlFbn1e0d761lw1gpw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21886,7 +21886,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.1",
+        "maplibre-gl-raster": "^0.14.2",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.2",
+        "maplibre-gl-raster": "^0.14.3",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
@@ -17075,9 +17075,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.2.tgz",
-      "integrity": "sha512-MQszsPz6iyUOjWulqwyRPuYWRPz99VH7yoBod7b8ok9fkFcwOXgC0wUwpXoMiLb5N/aIRlFbn1e0d761lw1gpw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.3.tgz",
+      "integrity": "sha512-F2FovnXtat/reCJVXZj2XnPeZP56Z8ONTr5Xwgu5MTGrMeZPl5nYhd4FfWXNRGunwZ8PlD2eCVDqKgL1aA4kcg==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -21886,7 +21886,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.2",
+        "maplibre-gl-raster": "^0.14.3",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -52,7 +52,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.2",
+    "maplibre-gl-raster": "^0.14.3",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,6 +32,7 @@
     "@turf/union": "^7.3.5",
     "cog-tiler-wasm": "^0.3.1",
     "geotiff": "^3.0.5",
+    "geotiff-geokeys-to-proj4": "^2024.4.13",
     "h5wasm": "^0.10.3",
     "jspdf": "^4.2.1",
     "mapillary-js": "^4.1.2",
@@ -63,7 +64,8 @@
     "pmtiles": "^4.4.1",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
-    "three": "^0.185.1"
+    "three": "^0.185.1",
+    "whitebox-wasm": "^0.4.1"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -52,7 +52,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.0",
+    "maplibre-gl-raster": "^0.14.1",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -52,7 +52,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.1",
+    "maplibre-gl-raster": "^0.14.2",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -189,9 +189,14 @@ export {
   closeRasterLayerPanel,
   openRasterLayerPanel,
   restoreRasterLayers,
+  setLocalRasterFileReader,
+  setLocalRasterPicker,
   setNonTiledRasterHandler,
   setRasterPixelInspect,
+  type LocalRasterFileReader,
+  type LocalRasterPicker,
   type NonTiledRasterRequest,
+  type PickedLocalRaster,
 } from "./plugins/maplibre-raster";
 export {
   RASTER_MAX_CLASSES,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -185,6 +185,7 @@ export {
 } from "./plugins/maplibre-3d-tiles";
 export {
   addRasterToMap,
+  prepareRasterControl,
   applyRasterLayerOrder,
   closeRasterLayerPanel,
   openRasterLayerPanel,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -1147,10 +1147,16 @@ async function openLocalRasterPicker(): Promise<void> {
     for (const picked of await picker()) {
       // Sequential, matching the drag-and-drop path: each add awaits the
       // GeoTIFF header, and the control zooms to the raster it just added.
-      await addRasterToMap(app, picked.file, {
-        name: picked.file.name,
-        localPath: picked.path,
-      });
+      // Each add is isolated so one unreadable pick does not silently discard
+      // the rest of a multi-file selection.
+      try {
+        await addRasterToMap(app, picked.file, {
+          name: picked.file.name,
+          localPath: picked.path,
+        });
+      } catch (error) {
+        console.error(`[GeoLibre] Failed to add the raster "${picked.file.name}"`, error);
+      }
     }
   } catch (error) {
     console.error("[GeoLibre] Failed to add a raster from the file picker", error);

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -35,13 +35,11 @@ const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
 
 // The rendering backend rasters are decoded with unless the user picks another
-// one in the panel. Upstream defaults to `maplibre-gl-raster` (deck.gl on the
-// GPU), which draws through a deck.gl overlay rather than a MapLibre style
-// layer -- on the desktop build that overlay is a separate canvas stacked above
-// the map, so a raster always covers the vector layers above it in the layer
-// list no matter how they are ordered (issue #1463). `cog-tiler-wasm` decodes
-// tiles on the CPU in WebAssembly and feeds them to a *native* MapLibre raster
-// source/layer, so ordering is the map's own and works in both builds.
+// one in the panel. `cog-tiler-wasm` feeds a native MapLibre raster source/layer,
+// so ordering is the map's own in both the web and desktop builds. Tauri local
+// files are exposed through its range-capable asset protocol; do not switch the
+// desktop default back to the GPU engine to work around local-file stalls, since
+// that would only mask an asset-protocol/read-path regression.
 //
 // Trade-off: the WASM tiler renders from its own built-in colormaps, so the
 // GPU-only symbology GeoLibre injects into the deck.gl pipeline -- "Classify
@@ -223,11 +221,11 @@ export function setNonTiledRasterHandler(handler: NonTiledRasterHandler | null):
  * session recorded. Only the desktop host can implement this; in the browser
  * there is no path and none is registered.
  */
-export type LocalRasterFileReader = (path: string) => Promise<File>;
+export type LocalRasterFileReader = (path: string) => Promise<File | string>;
 
 /** A raster the user picked from a native file dialog: its bytes and its path. */
 export interface PickedLocalRaster {
-  file: File;
+  file: File | string;
   path: string;
 }
 
@@ -356,6 +354,24 @@ export async function addRasterToMap(
     syncRasterLayersToStoreForRuntime(control);
   }
   return id;
+}
+
+/**
+ * Mount and warm the raster control without opening its panel.
+ *
+ * Desktop calls this as soon as a native file drag enters the window, so the
+ * control and its selected rendering backend can initialize while the user is
+ * still positioning the drop. Without that head start, drag-and-drop pays the
+ * full lazy-import/setup cost after release; the Add Raster Layer picker hides
+ * the same work behind the native file dialog and therefore feels immediate.
+ *
+ * Safe to call repeatedly: {@link ensureRasterControl} reuses the mounted
+ * control and the module-level import promises.
+ *
+ * @param app - The GeoLibre app API for the current map.
+ */
+export async function prepareRasterControl(app: GeoLibreAppAPI): Promise<void> {
+  await ensureRasterControl(app);
 }
 
 /**
@@ -619,8 +635,8 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
  * @param control - The mounted raster control.
  * @returns The re-read files, by store layer id.
  */
-async function readLocalRasterFiles(control: RasterControl): Promise<Map<string, File>> {
-  const files = new Map<string, File>();
+async function readLocalRasterFiles(control: RasterControl): Promise<Map<string, File | string>> {
+  const files = new Map<string, File | string>();
   const reader = localRasterFileReader;
   if (!reader) return files;
 
@@ -1165,11 +1181,18 @@ async function openLocalRasterPicker(): Promise<void> {
       // the rest of a multi-file selection.
       try {
         await addRasterToMap(app, picked.file, {
-          name: picked.file.name,
+          name:
+            picked.file instanceof File
+              ? picked.file.name
+              : picked.path.split(/[\\/]/).pop() || picked.path,
           localPath: picked.path,
         });
       } catch (error) {
-        console.error(`[GeoLibre] Failed to add the raster "${picked.file.name}"`, error);
+        const name =
+          picked.file instanceof File
+            ? picked.file.name
+            : picked.path.split(/[\\/]/).pop() || picked.path;
+        console.error(`[GeoLibre] Failed to add the raster "${name}"`, error);
       }
     }
   } catch (error) {

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -124,6 +124,7 @@ type MapboxOverlayConstructor = new (props: Record<string, unknown>) => OverlayL
 type RasterLayerManagerInternals = {
   /** The currently selected raster id (read to restore it after inspect). */
   selectedId?: string | null;
+  _device?: unknown;
   _deps?: {
     createOverlay?: (map: MapControlHost, options: OverlayFactoryOptions) => OverlayLike;
     removeOverlay?: (map: MapControlHost, overlay: OverlayLike) => void;
@@ -681,6 +682,7 @@ async function ensureRasterControl(app: GeoLibreAppAPI): Promise<RasterControl |
     // The control mounts hidden: project restore must not surface a map
     // button the user never asked for. openRasterLayerPanel shows it.
     await patchTauriRasterOverlayFactory(rasterControl);
+    await warmTauriWasmEngine(rasterControl);
     // On web the control renders interleaved, which shares deck.gl's per-map
     // Deck with the other interleaved overlays; route it through the shared
     // overlay so it coexists with them (#1149). No-op on Tauri (overlaid).
@@ -898,6 +900,33 @@ async function patchTauriRasterOverlayFactory(control: RasterControl): Promise<v
     const loadGeoTIFF = deps.loadGeoTIFF;
     deps.loadGeoTIFF = async (url) => patchGeoTiffNumericNodata(await loadGeoTIFF(url));
     deps.geolibreTauriNodataPatched = true;
+  }
+}
+
+/**
+ * Initialize Tauri's raster GPU canvas once before starting the WASM backend.
+ *
+ * WebKitGTK on native Wayland can leave concurrent WebAssembly initialization
+ * pending until an accelerated canvas has created its device. The visible
+ * symptom is a fully loaded raster entry whose WASM source never opens; choosing
+ * the GPU engine and then switching back immediately releases it. Perform that
+ * same one-time initialization while the control is still hidden, then restore
+ * the requested WASM default before any raster is added.
+ */
+async function warmTauriWasmEngine(control: RasterControl): Promise<void> {
+  if (!isTauriRuntime() || control.getEngine() !== "cog-tiler-wasm") return;
+
+  const manager = (control as unknown as RasterControlInternals)._layerManager;
+  if (!manager) return;
+
+  try {
+    control.setEngine("maplibre-gl-raster");
+    const deadline = performance.now() + 2_000;
+    while (!manager._device && performance.now() < deadline) {
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 16));
+    }
+  } finally {
+    control.setEngine("cog-tiler-wasm");
   }
 }
 

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -16,6 +16,7 @@ import {
 import {
   isRasterControlStoreLayer,
   rememberLocalRasterPath,
+  rendersNativeMapLibreLayer,
   resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
@@ -729,7 +730,20 @@ function createRasterControl(RasterControlClass: RasterControlConstructor): Rast
   // deck.gl's COG tile traversal does not support MapLibre's globe view
   // ("TODO: implement getBoundingVolume in Globe view"), so adding a raster
   // switches the map to mercator, like the other deck.gl-backed plugins.
-  control.on("rasteradd", () => ensureMercatorProjection(control.getMap()));
+  // Only the deck.gl engine needs this: the WASM and TiTiler engines render
+  // through a native MapLibre raster layer, which draws on the globe just like
+  // any other raster source, so forcing mercator there would drop the user out
+  // of globe view for no reason.
+  // Also on rasterchange, which is what setEngine emits: switching the panel
+  // from the WASM engine back to the deck.gl one has to force mercator for the
+  // rasters already on the map, not just for the next one added.
+  for (const event of ["rasteradd", "rasterchange"] as const) {
+    control.on(event, () => {
+      if (rendersNativeMapLibreLayer(control.getEngine())) return;
+      if (control.getRasters().length === 0) return;
+      ensureMercatorProjection(control.getMap());
+    });
+  }
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
     control.on(event, () => syncRasterLayersToStoreForRuntime(control));
   }

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -15,6 +15,7 @@ import {
 } from "./shared-deck-overlay";
 import {
   isRasterControlStoreLayer,
+  rememberLocalRasterPath,
   resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
@@ -31,6 +32,22 @@ import { disposeAllPaletteLegends, disposePaletteLegend } from "./raster-palette
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
+
+// The rendering backend rasters are decoded with unless the user picks another
+// one in the panel. Upstream defaults to `maplibre-gl-raster` (deck.gl on the
+// GPU), which draws through a deck.gl overlay rather than a MapLibre style
+// layer -- on the desktop build that overlay is a separate canvas stacked above
+// the map, so a raster always covers the vector layers above it in the layer
+// list no matter how they are ordered (issue #1463). `cog-tiler-wasm` decodes
+// tiles on the CPU in WebAssembly and feeds them to a *native* MapLibre raster
+// source/layer, so ordering is the map's own and works in both builds.
+//
+// Trade-off: the WASM tiler renders from its own built-in colormaps, so the
+// GPU-only symbology GeoLibre injects into the deck.gl pipeline -- "Classify
+// into discrete classes" and custom color ramps (see raster-symbology-texture)
+// -- does not apply while this engine is active. Users who need it can switch
+// the panel's Rendering engine back to maplibre-gl-raster (GPU).
+const DEFAULT_RASTER_ENGINE: RenderEngine = "cog-tiler-wasm";
 
 // One-click sample COGs shown in the panel's "Load sample data" dropdown.
 // Edit this list to offer different (or more) demonstration rasters; loading
@@ -137,6 +154,9 @@ let rasterControlClassPromise: Promise<RasterControlConstructor> | null = null;
 let mapboxOverlayClassPromise: Promise<MapboxOverlayConstructor> | null = null;
 let rasterControl: RasterControl | null = null;
 let rasterControlMounted = false;
+// The host API the mounted control belongs to, so panel chrome wired outside a
+// call that carries it (the browse-button interception) can still add layers.
+let rasterHostApp: GeoLibreAppAPI | null = null;
 let restorePanelExpandTimeout: number | null = null;
 let rasterControlInterleaved = true;
 // Unsubscribes the web raster overlay proxy from the shared Deck's device
@@ -197,6 +217,52 @@ export function setNonTiledRasterHandler(handler: NonTiledRasterHandler | null):
   nonTiledRasterHandler = handler;
 }
 
+/**
+ * Reads a raster off the local filesystem, given the absolute path a previous
+ * session recorded. Only the desktop host can implement this; in the browser
+ * there is no path and none is registered.
+ */
+export type LocalRasterFileReader = (path: string) => Promise<File>;
+
+/** A raster the user picked from a native file dialog: its bytes and its path. */
+export interface PickedLocalRaster {
+  file: File;
+  path: string;
+}
+
+/**
+ * Opens a native "choose a raster file" dialog. Registered by the desktop host
+ * so the panel's own browse button yields files whose paths GeoLibre can record
+ * (a webview `<input type="file">` gives a `File` with no path, which is why a
+ * panel-opened raster used to be lost on project reload). Resolves to an empty
+ * array when the user cancels.
+ */
+export type LocalRasterPicker = () => Promise<PickedLocalRaster[]>;
+
+let localRasterFileReader: LocalRasterFileReader | null = null;
+let localRasterPicker: LocalRasterPicker | null = null;
+
+/**
+ * Register (or clear, with `null`) the reader that reloads a File-backed raster
+ * from its recorded path when a saved project is reopened. Without one, such a
+ * raster is dropped on restore with a notice, as before.
+ *
+ * @param reader - The reader, or `null` to unregister.
+ */
+export function setLocalRasterFileReader(reader: LocalRasterFileReader | null): void {
+  localRasterFileReader = reader;
+}
+
+/**
+ * Register (or clear, with `null`) the native file picker the raster panel's
+ * browse button should use instead of its built-in `<input type="file">`.
+ *
+ * @param picker - The picker, or `null` to unregister.
+ */
+export function setLocalRasterPicker(picker: LocalRasterPicker | null): void {
+  localRasterPicker = picker;
+}
+
 /** Whether a raster load error is the upstream "striped, not tiled" failure.
  * maplibre-gl-raster (re-verified against v0.12.0) rejects non-tiled GeoTIFFs with a message
  * containing "not tiled"; this is the only signal it exposes, so the match is
@@ -231,6 +297,7 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
         // every open so the panel chrome stays wired even if a future
         // upstream release builds the panel DOM lazily on first expand.
         wireRasterCloseButton(control);
+        wireRasterBrowseButton(control);
         applyRasterPanelClass(control);
       } catch (error) {
         console.error("[GeoLibre] Failed to open the raster layer panel", error);
@@ -250,12 +317,14 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
  *
  * @param app - The GeoLibre app API.
  * @param source - A remote COG URL or a local GeoTIFF File.
- * @param options - Optional display name for the layer.
+ * @param options - Optional display name for the layer, and, when the host read
+ *   the File off disk, the absolute path it came from so a saved project can
+ *   reload it.
  */
 export async function addRasterToMap(
   app: GeoLibreAppAPI,
   source: string | File,
-  options: { name?: string; defaults?: RasterVisualizationDefaults } = {},
+  options: { name?: string; localPath?: string; defaults?: RasterVisualizationDefaults } = {},
 ): Promise<string> {
   const control = await ensureRasterControl(app);
   if (!control) {
@@ -278,6 +347,13 @@ export async function addRasterToMap(
     ...(options.defaults?.colormap ? { state: { colormap: options.defaults.colormap } } : {}),
   });
   applyRgbBandDefaults(control, id, options.defaults?.rgbBands);
+  if (options.localPath) {
+    // The id only exists once addRaster resolves, which is after the rasteradd
+    // sync has already written the store layer -- so record the path and re-run
+    // the (diffing, idempotent) sync to put it on the layer.
+    rememberLocalRasterPath(id, options.localPath);
+    syncRasterLayersToStoreForRuntime(control);
+  }
   return id;
 }
 
@@ -366,6 +442,7 @@ export function closeRasterLayerPanel(app: GeoLibreAppAPI): void {
   resetRasterStoreSyncSuspension();
   rasterControl = null;
   rasterControlMounted = false;
+  rasterHostApp = null;
 }
 
 // The panel selection in effect before inspect stole focus, so it can be
@@ -402,11 +479,16 @@ export function setRasterPixelInspect(layerId: string, enabled: boolean): void {
 }
 
 /**
- * Replays URL-backed rasters from the loaded project into the control and
- * drops control rasters the project does not contain. Called by the desktop
- * shell whenever a project is loaded or the map is reinitialised, mirroring
- * restoreThreeDTilesLayers. Local-file rasters cannot be reloaded from a
- * saved project, so their panel entries are removed with a notice.
+ * Replays rasters from the loaded project into the control and drops control
+ * rasters the project does not contain. Called by the desktop shell whenever a
+ * project is loaded or the map is reinitialised, mirroring
+ * restoreThreeDTilesLayers.
+ *
+ * URL-backed rasters replay from `source.url`. A raster that was opened from a
+ * local file replays from `metadata.localFilePath` when the host registered a
+ * reader (desktop) and the file is still there; otherwise -- the browser, a
+ * moved file, a project carried to another machine -- its panel entry is
+ * removed with a notice, as before.
  *
  * @param app - The GeoLibre app API.
  */
@@ -417,6 +499,12 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
   void (async () => {
     const control = await ensureRasterControl(app);
     if (!control) return;
+
+    // Read every local raster off disk BEFORE the suspension block below, so
+    // the replay stays synchronous. An await inside it would end the window
+    // early, and the next control event would then prune the not-yet-replayed
+    // layers out of the store.
+    const localFiles = await readLocalRasterFiles(control);
 
     // Re-read the store after the await: the project may have changed while
     // the control class was loading.
@@ -454,7 +542,10 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
 
         const url =
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;
-        if (!url) {
+        // A local file that was re-read above replays from its bytes; the
+        // control re-derives its own blob URL from the File, as on a fresh add.
+        const source = url ?? localFiles.get(layer.id);
+        if (!source) {
           // Console-only on purpose for this first pass: the plugin layer has
           // no toast/notification API today. Surface this through an in-app
           // notification once one is exposed to plugins.
@@ -469,7 +560,7 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
 
         pending.push(
           control
-            .addRaster(url, {
+            .addRaster(source, {
               id: layer.id,
               name: layer.name,
               state: {
@@ -515,6 +606,46 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
   });
 }
 
+/**
+ * Re-reads every project raster that carries a recorded local path and is not
+ * already loaded in the control, keyed by layer id. Also re-registers each path
+ * so the raster stays restorable when the project is saved again.
+ *
+ * Resolves to an empty map in the browser (no reader is registered) and skips
+ * any file that has since been moved or deleted -- the caller then falls back
+ * to dropping that layer with a notice.
+ *
+ * @param control - The mounted raster control.
+ * @returns The re-read files, by store layer id.
+ */
+async function readLocalRasterFiles(control: RasterControl): Promise<Map<string, File>> {
+  const files = new Map<string, File>();
+  const reader = localRasterFileReader;
+  if (!reader) return files;
+
+  for (const layer of useAppStore.getState().layers) {
+    if (!isRasterControlStoreLayer(layer)) continue;
+    if (control.getRaster(layer.id)) continue;
+    if (typeof layer.source.url === "string" && layer.source.url) continue;
+    const path = layer.metadata.localFilePath;
+    if (typeof path !== "string" || !path) continue;
+
+    try {
+      files.set(layer.id, await reader(path));
+      // The in-memory registry does not survive a project reload, so re-seed it
+      // from the project file; otherwise the next save would drop the path and
+      // the raster would become unrestorable again.
+      rememberLocalRasterPath(layer.id, path);
+    } catch (error) {
+      console.warn(
+        `[GeoLibre] Could not re-read raster layer "${layer.name}" from "${path}".`,
+        error,
+      );
+    }
+  }
+  return files;
+}
+
 async function ensureRasterControl(app: GeoLibreAppAPI): Promise<RasterControl | null> {
   const RasterControlClass = await getRasterControlClass();
 
@@ -525,9 +656,11 @@ async function ensureRasterControl(app: GeoLibreAppAPI): Promise<RasterControl |
     if (!added) {
       unwireRasterStoreSync();
       rasterControl = null;
+      rasterHostApp = null;
       return null;
     }
     rasterControlMounted = true;
+    rasterHostApp = app;
     // The control mounts hidden: project restore must not surface a map
     // button the user never asked for. openRasterLayerPanel shows it.
     await patchTauriRasterOverlayFactory(rasterControl);
@@ -542,6 +675,7 @@ async function ensureRasterControl(app: GeoLibreAppAPI): Promise<RasterControl |
     activateRasterClassification(rasterControl);
     hideRasterControl(rasterControl);
     wireRasterCloseButton(rasterControl);
+    wireRasterBrowseButton(rasterControl);
     applyRasterPanelClass(rasterControl);
   }
 
@@ -583,6 +717,10 @@ function createRasterControl(RasterControlClass: RasterControlConstructor): Rast
     // The panel doubles as the Add Raster Layer dialog, so it stays open
     // until the user closes it; clicking the map must not collapse it.
     closeOnOutsideClick: false,
+    engine: DEFAULT_RASTER_ENGINE,
+    // Only consulted while the deck.gl engine is selected; kept accurate so
+    // switching the panel back to maplibre-gl-raster still gets the overlay
+    // mode the runtime supports.
     interleaved: rasterControlInterleaved,
     panelWidth: 380,
     title: "Add Raster Layer",
@@ -602,6 +740,7 @@ function createRasterControl(RasterControlClass: RasterControlConstructor): Rast
     if (!event.layerId) return;
     disposeRasterClassification(event.layerId);
     disposePaletteLegend(event.layerId);
+    rememberLocalRasterPath(event.layerId, undefined);
   });
   // A striped (non-tiled) GeoTIFF cannot be streamed as tiles, so the upstream
   // fails the layer with a "not tiled" error. Offer the registered host handler
@@ -687,6 +826,10 @@ function createRasterControl(RasterControlClass: RasterControlConstructor): Rast
 function syncRasterLayersToStoreForRuntime(control: RasterControl): void {
   syncRasterLayersToStoreWithOptions(control, {
     interleaved: rasterControlInterleaved,
+    // Read live rather than captured: the user can switch the backend from the
+    // panel at any time, and the store layer's native-layer bookkeeping differs
+    // per engine (see createRasterStoreLayer).
+    engine: control.getEngine(),
   });
 }
 
@@ -867,6 +1010,7 @@ function patchRasterControlOnRemove(
     // restoreRasterLayers can replay them into the successor control.
     rasterControl = null;
     rasterControlMounted = false;
+    rasterHostApp = null;
   };
 }
 
@@ -906,6 +1050,7 @@ function applyRestoredRasterPanelState(control: RasterControl, panelCollapsed: b
     try {
       control.expand();
       wireRasterCloseButton(control);
+      wireRasterBrowseButton(control);
       applyRasterPanelClass(control);
     } catch (error) {
       console.error("[GeoLibre] Failed to restore raster panel state", error);
@@ -946,4 +1091,68 @@ function wireRasterCloseButton(control: RasterControl): void {
   }
   closeButton.dataset.geolibreCloseWired = "true";
   closeButton.addEventListener("click", () => hideRasterControl(control));
+}
+
+// The panel's "click to browse" drop zone opens a hidden <input type="file">,
+// which in a webview yields a File with no filesystem path -- so a raster added
+// that way could never be reloaded from a saved project (issue #1463). When the
+// host registered a native picker (desktop), route the browse action through it
+// instead so the path is recorded.
+//
+// Listens on the panel in the CAPTURE phase rather than on the drop zone: a
+// capturing ancestor listener always runs before the target's own listeners,
+// whereas at the target both phases run in registration order -- and upstream
+// registered first. stopPropagation then keeps the event from reaching the drop
+// zone's handler at all. The selectors mirror maplibre-gl-raster's rendered
+// panel (re-verified against v0.14.0); if `.mlr-drop-zone` is renamed the
+// listener simply never matches and the built-in input takes over again.
+function wireRasterBrowseButton(control: RasterControl): void {
+  const panel = (control as unknown as RasterControlInternals)._panel;
+  if (!panel || panel.dataset.geolibreBrowseWired === "true") return;
+  panel.dataset.geolibreBrowseWired = "true";
+
+  const intercept = (event: Event): boolean => {
+    if (!localRasterPicker) return false;
+    const target = event.target;
+    if (!(target instanceof Element) || !target.closest(".mlr-drop-zone")) return false;
+    event.preventDefault();
+    event.stopPropagation();
+    void openLocalRasterPicker();
+    return true;
+  };
+
+  panel.addEventListener("click", intercept, true);
+  // The drop zone is keyboard-operable (role="button"); Enter/Space go through
+  // the same hidden input, so they need the same interception.
+  panel.addEventListener(
+    "keydown",
+    (event) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      intercept(event);
+    },
+    true,
+  );
+}
+
+/**
+ * Opens the host's native raster picker and adds every pick, recording the
+ * filesystem path each one came from. A cancelled dialog resolves to an empty
+ * list and adds nothing.
+ */
+async function openLocalRasterPicker(): Promise<void> {
+  const picker = localRasterPicker;
+  const app = rasterHostApp;
+  if (!picker || !app) return;
+  try {
+    for (const picked of await picker()) {
+      // Sequential, matching the drag-and-drop path: each add awaits the
+      // GeoTIFF header, and the control zooms to the raster it just added.
+      await addRasterToMap(app, picked.file, {
+        name: picked.file.name,
+        localPath: picked.path,
+      });
+    }
+  } catch (error) {
+    console.error("[GeoLibre] Failed to add a raster from the file picker", error);
+  }
 }

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -1,7 +1,39 @@
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, styleValue, useAppStore } from "@geolibre/core";
-import type { RasterLayerInfo, RasterLayerState } from "maplibre-gl-raster";
+import type { RasterLayerInfo, RasterLayerState, RenderEngine } from "maplibre-gl-raster";
 
 export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
+
+// Absolute filesystem paths of File-backed rasters, by raster id. The control
+// only ever sees a browser `File` -- the desktop host reads the bytes off disk
+// and wraps them -- so the path that would let a saved project reload the
+// raster is not recoverable from `RasterLayerInfo`. Hosts that opened the file
+// by path record it here, and it is mirrored onto the store layer as
+// `metadata.localFilePath` so it survives into the project file (issue #1463).
+const localRasterPaths = new Map<string, string>();
+
+/**
+ * Record (or, with `undefined`, forget) the absolute path a File-backed raster
+ * was read from, so a saved project can reload it. Callers that only have a
+ * browser `File` (a web drag-and-drop, a tool output) pass nothing and the
+ * raster stays unrestorable, as before.
+ *
+ * @param id - The raster/store layer id.
+ * @param path - The absolute filesystem path, or undefined to forget it.
+ */
+export function rememberLocalRasterPath(id: string, path: string | undefined): void {
+  if (path) localRasterPaths.set(id, path);
+  else localRasterPaths.delete(id);
+}
+
+/**
+ * The absolute path recorded for a File-backed raster, if any.
+ *
+ * @param id - The raster/store layer id.
+ * @returns The path, or undefined when the raster was not opened by path.
+ */
+export function localRasterPath(id: string): string | undefined {
+  return localRasterPaths.get(id);
+}
 
 /**
  * The slice of the maplibre-gl-raster RasterControl surface the store sync
@@ -18,7 +50,25 @@ export type RasterSyncableControl = {
 
 export type RasterSyncOptions = {
   interleaved?: boolean;
+  /**
+   * The control's active rendering backend. `maplibre-gl-raster` draws through
+   * a deck.gl overlay; the other two add a real MapLibre raster source/layer
+   * whose layer id is the raster id. Defaults to the deck.gl engine so callers
+   * that predate the option keep their behavior.
+   */
+  engine?: RenderEngine;
 };
+
+/**
+ * Whether an engine renders through a native MapLibre raster layer (rather than
+ * a deck.gl overlay). Those layers carry a real style layer id, so layer-sync
+ * can move them for ordering in every runtime -- including the desktop build,
+ * where the deck.gl overlay is a separate stacked canvas with no style layer at
+ * all (issue #1463).
+ */
+function rendersNativeMapLibreLayer(engine: RenderEngine): boolean {
+  return engine === "cog-tiler-wasm" || engine === "titiler";
+}
 
 let syncedControl: RasterSyncableControl | null = null;
 let storeUnsubscribe: (() => void) | null = null;
@@ -63,6 +113,7 @@ export function createRasterStoreLayer(
   options: RasterSyncOptions = {},
 ): GeoLibreLayer {
   const interleaved = options.interleaved ?? true;
+  const nativeMapLibreLayer = rendersNativeMapLibreLayer(options.engine ?? "maplibre-gl-raster");
   const url = info.source.kind === "url" ? info.source.url : undefined;
   // The control retains a File-backed raster's original bytes behind a blob
   // URL (source.objectUrl). Surface it as metadata.localBytesUrl so in-browser
@@ -71,6 +122,9 @@ export function createRasterStoreLayer(
   // the Add Data > Raster Layer panel's own drop zone, and tool outputs - since
   // they all funnel through the control's addRaster.
   const localBytesUrl = info.source.kind === "file" ? info.source.objectUrl : undefined;
+  // Only meaningful for a File-backed raster: a URL raster already restores
+  // from source.url, and the path registry is never populated for one.
+  const localFilePath = info.source.kind === "file" ? localRasterPaths.get(info.id) : undefined;
   const sourcePath = url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
   return {
     id: info.id,
@@ -85,16 +139,22 @@ export function createRasterStoreLayer(
     style: { ...DEFAULT_LAYER_STYLE },
     metadata: {
       customLayerType: "raster",
+      // Not literally a deck.gl layer under the WASM/TiTiler engines, but the
+      // flag is what makes layer-sync forward the computed beforeId to the
+      // control (applyRasterLayerOrder -> setRasterBeforeId). Those engines
+      // re-apply their own moveLayer on every render-setting change, so without
+      // it a later opacity edit would silently pull the raster back to the top.
       externalDeckLayer: true,
       externalNativeLayer: true,
       identifiable: false,
-      // In interleaved mode the deck.gl overlay inserts one custom style
-      // layer per raster, keyed by the raster id, so ordering moves reach it.
-      // The Tauri/WebKit fallback uses a separate deck.gl canvas, so there is
-      // no MapLibre style layer id to sync.
-      nativeLayerIds: interleaved ? [info.id] : [],
+      // The WASM/TiTiler engines add a native MapLibre raster layer keyed by
+      // the raster id, in every runtime. With the deck.gl engine there is a
+      // style layer id only in interleaved mode, where the overlay inserts one
+      // custom style layer per raster; the Tauri/WebKit fallback uses a
+      // separate deck.gl canvas, so there is no MapLibre style layer to sync.
+      nativeLayerIds: nativeMapLibreLayer || interleaved ? [info.id] : [],
       panelCollapsed,
-      rasterOverlayMode: interleaved ? "interleaved" : "overlaid",
+      rasterOverlayMode: nativeMapLibreLayer ? "native" : interleaved ? "interleaved" : "overlaid",
       // The visualization state is persisted so restoreRasterLayers can
       // replay URL-backed rasters when a saved project is reopened.
       rasterSource: info.source.kind,
@@ -108,6 +168,10 @@ export function createRasterStoreLayer(
       sourceIds: [],
       sourceKind: RASTER_SOURCE_KIND,
       ...(localBytesUrl ? { localBytesUrl } : {}),
+      // Persisted so restoreRasterLayers can re-read the file when the project
+      // is reopened on the machine that holds it (desktop only -- the browser
+      // has no path). Absent for a raster added from a browser File.
+      ...(localFilePath ? { localFilePath } : {}),
       ...(info.bounds
         ? {
             bounds: [info.bounds.west, info.bounds.south, info.bounds.east, info.bounds.north],

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -66,7 +66,7 @@ export type RasterSyncOptions = {
  * where the deck.gl overlay is a separate stacked canvas with no style layer at
  * all (issue #1463).
  */
-function rendersNativeMapLibreLayer(engine: RenderEngine): boolean {
+export function rendersNativeMapLibreLayer(engine: RenderEngine): boolean {
   return engine === "cog-tiler-wasm" || engine === "titiler";
 }
 

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -114,18 +114,37 @@ export function createRasterStoreLayer(
 ): GeoLibreLayer {
   const interleaved = options.interleaved ?? true;
   const nativeMapLibreLayer = rendersNativeMapLibreLayer(options.engine ?? "maplibre-gl-raster");
-  const url = info.source.kind === "url" ? info.source.url : undefined;
+  // Desktop local paths are handed to the control as Tauri asset-protocol URLs
+  // so COG reads stay range-based. The path registry distinguishes those from
+  // genuinely remote URL rasters; never persist the session-specific asset URL.
+  const candidateLocalPath = localRasterPaths.get(info.id);
+  const localFilePath =
+    info.source.kind === "file" ||
+    (info.source.kind === "url" &&
+      (info.source.url.startsWith("asset:") ||
+        /^https?:\/\/asset\.localhost(?:\/|$)/i.test(info.source.url)))
+      ? candidateLocalPath
+      : undefined;
+  const url = info.source.kind === "url" && !localFilePath ? info.source.url : undefined;
   // The control retains a File-backed raster's original bytes behind a blob
   // URL (source.objectUrl). Surface it as metadata.localBytesUrl so in-browser
   // tools (the WASM Whitebox runner, the symbology stats reader, raster export)
   // can read the bytes back. This covers every File-add path - drag-and-drop,
   // the Add Data > Raster Layer panel's own drop zone, and tool outputs - since
   // they all funnel through the control's addRaster.
-  const localBytesUrl = info.source.kind === "file" ? info.source.objectUrl : undefined;
-  // Only meaningful for a File-backed raster: a URL raster already restores
-  // from source.url, and the path registry is never populated for one.
-  const localFilePath = info.source.kind === "file" ? localRasterPaths.get(info.id) : undefined;
-  const sourcePath = url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
+  const localBytesUrl =
+    info.source.kind === "file"
+      ? info.source.objectUrl
+      : localFilePath && info.source.kind === "url"
+        ? info.source.url
+        : undefined;
+  const sourcePath =
+    url ??
+    (localFilePath
+      ? localFilePath.split(/[\\/]/).pop() || localFilePath
+      : info.source.kind === "file"
+        ? info.source.fileName
+        : info.id);
   return {
     id: info.id,
     name: info.name,
@@ -157,7 +176,7 @@ export function createRasterStoreLayer(
       rasterOverlayMode: nativeMapLibreLayer ? "native" : interleaved ? "interleaved" : "overlaid",
       // The visualization state is persisted so restoreRasterLayers can
       // replay URL-backed rasters when a saved project is reopened.
-      rasterSource: info.source.kind,
+      rasterSource: localFilePath ? "file" : info.source.kind,
       rasterState: serializableRasterState(info.state),
       // Band metadata powers the symbology panel's band / RGB pickers. Known
       // only once the GeoTIFF header loads (null until then). The Map is

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -305,6 +305,33 @@ describe("syncRasterLayersToStore", () => {
     assert.deepEqual(layer.metadata.nativeLayerIds, []);
   });
 
+  // localFilePath is derived from the path registry on every sync rather than
+  // carried in GEOLIBRE_OWNED_METADATA_KEYS, so a repeated sync (any control
+  // event: an opacity drag, a header load) must not drop it. The registry
+  // outlives a control teardown -- LayerManager.destroy() clears its layers
+  // without emitting rasterremove -- so the only thing that forgets a path is
+  // an actual raster removal, which drops the store layer too.
+  it("keeps a local raster's path across repeated syncs", () => {
+    const fileInfo = rasterInfo({
+      source: { kind: "file", fileName: "local.tif", objectUrl: "blob:x" },
+    });
+    rememberLocalRasterPath("raster-1", "/data/local.tif");
+    try {
+      syncRasterLayersToStore(fakeControl([fileInfo]).control);
+      assert.equal(useAppStore.getState().layers[0].metadata.localFilePath, "/data/local.tif");
+
+      // A later control event rebuilds the metadata wholesale.
+      syncRasterLayersToStore(
+        fakeControl([{ ...fileInfo, state: rasterState({ opacity: 0.4 }) }]).control,
+      );
+      const layer = useAppStore.getState().layers[0];
+      assert.equal(layer.opacity, 0.4);
+      assert.equal(layer.metadata.localFilePath, "/data/local.tif");
+    } finally {
+      rememberLocalRasterPath("raster-1", undefined);
+    }
+  });
+
   it("removes store layers whose rasters are gone", () => {
     const { control } = fakeControl([rasterInfo()]);
     syncRasterLayersToStore(control);

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -8,6 +8,7 @@ import {
   localRasterPath,
   rememberLocalRasterPath,
   removeRasterStoreLayers,
+  rendersNativeMapLibreLayer,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
   syncRasterLayersToStore,
@@ -77,6 +78,19 @@ function otherStoreLayer(id = "unrelated"): GeoLibreLayer {
     metadata: {},
   };
 }
+
+// The projection rule in maplibre-raster.ts keys off this: only the deck.gl
+// engine cannot draw on the globe, so only it forces the map to mercator.
+describe("rendersNativeMapLibreLayer", () => {
+  it("is true for the engines backed by a real MapLibre raster layer", () => {
+    assert.equal(rendersNativeMapLibreLayer("cog-tiler-wasm"), true);
+    assert.equal(rendersNativeMapLibreLayer("titiler"), true);
+  });
+
+  it("is false for the deck.gl engine", () => {
+    assert.equal(rendersNativeMapLibreLayer("maplibre-gl-raster"), false);
+  });
+});
 
 describe("createRasterStoreLayer", () => {
   it("mirrors a URL raster as an external custom cog layer", () => {

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -248,6 +248,28 @@ describe("createRasterStoreLayer", () => {
     }
   });
 
+  it("persists a Tauri asset URL as a local path instead of a session URL", () => {
+    rememberLocalRasterPath("raster-1", "/data/local.tif");
+    try {
+      const layer = createRasterStoreLayer(
+        rasterInfo({
+          source: {
+            kind: "url",
+            url: "http://asset.localhost/%2Fdata%2Flocal.tif",
+          },
+        }),
+      );
+
+      assert.equal(layer.metadata.localFilePath, "/data/local.tif");
+      assert.equal(layer.metadata.rasterSource, "file");
+      assert.equal(layer.metadata.localBytesUrl, "http://asset.localhost/%2Fdata%2Flocal.tif");
+      assert.equal(layer.source.url, undefined);
+      assert.equal(layer.sourcePath, "local.tif");
+    } finally {
+      rememberLocalRasterPath("raster-1", undefined);
+    }
+  });
+
   it("persists band count and serializes band names to pairs", () => {
     const layer = createRasterStoreLayer(
       rasterInfo({

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -5,6 +5,8 @@ import type { RasterLayerInfo, RasterLayerState } from "maplibre-gl-raster";
 import {
   createRasterStoreLayer,
   isRasterControlStoreLayer,
+  localRasterPath,
+  rememberLocalRasterPath,
   removeRasterStoreLayers,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
@@ -165,6 +167,71 @@ describe("createRasterStoreLayer", () => {
     assert.equal(layer.metadata.externalDeckLayer, true);
     assert.equal(layer.metadata.rasterOverlayMode, "overlaid");
     assert.deepEqual(layer.metadata.nativeLayerIds, []);
+  });
+
+  // The WASM/TiTiler engines add a real MapLibre raster layer keyed by the
+  // raster id, so ordering works even in the runtime that forces the deck.gl
+  // overlay into its own stacked canvas (issue #1463).
+  for (const engine of ["cog-tiler-wasm", "titiler"] as const) {
+    it(`gives the ${engine} engine a native layer id even when not interleaved`, () => {
+      const layer = createRasterStoreLayer(rasterInfo(), true, {
+        interleaved: false,
+        engine,
+      });
+
+      assert.equal(layer.metadata.rasterOverlayMode, "native");
+      assert.deepEqual(layer.metadata.nativeLayerIds, ["raster-1"]);
+      // Still set: it is what makes layer-sync push the computed beforeId back
+      // into the control, which those engines re-apply on every render change.
+      assert.equal(layer.metadata.externalDeckLayer, true);
+    });
+  }
+
+  it("keeps the deck.gl engine's overlay bookkeeping when named explicitly", () => {
+    const layer = createRasterStoreLayer(rasterInfo(), true, {
+      interleaved: false,
+      engine: "maplibre-gl-raster",
+    });
+
+    assert.equal(layer.metadata.rasterOverlayMode, "overlaid");
+    assert.deepEqual(layer.metadata.nativeLayerIds, []);
+  });
+
+  it("records a local raster's path so a saved project can reload it", () => {
+    rememberLocalRasterPath("raster-1", "/data/local.tif");
+    try {
+      const layer = createRasterStoreLayer(
+        rasterInfo({
+          source: { kind: "file", fileName: "local.tif", objectUrl: "blob:x" },
+        }),
+      );
+
+      assert.equal(layer.metadata.localFilePath, "/data/local.tif");
+      assert.equal(localRasterPath("raster-1"), "/data/local.tif");
+    } finally {
+      rememberLocalRasterPath("raster-1", undefined);
+    }
+  });
+
+  it("omits the path for a raster added without one, and after it is forgotten", () => {
+    const fileInfo = rasterInfo({
+      source: { kind: "file", fileName: "local.tif", objectUrl: "blob:x" },
+    });
+    assert.equal("localFilePath" in createRasterStoreLayer(fileInfo).metadata, false);
+
+    rememberLocalRasterPath("raster-1", "/data/local.tif");
+    rememberLocalRasterPath("raster-1", undefined);
+    assert.equal("localFilePath" in createRasterStoreLayer(fileInfo).metadata, false);
+    assert.equal(localRasterPath("raster-1"), undefined);
+  });
+
+  it("never claims a path for a URL raster, even if one was recorded", () => {
+    rememberLocalRasterPath("raster-1", "/data/stale.tif");
+    try {
+      assert.equal("localFilePath" in createRasterStoreLayer(rasterInfo()).metadata, false);
+    } finally {
+      rememberLocalRasterPath("raster-1", undefined);
+    }
   });
 
   it("persists band count and serializes band names to pairs", () => {


### PR DESCRIPTION
Fixes #1463.

Three separate desktop-facing raster problems from that issue.

## 1. Rasters disappear from a reopened project

A local raster reaches `maplibre-gl-raster` as a browser `File`: the desktop host reads the bytes off disk and wraps them, discarding the path. Nothing on the store layer pointed at the original file, so `restoreRasterLayers` dropped every local raster on project open (console notice only) while the vector layers restored fine, exactly as reported.

- The path is now recorded alongside the raster (`metadata.localFilePath`) whenever the host has one, and re-read on project open through a host-registered reader (`setLocalRasterFileReader`). A moved or deleted file falls back to the old drop-with-notice behavior.
- The panel's "click to browse" drop zone opens a hidden `<input type="file">`, whose `File` has no path in a webview, so a panel-opened raster could never be restorable. On desktop that click is now routed to the native file dialog (`setLocalRasterPicker`) so it carries a path too. Drag-and-drop and the Browser panel's Files tree already had paths and now pass them through.
- Unchanged in the browser, which has no filesystem path to record: neither hook is registered there.

## 2. Rasters obscure the vector layers above them

The deck.gl engine draws through an overlay that, in the desktop build, is a separate canvas stacked over the map with no MapLibre style layer at all, so layer order could never reach it.

Rasters now default to the `cog-tiler-wasm` engine, which decodes tiles in WebAssembly and feeds a **native** MapLibre raster source/layer, so ordering is the map's own. The store sync is engine-aware: the WASM and TiTiler engines record the real style layer id in `nativeLayerIds` in every runtime, while the deck.gl engine keeps its existing interleaved/overlaid bookkeeping.

**Trade-off worth knowing before merging:** the WASM tiler renders from its own built-in colormaps, so "Classify into discrete classes" and custom color ramps -- which GeoLibre implements by patching the deck.gl render pipeline (`raster-symbology-texture.ts`) -- silently do not apply while it is active. The panel's Rendering engine selector still offers `maplibre-gl-raster (GPU)` for anyone who needs them. Making classification work under the WASM engine needs a custom-LUT parameter in `cog-tiler-wasm` upstream.

## 3. `GET request failed (network/TLS/CORS)` on a `data:image/png` URL

The Tauri CSP allowed `data:` in `img-src` but not in `connect-src`. MapLibre **fetches** an image source's URL rather than assigning it to an `<img>` (`ImageRequest.getImage` -> `makeRequest`), so a data-URI image is matched against `connect-src` -- and a KML/KMZ `<GroundOverlay>` (which GeoLibre extracts to a `data:image/png` URL) or a deck.gl icon atlas died with an opaque "Load failed" on desktop only. The web CSP in `docker/nginx.conf` already carried `data:` for exactly this reason; the desktop one now matches, and both comments explain why it must stay.

## Verification

Driven in a real browser with Playwright against `dem.tif` and `us_regions.geojson`, in **both light and dark themes**:

- The raster now appears in the map style as a real `raster` layer (`raster-631491e | raster`), not a deck.gl overlay.
- Moving the raster above the polygon layer and back flips the style order and the rendering both ways.
- Opening a saved project that references a local raster by path: reproduced the layer being dropped, then confirmed it restores and renders with its saved symbology (single band, `terrain` ramp), with `localFilePath` still on the layer so a re-save stays restorable.
- Clicking "click to browse" invokes the registered picker exactly once (no double-add from the built-in input) and records the path on the layer.
- The `connect-src` behavior was confirmed empirically: with the Tauri CSP string, `fetch()` of a `data:` URL throws; adding `data:` makes it succeed.

`npm run build`, the frontend suite (4022 pass), `cargo build` for the Tauri crate, and `pre-commit` on the changed files are all green. Six tests added for the engine-aware sync and the path registry.

**Not verified end to end on a packaged desktop build:** the CSP change only takes effect in `tauri:build` (dev serves from the vite devUrl), and the two Tauri wrappers (`readRasterFileAtPath`, `pickLocalRasterFiles`) are thin calls over `readFile`/`open`, already used elsewhere in `tauri-io.ts`. Worth a smoke test on desktop before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native desktop raster browsing with path-aware selection and host-assisted local reload.
  * Improved raster restore so locally saved rasters can be reopened reliably by original filesystem path.
  * Switched default raster rendering engine to `cog-tiler-wasm`, with better native-vs-overlaid behavior.
* **Bug Fixes**
  * Prevented local raster layers from being pruned too early during project restore.
  * Clear remembered local raster paths when rasters are removed.
* **Security**
  * Updated desktop CSP to support the Tauri asset protocol (`asset:`) and asset-localhost loading.
* **Tests**
  * Expanded raster-layer sync tests for engine classification and local-path persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->