### PR TITLE
feat(detection): support geotagged photos

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ObjectDetectionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ObjectDetectionDialog.tsx
@@ -2,6 +2,7 @@ import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   detectObjects,
+  readDetectionImage,
   readRasterData,
   type Detection,
   type RasterData,
@@ -29,16 +30,25 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { clamp } from "../../lib/clamp";
-import { openLocalDataFileWithFallback } from "../../lib/tauri-io";
 import { reprojectFeatureCollectionToWgs84 } from "../../lib/duckdb-vector-loader";
 import { BUILTIN_DETECTION_MODELS, fetchDetectionModel } from "../../lib/detection-models";
+import { readPhotoLocation } from "../../lib/geotagged-photos";
+import {
+  DETECTION_PHOTO_EXTENSIONS,
+  detectionClassLabel,
+  detectionPhotoMimeType,
+  detectionsToPhotoFeatureCollection,
+  isDetectionPhotoFileName,
+} from "../../lib/object-detection-photo";
+import { openLocalDataFileWithFallback } from "../../lib/tauri-io";
 
 interface ObjectDetectionDialogProps {
   mapControllerRef: React.RefObject<MapController | null>;
 }
 
-const IMAGE_FILTERS = [{ name: "Imagery", extensions: ["tif", "tiff"] }];
-const IMAGE_ACCEPT = ".tif,.tiff";
+const IMAGE_EXTENSIONS = ["tif", "tiff", ...DETECTION_PHOTO_EXTENSIONS];
+const IMAGE_FILTERS = [{ name: "Imagery", extensions: IMAGE_EXTENSIONS }];
+const IMAGE_ACCEPT = IMAGE_EXTENSIONS.map((extension) => `.${extension}`).join(",");
 const MODEL_FILTERS = [{ name: "ONNX model", extensions: ["onnx"] }];
 const MODEL_ACCEPT = ".onnx";
 
@@ -77,7 +87,7 @@ function epsgFromGeoKeys(geoKeys: Record<string, unknown>): number | null {
  * falling back to `class_<index>` when the list is short or empty.
  */
 function classLabel(names: string[], index: number): string {
-  return names[index]?.trim() || `class_${index}`;
+  return detectionClassLabel(names, index);
 }
 
 /**
@@ -155,9 +165,11 @@ function detectionsToFeatureCollection(
 /**
  * Object detection panel (issue #902). A floating, draggable panel (not a modal)
  * that runs a user-supplied YOLO model exported to ONNX entirely in the browser
- * (onnxruntime-web) against a chosen GeoTIFF, georeferences the detected boxes,
- * and adds one GeoJSON layer per detected class. The map stays interactive while
- * the panel is open, matching the Raster Subset / Pixel Time Series panels.
+ * (onnxruntime-web) against a chosen GeoTIFF or geotagged photo. GeoTIFF boxes
+ * keep their raster georeferencing; photo detections become points at the
+ * camera's GPS location. Each detected class becomes a GeoJSON layer. The map
+ * stays interactive while the panel is open, matching the Raster Subset / Pixel
+ * Time Series panels.
  *
  * Unlike AI Segmentation, inference is client-side, so this works in both the
  * web and desktop builds with no Python sidecar.
@@ -311,6 +323,25 @@ export function ObjectDetectionDialog({
     inferringRef.current = true;
     setRunning(true);
     try {
+      const isPhoto = isDetectionPhotoFileName(imageName);
+      let photoLocation: [number, number] | null = null;
+      let raster: RasterData;
+      if (isPhoto) {
+        const mimeType = detectionPhotoMimeType(imageName);
+        const [decoded, location] = await Promise.all([
+          readDetectionImage(imageBytes, mimeType),
+          readPhotoLocation(new Blob([imageBytes], { type: mimeType })),
+        ]);
+        if (!location) {
+          setError(t("objectDetection.error.photoLocation"));
+          return;
+        }
+        raster = decoded;
+        photoLocation = location;
+      } else {
+        raster = await readRasterData(imageBytes);
+      }
+
       // Resolve the model bytes: download (and cache) the chosen built-in model,
       // or use the user-supplied file.
       let modelData = modelBytes;
@@ -334,7 +365,6 @@ export function ObjectDetectionDialog({
         setError(t("objectDetection.error.chooseModel"));
         return;
       }
-      const raster = await readRasterData(imageBytes);
       const detections = await detectObjects(raster, modelData, {
         inputSize,
         confidenceThreshold: confidence,
@@ -348,10 +378,13 @@ export function ObjectDetectionDialog({
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean);
-      const tagged = detectionsToFeatureCollection(detections, raster, names);
-      // Reproject once for the whole batch, then split by class so each class
-      // becomes its own layer (issue #902: "classes can be created as layers").
-      const fc = await reprojectFeatureCollectionToWgs84(tagged);
+      const fc = photoLocation
+        ? detectionsToPhotoFeatureCollection(detections, photoLocation, names, imageName)
+        : await reprojectFeatureCollectionToWgs84(
+            detectionsToFeatureCollection(detections, raster, names),
+          );
+      // Split by class so each class becomes its own layer (issue #902:
+      // "classes can be created as layers").
       const byClass = new Map<string, Feature[]>();
       for (const feature of fc.features) {
         const cls = String(feature.properties?.class ?? "detection");
@@ -373,13 +406,20 @@ export function ObjectDetectionDialog({
       let maxX = -Infinity;
       let maxY = -Infinity;
       for (const feature of fc.features) {
-        if (feature.geometry?.type !== "Polygon") continue;
-        for (const ring of feature.geometry.coordinates) {
-          for (const [x, y] of ring) {
-            if (x < minX) minX = x;
-            if (x > maxX) maxX = x;
-            if (y < minY) minY = y;
-            if (y > maxY) maxY = y;
+        if (feature.geometry?.type === "Point") {
+          const [x, y] = feature.geometry.coordinates;
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        } else if (feature.geometry?.type === "Polygon") {
+          for (const ring of feature.geometry.coordinates) {
+            for (const [x, y] of ring) {
+              if (x < minX) minX = x;
+              if (x > maxX) maxX = x;
+              if (y < minY) minY = y;
+              if (y > maxY) maxY = y;
+            }
           }
         }
       }
@@ -400,6 +440,7 @@ export function ObjectDetectionDialog({
     }
   }, [
     imageBytes,
+    imageName,
     modelSource,
     modelBytes,
     builtinModelId,

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3441,10 +3441,10 @@
   },
   "objectDetection": {
     "title": "Object Detection",
-    "description": "Run a YOLO model exported to ONNX over a GeoTIFF, fully in the browser. Detected boxes are georeferenced and each class is added as its own layer.",
-    "hint": "Use a built-in COCO model (downloaded and cached once) or bring your own YOLOv5/v8/v11 ONNX. Detection runs locally in the browser. Built-in models detect everyday objects; for aerial imagery, supply your own overhead-trained model.",
-    "imageLabel": "Image (GeoTIFF)",
-    "imagePlaceholder": "Choose a GeoTIFF…",
+    "description": "Run a YOLO model exported to ONNX over a GeoTIFF or geotagged photo, fully in the browser. Each detected class is added as its own layer.",
+    "hint": "Use a built-in COCO model (downloaded and cached once) or bring your own YOLOv5/v8/v11 ONNX. GeoTIFF detections become georeferenced boxes. Photo detections become points at the camera's GPS location because a photo does not define a ground footprint.",
+    "imageLabel": "Image (GeoTIFF or geotagged photo)",
+    "imagePlaceholder": "Choose a GeoTIFF, JPEG, PNG, or WebP…",
     "chooseImage": "Choose image",
     "modelLabel": "Model",
     "modelSourceBuiltin": "Built-in (download)",
@@ -3464,7 +3464,8 @@
     "added": "Added {{count}} detection(s) across {{classes}} class(es).",
     "layerName": "Detection: {{class}}",
     "error": {
-      "chooseImage": "Choose an image (GeoTIFF) to run detection on.",
+      "chooseImage": "Choose a GeoTIFF or geotagged photo to run detection on.",
+      "photoLocation": "This photo has no usable GPS coordinates. Choose a geotagged photo.",
       "chooseModel": "Choose a YOLO model exported to ONNX (.onnx).",
       "downloadModel": "Could not download the model. Check your connection and try again.",
       "failed": "Detection failed."

--- a/apps/geolibre-desktop/src/lib/geotagged-photos.ts
+++ b/apps/geolibre-desktop/src/lib/geotagged-photos.ts
@@ -296,6 +296,18 @@ async function readPhotoExif(file: Blob): Promise<PhotoExif | null> {
   }
 }
 
+/**
+ * Read a photo's usable EXIF GPS position.
+ *
+ * @param file Encoded photo bytes supported by the EXIF parser.
+ * @returns `[longitude, latitude]`, or null when the image has no valid fix.
+ */
+export async function readPhotoLocation(file: Blob): Promise<[number, number] | null> {
+  const exif = await readPhotoExif(file);
+  const coordinate = exif && isValidLngLat(exif.longitude, exif.latitude);
+  return coordinate ? [coordinate.lng, coordinate.lat] : null;
+}
+
 /** The image data URLs generated for one photo. */
 interface PhotoImages {
   /** Downscaled JPEG thumbnail (data URL) for the map marker/popup, or null. */

--- a/apps/geolibre-desktop/src/lib/object-detection-photo.ts
+++ b/apps/geolibre-desktop/src/lib/object-detection-photo.ts
@@ -1,0 +1,76 @@
+import type { Detection } from "@geolibre/processing";
+import type { Feature, FeatureCollection, Point } from "geojson";
+
+/** Browser-decodable photo extensions accepted by Object Detection. */
+export const DETECTION_PHOTO_EXTENSIONS = ["jpg", "jpeg", "png", "webp"] as const;
+
+function fileExtension(name: string): string {
+  return name.split(".").pop()?.toLowerCase() ?? "";
+}
+
+/** Whether a selected Object Detection input is a regular photo. */
+export function isDetectionPhotoFileName(name: string): boolean {
+  return (DETECTION_PHOTO_EXTENSIONS as readonly string[]).includes(fileExtension(name));
+}
+
+/** MIME type for a supported Object Detection photo filename. */
+export function detectionPhotoMimeType(name: string): string {
+  const extension = fileExtension(name);
+  if (extension === "jpg" || extension === "jpeg") return "image/jpeg";
+  if (extension === "png") return "image/png";
+  if (extension === "webp") return "image/webp";
+  return "application/octet-stream";
+}
+
+/** Resolve a model class label, falling back when the user supplied no name. */
+export function detectionClassLabel(names: string[], index: number): string {
+  return names[index]?.trim() || `class_${index}`;
+}
+
+/**
+ * Locate regular-photo detections at the photo's camera position.
+ *
+ * A GPS tag supplies only the camera point, not a ground footprint or pixel
+ * scale, so manufacturing map polygons from pixel boxes would be misleading.
+ * Each result is therefore a point at the photo location, with the original
+ * pixel bounding box retained as attributes for inspection and export.
+ *
+ * @param detections YOLO boxes in source-photo pixels.
+ * @param coordinate Photo camera location as `[longitude, latitude]`.
+ * @param names Model class names in output order.
+ * @param imageName Selected photo filename.
+ * @returns One point feature per detected object.
+ */
+export function detectionsToPhotoFeatureCollection(
+  detections: Detection[],
+  coordinate: [number, number],
+  names: string[],
+  imageName: string,
+): FeatureCollection<Point> {
+  const features: Feature<Point>[] = detections.map((detection) => {
+    const [minX, minY, maxX, maxY] = detection.bbox.map((value) => Number(value.toFixed(2))) as [
+      number,
+      number,
+      number,
+      number,
+    ];
+    return {
+      type: "Feature",
+      properties: {
+        class: detectionClassLabel(names, detection.classIndex),
+        class_index: detection.classIndex,
+        score: Number(detection.score.toFixed(4)),
+        image_name: imageName,
+        bbox_min_x: minX,
+        bbox_min_y: minY,
+        bbox_max_x: maxX,
+        bbox_max_y: maxY,
+      },
+      geometry: {
+        type: "Point",
+        coordinates: [coordinate[0], coordinate[1]],
+      },
+    };
+  });
+  return { type: "FeatureCollection", features };
+}

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -216,7 +216,13 @@ export {
   type PmtilesExtractResult,
   type PmtilesSourceInfo,
 } from "./pmtiles-extract";
-export { detectObjects, type Detection, type DetectionOptions } from "./object-detection";
+export {
+  detectObjects,
+  rasterFromRgba,
+  readDetectionImage,
+  type Detection,
+  type DetectionOptions,
+} from "./object-detection";
 export {
   segmentEverything,
   type SegmentMask,

--- a/packages/processing/src/object-detection.ts
+++ b/packages/processing/src/object-detection.ts
@@ -3,10 +3,10 @@
  *
  * Complements the AI Segmentation toolbox (which proxies SAM3 through the Python
  * sidecar) with a fully client-side path: a user-supplied YOLO model exported to
- * ONNX runs against a chosen raster via `onnxruntime-web`, and the detected
- * bounding boxes come back in source-raster pixel coordinates. The caller
- * (the detection dialog) georeferences those pixel boxes with the raster's
- * geotransform and turns each class into a GeoJSON layer.
+ * ONNX runs against a chosen raster or regular photo via `onnxruntime-web`, and
+ * the detected bounding boxes come back in source-image pixel coordinates. The
+ * caller (the detection dialog) georeferences GeoTIFF boxes with the raster's
+ * transform or locates photo results at the camera's GPS position.
  *
  * Keeping inference in the browser means detection works in the web build with
  * no sidecar, mirroring how the client raster tools (`raster-client.ts`) run on
@@ -23,7 +23,7 @@
 import { loadOrt } from "./ort";
 import type { RasterData } from "./raster-client";
 
-/** A single detection in **source raster pixel** coordinates. */
+/** A single detection in **source image pixel** coordinates. */
 export interface Detection {
   /** Bounding box `[minX, minY, maxX, maxY]` in source pixels (top-left origin). */
   bbox: [number, number, number, number];
@@ -53,10 +53,108 @@ const DEFAULT_CONFIDENCE = 0.25;
 const DEFAULT_IOU = 0.45;
 /** Letterbox padding colour (YOLO uses 114/255 grey). */
 const PAD_VALUE = 114 / 255;
+/**
+ * Maximum bytes allocated for the three Float32 bands decoded from a regular
+ * image. The browser also holds the source bitmap and canvas RGBA buffer, so
+ * keeping this below the raster engine's 512 MB ceiling avoids multi-gigabyte
+ * peaks on very large phone panoramas.
+ */
+const MAX_DETECTION_IMAGE_BYTES = 256 * 1024 * 1024;
 
 // Re-exported for the guard test (tests/object-detection.test.ts), which asserts
 // the CDN WASM version matches the pinned onnxruntime-web dependency.
 export { ORT_VERSION } from "./ort";
+
+function detectionImagePixelCount(width: number, height: number): number {
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width < 1 || height < 1) {
+    throw new Error("Image dimensions must be positive integers.");
+  }
+  const pixels = width * height;
+  const estimatedBytes = pixels * 3 * Float32Array.BYTES_PER_ELEMENT;
+  if (!Number.isSafeInteger(pixels) || estimatedBytes > MAX_DETECTION_IMAGE_BYTES) {
+    throw new Error("This image is too large for in-browser object detection.");
+  }
+  return pixels;
+}
+
+/**
+ * Convert browser RGBA pixels into the {@link RasterData} shape consumed by
+ * the detection engine.
+ *
+ * Regular photos have no pixel-to-world transform, so their placeholder
+ * georeferencing is deliberately neutral. Callers must use the photo's own GPS
+ * location for result geometry instead of treating these pixel coordinates as
+ * map coordinates.
+ *
+ * @param width Decoded image width in pixels.
+ * @param height Decoded image height in pixels.
+ * @param rgba Row-major RGBA bytes, four entries per pixel.
+ * @returns Three 8-bit-valued Float32 RGB bands.
+ */
+export function rasterFromRgba(width: number, height: number, rgba: Uint8ClampedArray): RasterData {
+  const pixels = detectionImagePixelCount(width, height);
+  if (rgba.length !== pixels * 4) {
+    throw new Error("Decoded image pixels do not match its dimensions.");
+  }
+
+  const red = new Float32Array(pixels);
+  const green = new Float32Array(pixels);
+  const blue = new Float32Array(pixels);
+  for (let pixel = 0, offset = 0; pixel < pixels; pixel += 1, offset += 4) {
+    red[pixel] = rgba[offset];
+    green[pixel] = rgba[offset + 1];
+    blue[pixel] = rgba[offset + 2];
+  }
+  return {
+    bands: [red, green, blue],
+    width,
+    height,
+    originX: 0,
+    originY: 0,
+    resX: 1,
+    resY: 1,
+    nodata: null,
+    geoKeys: {},
+  };
+}
+
+/**
+ * Decode JPEG, PNG, or WebP bytes into RGB bands for object detection.
+ *
+ * @param bytes Encoded browser-readable image bytes.
+ * @param mimeType MIME type inferred from the selected filename.
+ * @returns A raster-shaped RGB image with neutral georeferencing.
+ */
+export async function readDetectionImage(
+  bytes: ArrayBuffer,
+  mimeType: string,
+): Promise<RasterData> {
+  if (typeof createImageBitmap !== "function" || typeof document === "undefined") {
+    throw new Error("This browser cannot decode the selected image.");
+  }
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(new Blob([bytes], { type: mimeType }), {
+      imageOrientation: "from-image",
+    });
+  } catch {
+    throw new Error("Could not decode the selected image.");
+  }
+
+  try {
+    detectionImagePixelCount(bitmap.width, bitmap.height);
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) throw new Error("Could not create an image canvas.");
+    context.drawImage(bitmap, 0, 0);
+    const rgba = context.getImageData(0, 0, bitmap.width, bitmap.height).data;
+    return rasterFromRgba(bitmap.width, bitmap.height, rgba);
+  } finally {
+    bitmap.close();
+  }
+}
 
 /**
  * Pull three colour channels and a normalisation divisor out of a
@@ -70,7 +168,7 @@ export { ORT_VERSION } from "./ort";
  * NoData and non-finite samples are excluded from that maximum so a sea of
  * NoData (or a few sentinel pixels) cannot skew the scale.
  *
- * @param raster The decoded source raster.
+ * @param raster The decoded source image in `RasterData` form.
  * @returns The per-channel band arrays, the divisor, and the source NoData.
  */
 export function rgbBands(raster: RasterData): {
@@ -332,10 +430,10 @@ export function decodeYolo(
 }
 
 /**
- * Run an ONNX YOLO model over a raster and return the detected boxes in source
- * raster pixel coordinates.
+ * Run an ONNX YOLO model over an image and return the detected boxes in source
+ * image pixel coordinates.
  *
- * @param raster The decoded source raster (from `readRasterData`).
+ * @param raster The decoded source image from `readRasterData` or `readDetectionImage`.
  * @param modelBytes The `.onnx` model file bytes.
  * @param options Input size and confidence/NMS thresholds.
  * @returns Detections in source-pixel space, after non-maximum suppression.

--- a/tests/object-detection-photo.test.ts
+++ b/tests/object-detection-photo.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  detectionPhotoMimeType,
+  detectionsToPhotoFeatureCollection,
+  isDetectionPhotoFileName,
+} from "../apps/geolibre-desktop/src/lib/object-detection-photo";
+import { rasterFromRgba } from "../packages/processing/src/object-detection";
+
+describe("regular photo detection input", () => {
+  it("recognizes only the browser-decodable photo formats", () => {
+    for (const name of ["photo.jpg", "photo.JPEG", "photo.png", "photo.webp"]) {
+      assert.equal(isDetectionPhotoFileName(name), true, name);
+    }
+    for (const name of ["raster.tif", "photo.heic", "model.onnx", "photo"]) {
+      assert.equal(isDetectionPhotoFileName(name), false, name);
+    }
+    assert.equal(detectionPhotoMimeType("photo.jpeg"), "image/jpeg");
+    assert.equal(detectionPhotoMimeType("photo.png"), "image/png");
+    assert.equal(detectionPhotoMimeType("photo.webp"), "image/webp");
+  });
+
+  it("splits RGBA pixels into three RGB raster bands", () => {
+    const raster = rasterFromRgba(2, 1, new Uint8ClampedArray([10, 20, 30, 255, 40, 50, 60, 128]));
+    assert.deepEqual(
+      raster.bands.map((band) => [...band]),
+      [
+        [10, 40],
+        [20, 50],
+        [30, 60],
+      ],
+    );
+    assert.equal(raster.width, 2);
+    assert.equal(raster.height, 1);
+    assert.deepEqual(raster.geoKeys, {});
+  });
+
+  it("rejects an RGBA buffer that does not match its dimensions", () => {
+    assert.throws(
+      () => rasterFromRgba(2, 2, new Uint8ClampedArray(4)),
+      /do not match its dimensions/,
+    );
+  });
+});
+
+describe("photo detection results", () => {
+  it("stores detections as GPS points with their pixel boxes", () => {
+    const collection = detectionsToPhotoFeatureCollection(
+      [
+        {
+          bbox: [10.123, 20.456, 30.789, 40.987],
+          classIndex: 1,
+          score: 0.87654,
+        },
+      ],
+      [-122.2585, 37.8719],
+      ["person", "bicycle"],
+      "campus.jpg",
+    );
+
+    assert.deepEqual(collection, {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {
+            class: "bicycle",
+            class_index: 1,
+            score: 0.8765,
+            image_name: "campus.jpg",
+            bbox_min_x: 10.12,
+            bbox_min_y: 20.46,
+            bbox_max_x: 30.79,
+            bbox_max_y: 40.99,
+          },
+          geometry: {
+            type: "Point",
+            coordinates: [-122.2585, 37.8719],
+          },
+        },
+      ],
+    });
+  });
+
+  it("falls back to a generated class name", () => {
+    const collection = detectionsToPhotoFeatureCollection(
+      [{ bbox: [0, 0, 1, 1], classIndex: 3, score: 1 }],
+      [1, 2],
+      [],
+      "photo.png",
+    );
+    assert.equal(collection.features[0].properties?.class, "class_3");
+  });
+});


### PR DESCRIPTION
## Summary

- accept JPEG, PNG, and WebP inputs in Object Detection alongside GeoTIFF
- decode regular photos for browser-side YOLO inference and read their EXIF GPS location
- add detections as camera-location points with class, score, filename, and pixel bounding-box attributes
- show an actionable error when a selected photo has no usable GPS coordinates

Fixes #1431

## Verification

- npm run lint
- npm run build
- npm run test:frontend
- pre-commit run --all-files
- verified successful built-in YOLO detection with a geotagged JPEG in light and dark themes
- verified the no-GPS photo error path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Object detection now supports GeoTIFFs and geotagged JPEG, PNG, and WebP photos.
  * Photo detections are placed on the map using GPS coordinates and displayed as point features.
  * Added validation and messaging when photos lack usable GPS data.
  * Map fitting now includes both photo points and raster detection areas.

* **Bug Fixes**
  * Improved detection labels and handling of supported image formats.

* **Tests**
  * Added coverage for photo formats, image conversion, labeling, and geospatial detection output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->