### PR TITLE
feat(style): classify vector-tile layers by tile attributes

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -80,6 +80,7 @@ import {
   useState,
 } from "react";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
+import { loadedVectorTileFeatures } from "../../hooks/useVectorTileGeometryBackfill";
 import { clamp } from "../../lib/clamp";
 import {
   getAttributePropertyNames,
@@ -1156,8 +1157,11 @@ export function StylePanel({
   // classification needs its values, so categorized and graduated styling
   // remain available without defeating tiled rendering.
   useEffect(() => {
+    const usesDuckDbVector = layer?.metadata.sourceKind === "maplibre-gl-vector";
+    const usesVectorTiles =
+      layer?.type === "vector-tiles" || layer?.type === "pmtiles" || layer?.type === "mbtiles";
     const needsValues =
-      layer?.metadata.sourceKind === "maplibre-gl-vector" &&
+      (usesDuckDbVector || usesVectorTiles) &&
       !layer.geojson &&
       (draftVectorStyleMode === "graduated" || draftVectorStyleMode === "categorized") &&
       draftVectorStyleProperty !== "";
@@ -1177,7 +1181,17 @@ export function StylePanel({
     );
     setVectorPropertyValuesLoading(true);
     setVectorPropertyValuesUnavailable(false);
-    void getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
+    const map = mapControllerRef.current?.getMap();
+    const valuesPromise = usesDuckDbVector
+      ? getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
+      : Promise.resolve(
+          map
+            ? loadedVectorTileFeatures(map, layer)
+                .map((feature) => feature.properties?.[draftVectorStyleProperty])
+                .filter((value) => value !== null && value !== undefined)
+            : null,
+        );
+    void valuesPromise
       .then((values) => {
         if (cancelled) return;
         if (values === null) {
@@ -1216,7 +1230,6 @@ export function StylePanel({
   useEffect(() => {
     if (
       !layer ||
-      layer.metadata.sourceKind !== "maplibre-gl-vector" ||
       !loadedVectorPropertyValues ||
       loadedVectorPropertyValues.layerId !== layer.id ||
       loadedVectorPropertyValues.property !== draftVectorStyleProperty ||
@@ -1540,7 +1553,12 @@ export function StylePanel({
     draftExtrusionHeightProperty,
   )
     ? extrusionHeightPropertyOptions
-    : [draftExtrusionHeightProperty, ...extrusionHeightPropertyOptions].filter(Boolean);
+    : extrusionHeightPropertyOptions;
+  const defaultExtrusionHeightProperty = extrusionHeightPropertyOptions.includes(
+    draftExtrusionHeightProperty,
+  )
+    ? draftExtrusionHeightProperty
+    : (extrusionHeightPropertyOptions[0] ?? "");
   const currentVectorStops = styleValue(style, "vectorStyleStops");
   const vectorStyleSettingsChanged =
     draftVectorStyleMode !== styleValue(style, "vectorStyleMode") ||
@@ -4217,9 +4235,11 @@ export function StylePanel({
                     checked={extrusionEnabled && !elevation3dActive}
                     onChange={() => {
                       setVectorStyleError(null);
+                      setDraftExtrusionHeightProperty(defaultExtrusionHeightProperty);
                       setLayerStyle(layer.id, {
                         extrusionEnabled: true,
                         elevation3dEnabled: false,
+                        extrusionHeightProperty: defaultExtrusionHeightProperty,
                       });
                     }}
                   />

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1181,17 +1181,44 @@ export function StylePanel({
     );
     setVectorPropertyValuesLoading(true);
     setVectorPropertyValuesUnavailable(false);
-    const map = mapControllerRef.current?.getMap();
-    const valuesPromise = usesDuckDbVector
-      ? getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
-      : Promise.resolve(
-          map
-            ? loadedVectorTileFeatures(map, layer)
-                .map((feature) => feature.properties?.[draftVectorStyleProperty])
-                .filter((value) => value !== null && value !== undefined)
-            : null,
-        );
-    void valuesPromise
+
+    if (!usesDuckDbVector) {
+      // Tiled sources only expose the features currently loaded, so an empty
+      // sample means the tiles have not arrived yet rather than an empty
+      // attribute — keep re-reading until the map settles with features.
+      const map = mapControllerRef.current?.getMap();
+      if (!map) {
+        setLoadedVectorPropertyValues(null);
+        setVectorPropertyValuesUnavailable(true);
+        setVectorPropertyValuesLoading(false);
+        return;
+      }
+      const sampleValues = (): boolean => {
+        const features = loadedVectorTileFeatures(map, layer);
+        if (features.length === 0) return false;
+        setLoadedVectorPropertyValues({
+          layerId: layer.id,
+          property: draftVectorStyleProperty,
+          values: features
+            .map((feature) => feature.properties?.[draftVectorStyleProperty])
+            .filter((value) => value !== null && value !== undefined),
+        });
+        setVectorPropertyValuesLoading(false);
+        return true;
+      };
+      if (sampleValues()) return;
+      const onIdle = (): void => {
+        if (cancelled) return;
+        if (sampleValues()) map.off("idle", onIdle);
+      };
+      map.on("idle", onIdle);
+      return () => {
+        cancelled = true;
+        map.off("idle", onIdle);
+      };
+    }
+
+    void getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
       .then((values) => {
         if (cancelled) return;
         if (values === null) {
@@ -1225,6 +1252,7 @@ export function StylePanel({
     layer?.geojson,
     layer?.id,
     layer?.metadata.sourceKind,
+    layer?.type,
   ]);
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -697,6 +697,14 @@ const STYLE_PANEL_ASIDE_CLASS =
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
 
+/**
+ * How long to wait for a tiled source to produce features before reporting its
+ * attributes as unavailable. A tiled layer whose data sits outside the viewport
+ * never yields a sample, and the map may already be idle, so the wait has to be
+ * bounded in wall-clock time rather than in retries.
+ */
+const VECTOR_TILE_SAMPLE_TIMEOUT_MS = 6000;
+
 function stepPrecision(step: number): number {
   const [, decimals = ""] = String(step).split(".");
   return decimals.length;
@@ -1207,14 +1215,27 @@ export function StylePanel({
         return true;
       };
       if (sampleValues()) return;
+      let timer: ReturnType<typeof setTimeout> | undefined;
       const onIdle = (): void => {
-        if (cancelled) return;
-        if (sampleValues()) map.off("idle", onIdle);
+        if (cancelled || !sampleValues()) return;
+        map.off("idle", onIdle);
+        clearTimeout(timer);
       };
+      // The sample may never fill: the layer's data can lie outside the
+      // viewport, and a map that is already idle fires no further events. Give
+      // up rather than leaving the panel loading with Apply disabled forever.
+      timer = setTimeout(() => {
+        if (cancelled) return;
+        map.off("idle", onIdle);
+        setLoadedVectorPropertyValues(null);
+        setVectorPropertyValuesUnavailable(true);
+        setVectorPropertyValuesLoading(false);
+      }, VECTOR_TILE_SAMPLE_TIMEOUT_MS);
       map.on("idle", onIdle);
       return () => {
         cancelled = true;
         map.off("idle", onIdle);
+        clearTimeout(timer);
       };
     }
 

--- a/apps/geolibre-desktop/src/hooks/useVectorTileGeometryBackfill.ts
+++ b/apps/geolibre-desktop/src/hooks/useVectorTileGeometryBackfill.ts
@@ -1,5 +1,5 @@
 /**
- * Backfills `metadata.geometryType` for vector-tile layers that don't carry it.
+ * Backfills attributes derived from loaded features for vector-tile layers.
  *
  * A vector-tile layer has no local features, so its geometry (point / line /
  * polygon) is only known if a source set the hint — the GeoLens plugin does for
@@ -29,26 +29,37 @@ function sourceLayerOf(layer: GeoLibreLayer): string | undefined {
   return undefined;
 }
 
-/** The dominant geometry kind among a layer's loaded tile features, or null. */
-function dominantGeometry(
+function liveSourceId(layer: GeoLibreLayer): string {
+  const externalSourceId = layer.source.sourceId;
+  return typeof externalSourceId === "string" && externalSourceId
+    ? externalSourceId
+    : sourceId(layer.id);
+}
+
+/** A bounded sample of features currently loaded for a vector-tile layer. */
+export function loadedVectorTileFeatures(
   map: MapLibreMap,
   layer: GeoLibreLayer,
-): "point" | "line" | "polygon" | null {
+): ReturnType<MapLibreMap["querySourceFeatures"]> {
   const sourceLayer = sourceLayerOf(layer);
-  let features;
   try {
-    features = map.querySourceFeatures(
-      sourceId(layer.id),
-      sourceLayer ? { sourceLayer } : undefined,
-    );
+    return map
+      .querySourceFeatures(liveSourceId(layer), sourceLayer ? { sourceLayer } : undefined)
+      .slice(0, 400);
   } catch {
-    return null; // source not added yet
+    return []; // source not added yet
   }
+}
+
+/** The dominant geometry kind among sampled tile features, or null. */
+function dominantGeometry(
+  features: ReturnType<MapLibreMap["querySourceFeatures"]>,
+): "point" | "line" | "polygon" | null {
   if (!features || features.length === 0) return null;
   let polygon = 0;
   let line = 0;
   let point = 0;
-  for (const feature of features.slice(0, 400)) {
+  for (const feature of features) {
     const type = feature.geometry?.type ?? "";
     if (type.includes("Polygon")) polygon++;
     else if (type.includes("LineString")) line++;
@@ -59,6 +70,17 @@ function dominantGeometry(
   if (polygon >= line && polygon >= point) return "polygon";
   if (line >= point) return "line";
   return "point";
+}
+
+/** Sorted attribute names present in sampled tile features. */
+function attributeFields(features: ReturnType<MapLibreMap["querySourceFeatures"]>): string[] {
+  const fields = new Set<string>();
+  for (const feature of features) {
+    for (const field of Object.keys(feature.properties ?? {})) fields.add(field);
+  }
+  return Array.from(fields).sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }),
+  );
 }
 
 /**
@@ -79,25 +101,42 @@ export function useVectorTileGeometryBackfill(
     const map = app.getMap?.();
     if (!map) return;
 
-    const needsGeometry = () =>
+    const needsBackfill = () =>
       useAppStore
         .getState()
         .layers.filter(
           (layer) =>
-            VECTOR_TILE_TYPES.has(layer.type) && typeof layer.metadata.geometryType !== "string",
+            VECTOR_TILE_TYPES.has(layer.type) &&
+            (typeof layer.metadata.geometryType !== "string" ||
+              !Array.isArray(layer.metadata.fields) ||
+              layer.metadata.fields.length === 0),
         );
 
-    if (needsGeometry().length === 0) return;
+    if (needsBackfill().length === 0) return;
 
     const backfill = (): void => {
-      for (const layer of needsGeometry()) {
-        const geometryType = dominantGeometry(map, layer);
-        if (!geometryType) continue;
+      for (const layer of needsBackfill()) {
+        const features = loadedVectorTileFeatures(map, layer);
+        if (features.length === 0) continue;
+        const geometryType = dominantGeometry(features);
+        const fields = attributeFields(features);
         const current = useAppStore.getState().layers.find((l) => l.id === layer.id);
-        if (current && typeof current.metadata.geometryType !== "string") {
-          useAppStore
-            .getState()
-            .updateLayer(layer.id, { metadata: { ...current.metadata, geometryType } });
+        if (current) {
+          const metadata = { ...current.metadata };
+          let changed = false;
+          if (geometryType && typeof metadata.geometryType !== "string") {
+            metadata.geometryType = geometryType;
+            changed = true;
+          }
+          if (
+            (!Array.isArray(metadata.fields) || metadata.fields.length === 0) &&
+            fields.length > 0
+          ) {
+            metadata.fields = fields;
+            changed = true;
+          }
+          if (!changed) continue;
+          useAppStore.getState().updateLayer(layer.id, { metadata });
         }
       }
     };

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -158,6 +158,8 @@ const lidarControlPosition: GeoLibreMapControlPosition = "top-left";
 const splattingControlPosition: GeoLibreMapControlPosition = "top-left";
 
 const FLATGEOBUF_SAMPLE_URL = "https://flatgeobuf.org/test/data/UScounties.fgb";
+const BUILDING_COUNT_H3_PMTILES_SAMPLE_URL =
+  "https://data.source.coop/giswqs/opengeos/building_count_h3.pmtiles";
 const PMTILES_SAMPLE_URL =
   "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-06-17.0/buildings.pmtiles";
 const ZARR_SAMPLE_URL =
@@ -262,7 +264,10 @@ const PMTILES_OPTIONS = {
   defaultLineColor: DEFAULT_LAYER_STYLE.strokeColor,
   defaultOpacity: 0.8,
   defaultPickable: false,
-  sampleData: [{ label: "Overture buildings", url: PMTILES_SAMPLE_URL }],
+  sampleData: [
+    { label: "Overture buildings", url: PMTILES_SAMPLE_URL },
+    { label: "H3 building counts", url: BUILDING_COUNT_H3_PMTILES_SAMPLE_URL },
+  ],
   fontColor: "hsl(var(--popover-foreground))",
 } satisfies PMTilesLayerControlOptions;
 

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -70,6 +70,10 @@ const SAMPLE_VECTOR_DATASETS: VectorSampleDataset[] = [
     label: "Las Vegas buildings",
     url: "https://data.source.coop/giswqs/opengeos/las-vegas-buildings.geojson",
   },
+  {
+    label: "H3 building counts",
+    url: "https://data.source.coop/giswqs/opengeos/building_count_h3.parquet",
+  },
 ];
 
 // This type mirrors an undocumented private member of VectorControl from


### PR DESCRIPTION
## Summary
- Backfill `metadata.fields` (alongside the existing `geometryType`) for vector-tile layers from a bounded sample of the features already loaded in the viewport, so the Style panel can list their attributes.
- Let graduated and categorized styling work for `vector-tiles` / `pmtiles` / `mbtiles` layers by reading classification values from loaded tile features, instead of only for DuckDB-backed vector sources.
- Default the 3D extrusion height property to a field the layer actually has when extrusion is switched on, rather than leaving a stale or absent property selected.
- Add an H3 building-counts sample dataset to the PMTiles and vector sample lists.

## Test plan
- [ ] `npm run test:frontend` passes (4256 pass, 1 skipped locally).
- [ ] `pre-commit run --files <changed files>` clean, including the `npm build` hook.
- [ ] Load the "H3 building counts" PMTiles sample, open the Style panel, and confirm the attribute list is populated and graduated/categorized styling renders a classified map.
- [ ] Do the same with the "H3 building counts" GeoParquet sample to confirm the DuckDB path is unchanged.
- [ ] Enable 3D extrusion on a polygon vector-tile layer and confirm the height property preselects a real numeric field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “H3 building counts” preset to both vector and PMTiles data controls.
  * Enhanced attribute-driven styling by sampling values from currently loaded vector-tile layers (not just GeoJSON).
  * Improved 3D extrusion mode by auto-selecting a default extrusion-height property from available options.

* **Bug Fixes / Improvements**
  * More reliable detection of geometry type and available attribute fields for vector-tile-like layers by backfilling missing metadata from loaded tile features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->