### PR TITLE
Fix saved 3D Tiles rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16605,9 +16605,9 @@
       }
     },
     "node_modules/maplibre-gl-3d-tiles": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.4.tgz",
-      "integrity": "sha512-uo79jaIvvWQ+xoMYstd+QlvMuH2Siv18LeKVg9IjIjyNY6Wub0FOGgnTpz827N7UPIb2BrggHHpR8VFuf6W7/A==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.5.tgz",
+      "integrity": "sha512-27J46dYDuvkHZZnIVCYTH92IcHuIq+J9OyiEYZ1kknz++HHob4S5CEWqnc8krXCHbw2LzsqatAcRWSSv7j3YvA==",
       "license": "MIT",
       "dependencies": {
         "3d-tiles-renderer": "^0.4.27",
@@ -21871,7 +21871,7 @@
         "jspdf": "^4.2.1",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.5.4",
+        "maplibre-gl-3d-tiles": "^0.5.5",
         "maplibre-gl-basemap-control": "^0.13.0",
         "maplibre-gl-components": "^0.29.0",
         "maplibre-gl-duckdb": "^0.2.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -37,7 +37,7 @@
     "jspdf": "^4.2.1",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.5.4",
+    "maplibre-gl-3d-tiles": "^0.5.5",
     "maplibre-gl-basemap-control": "^0.13.0",
     "maplibre-gl-components": "^0.29.0",
     "maplibre-gl-duckdb": "^0.2.3",

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -11,6 +11,7 @@ import {
   useAppStore,
 } from "@geolibre/core";
 import type { Layer } from "@deck.gl/core";
+import type { Map as MapLibreMap } from "maplibre-gl";
 import {
   DEFAULT_TILESET_URL,
   ThreeDTilesControl,
@@ -86,6 +87,7 @@ let threeDTilesStoreUnsubscribe: (() => void) | null = null;
 let threeDTilesStoreSyncSuspended = 0;
 let threeDTilesRuntimeEnvUnsubscribe: (() => void) | null = null;
 let activeThreeDTilesApp: GeoLibreAppAPI | null = null;
+const pendingThreeDTilesStyleRestores = new WeakSet<MapLibreMap>();
 
 // The Google tiles render through the shared interleaved deck overlay
 // (./shared-deck-overlay.ts) under the "google-3d-tiles" source, so they coexist
@@ -150,6 +152,11 @@ export function restoreThreeDTilesLayers(app: GeoLibreAppAPI): void {
   const layers = useAppStore.getState().layers.filter(isThreeDTilesControlLayer);
   if (layers.length === 0) return;
 
+  const map = app.getMap?.();
+  if (map && deferThreeDTilesRestoreUntilMapIdle(map, () => restoreThreeDTilesLayers(app))) {
+    return;
+  }
+
   const control = runWithThreeDTilesStoreSyncSuspended(() => ensureThreeDTilesControl(app));
   if (!control) return;
 
@@ -169,6 +176,35 @@ export function restoreThreeDTilesLayers(app: GeoLibreAppAPI): void {
   } catch (error) {
     console.error("[GeoLibre] Failed to restore 3D Tiles layers", error);
   }
+}
+
+/**
+ * Queue one restore after an in-progress MapLibre style load becomes idle.
+ *
+ * Project restoration can run while the saved basemap is still replacing the
+ * initial style. MapLibre accepts a custom layer during that window, then
+ * discards it when the new style finishes loading. This mirrors the upstream
+ * control's style-ready guard. The `idle` event is used because the host's
+ * initial `load` callback can run after `style.load` while `isStyleLoaded()`
+ * remains false. Repeated restore passes are deduplicated.
+ *
+ * @param map - The MapLibre map receiving the restored custom layer.
+ * @param restore - Replays the current project state after the map becomes idle.
+ * @returns True when restoration was deferred, otherwise false.
+ */
+export function deferThreeDTilesRestoreUntilMapIdle(
+  map: MapLibreMap,
+  restore: () => void,
+): boolean {
+  if (map.isStyleLoaded()) return false;
+  if (pendingThreeDTilesStyleRestores.has(map)) return true;
+
+  pendingThreeDTilesStyleRestores.add(map);
+  map.once("idle", () => {
+    pendingThreeDTilesStyleRestores.delete(map);
+    restore();
+  });
+  return true;
 }
 
 function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {

--- a/tests/three-d-tiles.test.ts
+++ b/tests/three-d-tiles.test.ts
@@ -8,12 +8,61 @@ import {
   resolveThreeDTilesRequestHeaders,
   stripGoogleMapsApiKeyHeader,
 } from "../packages/core/src/three-d-tiles";
+import { deferThreeDTilesRestoreUntilMapIdle } from "../packages/plugins/src/plugins/maplibre-3d-tiles";
 
 // Shared 3D-Tiles header resolution: Google Photorealistic tiles keep their
 // X-GOOG-API-KEY out of the store and have it re-injected at render time. Both
 // the MapLibre and Cesium render paths must resolve it the same way.
 
 const GOOGLE = "https://tile.googleapis.com/v1/3dtiles/root.json";
+
+describe("deferThreeDTilesRestoreUntilMapIdle", () => {
+  it("continues immediately when the style is ready", () => {
+    const map = {
+      isStyleLoaded: () => true,
+      once: () => {
+        throw new Error("style listener should not be registered");
+      },
+    } as unknown as Parameters<typeof deferThreeDTilesRestoreUntilMapIdle>[0];
+
+    assert.equal(
+      deferThreeDTilesRestoreUntilMapIdle(map, () => {}),
+      false,
+    );
+  });
+
+  it("queues one restore until an in-progress style load finishes", () => {
+    const listeners: Array<() => void> = [];
+    const map = {
+      isStyleLoaded: () => false,
+      once: (event: string, listener: () => void) => {
+        assert.equal(event, "idle");
+        listeners.push(listener);
+      },
+    } as unknown as Parameters<typeof deferThreeDTilesRestoreUntilMapIdle>[0];
+    let firstRestoreCount = 0;
+    let duplicateRestoreCount = 0;
+
+    assert.equal(
+      deferThreeDTilesRestoreUntilMapIdle(map, () => {
+        firstRestoreCount += 1;
+      }),
+      true,
+    );
+    assert.equal(
+      deferThreeDTilesRestoreUntilMapIdle(map, () => {
+        duplicateRestoreCount += 1;
+      }),
+      true,
+    );
+    assert.equal(listeners.length, 1);
+
+    listeners[0]();
+
+    assert.equal(firstRestoreCount, 1);
+    assert.equal(duplicateRestoreCount, 0);
+  });
+});
 
 describe("resolveThreeDTilesRequestHeaders", () => {
   it("passes non-Google tileset headers through unchanged", () => {


### PR DESCRIPTION
## Summary

- defer saved 3D Tiles restoration until MapLibre finishes the active style load
- deduplicate restore callbacks during the same style transition
- update `maplibre-gl-3d-tiles` to v0.5.5 so tiles remain visible on transparent or hidden backgrounds
- add regression tests for immediate and deferred restoration

Fixes #1390.

## Verification

- `pre-commit run --all-files`
- `npm run lint`
- `npm run build`
- `npm run test:frontend:coverage`
- `npm run test:worker`
- `npm run check:rust`
- verified the reported AGI HQ project in a real browser in light and dark themes with the Background layer hidden and no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of 3D Tiles layers during MapLibre map loading.
  - Prevented duplicate restoration attempts while the map is waiting to become idle.
  - Updated the 3D Tiles integration dependency to improve compatibility and reliability.

- **Tests**
  - Added coverage for deferred layer restoration and duplicate-request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->