### PR TITLE
fix(style): auto-fill proportional size range and show it in print legend

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2874,7 +2874,9 @@ export function StylePanel({
               )}
             </Select>
             {vectorPropertyValuesLoading && (
-              <p className="text-xs text-muted-foreground">{t("attributeTable.loadingAttributes")}</p>
+              <p className="text-xs text-muted-foreground">
+                {t("attributeTable.loadingAttributes")}
+              </p>
             )}
             {vectorPropertyValuesUnavailable && (
               <p className="text-xs text-destructive">

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1044,6 +1044,14 @@ export function StylePanel({
   // Layers whose style suggestions the user waved off this session (#1519).
   const [dismissedSuggestions, setDismissedSuggestions] = useState<Set<string>>(() => new Set());
   const [extrusionError, setExtrusionError] = useState<string | null>(null);
+  const [proportionalSizeError, setProportionalSizeError] = useState<string | null>(null);
+  // Tracks auto-seeded proportional min/max so later tile samples can refine the
+  // range without overwriting a user's intentional 0–100 (or other) edit.
+  const seededProportionalBoundsRef = useRef<{
+    key: string;
+    min: number;
+    max: number;
+  } | null>(null);
   const [loadedVectorPropertyValues, setLoadedVectorPropertyValues] = useState<{
     layerId: string;
     /** Attribute samples keyed by property name (classification and/or size field). */
@@ -1324,25 +1332,60 @@ export function StylePanel({
   ]);
 
   // When tiled attribute samples arrive for the proportional size field, seed
-  // min/max if the style is still on the default 0–100 range (so a later
-  // user edit is not overwritten by a tile refresh).
+  // (or refine) min/max. A ref records the last auto-applied range so a user's
+  // intentional 0–100 is never overwritten, while a partial first tile sample
+  // can still widen as more tiles load.
   useEffect(() => {
     if (!layer || !loadedVectorPropertyValues) return;
     if (!styleValue(layer.style, "proportionalSizeEnabled")) return;
     const property = styleValue(layer.style, "proportionalSizeProperty");
     if (!property || loadedVectorPropertyValues.layerId !== layer.id) return;
     const values = loadedVectorPropertyValues.byProperty[property];
-    if (!values) return;
+    // An empty tile sample is inconclusive — wait for features with values.
+    if (!values || values.length === 0) return;
+    const bounds = proportionalSizeBounds(layer, property, values);
+    if (!bounds) return;
+
+    const seedKey = `${layer.id}:${property}`;
     const minValue = styleValue(layer.style, "proportionalSizeMinValue");
     const maxValue = styleValue(layer.style, "proportionalSizeMaxValue");
+    const seeded = seededProportionalBoundsRef.current;
+
+    if (seeded?.key === seedKey) {
+      // Still wearing our auto-seed: refine when a richer sample expands/shifts it.
+      if (
+        minValue === seeded.min &&
+        maxValue === seeded.max &&
+        (bounds.min !== seeded.min || bounds.max !== seeded.max)
+      ) {
+        seededProportionalBoundsRef.current = {
+          key: seedKey,
+          min: bounds.min,
+          max: bounds.max,
+        };
+        setLayerStyle(layer.id, {
+          proportionalSizeMinValue: bounds.min,
+          proportionalSizeMaxValue: bounds.max,
+        });
+      }
+      return;
+    }
+
+    // New layer/property pair: only auto-seed from the unseeded defaults.
     if (
       minValue !== DEFAULT_LAYER_STYLE.proportionalSizeMinValue ||
       maxValue !== DEFAULT_LAYER_STYLE.proportionalSizeMaxValue
     ) {
+      // Non-default without our seed record → intentional; don't overwrite.
+      seededProportionalBoundsRef.current = { key: seedKey, min: minValue, max: maxValue };
       return;
     }
-    const bounds = proportionalSizeBounds(layer, property, values);
-    if (!bounds) return;
+
+    seededProportionalBoundsRef.current = {
+      key: seedKey,
+      min: bounds.min,
+      max: bounds.max,
+    };
     setLayerStyle(layer.id, {
       proportionalSizeMinValue: bounds.min,
       proportionalSizeMaxValue: bounds.max,
@@ -1354,6 +1397,8 @@ export function StylePanel({
   // does not re-collapse while the user edits other style fields.
   useEffect(() => {
     setShowBasemapStyleLayers(false);
+    seededProportionalBoundsRef.current = null;
+    setProportionalSizeError(null);
   }, [layer?.id]);
 
   // Heatmap/cluster apply to point layers in two render paths: core GeoJSON
@@ -1672,10 +1717,11 @@ export function StylePanel({
     draftVectorStyleClassificationScheme !== styleValue(style, "vectorStyleClassificationScheme") ||
     draftVectorStyleExpression !== styleValue(style, "vectorStyleExpression") ||
     JSON.stringify(draftVectorStyleStops) !== JSON.stringify(currentVectorStops);
-  const draftVectorPropertyValues =
+  const matchingPropertyValues = (property: string): unknown[] | undefined =>
     loadedVectorPropertyValues?.layerId === layer.id
-      ? loadedVectorPropertyValues.byProperty[draftVectorStyleProperty]
+      ? loadedVectorPropertyValues.byProperty[property]
       : undefined;
+  const draftVectorPropertyValues = matchingPropertyValues(draftVectorStyleProperty);
   const regenerateDraftVectorStyleStops = (
     mode: VectorStyleMode,
     property: string,
@@ -2761,15 +2807,14 @@ export function StylePanel({
       {vectorStyleError && <p className="text-xs text-destructive">{vectorStyleError}</p>}
     </div>
   );
-  /** Seed min/max from the field's numeric range when proportional sizing turns on or the field changes. */
-  const matchingPropertyValues = (property: string): unknown[] | undefined =>
-    loadedVectorPropertyValues?.layerId === layer.id
-      ? loadedVectorPropertyValues.byProperty[property]
-      : undefined;
-
-  /** True when we already have a sample that can prove the field has (or lacks) a usable range. */
-  const hasPropertySample = (property: string): boolean =>
-    Boolean(layer.geojson?.features?.length) || matchingPropertyValues(property) !== undefined;
+  /** True when a sample can prove the field lacks a usable numeric range (non-empty). */
+  const hasDecisivePropertySample = (property: string): boolean => {
+    if (layer.geojson?.features?.length) return true;
+    const sample = matchingPropertyValues(property);
+    // Empty tile samples are inconclusive — sparse/null viewport values must not
+    // disable a field that is numeric elsewhere in the dataset.
+    return Array.isArray(sample) && sample.length > 0;
+  };
 
   const proportionalBoundsPatch = (property: string) => {
     const bounds = proportionalSizeBounds(layer, property, matchingPropertyValues(property));
@@ -2778,13 +2823,24 @@ export function StylePanel({
       : null;
   };
 
-  const clearProportionalSizeField = (disable: boolean) =>
+  const rememberProportionalSeed = (
+    property: string,
+    min: number,
+    max: number,
+  ) => {
+    seededProportionalBoundsRef.current = { key: `${layer.id}:${property}`, min, max };
+  };
+
+  const clearProportionalSizeField = (disable: boolean, error: string | null = null) => {
+    seededProportionalBoundsRef.current = null;
+    setProportionalSizeError(error);
     setLayerStyle(layer.id, {
       ...(disable ? { proportionalSizeEnabled: false } : {}),
       proportionalSizeProperty: "",
       proportionalSizeMinValue: DEFAULT_LAYER_STYLE.proportionalSizeMinValue,
       proportionalSizeMaxValue: DEFAULT_LAYER_STYLE.proportionalSizeMaxValue,
     });
+  };
 
   const proportionalSizeControls = (
     <div className="space-y-3">
@@ -2798,27 +2854,36 @@ export function StylePanel({
             onChange={(event) => {
               const enabled = event.target.checked;
               if (!enabled) {
+                setProportionalSizeError(null);
                 setLayerStyle(layer.id, { proportionalSizeEnabled: false });
                 return;
               }
               if (!proportionalProperty) {
+                setProportionalSizeError(null);
                 setLayerStyle(layer.id, { proportionalSizeEnabled: true });
                 return;
               }
               const boundsPatch = proportionalBoundsPatch(proportionalProperty);
               if (boundsPatch) {
+                setProportionalSizeError(null);
+                rememberProportionalSeed(
+                  proportionalProperty,
+                  boundsPatch.proportionalSizeMinValue,
+                  boundsPatch.proportionalSizeMaxValue,
+                );
                 setLayerStyle(layer.id, {
                   proportionalSizeEnabled: true,
                   ...boundsPatch,
                 });
                 return;
               }
-              // Sample proves the field is unusable — do not enable with a stale range.
-              if (hasPropertySample(proportionalProperty)) {
-                clearProportionalSizeField(true);
+              // Non-empty sample proves the field is unusable — do not enable with a stale range.
+              if (hasDecisivePropertySample(proportionalProperty)) {
+                clearProportionalSizeField(true, t("style.symbology.errorProportionalSizeField"));
                 return;
               }
-              // Tiled / unloaded: enable and keep the field; the loader effect seeds bounds.
+              // Tiled / unloaded / empty sample: enable and keep the field; the loader seeds bounds.
+              setProportionalSizeError(null);
               setLayerStyle(layer.id, { proportionalSizeEnabled: true });
             }}
           />
@@ -2840,18 +2905,26 @@ export function StylePanel({
                 }
                 const boundsPatch = proportionalBoundsPatch(property);
                 if (boundsPatch) {
+                  setProportionalSizeError(null);
+                  rememberProportionalSeed(
+                    property,
+                    boundsPatch.proportionalSizeMinValue,
+                    boundsPatch.proportionalSizeMaxValue,
+                  );
                   setLayerStyle(layer.id, {
                     proportionalSizeProperty: property,
                     ...boundsPatch,
                   });
                   return;
                 }
-                // Sample proves nonnumeric / empty / constant — reject and clear stale range.
-                if (hasPropertySample(property)) {
-                  clearProportionalSizeField(true);
+                // Non-empty sample proves nonnumeric / constant — reject and clear stale range.
+                if (hasDecisivePropertySample(property)) {
+                  clearProportionalSizeField(true, t("style.symbology.errorProportionalSizeField"));
                   return;
                 }
-                // No sample yet (tiled): commit the field and reset to defaults until load.
+                // No decisive sample yet (tiled/empty): commit the field; defaults until load.
+                seededProportionalBoundsRef.current = null;
+                setProportionalSizeError(null);
                 setLayerStyle(layer.id, {
                   proportionalSizeProperty: property,
                   proportionalSizeMinValue: DEFAULT_LAYER_STYLE.proportionalSizeMinValue,
@@ -2882,6 +2955,9 @@ export function StylePanel({
               <p className="text-xs text-destructive">
                 {t("style.symbology.errorAttributesUnavailable")}
               </p>
+            )}
+            {proportionalSizeError && (
+              <p className="text-xs text-destructive">{proportionalSizeError}</p>
             )}
           </div>
           <div className="grid grid-cols-2 gap-3">

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -98,6 +98,7 @@ import {
   getPropertyValues,
   isCategoricalProperty,
   isNumericProperty,
+  proportionalSizeBounds,
 } from "../../lib/vector-style-classification";
 import { buildStyleSuggestions, type StyleSuggestion } from "../../lib/style-suggestions";
 
@@ -2708,6 +2709,14 @@ export function StylePanel({
       {vectorStyleError && <p className="text-xs text-destructive">{vectorStyleError}</p>}
     </div>
   );
+  /** Seed min/max from the field's numeric range when proportional sizing turns on or the field changes. */
+  const proportionalBoundsPatch = (property: string) => {
+    const bounds = proportionalSizeBounds(layer, property);
+    return bounds
+      ? { proportionalSizeMinValue: bounds.min, proportionalSizeMaxValue: bounds.max }
+      : {};
+  };
+
   const proportionalSizeControls = (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-2">
@@ -2717,11 +2726,17 @@ export function StylePanel({
             id="proportionalSizeEnabled"
             type="checkbox"
             checked={proportionalEnabled}
-            onChange={(event) =>
-              setLayerStyle(layer.id, {
-                proportionalSizeEnabled: event.target.checked,
-              })
-            }
+            onChange={(event) => {
+              const enabled = event.target.checked;
+              if (enabled && proportionalProperty) {
+                setLayerStyle(layer.id, {
+                  proportionalSizeEnabled: true,
+                  ...proportionalBoundsPatch(proportionalProperty),
+                });
+                return;
+              }
+              setLayerStyle(layer.id, { proportionalSizeEnabled: enabled });
+            }}
           />
           {t("style.symbology.sizeByValue")}
         </label>
@@ -2733,11 +2748,13 @@ export function StylePanel({
             <Select
               id="proportionalSizeProperty"
               value={proportionalProperty}
-              onChange={(event) =>
+              onChange={(event) => {
+                const property = event.target.value;
                 setLayerStyle(layer.id, {
-                  proportionalSizeProperty: event.target.value,
-                })
-              }
+                  proportionalSizeProperty: property,
+                  ...proportionalBoundsPatch(property),
+                });
+              }}
               disabled={vectorStylePropertyOptions.length === 0}
             >
               {vectorStylePropertyOptions.length === 0 ? (

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2823,11 +2823,7 @@ export function StylePanel({
       : null;
   };
 
-  const rememberProportionalSeed = (
-    property: string,
-    min: number,
-    max: number,
-  ) => {
+  const rememberProportionalSeed = (property: string, min: number, max: number) => {
     seededProportionalBoundsRef.current = { key: `${layer.id}:${property}`, min, max };
   };
 

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1148,19 +1148,37 @@ export function StylePanel({
 
   // Add Vector Layer keeps large tiled datasets in DuckDB instead of copying
   // their geometry into the app store. Read only the selected attribute when
-  // classification needs its values, so categorized and graduated styling
-  // remain available without defeating tiled rendering.
+  // classification or proportional sizing needs its values, so categorized /
+  // graduated styling and size-by-value remain available without defeating
+  // tiled rendering.
   useEffect(() => {
-    const usesDuckDbVector = layer?.metadata.sourceKind === "maplibre-gl-vector";
+    if (!layer) return;
+    const usesDuckDbVector = layer.metadata.sourceKind === "maplibre-gl-vector";
     const usesVectorTiles =
-      layer?.type === "vector-tiles" || layer?.type === "pmtiles" || layer?.type === "mbtiles";
-    const needsValues =
-      (usesDuckDbVector || usesVectorTiles) &&
-      !layer.geojson &&
+      layer.type === "vector-tiles" || layer.type === "pmtiles" || layer.type === "mbtiles";
+    if (!(usesDuckDbVector || usesVectorTiles) || layer.geojson) {
+      setLoadedVectorPropertyValues(null);
+      setVectorPropertyValuesLoading(false);
+      setVectorPropertyValuesUnavailable(false);
+      return;
+    }
+
+    const classificationNeedsValues =
       (draftVectorStyleMode === "graduated" || draftVectorStyleMode === "categorized") &&
       draftVectorStyleProperty !== "";
+    const proportionalPropertyToLoad = styleValue(layer.style, "proportionalSizeProperty");
+    const proportionalNeedsValues =
+      styleValue(layer.style, "proportionalSizeEnabled") && proportionalPropertyToLoad !== "";
+    // Prefer the classification field when both need values so graduated /
+    // categorized stop regeneration keeps the existing load path. Proportional
+    // sizing in single mode (or with the same field) still gets a sample.
+    const propertyToLoad = classificationNeedsValues
+      ? draftVectorStyleProperty
+      : proportionalNeedsValues
+        ? proportionalPropertyToLoad
+        : "";
 
-    if (!needsValues) {
+    if (!propertyToLoad) {
       setLoadedVectorPropertyValues(null);
       setVectorPropertyValuesLoading(false);
       setVectorPropertyValuesUnavailable(false);
@@ -1169,9 +1187,7 @@ export function StylePanel({
 
     let cancelled = false;
     setLoadedVectorPropertyValues((current) =>
-      current?.layerId === layer.id && current.property === draftVectorStyleProperty
-        ? current
-        : null,
+      current?.layerId === layer.id && current.property === propertyToLoad ? current : null,
     );
     setVectorPropertyValuesLoading(true);
     setVectorPropertyValuesUnavailable(false);
@@ -1192,9 +1208,9 @@ export function StylePanel({
         if (features.length === 0) return false;
         setLoadedVectorPropertyValues({
           layerId: layer.id,
-          property: draftVectorStyleProperty,
+          property: propertyToLoad,
           values: features
-            .map((feature) => feature.properties?.[draftVectorStyleProperty])
+            .map((feature) => feature.properties?.[propertyToLoad])
             .filter((value) => value !== null && value !== undefined),
         });
         setVectorPropertyValuesLoading(false);
@@ -1225,7 +1241,7 @@ export function StylePanel({
       };
     }
 
-    void getVectorLayerPropertyValues(layer.id, draftVectorStyleProperty)
+    void getVectorLayerPropertyValues(layer.id, propertyToLoad)
       .then((values) => {
         if (cancelled) return;
         if (values === null) {
@@ -1235,7 +1251,7 @@ export function StylePanel({
         }
         setLoadedVectorPropertyValues({
           layerId: layer.id,
-          property: draftVectorStyleProperty,
+          property: propertyToLoad,
           values,
         });
       })
@@ -1259,6 +1275,8 @@ export function StylePanel({
     layer?.geojson,
     layer?.id,
     layer?.metadata.sourceKind,
+    layer?.style.proportionalSizeEnabled,
+    layer?.style.proportionalSizeProperty,
     layer?.type,
   ]);
 
@@ -1295,6 +1313,36 @@ export function StylePanel({
     layer?.metadata.sourceKind,
     loadedVectorPropertyValues,
   ]);
+
+  // When tiled attribute samples arrive for the proportional size field, seed
+  // min/max if the style is still on the default 0–100 range (so a later
+  // user edit is not overwritten by a tile refresh).
+  useEffect(() => {
+    if (!layer || !loadedVectorPropertyValues) return;
+    if (!styleValue(layer.style, "proportionalSizeEnabled")) return;
+    const property = styleValue(layer.style, "proportionalSizeProperty");
+    if (
+      !property ||
+      loadedVectorPropertyValues.layerId !== layer.id ||
+      loadedVectorPropertyValues.property !== property
+    ) {
+      return;
+    }
+    const minValue = styleValue(layer.style, "proportionalSizeMinValue");
+    const maxValue = styleValue(layer.style, "proportionalSizeMaxValue");
+    if (
+      minValue !== DEFAULT_LAYER_STYLE.proportionalSizeMinValue ||
+      maxValue !== DEFAULT_LAYER_STYLE.proportionalSizeMaxValue
+    ) {
+      return;
+    }
+    const bounds = proportionalSizeBounds(layer, property, loadedVectorPropertyValues.values);
+    if (!bounds) return;
+    setLayerStyle(layer.id, {
+      proportionalSizeMinValue: bounds.min,
+      proportionalSizeMaxValue: bounds.max,
+    });
+  }, [layer, loadedVectorPropertyValues, setLayerStyle]);
 
   // Reset the "show basemap layers" advanced toggle back to its clean default
   // whenever a different layer is selected. Keyed on the layer id alone so it
@@ -2710,12 +2758,30 @@ export function StylePanel({
     </div>
   );
   /** Seed min/max from the field's numeric range when proportional sizing turns on or the field changes. */
+  const matchingPropertyValues = (property: string): unknown[] | undefined =>
+    loadedVectorPropertyValues?.layerId === layer.id &&
+    loadedVectorPropertyValues.property === property
+      ? loadedVectorPropertyValues.values
+      : undefined;
+
+  /** True when we already have a sample that can prove the field has (or lacks) a usable range. */
+  const hasPropertySample = (property: string): boolean =>
+    Boolean(layer.geojson?.features?.length) || matchingPropertyValues(property) !== undefined;
+
   const proportionalBoundsPatch = (property: string) => {
-    const bounds = proportionalSizeBounds(layer, property);
+    const bounds = proportionalSizeBounds(layer, property, matchingPropertyValues(property));
     return bounds
       ? { proportionalSizeMinValue: bounds.min, proportionalSizeMaxValue: bounds.max }
-      : {};
+      : null;
   };
+
+  const clearProportionalSizeField = (disable: boolean) =>
+    setLayerStyle(layer.id, {
+      ...(disable ? { proportionalSizeEnabled: false } : {}),
+      proportionalSizeProperty: "",
+      proportionalSizeMinValue: DEFAULT_LAYER_STYLE.proportionalSizeMinValue,
+      proportionalSizeMaxValue: DEFAULT_LAYER_STYLE.proportionalSizeMaxValue,
+    });
 
   const proportionalSizeControls = (
     <div className="space-y-3">
@@ -2728,14 +2794,29 @@ export function StylePanel({
             checked={proportionalEnabled}
             onChange={(event) => {
               const enabled = event.target.checked;
-              if (enabled && proportionalProperty) {
+              if (!enabled) {
+                setLayerStyle(layer.id, { proportionalSizeEnabled: false });
+                return;
+              }
+              if (!proportionalProperty) {
+                setLayerStyle(layer.id, { proportionalSizeEnabled: true });
+                return;
+              }
+              const boundsPatch = proportionalBoundsPatch(proportionalProperty);
+              if (boundsPatch) {
                 setLayerStyle(layer.id, {
                   proportionalSizeEnabled: true,
-                  ...proportionalBoundsPatch(proportionalProperty),
+                  ...boundsPatch,
                 });
                 return;
               }
-              setLayerStyle(layer.id, { proportionalSizeEnabled: enabled });
+              // Sample proves the field is unusable — do not enable with a stale range.
+              if (hasPropertySample(proportionalProperty)) {
+                clearProportionalSizeField(true);
+                return;
+              }
+              // Tiled / unloaded: enable and keep the field; the loader effect seeds bounds.
+              setLayerStyle(layer.id, { proportionalSizeEnabled: true });
             }}
           />
           {t("style.symbology.sizeByValue")}
@@ -2750,9 +2831,28 @@ export function StylePanel({
               value={proportionalProperty}
               onChange={(event) => {
                 const property = event.target.value;
+                if (!property) {
+                  clearProportionalSizeField(false);
+                  return;
+                }
+                const boundsPatch = proportionalBoundsPatch(property);
+                if (boundsPatch) {
+                  setLayerStyle(layer.id, {
+                    proportionalSizeProperty: property,
+                    ...boundsPatch,
+                  });
+                  return;
+                }
+                // Sample proves nonnumeric / empty / constant — reject and clear stale range.
+                if (hasPropertySample(property)) {
+                  clearProportionalSizeField(true);
+                  return;
+                }
+                // No sample yet (tiled): commit the field and reset to defaults until load.
                 setLayerStyle(layer.id, {
                   proportionalSizeProperty: property,
-                  ...proportionalBoundsPatch(property),
+                  proportionalSizeMinValue: DEFAULT_LAYER_STYLE.proportionalSizeMinValue,
+                  proportionalSizeMaxValue: DEFAULT_LAYER_STYLE.proportionalSizeMaxValue,
                 });
               }}
               disabled={vectorStylePropertyOptions.length === 0}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1046,8 +1046,8 @@ export function StylePanel({
   const [extrusionError, setExtrusionError] = useState<string | null>(null);
   const [loadedVectorPropertyValues, setLoadedVectorPropertyValues] = useState<{
     layerId: string;
-    property: string;
-    values: unknown[];
+    /** Attribute samples keyed by property name (classification and/or size field). */
+    byProperty: Record<string, unknown[]>;
   } | null>(null);
   const [vectorPropertyValuesLoading, setVectorPropertyValuesLoading] = useState(false);
   const [vectorPropertyValuesUnavailable, setVectorPropertyValuesUnavailable] = useState(false);
@@ -1147,10 +1147,12 @@ export function StylePanel({
   ]);
 
   // Add Vector Layer keeps large tiled datasets in DuckDB instead of copying
-  // their geometry into the app store. Read only the selected attribute when
-  // classification or proportional sizing needs its values, so categorized /
+  // their geometry into the app store. Read only the selected attribute(s) when
+  // classification or proportional sizing needs values, so categorized /
   // graduated styling and size-by-value remain available without defeating
-  // tiled rendering.
+  // tiled rendering. Classification and size fields are sampled together when
+  // they differ so proportional min/max can still seed from field B while
+  // graduated colors load field A.
   useEffect(() => {
     if (!layer) return;
     const usesDuckDbVector = layer.metadata.sourceKind === "maplibre-gl-vector";
@@ -1169,16 +1171,12 @@ export function StylePanel({
     const proportionalPropertyToLoad = styleValue(layer.style, "proportionalSizeProperty");
     const proportionalNeedsValues =
       styleValue(layer.style, "proportionalSizeEnabled") && proportionalPropertyToLoad !== "";
-    // Prefer the classification field when both need values so graduated /
-    // categorized stop regeneration keeps the existing load path. Proportional
-    // sizing in single mode (or with the same field) still gets a sample.
-    const propertyToLoad = classificationNeedsValues
-      ? draftVectorStyleProperty
-      : proportionalNeedsValues
-        ? proportionalPropertyToLoad
-        : "";
+    const propertiesToLoad = [
+      ...(classificationNeedsValues ? [draftVectorStyleProperty] : []),
+      ...(proportionalNeedsValues ? [proportionalPropertyToLoad] : []),
+    ].filter((property, index, all) => property !== "" && all.indexOf(property) === index);
 
-    if (!propertyToLoad) {
+    if (propertiesToLoad.length === 0) {
       setLoadedVectorPropertyValues(null);
       setVectorPropertyValuesLoading(false);
       setVectorPropertyValuesUnavailable(false);
@@ -1187,7 +1185,12 @@ export function StylePanel({
 
     let cancelled = false;
     setLoadedVectorPropertyValues((current) =>
-      current?.layerId === layer.id && current.property === propertyToLoad ? current : null,
+      current?.layerId === layer.id &&
+      propertiesToLoad.every((property) =>
+        Object.prototype.hasOwnProperty.call(current.byProperty, property),
+      )
+        ? current
+        : null,
     );
     setVectorPropertyValuesLoading(true);
     setVectorPropertyValuesUnavailable(false);
@@ -1206,13 +1209,13 @@ export function StylePanel({
       const sampleValues = (): boolean => {
         const features = loadedVectorTileFeatures(map, layer);
         if (features.length === 0) return false;
-        setLoadedVectorPropertyValues({
-          layerId: layer.id,
-          property: propertyToLoad,
-          values: features
-            .map((feature) => feature.properties?.[propertyToLoad])
-            .filter((value) => value !== null && value !== undefined),
-        });
+        const byProperty: Record<string, unknown[]> = {};
+        for (const property of propertiesToLoad) {
+          byProperty[property] = features
+            .map((feature) => feature.properties?.[property])
+            .filter((value) => value !== null && value !== undefined);
+        }
+        setLoadedVectorPropertyValues({ layerId: layer.id, byProperty });
         setVectorPropertyValuesLoading(false);
         return true;
       };
@@ -1241,19 +1244,24 @@ export function StylePanel({
       };
     }
 
-    void getVectorLayerPropertyValues(layer.id, propertyToLoad)
-      .then((values) => {
+    void Promise.all(
+      propertiesToLoad.map(async (property) => {
+        const values = await getVectorLayerPropertyValues(layer.id, property);
+        return [property, values] as const;
+      }),
+    )
+      .then((entries) => {
         if (cancelled) return;
-        if (values === null) {
-          setLoadedVectorPropertyValues(null);
-          setVectorPropertyValuesUnavailable(true);
-          return;
+        const byProperty: Record<string, unknown[]> = {};
+        for (const [property, values] of entries) {
+          if (values === null) {
+            setLoadedVectorPropertyValues(null);
+            setVectorPropertyValuesUnavailable(true);
+            return;
+          }
+          byProperty[property] = values;
         }
-        setLoadedVectorPropertyValues({
-          layerId: layer.id,
-          property: propertyToLoad,
-          values,
-        });
+        setLoadedVectorPropertyValues({ layerId: layer.id, byProperty });
       })
       .catch((error) => {
         if (!cancelled) {
@@ -1285,11 +1293,12 @@ export function StylePanel({
       !layer ||
       !loadedVectorPropertyValues ||
       loadedVectorPropertyValues.layerId !== layer.id ||
-      loadedVectorPropertyValues.property !== draftVectorStyleProperty ||
       (draftVectorStyleMode !== "graduated" && draftVectorStyleMode !== "categorized")
     ) {
       return;
     }
+    const values = loadedVectorPropertyValues.byProperty[draftVectorStyleProperty];
+    if (!values) return;
 
     setDraftVectorStyleStops(
       createDefaultStops(
@@ -1299,7 +1308,7 @@ export function StylePanel({
         draftVectorStyleClassCount,
         draftVectorStyleColorRamp,
         draftVectorStyleClassificationScheme,
-        loadedVectorPropertyValues.values,
+        values,
       ),
     );
   }, [
@@ -1321,13 +1330,9 @@ export function StylePanel({
     if (!layer || !loadedVectorPropertyValues) return;
     if (!styleValue(layer.style, "proportionalSizeEnabled")) return;
     const property = styleValue(layer.style, "proportionalSizeProperty");
-    if (
-      !property ||
-      loadedVectorPropertyValues.layerId !== layer.id ||
-      loadedVectorPropertyValues.property !== property
-    ) {
-      return;
-    }
+    if (!property || loadedVectorPropertyValues.layerId !== layer.id) return;
+    const values = loadedVectorPropertyValues.byProperty[property];
+    if (!values) return;
     const minValue = styleValue(layer.style, "proportionalSizeMinValue");
     const maxValue = styleValue(layer.style, "proportionalSizeMaxValue");
     if (
@@ -1336,7 +1341,7 @@ export function StylePanel({
     ) {
       return;
     }
-    const bounds = proportionalSizeBounds(layer, property, loadedVectorPropertyValues.values);
+    const bounds = proportionalSizeBounds(layer, property, values);
     if (!bounds) return;
     setLayerStyle(layer.id, {
       proportionalSizeMinValue: bounds.min,
@@ -1668,9 +1673,8 @@ export function StylePanel({
     draftVectorStyleExpression !== styleValue(style, "vectorStyleExpression") ||
     JSON.stringify(draftVectorStyleStops) !== JSON.stringify(currentVectorStops);
   const draftVectorPropertyValues =
-    loadedVectorPropertyValues?.layerId === layer.id &&
-    loadedVectorPropertyValues.property === draftVectorStyleProperty
-      ? loadedVectorPropertyValues.values
+    loadedVectorPropertyValues?.layerId === layer.id
+      ? loadedVectorPropertyValues.byProperty[draftVectorStyleProperty]
       : undefined;
   const regenerateDraftVectorStyleStops = (
     mode: VectorStyleMode,
@@ -2759,9 +2763,8 @@ export function StylePanel({
   );
   /** Seed min/max from the field's numeric range when proportional sizing turns on or the field changes. */
   const matchingPropertyValues = (property: string): unknown[] | undefined =>
-    loadedVectorPropertyValues?.layerId === layer.id &&
-    loadedVectorPropertyValues.property === property
-      ? loadedVectorPropertyValues.values
+    loadedVectorPropertyValues?.layerId === layer.id
+      ? loadedVectorPropertyValues.byProperty[property]
       : undefined;
 
   /** True when we already have a sample that can prove the field has (or lacks) a usable range. */
@@ -2870,6 +2873,14 @@ export function StylePanel({
                 </>
               )}
             </Select>
+            {vectorPropertyValuesLoading && (
+              <p className="text-xs text-muted-foreground">{t("attributeTable.loadingAttributes")}</p>
+            )}
+            {vectorPropertyValuesUnavailable && (
+              <p className="text-xs text-destructive">
+                {t("style.symbology.errorAttributesUnavailable")}
+              </p>
+            )}
           </div>
           <div className="grid grid-cols-2 gap-3">
             <NumericStyleInput

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2886,6 +2886,10 @@ export function StylePanel({
           {t("style.symbology.sizeByValue")}
         </label>
       </div>
+      {/* Outside the `proportionalEnabled` guard on purpose: rejecting a field
+          from the checkbox leaves proportional sizing off, so a message nested
+          inside that branch would unmount in the same render that set it. */}
+      {proportionalSizeError && <p className="text-xs text-destructive">{proportionalSizeError}</p>}
       {proportionalEnabled && (
         <>
           <div className="space-y-2">
@@ -2914,8 +2918,13 @@ export function StylePanel({
                   return;
                 }
                 // Non-empty sample proves nonnumeric / constant — reject and clear stale range.
+                // Stay enabled: the user is mid-edit here, so keep the field select
+                // mounted next to the message instead of collapsing the section.
                 if (hasDecisivePropertySample(property)) {
-                  clearProportionalSizeField(true, t("style.symbology.errorProportionalSizeField"));
+                  clearProportionalSizeField(
+                    false,
+                    t("style.symbology.errorProportionalSizeField"),
+                  );
                   return;
                 }
                 // No decisive sample yet (tiled/empty): commit the field; defaults until load.
@@ -2951,9 +2960,6 @@ export function StylePanel({
               <p className="text-xs text-destructive">
                 {t("style.symbology.errorAttributesUnavailable")}
               </p>
-            )}
-            {proportionalSizeError && (
-              <p className="text-xs text-destructive">{proportionalSizeError}</p>
             )}
           </div>
           <div className="grid grid-cols-2 gap-3">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4134,6 +4134,7 @@
       "schemeFirstValues": "First values",
       "errorChooseAttribute": "Choose an attribute for this style mode.",
       "errorAttributesUnavailable": "Could not load this layer's attribute values.",
+      "errorProportionalSizeField": "Size field must be numeric with more than one distinct value.",
       "errorGraduatedStops": "Graduated style requires at least two numeric stops.",
       "errorCategorizedStops": "Categorized style requires at least one category.",
       "invertedFill": "Inverted fill",

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -1996,7 +1996,15 @@ function drawLegend(
   // multi-class entry renders a layer heading (when groupByLayer is on) above
   // its class swatches, or just the flat class swatches when it is off. A row
   // draws a swatch when it has a color or a marker; a group heading has neither.
-  const rows: { color: string; text: string; marker?: LegendMarker; size?: number }[] = [];
+  // `entryId` keeps proportional scaling scoped to one legend entry even when
+  // groupByLayer is off and adjacent layers' size rows become contiguous.
+  const rows: {
+    entryId: string;
+    color: string;
+    text: string;
+    marker?: LegendMarker;
+    size?: number;
+  }[] = [];
   for (const entry of entries) {
     if (entry.swatches.length <= 1) {
       // Prefer the swatch's own label so a multi-class entry collapsed to one
@@ -2005,17 +2013,26 @@ function drawLegend(
       // entries carry no swatch label, so they still show entry.name.
       const swatch = entry.swatches[0];
       rows.push({
+        entryId: entry.id,
         color: swatch?.color ?? "#999999",
         text: swatch?.label ?? entry.name,
         marker: swatch?.marker,
         size: swatch?.size,
       });
     } else {
-      if (opts.groupByLayer) rows.push({ color: "", text: entry.name });
+      if (opts.groupByLayer) {
+        rows.push({ entryId: entry.id, color: "", text: entry.name });
+      }
       for (const sw of entry.swatches) {
         // Carry the marker so a marker + diagram layer (a multi-swatch entry
         // whose primary swatch is the marker) draws its marker, not a square.
-        rows.push({ color: sw.color, text: sw.label ?? "", marker: sw.marker, size: sw.size });
+        rows.push({
+          entryId: entry.id,
+          color: sw.color,
+          text: sw.label ?? "",
+          marker: sw.marker,
+          size: sw.size,
+        });
       }
     }
   }
@@ -2026,25 +2043,18 @@ function drawLegend(
   // Cap proportional circles so a huge max radius still fits the legend box,
   // while keeping ratios within each entry (same idea as the on-map LegendSwatch).
   const MAX_CIRCLE_R = swatch * 0.55;
-  const rowScale: number[] = rows.map(() => 1);
-  {
-    let i = 0;
-    while (i < rows.length) {
-      if (rows[i]!.size === undefined) {
-        i += 1;
-        continue;
-      }
-      let j = i;
-      let maxSize = 0;
-      while (j < rows.length && rows[j]!.size !== undefined) {
-        maxSize = Math.max(maxSize, rows[j]!.size!);
-        j += 1;
-      }
-      const scale = maxSize > MAX_CIRCLE_R ? MAX_CIRCLE_R / maxSize : 1;
-      for (let k = i; k < j; k++) rowScale[k] = scale;
-      i = j;
-    }
+  const entryMaxSize = new Map<string, number>();
+  for (const r of rows) {
+    if (r.size === undefined) continue;
+    entryMaxSize.set(r.entryId, Math.max(entryMaxSize.get(r.entryId) ?? 0, r.size));
   }
+  const entryScale = new Map<string, number>();
+  for (const [entryId, maxSize] of entryMaxSize) {
+    entryScale.set(entryId, maxSize > MAX_CIRCLE_R ? MAX_CIRCLE_R / maxSize : 1);
+  }
+  const rowScale: number[] = rows.map((r) =>
+    r.size !== undefined ? (entryScale.get(r.entryId) ?? 1) : 1,
+  );
 
   // Measure required width.
   ctx.save();

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -202,6 +202,12 @@ export interface LegendSwatch {
    * back to the square if a custom SVG icon has not been preloaded.
    */
   marker?: LegendMarker;
+  /**
+   * Circle radius in map pixels for a proportional-symbol row. When set, the
+   * legend draws a filled circle instead of a color square (scaled to fit the
+   * legend box, keeping ratios across the entry).
+   */
+  size?: number;
 }
 
 export interface LegendEntry {
@@ -1990,7 +1996,7 @@ function drawLegend(
   // multi-class entry renders a layer heading (when groupByLayer is on) above
   // its class swatches, or just the flat class swatches when it is off. A row
   // draws a swatch when it has a color or a marker; a group heading has neither.
-  const rows: { color: string; text: string; marker?: LegendMarker }[] = [];
+  const rows: { color: string; text: string; marker?: LegendMarker; size?: number }[] = [];
   for (const entry of entries) {
     if (entry.swatches.length <= 1) {
       // Prefer the swatch's own label so a multi-class entry collapsed to one
@@ -2002,19 +2008,43 @@ function drawLegend(
         color: swatch?.color ?? "#999999",
         text: swatch?.label ?? entry.name,
         marker: swatch?.marker,
+        size: swatch?.size,
       });
     } else {
       if (opts.groupByLayer) rows.push({ color: "", text: entry.name });
       for (const sw of entry.swatches) {
         // Carry the marker so a marker + diagram layer (a multi-swatch entry
         // whose primary swatch is the marker) draws its marker, not a square.
-        rows.push({ color: sw.color, text: sw.label ?? "", marker: sw.marker });
+        rows.push({ color: sw.color, text: sw.label ?? "", marker: sw.marker, size: sw.size });
       }
     }
   }
 
   const rowHasSwatch = (r: { color: string; marker?: LegendMarker }): boolean =>
     Boolean(r.color) || Boolean(r.marker);
+
+  // Cap proportional circles so a huge max radius still fits the legend box,
+  // while keeping ratios within each entry (same idea as the on-map LegendSwatch).
+  const MAX_CIRCLE_R = swatch * 0.55;
+  const rowScale: number[] = rows.map(() => 1);
+  {
+    let i = 0;
+    while (i < rows.length) {
+      if (rows[i]!.size === undefined) {
+        i += 1;
+        continue;
+      }
+      let j = i;
+      let maxSize = 0;
+      while (j < rows.length && rows[j]!.size !== undefined) {
+        maxSize = Math.max(maxSize, rows[j]!.size!);
+        j += 1;
+      }
+      const scale = maxSize > MAX_CIRCLE_R ? MAX_CIRCLE_R / maxSize : 1;
+      for (let k = i; k < j; k++) rowScale[k] = scale;
+      i = j;
+    }
+  }
 
   // Measure required width.
   ctx.save();
@@ -2053,7 +2083,8 @@ function drawLegend(
     cy += unit;
   }
 
-  for (const r of rows) {
+  for (let index = 0; index < rows.length; index++) {
+    const r = rows[index]!;
     cy += rowH;
     const hasSwatch = rowHasSwatch(r);
     const textX = hasSwatch ? x + pad + swatch + unit : x + pad;
@@ -2061,6 +2092,17 @@ function drawLegend(
     const sy = cy - swatch * 0.85;
     if (r.marker) {
       drawLegendMarker(ctx, r.marker, sx, sy, swatch, r.color, opts.markerIcons);
+    } else if (r.size !== undefined && r.color) {
+      const radius = Math.max(unit * 0.35, r.size * rowScale[index]!);
+      const cx = sx + swatch / 2;
+      const cyc = sy + swatch / 2;
+      ctx.beginPath();
+      ctx.arc(cx, cyc, radius, 0, Math.PI * 2);
+      ctx.fillStyle = r.color;
+      ctx.fill();
+      ctx.strokeStyle = BORDER;
+      ctx.lineWidth = Math.max(1, unit * 0.1);
+      ctx.stroke();
     } else if (r.color) {
       ctx.fillStyle = r.color;
       ctx.fillRect(sx, sy, swatch, swatch);

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -7,6 +7,7 @@ import {
   effectiveVectorRules,
   isHexColor,
   normalizeHexColor,
+  proportionalSizeRange,
   styleValue,
   type GeoLibreLayer,
   type LayerStyle,
@@ -14,6 +15,7 @@ import {
   type LegendConfig,
   type LegendItemOverride,
   type MarkerShape,
+  type ProportionalSizeRange,
   type VectorStyleStop,
 } from "@geolibre/core";
 import type { LegendEntry, LegendMarker, LegendSwatch } from "./print-layout";
@@ -79,16 +81,45 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
     // Diagram symbology adds one labeled swatch per charted attribute after the
     // base symbology's swatches, mirroring the QGIS legend.
     const diagrams = diagramSwatches(layer);
+    const sizeRange = layerSupportsProportionalLegend(layer)
+      ? proportionalSizeRange(layer.style)
+      : null;
     if (
       (mode === "graduated" || mode === "categorized") &&
       Array.isArray(stops) &&
       stops.length > 0
     ) {
-      return [...rampSwatches(stops, mode), ...diagrams];
+      const ramp = rampSwatches(stops, mode);
+      const classProperty = styleValue(layer.style, "vectorStyleProperty");
+      // Same field classified and sized: merge sizes into the class rows so the
+      // print legend matches the on-map auto-legend (one block, not two).
+      if (sizeRange && mode === "graduated" && sizeRange.property === classProperty) {
+        return [...sizeClassSwatches(ramp, stops, sizeRange), ...diagrams];
+      }
+      return [
+        ...ramp,
+        ...(sizeRange ? proportionalSizeSwatches(sizeRange, sizeRampColor(ramp, layer.style)) : []),
+        ...diagrams,
+      ];
     }
     if (mode === "rule-based") {
       const swatches = ruleSwatches(layer);
-      if (swatches.length > 0) return [...swatches, ...diagrams];
+      if (swatches.length > 0) {
+        return [
+          ...swatches,
+          ...(sizeRange
+            ? proportionalSizeSwatches(sizeRange, sizeRampColor(swatches, layer.style))
+            : []),
+          ...diagrams,
+        ];
+      }
+    }
+    // Single symbology with proportional sizing: the size ramp IS the legend.
+    if (sizeRange) {
+      return [
+        ...proportionalSizeSwatches(sizeRange, styleValue(layer.style, "fillColor") || NEUTRAL_SWATCH),
+        ...diagrams,
+      ];
     }
     const primary = pointMarkerSwatch(layer.style) ?? {
       color: styleValue(layer.style, "fillColor"),
@@ -225,6 +256,9 @@ export function applyLegendConfig(base: LegendEntry[], config: LegendConfig): Le
         // diagram symbology (a multi-swatch entry: [marker primary, ...diagrams])
         // still draws its marker rather than regressing to a color square.
         marker: swatch.marker,
+        // Preserve proportional-symbol sizes so a customized size-ramp entry
+        // still draws graduated circles in the print layout.
+        size: swatch.size,
       });
     });
     // Every class hidden: drop the whole entry rather than render an empty box.
@@ -421,6 +455,77 @@ function rampSwatches(
     color: stop.color,
     label: mode === "graduated" ? `≥ ${formatStopValue(stop.value)}` : formatStopValue(stop.value),
   }));
+}
+
+/**
+ * Whether the map would size this layer's symbols (circles / line strokes).
+ * Polygon fills ignore proportional sizing, matching the on-map auto-legend.
+ */
+function layerSupportsProportionalLegend(layer: GeoLibreLayer): boolean {
+  const geometryType =
+    typeof layer.metadata?.geometryType === "string" ? layer.metadata.geometryType : null;
+  if (geometryType === "point" || geometryType === "line") return true;
+  if (geometryType === "polygon") return false;
+
+  const features = layer.geojson?.features;
+  if (!features || features.length === 0) return true;
+  for (const feature of features.slice(0, 200)) {
+    const type = feature.geometry?.type ?? "";
+    if (type === "Point" || type === "MultiPoint") return true;
+    if (type === "LineString" || type === "MultiLineString") return true;
+    if (type === "Polygon" || type === "MultiPolygon") return false;
+  }
+  return true;
+}
+
+function lerp(from: number, to: number, ratio: number): number {
+  return from + (to - from) * ratio;
+}
+
+/**
+ * Proportional-symbol size rows: min / middle / max symbol sizes with their
+ * data values, mirroring the interpolate the map renders and the on-map legend.
+ */
+function proportionalSizeSwatches(range: ProportionalSizeRange, color: string): LegendSwatch[] {
+  return [0, 0.5, 1].map((ratio) => ({
+    color,
+    label: formatStopValue(lerp(range.minValue, range.maxValue, ratio)),
+    size: lerp(range.minRadius, range.maxRadius, ratio),
+  }));
+}
+
+/**
+ * Size each graduated class swatch at the symbol the map draws for that class
+ * (midpoint of the class range, or the lower bound for the open-ended top
+ * class). Applied when color and size read the same field.
+ */
+function sizeClassSwatches(
+  swatches: { color: string; label: string }[],
+  stops: VectorStyleStop[],
+  range: ProportionalSizeRange,
+): LegendSwatch[] {
+  return swatches.map((swatch, index) => {
+    const from = Number(stops[index]?.value);
+    const to = Number(stops[index + 1]?.value);
+    const representative = Number.isFinite(to) ? (from + to) / 2 : from;
+    if (!Number.isFinite(representative)) return swatch;
+    const ratio = (representative - range.minValue) / (range.maxValue - range.minValue);
+    return {
+      ...swatch,
+      size: lerp(range.minRadius, range.maxRadius, Math.min(1, Math.max(0, ratio))),
+    };
+  });
+}
+
+/** Fill color for a standalone size ramp appended after class rows. */
+function sizeRampColor(
+  classSwatches: { color: string }[],
+  style: LayerStyle,
+): string {
+  if (classSwatches.length > 0) {
+    return classSwatches[Math.floor(classSwatches.length / 2)]!.color;
+  }
+  return styleValue(style, "fillColor") || NEUTRAL_SWATCH;
 }
 
 function sampleEvenly<T>(items: T[], count: number): T[] {

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -89,12 +89,16 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
       Array.isArray(stops) &&
       stops.length > 0
     ) {
-      const ramp = rampSwatches(stops, mode);
+      // Sample once so color/label rows and proportional sizes stay paired when
+      // the class list exceeds MAX_RAMP_SWATCHES.
+      const displayedStops =
+        stops.length > MAX_RAMP_SWATCHES ? sampleEvenly(stops, MAX_RAMP_SWATCHES) : stops;
+      const ramp = rampSwatches(displayedStops, mode);
       const classProperty = styleValue(layer.style, "vectorStyleProperty");
       // Same field classified and sized: merge sizes into the class rows so the
       // print legend matches the on-map auto-legend (one block, not two).
       if (sizeRange && mode === "graduated" && sizeRange.property === classProperty) {
-        return [...sizeClassSwatches(ramp, stops, sizeRange), ...diagrams];
+        return [...sizeClassSwatches(ramp, displayedStops, sizeRange), ...diagrams];
       }
       return [
         ...ramp,
@@ -450,8 +454,7 @@ function rampSwatches(
   stops: VectorStyleStop[],
   mode: "graduated" | "categorized",
 ): { color: string; label: string }[] {
-  const limited = stops.length > MAX_RAMP_SWATCHES ? sampleEvenly(stops, MAX_RAMP_SWATCHES) : stops;
-  return limited.map((stop) => ({
+  return stops.map((stop) => ({
     color: stop.color,
     label: mode === "graduated" ? `≥ ${formatStopValue(stop.value)}` : formatStopValue(stop.value),
   }));

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -117,7 +117,10 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
     // Single symbology with proportional sizing: the size ramp IS the legend.
     if (sizeRange) {
       return [
-        ...proportionalSizeSwatches(sizeRange, styleValue(layer.style, "fillColor") || NEUTRAL_SWATCH),
+        ...proportionalSizeSwatches(
+          sizeRange,
+          styleValue(layer.style, "fillColor") || NEUTRAL_SWATCH,
+        ),
         ...diagrams,
       ];
     }
@@ -518,10 +521,7 @@ function sizeClassSwatches(
 }
 
 /** Fill color for a standalone size ramp appended after class rows. */
-function sizeRampColor(
-  classSwatches: { color: string }[],
-  style: LayerStyle,
-): string {
+function sizeRampColor(classSwatches: { color: string }[], style: LayerStyle): string {
   if (classSwatches.length > 0) {
     return classSwatches[Math.floor(classSwatches.length / 2)]!.color;
   }

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -164,6 +164,27 @@ export function createCategorizedStops(
 }
 
 /**
+ * Numeric min/max for a property, used to seed proportional-symbol value
+ * bounds when the user picks a size field. Returns `null` when the column has
+ * no finite numbers or every value is the same (a zero-width range cannot
+ * drive an interpolate).
+ */
+export function proportionalSizeBounds(
+  layer: ClassifiableLayer,
+  property: string,
+  propertyValues?: unknown[],
+): { min: number; max: number } | null {
+  if (!property) return null;
+  const values = (propertyValues ?? getPropertyValues(layer, property))
+    .map(finitePropertyNumber)
+    .filter((value): value is number => value !== null);
+  if (values.length === 0) return null;
+  const { min, max } = numericBounds(values);
+  if (!(Number.isFinite(min) && Number.isFinite(max)) || min === max) return null;
+  return { min, max };
+}
+
+/**
  * True when a property has at least two *distinct* finite numeric values, so a
  * graduated classification has a range to break up.
  *

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -748,4 +748,48 @@ describe("buildLegend proportional size", () => {
       [4, 8, 12],
     );
   });
+
+  it("pairs sampled graduated colors with sizes from the same displayed stops", () => {
+    // More than MAX_RAMP_SWATCHES (6) classes: sampling must keep each
+    // displayed color/label paired with the size for that same stop, not an
+    // index into the unsampled list.
+    const stops = Array.from({ length: 10 }, (_, index) => ({
+      value: index * 10,
+      color: `#${(index * 25).toString(16).padStart(2, "0")}0000`,
+    }));
+    const legend = buildLegend([
+      makeLayer({
+        id: "many",
+        name: "Many classes",
+        metadata: { geometryType: "point" },
+        style: {
+          vectorStyleMode: "graduated",
+          vectorStyleProperty: "pop",
+          vectorStyleStops: stops,
+          fillColor: "#ffffff",
+          proportionalSizeEnabled: true,
+          proportionalSizeProperty: "pop",
+          proportionalSizeMinValue: 0,
+          proportionalSizeMaxValue: 90,
+          proportionalSizeMinRadius: 4,
+          proportionalSizeMaxRadius: 22,
+        } as unknown as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 6);
+    // Even sample of 10 → values 0,20,40,50,70,90. Sizes use midpoints between
+    // consecutive displayed stops (open-ended top class at its lower bound).
+    const sizeAt = (value: number) => 4 + (value / 90) * 18;
+    assert.deepEqual(
+      legend[0].swatches.map((swatch) => [swatch.label, swatch.size]),
+      [
+        ["≥ 0", sizeAt(10)],
+        ["≥ 20", sizeAt(30)],
+        ["≥ 40", sizeAt(45)],
+        ["≥ 50", sizeAt(60)],
+        ["≥ 70", sizeAt(80)],
+        ["≥ 90", sizeAt(90)],
+      ],
+    );
+  });
 });

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -672,3 +672,80 @@ describe("legend config mutations", () => {
     assert.deepEqual(unchanged.order, []);
   });
 });
+
+describe("buildLegend proportional size", () => {
+  it("emits a three-step size ramp for a point layer with proportional sizing", () => {
+    const legend = buildLegend([
+      makeLayer({
+        id: "apiaries",
+        name: "Apiaries",
+        metadata: { geometryType: "point" },
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#3b82f6",
+          proportionalSizeEnabled: true,
+          proportionalSizeProperty: "nb_ruches",
+          proportionalSizeMinValue: 2,
+          proportionalSizeMaxValue: 48,
+          proportionalSizeMinRadius: 4,
+          proportionalSizeMaxRadius: 24,
+        } as unknown as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend.length, 1);
+    assert.deepEqual(
+      legend[0].swatches.map((swatch) => [swatch.label, swatch.size, swatch.color]),
+      [
+        ["2", 4, "#3b82f6"],
+        ["25", 14, "#3b82f6"],
+        ["48", 24, "#3b82f6"],
+      ],
+    );
+  });
+
+  it("omits the size ramp for polygon layers", () => {
+    const legend = buildLegend([
+      makeLayer({
+        id: "zones",
+        name: "Zones",
+        metadata: { geometryType: "polygon" },
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#22c55e",
+          proportionalSizeEnabled: true,
+          proportionalSizeProperty: "area",
+          proportionalSizeMinValue: 0,
+          proportionalSizeMaxValue: 100,
+          proportionalSizeMinRadius: 4,
+          proportionalSizeMaxRadius: 24,
+        } as unknown as LayerStyle,
+      }),
+    ]);
+    assert.deepEqual(legend[0].swatches, [{ color: "#22c55e" }]);
+  });
+
+  it("preserves sizes through applyLegendConfig", () => {
+    const base = buildLegend([
+      makeLayer({
+        id: "pts",
+        name: "Points",
+        metadata: { geometryType: "point" },
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#111111",
+          proportionalSizeEnabled: true,
+          proportionalSizeProperty: "pop",
+          proportionalSizeMinValue: 0,
+          proportionalSizeMaxValue: 100,
+          proportionalSizeMinRadius: 4,
+          proportionalSizeMaxRadius: 12,
+        } as unknown as LayerStyle,
+      }),
+    ]);
+    const applied = applyLegendConfig(base, config());
+    assert.deepEqual(
+      applied[0].swatches.map((swatch) => swatch.size),
+      [4, 8, 12],
+    );
+  });
+});

--- a/tests/vector-style-classification.test.ts
+++ b/tests/vector-style-classification.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   createCategorizedStops,
   createGraduatedStops,
+  proportionalSizeBounds,
 } from "../apps/geolibre-desktop/src/lib/vector-style-classification";
 
 const tiledLayer = {};
@@ -91,5 +92,41 @@ describe("vector style classification", () => {
 
     assert.equal(stops.length, 3);
     assert.equal(new Set(stops.map((stop) => stop.value)).size, 3);
+  });
+});
+
+describe("proportionalSizeBounds", () => {
+  it("returns the numeric min and max of a property", () => {
+    const layer = {
+      geojson: {
+        features: [
+          { properties: { count: 12 } },
+          { properties: { count: 4 } },
+          { properties: { count: "40" } },
+          { properties: { count: null } },
+        ],
+      },
+    };
+    assert.deepEqual(proportionalSizeBounds(layer, "count"), { min: 4, max: 40 });
+  });
+
+  it("returns null for an empty, missing, or constant column", () => {
+    assert.equal(proportionalSizeBounds({}, "count"), null);
+    assert.equal(proportionalSizeBounds({ geojson: { features: [] } }, "count"), null);
+    assert.equal(
+      proportionalSizeBounds(
+        {
+          geojson: {
+            features: [{ properties: { count: 7 } }, { properties: { count: 7 } }],
+          },
+        },
+        "count",
+      ),
+      null,
+    );
+  });
+
+  it("accepts separately loaded property values", () => {
+    assert.deepEqual(proportionalSizeBounds({}, "height", [1, 5, 9]), { min: 1, max: 9 });
   });
 });


### PR DESCRIPTION
## Summary
- Auto-fill `proportionalSizeMinValue` / `proportionalSizeMaxValue` from the selected field's numeric range when enabling proportional sizing or changing the size field (fixes the stuck 0–100 defaults).
- Include proportional-symbol size ramp swatches in the Print Layout legend (and draw them as graduated circles), matching what Controls → Legend already shows via the on-map auto-legend.

Fixes #1543

## Test plan
- [ ] Import a point CSV with a numeric attribute (e.g. the apiaries file from #1543)
- [ ] Style → enable Proportional size → pick the numeric field
- [ ] Confirm Min/Max value inputs update to the data range (not 0 / 100)
- [ ] Controls → Legend shows the three size gradients
- [ ] Print Layout → show legend includes the same size ramp (circles of increasing size)
- [ ] `node --import tsx --test tests/vector-style-classification.test.ts tests/print-legend.test.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Proportional symbol legends now render scalable circle swatches for eligible point layers (including proportional ramps), with consistent sizing within each legend entry.
  - Proportional sizing in the Style panel can seed and refine editable min/max bounds from numeric attribute ranges and supports combined graduated/categorized + proportional styling.
  - Added a new validation message for non-numeric or insufficient-variation proportional size fields.
- **Bug Fixes**
  - Improved attribute sampling/loading for tiled layers and prevented overwriting user-edited min/max; proportional size remains correctly paired with displayed graduated stops.
- **Tests**
  - Added coverage for proportional legend building, size-stop pairing, and `proportionalSizeBounds` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->