### PR TITLE
fix(i18n): distinguish Chinese progress strings from action labels and unify "sidecar"

### DIFF
--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1822,8 +1822,8 @@
       "saveVideoMp4": "保存为 MP4",
       "saveVideoWebm": "保存为 WebM",
       "estimatedLength": "≈ {{seconds}} 秒",
-      "recordingStatus": "录制中… {{percent}}%",
-      "savingVideo": "保存视频…",
+      "recordingStatus": "正在录制… {{percent}}%",
+      "savingVideo": "正在保存视频…",
       "stop": "停止",
       "videoSaved": "已保存 {{name}}",
       "videoError": "无法录制动画。请重试。",
@@ -2141,8 +2141,8 @@
       "inputPoints": "输入点（GeoJSON）",
       "engine": "引擎",
       "engineClient": "客户端（浏览器）",
-      "engineSidecar": "边车（rasterio/GDAL）",
-      "clientHint": "在您的浏览器中计算并将结果添加到地图。对于大型栅格或地理坐标系地形，建议使用边车服务。",
+      "engineSidecar": "Sidecar（rasterio/GDAL）",
+      "clientHint": "在您的浏览器中计算并将结果添加到地图。对于大型栅格或地理坐标系地形，建议使用 Sidecar。",
       "switchToClientHint": "或将引擎切换为客户端以在浏览器中运行此工具。",
       "chooseGeoTiff": "选择一个 GeoTIFF",
       "downloadGeoTiff": "下载 GeoTIFF",
@@ -2470,7 +2470,7 @@
       "description": {
         "postgis": "对已加载的图层运行 PostGIS SQL。已加载 PostGIS 扩展，因此可以使用 ST_* 函数。首次运行会加载约 19 MB 的数据库引擎。",
         "duckdb": "对已加载的图层、文件和 URL 运行 DuckDB SQL。已加载 spatial 扩展，因此可以使用 ST_* 函数。支持云 URL（s3://、gs://、az://）访问公开数据。",
-        "sedona": "对已加载的图层运行 Apache Sedona 空间 SQL。在浏览器中通过 CereusDB（SedonaDB 的 WebAssembly 构建版本）运行；在桌面版中，如果安装了可选的 sedona 扩展，则使用 SedonaDB 边车服务。可以使用 ST_* 函数。"
+        "sedona": "对已加载的图层运行 Apache Sedona 空间 SQL。在浏览器中通过 CereusDB（SedonaDB 的 WebAssembly 构建版本）运行；在桌面版中，如果安装了可选的 sedona 扩展，则使用 SedonaDB Sidecar。可以使用 ST_* 函数。"
       },
       "title": "SQL 工作区",
       "engine": "SQL 引擎",
@@ -2558,7 +2558,7 @@
     "summary": "已选择 {{selected}}/{{total}} 个要素（匹配 {{matched}} 个）。",
     "evaluationErrors": "{{count}} 个要素无法求值，未被匹配。",
     "unevaluableDisjoint": "{{count}} 个要素因几何无法求值而被排除。",
-    "tooManyPairs": "此比较需要 {{pairs}} 次要素对测试（上限 {{limit}}）。请改用“处理 → GeoLibre → 矢量 → 按位置选择”并选择边车引擎。",
+    "tooManyPairs": "此比较需要 {{pairs}} 次要素对测试（上限 {{limit}}）。请改用“处理 → GeoLibre → 矢量 → 按位置选择”并选择 Sidecar 引擎。",
     "exportedLayerName": "{{name}}（选择集）"
   },
   "loadEditorFeatures": {
@@ -2720,7 +2720,7 @@
     "search": "搜索此视图",
     "loadMore": "加载更多",
     "searching": "搜索中…",
-    "loadingMore": "加载更多…",
+    "loadingMore": "正在加载更多…",
     "noResults": "此区域未找到影像。",
     "showing": "显示 {{shown}} / {{total}} 张图像。",
     "searchError": "无法访问 OpenAerialMap：{{message}}。请重试。",
@@ -3337,14 +3337,14 @@
       "run": "运行",
       "running": "正在运行…",
       "runLocal": "本地运行 (WASM)",
-      "runLocalHint": "在 WebAssembly 中本地运行（无需 Python 边车服务）",
-      "runningLocally": "正在使用 WebAssembly 本地运行。无需边车服务。",
+      "runLocalHint": "在 WebAssembly 中本地运行（无需 Python Sidecar）",
+      "runningLocally": "正在使用 WebAssembly 本地运行。无需 Sidecar。",
       "copyLink": "复制链接",
       "copyLinkCopied": "已复制！",
       "copyLinkHint": "复制可分享的链接，用当前设置打开此工具",
       "copyLinkFailed": "无法将链接复制到剪贴板。",
       "catalogSnapshotError": "无法加载 Whitebox 工具目录快照。",
-      "localRunnerError": "无法加载本地（WASM）工具运行器。请刷新后重试，或在边车服务可用时改用它。",
+      "localRunnerError": "无法加载本地（WASM）工具运行器。请刷新后重试，或在 Sidecar 可用时改用它。",
       "output": {
         "geojson": "GeoJSON（添加到地图）",
         "geoparquet": "GeoParquet（下载，保留坐标系）",
@@ -3446,7 +3446,7 @@
     "error": {
       "chooseImage": "请选择要分割的图像 (GeoTIFF)。",
       "enterPrompt": "请输入文本提示，例如“树木”或“建筑物”。",
-      "startServer": "无法启动 GeoLibre 边车服务。",
+      "startServer": "无法启动 GeoLibre Sidecar。",
       "failed": "分割失败。"
     },
     "noObjects": "未找到任何对象。",


### PR DESCRIPTION
Fixes the cases reported in #1569.

`zh.json` only — no code, no other locale.

### Progress states that read as actions

`docs/i18n.md` notes the non-English catalogs were machine-seeded, and a few Chinese progress strings came out as bare verb phrases, which in Chinese read as a command (“save video”) rather than a state (“saving video”). Where the same English string appears in a sibling panel it is already correct, so these are outliers rather than the convention:

| key | en | before | after |
|---|---|---|---|
| `toolbar.routeAnimation.savingVideo` | `Saving video…` | `保存视频…` | `正在保存视频…` |
| `toolbar.routeAnimation.recordingStatus` | `Recording… {{percent}}%` | `录制中… {{percent}}%` | `正在录制… {{percent}}%` |
| `openAerialMap.loadingMore` | `Loading more…` | `加载更多…` | `正在加载更多…` |

`recordTour.savingStatus` and `recordVideo.savingStatus` were already `正在保存视频…`, `recordTour.recordingStatus` already `正在录制…`, and `gallery.loadingMore` / `earthdataGis.loadingMore` already `正在加载更多…`. Of the 96 English strings in `en.json` ending in `-ing…`, 78 were already `正在X…` in `zh.json`, so this follows the catalog's own majority pattern.

The first one is what made me start looking: `保存视频…` is byte-identical to the Chinese for the `Save video…` **buttons** in the other two recording panels, and in `RouteAnimationPanel.tsx:609` it is rendered inside a `role="status" aria-live="polite"` region, so a screen reader announces an imperative while the export runs.

For `openAerialMap`, the two strings are on screen at the same time rather than alternating: `loadMore` is the button's `textContent` (`maplibre-openaerialmap.ts:899`) and `loadingMore` goes to a separate status div via `setStatus` (`:1038`), and the button is not hidden while a page loads — so mid-load the panel showed `加载更多…` directly above a button reading `加载更多`.

### An instruction pointing at a label that isn't there

`selection.tooManyPairs` told the user to pick 边车引擎:

> 此比较需要 {{pairs}} 次要素对测试（上限 {{limit}}）。请改用“处理 → GeoLibre → 矢量 → 按位置选择”并选择**边车**引擎。

The engine option in that dialog is `processing.vectorTools.engineSidecar`, which renders `Sidecar（GeoPandas）` — 边车 appears nowhere in it. Now reads `并选择 Sidecar 引擎`.

### “sidecar” unified

24 English strings mention the sidecar. In `zh.json` 16 already kept `Sidecar`, 6 used `边车服务`, 2 used `边车`. The clearest symptom was two engine pickers of identical shape disagreeing:

| key | en | before | after |
|---|---|---|---|
| `processing.vectorTools.engineSidecar` | `Sidecar (GeoPandas)` | `Sidecar（GeoPandas）` | *(unchanged)* |
| `toolbar.rasterTool.engineSidecar` | `Sidecar (rasterio/GDAL)` | `边车（rasterio/GDAL）` | `Sidecar（rasterio/GDAL）` |

边车 is a literal calque of “sidecar” (the motorcycle attachment) and is not established Chinese technical vocabulary the way 容器 / 进程 are; Chinese developer material generally leaves the term in English. Standardising on the untranslated form also keeps the UI term matching `docs/`, the CLI output, and the `geolibre-server` process name a user would see. The other strings changed for this are `toolbar.rasterTool.clientHint`, `toolbar.sqlWorkspace.description.sedona`, `processing.whitebox.runLocalHint`, `processing.whitebox.runningLocally`, `processing.whitebox.localRunnerError`, `segmentation.error.startServer`, and the `selection.tooManyPairs` above.

Happy to flip the whole set to 边车服务 instead if you'd rather have it fully translated — the point is that it should be one of the two, not both.

Note that `processing.sidecar.intro` → 辅助程序 and `segmentation.sidecar.intro` → 辅助服务器 are deliberately left alone: those translate the English word “helper”, not “sidecar”.

### Verification

- `tests/i18n-catalogs.test.ts` — 32/32 pass: no keys absent from `en.json`, and every placeholder preserved (the three interpolated strings keep `{{percent}}`, `{{pairs}}`, `{{limit}}`).
- `npm run test:frontend` — 4418 pass, 0 fail.
- `npm run build` — clean.
- `oxfmt@0.59.0 --check` on the file — already correctly formatted.
- No keys added or removed, so the `i18next.d.ts` typing is unaffected.
- Each changed string was checked at its render site, not just in the catalog: `RouteAnimationPanel.tsx:597,609` and `packages/plugins/src/plugins/maplibre-openaerialmap.ts:899,1038`.

### Deliberately not touched

While reading the catalog I found 50 English labels with more than one Chinese rendering; after setting aside the ~20 where the context genuinely differs, about 30 are real inconsistencies (`Colormap` → 色彩映射 / 颜色映射, `Dashboard` → 仪表盘 / 仪表板, `Sum` → 求和 / 总和, `Min zoom` → 最小缩放 / 最小缩放级别). Those are cosmetic rather than misleading, so they are not in this PR — see #1569 if you want them as a follow-up.

I also left alone the divergences that are correct because the context differs — `Center` 居中 (`printLayout.align.center`) vs 中心 (`h3Plugin.center`), `Left` 左对齐 (`printLayout.align.left`) vs 左侧 (`style.labels.anchorLeft`), `Line` 折线图 (`dashboard.chartType.line`) vs 线 (`fieldCollection.geom.line`), `Heading` 标题 (`printLayout.dataBlocks.titleLabel`) vs 航向 (`toolbar.flightSim.heading`), `Scale` 比例尺 (`toolbar.mapControl.scale`) vs 缩放比例 (`toolbar.scenegraph.scale`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Chinese interface text for clearer processing and loading statuses.
  * Standardized references to Sidecar services and engines across raster, SQL, selection, Whitebox, and AI segmentation tools.
  * Refined route recording, video-saving, pagination, and local-processing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->