### PR TITLE
fix(mobile): correct the app name on iOS and collapse Style by default

### DIFF
--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' asset: data: blob: https: http://asset.localhost http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' asset: data: blob: https: http://asset.localhost; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; frame-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost asset: data: blob: https: http://asset.localhost http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' asset: data: blob: https: http://asset.localhost; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; frame-src 'self' http://127.0.0.1:* http://localhost:* https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "assetProtocol": {
         "enable": true,
         "scope": []

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -84,6 +84,7 @@ import type { ProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import { useVectorTileGeometryBackfill } from "../../hooks/useVectorTileGeometryBackfill";
 import type { ThemeMode } from "../../hooks/useThemeMode";
+import { isMobile } from "../../lib/is-mobile";
 import { isTauri } from "../../lib/tauri-io";
 import { isMaptoolkitBasemapActive } from "../../lib/maptoolkit-basemap";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
@@ -1386,7 +1387,11 @@ export function TopToolbar({
   // its trigger Button this class instead of `toolbarButtonClass`.
   const toolbarSecondaryButtonClass = cn(toolbarButtonClass, "hidden md:inline-flex");
   const toolbarIconClassName = cn("h-3.5 w-3.5", showLabels && "sm:me-1");
-  const appTitle = isTauri() ? "GeoLibre Desktop" : "GeoLibre";
+  // "GeoLibre Desktop" is the *desktop* product name. `isTauri()` alone is true
+  // on iOS and Android too — where the app is named plain "GeoLibre" (the bundle
+  // name from tauri.ios.conf.json, the home-screen icon, and the store listing),
+  // so titling it "GeoLibre Desktop" there contradicts every other surface.
+  const appTitle = isTauri() && !isMobile() ? "GeoLibre Desktop" : "GeoLibre";
   const renderToolbarLabel = (label: string) =>
     showLabels ? <span className="hidden sm:inline">{label}</span> : null;
   const chrome: ToolbarChrome = {

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -84,6 +84,7 @@ import {
   useState,
 } from "react";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
+import { isMobile } from "../../lib/is-mobile";
 import { loadedVectorTileFeatures } from "../../hooks/useVectorTileGeometryBackfill";
 import { clamp } from "../../lib/clamp";
 import {
@@ -962,7 +963,14 @@ export function StylePanel({
   const updateLayer = useAppStore((s) => s.updateLayer);
   const moveLayer = useAppStore((s) => s.moveLayer);
   const projectName = useAppStore((s) => s.projectName);
-  const [internalCollapsed, setInternalCollapsed] = useState(getIsMobileViewport);
+  // Start collapsed on a narrow viewport *or* on a mobile platform. The viewport
+  // check alone misses the iPad: it is ~1024pt wide, so it reads as a desktop
+  // and opens Layers and Style at once, squeezing the map into a narrow strip
+  // between them. Initial state only — the user can expand the panel, and the
+  // choice sticks for the session.
+  const [internalCollapsed, setInternalCollapsed] = useState(
+    () => getIsMobileViewport() || isMobile(),
+  );
   // In the shared right-sidebar mode the parent owns collapse (controlled);
   // otherwise the panel manages it locally. `setIsCollapsed` routes to whichever
   // owner applies so every existing call site keeps working.


### PR DESCRIPTION
Found while capturing App Store screenshots on the iPad simulator — the first time GeoLibre has actually **run** on iOS rather than merely being built and signed.

## App name

```ts
// before
const appTitle = isTauri() ? "GeoLibre Desktop" : "GeoLibre";
```

`isTauri()` is true on iOS and Android too, so the iPad titlebar read **"GeoLibre Desktop"** while the home-screen icon, the bundle name from `tauri.ios.conf.json`, and the App Store listing all say **"GeoLibre"**. It appears in the top-left of every iPad screenshot.

Gated on `!isMobile()`, which already handles iPadOS's desktop-class user agent via `maxTouchPoints` — a plain UA check would miss the iPad.

## Style panel default

It already started collapsed via `getIsMobileViewport()` — but that is a *viewport-width* test, and an iPad is ~1024pt wide, so it read as a desktop. Layers and Style both opened and squeezed the map into a vertical strip about a third of the window. It reads as broken rather than dense.

Now also considers the platform, so a large screen on a mobile device still starts collapsed. **Initial state only** — the user can expand the panel and it stays open for the session. (Reusing the existing `autoCollapse` prop would have re-collapsed it on every render.)

| | before | after |
|---|---|---|
| Title | GeoLibre Desktop | **GeoLibre** |
| Style panel | expanded | **collapsed to rail** |
| Map width | ~1/3 of window | ~2/3 |

## CSP

Adds `ipc:` and `http://ipc.localhost` to `connect-src`. Tauri v2 injects these only when it generates the CSP; this app defines a **custom** one, so the IPC origin was never allowlisted — the same treatment `asset:` / `http://asset.localhost` already receive. Both spellings are required because the scheme differs by platform (`ipc://localhost` on iOS/macOS/Linux, `http://ipc.localhost` on Windows/Android).

**Honest caveat:** this is *not* confirmed to silence the "IPC custom protocol failed, Tauri will now use the postMessage interface" startup warning, which is what prompted the change. Evidence points elsewhere:

- `diagnostics.ts` attributes it to the custom protocol still being registered on the first call (issues #332, #657), not to a policy denial
- no CSP violation appears anywhere in the iOS log
- the failing calls are the earliest startup ones (`load_external_plugin_bundles`, `read_admin_profile`), consistent with a race

The warning is also already handled by design — downgraded to a warning and kept out of the console, while still recorded in the diagnostics panel. The CSP entries are correct to have regardless, and would matter once the protocol does register.

## Verification

- Both UI fixes confirmed on the iPad Pro 13" simulator (iOS 26.5) with before/after screenshots.
- `tsc -b` clean.
- Frontend suite: 4317/4322 pass. The 4 failures are `tests/metainfo-generated.test.ts`, which fails identically on clean `main` — `scripts/render-linux-metainfo.sh` uses `date -d`, a GNU extension absent from BSD/macOS `date`. Passes on Linux CI; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile device detection so the Style panel starts collapsed on devices such as iPad.
  * Updated product branding to display the appropriate title across desktop and mobile environments.
  * Improved desktop app communication for more reliable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->