### PR TITLE
fix(backend): gate PostGIS connections behind a host allowlist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,12 @@ ENV GEOLIBRE_CONVERSION_PYTHON=/usr/local/bin/python \
     GEOLIBRE_CONVERSION_ROOTS=/data
 RUN mkdir -p /data
 
+# For the same reason, the sidecar's PostGIS endpoints refuse every destination
+# until GEOLIBRE_POSTGIS_HOSTS names the allowed databases (comma-separated
+# `host` or `host:port`) — otherwise a same-origin caller could aim them at
+# hosts only this container can reach. Deliberately left unset: set it at
+# `docker run` time to enable PostGIS, or `*` to accept any connection string.
+
 # WARNING: docker/nginx.conf's CSP allows http://localhost:* / http://127.0.0.1:*
 # (and ws:// equivalents) in connect-src for local-dev data sources (PMTiles/COGs
 # from a dev server on another port). This image is intended for local/single-user

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -55,6 +55,17 @@ const MARTIN_START_ATTEMPTS: usize = 3;
 const MARTIN_HEALTH_ATTEMPTS: usize = 30;
 const SIDECAR_HEALTH_ATTEMPTS: usize = 180;
 const SIDECAR_PORT: u16 = 8765;
+// The sidecar's PostGIS endpoints refuse every destination until this variable
+// names the allowed hosts — the check that stops a *shared* deployment (the
+// Docker image, where the sidecar is reachable same-origin through the nginx
+// proxy) from being pointed at arbitrary internal databases. See
+// `_validate_postgis_target` in backend/geolibre_server/app/postgis.py.
+const POSTGIS_HOSTS_ENV: &str = "GEOLIBRE_POSTGIS_HOSTS";
+// Desktop is the case that restriction is not aimed at: the sidecar is
+// loopback-bound, token-authenticated, and spawned for one user who is also its
+// operator, so it would only mean a user cannot reach their own database
+// without setting an environment variable for a process the app launches.
+const POSTGIS_HOSTS_DESKTOP_DEFAULT: &str = "*";
 // The desktop JupyterLab server for the Notebook panel. Loopback-bound and
 // token-gated; uses its own uv project environment so it never disturbs the
 // FastAPI sidecar's env. First start can be slow while uv syncs JupyterLab.
@@ -1673,6 +1684,12 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
         .app_data_dir()
         .map_err(|error| format!("Could not resolve app data directory: {error}"))?
         .join("runtime");
+    // A value already in the environment wins, so a desktop user who does want
+    // the allowlist can narrow it by launching the app with it set.
+    let postgis_hosts = env::var(POSTGIS_HOSTS_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| POSTGIS_HOSTS_DESKTOP_DEFAULT.to_string());
 
     let mut command = Command::new(&uv);
     command
@@ -1698,6 +1715,7 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
         .env("GEOLIBRE_UV", &uv)
         .env("GEOLIBRE_SIDECAR_TOKEN", sidecar_token())
         .env("GEOLIBRE_RUNTIME_DIR", &runtime_dir)
+        .env(POSTGIS_HOSTS_ENV, &postgis_hosts)
         .env("UV_CACHE_DIR", runtime_dir.join("uv-cache"))
         .env("UV_PYTHON_INSTALL_DIR", runtime_dir.join("uv-python"))
         .env("UV_PROJECT_ENVIRONMENT", runtime_dir.join("sidecar-server"))

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -59,7 +59,8 @@ const SIDECAR_PORT: u16 = 8765;
 // names the allowed hosts — the check that stops a *shared* deployment (the
 // Docker image, where the sidecar is reachable same-origin through the nginx
 // proxy) from being pointed at arbitrary internal databases. See
-// `_validate_postgis_target` in backend/geolibre_server/app/postgis.py.
+// `_validate_postgis_target` in
+// backend/geolibre_server/geolibre_server/app/postgis.py.
 const POSTGIS_HOSTS_ENV: &str = "GEOLIBRE_POSTGIS_HOSTS";
 // Desktop is the case that restriction is not aimed at: the sidecar is
 // loopback-bound, token-authenticated, and spawned for one user who is also its

--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -119,6 +119,14 @@ restrict it. Every host in a libpq failover connection string must be allowed.
 Implicit local connections, Unix sockets, and `service=` connection strings are
 rejected so they cannot bypass the allowlist.
 
+Set it to `*` to lift the restriction and accept any connection string. The
+**desktop app** passes `*` when it spawns its own sidecar — that one is
+loopback-bound, token-authenticated, and serves the single user who is also its
+operator. Setting the variable before launching the desktop app overrides that
+default, so a desktop user can still narrow it. A deployment where the sidecar
+is reachable by untrusted same-origin content (the bundled Docker image) leaves
+it unset, and PostGIS stays off until an operator lists the databases.
+
 ## Endpoints
 
 | Method | Path | Description |

--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -115,7 +115,9 @@ geolibre-server
 ```
 
 An entry without a port allows that host on any port; include `:port` to
-restrict it. Every host in a libpq failover connection string must be allowed.
+restrict it. IPv6 entries must be bracketed either way (`[2001:db8::10]`),
+since an unbracketed `2001:db8::10:5432` is itself a valid address rather than
+an address and a port. Every host in a libpq failover connection string must be allowed.
 Implicit local connections, Unix sockets, `service=`, and `hostaddr=`
 connection strings are rejected so they cannot bypass the allowlist.
 

--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -116,8 +116,8 @@ geolibre-server
 
 An entry without a port allows that host on any port; include `:port` to
 restrict it. Every host in a libpq failover connection string must be allowed.
-Implicit local connections, Unix sockets, and `service=` connection strings are
-rejected so they cannot bypass the allowlist.
+Implicit local connections, Unix sockets, `service=`, and `hostaddr=`
+connection strings are rejected so they cannot bypass the allowlist.
 
 Set it to `*` to lift the restriction and accept any connection string. The
 **desktop app** passes `*` when it spawns its own sidecar — that one is

--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -119,7 +119,8 @@ restrict it. Every host in a libpq failover connection string must be allowed.
 Implicit local connections, Unix sockets, `service=`, and `hostaddr=`
 connection strings are rejected so they cannot bypass the allowlist.
 
-Set it to `*` to lift the restriction and accept any connection string. The
+Set it to `*` — on its own, since mixing it with hosts reads as a narrowing but
+is not one — to lift the restriction and accept any connection string. The
 **desktop app** passes `*` when it spawns its own sidecar — that one is
 loopback-bound, token-authenticated, and serves the single user who is also its
 operator. Setting the variable before launching the desktop app overrides that

--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -103,6 +103,22 @@ build of SedonaDB — so the Apache Sedona engine works with **no sidecar** too.
 returns rows (geometry as WKT) plus a GeoJSON FeatureCollection when the result
 has a geometry column.
 
+## PostGIS connections
+
+The optional PostGIS endpoints are disabled until their database destinations
+are explicitly allowed. Set `GEOLIBRE_POSTGIS_HOSTS` to a comma-separated list
+of exact hostnames or IP addresses before starting the sidecar:
+
+```bash
+GEOLIBRE_POSTGIS_HOSTS='db.internal,db.example.com:5433,[2001:db8::10]:5432'
+geolibre-server
+```
+
+An entry without a port allows that host on any port; include `:port` to
+restrict it. Every host in a libpq failover connection string must be allowed.
+Implicit local connections, Unix sockets, and `service=` connection strings are
+rejected so they cannot bypass the allowlist.
+
 ## Endpoints
 
 | Method | Path | Description |

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -23,8 +23,10 @@ Security posture:
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
+import os
 import re
 from typing import Any, Optional
 
@@ -39,6 +41,8 @@ logger = logging.getLogger(__name__)
 # Statement timeout applied to every sidecar-issued session so a bad query or
 # an unresponsive server cannot pin a FastAPI worker thread indefinitely.
 _STATEMENT_TIMEOUT_MS = 60_000
+_POSTGIS_HOSTS_ENV = "GEOLIBRE_POSTGIS_HOSTS"
+_DEFAULT_POSTGRES_PORT = 5432
 
 # Username is optional (postgresql://:pw@host relies on PGUSER), so the group
 # is zero-or-more: an empty username must not let the password through. The
@@ -64,6 +68,7 @@ def psycopg_import_error() -> Optional[str]:
 
 def _import_psycopg() -> Any:
     import psycopg
+    import psycopg.conninfo  # noqa: F401 - make psycopg.conninfo reachable
     import psycopg.types.json  # noqa: F401 - make psycopg.types.json.Json reachable
 
     return psycopg
@@ -79,6 +84,115 @@ def _sanitize_error(message: str) -> str:
     """
     scrubbed = _PASSWORD_URL_RE.sub(r"\1****@", message)
     return _PASSWORD_KV_RE.sub(r"\1****", scrubbed)
+
+
+def _normalize_host(host: str) -> str:
+    """Return a stable representation for exact host allowlist comparisons."""
+    candidate = host.strip()
+    if not candidate or candidate.startswith("/"):
+        raise ValueError("PostgreSQL host must be a TCP hostname or IP address")
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        return str(ipaddress.ip_address(candidate))
+    except ValueError:
+        # DNS names are case-insensitive and a final dot only marks the DNS
+        # root; treating both spellings alike avoids surprising mismatches.
+        return candidate.rstrip(".").lower()
+
+
+def _allowed_postgis_targets(value: str) -> set[tuple[str, Optional[int]]]:
+    """Parse comma-separated ``host`` or ``host:port`` allowlist entries."""
+    targets: set[tuple[str, Optional[int]]] = set()
+    for raw_entry in value.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        host = entry
+        port: Optional[int] = None
+        if entry.startswith("["):
+            closing = entry.find("]")
+            if closing < 0:
+                raise ValueError("invalid bracketed IPv6 address")
+            host = entry[1:closing]
+            suffix = entry[closing + 1 :]
+            if suffix:
+                if not suffix.startswith(":"):
+                    raise ValueError("invalid characters after IPv6 address")
+                port = int(suffix[1:])
+        elif entry.count(":") == 1:
+            host, port_text = entry.rsplit(":", 1)
+            port = int(port_text)
+        elif entry.count(":") > 1:
+            # A bare IPv6 address is accepted; brackets are required only when
+            # an allowlist entry also specifies a port.
+            ipaddress.IPv6Address(entry)
+        if port is not None and not 1 <= port <= 65535:
+            raise ValueError("port must be between 1 and 65535")
+        targets.add((_normalize_host(host), port))
+    return targets
+
+
+def _validate_postgis_target(conninfo: dict[str, str]) -> tuple[str, str]:
+    """Validate every destination and return explicit libpq host/port lists."""
+    configured = os.environ.get(_POSTGIS_HOSTS_ENV, "")
+    try:
+        allowed = _allowed_postgis_targets(configured)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"{_POSTGIS_HOSTS_ENV} is invalid",
+        ) from exc
+    if not allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=f"PostGIS access is disabled; configure {_POSTGIS_HOSTS_ENV}",
+        )
+
+    # A service can load (and change) hosts from pg_service.conf after this
+    # validation. Requiring an explicit DSN host closes that indirection.
+    if conninfo.get("service"):
+        raise HTTPException(
+            status_code=400,
+            detail="PostgreSQL service connection strings are not supported",
+        )
+    # libpq connects to hostaddr while retaining host for authentication and
+    # display, which would otherwise let an allowlisted name mask any IP.
+    if conninfo.get("hostaddr"):
+        raise HTTPException(
+            status_code=400,
+            detail="PostgreSQL hostaddr connection strings are not supported",
+        )
+    hosts = conninfo.get("host", "").split(",")
+    if not hosts or any(not host.strip() for host in hosts):
+        raise HTTPException(
+            status_code=400,
+            detail="PostgreSQL connection must specify an allowed TCP host",
+        )
+    raw_ports = conninfo.get("port", "")
+    ports = raw_ports.split(",") if raw_ports else [str(_DEFAULT_POSTGRES_PORT)]
+    if len(ports) == 1:
+        ports *= len(hosts)
+    if len(ports) != len(hosts) or any(not port for port in ports):
+        raise HTTPException(status_code=400, detail="Invalid PostgreSQL host/port list")
+
+    for host, port_text in zip(hosts, ports):
+        try:
+            normalized_host = _normalize_host(host)
+            port = int(port_text)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid PostgreSQL host or port") from exc
+        if not 1 <= port <= 65535:
+            raise HTTPException(status_code=400, detail="Invalid PostgreSQL port")
+        if (normalized_host, port) not in allowed and (
+            normalized_host,
+            None,
+        ) not in allowed:
+            raise HTTPException(
+                status_code=403,
+                detail="PostgreSQL host or port is not allowed",
+            )
+    return ",".join(hosts), ",".join(ports)
 
 
 class PostgisTablesRequest(BaseModel):
@@ -125,11 +239,18 @@ def _connect(connection: str) -> Any:
         raise HTTPException(status_code=400, detail="connection is required")
     psycopg = _import_psycopg()
     try:
+        conninfo = psycopg.conninfo.conninfo_to_dict(connection.strip())
+        validated_hosts, validated_ports = _validate_postgis_target(conninfo)
         return psycopg.connect(
             connection.strip(),
+            host=validated_hosts,
+            hostaddr="",
+            port=validated_ports,
             connect_timeout=10,
             options=f"-c statement_timeout={_STATEMENT_TIMEOUT_MS}",
         )
+    except HTTPException:
+        raise
     except Exception as exc:  # noqa: BLE001 - surface a stable, scrubbed error
         raise HTTPException(
             status_code=400,

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -145,9 +145,11 @@ def _allowed_postgis_targets(value: str) -> Optional[set[tuple[str, Optional[int
             host, port_text = entry.rsplit(":", 1)
             port = int(port_text)
         elif entry.count(":") > 1:
-            # A bare IPv6 address is accepted; brackets are required only when
-            # an allowlist entry also specifies a port.
-            ipaddress.IPv6Address(entry)
+            # An unbracketed IPv6 address that carries a port is itself a valid
+            # address (`2001:db8::1:5432` parses cleanly), so the two spellings
+            # cannot be told apart. Requiring brackets refuses the typo instead
+            # of quietly allowing any port on an address nobody meant.
+            raise ValueError("IPv6 entries must be bracketed, e.g. [2001:db8::1]:5432")
         if port is not None and not 1 <= port <= 65535:
             raise ValueError("port must be between 1 and 65535")
         targets.add((_normalize_host(host), port))

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -202,8 +202,12 @@ def _validate_postgis_target(conninfo: dict[str, str]) -> Optional[tuple[str, st
     ports = raw_ports.split(",") if raw_ports else [str(_DEFAULT_POSTGRES_PORT)]
     if len(ports) == 1:
         ports *= len(hosts)
-    if len(ports) != len(hosts) or any(not port for port in ports):
+    if len(ports) != len(hosts):
         raise HTTPException(status_code=400, detail="Invalid PostgreSQL host/port list")
+    # libpq reads an empty item in a comma-separated port list as "the default
+    # port for this host" (`host=a,b port=,5433`), so fill those in rather than
+    # refusing a failover DSN the server would have accepted.
+    ports = [port if port else str(_DEFAULT_POSTGRES_PORT) for port in ports]
 
     for host, port_text in zip(hosts, ports):
         try:

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -43,6 +43,12 @@ logger = logging.getLogger(__name__)
 _STATEMENT_TIMEOUT_MS = 60_000
 _POSTGIS_HOSTS_ENV = "GEOLIBRE_POSTGIS_HOSTS"
 _DEFAULT_POSTGRES_PORT = 5432
+# Allowlist entry that lifts the restriction entirely. The desktop app passes
+# it when it spawns its own sidecar: there the caller and the operator are the
+# same person, and the sidecar is loopback-bound and token-authenticated. A
+# shared deployment (Docker/nginx proxy) leaves the variable unset and stays
+# closed, so the permissive mode is only ever reached by an explicit opt-in.
+_UNRESTRICTED = "*"
 
 # Username is optional (postgresql://:pw@host relies on PGUSER), so the group
 # is zero-or-more: an empty username must not let the password through. The
@@ -101,13 +107,21 @@ def _normalize_host(host: str) -> str:
         return candidate.rstrip(".").lower()
 
 
-def _allowed_postgis_targets(value: str) -> set[tuple[str, Optional[int]]]:
-    """Parse comma-separated ``host`` or ``host:port`` allowlist entries."""
+def _allowed_postgis_targets(value: str) -> Optional[set[tuple[str, Optional[int]]]]:
+    """Parse comma-separated ``host`` or ``host:port`` allowlist entries.
+
+    Returns:
+        The allowed ``(host, port)`` pairs, where a ``None`` port allows any
+        port on that host, or ``None`` when the value is ``*`` and the
+        restriction is lifted altogether.
+    """
     targets: set[tuple[str, Optional[int]]] = set()
     for raw_entry in value.split(","):
         entry = raw_entry.strip()
         if not entry:
             continue
+        if entry == _UNRESTRICTED:
+            return None
         host = entry
         port: Optional[int] = None
         if entry.startswith("["):
@@ -133,8 +147,21 @@ def _allowed_postgis_targets(value: str) -> set[tuple[str, Optional[int]]]:
     return targets
 
 
-def _validate_postgis_target(conninfo: dict[str, str]) -> tuple[str, str]:
-    """Validate every destination and return explicit libpq host/port lists."""
+def _validate_postgis_target(conninfo: dict[str, str]) -> Optional[tuple[str, str]]:
+    """Validate every destination against the allowlist.
+
+    Args:
+        conninfo: The parsed libpq connection keywords of the request's DSN.
+
+    Returns:
+        The explicit ``host``/``port`` lists to pin the connection to, or
+        ``None`` when the allowlist is unrestricted and the DSN should be used
+        as given (including Unix sockets and ``service=`` indirection).
+
+    Raises:
+        HTTPException: The allowlist is unset, malformed, or does not cover
+            every destination the connection string names.
+    """
     configured = os.environ.get(_POSTGIS_HOSTS_ENV, "")
     try:
         allowed = _allowed_postgis_targets(configured)
@@ -143,6 +170,8 @@ def _validate_postgis_target(conninfo: dict[str, str]) -> tuple[str, str]:
             status_code=500,
             detail=f"{_POSTGIS_HOSTS_ENV} is invalid",
         ) from exc
+    if allowed is None:
+        return None
     if not allowed:
         raise HTTPException(
             status_code=403,
@@ -240,12 +269,21 @@ def _connect(connection: str) -> Any:
     psycopg = _import_psycopg()
     try:
         conninfo = psycopg.conninfo.conninfo_to_dict(connection.strip())
-        validated_hosts, validated_ports = _validate_postgis_target(conninfo)
+        validated = _validate_postgis_target(conninfo)
+        # Pin libpq to the destinations that were actually validated, so a DSN
+        # spelling the parser and libpq read differently cannot drift between
+        # the check and the connect. Unrestricted mode has nothing to pin.
+        overrides: dict[str, Any] = {}
+        if validated is not None:
+            validated_hosts, validated_ports = validated
+            overrides = {
+                "host": validated_hosts,
+                "hostaddr": "",
+                "port": validated_ports,
+            }
         return psycopg.connect(
             connection.strip(),
-            host=validated_hosts,
-            hostaddr="",
-            port=validated_ports,
+            **overrides,
             connect_timeout=10,
             options=f"-c statement_timeout={_STATEMENT_TIMEOUT_MS}",
         )

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -95,10 +95,12 @@ def _sanitize_error(message: str) -> str:
 def _normalize_host(host: str) -> str:
     """Return a stable representation for exact host allowlist comparisons."""
     candidate = host.strip()
-    if not candidate or candidate.startswith("/"):
-        raise ValueError("PostgreSQL host must be a TCP hostname or IP address")
     if candidate.startswith("[") and candidate.endswith("]"):
         candidate = candidate[1:-1]
+    # After the unwrap, so a bracketed-empty "[]" is rejected rather than
+    # normalizing to the empty string.
+    if not candidate or candidate.startswith("/"):
+        raise ValueError("PostgreSQL host must be a TCP hostname or IP address")
     try:
         return str(ipaddress.ip_address(candidate))
     except ValueError:

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -116,14 +116,19 @@ def _allowed_postgis_targets(value: str) -> Optional[set[tuple[str, Optional[int
         The allowed ``(host, port)`` pairs, where a ``None`` port allows any
         port on that host, or ``None`` when the value is ``*`` and the
         restriction is lifted altogether.
+
+    Raises:
+        ValueError: An entry is malformed, or ``*`` is mixed with hosts.
     """
+    entries = [entry.strip() for entry in value.split(",") if entry.strip()]
+    # `*` alongside hosts reads as a narrowing but is not one, so refuse it
+    # rather than leaving an operator who meant to narrow wide open.
+    if _UNRESTRICTED in entries:
+        if len(entries) > 1:
+            raise ValueError(f"'{_UNRESTRICTED}' must be the only entry")
+        return None
     targets: set[tuple[str, Optional[int]]] = set()
-    for raw_entry in value.split(","):
-        entry = raw_entry.strip()
-        if not entry:
-            continue
-        if entry == _UNRESTRICTED:
-            return None
+    for entry in entries:
         host = entry
         port: Optional[int] = None
         if entry.startswith("["):
@@ -194,14 +199,21 @@ def _validate_postgis_target(conninfo: dict[str, str]) -> Optional[tuple[str, st
             status_code=400,
             detail="PostgreSQL hostaddr connection strings are not supported",
         )
-    hosts = conninfo.get("host", "").split(",")
-    if not hosts or any(not host.strip() for host in hosts):
+    # Each item is stripped here, not just when comparing: the list is rejoined
+    # into the `host`/`port` overrides, and libpq would take stray whitespace
+    # from a quoted multi-host DSN (`host='a, b'`) as part of the name.
+    hosts = [host.strip() for host in conninfo.get("host", "").split(",")]
+    if not hosts or any(not host for host in hosts):
         raise HTTPException(
             status_code=400,
             detail="PostgreSQL connection must specify an allowed TCP host",
         )
     raw_ports = conninfo.get("port", "")
-    ports = raw_ports.split(",") if raw_ports else [str(_DEFAULT_POSTGRES_PORT)]
+    ports = (
+        [port.strip() for port in raw_ports.split(",")]
+        if raw_ports
+        else [str(_DEFAULT_POSTGRES_PORT)]
+    )
     if len(ports) == 1:
         ports *= len(hosts)
     if len(ports) != len(hosts):

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -106,6 +106,13 @@ def test_postgis_allowlist_parses_hosts_ips_and_ports() -> None:
     }
 
 
+def test_postgis_allowlist_requires_brackets_for_ipv6() -> None:
+    """An unbracketed `2001:db8::1:5432` is a valid address, not host plus port."""
+    with pytest.raises(ValueError):
+        _allowed_postgis_targets("2001:db8::1:5432")
+    assert _allowed_postgis_targets("[2001:db8::1]") == {("2001:db8::1", None)}
+
+
 def test_postgis_wildcard_lifts_the_restriction(monkeypatch) -> None:
     """``*`` (what the desktop app passes its own sidecar) allows any DSN."""
     assert _allowed_postgis_targets("*") is None

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -108,7 +108,10 @@ def test_postgis_allowlist_parses_hosts_ips_and_ports() -> None:
 
 def test_postgis_wildcard_lifts_the_restriction(monkeypatch) -> None:
     """``*`` (what the desktop app passes its own sidecar) allows any DSN."""
-    assert _allowed_postgis_targets("db.example,*") is None
+    assert _allowed_postgis_targets("*") is None
+    # Mixing it with hosts looks like a narrowing but is not one.
+    with pytest.raises(ValueError):
+        _allowed_postgis_targets("db.example,*")
     monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "*")
     for conninfo in (
         {"host": "anything.internal", "port": "5432"},
@@ -151,6 +154,17 @@ def test_postgis_allowlist_validates_every_failover_host(monkeypatch) -> None:
     with pytest.raises(HTTPException) as exc:
         _validate_postgis_target({"host": "db-a.example,metadata.internal", "port": "5432"})
     assert exc.value.status_code == 403
+
+
+def test_postgis_host_list_whitespace_is_not_passed_to_libpq(monkeypatch) -> None:
+    """A quoted multi-host DSN can carry spacing libpq would read as the name."""
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "db-a.example,db-b.example")
+    assert _validate_postgis_target(
+        {"host": "db-a.example, db-b.example", "port": "5432, 5433"}
+    ) == (
+        "db-a.example,db-b.example",
+        "5432,5433",
+    )
 
 
 def test_postgis_allowlist_matches_dsn_host_case_insensitively(monkeypatch) -> None:

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -142,9 +142,28 @@ def test_postgis_allowlist_validates_every_failover_host(monkeypatch) -> None:
         "db-a.example,db-b.example",
         "5432,5433",
     )
+    # libpq reads an empty port item as that host's default port.
+    assert _validate_postgis_target({"host": "db-a.example,db-b.example", "port": ",5433"}) == (
+        "db-a.example,db-b.example",
+        "5432,5433",
+    )
     with pytest.raises(HTTPException) as exc:
         _validate_postgis_target({"host": "db-a.example,metadata.internal", "port": "5432"})
     assert exc.value.status_code == 403
+
+
+def test_postgis_allowlist_matches_dsn_host_case_insensitively(monkeypatch) -> None:
+    """Comparison normalizes the DSN host too, not just the allowlist entry."""
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "db.example")
+    # The host is returned as written: libpq resolves case and the DNS root dot.
+    assert _validate_postgis_target({"host": "DB.EXAMPLE."}) == ("DB.EXAMPLE.", "5432")
+
+
+def test_postgis_malformed_allowlist_is_a_server_error(monkeypatch) -> None:
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "db.example:99999")
+    with pytest.raises(HTTPException) as exc:
+        _validate_postgis_target({"host": "db.example"})
+    assert exc.value.status_code == 500
 
 
 def test_postgis_allowlist_rejects_indirect_destinations(monkeypatch) -> None:

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -105,6 +105,19 @@ def test_postgis_allowlist_parses_hosts_ips_and_ports() -> None:
     }
 
 
+def test_postgis_wildcard_lifts_the_restriction(monkeypatch) -> None:
+    """``*`` (what the desktop app passes its own sidecar) allows any DSN."""
+    assert _allowed_postgis_targets("db.example,*") is None
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "*")
+    for conninfo in (
+        {"host": "anything.internal", "port": "5432"},
+        {"host": "/var/run/postgresql"},
+        {"service": "production"},
+        {},
+    ):
+        assert _validate_postgis_target(conninfo) is None
+
+
 def test_postgis_access_is_disabled_without_allowlist(monkeypatch) -> None:
     monkeypatch.delenv("GEOLIBRE_POSTGIS_HOSTS", raising=False)
     with pytest.raises(HTTPException) as exc:

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -22,6 +22,7 @@ from geolibre_server.app.postgis import (
     PostgisTablesRequest,
     PostgisWriteRequest,
     _allowed_postgis_targets,
+    _normalize_host,
     _sanitize_error,
     _validate_postgis_target,
     postgis_read,
@@ -177,6 +178,32 @@ def test_postgis_allowlist_rejects_indirect_destinations(monkeypatch) -> None:
         with pytest.raises(HTTPException) as exc:
             _validate_postgis_target(conninfo)
         assert exc.value.status_code == 400
+
+
+def test_postgis_bracketed_empty_host_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        _normalize_host("[]")
+
+
+@requires_psycopg
+def test_nested_dbname_cannot_redirect_the_connection(monkeypatch) -> None:
+    """A conninfo-shaped ``dbname`` must not move the connection off its host.
+
+    libpq re-parses a ``dbname`` that looks like a connection string only on
+    its keyword/value array path (``expand_dbname``); psycopg hands the DSN to
+    ``PQconnectStart`` as a *string*, whose parser leaves the value literal. If
+    a psycopg upgrade ever switched paths, a nested ``dbname`` would become a
+    way past the allowlist, so the behavior is pinned here: the attempt must
+    still land on the validated loopback host, never on the embedded one.
+    """
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "127.0.0.1:1")
+    request = PostgisTablesRequest(
+        connection="host=127.0.0.1 port=1 dbname='host=192.0.2.9 port=5432 dbname=real'",
+    )
+    with pytest.raises(HTTPException) as exc:
+        postgis_tables(request)
+    assert exc.value.status_code == 400
+    assert "192.0.2.9" not in str(exc.value.detail)
 
 
 @requires_psycopg

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -5,8 +5,9 @@ Two tiers:
 - Validation and status tests that need only psycopg installed (no server).
 - Live round-trip tests against a real PostGIS database, enabled by setting
   ``GEOLIBRE_TEST_POSTGIS_DSN`` to a connection string with rights to create
-  and drop tables. Without it they skip, mirroring how the other optional
-  engines (geopandas/rasterio/sedona) gate their suites.
+  and drop tables and allowing its host with ``GEOLIBRE_POSTGIS_HOSTS``.
+  Without it they skip, mirroring how the other optional engines
+  (geopandas/rasterio/sedona) gate their suites.
 """
 
 from __future__ import annotations
@@ -20,7 +21,9 @@ from geolibre_server.app.postgis import (
     PostgisReadRequest,
     PostgisTablesRequest,
     PostgisWriteRequest,
+    _allowed_postgis_targets,
     _sanitize_error,
+    _validate_postgis_target,
     postgis_read,
     postgis_status,
     postgis_tables,
@@ -91,6 +94,59 @@ def test_sanitize_error_scrubs_passwords() -> None:
     assert "****@db.example.com" in scrubbed
 
 
+def test_postgis_allowlist_parses_hosts_ips_and_ports() -> None:
+    assert _allowed_postgis_targets(
+        "DB.EXAMPLE., db.internal:5433, 10.0.0.4, [2001:db8::1]:5432"
+    ) == {
+        ("db.example", None),
+        ("db.internal", 5433),
+        ("10.0.0.4", None),
+        ("2001:db8::1", 5432),
+    }
+
+
+def test_postgis_access_is_disabled_without_allowlist(monkeypatch) -> None:
+    monkeypatch.delenv("GEOLIBRE_POSTGIS_HOSTS", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        _validate_postgis_target({"host": "db.example"})
+    assert exc.value.status_code == 403
+
+
+def test_postgis_allowlist_rejects_unlisted_and_wrong_port(monkeypatch) -> None:
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "db.example:5433")
+    for conninfo in (
+        {"host": "internal.example", "port": "5433"},
+        {"host": "db.example", "port": "5432"},
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _validate_postgis_target(conninfo)
+        assert exc.value.status_code == 403
+
+
+def test_postgis_allowlist_validates_every_failover_host(monkeypatch) -> None:
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "db-a.example:5432,db-b.example:5433")
+    assert _validate_postgis_target({"host": "db-a.example,db-b.example", "port": "5432,5433"}) == (
+        "db-a.example,db-b.example",
+        "5432,5433",
+    )
+    with pytest.raises(HTTPException) as exc:
+        _validate_postgis_target({"host": "db-a.example,metadata.internal", "port": "5432"})
+    assert exc.value.status_code == 403
+
+
+def test_postgis_allowlist_rejects_indirect_destinations(monkeypatch) -> None:
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "localhost")
+    for conninfo in (
+        {},
+        {"host": "/var/run/postgresql"},
+        {"service": "production"},
+        {"host": "localhost", "hostaddr": "169.254.169.254"},
+    ):
+        with pytest.raises(HTTPException) as exc:
+            _validate_postgis_target(conninfo)
+        assert exc.value.status_code == 400
+
+
 @requires_psycopg
 def test_empty_connection_rejected() -> None:
     with pytest.raises(HTTPException) as exc:
@@ -99,7 +155,8 @@ def test_empty_connection_rejected() -> None:
 
 
 @requires_psycopg
-def test_connect_failure_does_not_leak_password() -> None:
+def test_connect_failure_does_not_leak_password(monkeypatch) -> None:
+    monkeypatch.setenv("GEOLIBRE_POSTGIS_HOSTS", "127.0.0.1:1")
     request = PostgisReadRequest(
         connection="postgresql://alice:sekretpw@127.0.0.1:1/nope",
         table="whatever",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,6 +151,13 @@ image). Mount your files there:
 docker run --rm -p 8080:80 -v "$PWD/data:/data" ghcr.io/opengeos/geolibre:latest
 ```
 
+The sidecar's PostGIS endpoints are gated the same way: they refuse every
+destination until `GEOLIBRE_POSTGIS_HOSTS` lists the allowed databases, so that
+a caller reaching the image cannot aim them at hosts only the container can
+reach. Pass `-e GEOLIBRE_POSTGIS_HOSTS='db.internal:5432'` (or `*` to accept any
+connection string) to enable them. The desktop app is not affected: its sidecar
+is loopback-bound and started for a single user, so it defaults to unrestricted.
+
 `freestiler` and `whitebox-workflows` publish no linux/arm64 wheels, so they are
 installed on **amd64 only**; on arm64 the sidecar reports those tools
 unavailable. This does not affect the browser's own PMTiles and Whitebox


### PR DESCRIPTION
## Summary
- The PostGIS sidecar endpoints previously connected to any host named in a request's connection string. They are now disabled until `GEOLIBRE_POSTGIS_HOSTS` lists the allowed `host` or `host:port` destinations, and every host in a libpq failover list is checked. The validated host and port are passed explicitly to `psycopg.connect` so the DSN cannot be read one way by the check and another by libpq.
- Indirect destinations that could bypass the check are rejected: `service=` connection strings, `hostaddr`, Unix sockets, and implicit local connections.
- `*` lifts the restriction. The desktop app passes it when it spawns its own sidecar, which is loopback-bound, token-authenticated, and serves the single user who is also its operator; a value already in the environment still wins, so a desktop user can narrow it. The Docker image deliberately leaves the variable unset, so PostGIS there stays off until an operator lists the databases. This mirrors how `GEOLIBRE_CONVERSION_ROOTS` is unset on desktop and set in the image.
- Documented the setting in the sidecar README, the Dockerfile, and the Docker section of the getting-started guide, and added unit tests for allowlist parsing, denial, failover lists, the rejected indirect forms, and the unrestricted mode.

## Test plan
- [x] `python -m pytest backend/geolibre_server/tests/test_postgis.py` (13 passed; live round-trip tests skip without a DSN)
- [x] `ruff` and `ruff-format` on the changed files
- [ ] CI `cargo check` for the Tauri crate (no Rust toolchain available where this was written)
- [ ] Desktop: load and edit a PostGIS table with no environment variable set, confirming it still works
- [ ] Desktop launched with `GEOLIBRE_POSTGIS_HOSTS` set to a narrower list: confirm an unlisted host is refused
- [ ] Docker image with the variable unset: confirm the PostGIS endpoints return 403, and that passing `-e GEOLIBRE_POSTGIS_HOSTS=...` enables the listed database

## Note
Running the sidecar by hand for web development (`geolibre-server` outside the desktop app) now needs `GEOLIBRE_POSTGIS_HOSTS` set, or the PostGIS endpoints answer 403. That is the intended default for anything the desktop app did not spawn, and it is documented in the sidecar README.

## Acknowledgment

Credits to Michael Chesang (Threat Lance Security) for reporting this issue. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * PostGIS connections are now restricted to explicitly allowlisted hosts and ports.
  * Unsupported or indirect connection formats are rejected.
  * Connections remain disabled when no allowlist is configured.

* **Documentation**
  * Added configuration guidance for `GEOLIBRE_POSTGIS_HOSTS`, including wildcard and IPv6 examples.
  * Documented default behavior for Docker deployments and the desktop app.

* **Bug Fixes**
  * Improved protection against connection redirection and sensitive connection details appearing in errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->