### PR TITLE
fix(processing): correct the Download OSM Vector form (geolibre-wasm 1.4.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14234,9 +14234,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.4.0.tgz",
-      "integrity": "sha512-3aPjjE4LDK2DTUjov0ISysqbjZarqr9yM7ICEL5zqwS6XLwkXiF7NiNHHVj2rgdKZuJsuMwJ/LjdYqbmHkvm4w==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.4.2.tgz",
+      "integrity": "sha512-HR4WXCfSsbtWsfBjPi4Z6f+vuqcNhUSpEwonWswuCgGOiPtwe7nlrrEMtop5EnSX+fl+ZbewvO6uhfM0TINZoA==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -22042,7 +22042,7 @@
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^1.4.0",
+        "geolibre-wasm": "^1.4.2",
         "geotiff": "^3.0.5",
         "onnxruntime-web": "1.27.0"
       },

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -33,7 +33,7 @@
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^1.4.0",
+    "geolibre-wasm": "^1.4.2",
     "geotiff": "^3.0.5",
     "onnxruntime-web": "1.27.0"
   },


### PR DESCRIPTION
Consumes the upstream fix from opengeos/geolibre-rust#510, released as `geolibre-wasm` 1.4.2.

## Problem

The WASM tool manifest mistyped six of `download_osm_vector`'s parameters, because the tool ships its own params and so fell through to keyword inference:

| param | manifest said | actually |
| --- | --- | --- |
| `split_output_by_geometry` | vector **input** | a bool flag |
| `provenance_output` | json **input** (existing) | a JSON sidecar the tool writes |
| `cache_dir` | json input | a directory path (`as_str`) |
| `input_extent_epsg`, `output_epsg` | float | int |
| `timeout_seconds`, `max_elements`, `max_chunk_count`, `chunk_parallel_requests`, `cache_ttl_hours` | float | int (`as_u64`) |

The first one made the tool unrunnable in the browser: the runner resolves inputs before running, so it demanded a layer to satisfy a checkbox and failed with `Missing vector input for "split_output_by_geometry"` no matter how the extent was entered. The rest showed up as the wrong widget: a file-browse for a checkbox, a save-path for an EPSG code, and 0.1-step decimal fields for counts, where a fractional value the form allowed was silently swapped for the tool's default.

## Change

Bump `geolibre-wasm` to ^1.4.2 (`packages/processing/package.json`, the only place it is declared) plus the lockfile. No app code changes: the dialog already routes each widget off the manifest kind, so correcting the manifest is enough.

Per the conventions in CLAUDE.md for a `geolibre-wasm` bump:
- `node scripts/gen-whitebox-menu-catalog.mjs` re-run, no diff (the release adds/renames no tools).
- `MAX_VECTOR_PMTILES_ZOOM` still mirrors the tiler's cap of 18: `tests/wasm-convert.test.ts` ("accepts the documented maximum zoom and rejects one deeper") passes.

## Verification

Drove the real app at `?tool=download_osm_vector`, light and dark themes:

- **Form, browser (WASM) engine:** `split_output_by_geometry` now renders as a checkbox (`INPUT:checkbox`, label "Enabled") instead of a layer/path picker, `output_epsg` as the CRS picker, `cache_dir` as a text field, the counts as integer steppers, and the `filter_preset` / `overpass_profile` dropdowns are preserved.
- **Run, sidecar engine:** with the extent `-115.2037, 36.1075, -115.1350, 36.1186` over Las Vegas and `filter_preset=roads`, the job **succeeded**: `downloaded 6965 feature(s) from OSM`, writing the GeoJSON output and the provenance sidecar.
- `npm run build`, `npm run test:frontend` (4406 passed), `pre-commit` on the changed files: all green.

## Known limitation, unchanged by this PR

The tool still cannot complete in the **browser** engine. Past the manifest fix it now reaches the network step and fails there:

```
querying Overpass API at https://overpass-api.de/api/interpreter for bbox (...)
execution error: Overpass request failed: Dns Failed: resolve dns name
'overpass-api.de:443': operation not supported on this platform
```

The WASI runtime has no sockets, so an Overpass query can only run through the Python sidecar (desktop, or the Docker build). That is a platform limit, not a manifest one. Worth a follow-up: the dialog could tell the user a network-dependent tool needs the sidecar instead of surfacing a DNS error, but there is no mechanism for that today and it is out of scope here.

Related: #1561 adds the map-extent picker for this tool's area of interest (fixes #1541).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the geospatial processing component to a newer version, incorporating the latest available fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->