### PR TITLE
fix: update time slider to 1.8.3

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -81,7 +81,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",
-    "maplibre-gl-time-slider": "^1.8.2",
+    "maplibre-gl-time-slider": "^1.8.3",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.2",
     "openai": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",
-        "maplibre-gl-time-slider": "^1.8.2",
+        "maplibre-gl-time-slider": "^1.8.3",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.2",
         "openai": "^7.0.0",
@@ -17236,9 +17236,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.2.tgz",
-      "integrity": "sha512-JhCg1JiFMn6F/uIWxntgHEm2M2gPYfbJMKgbFKUHD1+yzeM+KSY3e21T30T2wX7qrns15WPk9XJfj8vi+QX7vQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.3.tgz",
+      "integrity": "sha512-RcMMGyr7RHIDAWffG1ijJWQ7FRiKuVyrpIqIh9bBTdtQTjOqX9Jys/YOrJ7RBmG8mPiJbB66YwmVDa4RguRWVg==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -21917,7 +21917,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",
-        "maplibre-gl-time-slider": "^1.8.2",
+        "maplibre-gl-time-slider": "^1.8.3",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.2",
         "netcdfjs": "^4.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -56,7 +56,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",
-    "maplibre-gl-time-slider": "^1.8.2",
+    "maplibre-gl-time-slider": "^1.8.3",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.2",
     "netcdfjs": "^4.0.0",


### PR DESCRIPTION
## Summary

- update both Time Slider dependency declarations to `maplibre-gl-time-slider@^1.8.3`
- refresh the lockfile to consume the adaptive short-range axis labels from opengeos/maplibre-gl-time-slider#39
- show month and year labels for short monthly ranges instead of only a year boundary

## Testing

- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/package.json packages/plugins/package.json package-lock.json`
- verified Dec 2023 through Feb 2024 renders `Dec 2023`, `Jan 2024`, and `Feb 2024` in GeoLibre
- verified the Time Slider in both light and dark themes with no browser console errors

Upstream issue: opengeos/maplibre-gl-time-slider#38
Upstream fix: opengeos/maplibre-gl-time-slider#39
Release: https://github.com/opengeos/maplibre-gl-time-slider/releases/tag/v1.8.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the map time slider to the latest available version.
  * Includes the latest enhancements and fixes for a smoother, more reliable timeline experience across the desktop application and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->