### PR TITLE
fix(time-slider): close the dock when the last temporal binding is removed

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -90,6 +90,7 @@ import {
   usePluginRegistry,
   useProjectPluginTrust,
   useSwipeSplitViewExclusivity,
+  useTimeSliderAutoClose,
 } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { hasReverseGeocodeConsent } from "../../lib/reverse-geocode-consent";
@@ -735,6 +736,9 @@ export function DesktopShell({
   // Keep Layer Swipe and split view mutually exclusive (#844): entering a
   // multi-pane grid turns the swipe slider off.
   useSwipeSplitViewExclusivity(mapControllerRef);
+  // Close a binding-opened Time Slider once the last temporal layer is gone
+  // (#1512), so the dock does not linger over a map with no timeline.
+  useTimeSliderAutoClose(mapControllerRef);
   // Live-collaboration session. Owned here (rather than in TopToolbar) so both
   // the Collaborate dialog and the on-canvas status badge share one socket, and
   // so the dialog stays mounted in toolbar-hidden layouts.

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -65,7 +65,12 @@ import {
   placeholderMessage,
 } from "@geolibre/map";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
-import { bindTemporalLayer, createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
+import {
+  activateTimeSliderForBinding,
+  bindTemporalLayer,
+  createAppAPI,
+  usePluginRegistry,
+} from "../../hooks/usePlugins";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
 import {
   clearFeatureSelection,
@@ -1703,9 +1708,7 @@ export function LayerPanel({
       },
       timeFilter: undefined,
     });
-    if (!isPluginActive(TIME_SLIDER_PLUGIN_ID)) {
-      togglePlugin(TIME_SLIDER_PLUGIN_ID, createAppAPI(mapControllerRef));
-    }
+    activateTimeSliderForBinding(mapControllerRef);
     closeBindTimeSliderDialog();
   }, [
     bindTimeSliderLayer,
@@ -1717,8 +1720,6 @@ export function LayerPanel({
     bindWindowMode,
     mapControllerRef,
     updateLayer,
-    isPluginActive,
-    togglePlugin,
     closeBindTimeSliderDialog,
     t,
   ]);

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -9,6 +9,7 @@ import {
   buildSelectorTimeBinding,
   registerTemporalLayer,
   unregisterTemporalLayer,
+  isTimeSliderIdle,
   TIME_SLIDER_PLUGIN_ID,
   type TemporalLayerAdapter,
   setZarrLayerSelector,
@@ -106,6 +107,7 @@ import { pickZarrDirectory, zarrDirectoryPickerSupported } from "../lib/zarr-dir
 import { openExternalLink } from "../lib/open-external";
 import { fetchUrlBytes } from "../lib/native-http";
 import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
+import { setTimeSliderOpenedByBinding, shouldCloseTimeSliderDock } from "../lib/time-slider-dock";
 import { createWmsTileUrl, normalizeWmsVersion } from "../components/layout/add-data/helpers";
 import { createExternalNativeStoreLayer } from "../lib/external-native-layer";
 import { mergeStringLists } from "../lib/string-lists";
@@ -238,6 +240,17 @@ setEarthdataCogSaver(async (geoTiffBytes, defaultName) => {
 if (zarrDirectoryPickerSupported()) {
   setZarrLocalStoreProvider(pickZarrDirectory);
 }
+
+// Forget that a binding opened the Time Slider dock as soon as the plugin goes
+// inactive by any route (#1512), so a later manual activation is not mistaken
+// for a binding-opened one and closed out from under the user.
+let timeSliderWasActive = false;
+manager.subscribe(() => {
+  const active = manager.isActive(TIME_SLIDER_PLUGIN_ID);
+  if (active === timeSliderWasActive) return;
+  timeSliderWasActive = active;
+  if (!active) setTimeSliderOpenedByBinding(false);
+});
 
 let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;
@@ -704,10 +717,83 @@ export function bindTemporalLayer(
     // dialog does when it commits).
     timeFilter: undefined,
   });
-  if (!manager.isActive(TIME_SLIDER_PLUGIN_ID)) {
-    manager.toggle(TIME_SLIDER_PLUGIN_ID, createAppAPI(mapControllerRef));
-  }
+  activateTimeSliderForBinding(mapControllerRef);
   return true;
+}
+
+/**
+ * Open the Time Slider dock because a layer was just bound to it, and remember
+ * that the binding is what opened it so {@link useTimeSliderAutoClose} may close
+ * it again when the last binding goes away (#1512).
+ *
+ * A no-op when the dock is already showing — including when the user opened it
+ * themselves, which deliberately leaves the "opened by a binding" flag false so
+ * their dock is never taken away underneath them.
+ *
+ * Call this **after** the binding has been written to the layer's metadata, so
+ * the dock adopts it on activation.
+ *
+ * @param mapControllerRef - Used to build the app API for activation.
+ */
+export function activateTimeSliderForBinding(
+  mapControllerRef?: RefObject<MapController | null>,
+): void {
+  if (manager.isActive(TIME_SLIDER_PLUGIN_ID)) return;
+  const before = JSON.stringify(projectPluginStateSnapshot());
+  try {
+    manager.activate(TIME_SLIDER_PLUGIN_ID, createAppAPI(mapControllerRef));
+  } catch (error) {
+    // Plugin controls are imperative MapLibre code, so a throw here would escape
+    // React's error boundaries. Contain it, exactly as usePluginRegistry.toggle
+    // does, and leave the project state unwritten.
+    reportPluginError(TIME_SLIDER_PLUGIN_ID, "toggle", error);
+    return;
+  }
+  setTimeSliderOpenedByBinding(manager.isActive(TIME_SLIDER_PLUGIN_ID));
+  persistProjectPluginState(before);
+}
+
+/**
+ * Close a binding-opened Time Slider once it has nothing left to drive (#1512).
+ *
+ * `activatePlugin` / `registerTemporalLayer({ bind: true })` open the dock when
+ * the first temporal layer appears, but nothing closed it again when the last
+ * one went away by a route other than the Layers panel's explicit "Unbind"
+ * action — removing the bound layer, or a plugin swapping a temporal dataset for
+ * a single-period one. The dock then lingered over the map, implying a timeline
+ * no layer has.
+ *
+ * Only a dock opened *by* a binding is closed; one the user opened from the
+ * Plugins menu stays put. `isTimeSliderIdle` additionally keeps it open while
+ * the dock's own raster sources or a KML `<TimeSpan>` overlay remain, since the
+ * dock is the only way to reach those.
+ *
+ * Mounted once near the app root so it covers every way a binding can
+ * disappear, not just the Layers panel.
+ */
+export function useTimeSliderAutoClose(mapControllerRef: RefObject<MapController | null>): void {
+  useEffect(() => {
+    // Subscribed rather than selected from the store so no component re-renders
+    // on every layer edit just to run this check.
+    const check = () => {
+      if (!shouldCloseTimeSliderDock(manager.isActive(TIME_SLIDER_PLUGIN_ID), isTimeSliderIdle)) {
+        return;
+      }
+      const before = JSON.stringify(projectPluginStateSnapshot());
+      try {
+        // Deactivating prunes the dock's own store layers, which re-enters this
+        // subscription; those passes find the dock already idle-and-closing and
+        // the plugin's own deactivate is a no-op once its control is gone.
+        manager.deactivate(TIME_SLIDER_PLUGIN_ID, createAppAPI(mapControllerRef));
+      } catch (error) {
+        reportPluginError(TIME_SLIDER_PLUGIN_ID, "toggle", error);
+        return;
+      }
+      persistProjectPluginState(before);
+    };
+    check();
+    return useAppStore.subscribe(check);
+  }, [mapControllerRef]);
 }
 
 export function createAppAPI(mapControllerRef?: RefObject<MapController | null>) {
@@ -873,6 +959,23 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       const activated = await manager.activate(pluginId, api);
       if (!activated || !manager.isActive(pluginId)) return false;
       return state === undefined ? true : manager.applyPluginState(pluginId, api, state);
+    },
+    // The counterpart of activatePlugin, so a plugin that opened another
+    // plugin's panel can close it again (#1512). Persisted like the toolbar's
+    // own toggle, so the project records the panel as off; a throw from the
+    // target's imperative teardown is contained rather than escaping into the
+    // caller.
+    deactivatePlugin: (pluginId: string) => {
+      if (!manager.isActive(pluginId)) return false;
+      const before = JSON.stringify(projectPluginStateSnapshot());
+      try {
+        manager.deactivate(pluginId, api);
+      } catch (error) {
+        reportPluginError(pluginId, "deactivate", error);
+        return false;
+      }
+      persistProjectPluginState(before);
+      return !manager.isActive(pluginId);
     },
     queryOvertureFeatures,
     addLayerGroup: (name?: string, layerIds?: string[]) =>

--- a/apps/geolibre-desktop/src/lib/time-slider-dock.ts
+++ b/apps/geolibre-desktop/src/lib/time-slider-dock.ts
@@ -1,0 +1,51 @@
+/**
+ * Whether the Time Slider dock is open *because* a layer was bound to it, as
+ * opposed to the user opening it from the Plugins menu.
+ *
+ * The distinction is the whole policy behind {@link shouldCloseTimeSliderDock}:
+ * a dock that a binding opened is closed again when the last binding goes away,
+ * while a dock the user opened stays put even with an empty timeline — they may
+ * be about to add a raster time series through its own "Add data" form.
+ */
+let openedByBinding = false;
+
+/**
+ * Record how the dock came to be open. Set true right after a binding activates
+ * it, and false whenever the plugin goes inactive by any route so a later manual
+ * activation starts from a clean slate.
+ *
+ * @param opened - True when a binding is what opened the dock.
+ */
+export function setTimeSliderOpenedByBinding(opened: boolean): void {
+  openedByBinding = opened;
+}
+
+/** Whether a binding, rather than the user, opened the dock. */
+export function isTimeSliderOpenedByBinding(): boolean {
+  return openedByBinding;
+}
+
+/**
+ * Whether a binding-opened Time Slider dock now has nothing left to drive and
+ * should close itself (#1512).
+ *
+ * `isIdle` is what keeps this honest about the dock's other duties: the dock
+ * stays open while any binding, dock raster source, or KML `<TimeSpan>` overlay
+ * remains, because it is the only way to reach the last two. It is taken as a
+ * thunk so the layer scan is skipped on the overwhelmingly common path (a dock
+ * the user opened, or none at all), and so this module stays free of the plugins
+ * barrel.
+ *
+ * @param active - Whether the Time Slider plugin is currently active.
+ * @param isIdle - Reads whether the slider has anything left to drive, normally
+ *   `isTimeSliderIdle` from `@geolibre/plugins`.
+ * @returns True when the dock should be deactivated.
+ */
+export function shouldCloseTimeSliderDock(active: boolean, isIdle: () => boolean): boolean {
+  return openedByBinding && active && isIdle();
+}
+
+/** Reset the module state between tests. */
+export function __resetTimeSliderDockForTests(): void {
+  openedByBinding = false;
+}

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -568,6 +568,19 @@ Call the returned function, or `app.unregisterTemporalLayer?.(layerId)`, to drop
 
 A bound cube shares the timeline with any vector bindings and dated overlays: the track spans the union of their extents, and the widest dataset sets the stepping granularity.
 
+**Closing the dock again.** A dock that a binding opened closes itself once the last temporal layer is gone, so it never lingers over a map with no timeline. Removing the bound layer is enough; if your plugin keeps the layer and only drops its binding, clear `layer.metadata.timeBinding` as well as unregistering the adapter. A dock the *user* opened from the Plugins menu is left alone, and so is one that still has raster sources of its own or a KML `<TimeSpan>` overlay to drive.
+
+## Activating and deactivating other plugins
+
+```typescript
+await app.activatePlugin?.("maplibre-gl-time-slider");
+app.deactivatePlugin?.("maplibre-gl-time-slider");
+```
+
+`activatePlugin` takes an optional second argument, a project-state patch applied once the target is active; it resolves false when the plugin is unavailable, refuses to activate, or rejects the state. `deactivatePlugin` is its counterpart and returns true when the plugin ended up inactive.
+
+Neither may target the **calling** plugin: `activatePlugin` on yourself is meaningless, and deactivating yourself would unmount the code still on the stack. Both return false in that case.
+
 ## Custom (WebGL) layers and paint ownership
 
 `registerExternalNativeLayer` mirrors a layer the plugin added to the map itself into GeoLibre's layer store, so it appears in the Layers panel and persists with the project:

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -529,7 +529,8 @@ function scopeAppToPlugin(
   const { onControlAdded } = options;
   const register = app.registerToolbarMenu;
   const activatePlugin = app.activatePlugin;
-  if (!register && !onControlAdded && !activatePlugin) return app;
+  const deactivatePlugin = app.deactivatePlugin;
+  if (!register && !onControlAdded && !activatePlugin && !deactivatePlugin) return app;
 
   const scoped: GeoLibreAppAPI = { ...app };
 
@@ -556,6 +557,14 @@ function scopeAppToPlugin(
   if (activatePlugin) {
     scoped.activatePlugin = async (targetPluginId, state) =>
       targetPluginId === pluginId ? false : activatePlugin(targetPluginId, state);
+  }
+
+  if (deactivatePlugin) {
+    // Same self-guard as activatePlugin, for a stronger reason: deactivating the
+    // caller would run its own `deactivate` from inside whichever callback is
+    // executing, unmounting the code still on the stack.
+    scoped.deactivatePlugin = (targetPluginId) =>
+      targetPluginId === pluginId ? false : deactivatePlugin(targetPluginId);
   }
 
   return scoped;

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -425,6 +425,21 @@ export interface GeoLibreAppAPI {
    */
   activatePlugin?: (pluginId: string, state?: unknown) => Promise<boolean>;
   /**
+   * Deactivate an installed plugin, the counterpart of {@link activatePlugin}.
+   * Lets a plugin that opened another plugin's panel close it again when the
+   * reason for opening it is gone — for example a plugin that bound its layer to
+   * the Time Slider and has since unbound the last one.
+   *
+   * A plugin may not deactivate **itself**: tearing a plugin down from inside
+   * its own callback would unmount the code that is still running. Such a call
+   * returns false, mirroring how `activatePlugin` refuses to reactivate the
+   * caller.
+   *
+   * Returns true when the plugin ended up inactive, false when it is unknown,
+   * was not active, is the caller, or threw while unmounting.
+   */
+  deactivatePlugin?: (pluginId: string) => boolean;
+  /**
    * Query a bounded set of features from GeoLibre's official Overture Maps
    * PMTiles integration. The host enforces tile and feature limits.
    */

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -1057,4 +1057,37 @@ describe("PluginManager plugin coordination", () => {
     assert.equal(manager.isActive("first"), true);
     assert.equal(manager.isActive("second"), true);
   });
+
+  it("lets one plugin deactivate another but never itself", () => {
+    const manager = new PluginManager();
+    const coordinatingApp = {
+      ...app,
+      deactivatePlugin: (id: string) => {
+        manager.deactivate(id, coordinatingApp);
+        return !manager.isActive(id);
+      },
+    } as GeoLibreAppAPI;
+    let closer: GeoLibreAppAPI | null = null;
+    manager.register(
+      testPlugin({
+        id: "closer",
+        activate: (scopedApp) => {
+          closer = scopedApp;
+        },
+      }),
+    );
+    manager.register(testPlugin({ id: "dock" }));
+
+    manager.activate("dock", coordinatingApp);
+    manager.activate("closer", coordinatingApp);
+    assert.ok(closer);
+
+    // Deactivating itself is refused, so the plugin that is still running is
+    // never unmounted from inside its own call.
+    assert.equal(closer!.deactivatePlugin?.("closer"), false);
+    assert.equal(manager.isActive("closer"), true);
+
+    assert.equal(closer!.deactivatePlugin?.("dock"), true);
+    assert.equal(manager.isActive("dock"), false);
+  });
 });

--- a/tests/time-slider-auto-close.test.ts
+++ b/tests/time-slider-auto-close.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import { isTimeSliderIdle } from "../packages/plugins/src/plugins/maplibre-time-slider";
+import {
+  __resetTimeSliderDockForTests,
+  isTimeSliderOpenedByBinding,
+  setTimeSliderOpenedByBinding,
+  shouldCloseTimeSliderDock as shouldClose,
+} from "../apps/geolibre-desktop/src/lib/time-slider-dock";
+
+// The app passes the real `isTimeSliderIdle`, so these exercise the whole
+// predicate rather than a stand-in for the "nothing left to drive" half.
+const shouldCloseTimeSliderDock = (active: boolean): boolean =>
+  shouldClose(active, isTimeSliderIdle);
+
+// The dock closes itself once the last temporal binding is gone (#1512), but
+// only when a binding is what opened it. These assert the policy that decides
+// that; `isTimeSliderIdle` (tested in time-slider-config.test.ts) supplies the
+// "nothing left to drive" half.
+
+const layer = (id: string, metadata: Record<string, unknown>): GeoLibreLayer => ({
+  id,
+  name: id,
+  type: "geojson",
+  source: { type: "geojson" },
+  visible: true,
+  opacity: 1,
+  style: { ...DEFAULT_LAYER_STYLE },
+  metadata,
+});
+
+const withLayers = (layers: GeoLibreLayer[]): void => {
+  useAppStore.setState({ layers });
+};
+
+const boundLayer = layer("points", {
+  timeBinding: { property: "date", valueKind: "iso" },
+});
+
+describe("time slider auto-close", () => {
+  afterEach(() => {
+    withLayers([]);
+    __resetTimeSliderDockForTests();
+  });
+
+  it("closes a binding-opened dock once the bound layer is gone", () => {
+    setTimeSliderOpenedByBinding(true);
+    withLayers([boundLayer]);
+    assert.equal(shouldCloseTimeSliderDock(true), false);
+
+    // The layer is removed rather than unbound, which is the route the Layers
+    // panel's Unbind action never sees.
+    withLayers([]);
+    assert.equal(shouldCloseTimeSliderDock(true), true);
+  });
+
+  it("leaves a dock the user opened alone, even with nothing to drive", () => {
+    withLayers([]);
+    assert.equal(isTimeSliderOpenedByBinding(), false);
+    assert.equal(shouldCloseTimeSliderDock(true), false);
+  });
+
+  it("leaves a user-opened dock alone after a bind/remove round trip", () => {
+    // Binding a layer into an already-open dock must not adopt it: the user
+    // opened it, so it is theirs to close.
+    withLayers([boundLayer]);
+    withLayers([]);
+    assert.equal(shouldCloseTimeSliderDock(true), false);
+  });
+
+  it("keeps a binding-opened dock while another binding remains", () => {
+    setTimeSliderOpenedByBinding(true);
+    withLayers([
+      layer("cube", {
+        timeBinding: {
+          kind: "selector",
+          dimension: "time",
+          min: Date.UTC(2020, 0, 1),
+          max: Date.UTC(2020, 0, 31),
+          granularity: "day",
+        },
+      }),
+    ]);
+    assert.equal(shouldCloseTimeSliderDock(true), false);
+  });
+
+  it("keeps a binding-opened dock while it owns raster sources of its own", () => {
+    // Closing it would take the user's COG stack with it: the dock is the only
+    // place those sources can be managed.
+    setTimeSliderOpenedByBinding(true);
+    withLayers([layer("cog", { sourceKind: "time-slider" })]);
+    assert.equal(shouldCloseTimeSliderDock(true), false);
+  });
+
+  it("does nothing when the plugin is already inactive", () => {
+    setTimeSliderOpenedByBinding(true);
+    withLayers([]);
+    assert.equal(shouldCloseTimeSliderDock(false), false);
+  });
+
+  it("forgets the binding origin once the dock is closed", () => {
+    // usePlugins clears the flag on every deactivation, so a later manual
+    // activation starts from a clean slate.
+    setTimeSliderOpenedByBinding(true);
+    setTimeSliderOpenedByBinding(false);
+    withLayers([]);
+    assert.equal(shouldCloseTimeSliderDock(true), false);
+  });
+});


### PR DESCRIPTION
Fixes #1512

## Problem

A plugin (or the Layers panel) opening the Time Slider on the first temporal layer had no symmetric way to close it again. Once the only bound layer was removed, or replaced by a non-temporal one, the dock stayed on screen with an empty timeline, implying a time axis the active data does not have. Only the Layers panel's explicit **Unbind** action closed it.

`reconcileBoundLayers` already restored `preBindingRange` when the registry emptied, but nothing deactivated the plugin.

## Fix

Both directions the issue proposed:

**1. Auto-close on empty (policy stays in GeoLibre, no plugin changes needed).** `useTimeSliderAutoClose`, mounted once in `DesktopShell` next to `useSwipeSplitViewExclusivity`, watches the store and closes the dock once the slider has nothing left to drive. Being a store subscription rather than a call site, it covers every route into that state — removing the bound layer, a project switch, a plugin swapping a temporal dataset for a single-period one — not just the Layers panel.

The policy distinguishes a **binding-opened** dock from a **user-opened** one (`apps/geolibre-desktop/src/lib/time-slider-dock.ts`): a dock the user opened from the Plugins menu is never yanked away, since they may be about to add a raster time series through its own *Add data* form. `isTimeSliderIdle` supplies the other half, so the dock also stays open while its own raster sources or a KML `<TimeSpan>` overlay remain.

**2. `deactivatePlugin(pluginId)` on `GeoLibreAppAPI`**, the counterpart of `activatePlugin`, so a plugin can close a panel it opened. Like `activatePlugin` it refuses to target the caller, which would unmount the code still on the stack.

Binding activation now goes through one `activateTimeSliderForBinding` helper shared by the plugin API and the Layers panel's bind dialog, which also fixes the plugin-API path not persisting the plugin state into the project.

## Verification

Driven in a browser against `time_points.geojson` (2015-2022), in **light and dark themes**:

| Scenario | Before | After |
| --- | --- | --- |
| Bind a layer, then **remove** it | dock stays, empty | dock closes |
| Bind, then **unbind** | dock closes | dock closes (unchanged) |
| Dock opened from **Plugins > Time Slider > Activate**, then bind + remove a layer | dock stays | dock stays |

New unit tests: `tests/time-slider-auto-close.test.ts` (7 cases over the close policy, running the real `isTimeSliderIdle`) and a `PluginManager` case asserting one plugin can deactivate another but never itself. Full frontend suite passes (4250/4251, 1 pre-existing skip); `tsc -b` and `pre-commit` clean.

## Docs

`docs/plugin-api.md` gains an "Activating and deactivating other plugins" section and a note on when a bound dock closes itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time Slider docks opened through layer binding now close automatically when no bound temporal layers remain.
  * Binding a layer to the Time Slider now opens and activates the dock automatically.
  * Plugins can deactivate other plugins through the app API, with safeguards against self-deactivation.

* **Documentation**
  * Added guidance for Time Slider auto-close behavior and plugin activation/deactivation methods.

* **Bug Fixes**
  * Prevented manually opened Time Slider docks from closing unexpectedly.
  * Improved plugin state persistence and error handling during activation and deactivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->