### PR TITLE
fix(time-slider): honor temporal adapter cadence

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -686,7 +686,10 @@ export function bindTemporalLayer(
   adapter: TemporalLayerAdapter,
   mapControllerRef?: RefObject<MapController | null>,
 ): boolean {
-  const binding = buildSelectorTimeBinding(adapter.dimension ?? "time", adapter.getTimeValues());
+  const binding = buildSelectorTimeBinding(adapter.dimension ?? "time", adapter.getTimeValues(), {
+    granularity: adapter.granularity,
+    displayUnits: adapter.displayUnits,
+  });
   if (!binding) return false;
   const store = useAppStore.getState();
   const layer = store.layers.find((item) => item.id === layerId);

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -466,6 +466,7 @@ let preBindingRange: {
   // value (setRange treats a null/undefined end as open).
   end: string | undefined;
   granularity: TimeBinding["granularity"];
+  granularities: TimeGranularity[];
 } | null = null;
 // Guards our own timeFilter writes from re-entering the store subscription.
 let applyingBoundFilters = false;
@@ -727,6 +728,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
     let max = Number.NEGATIVE_INFINITY;
     let granularity: TimeGranularity =
       bound[0]?.binding.granularity ?? selectors[0]?.binding.granularity ?? "day";
+    const displayUnits = new Set<TimeGranularity>();
     let widestSpan = -1;
     // A vector filter binding and a data cube's selector binding describe the
     // same thing here — an extent plus a suggested stepping unit — so they feed
@@ -739,6 +741,9 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
       if (span > widestSpan) {
         widestSpan = span;
         granularity = binding.granularity;
+      }
+      if (isSelectorTimeBinding(binding)) {
+        for (const unit of binding.displayUnits ?? []) displayUnits.add(unit);
       }
     }
     // Fold in the time-overlay frames' extents so the track covers them too.
@@ -758,7 +763,10 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
     ) {
       granularity = pickGranularity(max - min);
     }
-    const rangeKey = `${min}|${max}|${granularity}`;
+    const orderedDisplayUnits = (["hour", "day", "month", "year"] as TimeGranularity[]).filter(
+      (unit) => displayUnits.has(unit),
+    );
+    const rangeKey = `${min}|${max}|${granularity}|${orderedDisplayUnits.join(",")}`;
     if (rangeKey !== lastBoundRangeKey) {
       // Capture the range the control had before any binding overrode it, so it
       // can be restored when every binding is later removed.
@@ -768,10 +776,17 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
           start: config.startDate,
           end: config.endDate,
           granularity: config.granularity,
+          granularities: [...(config.granularities ?? ["hour", "day", "month", "year"])],
         };
       }
       lastBoundRangeKey = rangeKey;
       control.setRange(new Date(min), new Date(max), undefined, granularity);
+      control.setGranularities(
+        orderedDisplayUnits.length > 0
+          ? orderedDisplayUnits
+          : (preBindingRange?.granularities ??
+              control.getConfig().granularities ?? ["hour", "day", "month", "year"]),
+      );
     }
   } else {
     // The last binding/frame was removed: restore the pre-binding range so any
@@ -783,6 +798,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
         undefined,
         preBindingRange.granularity,
       );
+      control.setGranularities(preBindingRange.granularities);
     }
     preBindingRange = null;
     lastBoundRangeKey = null;

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -20,6 +20,7 @@ import {
   nearestTimeIndex,
   resolveSelectorDisplayUnits,
   subscribeTemporalLayers,
+  TIME_GRANULARITIES,
   toEpochMsAxis,
   type SelectorTimeBinding,
   type TemporalLayerAdapter,
@@ -774,7 +775,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
           start: config.startDate,
           end: config.endDate,
           granularity: config.granularity,
-          granularities: [...(config.granularities ?? ["hour", "day", "month", "year"])],
+          granularities: [...(config.granularities ?? TIME_GRANULARITIES)],
         };
       }
       lastBoundRangeKey = rangeKey;
@@ -783,7 +784,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
         orderedDisplayUnits
           ? orderedDisplayUnits
           : (preBindingRange?.granularities ??
-              control.getConfig().granularities ?? ["hour", "day", "month", "year"]),
+              control.getConfig().granularities ?? [...TIME_GRANULARITIES]),
       );
     }
   } else {
@@ -810,6 +811,11 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
   scheduleSelectorTimes(control);
   applyBoundFilters(control, bound);
   applyTimeOverlayVisibility(control, frames);
+}
+
+/** Exercise binding reconciliation with a stub control in unit tests. */
+export function __reconcileBoundLayersForTests(control: TimeSliderControl): void {
+  reconcileBoundLayers(control);
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -18,6 +18,7 @@ import {
   getTemporalLayerAdapter,
   isSelectorTimeBinding,
   nearestTimeIndex,
+  resolveSelectorDisplayUnits,
   subscribeTemporalLayers,
   toEpochMsAxis,
   type SelectorTimeBinding,
@@ -728,7 +729,6 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
     let max = Number.NEGATIVE_INFINITY;
     let granularity: TimeGranularity =
       bound[0]?.binding.granularity ?? selectors[0]?.binding.granularity ?? "day";
-    const displayUnits = new Set<TimeGranularity>();
     let widestSpan = -1;
     // A vector filter binding and a data cube's selector binding describe the
     // same thing here — an extent plus a suggested stepping unit — so they feed
@@ -741,9 +741,6 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
       if (span > widestSpan) {
         widestSpan = span;
         granularity = binding.granularity;
-      }
-      if (isSelectorTimeBinding(binding)) {
-        for (const unit of binding.displayUnits ?? []) displayUnits.add(unit);
       }
     }
     // Fold in the time-overlay frames' extents so the track covers them too.
@@ -763,10 +760,11 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
     ) {
       granularity = pickGranularity(max - min);
     }
-    const orderedDisplayUnits = (["hour", "day", "month", "year"] as TimeGranularity[]).filter(
-      (unit) => displayUnits.has(unit),
+    const orderedDisplayUnits = resolveSelectorDisplayUnits(
+      selectors.map(({ binding }) => binding),
+      granularity,
     );
-    const rangeKey = `${min}|${max}|${granularity}|${orderedDisplayUnits.join(",")}`;
+    const rangeKey = `${min}|${max}|${granularity}|${orderedDisplayUnits?.join(",") ?? ""}`;
     if (rangeKey !== lastBoundRangeKey) {
       // Capture the range the control had before any binding overrode it, so it
       // can be restored when every binding is later removed.
@@ -782,7 +780,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
       lastBoundRangeKey = rangeKey;
       control.setRange(new Date(min), new Date(max), undefined, granularity);
       control.setGranularities(
-        orderedDisplayUnits.length > 0
+        orderedDisplayUnits
           ? orderedDisplayUnits
           : (preBindingRange?.granularities ??
               control.getConfig().granularities ?? ["hour", "day", "month", "year"]),

--- a/packages/plugins/src/plugins/temporal-layers.ts
+++ b/packages/plugins/src/plugins/temporal-layers.ts
@@ -28,6 +28,16 @@ export interface TemporalLayerAdapter {
    * axis the timeline was bound to. Defaults to `"time"`.
    */
   dimension?: string;
+  /**
+   * Stepping unit for the Time Slider. When omitted, GeoLibre derives one from
+   * the full axis span.
+   */
+  granularity?: TimeGranularity;
+  /**
+   * Units offered by the Time Slider's granularity controls. For example, a
+   * daily cube can use `["day"]` to keep the track and labels at its cadence.
+   */
+  displayUnits?: TimeGranularity[];
 }
 
 /**
@@ -48,6 +58,8 @@ export interface SelectorTimeBinding {
   max: number;
   /** Suggested stepping granularity derived from the axis span. */
   granularity: TimeGranularity;
+  /** Units offered by the Time Slider while this binding is active. */
+  displayUnits?: TimeGranularity[];
 }
 
 /**
@@ -142,6 +154,7 @@ export function nearestTimeIndex(axis: readonly number[], targetMs: number): num
 export function buildSelectorTimeBinding(
   dimension: string,
   values: ReadonlyArray<Date | number | string> | null | undefined,
+  options?: Pick<TemporalLayerAdapter, "granularity" | "displayUnits">,
 ): SelectorTimeBinding | null {
   const axis = toEpochMsAxis(values);
   if (!axis) return null;
@@ -161,7 +174,8 @@ export function buildSelectorTimeBinding(
     dimension: dimension.trim() || "time",
     min,
     max,
-    granularity: pickGranularity(max - min),
+    granularity: options?.granularity ?? pickGranularity(max - min),
+    ...(options?.displayUnits ? { displayUnits: [...options.displayUnits] } : {}),
   };
 }
 

--- a/packages/plugins/src/plugins/temporal-layers.ts
+++ b/packages/plugins/src/plugins/temporal-layers.ts
@@ -1,6 +1,6 @@
 import { parseTimeValue, pickGranularity, type TimeGranularity } from "./time-slider-binding";
 
-const TIME_GRANULARITIES: TimeGranularity[] = ["hour", "day", "month", "year"];
+export const TIME_GRANULARITIES: readonly TimeGranularity[] = ["hour", "day", "month", "year"];
 
 /**
  * A layer whose time is an **internal dimension** rather than a feature property

--- a/packages/plugins/src/plugins/temporal-layers.ts
+++ b/packages/plugins/src/plugins/temporal-layers.ts
@@ -1,5 +1,7 @@
 import { parseTimeValue, pickGranularity, type TimeGranularity } from "./time-slider-binding";
 
+const TIME_GRANULARITIES: TimeGranularity[] = ["hour", "day", "month", "year"];
+
 /**
  * A layer whose time is an **internal dimension** rather than a feature property
  * or a separate dated source: a Zarr data cube with a `time` axis, a plugin's
@@ -169,14 +171,40 @@ export function buildSelectorTimeBinding(
   // A single-slice cube still needs a non-zero span so the slider can move,
   // matching the vector path's treatment of a single-instant dataset.
   if (max <= min) max = min + 86_400_000;
+  const granularity = options?.granularity ?? pickGranularity(max - min);
+  const displayUnits = options?.displayUnits
+    ? TIME_GRANULARITIES.filter(
+        (unit) => unit === granularity || options.displayUnits?.includes(unit),
+      )
+    : undefined;
   return {
     kind: "selector",
     dimension: dimension.trim() || "time",
     min,
     max,
-    granularity: options?.granularity ?? pickGranularity(max - min),
-    ...(options?.displayUnits ? { displayUnits: [...options.displayUnits] } : {}),
+    granularity,
+    ...(displayUnits ? { displayUnits } : {}),
   };
+}
+
+/**
+ * Resolve display-unit constraints for a shared slider. Constrained selector
+ * bindings contribute their intersection. If that intersection cannot expose
+ * the active stepping unit, the active unit is the only safe shared control.
+ */
+export function resolveSelectorDisplayUnits(
+  bindings: readonly SelectorTimeBinding[],
+  activeGranularity: TimeGranularity,
+): TimeGranularity[] | undefined {
+  const constrained = bindings.filter(
+    (binding): binding is SelectorTimeBinding & { displayUnits: TimeGranularity[] } =>
+      Boolean(binding.displayUnits?.length),
+  );
+  if (constrained.length === 0) return undefined;
+  const intersection = TIME_GRANULARITIES.filter((unit) =>
+    constrained.every((binding) => binding.displayUnits.includes(unit)),
+  );
+  return intersection.includes(activeGranularity) ? intersection : [activeGranularity];
 }
 
 // ----- Registry --------------------------------------------------------------

--- a/tests/temporal-layers.test.ts
+++ b/tests/temporal-layers.test.ts
@@ -8,6 +8,7 @@ import {
   isSelectorTimeBinding,
   nearestTimeIndex,
   registerTemporalLayer,
+  resolveSelectorDisplayUnits,
   subscribeTemporalLayers,
   toEpochMsAxis,
   type TemporalLayerAdapter,
@@ -108,6 +109,43 @@ describe("buildSelectorTimeBinding", () => {
     assert.ok(binding);
     assert.equal(binding.granularity, "day");
     assert.deepEqual(binding.displayUnits, ["day"]);
+  });
+
+  it("keeps the active granularity in the displayed slider units", () => {
+    const binding = buildSelectorTimeBinding("time", [Date.UTC(2020, 0, 1), Date.UTC(2020, 0, 2)], {
+      granularity: "day",
+      displayUnits: ["month"],
+    });
+    assert.deepEqual(binding?.displayUnits, ["day", "month"]);
+  });
+
+  it("intersects shared display units and falls back to the active granularity", () => {
+    const base = {
+      kind: "selector" as const,
+      dimension: "time",
+      min: Date.UTC(2020, 0, 1),
+      max: Date.UTC(2020, 0, 2),
+    };
+    assert.deepEqual(
+      resolveSelectorDisplayUnits(
+        [
+          { ...base, granularity: "day", displayUnits: ["day", "month"] },
+          { ...base, granularity: "month", displayUnits: ["month"] },
+        ],
+        "month",
+      ),
+      ["month"],
+    );
+    assert.deepEqual(
+      resolveSelectorDisplayUnits(
+        [
+          { ...base, granularity: "day", displayUnits: ["day"] },
+          { ...base, granularity: "month", displayUnits: ["month"] },
+        ],
+        "day",
+      ),
+      ["day"],
+    );
   });
 
   it("gives a single-slice cube a non-zero span so the slider can still move", () => {

--- a/tests/temporal-layers.test.ts
+++ b/tests/temporal-layers.test.ts
@@ -99,6 +99,17 @@ describe("buildSelectorTimeBinding", () => {
     assert.equal(binding.granularity, "day");
   });
 
+  it("honors an adapter's granularity and displayed slider units", () => {
+    const values = Array.from({ length: 35 * 365 }, (_, i) => Date.UTC(1990, 0, 1) + i * DAY);
+    const binding = buildSelectorTimeBinding("time", values, {
+      granularity: "day",
+      displayUnits: ["day"],
+    });
+    assert.ok(binding);
+    assert.equal(binding.granularity, "day");
+    assert.deepEqual(binding.displayUnits, ["day"]);
+  });
+
   it("gives a single-slice cube a non-zero span so the slider can still move", () => {
     const binding = buildSelectorTimeBinding("time", [Date.UTC(2020, 0, 1)]);
     assert.ok(binding);

--- a/tests/time-slider-config.test.ts
+++ b/tests/time-slider-config.test.ts
@@ -2,13 +2,15 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import {
+  __reconcileBoundLayersForTests,
   configToOptions,
   getLayerTimeBinding,
   createStoreLayer,
   isTimeSliderIdle,
   maplibreTimeSliderPlugin,
 } from "../packages/plugins/src/plugins/maplibre-time-slider";
-import type { SourceSpec } from "maplibre-gl-time-slider";
+import { registerTemporalLayer } from "../packages/plugins/src/plugins/temporal-layers";
+import type { SourceSpec, TimeSliderControl } from "maplibre-gl-time-slider";
 
 // applyProjectState / getProjectState touch no app methods while no control is
 // active (the plugin is never activated here), so a bare stub satisfies the type.
@@ -66,6 +68,60 @@ describe("Time Slider open-ended end date persistence", () => {
     const config = baseConfig();
     delete config.startDate;
     assert.equal(apply(config), false);
+  });
+});
+
+describe("Time Slider selector display-unit restoration", () => {
+  it("restores the previous controls after the last selector is unbound", () => {
+    const store = useAppStore.getState();
+    const previousLayers = store.layers;
+    const layer = {
+      id: "restore-units",
+      name: "Daily cube",
+      type: "geojson",
+      source: {},
+      visible: true,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {
+        timeBinding: {
+          kind: "selector",
+          dimension: "time",
+          min: Date.UTC(2020, 0, 1),
+          max: Date.UTC(2020, 0, 2),
+          granularity: "day",
+          displayUnits: ["day"],
+        },
+      },
+    } satisfies GeoLibreLayer;
+    const ranges: unknown[][] = [];
+    const granularities: string[][] = [];
+    const control = {
+      getConfig: () =>
+        baseConfig({
+          granularities: ["year", "month"],
+        }),
+      setRange: (...args: unknown[]) => ranges.push(args),
+      setGranularities: (units: string[]) => granularities.push(units),
+    } as unknown as TimeSliderControl;
+    const detach = registerTemporalLayer(layer.id, {
+      getTimeValues: () => [Date.UTC(2020, 0, 1), Date.UTC(2020, 0, 2)],
+      setTime: () => {},
+    });
+
+    try {
+      useAppStore.setState({ layers: [layer] });
+      __reconcileBoundLayersForTests(control);
+      assert.deepEqual(granularities.at(-1), ["day"]);
+
+      useAppStore.getState().updateLayer(layer.id, { metadata: {} });
+      __reconcileBoundLayersForTests(control);
+      assert.deepEqual(granularities.at(-1), ["year", "month"]);
+      assert.equal(ranges.at(-1)?.[3], "year");
+    } finally {
+      detach();
+      useAppStore.setState({ layers: previousLayers });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- let temporal layer adapters override span-derived stepping granularity
- let adapters constrain the granularity controls shown on the Time Slider
- persist and restore displayed units with selector bindings

## Verification

- reproduced a 35-year daily axis resolving to yearly cadence before the fix
- verified daily stepping and a day-only control in light and dark themes
- verified Next advances from 1990 Jan 01 to 1990 Jan 02
- npm run build
- npm run test:frontend
- pre-commit run --files apps/geolibre-desktop/src/hooks/usePlugins.ts packages/plugins/src/plugins/maplibre-time-slider.ts packages/plugins/src/plugins/temporal-layers.ts tests/temporal-layers.test.ts

Fixes #1501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated selector time bindings to honor adapter-provided stepping granularity and allowed display units.
  * Improved time-slider reconciliation to respect the allowed granularities list when updating the control range and granularities.
  * Restores both prior range stepping and prior allowed granularities when selector-bound layers are removed.
* **Tests**
  * Expanded temporal layer and time-slider configuration tests to validate granularity/display-units persistence, intersection logic, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->