### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -91,7 +91,7 @@ The **Apache Sedona** engine of the SQL Workspace runs Sedona spatial SQL on
 through the `/sql` endpoints. It is an optional extra:
 
 ```bash
-pip install -e ".[sedona]"   # apache-sedona[db] + geopandas + shapely
+pip install -e ".[sedona]"   # 'apache-sedona[db]' + geopandas + shapely
 geolibre-server
 ```
 

--- a/backend/geolibre_server/geolibre_server/app/ml.py
+++ b/backend/geolibre_server/geolibre_server/app/ml.py
@@ -85,7 +85,7 @@ def _require_httpx():
         import httpx  # noqa: PLC0415
     except ImportError as exc:  # pragma: no cover - exercised via status path
         raise RuntimeBootstrapError(
-            "The 'ml' extra is not installed. Install with: pip install geolibre-server[ml]"
+            "The 'ml' extra is not installed. Install with: pip install \"geolibre-server[ml]\""
         ) from exc
     return httpx
 
@@ -186,7 +186,7 @@ def _ensure_server() -> str:
             if command is None:
                 raise RuntimeBootstrapError(
                     "samgeo-api was not found on PATH. Install the segmentation "
-                    "stack with: pip install segment-geospatial[api,samgeo3], or set "
+                    'stack with: pip install "segment-geospatial[api,samgeo3]", or set '
                     "GEOLIBRE_ML_SAMGEO_URL to an existing samgeo-api server."
                 )
 
@@ -332,7 +332,7 @@ def ml_status():
 
     payload["message"] = (
         "Segmentation backend is unavailable. Install it with: "
-        "pip install segment-geospatial[api,samgeo3], or set "
+        'pip install "segment-geospatial[api,samgeo3]", or set '
         "GEOLIBRE_ML_SAMGEO_URL to an existing samgeo-api server."
     )
     return payload

--- a/python/README.md
+++ b/python/README.md
@@ -102,7 +102,7 @@ m.to_project()["mapView"]["center"]
   (works in the running server with no restart where it is installed). On other
   remote servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)` to
   use that same remote path; `Map(server_proxy=False)` forces the direct path.
-- Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
+- Optional extras: `pip install "geolibre[all]"` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)` and for reading **local** vector files
   (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`/`add_kml`/`add_gpkg`),
   which the kernel reads and inlines as GeoJSON. Remote URLs for the same formats stream through


### PR DESCRIPTION
## Summary
- Quote `pip install` examples and install hints that include extras.

## Why
- Shells such as zsh glob unquoted bracket expressions before `pip` receives them, so `pip install segment-geospatial[api,samgeo3]` fails with `zsh: no matches found`.

## Scope
- `backend/geolibre_server/README.md` - the Sedona extra comment.
- `backend/geolibre_server/geolibre_server/app/ml.py` - the three install hints the sidecar shows the user (`geolibre-server[ml]`, and the two `segment-geospatial[api,samgeo3]` messages surfaced by `/ml/status` and the segmentation bootstrap).
- `python/README.md` - the `geolibre[all]` extras note.
- A repo-wide scan for `pip install ...[extra]` finds no remaining unquoted occurrences; the rest of the docs (`docs/getting-started.md`, `docs/contributing.md`, `docs/python.md`, `docs/user-guide/segmentation.md`, `CLAUDE.md`, CI) already quote theirs.
- No dependency or runtime behavior changes; the message text is the only thing that moves.

## Testing
- `pytest backend/geolibre_server/tests/test_ml.py` (10 passed) - `test_ml.py` asserts on the segmentation status message, so it covers the reworded string.
- `pre-commit run --files <changed paths>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and setup messages to improve shell compatibility.
  * Clarified optional package installation commands for geospatial and machine-learning features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->