### PR TITLE
fix(map): patch Popup.prototype instead of the maplibre namespace

### DIFF
--- a/packages/map/src/globe-popup-occlusion.ts
+++ b/packages/map/src/globe-popup-occlusion.ts
@@ -1,34 +1,54 @@
-import type maplibregl from "maplibre-gl";
+import type { Popup, PopupOptions } from "maplibre-gl";
 
 /** JS-observable marker for occluded popups; visual hiding is applied inline. */
 export const GLOBE_POPUP_OCCLUDED_CLASS = "geolibre-globe-popup-occluded";
 
-const PATCHED_POPUP_MARKER = "__geolibreGlobePopupOcclusionPatched";
 const DEFAULT_OCCLUDED_OPACITY = 0;
 const ZERO_OPACITY_STRING = /^[+-]?(?:0+(?:\.0*)?|\.(?:0+))$/;
 
-type PopupConstructor = new (options?: maplibregl.PopupOptions) => maplibregl.Popup;
+// Registered with Symbol.for so a second copy of this module (a duplicated
+// @geolibre/map inside a plugin bundle) recognizes the first copy's work and
+// does not wrap `addTo` — or a popup's `_updateOpacity` — twice.
+const PATCHED_PROTOTYPE = Symbol.for("geolibre.globePopupOcclusion.patchedPrototype");
+const INSTRUMENTED_POPUP = Symbol.for("geolibre.globePopupOcclusion.instrumentedPopup");
 
-type PatchablePopupConstructor = PopupConstructor & {
-  [PATCHED_POPUP_MARKER]?: true;
-};
+type PopupConstructor = new (options?: PopupOptions) => Popup;
 
-interface PatchableMapLibre {
-  Popup: PatchablePopupConstructor;
+/**
+ * The slice of the MapLibre entry point this module touches.
+ *
+ * Typed structurally instead of as `typeof maplibregl` so it accepts both v5's
+ * mutable default-export object and v6's ESM module namespace object.
+ */
+export interface MapLibrePopupNamespace {
+  Popup: PopupConstructor;
+}
+
+interface PatchablePopupPrototype {
+  addTo: (this: unknown, map: unknown) => unknown;
+  [PATCHED_PROTOTYPE]?: true;
+}
+
+interface OccludableTransform {
+  isLocationOccluded?: (lngLat: unknown) => boolean;
+}
+
+interface PopupHostMap {
+  /** MapLibre v6: `Map` no longer extends `Camera`, so the transform moved here. */
+  _camera?: { transform?: OccludableTransform };
+  /** MapLibre v5: `Map extends Camera`, so the transform is on the map itself. */
+  transform?: OccludableTransform;
 }
 
 interface PopupInternals {
   _container?: HTMLElement;
-  _map?: {
-    transform?: {
-      isLocationOccluded?: (lngLat: unknown) => boolean;
-    };
-  };
-  _updateOpacity?: () => void;
+  _map?: PopupHostMap;
+  _updateOpacity?: (...args: unknown[]) => void;
   getLngLat: () => unknown;
   options?: {
     locationOccludedOpacity?: number | string | null;
   };
+  [INSTRUMENTED_POPUP]?: true;
 }
 
 interface InteractiveStyles {
@@ -37,6 +57,20 @@ interface InteractiveStyles {
 }
 
 const hiddenPopupStyles = new WeakMap<HTMLElement, InteractiveStyles>();
+
+/**
+ * Resolve the transform MapLibre computes globe occlusion against.
+ *
+ * v6 split `Camera` out of `Map` and its own `Popup` reads
+ * `_map._camera.transform`; v5 exposes `_map.transform` directly. Both are
+ * checked because this module ships against either. Getting this wrong fails
+ * silently — the occlusion check just never runs — so it stays in one place.
+ */
+function resolveOccludableTransform(
+  map: PopupHostMap | undefined,
+): OccludableTransform | undefined {
+  return map?._camera?.transform ?? map?.transform;
+}
 
 function shouldSuppressInteraction(popup: PopupInternals): boolean {
   const opacity = popup.options?.locationOccludedOpacity;
@@ -74,11 +108,11 @@ function setPopupOccluded(container: HTMLElement, occluded: boolean): void {
   container.style.visibility = "hidden";
 }
 
-export function syncPopupGlobeOcclusion(popup: maplibregl.Popup): boolean {
+export function syncPopupGlobeOcclusion(popup: Popup): boolean {
   const popupInternals = popup as unknown as PopupInternals;
   const container = popupInternals._container;
   const opacity = popupInternals.options?.locationOccludedOpacity;
-  const transform = popupInternals._map?.transform;
+  const transform = resolveOccludableTransform(popupInternals._map);
   const isLocationOccluded = transform?.isLocationOccluded;
 
   if (!container || opacity === undefined || opacity === null) {
@@ -93,27 +127,57 @@ export function syncPopupGlobeOcclusion(popup: maplibregl.Popup): boolean {
   return occluded;
 }
 
-export function installGlobePopupOcclusion(maplibre: typeof maplibregl): void {
-  const api = maplibre as unknown as PatchableMapLibre;
-  const OriginalPopup = api.Popup;
-  if (OriginalPopup[PATCHED_POPUP_MARKER]) return;
+/**
+ * Give one popup instance the occlusion behavior: opt it into MapLibre's own
+ * occlusion math, then wrap the opacity update so the interaction suppression
+ * and marker class ride along.
+ *
+ * MapLibre assigns `_updateOpacity` as an instance arrow inside the `Popup`
+ * constructor, so it shadows anything installed on the prototype — the wrap has
+ * to happen per instance rather than once on `Popup.prototype`.
+ */
+function instrumentPopup(popup: PopupInternals): void {
+  if (popup[INSTRUMENTED_POPUP]) return;
+  popup[INSTRUMENTED_POPUP] = true;
 
-  class GeoLibrePopup extends OriginalPopup {
-    constructor(options: maplibregl.PopupOptions = {}) {
-      super({
-        ...options,
-        locationOccludedOpacity: options.locationOccludedOpacity ?? DEFAULT_OCCLUDED_OPACITY,
-      });
-
-      const popup = this as unknown as PopupInternals;
-      const updateOpacity = popup._updateOpacity;
-      popup._updateOpacity = () => {
-        if (popup.getLngLat()) updateOpacity?.call(this);
-        syncPopupGlobeOcclusion(this);
-      };
-    }
+  // MapLibre skips the occlusion check entirely unless this option is set, so
+  // default it on every popup — including ones a plugin constructed itself.
+  if (popup.options) {
+    popup.options.locationOccludedOpacity ??= DEFAULT_OCCLUDED_OPACITY;
   }
 
-  GeoLibrePopup[PATCHED_POPUP_MARKER] = true;
-  api.Popup = GeoLibrePopup;
+  const updateOpacity = popup._updateOpacity;
+  popup._updateOpacity = (...args: unknown[]) => {
+    if (popup.getLngLat()) updateOpacity?.apply(popup, args);
+    syncPopupGlobeOcclusion(popup as unknown as Popup);
+  };
+}
+
+/**
+ * Install globe-occlusion behavior on every MapLibre popup, including ones
+ * constructed by third-party plugins.
+ *
+ * This patches `Popup.prototype.addTo` rather than replacing `maplibre.Popup`.
+ * A v6 module namespace object is sealed and rejects assignment
+ * (`TypeError: Cannot assign to property 'Popup' of [object Module]`), while
+ * the `Popup` class it exposes is an ordinary mutable object. Patching the
+ * prototype also reaches consumers a namespace swap never could: plugins that
+ * `import { Popup } from "maplibre-gl"` by name, and popups (or subclasses)
+ * created before this runs.
+ *
+ * `addTo` is the hook because it is the one prototype method every popup goes
+ * through on its way onto a map — `Marker#togglePopup` routes through it too —
+ * and it wraps before MapLibre's own `_update()`/`_updateOpacity()` runs, so
+ * the first painted frame is already correct.
+ */
+export function installGlobePopupOcclusion(maplibre: MapLibrePopupNamespace): void {
+  const prototype = maplibre.Popup.prototype as unknown as PatchablePopupPrototype;
+  if (prototype[PATCHED_PROTOTYPE]) return;
+
+  const originalAddTo = prototype.addTo;
+  prototype.addTo = function (this: unknown, map: unknown) {
+    instrumentPopup(this as PopupInternals);
+    return originalAddTo.call(this, map);
+  };
+  prototype[PATCHED_PROTOTYPE] = true;
 }

--- a/tests/globe-popup-occlusion.test.ts
+++ b/tests/globe-popup-occlusion.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type maplibregl from "maplibre-gl";
+import type { PopupOptions } from "maplibre-gl";
 import {
   GLOBE_POPUP_OCCLUDED_CLASS,
   installGlobePopupOcclusion,
+  type MapLibrePopupNamespace,
 } from "../packages/map/src/globe-popup-occlusion";
 
 interface FakeContainer {
@@ -14,6 +15,25 @@ interface FakeContainer {
     visibility: string;
   };
 }
+
+interface FakeTransform {
+  isLocationOccluded: (lngLat?: unknown) => boolean;
+}
+
+/**
+ * Where the transform hangs off the map: v5 exposes `map.transform`, v6 moved
+ * it to `map._camera.transform` when `Map` stopped extending `Camera`.
+ */
+type TransformShape = "v5" | "v6";
+
+type TestPopup = {
+  _container: HTMLElement;
+  _map: unknown;
+  _updateOpacity: () => void;
+  options: PopupOptions;
+  addTo: (map: unknown) => unknown;
+  getLngLat: () => unknown;
+};
 
 function createClassList(): DOMTokenList {
   const classes = new Set<string>();
@@ -46,24 +66,30 @@ function createContainer(): HTMLElement {
   return container as unknown as HTMLElement;
 }
 
-function createMaplibreStub(): typeof maplibregl {
+function createMap(transform: FakeTransform, shape: TransformShape): unknown {
+  return shape === "v6" ? { _camera: { transform } } : { transform };
+}
+
+function neverOccluded(): FakeTransform {
+  return { isLocationOccluded: () => false };
+}
+
+function createMaplibreStub(shape: TransformShape): MapLibrePopupNamespace {
   class FakePopup {
     _container = createContainer();
-    _map = {
-      transform: {
-        isLocationOccluded(_lngLat?: unknown) {
-          return false;
-        },
-      },
-    };
+    _map: { _camera?: { transform: FakeTransform }; transform?: FakeTransform } = {};
     _updateOpacity: () => void;
-    options: maplibregl.PopupOptions;
+    options: PopupOptions;
 
-    constructor(options: maplibregl.PopupOptions = {}) {
+    constructor(options: PopupOptions = {}) {
       this.options = options;
+      // MapLibre assigns _updateOpacity as an instance arrow in the Popup
+      // constructor, which is why the patch wraps per instance, not on the
+      // prototype. Each version reads the transform from its own location.
       this._updateOpacity = () => {
         if (this.options.locationOccludedOpacity === undefined) return;
-        if (this._map.transform.isLocationOccluded()) {
+        const transform = shape === "v6" ? this._map._camera?.transform : this._map.transform;
+        if (transform?.isLocationOccluded()) {
           this._container.style.opacity = `${this.options.locationOccludedOpacity}`;
         } else {
           this._container.style.opacity = "";
@@ -71,85 +97,103 @@ function createMaplibreStub(): typeof maplibregl {
       };
     }
 
+    // Mirrors MapLibre: addTo attaches the map, then runs an update pass.
+    addTo(map: unknown) {
+      this._map = map as FakePopup["_map"];
+      this._updateOpacity();
+      return this;
+    }
+
     getLngLat() {
       return { lng: 0, lat: 0 };
     }
   }
 
-  return {
-    Popup: FakePopup,
-  } as unknown as typeof maplibregl;
+  return { Popup: FakePopup } as unknown as MapLibrePopupNamespace;
+}
+
+/** Construct a popup and put it on a map, the way real code reaches occlusion. */
+function openPopup(
+  maplibre: MapLibrePopupNamespace,
+  shape: TransformShape,
+  options?: PopupOptions,
+  transform: FakeTransform = neverOccluded(),
+): TestPopup {
+  const popup = new maplibre.Popup(options) as unknown as TestPopup;
+  popup.addTo(createMap(transform, shape));
+  return popup;
+}
+
+for (const shape of ["v5", "v6"] as const) {
+  describe(`installGlobePopupOcclusion (maplibre ${shape} transform)`, () => {
+    it("defaults popups to hidden globe occlusion and restores interaction", () => {
+      const maplibre = createMaplibreStub(shape);
+      installGlobePopupOcclusion(maplibre);
+
+      const popup = openPopup(maplibre, shape);
+      assert.equal(popup.options.locationOccludedOpacity, 0);
+
+      popup._map = createMap({ isLocationOccluded: () => true }, shape);
+      popup._updateOpacity();
+
+      assert.equal(popup._container.style.opacity, "0");
+      assert.equal(popup._container.style.pointerEvents, "none");
+      assert.equal(popup._container.style.visibility, "hidden");
+      assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), true);
+
+      popup._map = createMap({ isLocationOccluded: () => false }, shape);
+      popup._updateOpacity();
+
+      assert.equal(popup._container.style.opacity, "");
+      assert.equal(popup._container.style.pointerEvents, "auto");
+      assert.equal(popup._container.style.visibility, "visible");
+      assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), false);
+    });
+
+    it("hides an already-occluded popup on the first frame after addTo", () => {
+      const maplibre = createMaplibreStub(shape);
+      installGlobePopupOcclusion(maplibre);
+
+      const popup = openPopup(maplibre, shape, undefined, { isLocationOccluded: () => true });
+
+      assert.equal(popup._container.style.opacity, "0");
+      assert.equal(popup._container.style.pointerEvents, "none");
+      assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), true);
+    });
+
+    it("respects explicit nonzero locationOccludedOpacity values", () => {
+      const maplibre = createMaplibreStub(shape);
+      installGlobePopupOcclusion(maplibre);
+
+      const popup = openPopup(maplibre, shape, { locationOccludedOpacity: 0.35 });
+
+      popup._map = createMap({ isLocationOccluded: () => true }, shape);
+      popup._updateOpacity();
+
+      assert.equal(popup.options.locationOccludedOpacity, 0.35);
+      assert.equal(popup._container.style.opacity, "0.35");
+      assert.equal(popup._container.style.pointerEvents, "auto");
+      assert.equal(popup._container.style.visibility, "visible");
+      assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), false);
+    });
+  });
 }
 
 describe("installGlobePopupOcclusion", () => {
-  it("defaults popups to hidden globe occlusion and restores interaction", () => {
-    const maplibre = createMaplibreStub();
-    installGlobePopupOcclusion(maplibre);
-
-    const popup = new maplibre.Popup() as maplibregl.Popup & {
-      _container: HTMLElement;
-      _map: { transform: { isLocationOccluded: () => boolean } };
-      _updateOpacity: () => void;
-      options: maplibregl.PopupOptions;
-    };
-    assert.equal(popup.options.locationOccludedOpacity, 0);
-
-    popup._map.transform.isLocationOccluded = () => true;
-    popup._updateOpacity();
-
-    assert.equal(popup._container.style.opacity, "0");
-    assert.equal(popup._container.style.pointerEvents, "none");
-    assert.equal(popup._container.style.visibility, "hidden");
-    assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), true);
-
-    popup._map.transform.isLocationOccluded = () => false;
-    popup._updateOpacity();
-
-    assert.equal(popup._container.style.opacity, "");
-    assert.equal(popup._container.style.pointerEvents, "auto");
-    assert.equal(popup._container.style.visibility, "visible");
-    assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), false);
-  });
-
-  it("respects explicit nonzero locationOccludedOpacity values", () => {
-    const maplibre = createMaplibreStub();
-    installGlobePopupOcclusion(maplibre);
-
-    const popup = new maplibre.Popup({
-      locationOccludedOpacity: 0.35,
-    }) as maplibregl.Popup & {
-      _container: HTMLElement;
-      _map: { transform: { isLocationOccluded: () => boolean } };
-      _updateOpacity: () => void;
-      options: maplibregl.PopupOptions;
-    };
-
-    popup._map.transform.isLocationOccluded = () => true;
-    popup._updateOpacity();
-
-    assert.equal(popup.options.locationOccludedOpacity, 0.35);
-    assert.equal(popup._container.style.opacity, "0.35");
-    assert.equal(popup._container.style.pointerEvents, "auto");
-    assert.equal(popup._container.style.visibility, "visible");
-    assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), false);
-  });
+  const shape = "v6" as const;
 
   // Real browsers normalize " 0 " to "0"; the fake container stores it verbatim.
   for (const opacity of ["0", "0.0", " 0 "]) {
     it(`suppresses interaction for zero opacity string ${opacity}`, () => {
-      const maplibre = createMaplibreStub();
+      const maplibre = createMaplibreStub(shape);
       installGlobePopupOcclusion(maplibre);
 
-      const popup = new maplibre.Popup({
-        locationOccludedOpacity: opacity,
-      }) as maplibregl.Popup & {
-        _container: HTMLElement;
-        _map: { transform: { isLocationOccluded: () => boolean } };
-        _updateOpacity: () => void;
-      };
-
-      popup._map.transform.isLocationOccluded = () => true;
-      popup._updateOpacity();
+      const popup = openPopup(
+        maplibre,
+        shape,
+        { locationOccludedOpacity: opacity },
+        { isLocationOccluded: () => true },
+      );
 
       assert.equal(popup._container.style.opacity, opacity);
       assert.equal(popup._container.style.pointerEvents, "none");
@@ -161,19 +205,15 @@ describe("installGlobePopupOcclusion", () => {
   for (const opacity of ["", " "]) {
     // Browsers reject " " as CSS opacity; the fake container stores it verbatim.
     it(`does not suppress interaction for blank opacity ${JSON.stringify(opacity)}`, () => {
-      const maplibre = createMaplibreStub();
+      const maplibre = createMaplibreStub(shape);
       installGlobePopupOcclusion(maplibre);
 
-      const popup = new maplibre.Popup({
-        locationOccludedOpacity: opacity,
-      }) as maplibregl.Popup & {
-        _container: HTMLElement;
-        _map: { transform: { isLocationOccluded: () => boolean } };
-        _updateOpacity: () => void;
-      };
-
-      popup._map.transform.isLocationOccluded = () => true;
-      popup._updateOpacity();
+      const popup = openPopup(
+        maplibre,
+        shape,
+        { locationOccludedOpacity: opacity },
+        { isLocationOccluded: () => true },
+      );
 
       assert.equal(popup._container.style.opacity, opacity);
       assert.equal(popup._container.style.pointerEvents, "auto");
@@ -183,19 +223,15 @@ describe("installGlobePopupOcclusion", () => {
   }
 
   it("does not suppress interaction for non-decimal zero opacity strings", () => {
-    const maplibre = createMaplibreStub();
+    const maplibre = createMaplibreStub(shape);
     installGlobePopupOcclusion(maplibre);
 
-    const popup = new maplibre.Popup({
-      locationOccludedOpacity: "0e0",
-    }) as maplibregl.Popup & {
-      _container: HTMLElement;
-      _map: { transform: { isLocationOccluded: () => boolean } };
-      _updateOpacity: () => void;
-    };
-
-    popup._map.transform.isLocationOccluded = () => true;
-    popup._updateOpacity();
+    const popup = openPopup(
+      maplibre,
+      shape,
+      { locationOccludedOpacity: "0e0" },
+      { isLocationOccluded: () => true },
+    );
 
     assert.equal(popup._container.style.opacity, "0e0");
     assert.equal(popup._container.style.pointerEvents, "auto");
@@ -204,26 +240,17 @@ describe("installGlobePopupOcclusion", () => {
   });
 
   it("calls isLocationOccluded with the transform receiver", () => {
-    const maplibre = createMaplibreStub();
+    const maplibre = createMaplibreStub(shape);
     installGlobePopupOcclusion(maplibre);
 
-    const popup = new maplibre.Popup() as maplibregl.Popup & {
-      _container: HTMLElement;
-      _map: {
-        transform: {
-          receiverMarker: string;
-          isLocationOccluded: (lngLat?: unknown) => boolean;
-        };
-      };
-      _updateOpacity: () => void;
-    };
-
-    popup._map.transform = {
+    const popup = openPopup(maplibre, shape);
+    const transform = {
       receiverMarker: "transform",
       isLocationOccluded(this: { receiverMarker: string }) {
         return this.receiverMarker === "transform";
       },
     };
+    popup._map = createMap(transform, shape);
     popup._updateOpacity();
 
     assert.equal(popup._container.style.opacity, "0");
@@ -231,21 +258,21 @@ describe("installGlobePopupOcclusion", () => {
   });
 
   it("treats a popup with no coordinate as visible", () => {
-    const maplibre = createMaplibreStub();
+    const maplibre = createMaplibreStub(shape);
     installGlobePopupOcclusion(maplibre);
 
-    const popup = new maplibre.Popup() as maplibregl.Popup & {
-      _container: HTMLElement;
-      _map: { transform: { isLocationOccluded: () => boolean } };
-      _updateOpacity: () => void;
-      getLngLat: () => undefined;
-    };
+    const popup = openPopup(maplibre, shape);
     let called = false;
     popup.getLngLat = () => undefined;
-    popup._map.transform.isLocationOccluded = () => {
-      called = true;
-      return true;
-    };
+    popup._map = createMap(
+      {
+        isLocationOccluded: () => {
+          called = true;
+          return true;
+        },
+      },
+      shape,
+    );
     popup._updateOpacity();
 
     assert.equal(called, false);
@@ -254,12 +281,49 @@ describe("installGlobePopupOcclusion", () => {
     assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), false);
   });
 
-  it("is idempotent", () => {
-    const maplibre = createMaplibreStub();
-    installGlobePopupOcclusion(maplibre);
-    const once = maplibre.Popup;
+  // MapLibre v6 ships an ESM namespace object, which is sealed: the old
+  // `maplibre.Popup = GeoLibrePopup` swap threw and the map never mounted.
+  it("does not assign to the maplibre namespace", () => {
+    const maplibre = Object.freeze(createMaplibreStub(shape));
+    const Original = maplibre.Popup;
+
     installGlobePopupOcclusion(maplibre);
 
-    assert.equal(maplibre.Popup, once);
+    assert.equal(maplibre.Popup, Original);
+
+    const popup = openPopup(maplibre, shape, undefined, { isLocationOccluded: () => true });
+    assert.equal(popup._container.style.opacity, "0");
+  });
+
+  it("patches popups constructed before it runs", () => {
+    const maplibre = createMaplibreStub(shape);
+    const popup = new maplibre.Popup() as unknown as TestPopup;
+
+    installGlobePopupOcclusion(maplibre);
+    popup.addTo(createMap({ isLocationOccluded: () => true }, shape));
+
+    assert.equal(popup.options.locationOccludedOpacity, 0);
+    assert.equal(popup._container.style.opacity, "0");
+    assert.equal(popup._container.classList.contains(GLOBE_POPUP_OCCLUDED_CLASS), true);
+  });
+
+  it("wraps a popup only once across repeated addTo calls", () => {
+    const maplibre = createMaplibreStub(shape);
+    installGlobePopupOcclusion(maplibre);
+
+    const popup = openPopup(maplibre, shape);
+    const wrapped = popup._updateOpacity;
+    popup.addTo(createMap(neverOccluded(), shape));
+
+    assert.equal(popup._updateOpacity, wrapped);
+  });
+
+  it("is idempotent", () => {
+    const maplibre = createMaplibreStub(shape);
+    installGlobePopupOcclusion(maplibre);
+    const once = (maplibre.Popup.prototype as { addTo: unknown }).addTo;
+    installGlobePopupOcclusion(maplibre);
+
+    assert.equal((maplibre.Popup.prototype as { addTo: unknown }).addTo, once);
   });
 });


### PR DESCRIPTION
Clears **blocker 3** of #1489, and a second break in the same file that the issue did not catch.

## Blocker 3a — the reported crash

`installGlobePopupOcclusion` installed globe occlusion by replacing the export:

```ts
api.Popup = GeoLibrePopup;   // map-controller.ts calls this at map construction
```

That works only because v5's CJS/UMD default export is a mutable object. A v6 ESM module namespace is sealed and rejects `[[Set]]` regardless of the `writable` flag, so the assignment throws before the map canvas mounts:

```
TypeError: Cannot assign to property 'Popup' of [object Module]
```

## Blocker 3b — the same file breaks again, silently

v6 stopped having `Map` extend `Camera` (`declare class Map extends Evented`, with a private `_camera: Camera`). `map.transform` is gone, and v6's own `Popup` reads `this._map._camera.transform.isLocationOccluded(...)`.

Our mirror read `popupInternals._map?.transform`. Under v6 that is `undefined` — and because the lookup is optional-chained, nothing throws: `occluded` is simply always `false` and popups on the back of the globe stay visible. A green build **and** a green e2e run would both have missed it. This was the only `map.transform` read in the repo, so it is contained to this file.

## The fix

Patch `Popup.prototype.addTo` rather than the namespace binding. The binding is frozen; the `Popup` class it exposes is an ordinary mutable object.

- `addTo` is the single prototype method every popup passes through on its way onto a map (`Marker#togglePopup` routes through it too), and the wrap runs before MapLibre's own `_update()` → `_updateOpacity()`, so the first painted frame is already correct.
- `_updateOpacity` is assigned as an **instance arrow inside the `Popup` constructor** in both v5 and v6, so it shadows anything put on the prototype — it still has to be wrapped per instance. Worth knowing before anyone tries the simpler-looking version.
- Both transform locations now resolve through one documented helper.

The parameter is typed structurally (`{ Popup: PopupConstructor }`) instead of `typeof maplibregl`, so it accepts v5's default-export object and v6's namespace alike, and the type-only import moved to named imports (`import type { Popup, PopupOptions }`), which both versions export.

## Behavior

Identical for everything the old patch reached, and **wider** — the namespace swap could never reach:

- plugins that `import { Popup } from "maplibre-gl"` by name and call `new Popup()`. `maplibre-gl-raster` does exactly that (`import maplibregl, { Popup } from "maplibre-gl"`), as does our own `maplibre-reverse-geocode` plugin — those popups have had no occlusion at all.
- popups, or `class X extends maplibregl.Popup` subclasses, created before `installGlobePopupOcclusion` ran.

This also means the design question the issue flagged — keep the global patch or export a `GeoLibrePopup` for our own call sites — does not have to be traded away: 7 installed packages construct popups (`maplibre-gl-components`, `-duckdb`, `-geoagent`, `-geo-editor`, `-raster`, `-vector`, `@geoman-io/maplibre-geoman-free`), including the two external ones we cannot fix, and all keep working.

## Verification

- `tests/globe-popup-occlusion.test.ts` reworked: 18 tests, every behavior case run against **both** transform shapes (`map.transform` and `map._camera.transform`), plus regression tests for the mechanism itself — install against a **frozen** namespace, popups constructed before install, and single-wrap across repeated `addTo`.
- The shipped module driven against **real `maplibre-gl` 5.24.0 and 6.0.0** `Popup` classes: install succeeds on both, occlusion applies through each version's transform path, and named-import + subclass + pre-install popups are all covered. On v6 the old mechanism throws exactly as reported.
- **In a browser on the running app**: with the globe projection, a popup at `[180, 0]` while the camera is at `[0, 0]` gets `opacity: 0`, `visibility: hidden`, `pointer-events: none` and the `geolibre-globe-popup-occluded` class, then restores when the globe is rotated to face it. No page errors.
- `npm run test:frontend` 4234 passed / 0 failed · `tsc -b && vite build` clean · `npm run lint` 0 errors.
- `npm run test:e2e` 20 passed / 3 failed — all three (`a11y`, both `export` specs) reproduce identically on `main` with this branch stashed, so they are pre-existing/flaky here, not caused by this change.

This lands on 5.x and is v5-safe; it does not move `maplibre-gl`. Blockers 1 (external packages) and 2 (no CJS build under `node --test`) are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved globe popup occlusion compatibility across MapLibre v5 and v6.
  * Preserved popup opacity behavior when locations are hidden behind the globe.
  * Ensured popup occlusion works for popups created before or after setup.
  * Prevented duplicate instrumentation when popups are added repeatedly.
* **Reliability**
  * Improved compatibility with sealed or frozen MapLibre configuration objects.
  * Installer behavior is now safe to repeat without unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->