### PR TITLE
fix(plugins): invalidate stale bundled assets

### DIFF
--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -22,6 +22,7 @@ import {
   managedUrlSourcesForIds,
   pluginAssetUrlFromSource,
   resolvePluginAssetUrl,
+  withPluginAssetCacheToken,
 } from "./plugin-asset-url";
 import {
   computePluginBundleHash,
@@ -292,8 +293,14 @@ async function loadPluginUrlBundle(
     throw new Error("Plugin manifest is invalid.");
   }
 
-  const entryUrl = resolvePluginAssetUrl(manifestUrl, manifest.entry);
-  const styleUrl = manifest.style ? resolvePluginAssetUrl(manifestUrl, manifest.style) : null;
+  const cacheToken = pluginAssetCacheToken(manifestResponse, manifest);
+  const entryUrl = withPluginAssetCacheToken(
+    resolvePluginAssetUrl(manifestUrl, manifest.entry),
+    cacheToken,
+  );
+  const styleUrl = manifest.style
+    ? withPluginAssetCacheToken(resolvePluginAssetUrl(manifestUrl, manifest.style), cacheToken)
+    : null;
   const [entrySource, styleSource] = await Promise.all([
     fetchPluginText(entryUrl, "plugin entry", signal),
     styleUrl ? fetchPluginText(styleUrl, "plugin style", signal) : Promise.resolve(null),
@@ -306,6 +313,21 @@ async function loadPluginUrlBundle(
     entrySource,
     styleSource,
   };
+}
+
+function pluginAssetCacheToken(
+  response: Response,
+  manifest: GeoLibreExternalPluginManifest,
+): string {
+  return [
+    manifest.id,
+    manifest.version,
+    response.headers.get("etag"),
+    response.headers.get("last-modified"),
+  ]
+    .map((value) => value?.trim())
+    .filter(Boolean)
+    .join("|");
 }
 
 async function fetchPluginText(url: string, label: string, signal?: AbortSignal): Promise<string> {

--- a/apps/geolibre-desktop/src/lib/plugin-asset-url.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-asset-url.ts
@@ -58,6 +58,20 @@ export function resolvePluginAssetUrl(manifestUrl: string, path: string): string
   return resolved.toString();
 }
 
+/**
+ * Append a cache token to a resolved plugin asset URL.
+ *
+ * Bundled plugin entries use stable filenames such as `dist/index.js`; adding
+ * a token lets a fresh manifest force browsers and CDNs past a stale entry.
+ */
+export function withPluginAssetCacheToken(url: string, token: string | null | undefined): string {
+  const value = token?.trim();
+  if (!value) return url;
+  const resolved = new URL(url);
+  resolved.searchParams.set("__geolibre_plugin_cache", value);
+  return resolved.toString();
+}
+
 // Resolve a plugin asset URL from the plugin's loaded source. Returns null for
 // a missing source, a desktop filesystem source (no URL base), or an unsafe
 // relative path, so callers can treat null as "no bundled asset URL".

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -119,6 +119,17 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
     }
 
+    # Bundled plugin entries live under fixed paths like
+    # /plugins/nasa-opera/dist/index.js. They are not content-hashed, so they
+    # must revalidate on every deployment instead of inheriting the immutable
+    # asset rule below.
+    location ^~ /plugins/ {
+        try_files $uri =404;
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    }
+
     location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf)$ {
         try_files $uri =404;
         add_header Cache-Control "public, max-age=31536000, immutable";

--- a/tests/plugin-asset-url.test.ts
+++ b/tests/plugin-asset-url.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  resolvePluginAssetUrl,
+  withPluginAssetCacheToken,
+} from "../apps/geolibre-desktop/src/lib/plugin-asset-url";
+
+describe("plugin asset URLs", () => {
+  it("appends a cache token to resolved plugin asset URLs", () => {
+    const assetUrl = resolvePluginAssetUrl(
+      "https://example.com/plugins/nasa-opera/plugin.json",
+      "dist/index.js",
+    );
+
+    assert.equal(
+      withPluginAssetCacheToken(assetUrl, 'geolibre-nasa-opera|0.3.0|W/"abc"'),
+      "https://example.com/plugins/nasa-opera/dist/index.js?__geolibre_plugin_cache=geolibre-nasa-opera%7C0.3.0%7CW%2F%22abc%22",
+    );
+  });
+
+  it("leaves plugin asset URLs unchanged without a cache token", () => {
+    const assetUrl = "https://example.com/plugins/nasa-opera/dist/style.css";
+
+    assert.equal(withPluginAssetCacheToken(assetUrl, ""), assetUrl);
+  });
+});


### PR DESCRIPTION
## Summary

- append manifest-derived cache tokens to plugin entry and style requests
- make nginx revalidate bundled plugin files with stable paths
- add unit coverage for plugin asset cache tokens

## Testing

- pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin asset caching so updated plugin versions are detected reliably.
  * Added cache-busting support for plugin entry and style assets.
  * Ensured missing plugin files return a clear 404 response.

* **Security**
  * Added standard security headers to plugin asset responses.
  * Enforced revalidation for bundled plugin assets.

* **Tests**
  * Added coverage for cache-token handling, URL encoding, and unchanged URLs when no token is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->