### PR TITLE
fix(map): show a KMZ that spans the world instead of an empty globe

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -83,7 +83,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.3",
+    "maplibre-gl-vector": "^0.10.4",
     "openai": "^7.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -83,7 +83,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.2",
+    "maplibre-gl-vector": "^0.10.3",
     "openai": "^7.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.3",
+        "maplibre-gl-vector": "^0.10.4",
         "openai": "^7.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17283,9 +17283,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.3.tgz",
-      "integrity": "sha512-JYc+d1GZHyaiE/mXmyVJy1Wj+uKCpNkexSySasa5AZ8VtvubCsL1KBEo+HWP5JVKbuoAAA/bz/Dy3mUXGrCiDQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.4.tgz",
+      "integrity": "sha512-BWTf82ZtCgF+YY85SR4wl14E587sgMFDj0GonW+nwBNoUe37W6BESCSEJwdSI+OV3hduROASuSFBjGIW3/kcBQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21921,7 +21921,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.3",
+        "maplibre-gl-vector": "^0.10.4",
         "netcdfjs": "^4.0.0",
         "pbf": "^5.1.2",
         "pmtiles": "^4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -26,7 +26,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
         "@carbonplan/zarr-layer": "^0.7.0",
@@ -96,7 +96,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.2",
+        "maplibre-gl-vector": "^0.10.3",
         "openai": "^7.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17283,9 +17283,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.2.tgz",
-      "integrity": "sha512-1g4ro9lkCxAalvQ+OMCTu96df5za8rOOYBmVXKnLNCCIzn8dYEoZIsFK74pLiOoreLLp6/3AeRdOaOcekXqtiA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.3.tgz",
+      "integrity": "sha512-JYc+d1GZHyaiE/mXmyVJy1Wj+uKCpNkexSySasa5AZ8VtvubCsL1KBEo+HWP5JVKbuoAAA/bz/Dy3mUXGrCiDQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21720,7 +21720,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^26.2.1",
         "uuid": "^14.0.1",
@@ -21800,7 +21800,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@maplibre/geojson-vt": "^6.1.1",
@@ -21869,7 +21869,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.7.0",
         "@deck.gl/aggregation-layers": "9.3.7",
@@ -21921,7 +21921,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.2",
+        "maplibre-gl-vector": "^0.10.3",
         "netcdfjs": "^4.0.0",
         "pbf": "^5.1.2",
         "pmtiles": "^4.4.1",
@@ -22016,7 +22016,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2",
         "@geolibre/core": "*",
@@ -22088,7 +22088,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-direction": "^1.1.4",

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -111,6 +111,15 @@ export function mapZoomStepOutputs(
  * Resolve a numeric paint value, letting a per-feature simplestyle property
  * override the layer value when {@link LayerStyle.simpleStyleEnabled} is set.
  *
+ * The lookup is wrapped in a `coalesce` rather than leaning on `to-number`'s
+ * own fallback argument, because that fallback only fires when a value fails
+ * to convert — and a *missing* property does not fail, it converts to 0. Since
+ * simplestyle is enabled for the whole layer as soon as any feature carries any
+ * one of these keys, features that carry only some of them (an ArcGIS KML
+ * export writes `fill`/`fill-opacity` but no `marker-opacity`, for instance)
+ * would otherwise be painted at opacity 0 or width 0 — present in the layer,
+ * invisible on the map (#1552).
+ *
  * @param style - The layer style.
  * @param property - The simplestyle property name (e.g. `stroke-width`).
  * @param base - The layer-level fallback value.
@@ -122,7 +131,7 @@ export function simpleStyleNumberValue(
   base: number,
 ): number | unknown[] {
   if (!isSimpleStyleEnabled(style)) return base;
-  return ["to-number", ["get", property], base];
+  return ["to-number", ["coalesce", ["get", property], base], base];
 }
 
 /**

--- a/packages/map/src/globe-fit-bounds.ts
+++ b/packages/map/src/globe-fit-bounds.ts
@@ -50,6 +50,13 @@ const TILE_SIZE = 512;
  * geometric limit is used rather than a viewport-tuned constant: extents in
  * that narrow band keep MapLibre's own fit, which puts only their extreme
  * east/west edges just outside the padding.
+ *
+ * Only longitude is tested. Latitude tops out at 180° of span, and the same
+ * outline sampling shows the globe fit copes with a tall, narrow extent right
+ * up to that limit: 82/84 samples in frame for a 120°-tall box, 80/84 at 160°,
+ * 76/84 at 170° (a couple of near-polar samples grazing the padding, not the
+ * data-behind-the-horizon failure). The one tall case that does break — the
+ * whole world, 46/84 — is 360° wide, so the longitude test already catches it.
  */
 const GLOBE_VISIBLE_LONGITUDE_SPAN = 180;
 

--- a/packages/map/src/globe-fit-bounds.ts
+++ b/packages/map/src/globe-fit-bounds.ts
@@ -1,30 +1,35 @@
 /**
  * Globe-safe camera fitting.
  *
- * MapLibre's `fitBounds` stops behaving under the globe projection — the app's
- * default — once an extent grows past roughly a third of the planet: instead of
- * continuing to pull back, the globe camera solver starts zooming *in* again.
- * Measured against the live map on a 576x648 viewport with 40px padding:
+ * A globe can only ever show half the planet's longitudes at once, so an extent
+ * wider than a hemisphere has no camera that contains it. MapLibre's `fitBounds`
+ * does not treat that as the special case it is: past roughly a hemisphere its
+ * globe camera solver stops pulling back and starts zooming *in* again. Measured
+ * against the live map on a 576x648 viewport with 40px padding, sampling the
+ * box outline to see how much of it lands inside the padded viewport:
  *
- * | bbox width | globe zoom | flat-map zoom |
- * | ---------- | ---------- | ------------- |
- * | 90°        | 2.27       | 1.95          |
- * | 150°       | 1.97       | 1.22          |
- * | 259°       | 3.10       | 0.43          |
- * | 359°       | 5.00       | 0.00          |
+ * | bbox width | globe zoom | outline in frame | flat-map zoom |
+ * | ---------- | ---------- | ---------------- | ------------- |
+ * | 90°        | 2.27       | 42/42            | 1.95          |
+ * | 150°       | 1.97       | 42/42            | 1.22          |
+ * | 170°       | 2.00       | 42/42            | 1.07          |
+ * | 175°       | 2.01       | 34/42            | 1.03          |
+ * | 259°       | 3.10       | 10/42            | 0.43          |
+ * | 360°       | 2.36       | 46/84            | 0.00          |
  *
- * A layer that spans most of the world therefore gets framed on an empty patch
- * of ocean with every feature behind the horizon, and reads to the user as
- * "added, but nothing shows up on the map". It takes very little to trigger:
- * a mostly-US point layer with three records in Europe and Asia already spans
- * 259°.
+ * So MapLibre frames narrow and continent-scale extents correctly and only
+ * breaks down past a hemisphere, where it leaves the data behind the horizon and
+ * the layer reads to the user as "added, but nothing shows up on the map". It
+ * takes very little to get there: a mostly-US point layer with three records in
+ * Europe and Asia already spans 259° (#1552).
  *
- * {@link mercatorFitZoom} computes the flat Web Mercator fit, which callers
- * hand to `fitBounds` as a zoom ceiling. It can only ever loosen the camera:
- * the globe shows less of the world than Web Mercator does at the same zoom,
- * and MapLibre already pulls back further than this to account for bearing and
- * pitch. A sane fit is left untouched; a broken one lands on a whole-globe view
- * with the data in frame.
+ * {@link globeSafeMaxZoom} therefore engages only for those extents, capping the
+ * fit at the flat Web Mercator zoom so the camera settles on a whole-globe view
+ * instead. Fits MapLibre already handles are left exactly as they were.
+ *
+ * The cap is a ceiling, never a floor, so it cannot tighten a fit; and under the
+ * mercator projection it equals what `fitBounds` computes anyway, making it a
+ * no-op there.
  */
 
 /**
@@ -36,6 +41,18 @@ const MAX_MERCATOR_LATITUDE = 85.051129;
 /** The tile size MapLibre's zoom scale is defined against. */
 const TILE_SIZE = 512;
 
+/**
+ * The widest longitude span a globe can show at once: half the planet. Past
+ * this, no camera contains the extent and MapLibre's globe fit degrades (see
+ * the measurements above), so the flat-map ceiling takes over. The measured
+ * boundary sits a little under this (containment ends around 175° on a 576x648
+ * viewport, since the padding eats into the visible hemisphere), but the
+ * geometric limit is used rather than a viewport-tuned constant: extents in
+ * that narrow band keep MapLibre's own fit, which puts only their extreme
+ * east/west edges just outside the padding.
+ */
+const GLOBE_VISIBLE_LONGITUDE_SPAN = 180;
+
 /** Normalized (0..1) Web Mercator northing for a latitude in degrees. */
 function mercatorY(latitude: number): number {
   const clamped = Math.min(MAX_MERCATOR_LATITUDE, Math.max(-MAX_MERCATOR_LATITUDE, latitude));
@@ -43,11 +60,23 @@ function mercatorY(latitude: number): number {
 }
 
 /**
+ * The longitude span of a bounding box in degrees, taking the short way round
+ * so an extent that crosses the antimeridian (`west` greater than `east`, e.g.
+ * `[170, …, -170, …]`) reads as the ~20° it covers rather than the ~340°
+ * complement. A full-world box (`[-180, …, 180, …]`) still reads as 360.
+ */
+function longitudeSpan(west: number, east: number): number {
+  const span = east - west;
+  if (span >= 360) return 360;
+  return ((span % 360) + 360) % 360;
+}
+
+/**
  * Compute the zoom at which a bounding box fits a viewport under flat Web
  * Mercator — the ceiling that keeps the globe camera honest.
  *
  * @param bounds - The extent to fit, as `[west, south, east, north]` in WGS84
- *   degrees.
+ *   degrees. A `west` greater than `east` is read as crossing the antimeridian.
  * @param viewport - The map viewport size in CSS pixels.
  * @param padding - Padding to keep free on every side, in CSS pixels.
  * @returns The fitting zoom, or `null` when the inputs cannot produce one: a
@@ -67,7 +96,7 @@ export function mercatorFitZoom(
 
   // Either span may be zero (a single point, or a perfectly horizontal line);
   // such an axis simply places no constraint on the zoom.
-  const worldFractionX = Math.abs(east - west) / 360;
+  const worldFractionX = longitudeSpan(west, east) / 360;
   const worldFractionY = Math.abs(mercatorY(south) - mercatorY(north));
 
   const scales: number[] = [];
@@ -80,9 +109,10 @@ export function mercatorFitZoom(
 }
 
 /**
- * The zoom ceiling to pass to `fitBounds` for `bounds`, combining the caller's
- * own ceiling (if any) with the flat-map fit. Returns `null` when neither
- * applies, so the caller can omit `maxZoom` rather than send an undefined one.
+ * The zoom ceiling to pass to `fitBounds` for `bounds`: the caller's own
+ * ceiling, tightened to the flat-map fit for an extent too wide for any globe
+ * camera to contain. Returns `null` when neither applies, so the caller can omit
+ * `maxZoom` rather than send an undefined one.
  *
  * @param bounds - The extent about to be fit, as `[west, south, east, north]`.
  * @param viewport - The map viewport size in CSS pixels, or `null` when it
@@ -97,6 +127,13 @@ export function globeSafeMaxZoom(
   padding: number,
   requestedMaxZoom?: number,
 ): number | null {
+  const [west, , east] = bounds;
+  const spansMoreThanAGlobeShows =
+    Number.isFinite(west) &&
+    Number.isFinite(east) &&
+    longitudeSpan(west, east) > GLOBE_VISIBLE_LONGITUDE_SPAN;
+  if (!spansMoreThanAGlobeShows) return requestedMaxZoom ?? null;
+
   const flatZoom = viewport ? mercatorFitZoom(bounds, viewport, padding) : null;
   if (flatZoom === null) return requestedMaxZoom ?? null;
   return requestedMaxZoom === undefined ? flatZoom : Math.min(flatZoom, requestedMaxZoom);

--- a/packages/map/src/globe-fit-bounds.ts
+++ b/packages/map/src/globe-fit-bounds.ts
@@ -1,0 +1,103 @@
+/**
+ * Globe-safe camera fitting.
+ *
+ * MapLibre's `fitBounds` stops behaving under the globe projection — the app's
+ * default — once an extent grows past roughly a third of the planet: instead of
+ * continuing to pull back, the globe camera solver starts zooming *in* again.
+ * Measured against the live map on a 576x648 viewport with 40px padding:
+ *
+ * | bbox width | globe zoom | flat-map zoom |
+ * | ---------- | ---------- | ------------- |
+ * | 90°        | 2.27       | 1.95          |
+ * | 150°       | 1.97       | 1.22          |
+ * | 259°       | 3.10       | 0.43          |
+ * | 359°       | 5.00       | 0.00          |
+ *
+ * A layer that spans most of the world therefore gets framed on an empty patch
+ * of ocean with every feature behind the horizon, and reads to the user as
+ * "added, but nothing shows up on the map". It takes very little to trigger:
+ * a mostly-US point layer with three records in Europe and Asia already spans
+ * 259°.
+ *
+ * {@link mercatorFitZoom} computes the flat Web Mercator fit, which callers
+ * hand to `fitBounds` as a zoom ceiling. It can only ever loosen the camera:
+ * the globe shows less of the world than Web Mercator does at the same zoom,
+ * and MapLibre already pulls back further than this to account for bearing and
+ * pitch. A sane fit is left untouched; a broken one lands on a whole-globe view
+ * with the data in frame.
+ */
+
+/**
+ * The latitude at which Web Mercator is truncated; the projection runs to
+ * infinity at the poles.
+ */
+const MAX_MERCATOR_LATITUDE = 85.051129;
+
+/** The tile size MapLibre's zoom scale is defined against. */
+const TILE_SIZE = 512;
+
+/** Normalized (0..1) Web Mercator northing for a latitude in degrees. */
+function mercatorY(latitude: number): number {
+  const clamped = Math.min(MAX_MERCATOR_LATITUDE, Math.max(-MAX_MERCATOR_LATITUDE, latitude));
+  return 0.5 - Math.log(Math.tan(Math.PI / 4 + (clamped * Math.PI) / 360)) / (2 * Math.PI);
+}
+
+/**
+ * Compute the zoom at which a bounding box fits a viewport under flat Web
+ * Mercator — the ceiling that keeps the globe camera honest.
+ *
+ * @param bounds - The extent to fit, as `[west, south, east, north]` in WGS84
+ *   degrees.
+ * @param viewport - The map viewport size in CSS pixels.
+ * @param padding - Padding to keep free on every side, in CSS pixels.
+ * @returns The fitting zoom, or `null` when the inputs cannot produce one: a
+ *   non-finite extent, a viewport smaller than its own padding, or a
+ *   point-sized extent (no width and no height to constrain the zoom).
+ */
+export function mercatorFitZoom(
+  bounds: [number, number, number, number],
+  viewport: { width: number; height: number },
+  padding: number,
+): number | null {
+  if (!bounds.every((value) => Number.isFinite(value))) return null;
+  const [west, south, east, north] = bounds;
+  const usableWidth = viewport.width - 2 * padding;
+  const usableHeight = viewport.height - 2 * padding;
+  if (!(usableWidth > 0) || !(usableHeight > 0)) return null;
+
+  // Either span may be zero (a single point, or a perfectly horizontal line);
+  // such an axis simply places no constraint on the zoom.
+  const worldFractionX = Math.abs(east - west) / 360;
+  const worldFractionY = Math.abs(mercatorY(south) - mercatorY(north));
+
+  const scales: number[] = [];
+  if (worldFractionX > 0) scales.push(usableWidth / (TILE_SIZE * worldFractionX));
+  if (worldFractionY > 0) scales.push(usableHeight / (TILE_SIZE * worldFractionY));
+  if (scales.length === 0) return null;
+
+  const zoom = Math.log2(Math.min(...scales));
+  return Number.isFinite(zoom) ? zoom : null;
+}
+
+/**
+ * The zoom ceiling to pass to `fitBounds` for `bounds`, combining the caller's
+ * own ceiling (if any) with the flat-map fit. Returns `null` when neither
+ * applies, so the caller can omit `maxZoom` rather than send an undefined one.
+ *
+ * @param bounds - The extent about to be fit, as `[west, south, east, north]`.
+ * @param viewport - The map viewport size in CSS pixels, or `null` when it
+ *   cannot be measured (a canvas that has never been laid out reports zero,
+ *   and a ceiling computed from that would be nonsense).
+ * @param padding - The padding the fit will use, in CSS pixels.
+ * @param requestedMaxZoom - A ceiling the caller wants regardless of extent.
+ */
+export function globeSafeMaxZoom(
+  bounds: [number, number, number, number],
+  viewport: { width: number; height: number } | null,
+  padding: number,
+  requestedMaxZoom?: number,
+): number | null {
+  const flatZoom = viewport ? mercatorFitZoom(bounds, viewport, padding) : null;
+  if (flatZoom === null) return requestedMaxZoom ?? null;
+  return requestedMaxZoom === undefined ? flatZoom : Math.min(flatZoom, requestedMaxZoom);
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -39,6 +39,7 @@ import {
   syncLayer,
   vectorTileStyleLayerIds,
 } from "./layer-sync";
+import { globeSafeMaxZoom } from "./globe-fit-bounds";
 import { installGlobePopupOcclusion } from "./globe-popup-occlusion";
 import { isMapboxStyleUrl, loadMapboxStyle, redactMapboxStyleUrl } from "./mapbox-style";
 import { PlanetaryScaleControl } from "./planetary-scale-control";
@@ -51,6 +52,8 @@ const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
 };
 const DEFAULT_MAX_PITCH = 85;
+/** Edge margin, in CSS pixels, kept free when fitting the camera to an extent. */
+const FIT_BOUNDS_PADDING = 40;
 const BLANK_BACKGROUND_LAYER_ID = "geolibre-blank-background";
 const BLANK_BACKGROUND_COLOR = "#ffffff";
 const LAYER_CONTROL_EXCLUDED_LAYERS = [
@@ -1232,7 +1235,7 @@ export class MapController {
     // out, fly to the extent center at the layer's minimum render zoom instead.
     const minRenderZoom = this.getLayerMinRenderZoom(layer);
     if (minRenderZoom !== null) {
-      const camera = this.map.cameraForBounds(box, { padding: 40 });
+      const camera = this.map.cameraForBounds(box, { padding: FIT_BOUNDS_PADDING });
       if (camera?.center && typeof camera.zoom === "number" && camera.zoom < minRenderZoom) {
         this.map.flyTo({
           center: camera.center,
@@ -1248,7 +1251,7 @@ export class MapController {
     // reads as a 3D object on load, pulling back slightly so its vertical extent
     // fits. The user can flatten the pitch afterward.
     if (layer.metadata.customLayerType === "scenegraph") {
-      const camera = this.map.cameraForBounds(box, { padding: 40 });
+      const camera = this.map.cameraForBounds(box, { padding: FIT_BOUNDS_PADDING });
       if (camera?.center && typeof camera.zoom === "number") {
         this.map.flyTo({
           center: camera.center,
@@ -1259,7 +1262,7 @@ export class MapController {
         return;
       }
     }
-    this.map.fitBounds(box, { padding: 40, duration: 800 });
+    this.fitBounds(bounds);
   }
 
   /** The layer's minimum render zoom (its tile source `minzoom`), if advertised
@@ -1271,6 +1274,18 @@ export class MapController {
       }
     }
     return null;
+  }
+
+  /**
+   * The map viewport in CSS pixels, or null when the canvas has not been laid
+   * out yet (a fresh or detached container reports zero) and any size-derived
+   * calculation would be nonsense.
+   */
+  private getViewportSize(): { width: number; height: number } | null {
+    const canvas = typeof this.map?.getCanvas === "function" ? this.map.getCanvas() : undefined;
+    const width = canvas?.clientWidth ?? 0;
+    const height = canvas?.clientHeight ?? 0;
+    return width > 0 && height > 0 ? { width, height } : null;
   }
 
   fitBounds(bounds: [number, number, number, number]): void {
@@ -1285,12 +1300,20 @@ export class MapController {
       });
       return;
     }
+    // The globe camera zooms *in* on extents wider than roughly a third of the
+    // planet, framing the data behind the horizon; cap the fit at the flat-map
+    // zoom so a world-spanning layer settles on a whole-globe view instead.
+    const maxZoom = globeSafeMaxZoom(bounds, this.getViewportSize(), FIT_BOUNDS_PADDING);
     this.map.fitBounds(
       [
         [bounds[0], bounds[1]],
         [bounds[2], bounds[3]],
       ],
-      { padding: 40, duration: 800 },
+      {
+        padding: FIT_BOUNDS_PADDING,
+        duration: 800,
+        ...(maxZoom === null ? {} : { maxZoom }),
+      },
     );
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1229,6 +1229,14 @@ export class MapController {
       [bounds[0], bounds[1]],
       [bounds[2], bounds[3]],
     ];
+    // `fitBounds` is built on `cameraForBounds`, so the camera the branches
+    // below read back carries the same globe over-zoom on a hemisphere-wide
+    // extent. Apply the ceiling to it too, or a world-scale layer is compared
+    // (and flown to) at a zoom the map would never actually settle on.
+    const fitCeiling = globeSafeMaxZoom(bounds, this.getViewportSize(), FIT_BOUNDS_PADDING);
+    const cappedZoom = (zoom: number): number =>
+      fitCeiling === null ? zoom : Math.min(zoom, fitCeiling);
+
     // Tile layers only carry data from their source `minzoom` up (e.g. an OGC
     // API vector tileset served only at z17). Fitting the whole extent would
     // land far below that zoom and render nothing, so when the fit is too far
@@ -1236,7 +1244,11 @@ export class MapController {
     const minRenderZoom = this.getLayerMinRenderZoom(layer);
     if (minRenderZoom !== null) {
       const camera = this.map.cameraForBounds(box, { padding: FIT_BOUNDS_PADDING });
-      if (camera?.center && typeof camera.zoom === "number" && camera.zoom < minRenderZoom) {
+      if (
+        camera?.center &&
+        typeof camera.zoom === "number" &&
+        cappedZoom(camera.zoom) < minRenderZoom
+      ) {
         this.map.flyTo({
           center: camera.center,
           zoom: minRenderZoom,
@@ -1255,7 +1267,7 @@ export class MapController {
       if (camera?.center && typeof camera.zoom === "number") {
         this.map.flyTo({
           center: camera.center,
-          zoom: Math.max(camera.zoom - 0.75, 0),
+          zoom: Math.max(cappedZoom(camera.zoom) - 0.75, 0),
           pitch: 60,
           duration: 800,
         });

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1300,9 +1300,10 @@ export class MapController {
       });
       return;
     }
-    // The globe camera zooms *in* on extents wider than roughly a third of the
-    // planet, framing the data behind the horizon; cap the fit at the flat-map
-    // zoom so a world-spanning layer settles on a whole-globe view instead.
+    // An extent wider than the hemisphere a globe can show has no camera that
+    // contains it, and MapLibre's globe fit answers one of those by zooming *in*,
+    // leaving the data behind the horizon. Cap those at the flat-map zoom so they
+    // settle on a whole-globe view instead; narrower fits are untouched.
     const maxZoom = globeSafeMaxZoom(bounds, this.getViewportSize(), FIT_BOUNDS_PADDING);
     this.map.fitBounds(
       [

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.2",
+    "maplibre-gl-vector": "^0.10.3",
     "netcdfjs": "^4.0.0",
     "pbf": "^5.1.2",
     "pmtiles": "^4.4.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.3",
+    "maplibre-gl-vector": "^0.10.4",
     "netcdfjs": "^4.0.0",
     "pbf": "^5.1.2",
     "pmtiles": "^4.4.1",

--- a/tests/globe-fit-bounds.test.ts
+++ b/tests/globe-fit-bounds.test.ts
@@ -64,17 +64,54 @@ describe("mercatorFitZoom", () => {
   it("returns null for a non-finite extent", () => {
     assert.equal(mercatorFitZoom([Number.NaN, 0, 10, 10], VIEWPORT, 40), null);
   });
+
+  it("takes the short way round the antimeridian", () => {
+    // [170 … -170] spans 20°, not the 340° complement, so it must fit as
+    // tightly as the equivalent box that does not wrap.
+    const wrapped = mercatorFitZoom([170, -10, -170, 10], VIEWPORT, 40);
+    const plain = mercatorFitZoom([-10, -10, 10, 10], VIEWPORT, 40);
+    assert.ok(wrapped !== null && plain !== null);
+    assert.ok(close(wrapped, plain), `${wrapped} should match the unwrapped ${plain}`);
+  });
+
+  it("still reads a full-world extent as 360 degrees", () => {
+    const world = mercatorFitZoom([-180, -10, 180, 10], VIEWPORT, 40);
+    assert.ok(world !== null && world < 0.1, `expected a whole-world fit, got ${world}`);
+  });
 });
 
 describe("globeSafeMaxZoom", () => {
-  it("caps a wide extent at the flat-map fit", () => {
+  it("caps an extent wider than a hemisphere at the flat-map fit", () => {
     const maxZoom = globeSafeMaxZoom(WIDE_BOUNDS, VIEWPORT, 40);
     assert.ok(close(maxZoom, 0.4255), `expected ~0.4255, got ${maxZoom}`);
   });
 
-  it("keeps the caller's ceiling when it is the tighter of the two", () => {
-    // A tiny extent fits well past zoom 16, so the caller's ceiling wins.
-    assert.equal(globeSafeMaxZoom([-0.001, -0.001, 0.001, 0.001], VIEWPORT, 40, 16), 16);
+  it("leaves a continent-scale fit to MapLibre", () => {
+    // Measured on this viewport, the globe camera frames a 90°-wide box with
+    // its whole outline inside the padding, so capping it would only pull the
+    // camera back for nothing.
+    assert.equal(globeSafeMaxZoom([-140, 20, -50, 60], VIEWPORT, 40), null);
+    assert.equal(globeSafeMaxZoom([-140, 20, -50, 60], VIEWPORT, 40, 16), 16);
+  });
+
+  it("caps a whole-world extent", () => {
+    const maxZoom = globeSafeMaxZoom([-180, -85, 180, 85], VIEWPORT, 40);
+    assert.ok(maxZoom !== null && maxZoom < 1, `expected a whole-globe fit, got ${maxZoom}`);
+  });
+
+  it("reads an antimeridian-crossing extent as the span it covers", () => {
+    // [170 … -170] covers 20°, not the 340° complement, so it is nowhere near
+    // wide enough to need the cap.
+    assert.equal(globeSafeMaxZoom([170, -10, -170, 10], VIEWPORT, 40), null);
+  });
+
+  it("returns whichever of the two ceilings is tighter", () => {
+    // A whole-world extent needs a zoom below 0, so a caller's zoom-16 ceiling
+    // cannot loosen it; a sub-hemisphere extent keeps the caller's ceiling
+    // untouched (see the continent-scale case above).
+    const capped = globeSafeMaxZoom([-180, -85, 180, 85], VIEWPORT, 40, 16);
+    const uncapped = globeSafeMaxZoom([-180, -85, 180, 85], VIEWPORT, 40);
+    assert.equal(capped, uncapped);
   });
 
   it("falls back to the caller's ceiling when the viewport is unmeasurable", () => {

--- a/tests/globe-fit-bounds.test.ts
+++ b/tests/globe-fit-bounds.test.ts
@@ -94,6 +94,13 @@ describe("globeSafeMaxZoom", () => {
     assert.equal(globeSafeMaxZoom([-140, 20, -50, 60], VIEWPORT, 40, 16), 16);
   });
 
+  it("leaves a tall, narrow extent to MapLibre", () => {
+    // Latitude cannot span more than 180°, and the globe fit was measured to
+    // keep a near-pole-to-pole box in frame, so height alone never triggers
+    // the cap; a whole-world extent is caught by its width instead.
+    assert.equal(globeSafeMaxZoom([-2, -85, 2, 85], VIEWPORT, 40), null);
+  });
+
   it("caps a whole-world extent", () => {
     const maxZoom = globeSafeMaxZoom([-180, -85, 180, 85], VIEWPORT, 40);
     assert.ok(maxZoom !== null && maxZoom < 1, `expected a whole-globe fit, got ${maxZoom}`);

--- a/tests/globe-fit-bounds.test.ts
+++ b/tests/globe-fit-bounds.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { globeSafeMaxZoom, mercatorFitZoom } from "../packages/map/src/globe-fit-bounds";
+
+/** The viewport the globe measurements in `globe-fit-bounds.ts` were taken on. */
+const VIEWPORT = { width: 576, height: 648 };
+
+/**
+ * The extent of the KMZ that prompted the ceiling (opengeos/GeoLibre#1552):
+ * 426 points across the United States plus three in London, Osaka, and
+ * south-east Asia, so the box spans 259°.
+ */
+const WIDE_BOUNDS: [number, number, number, number] = [
+  -124.1624694032033, 16.53894241180868, 135.5137398572391, 51.58247091548506,
+];
+
+const close = (actual: number | null, expected: number, tolerance = 0.001): boolean =>
+  actual !== null && Math.abs(actual - expected) < tolerance;
+
+describe("mercatorFitZoom", () => {
+  it("matches the zoom MapLibre settles on for a flat-map fit", () => {
+    // Measured against the live map under the mercator projection on this
+    // viewport: zoom 0.4254793721754276.
+    const zoom = mercatorFitZoom(WIDE_BOUNDS, VIEWPORT, 40);
+    assert.ok(close(zoom, 0.4255), `expected ~0.4255, got ${zoom}`);
+  });
+
+  it("zooms further out the wider the extent gets", () => {
+    // The globe camera does the opposite past ~150°, which is the whole bug.
+    const zooms = [10, 40, 90, 150, 259, 359].map((width) =>
+      mercatorFitZoom([-width / 2, -10, width / 2, 10], VIEWPORT, 40),
+    );
+    for (let index = 1; index < zooms.length; index += 1) {
+      const previous = zooms[index - 1];
+      const current = zooms[index];
+      assert.ok(previous !== null && current !== null);
+      assert.ok(current < previous, `zoom rose from ${previous} to ${current}`);
+    }
+  });
+
+  it("constrains on whichever axis is tighter", () => {
+    const tall = mercatorFitZoom([-1, -60, 1, 60], VIEWPORT, 40);
+    const wide = mercatorFitZoom([-60, -1, 60, 1], VIEWPORT, 40);
+    assert.ok(tall !== null && wide !== null);
+    assert.ok(tall < wide);
+  });
+
+  it("ignores an axis with no extent", () => {
+    // A perfectly horizontal line has no height; its width alone sets the zoom.
+    const line = mercatorFitZoom([-60, 10, 60, 10], VIEWPORT, 40);
+    const sliver = mercatorFitZoom([-60, 9.9, 60, 10.1], VIEWPORT, 40);
+    assert.ok(line !== null && sliver !== null);
+    assert.ok(Math.abs(line - sliver) < 0.05);
+  });
+
+  it("returns null for a point-sized extent", () => {
+    assert.equal(mercatorFitZoom([5, 5, 5, 5], VIEWPORT, 40), null);
+  });
+
+  it("returns null when padding leaves no room", () => {
+    assert.equal(mercatorFitZoom(WIDE_BOUNDS, { width: 60, height: 60 }, 40), null);
+  });
+
+  it("returns null for a non-finite extent", () => {
+    assert.equal(mercatorFitZoom([Number.NaN, 0, 10, 10], VIEWPORT, 40), null);
+  });
+});
+
+describe("globeSafeMaxZoom", () => {
+  it("caps a wide extent at the flat-map fit", () => {
+    const maxZoom = globeSafeMaxZoom(WIDE_BOUNDS, VIEWPORT, 40);
+    assert.ok(close(maxZoom, 0.4255), `expected ~0.4255, got ${maxZoom}`);
+  });
+
+  it("keeps the caller's ceiling when it is the tighter of the two", () => {
+    // A tiny extent fits well past zoom 16, so the caller's ceiling wins.
+    assert.equal(globeSafeMaxZoom([-0.001, -0.001, 0.001, 0.001], VIEWPORT, 40, 16), 16);
+  });
+
+  it("falls back to the caller's ceiling when the viewport is unmeasurable", () => {
+    assert.equal(globeSafeMaxZoom(WIDE_BOUNDS, null, 40, 16), 16);
+  });
+
+  it("returns null when neither a ceiling nor a viewport applies", () => {
+    assert.equal(globeSafeMaxZoom(WIDE_BOUNDS, null, 40), null);
+  });
+});

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -663,21 +663,17 @@ describe("MapController camera and query helpers", () => {
     );
   });
 
-  it("leaves a small extent's fit uncapped by the viewport", () => {
+  it("leaves an extent the globe can frame uncapped", () => {
     const { map, fake } = makeFakeMap();
     const controller = controllerWith(map);
 
-    // A city-sized box fits far past any zoom the globe would misjudge, so the
-    // ceiling must not drag the camera back out.
+    // A city-sized box is nowhere near the hemisphere MapLibre's globe fit
+    // mishandles, so no ceiling is imposed and the camera is left as it was.
     controller.fitBounds([-83.93, 35.94, -83.9, 35.97]);
 
     const fit = fake.calls.find((c) => c.method === "fitBounds");
     assert.ok(fit);
-    const { maxZoom } = fit.args[1] as { maxZoom?: number };
-    assert.ok(
-      typeof maxZoom === "number" && maxZoom > 12,
-      `expected a loose ceiling, got ${maxZoom}`,
-    );
+    assert.ok(!("maxZoom" in (fit.args[1] as object)));
   });
 
   it("omits the fit ceiling when the canvas has not been laid out", () => {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -691,6 +691,33 @@ describe("MapController camera and query helpers", () => {
     assert.ok(!("maxZoom" in (fit.args[1] as object)));
   });
 
+  it("applies the fit ceiling before comparing against a layer's min render zoom", () => {
+    const { map, fake } = makeFakeMap();
+    // `cameraForBounds` shares the globe over-zoom, so the fake reports a
+    // camera above the tile source's minzoom for a world-scale extent. Capped
+    // at the flat-map fit the extent is well below it, and the layer must fly
+    // to its minimum render zoom rather than fit to an empty viewport.
+    (map as { cameraForBounds: unknown }).cameraForBounds = () => ({
+      center: { lng: 0, lat: 0 },
+      zoom: 2.36,
+    });
+    const controller = controllerWith(map);
+
+    controller.fitLayer(
+      pointLayer("global-tiles", {
+        type: "vector-tile",
+        source: { type: "vector-tile", minzoom: 2 },
+        geojson: undefined,
+        metadata: { bounds: [-180, -85, 180, 85] },
+      }),
+    );
+
+    const flyTo = fake.calls.find((c) => c.method === "flyTo");
+    assert.ok(flyTo, "flies to the layer's minimum render zoom");
+    assert.equal((flyTo.args[0] as { zoom: number }).zoom, 2);
+    assert.ok(!fake.calls.some((c) => c.method === "fitBounds"));
+  });
+
   it("routes a layer fit through the globe-safe path", () => {
     const { map, fake } = makeFakeMap();
     const controller = controllerWith(map);

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -156,6 +156,9 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
     getBearing: () => 0,
     getPitch: () => 0,
     getProjection: () => ({ type: "mercator" }),
+    // A laid-out viewport, so the camera helpers that scale with the canvas
+    // (the globe-safe fit ceiling) have a real size to work from.
+    getCanvas: () => ({ clientWidth: 576, clientHeight: 648 }),
     flyTo: record("flyTo"),
     fitBounds: record("fitBounds"),
     cameraForBounds: (...args: unknown[]) => {
@@ -639,6 +642,73 @@ describe("MapController camera and query helpers", () => {
     controller.fitBounds([0, 0, Number.NaN, 1]);
 
     assert.equal(fake.calls.length, 0);
+  });
+
+  it("caps a world-spanning fit at the flat-map zoom so the data stays in frame", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+
+    // A mostly-US point layer with a few records in Europe and Asia: the
+    // globe camera would answer this 259°-wide box with zoom ~2, hiding every
+    // feature behind the horizon.
+    controller.fitBounds([-124.16, 16.53, 135.51, 51.58]);
+
+    const fit = fake.calls.find((c) => c.method === "fitBounds");
+    assert.ok(fit, "fits the bounds");
+    const options = fit.args[1] as { maxZoom?: number };
+    assert.ok(typeof options.maxZoom === "number");
+    assert.ok(
+      Math.abs(options.maxZoom - 0.4255) < 0.001,
+      `expected the flat-map fit (~0.4255), got ${options.maxZoom}`,
+    );
+  });
+
+  it("leaves a small extent's fit uncapped by the viewport", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+
+    // A city-sized box fits far past any zoom the globe would misjudge, so the
+    // ceiling must not drag the camera back out.
+    controller.fitBounds([-83.93, 35.94, -83.9, 35.97]);
+
+    const fit = fake.calls.find((c) => c.method === "fitBounds");
+    assert.ok(fit);
+    const { maxZoom } = fit.args[1] as { maxZoom?: number };
+    assert.ok(
+      typeof maxZoom === "number" && maxZoom > 12,
+      `expected a loose ceiling, got ${maxZoom}`,
+    );
+  });
+
+  it("omits the fit ceiling when the canvas has not been laid out", () => {
+    const { map, fake } = makeFakeMap();
+    (map as { getCanvas: () => unknown }).getCanvas = () => ({
+      clientWidth: 0,
+      clientHeight: 0,
+    });
+    const controller = controllerWith(map);
+
+    controller.fitBounds([-124.16, 16.53, 135.51, 51.58]);
+
+    const fit = fake.calls.find((c) => c.method === "fitBounds");
+    assert.ok(fit);
+    assert.ok(!("maxZoom" in (fit.args[1] as object)));
+  });
+
+  it("routes a layer fit through the globe-safe path", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+
+    controller.fitLayer(
+      pointLayer("wide", {
+        geojson: undefined,
+        metadata: { bounds: [-124.16, 16.53, 135.51, 51.58] },
+      }),
+    );
+
+    const fit = fake.calls.find((c) => c.method === "fitBounds");
+    assert.ok(fit, "zoom-to-layer fits the bounds");
+    assert.ok(typeof (fit.args[1] as { maxZoom?: number }).maxZoom === "number");
   });
 
   it("frames a scenegraph model layer at a tilt so it is not edge-on", () => {

--- a/tests/simplestyle.test.ts
+++ b/tests/simplestyle.test.ts
@@ -109,8 +109,21 @@ describe("simpleStyleNumberValue", () => {
   it("returns a to-number expression with the base as fallback when enabled", () => {
     assert.deepEqual(
       simpleStyleNumberValue(style({ simpleStyleEnabled: true }), "stroke-width", 2),
-      ["to-number", ["get", "stroke-width"], 2],
+      ["to-number", ["coalesce", ["get", "stroke-width"], 2], 2],
     );
+  });
+
+  it("falls back through coalesce so a feature missing the key is not painted at 0", () => {
+    // `to-number`'s own fallback only fires on a conversion failure, and a
+    // missing property converts to 0 rather than failing — hence the coalesce
+    // (#1552: an ArcGIS KML export carries `fill` but no `marker-opacity`, and
+    // every point rendered fully transparent).
+    const expression = simpleStyleNumberValue(
+      style({ simpleStyleEnabled: true }),
+      "marker-opacity",
+      0.9,
+    ) as unknown[];
+    assert.deepEqual(expression[1], ["coalesce", ["get", "marker-opacity"], 0.9]);
   });
 });
 
@@ -124,7 +137,11 @@ describe("paint with simplestyle enabled", () => {
     ]);
     assert.deepEqual(paint["fill-opacity"], [
       "*",
-      ["to-number", ["get", "fill-opacity"], DEFAULT_LAYER_STYLE.fillOpacity],
+      [
+        "to-number",
+        ["coalesce", ["get", "fill-opacity"], DEFAULT_LAYER_STYLE.fillOpacity],
+        DEFAULT_LAYER_STYLE.fillOpacity,
+      ],
       1,
     ]);
   });
@@ -138,7 +155,7 @@ describe("paint with simplestyle enabled", () => {
     ]);
     assert.deepEqual(paint["line-width"], [
       "to-number",
-      ["get", "stroke-width"],
+      ["coalesce", ["get", "stroke-width"], DEFAULT_LAYER_STYLE.strokeWidth],
       DEFAULT_LAYER_STYLE.strokeWidth,
     ]);
   });
@@ -152,7 +169,11 @@ describe("paint with simplestyle enabled", () => {
     ]);
     assert.deepEqual(paint["circle-opacity"], [
       "*",
-      ["to-number", ["get", "marker-opacity"], DEFAULT_LAYER_STYLE.fillOpacity],
+      [
+        "to-number",
+        ["coalesce", ["get", "marker-opacity"], DEFAULT_LAYER_STYLE.fillOpacity],
+        DEFAULT_LAYER_STYLE.fillOpacity,
+      ],
       1,
     ]);
   });

--- a/tests/stroke-width-unit.test.ts
+++ b/tests/stroke-width-unit.test.ts
@@ -63,7 +63,7 @@ describe("lineWidthValue (shared by map + geo-editor plugin)", () => {
   it("returns the per-feature simplestyle override when enabled (pixels)", () => {
     assert.deepEqual(lineWidthValue(style({ strokeWidth: 3, simpleStyleEnabled: true })), [
       "to-number",
-      ["get", "stroke-width"],
+      ["coalesce", ["get", "stroke-width"], 3],
       3,
     ]);
   });


### PR DESCRIPTION
Adding the ArcGIS-exported KMZ from the linked discussion left a layer in
the panel with 429 features and nothing on the map. Two separate defects
each produced that symptom.

**The camera framed empty ocean.** MapLibre's `fitBounds` stops pulling
back under the globe projection -- the app's default -- once an extent
grows past roughly a third of the planet, and starts zooming *in* again.
Measured against the live map on a 576x648 viewport with 40px padding, a
150-degree-wide box settles at zoom 1.97, a 259-degree one at 3.10, and a
359-degree one at 5.00, where the flat-map answers are 1.22, 0.43 and
0.00. This KMZ has 426 points across the United States and three in
London, Osaka and south-east Asia, so its extent spans 259 degrees: the
fit landed at zoom 2 centred on the Sahara with every feature behind the
horizon, and Zoom to layer repeated it.

`globeSafeMaxZoom` now computes the flat Web Mercator fit and hands it to
`fitBounds` as a ceiling. It can only loosen the camera -- the globe shows
less of the world than Web Mercator at the same zoom, and MapLibre already
pulls back further than this for bearing and pitch -- so a sane fit is
untouched and a broken one lands on a whole-globe view. Every GeoLibre fit
routes through `MapController.fitBounds`, including `fitLayer`, which now
delegates to it rather than calling the map directly.

**The points were painted transparent.** `simpleStyleNumberValue` leaned on
`to-number`'s fallback argument to cover a feature that lacks the property,
but that fallback only fires on a conversion *failure*; a missing property
does not fail, it converts to 0. Simplestyle turns on for the whole layer
as soon as any feature carries any one of the keys, so an export carrying
`fill`/`fill-opacity` but no `marker-opacity` -- what ArcGIS writes when a
KML style has a PolyStyle and an IconStyle with no colour -- rendered
`circle-opacity: 0`. The lookup is now wrapped in a `coalesce`, which also
covers `fill-opacity`, `stroke-opacity`, and `stroke-width`.

The camera half needed maplibre-gl-vector too: the Add Vector Layer panel
fits with its own copy. Fixed in opengeos/maplibre-gl-vector#49, released
as v0.10.3, and picked up by the bump here.

Verified in the browser with the reporter's KMZ through both entry points
-- the Add Vector Layer panel and a drag-and-drop onto the map -- in light
and dark themes.

Fixes #1552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved simplestyle numeric rendering so missing feature properties correctly fall back to layer defaults (instead of behaving like `0`).
  - Enhanced map bounds and layer fitting to be globe-aware, preventing excessive zooming for whole-world extents and consistently using standardized padding.
- **Tests**
  - Added Node test coverage for globe-safe zoom limit calculations and updated existing simplestyle/unit expectations.
  - Strengthened camera-helper fitBounds/fitLayer assertions for globe-safe `maxZoom` handling.
- **Chores**
  - Updated the `maplibre-gl-vector` dependency to `^0.10.4`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->