### PR TITLE
fix(ios): stamp a valid unique build number and declare export compliance

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -288,12 +288,15 @@ jobs:
         run: |
           set -euo pipefail
           gen="apps/geolibre-desktop/src-tauri/gen/apple"
-          archive="$(find "$gen/build" -maxdepth 1 -name '*.xcarchive' | head -1)"
+          # `|| true` so a missing directory falls through to the check below:
+          # find exits non-zero, and under pipefail that would otherwise abort
+          # the step with a bare failure instead of the message underneath.
+          archive="$(find "$gen/build" -maxdepth 1 -name '*.xcarchive' | head -1 || true)"
           if [ -z "$archive" ]; then
             echo "::error::No .xcarchive produced under $gen/build"
             exit 1
           fi
-          app="$(find "$archive/Products/Applications" -maxdepth 1 -name '*.app' | head -1)"
+          app="$(find "$archive/Products/Applications" -maxdepth 1 -name '*.app' | head -1 || true)"
           if [ -z "$app" ]; then
             echo "::error::No .app inside $archive"
             exit 1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -126,9 +126,10 @@ jobs:
       - name: Generate iOS project
         # gen/apple is not committed; regenerate it on the clean runner. The
         # Tauri CLI is resolved through the geolibre-desktop workspace. This also
-        # merges src-tauri/tauri.ios.conf.json (bundle id, drops the Python
-        # backend) and src-tauri/Info.ios.plist (the NSLocation usage string) into
-        # the generated Xcode project.
+        # picks up src-tauri/tauri.ios.conf.json (bundle id, drops the Python
+        # backend). src-tauri/Info.ios.plist (the NSLocation usage string) is
+        # *not* merged here — that happens during the `tauri ios build` step
+        # below, which is why regenerating the project alone never shows it.
         working-directory: apps/geolibre-desktop
         run: npx tauri ios init
 
@@ -264,8 +265,21 @@ jobs:
         # to the version, yielding e.g. "2.4.0.42" — four components, while
         # CFBundleVersion may contain at most three period-separated integers.
         # App Store Connect rejects that at upload (ITMS-90060), so the flag is
-        # unusable here. Stamping the archive instead keeps the value a single
-        # integer that rises forever and never collides.
+        # unusable here. Stamping the archive instead keeps the value inside the
+        # three-component budget while rising forever.
+        #
+        # GITHUB_RUN_NUMBER alone is not enough: it is fixed for the lifetime of
+        # a run, so re-running a run that already produced an uploaded IPA would
+        # regenerate the same CFBundleVersion. GITHUB_RUN_ATTEMPT is appended on
+        # re-runs (attempt 1 is left bare so the common case stays a single
+        # integer), giving e.g. "42" then "42.2" — still at most three
+        # components, and ordered the way App Store Connect compares them.
+        #
+        # Apple also requires each upload to sort *above* the last one consumed
+        # for the same marketing version. The one hand-uploaded 2.4.0 build used
+        # CFBundleVersion 2.4.0, and dotted-integer comparison makes any run
+        # number from 3 up ("N" reads as N.0.0) beat it. The counter is already
+        # past that, so it only ever climbs from here.
         #
         # Safe to edit the archive at this point: it was built unsigned, and the
         # export step below is what signs it, so the seal is computed over this
@@ -285,14 +299,23 @@ jobs:
             exit 1
           fi
 
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $GITHUB_RUN_NUMBER" "$app/Info.plist"
+          build="$GITHUB_RUN_NUMBER"
+          if [ "${GITHUB_RUN_ATTEMPT:-1}" != "1" ]; then
+            build="$GITHUB_RUN_NUMBER.$GITHUB_RUN_ATTEMPT"
+          fi
+
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build" "$app/Info.plist"
           # Keep the archive's own summary metadata consistent; not fatal if the
           # key is absent in a future Xcode's archive layout.
-          /usr/libexec/PlistBuddy -c "Set :ApplicationProperties:CFBundleVersion $GITHUB_RUN_NUMBER" \
+          /usr/libexec/PlistBuddy -c "Set :ApplicationProperties:CFBundleVersion $build" \
             "$archive/Info.plist" 2>/dev/null || true
 
           short="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Info.plist")"
-          echo "::notice::Version $short, build $GITHUB_RUN_NUMBER"
+          echo "::notice::Version $short, build $build"
+          # Handed to the verify step so it asserts against what was actually
+          # stamped rather than recomputing it and agreeing with itself.
+          echo "IOS_BUILD_NUMBER=$build" >> "$GITHUB_ENV"
+          echo "IOS_SHORT_VERSION=$short" >> "$GITHUB_ENV"
 
       - name: Export signed IPA
         if: steps.signing.outputs.present == 'true'
@@ -431,12 +454,21 @@ jobs:
             echo "::error::CFBundleVersion '$build' is not at most three period-separated integers; App Store Connect will reject it"
             exit 1
           fi
-          if [ "$build" != "$GITHUB_RUN_NUMBER" ]; then
-            echo "::error::CFBundleVersion is '$build', expected the stamped '$GITHUB_RUN_NUMBER'"
+          if [ "$build" != "$IOS_BUILD_NUMBER" ]; then
+            echo "::error::CFBundleVersion is '$build', expected the stamped '$IOS_BUILD_NUMBER'"
             exit 1
           fi
 
-          echo "IPA $ipa: bundle id $EXPECTED_BUNDLE_ID, signed by $authority."
+          # The marketing version is never stamped, only carried through from
+          # tauri.conf.json — so assert it survived export unchanged rather than
+          # trusting that nothing rewrote the plist between archive and IPA.
+          short="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Info.plist")"
+          if [ "$short" != "$IOS_SHORT_VERSION" ]; then
+            echo "::error::CFBundleShortVersionString is '$short', expected '$IOS_SHORT_VERSION'"
+            exit 1
+          fi
+
+          echo "IPA $ipa: bundle id $EXPECTED_BUNDLE_ID, version $short ($build), signed by $authority."
           echo "IPA_PATH=$ipa" >> "$GITHUB_ENV"
 
       - name: Clean up the signing keychain

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -253,6 +253,47 @@ jobs:
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
         run: npx tauri ios build --no-sign
 
+      - name: Stamp a unique build number
+        if: steps.signing.outputs.present == 'true'
+        # App Store Connect permanently consumes a CFBundleVersion per marketing
+        # version, so every upload needs a new one. CFBundleVersion here would
+        # otherwise be the tauri.conf.json version (2.4.0) on every run, and the
+        # second upload of a given version would be refused.
+        #
+        # This is NOT done with `tauri ios build --build-number`: that *appends*
+        # to the version, yielding e.g. "2.4.0.42" — four components, while
+        # CFBundleVersion may contain at most three period-separated integers.
+        # App Store Connect rejects that at upload (ITMS-90060), so the flag is
+        # unusable here. Stamping the archive instead keeps the value a single
+        # integer that rises forever and never collides.
+        #
+        # Safe to edit the archive at this point: it was built unsigned, and the
+        # export step below is what signs it, so the seal is computed over this
+        # plist rather than invalidated by it. CFBundleShortVersionString — the
+        # version users actually see — is deliberately left alone.
+        run: |
+          set -euo pipefail
+          gen="apps/geolibre-desktop/src-tauri/gen/apple"
+          archive="$(find "$gen/build" -maxdepth 1 -name '*.xcarchive' | head -1)"
+          if [ -z "$archive" ]; then
+            echo "::error::No .xcarchive produced under $gen/build"
+            exit 1
+          fi
+          app="$(find "$archive/Products/Applications" -maxdepth 1 -name '*.app' | head -1)"
+          if [ -z "$app" ]; then
+            echo "::error::No .app inside $archive"
+            exit 1
+          fi
+
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $GITHUB_RUN_NUMBER" "$app/Info.plist"
+          # Keep the archive's own summary metadata consistent; not fatal if the
+          # key is absent in a future Xcode's archive layout.
+          /usr/libexec/PlistBuddy -c "Set :ApplicationProperties:CFBundleVersion $GITHUB_RUN_NUMBER" \
+            "$archive/Info.plist" 2>/dev/null || true
+
+          short="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Info.plist")"
+          echo "::notice::Version $short, build $GITHUB_RUN_NUMBER"
+
       - name: Export signed IPA
         if: steps.signing.outputs.present == 'true'
         env:
@@ -379,6 +420,19 @@ jobs:
 
           if [ ! -f "$app/embedded.mobileprovision" ]; then
             echo "::error::$ipa has no embedded provisioning profile"
+            exit 1
+          fi
+
+          # CFBundleVersion must be at most three period-separated integers or
+          # App Store Connect rejects the upload (ITMS-90060) — after the whole
+          # build. Assert the shape here, where it costs nothing.
+          build="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Info.plist")"
+          if ! printf '%s' "$build" | grep -qE '^[0-9]+(\.[0-9]+){0,2}$'; then
+            echo "::error::CFBundleVersion '$build' is not at most three period-separated integers; App Store Connect will reject it"
+            exit 1
+          fi
+          if [ "$build" != "$GITHUB_RUN_NUMBER" ]; then
+            echo "::error::CFBundleVersion is '$build', expected the stamped '$GITHUB_RUN_NUMBER'"
             exit 1
           fi
 

--- a/apps/geolibre-desktop/src-tauri/Info.ios.plist
+++ b/apps/geolibre-desktop/src-tauri/Info.ios.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
   iOS-only Info.plist keys, merged into the generated
-  gen/apple/geolibre_iOS/Info.plist at build time (gen/apple is generated and
-  git-ignored, so per-key overrides must live here to survive regeneration).
+  gen/apple/geolibre-desktop_iOS/Info.plist at build time (gen/apple is generated
+  and git-ignored, so per-key overrides must live here to survive regeneration;
+  the directory is named from the Cargo package, not from productName).
   Tauri v2 merges src-tauri/Info.plist (all Apple), Info.ios.plist (iOS), and
-  Info.macos.plist (macOS).
+  Info.macos.plist (macOS). The merge runs during `tauri ios build`/`dev`, not
+  during `tauri ios init`.
 
   The location string is REQUIRED, not cosmetic: unlike Android — where the
   geolocation plugin declares the runtime permission and the OS shows a generic
@@ -21,5 +23,21 @@
   <dict>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>GeoLibre uses your location to center the map, capture GPS points during Field Collection, and record GPS tracks.</string>
+
+    <!--
+      Export compliance. App Store Connect asks about encryption on *every*
+      upload, and a build with the question unanswered cannot be submitted or
+      sent to TestFlight ("Missing Compliance"). Declaring it here answers it
+      once, at build time, instead of by hand per upload.
+
+      `false` asserts that GeoLibre's use of encryption is limited to what Apple
+      treats as exempt: HTTPS/TLS through the system libraries for basemap
+      tiles, geocoding, the AI assistant, cloud catalogs, and the collaboration
+      relay. GeoLibre ships no cryptography of its own and implements no custom
+      encryption. Revisit this if that ever changes — it is a legal declaration,
+      not a build flag.
+    -->
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
   </dict>
 </plist>

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -18,12 +18,10 @@ demand (same as the desktop and Android builds).
 >   archived, exported under manual signing, verified the signature, and
 >   published the `geolibre-ios-ipa` artifact.
 >
-> What has **not** happened: any App Store Connect upload or review submission.
-> Uploading additionally needs an App Store Connect app record for the bundle id,
-> and a `CFBundleVersion` that increases on every upload — it is currently the
-> `tauri.conf.json` version, so a second upload of the same version is rejected
-> (pass `tauri ios build --build-number ...`). Everything below still has to be
-> run on a Mac (iOS cannot be cross-compiled from Linux).
+> A first build (version 2.4.0, build 2.4.0) has been uploaded to App Store
+> Connect by hand via Transporter. What has **not** happened: any submission for
+> review. Everything below still has to be run on a Mac (iOS cannot be
+> cross-compiled from Linux).
 
 ## What works on iOS vs desktop
 
@@ -293,10 +291,25 @@ onboarding.
    handling — not a wrapper that loads a remote URL. Keep it that way: ship the
    web assets in the binary (the default here), don't point the webview at
    `geolibre.app`.
-3. **Upload** the `.ipa` from the `geolibre-ios-ipa` CI artifact (or Xcode) to a
-   TestFlight build, then submit that build for App Store review. The build
-   number (`CFBundleVersion`) is derived from the version in `tauri.conf.json`
-   and must increase on every upload.
+3. **Upload** the `.ipa` from the `geolibre-ios-ipa` CI artifact (or via
+   Transporter / Xcode Organizer) to a TestFlight build, then submit that build
+   for App Store review.
+
+   **Build numbers.** App Store Connect consumes a `CFBundleVersion`
+   permanently per marketing version, so every upload needs a fresh one. CI
+   stamps the archive's `CFBundleVersion` with `$GITHUB_RUN_NUMBER` — a single
+   integer that only ever rises — while `CFBundleShortVersionString` keeps
+   tracking `tauri.conf.json` and stays the version users see.
+
+   This is deliberately **not** done with `tauri ios build --build-number`:
+   that flag *appends* to the version, producing e.g. `2.4.0.42`. A
+   `CFBundleVersion` may hold at most **three** period-separated integers, so
+   App Store Connect rejects a four-component value at upload
+   (`ITMS-90060`) — after the whole build has run. The verify step asserts the
+   shape for that reason.
+
+   Uploading by hand (no CI) means setting the build number yourself if the
+   marketing version has been uploaded before.
 4. **Store listing:** icon (already generated under `src-tauri/icons/ios`),
    screenshots for the required device sizes (6.7" and 6.5" iPhone, plus 12.9"
    iPad — a GIS workspace is genuinely iPad-appropriate), description, keywords.
@@ -306,21 +319,25 @@ onboarding.
    collected by a backend. Point the privacy policy URL at the published
    [privacy policy](privacy.md).
 6. **Age rating** questionnaire and category (Navigation or Productivity).
-7. **Export compliance.** App Store Connect asks about encryption on *every*
-   upload, and an unanswered build cannot be submitted or sent to testers. To
-   answer it once instead of per upload, add the key to
-   `src-tauri/Info.ios.plist`:
+7. **Export compliance.** Already declared in `src-tauri/Info.ios.plist`:
 
    ```xml
    <key>ITSAppUsesNonExemptEncryption</key>
    <false/>
    ```
 
-   `false` is the right answer only if GeoLibre's use of encryption stays
-   limited to what Apple treats as exempt — HTTPS/TLS via the system libraries
-   for tiles, geocoding, the AI assistant, and the collaboration relay. That is
-   true today, but it is a **legal declaration**, so confirm it before adding the
-   key, and revisit it if the app ever ships its own cryptography.
+   App Store Connect asks about encryption on *every* upload, and a build with
+   the question unanswered cannot be submitted or sent to testers ("Missing
+   Compliance"). Declaring it in the plist answers it once, at build time.
+
+   `false` asserts that GeoLibre's use of encryption stays limited to what Apple
+   treats as exempt — HTTPS/TLS via the system libraries for tiles, geocoding,
+   the AI assistant, cloud catalogs, and the collaboration relay — and that the
+   app ships no cryptography of its own. That holds today, but it is a **legal
+   declaration**, not a build flag: revisit it if that ever changes.
+
+   Builds uploaded before this key was added (the first 2.4.0 upload) still
+   need the question answered by hand in App Store Connect.
 
 ## Known limitations / follow-ups
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -296,10 +296,18 @@ onboarding.
    for App Store review.
 
    **Build numbers.** App Store Connect consumes a `CFBundleVersion`
-   permanently per marketing version, so every upload needs a fresh one. CI
-   stamps the archive's `CFBundleVersion` with `$GITHUB_RUN_NUMBER` — a single
-   integer that only ever rises — while `CFBundleShortVersionString` keeps
-   tracking `tauri.conf.json` and stays the version users see.
+   permanently per marketing version, and each upload must also sort above the
+   last one consumed, so every upload needs a fresh, higher value. CI stamps the
+   archive's `CFBundleVersion` with `$GITHUB_RUN_NUMBER` — an integer that only
+   ever rises — while `CFBundleShortVersionString` keeps tracking
+   `tauri.conf.json` and stays the version users see.
+
+   Re-running an existing run appends `$GITHUB_RUN_ATTEMPT` (`42` becomes
+   `42.2`), because the run number itself is fixed for a run's lifetime: without
+   the suffix, re-running a run whose IPA was already uploaded would regenerate
+   the same build number. The one hand-uploaded 2.4.0 build used `2.4.0`, which
+   a bare run number of 3 or more already beats under Apple's dotted-integer
+   comparison.
 
    This is deliberately **not** done with `tauri ios build --build-number`:
    that flag *appends* to the version, producing e.g. `2.4.0.42`. A


### PR DESCRIPTION
Follow-up to #1546, closing the two gaps that block a *repeatable* App Store upload. The first `2.4.0` build has now been uploaded by hand via Transporter, so both are live problems rather than theoretical.

## Build numbers

App Store Connect consumes a `CFBundleVersion` permanently per marketing version. Ours was always the `tauri.conf.json` version (`2.4.0`), so the **second** upload of any version would be refused — including a rebuild after a review rejection.

**The obvious fix is a trap.** `tauri ios build --build-number` *appends* to the version:

```
--build-number 42  →  CFBundleVersion = 2.4.0.42
```

That's four period-separated integers; `CFBundleVersion` allows at most **three**. App Store Connect rejects it (`ITMS-90060`) — after a full macOS build has run. I only found this by trying it, having initially recommended exactly that flag.

Instead CI stamps the archive's `CFBundleVersion` with `$GITHUB_RUN_NUMBER`, a single integer that only rises. Editing the archive is safe at that point: it is built **unsigned** and the export step is what signs it, so the seal is computed *over* the edited plist rather than invalidated by it. `CFBundleShortVersionString` is untouched, so users still see `2.4.0`.

The verify step now also asserts `CFBundleVersion` is ≤3 integers **and** equals the stamp, so a regression fails in CI instead of at upload.

## Export compliance

`ITSAppUsesNonExemptEncryption = false` in `Info.ios.plist`. Without it, every upload lands as **"Missing Compliance"** and cannot be submitted or sent to TestFlight until answered by hand in the web UI.

The comment records the basis rather than just the value: encryption limited to system HTTPS/TLS (tiles, geocoding, AI assistant, cloud catalogs, collaboration relay), no bundled cryptography, and that it is a legal declaration to revisit if that changes.

Also fixes a stale `geolibre_iOS` path in that file's comment — the generated directory is `geolibre-desktop_iOS`, named from the Cargo package, same error already corrected in the docs.

## Verification

Run locally end to end, not just reasoned about:

- `ITSAppUsesNonExemptEncryption` confirmed present in the **generated** plist after a real build (the merge happens at build time, so it needed checking rather than assuming).
- Stamped a real archive, exported, and confirmed the signature is still valid over the modified plist: `codesign --verify --deep --strict` → valid, `Apple Distribution: Qiusheng Wu`.
- Resulting signed IPA: version `2.4.0`, build `5`, `org.geolibre.app`, embedded App Store profile, `encryption declared: false`.
- The new shape gate rejects `2.4.0.42` and `1.2.3.4`, accepts `5` / `42` / `2.4.0`.
- Workflow YAML parses; every `run:` block passes `bash -n`.

Next CI build number will be **5**, which sorts above the already-uploaded `2.4.0`.

## Note

The build already in App Store Connect predates this key, so its "Missing Compliance" still has to be answered by hand. Only future builds are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced iOS CI build stamping by setting a unique, App Store–compatible `CFBundleVersion` per run (using run number and attempt for re-runs) while keeping the short version tied to project config.
  * Strengthened signed IPA verification to validate both `CFBundleVersion` format and exact match to the stamped value, plus `CFBundleShortVersionString` alignment.
  * Added an iOS App Store encryption compliance declaration (`ITSAppUsesNonExemptEncryption=false`) for build-time submission clarity.
* **Documentation**
  * Updated iOS publishing guidance to match the new CI `CFBundleVersion` stamping, explain re-run behavior, and cover manual upload requirements and encryption question handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->