### PR TITLE
feat(print): support touch drag for print extent drawing

### DIFF
--- a/apps/geolibre-desktop/src/lib/print-extent.ts
+++ b/apps/geolibre-desktop/src/lib/print-extent.ts
@@ -7,7 +7,7 @@
  * line layers) that persists after the drag so the user can see and re-draw it.
  * {@link captureMapImage} later crops the snapshot to this extent.
  */
-import type { GeoJSONSource, Map as MapLibreMap, MapMouseEvent } from "maplibre-gl";
+import type { GeoJSONSource, Map as MapLibreMap, MapMouseEvent, MapTouchEvent } from "maplibre-gl";
 
 /** A geographic bounding box as `[west, south, east, north]`. */
 export type PrintExtent = [number, number, number, number];
@@ -144,12 +144,15 @@ export interface DrawPrintExtentOptions {
 }
 
 /**
- * Enter interactive draw mode: the next click-and-drag on the map defines the
- * print extent. Resolves with the drawn extent, or `null` if the user cancels
- * (Escape) or the gesture is degenerate (a click with no drag).
+ * Enter interactive draw mode: the next click-and-drag (or single-finger
+ * touch drag) on the map defines the print extent. Resolves with the drawn
+ * extent, or `null` if the user cancels (Escape, a touch cancel, or a second
+ * finger joining mid-drag) or the gesture is degenerate (a click/tap with no
+ * drag).
  *
- * Map panning is suspended during the drag and restored afterwards; the drawn
- * box is left on the map so the caller can show it until it is cleared.
+ * Map panning and two-finger touch gestures are suspended during the drag and
+ * restored afterwards; the drawn box is left on the map so the caller can show
+ * it until it is cleared.
  */
 export function drawPrintExtent(
   map: MapLibreMap,
@@ -168,9 +171,16 @@ export function drawPrintExtent(
     const panWasEnabled = map.dragPan.isEnabled();
     const scrollWasEnabled = map.scrollZoom.isEnabled();
     const dblClickWasEnabled = map.doubleClickZoom.isEnabled();
+    const touchZoomWasEnabled = map.touchZoomRotate.isEnabled();
+    const touchPitchWasEnabled = map.touchPitch.isEnabled();
     map.dragPan.disable();
     map.scrollZoom.disable();
     map.doubleClickZoom.disable();
+    // Also suspend two-finger gestures: dragPan already covers single-finger
+    // touch panning, but a second finger landing mid-draw would otherwise pinch
+    // -zoom or rotate the map under the box being drawn.
+    map.touchZoomRotate.disable();
+    map.touchPitch.disable();
 
     let start: { x: number; y: number } | null = null;
     let settled = false;
@@ -184,6 +194,10 @@ export function drawPrintExtent(
       map.off("mousedown", onDown);
       map.off("mousemove", onMapMove);
       map.off("mouseup", onMapUp);
+      map.off("touchstart", onTouchStart);
+      map.off("touchmove", onTouchMove);
+      map.off("touchend", onTouchEnd);
+      map.off("touchcancel", onTouchCancel);
       window.removeEventListener("mousemove", onWindowMove);
       window.removeEventListener("mouseup", onWindowUp);
       window.removeEventListener("keydown", onKey);
@@ -193,6 +207,8 @@ export function drawPrintExtent(
       if (panWasEnabled) map.dragPan.enable();
       if (scrollWasEnabled) map.scrollZoom.enable();
       if (dblClickWasEnabled) map.doubleClickZoom.enable();
+      if (touchZoomWasEnabled) map.touchZoomRotate.enable();
+      if (touchPitchWasEnabled) map.touchPitch.enable();
       // Clear any caller-drawn preview on every exit (commit, cancel, abort).
       options.onPreview?.(null);
       resolve(result);
@@ -261,17 +277,20 @@ export function drawPrintExtent(
     };
 
     // Schedule a single preview per animation frame from the latest pointer
-    // position (both the map and window move handlers feed this, so over-canvas
-    // motion that fires both is still drawn only once per frame).
-    const queueMove = (clientX: number, clientY: number, shiftKey: boolean) => {
+    // position (the map's own mousemove/touchmove and the window fallback all
+    // feed this, so motion that fires more than one of those in a frame is
+    // still drawn only once). Takes an already canvas-relative point so mouse
+    // (via pointFromClient) and touch (via MapTouchEvent.point, which
+    // MapLibre already reports relative to the map container) share one path.
+    const queueCanvasMove = (point: { x: number; y: number }, shiftKey: boolean) => {
       if (!start) return;
-      pendingMove = { x: clientX, y: clientY, shiftKey };
+      pendingMove = { x: point.x, y: point.y, shiftKey };
       if (!moveRaf) {
         moveRaf = requestAnimationFrame(() => {
           moveRaf = 0;
           const move = pendingMove;
           pendingMove = null;
-          if (move) preview(pointFromClient(move.x, move.y), move.shiftKey);
+          if (move) preview({ x: move.x, y: move.y }, move.shiftKey);
         });
       }
     };
@@ -288,8 +307,12 @@ export function drawPrintExtent(
       start = pointFromClient(e.originalEvent.clientX, e.originalEvent.clientY);
     };
     const onMapMove = (e: MapMouseEvent) =>
-      queueMove(e.originalEvent.clientX, e.originalEvent.clientY, e.originalEvent.shiftKey);
-    const onWindowMove = (e: MouseEvent) => queueMove(e.clientX, e.clientY, e.shiftKey);
+      queueCanvasMove(
+        pointFromClient(e.originalEvent.clientX, e.originalEvent.clientY),
+        e.originalEvent.shiftKey,
+      );
+    const onWindowMove = (e: MouseEvent) =>
+      queueCanvasMove(pointFromClient(e.clientX, e.clientY), e.shiftKey);
     const onMapUp = (e: MapMouseEvent) => {
       if (e.originalEvent.button !== 0) return;
       commit(
@@ -308,15 +331,55 @@ export function drawPrintExtent(
     // mouseup would never arrive, leaving the interaction armed so the next
     // unrelated click anywhere would commit a stray extent. Note: in an embedded
     // iframe this also fires when the parent frame is clicked; that's fine for
-    // the desktop and top-level web builds, but revisit if the mouse-only path
-    // below is ever extended to a Jupyter/embedded context.
+    // the desktop and top-level web builds, but revisit if this is ever
+    // extended to a Jupyter/embedded context.
     const onBlur = () => finish(null);
 
-    // TODO: mouse-only for now (the print workflow is desktop-centric). Add a
-    // touch / pointer-event path for tablets and touchscreens as a follow-up.
+    // TouchEvent carries UIEvent's modifier keys in most engines (e.g. an
+    // external keyboard paired with a tablet); fall back to false where a
+    // browser omits it rather than throwing.
+    const touchShiftKey = (e: MapTouchEvent): boolean =>
+      Boolean((e.originalEvent as unknown as { shiftKey?: boolean }).shiftKey);
+
+    // Touch support (tablets, touchscreens): a single-finger drag defines the
+    // same rubber-band box as a mouse drag. `MapTouchEvent.point` is already
+    // reported relative to the map container, and — unlike mouse, where a
+    // release outside the canvas needs the window fallback below — a touch
+    // sequence stays targeted at its origin element for its whole lifetime, so
+    // touchmove/touchend keep arriving here even once the finger leaves the
+    // canvas. No window-level touch listeners are needed.
+    const onTouchStart = (e: MapTouchEvent) => {
+      // Only a single finger starts a draw. touchZoomRotate/touchPitch are
+      // disabled above, but this also guards a stray secondary contact point
+      // reported alongside the first.
+      if (e.points.length !== 1) return;
+      start = { x: e.point.x, y: e.point.y };
+    };
+    const onTouchMove = (e: MapTouchEvent) => {
+      if (!start) return;
+      // A second finger joining mid-draw reads as an attempted pinch/rotate,
+      // not a continued drag: cancel rather than draw from an ambiguous
+      // multi-touch center point, and let the user restart the tool.
+      if (e.points.length > 1) {
+        finish(null);
+        return;
+      }
+      queueCanvasMove({ x: e.point.x, y: e.point.y }, touchShiftKey(e));
+    };
+    const onTouchEnd = (e: MapTouchEvent) => {
+      commit({ x: e.point.x, y: e.point.y }, touchShiftKey(e));
+    };
+    // The OS or browser reclaiming the gesture (e.g. an incoming call, a
+    // system edge-swipe) — there is no completed drag to commit.
+    const onTouchCancel = () => finish(null);
+
     map.on("mousedown", onDown);
     map.on("mousemove", onMapMove);
     map.on("mouseup", onMapUp);
+    map.on("touchstart", onTouchStart);
+    map.on("touchmove", onTouchMove);
+    map.on("touchend", onTouchEnd);
+    map.on("touchcancel", onTouchCancel);
     window.addEventListener("mousemove", onWindowMove);
     window.addEventListener("mouseup", onWindowUp);
     window.addEventListener("keydown", onKey);

--- a/apps/geolibre-desktop/src/lib/print-extent.ts
+++ b/apps/geolibre-desktop/src/lib/print-extent.ts
@@ -349,6 +349,15 @@ export function drawPrintExtent(
     // touchmove/touchend keep arriving here even once the finger leaves the
     // canvas. No window-level touch listeners are needed.
     const onTouchStart = (e: MapTouchEvent) => {
+      // A fresh contact landing while a draw is already armed reads as an
+      // attempted pinch/rotate, so cancel — matching onTouchMove below. Merely
+      // ignoring it would leave `start` set from the first finger, and a later
+      // touchend from *either* finger would then commit against a release point
+      // that has nothing to do with the drag the user was making. `touchstart`
+      // derives its points from the native `touches` list (every active
+      // contact), so a second finger always surfaces here while the first is
+      // still down.
+      if (start) return finish(null);
       // Only a single finger starts a draw. touchZoomRotate/touchPitch are
       // disabled above, but this also guards a stray secondary contact point
       // reported alongside the first.
@@ -367,6 +376,15 @@ export function drawPrintExtent(
       queueCanvasMove({ x: e.point.x, y: e.point.y }, touchShiftKey(e));
     };
     const onTouchEnd = (e: MapTouchEvent) => {
+      // `touchend` is the one touch event whose point comes from the native
+      // `changedTouches` (the finger that just lifted) rather than the contacts
+      // still down — which is exactly the point wanted here: onTouchStart
+      // cancels as soon as a second contact reaches the canvas, so while
+      // `start` is set there is exactly one canvas-originated finger down and it
+      // is the one lifting. Deliberately *not* gated on
+      // `originalEvent.touches.length === 0`: `touches` is surface-wide, so an
+      // unrelated contact away from the canvas (a thumb steadying a tablet)
+      // would swallow a legitimate release and wedge the tool armed.
       commit({ x: e.point.x, y: e.point.y }, touchShiftKey(e));
     };
     // The OS or browser reclaiming the gesture (e.g. an incoming call, a

--- a/tests/print-extent.test.ts
+++ b/tests/print-extent.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { drawPrintExtent } from "../apps/geolibre-desktop/src/lib/print-extent";
+
+/**
+ * Tests for the "Draw print extent" interaction (`print-extent.ts`), which had
+ * no coverage before: it is DOM-driven (mousedown/mousemove/mouseup on the
+ * MapLibre map, plus window-level fallback listeners, plus touch support) so
+ * this file stubs the pieces `node --test` doesn't provide — `window`,
+ * `requestAnimationFrame` — and a minimal event-emitting fake `Map`, closely
+ * mirroring how `assistant-provider.test.ts` stubs `globalThis.window`.
+ *
+ * Coordinates: the fake canvas reports a bounding rect at (left: 100, top: 50),
+ * and the fake `unproject` maps a canvas-relative pixel (x, y) to
+ * `{ lng: x / 10, lat: y / 10 }` — not geographically meaningful, just a
+ * deterministic, invertible mapping so the resulting extent is easy to assert.
+ */
+
+type Listener = (event: unknown) => void;
+
+function fakeHandler() {
+  let enabled = true;
+  return {
+    isEnabled: () => enabled,
+    enable: () => {
+      enabled = true;
+    },
+    disable: () => {
+      enabled = false;
+    },
+  };
+}
+
+class FakeMap {
+  listeners = new Map<string, Listener[]>();
+  dragPan = fakeHandler();
+  scrollZoom = fakeHandler();
+  doubleClickZoom = fakeHandler();
+  touchZoomRotate = fakeHandler();
+  touchPitch = fakeHandler();
+  private canvasEl = {
+    style: { cursor: "" },
+    getBoundingClientRect: () => ({
+      left: 100,
+      top: 50,
+      right: 900,
+      bottom: 650,
+      width: 800,
+      height: 600,
+    }),
+  };
+
+  getCanvas() {
+    return this.canvasEl;
+  }
+
+  on(type: string, fn: Listener) {
+    const list = this.listeners.get(type) ?? [];
+    list.push(fn);
+    this.listeners.set(type, list);
+  }
+
+  off(type: string, fn: Listener) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((l) => l !== fn),
+    );
+  }
+
+  emit(type: string, event: unknown) {
+    for (const fn of this.listeners.get(type) ?? []) fn(event);
+  }
+
+  unproject([x, y]: [number, number]) {
+    return { lng: x / 10, lat: y / 10 };
+  }
+
+  // The print-extent source/layer plumbing is exercised via `drawBox: false`
+  // in these tests (they assert on the resolved/previewed extent, not the
+  // MapLibre rendering side effects), but stub it anyway in case a test needs
+  // the default.
+  addSource() {}
+  getSource() {
+    return undefined;
+  }
+  addLayer() {}
+  getLayer() {
+    return undefined;
+  }
+  removeLayer() {}
+  removeSource() {}
+  setLayoutProperty() {}
+}
+
+let originalWindow: typeof globalThis.window;
+let originalRaf: typeof globalThis.requestAnimationFrame;
+let originalCancelRaf: typeof globalThis.cancelAnimationFrame;
+let windowListeners: Map<string, Listener[]>;
+
+/** Fire a `type` listener registered on the stubbed `globalThis.window`. */
+function dispatchWindowEvent(type: string, event: unknown) {
+  for (const fn of windowListeners.get(type) ?? []) fn(event);
+}
+
+beforeEach(() => {
+  originalWindow = globalThis.window;
+  originalRaf = globalThis.requestAnimationFrame;
+  originalCancelRaf = globalThis.cancelAnimationFrame;
+  windowListeners = new Map<string, Listener[]>();
+  globalThis.window = {
+    addEventListener: (type: string, fn: Listener) => {
+      const list = windowListeners.get(type) ?? [];
+      list.push(fn);
+      windowListeners.set(type, list);
+    },
+    removeEventListener: (type: string, fn: Listener) => {
+      windowListeners.set(
+        type,
+        (windowListeners.get(type) ?? []).filter((l) => l !== fn),
+      );
+    },
+  } as unknown as Window & typeof globalThis;
+  // Synchronous "next frame" so preview()/commit() effects are observable
+  // immediately after emitting an event, with no real animation timing.
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
+});
+
+afterEach(() => {
+  globalThis.window = originalWindow;
+  globalThis.requestAnimationFrame = originalRaf;
+  globalThis.cancelAnimationFrame = originalCancelRaf;
+});
+
+describe("drawPrintExtent (mouse)", () => {
+  it("resolves the dragged extent on mouseup", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("mousedown", { originalEvent: { button: 0, clientX: 150, clientY: 100 } });
+    map.emit("mousemove", {
+      originalEvent: { button: 0, clientX: 250, clientY: 200, shiftKey: false },
+    });
+    map.emit("mouseup", {
+      originalEvent: { button: 0, clientX: 350, clientY: 300, shiftKey: false },
+    });
+    // Canvas-relative: (50, 50) -> (250, 250); unproject/10 -> [5, 5, 25, 25].
+    assert.deepEqual(await promise, [5, 5, 25, 25]);
+  });
+
+  it("discards a click with no drag", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("mousedown", { originalEvent: { button: 0, clientX: 150, clientY: 100 } });
+    map.emit("mouseup", {
+      originalEvent: { button: 0, clientX: 150, clientY: 100, shiftKey: false },
+    });
+    assert.equal(await promise, null);
+  });
+
+  it("cancels on Escape mid-drag", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("mousedown", { originalEvent: { button: 0, clientX: 150, clientY: 100 } });
+    map.emit("mousemove", {
+      originalEvent: { button: 0, clientX: 250, clientY: 200, shiftKey: false },
+    });
+    dispatchWindowEvent("keydown", { key: "Escape" });
+    assert.equal(await promise, null);
+  });
+
+  it("restores dragPan/scrollZoom/doubleClickZoom/touch handlers after resolving", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    assert.equal(map.dragPan.isEnabled(), false);
+    assert.equal(map.touchZoomRotate.isEnabled(), false);
+    assert.equal(map.touchPitch.isEnabled(), false);
+    map.emit("mousedown", { originalEvent: { button: 0, clientX: 150, clientY: 100 } });
+    map.emit("mouseup", {
+      originalEvent: { button: 0, clientX: 350, clientY: 300, shiftKey: false },
+    });
+    await promise;
+    assert.equal(map.dragPan.isEnabled(), true);
+    assert.equal(map.scrollZoom.isEnabled(), true);
+    assert.equal(map.doubleClickZoom.isEnabled(), true);
+    assert.equal(map.touchZoomRotate.isEnabled(), true);
+    assert.equal(map.touchPitch.isEnabled(), true);
+  });
+});
+
+describe("drawPrintExtent (touch)", () => {
+  it("resolves the dragged extent on a single-finger touchend", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    map.emit("touchmove", {
+      points: [{ x: 160, y: 160 }],
+      point: { x: 160, y: 160 },
+      originalEvent: {},
+    });
+    map.emit("touchend", { points: [], point: { x: 260, y: 260 }, originalEvent: {} });
+    // Touch points are already canvas-relative: (60,60) -> (260,260) -> [6, 6, 26, 26].
+    assert.deepEqual(await promise, [6, 6, 26, 26]);
+  });
+
+  it("cancels the draw when a second finger joins mid-drag", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    map.emit("touchmove", {
+      points: [
+        { x: 160, y: 160 },
+        { x: 200, y: 200 },
+      ],
+      point: { x: 180, y: 180 },
+      originalEvent: {},
+    });
+    assert.equal(await promise, null);
+  });
+
+  it("cancels on touchcancel", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    map.emit("touchcancel", { points: [], point: { x: 60, y: 60 }, originalEvent: {} });
+    assert.equal(await promise, null);
+  });
+
+  it("ignores a touchstart with more than one finger and stays armed for a real drag", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    // Two fingers down at once: not a draw start, so `start` is never set and
+    // the tool stays armed (mirrors "ignore a stray mouseup before a press"
+    // for the mouse path) rather than resolving out from under the caller.
+    map.emit("touchstart", {
+      points: [
+        { x: 60, y: 60 },
+        { x: 100, y: 100 },
+      ],
+      point: { x: 80, y: 80 },
+      originalEvent: {},
+    });
+    map.emit("touchend", { points: [], point: { x: 260, y: 260 }, originalEvent: {} });
+    // A stray touchend with no `start` must not resolve the draw either.
+    let settled = false;
+    void promise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    assert.equal(settled, false);
+    // A proper single-finger drag afterwards still completes normally.
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    map.emit("touchend", { points: [], point: { x: 260, y: 260 }, originalEvent: {} });
+    assert.deepEqual(await promise, [6, 6, 26, 26]);
+  });
+
+  it("disables touchZoomRotate/touchPitch for the duration of the draw", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    assert.equal(map.touchZoomRotate.isEnabled(), false);
+    assert.equal(map.touchPitch.isEnabled(), false);
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    map.emit("touchend", { points: [], point: { x: 260, y: 260 }, originalEvent: {} });
+    await promise;
+    assert.equal(map.touchZoomRotate.isEnabled(), true);
+    assert.equal(map.touchPitch.isEnabled(), true);
+  });
+});

--- a/tests/print-extent.test.ts
+++ b/tests/print-extent.test.ts
@@ -229,6 +229,81 @@ describe("drawPrintExtent (touch)", () => {
     assert.equal(await promise, null);
   });
 
+  it("cancels the draw when a second finger lands mid-draw without moving", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    // A second finger touching down re-fires touchstart with *both* contacts
+    // (touchstart's points come from the native `touches` list). Cancel here
+    // rather than stay armed, so no later release can commit against it.
+    map.emit("touchstart", {
+      points: [
+        { x: 60, y: 60 },
+        { x: 200, y: 200 },
+      ],
+      point: { x: 130, y: 130 },
+      originalEvent: {},
+    });
+    assert.equal(await promise, null);
+  });
+
+  it("does not commit a bogus extent when a second finger lifts before the first", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    map.emit("touchmove", {
+      points: [{ x: 160, y: 160 }],
+      point: { x: 160, y: 160 },
+      originalEvent: {},
+    });
+    // Second finger down, then straight back up with no touchmove in between.
+    // touchend reports the *lifted* finger (changedTouches), so before the
+    // touchstart cancel this committed [6, 6, 46, 46] from the wrong finger
+    // while the tracked one was still mid-drag.
+    map.emit("touchstart", {
+      points: [
+        { x: 160, y: 160 },
+        { x: 460, y: 460 },
+      ],
+      point: { x: 310, y: 310 },
+      originalEvent: {},
+    });
+    map.emit("touchend", {
+      points: [{ x: 460, y: 460 }],
+      point: { x: 460, y: 460 },
+      originalEvent: { touches: [{}] },
+    });
+    assert.equal(await promise, null);
+  });
+
+  it("commits a single-finger drag even while an unrelated contact stays on the surface", async () => {
+    const map = new FakeMap();
+    const promise = drawPrintExtent(map as never, { drawBox: false });
+    map.emit("touchstart", {
+      points: [{ x: 60, y: 60 }],
+      point: { x: 60, y: 60 },
+      originalEvent: {},
+    });
+    // A contact that started off the canvas (a thumb steadying a tablet) never
+    // reaches these handlers, but it does stay in the surface-wide
+    // `originalEvent.touches`. The release must still commit rather than being
+    // swallowed, which is why touchend is not gated on that list being empty.
+    map.emit("touchend", {
+      points: [{ x: 260, y: 260 }],
+      point: { x: 260, y: 260 },
+      originalEvent: { touches: [{}] },
+    });
+    assert.deepEqual(await promise, [6, 6, 26, 26]);
+  });
+
   it("cancels on touchcancel", async () => {
     const map = new FakeMap();
     const promise = drawPrintExtent(map as never, { drawBox: false });


### PR DESCRIPTION
Adds single-finger touch support to the "Draw print extent" tool in the Print Layout dialog, which was previously mouse-only (a TODO in the code called this out as a follow-up). A second finger joining mid-drag cancels the draw rather than committing an extent from an ambiguous multi-touch point, and touchZoomRotate/touchPitch are suspended for the duration of the draw and restored after, matching the existing dragPan/scrollZoom/doubleClickZoom handling.

Also adds tests/print-extent.test.ts (9 tests) — this module had no prior coverage.

Verified against the actual maplibre-gl@5.24.0 type definitions (MapTouchEvent.point, touchZoomRotate, touchPitch). Manual QA on a real touchscreen/tablet is recommended before merge — the test suite covers the interaction logic in a headless harness, not real touch input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added touch support for drawing print extents, including single-finger dragging and two-finger gesture handling.
  * Temporarily pauses map touch zoom/rotation and pitch interactions during drawing, then restores them afterward.
* **Bug Fixes**
  * Improved cancellation and edge-case handling for Escape, multi-touch entry, touchcancel, and interrupted drags to prevent incorrect commits.
* **Tests**
  * Added DOM-driven mouse/touch test coverage, including deterministic interaction simulations and verification that handlers are correctly restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->