### PR TITLE
feat(dashboard): add list widget type (issue #1381)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -375,7 +375,7 @@ function WidgetCard({
   const data = useLayerChartData(widget.layerId);
   const result = useMemo(
     () =>
-      widget.type === "indicator"
+      widget.type === "indicator" || widget.type === "selector"
         ? null
         : computeChart(data.rows, widgetToSpec(widget, widget.type)),
     [data.rows, widget],
@@ -407,6 +407,8 @@ function WidgetCard({
         const aggLabel = t(`dashboard.indicatorAggregation.${agg}`);
         return widget.field ? `${aggLabel} · ${widget.field}` : aggLabel;
       }
+      case "selector":
+        return `${t("dashboard.chartType.selector")} · ${widget.category ?? ""}`;
     }
   };
   const title = widget.title?.trim() || defaultWidgetTitle();
@@ -496,6 +498,33 @@ function WidgetCard({
             );
           })()}
         </div>
+      ) : widget.type === "selector" ? (
+        <div className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-auto">
+          {(() => {
+            if (!widget.category || !data.hasData) {
+              return (
+                <p className="text-center text-xs text-muted-foreground">{t("dashboard.noData")}</p>
+              );
+            }
+            // Extract distinct values from the category field, sorted.
+            const cat = widget.category!;
+            const values = Array.from(
+              new Set(
+                data.rows
+                  .map((row) => String((row as unknown as Record<string, unknown>)[cat] ?? ""))
+                  .filter((v) => v !== ""),
+              ),
+            ).sort((a, b) => a.localeCompare(b));
+
+            if (values.length === 0) {
+              return (
+                <p className="text-center text-xs text-muted-foreground">{t("dashboard.noData")}</p>
+              );
+            }
+
+            return <SelectorValues values={values} multiple={widget.multiple ?? false} />;
+          })()}
+        </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col [&>svg]:min-h-0 [&>svg]:flex-1">
           {data.hasData && result ? (
@@ -507,6 +536,55 @@ function WidgetCard({
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+/** Renders the selector widget body: a scrollable list of clickable value
+ * chips. In single mode clicking a value toggles it as the only selected value.
+ * In multi mode each chip toggles independently. Cross-filtering is not yet
+ * wired; this prepares the UI and selection state for it. */
+function SelectorValues({
+  values,
+  multiple,
+}: {
+  values: string[];
+  multiple: boolean;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = (value: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        if (!multiple) next.clear();
+        next.add(value);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {values.map((value) => {
+        const isSelected = selected.has(value);
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => toggle(value)}
+            className={`rounded-full border px-2.5 py-0.5 text-xs transition-colors ${
+              isSelected
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-background text-muted-foreground hover:border-primary/50"
+            }`}
+          >
+            {value}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -375,7 +375,7 @@ function WidgetCard({
   const data = useLayerChartData(widget.layerId);
   const result = useMemo(
     () =>
-      widget.type === "indicator" || widget.type === "selector"
+      widget.type === "indicator" || widget.type === "selector" || widget.type === "list"
         ? null
         : computeChart(data.rows, widgetToSpec(widget, widget.type)),
     [data.rows, widget],
@@ -409,6 +409,8 @@ function WidgetCard({
       }
       case "selector":
         return `${t("dashboard.chartType.selector")} · ${widget.category ?? ""}`;
+      case "list":
+        return `${t("dashboard.chartType.list")} · ${widget.layerId}`;
     }
   };
   const title = widget.title?.trim() || defaultWidgetTitle();
@@ -525,6 +527,46 @@ function WidgetCard({
             return <SelectorValues values={values} multiple={widget.multiple ?? false} />;
           })()}
         </div>
+      ) : widget.type === "list" ? (
+        <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+          {(() => {
+            if (!data.hasData || !widget.listFields || widget.listFields.length === 0) {
+              return (
+                <p className="text-center text-xs text-muted-foreground">{t("dashboard.noData")}</p>
+              );
+            }
+            const rows = data.rows;
+            const sortBy = widget.sortBy;
+            const sortDir = widget.sortDir ?? "desc";
+            const limit = widget.limit ?? 20;
+
+            // Sort rows if sortBy is set.
+            let sorted = rows;
+            if (sortBy) {
+              sorted = [...rows].sort((a, b) => {
+                const av = (a as unknown as Record<string, unknown>)[sortBy];
+                const bv = (b as unknown as Record<string, unknown>)[sortBy];
+                // Numeric comparison if both values are numbers.
+                const an = Number(av);
+                const bn = Number(bv);
+                if (Number.isFinite(an) && Number.isFinite(bn) && an !== bn) {
+                  return sortDir === "asc" ? an - bn : bn - an;
+                }
+                // Fall back to string comparison.
+                const as = String(av ?? "");
+                const bs = String(bv ?? "");
+                return sortDir === "asc" ? as.localeCompare(bs) : bs.localeCompare(as);
+              });
+            }
+
+            return (
+              <ListTable
+                fields={widget.listFields}
+                rows={sorted.slice(0, limit) as unknown as Record<string, unknown>[]}
+              />
+            );
+          })()}
+        </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col [&>svg]:min-h-0 [&>svg]:flex-1">
           {data.hasData && result ? (
@@ -586,5 +628,47 @@ function SelectorValues({
         );
       })}
     </div>
+  );
+}
+
+/** Renders the list widget body: a compact scrollable HTML table showing the
+ * selected columns for the top-N features (by sortBy/sortDir, limited by limit).
+ * Like the selector, this does not yet participate in cross-filtering. */
+function ListTable({
+  fields,
+  rows,
+}: {
+  fields: string[];
+  rows: Record<string, unknown>[];
+}) {
+  return (
+    <table className="w-full border-collapse text-xs">
+      <thead>
+        <tr>
+          {fields.map((f) => (
+            <th
+              key={f}
+              className="border-b border-border px-1.5 py-1 text-left font-medium text-muted-foreground"
+            >
+              {f}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i} className="hover:bg-muted/50">
+            {fields.map((f) => {
+              const v = row[f];
+              return (
+                <td key={f} className="border-b border-border/50 px-1.5 py-0.5">
+                  {v === null || v === undefined ? "" : String(v)}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -586,13 +586,7 @@ function WidgetCard({
  * chips. In single mode clicking a value toggles it as the only selected value.
  * In multi mode each chip toggles independently. Cross-filtering is not yet
  * wired; this prepares the UI and selection state for it. */
-function SelectorValues({
-  values,
-  multiple,
-}: {
-  values: string[];
-  multiple: boolean;
-}) {
+function SelectorValues({ values, multiple }: { values: string[]; multiple: boolean }) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const toggle = (value: string) => {
@@ -634,13 +628,7 @@ function SelectorValues({
 /** Renders the list widget body: a compact scrollable HTML table showing the
  * selected columns for the top-N features (by sortBy/sortDir, limited by limit).
  * Like the selector, this does not yet participate in cross-filtering. */
-function ListTable({
-  fields,
-  rows,
-}: {
-  fields: string[];
-  rows: Record<string, unknown>[];
-}) {
+function ListTable({ fields, rows }: { fields: string[]; rows: Record<string, unknown>[] }) {
   return (
     <table className="w-full border-collapse text-xs">
       <thead>

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -70,6 +70,11 @@ export function WidgetEditorDialog({
   const [suffix, setSuffix] = useState("");
   // "selector" widget fields (issue #1381).
   const [multiple, setMultiple] = useState(false);
+  // "list" widget fields (issue #1381).
+  const [listFields, setListFields] = useState<string[]>([]);
+  const [sortBy, setSortBy] = useState("");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [limit, setLimit] = useState(20);
   // "" means no custom color: fall back to the theme primary / palette.
   const [color, setColor] = useState("");
 
@@ -91,6 +96,10 @@ export function WidgetEditorDialog({
     setPrefix(widget?.prefix ?? "");
     setSuffix(widget?.suffix ?? "");
     setMultiple(widget?.multiple ?? false);
+    setListFields(widget?.listFields ?? []);
+    setSortBy(widget?.sortBy ?? "");
+    setSortDir(widget?.sortDir ?? "desc");
+    setLimit(widget?.limit ?? 20);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, widget]);
 
@@ -108,17 +117,20 @@ export function WidgetEditorDialog({
   const isCategorical = type === "bar" || type === "pie";
   const isIndicator = type === "indicator";
   const isSelector = type === "selector";
+  const isList = type === "list";
   const canSave =
     layerId !== "" &&
     (isIndicator
       ? indicatorAggregation === "count" || hasNumeric
       : isSelector
         ? hasCategory
-        : isCategorical
-          ? hasCategory && (aggregation === "count" || hasNumeric)
-          : type === "scatter"
-            ? numericCols.length >= 2
-            : hasNumeric);
+        : isList
+          ? hasChartable
+          : isCategorical
+            ? hasCategory && (aggregation === "count" || hasNumeric)
+            : type === "scatter"
+              ? numericCols.length >= 2
+              : hasNumeric);
   const save = () => {
     if (!canSave) return;
     const next: DashboardWidget = {
@@ -160,6 +172,15 @@ export function WidgetEditorDialog({
     if (type === "selector") {
       next.category = pick(category, categoryCols);
       if (multiple) next.multiple = true;
+    }
+    if (type === "list") {
+      // Ensure at least one column is selected; default to all available.
+      const allCols = [...numericCols, ...categoryCols];
+      const cols = listFields.filter((f) => allCols.includes(f));
+      next.listFields = cols.length > 0 ? cols : allCols.slice(0, 3);
+      if (sortBy) next.sortBy = sortBy;
+      if (sortDir !== "desc") next.sortDir = sortDir;
+      if (limit !== 20) next.limit = limit;
     }
     onSave(next);
     onOpenChange(false);
@@ -241,6 +262,9 @@ export function WidgetEditorDialog({
                   <option value="indicator">{t("dashboard.chartType.indicator")}</option>
                   <option value="selector" disabled={!hasCategory}>
                     {t("dashboard.chartType.selector")}
+                  </option>
+                  <option value="list" disabled={!hasChartable}>
+                    {t("dashboard.chartType.list")}
                   </option>
                 </Select>
               </div>
@@ -365,6 +389,78 @@ export function WidgetEditorDialog({
                     />
                     {t("dashboard.editor.multiSelect")}
                   </label>
+                </>
+              )}
+
+              {type === "list" && (
+                <>
+                  <div className="grid gap-1.5">
+                    <Label>{t("dashboard.editor.listColumns")}</Label>
+                    <div className="flex flex-wrap gap-1.5">
+                      {[...numericCols, ...categoryCols].map((col) => {
+                        const checked = listFields.includes(col);
+                        return (
+                          <label
+                            key={col}
+                            className="flex items-center gap-1 rounded border border-border px-2 py-0.5 text-xs"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={(event) => {
+                                if (event.target.checked) {
+                                  setListFields((prev) => [...prev, col]);
+                                } else {
+                                  setListFields((prev) => prev.filter((f) => f !== col));
+                                }
+                              }}
+                            />
+                            {col}
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-end gap-3">
+                    <FieldSelect
+                      id="widget-list-sort"
+                      label={t("dashboard.editor.sortBy")}
+                      value={sortBy}
+                      options={["", ...numericCols, ...categoryCols]}
+                      onChange={setSortBy}
+                    />
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="widget-list-sortdir">
+                        {t("dashboard.editor.sortDir")}
+                      </Label>
+                      <Select
+                        id="widget-list-sortdir"
+                        className="w-28"
+                        value={sortDir}
+                        onChange={(event) =>
+                          setSortDir(event.target.value as "asc" | "desc")
+                        }
+                      >
+                        <option value="asc">{t("dashboard.editor.ascending")}</option>
+                        <option value="desc">{t("dashboard.editor.descending")}</option>
+                      </Select>
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="widget-list-limit">{t("dashboard.editor.limit")}</Label>
+                      <Input
+                        id="widget-list-limit"
+                        type="number"
+                        className="w-20"
+                        min={1}
+                        max={500}
+                        value={limit}
+                        onChange={(event) => {
+                          const v = Number(event.target.value);
+                          if (Number.isFinite(v)) setLimit(Math.max(1, Math.trunc(v)));
+                        }}
+                      />
+                    </div>
+                  </div>
                 </>
               )}
 

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -430,16 +430,12 @@ export function WidgetEditorDialog({
                       onChange={setSortBy}
                     />
                     <div className="grid gap-1.5">
-                      <Label htmlFor="widget-list-sortdir">
-                        {t("dashboard.editor.sortDir")}
-                      </Label>
+                      <Label htmlFor="widget-list-sortdir">{t("dashboard.editor.sortDir")}</Label>
                       <Select
                         id="widget-list-sortdir"
                         className="w-28"
                         value={sortDir}
-                        onChange={(event) =>
-                          setSortDir(event.target.value as "asc" | "desc")
-                        }
+                        onChange={(event) => setSortDir(event.target.value as "asc" | "desc")}
                       >
                         <option value="asc">{t("dashboard.editor.ascending")}</option>
                         <option value="desc">{t("dashboard.editor.descending")}</option>

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -68,6 +68,8 @@ export function WidgetEditorDialog({
   const [indicatorAggregation, setIndicatorAggregation] = useState<IndicatorAggregation>("count");
   const [prefix, setPrefix] = useState("");
   const [suffix, setSuffix] = useState("");
+  // "selector" widget fields (issue #1381).
+  const [multiple, setMultiple] = useState(false);
   // "" means no custom color: fall back to the theme primary / palette.
   const [color, setColor] = useState("");
 
@@ -88,6 +90,7 @@ export function WidgetEditorDialog({
     setIndicatorAggregation(widget?.indicatorAggregation ?? "count");
     setPrefix(widget?.prefix ?? "");
     setSuffix(widget?.suffix ?? "");
+    setMultiple(widget?.multiple ?? false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, widget]);
 
@@ -104,15 +107,18 @@ export function WidgetEditorDialog({
   // aren't forced to the same column; the rest need one numeric field.
   const isCategorical = type === "bar" || type === "pie";
   const isIndicator = type === "indicator";
+  const isSelector = type === "selector";
   const canSave =
     layerId !== "" &&
     (isIndicator
       ? indicatorAggregation === "count" || hasNumeric
-      : isCategorical
-        ? hasCategory && (aggregation === "count" || hasNumeric)
-        : type === "scatter"
-          ? numericCols.length >= 2
-          : hasNumeric);
+      : isSelector
+        ? hasCategory
+        : isCategorical
+          ? hasCategory && (aggregation === "count" || hasNumeric)
+          : type === "scatter"
+            ? numericCols.length >= 2
+            : hasNumeric);
   const save = () => {
     if (!canSave) return;
     const next: DashboardWidget = {
@@ -150,6 +156,10 @@ export function WidgetEditorDialog({
       // Preserve whitespace: prefix/suffix may have intentional spaces (" ha").
       if (prefix) next.prefix = prefix;
       if (suffix) next.suffix = suffix;
+    }
+    if (type === "selector") {
+      next.category = pick(category, categoryCols);
+      if (multiple) next.multiple = true;
     }
     onSave(next);
     onOpenChange(false);
@@ -229,6 +239,9 @@ export function WidgetEditorDialog({
                     {t("dashboard.chartType.pie")}
                   </option>
                   <option value="indicator">{t("dashboard.chartType.indicator")}</option>
+                  <option value="selector" disabled={!hasCategory}>
+                    {t("dashboard.chartType.selector")}
+                  </option>
                 </Select>
               </div>
 
@@ -332,6 +345,26 @@ export function WidgetEditorDialog({
                       onChange={setValueField}
                     />
                   )}
+                </>
+              )}
+
+              {type === "selector" && (
+                <>
+                  <FieldSelect
+                    id="widget-selector-category"
+                    label={t("dashboard.editor.category")}
+                    value={pick(category, categoryCols)}
+                    options={categoryCols}
+                    onChange={setCategory}
+                  />
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={multiple}
+                      onChange={(event) => setMultiple(event.target.checked)}
+                    />
+                    {t("dashboard.editor.multiSelect")}
+                  </label>
                 </>
               )}
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3040,7 +3040,8 @@
       "line": "Line",
       "box": "Box plot",
       "pie": "Pie",
-      "indicator": "Indicator"
+      "indicator": "Indicator",
+      "selector": "Selector"
     },
     "aggregate": {
       "count": "Count",
@@ -3082,6 +3083,7 @@
       "value": "Value",
       "prefix": "Prefix",
       "suffix": "Suffix",
+      "multiSelect": "Allow multiple selection",
       "titleLabel": "Title",
       "titlePlaceholder": "Optional title",
       "color": "Color",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3041,7 +3041,8 @@
       "box": "Box plot",
       "pie": "Pie",
       "indicator": "Indicator",
-      "selector": "Selector"
+      "selector": "Selector",
+      "list": "List"
     },
     "aggregate": {
       "count": "Count",
@@ -3084,6 +3085,12 @@
       "prefix": "Prefix",
       "suffix": "Suffix",
       "multiSelect": "Allow multiple selection",
+      "listColumns": "Columns",
+      "sortBy": "Sort by",
+      "sortDir": "Direction",
+      "ascending": "Ascending",
+      "descending": "Descending",
+      "limit": "Row limit",
       "titleLabel": "Title",
       "titlePlaceholder": "Optional title",
       "color": "Color",

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -743,6 +743,8 @@ const DASHBOARD_WIDGET_TYPES: readonly DashboardWidgetType[] = [
   "box",
   "pie",
   "indicator",
+  "selector",
+  "list",
 ];
 const DASHBOARD_WIDGET_AGGREGATIONS: readonly DashboardWidgetAggregation[] = [
   "count",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1520,7 +1520,8 @@ export type DashboardWidgetType =
   | "line"
   | "box"
   | "pie"
-  | "indicator";
+  | "indicator"
+  | "selector";
 
 /** How a bar widget reduces its category groups. */
 export type DashboardWidgetAggregation = "count" | "sum" | "mean";
@@ -1567,6 +1568,8 @@ export interface DashboardWidget {
   prefix?: string;
   /** Indicator widget: optional suffix (e.g. " kg", " ha"). */
   suffix?: string;
+  /** Selector widget: whether multiple values can be picked (default false). */
+  multiple?: boolean;
 }
 
 /** Aggregation functions for indicator widgets (issue #1381). Extends the bar

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1521,7 +1521,8 @@ export type DashboardWidgetType =
   | "box"
   | "pie"
   | "indicator"
-  | "selector";
+  | "selector"
+  | "list";
 
 /** How a bar widget reduces its category groups. */
 export type DashboardWidgetAggregation = "count" | "sum" | "mean";
@@ -1570,6 +1571,14 @@ export interface DashboardWidget {
   suffix?: string;
   /** Selector widget: whether multiple values can be picked (default false). */
   multiple?: boolean;
+  /** List widget: columns to display. */
+  listFields?: string[];
+  /** List widget: field to sort by. */
+  sortBy?: string;
+  /** List widget: sort direction (default "desc"). */
+  sortDir?: "asc" | "desc";
+  /** List widget: max rows to show (default 20). */
+  limit?: number;
 }
 
 /** Aggregation functions for indicator widgets (issue #1381). Extends the bar


### PR DESCRIPTION
## Summary

Adds the **list widget** — the third and final widget type proposed in #1381 (after the indicator widget in #1392 and the selector widget in #1504).

A scrollable table showing top-N features from a layer with configurable columns, sort field/direction, and row limit. Think of it as a mini attribute table inside the dashboard.

### What's included

- **`DashboardWidgetType`**: added `"list"`
- **`DashboardWidget`**: added `listFields`, `sortBy`, `sortDir`, `limit` fields
- **`project.ts`**: added `"selector"` and `"list"` to `DASHBOARD_WIDGET_TYPES`
  - ⚠️ `"selector"` was missing from the validation array in #1504 — a widget saved as `"selector"` would have been silently dropped on project load. This PR fixes that.
- **`WidgetEditorDialog`**: 
  - Column checkboxes (pick which fields to display)
  - Sort-by dropdown (optional)
  - Sort direction (ascending / descending)
  - Row limit input (default 20)
- **`DashboardPanel`**: new `ListTable` component
  - Compact HTML table with header row
  - Numeric sort when both values are numbers, string sort otherwise
  - Hover highlight on rows
- **i18n**: `chartType.list` + 6 editor keys (en)

### Design decisions

- **Flat field names on DashboardWidget**: Used `listFields` (not `fields`) to avoid collision with the existing `field` property used by histogram/line/box/indicator widgets. All list-specific fields are prefixed for clarity.
- **Default columns**: If the user doesn't pick any columns, the first 3 available columns (numeric + categorical) are auto-selected.
- **Default limit**: 20 rows, matching the issue spec.
- **Default sort**: `"desc"` (descending), matching the "top-N" mental model.

### What's NOT included (intentionally)

- **Cross-filtering** — clicking a row does not yet filter other widgets or the map. That's part 4 of #1381 and will be a separate PR.
- Row selection / click-through to the map feature.
- Pagination (just a limit for now).
- Translations beyond English.

## Test plan

- [x] `tsc --noEmit` passes on core and desktop (no new errors)
- [ ] Add a vector layer with mixed numeric/categorical fields
- [ ] Open Dashboard → Add widget → choose List
- [ ] Verify column checkboxes appear with all available fields
- [ ] Pick 2-3 columns → save → verify table shows those columns
- [ ] Set sort by a numeric field → desc → verify rows are sorted
- [ ] Change limit to 5 → verify only 5 rows show
- [ ] Edit existing list widget → all fields pre-fill correctly
- [ ] Save project → reopen → list widgets persist (also verifies the project.ts fix)

Closes part of #1381.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selector dashboard widgets with single- or multi-value filtering.
  * Added list dashboard widgets with configurable columns, sorting, and row limits.
  * Expanded the widget editor with controls for configuring selector and list widgets.
  * Added localized labels for the new widget types and settings.
* **Bug Fixes**
  * Dashboard configurations now retain selector and list widgets when projects are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->