### PR TITLE
fix(runtime): use bundled PROJ data in managed sidecars

### DIFF
--- a/backend/geolibre_server/geolibre_server/app/runtime.py
+++ b/backend/geolibre_server/geolibre_server/app/runtime.py
@@ -60,6 +60,10 @@ def _clean_env() -> dict[str, str]:
     """Return a Python subprocess environment suitable for extension imports."""
     env = dict(os.environ)
     env.pop("PYTHONHOME", None)
+    # PyPI geospatial wheels bundle a matching PROJ database. Inherited search
+    # paths can redirect them to an absent or incompatible system installation.
+    env.pop("PROJ_DATA", None)
+    env.pop("PROJ_LIB", None)
     env["PYTHONIOENCODING"] = "utf-8"
     env["PYTHONUTF8"] = "1"
     return env

--- a/backend/geolibre_server/tests/test_runtime.py
+++ b/backend/geolibre_server/tests/test_runtime.py
@@ -1,0 +1,22 @@
+"""Tests for shared managed-runtime environment handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from geolibre_server.app.runtime import _clean_env
+
+
+def test_clean_env_drops_inherited_proj_search_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed geospatial wheels must discover their own bundled PROJ data."""
+    monkeypatch.setenv("PROJ_DATA", "/system/share/proj")
+    monkeypatch.setenv("PROJ_LIB", "/legacy/system/share/proj")
+    monkeypatch.setenv("GEOLIBRE_RUNTIME_DIR", "/managed/geolibre")
+
+    env = _clean_env()
+
+    assert "PROJ_DATA" not in env
+    assert "PROJ_LIB" not in env
+    assert env["GEOLIBRE_RUNTIME_DIR"] == "/managed/geolibre"


### PR DESCRIPTION
## Summary

- Remove inherited `PROJ_DATA` and `PROJ_LIB` values from managed Python subprocess environments.
- Allow Rasterio/GDAL wheels to discover their compatible bundled `proj.db`.
- Add regression coverage confirming PROJ search paths are removed while unrelated environment variables are preserved.

## Context

This addresses the `Cannot find proj.db` error reported on Windows in #1354. The failure is consistent with inherited PROJ search paths redirecting the managed geospatial environment away from the database bundled with its installed wheels.

## Testing

- `python -m pytest tests/test_runtime.py -q`
- Result: `1 passed`

Fixes #1354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed runtime setup by preventing inherited PROJ environment settings from redirecting geospatial components to incompatible or unavailable installations.
  * Preserved the configured runtime directory while cleaning environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->