### PR TITLE
fix: update time slider to 1.8.4

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -81,7 +81,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",
-    "maplibre-gl-time-slider": "^1.8.3",
+    "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.2",
     "openai": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",
-        "maplibre-gl-time-slider": "^1.8.3",
+        "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.2",
         "openai": "^7.0.0",
@@ -17236,9 +17236,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.3.tgz",
-      "integrity": "sha512-RcMMGyr7RHIDAWffG1ijJWQ7FRiKuVyrpIqIh9bBTdtQTjOqX9Jys/YOrJ7RBmG8mPiJbB66YwmVDa4RguRWVg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.8.4.tgz",
+      "integrity": "sha512-gMe18HbMBuibSR8vnyIgxSx0KrmTvl9p8tg3RAksmGG2gUmCBIUyhhK4GBXfgUENK0JDnNe6X62kh2m3wcU/cw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -21918,7 +21918,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",
-        "maplibre-gl-time-slider": "^1.8.3",
+        "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.2",
         "netcdfjs": "^4.0.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -57,7 +57,7 @@
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",
-    "maplibre-gl-time-slider": "^1.8.3",
+    "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.2",
     "netcdfjs": "^4.0.0",


### PR DESCRIPTION
Bumps `maplibre-gl-time-slider` from 1.8.3 to 1.8.4 in both manifests that list it (`apps/geolibre-desktop`, `packages/plugins`), so the workspace resolves a single copy.

## What it fixes

Upstream [opengeos/maplibre-gl-time-slider#41](https://github.com/opengeos/maplibre-gl-time-slider/pull/41) (fixes [#40](https://github.com/opengeos/maplibre-gl-time-slider/issues/40)) replaces the tick-labeling threshold bands with one span-driven ladder. The old code labeled every period at 12 or fewer, otherwise jumped to a fixed next-coarser unit, so ranges between the bands under-labeled badly:

- A 31-step **daily** range fell past the short-range limit to month labels, and the only month boundary in range was January 1, which rendered as a bare year. One label over an empty track.
- A **monthly** range of 13 to 24 months showed only its year boundaries.

Labeling now comes from a ladder of round calendar cadences (1h through 1000y), filtered to those no finer than the active granularity, picking the rung nearest `span / labelBudget`. Steps stay expressed as calendar units, so nothing drifts across leap years.

## Verification

Driven in the running app with the Time Slider plugin active, at a 337px track:

| Range | Before | After |
| --- | --- | --- |
| Daily, 2026-01-01 to 2026-01-31 | `2026` | `Jan 01 2026 / Jan 08 / Jan 15 / Jan 22 / Jan 29` |
| Monthly, 2023-01 to 2024-12 | `2023 / 2024` | `Jan 2023 / Jul 2023 / Jan 2024 / Jul 2024` |
| Yearly, 1984 to 2013 (plugin default) | `1990 / 2000 / 2010` | unchanged |

Checked in both light and dark mode via the app's theme toggle; the plugin's theme sync applies `ts-theme-dark` correctly and no labels are suppressed by the overlap pass in either.

`pre-commit run --files <changed>` passes, including the `npm build` hook. The diff is limited to the two version ranges and the corresponding lockfile entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the map time slider component to the latest compatible patch version, including the desktop app and plugin experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->