### PR TITLE
feat(plugins): expose queryZarrLayer for click-to-value on native Zarr layers

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -7,6 +7,7 @@ import {
   addRasterToMap,
   addZarrRasterLayer,
   buildSelectorTimeBinding,
+  queryZarrLayer,
   registerTemporalLayer,
   unregisterTemporalLayer,
   isTimeSliderIdle,
@@ -85,6 +86,9 @@ import type {
   GeoLibreTileLayerOptions,
   GeoLibreWmsLayerOptions,
   GeoLibreZarrLayerOptions,
+  GeoLibreZarrQueryGeometry,
+  GeoLibreZarrQueryOptions,
+  GeoLibreZarrQuerySelector,
 } from "@geolibre/plugins";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -940,6 +944,15 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       }),
     setZarrLayerSelector: (layerId: string, selector: Record<string, number | string>) =>
       setZarrLayerSelector(layerId, selector),
+    // Click-to-value and region statistics on a natively rendered cube: the
+    // renderer owns the grid, so it reprojects the WGS84 geometry and masks fill
+    // values itself instead of every plugin re-reading the store (#1555).
+    queryZarrLayer: (
+      layerId: string,
+      geometry: GeoLibreZarrQueryGeometry,
+      selector?: GeoLibreZarrQuerySelector,
+      options?: GeoLibreZarrQueryOptions,
+    ) => queryZarrLayer(layerId, geometry, selector, options),
     // A layer whose time is an internal dimension joins the Time Slider through
     // an adapter rather than a filter or a source swap. Registering only makes
     // it bindable; `bind` writes the binding and opens the dock, which is what a

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -95,6 +95,13 @@ export interface GeoLibreAppAPI {
     layerId: string,
     selector: Record<string, number | string>,
   ) => Promise<boolean>;
+  // Click-to-value / region statistics on a Zarr layer (see "Zarr layers").
+  queryZarrLayer?: (
+    layerId: string,
+    geometry: GeoLibreZarrQueryGeometry,
+    selector?: GeoLibreZarrQuerySelector,
+    options?: GeoLibreZarrQueryOptions,
+  ) => Promise<GeoLibreZarrQueryResult | null>;
   // Register a layer the plugin added to the map itself, so it appears in the
   // Layers panel (see "Custom (WebGL) layers and paint ownership" below).
   registerExternalNativeLayer?: (
@@ -527,6 +534,58 @@ if (layerId) {
 `addZarrLayer` is headless: it does not open the Zarr panel (the user can still open it from **Add Data → Zarr Layer** to tweak colormap and color limits). It resolves with the new layer's id once the layer is registered, and rejects when `variable` is missing or the store cannot be read. The layer supports visibility, opacity, ordering, and removal from the Layers panel like any other layer.
 
 `selector` picks a slice by coordinate **value**, not by index: on a `month` axis of 1-12, December is `{ month: 12 }`. The panel's Selector (JSON) field means the same thing, and editing it now re-slices the layers already on the map.
+
+### Click-to-value and region statistics
+
+`queryZarrLayer` reads the layer's values under a GeoJSON geometry: a `Point` for Identify, a `Polygon` / `MultiPolygon` for zonal statistics. It is the read counterpart of `setZarrLayerSelector`, reaching the same live renderer by layer id.
+
+```typescript
+export type GeoLibreZarrQueryGeometry =
+  | { type: "Point"; coordinates: [number, number] }        // WGS84 lng/lat
+  | { type: "Polygon"; coordinates: number[][][] }
+  | { type: "MultiPolygon"; coordinates: number[][][][] };
+
+// Dimension values to read instead of the slice on screen. A list per dimension
+// (e.g. { month: [1, 7] }) nests the returned values by that dimension.
+export type GeoLibreZarrQuerySelector = Record<
+  string,
+  number | string | number[] | string[] | { selected: number | string | number[] | string[]; type?: "index" | "value" }
+>;
+
+export interface GeoLibreZarrQueryOptions {
+  signal?: AbortSignal;                    // cancel a query the user moved past
+  includeSpatialCoordinates?: boolean;     // default true
+}
+
+// { [variable]: values, dimensions, coordinates }
+export interface GeoLibreZarrQueryResult {
+  [variable: string]: unknown;
+  dimensions: string[];
+  coordinates: { [key: string]: (number | string)[] };
+}
+```
+
+```typescript
+// Identify: read the value under a map click, for the slice on screen.
+map.on("click", async (event) => {
+  const { lng, lat } = event.lngLat;
+  const result = await app.queryZarrLayer?.(layerId, {
+    type: "Point",
+    coordinates: [lng, lat],
+  });
+  const [value] = (result?.sst as number[]) ?? [];
+  showReadout(value); // undefined outside the store's grid
+});
+
+// Zonal statistics: every pixel inside a polygon, on another time slice.
+const region = await app.queryZarrLayer?.(layerId, aoi.geometry, { time: 12 });
+```
+
+The renderer already holds the store's grid, so it does the reprojection and fill-value masking: pass a WGS84 `[lng, lat]` straight from a map click rather than opening the store again with your own zarrita point read. Note the returned `coordinates` are in the store's **source** CRS (Web Mercator meters for EPSG:3857, degrees for EPSG:4326, source units for a custom-proj4 dataset), not WGS84.
+
+Values come back **empty** rather than as an error for a geometry outside the store's grid, and for a layer whose first chunks have not loaded yet, so a query fired immediately after `addZarrLayer` resolves can be empty even though the id is live. `queryZarrLayer` itself resolves to `null` when no live Zarr layer has that id, and an aborted query **rejects** (an abort error), so guard the call if you cancel on every new click.
+
+A `selector` passed here only scopes the read: the layer keeps rendering the slice it was on, so an Identify readout for another time does not disturb the map. Use `setZarrLayerSelector` when you do want the display to move.
 
 The panel can also open a store from a folder on disk, via a **Browse folder** button next to the Zarr URL. It appears in the desktop app and in browsers with the File System Access API (Chromium), since reading a folder needs a filesystem API the plugin cannot supply; elsewhere the panel is unchanged. A local cube binds to the Time Slider like a remote one — its CF `units` are read out of the folder, because its recorded URL is an identifier rather than an address.
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -107,6 +107,7 @@ export {
   addCloudNetcdfLayer,
   type CloudNetcdfLayerOptions,
   addZarrRasterLayer,
+  queryZarrLayer,
   setZarrLayerSelector,
   setZarrLocalStoreProvider,
   type ZarrRasterLayerOptions,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -6,6 +6,13 @@ import {
   setExternalNativePaintBridge,
   useAppStore,
 } from "@geolibre/core";
+import type {
+  QueryGeometry,
+  QueryOptions,
+  QueryResult,
+  Selector,
+  ZarrLayer,
+} from "@carbonplan/zarr-layer";
 import type { Layer } from "@deck.gl/core";
 import type { MapboxOverlay } from "@deck.gl/mapbox";
 import { RasterLayer, type RasterLayerProps } from "@developmentseed/deck.gl-raster";
@@ -2497,6 +2504,50 @@ export async function setZarrLayerSelector(
     });
   }
   return true;
+}
+
+/**
+ * Read the data values of a live Zarr layer under a GeoJSON geometry: a `Point`
+ * for click-to-value, a `Polygon`/`MultiPolygon` for region statistics.
+ *
+ * The read side of {@link setZarrLayerSelector}, and the reason a plugin does
+ * not need its own zarrita point reader: the renderer already holds the store's
+ * grid, so it does the CRS reprojection and fill-value masking itself. Pass a
+ * WGS84 `[lng, lat]` straight from a map click; the returned `coordinates` are
+ * in the store's **source** CRS (Web Mercator meters for EPSG:3857, degrees for
+ * EPSG:4326, source units for a custom proj4 dataset).
+ *
+ * The renderer answers with empty value arrays rather than an error when the
+ * geometry falls outside the store's grid, or when the layer has not finished
+ * loading its first chunks — so a query fired immediately after the add can
+ * come back empty even though the id is live. An aborted query rejects.
+ *
+ * `selector` scopes the read only: the layer keeps rendering the slice it is on,
+ * so an Identify readout for another time leaves the map alone. Moving the
+ * display is {@link setZarrLayerSelector}'s job.
+ *
+ * @param layerId A layer id returned by {@link addZarrRasterLayer} (or a layer
+ *   the Zarr panel added).
+ * @param geometry The query geometry, in WGS84.
+ * @param selector Dimensions to read instead of the layer's current selector,
+ *   e.g. `{ time: 12 }`. Omit to read the slice on screen.
+ * @param options `signal` to cancel the read, `includeSpatialCoordinates` to
+ *   drop the per-pixel coordinate arrays (default: included).
+ * @returns The renderer's result, or null when there is no live Zarr layer with
+ *   that id (the counterpart of {@link setZarrLayerSelector} returning false).
+ */
+export async function queryZarrLayer(
+  layerId: string,
+  geometry: QueryGeometry,
+  selector?: Selector,
+  options?: QueryOptions,
+): Promise<QueryResult | null> {
+  const instance = zarrControl?.getLayersMap().get(layerId) as
+    | Pick<ZarrLayer, "queryData">
+    | undefined;
+  if (!instance || typeof instance.queryData !== "function") return null;
+
+  return instance.queryData(geometry, selector, options);
 }
 // ----- Zarr time axis --------------------------------------------------------
 // A Zarr cube's time is an internal dimension, so the Time Slider drives it

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -4,6 +4,12 @@ import type {
   GeoLibreLayer,
   LayerStyle,
 } from "@geolibre/core";
+import type {
+  QueryGeometry as ZarrQueryGeometry,
+  QueryOptions as ZarrQueryOptions,
+  QueryResult as ZarrQueryResult,
+  Selector as ZarrSelector,
+} from "@carbonplan/zarr-layer";
 import type { FeatureCollection, Geometry } from "geojson";
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 import type { OvertureTheme } from "maplibre-gl-overture-maps";
@@ -235,6 +241,27 @@ export interface GeoLibreZarrLayerOptions {
   beforeLayerId?: string;
 }
 
+// The query surface of `GeoLibreAppAPI.queryZarrLayer`, aliased from the
+// renderer's own types so a plugin can annotate its calls without adding
+// @carbonplan/zarr-layer as a dependency of its own — and so a change to the
+// renderer's contract fails the host build rather than drifting silently.
+
+/** A WGS84 `Point` (click-to-value) or `Polygon`/`MultiPolygon` (region stats). */
+export type GeoLibreZarrQueryGeometry = ZarrQueryGeometry;
+/**
+ * Dimensions to read instead of the layer's current selector. Accepts a list per
+ * dimension (e.g. `{ month: [1, 7] }`), which nests the returned values by that
+ * dimension's values.
+ */
+export type GeoLibreZarrQuerySelector = ZarrSelector;
+/** `signal` to cancel the read; `includeSpatialCoordinates` (default true). */
+export type GeoLibreZarrQueryOptions = ZarrQueryOptions;
+/**
+ * `{ [variable]: values, dimensions, coordinates }`, where `coordinates` are in
+ * the store's **source** CRS, not WGS84.
+ */
+export type GeoLibreZarrQueryResult = ZarrQueryResult;
+
 /**
  * Describes the file-type filter shown by the host's save/open dialog so
  * plugins can label exports/imports (e.g. JSON, GeoJSON, CSV) without knowing
@@ -374,6 +401,34 @@ export interface GeoLibreAppAPI {
     layerId: string,
     selector: Record<string, number | string>,
   ) => Promise<boolean>;
+  /**
+   * Read the values of a layer added by {@link addZarrLayer} under a GeoJSON
+   * geometry: a `Point` for click-to-value (Identify), a `Polygon` /
+   * `MultiPolygon` for region statistics. The read counterpart of
+   * {@link setZarrLayerSelector}.
+   *
+   * The host's renderer already holds the store's grid, so it does the CRS
+   * reprojection and fill-value masking: pass a WGS84 `[lng, lat]` straight from
+   * a map click rather than reading the store again with your own zarrita
+   * point-read. Note the returned `coordinates` are in the store's **source**
+   * CRS, not WGS84.
+   *
+   * Pass `selector` to read a slice other than the one on screen (e.g. another
+   * `time`) — the layer keeps rendering the slice it is on, so a readout does not
+   * disturb the map — and `options.signal` to cancel a query the user has moved
+   * past. Values come back empty — not an error — for a geometry outside the
+   * store's grid, or for a layer whose first chunks have not loaded yet; an
+   * aborted query rejects. Resolves to null when there is no live Zarr layer
+   * with that id.
+   *
+   * Typed optional for forward-compatibility, so call it with optional chaining.
+   */
+  queryZarrLayer?: (
+    layerId: string,
+    geometry: GeoLibreZarrQueryGeometry,
+    selector?: GeoLibreZarrQuerySelector,
+    options?: GeoLibreZarrQueryOptions,
+  ) => Promise<GeoLibreZarrQueryResult | null>;
   /**
    * Declare that a layer's time is an **internal dimension** the Time Slider can
    * drive, by registering a {@link TemporalLayerAdapter} for it. This is the

--- a/tests/zarr-layer-api.test.ts
+++ b/tests/zarr-layer-api.test.ts
@@ -4,6 +4,7 @@ import { getExternalNativePaintBridge, pluginOwnsPaint, useAppStore } from "@geo
 import {
   __setComponentsModuleLoaderForTests,
   addZarrRasterLayer,
+  queryZarrLayer,
   setZarrLayerSelector,
   type ComponentsModules,
 } from "../packages/plugins/src/plugins/maplibre-components.ts";
@@ -42,7 +43,17 @@ const addCalls: { url?: string; variable?: string; options?: StubAddOptions }[] 
 const opacityCalls: { layerId: string; opacity: number }[] = [];
 const visibilityCalls: { layerId: string; visible: boolean; opacity?: number }[] = [];
 const selectorCalls: Record<string, number | string>[] = [];
+const queryCalls: { geometry: unknown; selector?: unknown; options?: unknown }[] = [];
 let failNextAdd: string | null = null;
+
+// What the stub renderer answers a query with: values plus the store's own
+// spatial axis names, whose coordinates are in the source CRS (see the
+// renderer's QueryResult contract).
+const QUERY_RESULT = {
+  sst: [12.5],
+  dimensions: ["y", "x"],
+  coordinates: { y: [1234567.5], x: [-987654.5] },
+};
 
 class ZarrLayerControlStub {
   private handlers = new Map<string, Set<(event: unknown) => void>>();
@@ -58,7 +69,17 @@ class ZarrLayerControlStub {
     proj4?: string;
     bounds?: [number, number, number, number];
   }[] = [];
-  private instances = new Map<string, { setSelector: (s: never) => Promise<void> }>();
+  private instances = new Map<
+    string,
+    {
+      setSelector: (s: never) => Promise<void>;
+      queryData: (
+        geometry: unknown,
+        selector?: unknown,
+        options?: unknown,
+      ) => Promise<typeof QUERY_RESULT>;
+    }
+  >();
   private counter = 0;
 
   on(event: string, handler: (event: unknown) => void) {
@@ -98,6 +119,10 @@ class ZarrLayerControlStub {
     this.instances.set(id, {
       setSelector: async (selector) => {
         selectorCalls.push(selector as Record<string, number | string>);
+      },
+      queryData: async (geometry, selector, options) => {
+        queryCalls.push({ geometry, selector, options });
+        return QUERY_RESULT;
       },
     });
     this.emit("layeradd", { url, layerId: id, state: { layers: this.layers } });
@@ -305,5 +330,76 @@ describe("setZarrLayerSelector", () => {
   it("reports false for a layer the Zarr renderer does not own", async () => {
     installStubModule();
     assert.equal(await setZarrLayerSelector("not-a-zarr-layer", { month: 2 }), false);
+  });
+});
+
+// The read counterpart: a plugin that renders through addZarrLayer has no handle
+// on the renderer's layer instance, so click-to-value and region statistics have
+// to reach `queryData` by layer id (opengeos/GeoLibre#1555).
+describe("queryZarrLayer", () => {
+  it("reads the clicked point through the renderer and returns its result", async () => {
+    installStubModule();
+    queryCalls.length = 0;
+
+    const id = await addZarrRasterLayer(app, {
+      url: "https://example.org/oisst.zarr",
+      variable: "sst",
+      selector: { time: 0 },
+    });
+
+    const point = { type: "Point" as const, coordinates: [-30.5, 42.25] as [number, number] };
+    const result = await queryZarrLayer(id, point);
+
+    // Handed to the renderer untouched: it owns the reprojection into the
+    // store's grid, so the WGS84 click must not be transformed on the way in.
+    assert.deepEqual(queryCalls.at(-1)?.geometry, point);
+    assert.equal(queryCalls.at(-1)?.selector, undefined);
+    assert.deepEqual(result, QUERY_RESULT);
+  });
+
+  it("forwards a selector override, a polygon, and the abort signal", async () => {
+    installStubModule();
+    queryCalls.length = 0;
+    selectorCalls.length = 0;
+
+    const id = await addZarrRasterLayer(app, {
+      url: "https://example.org/oisst.zarr",
+      variable: "sst",
+      selector: { time: 0 },
+    });
+
+    const controller = new AbortController();
+    const polygon = {
+      type: "Polygon" as const,
+      coordinates: [
+        [
+          [-31, 42],
+          [-30, 42],
+          [-30, 43],
+          [-31, 43],
+          [-31, 42],
+        ],
+      ],
+    };
+    await queryZarrLayer(id, polygon, { time: 12 }, { signal: controller.signal });
+
+    const call = queryCalls.at(-1);
+    assert.deepEqual(call?.geometry, polygon);
+    // A region query on a slice other than the one on screen: the override must
+    // reach the renderer without re-selecting the layer itself.
+    assert.deepEqual(call?.selector, { time: 12 });
+    assert.equal(
+      (call?.options as { signal?: AbortSignal } | undefined)?.signal,
+      controller.signal,
+    );
+    assert.deepEqual(selectorCalls.at(-1), undefined);
+  });
+
+  it("resolves null for a layer the Zarr renderer does not own", async () => {
+    installStubModule();
+    assert.equal(
+      await queryZarrLayer("not-a-zarr-layer", { type: "Point", coordinates: [0, 0] }),
+      null,
+    );
   });
 });


### PR DESCRIPTION
Fixes #1555.

Implements option 1 from the issue: a passthrough on `GeoLibreAppAPI`, so a plugin that renders a cube with `addZarrLayer` can read its values.

## The gap

`addZarrLayer` returns only a layer id, and the `@carbonplan/zarr-layer` instance lives in module scope inside `maplibre-components.ts`, so `queryData` was unreachable on the native path. A plugin wanting click-to-value had to open the store a second time with its own zarrita point read, duplicating the reprojection and chunk indexing the renderer had already done.

## The change

`queryZarrLayer(layerId, geometry, selector?, options?)` is the read counterpart of `setZarrLayerSelector`: it looks the layer up in the control's layers map by id and delegates to the instance's `queryData`, resolving `null` for an id the Zarr renderer does not own (matching `setZarrLayerSelector` resolving `false`).

- A `Point` (WGS84, straight from a map click) gives click-to-value; a `Polygon`/`MultiPolygon` gives region statistics.
- `selector` scopes the read only, so an Identify readout for another `time` does not move the slice on screen.
- `options.signal` cancels a read the user has moved past; `includeSpatialCoordinates: false` drops the per-pixel coordinate arrays.
- Returned `coordinates` are in the store's **source** CRS, which the docs now call out.
- The geometry/selector/options/result types are aliased from the renderer's own types (`GeoLibreZarrQueryGeometry` and friends), so a change to that contract fails the host build rather than a hand-copied shape drifting silently, and a plugin does not need `@carbonplan/zarr-layer` as its own dependency.

Option 2 (wiring this into GeoLibre's own Identify tool, with host-owned presentation) is deliberately left out of scope: it is a UI decision on top of this primitive, and each plugin can now present the value in its own panel.

## Verification

Driven in the real web app (dev server) with a throwaway drop-in plugin standing in for the Open Climate Service plugin, against the public NOAA OI SST V2 monthly Zarr store (`sst`, 1-degree global grid), in **both light and dark themes**:

- Before the change: `typeof app.queryZarrLayer === "undefined"` while `setZarrLayerSelector` was already a function; the probe reported that click-to-value was impossible.
- After: a click at -127.891, 6.687 returned `{"sst":[27.42],"dimensions":["lat","lon"],"coordinates":{"lat":[6.5],"lon":[-127.5]}}` (source-CRS cell center on the 1-degree grid), and a 4-degree box around it returned 16 pixels, mean 27.33.
- A point outside the grid returned empty value arrays rather than an error; a `{ time: 400 }` override read a different slice without changing the rendered one; `includeSpatialCoordinates: false` dropped the coordinate arrays; an unknown layer id resolved `null`; an aborted query rejected.

Gates: `npm run build`, the full frontend suite (4337 pass, 3 new tests in `tests/zarr-layer-api.test.ts`), and pre-commit on the changed files.
