### PR TITLE
feat: add KML and KMZ layer export

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -119,7 +119,7 @@ import {
   exportVectorLayer,
   formatAttributeValue,
   geojsonVectorSourceId,
-  KmlCoordinateError,
+  kmlExportErrorMessage,
   sanitizeExportFileName,
   shapefileFieldWarnings,
   type VectorExportFormat,
@@ -940,17 +940,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     } catch (error) {
       console.error("Failed to export attribute table", error);
       setExportError(
-        error instanceof KmlCoordinateError
-          ? error.featureId == null
-            ? t("vectorExport.invalidKmlCoordinatesAtIndex", {
-                index: error.featureIndex,
-              })
-            : t("vectorExport.invalidKmlCoordinatesById", {
-                id: error.featureId,
-              })
-          : error instanceof Error
-            ? error.message
-            : t("attributeTable.exportFailed"),
+        kmlExportErrorMessage(error, t) ??
+          (error instanceof Error ? error.message : t("attributeTable.exportFailed")),
       );
     }
   };

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -119,6 +119,7 @@ import {
   exportVectorLayer,
   formatAttributeValue,
   geojsonVectorSourceId,
+  KmlCoordinateError,
   sanitizeExportFileName,
   shapefileFieldWarnings,
   type VectorExportFormat,
@@ -938,7 +939,19 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       }
     } catch (error) {
       console.error("Failed to export attribute table", error);
-      setExportError(error instanceof Error ? error.message : t("attributeTable.exportFailed"));
+      setExportError(
+        error instanceof KmlCoordinateError
+          ? error.featureId == null
+            ? t("vectorExport.invalidKmlCoordinatesAtIndex", {
+                index: error.featureIndex,
+              })
+            : t("vectorExport.invalidKmlCoordinatesById", {
+                id: error.featureId,
+              })
+          : error instanceof Error
+            ? error.message
+            : t("attributeTable.exportFailed"),
+      );
     }
   };
 

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1661,6 +1661,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             <DropdownMenuItem onSelect={() => void exportLayer("geopackage")}>
               GeoPackage
             </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void exportLayer("kml")}>KML</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void exportLayer("kmz")}>KMZ</DropdownMenuItem>
             <DropdownMenuItem onSelect={() => void exportLayer("shapefile")}>
               Shapefile (zipped)
             </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -928,7 +928,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       if (!exportGeojson) return;
 
       const baseName = sanitizeExportFileName(layer.name);
-      const savedPath = await exportVectorLayer(exportGeojson, format, baseName);
+      const savedPath = await exportVectorLayer(exportGeojson, format, baseName, layer.name);
       // Surface Shapefile field-name limitations (10-char truncation and any
       // resulting collisions) only when a file was actually written; a null
       // path means the user cancelled the save dialog.

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -182,6 +182,7 @@ import { canExtractRasterSubset } from "../../lib/raster-subset-export";
 import {
   exportVectorLayer,
   geojsonVectorSourceId,
+  KmlCoordinateError,
   resolveLayerGeojson,
   sanitizeExportFileName,
   shapefileFieldWarnings,
@@ -1239,7 +1240,18 @@ export function LayerPanel({
           scheduleStatusClear(layer.id);
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : t("layers.exportLayerError");
+        const message =
+          error instanceof KmlCoordinateError
+            ? error.featureId == null
+              ? t("vectorExport.invalidKmlCoordinatesAtIndex", {
+                  index: error.featureIndex,
+                })
+              : t("vectorExport.invalidKmlCoordinatesById", {
+                  id: error.featureId,
+                })
+            : error instanceof Error
+              ? error.message
+              : t("layers.exportLayerError");
         setRefreshStatuses((current) => ({
           ...current,
           [layer.id]: { type: "error", message },

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -3127,6 +3127,20 @@ export function LayerPanel({
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
                                   onSelect={() => {
+                                    void handleExportLayer(layer, "kml");
+                                  }}
+                                >
+                                  KML
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onSelect={() => {
+                                    void handleExportLayer(layer, "kmz");
+                                  }}
+                                >
+                                  KMZ
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  onSelect={() => {
                                     void handleExportLayer(layer, "shapefile");
                                   }}
                                 >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1217,6 +1217,7 @@ export function LayerPanel({
           geojson,
           format,
           sanitizeExportFileName(layer.name),
+          layer.name,
         );
         // A null path means the user cancelled the save dialog, so no note.
         if (savedPath !== null) {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -182,7 +182,7 @@ import { canExtractRasterSubset } from "../../lib/raster-subset-export";
 import {
   exportVectorLayer,
   geojsonVectorSourceId,
-  KmlCoordinateError,
+  kmlExportErrorMessage,
   resolveLayerGeojson,
   sanitizeExportFileName,
   shapefileFieldWarnings,
@@ -1241,17 +1241,8 @@ export function LayerPanel({
         }
       } catch (error) {
         const message =
-          error instanceof KmlCoordinateError
-            ? error.featureId == null
-              ? t("vectorExport.invalidKmlCoordinatesAtIndex", {
-                  index: error.featureIndex,
-                })
-              : t("vectorExport.invalidKmlCoordinatesById", {
-                  id: error.featureId,
-                })
-            : error instanceof Error
-              ? error.message
-              : t("layers.exportLayerError");
+          kmlExportErrorMessage(error, t) ??
+          (error instanceof Error ? error.message : t("layers.exportLayerError"));
         setRefreshStatuses((current) => ({
           ...current,
           [layer.id]: { type: "error", message },

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -47,6 +47,7 @@ import {
 import type { LargeVectorDataset } from "../../lib/duckdb-vector-guard";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
 import { beginProcessingRun, type ProcessingRunTracker } from "../../lib/processing-history";
+import { KmlCoordinateError } from "../../lib/vector-export-errors";
 import i18n from "../../i18n";
 
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
@@ -862,7 +863,17 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
+        err instanceof KmlCoordinateError
+          ? err.featureId == null
+            ? i18n.t("vectorExport.invalidKmlCoordinatesAtIndex", {
+                index: err.featureIndex,
+              })
+            : i18n.t("vectorExport.invalidKmlCoordinatesById", {
+                id: err.featureId,
+              })
+          : err instanceof Error
+            ? err.message
+            : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -47,7 +47,6 @@ import {
 import type { LargeVectorDataset } from "../../lib/duckdb-vector-guard";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
 import { beginProcessingRun, type ProcessingRunTracker } from "../../lib/processing-history";
-import { KmlCoordinateError } from "../../lib/vector-export-errors";
 import i18n from "../../i18n";
 
 const RUNNING_JOB_STATUSES = new Set(["pending", "running"]);
@@ -863,17 +862,7 @@ export function ConversionDialog() {
       );
     } catch (err) {
       const detail =
-        err instanceof KmlCoordinateError
-          ? err.featureId == null
-            ? i18n.t("vectorExport.invalidKmlCoordinatesAtIndex", {
-                index: err.featureIndex,
-              })
-            : i18n.t("vectorExport.invalidKmlCoordinatesById", {
-                id: err.featureId,
-              })
-          : err instanceof Error
-            ? err.message
-            : i18n.t("toolbar.conversion.convertFailed");
+        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4373,7 +4373,7 @@
     }
   },
   "vectorExport": {
-    "invalidKmlCoordinatesAtIndex": "KML export could not write feature at index {{index}} because it has invalid coordinates.",
+    "invalidKmlCoordinatesByPosition": "KML export could not write feature {{position}} because it has invalid coordinates.",
     "invalidKmlCoordinatesById": "KML export could not write feature ID {{id}} because it has invalid coordinates."
   },
   "layers": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4372,6 +4372,10 @@
       "minMaxInvalid": "Min must be less than or equal to Max."
     }
   },
+  "vectorExport": {
+    "invalidKmlCoordinatesAtIndex": "KML export could not write feature at index {{index}} because it has invalid coordinates.",
+    "invalidKmlCoordinatesById": "KML export could not write feature ID {{id}} because it has invalid coordinates."
+  },
   "layers": {
     "panelCollapsedLabel": "Layers (collapsed)",
     "expand": "Expand layers",

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -220,12 +220,12 @@ function styleKml(properties: GeoJsonProperties): string | null {
   return `<Style>${sections.join("")}</Style>`;
 }
 
-function featureKml(feature: Feature): string {
+function featureKml(feature: Feature, style: string | null): string {
   const properties = feature.properties ?? {};
   const contents = [
     propertyElement(properties, "name"),
     propertyElement(properties, "description"),
-    styleKml(properties),
+    style,
     extendedDataKml(feature),
     feature.geometry ? geometryKml(feature.geometry) : null,
   ].filter((value): value is string => value !== null);
@@ -243,18 +243,39 @@ function featureKml(feature: Feature): string {
  * Google Earth and other KML clients.
  */
 export function writeKml(geojson: FeatureCollection, documentName: string): string {
+  const featureStyles = geojson.features.map((feature) => styleKml(feature.properties));
+  const styleCounts = new Map<string, number>();
+  for (const style of featureStyles) {
+    if (style) styleCounts.set(style, (styleCounts.get(style) ?? 0) + 1);
+  }
+
+  const sharedStyles = new Map<string, string>();
+  for (const [style, count] of styleCounts) {
+    if (count > 1) sharedStyles.set(style, `style-${sharedStyles.size + 1}`);
+  }
+  const styleDefinitions = Array.from(sharedStyles, ([style, id]) =>
+    indentXml(style.replace("<Style>", `<Style id="${id}">`), 4),
+  );
+
   const placemarks = geojson.features.map((feature, index) => {
     try {
-      return indentXml(featureKml(feature), 4);
+      const style = featureStyles[index];
+      const sharedStyleId = style ? sharedStyles.get(style) : undefined;
+      return indentXml(
+        featureKml(feature, sharedStyleId ? `<styleUrl>#${sharedStyleId}</styleUrl>` : style),
+        4,
+      );
     } catch (error) {
       const reference = feature.id == null ? `at index ${index}` : `with id ${feature.id}`;
       const message = error instanceof Error ? error.message : String(error);
       throw new Error(`Unable to export KML feature ${reference}: ${message}`);
     }
   });
-  const documentContents = [`    <name>${xmlSafeText(documentName)}</name>`, ...placemarks].join(
-    "\n",
-  );
+  const documentContents = [
+    `    <name>${xmlSafeText(documentName)}</name>`,
+    ...styleDefinitions,
+    ...placemarks,
+  ].join("\n");
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     `<kml xmlns="${KML_NAMESPACE}">`,

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -1,6 +1,9 @@
 import type { Feature, FeatureCollection, GeoJsonProperties, Geometry, Position } from "geojson";
+import { KmlCoordinateError } from "./vector-export-errors";
 
 const KML_NAMESPACE = "http://www.opengis.net/kml/2.2";
+
+class InvalidCoordinateError extends Error {}
 
 function xmlSafeText(value: unknown): string {
   return String(value)
@@ -39,7 +42,7 @@ function decimalText(value: number): string {
 
 function positionText(position: Position): string {
   if (position.length < 2 || position.slice(0, 3).some((value) => !Number.isFinite(value))) {
-    throw new Error("KML export requires finite longitude and latitude coordinates.");
+    throw new InvalidCoordinateError();
   }
   return position
     .slice(0, 3)
@@ -266,9 +269,10 @@ export function writeKml(geojson: FeatureCollection, documentName: string): stri
         4,
       );
     } catch (error) {
-      const reference = feature.id == null ? `at index ${index}` : `with id ${feature.id}`;
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Unable to export KML feature ${reference}: ${message}`);
+      if (error instanceof InvalidCoordinateError) {
+        throw new KmlCoordinateError(index, feature.id);
+      }
+      throw error;
     }
   });
   const documentContents = [

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -20,11 +20,31 @@ function indentXml(xml: string, spaces: number): string {
     .join("\n");
 }
 
+function decimalText(value: number): string {
+  const text = String(value);
+  const match = /^(-?)(\d+)(?:\.(\d+))?e([+-]?\d+)$/i.exec(text);
+  if (!match) return text;
+
+  const [, sign, integer, fraction = "", rawExponent] = match;
+  const digits = `${integer}${fraction}`;
+  const decimalIndex = integer.length + Number(rawExponent);
+  if (decimalIndex <= 0) {
+    return `${sign}0.${"0".repeat(-decimalIndex)}${digits}`;
+  }
+  if (decimalIndex >= digits.length) {
+    return `${sign}${digits}${"0".repeat(decimalIndex - digits.length)}`;
+  }
+  return `${sign}${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`;
+}
+
 function positionText(position: Position): string {
   if (position.length < 2 || position.slice(0, 3).some((value) => !Number.isFinite(value))) {
     throw new Error("KML export requires finite longitude and latitude coordinates.");
   }
-  return position.slice(0, 3).join(",");
+  return position
+    .slice(0, 3)
+    .map((value) => decimalText(value))
+    .join(",");
 }
 
 function coordinatesText(positions: Position[]): string {
@@ -122,9 +142,22 @@ function propertyElement(properties: GeoJsonProperties, key: string): string | n
 }
 
 function extendedDataKml(feature: Feature): string | null {
-  const entries = Object.entries(feature.properties ?? {});
-  if (feature.id != null && !Object.hasOwn(feature.properties ?? {}, "feature_id")) {
-    entries.unshift(["feature_id", feature.id]);
+  const properties = feature.properties ?? {};
+  const entries = Object.entries(properties).filter(
+    ([key, value]) =>
+      !((key === "name" || key === "description") && value != null && typeof value !== "object"),
+  );
+  if (feature.id != null) {
+    let idKey = "feature_id";
+    if (Object.hasOwn(properties, idKey)) {
+      idKey = "geojson_feature_id";
+      let suffix = 2;
+      while (Object.hasOwn(properties, idKey)) {
+        idKey = `geojson_feature_id_${suffix}`;
+        suffix += 1;
+      }
+    }
+    entries.unshift([idKey, feature.id]);
   }
   if (entries.length === 0) return null;
   const data = entries.map(
@@ -204,9 +237,10 @@ function featureKml(feature: Feature): string {
 /**
  * Convert a GeoJSON FeatureCollection to a KML 2.2 document.
  *
- * All feature properties are retained in ExtendedData. Common `name`,
- * `description`, and simplestyle properties are also promoted to their native
- * KML elements for display in Google Earth and other KML clients.
+ * Feature properties are retained in ExtendedData, except primitive `name` and
+ * `description` values that are represented by their native KML elements.
+ * Simplestyle properties are also promoted to native KML styles for display in
+ * Google Earth and other KML clients.
  */
 export function writeKml(geojson: FeatureCollection, documentName: string): string {
   const placemarks = geojson.features.map((feature, index) => {

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -1,10 +1,4 @@
-import type {
-  Feature,
-  FeatureCollection,
-  GeoJsonProperties,
-  Geometry,
-  Position,
-} from "geojson";
+import type { Feature, FeatureCollection, GeoJsonProperties, Geometry, Position } from "geojson";
 
 const KML_NAMESPACE = "http://www.opengis.net/kml/2.2";
 
@@ -209,10 +203,9 @@ function featureKml(feature: Feature): string {
  */
 export function writeKml(geojson: FeatureCollection, documentName: string): string {
   const placemarks = geojson.features.map((feature) => indentXml(featureKml(feature), 4));
-  const documentContents = [
-    `    <name>${xmlSafeText(documentName)}</name>`,
-    ...placemarks,
-  ].join("\n");
+  const documentContents = [`    <name>${xmlSafeText(documentName)}</name>`, ...placemarks].join(
+    "\n",
+  );
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     `<kml xmlns="${KML_NAMESPACE}">`,

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -1,0 +1,224 @@
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  Position,
+} from "geojson";
+
+const KML_NAMESPACE = "http://www.opengis.net/kml/2.2";
+
+function xmlSafeText(value: unknown): string {
+  return String(value)
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, "\uFFFD")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function indentXml(xml: string, spaces: number): string {
+  const indentation = " ".repeat(spaces);
+  return xml
+    .split("\n")
+    .map((line) => `${indentation}${line}`)
+    .join("\n");
+}
+
+function positionText(position: Position): string {
+  if (position.length < 2 || position.slice(0, 3).some((value) => !Number.isFinite(value))) {
+    throw new Error("KML export requires finite longitude and latitude coordinates.");
+  }
+  return position.slice(0, 3).join(",");
+}
+
+function coordinatesText(positions: Position[]): string {
+  return positions.map(positionText).join(" ");
+}
+
+function closedRing(ring: Position[]): Position[] {
+  if (ring.length === 0) return ring;
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  if (
+    first.length === last.length &&
+    first.every((coordinate, index) => coordinate === last[index])
+  ) {
+    return ring;
+  }
+  return [...ring, first];
+}
+
+function polygonKml(coordinates: Position[][]): string {
+  const [outer, ...inner] = coordinates;
+  const boundaries: string[] = [];
+  if (outer) {
+    boundaries.push(
+      "<outerBoundaryIs>",
+      "  <LinearRing>",
+      `    <coordinates>${coordinatesText(closedRing(outer))}</coordinates>`,
+      "  </LinearRing>",
+      "</outerBoundaryIs>",
+    );
+  }
+  for (const ring of inner) {
+    boundaries.push(
+      "<innerBoundaryIs>",
+      "  <LinearRing>",
+      `    <coordinates>${coordinatesText(closedRing(ring))}</coordinates>`,
+      "  </LinearRing>",
+      "</innerBoundaryIs>",
+    );
+  }
+  if (boundaries.length === 0) return "<Polygon />";
+  return `<Polygon>\n${indentXml(boundaries.join("\n"), 2)}\n</Polygon>`;
+}
+
+function multiGeometryKml(geometries: Geometry[]): string {
+  if (geometries.length === 0) return "<MultiGeometry />";
+  return `<MultiGeometry>\n${geometries
+    .map((geometry) => indentXml(geometryKml(geometry), 2))
+    .join("\n")}\n</MultiGeometry>`;
+}
+
+function geometryKml(geometry: Geometry): string {
+  switch (geometry.type) {
+    case "Point":
+      return `<Point><coordinates>${positionText(geometry.coordinates)}</coordinates></Point>`;
+    case "MultiPoint":
+      return multiGeometryKml(
+        geometry.coordinates.map((coordinates) => ({ type: "Point", coordinates })),
+      );
+    case "LineString":
+      return `<LineString><coordinates>${coordinatesText(geometry.coordinates)}</coordinates></LineString>`;
+    case "MultiLineString":
+      return multiGeometryKml(
+        geometry.coordinates.map((coordinates) => ({ type: "LineString", coordinates })),
+      );
+    case "Polygon":
+      return polygonKml(geometry.coordinates);
+    case "MultiPolygon":
+      return multiGeometryKml(
+        geometry.coordinates.map((coordinates) => ({ type: "Polygon", coordinates })),
+      );
+    case "GeometryCollection":
+      return multiGeometryKml(geometry.geometries);
+  }
+}
+
+function propertyText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value !== "object") return String(value);
+  return JSON.stringify(value) ?? String(value);
+}
+
+function propertyElement(properties: GeoJsonProperties, key: string): string | null {
+  const value = properties?.[key];
+  return value == null || typeof value === "object"
+    ? null
+    : `<${key}>${xmlSafeText(value)}</${key}>`;
+}
+
+function extendedDataKml(feature: Feature): string | null {
+  const entries = Object.entries(feature.properties ?? {});
+  if (feature.id != null && !Object.hasOwn(feature.properties ?? {}, "feature_id")) {
+    entries.unshift(["feature_id", feature.id]);
+  }
+  if (entries.length === 0) return null;
+  const data = entries.map(
+    ([key, value]) =>
+      `<Data name="${xmlSafeText(key)}"><value>${xmlSafeText(propertyText(value))}</value></Data>`,
+  );
+  return `<ExtendedData>\n${data.map((entry) => indentXml(entry, 2)).join("\n")}\n</ExtendedData>`;
+}
+
+function opacityByte(value: unknown): string {
+  const opacity = typeof value === "number" ? value : Number(value ?? 1);
+  const normalized = Number.isFinite(opacity) ? Math.min(1, Math.max(0, opacity)) : 1;
+  return Math.round(normalized * 255)
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function kmlColor(color: unknown, opacity: unknown): string | null {
+  if (typeof color !== "string") return null;
+  const match = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim());
+  if (!match) return null;
+  const hex =
+    match[1].length === 3
+      ? match[1]
+          .split("")
+          .map((digit) => `${digit}${digit}`)
+          .join("")
+      : match[1];
+  const red = hex.slice(0, 2);
+  const green = hex.slice(2, 4);
+  const blue = hex.slice(4, 6);
+  return `${opacityByte(opacity)}${blue}${green}${red}`.toLowerCase();
+}
+
+function styleKml(properties: GeoJsonProperties): string | null {
+  if (!properties) return null;
+  const sections: string[] = [];
+
+  const markerColor = kmlColor(properties["marker-color"], properties["marker-opacity"]);
+  if (markerColor) {
+    sections.push(`<IconStyle><color>${markerColor}</color></IconStyle>`);
+  }
+
+  const strokeColor = kmlColor(properties.stroke, properties["stroke-opacity"]);
+  const strokeWidth = Number(properties["stroke-width"]);
+  if (strokeColor || Number.isFinite(strokeWidth)) {
+    const values = [
+      strokeColor ? `<color>${strokeColor}</color>` : null,
+      Number.isFinite(strokeWidth) ? `<width>${strokeWidth}</width>` : null,
+    ].filter((value): value is string => value !== null);
+    sections.push(`<LineStyle>${values.join("")}</LineStyle>`);
+  }
+
+  const fillColor = kmlColor(properties.fill, properties["fill-opacity"]);
+  if (fillColor) {
+    sections.push(`<PolyStyle><color>${fillColor}</color></PolyStyle>`);
+  }
+
+  if (sections.length === 0) return null;
+  return `<Style>${sections.join("")}</Style>`;
+}
+
+function featureKml(feature: Feature): string {
+  const properties = feature.properties ?? {};
+  const contents = [
+    propertyElement(properties, "name"),
+    propertyElement(properties, "description"),
+    styleKml(properties),
+    extendedDataKml(feature),
+    feature.geometry ? geometryKml(feature.geometry) : null,
+  ].filter((value): value is string => value !== null);
+
+  if (contents.length === 0) return "<Placemark />";
+  return `<Placemark>\n${contents.map((value) => indentXml(value, 2)).join("\n")}\n</Placemark>`;
+}
+
+/**
+ * Convert a GeoJSON FeatureCollection to a KML 2.2 document.
+ *
+ * All feature properties are retained in ExtendedData. Common `name`,
+ * `description`, and simplestyle properties are also promoted to their native
+ * KML elements for display in Google Earth and other KML clients.
+ */
+export function writeKml(geojson: FeatureCollection, documentName: string): string {
+  const placemarks = geojson.features.map((feature) => indentXml(featureKml(feature), 4));
+  const documentContents = [
+    `    <name>${xmlSafeText(documentName)}</name>`,
+    ...placemarks,
+  ].join("\n");
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<kml xmlns="${KML_NAMESPACE}">`,
+    "  <Document>",
+    documentContents,
+    "  </Document>",
+    "</kml>",
+  ].join("\n");
+}

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -55,6 +55,9 @@ function coordinatesText(positions: Position[]): string {
 }
 
 function hasAltitude(position: Position): boolean {
+  // KML applies altitude mode to the entire geometry. For mixed-dimensional
+  // GeoJSON, preserve supplied altitudes and let KML interpret 2D vertices as
+  // having its implicit zero altitude.
   return position.length >= 3;
 }
 
@@ -134,7 +137,7 @@ function geometryKml(geometry: Geometry): string {
 function propertyText(value: unknown): string {
   if (value == null) return "";
   if (typeof value !== "object") return String(value);
-  return JSON.stringify(value) ?? String(value);
+  return JSON.stringify(value);
 }
 
 function propertyElement(properties: GeoJsonProperties, key: string): string | null {

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -31,6 +31,10 @@ function coordinatesText(positions: Position[]): string {
   return positions.map(positionText).join(" ");
 }
 
+function hasAltitude(position: Position): boolean {
+  return position.length >= 3;
+}
+
 function closedRing(ring: Position[]): Position[] {
   if (ring.length === 0) return ring;
   const first = ring[0];
@@ -66,7 +70,10 @@ function polygonKml(coordinates: Position[][]): string {
     );
   }
   if (boundaries.length === 0) return "<Polygon />";
-  return `<Polygon>\n${indentXml(boundaries.join("\n"), 2)}\n</Polygon>`;
+  const contents = coordinates.some((ring) => ring.some(hasAltitude))
+    ? ["<altitudeMode>absolute</altitudeMode>", ...boundaries]
+    : boundaries;
+  return `<Polygon>\n${indentXml(contents.join("\n"), 2)}\n</Polygon>`;
 }
 
 function multiGeometryKml(geometries: Geometry[]): string {
@@ -79,13 +86,13 @@ function multiGeometryKml(geometries: Geometry[]): string {
 function geometryKml(geometry: Geometry): string {
   switch (geometry.type) {
     case "Point":
-      return `<Point><coordinates>${positionText(geometry.coordinates)}</coordinates></Point>`;
+      return `<Point>${hasAltitude(geometry.coordinates) ? "<altitudeMode>absolute</altitudeMode>" : ""}<coordinates>${positionText(geometry.coordinates)}</coordinates></Point>`;
     case "MultiPoint":
       return multiGeometryKml(
         geometry.coordinates.map((coordinates) => ({ type: "Point", coordinates })),
       );
     case "LineString":
-      return `<LineString><coordinates>${coordinatesText(geometry.coordinates)}</coordinates></LineString>`;
+      return `<LineString>${geometry.coordinates.some(hasAltitude) ? "<altitudeMode>absolute</altitudeMode>" : ""}<coordinates>${coordinatesText(geometry.coordinates)}</coordinates></LineString>`;
     case "MultiLineString":
       return multiGeometryKml(
         geometry.coordinates.map((coordinates) => ({ type: "LineString", coordinates })),

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -209,7 +209,15 @@ function featureKml(feature: Feature): string {
  * KML elements for display in Google Earth and other KML clients.
  */
 export function writeKml(geojson: FeatureCollection, documentName: string): string {
-  const placemarks = geojson.features.map((feature) => indentXml(featureKml(feature), 4));
+  const placemarks = geojson.features.map((feature, index) => {
+    try {
+      return indentXml(featureKml(feature), 4);
+    } catch (error) {
+      const reference = feature.id == null ? `at index ${index}` : `with id ${feature.id}`;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Unable to export KML feature ${reference}: ${message}`);
+    }
+  });
   const documentContents = [`    <name>${xmlSafeText(documentName)}</name>`, ...placemarks].join(
     "\n",
   );

--- a/apps/geolibre-desktop/src/lib/kml-writer.ts
+++ b/apps/geolibre-desktop/src/lib/kml-writer.ts
@@ -170,15 +170,15 @@ function extendedDataKml(feature: Feature): string | null {
   return `<ExtendedData>\n${data.map((entry) => indentXml(entry, 2)).join("\n")}\n</ExtendedData>`;
 }
 
-function opacityByte(value: unknown): string {
-  const opacity = typeof value === "number" ? value : Number(value ?? 1);
-  const normalized = Number.isFinite(opacity) ? Math.min(1, Math.max(0, opacity)) : 1;
+function opacityByte(value: unknown, defaultOpacity = 1): string {
+  const opacity = typeof value === "number" ? value : Number(value ?? defaultOpacity);
+  const normalized = Number.isFinite(opacity) ? Math.min(1, Math.max(0, opacity)) : defaultOpacity;
   return Math.round(normalized * 255)
     .toString(16)
     .padStart(2, "0");
 }
 
-function kmlColor(color: unknown, opacity: unknown): string | null {
+function kmlColor(color: unknown, opacity: unknown, defaultOpacity = 1): string | null {
   if (typeof color !== "string") return null;
   const match = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim());
   if (!match) return null;
@@ -192,7 +192,7 @@ function kmlColor(color: unknown, opacity: unknown): string | null {
   const red = hex.slice(0, 2);
   const green = hex.slice(2, 4);
   const blue = hex.slice(4, 6);
-  return `${opacityByte(opacity)}${blue}${green}${red}`.toLowerCase();
+  return `${opacityByte(opacity, defaultOpacity)}${blue}${green}${red}`.toLowerCase();
 }
 
 function styleKml(properties: GeoJsonProperties): string | null {
@@ -214,7 +214,7 @@ function styleKml(properties: GeoJsonProperties): string | null {
     sections.push(`<LineStyle>${values.join("")}</LineStyle>`);
   }
 
-  const fillColor = kmlColor(properties.fill, properties["fill-opacity"]);
+  const fillColor = kmlColor(properties.fill, properties["fill-opacity"], 0.6);
   if (fillColor) {
     sections.push(`<PolyStyle><color>${fillColor}</color></PolyStyle>`);
   }

--- a/apps/geolibre-desktop/src/lib/vector-export-errors.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export-errors.ts
@@ -1,0 +1,12 @@
+/** Error raised when a GeoJSON feature contains coordinates KML cannot serialize. */
+export class KmlCoordinateError extends Error {
+  readonly featureId: string | number | undefined;
+  readonly featureIndex: number;
+
+  constructor(featureIndex: number, featureId: string | number | undefined) {
+    super("KML_INVALID_COORDINATE");
+    this.name = "KmlCoordinateError";
+    this.featureId = featureId;
+    this.featureIndex = featureIndex;
+  }
+}

--- a/apps/geolibre-desktop/src/lib/vector-export-errors.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export-errors.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from "i18next";
+
 /** Error raised when a GeoJSON feature contains coordinates KML cannot serialize. */
 export class KmlCoordinateError extends Error {
   readonly featureId: string | number | undefined;
@@ -9,4 +11,16 @@ export class KmlCoordinateError extends Error {
     this.featureId = featureId;
     this.featureIndex = featureIndex;
   }
+}
+
+/** Return a localized KML coordinate error, or null for an unrelated error. */
+export function kmlExportErrorMessage(error: unknown, t: TFunction): string | null {
+  if (!(error instanceof KmlCoordinateError)) return null;
+  return error.featureId == null
+    ? t("vectorExport.invalidKmlCoordinatesByPosition", {
+        position: error.featureIndex + 1,
+      })
+    : t("vectorExport.invalidKmlCoordinatesById", {
+        id: error.featureId,
+      });
 }

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -5,7 +5,7 @@ import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 import { saveBinaryFileWithFallback, saveTextFileWithFallback } from "./tauri-io";
 import { type BinaryVectorExportFormat, exportBinaryVectorLayer } from "./vector-exporter";
 
-export type VectorExportFormat = "geojson" | "csv" | BinaryVectorExportFormat;
+export type VectorExportFormat = "geojson" | "csv" | "kml" | BinaryVectorExportFormat;
 
 /** Render an attribute value as the plain string used in CSV cells and inputs. */
 export function formatAttributeValue(value: unknown): string {
@@ -57,6 +57,8 @@ function exportFormatLabel(format: BinaryVectorExportFormat): string {
       return "GeoPackage";
     case "shapefile":
       return "Shapefile (zipped)";
+    case "kmz":
+      return "KMZ";
   }
 }
 
@@ -68,6 +70,8 @@ function exportFileExtension(format: BinaryVectorExportFormat): string {
       return "gpkg";
     case "shapefile":
       return "zip";
+    case "kmz":
+      return "kmz";
   }
 }
 
@@ -79,6 +83,8 @@ function exportMimeType(format: BinaryVectorExportFormat): string {
       return "application/geopackage+sqlite3";
     case "shapefile":
       return "application/zip";
+    case "kmz":
+      return "application/vnd.google-earth.kmz";
   }
 }
 
@@ -173,28 +179,44 @@ export function shapefileFieldWarnings(geojson: FeatureCollection): string[] {
 }
 
 async function exportTextLayer(
-  format: "geojson" | "csv",
+  format: "geojson" | "csv" | "kml",
   geojson: FeatureCollection,
   baseName: string,
 ): Promise<string | null> {
   const isCsv = format === "csv";
-  const content = isCsv ? geojsonToCsv(geojson) : JSON.stringify(geojson, null, 2);
+  const isKml = format === "kml";
+  const content = isCsv
+    ? geojsonToCsv(geojson)
+    : isKml
+      ? (await import("./kml-writer")).writeKml(geojson, baseName)
+      : JSON.stringify(geojson, null, 2);
+  const extension = isCsv ? "csv" : isKml ? "kml" : "geojson";
+  const label = isCsv ? "CSV" : isKml ? "KML" : "GeoJSON";
+  const mimeType = isCsv
+    ? "text/csv"
+    : isKml
+      ? "application/vnd.google-earth.kml+xml"
+      : "application/geo+json";
   return saveTextFileWithFallback(content, {
-    defaultName: `${baseName}.${isCsv ? "csv" : "geojson"}`,
+    defaultName: `${baseName}.${extension}`,
     filters: [
       isCsv
-        ? { name: "CSV", extensions: ["csv"] }
-        : { name: "GeoJSON", extensions: ["geojson", "json"] },
+        ? { name: label, extensions: [extension] }
+        : isKml
+          ? { name: label, extensions: [extension] }
+          : { name: label, extensions: ["geojson", "json"] },
     ],
     browserTypes: [
       {
-        description: isCsv ? "CSV" : "GeoJSON",
+        description: label,
         accept: isCsv
           ? { "text/csv": [".csv"] }
-          : { "application/geo+json": [".geojson", ".json"] },
+          : isKml
+            ? { "application/vnd.google-earth.kml+xml": [".kml"] }
+            : { "application/geo+json": [".geojson", ".json"] },
       },
     ],
-    mimeType: isCsv ? "text/csv" : "application/geo+json",
+    mimeType,
   });
 }
 
@@ -229,7 +251,7 @@ export async function exportVectorLayer(
   format: VectorExportFormat,
   baseName: string,
 ): Promise<string | null> {
-  if (format === "geojson" || format === "csv") {
+  if (format === "geojson" || format === "csv" || format === "kml") {
     return exportTextLayer(format, geojson, baseName);
   }
   return exportBinaryLayer(format, geojson, baseName);

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -5,7 +5,7 @@ import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 import { saveBinaryFileWithFallback, saveTextFileWithFallback } from "./tauri-io";
 import { type BinaryVectorExportFormat, exportBinaryVectorLayer } from "./vector-exporter";
 
-export { KmlCoordinateError } from "./vector-export-errors";
+export { KmlCoordinateError, kmlExportErrorMessage } from "./vector-export-errors";
 
 type TextVectorExportFormat = "geojson" | "csv" | "kml";
 

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -212,7 +212,7 @@ export function shapefileFieldWarnings(geojson: FeatureCollection): string[] {
 async function textExportContent(
   format: TextVectorExportFormat,
   geojson: FeatureCollection,
-  baseName: string,
+  documentName: string,
 ): Promise<string> {
   switch (format) {
     case "geojson":
@@ -220,7 +220,7 @@ async function textExportContent(
     case "csv":
       return geojsonToCsv(geojson);
     case "kml":
-      return (await import("./kml-writer")).writeKml(geojson, baseName);
+      return (await import("./kml-writer")).writeKml(geojson, documentName);
   }
 }
 
@@ -228,8 +228,9 @@ async function exportTextLayer(
   format: TextVectorExportFormat,
   geojson: FeatureCollection,
   baseName: string,
+  documentName: string,
 ): Promise<string | null> {
-  const content = await textExportContent(format, geojson, baseName);
+  const content = await textExportContent(format, geojson, documentName);
   const { extension, filterExtensions, label, mimeType } = TEXT_EXPORT_FORMATS[format];
   return saveTextFileWithFallback(content, {
     defaultName: `${baseName}.${extension}`,
@@ -250,8 +251,9 @@ async function exportBinaryLayer(
   format: BinaryVectorExportFormat,
   geojson: FeatureCollection,
   baseName: string,
+  documentName: string,
 ): Promise<string | null> {
-  const result = await exportBinaryVectorLayer(geojson, format, baseName);
+  const result = await exportBinaryVectorLayer(geojson, format, baseName, documentName);
   const label = exportFormatLabel(format);
   const extension = exportFileExtension(format);
   return saveBinaryFileWithFallback(result.data, {
@@ -271,16 +273,19 @@ async function exportBinaryLayer(
  * Save a vector layer's features to disk in the requested format, prompting
  * with the native (Tauri) or browser file-save dialog. Returns the saved path
  * (a name in the browser), or null when the user cancels the save dialog.
+ * The optional document name preserves the human-readable layer title inside
+ * KML and KMZ while the base name remains safe for the filesystem.
  */
 export async function exportVectorLayer(
   geojson: FeatureCollection,
   format: VectorExportFormat,
   baseName: string,
+  documentName = baseName,
 ): Promise<string | null> {
   if (format === "geojson" || format === "csv" || format === "kml") {
-    return exportTextLayer(format, geojson, baseName);
+    return exportTextLayer(format, geojson, baseName, documentName);
   }
-  return exportBinaryLayer(format, geojson, baseName);
+  return exportBinaryLayer(format, geojson, baseName, documentName);
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -5,7 +5,38 @@ import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 import { saveBinaryFileWithFallback, saveTextFileWithFallback } from "./tauri-io";
 import { type BinaryVectorExportFormat, exportBinaryVectorLayer } from "./vector-exporter";
 
-export type VectorExportFormat = "geojson" | "csv" | "kml" | BinaryVectorExportFormat;
+type TextVectorExportFormat = "geojson" | "csv" | "kml";
+
+export type VectorExportFormat = TextVectorExportFormat | BinaryVectorExportFormat;
+
+const TEXT_EXPORT_FORMATS: Record<
+  TextVectorExportFormat,
+  {
+    extension: string;
+    filterExtensions: string[];
+    label: string;
+    mimeType: string;
+  }
+> = {
+  geojson: {
+    extension: "geojson",
+    filterExtensions: ["geojson", "json"],
+    label: "GeoJSON",
+    mimeType: "application/geo+json",
+  },
+  csv: {
+    extension: "csv",
+    filterExtensions: ["csv"],
+    label: "CSV",
+    mimeType: "text/csv",
+  },
+  kml: {
+    extension: "kml",
+    filterExtensions: ["kml"],
+    label: "KML",
+    mimeType: "application/vnd.google-earth.kml+xml",
+  },
+};
 
 /** Render an attribute value as the plain string used in CSV cells and inputs. */
 export function formatAttributeValue(value: unknown): string {
@@ -178,42 +209,37 @@ export function shapefileFieldWarnings(geojson: FeatureCollection): string[] {
   return warnings;
 }
 
+async function textExportContent(
+  format: TextVectorExportFormat,
+  geojson: FeatureCollection,
+  baseName: string,
+): Promise<string> {
+  switch (format) {
+    case "geojson":
+      return JSON.stringify(geojson, null, 2);
+    case "csv":
+      return geojsonToCsv(geojson);
+    case "kml":
+      return (await import("./kml-writer")).writeKml(geojson, baseName);
+  }
+}
+
 async function exportTextLayer(
-  format: "geojson" | "csv" | "kml",
+  format: TextVectorExportFormat,
   geojson: FeatureCollection,
   baseName: string,
 ): Promise<string | null> {
-  const isCsv = format === "csv";
-  const isKml = format === "kml";
-  const content = isCsv
-    ? geojsonToCsv(geojson)
-    : isKml
-      ? (await import("./kml-writer")).writeKml(geojson, baseName)
-      : JSON.stringify(geojson, null, 2);
-  const extension = isCsv ? "csv" : isKml ? "kml" : "geojson";
-  const label = isCsv ? "CSV" : isKml ? "KML" : "GeoJSON";
-  const mimeType = isCsv
-    ? "text/csv"
-    : isKml
-      ? "application/vnd.google-earth.kml+xml"
-      : "application/geo+json";
+  const content = await textExportContent(format, geojson, baseName);
+  const { extension, filterExtensions, label, mimeType } = TEXT_EXPORT_FORMATS[format];
   return saveTextFileWithFallback(content, {
     defaultName: `${baseName}.${extension}`,
-    filters: [
-      isCsv
-        ? { name: label, extensions: [extension] }
-        : isKml
-          ? { name: label, extensions: [extension] }
-          : { name: label, extensions: ["geojson", "json"] },
-    ],
+    filters: [{ name: label, extensions: filterExtensions }],
     browserTypes: [
       {
         description: label,
-        accept: isCsv
-          ? { "text/csv": [".csv"] }
-          : isKml
-            ? { "application/vnd.google-earth.kml+xml": [".kml"] }
-            : { "application/geo+json": [".geojson", ".json"] },
+        accept: {
+          [mimeType]: filterExtensions.map((candidate) => `.${candidate}`),
+        },
       },
     ],
     mimeType,

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -5,6 +5,8 @@ import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 import { saveBinaryFileWithFallback, saveTextFileWithFallback } from "./tauri-io";
 import { type BinaryVectorExportFormat, exportBinaryVectorLayer } from "./vector-exporter";
 
+export { KmlCoordinateError } from "./vector-export-errors";
+
 type TextVectorExportFormat = "geojson" | "csv" | "kml";
 
 export type VectorExportFormat = TextVectorExportFormat | BinaryVectorExportFormat;

--- a/apps/geolibre-desktop/src/lib/vector-exporter.ts
+++ b/apps/geolibre-desktop/src/lib/vector-exporter.ts
@@ -1,6 +1,6 @@
 import type { FeatureCollection } from "geojson";
 
-export type BinaryVectorExportFormat = "geoparquet" | "geopackage" | "shapefile";
+export type BinaryVectorExportFormat = "geoparquet" | "geopackage" | "shapefile" | "kmz";
 
 export interface BinaryVectorExportResult {
   data: Uint8Array;
@@ -50,6 +50,15 @@ async function exportShapefileZip(
   });
 }
 
+/** Package a KML document as the conventional `doc.kml` entry in a KMZ file. */
+async function exportKmz(geojson: FeatureCollection, documentName: string): Promise<Uint8Array> {
+  const [{ writeKml }, { strToU8, zipSync }] = await Promise.all([
+    import("./kml-writer"),
+    import("fflate"),
+  ]);
+  return zipSync({ "doc.kml": strToU8(writeKml(geojson, documentName)) });
+}
+
 export async function exportBinaryVectorLayer(
   geojson: FeatureCollection,
   format: BinaryVectorExportFormat,
@@ -73,6 +82,12 @@ export async function exportBinaryVectorLayer(
         data: await exportShapefileZip(geojson, layerName),
         extension: "zip",
         mimeType: "application/zip",
+      };
+    case "kmz":
+      return {
+        data: await exportKmz(geojson, layerName),
+        extension: "kmz",
+        mimeType: "application/vnd.google-earth.kmz",
       };
   }
 }

--- a/apps/geolibre-desktop/src/lib/vector-exporter.ts
+++ b/apps/geolibre-desktop/src/lib/vector-exporter.ts
@@ -63,6 +63,7 @@ export async function exportBinaryVectorLayer(
   geojson: FeatureCollection,
   format: BinaryVectorExportFormat,
   layerName: string,
+  documentName = layerName,
 ): Promise<BinaryVectorExportResult> {
   switch (format) {
     case "geoparquet":
@@ -85,7 +86,7 @@ export async function exportBinaryVectorLayer(
       };
     case "kmz":
       return {
-        data: await exportKmz(geojson, layerName),
+        data: await exportKmz(geojson, documentName),
         extension: "kmz",
         mimeType: "application/vnd.google-earth.kmz",
       };

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -148,6 +148,7 @@ describe("KML text export", () => {
     let pickerOptions: unknown;
     let savedContent: unknown;
     const originalWindow = globalThis.window;
+    const originalSelfDescriptor = Object.getOwnPropertyDescriptor(globalThis, "self");
     const mockWindow = {
       showSaveFilePicker: async (options: unknown) => {
         pickerOptions = options;
@@ -194,6 +195,11 @@ describe("KML text export", () => {
           configurable: true,
           value: originalWindow,
         });
+      }
+      if (originalSelfDescriptor === undefined) {
+        Reflect.deleteProperty(globalThis, "self");
+      } else {
+        Object.defineProperty(globalThis, "self", originalSelfDescriptor);
       }
     }
   });

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import type { FeatureCollection } from "geojson";
 import { strFromU8, unzipSync } from "fflate";
 import { writeKml } from "../apps/geolibre-desktop/src/lib/kml-writer";
+import { KmlCoordinateError } from "../apps/geolibre-desktop/src/lib/vector-export-errors";
 import { exportBinaryVectorLayer } from "../apps/geolibre-desktop/src/lib/vector-exporter";
 
 const SAMPLE: FeatureCollection = {
@@ -230,41 +231,34 @@ describe("writeKml", () => {
   });
 
   it("rejects invalid coordinates instead of creating a corrupt KML file", () => {
-    assert.throws(
-      () =>
-        writeKml(
-          {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                properties: {},
-                geometry: { type: "Point", coordinates: [Number.NaN, 20] },
-              },
-            ],
-          },
-          "Invalid",
-        ),
-      /feature at index 0: KML export requires finite longitude and latitude/,
-    );
-    assert.throws(
-      () =>
-        writeKml(
-          {
-            type: "FeatureCollection",
-            features: [
-              {
-                type: "Feature",
-                id: "invalid-feature",
-                properties: {},
-                geometry: { type: "Point", coordinates: [Number.NaN, 20] },
-              },
-            ],
-          },
-          "Invalid",
-        ),
-      /feature with id invalid-feature: KML export requires finite longitude and latitude/,
-    );
+    for (const [id, expectedIndex] of [
+      [undefined, 0],
+      ["invalid-feature", 0],
+    ] as const) {
+      assert.throws(
+        () =>
+          writeKml(
+            {
+              type: "FeatureCollection",
+              features: [
+                {
+                  type: "Feature",
+                  ...(id === undefined ? {} : { id }),
+                  properties: {},
+                  geometry: { type: "Point", coordinates: [Number.NaN, 20] },
+                },
+              ],
+            },
+            "Invalid",
+          ),
+        (error) => {
+          assert.ok(error instanceof KmlCoordinateError);
+          assert.equal(error.featureId, id);
+          assert.equal(error.featureIndex, expectedIndex);
+          return true;
+        },
+      );
+    }
   });
 });
 

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { FeatureCollection } from "geojson";
+import { strFromU8, unzipSync } from "fflate";
+import { writeKml } from "../apps/geolibre-desktop/src/lib/kml-writer";
+import { exportBinaryVectorLayer } from "../apps/geolibre-desktop/src/lib/vector-exporter";
+
+const SAMPLE: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      id: "city-1",
+      geometry: { type: "Point", coordinates: [-115.14, 36.17, 610] },
+      properties: {
+        name: "Las Vegas & Valley",
+        description: 'A <sample> "place"',
+        population: 641_903,
+        active: true,
+        details: { state: "Nevada" },
+        "marker-color": "#123456",
+        "marker-opacity": 0.5,
+      },
+    },
+  ],
+};
+
+describe("writeKml", () => {
+  it("writes a KML 2.2 document with escaped names, attributes, and altitude", () => {
+    const kml = writeKml(SAMPLE, "Cities & towns");
+
+    assert.match(kml, /^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    assert.match(kml, /<kml xmlns="http:\/\/www\.opengis\.net\/kml\/2\.2">/);
+    assert.match(kml, /<name>Cities &amp; towns<\/name>/);
+    assert.match(kml, /<name>Las Vegas &amp; Valley<\/name>/);
+    assert.match(kml, /<description>A &lt;sample&gt; &quot;place&quot;<\/description>/);
+    assert.match(kml, /<Data name="population"><value>641903<\/value><\/Data>/);
+    assert.match(kml, /<Data name="active"><value>true<\/value><\/Data>/);
+    assert.match(
+      kml,
+      /<Data name="details"><value>\{&quot;state&quot;:&quot;Nevada&quot;\}<\/value><\/Data>/,
+    );
+    assert.match(kml, /<Data name="feature_id"><value>city-1<\/value><\/Data>/);
+    assert.match(kml, /<Point><coordinates>-115\.14,36\.17,610<\/coordinates><\/Point>/);
+    assert.match(kml, /<IconStyle><color>80563412<\/color><\/IconStyle>/);
+  });
+
+  it("writes every GeoJSON geometry type and closes open polygon rings", () => {
+    const kml = writeKml(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "GeometryCollection",
+              geometries: [
+                { type: "MultiPoint", coordinates: [[1, 2], [3, 4]] },
+                {
+                  type: "MultiLineString",
+                  coordinates: [
+                    [
+                      [0, 0],
+                      [1, 1],
+                    ],
+                    [
+                      [2, 2],
+                      [3, 3],
+                    ],
+                  ],
+                },
+                {
+                  type: "MultiPolygon",
+                  coordinates: [
+                    [
+                      [
+                        [0, 0],
+                        [1, 0],
+                        [1, 1],
+                        [0, 1],
+                      ],
+                    ],
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+      "All geometries",
+    );
+
+    assert.equal((kml.match(/<Point>/g) ?? []).length, 2);
+    assert.equal((kml.match(/<LineString>/g) ?? []).length, 2);
+    assert.equal((kml.match(/<Polygon>/g) ?? []).length, 1);
+    assert.match(kml, /<coordinates>0,0 1,0 1,1 0,1 0,0<\/coordinates>/);
+    assert.ok((kml.match(/<MultiGeometry>/g) ?? []).length >= 4);
+  });
+
+  it("rejects invalid coordinates instead of creating a corrupt KML file", () => {
+    assert.throws(
+      () =>
+        writeKml(
+          {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {},
+                geometry: { type: "Point", coordinates: [Number.NaN, 20] },
+              },
+            ],
+          },
+          "Invalid",
+        ),
+      /finite longitude and latitude/,
+    );
+  });
+});
+
+describe("KMZ export", () => {
+  it("packages the generated document as doc.kml with the registered MIME type", async () => {
+    const result = await exportBinaryVectorLayer(SAMPLE, "kmz", "Cities");
+    const files = unzipSync(result.data);
+
+    assert.deepEqual(Object.keys(files), ["doc.kml"]);
+    assert.equal(strFromU8(files["doc.kml"]), writeKml(SAMPLE, "Cities"));
+    assert.equal(result.extension, "kmz");
+    assert.equal(result.mimeType, "application/vnd.google-earth.kmz");
+  });
+});

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -44,6 +44,7 @@ describe("writeKml", () => {
       kml,
       /<Data name="details"><value>\{&quot;state&quot;:&quot;Nevada&quot;\}<\/value><\/Data>/,
     );
+    assert.doesNotMatch(kml, /<Data name="(?:name|description)">/);
     assert.match(kml, /<Data name="feature_id"><value>city-1<\/value><\/Data>/);
     assert.match(
       kml,
@@ -160,6 +161,49 @@ describe("writeKml", () => {
     assert.equal((kml.match(/<altitudeMode>absolute<\/altitudeMode>/g) ?? []).length, 2);
   });
 
+  it("writes small coordinates as plain decimals", () => {
+    const kml = writeKml(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [5e-7, -5e-7] },
+          },
+        ],
+      },
+      "Small coordinates",
+    );
+
+    assert.match(kml, /<coordinates>0\.0000005,-0\.0000005<\/coordinates>/);
+    assert.doesNotMatch(kml, /<coordinates>[^<]*e[+-]?\d+/i);
+  });
+
+  it("preserves GeoJSON feature IDs when attribute names collide", () => {
+    const kml = writeKml(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "source-id",
+            properties: {
+              feature_id: "attribute-id",
+              geojson_feature_id: "another-attribute",
+            },
+            geometry: { type: "Point", coordinates: [0, 0] },
+          },
+        ],
+      },
+      "ID collision",
+    );
+
+    assert.match(kml, /<Data name="feature_id"><value>attribute-id<\/value><\/Data>/);
+    assert.match(kml, /<Data name="geojson_feature_id"><value>another-attribute<\/value><\/Data>/);
+    assert.match(kml, /<Data name="geojson_feature_id_2"><value>source-id<\/value><\/Data>/);
+  });
+
   it("rejects invalid coordinates instead of creating a corrupt KML file", () => {
     assert.throws(
       () =>
@@ -178,16 +222,34 @@ describe("writeKml", () => {
         ),
       /feature at index 0: KML export requires finite longitude and latitude/,
     );
+    assert.throws(
+      () =>
+        writeKml(
+          {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                id: "invalid-feature",
+                properties: {},
+                geometry: { type: "Point", coordinates: [Number.NaN, 20] },
+              },
+            ],
+          },
+          "Invalid",
+        ),
+      /feature with id invalid-feature: KML export requires finite longitude and latitude/,
+    );
   });
 });
 
 describe("KMZ export", () => {
   it("packages the generated document as doc.kml with the registered MIME type", async () => {
-    const result = await exportBinaryVectorLayer(SAMPLE, "kmz", "Cities");
+    const result = await exportBinaryVectorLayer(SAMPLE, "kmz", "Cities", "Cities & towns");
     const files = unzipSync(result.data);
 
     assert.deepEqual(Object.keys(files), ["doc.kml"]);
-    assert.equal(strFromU8(files["doc.kml"]), writeKml(SAMPLE, "Cities"));
+    assert.equal(strFromU8(files["doc.kml"]), writeKml(SAMPLE, "Cities & towns"));
     assert.equal(result.extension, "kmz");
     assert.equal(result.mimeType, "application/vnd.google-earth.kmz");
   });
@@ -221,10 +283,10 @@ describe("KML text export", () => {
 
     try {
       const { exportVectorLayer } = await import("../apps/geolibre-desktop/src/lib/vector-export");
-      const savedName = await exportVectorLayer(SAMPLE, "kml", "Cities");
+      const savedName = await exportVectorLayer(SAMPLE, "kml", "Cities", "Cities & towns");
 
       assert.equal(savedName, "Cities.kml");
-      assert.equal(savedContent, writeKml(SAMPLE, "Cities"));
+      assert.equal(savedContent, writeKml(SAMPLE, "Cities & towns"));
       assert.deepEqual(pickerOptions, {
         suggestedName: "Cities.kml",
         types: [

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -234,6 +234,34 @@ describe("writeKml", () => {
     assert.equal((kml.match(/<IconStyle>/g) ?? []).length, 1);
   });
 
+  it("uses the simplestyle default opacity for polygon fills", () => {
+    const kml = writeKml(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { fill: "#336699" },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [1, 0],
+                  [1, 1],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      "Default fill opacity",
+    );
+
+    assert.match(kml, /<PolyStyle><color>99996633<\/color><\/PolyStyle>/);
+  });
+
   it("rejects invalid coordinates instead of creating a corrupt KML file", () => {
     for (const [id, expectedIndex] of [
       [undefined, 0],

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { FeatureCollection } from "geojson";
 import { strFromU8, unzipSync } from "fflate";
+import type { TFunction } from "i18next";
 import { writeKml } from "../apps/geolibre-desktop/src/lib/kml-writer";
-import { KmlCoordinateError } from "../apps/geolibre-desktop/src/lib/vector-export-errors";
+import {
+  KmlCoordinateError,
+  kmlExportErrorMessage,
+} from "../apps/geolibre-desktop/src/lib/vector-export-errors";
 import { exportBinaryVectorLayer } from "../apps/geolibre-desktop/src/lib/vector-exporter";
 
 const SAMPLE: FeatureCollection = {
@@ -271,6 +275,23 @@ describe("KMZ export", () => {
     assert.equal(strFromU8(files["doc.kml"]), writeKml(SAMPLE, "Cities & towns"));
     assert.equal(result.extension, "kmz");
     assert.equal(result.mimeType, "application/vnd.google-earth.kmz");
+  });
+});
+
+describe("KML export errors", () => {
+  it("localizes feature IDs and one-based feature positions", () => {
+    const t = ((key: string, values: Record<string, unknown>) =>
+      `${key}:${String(values.id ?? values.position)}`) as TFunction;
+
+    assert.equal(
+      kmlExportErrorMessage(new KmlCoordinateError(0, undefined), t),
+      "vectorExport.invalidKmlCoordinatesByPosition:1",
+    );
+    assert.equal(
+      kmlExportErrorMessage(new KmlCoordinateError(4, "city-5"), t),
+      "vectorExport.invalidKmlCoordinatesById:city-5",
+    );
+    assert.equal(kmlExportErrorMessage(new Error("other"), t), null);
   });
 });
 

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -20,6 +20,10 @@ const SAMPLE: FeatureCollection = {
         details: { state: "Nevada" },
         "marker-color": "#123456",
         "marker-opacity": 0.5,
+        stroke: "#00ff00",
+        "stroke-width": 3,
+        fill: "#0000ff",
+        "fill-opacity": 0.25,
       },
     },
   ],
@@ -43,6 +47,8 @@ describe("writeKml", () => {
     assert.match(kml, /<Data name="feature_id"><value>city-1<\/value><\/Data>/);
     assert.match(kml, /<Point><coordinates>-115\.14,36\.17,610<\/coordinates><\/Point>/);
     assert.match(kml, /<IconStyle><color>80563412<\/color><\/IconStyle>/);
+    assert.match(kml, /<LineStyle><color>ff00ff00<\/color><width>3<\/width><\/LineStyle>/);
+    assert.match(kml, /<PolyStyle><color>40ff0000<\/color><\/PolyStyle>/);
   });
 
   it("writes every GeoJSON geometry type and closes open polygon rings", () => {
@@ -134,5 +140,61 @@ describe("KMZ export", () => {
     assert.equal(strFromU8(files["doc.kml"]), writeKml(SAMPLE, "Cities"));
     assert.equal(result.extension, "kmz");
     assert.equal(result.mimeType, "application/vnd.google-earth.kmz");
+  });
+});
+
+describe("KML text export", () => {
+  it("writes KML through the browser save picker with matching format metadata", async () => {
+    let pickerOptions: unknown;
+    let savedContent: unknown;
+    const originalWindow = globalThis.window;
+    const mockWindow = {
+      showSaveFilePicker: async (options: unknown) => {
+        pickerOptions = options;
+        return {
+          name: "Cities.kml",
+          createWritable: async () => ({
+            write: async (content: unknown) => {
+              savedContent = content;
+            },
+            close: async () => undefined,
+          }),
+        };
+      },
+    };
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: mockWindow,
+    });
+    (globalThis as { self?: unknown }).self ??= globalThis;
+
+    try {
+      const { exportVectorLayer } = await import("../apps/geolibre-desktop/src/lib/vector-export");
+      const savedName = await exportVectorLayer(SAMPLE, "kml", "Cities");
+
+      assert.equal(savedName, "Cities.kml");
+      assert.equal(savedContent, writeKml(SAMPLE, "Cities"));
+      assert.deepEqual(pickerOptions, {
+        suggestedName: "Cities.kml",
+        types: [
+          {
+            description: "KML",
+            accept: {
+              "application/vnd.google-earth.kml+xml": [".kml"],
+            },
+          },
+        ],
+        excludeAcceptAllOption: false,
+      });
+    } finally {
+      if (originalWindow === undefined) {
+        Reflect.deleteProperty(globalThis, "window");
+      } else {
+        Object.defineProperty(globalThis, "window", {
+          configurable: true,
+          value: originalWindow,
+        });
+      }
+    }
   });
 });

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -176,7 +176,7 @@ describe("writeKml", () => {
           },
           "Invalid",
         ),
-      /finite longitude and latitude/,
+      /feature at index 0: KML export requires finite longitude and latitude/,
     );
   });
 });

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -56,7 +56,13 @@ describe("writeKml", () => {
             geometry: {
               type: "GeometryCollection",
               geometries: [
-                { type: "MultiPoint", coordinates: [[1, 2], [3, 4]] },
+                {
+                  type: "MultiPoint",
+                  coordinates: [
+                    [1, 2],
+                    [3, 4],
+                  ],
+                },
                 {
                   type: "MultiLineString",
                   coordinates: [

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -45,7 +45,10 @@ describe("writeKml", () => {
       /<Data name="details"><value>\{&quot;state&quot;:&quot;Nevada&quot;\}<\/value><\/Data>/,
     );
     assert.match(kml, /<Data name="feature_id"><value>city-1<\/value><\/Data>/);
-    assert.match(kml, /<Point><coordinates>-115\.14,36\.17,610<\/coordinates><\/Point>/);
+    assert.match(
+      kml,
+      /<Point><altitudeMode>absolute<\/altitudeMode><coordinates>-115\.14,36\.17,610<\/coordinates><\/Point>/,
+    );
     assert.match(kml, /<IconStyle><color>80563412<\/color><\/IconStyle>/);
     assert.match(kml, /<LineStyle><color>ff00ff00<\/color><width>3<\/width><\/LineStyle>/);
     assert.match(kml, /<PolyStyle><color>40ff0000<\/color><\/PolyStyle>/);
@@ -108,6 +111,53 @@ describe("writeKml", () => {
     assert.equal((kml.match(/<Polygon>/g) ?? []).length, 1);
     assert.match(kml, /<coordinates>0,0 1,0 1,1 0,1 0,0<\/coordinates>/);
     assert.ok((kml.match(/<MultiGeometry>/g) ?? []).length >= 4);
+  });
+
+  it("uses absolute altitude mode for three-dimensional geometries only", () => {
+    const kml = writeKml(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "GeometryCollection",
+              geometries: [
+                {
+                  type: "LineString",
+                  coordinates: [
+                    [0, 0, 10],
+                    [1, 1, 20],
+                  ],
+                },
+                {
+                  type: "Polygon",
+                  coordinates: [
+                    [
+                      [0, 0, 10],
+                      [1, 0, 10],
+                      [1, 1, 10],
+                      [0, 0, 10],
+                    ],
+                  ],
+                },
+                { type: "Point", coordinates: [2, 2] },
+              ],
+            },
+          },
+        ],
+      },
+      "Altitude",
+    );
+
+    assert.match(
+      kml,
+      /<LineString><altitudeMode>absolute<\/altitudeMode><coordinates>0,0,10 1,1,20<\/coordinates><\/LineString>/,
+    );
+    assert.match(kml, /<Polygon>\s+<altitudeMode>absolute<\/altitudeMode>/);
+    assert.match(kml, /<Point><coordinates>2,2<\/coordinates><\/Point>/);
+    assert.equal((kml.match(/<altitudeMode>absolute<\/altitudeMode>/g) ?? []).length, 2);
   });
 
   it("rejects invalid coordinates instead of creating a corrupt KML file", () => {

--- a/tests/kml-writer.test.ts
+++ b/tests/kml-writer.test.ts
@@ -204,6 +204,31 @@ describe("writeKml", () => {
     assert.match(kml, /<Data name="geojson_feature_id_2"><value>source-id<\/value><\/Data>/);
   });
 
+  it("shares repeated styles while keeping per-feature references", () => {
+    const kml = writeKml(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { "marker-color": "#123456" },
+            geometry: { type: "Point", coordinates: [0, 0] },
+          },
+          {
+            type: "Feature",
+            properties: { "marker-color": "#123456" },
+            geometry: { type: "Point", coordinates: [1, 1] },
+          },
+        ],
+      },
+      "Shared style",
+    );
+
+    assert.equal((kml.match(/<Style id="style-1">/g) ?? []).length, 1);
+    assert.equal((kml.match(/<styleUrl>#style-1<\/styleUrl>/g) ?? []).length, 2);
+    assert.equal((kml.match(/<IconStyle>/g) ?? []).length, 1);
+  });
+
   it("rejects invalid coordinates instead of creating a corrupt KML file", () => {
     assert.throws(
       () =>


### PR DESCRIPTION
## Summary

- add KML and KMZ options to layer and attribute table exports
- preserve GeoJSON geometries, feature attributes, IDs, altitude coordinates, and simplestyle colors
- package KMZ output with the conventional `doc.kml` archive entry

## Testing

- `npm run build`
- `npm run test:frontend`
- `pre-commit run --all-files`
- exported `us_cities.geojson` to KML in light mode and KMZ in dark mode, then imported both files back into GeoLibre

Fixes #1566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **KML** and **KMZ** to the vector export menus (layer export and attribute table export).
  * Desktop exports now support **KML 2.2** generation (including multiple geometry types, XML-safe text, styling from available properties, and optional altitude-aware output).
  * **KMZ** export packages the generated KML with the correct **.kmz** extension and **KMZ MIME type**.
* **Bug Fixes**
  * Prevents KML/KMZ export when coordinates contain non-finite longitude/latitude values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->