### PR TITLE
fix(ios): make the signed CI path work and document the real build recipe

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -45,7 +45,15 @@ jobs:
     name: Build iOS app
     # Apple Silicon macOS image; ships a recent Xcode + CocoaPods. Pin the major
     # image so a runner update can't silently change the Xcode/SDK under us.
-    runs-on: macos-14
+    #
+    # macos-14 does NOT work: `tauri ios init` generates an Xcode project in
+    # object format 77, which only Xcode 16+ can open. That image's Xcode is
+    # older, so the archive died before compiling anything with:
+    #   The project 'geolibre-desktop' cannot be opened because it is in a
+    #   future Xcode project file format (77).
+    # The floor is therefore set by the Tauri CLI's generated project format,
+    # not by our own code — re-check it when the Tauri CLI is bumped.
+    runs-on: macos-15
     permissions:
       contents: write
     steps:
@@ -53,6 +61,33 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+
+      - name: Select the newest available Xcode
+        # The image default is not trusted: it moves under us on image updates,
+        # and too-old is a hard failure (project format 77 needs Xcode 16+) while
+        # too-old-but-openable is a *silent* one — App Store Connect rejects
+        # uploads built against an SDK below its current floor, which would only
+        # surface after a full archive. Pick the newest Xcode present and record
+        # the version and SDK in the log so a rejected upload can be diagnosed
+        # from the run rather than guessed at.
+        run: |
+          set -euo pipefail
+          newest="$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)"
+          if [ -z "$newest" ]; then
+            echo "::error::No Xcode found on the runner"
+            exit 1
+          fi
+          sudo xcode-select -s "$newest/Contents/Developer"
+
+          version="$(xcodebuild -version | head -1 | awk '{print $2}')"
+          major="${version%%.*}"
+          if [ "$major" -lt 16 ]; then
+            echo "::error::Xcode $version is too old — the generated project uses object format 77, which requires Xcode 16+. Use a newer runner image."
+            exit 1
+          fi
+          echo "::notice::Using Xcode $version at $newest"
+          xcodebuild -version
+          xcodebuild -showsdks | grep -i "iOS" || true
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -244,21 +244,29 @@ jobs:
             cert="Apple Distribution"
           fi
 
+          # Built with PlistBuddy rather than a heredoc so the values are encoded
+          # by a plist writer instead of pasted into raw XML. PROFILE_NAME comes
+          # from the Developer portal and is free text: a display name like
+          # "GeoLibre R&D" would produce malformed XML by string interpolation,
+          # and xcodebuild would reject the options file with an unhelpful parse
+          # error rather than pointing at the name.
           opts="$RUNNER_TEMP/ExportOptions.plist"
-          cat > "$opts" <<PLIST
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0"><dict>
-            <key>method</key><string>$EXPORT_METHOD</string>
-            <key>teamID</key><string>$APPLE_TEAM_ID</string>
-            <key>signingStyle</key><string>manual</string>
-            <key>signingCertificate</key><string>$cert</string>
-            <key>provisioningProfiles</key><dict>
-              <key>$EXPECTED_BUNDLE_ID</key><string>$PROFILE_NAME</string>
-            </dict>
-            <key>uploadSymbols</key><true/>
-          </dict></plist>
-          PLIST
+          rm -f "$opts"
+          plutil -create xml1 "$opts"
+          /usr/libexec/PlistBuddy \
+            -c "Add :method string $EXPORT_METHOD" \
+            -c "Add :teamID string $APPLE_TEAM_ID" \
+            -c "Add :signingStyle string manual" \
+            -c "Add :signingCertificate string $cert" \
+            -c "Add :uploadSymbols bool true" \
+            -c "Add :provisioningProfiles dict" \
+            -c "Add :provisioningProfiles:$EXPECTED_BUNDLE_ID string $PROFILE_NAME" \
+            "$opts"
+          plutil -lint "$opts"
+
+          # Carried to the verify step so it can assert the *shipped* signature
+          # matches the certificate this export actually asked for.
+          echo "SIGNING_CERT=$cert" >> "$GITHUB_ENV"
 
           # APPLE_IOS_PROVISIONING_PROFILE_BASE64 must hold a *manually managed*
           # profile created in the Developer portal. An Xcode-managed one (the
@@ -313,15 +321,23 @@ jobs:
           # An unsigned .ipa is structurally valid and passes every check above,
           # so signing is verified explicitly — otherwise the failure surfaces at
           # App Store Connect upload time, the most expensive place to find it.
-          if ! codesign --verify --strict "$app" 2>/dev/null; then
+          # --deep because App Store validation is itself deep: without it only
+          # the outer bundle's seal is checked, and an unsigned or mismatched
+          # nested binary would pass here and still be rejected at upload.
+          if ! codesign --verify --deep --strict "$app" 2>/dev/null; then
             echo "::error::$ipa failed codesign verification"
             exit 1
           fi
+
+          # Asserted against the certificate the export step actually requested,
+          # not merely "some Apple identity". A distribution build that came out
+          # signed for development is not submittable, and accepting either kind
+          # here would let that through to fail at upload instead.
           authority="$(codesign -dvvv "$app" 2>&1 | grep '^Authority=' | head -1 | cut -d= -f2-)"
           case "$authority" in
-            "Apple Distribution"*|"Apple Development"*) ;;
+            "$SIGNING_CERT"*) ;;
             *)
-              echo "::error::$ipa signed by unexpected authority '$authority'"
+              echo "::error::$ipa signed by '$authority', expected '$SIGNING_CERT'"
               exit 1
               ;;
           esac

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -168,49 +168,170 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: \
             -s -k "$keychain_pass" "$keychain" >/dev/null
 
-          # Install the provisioning profile where Xcode looks for it.
-          profiles="$HOME/Library/MobileDevice/Provisioning Profiles"
-          mkdir -p "$profiles"
-          echo "$APPLE_IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode \
-            > "$profiles/geolibre.mobileprovision"
+          # Install the provisioning profile where Xcode looks for it. Xcode 16+
+          # reads UserData/Provisioning Profiles; older versions read the
+          # MobileDevice path. Install to both so the job is not coupled to the
+          # runner image's Xcode version.
+          profile="$RUNNER_TEMP/geolibre.mobileprovision"
+          echo "$APPLE_IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile"
 
-      - name: Build signed IPA
+          # The export step must name the profile, so read its identity out of
+          # the decoded payload rather than hardcoding a name that would silently
+          # drift from whatever profile the secret actually holds.
+          plist="$RUNNER_TEMP/profile.plist"
+          security cms -D -i "$profile" > "$plist"
+          profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$plist")"
+          profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$plist")"
+          rm -f "$plist"
+          echo "PROFILE_NAME=$profile_name" >> "$GITHUB_ENV"
+          echo "PROFILE_UUID=$profile_uuid" >> "$GITHUB_ENV"
+
+          for dir in "$HOME/Library/MobileDevice/Provisioning Profiles" \
+                     "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"; do
+            mkdir -p "$dir"
+            cp "$profile" "$dir/$profile_uuid.mobileprovision"
+          done
+          rm -f "$profile"
+          echo "::notice::Installed provisioning profile '$profile_name' ($profile_uuid)."
+
+      # The archive and the export are deliberately two steps.
+      #
+      # `tauri ios build --export-method ...` cannot sign this project: the Xcode
+      # project `tauri ios init` generates bakes CODE_SIGN_IDENTITY = "iPhone
+      # Developer" into both configurations, so Xcode's automatic signing looks
+      # for an *iOS App Development* profile no matter which export method is
+      # requested — and then fails ("Your team has no devices from which to
+      # generate a provisioning profile"). Installing an App Store profile above
+      # does not help, because that changes which profile is available, not which
+      # type Xcode goes looking for. Forcing CODE_SIGN_IDENTITY="Apple
+      # Distribution" fails differently: Xcode refuses to mix an automatic
+      # signing style with a manually specified identity.
+      #
+      # Archiving unsigned sidesteps the whole resolution problem, and the export
+      # step then signs with the imported identity under an explicit *manual*
+      # style. Distribution profiles do not enumerate devices, so no device has to
+      # be registered to the team.
+      - name: Archive (unsigned)
         if: steps.signing.outputs.present == 'true'
         working-directory: apps/geolibre-desktop
         env:
-          # Tauri passes this through to the Xcode DEVELOPMENT_TEAM setting. The
-          # Team ID is account-wide, so this reuses the existing macOS/Homebrew
-          # signing secret rather than duplicating it.
-          APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+        run: npx tauri ios build --no-sign
+
+      - name: Export signed IPA
+        if: steps.signing.outputs.present == 'true'
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # Passed via env, not interpolated into the run script, so a workflow
           # context expression can't be injected into the shell.
           EXPORT_METHOD: ${{ github.event.inputs.export_method || 'app-store-connect' }}
         run: |
-          npx tauri ios build --export-method "$EXPORT_METHOD"
+          set -euo pipefail
+          gen="apps/geolibre-desktop/src-tauri/gen/apple"
 
-      - name: Verify built bundle id
+          archive="$(find "$gen/build" -maxdepth 1 -name '*.xcarchive' | head -1)"
+          if [ -z "$archive" ]; then
+            echo "::error::No .xcarchive produced under $gen/build"
+            exit 1
+          fi
+
+          # The signing certificate has to match the profile type the export
+          # method implies, or xcodebuild fails deep inside the export with an
+          # opaque error.
+          if [ "$EXPORT_METHOD" = "debugging" ]; then
+            cert="Apple Development"
+          else
+            cert="Apple Distribution"
+          fi
+
+          opts="$RUNNER_TEMP/ExportOptions.plist"
+          cat > "$opts" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>method</key><string>$EXPORT_METHOD</string>
+            <key>teamID</key><string>$APPLE_TEAM_ID</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>signingCertificate</key><string>$cert</string>
+            <key>provisioningProfiles</key><dict>
+              <key>$EXPECTED_BUNDLE_ID</key><string>$PROFILE_NAME</string>
+            </dict>
+            <key>uploadSymbols</key><true/>
+          </dict></plist>
+          PLIST
+
+          # APPLE_IOS_PROVISIONING_PROFILE_BASE64 must hold a *manually managed*
+          # profile created in the Developer portal. An Xcode-managed one (the
+          # kind Xcode generates itself, named "iOS Team Store Provisioning
+          # Profile: ...") is rejected here with:
+          #   Provisioning profile "..." is Xcode managed, but signing settings
+          #   require a manually managed profile.
+          # Likewise the .p12 must be an Apple Distribution certificate; a
+          # cloud-managed signing identity is not exportable and will surface as
+          # 'No signing certificate "iOS Distribution" found'.
+          #
+          # No -allowProvisioningUpdates: signing assets come from the secrets,
+          # and the runner has no Apple account session to create them with. If
+          # something is missing this must fail loudly rather than silently
+          # reach out to Apple.
+          xcodebuild -exportArchive \
+            -archivePath "$archive" \
+            -exportOptionsPlist "$opts" \
+            -exportPath "$gen/build/export"
+
+      - name: Verify the signed IPA
         if: steps.signing.outputs.present == 'true'
         # Assert on the shipped bytes, not the config: the App Store burns the
         # bundle id from the .ipa on first upload and it can never be changed, so
         # it is checked rather than assumed (mirrors android.yml's package-id
         # gate).
+        #
+        # The path is pinned to the export directory rather than searched for.
+        # The unsigned archive step also leaves an .ipa behind (under
+        # build/arm64), so a `find ... | head -1` here could pick the *unsigned*
+        # one and upload something that cannot be submitted.
         run: |
           set -euo pipefail
-          ipa="$(find apps/geolibre-desktop/src-tauri/gen/apple -name '*.ipa' | head -1)"
+          gen="apps/geolibre-desktop/src-tauri/gen/apple"
+          ipa="$(find "$gen/build/export" -maxdepth 1 -name '*.ipa' | head -1)"
           if [ -z "$ipa" ]; then
-            echo "::error::No .ipa produced under gen/apple"
+            echo "::error::No .ipa produced under $gen/build/export"
             exit 1
           fi
+
           workdir="$(mktemp -d)"
           unzip -o -q "$ipa" -d "$workdir"
-          plist="$(find "$workdir/Payload" -maxdepth 2 -name Info.plist | head -1)"
+          app="$(find "$workdir/Payload" -maxdepth 1 -name '*.app' | head -1)"
+          plist="$app/Info.plist"
+
           bid="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")"
           if [ "$bid" != "$EXPECTED_BUNDLE_ID" ]; then
             echo "::error::$ipa has bundle id '$bid', expected '$EXPECTED_BUNDLE_ID'"
             exit 1
           fi
-          echo "IPA $ipa reports bundle id $EXPECTED_BUNDLE_ID."
+
+          # An unsigned .ipa is structurally valid and passes every check above,
+          # so signing is verified explicitly — otherwise the failure surfaces at
+          # App Store Connect upload time, the most expensive place to find it.
+          if ! codesign --verify --strict "$app" 2>/dev/null; then
+            echo "::error::$ipa failed codesign verification"
+            exit 1
+          fi
+          authority="$(codesign -dvvv "$app" 2>&1 | grep '^Authority=' | head -1 | cut -d= -f2-)"
+          case "$authority" in
+            "Apple Distribution"*|"Apple Development"*) ;;
+            *)
+              echo "::error::$ipa signed by unexpected authority '$authority'"
+              exit 1
+              ;;
+          esac
+
+          if [ ! -f "$app/embedded.mobileprovision" ]; then
+            echo "::error::$ipa has no embedded provisioning profile"
+            exit 1
+          fi
+
+          echo "IPA $ipa: bundle id $EXPECTED_BUNDLE_ID, signed by $authority."
           echo "IPA_PATH=$ipa" >> "$GITHUB_ENV"
 
       - name: Clean up the signing keychain
@@ -220,7 +341,12 @@ jobs:
           if [ -n "${SIGNING_KEYCHAIN:-}" ] && [ -f "$SIGNING_KEYCHAIN" ]; then
             security delete-keychain "$SIGNING_KEYCHAIN" || true
           fi
-          rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/geolibre.mobileprovision" || true
+          # Mirrors both install locations above, keyed by UUID. Guarded because
+          # this runs on failure too, possibly before PROFILE_UUID was set.
+          if [ -n "${PROFILE_UUID:-}" ]; then
+            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision" || true
+            rm -f "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles/$PROFILE_UUID.mobileprovision" || true
+          fi
 
       - name: Upload signed IPA
         if: steps.signing.outputs.present == 'true'

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -5,19 +5,25 @@ v2 mobile** — no separate app. The webview UI (WKWebView) is bundled in the ap
 so the shell works offline; map tiles and the heavier engines are fetched on
 demand (same as the desktop and Android builds).
 
-> **Status: builds and signs locally; not yet shipped.** The full pipeline has
-> been run through on a Mac (Xcode 26.6 / iOS SDK 26.5): `tauri ios init` →
-> unsigned archive → `xcodebuild -exportArchive` produces a **submittable**
-> `.ipa` — bundle id `org.geolibre.app`, signed by *Apple Distribution*,
+> **Status: builds and signs, locally and in CI; not yet shipped.** The pipeline
+> has been run end to end both ways and produces a **submittable** `.ipa` —
+> bundle id `org.geolibre.app`, signed by *Apple Distribution*,
 > `get-task-allow=false`, an embedded App Store provisioning profile, the merged
-> location usage string, and the web assets embedded in the binary. The
-> manual-signing recipe CI uses has also been exercised locally against a
-> portal-issued certificate and profile.
+> location usage string, and the web assets embedded in the binary.
 >
-> What has **not** happened: a run of the signed **CI** job on a GitHub runner,
-> and any App Store Connect upload or review submission. Uploading additionally
-> needs an App Store Connect app record for the bundle id. Everything below still
-> has to be run on a Mac (iOS cannot be cross-compiled from Linux).
+> - **Locally** on a Mac (Xcode 26.6 / iOS SDK 26.5): `tauri ios init` → unsigned
+>   archive → `xcodebuild -exportArchive`.
+> - **In CI**, the signed job has run green on a `macos-15` runner (Xcode 26.3):
+>   it imported the certificate and profile from the `APPLE_IOS_*` secrets,
+>   archived, exported under manual signing, verified the signature, and
+>   published the `geolibre-ios-ipa` artifact.
+>
+> What has **not** happened: any App Store Connect upload or review submission.
+> Uploading additionally needs an App Store Connect app record for the bundle id,
+> and a `CFBundleVersion` that increases on every upload — it is currently the
+> `tauri.conf.json` version, so a second upload of the same version is rejected
+> (pass `tauri ios build --build-number ...`). Everything below still has to be
+> run on a Mac (iOS cannot be cross-compiled from Linux).
 
 ## What works on iOS vs desktop
 
@@ -223,16 +229,21 @@ they're created under the **same paid Apple Developer account** at no extra cost
 add an Apple Distribution certificate and an App Store provisioning profile for
 `org.geolibre.app` in the Developer portal, and reuse the existing `APPLE_TEAM_ID`.
 
-> **The signed CI job has not yet run on a GitHub runner.** The job archives with
+> **Why the job archives and exports as two steps.** It archives with
 > `npx tauri ios build --no-sign` and then signs in a separate
 > `xcodebuild -exportArchive` step using **manual** signing, for the reason given
 > under *Build*: `tauri ios build --export-method` cannot sign this project,
 > because the generated project bakes in `CODE_SIGN_IDENTITY = "iPhone
 > Developer"` and automatic signing therefore hunts for a development profile no
-> matter what the export method says. That sequence has been reproduced locally
-> against a portal-issued certificate and profile and produces a valid signed
-> `.ipa`, but the workflow itself is still unexercised end to end — treat the
-> first release-triggered run as a bring-up.
+> matter what the export method says.
+>
+> This has been verified on a runner — a `workflow_dispatch` run with
+> `export_method: app-store-connect` completed green, reporting
+> `IPA ... bundle id org.geolibre.app, signed by Apple Distribution` and
+> publishing the `geolibre-ios-ipa` artifact. What remains unexercised is the
+> **release-triggered** entry point (the job has only been started manually) and
+> everything downstream of the artifact: no build has been uploaded to App Store
+> Connect.
 
 > **The runner's Xcode sets a hard floor.** `tauri ios init` generates an Xcode
 > project in **object format 77**, which only **Xcode 16+** can open. On

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -5,14 +5,19 @@ v2 mobile** — no separate app. The webview UI (WKWebView) is bundled in the ap
 so the shell works offline; map tiles and the heavier engines are fetched on
 demand (same as the desktop and Android builds).
 
-> **Status: builds, unsigned; not yet shipped.** The full local pipeline has been
-> run through on a Mac (Xcode 26.6 / iOS SDK 26.5): `tauri ios init` →
-> `tauri ios build --no-sign` produces `gen/apple/build/arm64/GeoLibre.ipa` with
-> the correct bundle id (`org.geolibre.app`), the merged location usage string,
-> and the web assets embedded in the binary. What has **not** happened is a
-> *signed* build or an App Store upload — that needs the Apple Distribution
-> certificate and provisioning profile described under *Signing*. Everything
-> below still has to be run on a Mac (iOS cannot be cross-compiled from Linux).
+> **Status: builds and signs locally; not yet shipped.** The full pipeline has
+> been run through on a Mac (Xcode 26.6 / iOS SDK 26.5): `tauri ios init` →
+> unsigned archive → `xcodebuild -exportArchive` produces a **submittable**
+> `.ipa` — bundle id `org.geolibre.app`, signed by *Apple Distribution*,
+> `get-task-allow=false`, an embedded App Store provisioning profile, the merged
+> location usage string, and the web assets embedded in the binary. The
+> manual-signing recipe CI uses has also been exercised locally against a
+> portal-issued certificate and profile.
+>
+> What has **not** happened: a run of the signed **CI** job on a GitHub runner,
+> and any App Store Connect upload or review submission. Uploading additionally
+> needs an App Store Connect app record for the bundle id. Everything below still
+> has to be run on a Mac (iOS cannot be cross-compiled from Linux).
 
 ## What works on iOS vs desktop
 
@@ -216,16 +221,16 @@ they're created under the **same paid Apple Developer account** at no extra cost
 add an Apple Distribution certificate and an App Store provisioning profile for
 `org.geolibre.app` in the Developer portal, and reuse the existing `APPLE_TEAM_ID`.
 
-> **The signed CI path is unproven and probably broken.** No repository has ever
-> had the `APPLE_IOS_*` secrets set, so the "Build signed IPA" step has never
-> run. It calls `npx tauri ios build --export-method "$EXPORT_METHOD"` — the
-> exact command that fails locally on the baked-in `CODE_SIGN_IDENTITY = "iPhone
-> Developer"` (see *Build*). Importing an App Store profile into the runner's
-> keychain does not change which *type* of profile Xcode's automatic signing goes
-> looking for, so the step is expected to fail the same way the first time it is
-> exercised. Fix it the same way as locally: archive with `--no-sign`, then run a
-> separate `xcodebuild -exportArchive` step. Do that before depending on a
-> release-triggered build.
+> **The signed CI job has not yet run on a GitHub runner.** The job archives with
+> `npx tauri ios build --no-sign` and then signs in a separate
+> `xcodebuild -exportArchive` step using **manual** signing, for the reason given
+> under *Build*: `tauri ios build --export-method` cannot sign this project,
+> because the generated project bakes in `CODE_SIGN_IDENTITY = "iPhone
+> Developer"` and automatic signing therefore hunts for a development profile no
+> matter what the export method says. That sequence has been reproduced locally
+> against a portal-issued certificate and profile and produces a valid signed
+> `.ipa`, but the workflow itself is still unexercised end to end — treat the
+> first release-triggered run as a bring-up.
 
 > **Check the runner's Xcode before relying on CI for a submission.** The job
 > pins `runs-on: macos-14` and uses whatever Xcode that image happens to default

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -5,10 +5,14 @@ v2 mobile** — no separate app. The webview UI (WKWebView) is bundled in the ap
 so the shell works offline; map tiles and the heavier engines are fetched on
 demand (same as the desktop and Android builds).
 
-> **Status: scaffolding.** The iOS config, `Info.ios.plist`, and CI workflow are
-> in place, but — unlike Android — no iOS build has been shipped yet. Everything
-> below has to be run and verified on a Mac (iOS cannot be cross-compiled from
-> Linux). Treat the first `tauri ios build` as a bring-up, not a routine build.
+> **Status: builds, unsigned; not yet shipped.** The full local pipeline has been
+> run through on a Mac (Xcode 26.6 / iOS SDK 26.5): `tauri ios init` →
+> `tauri ios build --no-sign` produces `gen/apple/build/arm64/GeoLibre.ipa` with
+> the correct bundle id (`org.geolibre.app`), the merged location usage string,
+> and the web assets embedded in the binary. What has **not** happened is a
+> *signed* build or an App Store upload — that needs the Apple Distribution
+> certificate and provisioning profile described under *Signing*. Everything
+> below still has to be run on a Mac (iOS cannot be cross-compiled from Linux).
 
 ## What works on iOS vs desktop
 
@@ -43,7 +47,7 @@ string is present.** GeoLibre supplies it in
 ```
 
 Tauri merges `Info.ios.plist` into the generated
-`gen/apple/geolibre_iOS/Info.plist` at build time. `gen/apple` is git-ignored, so
+`gen/apple/geolibre-desktop_iOS/Info.plist` at build time. `gen/apple` is git-ignored, so
 this file is the durable home for the string — the same reason Android's manifest
 permissions come from the plugin rather than a hand-edited, regenerated manifest.
 It covers all three location consumers: Field Collection, GPS Tracking, and the
@@ -74,8 +78,60 @@ rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
 cd apps/geolibre-desktop
 npx tauri ios init                     # generate src-tauri/gen/apple (once)
 npx tauri ios dev                      # run in the simulator / on a tethered device
-npx tauri ios build                    # release archive → signed .ipa (needs signing, below)
+npx tauri ios build --no-sign          # unsigned .ipa + .xcarchive (no Apple account needed)
 ```
+
+> **`npx tauri ios build --export-method app-store-connect` does not work as-is.**
+> The project `tauri ios init` generates bakes `CODE_SIGN_IDENTITY = "iPhone
+> Developer"` into *both* the debug and release configurations, so Xcode resolves
+> **development** signing even when the export method is App Store. Automatic
+> development signing then demands a registered device and fails with:
+>
+> ```
+> error: Your team has no devices from which to generate a provisioning profile.
+> error: No profiles for 'org.geolibre.app' were found: Xcode couldn't find any
+>        iOS App Development provisioning profiles matching 'org.geolibre.app'.
+> ```
+>
+> Overriding `CODE_SIGN_IDENTITY="Apple Distribution"` does not help either —
+> Xcode rejects it as *"automatically signed for development, but a conflicting
+> code signing identity … has been manually specified."*
+>
+> Split the archive from the export instead. Archive **unsigned**, then let the
+> export step do the distribution signing — this needs no registered device, and
+> Xcode creates the Apple Distribution certificate, registers the App ID, and
+> generates the App Store profile on the fly:
+>
+> ```bash
+> cd apps/geolibre-desktop
+> npx tauri ios build --no-sign          # → gen/apple/build/geolibre-desktop_iOS.xcarchive
+>
+> G=src-tauri/gen/apple
+> cat > "$G/ExportOptions-appstore.plist" <<'PLIST'
+> <?xml version="1.0" encoding="UTF-8"?>
+> <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+> <plist version="1.0"><dict>
+>   <key>method</key><string>app-store-connect</string>
+>   <key>teamID</key><string>YOUR_TEAM_ID</string>
+>   <key>signingStyle</key><string>automatic</string>
+>   <key>uploadSymbols</key><true/>
+> </dict></plist>
+> PLIST
+>
+> xcodebuild -exportArchive -allowProvisioningUpdates \
+>   -archivePath "$G/build/geolibre-desktop_iOS.xcarchive" \
+>   -exportOptionsPlist "$G/ExportOptions-appstore.plist" \
+>   -exportPath "$G/build/appstore"
+> ```
+>
+> This produces a genuinely submittable `build/appstore/GeoLibre.ipa`: signed by
+> `Apple Distribution`, `get-task-allow=false`, entitlement
+> `<TEAM>.org.geolibre.app`, and an embedded *iOS Team Store Provisioning
+> Profile*. Verify with `codesign -dvvv` before uploading.
+>
+> Note the certificate Xcode creates this way is **Cloud Managed**, so it does
+> *not* appear in `security find-identity -v -p codesigning`. An empty identity
+> list is not evidence the signing failed — check the `.ipa` itself.
 
 - `gen/apple` is generated (git-ignored) and regenerated on demand. `init` also
   merges `tauri.ios.conf.json` (bundle id, drops the Python backend) and
@@ -89,8 +145,17 @@ npx tauri ios build                    # release archive → signed .ipa (needs 
 
   ```bash
   /usr/libexec/PlistBuddy -c 'Print :NSLocationWhenInUseUsageDescription' \
-    src-tauri/gen/apple/geolibre_iOS/Info.plist
+    src-tauri/gen/apple/geolibre-desktop_iOS/Info.plist
   ```
+
+  The merge happens during `tauri ios build`/`dev`, **not** during `ios init` —
+  straight after `init` the generated plist does not contain the key yet, and
+  that is expected. Note also that the Xcode project, target, and plist
+  directory are named from the **Cargo package** (`geolibre-desktop` in
+  `src-tauri/Cargo.toml`), not from `productName`. The user-visible app name and
+  bundle id still come from `tauri.ios.conf.json` — they land as `PRODUCT_NAME:
+  GeoLibre` and `PRODUCT_BUNDLE_IDENTIFIER: org.geolibre.app` in the generated
+  `project.yml`.
 
 ## Signing
 
@@ -103,9 +168,22 @@ there is no debug-keystore shortcut like Android's. You need:
 3. A **provisioning profile** for the `org.geolibre.app` app id.
 4. Your **Team ID** (App Store Connect → Membership).
 
-Locally, opening `gen/apple/geolibre.xcodeproj` in Xcode once and enabling
+Locally, opening `gen/apple/geolibre-desktop.xcodeproj` in Xcode once and enabling
 "Automatically manage signing" with your team is the simplest path. For CI, the
 identity is imported from secrets (below).
+
+> **The local and CI identities are not interchangeable.** The export recipe
+> above lets Xcode create a **Cloud Managed** Apple Distribution certificate and
+> an Xcode-managed profile. Neither can be fed to CI: a cloud-managed identity
+> has no exportable private key, so there is no `.p12` to base64, and CI's
+> manual-signing export rejects an Xcode-managed profile outright
+> (*"is Xcode managed, but signing settings require a manually managed
+> profile"*). For CI you must create a **separate, manually managed** pair in the
+> Developer portal — an Apple Distribution certificate from a CSR you generate in
+> Keychain Access (so you hold the private key and can export the `.p12`), plus
+> an App Store provisioning profile for `org.geolibre.app` bound to it. Holding
+> both a cloud-managed and a manual distribution certificate at once is fine and
+> normal.
 
 ## Continuous integration
 
@@ -138,6 +216,26 @@ they're created under the **same paid Apple Developer account** at no extra cost
 add an Apple Distribution certificate and an App Store provisioning profile for
 `org.geolibre.app` in the Developer portal, and reuse the existing `APPLE_TEAM_ID`.
 
+> **The signed CI path is unproven and probably broken.** No repository has ever
+> had the `APPLE_IOS_*` secrets set, so the "Build signed IPA" step has never
+> run. It calls `npx tauri ios build --export-method "$EXPORT_METHOD"` — the
+> exact command that fails locally on the baked-in `CODE_SIGN_IDENTITY = "iPhone
+> Developer"` (see *Build*). Importing an App Store profile into the runner's
+> keychain does not change which *type* of profile Xcode's automatic signing goes
+> looking for, so the step is expected to fail the same way the first time it is
+> exercised. Fix it the same way as locally: archive with `--no-sign`, then run a
+> separate `xcodebuild -exportArchive` step. Do that before depending on a
+> release-triggered build.
+
+> **Check the runner's Xcode before relying on CI for a submission.** The job
+> pins `runs-on: macos-14` and uses whatever Xcode that image happens to default
+> to. App Store Connect rejects uploads built against an SDK older than its
+> current floor, so an image defaulting to an older Xcode will still pass the
+> compile check and still produce an `.ipa` — and then fail at upload, which is
+> the most expensive place to find out. If that happens, pin the version
+> explicitly (`maxim-lobanov/setup-xcode`) or move the job to a newer `macos-*`
+> image. A local build is unaffected; this only concerns the CI artifact.
+
 The `workflow_dispatch` `export_method` input picks the export path
 (`app-store-connect` for TestFlight/App Store, `release-testing` for ad-hoc
 registered devices, `debugging` for development).
@@ -146,7 +244,7 @@ registered devices, `debugging` for development).
 
 - **Simulator:** `npx tauri ios dev` and pick a simulator, or open the Xcode
   project and Run. No paid account needed for the simulator.
-- **Your own device:** tether it, open `gen/apple/geolibre.xcodeproj` in Xcode,
+- **Your own device:** tether it, open `gen/apple/geolibre-desktop.xcodeproj` in Xcode,
   select the device, and Run (a free Apple ID allows 7-day device signing).
 - **Testers:** distribute a signed build through **TestFlight** (upload the `.ipa`
   via Xcode Organizer or Transporter, then invite testers in App Store Connect).
@@ -177,6 +275,21 @@ onboarding.
    collected by a backend. Point the privacy policy URL at the published
    [privacy policy](privacy.md).
 6. **Age rating** questionnaire and category (Navigation or Productivity).
+7. **Export compliance.** App Store Connect asks about encryption on *every*
+   upload, and an unanswered build cannot be submitted or sent to testers. To
+   answer it once instead of per upload, add the key to
+   `src-tauri/Info.ios.plist`:
+
+   ```xml
+   <key>ITSAppUsesNonExemptEncryption</key>
+   <false/>
+   ```
+
+   `false` is the right answer only if GeoLibre's use of encryption stays
+   limited to what Apple treats as exempt — HTTPS/TLS via the system libraries
+   for tiles, geocoding, the AI assistant, and the collaboration relay. That is
+   true today, but it is a **legal declaration**, so confirm it before adding the
+   key, and revisit it if the app ever ships its own cryptography.
 
 ## Known limitations / follow-ups
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -232,14 +232,27 @@ add an Apple Distribution certificate and an App Store provisioning profile for
 > `.ipa`, but the workflow itself is still unexercised end to end — treat the
 > first release-triggered run as a bring-up.
 
-> **Check the runner's Xcode before relying on CI for a submission.** The job
-> pins `runs-on: macos-14` and uses whatever Xcode that image happens to default
-> to. App Store Connect rejects uploads built against an SDK older than its
-> current floor, so an image defaulting to an older Xcode will still pass the
-> compile check and still produce an `.ipa` — and then fail at upload, which is
-> the most expensive place to find out. If that happens, pin the version
-> explicitly (`maxim-lobanov/setup-xcode`) or move the job to a newer `macos-*`
-> image. A local build is unaffected; this only concerns the CI artifact.
+> **The runner's Xcode sets a hard floor.** `tauri ios init` generates an Xcode
+> project in **object format 77**, which only **Xcode 16+** can open. On
+> `macos-14` the archive failed immediately, before compiling anything:
+>
+> ```
+> xcodebuild: error: Unable to load workspace '.../geolibre-desktop.xcodeproj/project.xcworkspace/'.
+>   Reason: The project 'geolibre-desktop' cannot be opened because it is in a
+>   future Xcode project file format (77).
+> ```
+>
+> The job therefore runs on `macos-15` and explicitly selects the newest Xcode on
+> the image rather than trusting its default, failing early with a clear message
+> if that is older than 16. Note this floor comes from the **Tauri CLI's**
+> generated project, not from anything in this repo — re-check it whenever the
+> Tauri CLI is bumped.
+>
+> Separately, App Store Connect rejects uploads built against an SDK below its
+> current floor. That failure is *silent* at build time — an older-but-openable
+> Xcode still produces an `.ipa` and only fails at upload. The Xcode version and
+> iOS SDK list are printed into the run log so a rejected upload can be diagnosed
+> from the run instead of guessed at.
 
 The `workflow_dispatch` `export_method` input picks the export path
 (`app-store-connect` for TestFlight/App Store, `release-testing` for ad-hoc

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -192,13 +192,15 @@ identity is imported from secrets (below).
 
 ## Continuous integration
 
-`.github/workflows/ios.yml` runs on `macos-14` on each published GitHub release
+`.github/workflows/ios.yml` runs on `macos-15` on each published GitHub release
 (and on demand via "Run workflow"). Because iOS can't be cross-compiled from
-Linux, this is the only mobile workflow that needs a macOS runner.
+Linux, this is the only mobile workflow that needs a macOS runner. The image is
+not free to choose — see the Xcode floor below.
 
 - **With Apple signing secrets set**, it imports the identity into a throwaway
-  keychain, archives, exports a signed `.ipa`, verifies its bundle id, and
-  uploads it as the `geolibre-ios-ipa` artifact:
+  keychain, archives **unsigned**, exports a signed `.ipa` under manual signing,
+  verifies the bundle id and the signature, and uploads it as the
+  `geolibre-ios-ipa` artifact:
   - `APPLE_IOS_CERTIFICATE_BASE64` — `base64 -i dist.p12`
   - `APPLE_IOS_CERTIFICATE_PASSWORD`
   - `APPLE_IOS_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`


### PR DESCRIPTION
## What

First real iOS bring-up on a Mac. The app **builds and signs** — I produced a submittable `.ipa` (Apple Distribution, `get-task-allow=false`, entitlement `<TEAM>.org.geolibre.app`, embedded App Store profile). Getting there turned up that the documented build command cannot work, and that the signed CI path would fail the first time anyone set the secrets.

## The core problem

The Xcode project `tauri ios init` generates bakes `CODE_SIGN_IDENTITY = "iPhone Developer"` into **both** configurations. So `tauri ios build --export-method app-store-connect` resolves *development* signing regardless of export method, and dies:

```
error: Your team has no devices from which to generate a provisioning profile.
error: No profiles for 'org.geolibre.app' were found ... iOS App Development
```

Forcing `CODE_SIGN_IDENTITY="Apple Distribution"` fails differently — Xcode refuses to mix an automatic signing style with a manually specified identity.

**Fix:** split archive from export. Archive unsigned, then sign during `xcodebuild -exportArchive`. Distribution profiles don't enumerate devices, so no device registration is needed.

## CI changes

- Replace `Build signed IPA` with `Archive (unsigned)` + `Export signed IPA` (manual signing style).
- Read the profile's name/UUID from the secret rather than hardcoding a filename; install to both the Xcode 16+ and legacy profile locations.
- **Pin the verify step to the export directory.** The unsigned archive also leaves an `.ipa` behind, so the previous `find ... | head -1` could have picked the *unsigned* one and published it as the release artifact.
- Assert signature, signing authority, and embedded profile. An unsigned `.ipa` passes a bundle-id check and only fails at upload time.

## Docs

- Correct three paths that never existed — the generated project is `geolibre-desktop_iOS` / `geolibre-desktop.xcodeproj`, named from the **Cargo package**, not `productName`. The plist verification command pointed at a nonexistent file.
- Note the `Info.ios.plist` merge happens at *build*, not `init`.
- Record that a cloud-managed local identity **cannot** be reused for CI (no exportable private key; manual-signing export rejects Xcode-managed profiles).
- Add the export-compliance (`ITSAppUsesNonExemptEncryption`) step.
- Flag that the `macos-14` runner's Xcode version should be checked before trusting a CI artifact for submission.

## Verification

- `cargo build --lib --release --target aarch64-apple-ios` — passes (warnings only).
- `tauri ios build --no-sign` → archive + unsigned `.ipa`; `NSLocationWhenInUseUsageDescription` confirmed present in the merged plist.
- `xcodebuild -exportArchive` with automatic distribution signing → signed `.ipa`, verified with `codesign --verify --deep --strict`.
- Workflow YAML parses; every `run:` block passes `bash -n`.

**Not verified:** the CI export step itself, because it needs a portal-issued Apple Distribution `.p12` and a manually managed App Store profile, which don't exist yet. The comments record the two specific errors that appear if Xcode-managed assets are supplied by mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release**
  * Updated the iOS CI workflow to use a newer macOS runner and select the newest available Xcode (requires Xcode 16+).
  * Improved CI signing/export by installing the provisioning profile from the provided secret, archiving unsigned first, then generating export options dynamically and exporting a signed IPA.
  * Strengthened post-export verification (bundle identifier match, codesigning verification/authority, and embedded provisioning profile) and made cleanup UUID-based.

* **Documentation**
  * Updated iOS guidance for local and CI workflows, including the correct unsigned-archive-then-export process and required App Store export compliance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->