### PR TITLE
fix(basemaps): make the basemap control's Mapbox styles load

### DIFF
--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -76,6 +76,19 @@ if (!process.env.VITE_CESIUM_TOKEN) {
   }
 }
 
+// Mapbox access token for the basemap control's Mapbox styles: same
+// bare→prefixed bridge as the Google Maps and Cesium keys. `MAPBOX_TOKEN` is the
+// spelling Mapbox's own tooling uses, so accept it from the shell or an .env
+// file and surface it as `VITE_MAPBOX_ACCESS_TOKEN`; getMapboxAccessToken() then
+// lets a runtime Settings override win over this build-time value.
+if (!process.env.VITE_MAPBOX_ACCESS_TOKEN) {
+  const mapboxAccessToken =
+    process.env.MAPBOX_TOKEN || FILE_ENV.VITE_MAPBOX_ACCESS_TOKEN || FILE_ENV.MAPBOX_TOKEN;
+  if (mapboxAccessToken) {
+    process.env.VITE_MAPBOX_ACCESS_TOKEN = mapboxAccessToken;
+  }
+}
+
 // Earth Engine OAuth client ID: same bare→prefixed bridge as the Google Maps
 // and Cesium keys. The app reads `import.meta.env.VITE_GEE_OAUTH_CLIENT_ID`, so
 // a bare `GEE_OAUTH_CLIENT_ID` (shell/.zshrc or an .env file) is surfaced under

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,7 @@ export {
 export {
   getCesiumIonToken,
   getGoogleMapsApiKey,
+  getMapboxAccessToken,
   getProtomapsApiKey,
   getProtomapsStyleUrl,
   getRuntimeEnvironment,

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -102,6 +102,14 @@ export function getGoogleMapsApiKey(env?: Record<string, string | undefined>): s
  * there too). When unset, the Mapbox basemaps prompt for a token in the basemap
  * panel's API keys view instead.
  *
+ * Note the precedence, shared with {@link getGoogleMapsApiKey} and
+ * {@link getCesiumIonToken}: the prefixed name always wins over the bare one,
+ * and `getRuntimeEnvironment` merges build-time and runtime vars into one
+ * record. So a build that baked in `VITE_MAPBOX_ACCESS_TOKEN` is overridden at
+ * runtime by a Settings entry under that *same* prefixed name; a bare
+ * `MAPBOX_TOKEN` entry is a fallback for when nothing was baked in, not a way
+ * to override a baked token.
+ *
  * @param env - Environment record (defaults to the runtime environment);
  *   injectable for testing.
  * @returns The trimmed token, or undefined when unset.

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -91,6 +91,28 @@ export function getGoogleMapsApiKey(env?: Record<string, string | undefined>): s
 }
 
 /**
+ * Resolves the Mapbox access token from the runtime environment.
+ *
+ * The basemap control's Mapbox styles authenticate with the user's own token.
+ * It is supplied via `VITE_MAPBOX_ACCESS_TOKEN` (baked in at build time from the
+ * bare `MAPBOX_TOKEN` env var, which `vite.config.ts` copies into the prefixed
+ * name — the spelling Mapbox's own tooling uses) or set at runtime through
+ * Settings → Environment variables (`window.__GEOLIBRE_RUNTIME_ENV__`, which
+ * bypasses Vite's envPrefix allowlist, so a bare `MAPBOX_TOKEN` entry works
+ * there too). When unset, the Mapbox basemaps prompt for a token in the basemap
+ * panel's API keys view instead.
+ *
+ * @param env - Environment record (defaults to the runtime environment);
+ *   injectable for testing.
+ * @returns The trimmed token, or undefined when unset.
+ */
+export function getMapboxAccessToken(env?: Record<string, string | undefined>): string | undefined {
+  const runtimeEnv = env ?? getRuntimeEnvironment();
+  const trimmed = runtimeEnv.VITE_MAPBOX_ACCESS_TOKEN?.trim() || runtimeEnv.MAPBOX_TOKEN?.trim();
+  return trimmed || undefined;
+}
+
+/**
  * Resolves the Cesium Ion access token from the runtime environment.
  *
  * The 3D-globe view's world imagery and terrain need a Cesium Ion token. It is

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -57,6 +57,7 @@ export {
   isMapboxStyleUrl,
   loadMapboxStyle,
   mapboxAccessTokenFromStyleUrl,
+  redactMapboxStyleUrl,
   resolveMapboxInternalUrl,
   transformMapboxStyle,
 } from "./mapbox-style";

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -54,6 +54,13 @@ export {
   type ProtomapsBasemapStyleOptions,
 } from "./protomaps-basemap";
 export {
+  isMapboxStyleUrl,
+  loadMapboxStyle,
+  mapboxAccessTokenFromStyleUrl,
+  resolveMapboxInternalUrl,
+  transformMapboxStyle,
+} from "./mapbox-style";
+export {
   ensureRemotePMTilesArchive,
   hasPMTilesArchive,
   pmtilesNativeLayerIds,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -384,6 +384,9 @@ export class MapController {
   // Bumped on every style application so an asynchronously resolved style (the
   // Mapbox path in applyStyleToMap) can tell whether it is still the current one.
   private styleGeneration = 0;
+  // Aborts the in-flight Mapbox descriptor request, so a superseded basemap
+  // change (or destroy) does not leave the fetch running.
+  private pendingMapboxStyleAbort: AbortController | null = null;
   private basemapVisible = true;
   private basemapOpacity = 1;
   private mapPreferences: MapPreferences = DEFAULT_PROJECT_PREFERENCES.map;
@@ -876,6 +879,7 @@ export class MapController {
       clearTimeout(this.layerControlStyleRefreshTimer);
       this.layerControlStyleRefreshTimer = null;
     }
+    this.abortPendingMapboxStyle();
     this.map?.remove();
     this.map = null;
     this.styleReady = false;
@@ -925,6 +929,11 @@ export class MapController {
     const map = this.map;
     if (!map) return;
     const generation = ++this.styleGeneration;
+    // Drop any descriptor still in flight for the basemap this one replaces:
+    // its result is already destined for the generation check below, so the
+    // request is pure waste. Also covers a request that never settles, which
+    // would otherwise keep its closure (and this controller) alive.
+    this.abortPendingMapboxStyle();
 
     if (!isMapboxStyleUrl(url)) {
       this.beginStyleSwap();
@@ -932,7 +941,9 @@ export class MapController {
       return;
     }
 
-    void loadMapboxStyle(url)
+    const pending = new AbortController();
+    this.pendingMapboxStyleAbort = pending;
+    void loadMapboxStyle(url, pending.signal)
       .then((style) => {
         if (this.map !== map || this.styleGeneration !== generation) return;
         this.beginStyleSwap();
@@ -950,7 +961,25 @@ export class MapController {
           `Failed to load the Mapbox basemap style "${redactMapboxStyleUrl(url)}".`,
           error,
         );
+      })
+      .finally(() => {
+        if (this.pendingMapboxStyleAbort === pending) {
+          this.pendingMapboxStyleAbort = null;
+        }
       });
+  }
+
+  /**
+   * Cancels an in-flight Mapbox descriptor request, if any.
+   *
+   * An abort rejects the fetch with an `AbortError`, but that rejection always
+   * lands on a superseded generation (this is only called after bumping it, or
+   * from `destroy`, which nulls the map), so the handlers above return before
+   * reaching the warning — no aborted request is ever reported as a failure.
+   */
+  private abortPendingMapboxStyle(): void {
+    this.pendingMapboxStyleAbort?.abort();
+    this.pendingMapboxStyleAbort = null;
   }
 
   setBasemapVisible(visible: boolean): void {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -40,7 +40,7 @@ import {
   vectorTileStyleLayerIds,
 } from "./layer-sync";
 import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
-import { isMapboxStyleUrl, loadMapboxStyle } from "./mapbox-style";
+import { isMapboxStyleUrl, loadMapboxStyle, redactMapboxStyleUrl } from "./mapbox-style";
 import { PlanetaryScaleControl } from "./planetary-scale-control";
 import { getOfflineBasemapStyle, isOfflineBasemapSentinel } from "./protomaps-basemap";
 import { ResetBearingControl } from "./reset-bearing-control";
@@ -885,14 +885,28 @@ export class MapController {
   setStyle(url: string): void {
     if (!this.map) return;
     this.basemapStyleUrl = url;
-    this.styleReady = false;
-    this.basemapOriginalPaintValues.clear();
-    this.removeLayerControl();
     this.applyStyleToMap(url);
     // Switching to/from a planetary basemap changes the active body (the store's
     // ellipsoid subscription runs first, so the singleton is already current),
     // so redraw the scale bar for the new radius without waiting for a pan.
     this.scaleControl?.refresh();
+  }
+
+  /**
+   * Tears down the state that belongs to the outgoing style, immediately before
+   * the incoming one is handed to MapLibre. `style.load` rebuilds all of it.
+   *
+   * Deliberately called per style application rather than at the top of
+   * `setStyle`: the Mapbox path below only reaches `map.setStyle` after an
+   * asynchronous fetch, and tearing down first would leave the controller
+   * wedged if that fetch failed — `styleReady` stuck false with no `style.load`
+   * coming to clear it, so layer syncing, basemap visibility/opacity and the
+   * layer control would all stay disabled over a still-rendered old style.
+   */
+  private beginStyleSwap(): void {
+    this.styleReady = false;
+    this.basemapOriginalPaintValues.clear();
+    this.removeLayerControl();
   }
 
   /**
@@ -913,6 +927,7 @@ export class MapController {
     const generation = ++this.styleGeneration;
 
     if (!isMapboxStyleUrl(url)) {
+      this.beginStyleSwap();
       map.setStyle(resolveMapStyle(url));
       return;
     }
@@ -920,16 +935,21 @@ export class MapController {
     void loadMapboxStyle(url)
       .then((style) => {
         if (this.map !== map || this.styleGeneration !== generation) return;
+        this.beginStyleSwap();
         map.setStyle(style, { validate: false });
       })
       .catch((error: unknown) => {
         if (this.map !== map || this.styleGeneration !== generation) return;
-        // Leave the current style alone: the basemap control watches its own
-        // parallel setStyle and rolls the basemap back through the store when a
-        // provider style fails, which lands here as a newer generation. When
-        // there is no control in play (a reopened project, a split-view pane)
-        // the map keeps whatever it had, which beats blanking it.
-        console.warn(`Failed to load the Mapbox basemap style "${url}".`, error);
+        // Nothing was torn down (beginStyleSwap runs only on success), so the
+        // controller stays fully live over the style it already had — better
+        // than blanking the map. The basemap control watches its own parallel
+        // setStyle and rolls the basemap back through the store when a provider
+        // style fails, which arrives here as a newer generation.
+        // The URL carries the user's access_token, so log the descriptor id only.
+        console.warn(
+          `Failed to load the Mapbox basemap style "${redactMapboxStyleUrl(url)}".`,
+          error,
+        );
       });
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -40,6 +40,7 @@ import {
   vectorTileStyleLayerIds,
 } from "./layer-sync";
 import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
+import { isMapboxStyleUrl, loadMapboxStyle } from "./mapbox-style";
 import { PlanetaryScaleControl } from "./planetary-scale-control";
 import { getOfflineBasemapStyle, isOfflineBasemapSentinel } from "./protomaps-basemap";
 import { ResetBearingControl } from "./reset-bearing-control";
@@ -380,6 +381,9 @@ export class MapController {
   // (reentrancy guard against a sync loop). See syncLayerControlState.
   private refreshingStyleEditor = false;
   private basemapStyleUrl = DEFAULT_BASEMAP;
+  // Bumped on every style application so an asynchronously resolved style (the
+  // Mapbox path in applyStyleToMap) can tell whether it is still the current one.
+  private styleGeneration = 0;
   private basemapVisible = true;
   private basemapOpacity = 1;
   private mapPreferences: MapPreferences = DEFAULT_PROJECT_PREFERENCES.map;
@@ -422,9 +426,14 @@ export class MapController {
     const maxPitch = clampNumber(mapPreferences.maxPitch, 0, DEFAULT_MAX_PITCH);
     this.mapPreferences = mapPreferences;
     this.basemapStyleUrl = options.styleUrl ?? DEFAULT_BASEMAP;
+    // A Mapbox descriptor has to be fetched and rewritten before MapLibre will
+    // take it (see applyStyleToMap), which the Map constructor cannot wait for.
+    // Start blank and apply it below, as soon as the listeners are wired — the
+    // path a project saved with a Mapbox basemap and a split-view pane both take.
+    const deferMapboxStyle = isMapboxStyleUrl(this.basemapStyleUrl);
     this.map = new maplibregl.Map({
       container,
-      style: resolveMapStyle(this.basemapStyleUrl),
+      style: deferMapboxStyle ? createBlankMapStyle() : resolveMapStyle(this.basemapStyleUrl),
       center: view?.center ?? [-100, 40],
       zoom: view?.zoom ?? 2,
       bearing: view?.bearing ?? 0,
@@ -496,6 +505,10 @@ export class MapController {
     this.addAttributionControl();
     this.addLogoControl();
     this.addMaptoolkitLogoControl();
+    // Kick off the deferred Mapbox descriptor fetch now that `style.load` and
+    // `styledata` are wired, so the real style is treated exactly like a later
+    // basemap switch rather than racing the listeners above.
+    if (deferMapboxStyle) this.applyStyleToMap(this.basemapStyleUrl);
     return this.map;
   }
 
@@ -875,11 +888,49 @@ export class MapController {
     this.styleReady = false;
     this.basemapOriginalPaintValues.clear();
     this.removeLayerControl();
-    this.map.setStyle(resolveMapStyle(url));
+    this.applyStyleToMap(url);
     // Switching to/from a planetary basemap changes the active body (the store's
     // ellipsoid subscription runs first, so the singleton is already current),
     // so redraw the scale bar for the new radius without waiting for a pan.
     this.scaleControl?.refresh();
+  }
+
+  /**
+   * Hands a basemap style URL to MapLibre.
+   *
+   * Everything except Mapbox resolves synchronously, so `setStyle` is handed the
+   * URL (or the inline style a GeoLibre sentinel expands to) directly. Mapbox
+   * style descriptors are Mapbox-flavored and must be fetched and rewritten
+   * before MapLibre will accept them (see ./mapbox-style), which makes that path
+   * asynchronous: a generation counter drops the result of a swap the user has
+   * already superseded, so a slow descriptor can never overwrite a newer
+   * basemap. Validation is off for those, matching how the basemap control
+   * applies them — the descriptor is transformed to spec, not authored here.
+   */
+  private applyStyleToMap(url: string): void {
+    const map = this.map;
+    if (!map) return;
+    const generation = ++this.styleGeneration;
+
+    if (!isMapboxStyleUrl(url)) {
+      map.setStyle(resolveMapStyle(url));
+      return;
+    }
+
+    void loadMapboxStyle(url)
+      .then((style) => {
+        if (this.map !== map || this.styleGeneration !== generation) return;
+        map.setStyle(style, { validate: false });
+      })
+      .catch((error: unknown) => {
+        if (this.map !== map || this.styleGeneration !== generation) return;
+        // Leave the current style alone: the basemap control watches its own
+        // parallel setStyle and rolls the basemap back through the store when a
+        // provider style fails, which lands here as a newer generation. When
+        // there is no control in play (a reopened project, a split-view pane)
+        // the map keeps whatever it had, which beats blanking it.
+        console.warn(`Failed to load the Mapbox basemap style "${url}".`, error);
+      });
   }
 
   setBasemapVisible(visible: boolean): void {

--- a/packages/map/src/mapbox-style.ts
+++ b/packages/map/src/mapbox-style.ts
@@ -1,0 +1,185 @@
+/**
+ * Adapter that makes Mapbox-hosted styles loadable by MapLibre.
+ *
+ * The basemap control (`maplibre-gl-basemap-control`) offers eight Mapbox
+ * styles whose descriptors live at
+ * `https://api.mapbox.com/styles/v1/mapbox/<styleId>?access_token=<token>`.
+ * Those descriptors are Mapbox-flavored GL styles and MapLibre cannot consume
+ * them as-is, for two reasons:
+ *
+ *  1. **`mapbox://` URLs.** The sprite, glyphs and vector/raster sources are
+ *     addressed with Mapbox's private scheme (`mapbox://sprites/mapbox/...`,
+ *     `mapbox://fonts/mapbox/...`, `mapbox://mapbox.satellite`). MapLibre has no
+ *     resolver for it, so every one of those requests fails and the map renders
+ *     empty even when the descriptor itself loads.
+ *  2. **`projection: { name: … }`.** Mapbox names its projection `name`;
+ *     MapLibre's spec calls it `type`. MapLibre's style validator rejects the
+ *     unknown property with `name: unknown property "name"` and — because
+ *     `Style._load` bails on the first validation failure — abandons the whole
+ *     style, blanking the map.
+ *
+ * The control handles both itself when it applies a style (it passes a
+ * `transformStyle`), but GeoLibre is store-driven: the basemap change is written
+ * to `basemapStyleUrl` and re-applied by {@link MapController}, and a reopened
+ * project or a split-view pane applies the saved URL with no control involved at
+ * all. So the rewrite has to live on GeoLibre's own style path, which is here.
+ *
+ * The access token is read back out of the style URL's `access_token` query
+ * parameter, which is exactly where the control put it — that keeps this module
+ * free of credential plumbing and makes a saved project self-contained.
+ */
+
+import type maplibregl from "maplibre-gl";
+
+/** Host serving both the style descriptors and the `mapbox://` redirect targets. */
+const MAPBOX_API_HOST = "api.mapbox.com";
+const MAPBOX_STYLE_PATH_PREFIX = "/styles/v1/";
+
+/**
+ * Whether a basemap style URL points at a Mapbox-hosted style descriptor, and
+ * therefore needs {@link loadMapboxStyle} rather than a plain `setStyle(url)`.
+ *
+ * @param styleUrl - The basemap style URL (or a GeoLibre sentinel, which never
+ *   matches).
+ * @returns True for `https://api.mapbox.com/styles/v1/…` URLs.
+ */
+export function isMapboxStyleUrl(styleUrl: string | undefined): boolean {
+  if (!styleUrl) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(styleUrl);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.protocol === "https:" &&
+    parsed.hostname === MAPBOX_API_HOST &&
+    parsed.pathname.startsWith(MAPBOX_STYLE_PATH_PREFIX)
+  );
+}
+
+/**
+ * Extracts the Mapbox access token the style URL carries.
+ *
+ * @param styleUrl - A Mapbox style descriptor URL.
+ * @returns The raw (decoded) token, or an empty string when the URL has none.
+ */
+export function mapboxAccessTokenFromStyleUrl(styleUrl: string): string {
+  try {
+    return new URL(styleUrl).searchParams.get("access_token")?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Rewrites a single `mapbox://` URL to its public HTTPS equivalent.
+ *
+ * Mirrors the three forms Mapbox styles use — sprites, font stacks, and tileset
+ * sources — and returns anything else untouched, so an already-HTTPS URL (or a
+ * scheme added by a future style) passes through unchanged.
+ *
+ * @param url - The URL taken from the style descriptor.
+ * @param encodedAccessToken - The URI-encoded Mapbox access token.
+ * @returns The resolved HTTPS URL, or the input when it is not a `mapbox://` URL.
+ */
+export function resolveMapboxInternalUrl(url: string, encodedAccessToken: string): string {
+  const sprite = /^mapbox:\/\/sprites\/([^/]+)\/(.+)$/.exec(url);
+  if (sprite) {
+    return `https://${MAPBOX_API_HOST}/styles/v1/${sprite[1]}/${sprite[2]}/sprite?access_token=${encodedAccessToken}`;
+  }
+
+  const fonts = /^mapbox:\/\/fonts\/([^/]+)\/(.+)$/.exec(url);
+  if (fonts) {
+    return `https://${MAPBOX_API_HOST}/fonts/v1/${fonts[1]}/${fonts[2]}?access_token=${encodedAccessToken}`;
+  }
+
+  if (url.startsWith("mapbox://")) {
+    // Everything else is a tileset id (possibly a comma-joined list), served as
+    // TileJSON from the v4 endpoint. The returned TileJSON carries tile URLs
+    // that already include the token, so nothing downstream needs rewriting.
+    return `https://${MAPBOX_API_HOST}/v4/${url.slice("mapbox://".length)}.json?secure&access_token=${encodedAccessToken}`;
+  }
+
+  return url;
+}
+
+/** Resolves the `sprite` field, which is either one URL or a named list. */
+function resolveMapboxSprite(
+  sprite: maplibregl.StyleSpecification["sprite"],
+  encodedAccessToken: string,
+): maplibregl.StyleSpecification["sprite"] {
+  if (typeof sprite === "string") return resolveMapboxInternalUrl(sprite, encodedAccessToken);
+  if (Array.isArray(sprite)) {
+    return sprite.map((entry) => ({
+      ...entry,
+      url: resolveMapboxInternalUrl(entry.url, encodedAccessToken),
+    }));
+  }
+  return sprite;
+}
+
+/**
+ * Converts a Mapbox style descriptor into one MapLibre accepts.
+ *
+ * Resolves every `mapbox://` URL (sources, sprite, glyphs) against the public
+ * HTTPS endpoints and replaces Mapbox's `projection: { name: … }` with the
+ * MapLibre spelling. The projection is pinned to `mercator` rather than
+ * translated: `MapController.enforceProjection` re-applies the user's own
+ * globe/mercator preference as soon as the style loads, so carrying Mapbox's
+ * choice over would only be overwritten a moment later.
+ *
+ * @param style - The descriptor as fetched from Mapbox.
+ * @param accessToken - The raw Mapbox access token.
+ * @returns A new style object; the input is not mutated.
+ */
+export function transformMapboxStyle(
+  style: maplibregl.StyleSpecification,
+  accessToken: string,
+): maplibregl.StyleSpecification {
+  const encodedAccessToken = encodeURIComponent(accessToken);
+  const sources = Object.fromEntries(
+    Object.entries(style.sources ?? {}).map(([id, source]) => {
+      if (
+        source &&
+        typeof source === "object" &&
+        "url" in source &&
+        typeof source.url === "string"
+      ) {
+        return [id, { ...source, url: resolveMapboxInternalUrl(source.url, encodedAccessToken) }];
+      }
+      return [id, source];
+    }),
+  ) as maplibregl.StyleSpecification["sources"];
+
+  return {
+    ...style,
+    glyphs:
+      typeof style.glyphs === "string"
+        ? resolveMapboxInternalUrl(style.glyphs, encodedAccessToken)
+        : style.glyphs,
+    sprite: resolveMapboxSprite(style.sprite, encodedAccessToken),
+    projection: { type: "mercator" },
+    sources,
+  };
+}
+
+/**
+ * Fetches a Mapbox style descriptor and returns it in MapLibre form.
+ *
+ * @param styleUrl - A Mapbox style URL, including its `access_token` parameter.
+ * @param signal - Optional abort signal for a superseded basemap change.
+ * @returns The transformed style, ready for `map.setStyle(style, { validate: false })`.
+ * @throws When the descriptor cannot be fetched (bad token, offline, 404).
+ */
+export async function loadMapboxStyle(
+  styleUrl: string,
+  signal?: AbortSignal,
+): Promise<maplibregl.StyleSpecification> {
+  const response = await fetch(styleUrl, { signal });
+  if (!response.ok) {
+    throw new Error(`Mapbox style request failed (${response.status} ${response.statusText})`);
+  }
+  const style = (await response.json()) as maplibregl.StyleSpecification;
+  return transformMapboxStyle(style, mapboxAccessTokenFromStyleUrl(styleUrl));
+}

--- a/packages/map/src/mapbox-style.ts
+++ b/packages/map/src/mapbox-style.ts
@@ -73,6 +73,25 @@ export function mapboxAccessTokenFromStyleUrl(styleUrl: string): string {
 }
 
 /**
+ * A Mapbox style URL with its credentials stripped, safe to put in a log line.
+ *
+ * Every Mapbox URL here carries the user's `access_token` in its query string,
+ * so the raw URL must never reach the console (or anything that captures it).
+ * The path alone identifies which style failed, which is all a log needs.
+ *
+ * @param styleUrl - A Mapbox style descriptor URL.
+ * @returns The URL's path, or `"(unparseable URL)"` when it is not a URL.
+ */
+export function redactMapboxStyleUrl(styleUrl: string): string {
+  try {
+    const parsed = new URL(styleUrl);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return "(unparseable URL)";
+  }
+}
+
+/**
  * Rewrites a single `mapbox://` URL to its public HTTPS equivalent.
  *
  * Mirrors the three forms Mapbox styles use — sprites, font stacks, and tileset

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -1,4 +1,9 @@
-import { getGoogleMapsApiKey, getProtomapsApiKey, useAppStore } from "@geolibre/core";
+import {
+  getGoogleMapsApiKey,
+  getMapboxAccessToken,
+  getProtomapsApiKey,
+  useAppStore,
+} from "@geolibre/core";
 import {
   BasemapControl,
   type BasemapChangeEvent,
@@ -76,13 +81,19 @@ function getAmazonCredentials(): { amazonApiKey: string; awsRegion?: string } | 
 function getStyleProviderCredentials(): {
   protomapsApiKey?: string;
   stadiaApiKey?: string;
+  mapboxAccessToken?: string;
 } {
   const env = getRuntimeEnvironment();
   const protomapsApiKey = getProtomapsApiKey(env);
   const stadiaApiKey = env.VITE_STADIA_API_KEY?.trim() || undefined;
+  // Mapbox styles need the user's own access token. Same "only when set" rule as
+  // the others: the panel's API keys view has a Mapbox field, so pushing an
+  // empty string would clobber a token typed there.
+  const mapboxAccessToken = getMapboxAccessToken(env);
   return {
     ...(protomapsApiKey ? { protomapsApiKey } : {}),
     ...(stadiaApiKey ? { stadiaApiKey } : {}),
+    ...(mapboxAccessToken ? { mapboxAccessToken } : {}),
   };
 }
 
@@ -275,9 +286,10 @@ function addRuntimeEnvListener(): void {
       basemapControl.setAmazonCredentials(amazon.amazonApiKey, amazon.awsRegion);
     }
     // Same rule for the style-provider keys: push only what the user actually set.
-    const { protomapsApiKey, stadiaApiKey } = getStyleProviderCredentials();
+    const { protomapsApiKey, stadiaApiKey, mapboxAccessToken } = getStyleProviderCredentials();
     if (protomapsApiKey) basemapControl.setProtomapsApiKey(protomapsApiKey);
     if (stadiaApiKey) basemapControl.setStadiaApiKey(stadiaApiKey);
+    if (mapboxAccessToken) basemapControl.setMapboxAccessToken(mapboxAccessToken);
   };
 
   window.addEventListener("geolibre:runtime-env-change", handleRuntimeEnvChange);

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1342,3 +1342,111 @@ describe("MapController terrain auto-enable", () => {
     }
   });
 });
+
+describe("MapController Mapbox descriptor requests", () => {
+  const MAPBOX_STREETS = "https://api.mapbox.com/styles/v1/mapbox/streets-v12?access_token=tok";
+  const MAPBOX_DARK = "https://api.mapbox.com/styles/v1/mapbox/dark-v11?access_token=tok";
+  const OPENFREEMAP = "https://tiles.openfreemap.org/styles/liberty";
+
+  /** Minimal map stub: setStyle/remove are all the Mapbox path touches. */
+  function mapboxController(): { controller: MapController; styles: unknown[] } {
+    const styles: unknown[] = [];
+    const map = {
+      setStyle: (style: unknown) => {
+        styles.push(style);
+      },
+      remove: () => {},
+      addControl: () => {},
+      removeControl: () => {},
+      getTerrain: () => null,
+      setTerrain: () => {},
+      once: () => {},
+      on: () => {},
+      off: () => {},
+    };
+    const controller = createMapController();
+    const internal = controller as unknown as MapControllerInternals;
+    internal.map = map;
+    internal.styleReady = true;
+    return { controller, styles };
+  }
+
+  /**
+   * Runs `body` with a fetch that never settles on its own, so a descriptor
+   * request stays in flight until something aborts its signal. Every signal
+   * handed to fetch is collected in order.
+   */
+  async function withPendingFetch(
+    body: (signals: (AbortSignal | undefined)[]) => Promise<void> | void,
+  ): Promise<void> {
+    const signals: (AbortSignal | undefined)[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((_input: unknown, init?: { signal?: AbortSignal }) => {
+      signals.push(init?.signal);
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    }) as typeof globalThis.fetch;
+    try {
+      await body(signals);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  it("aborts a descriptor request the next basemap supersedes", async () => {
+    await withPendingFetch(async (signals) => {
+      const warnings: unknown[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => warnings.push(args);
+      const { controller } = mapboxController();
+      try {
+        controller.setStyle(MAPBOX_STREETS);
+        controller.setStyle(MAPBOX_DARK);
+
+        assert.equal(signals.length, 2);
+        assert.equal(signals[0]?.aborted, true);
+        assert.equal(signals[1]?.aborted, false);
+
+        // The abort rejection is this controller cancelling its own request,
+        // so it must not surface as a failed-style warning.
+        await Promise.resolve();
+        await Promise.resolve();
+        assert.deepEqual(warnings, []);
+      } finally {
+        console.warn = originalWarn;
+        controller.destroy();
+      }
+    });
+  });
+
+  it("aborts a pending descriptor request when a non-Mapbox style is applied", async () => {
+    await withPendingFetch((signals) => {
+      const { controller, styles } = mapboxController();
+      try {
+        controller.setStyle(MAPBOX_STREETS);
+        controller.setStyle(OPENFREEMAP);
+
+        // The plain URL resolves synchronously, and no second fetch is made.
+        assert.deepEqual(styles, [OPENFREEMAP]);
+        assert.equal(signals.length, 1);
+        assert.equal(signals[0]?.aborted, true);
+      } finally {
+        controller.destroy();
+      }
+    });
+  });
+
+  it("aborts a pending descriptor request on destroy", async () => {
+    await withPendingFetch((signals) => {
+      const { controller } = mapboxController();
+      controller.setStyle(MAPBOX_STREETS);
+      assert.equal(signals[0]?.aborted, false);
+
+      controller.destroy();
+      assert.equal(signals[0]?.aborted, true);
+    });
+  });
+});

--- a/tests/mapbox-style.test.ts
+++ b/tests/mapbox-style.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
+import { getMapboxAccessToken } from "@geolibre/core";
+import type maplibregl from "maplibre-gl";
+import {
+  isMapboxStyleUrl,
+  mapboxAccessTokenFromStyleUrl,
+  resolveMapboxInternalUrl,
+  transformMapboxStyle,
+} from "../packages/map/src/mapbox-style";
+
+/**
+ * A Mapbox style descriptor in the shape `api.mapbox.com/styles/v1/mapbox/*`
+ * actually serves: `mapbox://` sprite/glyphs/source URLs and Mapbox's
+ * `projection: { name }` spelling. Both are what MapLibre chokes on.
+ */
+function mapboxDescriptor(): maplibregl.StyleSpecification {
+  return {
+    version: 8,
+    name: "Mapbox Streets",
+    sprite: "mapbox://sprites/mapbox/streets-v12",
+    glyphs: "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    projection: { name: "globe" },
+    sources: {
+      composite: {
+        type: "vector",
+        url: "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2",
+      },
+      hosted: {
+        type: "raster",
+        tiles: ["https://example.com/{z}/{x}/{y}.png"],
+      },
+    },
+    layers: [{ id: "bg", type: "background", paint: { "background-color": "#fff" } }],
+  } as unknown as maplibregl.StyleSpecification;
+}
+
+describe("isMapboxStyleUrl", () => {
+  it("matches Mapbox style descriptor URLs", () => {
+    assert.equal(
+      isMapboxStyleUrl("https://api.mapbox.com/styles/v1/mapbox/streets-v12?access_token=pk.abc"),
+      true,
+    );
+    assert.equal(isMapboxStyleUrl("https://api.mapbox.com/styles/v1/someone/custom"), true);
+  });
+
+  it("rejects other basemap URLs and GeoLibre sentinels", () => {
+    assert.equal(isMapboxStyleUrl(undefined), false);
+    assert.equal(isMapboxStyleUrl(""), false);
+    assert.equal(isMapboxStyleUrl("https://tiles.openfreemap.org/styles/liberty"), false);
+    // Not a style descriptor, so it needs no rewrite (and must not be fetched).
+    assert.equal(isMapboxStyleUrl("https://api.mapbox.com/v4/mapbox.satellite.json"), false);
+    assert.equal(isMapboxStyleUrl("geolibre://planetary/moon"), false);
+    // A look-alike host must not be treated as Mapbox.
+    assert.equal(isMapboxStyleUrl("https://api.mapbox.com.evil.test/styles/v1/x"), false);
+    assert.equal(isMapboxStyleUrl("not a url"), false);
+  });
+});
+
+describe("mapboxAccessTokenFromStyleUrl", () => {
+  it("reads the token the control embedded in the URL", () => {
+    assert.equal(
+      mapboxAccessTokenFromStyleUrl(
+        "https://api.mapbox.com/styles/v1/mapbox/dark-v11?access_token=pk.token",
+      ),
+      "pk.token",
+    );
+  });
+
+  it("returns an empty string when there is no token", () => {
+    assert.equal(mapboxAccessTokenFromStyleUrl("https://api.mapbox.com/styles/v1/mapbox/x"), "");
+    assert.equal(mapboxAccessTokenFromStyleUrl("nonsense"), "");
+  });
+});
+
+describe("resolveMapboxInternalUrl", () => {
+  it("rewrites sprite, font and tileset URLs to public HTTPS endpoints", () => {
+    assert.equal(
+      resolveMapboxInternalUrl("mapbox://sprites/mapbox/streets-v12", "tok"),
+      "https://api.mapbox.com/styles/v1/mapbox/streets-v12/sprite?access_token=tok",
+    );
+    assert.equal(
+      resolveMapboxInternalUrl("mapbox://fonts/mapbox/{fontstack}/{range}.pbf", "tok"),
+      "https://api.mapbox.com/fonts/v1/mapbox/{fontstack}/{range}.pbf?access_token=tok",
+    );
+    assert.equal(
+      resolveMapboxInternalUrl("mapbox://mapbox.satellite", "tok"),
+      "https://api.mapbox.com/v4/mapbox.satellite.json?secure&access_token=tok",
+    );
+    // Comma-joined tileset lists are a single v4 request.
+    assert.equal(
+      resolveMapboxInternalUrl("mapbox://mapbox.a,mapbox.b", "tok"),
+      "https://api.mapbox.com/v4/mapbox.a,mapbox.b.json?secure&access_token=tok",
+    );
+  });
+
+  it("leaves non-mapbox:// URLs untouched", () => {
+    assert.equal(
+      resolveMapboxInternalUrl("https://example.com/tiles.json", "tok"),
+      "https://example.com/tiles.json",
+    );
+  });
+});
+
+describe("transformMapboxStyle", () => {
+  it("produces a style MapLibre's validator accepts", () => {
+    const raw = mapboxDescriptor();
+    // Guard the premise: the untransformed descriptor is what MapLibre rejects,
+    // and Style._load bails on the first validation error, blanking the map.
+    assert.deepEqual(
+      validateStyleMin(raw).map((error) => error.message),
+      ['name: unknown property "name"'],
+    );
+
+    assert.deepEqual(validateStyleMin(transformMapboxStyle(raw, "pk.token")), []);
+  });
+
+  it("resolves every mapbox:// URL with the encoded token", () => {
+    const style = transformMapboxStyle(mapboxDescriptor(), "pk a/b");
+    const encoded = encodeURIComponent("pk a/b");
+
+    assert.equal(
+      style.sprite,
+      `https://api.mapbox.com/styles/v1/mapbox/streets-v12/sprite?access_token=${encoded}`,
+    );
+    assert.equal(
+      style.glyphs,
+      `https://api.mapbox.com/fonts/v1/mapbox/{fontstack}/{range}.pbf?access_token=${encoded}`,
+    );
+    const composite = style.sources.composite as { url: string };
+    assert.equal(
+      composite.url,
+      `https://api.mapbox.com/v4/mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2.json?secure&access_token=${encoded}`,
+    );
+  });
+
+  it("pins the projection to mercator and leaves tile-backed sources alone", () => {
+    const style = transformMapboxStyle(mapboxDescriptor(), "tok");
+    // MapController.enforceProjection re-applies the user's own preference right
+    // after the style loads, so Mapbox's choice is deliberately not carried over.
+    assert.deepEqual(style.projection, { type: "mercator" });
+    assert.deepEqual(style.sources.hosted, {
+      type: "raster",
+      tiles: ["https://example.com/{z}/{x}/{y}.png"],
+    });
+  });
+
+  it("does not mutate the fetched descriptor", () => {
+    const raw = mapboxDescriptor();
+    transformMapboxStyle(raw, "tok");
+    assert.equal(raw.sprite, "mapbox://sprites/mapbox/streets-v12");
+    assert.deepEqual(raw.projection, { name: "globe" } as unknown as typeof raw.projection);
+  });
+});
+
+describe("getMapboxAccessToken", () => {
+  it("returns undefined when env is missing or blank", () => {
+    assert.equal(getMapboxAccessToken({}), undefined);
+    assert.equal(getMapboxAccessToken({ VITE_MAPBOX_ACCESS_TOKEN: "  " }), undefined);
+    assert.equal(getMapboxAccessToken({ MAPBOX_TOKEN: "" }), undefined);
+  });
+
+  it("prefers the VITE_ name and falls back to the bare MAPBOX_TOKEN", () => {
+    assert.equal(
+      getMapboxAccessToken({ VITE_MAPBOX_ACCESS_TOKEN: "  pk.prefixed  " }),
+      "pk.prefixed",
+    );
+    assert.equal(getMapboxAccessToken({ MAPBOX_TOKEN: "  pk.bare  " }), "pk.bare");
+    assert.equal(
+      getMapboxAccessToken({ VITE_MAPBOX_ACCESS_TOKEN: "pk.a", MAPBOX_TOKEN: "pk.b" }),
+      "pk.a",
+    );
+    assert.equal(
+      getMapboxAccessToken({ VITE_MAPBOX_ACCESS_TOKEN: "   ", MAPBOX_TOKEN: "pk.b" }),
+      "pk.b",
+    );
+  });
+});

--- a/tests/mapbox-style.test.ts
+++ b/tests/mapbox-style.test.ts
@@ -6,6 +6,7 @@ import type maplibregl from "maplibre-gl";
 import {
   isMapboxStyleUrl,
   mapboxAccessTokenFromStyleUrl,
+  redactMapboxStyleUrl,
   resolveMapboxInternalUrl,
   transformMapboxStyle,
 } from "../packages/map/src/mapbox-style";
@@ -68,9 +69,32 @@ describe("mapboxAccessTokenFromStyleUrl", () => {
     );
   });
 
+  it("trims a token padded by the query string", () => {
+    assert.equal(
+      mapboxAccessTokenFromStyleUrl(
+        "https://api.mapbox.com/styles/v1/mapbox/dark-v11?access_token=%20pk.token%20",
+      ),
+      "pk.token",
+    );
+  });
+
   it("returns an empty string when there is no token", () => {
     assert.equal(mapboxAccessTokenFromStyleUrl("https://api.mapbox.com/styles/v1/mapbox/x"), "");
     assert.equal(mapboxAccessTokenFromStyleUrl("nonsense"), "");
+  });
+});
+
+describe("redactMapboxStyleUrl", () => {
+  it("drops the query string so the access token never reaches a log", () => {
+    const redacted = redactMapboxStyleUrl(
+      "https://api.mapbox.com/styles/v1/mapbox/streets-v12?access_token=pk.secret",
+    );
+    assert.equal(redacted, "https://api.mapbox.com/styles/v1/mapbox/streets-v12");
+    assert.ok(!redacted.includes("pk.secret"));
+  });
+
+  it("never echoes an unparseable URL back", () => {
+    assert.equal(redactMapboxStyleUrl("not a url?access_token=pk.secret"), "(unparseable URL)");
   });
 });
 
@@ -151,6 +175,12 @@ describe("transformMapboxStyle", () => {
     transformMapboxStyle(raw, "tok");
     assert.equal(raw.sprite, "mapbox://sprites/mapbox/streets-v12");
     assert.deepEqual(raw.projection, { name: "globe" } as unknown as typeof raw.projection);
+    // Nested too: rewriting a source URL in place would leave the descriptor
+    // unusable for a retry while still passing the top-level assertions above.
+    assert.equal(
+      (raw.sources.composite as { url: string }).url,
+      "mapbox://mapbox.mapbox-streets-v8,mapbox.mapbox-terrain-v2",
+    );
   });
 });
 


### PR DESCRIPTION
## Problem

Every Mapbox basemap in the basemap control failed with

```
name: unknown property "name"
```

and left a blank map.

## Root cause

`maplibre-gl-basemap-control` applies a Mapbox style correctly: it calls `map.setStyle(url, { validate: false, transformStyle })`, where the transform rewrites the `mapbox://` sprite/glyphs/source URLs and replaces Mapbox's `projection: { name: … }` with the spec's `{ type: … }`.

GeoLibre is store-driven, though. The plugin writes the URL to `basemapStyleUrl`, and `MapController.setStyle` re-applies it with a plain `map.setStyle(url)` — no transform, validation on. MapLibre's validator then reports `projection.name` as unknown, and `Style._load` returns on the first validation error, so the whole style is discarded.

The exact message is reproducible against the live descriptor:

```js
validateStyleMin(await (await fetch('https://api.mapbox.com/styles/v1/mapbox/streets-v12?access_token=…')).json())
// [ 'name: unknown property "name"' ]   ← Mapbox ships projection: { name: "globe" }
```

Three of the eight styles (`satellite-v9`, `navigation-day-v1`, `navigation-night-v1`) carry no `projection` block, so they passed validation — and still rendered empty, because nothing resolves their `mapbox://` sprite, glyphs and sources.

## Fix

Teach GeoLibre's own style path about Mapbox rather than depending on the control's:

- **`packages/map/src/mapbox-style.ts`** (new) — detects `api.mapbox.com/styles/v1/…` URLs, fetches the descriptor, resolves every `mapbox://` URL against the public HTTPS endpoints, and pins the projection to the MapLibre spelling.
- **`MapController`** — `applyStyleToMap` routes Mapbox URLs through that loader and applies the result with `validate: false`; a generation counter drops a descriptor whose basemap the user has already switched away from. The constructor starts blank and applies asynchronously for the same reason.

Putting it here also fixes the paths the control is not part of: a **project reopened with a Mapbox basemap** and a **split-view pane**, both of which construct a `MapController` straight from the saved URL. The access token is read back out of the URL's `access_token` parameter — where the control put it — so applying a style needs no credential plumbing and a saved project stays self-contained.

Separately, `MAPBOX_TOKEN` / `VITE_MAPBOX_ACCESS_TOKEN` is now wired to the control's `mapboxAccessToken` option (same bare→prefixed Vite bridge as the Google Maps and Cesium keys), so the panel's API-keys field arrives pre-filled. Pushed only when set, matching the other panel-enterable providers.

No CSP change needed — both CSPs already allow `https:` in `connect-src` and `img-src`.

## Verification

Driven in a real browser against the dev server with a live Mapbox token:

- **Mapbox Streets** — descriptor, `sprite.json`, `sprite.png`, the v4 TileJSON and every `.vector.pbf` and font `.pbf` return 200; labels, roads and boundaries render. 0 console errors.
- **Mapbox Satellite** — `mapbox://mapbox.satellite` resolves and `.png` tiles return 200. 0 console errors.
- **Split view (two columns)** — the second pane, a fresh `MapController` built from the Mapbox URL, renders identically. This is the constructor path.
- **Back to OpenFreeMap Liberty** — non-Mapbox styles still switch cleanly afterwards, so nothing regressed.
- API-keys panel shows the Mapbox field pre-filled from the shell env.

`npm run test:frontend` — 4188 passing / 0 failing, including 12 new cases in `tests/mapbox-style.test.ts` that assert the untransformed descriptor is what MapLibre rejects and the transformed one validates clean. `npm run lint` (0 errors) and `npm run build` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Mapbox-hosted basemap style URLs, including async fetch/apply and Mapbox-to-MapLibre style transformation.
  * Exposed Mapbox-style utility APIs (URL detection, token extraction, redaction, internal URL rewriting, style loading).
  * Added runtime Mapbox access-token retrieval and propagated it into the basemap control when available.
* **Bug Fixes**
  * Prevented stale/out-of-order async style loads from overwriting newer selections.
  * If a Mapbox style fails to load, the currently applied style remains unchanged.
* **Tests**
  * Added comprehensive tests for Mapbox URL detection, token parsing/redaction, URL rewriting, and style transformation.
  * Added MapController tests covering cancellation behavior for Mapbox descriptor fetches.
* **Chores**
  * Improved build-time environment variable bridging for Mapbox tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->