### PR TITLE
fix(map): restack layers top-down so a late control layer cannot bury the rest

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -979,8 +979,19 @@ export class MapController {
       }
     }
 
-    for (const [index, layer] of layers.entries()) {
-      syncLayer(map, layer, this.getBeforeStyleLayerId(layers, index));
+    // Top-down (`layers` is bottom-to-top, so the last entry is the topmost).
+    // Each layer is placed *beneath* the first style layer belonging to a layer
+    // above it, so every anchor must already sit where this pass wants it.
+    // Walking bottom-up would anchor a layer to a neighbour that has not been
+    // moved yet, which mis-stacks the whole map for one pass whenever a layer's
+    // native style layers appear out of band. An Add Vector Layer restore does
+    // exactly that: its control adds the layers on top of the style once the
+    // data has loaded, long after the first sync pass ran. A later sync would
+    // converge, but a map-only embed (`?maponly`) has no panels to trigger one,
+    // so the wrong stack is what the viewer keeps looking at. See
+    // opengeos/GeoLibre#1404.
+    for (let index = layers.length - 1; index >= 0; index -= 1) {
+      syncLayer(map, layers[index], this.getBeforeStyleLayerId(layers, index));
     }
     this.layerIds = nextIds;
     this.syncedLayers = layers;

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -237,7 +237,31 @@ function rasterLayer(id: string, patch: Partial<GeoLibreLayer> = {}): GeoLibreLa
   };
 }
 
+// An Add Vector Layer entry: the maplibre-gl-vector control owns the paint and
+// creates the native style layers itself, so the store layer only names them.
+function controlVectorLayer(id: string, patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      controlOwnsPaint: true,
+      customLayerType: "fill",
+      externalNativeLayer: true,
+      nativeLayerIds: [`${id}-fill`, `${id}-outline`],
+      sourceIds: [`${id}-source`],
+      sourceKind: "maplibre-gl-vector",
+    },
+    ...patch,
+  };
+}
+
 const circleId = (id: string) => `layer-${id}-circle`;
+const rasterId = (id: string) => `layer-${id}-raster`;
 const srcId = (id: string) => `source-${id}`;
 
 describe("MapController.syncLayers reconciliation", () => {
@@ -298,6 +322,30 @@ describe("MapController.syncLayers reconciliation", () => {
       fake.calls.some((c) => c.method === "moveLayer"),
       "reorder is applied via moveLayer, not a teardown",
     );
+  });
+
+  it("restacks every layer in one pass when a control adds its style layers late", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    // Bottom to top: a raster underlay, an Add Vector Layer polygon layer, and a
+    // point overlay, the shape of the shared project in opengeos/GeoLibre#1404.
+    const layers = [rasterLayer("under"), controlVectorLayer("vec"), pointLayer("over")];
+    const userOrder = () => fake.order.filter((id) => id !== "basemap-bg");
+
+    controller.syncLayers(layers);
+    // The control's data is still loading, so its native layers do not exist yet.
+    assert.deepEqual(userOrder(), [rasterId("under"), circleId("over")]);
+
+    // maplibre-gl-vector finishes loading and adds its layers on top of the
+    // style; the store write that follows drives one more sync pass.
+    const styled = map as unknown as {
+      addLayer: (spec: Record<string, unknown>) => void;
+    };
+    styled.addLayer({ id: "vec-fill", type: "fill", paint: {} });
+    styled.addLayer({ id: "vec-outline", type: "line", paint: {} });
+    controller.syncLayers(layers);
+
+    assert.deepEqual(userOrder(), [rasterId("under"), "vec-fill", "vec-outline", circleId("over")]);
   });
 
   it("updates data in place via setData rather than recreating the source", () => {


### PR DESCRIPTION
## Problem

Reported in [discussion #1404](https://github.com/opengeos/GeoLibre/discussions/1404#discussioncomment-17796606): a shared project opened with `&maponly` renders its choropleth polygon layer as bare basemap. The point layer above it and the Legend both render correctly, and toggling the polygon layer's visibility off and on in the on-map layer selector repaints it.

## Root cause

`MapController.syncLayers` walked the store's layer array bottom-up and anchored each layer beneath the first style layer belonging to a layer above it. That only works when the anchor already sits where this pass wants it, which is not true when a layer's native style layers appear out of band: the Add Vector Layer control creates its `fill`/`outline`/`label` layers on top of the style once its data has loaded, well after the first sync pass ran.

The next pass then pinned every layer below the control layer to the wrong neighbour. In the reported project (bottom to top: a GEBCO WMS raster, the Add Vector Layer choropleth, two overlay layers, a point layer) the WMS raster was lifted from the bottom of the stack to just under the point layer, where it painted over the choropleth.

A second sync pass converges on the right stack, which is why the full editor usually looks fine: mounted panels keep writing to the store. `?maponly` mounts no panels, so nothing triggers that extra pass and the viewer keeps looking at the wrong order. Toggling visibility works as a workaround because it forces one more pass.

## Fix

Iterate top-down in `syncLayers`. Every anchor has then already been placed during the same pass, so one pass produces the correct stack no matter when a control added its layers.

## Verification

The reporter's actual shared project (`world-map-of-paediatric-palliative-care-development.geolibre.json`, served locally) driven in a real browser with Playwright.

Style-layer order before the fix, in both `?maponly` and the full editor (the WMS raster sits above the choropleth):

```
vector-ck0m70z-fill / -outline / -label
layer-ee4a89a1-…-fill / -line     (Overlays Areas)
layer-a9cee121-…-line             (Overlays Borders)
layer-e7ac324f-…-raster           (Bathymetry WMS)  <-- should be bottom-most
layer-7535f56a-…-circle           (PC Services)
```

After the fix, matching the project's own layer order:

```
layer-e7ac324f-…-raster           (Bathymetry WMS)
vector-ck0m70z-fill / -outline / -label
layer-ee4a89a1-…-fill / -line
layer-a9cee121-…-line
layer-7535f56a-…-circle
```

Checked visually in `?maponly` (light and dark) and in the full editor (light and dark): the bathymetry now renders under the basemap land, and the choropleth and graduated circles both paint. Also re-checked a two-layer URL-backed project (source.coop countries GeoParquet with a categorized fill plus US cities with graduated circles).

`tests/map-controller.test.ts` gains a regression test that reproduces the ordering in the fake map: it fails on `main` and passes here. Full frontend suite (4176 tests), `npm run lint`, and `npm run build` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected map layer stacking when native style layers are added or restored after the initial synchronization.
  * Improved layer ordering for vector layers, restored layers, and map-only embeds.

* **Tests**
  * Added coverage to verify that newly introduced native layers are correctly repositioned during subsequent synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->