### PR TITLE
feat(processing): pick a CRS from a searchable list on EPSG parameters

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -99,15 +99,19 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                 role="option"
                 aria-selected={position === activeIndex}
                 id={`${listId}-option-${position}`}
+                // Out of the tab order: with `aria-activedescendant` on the
+                // search box, DOM focus stays there and the arrow keys move a
+                // virtual highlight. Leaving 300 rows as tab stops would also
+                // bury the rest of the form behind them.
+                tabIndex={-1}
                 className={cn(
                   "flex w-full items-baseline justify-between gap-2 px-2 py-1 text-start text-xs hover:bg-accent",
                   position === activeIndex && "bg-accent",
                 )}
                 onMouseEnter={() => setActiveIndex(position)}
-                // click, not mousedown: these are real buttons, so a keyboard
-                // user who tabs onto a row can activate it with Enter/Space,
-                // which fires click and not mousedown. Nothing closes the panel
-                // on pointerdown inside it, so the click still lands.
+                // click, not mousedown: nothing closes the panel on pointerdown
+                // inside it, so the click lands, and a click is what a row
+                // reached by any means fires.
                 onClick={() => choose(entry)}
                 onFocus={() => setActiveIndex(position)}
               >
@@ -121,8 +125,22 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
     );
 
   return (
-    <div className="relative grid gap-1" ref={containerRef}>
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+    <div
+      className="grid gap-1"
+      ref={containerRef}
+      // Tabbing (or clicking) out of the control entirely dismisses the panel.
+      // The rows are not tab stops, so without this a keyboard user who tabs
+      // past the search box would leave an open panel behind with no way to
+      // close it. onBlur is React's focusout, so it fires for focus leaving any
+      // descendant; a relatedTarget still inside the control is not a departure.
+      onBlur={(event) => {
+        if (open && !containerRef.current?.contains(event.relatedTarget as Node | null)) close();
+      }}
+    >
+      {/* The panel's positioning context is this row alone, not the outer
+          container: `top-full` against the container would resolve past the
+          selected-CRS label below, detaching the panel from the button. */}
+      <div className="relative grid grid-cols-[minmax(0,1fr)_auto] gap-2">
         <Input
           id={id}
           type="text"
@@ -141,73 +159,73 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
           <Globe2 className="h-3.5 w-3.5" aria-hidden="true" />
           {t("processing.whitebox.crs.browse")}
         </Button>
-      </div>
 
-      {open ? (
-        <div
-          ref={panelRef}
-          className="absolute top-full z-30 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
-          // On the panel rather than the search box, so Escape dismisses it from
-          // anywhere inside, including a row a keyboard user has tabbed onto.
-          onKeyDown={(event) => {
-            if (event.key === "Escape") {
-              event.preventDefault();
-              close();
-            }
-          }}
-        >
-          <div className="relative border-b p-1.5">
-            <Search
-              className="pointer-events-none absolute start-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <Input
-              ref={searchRef}
-              type="text"
-              role="combobox"
-              aria-expanded
-              // Only while the list is actually rendered: with no matches the
-              // <ul> is replaced by the "no results" message, and pointing at an
-              // id that is not in the DOM tells a screen reader nothing.
-              aria-controls={ordered.length > 0 ? listId : undefined}
-              aria-activedescendant={
-                ordered.length > 0 ? `${listId}-option-${activeIndex}` : undefined
+        {open ? (
+          <div
+            ref={panelRef}
+            className="absolute top-full z-30 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+            // On the panel rather than the search box, so Escape dismisses it
+            // from anywhere inside it.
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                close();
               }
-              aria-label={t("processing.whitebox.crs.searchLabel")}
-              placeholder={t("processing.whitebox.crs.searchPlaceholder")}
-              className="h-8 ps-7 text-xs"
-              value={query}
-              onChange={(event) => {
-                setQuery(event.target.value);
-                setActiveIndex(0);
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "ArrowDown") {
-                  event.preventDefault();
-                  setActiveIndex((index) => Math.min(index + 1, ordered.length - 1));
-                } else if (event.key === "ArrowUp") {
-                  event.preventDefault();
-                  setActiveIndex((index) => Math.max(index - 1, 0));
-                } else if (event.key === "Enter") {
-                  event.preventDefault();
-                  const entry = ordered[activeIndex];
-                  if (entry) choose(entry);
+            }}
+          >
+            <div className="relative border-b p-1.5">
+              <Search
+                className="pointer-events-none absolute start-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <Input
+                ref={searchRef}
+                type="text"
+                role="combobox"
+                aria-expanded
+                // Only while the list is actually rendered: with no matches the
+                // <ul> is replaced by the "no results" message, and pointing at an
+                // id that is not in the DOM tells a screen reader nothing.
+                aria-controls={ordered.length > 0 ? listId : undefined}
+                aria-activedescendant={
+                  ordered.length > 0 ? `${listId}-option-${activeIndex}` : undefined
                 }
-              }}
-            />
+                aria-label={t("processing.whitebox.crs.searchLabel")}
+                placeholder={t("processing.whitebox.crs.searchPlaceholder")}
+                className="h-8 ps-7 text-xs"
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setActiveIndex(0);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setActiveIndex((index) => Math.min(index + 1, ordered.length - 1));
+                  } else if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setActiveIndex((index) => Math.max(index - 1, 0));
+                  } else if (event.key === "Enter") {
+                    event.preventDefault();
+                    const entry = ordered[activeIndex];
+                    if (entry) choose(entry);
+                  }
+                }}
+              />
+            </div>
+            {ordered.length === 0 ? (
+              <p className="px-2 py-2 text-xs text-muted-foreground">
+                {t("processing.whitebox.crs.noResults")}
+              </p>
+            ) : (
+              <ul id={listId} role="listbox" className="max-h-64 overflow-y-auto py-1">
+                {renderGroup(t("processing.whitebox.crs.geographic"), geographic, 0)}
+                {renderGroup(t("processing.whitebox.crs.projected"), projected, geographic.length)}
+              </ul>
+            )}
           </div>
-          {ordered.length === 0 ? (
-            <p className="px-2 py-2 text-xs text-muted-foreground">
-              {t("processing.whitebox.crs.noResults")}
-            </p>
-          ) : (
-            <ul id={listId} role="listbox" className="max-h-64 overflow-y-auto py-1">
-              {renderGroup(t("processing.whitebox.crs.geographic"), geographic, 0)}
-              {renderGroup(t("processing.whitebox.crs.projected"), projected, geographic.length)}
-            </ul>
-          )}
-        </div>
-      ) : null}
+        ) : null}
+      </div>
 
       {selected ? (
         <p className="text-xs text-muted-foreground">{formatCrsLabel(selected)}</p>

--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -104,12 +104,12 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                   position === activeIndex && "bg-accent",
                 )}
                 onMouseEnter={() => setActiveIndex(position)}
-                // mousedown, so the choice lands before the outside-click
-                // handler or the search box's blur can close the panel.
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  choose(entry);
-                }}
+                // click, not mousedown: these are real buttons, so a keyboard
+                // user who tabs onto a row can activate it with Enter/Space,
+                // which fires click and not mousedown. Nothing closes the panel
+                // on pointerdown inside it, so the click still lands.
+                onClick={() => choose(entry)}
+                onFocus={() => setActiveIndex(position)}
               >
                 <span>{entry.name}</span>
                 <span className="shrink-0 tabular-nums text-muted-foreground">{entry.code}</span>
@@ -147,6 +147,14 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
         <div
           ref={panelRef}
           className="absolute top-full z-30 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+          // On the panel rather than the search box, so Escape dismisses it from
+          // anywhere inside, including a row a keyboard user has tabbed onto.
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              close();
+            }
+          }}
         >
           <div className="relative border-b p-1.5">
             <Search
@@ -181,9 +189,6 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                   event.preventDefault();
                   const entry = ordered[activeIndex];
                   if (entry) choose(entry);
-                } else if (event.key === "Escape") {
-                  event.preventDefault();
-                  close();
                 }
               }}
             />

--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -37,6 +37,7 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
   const containerRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const matches = useMemo(() => searchCrsCatalog(query), [query]);
   // Group before ranking is applied to the display: the request was for the list
@@ -50,10 +51,17 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
 
   // Every way of leaving the panel clears the search, so reopening it starts on
   // the curated default list rather than resuming a search the user dismissed.
-  const close = useCallback(() => {
+  //
+  // `restoreFocus` is for the deliberate dismissals (Escape, picking a row, the
+  // toggle): the focused element unmounts with the panel, so without this focus
+  // would land on <body> and the keyboard flow would be lost. It stays off when
+  // focus has already left the control or the user clicked elsewhere, where
+  // pulling focus back to the trigger would fight them.
+  const close = useCallback((restoreFocus = false) => {
     setOpen(false);
     setQuery("");
     setActiveIndex(0);
+    if (restoreFocus) triggerRef.current?.focus();
   }, []);
 
   // Close on a click anywhere outside the control (the panel floats over the
@@ -76,9 +84,19 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
     panelRef.current?.scrollIntoView?.({ block: "nearest" });
   }, [open]);
 
+  // Keep the arrow-key highlight visible. DOM focus stays on the search box, so
+  // the list never scrolls on its own, and a broad query ("utm") returns far
+  // more rows than the capped list shows.
+  useEffect(() => {
+    if (!open || ordered.length === 0) return;
+    document.getElementById(`${listId}-option-${activeIndex}`)?.scrollIntoView?.({
+      block: "nearest",
+    });
+  }, [activeIndex, listId, open, ordered.length]);
+
   const choose = (entry: CrsEntry) => {
     onChange(String(entry.code));
-    close();
+    close(true);
   };
 
   const renderGroup = (label: string, entries: CrsEntry[], offset: number) =>
@@ -150,11 +168,12 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
           onChange={(event) => onChange(event.target.value)}
         />
         <Button
+          ref={triggerRef}
           type="button"
           variant="outline"
           aria-haspopup="listbox"
           aria-expanded={open}
-          onClick={() => (open ? close() : setOpen(true))}
+          onClick={() => (open ? close(true) : setOpen(true))}
         >
           <Globe2 className="h-3.5 w-3.5" aria-hidden="true" />
           {t("processing.whitebox.crs.browse")}
@@ -169,7 +188,7 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
             onKeyDown={(event) => {
               if (event.key === "Escape") {
                 event.preventDefault();
-                close();
+                close(true);
               }
             }}
           >
@@ -201,7 +220,9 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                 onKeyDown={(event) => {
                   if (event.key === "ArrowDown") {
                     event.preventDefault();
-                    setActiveIndex((index) => Math.min(index + 1, ordered.length - 1));
+                    // Floor the ceiling at 0 so an empty result set leaves the
+                    // index at 0 rather than walking it negative.
+                    setActiveIndex((index) => Math.min(index + 1, Math.max(ordered.length - 1, 0)));
                   } else if (event.key === "ArrowUp") {
                     event.preventDefault();
                     setActiveIndex((index) => Math.max(index - 1, 0));

--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -1,0 +1,203 @@
+import { Button, Input, cn } from "@geolibre/ui";
+import { Globe2, Search } from "lucide-react";
+import { type ReactElement, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  type CrsEntry,
+  crsEntryForCode,
+  formatCrsLabel,
+  searchCrsCatalog,
+} from "../../lib/crs-catalog";
+
+export interface CrsPickerInputProps {
+  id: string;
+  /** The parameter's current value: an EPSG code as typed, or blank. */
+  value: string;
+  onChange: (value: unknown) => void;
+}
+
+/**
+ * An EPSG-code field with a searchable CRS list beside it (GeoLibre#1538).
+ *
+ * The text box remains the source of truth and accepts any code, so a system the
+ * curated catalog omits can still be typed; the picker is a shortcut that
+ * searches by name or code and separates geographic from projected systems, the
+ * way QGIS does. Whenever the typed code names a catalog entry, its name is
+ * shown under the field, which also confirms that a remembered code is the CRS
+ * the user meant.
+ *
+ * @param props - The field id, its current value, and an onChange callback.
+ */
+export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): ReactElement {
+  const { t } = useTranslation();
+  const listId = `${useId()}-crs-list`;
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const matches = useMemo(() => searchCrsCatalog(query), [query]);
+  // Group before ranking is applied to the display: the request was for the list
+  // to be split by type, so all geographic hits precede the projected ones while
+  // each group keeps the search's own ordering.
+  const geographic = useMemo(() => matches.filter((m) => m.kind === "geographic"), [matches]);
+  const projected = useMemo(() => matches.filter((m) => m.kind === "projected"), [matches]);
+  // Flat, visual-order list so arrow keys walk the rows as they are rendered.
+  const ordered = useMemo(() => [...geographic, ...projected], [geographic, projected]);
+  const selected = crsEntryForCode(value);
+
+  // Close on a click anywhere outside the control (the panel floats over the
+  // tool form, so there is no backdrop to catch the click).
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    searchRef.current?.focus();
+    // The panel floats inside the tool form's scroll container, which clips it
+    // when the field sits low in a long form. Reveal the whole panel, not just
+    // the field the focus above scrolled to.
+    panelRef.current?.scrollIntoView?.({ block: "nearest" });
+  }, [open]);
+
+  const choose = (entry: CrsEntry) => {
+    onChange(String(entry.code));
+    setOpen(false);
+    setQuery("");
+    setActiveIndex(0);
+  };
+
+  const renderGroup = (label: string, entries: CrsEntry[], offset: number) =>
+    entries.length === 0 ? null : (
+      <>
+        <li
+          role="presentation"
+          className="sticky top-0 bg-popover px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          {label}
+        </li>
+        {entries.map((entry, index) => {
+          const position = offset + index;
+          return (
+            <li key={entry.code}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={position === activeIndex}
+                id={`${listId}-option-${position}`}
+                className={cn(
+                  "flex w-full items-baseline justify-between gap-2 px-2 py-1 text-start text-xs hover:bg-accent",
+                  position === activeIndex && "bg-accent",
+                )}
+                onMouseEnter={() => setActiveIndex(position)}
+                // mousedown, so the choice lands before the outside-click
+                // handler or the search box's blur can close the panel.
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  choose(entry);
+                }}
+              >
+                <span>{entry.name}</span>
+                <span className="shrink-0 tabular-nums text-muted-foreground">{entry.code}</span>
+              </button>
+            </li>
+          );
+        })}
+      </>
+    );
+
+  return (
+    <div className="relative grid gap-1" ref={containerRef}>
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+        <Input
+          id={id}
+          type="text"
+          inputMode="numeric"
+          value={value}
+          placeholder={t("processing.whitebox.crs.codePlaceholder")}
+          onChange={(event) => onChange(event.target.value)}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          onClick={() => setOpen((wasOpen) => !wasOpen)}
+        >
+          <Globe2 className="h-3.5 w-3.5" aria-hidden="true" />
+          {t("processing.whitebox.crs.browse")}
+        </Button>
+      </div>
+
+      {open ? (
+        <div
+          ref={panelRef}
+          className="absolute top-full z-30 mt-1 w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+        >
+          <div className="relative border-b p-1.5">
+            <Search
+              className="pointer-events-none absolute start-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              ref={searchRef}
+              type="text"
+              role="combobox"
+              aria-expanded
+              aria-controls={listId}
+              aria-activedescendant={
+                ordered.length > 0 ? `${listId}-option-${activeIndex}` : undefined
+              }
+              aria-label={t("processing.whitebox.crs.searchLabel")}
+              placeholder={t("processing.whitebox.crs.searchPlaceholder")}
+              className="h-8 ps-7 text-xs"
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault();
+                  setActiveIndex((index) => Math.min(index + 1, ordered.length - 1));
+                } else if (event.key === "ArrowUp") {
+                  event.preventDefault();
+                  setActiveIndex((index) => Math.max(index - 1, 0));
+                } else if (event.key === "Enter") {
+                  event.preventDefault();
+                  const entry = ordered[activeIndex];
+                  if (entry) choose(entry);
+                } else if (event.key === "Escape") {
+                  event.preventDefault();
+                  setOpen(false);
+                }
+              }}
+            />
+          </div>
+          {ordered.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {t("processing.whitebox.crs.noResults")}
+            </p>
+          ) : (
+            <ul id={listId} role="listbox" className="max-h-64 overflow-y-auto py-1">
+              {renderGroup(t("processing.whitebox.crs.geographic"), geographic, 0)}
+              {renderGroup(t("processing.whitebox.crs.projected"), projected, geographic.length)}
+            </ul>
+          )}
+        </div>
+      ) : null}
+
+      {selected ? (
+        <p className="text-xs text-muted-foreground">{formatCrsLabel(selected)}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -1,6 +1,6 @@
 import { Button, Input, cn } from "@geolibre/ui";
 import { Globe2, Search } from "lucide-react";
-import { type ReactElement, useEffect, useId, useMemo, useRef, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type CrsEntry,
@@ -48,16 +48,24 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
   const ordered = useMemo(() => [...geographic, ...projected], [geographic, projected]);
   const selected = crsEntryForCode(value);
 
+  // Every way of leaving the panel clears the search, so reopening it starts on
+  // the curated default list rather than resuming a search the user dismissed.
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setActiveIndex(0);
+  }, []);
+
   // Close on a click anywhere outside the control (the panel floats over the
   // tool form, so there is no backdrop to catch the click).
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+      if (!containerRef.current?.contains(event.target as Node)) close();
     };
     document.addEventListener("pointerdown", onPointerDown);
     return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [open]);
+  }, [close, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -70,9 +78,7 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
 
   const choose = (entry: CrsEntry) => {
     onChange(String(entry.code));
-    setOpen(false);
-    setQuery("");
-    setActiveIndex(0);
+    close();
   };
 
   const renderGroup = (label: string, entries: CrsEntry[], offset: number) =>
@@ -130,7 +136,7 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
           variant="outline"
           aria-haspopup="listbox"
           aria-expanded={open}
-          onClick={() => setOpen((wasOpen) => !wasOpen)}
+          onClick={() => (open ? close() : setOpen(true))}
         >
           <Globe2 className="h-3.5 w-3.5" aria-hidden="true" />
           {t("processing.whitebox.crs.browse")}
@@ -177,7 +183,7 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                   if (entry) choose(entry);
                 } else if (event.key === "Escape") {
                   event.preventDefault();
-                  setOpen(false);
+                  close();
                 }
               }}
             />

--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -166,7 +166,10 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
               type="text"
               role="combobox"
               aria-expanded
-              aria-controls={listId}
+              // Only while the list is actually rendered: with no matches the
+              // <ul> is replaced by the "no results" message, and pointing at an
+              // id that is not in the DOM tells a screen reader nothing.
+              aria-controls={ordered.length > 0 ? listId : undefined}
               aria-activedescendant={
                 ordered.length > 0 ? `${listId}-option-${activeIndex}` : undefined
               }

--- a/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
+++ b/apps/geolibre-desktop/src/components/processing/CrsPickerInput.tsx
@@ -99,47 +99,51 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
     close(true);
   };
 
+  // A named `group` inside the listbox, the ARIA shape for a split option list:
+  // the group carries the name, so a screen reader announces "Geographic" or
+  // "Projected" as the virtual cursor crosses into it, and the sticky heading
+  // that shows the same word visually is hidden from the tree so it is not read
+  // twice. `presentation` on the heading alone would leave the split silent.
   const renderGroup = (label: string, entries: CrsEntry[], offset: number) =>
     entries.length === 0 ? null : (
-      <>
-        <li
-          role="presentation"
+      <div key={label} role="group" aria-label={label}>
+        <div
+          aria-hidden="true"
           className="sticky top-0 bg-popover px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
         >
           {label}
-        </li>
+        </div>
         {entries.map((entry, index) => {
           const position = offset + index;
           return (
-            <li key={entry.code}>
-              <button
-                type="button"
-                role="option"
-                aria-selected={position === activeIndex}
-                id={`${listId}-option-${position}`}
-                // Out of the tab order: with `aria-activedescendant` on the
-                // search box, DOM focus stays there and the arrow keys move a
-                // virtual highlight. Leaving 300 rows as tab stops would also
-                // bury the rest of the form behind them.
-                tabIndex={-1}
-                className={cn(
-                  "flex w-full items-baseline justify-between gap-2 px-2 py-1 text-start text-xs hover:bg-accent",
-                  position === activeIndex && "bg-accent",
-                )}
-                onMouseEnter={() => setActiveIndex(position)}
-                // click, not mousedown: nothing closes the panel on pointerdown
-                // inside it, so the click lands, and a click is what a row
-                // reached by any means fires.
-                onClick={() => choose(entry)}
-                onFocus={() => setActiveIndex(position)}
-              >
-                <span>{entry.name}</span>
-                <span className="shrink-0 tabular-nums text-muted-foreground">{entry.code}</span>
-              </button>
-            </li>
+            <button
+              key={entry.code}
+              type="button"
+              role="option"
+              aria-selected={position === activeIndex}
+              id={`${listId}-option-${position}`}
+              // Out of the tab order: with `aria-activedescendant` on the search
+              // box, DOM focus stays there and the arrow keys move a virtual
+              // highlight. Leaving 300 rows as tab stops would also bury the
+              // rest of the form behind them.
+              tabIndex={-1}
+              className={cn(
+                "flex w-full items-baseline justify-between gap-2 px-2 py-1 text-start text-xs hover:bg-accent",
+                position === activeIndex && "bg-accent",
+              )}
+              onMouseEnter={() => setActiveIndex(position)}
+              // click, not mousedown: nothing closes the panel on pointerdown
+              // inside it, so the click lands, and a click is what a row reached
+              // by any means fires.
+              onClick={() => choose(entry)}
+              onFocus={() => setActiveIndex(position)}
+            >
+              <span>{entry.name}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">{entry.code}</span>
+            </button>
           );
         })}
-      </>
+      </div>
     );
 
   return (
@@ -203,7 +207,7 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                 role="combobox"
                 aria-expanded
                 // Only while the list is actually rendered: with no matches the
-                // <ul> is replaced by the "no results" message, and pointing at an
+                // listbox is replaced by the "no results" message, and pointing at an
                 // id that is not in the DOM tells a screen reader nothing.
                 aria-controls={ordered.length > 0 ? listId : undefined}
                 aria-activedescendant={
@@ -239,10 +243,10 @@ export function CrsPickerInput({ id, value, onChange }: CrsPickerInputProps): Re
                 {t("processing.whitebox.crs.noResults")}
               </p>
             ) : (
-              <ul id={listId} role="listbox" className="max-h-64 overflow-y-auto py-1">
+              <div id={listId} role="listbox" className="max-h-64 overflow-y-auto py-1">
                 {renderGroup(t("processing.whitebox.crs.geographic"), geographic, 0)}
                 {renderGroup(t("processing.whitebox.crs.projected"), projected, geographic.length)}
-              </ul>
+              </div>
             )}
           </div>
         ) : null}

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -68,6 +68,7 @@ import {
   MAX_TRACKED_HISTORY_JOBS,
   type ProcessingRunTracker,
 } from "../../lib/processing-history";
+import { CrsPickerInput } from "./CrsPickerInput";
 import { SidecarHelpBanner } from "./SidecarHelpBanner";
 
 interface ProcessingDialogProps {
@@ -210,6 +211,18 @@ function isSubsetUrlParameter(tool: WhiteboxTool, param: WhiteboxToolParameter):
 // is a vector input): only a scalar string names a column.
 function isFieldParameter(param: WhiteboxToolParameter): boolean {
   return parameterKind(param) === "string" && isFieldParameterName(param.name);
+}
+
+// A numeric `epsg` parameter names a coordinate reference system, so the field
+// can offer a searchable CRS list instead of asking for a code from memory
+// (GeoLibre#1538). Matching the name suffix covers `epsg`
+// (assign_projection_vector), `dst_epsg` (reproject_vector/raster/lidar),
+// `epsg_code`, `output_epsg` and the rest without hard-coding tool ids. The kind
+// check keeps a *string* CRS override out (`sidewalks_epsg` takes an authority
+// string, not a bare code), since the picker fills in a plain numeric code.
+function isCrsParameter(param: WhiteboxToolParameter): boolean {
+  const kind = parameterKind(param);
+  return (kind === "int" || kind === "double") && /(^|_)epsg(_code)?$/i.test(param.name);
 }
 
 function isPathParameter(param: WhiteboxToolParameter): boolean {
@@ -2051,6 +2064,13 @@ function ParameterField({
             </option>
           ))}
         </Select>
+      ) : isCrsParameter(param) ? (
+        // Checked before the path and number branches (like the map-extent one
+        // below): an EPSG code is a number, but a bare stepper walks to
+        // unrelated systems, so this field gets the searchable CRS list instead
+        // (GeoLibre#1538). Placed ahead of isPathParameter so an epsg
+        // description that happens to mention a file can't shadow the picker.
+        <CrsPickerInput id={`whitebox-${param.name}`} value={valueText} onChange={onChange} />
       ) : onUseMapExtent ? (
         // Checked before the path/data-input branches: once isMapExtentParameter
         // has identified this bbox field, the "Use map extent" affordance should

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3518,6 +3518,15 @@
       "requiredSuffix": " | required",
       "selectField": "Select a field",
       "fieldName": "Field name",
+      "crs": {
+        "browse": "Browse",
+        "codePlaceholder": "EPSG code",
+        "searchLabel": "Search coordinate reference systems",
+        "searchPlaceholder": "Search by name or EPSG code",
+        "geographic": "Geographic",
+        "projected": "Projected",
+        "noResults": "No matching coordinate system. Any EPSG code can still be typed."
+      },
       "vectorUnitsNote": "Vector layers are read as WGS84, so distance, spacing and tolerance values are in degrees, not meters. 1° is about 111 km, and 0.001° is about 111 m."
     },
     "sidecar": {

--- a/apps/geolibre-desktop/src/lib/crs-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/crs-catalog.ts
@@ -249,13 +249,18 @@ export function parseEpsgCode(value: string | null | undefined): number | null {
   if (value === null || value === undefined) return null;
   // Strip an authority prefix in either the short (`EPSG:4326`) or the URN
   // (`urn:ogc:def:crs:EPSG::4326`) form, then require what is left to be nothing
-  // but the code. Anchoring both ends is what keeps unrelated text that merely
-  // ends in digits (`layer4326`) from resolving to a CRS, which would otherwise
-  // put a confident-looking name under the field mid-typing.
+  // but the code. Both ends are anchored: only a *recognized* prefix is stripped
+  // (so `unrelatedEPSG:4326` does not resolve) and nothing may follow the digits
+  // (so neither `layer4326` nor `EPSG:4326 EPSG:3857` does). Either would
+  // otherwise put a confident-looking CRS name under a half-typed field.
+  //
+  // The separator is as lenient as searchCrsCatalog's: the two agree on what
+  // counts as an EPSG prefix, so a value the picker can search (`EPSG 4326`,
+  // `EPSG4326`) is also a value the name label resolves.
   const match = String(value)
     .trim()
     .toUpperCase()
-    .replace(/^.*EPSG:+/, "")
+    .replace(/^(?:URN:OGC:DEF:CRS:)?EPSG\s*:*\s*/, "")
     .match(/^(\d{4,6})$/);
   if (!match) return null;
   const code = Number(match[1]);

--- a/apps/geolibre-desktop/src/lib/crs-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/crs-catalog.ts
@@ -209,6 +209,13 @@ const NAMED_PROJECTED_CRS: CrsEntry[] = (
  * Every CRS the picker offers: geographic systems, then named projected
  * systems, then the zone families. Ordered by how often each is reached for, so
  * the list is useful before anything is typed.
+ *
+ * Each family's zone span is the span EPSG actually registers, not a tidy round
+ * number, and the spans differ between families for real reasons: ETRS89 stops
+ * at zone 37 because 25838 (zone 38N) is deprecated, and GDA2020 covers zones
+ * 46-59 where GDA94 covers only 48-58, because the 2020 realization added the
+ * outer zones. Every code and name below was cross-checked against PROJ's EPSG
+ * database; keep it that way when adding entries, and leave deprecated codes out.
  */
 export const CRS_CATALOG: readonly CrsEntry[] = [
   ...GEOGRAPHIC_CRS,
@@ -216,7 +223,7 @@ export const CRS_CATALOG: readonly CrsEntry[] = [
   ...utmZones("WGS 84", 32600, "N", range(1, 60)),
   ...utmZones("WGS 84", 32700, "S", range(1, 60)),
   ...utmZones("NAD83", 26900, "N", range(1, 23)),
-  ...utmZones("ETRS89", 25800, "N", range(28, 38)),
+  ...utmZones("ETRS89", 25800, "N", range(28, 37)),
   ...mgaZones("GDA94", 28300, range(48, 58)),
   ...mgaZones("GDA2020", 7800, range(46, 59)),
   ...japanPlaneZones(),

--- a/apps/geolibre-desktop/src/lib/crs-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/crs-catalog.ts
@@ -1,0 +1,320 @@
+// A searchable catalog of coordinate reference systems for the Processing
+// toolbox's EPSG parameters.
+//
+// Tools such as `reproject_vector` and `assign_projection_vector` take their
+// target CRS as a bare EPSG code, which the dialog used to render as a plain
+// number box: the code had to be recalled from memory (GeoLibre#1538). These
+// entries back a QGIS-style picker that searches by name or code and separates
+// geographic from projected systems. The free-text field stays the source of
+// truth, so a code that is not listed here can still be typed.
+//
+// The catalog is curated rather than exhaustive (the EPSG dataset holds ~6000
+// geographic and projected systems, too much to bundle): every UTM/MGA/Japan/
+// China zone of the major datums, the world and polar projections, and the
+// national grids in common use. Names are the official EPSG dataset names, so a
+// label copied out of QGIS or PROJ matches what is shown here.
+
+/** Whether a CRS is a geographic (lon/lat) or a projected (planar) system. */
+export type CrsKind = "geographic" | "projected";
+
+/** One catalog entry: an EPSG code with its official name and kind. */
+export interface CrsEntry {
+  /** The numeric EPSG code, as tools expect it. */
+  code: number;
+  /** The official EPSG name, e.g. `WGS 84 / UTM zone 17N`. */
+  name: string;
+  kind: CrsKind;
+}
+
+/** Inclusive integer range helper for the zone families below. */
+function range(from: number, to: number): number[] {
+  return Array.from({ length: to - from + 1 }, (_, index) => from + index);
+}
+
+/**
+ * UTM-style zone family whose EPSG code is `codeBase + zone` and whose name is
+ * `<datum> / UTM zone <zone><hemisphere>` (the shape EPSG uses for WGS 84,
+ * NAD83 and ETRS89 alike).
+ */
+function utmZones(
+  datum: string,
+  codeBase: number,
+  hemisphere: "N" | "S",
+  zones: number[],
+): CrsEntry[] {
+  return zones.map((zone) => ({
+    code: codeBase + zone,
+    name: `${datum} / UTM zone ${zone}${hemisphere}`,
+    kind: "projected" as const,
+  }));
+}
+
+/** Australian Map Grid zones, named `<datum> / MGA zone <zone>` (no hemisphere). */
+function mgaZones(datum: string, codeBase: number, zones: number[]): CrsEntry[] {
+  return zones.map((zone) => ({
+    code: codeBase + zone,
+    name: `${datum} / MGA zone ${zone}`,
+    kind: "projected" as const,
+  }));
+}
+
+/** Roman numerals I..XIX, the way EPSG labels Japan's 19 plane rectangular zones. */
+const JAPAN_ZONE_NUMERALS = [
+  "I",
+  "II",
+  "III",
+  "IV",
+  "V",
+  "VI",
+  "VII",
+  "VIII",
+  "IX",
+  "X",
+  "XI",
+  "XII",
+  "XIII",
+  "XIV",
+  "XV",
+  "XVI",
+  "XVII",
+  "XVIII",
+  "XIX",
+];
+
+/** JGD2011 / Japan Plane Rectangular CS I..XIX (EPSG:6669-6687). */
+function japanPlaneZones(): CrsEntry[] {
+  return JAPAN_ZONE_NUMERALS.map((numeral, index) => ({
+    code: 6669 + index,
+    name: `JGD2011 / Japan Plane Rectangular CS ${numeral}`,
+    kind: "projected" as const,
+  }));
+}
+
+/** CGCS2000 / Gauss-Kruger zone 13..23 (EPSG:4491-4501), China's 6-degree belts. */
+function chinaGaussKrugerZones(): CrsEntry[] {
+  return range(13, 23).map((zone) => ({
+    code: 4478 + zone,
+    name: `CGCS2000 / Gauss-Kruger zone ${zone}`,
+    kind: "projected" as const,
+  }));
+}
+
+// Geographic systems, most widely used first so the picker's default list opens
+// on the ones a user is most likely to want.
+const GEOGRAPHIC_CRS: CrsEntry[] = (
+  [
+    [4326, "WGS 84"],
+    [4269, "NAD83"],
+    [6318, "NAD83(2011)"],
+    [4152, "NAD83(HARN)"],
+    [4267, "NAD27"],
+    [4258, "ETRS89"],
+    [4283, "GDA94"],
+    [7844, "GDA2020"],
+    [4277, "OSGB36"],
+    [4188, "OSNI 1952"],
+    [4230, "ED50"],
+    [4231, "ED87"],
+    [4171, "RGF93 v1"],
+    [4275, "NTF"],
+    [4314, "DHDN"],
+    [4289, "Amersfoort"],
+    [4149, "CH1903"],
+    [4150, "CH1903+"],
+    [4619, "SWEREF99"],
+    [4123, "KKJ"],
+    [4207, "Lisbon"],
+    [4265, "Monte Mario"],
+    [4237, "HD72"],
+    [4284, "Pulkovo 1942"],
+    [4200, "Pulkovo 1995"],
+    [4740, "PZ-90"],
+    [4674, "SIRGAS 2000"],
+    [4490, "China Geodetic Coordinate System 2000"],
+    [4555, "New Beijing"],
+    [4612, "JGD2000"],
+    [6668, "JGD2011"],
+    [4301, "Tokyo"],
+    [4739, "Hong Kong 1963(67)"],
+    [4756, "VN-2000"],
+    [4272, "NZGD49"],
+    [4322, "WGS 72"],
+  ] as [number, string][]
+).map(([code, name]) => ({ code, name, kind: "geographic" as const }));
+
+// Named projected systems: world and polar projections first, then the national
+// and continental grids. The zone families are appended after these.
+const NAMED_PROJECTED_CRS: CrsEntry[] = (
+  [
+    [3857, "WGS 84 / Pseudo-Mercator"],
+    [3395, "WGS 84 / World Mercator"],
+    [4087, "WGS 84 / World Equidistant Cylindrical"],
+    [8857, "WGS 84 / Equal Earth Greenwich"],
+    [3832, "WGS 84 / PDC Mercator"],
+    [6933, "WGS 84 / NSIDC EASE-Grid 2.0 Global"],
+    [6931, "WGS 84 / NSIDC EASE-Grid 2.0 North"],
+    [6932, "WGS 84 / NSIDC EASE-Grid 2.0 South"],
+    [3413, "WGS 84 / NSIDC Sea Ice Polar Stereographic North"],
+    [3976, "WGS 84 / NSIDC Sea Ice Polar Stereographic South"],
+    [3995, "WGS 84 / Arctic Polar Stereographic"],
+    [3031, "WGS 84 / Antarctic Polar Stereographic"],
+    [5070, "NAD83 / Conus Albers"],
+    [6350, "NAD83(2011) / Conus Albers"],
+    [3338, "NAD83 / Alaska Albers"],
+    [9311, "NAD27 / US National Atlas Equal Area"],
+    [3347, "NAD83 / Statistics Canada Lambert"],
+    [3978, "NAD83 / Canada Atlas Lambert"],
+    [3035, "ETRS89-extended / LAEA Europe"],
+    [3034, "ETRS89-extended / LCC Europe"],
+    [27700, "OSGB36 / British National Grid"],
+    [29903, "TM75 / Irish Grid"],
+    [2157, "IRENET95 / Irish Transverse Mercator"],
+    [28992, "Amersfoort / RD New"],
+    [2154, "RGF93 v1 / Lambert-93"],
+    [31370, "BD72 / Belgian Lambert 72"],
+    [3812, "ETRS89 / Belgian Lambert 2008"],
+    [21781, "CH1903 / LV03"],
+    [2056, "CH1903+ / LV95"],
+    [3067, "EUREF-FIN / TM35FIN(E,N)"],
+    [3006, "SWEREF99 TM"],
+    [3301, "Estonian Coordinate System of 1997"],
+    [3346, "LKS94 / Lithuania TM"],
+    [3059, "LKS-92 / Latvia TM"],
+    [2180, "ETRF2000-PL / CS92"],
+    [5514, "S-JTSK / Krovak East North"],
+    [23700, "HD72 / EOV"],
+    [3765, "HTRS96 / Croatia TM"],
+    [3844, "Pulkovo 1942(58) / Stereo70"],
+    [2100, "GGRS87 / Greek Grid"],
+    [2039, "Israel 1993 / Israeli TM Grid"],
+    [2048, "Hartebeesthoek94 / Lo19"],
+    [2055, "Hartebeesthoek94 / Lo33"],
+    [5880, "SIRGAS 2000 / Brazil Polyconic"],
+    [31983, "SIRGAS 2000 / UTM zone 23S"],
+    [3116, "MAGNA-SIRGAS / Colombia Bogota zone"],
+    [3414, "SVY21 / Singapore TM"],
+    [2326, "Hong Kong 1980 Grid System"],
+    [3826, "TWD97 / TM2 zone 121"],
+    [5179, "KGD2002 / Unified CS"],
+    [5186, "KGD2002 / Central Belt 2010"],
+    [2193, "NZGD2000 / New Zealand Transverse Mercator 2000"],
+    [3577, "GDA94 / Australian Albers"],
+    [9473, "GDA2020 / Australian Albers"],
+    [7845, "GDA2020 / GA LCC"],
+    [3112, "GDA94 / Geoscience Australia Lambert"],
+  ] as [number, string][]
+).map(([code, name]) => ({ code, name, kind: "projected" as const }));
+
+/**
+ * Every CRS the picker offers: geographic systems, then named projected
+ * systems, then the zone families. Ordered by how often each is reached for, so
+ * the list is useful before anything is typed.
+ */
+export const CRS_CATALOG: readonly CrsEntry[] = [
+  ...GEOGRAPHIC_CRS,
+  ...NAMED_PROJECTED_CRS,
+  ...utmZones("WGS 84", 32600, "N", range(1, 60)),
+  ...utmZones("WGS 84", 32700, "S", range(1, 60)),
+  ...utmZones("NAD83", 26900, "N", range(1, 23)),
+  ...utmZones("ETRS89", 25800, "N", range(28, 38)),
+  ...mgaZones("GDA94", 28300, range(48, 58)),
+  ...mgaZones("GDA2020", 7800, range(46, 59)),
+  ...japanPlaneZones(),
+  ...chinaGaussKrugerZones(),
+];
+
+const CRS_BY_CODE = new Map(CRS_CATALOG.map((entry) => [entry.code, entry]));
+
+/**
+ * The catalog entry for an EPSG code, or `undefined` when the code is not one of
+ * the curated systems (a valid code the tool will still accept).
+ *
+ * @param code - An EPSG code, as a number or as typed text (`4326`, `EPSG:4326`).
+ * @returns The matching entry, or `undefined`.
+ */
+export function crsEntryForCode(code: number | string | null | undefined): CrsEntry | undefined {
+  const parsed = typeof code === "number" ? code : parseEpsgCode(code);
+  return parsed === null ? undefined : CRS_BY_CODE.get(parsed);
+}
+
+/**
+ * Reads an EPSG code out of typed text, tolerating the `EPSG:` prefix, stray
+ * whitespace and the URN form. Returns null when no code is present, so callers
+ * can leave a partially typed field alone.
+ *
+ * @param value - Free text from an EPSG field.
+ * @returns The numeric code, or null.
+ */
+export function parseEpsgCode(value: string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const match = String(value)
+    .toUpperCase()
+    .match(/(?:EPSG:+)?(\d{4,6})\s*$/);
+  if (!match) return null;
+  const code = Number(match[1]);
+  return Number.isInteger(code) ? code : null;
+}
+
+/**
+ * A CRS as one line of display text: `WGS 84 / UTM zone 17N (EPSG:32617)`.
+ *
+ * @param entry - A catalog entry.
+ * @returns The name followed by its parenthesized EPSG code.
+ */
+export function formatCrsLabel(entry: CrsEntry): string {
+  return `${entry.name} (EPSG:${entry.code})`;
+}
+
+/** Rank buckets: an exact code match beats a code prefix, which beats a name hit. */
+const RANK_EXACT_CODE = 0;
+const RANK_CODE_PREFIX = 1;
+const RANK_NAME_PREFIX = 2;
+const RANK_NAME_MATCH = 3;
+
+/**
+ * Searches the catalog by CRS name or EPSG code. Every whitespace-separated
+ * token must match (so `utm 17n` narrows to the zone-17 north systems), matched
+ * against both the name and the code; an `EPSG:` prefix in the query is ignored.
+ * A blank query returns the catalog in its curated order.
+ *
+ * Results are ranked exact code, then code prefix, then name prefix, then any
+ * name hit, and within a rank keep the catalog's own order.
+ *
+ * @param query - The user's search text.
+ * @param limit - Maximum results to return.
+ * @returns Matching entries, best first.
+ */
+export function searchCrsCatalog(query: string, limit = 200): CrsEntry[] {
+  // Drop an `EPSG:` prefix so both `epsg:32617` and `32617` search by code.
+  const normalized = query
+    .toLowerCase()
+    .replace(/epsg\s*:+\s*/g, " ")
+    .trim();
+  if (!normalized) return CRS_CATALOG.slice(0, limit);
+  const tokens = normalized.split(/\s+/);
+
+  const ranked: { entry: CrsEntry; rank: number; order: number }[] = [];
+  CRS_CATALOG.forEach((entry, order) => {
+    const name = entry.name.toLowerCase();
+    const code = String(entry.code);
+    let rank = RANK_NAME_MATCH;
+    for (const token of tokens) {
+      if (code === token) {
+        rank = Math.min(rank, RANK_EXACT_CODE);
+      } else if (code.startsWith(token)) {
+        rank = Math.min(rank, RANK_CODE_PREFIX);
+      } else if (name.startsWith(token)) {
+        rank = Math.min(rank, RANK_NAME_PREFIX);
+      } else if (!name.includes(token)) {
+        // This token matches neither the name nor the code: reject the entry.
+        return;
+      }
+    }
+    ranked.push({ entry, rank, order });
+  });
+
+  return ranked
+    .sort((a, b) => a.rank - b.rank || a.order - b.order)
+    .slice(0, limit)
+    .map((item) => item.entry);
+}

--- a/apps/geolibre-desktop/src/lib/crs-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/crs-catalog.ts
@@ -247,9 +247,16 @@ export function crsEntryForCode(code: number | string | null | undefined): CrsEn
  */
 export function parseEpsgCode(value: string | null | undefined): number | null {
   if (value === null || value === undefined) return null;
+  // Strip an authority prefix in either the short (`EPSG:4326`) or the URN
+  // (`urn:ogc:def:crs:EPSG::4326`) form, then require what is left to be nothing
+  // but the code. Anchoring both ends is what keeps unrelated text that merely
+  // ends in digits (`layer4326`) from resolving to a CRS, which would otherwise
+  // put a confident-looking name under the field mid-typing.
   const match = String(value)
+    .trim()
     .toUpperCase()
-    .match(/(?:EPSG:+)?(\d{4,6})\s*$/);
+    .replace(/^.*EPSG:+/, "")
+    .match(/^(\d{4,6})$/);
   if (!match) return null;
   const code = Number(match[1]);
   return Number.isInteger(code) ? code : null;

--- a/apps/geolibre-desktop/src/lib/crs-catalog.ts
+++ b/apps/geolibre-desktop/src/lib/crs-catalog.ts
@@ -281,14 +281,18 @@ const RANK_NAME_MATCH = 3;
  * name hit, and within a rank keep the catalog's own order.
  *
  * @param query - The user's search text.
- * @param limit - Maximum results to return.
+ * @param limit - Maximum results to return; the whole catalog by default, so the
+ *   blank-query list is never silently truncated mid-family.
  * @returns Matching entries, best first.
  */
-export function searchCrsCatalog(query: string, limit = 200): CrsEntry[] {
-  // Drop an `EPSG:` prefix so both `epsg:32617` and `32617` search by code.
+export function searchCrsCatalog(query: string, limit = CRS_CATALOG.length): CrsEntry[] {
+  // Drop an `EPSG` prefix so `epsg:32617`, `EPSG 32617`, `EPSG32617` and a bare
+  // `32617` all search by code. Both the colon and the separator are optional:
+  // without that, a spelled-out `EPSG 4326` would leave `epsg` as a token that
+  // matches no name or code, rejecting every entry.
   const normalized = query
     .toLowerCase()
-    .replace(/epsg\s*:+\s*/g, " ")
+    .replace(/\bepsg\s*:*\s*/g, " ")
     .trim();
   if (!normalized) return CRS_CATALOG.slice(0, limit);
   const tokens = normalized.split(/\s+/);

--- a/tests/crs-catalog.test.ts
+++ b/tests/crs-catalog.test.ts
@@ -66,9 +66,27 @@ describe("parseEpsgCode", () => {
 });
 
 describe("searchCrsCatalog", () => {
-  it("returns the curated order for a blank query", () => {
+  it("returns the whole catalog, in curated order, for a blank query", () => {
     const results = searchCrsCatalog("");
     assert.equal(results[0].code, 4326);
+    // The default limit has to cover the catalog: a limit shorter than it would
+    // drop whole zone families off the end of the picker's default list, and
+    // they only reappear once the user types something specific.
+    assert.equal(results.length, CRS_CATALOG.length);
+    for (const code of [32760, 26923, 25838, 28358, 7859, 6687, 4501]) {
+      assert.ok(
+        results.some((entry) => entry.code === code),
+        `EPSG:${code} missing from the blank-query list`,
+      );
+    }
+  });
+
+  it("ignores an EPSG prefix written with or without a colon", () => {
+    // "EPSG 4326" is a natural way to type a code; leaving `epsg` as a token
+    // would match no name or code and reject every entry.
+    for (const query of ["EPSG 4326", "epsg4326", "EPSG:4326", "epsg :: 4326"]) {
+      assert.equal(searchCrsCatalog(query)[0]?.code, 4326, query);
+    }
   });
 
   it("ranks an exact code match first", () => {

--- a/tests/crs-catalog.test.ts
+++ b/tests/crs-catalog.test.ts
@@ -20,6 +20,7 @@ describe("CRS_CATALOG", () => {
       [32760, "WGS 84 / UTM zone 60S"],
       [26917, "NAD83 / UTM zone 17N"],
       [25832, "ETRS89 / UTM zone 32N"],
+      [25837, "ETRS89 / UTM zone 37N"],
       [28355, "GDA94 / MGA zone 55"],
       [7855, "GDA2020 / MGA zone 55"],
       [6669, "JGD2011 / Japan Plane Rectangular CS I"],
@@ -30,6 +31,21 @@ describe("CRS_CATALOG", () => {
     for (const [code, name] of expected) {
       assert.equal(crsEntryForCode(code)?.name, name, `EPSG:${code}`);
     }
+  });
+
+  it("stops each zone family where EPSG does", () => {
+    // Each family's span is what EPSG registers, not a round number, so an
+    // off-by-one would offer a code no tool accepts. ETRS89 stops at zone 37
+    // because 25838 (zone 38N) is deprecated; GDA2020 carries the outer zones
+    // 46/47/59 that GDA94 never had.
+    // No 7845 below the GDA2020 family: that code is GDA2020 / GA LCC, a
+    // curated entry, which is also why the family's own zone 45 is not
+    // generated.
+    for (const code of [25838, 25827, 28347, 28359, 7860, 26924, 4502]) {
+      assert.equal(crsEntryForCode(code)?.name, undefined, `EPSG:${code}`);
+    }
+    assert.equal(crsEntryForCode(7846)?.name, "GDA2020 / MGA zone 46");
+    assert.equal(crsEntryForCode(7859)?.name, "GDA2020 / MGA zone 59");
   });
 
   it("holds no duplicate codes", () => {
@@ -85,7 +101,7 @@ describe("searchCrsCatalog", () => {
     // drop whole zone families off the end of the picker's default list, and
     // they only reappear once the user types something specific.
     assert.equal(results.length, CRS_CATALOG.length);
-    for (const code of [32760, 26923, 25838, 28358, 7859, 6687, 4501]) {
+    for (const code of [32760, 26923, 25837, 28358, 7859, 6687, 4501]) {
       assert.ok(
         results.some((entry) => entry.code === code),
         `EPSG:${code} missing from the blank-query list`,

--- a/tests/crs-catalog.test.ts
+++ b/tests/crs-catalog.test.ts
@@ -62,6 +62,11 @@ describe("parseEpsgCode", () => {
     assert.equal(parseEpsgCode("326"), null);
     assert.equal(parseEpsgCode("WGS 84"), null);
     assert.equal(parseEpsgCode(undefined), null);
+    // Unrelated text that merely ends in digits must not resolve, or the picker
+    // would show a confident-looking CRS name for something the user is still
+    // typing.
+    assert.equal(parseEpsgCode("layer4326"), null);
+    assert.equal(parseEpsgCode("EPSG:4326 and more"), null);
   });
 });
 

--- a/tests/crs-catalog.test.ts
+++ b/tests/crs-catalog.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CRS_CATALOG,
+  crsEntryForCode,
+  formatCrsLabel,
+  parseEpsgCode,
+  searchCrsCatalog,
+} from "../apps/geolibre-desktop/src/lib/crs-catalog";
+
+describe("CRS_CATALOG", () => {
+  it("names the generated zone families the way EPSG does", () => {
+    // The zone families are produced by a loop, so a wrong code base or a
+    // hemisphere mix-up would mislabel a hundred entries at once.
+    const expected: [number, string][] = [
+      [32601, "WGS 84 / UTM zone 1N"],
+      [32617, "WGS 84 / UTM zone 17N"],
+      [32660, "WGS 84 / UTM zone 60N"],
+      [32701, "WGS 84 / UTM zone 1S"],
+      [32760, "WGS 84 / UTM zone 60S"],
+      [26917, "NAD83 / UTM zone 17N"],
+      [25832, "ETRS89 / UTM zone 32N"],
+      [28355, "GDA94 / MGA zone 55"],
+      [7855, "GDA2020 / MGA zone 55"],
+      [6669, "JGD2011 / Japan Plane Rectangular CS I"],
+      [6687, "JGD2011 / Japan Plane Rectangular CS XIX"],
+      [4491, "CGCS2000 / Gauss-Kruger zone 13"],
+      [4501, "CGCS2000 / Gauss-Kruger zone 23"],
+    ];
+    for (const [code, name] of expected) {
+      assert.equal(crsEntryForCode(code)?.name, name, `EPSG:${code}`);
+    }
+  });
+
+  it("holds no duplicate codes", () => {
+    const codes = CRS_CATALOG.map((entry) => entry.code);
+    assert.equal(new Set(codes).size, codes.length);
+  });
+
+  it("classifies the two kinds the picker groups by", () => {
+    assert.equal(crsEntryForCode(4326)?.kind, "geographic");
+    assert.equal(crsEntryForCode(3857)?.kind, "projected");
+    assert.equal(crsEntryForCode(32617)?.kind, "projected");
+    // Both groups have to be populated for the split list to make sense.
+    assert.ok(CRS_CATALOG.some((entry) => entry.kind === "geographic"));
+    assert.ok(CRS_CATALOG.some((entry) => entry.kind === "projected"));
+  });
+});
+
+describe("parseEpsgCode", () => {
+  it("reads a code from the forms a user types or pastes", () => {
+    assert.equal(parseEpsgCode("4326"), 4326);
+    assert.equal(parseEpsgCode("EPSG:32617"), 32617);
+    assert.equal(parseEpsgCode("epsg:3857 "), 3857);
+    assert.equal(parseEpsgCode("urn:ogc:def:crs:EPSG::26911"), 26911);
+  });
+
+  it("returns null for text with no code in it", () => {
+    // A partially typed field must not resolve to a name, which would flash a
+    // misleading CRS under the input while the user is still typing.
+    assert.equal(parseEpsgCode(""), null);
+    assert.equal(parseEpsgCode("326"), null);
+    assert.equal(parseEpsgCode("WGS 84"), null);
+    assert.equal(parseEpsgCode(undefined), null);
+  });
+});
+
+describe("searchCrsCatalog", () => {
+  it("returns the curated order for a blank query", () => {
+    const results = searchCrsCatalog("");
+    assert.equal(results[0].code, 4326);
+  });
+
+  it("ranks an exact code match first", () => {
+    // "3857" is also a prefix of nothing else, but 4326 vs 43261-style prefixes
+    // are why the exact match has to outrank a prefix hit.
+    assert.equal(searchCrsCatalog("3857")[0].code, 3857);
+    assert.equal(searchCrsCatalog("EPSG:32617")[0].code, 32617);
+    assert.equal(searchCrsCatalog("4326")[0].code, 4326);
+  });
+
+  it("narrows on every token, so a name and a zone can be combined", () => {
+    const results = searchCrsCatalog("utm 17n");
+    assert.ok(results.length > 0);
+    for (const entry of results) {
+      assert.match(entry.name, /UTM zone 17N/);
+    }
+    // Both datums that have a zone 17N are offered, not just the first.
+    assert.ok(results.some((entry) => entry.code === 32617));
+    assert.ok(results.some((entry) => entry.code === 26917));
+  });
+
+  it("finds a system by name", () => {
+    assert.ok(searchCrsCatalog("british national grid").some((entry) => entry.code === 27700));
+    assert.ok(searchCrsCatalog("pseudo-mercator").some((entry) => entry.code === 3857));
+  });
+
+  it("returns nothing when no entry matches every token", () => {
+    assert.deepEqual(searchCrsCatalog("utm mercator british"), []);
+    assert.deepEqual(searchCrsCatalog("nosuchcrs"), []);
+  });
+
+  it("honors the result limit", () => {
+    assert.equal(searchCrsCatalog("", 5).length, 5);
+  });
+});
+
+describe("formatCrsLabel", () => {
+  it("shows the name with its parenthesized code", () => {
+    assert.equal(
+      formatCrsLabel({ code: 32617, name: "WGS 84 / UTM zone 17N", kind: "projected" }),
+      "WGS 84 / UTM zone 17N (EPSG:32617)",
+    );
+  });
+});

--- a/tests/crs-catalog.test.ts
+++ b/tests/crs-catalog.test.ts
@@ -53,6 +53,10 @@ describe("parseEpsgCode", () => {
     assert.equal(parseEpsgCode("EPSG:32617"), 32617);
     assert.equal(parseEpsgCode("epsg:3857 "), 3857);
     assert.equal(parseEpsgCode("urn:ogc:def:crs:EPSG::26911"), 26911);
+    // Prefix forms the picker's search also accepts, so a value that can be
+    // searched is a value whose name label resolves.
+    assert.equal(parseEpsgCode("EPSG 4326"), 4326);
+    assert.equal(parseEpsgCode("epsg4326"), 4326);
   });
 
   it("returns null for text with no code in it", () => {
@@ -67,6 +71,9 @@ describe("parseEpsgCode", () => {
     // typing.
     assert.equal(parseEpsgCode("layer4326"), null);
     assert.equal(parseEpsgCode("EPSG:4326 and more"), null);
+    // Only a recognized prefix is stripped, and only one code may be present.
+    assert.equal(parseEpsgCode("unrelatedEPSG:4326"), null);
+    assert.equal(parseEpsgCode("EPSG:4326 EPSG:3857"), null);
   });
 });
 


### PR DESCRIPTION
Fixes #1538

## Problem

Every EPSG parameter in the Processing toolbox rendered as a bare number box with up/down steppers, so the target CRS of **Reproject Vector**, **Assign Projection Vector** and their siblings had to be recalled as a numeric code from memory. Stepping the value by 1 walks to an unrelated coordinate system, so the control offered nothing useful either.

## Change

Those fields now sit beside a **Browse** picker that searches a curated CRS catalog by name or EPSG code and splits the results into **Geographic** and **Projected** groups, the way QGIS does.

- The text box stays the source of truth and still accepts any code, so a system the catalog omits can be typed exactly as before.
- When the typed code names a catalog entry, its official EPSG name is shown under the field. That also confirms a remembered code is the CRS the user meant.
- Search matches on every whitespace-separated token against both the name and the code, so `utm 17n` narrows to the zone-17 north systems and `epsg:32617` resolves by code. Arrow keys, Enter and Escape work in the list.

The catalog (`apps/geolibre-desktop/src/lib/crs-catalog.ts`) covers the UTM / MGA / Japan plane rectangular / China Gauss-Kruger zone families of the major datums, the world and polar projections, and the national grids in common use, with the official EPSG dataset names so a label copied out of QGIS or PROJ matches. It is deliberately curated rather than exhaustive: the full EPSG set is ~6000 geographic and projected systems, and the free-text field already covers anything outside the list.

Fields are picked up by name suffix on numeric parameters (`epsg`, `dst_epsg`, `epsg_code`, `output_epsg`, `input_extent_epsg`, ...), so no tool ids are hard-coded and it reaches the raster and LiDAR reprojection tools too. The kind check keeps a *string* CRS override on its free-text field, since the picker fills in a plain numeric code.

## Verification

Driven in the browser against `us_cities.geojson`, in both light and dark themes:

- **Reproject Vector**: opened the picker, searched `utm 17n` (two datums offered), selected by Enter, field became `32617` with `WGS 84 / UTM zone 17N (EPSG:32617)` shown below; then searched `conus albers`, picked EPSG:5070 and ran the tool with the `us_cities` layer as input, which succeeded and added the reprojected output.
- **Assign Projection Vector**: same picker, searched `british`, selected `OSGB36 / British National Grid`, field became `27700`.
- **Download Osm Vector** (an EPSG field low in a long form): confirmed the floating panel is scrolled into view rather than clipped by the form's scroll container, and that the non-CRS numeric fields keep their existing steppers.

`npm run build`, `npm run test:frontend` (4346 pass) and `pre-commit run --files <changed>` are green. New unit coverage in `tests/crs-catalog.test.ts` pins the generated zone-family names and codes, the code parsing, and the search ranking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated searchable CRS picker for processing tool parameters that look like EPSG/EPSG code inputs.
  * Introduced a curated CRS catalog with geographic vs projected grouping, formatted labels, and search-by-name/EPSG.
  * Includes click-outside dismissal, keyboard navigation (up/down, enter, escape), and automatic focus when opened.
  * Added new CRS-related UI text, including guidance for searching and “no results”.
* **Bug Fixes**
  * Improved CRS code parsing and search ranking to better handle common EPSG input variants.
* **Tests**
  * Added unit tests covering CRS catalog lookups, parsing, search/ranking behavior, and label formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->