### PR TITLE
fix: adapt time slider tick density

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -81,7 +81,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.8.0",
+    "maplibre-gl-time-slider": "^1.8.2",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.2",
     "openai": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.8.0",
+        "maplibre-gl-time-slider": "^1.8.2",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.2",
         "openai": "^7.0.0",
@@ -17235,9 +17235,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.0.tgz",
-      "integrity": "sha512-OFyIFEBsGNoL/q8qLLMjKfPGYllU+z02CNhgpD02+pgSEHbTgSDPalAJDJhk8qg7I19z85eZ9TPLPboDhxP2jw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.2.tgz",
+      "integrity": "sha512-JhCg1JiFMn6F/uIWxntgHEm2M2gPYfbJMKgbFKUHD1+yzeM+KSY3e21T30T2wX7qrns15WPk9XJfj8vi+QX7vQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -21916,7 +21916,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.0",
-        "maplibre-gl-time-slider": "^1.8.0",
+        "maplibre-gl-time-slider": "^1.8.2",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.2",
         "netcdfjs": "^4.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -56,7 +56,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.0",
-    "maplibre-gl-time-slider": "^1.8.0",
+    "maplibre-gl-time-slider": "^1.8.2",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.2",
     "netcdfjs": "^4.0.0",


### PR DESCRIPTION
## Summary

- update `maplibre-gl-time-slider` to 1.8.2 in the desktop app and plugin package
- consume width-aware, calendar-aligned timeline ticks
- regenerate tick density when the timeline resizes and omit optional minors when they cannot fit

## Verification

- loaded `time_points.geojson` and bound its 2015-2024 date range to the Time Slider
- verified daily granularity at 36 px and 756 px track widths
- verified light and dark themes in the real app
- `npm run build`
- pre-commit checks on all changed files

Upstream: opengeos/maplibre-gl-time-slider#35, opengeos/maplibre-gl-time-slider#37
Release: https://github.com/opengeos/maplibre-gl-time-slider/releases/tag/v1.8.2

Fixes #1503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the time slider component to version 1.8.2 for improved stability and compatibility across the desktop app and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->