### PR TITLE
fix: enable symbology attributes for tiled vector layers

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -82,7 +82,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.8.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.1",
+    "maplibre-gl-vector": "^0.10.2",
     "openai": "^7.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/apps/geolibre-desktop/src/components/panels/StyleManagerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StyleManagerPanel.tsx
@@ -41,7 +41,10 @@ import { useTranslation } from "react-i18next";
 import { clamp } from "../../lib/clamp";
 import { isQmlStyleXml } from "../../lib/style-format";
 import { openLocalDataFileWithFallback, saveTextFileWithFallback } from "../../lib/tauri-io";
-import { createCategorizedStops, createGraduatedStops } from "./StylePanel";
+import {
+  createCategorizedStops,
+  createGraduatedStops,
+} from "../../lib/vector-style-classification";
 
 /** Default panel geometry (px); the user can drag it around the map area. */
 const PANEL_DEFAULT_W = 384;

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1055,6 +1055,7 @@ export function StylePanel({
     values: unknown[];
   } | null>(null);
   const [vectorPropertyValuesLoading, setVectorPropertyValuesLoading] = useState(false);
+  const [vectorPropertyValuesUnavailable, setVectorPropertyValuesUnavailable] = useState(false);
   // Which expression surface the shared Expression Builder is editing; null
   // when the builder is closed. Targets carry the owning layer id so an edit
   // can never be applied to a different layer than the one it was opened for
@@ -1164,6 +1165,7 @@ export function StylePanel({
     if (!needsValues) {
       setLoadedVectorPropertyValues(null);
       setVectorPropertyValuesLoading(false);
+      setVectorPropertyValuesUnavailable(false);
       return;
     }
 
@@ -1174,23 +1176,26 @@ export function StylePanel({
         : null,
     );
     setVectorPropertyValuesLoading(true);
+    setVectorPropertyValuesUnavailable(false);
     void getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
       .then((values) => {
         if (cancelled) return;
+        if (values === null) {
+          setLoadedVectorPropertyValues(null);
+          setVectorPropertyValuesUnavailable(true);
+          return;
+        }
         setLoadedVectorPropertyValues({
           layerId: layer.id,
           property: draftVectorStyleProperty,
-          values: values ?? [],
+          values,
         });
       })
       .catch((error) => {
         if (!cancelled) {
           console.error("[GeoLibre] Could not read vector attribute values", error);
-          setLoadedVectorPropertyValues({
-            layerId: layer.id,
-            property: draftVectorStyleProperty,
-            values: [],
-          });
+          setLoadedVectorPropertyValues(null);
+          setVectorPropertyValuesUnavailable(true);
         }
       })
       .finally(() => {
@@ -2107,6 +2112,11 @@ export function StylePanel({
           {vectorPropertyValuesLoading && (
             <p className="text-xs text-muted-foreground">{t("attributeTable.loadingAttributes")}</p>
           )}
+          {vectorPropertyValuesUnavailable && (
+            <p className="text-xs text-destructive">
+              {t("style.symbology.errorAttributesUnavailable")}
+            </p>
+          )}
         </div>
       )}
       {usesAttributeSymbology && (
@@ -2526,7 +2536,11 @@ export function StylePanel({
           type="button"
           size="sm"
           className="w-full"
-          disabled={!vectorStyleSettingsChanged || vectorPropertyValuesLoading}
+          disabled={
+            !vectorStyleSettingsChanged ||
+            vectorPropertyValuesLoading ||
+            vectorPropertyValuesUnavailable
+          }
           onClick={applyVectorStyleSettings}
         >
           {t("style.symbology.applyStyleType")}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -6,7 +6,6 @@ import {
   type ExpressionVariable,
   type FillPattern,
   type GeometryGeneratorType,
-  type GraduatedClassificationScheme,
   type LabelStyle,
   type LayerType,
   type LineDecoration,
@@ -18,9 +17,7 @@ import {
   type VectorStyleMode,
   type VectorStyleStop,
   collectDiagramData,
-  createGraduatedClassBreaks,
   geojsonHasZCoordinates,
-  interpolateRampColors,
   isStyleLibraryTargetLayer,
   parseJsonExpression,
   pluginOwnsPaint,
@@ -49,6 +46,7 @@ import {
   SKETCHES_SOURCE_KIND,
   TIME_SLIDER_SOURCE_KIND,
   countAtlasDroppedDiagrams,
+  getVectorLayerPropertyValues,
 } from "@geolibre/plugins";
 import { type MapController } from "@geolibre/map";
 import type { ParseKeys, TFunction } from "i18next";
@@ -87,6 +85,13 @@ import {
   getAttributePropertyNames,
   standardExpressionVariables,
 } from "../../lib/expression-inputs";
+import {
+  clampClassCount,
+  createCategorizedStops,
+  createGraduatedStops,
+  getPropertyValues,
+  numericBounds,
+} from "../../lib/vector-style-classification";
 
 /**
  * Data-defined label overrides (GH #1320): one row per {@link LabelStyle}
@@ -492,23 +497,6 @@ function RuleNumberInput({
   );
 }
 
-function getPropertyValues(
-  layer: {
-    geojson?: {
-      features?: Array<{
-        properties?: Record<string, unknown> | null;
-      }>;
-    };
-  },
-  property: string,
-): unknown[] {
-  if (!property) return [];
-
-  return (layer.geojson?.features ?? [])
-    .map((feature) => feature.properties?.[property])
-    .filter((value) => value !== null && value !== undefined);
-}
-
 const VECTOR_STYLE_COLORS = ["#2563eb", "#16a34a", "#f59e0b", "#dc2626", "#7c3aed", "#0891b2"];
 
 const VECTOR_STYLE_CLASS_COUNTS = Array.from({ length: 12 }, (_, index) => index + 1);
@@ -531,87 +519,6 @@ const CATEGORIZED_CLASSIFICATION_SCHEMES: ReadonlyArray<{
   { value: "first-values", labelKey: "style.symbology.schemeFirstValues" },
 ];
 
-// Exported for the Style Manager, which regenerates a layer's stops when a
-// ramp preset is applied to an already-classified layer.
-export function createGraduatedStops(
-  layer: Parameters<typeof getPropertyValues>[0],
-  property: string,
-  classCount: number,
-  colorRamp: string,
-  classificationScheme: string,
-): VectorStyleStop[] {
-  const values = getPropertyValues(layer, property)
-    .map((value) => Number(value))
-    .filter(Number.isFinite);
-  const count = clampClassCount(classCount, 2);
-  const colors = interpolateRampColors(colorRamp, count);
-  if (values.length === 0) {
-    return colors.map((color, index) => ({ value: index, color }));
-  }
-
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  if (min === max) return [{ value: min, color: colors.at(-1) ?? "#2563eb" }];
-
-  // The breaks are class lower bounds, so `count` classes give `count` stops
-  // and the top class is open-ended above (see createGraduatedClassBreaks).
-  // normalizeClassificationScheme keeps the scheme to the three known values;
-  // anything else classifies as equal interval, as it did before.
-  const breaks = createGraduatedClassBreaks(
-    values,
-    count,
-    classificationScheme as GraduatedClassificationScheme,
-  );
-
-  // Any scheme can yield fewer breaks than the requested count when the layer
-  // has few unique values (duplicate breaks collapse); align the color count so
-  // none are dropped.
-  const stopColors =
-    breaks.length === count ? colors : interpolateRampColors(colorRamp, breaks.length);
-
-  return breaks.map((value, index) => ({
-    value: Number(value.toPrecision(8)),
-    color: stopColors[index] ?? stopColors.at(-1) ?? "#2563eb",
-  }));
-}
-
-// Exported for the Style Manager (see createGraduatedStops above).
-export function createCategorizedStops(
-  layer: Parameters<typeof getPropertyValues>[0],
-  property: string,
-  classCount: number,
-  colorRamp: string,
-  classificationScheme: string,
-): VectorStyleStop[] {
-  const counts = new Map<string, number>();
-  const firstSeen = new Map<string, number>();
-  for (const value of getPropertyValues(layer, property)) {
-    const key = String(value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-    if (!firstSeen.has(key)) firstSeen.set(key, firstSeen.size);
-  }
-
-  const count = clampClassCount(classCount, 1);
-  const categories = Array.from(counts.entries()).sort((a, b) => {
-    if (classificationScheme === "alphabetical") {
-      return a[0].localeCompare(b[0], undefined, {
-        numeric: true,
-        sensitivity: "base",
-      });
-    }
-    if (classificationScheme === "first-values") {
-      return (firstSeen.get(a[0]) ?? 0) - (firstSeen.get(b[0]) ?? 0);
-    }
-    return b[1] - a[1] || a[0].localeCompare(b[0]);
-  });
-  const colors = interpolateRampColors(colorRamp, Math.min(count, categories.length || count));
-
-  return categories.slice(0, count).map(([value], index) => ({
-    value,
-    color: colors[index] ?? nextStopColor(index),
-  }));
-}
-
 function createDefaultStops(
   layer: Parameters<typeof getPropertyValues>[0],
   mode: VectorStyleMode,
@@ -619,19 +526,29 @@ function createDefaultStops(
   classCount: number,
   colorRamp: string,
   classificationScheme: string,
+  propertyValues?: unknown[],
 ): VectorStyleStop[] {
   if (mode === "graduated") {
-    return createGraduatedStops(layer, property, classCount, colorRamp, classificationScheme);
+    return createGraduatedStops(
+      layer,
+      property,
+      classCount,
+      colorRamp,
+      classificationScheme,
+      propertyValues,
+    );
   }
   if (mode === "categorized") {
-    return createCategorizedStops(layer, property, classCount, colorRamp, classificationScheme);
+    return createCategorizedStops(
+      layer,
+      property,
+      classCount,
+      colorRamp,
+      classificationScheme,
+      propertyValues,
+    );
   }
   return styleValue(DEFAULT_LAYER_STYLE, "vectorStyleStops");
-}
-
-function clampClassCount(value: number, min: number): number {
-  if (!Number.isFinite(value)) return min;
-  return Math.min(12, Math.max(min, Math.round(value)));
 }
 
 function normalizeVectorStyleClassCount(mode: VectorStyleMode, value: number): number {
@@ -660,7 +577,9 @@ function chooseDefaultStyleProperty(
     if (currentProperty && isNumericProperty(layer, currentProperty)) {
       return currentProperty;
     }
-    return chooseGraduatedProperty(layer, properties);
+    return (
+      chooseGraduatedProperty(layer, properties) || (!layer.geojson ? (properties[0] ?? "") : "")
+    );
   }
 
   if (mode === "categorized") {
@@ -697,7 +616,8 @@ function chooseGraduatedProperty(
       .filter(Number.isFinite);
     if (values.length < 2) continue;
 
-    const range = Math.max(...values) - Math.min(...values);
+    const { min, max } = numericBounds(values);
+    const range = max - min;
     const score = new Set(values).size * Math.log10(Math.max(1, range) + 1);
     if (score > bestScore) {
       bestProperty = property;
@@ -1129,6 +1049,12 @@ export function StylePanel({
   );
   const [vectorStyleError, setVectorStyleError] = useState<string | null>(null);
   const [extrusionError, setExtrusionError] = useState<string | null>(null);
+  const [loadedVectorPropertyValues, setLoadedVectorPropertyValues] = useState<{
+    layerId: string;
+    property: string;
+    values: unknown[];
+  } | null>(null);
+  const [vectorPropertyValuesLoading, setVectorPropertyValuesLoading] = useState(false);
   // Which expression surface the shared Expression Builder is editing; null
   // when the builder is closed. Targets carry the owning layer id so an edit
   // can never be applied to a different layer than the one it was opened for
@@ -1222,6 +1148,96 @@ export function StylePanel({
     layer?.style.vectorStyleMode,
     layer?.style.vectorStyleProperty,
     layer?.style.vectorStyleStops,
+  ]);
+
+  // Add Vector Layer keeps large tiled datasets in DuckDB instead of copying
+  // their geometry into the app store. Read only the selected attribute when
+  // classification needs its values, so categorized and graduated styling
+  // remain available without defeating tiled rendering.
+  useEffect(() => {
+    const needsValues =
+      layer?.metadata.sourceKind === "maplibre-gl-vector" &&
+      !layer.geojson &&
+      (draftVectorStyleMode === "graduated" || draftVectorStyleMode === "categorized") &&
+      draftVectorStyleProperty !== "";
+
+    if (!needsValues) {
+      setLoadedVectorPropertyValues(null);
+      setVectorPropertyValuesLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadedVectorPropertyValues((current) =>
+      current?.layerId === layer.id && current.property === draftVectorStyleProperty
+        ? current
+        : null,
+    );
+    setVectorPropertyValuesLoading(true);
+    void getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
+      .then((values) => {
+        if (cancelled) return;
+        setLoadedVectorPropertyValues({
+          layerId: layer.id,
+          property: draftVectorStyleProperty,
+          values: values ?? [],
+        });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("[GeoLibre] Could not read vector attribute values", error);
+          setLoadedVectorPropertyValues({
+            layerId: layer.id,
+            property: draftVectorStyleProperty,
+            values: [],
+          });
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setVectorPropertyValuesLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    draftVectorStyleMode,
+    draftVectorStyleProperty,
+    layer?.geojson,
+    layer?.id,
+    layer?.metadata.sourceKind,
+  ]);
+
+  useEffect(() => {
+    if (
+      !layer ||
+      !loadedVectorPropertyValues ||
+      loadedVectorPropertyValues.layerId !== layer.id ||
+      loadedVectorPropertyValues.property !== draftVectorStyleProperty ||
+      (draftVectorStyleMode !== "graduated" && draftVectorStyleMode !== "categorized")
+    ) {
+      return;
+    }
+
+    setDraftVectorStyleStops(
+      createDefaultStops(
+        layer,
+        draftVectorStyleMode,
+        draftVectorStyleProperty,
+        draftVectorStyleClassCount,
+        draftVectorStyleColorRamp,
+        draftVectorStyleClassificationScheme,
+        loadedVectorPropertyValues.values,
+      ),
+    );
+  }, [
+    draftVectorStyleClassCount,
+    draftVectorStyleClassificationScheme,
+    draftVectorStyleColorRamp,
+    draftVectorStyleMode,
+    draftVectorStyleProperty,
+    layer,
+    loadedVectorPropertyValues,
   ]);
 
   // Reset the "show basemap layers" advanced toggle back to its clean default
@@ -1526,6 +1542,11 @@ export function StylePanel({
     draftVectorStyleClassificationScheme !== styleValue(style, "vectorStyleClassificationScheme") ||
     draftVectorStyleExpression !== styleValue(style, "vectorStyleExpression") ||
     JSON.stringify(draftVectorStyleStops) !== JSON.stringify(currentVectorStops);
+  const draftVectorPropertyValues =
+    loadedVectorPropertyValues?.layerId === layer.id &&
+    loadedVectorPropertyValues.property === draftVectorStyleProperty
+      ? loadedVectorPropertyValues.values
+      : undefined;
   const regenerateDraftVectorStyleStops = (
     mode: VectorStyleMode,
     property: string,
@@ -1534,7 +1555,15 @@ export function StylePanel({
     classificationScheme: string,
   ) => {
     setDraftVectorStyleStops(
-      createDefaultStops(layer, mode, property, classCount, colorRamp, classificationScheme),
+      createDefaultStops(
+        layer,
+        mode,
+        property,
+        classCount,
+        colorRamp,
+        classificationScheme,
+        property === draftVectorStyleProperty ? draftVectorPropertyValues : undefined,
+      ),
     );
   };
   const extrusionSettingsChanged =
@@ -2072,6 +2101,9 @@ export function StylePanel({
               ))
             )}
           </Select>
+          {vectorPropertyValuesLoading && (
+            <p className="text-xs text-muted-foreground">{t("attributeTable.loadingAttributes")}</p>
+          )}
         </div>
       )}
       {usesAttributeSymbology && (
@@ -2491,7 +2523,7 @@ export function StylePanel({
           type="button"
           size="sm"
           className="w-full"
-          disabled={!vectorStyleSettingsChanged}
+          disabled={!vectorStyleSettingsChanged || vectorPropertyValuesLoading}
           onClick={applyVectorStyleSettings}
         >
           {t("style.symbology.applyStyleType")}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1211,6 +1211,7 @@ export function StylePanel({
   useEffect(() => {
     if (
       !layer ||
+      layer.metadata.sourceKind !== "maplibre-gl-vector" ||
       !loadedVectorPropertyValues ||
       loadedVectorPropertyValues.layerId !== layer.id ||
       loadedVectorPropertyValues.property !== draftVectorStyleProperty ||
@@ -1221,7 +1222,7 @@ export function StylePanel({
 
     setDraftVectorStyleStops(
       createDefaultStops(
-        layer,
+        { geojson: layer.geojson },
         draftVectorStyleMode,
         draftVectorStyleProperty,
         draftVectorStyleClassCount,
@@ -1236,7 +1237,9 @@ export function StylePanel({
     draftVectorStyleColorRamp,
     draftVectorStyleMode,
     draftVectorStyleProperty,
-    layer,
+    layer?.geojson,
+    layer?.id,
+    layer?.metadata.sourceKind,
     loadedVectorPropertyValues,
   ]);
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3985,6 +3985,7 @@
       "schemeAlphabetical": "Alphabetical",
       "schemeFirstValues": "First values",
       "errorChooseAttribute": "Choose an attribute for this style mode.",
+      "errorAttributesUnavailable": "Could not load this layer's attribute values.",
       "errorGraduatedStops": "Graduated style requires at least two numeric stops.",
       "errorCategorizedStops": "Categorized style requires at least one category.",
       "invertedFill": "Inverted fill",

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -60,6 +60,7 @@ export function createGraduatedStops(
   propertyValues?: unknown[],
 ): VectorStyleStop[] {
   const values = (propertyValues ?? getPropertyValues(layer, property))
+    .filter((value) => value !== null && value !== undefined)
     .map((value) => Number(value))
     .filter(Number.isFinite);
   const count = clampClassCount(classCount, 2);
@@ -88,7 +89,7 @@ export function createGraduatedStops(
     breaks.length === count ? colors : interpolateRampColors(colorRamp, breaks.length);
 
   return breaks.map((value, index) => ({
-    value: Number(value.toPrecision(8)),
+    value,
     color: stopColors[index] ?? stopColors.at(-1) ?? "#2563eb",
   }));
 }
@@ -104,31 +105,51 @@ export function createCategorizedStops(
   classificationScheme: string,
   propertyValues?: unknown[],
 ): VectorStyleStop[] {
-  const counts = new Map<string, number>();
-  const firstSeen = new Map<string, number>();
+  const categories = new Map<
+    string,
+    {
+      value: string | number;
+      count: number;
+      firstSeen: number;
+    }
+  >();
   for (const value of propertyValues ?? getPropertyValues(layer, property)) {
-    const key = String(value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-    if (!firstSeen.has(key)) firstSeen.set(key, firstSeen.size);
+    if (typeof value !== "string" && (typeof value !== "number" || !Number.isFinite(value))) {
+      continue;
+    }
+    const key = `${typeof value}:${String(value)}`;
+    const category = categories.get(key);
+    if (category) {
+      category.count += 1;
+    } else {
+      categories.set(key, {
+        value,
+        count: 1,
+        firstSeen: categories.size,
+      });
+    }
   }
 
   const count = clampClassCount(classCount, 1);
-  const categories = Array.from(counts.entries()).sort((a, b) => {
+  const sortedCategories = Array.from(categories.values()).sort((a, b) => {
     if (classificationScheme === "alphabetical") {
-      return a[0].localeCompare(b[0], undefined, {
+      return String(a.value).localeCompare(String(b.value), undefined, {
         numeric: true,
         sensitivity: "base",
       });
     }
     if (classificationScheme === "first-values") {
-      return (firstSeen.get(a[0]) ?? 0) - (firstSeen.get(b[0]) ?? 0);
+      return a.firstSeen - b.firstSeen;
     }
-    return b[1] - a[1] || a[0].localeCompare(b[0]);
+    return b.count - a.count || String(a.value).localeCompare(String(b.value));
   });
-  const colors = interpolateRampColors(colorRamp, Math.min(count, categories.length || count));
+  const colors = interpolateRampColors(
+    colorRamp,
+    Math.min(count, sortedCategories.length || count),
+  );
 
-  return categories.slice(0, count).map(([value], index) => ({
-    value,
+  return sortedCategories.slice(0, count).map((category, index) => ({
+    value: category.value,
     color:
       colors[index] ??
       CLASSIFICATION_FALLBACK_COLORS[index % CLASSIFICATION_FALLBACK_COLORS.length]!,

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -1,0 +1,136 @@
+import {
+  type GraduatedClassificationScheme,
+  type VectorStyleStop,
+  createGraduatedClassBreaks,
+  interpolateRampColors,
+} from "@geolibre/core";
+
+interface ClassifiableLayer {
+  geojson?: {
+    features?: Array<{
+      properties?: Record<string, unknown> | null;
+    }>;
+  };
+}
+
+const CLASSIFICATION_FALLBACK_COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#f59e0b",
+  "#dc2626",
+  "#7c3aed",
+  "#0891b2",
+];
+
+/** Return the non-null values of a GeoJSON property. */
+export function getPropertyValues(layer: ClassifiableLayer, property: string): unknown[] {
+  if (!property) return [];
+
+  return (layer.geojson?.features ?? [])
+    .map((feature) => feature.properties?.[property])
+    .filter((value) => value !== null && value !== undefined);
+}
+
+/** Find numeric bounds without spreading a potentially large array. */
+export function numericBounds(values: number[]): { min: number; max: number } {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return { min, max };
+}
+
+/** Clamp a requested class count to the supported range. */
+export function clampClassCount(value: number, min: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(12, Math.max(min, Math.round(value)));
+}
+
+/**
+ * Create graduated color stops from GeoJSON or separately loaded property values.
+ */
+export function createGraduatedStops(
+  layer: ClassifiableLayer,
+  property: string,
+  classCount: number,
+  colorRamp: string,
+  classificationScheme: string,
+  propertyValues?: unknown[],
+): VectorStyleStop[] {
+  const values = (propertyValues ?? getPropertyValues(layer, property))
+    .map((value) => Number(value))
+    .filter(Number.isFinite);
+  const count = clampClassCount(classCount, 2);
+  const colors = interpolateRampColors(colorRamp, count);
+  if (values.length === 0) {
+    return colors.map((color, index) => ({ value: index, color }));
+  }
+
+  const { min, max } = numericBounds(values);
+  if (min === max) return [{ value: min, color: colors.at(-1) ?? "#2563eb" }];
+
+  // The breaks are class lower bounds, so `count` classes give `count` stops
+  // and the top class is open-ended above (see createGraduatedClassBreaks).
+  // normalizeClassificationScheme keeps the scheme to the three known values;
+  // anything else classifies as equal interval, as it did before.
+  const breaks = createGraduatedClassBreaks(
+    values,
+    count,
+    classificationScheme as GraduatedClassificationScheme,
+  );
+
+  // Any scheme can yield fewer breaks than the requested count when the layer
+  // has few unique values (duplicate breaks collapse); align the color count so
+  // none are dropped.
+  const stopColors =
+    breaks.length === count ? colors : interpolateRampColors(colorRamp, breaks.length);
+
+  return breaks.map((value, index) => ({
+    value: Number(value.toPrecision(8)),
+    color: stopColors[index] ?? stopColors.at(-1) ?? "#2563eb",
+  }));
+}
+
+/**
+ * Create categorized color stops from GeoJSON or separately loaded property values.
+ */
+export function createCategorizedStops(
+  layer: ClassifiableLayer,
+  property: string,
+  classCount: number,
+  colorRamp: string,
+  classificationScheme: string,
+  propertyValues?: unknown[],
+): VectorStyleStop[] {
+  const counts = new Map<string, number>();
+  const firstSeen = new Map<string, number>();
+  for (const value of propertyValues ?? getPropertyValues(layer, property)) {
+    const key = String(value);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    if (!firstSeen.has(key)) firstSeen.set(key, firstSeen.size);
+  }
+
+  const count = clampClassCount(classCount, 1);
+  const categories = Array.from(counts.entries()).sort((a, b) => {
+    if (classificationScheme === "alphabetical") {
+      return a[0].localeCompare(b[0], undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    }
+    if (classificationScheme === "first-values") {
+      return (firstSeen.get(a[0]) ?? 0) - (firstSeen.get(b[0]) ?? 0);
+    }
+    return b[1] - a[1] || a[0].localeCompare(b[0]);
+  });
+  const colors = interpolateRampColors(colorRamp, Math.min(count, categories.length || count));
+
+  return categories.slice(0, count).map(([value], index) => ({
+    value,
+    color:
+      colors[index] ??
+      CLASSIFICATION_FALLBACK_COLORS[index % CLASSIFICATION_FALLBACK_COLORS.length]!,
+  }));
+}

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -48,6 +48,14 @@ export function clampClassCount(value: number, min: number): number {
   return Math.min(12, Math.max(min, Math.round(value)));
 }
 
+/** Convert a scalar numeric property value without coercing blanks or non-scalars. */
+function finitePropertyNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
 /**
  * Create graduated color stops from GeoJSON or separately loaded property values.
  */
@@ -60,9 +68,8 @@ export function createGraduatedStops(
   propertyValues?: unknown[],
 ): VectorStyleStop[] {
   const values = (propertyValues ?? getPropertyValues(layer, property))
-    .filter((value) => value !== null && value !== undefined)
-    .map((value) => Number(value))
-    .filter(Number.isFinite);
+    .map(finitePropertyNumber)
+    .filter((value): value is number => value !== null);
   const count = clampClassCount(classCount, 2);
   const colors = interpolateRampColors(colorRamp, count);
   if (values.length === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.8.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.1",
+        "maplibre-gl-vector": "^0.10.2",
         "openai": "^7.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17281,9 +17281,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.1.tgz",
-      "integrity": "sha512-1LZa8jGJ449gw6iaNX6J6y+apAUaerZtbWflGevmjNWIi0wBSJHM2sZV2L55F+30oakAL8JBOnS07G3YMDDoOw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.2.tgz",
+      "integrity": "sha512-1g4ro9lkCxAalvQ+OMCTu96df5za8rOOYBmVXKnLNCCIzn8dYEoZIsFK74pLiOoreLLp6/3AeRdOaOcekXqtiA==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21917,7 +21917,7 @@
         "maplibre-gl-swipe": "^0.11.0",
         "maplibre-gl-time-slider": "^1.8.0",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.1",
+        "maplibre-gl-vector": "^0.10.2",
         "netcdfjs": "^4.0.0",
         "pbf": "^5.1.2",
         "pmtiles": "^4.4.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl-swipe": "^0.11.0",
     "maplibre-gl-time-slider": "^1.8.0",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.1",
+    "maplibre-gl-vector": "^0.10.2",
     "netcdfjs": "^4.0.0",
     "pbf": "^5.1.2",
     "pmtiles": "^4.4.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -224,6 +224,7 @@ export { colormapColors, warmColormapColors } from "./plugins/colormap-colors";
 export { setTerrainMeasureLabels } from "./plugins/terrain-measure";
 export {
   closeVectorLayerPanel,
+  getVectorLayerPropertyValues,
   materializeEmbeddableVectorLayers,
   openVectorLayerPanel,
   reloadVectorControlLayer,

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -167,6 +167,20 @@ export async function reloadVectorControlLayer(id: string): Promise<VectorLayerI
 }
 
 /**
+ * Reads one Add Vector Layer attribute without materializing tiled geometry.
+ *
+ * @param id The store/control layer id.
+ * @param property The attribute field name.
+ * @returns Non-null field values, or null when the control cannot read them.
+ */
+export function getVectorLayerPropertyValues(
+  id: string,
+  property: string,
+): Promise<unknown[] | null> {
+  return vectorControl?.getLayerPropertyValues(id, property) ?? Promise.resolve(null);
+}
+
+/**
  * Replays URL-backed vector layers from the loaded project into the
  * control and drops control layers the project does not contain. Called by
  * the desktop shell whenever a project is loaded or the map is

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -173,11 +173,11 @@ export async function reloadVectorControlLayer(id: string): Promise<VectorLayerI
  * @param property The attribute field name.
  * @returns Non-null field values, or null when the control cannot read them.
  */
-export function getVectorLayerPropertyValues(
+export async function getVectorLayerPropertyValues(
   id: string,
   property: string,
 ): Promise<unknown[] | null> {
-  return vectorControl?.getLayerPropertyValues(id, property) ?? Promise.resolve(null);
+  return vectorControl?.getLayerPropertyValues(id, property) ?? null;
 }
 
 /**

--- a/tests/vector-style-classification.test.ts
+++ b/tests/vector-style-classification.test.ts
@@ -41,4 +41,40 @@ describe("vector style classification", () => {
       [0, 29_999.8, 59_999.6, 89_999.4, 119_999.2],
     );
   });
+
+  it("ignores nullish numeric values", () => {
+    const stops = createGraduatedStops(tiledLayer, "height", 2, "viridis", "equal-interval", [
+      null,
+      10,
+      20,
+    ]);
+
+    assert.deepEqual(
+      stops.map((stop) => stop.value),
+      [10, 15],
+    );
+  });
+
+  it("preserves numeric category values", () => {
+    const stops = createCategorizedStops(tiledLayer, "rank", 2, "viridis", "top-values", [1, 2, 1]);
+
+    assert.deepEqual(
+      stops.map((stop) => stop.value),
+      [1, 2],
+    );
+  });
+
+  it("keeps adjacent high-magnitude breaks distinct", () => {
+    const stops = createGraduatedStops(
+      tiledLayer,
+      "population",
+      3,
+      "viridis",
+      "equal-interval",
+      [1_000_000_000, 1_000_000_000.5, 1_000_000_001],
+    );
+
+    assert.equal(stops.length, 3);
+    assert.equal(new Set(stops.map((stop) => stop.value)).size, 3);
+  });
 });

--- a/tests/vector-style-classification.test.ts
+++ b/tests/vector-style-classification.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createCategorizedStops,
+  createGraduatedStops,
+} from "../apps/geolibre-desktop/src/lib/vector-style-classification";
+
+const tiledLayer = {};
+
+describe("vector style classification", () => {
+  it("classifies separately loaded values for a tiled layer", () => {
+    const stops = createCategorizedStops(tiledLayer, "Cluster Name", 3, "viridis", "top-values", [
+      "South",
+      "Central",
+      "North",
+      "Central",
+      "South",
+      "Central",
+    ]);
+
+    assert.deepEqual(
+      stops.map((stop) => stop.value),
+      ["Central", "South", "North"],
+    );
+  });
+
+  it("handles more values than function argument limits allow", () => {
+    const values = Array.from({ length: 150_000 }, (_, index) => index);
+    const stops = createGraduatedStops(
+      tiledLayer,
+      "height",
+      5,
+      "viridis",
+      "equal-interval",
+      values,
+    );
+
+    assert.equal(stops.length, 5);
+    assert.deepEqual(
+      stops.map((stop) => stop.value),
+      [0, 29_999.8, 59_999.6, 89_999.4, 119_999.2],
+    );
+  });
+});

--- a/tests/vector-style-classification.test.ts
+++ b/tests/vector-style-classification.test.ts
@@ -55,6 +55,21 @@ describe("vector style classification", () => {
     );
   });
 
+  it("does not coerce blank or non-scalar values to zero", () => {
+    const stops = createGraduatedStops(tiledLayer, "height", 2, "viridis", "equal-interval", [
+      "",
+      false,
+      [],
+      10,
+      "20",
+    ]);
+
+    assert.deepEqual(
+      stops.map((stop) => stop.value),
+      [10, 15],
+    );
+  });
+
   it("preserves numeric category values", () => {
     const stops = createCategorizedStops(tiledLayer, "rank", 2, "viridis", "top-values", [1, 2, 1]);
 


### PR DESCRIPTION
## Summary

- upgrade `maplibre-gl-vector` to 0.10.2 so tiled layers expose their attribute fields and selected column values
- load only the selected attribute for categorized and graduated styling without materializing tiled geometry
- handle large numeric columns without exceeding JavaScript function argument limits
- move classification helpers into a testable module and add regression coverage

Upstream support: opengeos/maplibre-gl-vector#47
Release: https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.10.2

Fixes #1475

## Testing

- `pre-commit run --all-files`
- frontend test suite with coverage
- worker type checks
- Rust check
- Playwright verification with a 60,000-feature GeoPackage in light categorized and dark graduated modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added categorized and graduated vector styling driven by attribute values in tiled vector layers (including when GeoJSON data isn’t in memory).
  * Introduced async attribute-value loading with clear UI feedback and safer “apply styling” behavior.
* **Bug Fixes**
  * Avoided unnecessary stop regeneration by reusing already-loaded attribute values.
  * Prevented applying vector styling while attribute values are unavailable.
* **Tests**
  * Added automated tests for categorized and graduated stop generation edge cases.
* **Chores**
  * Updated the vector rendering dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->