### PR TITLE
feat(release): embed AppImage update information and publish zsync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,17 +123,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name }}
-          # Read from the action's own output rather than globbing the bundle
-          # directory, which also holds the AppImage-packaged build tools.
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
-          mapfile -t images < <(jq -r '.[] | select(endswith(".AppImage"))' <<< "$ARTIFACT_PATHS")
-          if [[ ${#images[@]} -ne 1 ]]; then
-            echo "::error::Expected exactly one AppImage artifact, found ${#images[@]}"
-            exit 1
-          fi
-          scripts/embed-appimage-update-info.sh "${images[0]}"
-          gh release upload "$TAG" "${images[0]}" "${images[0]}.zsync" --clobber
+          image="$(scripts/select-single-appimage.sh "$ARTIFACT_PATHS")"
+          scripts/embed-appimage-update-info.sh "$image"
+          gh release upload "$TAG" "$image" "$image.zsync" --clobber
 
       - name: Build MSIX package
         id: build_msix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,14 @@ jobs:
             libxdo-dev \
             patchelf \
             rpm \
-            wget
+            wget \
+            zsync
 
       - name: Install frontend dependencies
         run: npm ci
 
       - name: Build and upload release assets
+        id: tauri
         uses: tauri-apps/tauri-action@v1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -106,6 +108,32 @@ jobs:
           tagName: ${{ github.event.release.tag_name }}
           args: ${{ matrix.args }}
           uploadPlainBinary: true
+
+      # Tauri's bundler leaves the AppImage runtime's 1 KiB `.upd_info` section
+      # zeroed, so AppImageUpdate, AppImageLauncher, AppManager and AM all
+      # report "no update information" and refuse to update the image. Fill it
+      # in and publish the matching `.zsync` so those tools fetch only the
+      # blocks that changed (~4 KiB in practice) instead of the whole ~120 MB
+      # image. The patched AppImage replaces the one tauri-action just attached:
+      # it differs only in that section, but the `.zsync` checksums have to
+      # describe the file actually being served.
+      - name: Embed AppImage update information
+        if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+          # Read from the action's own output rather than globbing the bundle
+          # directory, which also holds the AppImage-packaged build tools.
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: |
+          mapfile -t images < <(jq -r '.[] | select(endswith(".AppImage"))' <<< "$ARTIFACT_PATHS")
+          if [[ ${#images[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly one AppImage artifact, found ${#images[@]}"
+            exit 1
+          fi
+          scripts/embed-appimage-update-info.sh "${images[0]}"
+          gh release upload "$TAG" "${images[0]}" "${images[0]}.zsync" --clobber
 
       - name: Build MSIX package
         id: build_msix

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -162,13 +162,9 @@ jobs:
           TAG: v${{ steps.tauri.outputs.appVersion }}
           ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
         run: |
-          mapfile -t images < <(jq -r '.[] | select(endswith(".AppImage"))' <<< "$ARTIFACT_PATHS")
-          if [[ ${#images[@]} -ne 1 ]]; then
-            echo "::error::Expected exactly one AppImage artifact, found ${#images[@]}"
-            exit 1
-          fi
-          scripts/embed-appimage-update-info.sh "${images[0]}"
-          "${images[0]}" --appimage-updateinfo
+          image="$(scripts/select-single-appimage.sh "$ARTIFACT_PATHS")"
+          scripts/embed-appimage-update-info.sh "$image"
+          "$image" --appimage-updateinfo
 
       - name: Upload installers
         if: steps.want.outputs.build == 'true'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -110,7 +110,8 @@ jobs:
           workspaces: apps/geolibre-desktop/src-tauri -> target
 
       # Mirrors release.yml's Linux dependency list; libfuse2 and librsvg2-dev
-      # are needed for the AppImage bundle, rpm for the .rpm.
+      # are needed for the AppImage bundle, rpm for the .rpm, and zsync for the
+      # AppImage delta-update file.
       - name: Install Linux dependencies
         if: steps.want.outputs.build == 'true' && runner.os == 'Linux'
         run: |
@@ -127,7 +128,8 @@ jobs:
             libxdo-dev \
             patchelf \
             rpm \
-            wget
+            wget \
+            zsync
 
       - name: Install frontend dependencies
         if: steps.want.outputs.build == 'true'
@@ -138,6 +140,7 @@ jobs:
       # why no GITHUB_TOKEN is passed here -- the action only needs one to create
       # a release or upload assets to it, neither of which this workflow does.
       - name: Build the desktop bundles
+        id: tauri
         if: steps.want.outputs.build == 'true'
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0
         env:
@@ -146,6 +149,26 @@ jobs:
         with:
           projectPath: apps/geolibre-desktop
           args: ${{ matrix.args }}
+
+      # Same patch release.yml applies, minus the upload: it runs here so a
+      # break in the AppImage update information (a renamed bundle, a runtime
+      # without a .upd_info section) surfaces on a test build rather than
+      # halfway through a real release. The artifact uploaded below therefore
+      # carries the update information too.
+      - name: Embed AppImage update information
+        if: steps.want.outputs.build == 'true' && runner.os == 'Linux'
+        env:
+          REPO: ${{ github.repository }}
+          TAG: v${{ steps.tauri.outputs.appVersion }}
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: |
+          mapfile -t images < <(jq -r '.[] | select(endswith(".AppImage"))' <<< "$ARTIFACT_PATHS")
+          if [[ ${#images[@]} -ne 1 ]]; then
+            echo "::error::Expected exactly one AppImage artifact, found ${#images[@]}"
+            exit 1
+          fi
+          scripts/embed-appimage-update-info.sh "${images[0]}"
+          "${images[0]}" --appimage-updateinfo
 
       - name: Upload installers
         if: steps.want.outputs.build == 'true'

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -109,8 +109,9 @@ by Apple, so Gatekeeper allows them to open without any extra steps:
 
 GeoLibre offers several Linux install options. The AUR, COPR, and Flatpak
 packages auto-update (through your system package manager or `flatpak update`);
-the direct `.deb`, `.rpm`, and AppImage downloads are updated by re-downloading
-the new release.
+the AppImage updates itself in place with [AppImageUpdate](#appimage-any-distribution),
+and the direct `.deb` and `.rpm` downloads are updated by re-downloading the new
+release.
 
 ### Arch Linux / Manjaro (AUR)
 
@@ -171,6 +172,23 @@ chmod +x GeoLibre.Desktop_<version>_amd64.AppImage
 AppImages need FUSE. On distros that no longer ship it by default, install
 `libfuse2` (for example `sudo apt install libfuse2`) or run with
 `--appimage-extract-and-run`.
+
+#### Delta updates
+
+Releases after v2.3.0 embed update information in the AppImage, so
+[AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate),
+[AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher),
+[AppManager](https://github.com/kem-a/AppManager) and
+[AM](https://github.com/ivan-hc/AM) can update it in place. Each release also
+ships a `.zsync` file next to the AppImage, so an update transfers only the
+blocks that changed rather than the whole image:
+
+```bash
+appimageupdatetool GeoLibre.Desktop_<version>_amd64.AppImage
+```
+
+Check what an AppImage points at with
+`./GeoLibre.Desktop_<version>_amd64.AppImage --appimage-updateinfo`.
 
 ## Build from source
 

--- a/scripts/embed-appimage-update-info.sh
+++ b/scripts/embed-appimage-update-info.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Embed AppImage update information into a built AppImage and write the matching
+# zsync file next to it.
+#
+# An AppImage type-2 runtime reserves a 1 KiB `.upd_info` ELF section for a
+# single "update information" string. Tauri's bundler leaves it zeroed, so
+# AppImageUpdate, AppImageLauncher, AppManager and AM all report that the image
+# carries no update information and refuse to update it. Filling it in, plus
+# publishing a `.zsync` alongside the AppImage, lets those tools fetch only the
+# blocks that changed instead of the whole ~120 MB image.
+#
+# See https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information
+#
+# Usage:
+#   REPO=opengeos/GeoLibre TAG=v1.5.0 \
+#     scripts/embed-appimage-update-info.sh path/to/GeoLibre.Desktop_1.5.0_amd64.AppImage
+#
+#   # Print the update information string for a file name and exit (no writes):
+#   REPO=opengeos/GeoLibre TAG=v1.5.0 \
+#     scripts/embed-appimage-update-info.sh --print GeoLibre.Desktop_1.5.0_amd64.AppImage
+#
+# REPO (owner/name) and TAG (the release tag, e.g. v1.5.0) are both required.
+# The AppImage is patched in place, so run this before uploading it.
+set -euo pipefail
+
+: "${REPO:?Set REPO to the GitHub repository, e.g. opengeos/GeoLibre}"
+: "${TAG:?Set TAG to the release tag, e.g. v1.5.0}"
+
+print_only=false
+if [[ "${1:-}" == "--print" ]]; then
+  print_only=true
+  shift
+fi
+
+appimage="${1:?Pass the path to the .AppImage}"
+
+[[ "$REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || {
+  echo "REPO is not an owner/name pair: $REPO" >&2
+  exit 1
+}
+owner="${REPO%%/*}"
+name="${REPO##*/}"
+
+# The tag carries the version the bundler stamped into the file name.
+version="${TAG#v}"
+base="$(basename "$appimage")"
+
+# The update information has to match *every future* release, not just this one,
+# so the version in the file name becomes a glob. Rewriting it here (rather than
+# hard-coding the pattern) keeps the two in step, and the guard below turns a
+# future rename of the bundle into a loud failure instead of update information
+# that silently matches nothing.
+pattern="${base/_${version}_/_*_}"
+[[ "$pattern" != "$base" ]] || {
+  echo "AppImage name '$base' does not contain _${version}_; cannot derive a zsync pattern" >&2
+  exit 1
+}
+
+# `latest` makes the installed AppImage track the newest release rather than the
+# one it shipped in.
+update_information="gh-releases-zsync|${owner}|${name}|latest|${pattern}.zsync"
+
+if [[ "$print_only" == true ]]; then
+  printf '%s\n' "$update_information"
+  exit 0
+fi
+
+[[ -f "$appimage" ]] || {
+  echo "No such AppImage: $appimage" >&2
+  exit 1
+}
+
+# Columns of `objdump -h`: Idx Name Size VMA LMA "File off" Algn. The two hex
+# fields are converted in bash, not awk: `strtonum` is a gawk extension and the
+# Ubuntu runners' default awk is mawk.
+read -r size_hex offset_hex < <(
+  objdump -h "$appimage" | awk '$2 == ".upd_info" { print $3, $6; exit }'
+)
+[[ "${size_hex:-}" =~ ^[0-9a-fA-F]+$ && "${offset_hex:-}" =~ ^[0-9a-fA-F]+$ ]] || {
+  echo "No .upd_info section in $appimage; is it an AppImage type-2 runtime?" >&2
+  exit 1
+}
+size=$((16#$size_hex))
+offset=$((16#$offset_hex))
+(( size > 0 )) || {
+  echo "The .upd_info section in $appimage is empty" >&2
+  exit 1
+}
+# Leave room for the terminating NUL.
+(( ${#update_information} < size )) || {
+  echo "Update information (${#update_information} bytes) does not fit in the ${size}-byte .upd_info section" >&2
+  exit 1
+}
+
+# Overwrite the whole section, NUL-padded, rather than only the prefix: the
+# reader stops at the first NUL, so any leftover bytes would corrupt the string.
+# `dd` (not objcopy) because objcopy would rewrite the ELF and drop the squashfs
+# image appended after it.
+{
+  printf '%s' "$update_information"
+  head -c "$((size - ${#update_information}))" /dev/zero
+} | dd of="$appimage" bs=1 seek="$offset" count="$size" conv=notrunc status=none
+
+# Read it back so a silent short write cannot ship as a working AppImage.
+embedded="$(dd if="$appimage" bs=1 skip="$offset" count="$size" status=none | tr -d '\0')"
+[[ "$embedded" == "$update_information" ]] || {
+  echo "Verification failed: .upd_info holds '$embedded', expected '$update_information'" >&2
+  exit 1
+}
+echo "Embedded update information: $update_information"
+
+# zsync must be generated from the *patched* image, otherwise its checksums
+# describe a file that no longer exists. The URL is absolute so the client never
+# has to resolve it against the redirect GitHub serves release assets through.
+command -v zsyncmake >/dev/null || {
+  echo "zsyncmake not found; install the 'zsync' package" >&2
+  exit 1
+}
+zsyncmake \
+  -u "https://github.com/${REPO}/releases/download/${TAG}/${base}" \
+  -o "${appimage}.zsync" \
+  "$appimage"
+echo "Wrote ${appimage}.zsync"

--- a/scripts/select-single-appimage.sh
+++ b/scripts/select-single-appimage.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Print the one .AppImage path out of tauri-action's `artifactPaths` output.
+#
+# Both release.yml and test-build.yml have to hand exactly that path to
+# scripts/embed-appimage-update-info.sh. Reading the action's own output beats
+# globbing the bundle directory, which also holds the AppImage-packaged build
+# tools, and keeping the selection in one place stops the two workflows from
+# drifting apart.
+#
+# Usage:
+#   image="$(scripts/select-single-appimage.sh "$ARTIFACT_PATHS")"
+#
+# The argument is the JSON array tauri-action emits. Exits non-zero unless
+# exactly one entry ends in .AppImage, so a bundler change that stops producing
+# one (or starts producing several) fails the build rather than silently
+# patching the wrong file.
+set -euo pipefail
+
+# No apostrophe in the message: bash parses quotes inside ${var:?word}, so one
+# there would swallow the rest of the file.
+artifacts="${1:?Pass the artifactPaths JSON array from tauri-action}"
+
+mapfile -t images < <(jq -r '.[] | select(endswith(".AppImage"))' <<<"$artifacts")
+if [[ ${#images[@]} -ne 1 ]]; then
+  echo "Expected exactly one .AppImage in artifactPaths, found ${#images[@]}" >&2
+  exit 1
+fi
+printf '%s\n' "${images[0]}"

--- a/tests/appimage-update-info.test.ts
+++ b/tests/appimage-update-info.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// scripts/embed-appimage-update-info.sh derives the AppImage "update
+// information" string that the release workflow writes into the AppImage's
+// `.upd_info` ELF section. The zsync file name inside it is a glob built from
+// the bundle's own name, so a rename of the Tauri bundle would otherwise
+// produce update information that matches nothing and only fails on a user's
+// machine, months later, with "none of the artifacts matched the pattern".
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(repoRoot, "scripts", "embed-appimage-update-info.sh");
+
+function print(name: string, env: Record<string, string> = {}): string {
+  return execFileSync("bash", [script, "--print", name], {
+    env: { ...process.env, REPO: "opengeos/GeoLibre", TAG: "v2.3.0", ...env },
+    encoding: "utf8",
+    // Capture stderr instead of letting the failure cases print through to the
+    // test runner's own output.
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function printError(name: string, env: Record<string, string> = {}): string {
+  try {
+    print(name, env);
+  } catch (error) {
+    return String((error as { stderr?: Buffer }).stderr ?? "");
+  }
+  throw new Error(`expected embed-appimage-update-info.sh to fail for "${name}"`);
+}
+
+describe("embed-appimage-update-info.sh", () => {
+  it("derives gh-releases-zsync update information with the version globbed", () => {
+    assert.equal(
+      print("GeoLibre.Desktop_2.3.0_amd64.AppImage"),
+      "gh-releases-zsync|opengeos|GeoLibre|latest|GeoLibre.Desktop_*_amd64.AppImage.zsync",
+    );
+  });
+
+  it("takes the owner and repository from REPO", () => {
+    assert.equal(
+      print("GeoLibre.Desktop_2.3.0_amd64.AppImage", { REPO: "giswqs/Fork" }),
+      "gh-releases-zsync|giswqs|Fork|latest|GeoLibre.Desktop_*_amd64.AppImage.zsync",
+    );
+  });
+
+  it("accepts a full path, using only the file name in the pattern", () => {
+    assert.equal(
+      print("target/release/bundle/appimage/GeoLibre.Desktop_2.3.0_amd64.AppImage"),
+      "gh-releases-zsync|opengeos|GeoLibre|latest|GeoLibre.Desktop_*_amd64.AppImage.zsync",
+    );
+  });
+
+  it("fits in the 1 KiB .upd_info section", () => {
+    assert.ok(print("GeoLibre.Desktop_2.3.0_amd64.AppImage").length < 1024);
+  });
+
+  it("fails when the AppImage name does not carry the tag's version", () => {
+    assert.match(printError("GeoLibre.Desktop_amd64.AppImage"), /does not contain _2\.3\.0_/);
+  });
+
+  it("fails when REPO is not an owner/name pair", () => {
+    assert.match(
+      printError("GeoLibre.Desktop_2.3.0_amd64.AppImage", { REPO: "GeoLibre" }),
+      /not an owner\/name pair/,
+    );
+  });
+});

--- a/tests/appimage-update-info.test.ts
+++ b/tests/appimage-update-info.test.ts
@@ -69,3 +69,56 @@ describe("embed-appimage-update-info.sh", () => {
     );
   });
 });
+
+// The release and test-build workflows both feed the script above the one
+// AppImage out of tauri-action's artifactPaths. That selection lives in a
+// shared script so the two workflows cannot drift; guard the "exactly one"
+// contract here rather than only discovering a bundler change mid-release.
+const selectScript = path.join(repoRoot, "scripts", "select-single-appimage.sh");
+
+function select(artifacts: string[]): string {
+  return execFileSync("bash", [selectScript, JSON.stringify(artifacts)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function selectError(artifacts: string[]): string {
+  try {
+    select(artifacts);
+  } catch (error) {
+    return String((error as { stderr?: Buffer }).stderr ?? "");
+  }
+  throw new Error("expected select-single-appimage.sh to fail");
+}
+
+// jq ships on the GitHub-hosted runners this is gated on, but a contributor's
+// machine may not have it.
+const hasJq = (() => {
+  try {
+    execFileSync("jq", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe("select-single-appimage.sh", { skip: hasJq ? false : "jq is not installed" }, () => {
+  const appimage = "/build/bundle/appimage/GeoLibre.Desktop_2.3.0_amd64.AppImage";
+  const others = [
+    "/build/bundle/deb/GeoLibre.Desktop_2.3.0_amd64.deb",
+    "/build/bundle/rpm/GeoLibre.Desktop-2.3.0-1.x86_64.rpm",
+  ];
+
+  it("picks the AppImage out of the other bundles", () => {
+    assert.equal(select([others[0], appimage, others[1]]), appimage);
+  });
+
+  it("fails when there is no AppImage", () => {
+    assert.match(selectError(others), /found 0/);
+  });
+
+  it("fails when there is more than one AppImage", () => {
+    assert.match(selectError([appimage, "/build/other_2.3.0_amd64.AppImage"]), /found 2/);
+  });
+});


### PR DESCRIPTION
Fixes #1495

## Problem

The AppImage we ship carries no update information, so AppImageUpdate (and
AppImageLauncher, AppManager, AM) refuse to update it. Confirmed against the
released `GeoLibre.Desktop_2.3.0_amd64.AppImage`: the runtime's 1 KiB
`.upd_info` ELF section is 1024 zero bytes, and `appimageupdatetool` reports
exactly what the issue screenshot shows:

```
Could not find update information in the AppImage. Please contact the author
of the AppImage and ask them to embed update information.
```

Tauri's bundler does not fill that section in and has no option to.

## Change

- `scripts/embed-appimage-update-info.sh` writes
  `gh-releases-zsync|<owner>|<repo>|latest|<bundle>_*_amd64.AppImage.zsync`
  into `.upd_info` and generates the matching `.zsync` from the patched image.
  It uses `dd` rather than `objcopy`, which would rewrite the ELF and drop the
  squashfs appended after it, and reads the section back to verify.
- `release.yml` runs it on the built AppImage and uploads the patched image
  plus the `.zsync` (`--clobber`, since tauri-action has already attached the
  unpatched one). Adds `zsync` to the Linux dependency list.
- `test-build.yml` runs the same patch without uploading, so a break surfaces
  on a test build rather than halfway through a real release.
- `tests/appimage-update-info.test.ts` covers the string derivation and its
  guards via the script's `--print` mode.

The version in the bundle name becomes a glob so the update information keeps
matching future releases, and the script fails loudly if the bundle is ever
renamed rather than degrading into a pattern that matches nothing.

## Verification

Ran against the real released v2.3.0 AppImage.

The runtime's own reader now returns the string, and exactly 82 bytes (the
length of the string) changed in the 117 MB file:

```
$ ./GeoLibre.Desktop_2.3.0_amd64.AppImage --appimage-updateinfo
gh-releases-zsync|opengeos|GeoLibre|latest|GeoLibre.Desktop_*_amd64.AppImage.zsync
$ cmp -l original.AppImage patched.AppImage | wc -l
82
```

Full delta round trip with `appimageupdatetool`, using the unpatched v2.3.0
image as the seed and the patched one served from a local range-capable server
in place of the GitHub release:

```
zsync2: Usable data from seed files: 99.996513%
zsync2: checksum matches OK
zsync2: used 117456896 local, fetched 4096
Update successful.
```

The reconstructed file is byte-identical (same sha256) to the served AppImage.
4 KiB transferred instead of 112 MiB, which is the delta update the issue asks
for.

Also ran `npm run test:frontend` (4202 passing) and `pre-commit` on the changed
files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux AppImage releases now support in-place delta updates with embedded update metadata.
  * Release builds publish matching `.zsync` files alongside the AppImage for compatible update tools.
* **Documentation**
  * Updated Linux download guidance to clarify AppImage in-place updates and how DEB/RPM updates work.
  * Added a delta-update section with example commands and inspection guidance.
* **Tests**
  * Added automated coverage for update-information generation, artifact selection, and validation/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->