### PR TITLE
feat(style): smart styling on add and a Style suggestions strip

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1327,9 +1327,11 @@ export function StylePanel({
   const styleSuggestions = useMemo(() => {
     if (!layer || !isInitialLayerStyle(layer.style, layer.geojson)) return [];
     return buildStyleSuggestions(layer, getAttributePropertyNames(layer), {
-      supportsPointRenderer: supportsPointRendererFor(layer, isPointOnlyGeoJsonLayer(layer)),
+      // Reuse the memo above rather than re-scanning: supportsPointRendererFor
+      // takes `pointOnly` precisely so the caller can.
+      supportsPointRenderer: supportsPointRendererFor(layer, isPointOnly),
     });
-  }, [layer]);
+  }, [layer, isPointOnly]);
   // Expression Builder inputs, memoized for stable identities: the dialog
   // memoizes its validation/preview/field-type work off these props, so fresh
   // arrays on every panel render would defeat that memoization while the

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1,6 +1,8 @@
 import {
   DEFAULT_LAYER_STYLE,
+  isInitialLayerStyle,
   type DiagramField,
+  type GeoLibreLayer,
   type DiagramSizeMode,
   type DiagramType,
   type ExpressionVariable,
@@ -274,6 +276,25 @@ function isPointOnlyGeoJsonLayer(layer: {
     const type = feature.geometry?.type;
     return type === "Point" || type === "MultiPoint";
   });
+}
+
+/**
+ * True when the heatmap and cluster renderers apply to a layer: a point-only
+ * core GeoJSON layer, or a point layer painted by the maplibre-gl-vector
+ * control. Shared by the panel's own gating and the style-suggestion memo, so
+ * the two cannot disagree about where a heatmap is offerable.
+ *
+ * @param pointOnly - Result of {@link isPointOnlyGeoJsonLayer}, passed in so
+ *   the caller can reuse its memoized value instead of re-scanning features.
+ */
+function supportsPointRendererFor(layer: GeoLibreLayer, pointOnly: boolean): boolean {
+  if (hasExternalDeckLayer(layer)) return false;
+  if (!hasExternalNativeLayers(layer)) return pointOnly;
+  return (
+    layer.type === "geojson" &&
+    layer.metadata.sourceKind === "maplibre-gl-vector" &&
+    layer.metadata.geometryType === "point"
+  );
 }
 
 interface GeometryFlags {
@@ -1233,6 +1254,20 @@ export function StylePanel({
     () => (layer ? getGeometryFlags(layer) : { hasPoint: true, hasLine: true, hasPolygon: true }),
     [layer],
   );
+  // Style suggestions (#1519). The candidate scan reads every feature's
+  // properties, so it is memoized alongside the other per-feature scans rather
+  // than re-run on every panel render (an opacity drag, a zoom-range edit).
+  // Kept before the early returns below so the hook order stays stable.
+  //
+  // isInitialLayerStyle is the gate: a layer only gets suggestions while it
+  // still wears exactly what it was added with. The renderer mode alone would
+  // let an edited fill or a restored project keep being offered advice.
+  const styleSuggestions = useMemo(() => {
+    if (!layer || !isInitialLayerStyle(layer.style, layer.geojson)) return [];
+    return buildStyleSuggestions(layer, getAttributePropertyNames(layer), {
+      supportsPointRenderer: supportsPointRendererFor(layer, isPointOnlyGeoJsonLayer(layer)),
+    });
+  }, [layer]);
   // Expression Builder inputs, memoized for stable identities: the dialog
   // memoizes its validation/preview/field-type work off these props, so fresh
   // arrays on every panel render would defeat that memoization while the
@@ -1455,15 +1490,7 @@ export function StylePanel({
     (isRasterPaintLayer(layer.type) || isRasterTileLayer || isDeckRasterLayer);
   const hasTextMarkerControls = layer.type === "geojson" && hasTextMarkerFeatures(layer);
   // isPointOnly is memoized above the early returns to keep hook order stable.
-  const isCoreGeoJsonPoint =
-    isPointOnly && !hasExternalNativeLayers(layer) && !hasExternalDeckLayer(layer);
-  const isVectorControlPoint =
-    hasExternalNativeLayers(layer) &&
-    !hasExternalDeckLayer(layer) &&
-    layer.type === "geojson" &&
-    layer.metadata.sourceKind === "maplibre-gl-vector" &&
-    layer.metadata.geometryType === "point";
-  const supportsPointRenderer = isCoreGeoJsonPoint || isVectorControlPoint;
+  const supportsPointRenderer = supportsPointRendererFor(layer, isPointOnly);
   // The "Sketches" layer mixes geometry types under one style, so "Circle
   // radius" only applies to its point markers and is misleading otherwise (#483).
   const isSketchLayer = layer.metadata.sourceKind === SKETCHES_SOURCE_KIND;
@@ -2039,16 +2066,9 @@ export function StylePanel({
   const markerShape = styleValue(style, "markerShape");
 
   // --- Style suggestions (#1519) -------------------------------------------
-  // Offered only while the layer still carries its as-added symbology: once
-  // someone has chosen a renderer, second-guessing them is noise. Dismissal is
-  // per-layer and session-scoped — it is a nudge, not project state.
-  const suggestionsApply =
-    styleValue(style, "vectorStyleMode") === "single" &&
-    styleValue(style, "pointRenderer") === "single" &&
-    !dismissedSuggestions.has(layer.id);
-  const styleSuggestions = suggestionsApply
-    ? buildStyleSuggestions(layer, vectorStylePropertyOptions, { supportsPointRenderer })
-    : [];
+  // styleSuggestions is memoized above the early returns. Dismissal is
+  // per-layer and session-scoped — this is a nudge, not project state.
+  const visibleSuggestions = dismissedSuggestions.has(layer.id) ? [] : styleSuggestions;
 
   const applyStyleSuggestion = (suggestion: StyleSuggestion) => {
     if (suggestion.kind === "heatmap") {
@@ -2100,7 +2120,7 @@ export function StylePanel({
 
   const vectorSymbologyControls = (
     <div className="space-y-3">
-      {styleSuggestions.length > 0 && (
+      {visibleSuggestions.length > 0 && (
         <div className="space-y-2 rounded-md border border-dashed bg-muted/40 p-2">
           <div className="flex items-center gap-2">
             <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -2117,7 +2137,7 @@ export function StylePanel({
             </Button>
           </div>
           <div className="flex flex-wrap gap-1.5">
-            {styleSuggestions.map((suggestion) => (
+            {visibleSuggestions.map((suggestion) => (
               <Button
                 key={`${suggestion.kind}-${suggestion.property ?? ""}`}
                 variant="outline"

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1324,6 +1324,14 @@ export function StylePanel({
   // isInitialLayerStyle is the gate: a layer only gets suggestions while it
   // still wears exactly what it was added with. The renderer mode alone would
   // let an edited fill or a restored project keep being offered advice.
+  //
+  // Deliberately NOT keyed on `layer`: that is `layers.find(...)`, and every
+  // `updateLayer` patch (an opacity drag, a rename, a zoom-range edit) rebuilds
+  // the layer object, so a `[layer]` dependency would re-scan on exactly the
+  // interactions this memo exists to survive. The fields below are the only
+  // ones the call actually reads, and each keeps its identity across an
+  // unrelated patch.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const styleSuggestions = useMemo(() => {
     if (!layer || !isInitialLayerStyle(layer.style, layer.geojson)) return [];
     return buildStyleSuggestions(layer, getAttributePropertyNames(layer), {
@@ -1331,7 +1339,7 @@ export function StylePanel({
       // takes `pointOnly` precisely so the caller can.
       supportsPointRenderer: supportsPointRendererFor(layer, isPointOnly),
     });
-  }, [layer, isPointOnly]);
+  }, [layer?.id, layer?.type, layer?.style, layer?.geojson, layer?.metadata, isPointOnly]);
   // Expression Builder inputs, memoized for stable identities: the dialog
   // memoizes its validation/preview/field-type work off these props, so fresh
   // arrays on every panel render would defeat that memoization while the
@@ -2151,7 +2159,10 @@ export function StylePanel({
       DEFAULT_LAYER_STYLE.vectorStyleClassCount,
     );
     const classificationScheme = defaultClassificationScheme(mode);
-    const colorRamp = draftVectorStyleColorRamp;
+    // The layer's committed ramp, not the draft dropdown: a suggestion should
+    // start from the same baseline every time, not from a ramp someone left
+    // selected in the editor without applying it.
+    const colorRamp = styleValue(style, "vectorStyleColorRamp");
     const stops = normalizeVectorStyleStops(
       mode,
       createDefaultStops(layer, mode, property, classCount, colorRamp, classificationScheme),

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -67,8 +67,10 @@ import {
   PanelRightOpen,
   Plus,
   SlidersHorizontal,
+  Sparkles,
   SquareFunction,
   Trash2,
+  X,
 } from "lucide-react";
 import {
   type PointerEvent as ReactPointerEvent,
@@ -86,12 +88,15 @@ import {
   standardExpressionVariables,
 } from "../../lib/expression-inputs";
 import {
+  chooseGraduatedProperty,
   clampClassCount,
   createCategorizedStops,
   createGraduatedStops,
   getPropertyValues,
-  numericBounds,
+  isCategoricalProperty,
+  isNumericProperty,
 } from "../../lib/vector-style-classification";
+import { buildStyleSuggestions, type StyleSuggestion } from "../../lib/style-suggestions";
 
 /**
  * Data-defined label overrides (GH #1320): one row per {@link LabelStyle}
@@ -594,49 +599,6 @@ function chooseDefaultStyleProperty(
   return currentProperty;
 }
 
-function isNumericProperty(
-  layer: Parameters<typeof getPropertyValues>[0],
-  property: string,
-): boolean {
-  const values = getPropertyValues(layer, property);
-  const numericValues = values.map((value) => Number(value)).filter(Number.isFinite);
-  return numericValues.length > 1;
-}
-
-function chooseGraduatedProperty(
-  layer: Parameters<typeof getPropertyValues>[0],
-  properties: string[],
-): string {
-  let bestProperty = "";
-  let bestScore = -1;
-
-  for (const property of properties) {
-    const values = getPropertyValues(layer, property)
-      .map((value) => Number(value))
-      .filter(Number.isFinite);
-    if (values.length < 2) continue;
-
-    const { min, max } = numericBounds(values);
-    const range = max - min;
-    const score = new Set(values).size * Math.log10(Math.max(1, range) + 1);
-    if (score > bestScore) {
-      bestProperty = property;
-      bestScore = score;
-    }
-  }
-
-  return bestProperty;
-}
-
-function isCategoricalProperty(
-  layer: Parameters<typeof getPropertyValues>[0],
-  property: string,
-): boolean {
-  const values = getPropertyValues(layer, property).map((value) => String(value));
-  const uniqueCount = new Set(values).size;
-  return uniqueCount > 1 && uniqueCount <= 12;
-}
-
 function normalizeVectorStyleStops(
   mode: VectorStyleMode,
   stops: VectorStyleStop[],
@@ -1048,6 +1010,8 @@ export function StylePanel({
     DEFAULT_LAYER_STYLE.extrusionAdvancedStyleEnabled,
   );
   const [vectorStyleError, setVectorStyleError] = useState<string | null>(null);
+  // Layers whose style suggestions the user waved off this session (#1519).
+  const [dismissedSuggestions, setDismissedSuggestions] = useState<Set<string>>(() => new Set());
   const [extrusionError, setExtrusionError] = useState<string | null>(null);
   const [loadedVectorPropertyValues, setLoadedVectorPropertyValues] = useState<{
     layerId: string;
@@ -2074,8 +2038,99 @@ export function StylePanel({
   const markerEnabled = styleValue(style, "markerEnabled");
   const markerShape = styleValue(style, "markerShape");
 
+  // --- Style suggestions (#1519) -------------------------------------------
+  // Offered only while the layer still carries its as-added symbology: once
+  // someone has chosen a renderer, second-guessing them is noise. Dismissal is
+  // per-layer and session-scoped — it is a nudge, not project state.
+  const suggestionsApply =
+    styleValue(style, "vectorStyleMode") === "single" &&
+    styleValue(style, "pointRenderer") === "single" &&
+    !dismissedSuggestions.has(layer.id);
+  const styleSuggestions = suggestionsApply
+    ? buildStyleSuggestions(layer, vectorStylePropertyOptions, { supportsPointRenderer })
+    : [];
+
+  const applyStyleSuggestion = (suggestion: StyleSuggestion) => {
+    if (suggestion.kind === "heatmap") {
+      setLayerStyle(layer.id, { pointRenderer: "heatmap" });
+      return;
+    }
+    const mode = suggestion.kind;
+    const property = suggestion.property ?? "";
+    const classCount = normalizeVectorStyleClassCount(
+      mode,
+      DEFAULT_LAYER_STYLE.vectorStyleClassCount,
+    );
+    const classificationScheme = defaultClassificationScheme(mode);
+    const colorRamp = draftVectorStyleColorRamp;
+    const stops = normalizeVectorStyleStops(
+      mode,
+      createDefaultStops(layer, mode, property, classCount, colorRamp, classificationScheme),
+    );
+    // A suggestion that classifies to nothing (all-null column, one distinct
+    // value) would apply an empty renderer and blank the layer — the same
+    // guard applyVectorStyleSettings uses, just silent here.
+    if (mode === "graduated" ? stops.length < 2 : stops.length === 0) return;
+
+    setDraftVectorStyleMode(mode);
+    setDraftVectorStyleProperty(property);
+    setDraftVectorStyleClassCount(classCount);
+    setDraftVectorStyleClassificationScheme(classificationScheme);
+    setDraftVectorStyleStops(stops);
+    setVectorStyleError(null);
+    setLayerStyle(layer.id, {
+      vectorStyleMode: mode,
+      vectorStyleProperty: property,
+      vectorStyleClassCount: classCount,
+      vectorStyleColorRamp: colorRamp,
+      vectorStyleClassificationScheme: classificationScheme,
+      vectorStyleStops: stops,
+    });
+  };
+
+  const suggestionLabel = (suggestion: StyleSuggestion): string =>
+    suggestion.kind === "heatmap"
+      ? t("style.suggestions.heatmap")
+      : t(
+          suggestion.kind === "categorized"
+            ? "style.suggestions.categorize"
+            : "style.suggestions.graduate",
+          { field: suggestion.property },
+        );
+
   const vectorSymbologyControls = (
     <div className="space-y-3">
+      {styleSuggestions.length > 0 && (
+        <div className="space-y-2 rounded-md border border-dashed bg-muted/40 p-2">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <span className="text-xs font-medium">{t("style.suggestions.title")}</span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="ms-auto h-5 w-5"
+              aria-label={t("style.suggestions.dismiss")}
+              title={t("style.suggestions.dismiss")}
+              onClick={() => setDismissedSuggestions((current) => new Set(current).add(layer.id))}
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {styleSuggestions.map((suggestion) => (
+              <Button
+                key={`${suggestion.kind}-${suggestion.property ?? ""}`}
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => applyStyleSuggestion(suggestion)}
+              >
+                {suggestionLabel(suggestion)}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
       <div className="space-y-2">
         <Label htmlFor="vectorStyleMode">{t("style.symbology.styleType")}</Label>
         <Select

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -4314,6 +4314,13 @@
       "invertedFill": "تعبئة معكوسة",
       "invertedFillHint": "تعبئة خارج المعالم"
     },
+    "suggestions": {
+      "title": "اقتراحات التنسيق",
+      "dismiss": "إخفاء الاقتراحات",
+      "categorize": "تصنيف حسب {{field}}",
+      "graduate": "تدريج حسب {{field}}",
+      "heatmap": "خريطة حرارية"
+    },
     "selectLayerHint": "حدد طبقة لتحرير نمطها.",
     "layerOrderDefault": "ترتيب الطبقات (افتراضي)",
     "increaseValue": "زيادة {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Invertierte Füllung",
       "invertedFillHint": "Außenbereich füllen"
     },
+    "suggestions": {
+      "title": "Stilvorschläge",
+      "dismiss": "Vorschläge ausblenden",
+      "categorize": "Nach {{field}} kategorisieren",
+      "graduate": "Nach {{field}} abstufen",
+      "heatmap": "Heatmap"
+    },
     "selectLayerHint": "Wählen Sie eine Ebene aus, um ihren Stil zu bearbeiten.",
     "layerOrderDefault": "Ebenenreihenfolge (Standard)",
     "increaseValue": "{{label}} erhöhen",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4113,6 +4113,13 @@
       "invertedFill": "Inverted fill",
       "invertedFillHint": "Fill outside features"
     },
+    "suggestions": {
+      "title": "Style suggestions",
+      "dismiss": "Dismiss suggestions",
+      "categorize": "Categorize by {{field}}",
+      "graduate": "Graduate by {{field}}",
+      "heatmap": "Heatmap"
+    },
     "selectLayerHint": "Select a layer to edit its style.",
     "layerOrderDefault": "Layer order (default)",
     "increaseValue": "Increase {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Relleno invertido",
       "invertedFillHint": "Rellenar fuera de los elementos"
     },
+    "suggestions": {
+      "title": "Sugerencias de estilo",
+      "dismiss": "Descartar sugerencias",
+      "categorize": "Categorizar por {{field}}",
+      "graduate": "Graduar por {{field}}",
+      "heatmap": "Mapa de calor"
+    },
     "selectLayerHint": "Seleccione una capa para editar su estilo.",
     "layerOrderDefault": "Orden de capas (predeterminado)",
     "increaseValue": "Aumentar {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Remplissage inversé",
       "invertedFillHint": "Remplir hors des entités"
     },
+    "suggestions": {
+      "title": "Suggestions de style",
+      "dismiss": "Masquer les suggestions",
+      "categorize": "Catégoriser par {{field}}",
+      "graduate": "Graduer par {{field}}",
+      "heatmap": "Carte de chaleur"
+    },
     "selectLayerHint": "Sélectionnez une couche pour modifier son style.",
     "layerOrderDefault": "Ordre des couches (par défaut)",
     "increaseValue": "Augmenter {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "उलटा भराव",
       "invertedFillHint": "आकृतियों के बाहर भरें"
     },
+    "suggestions": {
+      "title": "शैली सुझाव",
+      "dismiss": "सुझाव बंद करें",
+      "categorize": "{{field}} के अनुसार वर्गीकृत करें",
+      "graduate": "{{field}} के अनुसार श्रेणीबद्ध करें",
+      "heatmap": "हीटमैप"
+    },
     "selectLayerHint": "इसकी शैली संपादित करने के लिए एक लेयर चुनें।",
     "layerOrderDefault": "लेयर क्रम (डिफ़ॉल्ट)",
     "increaseValue": "{{label}} बढ़ाएं",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -3980,6 +3980,13 @@
       "invertedFill": "Isian terbalik",
       "invertedFillHint": "Isi di luar fitur"
     },
+    "suggestions": {
+      "title": "Saran gaya",
+      "dismiss": "Tutup saran",
+      "categorize": "Kategorikan menurut {{field}}",
+      "graduate": "Gradasikan menurut {{field}}",
+      "heatmap": "Peta panas"
+    },
     "selectLayerHint": "Pilih layer untuk mengedit gayanya.",
     "layerOrderDefault": "Urutan layer (default)",
     "increaseValue": "Naikkan {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Riempimento invertito",
       "invertedFillHint": "Riempi fuori dagli elementi"
     },
+    "suggestions": {
+      "title": "Suggerimenti di stile",
+      "dismiss": "Ignora i suggerimenti",
+      "categorize": "Categorizza per {{field}}",
+      "graduate": "Gradua per {{field}}",
+      "heatmap": "Mappa di calore"
+    },
     "selectLayerHint": "Seleziona un livello per modificarne lo stile.",
     "layerOrderDefault": "Ordine dei livelli (predefinito)",
     "increaseValue": "Aumenta {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -3980,6 +3980,13 @@
       "invertedFill": "反転塗りつぶし",
       "invertedFillHint": "地物の外側を塗りつぶす"
     },
+    "suggestions": {
+      "title": "スタイルの提案",
+      "dismiss": "提案を閉じる",
+      "categorize": "{{field}} で分類",
+      "graduate": "{{field}} で段階分け",
+      "heatmap": "ヒートマップ"
+    },
     "selectLayerHint": "スタイルを編集するレイヤーを選択してください。",
     "layerOrderDefault": "レイヤー順序 (既定)",
     "increaseValue": "{{label}}を増やす",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "ინვერსიული შევსება",
       "invertedFillHint": "ობიექტების გარეთ შევსება"
     },
+    "suggestions": {
+      "title": "სტილის შემოთავაზებები",
+      "dismiss": "შემოთავაზებების დახურვა",
+      "categorize": "კატეგორიზაცია {{field}}-ის მიხედვით",
+      "graduate": "გრადაცია {{field}}-ის მიხედვით",
+      "heatmap": "სითბოს რუკა"
+    },
     "selectLayerHint": "აირჩიეთ შრე მისი სტილის რედაქტირებისთვის.",
     "layerOrderDefault": "შრეების რიგი (ნაგულისხმევი)",
     "increaseValue": "{{label}}-ის გაზრდა",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -3980,6 +3980,13 @@
       "invertedFill": "반전 채우기",
       "invertedFillHint": "피처 바깥쪽 채우기"
     },
+    "suggestions": {
+      "title": "스타일 제안",
+      "dismiss": "제안 닫기",
+      "categorize": "{{field}} 기준으로 분류",
+      "graduate": "{{field}} 기준으로 등급 구분",
+      "heatmap": "히트맵"
+    },
     "selectLayerHint": "스타일을 편집할 레이어를 선택하세요.",
     "layerOrderDefault": "레이어 순서(기본값)",
     "increaseValue": "{{label}} 늘리기",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Omgekeerde vulling",
       "invertedFillHint": "Buiten objecten vullen"
     },
+    "suggestions": {
+      "title": "Stijlsuggesties",
+      "dismiss": "Suggesties verbergen",
+      "categorize": "Categoriseren op {{field}}",
+      "graduate": "Gradueren op {{field}}",
+      "heatmap": "Heatmap"
+    },
     "selectLayerHint": "Selecteer een laag om de stijl ervan te bewerken.",
     "layerOrderDefault": "Laagvolgorde (standaard)",
     "increaseValue": "{{label}} verhogen",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Preenchimento invertido",
       "invertedFillHint": "Preencher fora das feições"
     },
+    "suggestions": {
+      "title": "Sugestões de estilo",
+      "dismiss": "Dispensar sugestões",
+      "categorize": "Categorizar por {{field}}",
+      "graduate": "Graduar por {{field}}",
+      "heatmap": "Mapa de calor"
+    },
     "selectLayerHint": "Selecione uma camada para editar seu estilo.",
     "layerOrderDefault": "Ordem das camadas (padrão)",
     "increaseValue": "Aumentar {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -4181,6 +4181,13 @@
       "invertedFill": "Инвертированная заливка",
       "invertedFillHint": "Заливка вне объектов"
     },
+    "suggestions": {
+      "title": "Предложения по стилю",
+      "dismiss": "Скрыть предложения",
+      "categorize": "Категоризовать по «{{field}}»",
+      "graduate": "Градуировать по «{{field}}»",
+      "heatmap": "Тепловая карта"
+    },
     "selectLayerHint": "Выберите слой, чтобы изменить его стиль.",
     "layerOrderDefault": "Порядок слоёв (по умолчанию)",
     "increaseValue": "Увеличить {{label}}",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -4047,6 +4047,13 @@
       "invertedFill": "Ters dolgu",
       "invertedFillHint": "Objelerin dışını doldur"
     },
+    "suggestions": {
+      "title": "Stil önerileri",
+      "dismiss": "Önerileri kapat",
+      "categorize": "{{field}} alanına göre kategorilendir",
+      "graduate": "{{field}} alanına göre derecelendir",
+      "heatmap": "Isı haritası"
+    },
     "selectLayerHint": "Stilini düzenlemek için bir katman seçin.",
     "layerOrderDefault": "Katman sırası (varsayılan)",
     "increaseValue": "{{label}} değerini artır",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -3980,6 +3980,13 @@
       "invertedFill": "反转填充",
       "invertedFillHint": "填充要素外部区域"
     },
+    "suggestions": {
+      "title": "样式建议",
+      "dismiss": "关闭建议",
+      "categorize": "按 {{field}} 分类",
+      "graduate": "按 {{field}} 分级",
+      "heatmap": "热力图"
+    },
     "selectLayerHint": "选择要编辑样式的图层。",
     "layerOrderDefault": "图层顺序（默认）",
     "increaseValue": "增加{{label}}",

--- a/apps/geolibre-desktop/src/lib/style-suggestions.ts
+++ b/apps/geolibre-desktop/src/lib/style-suggestions.ts
@@ -100,6 +100,37 @@ export type SuggestableLayer = ClassifiableLayer & {
 };
 
 /**
+ * Features read when *choosing* what to suggest.
+ *
+ * Every predicate below walks the layer's values, and it happens once per
+ * candidate column, so an unbounded scan is O(columns x features) on the main
+ * thread the moment the Style panel opens. Matching the cap `dominantGeometry`
+ * already applies for the same reason keeps that bounded.
+ *
+ * This bounds the *choice* only. Applying a suggestion classifies the layer
+ * through the ordinary Style panel path, which still sees every feature, so a
+ * sampled decision never produces sampled class breaks.
+ *
+ * The trade-off is real but small: on a layer with several comparable numeric
+ * columns the sample can rank them differently than a full scan would (on the
+ * USGS earthquake feed the pick moves from `dmin` to `gap`). Both are offers
+ * the user accepts or ignores, and the attribute dropdown sits directly below,
+ * so a different-but-reasonable suggestion costs less than an unbounded scan
+ * on the main thread every time the panel opens.
+ */
+const SUGGESTION_SAMPLE_SIZE = 500;
+
+/** A view of the layer over at most {@link SUGGESTION_SAMPLE_SIZE} features. */
+function sampleLayer(layer: SuggestableLayer): SuggestableLayer {
+  const features = layer.geojson?.features ?? [];
+  if (features.length <= SUGGESTION_SAMPLE_SIZE) return layer;
+  return {
+    ...layer,
+    geojson: { ...layer.geojson, features: features.slice(0, SUGGESTION_SAMPLE_SIZE) },
+  };
+}
+
+/**
  * Suggest up to three renderers for a layer, best first.
  *
  * @param layer - The layer to inspect; its GeoJSON supplies the values.
@@ -114,16 +145,18 @@ export function buildStyleSuggestions(
   options: { supportsPointRenderer: boolean },
 ): StyleSuggestion[] {
   const suggestions: StyleSuggestion[] = [];
-  const candidates = mappableProperties(layer, properties);
+  // Every predicate below scans values per column; do it over a bounded sample.
+  const sample = sampleLayer(layer);
+  const candidates = mappableProperties(sample, properties);
 
   // Categorized first: a low-cardinality label is what a reader most often
   // wants a map colored by, and it needs no scale to interpret.
-  const categorical = candidates.find((property) => isCategoricalProperty(layer, property));
+  const categorical = candidates.find((property) => isCategoricalProperty(sample, property));
   if (categorical) suggestions.push({ kind: "categorized", property: categorical });
 
   // No fallback to the unfiltered list: when every numeric column is an id or a
   // timestamp, offering none is better than recommending a meaningless one.
-  const numeric = chooseGraduatedProperty(layer, candidates);
+  const numeric = chooseGraduatedProperty(sample, candidates);
   if (numeric) suggestions.push({ kind: "graduated", property: numeric });
 
   if (

--- a/apps/geolibre-desktop/src/lib/style-suggestions.ts
+++ b/apps/geolibre-desktop/src/lib/style-suggestions.ts
@@ -45,17 +45,32 @@ function separateCamelCase(property: string): string {
 }
 
 /**
- * Share of distinct values above which a column is treated as an identifier
- * regardless of its name: a value per feature classifies into noise.
+ * Share of distinct values above which a *label* column is treated as an
+ * identifier regardless of its name: a value per feature classifies into noise.
  */
 const NEAR_UNIQUE_RATIO = 0.9;
 /** Below this many features, a high distinct ratio is just a small sample. */
 const NEAR_UNIQUE_MIN_FEATURES = 20;
 
-/** True when a column's values are so nearly all-distinct it behaves as an id. */
-function isNearUnique(layer: ClassifiableLayer, property: string): boolean {
+/** A value that reads as a number — not a blank, a boolean, or free text. */
+function isNumericValue(value: unknown): boolean {
+  if (value === null || value === "" || typeof value === "boolean") return false;
+  return Number.isFinite(Number(value));
+}
+
+/**
+ * True when a column's values are so nearly all-distinct it behaves as an id.
+ *
+ * Deliberately **not** applied to columns that are numeric throughout. A
+ * continuous measurement is near-unique by its nature — building heights,
+ * areas, populations — and rejecting those would throw away precisely the
+ * columns a graduated renderer exists to show. Numeric identifiers are caught
+ * by their name instead; distinctness cannot tell `height` from `parcel_id`.
+ */
+function isNearUniqueLabel(layer: ClassifiableLayer, property: string): boolean {
   const values = getPropertyValues(layer, property);
   if (values.length < NEAR_UNIQUE_MIN_FEATURES) return false;
+  if (values.every(isNumericValue)) return false;
   return new Set(values.map(String)).size / values.length > NEAR_UNIQUE_RATIO;
 }
 
@@ -74,7 +89,7 @@ function mappableProperties(layer: ClassifiableLayer, properties: string[]): str
     return (
       !UNMAPPABLE_NAME.test(normalized) &&
       !TIMESTAMP_NAME.test(normalized) &&
-      !isNearUnique(layer, property)
+      !isNearUniqueLabel(layer, property)
     );
   });
 }

--- a/apps/geolibre-desktop/src/lib/style-suggestions.ts
+++ b/apps/geolibre-desktop/src/lib/style-suggestions.ts
@@ -32,7 +32,17 @@ export const HEATMAP_SUGGESTION_MIN_FEATURES = 200;
  * milliseconds or row numbers.
  */
 const UNMAPPABLE_NAME = /(^|[_\s-])(id|fid|gid|oid|objectid|uid|uuid|key|index)$/i;
-const TIMESTAMP_NAME = /(time|timestamp|datetime|date|updated|created|epoch|_at)$/i;
+const TIMESTAMP_NAME = /(^|[_\s-])(time|timestamp|datetime|date|updated|created|epoch|at)$/i;
+
+/**
+ * Insert a separator at every camelCase boundary so the name patterns above see
+ * `featureId` and `createdAt` the same way they see `feature_id` and
+ * `created_at`. Matching those suffixes without a boundary would swallow
+ * ordinary words — `grid` ends in "id", `candidate` ends in "date".
+ */
+function separateCamelCase(property: string): string {
+  return property.replace(/([a-z0-9])([A-Z])/g, "$1_$2");
+}
 
 /**
  * Share of distinct values above which a column is treated as an identifier
@@ -59,12 +69,14 @@ function isNearUnique(layer: ClassifiableLayer, property: string): boolean {
  * panel volunteers.
  */
 function mappableProperties(layer: ClassifiableLayer, properties: string[]): string[] {
-  return properties.filter(
-    (property) =>
-      !UNMAPPABLE_NAME.test(property) &&
-      !TIMESTAMP_NAME.test(property) &&
-      !isNearUnique(layer, property),
-  );
+  return properties.filter((property) => {
+    const normalized = separateCamelCase(property);
+    return (
+      !UNMAPPABLE_NAME.test(normalized) &&
+      !TIMESTAMP_NAME.test(normalized) &&
+      !isNearUnique(layer, property)
+    );
+  });
 }
 
 /** The layer shape a suggestion is derived from. */

--- a/apps/geolibre-desktop/src/lib/style-suggestions.ts
+++ b/apps/geolibre-desktop/src/lib/style-suggestions.ts
@@ -1,0 +1,110 @@
+import {
+  chooseGraduatedProperty,
+  getPropertyValues,
+  isCategoricalProperty,
+  type ClassifiableLayer,
+} from "./vector-style-classification";
+
+/**
+ * One-click styling offers derived from a layer's own data (issue #1519).
+ *
+ * A newly added layer arrives with single-symbol styling, and turning that into
+ * a useful map means knowing which column to classify by — a decision the data
+ * can usually make for itself. These suggestions are built from the same
+ * predicates the Style panel already uses to pre-select an attribute when the
+ * user picks a renderer by hand, so the shortcut and the manual path never
+ * disagree about what a good field is.
+ */
+
+/** A renderer offered for a layer, with the attribute it would classify by. */
+export interface StyleSuggestion {
+  kind: "categorized" | "graduated" | "heatmap";
+  /** Attribute to classify by; unset for the heatmap suggestion. */
+  property?: string;
+}
+
+/** Feature count above which a point layer reads better as a density surface. */
+export const HEATMAP_SUGGESTION_MIN_FEATURES = 200;
+
+/**
+ * Column names that are numeric but carry no magnitude worth mapping —
+ * identifiers and timestamps. Classifying by them produces a legend of epoch
+ * milliseconds or row numbers.
+ */
+const UNMAPPABLE_NAME = /(^|[_\s-])(id|fid|gid|oid|objectid|uid|uuid|key|index)$/i;
+const TIMESTAMP_NAME = /(time|timestamp|datetime|date|updated|created|epoch|_at)$/i;
+
+/**
+ * Share of distinct values above which a column is treated as an identifier
+ * regardless of its name: a value per feature classifies into noise.
+ */
+const NEAR_UNIQUE_RATIO = 0.9;
+/** Below this many features, a high distinct ratio is just a small sample. */
+const NEAR_UNIQUE_MIN_FEATURES = 20;
+
+/** True when a column's values are so nearly all-distinct it behaves as an id. */
+function isNearUnique(layer: ClassifiableLayer, property: string): boolean {
+  const values = getPropertyValues(layer, property);
+  if (values.length < NEAR_UNIQUE_MIN_FEATURES) return false;
+  return new Set(values.map(String)).size / values.length > NEAR_UNIQUE_RATIO;
+}
+
+/**
+ * Columns worth *recommending* a classification on.
+ *
+ * A suggestion is held to a higher bar than the manual dropdown's pre-selection:
+ * offering "Graduate by time" on a feed whose `time` column is epoch
+ * milliseconds is worse than offering nothing, because it reads as advice. The
+ * manual path keeps its existing behavior — this filter only narrows what the
+ * panel volunteers.
+ */
+function mappableProperties(layer: ClassifiableLayer, properties: string[]): string[] {
+  return properties.filter(
+    (property) =>
+      !UNMAPPABLE_NAME.test(property) &&
+      !TIMESTAMP_NAME.test(property) &&
+      !isNearUnique(layer, property),
+  );
+}
+
+/** The layer shape a suggestion is derived from. */
+export type SuggestableLayer = ClassifiableLayer & {
+  geojson?: { features?: unknown[] };
+};
+
+/**
+ * Suggest up to three renderers for a layer, best first.
+ *
+ * @param layer - The layer to inspect; its GeoJSON supplies the values.
+ * @param properties - Attribute names the symbology controls offer.
+ * @param options - `supportsPointRenderer` gates the heatmap offer to layers
+ *   where the heatmap/cluster renderers actually apply (point-only layers).
+ * @returns Suggestions in display order; empty when nothing fits.
+ */
+export function buildStyleSuggestions(
+  layer: SuggestableLayer,
+  properties: string[],
+  options: { supportsPointRenderer: boolean },
+): StyleSuggestion[] {
+  const suggestions: StyleSuggestion[] = [];
+  const candidates = mappableProperties(layer, properties);
+
+  // Categorized first: a low-cardinality label is what a reader most often
+  // wants a map colored by, and it needs no scale to interpret.
+  const categorical = candidates.find((property) => isCategoricalProperty(layer, property));
+  if (categorical) suggestions.push({ kind: "categorized", property: categorical });
+
+  // No fallback to the unfiltered list: when every numeric column is an id or a
+  // timestamp, offering none is better than recommending a meaningless one.
+  const numeric = chooseGraduatedProperty(layer, candidates);
+  if (numeric) suggestions.push({ kind: "graduated", property: numeric });
+
+  if (
+    options.supportsPointRenderer &&
+    (layer.geojson?.features?.length ?? 0) >= HEATMAP_SUGGESTION_MIN_FEATURES
+  ) {
+    suggestions.push({ kind: "heatmap" });
+  }
+
+  return suggestions;
+}

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -164,13 +164,16 @@ export function createCategorizedStops(
 }
 
 /**
- * True when a property has at least two finite numeric values, so a graduated
- * classification has a range to break up.
+ * True when a property has at least two *distinct* finite numeric values, so a
+ * graduated classification has a range to break up.
+ *
+ * Distinct, not merely two values: a constant column yields a single class, and
+ * the Style panel then refuses to apply the renderer it was offered.
  */
 export function isNumericProperty(layer: ClassifiableLayer, property: string): boolean {
   const values = getPropertyValues(layer, property);
   const numericValues = values.map((value) => Number(value)).filter(Number.isFinite);
-  return numericValues.length > 1;
+  return new Set(numericValues).size > 1;
 }
 
 /**
@@ -188,11 +191,14 @@ export function chooseGraduatedProperty(layer: ClassifiableLayer, properties: st
     const values = getPropertyValues(layer, property)
       .map((value) => Number(value))
       .filter(Number.isFinite);
-    if (values.length < 2) continue;
+    // Distinct values, not just value count: a constant column cannot be split
+    // into the two stops a graduated renderer needs.
+    const distinct = new Set(values).size;
+    if (distinct < 2) continue;
 
     const { min, max } = numericBounds(values);
     const range = max - min;
-    const score = new Set(values).size * Math.log10(Math.max(1, range) + 1);
+    const score = distinct * Math.log10(Math.max(1, range) + 1);
     if (score > bestScore) {
       bestProperty = property;
       bestScore = score;

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -5,7 +5,7 @@ import {
   interpolateRampColors,
 } from "@geolibre/core";
 
-interface ClassifiableLayer {
+export interface ClassifiableLayer {
   geojson?: {
     features?: Array<{
       properties?: Record<string, unknown> | null;
@@ -161,4 +161,56 @@ export function createCategorizedStops(
       colors[index] ??
       CLASSIFICATION_FALLBACK_COLORS[index % CLASSIFICATION_FALLBACK_COLORS.length]!,
   }));
+}
+
+/**
+ * True when a property has at least two finite numeric values, so a graduated
+ * classification has a range to break up.
+ */
+export function isNumericProperty(layer: ClassifiableLayer, property: string): boolean {
+  const values = getPropertyValues(layer, property);
+  const numericValues = values.map((value) => Number(value)).filter(Number.isFinite);
+  return numericValues.length > 1;
+}
+
+/**
+ * Pick the numeric property that best suits a graduated renderer: the one with
+ * the most distinct values spread over the widest range, so the classes carry
+ * real information rather than splitting a near-constant column.
+ *
+ * @returns The property name, or `""` when no column qualifies.
+ */
+export function chooseGraduatedProperty(layer: ClassifiableLayer, properties: string[]): string {
+  let bestProperty = "";
+  let bestScore = -1;
+
+  for (const property of properties) {
+    const values = getPropertyValues(layer, property)
+      .map((value) => Number(value))
+      .filter(Number.isFinite);
+    if (values.length < 2) continue;
+
+    const { min, max } = numericBounds(values);
+    const range = max - min;
+    const score = new Set(values).size * Math.log10(Math.max(1, range) + 1);
+    if (score > bestScore) {
+      bestProperty = property;
+      bestScore = score;
+    }
+  }
+
+  return bestProperty;
+}
+
+/** Upper bound on distinct values before a column is too fine to categorize. */
+export const MAX_CATEGORICAL_VALUES = 12;
+
+/**
+ * True when a property has between 2 and {@link MAX_CATEGORICAL_VALUES}
+ * distinct values — enough to distinguish, few enough to read as a legend.
+ */
+export function isCategoricalProperty(layer: ClassifiableLayer, property: string): boolean {
+  const values = getPropertyValues(layer, property).map((value) => String(value));
+  const uniqueCount = new Set(values).size;
+  return uniqueCount > 1 && uniqueCount <= MAX_CATEGORICAL_VALUES;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from "./selection";
 export * from "./scale-units";
 export * from "./project";
 export * from "./style-library";
+export * from "./layer-defaults";
 export * from "./layer-style-clipboard";
 export * from "./layer-groups";
 export { createSampleStoryMap } from "./storymap-sample";

--- a/packages/core/src/layer-defaults.ts
+++ b/packages/core/src/layer-defaults.ts
@@ -53,20 +53,36 @@ export function darkenHex(hex: string, factor: number): string {
 }
 
 /**
+ * Layers that actually wear a palette color.
+ *
+ * Only {@link initialLayerStyle} hands out palette entries, and only
+ * `addGeoJsonLayer` calls it — but every other add path still spreads
+ * {@link DEFAULT_LAYER_STYLE}, so a raster, image, or 3D tileset carries
+ * `fillColor: "#3b82f6"` without rendering anything with it. Counting those as
+ * "using blue" would push the first vector layer in a raster-bearing project
+ * straight to red. Widen this set if another add path adopts the palette.
+ */
+function occupiesPaletteColor(layer: GeoLibreLayer): boolean {
+  return layer.type === "geojson";
+}
+
+/**
  * Pick the next layer color: the first palette entry no current layer is
  * already using, so deleting a layer frees its color back up rather than
  * leaving the cycle permanently offset. Falls back to cycling by layer count
  * once every entry is in use.
  *
- * @param layers - The project's current layers.
+ * @param layers - The project's current layers. Non-vector layers are ignored;
+ *   they carry the schema default fill without ever painting with it.
  * @returns A `#rrggbb` color from {@link LAYER_PALETTE}.
  */
 export function nextLayerPaletteColor(layers: readonly GeoLibreLayer[]): string {
+  const styled = layers.filter(occupiesPaletteColor);
   const used = new Set(
-    layers.map((layer) => (layer.style?.fillColor ?? "").toLowerCase()).filter(Boolean),
+    styled.map((layer) => (layer.style?.fillColor ?? "").toLowerCase()).filter(Boolean),
   );
   const free = LAYER_PALETTE.find((color) => !used.has(color.toLowerCase()));
-  return free ?? LAYER_PALETTE[layers.length % LAYER_PALETTE.length];
+  return free ?? LAYER_PALETTE[styled.length % LAYER_PALETTE.length];
 }
 
 /** The geometry family a layer is mostly made of. */
@@ -109,15 +125,17 @@ export function dominantGeometry(geojson: FeatureCollection | undefined): Domina
     }
   }
 
-  const total = counts.point + counts.line + counts.polygon;
-  if (!total) return "mixed";
+  if (!counts.point && !counts.line && !counts.polygon) return "mixed";
   const [family, count] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] as [
     "point" | "line" | "polygon",
     number,
   ];
-  // A clear majority, not just the largest slice: a 40/35/25 split has no
-  // geometry whose sizing suits the layer, so treat it as mixed.
-  return count / total > 0.5 ? family : "mixed";
+  // A clear majority of everything sampled, not just of the geometries this
+  // switch understands: two points among three GeometryCollections is not a
+  // point layer, so `sampled` is the denominator rather than the matched total.
+  // And a majority, not merely the largest slice — a 40/35/25 split has no
+  // geometry whose sizing suits the layer.
+  return count / sampled > 0.5 ? family : "mixed";
 }
 
 /**
@@ -163,4 +181,40 @@ export function initialLayerStyle(options: InitialLayerStyleOptions = {}): Layer
     ...GEOMETRY_DEFAULTS[dominantGeometry(geojson)],
     ...overrides,
   };
+}
+
+/**
+ * True when a layer still wears exactly what {@link initialLayerStyle} gave it.
+ *
+ * The renderer mode alone is too weak a test for "untouched": nudging the fill,
+ * outline, or opacity leaves the mode on `"single"`, and a project restored
+ * from disk can carry deliberate single-symbol styling. Both cases should stop
+ * the Style panel volunteering suggestions, which is what this gates.
+ *
+ * The fill color cannot be compared against a fixed value — it is whichever
+ * palette entry the layer drew — so the test is that it is *still a palette
+ * entry* with the outline derived from it, which a hand-picked color will not
+ * satisfy.
+ *
+ * @param style - The layer's current style.
+ * @param geojson - Its data, so the geometry-derived sizes can be recomputed.
+ * @returns `true` when nothing about the as-added look has been changed.
+ */
+export function isInitialLayerStyle(style: LayerStyle, geojson?: FeatureCollection): boolean {
+  // Authored symbology, whatever the paint fields say.
+  if (style.simpleStyleEnabled) return false;
+  if (style.vectorStyleMode !== "single") return false;
+  if (style.pointRenderer !== "single") return false;
+  if ((style.vectorRules?.length ?? 0) > 0) return false;
+
+  const palette: readonly string[] = LAYER_PALETTE;
+  if (!palette.includes(style.fillColor)) return false;
+  if (style.strokeColor !== darkenHex(style.fillColor, STROKE_DARKEN)) return false;
+
+  const expected = { ...DEFAULT_LAYER_STYLE, ...GEOMETRY_DEFAULTS[dominantGeometry(geojson)] };
+  return (
+    style.fillOpacity === expected.fillOpacity &&
+    style.strokeWidth === expected.strokeWidth &&
+    style.circleRadius === expected.circleRadius
+  );
 }

--- a/packages/core/src/layer-defaults.ts
+++ b/packages/core/src/layer-defaults.ts
@@ -52,18 +52,29 @@ export function darkenHex(hex: string, factor: number): string {
     .join("")}`;
 }
 
+/** Case-insensitive palette lookup, returning the canonical (lowercase) entry. */
+function paletteEntryOf(color: string | undefined): string | undefined {
+  const normalized = (color ?? "").trim().toLowerCase();
+  return LAYER_PALETTE.find((entry) => entry === normalized);
+}
+
 /**
- * Layers that actually wear a palette color.
+ * True when a style's colors are a palette assignment {@link initialLayerStyle}
+ * made: a palette fill *paired with* the outline derived from it.
  *
- * Only {@link initialLayerStyle} hands out palette entries, and only
- * `addGeoJsonLayer` calls it — but every other add path still spreads
- * {@link DEFAULT_LAYER_STYLE}, so a raster, image, or 3D tileset carries
- * `fillColor: "#3b82f6"` without rendering anything with it. Counting those as
- * "using blue" would push the first vector layer in a raster-bearing project
- * straight to red. Widen this set if another add path adopts the palette.
+ * The pairing is what makes this precise. Testing the fill alone — or the layer
+ * type — would miscount every layer built straight from
+ * {@link DEFAULT_LAYER_STYLE}, whose `fillColor` happens to be
+ * `LAYER_PALETTE[0]`: rasters and tilesets, but also the Add Data sources that
+ * assemble a geojson layer themselves (delimited text, GPX, GeoRSS, CAD, GDB,
+ * photos, PostGIS) instead of going through `addGeoJsonLayer`. Those carry the
+ * schema's own `strokeColor`, not one derived from the fill, so they no longer
+ * reserve blue and push the next added layer to red.
  */
-function occupiesPaletteColor(layer: GeoLibreLayer): boolean {
-  return layer.type === "geojson";
+function wearsPaletteColor(style: LayerStyle | undefined): boolean {
+  const entry = paletteEntryOf(style?.fillColor);
+  if (!entry) return false;
+  return (style?.strokeColor ?? "").trim().toLowerCase() === darkenHex(entry, STROKE_DARKEN);
 }
 
 /**
@@ -72,16 +83,14 @@ function occupiesPaletteColor(layer: GeoLibreLayer): boolean {
  * leaving the cycle permanently offset. Falls back to cycling by layer count
  * once every entry is in use.
  *
- * @param layers - The project's current layers. Non-vector layers are ignored;
- *   they carry the schema default fill without ever painting with it.
+ * @param layers - The project's current layers. Only those actually wearing a
+ *   palette assignment count; see {@link wearsPaletteColor}.
  * @returns A `#rrggbb` color from {@link LAYER_PALETTE}.
  */
 export function nextLayerPaletteColor(layers: readonly GeoLibreLayer[]): string {
-  const styled = layers.filter(occupiesPaletteColor);
-  const used = new Set(
-    styled.map((layer) => (layer.style?.fillColor ?? "").toLowerCase()).filter(Boolean),
-  );
-  const free = LAYER_PALETTE.find((color) => !used.has(color.toLowerCase()));
+  const styled = layers.filter((layer) => wearsPaletteColor(layer.style));
+  const used = new Set(styled.map((layer) => layer.style.fillColor.trim().toLowerCase()));
+  const free = LAYER_PALETTE.find((color) => !used.has(color));
   return free ?? LAYER_PALETTE[styled.length % LAYER_PALETTE.length];
 }
 
@@ -207,9 +216,7 @@ export function isInitialLayerStyle(style: LayerStyle, geojson?: FeatureCollecti
   if (style.pointRenderer !== "single") return false;
   if ((style.vectorRules?.length ?? 0) > 0) return false;
 
-  const palette: readonly string[] = LAYER_PALETTE;
-  if (!palette.includes(style.fillColor)) return false;
-  if (style.strokeColor !== darkenHex(style.fillColor, STROKE_DARKEN)) return false;
+  if (!wearsPaletteColor(style)) return false;
 
   const expected = { ...DEFAULT_LAYER_STYLE, ...GEOMETRY_DEFAULTS[dominantGeometry(geojson)] };
   return (

--- a/packages/core/src/layer-defaults.ts
+++ b/packages/core/src/layer-defaults.ts
@@ -1,0 +1,166 @@
+import type { FeatureCollection } from "geojson";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, type LayerStyle } from "./types";
+
+/**
+ * Initial styling for a newly added vector layer (issue #1519).
+ *
+ * {@link DEFAULT_LAYER_STYLE} stays exactly what it is — the schema fallback
+ * that fills gaps when a partial style is read back from a project file. It is
+ * deliberately NOT changed here: every load path spreads it under a saved
+ * style, so editing it would silently restyle existing projects.
+ *
+ * What this module adds is a separate decision made only at *add* time: give
+ * each new layer its own color, and pick sizes that suit the geometry it
+ * actually contains, so a stack of freshly loaded layers is legible without
+ * anyone opening the Style panel.
+ */
+
+/**
+ * Qualitative colors cycled across newly added layers, chosen to stay distinct
+ * at low opacity over both light and dark basemaps.
+ *
+ * Distinct from the classification palette the Style panel uses for the classes
+ * *within* one layer: this one separates layers from each other, and the two
+ * are free to diverge.
+ */
+export const LAYER_PALETTE = [
+  "#3b82f6", // blue — matches the historical default, so the first layer looks unchanged
+  "#ef4444", // red
+  "#22c55e", // green
+  "#a855f7", // purple
+  "#f97316", // orange
+  "#06b6d4", // cyan
+  "#ec4899", // pink
+  "#84cc16", // lime
+] as const;
+
+/** How much darker an outline is than its fill (0 = black, 1 = unchanged). */
+const STROKE_DARKEN = 0.55;
+
+/** Darken a `#rrggbb` color toward black by `factor`. */
+export function darkenHex(hex: string, factor: number): string {
+  const match = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return hex;
+  const value = Number.parseInt(match[1], 16);
+  const channels = [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff];
+  return `#${channels
+    .map((channel) =>
+      Math.max(0, Math.min(255, Math.round(channel * factor)))
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+/**
+ * Pick the next layer color: the first palette entry no current layer is
+ * already using, so deleting a layer frees its color back up rather than
+ * leaving the cycle permanently offset. Falls back to cycling by layer count
+ * once every entry is in use.
+ *
+ * @param layers - The project's current layers.
+ * @returns A `#rrggbb` color from {@link LAYER_PALETTE}.
+ */
+export function nextLayerPaletteColor(layers: readonly GeoLibreLayer[]): string {
+  const used = new Set(
+    layers.map((layer) => (layer.style?.fillColor ?? "").toLowerCase()).filter(Boolean),
+  );
+  const free = LAYER_PALETTE.find((color) => !used.has(color.toLowerCase()));
+  return free ?? LAYER_PALETTE[layers.length % LAYER_PALETTE.length];
+}
+
+/** The geometry family a layer is mostly made of. */
+export type DominantGeometry = "point" | "line" | "polygon" | "mixed";
+
+/** Features sampled when deciding a collection's dominant geometry. */
+const GEOMETRY_SAMPLE_SIZE = 500;
+
+/**
+ * Classify a collection by the geometry family most of its features carry,
+ * reading at most {@link GEOMETRY_SAMPLE_SIZE} features so a very large layer
+ * does not pay a full scan for a styling default.
+ *
+ * @param geojson - The collection to inspect.
+ * @returns The dominant family, or `"mixed"` when nothing has a clear majority
+ *   (or the collection is empty).
+ */
+export function dominantGeometry(geojson: FeatureCollection | undefined): DominantGeometry {
+  const features = geojson?.features ?? [];
+  if (!features.length) return "mixed";
+
+  const counts = { point: 0, line: 0, polygon: 0 };
+  const sampled = Math.min(features.length, GEOMETRY_SAMPLE_SIZE);
+  for (let index = 0; index < sampled; index++) {
+    switch (features[index]?.geometry?.type) {
+      case "Point":
+      case "MultiPoint":
+        counts.point += 1;
+        break;
+      case "LineString":
+      case "MultiLineString":
+        counts.line += 1;
+        break;
+      case "Polygon":
+      case "MultiPolygon":
+        counts.polygon += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  const total = counts.point + counts.line + counts.polygon;
+  if (!total) return "mixed";
+  const [family, count] = Object.entries(counts).sort((a, b) => b[1] - a[1])[0] as [
+    "point" | "line" | "polygon",
+    number,
+  ];
+  // A clear majority, not just the largest slice: a 40/35/25 split has no
+  // geometry whose sizing suits the layer, so treat it as mixed.
+  return count / total > 0.5 ? family : "mixed";
+}
+
+/**
+ * Per-geometry size and opacity overrides.
+ *
+ * One set of numbers cannot suit all three families: an opacity that lets a
+ * basemap read through a polygon makes a point look washed out, and a stroke
+ * heavy enough to see a line is a heavy outline on a polygon.
+ */
+const GEOMETRY_DEFAULTS: Record<DominantGeometry, Partial<LayerStyle>> = {
+  // Solid and slightly smaller: a point is read as a dot, not a translucent blob.
+  point: { circleRadius: 5, fillOpacity: 0.9, strokeWidth: 1 },
+  // A line's stroke *is* the symbol, so it carries the weight.
+  line: { strokeWidth: 2.5, fillOpacity: 1 },
+  // Translucent enough that the basemap underneath stays readable.
+  polygon: { fillOpacity: 0.45, strokeWidth: 1.5 },
+  mixed: {},
+};
+
+export interface InitialLayerStyleOptions {
+  /** The layer's data, used to pick geometry-appropriate sizes. */
+  geojson?: FeatureCollection;
+  /** Current project layers, so the new layer gets an unused palette color. */
+  layers?: readonly GeoLibreLayer[];
+  /** Style values that win over the computed defaults (e.g. a restored style). */
+  overrides?: Partial<LayerStyle>;
+}
+
+/**
+ * Build the style a newly added vector layer starts with: the schema defaults,
+ * plus its own palette color and geometry-appropriate sizing.
+ *
+ * @param options - Data and project context to derive the style from.
+ * @returns A complete {@link LayerStyle}.
+ */
+export function initialLayerStyle(options: InitialLayerStyleOptions = {}): LayerStyle {
+  const { geojson, layers = [], overrides } = options;
+  const fillColor = nextLayerPaletteColor(layers);
+  return {
+    ...DEFAULT_LAYER_STYLE,
+    fillColor,
+    strokeColor: darkenHex(fillColor, STROKE_DARKEN),
+    ...GEOMETRY_DEFAULTS[dominantGeometry(geojson)],
+    ...overrides,
+  };
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -16,6 +16,7 @@ import {
   createEmptyProject,
   DEFAULT_PROJECT_NAME,
 } from "./project";
+import { initialLayerStyle } from "./layer-defaults";
 import { DEFAULT_LAYER_GROUP_OPACITY, normalizeGroupContiguity } from "./layer-groups";
 import {
   DEFAULT_BASEMAP,
@@ -1465,10 +1466,13 @@ export const useAppStore = create<AppState>()(
           source: { type: "geojson" },
           visible: true,
           opacity: 1,
-          style: {
-            ...DEFAULT_LAYER_STYLE,
-            simpleStyleEnabled: hasSimpleStyleProperties(geojson),
-          },
+          // Its own palette color and geometry-appropriate sizing (#1519), so a
+          // stack of freshly added layers is legible without restyling each one.
+          style: initialLayerStyle({
+            geojson,
+            layers: get().layers,
+            overrides: { simpleStyleEnabled: hasSimpleStyleProperties(geojson) },
+          }),
           metadata: {},
           geojson,
           sourcePath,

--- a/tests/layer-defaults.test.ts
+++ b/tests/layer-defaults.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 
+/** A layer wearing a real palette assignment: the fill paired with its outline. */
 function styled(id: string, fillColor: string): GeoLibreLayer {
   return {
     id,
@@ -21,7 +22,22 @@ function styled(id: string, fillColor: string): GeoLibreLayer {
     source: { type: "geojson" },
     visible: true,
     opacity: 1,
-    style: { ...DEFAULT_LAYER_STYLE, fillColor },
+    style: { ...DEFAULT_LAYER_STYLE, fillColor, strokeColor: darkenHex(fillColor, 0.55) },
+    metadata: {},
+  };
+}
+
+/** A layer built straight from the schema defaults, as the Add Data sources and
+ *  every non-vector add path do — its fill happens to equal LAYER_PALETTE[0]. */
+function schemaStyled(id: string, type: GeoLibreLayer["type"] = "geojson"): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type,
+    source: { type },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
     metadata: {},
   };
 }
@@ -91,13 +107,6 @@ describe("nextLayerPaletteColor", () => {
     assert.equal(nextLayerPaletteColor(remaining), LAYER_PALETTE[1]);
   });
 
-  it("matches a used color case-insensitively", () => {
-    assert.equal(
-      nextLayerPaletteColor([styled("a", LAYER_PALETTE[0].toUpperCase())]),
-      LAYER_PALETTE[1],
-    );
-  });
-
   it("cycles by layer count once the whole palette is in use", () => {
     const all = LAYER_PALETTE.map((color, index) => styled(`l${index}`, color));
     assert.equal(nextLayerPaletteColor(all), LAYER_PALETTE[0]);
@@ -105,14 +114,32 @@ describe("nextLayerPaletteColor", () => {
     assert.equal(nextLayerPaletteColor([...all, styled("l8", LAYER_PALETTE[0])]), LAYER_PALETTE[1]);
   });
 
-  it("ignores layers that never paint with their fill color", () => {
-    // A raster carries DEFAULT_LAYER_STYLE (blue) without rendering it; the
-    // first vector layer should still get blue rather than skipping to red.
-    const raster: GeoLibreLayer = { ...styled("dem", LAYER_PALETTE[0]), type: "raster" };
-    assert.equal(nextLayerPaletteColor([raster]), LAYER_PALETTE[0]);
-    // ...and it must not shift the fallback cycle either.
+  it("ignores layers that never wore a palette assignment", () => {
+    // A raster carries DEFAULT_LAYER_STYLE, whose fill equals LAYER_PALETTE[0]
+    // without ever rendering it; the first vector layer should still get blue.
+    assert.equal(nextLayerPaletteColor([schemaStyled("dem", "raster")]), LAYER_PALETTE[0]);
+    // Same for the Add Data sources that assemble a geojson layer themselves
+    // rather than going through addGeoJsonLayer — the fill matches, but the
+    // outline is the schema's, not one derived from it.
+    assert.equal(nextLayerPaletteColor([schemaStyled("gpx")]), LAYER_PALETTE[0]);
+    // ...and neither shifts the fallback cycle.
     const all = LAYER_PALETTE.map((color, index) => styled(`l${index}`, color));
-    assert.equal(nextLayerPaletteColor([raster, ...all]), LAYER_PALETTE[0]);
+    assert.equal(
+      nextLayerPaletteColor([schemaStyled("dem", "raster"), schemaStyled("gpx"), ...all]),
+      LAYER_PALETTE[0],
+    );
+  });
+
+  it("matches a palette assignment whatever the hex casing", () => {
+    const upper: GeoLibreLayer = {
+      ...styled("a", LAYER_PALETTE[0]),
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        fillColor: LAYER_PALETTE[0].toUpperCase(),
+        strokeColor: darkenHex(LAYER_PALETTE[0], 0.55).toUpperCase(),
+      },
+    };
+    assert.equal(nextLayerPaletteColor([upper]), LAYER_PALETTE[1]);
   });
 });
 
@@ -218,6 +245,16 @@ describe("isInitialLayerStyle", () => {
       assert.equal(isInitialLayerStyle(style, points), false);
     });
   }
+
+  it("accepts an uppercase-hex palette assignment, matching nextLayerPaletteColor", () => {
+    const base = initialLayerStyle({ geojson: points });
+    const style = {
+      ...base,
+      fillColor: base.fillColor.toUpperCase(),
+      strokeColor: base.strokeColor.toUpperCase(),
+    };
+    assert.equal(isInitialLayerStyle(style, points), true);
+  });
 
   it("rejects a legacy project style whose colors predate the palette pairing", () => {
     // fillColor happens to be palette[0], but the old outline is not derived

--- a/tests/layer-defaults.test.ts
+++ b/tests/layer-defaults.test.ts
@@ -6,6 +6,7 @@ import {
   darkenHex,
   dominantGeometry,
   initialLayerStyle,
+  isInitialLayerStyle,
   nextLayerPaletteColor,
   useAppStore,
   type GeoLibreLayer,
@@ -97,9 +98,21 @@ describe("nextLayerPaletteColor", () => {
     );
   });
 
-  it("cycles once the whole palette is in use", () => {
+  it("cycles by layer count once the whole palette is in use", () => {
     const all = LAYER_PALETTE.map((color, index) => styled(`l${index}`, color));
-    assert.ok(LAYER_PALETTE.includes(nextLayerPaletteColor(all) as (typeof LAYER_PALETTE)[number]));
+    assert.equal(nextLayerPaletteColor(all), LAYER_PALETTE[0]);
+    // A ninth layer advances the cycle rather than pinning to one color.
+    assert.equal(nextLayerPaletteColor([...all, styled("l8", LAYER_PALETTE[0])]), LAYER_PALETTE[1]);
+  });
+
+  it("ignores layers that never paint with their fill color", () => {
+    // A raster carries DEFAULT_LAYER_STYLE (blue) without rendering it; the
+    // first vector layer should still get blue rather than skipping to red.
+    const raster: GeoLibreLayer = { ...styled("dem", LAYER_PALETTE[0]), type: "raster" };
+    assert.equal(nextLayerPaletteColor([raster]), LAYER_PALETTE[0]);
+    // ...and it must not shift the fallback cycle either.
+    const all = LAYER_PALETTE.map((color, index) => styled(`l${index}`, color));
+    assert.equal(nextLayerPaletteColor([raster, ...all]), LAYER_PALETTE[0]);
   });
 });
 
@@ -114,6 +127,23 @@ describe("dominantGeometry", () => {
     assert.equal(dominantGeometry(fc(["Point", "LineString"])), "mixed");
     assert.equal(dominantGeometry(fc([])), "mixed");
     assert.equal(dominantGeometry(undefined), "mixed");
+  });
+
+  it("counts geometries it does not understand against the majority", () => {
+    // Two points among five features is not a point layer, even though points
+    // are the only family the classifier recognizes here.
+    const mixed: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        ...fc(["Point", "Point"]).features,
+        ...Array.from({ length: 3 }, () => ({
+          type: "Feature" as const,
+          geometry: { type: "GeometryCollection" as const, geometries: [] },
+          properties: {},
+        })),
+      ],
+    } as FeatureCollection;
+    assert.equal(dominantGeometry(mixed), "mixed");
   });
 });
 
@@ -154,6 +184,46 @@ describe("initialLayerStyle", () => {
     });
     assert.equal(style.fillOpacity, 0.1);
     assert.equal(style.fillColor, "#000000");
+  });
+});
+
+describe("isInitialLayerStyle", () => {
+  const points = fc(["Point", "Point"]);
+
+  it("accepts what initialLayerStyle just produced", () => {
+    assert.equal(isInitialLayerStyle(initialLayerStyle({ geojson: points }), points), true);
+  });
+
+  it("rejects a hand-picked fill, which the mode alone would not catch", () => {
+    const style = { ...initialLayerStyle({ geojson: points }), fillColor: "#123456" };
+    assert.equal(isInitialLayerStyle(style, points), false);
+  });
+
+  it("rejects an outline no longer derived from the fill", () => {
+    const style = { ...initialLayerStyle({ geojson: points }), strokeColor: "#000000" };
+    assert.equal(isInitialLayerStyle(style, points), false);
+  });
+
+  for (const patch of [
+    { fillOpacity: 0.3 },
+    { strokeWidth: 8 },
+    { circleRadius: 20 },
+    { simpleStyleEnabled: true },
+    { vectorStyleMode: "categorized" as const },
+    { pointRenderer: "heatmap" as const },
+  ]) {
+    const field = Object.keys(patch)[0];
+    it(`rejects an edited ${field}`, () => {
+      const style = { ...initialLayerStyle({ geojson: points }), ...patch };
+      assert.equal(isInitialLayerStyle(style, points), false);
+    });
+  }
+
+  it("rejects a legacy project style whose colors predate the palette pairing", () => {
+    // fillColor happens to be palette[0], but the old outline is not derived
+    // from it — restored styling, so no suggestions.
+    const style = { ...DEFAULT_LAYER_STYLE, fillColor: "#3b82f6", strokeColor: "#1e40af" };
+    assert.equal(isInitialLayerStyle(style, points), false);
   });
 });
 

--- a/tests/layer-defaults.test.ts
+++ b/tests/layer-defaults.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  LAYER_PALETTE,
+  darkenHex,
+  dominantGeometry,
+  initialLayerStyle,
+  nextLayerPaletteColor,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+
+function styled(id: string, fillColor: string): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE, fillColor },
+    metadata: {},
+  };
+}
+
+function fc(types: string[]): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: types.map((type) => ({
+      type: "Feature",
+      geometry:
+        type === "Point"
+          ? { type: "Point", coordinates: [0, 0] }
+          : type === "LineString"
+            ? {
+                type: "LineString",
+                coordinates: [
+                  [0, 0],
+                  [1, 1],
+                ],
+              }
+            : {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [0, 0],
+                    [1, 0],
+                    [1, 1],
+                    [0, 0],
+                  ],
+                ],
+              },
+      properties: {},
+    })),
+  } as FeatureCollection;
+}
+
+describe("darkenHex", () => {
+  it("darkens each channel toward black", () => {
+    assert.equal(darkenHex("#ffffff", 0.5), "#808080");
+    assert.equal(darkenHex("#3b82f6", 0.55), "#204887");
+  });
+
+  it("leaves a value it cannot parse untouched", () => {
+    assert.equal(darkenHex("rgb(1,2,3)", 0.5), "rgb(1,2,3)");
+    assert.equal(darkenHex("#abc", 0.5), "#abc");
+  });
+});
+
+describe("nextLayerPaletteColor", () => {
+  it("starts at the historical default so the first layer looks unchanged", () => {
+    assert.equal(nextLayerPaletteColor([]), DEFAULT_LAYER_STYLE.fillColor);
+    assert.equal(nextLayerPaletteColor([]), LAYER_PALETTE[0]);
+  });
+
+  it("skips colors already in use", () => {
+    assert.equal(nextLayerPaletteColor([styled("a", LAYER_PALETTE[0])]), LAYER_PALETTE[1]);
+    assert.equal(
+      nextLayerPaletteColor([styled("a", LAYER_PALETTE[0]), styled("b", LAYER_PALETTE[1])]),
+      LAYER_PALETTE[2],
+    );
+  });
+
+  it("reuses a color freed by a deleted layer instead of drifting", () => {
+    // b was removed; its color should come back rather than the cycle staying
+    // permanently offset.
+    const remaining = [styled("a", LAYER_PALETTE[0]), styled("c", LAYER_PALETTE[2])];
+    assert.equal(nextLayerPaletteColor(remaining), LAYER_PALETTE[1]);
+  });
+
+  it("matches a used color case-insensitively", () => {
+    assert.equal(
+      nextLayerPaletteColor([styled("a", LAYER_PALETTE[0].toUpperCase())]),
+      LAYER_PALETTE[1],
+    );
+  });
+
+  it("cycles once the whole palette is in use", () => {
+    const all = LAYER_PALETTE.map((color, index) => styled(`l${index}`, color));
+    assert.ok(LAYER_PALETTE.includes(nextLayerPaletteColor(all) as (typeof LAYER_PALETTE)[number]));
+  });
+});
+
+describe("dominantGeometry", () => {
+  it("classifies a clear majority", () => {
+    assert.equal(dominantGeometry(fc(["Point", "Point", "Point"])), "point");
+    assert.equal(dominantGeometry(fc(["LineString", "LineString"])), "line");
+    assert.equal(dominantGeometry(fc(["Polygon", "Polygon", "Point"])), "polygon");
+  });
+
+  it("reports mixed when nothing holds a majority", () => {
+    assert.equal(dominantGeometry(fc(["Point", "LineString"])), "mixed");
+    assert.equal(dominantGeometry(fc([])), "mixed");
+    assert.equal(dominantGeometry(undefined), "mixed");
+  });
+});
+
+describe("initialLayerStyle", () => {
+  it("gives a point layer solid, smaller symbols", () => {
+    const style = initialLayerStyle({ geojson: fc(["Point", "Point"]) });
+    assert.equal(style.circleRadius, 5);
+    assert.equal(style.fillOpacity, 0.9);
+  });
+
+  it("gives a polygon layer a translucent fill so the basemap reads through", () => {
+    const style = initialLayerStyle({ geojson: fc(["Polygon", "Polygon"]) });
+    assert.equal(style.fillOpacity, 0.45);
+    assert.equal(style.strokeWidth, 1.5);
+  });
+
+  it("puts the weight on a line layer's stroke", () => {
+    assert.equal(initialLayerStyle({ geojson: fc(["LineString"]) }).strokeWidth, 2.5);
+  });
+
+  it("derives the outline from the assigned fill", () => {
+    const style = initialLayerStyle({ layers: [styled("a", LAYER_PALETTE[0])] });
+    assert.equal(style.fillColor, LAYER_PALETTE[1]);
+    assert.equal(style.strokeColor, darkenHex(LAYER_PALETTE[1], 0.55));
+  });
+
+  it("fills every schema key so a layer style is never partial", () => {
+    const style = initialLayerStyle();
+    for (const key of Object.keys(DEFAULT_LAYER_STYLE)) {
+      assert.ok(key in style, key);
+    }
+  });
+
+  it("lets overrides win over the computed defaults", () => {
+    const style = initialLayerStyle({
+      geojson: fc(["Point"]),
+      overrides: { fillOpacity: 0.1, fillColor: "#000000" },
+    });
+    assert.equal(style.fillOpacity, 0.1);
+    assert.equal(style.fillColor, "#000000");
+  });
+});
+
+describe("addGeoJsonLayer", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  it("gives each added layer its own color", () => {
+    useAppStore.getState().addGeoJsonLayer("a", fc(["Polygon"]));
+    useAppStore.getState().addGeoJsonLayer("b", fc(["Polygon"]));
+    useAppStore.getState().addGeoJsonLayer("c", fc(["Polygon"]));
+
+    const colors = useAppStore.getState().layers.map((layer) => layer.style.fillColor);
+    assert.equal(new Set(colors).size, 3, `expected distinct colors, got ${colors.join(", ")}`);
+    assert.equal(colors[0], LAYER_PALETTE[0]);
+  });
+
+  it("sizes an added layer for its geometry", () => {
+    useAppStore.getState().addGeoJsonLayer("points", fc(["Point", "Point"]));
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.style.circleRadius, 5);
+    assert.equal(layer.style.fillOpacity, 0.9);
+  });
+});

--- a/tests/style-suggestions.test.ts
+++ b/tests/style-suggestions.test.ts
@@ -210,3 +210,24 @@ describe("buildStyleSuggestions", () => {
     });
   });
 });
+
+describe("the scan bound", () => {
+  it("reads at most a bounded sample when choosing, however large the layer", () => {
+    // 5,000 features whose category only becomes high-cardinality past the cap.
+    // A full scan would see 5,000 distinct values and reject `zone`; a bounded
+    // one sees a handful and offers it. Asserting the offer is how we observe
+    // that the scan stopped.
+    const rows = Array.from({ length: 5000 }, (_, index) => ({
+      zone: index < 500 ? `Z${index % 4}` : `Z${index}`,
+    }));
+    const suggestions = buildStyleSuggestions(layerWith(rows), ["zone"], NO_POINTS);
+    assert.deepEqual(suggestions, [{ kind: "categorized", property: "zone" }]);
+  });
+
+  it("still reads every feature of a layer under the cap", () => {
+    const rows = Array.from({ length: 60 }, (_, index) => ({ zone: `Z${index}` }));
+    // 60 distinct values is well past the categorical limit, so nothing is
+    // offered — proof the sample did not truncate a small layer into shape.
+    assert.deepEqual(buildStyleSuggestions(layerWith(rows), ["zone"], NO_POINTS), []);
+  });
+});

--- a/tests/style-suggestions.test.ts
+++ b/tests/style-suggestions.test.ts
@@ -123,6 +123,39 @@ describe("buildStyleSuggestions", () => {
       assert.equal(graduated?.property, "mag");
     });
 
+    it("never suggests a camelCase identifier or timestamp column", () => {
+      // These evade a bare suffix match (no separator) and, on a small layer,
+      // also evade the near-unique ratio.
+      for (const name of ["featureId", "createdAt", "updatedAt", "objectId"]) {
+        const layer = layerWith([
+          { [name]: 1, score: 5 },
+          { [name]: 2, score: 40 },
+          { [name]: 3, score: 900 },
+        ]);
+        const graduated = buildStyleSuggestions(layer, [name, "score"], NO_POINTS).find(
+          (item) => item.kind === "graduated",
+        );
+        assert.equal(graduated?.property, "score", name);
+      }
+    });
+
+    it("keeps ordinary words that merely end in an excluded suffix", () => {
+      // "grid" ends in "id" and "candidate" ends in "date"; neither is an
+      // identifier, so a boundary is required rather than a bare suffix match.
+      for (const name of ["grid", "candidate", "valid"]) {
+        const layer = layerWith([{ [name]: 1 }, { [name]: 40 }, { [name]: 900 }]);
+        const graduated = buildStyleSuggestions(layer, [name], NO_POINTS).find(
+          (item) => item.kind === "graduated",
+        );
+        assert.equal(graduated?.property, name, name);
+      }
+    });
+
+    it("never suggests a constant numeric column, which cannot form two stops", () => {
+      const layer = layerWith([{ elevation: 100 }, { elevation: 100 }, { elevation: 100 }]);
+      assert.deepEqual(buildStyleSuggestions(layer, ["elevation"], NO_POINTS), []);
+    });
+
     it("never suggests an identifier column", () => {
       for (const name of ["id", "OBJECTID", "feature_id", "row-index", "uuid"]) {
         const layer = layerWith([

--- a/tests/style-suggestions.test.ts
+++ b/tests/style-suggestions.test.ts
@@ -170,15 +170,29 @@ describe("buildStyleSuggestions", () => {
       }
     });
 
-    it("never suggests a near-unique column even when its name looks innocent", () => {
+    it("never suggests a near-unique label column, whatever its name", () => {
       const rows = Array.from({ length: 50 }, (_, index) => ({
-        reading: index * 7.31,
+        ref: `bldg-${index}`,
         band: index % 4,
       }));
-      const graduated = buildStyleSuggestions(layerWith(rows), ["reading", "band"], NO_POINTS).find(
+      const graduated = buildStyleSuggestions(layerWith(rows), ["ref", "band"], NO_POINTS).find(
         (item) => item.kind === "graduated",
       );
       assert.equal(graduated?.property, "band");
+    });
+
+    it("still suggests a near-unique *measurement*, which is what graduation is for", () => {
+      // Matches the las_vegas_buildings dataset: an `id` of hashes plus a
+      // `height` that is 538 distinct across 540 features. Excluding a column
+      // for being near-unique would throw away the canonical choropleth —
+      // distinctness cannot tell a measurement from an identifier, so only
+      // non-numeric columns are judged that way.
+      const rows = Array.from({ length: 50 }, (_, index) => ({
+        id: `08b2986b81b34fff${index}`,
+        height: 2.5 + index * 0.37,
+      }));
+      const suggestions = buildStyleSuggestions(layerWith(rows), ["id", "height"], NO_POINTS);
+      assert.deepEqual(suggestions, [{ kind: "graduated", property: "height" }]);
     });
 
     it("keeps a small layer's distinct column, where the ratio proves nothing", () => {

--- a/tests/style-suggestions.test.ts
+++ b/tests/style-suggestions.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { FeatureCollection } from "geojson";
+import {
+  buildStyleSuggestions,
+  HEATMAP_SUGGESTION_MIN_FEATURES,
+} from "../apps/geolibre-desktop/src/lib/style-suggestions";
+
+/** A minimal layer shape: the suggestion builder only reads type + geojson. */
+function layerWith(
+  properties: Record<string, unknown>[],
+  geometryType: "Point" | "Polygon" = "Polygon",
+) {
+  const geojson: FeatureCollection = {
+    type: "FeatureCollection",
+    features: properties.map((props) => ({
+      type: "Feature",
+      geometry:
+        geometryType === "Point"
+          ? { type: "Point", coordinates: [0, 0] }
+          : {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [1, 0],
+                  [1, 1],
+                  [0, 0],
+                ],
+              ],
+            },
+      properties: props,
+    })),
+  } as FeatureCollection;
+  return { type: "geojson" as const, geojson };
+}
+
+const NO_POINTS = { supportsPointRenderer: false };
+
+describe("buildStyleSuggestions", () => {
+  it("suggests categorizing by a low-cardinality label", () => {
+    const layer = layerWith([{ zone: "A" }, { zone: "B" }, { zone: "A" }, { zone: "C" }]);
+    const suggestions = buildStyleSuggestions(layer, ["zone"], NO_POINTS);
+    assert.deepEqual(suggestions, [{ kind: "categorized", property: "zone" }]);
+  });
+
+  it("suggests graduating by the numeric column with the most spread", () => {
+    const layer = layerWith([
+      { pop: 10, flag: 1 },
+      { pop: 5000, flag: 1 },
+      { pop: 120000, flag: 0 },
+    ]);
+    const suggestions = buildStyleSuggestions(layer, ["pop", "flag"], NO_POINTS);
+    const graduated = suggestions.find((item) => item.kind === "graduated");
+    assert.equal(graduated?.property, "pop");
+  });
+
+  it("offers both when a layer has a label and a measure", () => {
+    const layer = layerWith([
+      { zone: "A", pop: 10 },
+      { zone: "B", pop: 5000 },
+      { zone: "A", pop: 120000 },
+    ]);
+    const kinds = buildStyleSuggestions(layer, ["zone", "pop"], NO_POINTS).map((s) => s.kind);
+    // Categorized first: a label needs no scale to read.
+    assert.deepEqual(kinds, ["categorized", "graduated"]);
+  });
+
+  it("skips a high-cardinality column that would produce a class per feature", () => {
+    const rows = Array.from({ length: 40 }, (_, index) => ({ id: `id-${index}` }));
+    const suggestions = buildStyleSuggestions(layerWith(rows), ["id"], NO_POINTS);
+    assert.equal(
+      suggestions.some((item) => item.kind === "categorized"),
+      false,
+    );
+  });
+
+  it("skips a single-valued column, which classifies to one class", () => {
+    const layer = layerWith([{ kind: "same" }, { kind: "same" }, { kind: "same" }]);
+    assert.deepEqual(buildStyleSuggestions(layer, ["kind"], NO_POINTS), []);
+  });
+
+  it("offers a heatmap only for a dense point layer", () => {
+    const dense = Array.from({ length: HEATMAP_SUGGESTION_MIN_FEATURES }, () => ({}));
+    const sparse = Array.from({ length: HEATMAP_SUGGESTION_MIN_FEATURES - 1 }, () => ({}));
+
+    assert.ok(
+      buildStyleSuggestions(layerWith(dense, "Point"), [], {
+        supportsPointRenderer: true,
+      }).some((item) => item.kind === "heatmap"),
+    );
+    assert.equal(
+      buildStyleSuggestions(layerWith(sparse, "Point"), [], {
+        supportsPointRenderer: true,
+      }).some((item) => item.kind === "heatmap"),
+      false,
+    );
+    // Not offered where the renderer does not apply, even when dense.
+    assert.equal(
+      buildStyleSuggestions(layerWith(dense), [], NO_POINTS).some(
+        (item) => item.kind === "heatmap",
+      ),
+      false,
+    );
+  });
+
+  it("returns nothing for a layer with no attributes", () => {
+    assert.deepEqual(buildStyleSuggestions(layerWith([{}, {}]), [], NO_POINTS), []);
+  });
+
+  describe("columns it refuses to recommend", () => {
+    it("never suggests a timestamp column, which legends as epoch numbers", () => {
+      const layer = layerWith([
+        { time: 1_700_000_000_000, mag: 2.5 },
+        { time: 1_700_000_050_000, mag: 4.1 },
+        { time: 1_700_000_090_000, mag: 6.3 },
+      ]);
+      const graduated = buildStyleSuggestions(layer, ["time", "mag"], NO_POINTS).find(
+        (item) => item.kind === "graduated",
+      );
+      // `time` scores higher than `mag` on raw spread, so this only passes
+      // because timestamps are excluded outright.
+      assert.equal(graduated?.property, "mag");
+    });
+
+    it("never suggests an identifier column", () => {
+      for (const name of ["id", "OBJECTID", "feature_id", "row-index", "uuid"]) {
+        const layer = layerWith([
+          { [name]: 1, score: 5 },
+          { [name]: 2, score: 40 },
+          { [name]: 3, score: 900 },
+        ]);
+        const graduated = buildStyleSuggestions(layer, [name, "score"], NO_POINTS).find(
+          (item) => item.kind === "graduated",
+        );
+        assert.equal(graduated?.property, "score", name);
+      }
+    });
+
+    it("never suggests a near-unique column even when its name looks innocent", () => {
+      const rows = Array.from({ length: 50 }, (_, index) => ({
+        reading: index * 7.31,
+        band: index % 4,
+      }));
+      const graduated = buildStyleSuggestions(layerWith(rows), ["reading", "band"], NO_POINTS).find(
+        (item) => item.kind === "graduated",
+      );
+      assert.equal(graduated?.property, "band");
+    });
+
+    it("keeps a small layer's distinct column, where the ratio proves nothing", () => {
+      // 3 rows, all distinct — too small a sample to call it an identifier.
+      const layer = layerWith([{ depth: 1 }, { depth: 90 }, { depth: 4000 }]);
+      const graduated = buildStyleSuggestions(layer, ["depth"], NO_POINTS).find(
+        (item) => item.kind === "graduated",
+      );
+      assert.equal(graduated?.property, "depth");
+    });
+
+    it("offers nothing rather than a meaningless column when only ids remain", () => {
+      const rows = Array.from({ length: 30 }, (_, index) => ({ objectid: index }));
+      assert.deepEqual(buildStyleSuggestions(layerWith(rows), ["objectid"], NO_POINTS), []);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1519.

A newly added layer no longer arrives looking exactly like every other one.

## What changed

**1. A color per layer.** Each added vector layer takes the next *unused* entry from a qualitative palette, with its outline derived from that fill. Deleting a layer frees its color back up rather than leaving the cycle permanently offset.

**2. Sizing follows the geometry.** One set of numbers cannot suit all three families — an opacity that lets a basemap read through a polygon makes a point look washed out, and a stroke heavy enough to see a line is a heavy outline on a polygon. Points get solid, smaller symbols; polygons a translucent fill; lines carry the weight on the stroke. The dominant family is read from a bounded sample so a large layer doesn't pay a full scan for a styling default.

**3. A Style suggestions strip.** Up to three one-click renderers derived from the layer's own attributes — *Categorize by …*, *Graduate by …*, *Heatmap* — shown at the top of the Style panel only while the layer still carries its as-added symbology. Dismissible per layer, session-scoped: it is a nudge, not project state.

## `DEFAULT_LAYER_STYLE` is deliberately untouched

It is the schema fallback that fills gaps when a partial style is read back from a project file — every load path spreads it *under* a saved style (`{ ...DEFAULT_LAYER_STYLE, ...layer.style }` in `project.ts`, `layer-sync.ts`, the SLD/QML/Mapbox importers, …). Editing it would silently restyle existing projects. The new `initialLayerStyle()` is a separate decision made only at *add* time.

The palette **starts at the historical default blue** (`#3b82f6`), so the first layer added to a fresh project keeps the fill it always had.

To be precise, that is fill parity, not pixel parity — and the difference is the feature working as intended. The outline is now derived from the fill (`#204887` rather than the old `#1e40af`), and the opacity, stroke width, and circle radius come from the layer's geometry. A first layer therefore looks *close to*, not identical to, what it did before.

## Suggestions are held to a higher bar than the dropdown

Verified against the live USGS earthquake feed, the first version suggested **"Graduate by time"** — a column of epoch milliseconds. It wins on raw spread, and it is exactly what `chooseGraduatedProperty` already pre-selects when you pick "Graduated" by hand. That is tolerable as a pre-fill and bad as advice, so the suggestion path now excludes identifier and timestamp columns outright (by name, and by a near-unique-values ratio that catches identifiers with innocent names). When only such columns remain, **no graduated suggestion is offered at all** rather than a meaningless one. The Style type dropdown keeps its existing behavior.

**Known limitation:** on that same feed the suggestion is now `Graduate by dmin` rather than `mag`. `dmin` is a real numeric measure with genuine spread, so this is a taste difference, not the epoch-milliseconds defect — and picking "the most interesting measure" needs domain knowledge the heuristic doesn't have. The dropdown is one click away for refining it.

## Refactor

`chooseGraduatedProperty` and `isCategoricalProperty` moved out of `StylePanel.tsx` into `lib/vector-style-classification.ts`, so the suggestion builder and the manual path share one definition of a good field instead of duplicating the rules. That also makes the logic testable — importing `StylePanel.tsx` from a test pulls in the whole plugin/Earth Engine chain.

## Verification

19 unit cases across `tests/layer-defaults.test.ts` and `tests/style-suggestions.test.ts`, covering palette assignment and color reuse, geometry classification and its mixed case, override precedence, and each column the suggester refuses to recommend.

Driven in a real browser with real data — dropping `us_states.geojson` (polygons) and the USGS 2.5+ month earthquake feed (2045 points):

- The two layers took distinct palette colors (blue, then red), visible on the Layers panel swatches; quake points rendered solid, states translucent.
- The strip appeared for the quakes layer offering `Categorize by alert`, `Graduate by dmin`, `Heatmap`.
- Clicking a suggestion applied it (`vectorStyleMode` → `graduated`, property → the suggested field) and the strip disappeared, since the layer is now styled.

## Checks

- `npm run build` — passes
- `npm run test:frontend` — 4285 pass, 0 fail
- `pre-commit run --files <changed>` — passes
- `style.suggestions.*` added to `en.json` and all 15 non-English locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dismissible **Style suggestions** in vector layer style controls, offering one-click options for **categorize**, **graduate**, and **heatmap** styling.
  * Suggestions show only when the layer is still in its default (newly added) styling state, with eligibility based on layer contents (including point-rendering support and heatmap density).
  * Improved geometry-aware, palette-based default styling for newly added vector layers.
  * Added localized UI text for style suggestions across supported languages.
* **Bug Fixes**
  * Prevented applying suggestions that would result in empty/invalid renderers.
* **Tests**
  * Added automated coverage for default layer styling and style-suggestion generation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
