### PR TITLE
fix(workers): stop edge proxies from following off-origin redirects

### DIFF
--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -7,6 +7,7 @@ import {
   sanitizeViewerPath,
 } from "../workers/viewer/src/proxy";
 import {
+  TILES_MAX_REDIRECT_HOPS,
   fetchAllowlistedUpstream,
   isAllowedTilesUpstreamUrl,
 } from "../workers/tiles/src/allowlisted-fetch";
@@ -18,6 +19,8 @@ describe("viewer proxy path sanitization", () => {
     assert.equal(sanitizeViewerPath("/../secret"), null);
     assert.equal(sanitizeViewerPath("/foo/../../etc/passwd"), null);
     assert.equal(sanitizeViewerPath("/foo%2e%2e/bar"), null);
+    assert.equal(sanitizeViewerPath("/foo%2f..%2fsecret"), null);
+    assert.equal(sanitizeViewerPath("/foo%2F..%2Fsecret"), null);
   });
 });
 
@@ -33,7 +36,7 @@ describe("viewer upstream allowlist", () => {
 });
 
 describe("viewer redirect policy", () => {
-  it("follows an in-prefix redirect and refuses a cross-origin Location", async () => {
+  it("follows an in-prefix redirect, strips cookies, and refuses cross-origin", async () => {
     const calls: string[] = [];
     const fetchImpl: typeof fetch = async (input) => {
       const url = String(input);
@@ -45,7 +48,14 @@ describe("viewer redirect policy", () => {
         });
       }
       if (url.endsWith("/demo/new")) {
-        return new Response("ok", { status: 200 });
+        return new Response("ok", {
+          status: 200,
+          headers: {
+            "set-cookie": "session=evil",
+            "set-cookie2": "also=evil",
+            "content-type": "text/plain",
+          },
+        });
       }
       return new Response("unexpected", { status: 500 });
     };
@@ -53,6 +63,8 @@ describe("viewer redirect policy", () => {
     const ok = await proxyViewerRequest(new Request("https://web.geolibre.app/old"), fetchImpl);
     assert.equal(ok.status, 200);
     assert.equal(await ok.text(), "ok");
+    assert.equal(ok.headers.get("set-cookie"), null);
+    assert.equal(ok.headers.get("set-cookie2"), null);
     assert.deepEqual(calls, ["https://geolibre.app/demo/old", "https://geolibre.app/demo/new"]);
 
     const evilFetch: typeof fetch = async () =>
@@ -62,6 +74,22 @@ describe("viewer redirect policy", () => {
       });
     const blocked = await proxyViewerRequest(new Request("https://web.geolibre.app/"), evilFetch);
     assert.equal(blocked.status, 502);
+  });
+
+  it("passes through 304 Not Modified instead of treating it as a broken redirect", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(null, {
+        status: 304,
+        headers: { etag: '"abc"' },
+      });
+    const response = await proxyViewerRequest(
+      new Request("https://web.geolibre.app/assets/app.js", {
+        headers: { "if-none-match": '"abc"' },
+      }),
+      fetchImpl,
+    );
+    assert.equal(response.status, 304);
+    assert.equal(response.headers.get("etag"), '"abc"');
   });
 
   it("rejects non-GET methods and caps redirect hops", async () => {
@@ -86,9 +114,19 @@ describe("viewer redirect policy", () => {
 });
 
 describe("tiles allowlisted fetch", () => {
-  it("refuses off-host redirects from an allowlisted origin", async () => {
+  it("refuses off-host and off-prefix S3 redirects", async () => {
     assert.equal(isAllowedTilesUpstreamUrl("https://api.openaerialmap.org/meta"), true);
     assert.equal(isAllowedTilesUpstreamUrl("https://evil.example/meta"), false);
+    assert.equal(
+      isAllowedTilesUpstreamUrl(
+        "https://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/mola-color/0/0/0.png",
+      ),
+      true,
+    );
+    assert.equal(
+      isAllowedTilesUpstreamUrl("https://s3-eu-west-1.amazonaws.com/other-bucket/secret"),
+      false,
+    );
 
     const fetchImpl: typeof fetch = async () =>
       new Response(null, {
@@ -102,7 +140,7 @@ describe("tiles allowlisted fetch", () => {
     );
   });
 
-  it("follows a same-host HTTPS redirect", async () => {
+  it("follows a same-host HTTPS redirect and caps hops", async () => {
     const fetchImpl: typeof fetch = async (input) => {
       const url = String(input);
       if (url.endsWith("/meta")) {
@@ -123,5 +161,20 @@ describe("tiles allowlisted fetch", () => {
     );
     assert.equal(response.status, 200);
     assert.equal(await response.text(), '{"ok":true}');
+
+    let hops = 0;
+    const looping: typeof fetch = async (input) => {
+      hops += 1;
+      const url = String(input);
+      return new Response(null, {
+        status: 302,
+        headers: { location: `${url}?n=${hops}` },
+      });
+    };
+    await assert.rejects(
+      () => fetchAllowlistedUpstream("https://api.openaerialmap.org/meta", {}, looping),
+      /Too many upstream redirects/,
+    );
+    assert.equal(hops, TILES_MAX_REDIRECT_HOPS + 1);
   });
 });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -32,6 +32,7 @@ describe("viewer upstream allowlist", () => {
     assert.equal(isAllowedUpstreamUrl("https://geolibre.app/"), false);
     assert.equal(isAllowedUpstreamUrl("https://evil.example/demo"), false);
     assert.equal(isAllowedUpstreamUrl("http://geolibre.app/demo"), false);
+    assert.equal(isAllowedUpstreamUrl("https://geolibre.app:8443/demo/assets/a.js"), false);
   });
 });
 
@@ -176,5 +177,20 @@ describe("tiles allowlisted fetch", () => {
       /Too many upstream redirects/,
     );
     assert.equal(hops, TILES_MAX_REDIRECT_HOPS + 1);
+  });
+
+  it("passes through 304 Not Modified with its ETag", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response(null, {
+        status: 304,
+        headers: { etag: '"tile-abc"' },
+      });
+    const response = await fetchAllowlistedUpstream(
+      "https://api.openaerialmap.org/meta",
+      { headers: { "if-none-match": '"tile-abc"' } },
+      fetchImpl,
+    );
+    assert.equal(response.status, 304);
+    assert.equal(response.headers.get("etag"), '"tile-abc"');
   });
 });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  MAX_REDIRECT_HOPS,
+  isAllowedUpstreamUrl,
+  proxyViewerRequest,
+  sanitizeViewerPath,
+} from "../workers/viewer/src/proxy";
+import {
+  fetchAllowlistedUpstream,
+  isAllowedTilesUpstreamUrl,
+} from "../workers/tiles/src/allowlisted-fetch";
+
+describe("viewer proxy path sanitization", () => {
+  it("accepts normal asset paths and rejects traversal", () => {
+    assert.equal(sanitizeViewerPath("/assets/index.js"), "/assets/index.js");
+    assert.equal(sanitizeViewerPath("/"), "/");
+    assert.equal(sanitizeViewerPath("/../secret"), null);
+    assert.equal(sanitizeViewerPath("/foo/../../etc/passwd"), null);
+    assert.equal(sanitizeViewerPath("/foo%2e%2e/bar"), null);
+  });
+});
+
+describe("viewer upstream allowlist", () => {
+  it("keeps fetches under https://geolibre.app/demo", () => {
+    assert.equal(isAllowedUpstreamUrl("https://geolibre.app/demo"), true);
+    assert.equal(isAllowedUpstreamUrl("https://geolibre.app/demo/"), true);
+    assert.equal(isAllowedUpstreamUrl("https://geolibre.app/demo/assets/a.js"), true);
+    assert.equal(isAllowedUpstreamUrl("https://geolibre.app/"), false);
+    assert.equal(isAllowedUpstreamUrl("https://evil.example/demo"), false);
+    assert.equal(isAllowedUpstreamUrl("http://geolibre.app/demo"), false);
+  });
+});
+
+describe("viewer redirect policy", () => {
+  it("follows an in-prefix redirect and refuses a cross-origin Location", async () => {
+    const calls: string[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/demo/old")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://geolibre.app/demo/new" },
+        });
+      }
+      if (url.endsWith("/demo/new")) {
+        return new Response("ok", { status: 200 });
+      }
+      return new Response("unexpected", { status: 500 });
+    };
+
+    const ok = await proxyViewerRequest(
+      new Request("https://web.geolibre.app/old"),
+      fetchImpl,
+    );
+    assert.equal(ok.status, 200);
+    assert.equal(await ok.text(), "ok");
+    assert.deepEqual(calls, [
+      "https://geolibre.app/demo/old",
+      "https://geolibre.app/demo/new",
+    ]);
+
+    const evilFetch: typeof fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.example/steal" },
+      });
+    const blocked = await proxyViewerRequest(
+      new Request("https://web.geolibre.app/"),
+      evilFetch,
+    );
+    assert.equal(blocked.status, 502);
+  });
+
+  it("rejects non-GET methods and caps redirect hops", async () => {
+    const method = await proxyViewerRequest(
+      new Request("https://web.geolibre.app/", { method: "POST" }),
+    );
+    assert.equal(method.status, 405);
+
+    let hops = 0;
+    const looping: typeof fetch = async (input) => {
+      hops += 1;
+      const url = String(input);
+      return new Response(null, {
+        status: 302,
+        headers: { location: `${url}?n=${hops}` },
+      });
+    };
+    const capped = await proxyViewerRequest(
+      new Request("https://web.geolibre.app/loop"),
+      looping,
+    );
+    assert.equal(capped.status, 502);
+    assert.equal(hops, MAX_REDIRECT_HOPS + 1);
+  });
+});
+
+describe("tiles allowlisted fetch", () => {
+  it("refuses off-host redirects from an allowlisted origin", async () => {
+    assert.equal(isAllowedTilesUpstreamUrl("https://api.openaerialmap.org/meta"), true);
+    assert.equal(isAllowedTilesUpstreamUrl("https://evil.example/meta"), false);
+
+    const fetchImpl: typeof fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.example/payload" },
+      });
+
+    await assert.rejects(
+      () => fetchAllowlistedUpstream("https://api.openaerialmap.org/meta", {}, fetchImpl),
+      /non-allowlisted/,
+    );
+  });
+
+  it("follows a same-host HTTPS redirect", async () => {
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/meta")) {
+        return new Response(null, {
+          status: 301,
+          headers: { location: "https://api.openaerialmap.org/meta/" },
+        });
+      }
+      return new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const response = await fetchAllowlistedUpstream(
+      "https://api.openaerialmap.org/meta",
+      {},
+      fetchImpl,
+    );
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '{"ok":true}');
+  });
+});

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -50,26 +50,17 @@ describe("viewer redirect policy", () => {
       return new Response("unexpected", { status: 500 });
     };
 
-    const ok = await proxyViewerRequest(
-      new Request("https://web.geolibre.app/old"),
-      fetchImpl,
-    );
+    const ok = await proxyViewerRequest(new Request("https://web.geolibre.app/old"), fetchImpl);
     assert.equal(ok.status, 200);
     assert.equal(await ok.text(), "ok");
-    assert.deepEqual(calls, [
-      "https://geolibre.app/demo/old",
-      "https://geolibre.app/demo/new",
-    ]);
+    assert.deepEqual(calls, ["https://geolibre.app/demo/old", "https://geolibre.app/demo/new"]);
 
     const evilFetch: typeof fetch = async () =>
       new Response(null, {
         status: 302,
         headers: { location: "https://evil.example/steal" },
       });
-    const blocked = await proxyViewerRequest(
-      new Request("https://web.geolibre.app/"),
-      evilFetch,
-    );
+    const blocked = await proxyViewerRequest(new Request("https://web.geolibre.app/"), evilFetch);
     assert.equal(blocked.status, 502);
   });
 
@@ -88,10 +79,7 @@ describe("viewer redirect policy", () => {
         headers: { location: `${url}?n=${hops}` },
       });
     };
-    const capped = await proxyViewerRequest(
-      new Request("https://web.geolibre.app/loop"),
-      looping,
-    );
+    const capped = await proxyViewerRequest(new Request("https://web.geolibre.app/loop"), looping);
     assert.equal(capped.status, 502);
     assert.equal(hops, MAX_REDIRECT_HOPS + 1);
   });

--- a/workers/tiles/src/allowlisted-fetch.ts
+++ b/workers/tiles/src/allowlisted-fetch.ts
@@ -1,0 +1,64 @@
+/**
+ * Allowlisted upstream hosts the tiles worker may fetch. Named proxies
+ * (OPM mosaics, USGS WMS, OAM meta, Source Cooperative, Protomaps) are never
+ * an open proxy — but a 302 from an allowlisted URL to an arbitrary Location
+ * would reintroduce that risk if `fetch` followed redirects automatically.
+ */
+export const TILES_ALLOWED_UPSTREAM_HOSTS = new Set([
+  "s3-eu-west-1.amazonaws.com",
+  "s3.us-east-2.amazonaws.com",
+  "s3.amazonaws.com",
+  "api.openaerialmap.org",
+  "source.coop",
+  "build.protomaps.com",
+  "planetarymaps.usgs.gov",
+]);
+
+export const TILES_MAX_REDIRECT_HOPS = 5;
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Whether a resolved upstream URL is HTTPS and on an allowlisted host.
+ */
+export function isAllowedTilesUpstreamUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && TILES_ALLOWED_UPSTREAM_HOSTS.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch an allowlisted upstream URL, following redirects only while they stay
+ * on HTTPS allowlisted hosts. Cross-host Locations are refused so a compromised
+ * or misconfigured origin cannot turn the worker into an open proxy.
+ */
+export async function fetchAllowlistedUpstream(
+  url: string,
+  init: RequestInit = {},
+  fetchImpl: FetchLike = fetch,
+): Promise<Response> {
+  if (!isAllowedTilesUpstreamUrl(url)) {
+    throw new Error(`Refused fetch to non-allowlisted upstream: ${url}`);
+  }
+
+  let target = url;
+  for (let hop = 0; hop <= TILES_MAX_REDIRECT_HOPS; hop++) {
+    const response = await fetchImpl(target, { ...init, redirect: "manual" });
+    if (response.status < 300 || response.status >= 400) {
+      return response;
+    }
+    const location = response.headers.get("location");
+    if (!location) {
+      return response;
+    }
+    const next = new URL(location, target).toString();
+    if (!isAllowedTilesUpstreamUrl(next)) {
+      throw new Error(`Refused redirect to non-allowlisted upstream: ${next}`);
+    }
+    target = next;
+  }
+  throw new Error("Too many upstream redirects");
+}

--- a/workers/tiles/src/allowlisted-fetch.ts
+++ b/workers/tiles/src/allowlisted-fetch.ts
@@ -1,30 +1,49 @@
 /**
- * Allowlisted upstream hosts the tiles worker may fetch. Named proxies
+ * Allowlisted upstream URL prefixes the tiles worker may fetch. Named proxies
  * (OPM mosaics, USGS WMS, OAM meta, Source Cooperative, Protomaps) are never
  * an open proxy — but a 302 from an allowlisted URL to an arbitrary Location
  * would reintroduce that risk if `fetch` followed redirects automatically.
+ *
+ * S3 entries are scoped to the known OPM dataset path prefixes (not the whole
+ * shared `s3*.amazonaws.com` host) so a redirect cannot jump to another bucket.
  */
-export const TILES_ALLOWED_UPSTREAM_HOSTS = new Set([
-  "s3-eu-west-1.amazonaws.com",
-  "s3.us-east-2.amazonaws.com",
-  "s3.amazonaws.com",
-  "api.openaerialmap.org",
-  "source.coop",
-  "build.protomaps.com",
-  "planetarymaps.usgs.gov",
-]);
+export const TILES_ALLOWED_URL_PREFIXES = [
+  "https://s3-eu-west-1.amazonaws.com/whereonmars.cartodb.net/",
+  "https://s3.us-east-2.amazonaws.com/opmmarstiles/",
+  "https://s3.amazonaws.com/opmbuilder/",
+  "https://api.openaerialmap.org/",
+  "https://source.coop/",
+  "https://build.protomaps.com/",
+  "https://planetarymaps.usgs.gov/",
+] as const;
+
+/** @deprecated Prefer {@link TILES_ALLOWED_URL_PREFIXES}; kept for tests/docs. */
+export const TILES_ALLOWED_UPSTREAM_HOSTS = new Set(
+  TILES_ALLOWED_URL_PREFIXES.map((prefix) => new URL(prefix).hostname),
+);
 
 export const TILES_MAX_REDIRECT_HOPS = 5;
 
-type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+/** HTTP statuses that carry a Location and should be followed manually. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** Cloudflare outgoing fetch options (`cf` cache hints, etc.). */
+export type TilesFetchInit = RequestInit & {
+  cf?: RequestInitCfProperties;
+};
+
+type FetchLike = (input: RequestInfo | URL, init?: TilesFetchInit) => Promise<Response>;
 
 /**
- * Whether a resolved upstream URL is HTTPS and on an allowlisted host.
+ * Whether a resolved upstream URL is HTTPS and under an allowlisted
+ * host+path prefix (not merely an allowlisted hostname).
  */
 export function isAllowedTilesUpstreamUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "https:" && TILES_ALLOWED_UPSTREAM_HOSTS.has(parsed.hostname);
+    if (parsed.protocol !== "https:") return false;
+    const candidate = `${parsed.origin}${parsed.pathname}`;
+    return TILES_ALLOWED_URL_PREFIXES.some((prefix) => candidate.startsWith(prefix));
   } catch {
     return false;
   }
@@ -32,12 +51,12 @@ export function isAllowedTilesUpstreamUrl(url: string): boolean {
 
 /**
  * Fetch an allowlisted upstream URL, following redirects only while they stay
- * on HTTPS allowlisted hosts. Cross-host Locations are refused so a compromised
- * or misconfigured origin cannot turn the worker into an open proxy.
+ * under an allowlisted HTTPS prefix. Cross-prefix Locations are refused so a
+ * compromised or misconfigured origin cannot turn the worker into an open proxy.
  */
 export async function fetchAllowlistedUpstream(
   url: string,
-  init: RequestInit = {},
+  init: TilesFetchInit = {},
   fetchImpl: FetchLike = fetch,
 ): Promise<Response> {
   if (!isAllowedTilesUpstreamUrl(url)) {
@@ -47,7 +66,8 @@ export async function fetchAllowlistedUpstream(
   let target = url;
   for (let hop = 0; hop <= TILES_MAX_REDIRECT_HOPS; hop++) {
     const response = await fetchImpl(target, { ...init, redirect: "manual" });
-    if (response.status < 300 || response.status >= 400) {
+    // Pass through non-redirect responses, including 304 Not Modified.
+    if (!REDIRECT_STATUSES.has(response.status)) {
       return response;
     }
     const location = response.headers.get("location");

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -269,10 +269,19 @@ async function resolveLatestBuildDate(): Promise<string> {
     // fetches next — so a later real range read could be served this 1-byte
     // body instead of its bytes. The resolved date is memoised in `latestCache`
     // already, so no edge cache is needed here.
-    const probe = await fetchAllowlistedUpstream(`${PMTILES_UPSTREAM}/${ymd}.pmtiles`, {
-      headers: { range: "bytes=0-0" },
-    });
-    if (probe.status === 206) {
+    const probe = await (async () => {
+      try {
+        return await fetchAllowlistedUpstream(`${PMTILES_UPSTREAM}/${ymd}.pmtiles`, {
+          headers: { range: "bytes=0-0" },
+        });
+      } catch (err) {
+        // A single day's probe must not abort the lookback — treat redirect/
+        // allowlist failures as a miss and try the previous day.
+        console.warn(`Protomaps build probe failed for ${ymd}: ${String(err)}`);
+        return null;
+      }
+    })();
+    if (probe?.status === 206) {
       latestCache = { date: ymd, at: now };
       return ymd;
     }
@@ -372,7 +381,7 @@ async function handleSourceCoop(request: Request, pathname: string): Promise<Res
       // cacheEverything is required for Cloudflare to edge-cache a URL with no
       // static file extension (cacheTtl alone does not).
       cf: { cacheEverything: true, cacheTtl: 300 },
-    } as RequestInit);
+    });
   } catch {
     return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
   }
@@ -549,7 +558,7 @@ export default {
           // cacheEverything is required for Cloudflare to edge-cache a URL with
           // no static file extension (cacheTtl alone does not).
           cf: { cacheEverything: true, cacheTtl: 120 },
-        } as RequestInit);
+        });
       } catch {
         return new Response("Bad Gateway", {
           status: 502,
@@ -613,7 +622,7 @@ export default {
     try {
       originResponse = await fetchAllowlistedUpstream(upstream, {
         cf: { cacheEverything: true, cacheTtl: 86400 },
-      } as RequestInit);
+      });
     } catch {
       return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
     }
@@ -691,7 +700,7 @@ async function handleWmsTile(
   try {
     origin = await fetchAllowlistedUpstream(wmsUrl, {
       cf: { cacheEverything: true, cacheTtl: 86400 },
-    } as RequestInit);
+    });
   } catch {
     return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
   }

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -35,6 +35,7 @@
 // forwards them unchanged. The reprojected WMS tiles are standard XYZ.
 
 import * as UPNG from "upng-js";
+import { fetchAllowlistedUpstream } from "./allowlisted-fetch";
 import { remapRowsToMercator, tileGeoBounds, wmsBboxFor } from "./reproject";
 
 /** Allowlisted OpenPlanetaryMap tile datasets → their upstream base URL. */
@@ -268,7 +269,7 @@ async function resolveLatestBuildDate(): Promise<string> {
     // fetches next — so a later real range read could be served this 1-byte
     // body instead of its bytes. The resolved date is memoised in `latestCache`
     // already, so no edge cache is needed here.
-    const probe = await fetch(`${PMTILES_UPSTREAM}/${ymd}.pmtiles`, {
+    const probe = await fetchAllowlistedUpstream(`${PMTILES_UPSTREAM}/${ymd}.pmtiles`, {
       headers: { range: "bytes=0-0" },
     });
     if (probe.status === 206) {
@@ -367,11 +368,11 @@ async function handleSourceCoop(request: Request, pathname: string): Promise<Res
   }
   let originResponse: Response;
   try {
-    originResponse = await fetch(upstream, {
+    originResponse = await fetchAllowlistedUpstream(upstream, {
       // cacheEverything is required for Cloudflare to edge-cache a URL with no
       // static file extension (cacheTtl alone does not).
       cf: { cacheEverything: true, cacheTtl: 300 },
-    });
+    } as RequestInit);
   } catch {
     return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
   }
@@ -446,7 +447,7 @@ async function handlePmtilesRange(request: Request, name: string): Promise<Respo
     // effect on Enterprise plans (silently ignored otherwise), so we don't rely
     // on it. Without cacheEverything, Cloudflare doesn't edge-cache the 206 at
     // all; the upstream still serves range requests directly.
-    originResponse = await fetch(`${PMTILES_UPSTREAM}/${target}`, {
+    originResponse = await fetchAllowlistedUpstream(`${PMTILES_UPSTREAM}/${target}`, {
       headers: { range },
     });
   } catch {
@@ -543,12 +544,12 @@ export default {
       }
       let originResponse: Response;
       try {
-        originResponse = await fetch(upstream.toString(), {
+        originResponse = await fetchAllowlistedUpstream(upstream.toString(), {
           headers: { accept: "application/json" },
           // cacheEverything is required for Cloudflare to edge-cache a URL with
           // no static file extension (cacheTtl alone does not).
           cf: { cacheEverything: true, cacheTtl: 120 },
-        });
+        } as RequestInit);
       } catch {
         return new Response("Bad Gateway", {
           status: 502,
@@ -610,9 +611,9 @@ export default {
     const upstream = `${base}/${z}/${x}/${y}.png`;
     let originResponse: Response;
     try {
-      originResponse = await fetch(upstream, {
+      originResponse = await fetchAllowlistedUpstream(upstream, {
         cf: { cacheEverything: true, cacheTtl: 86400 },
-      });
+      } as RequestInit);
     } catch {
       return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
     }
@@ -688,7 +689,9 @@ async function handleWmsTile(
 
   let origin: Response;
   try {
-    origin = await fetch(wmsUrl, { cf: { cacheEverything: true, cacheTtl: 86400 } });
+    origin = await fetchAllowlistedUpstream(wmsUrl, {
+      cf: { cacheEverything: true, cacheTtl: 86400 },
+    } as RequestInit);
   } catch {
     return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
   }

--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -23,13 +23,3 @@ export default {
     return proxyViewerRequest(request);
   },
 };
-
-export {
-  ALLOWED_UPSTREAM_HOSTS,
-  MAX_REDIRECT_HOPS,
-  VIEWER_ORIGIN,
-  isAllowedUpstreamUrl,
-  proxyViewerRequest,
-  sanitizeUpstreamResponse,
-  sanitizeViewerPath,
-} from "./proxy";

--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -10,36 +10,26 @@
 // paths, so requests map 1:1 regardless of which host they arrive on:
 //   {web,viewer}.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
 //
-// Origin redirects (e.g. trailing slash) are followed server-side so the public
-// hostname is preserved and geolibre.app/demo is never exposed.
+// Origin redirects (e.g. trailing slash) are followed server-side only when the
+// Location stays on https://geolibre.app/demo/… — a cross-origin or off-prefix
+// redirect is refused so this worker cannot become an open proxy.
 
-const ORIGIN = "https://geolibre.app/demo";
+import { proxyViewerRequest } from "./proxy";
 
 interface Env {}
 
 export default {
   async fetch(request: Request, _env: Env, _ctx: ExecutionContext): Promise<Response> {
-    const url = new URL(request.url);
-    const target = `${ORIGIN}${url.pathname}${url.search}`;
-
-    // Drop credential headers a public static-asset proxy never needs; keep the
-    // rest (e.g. Range, Accept-Encoding) so large-asset requests work.
-    const headers = new Headers(request.headers);
-    headers.delete("cookie");
-    headers.delete("authorization");
-
-    // Follow origin redirects (e.g. trailing slash) server-side to preserve the
-    // public URL. This assumes geolibre.app/demo never redirects back to a
-    // viewer host, which would otherwise make the worker loop on itself.
-    try {
-      return await fetch(target, {
-        method: request.method,
-        headers,
-        body: request.method === "GET" || request.method === "HEAD" ? null : request.body,
-        redirect: "follow",
-      });
-    } catch {
-      return new Response("Bad Gateway", { status: 502 });
-    }
+    return proxyViewerRequest(request);
   },
 };
+
+export {
+  ALLOWED_UPSTREAM_HOSTS,
+  MAX_REDIRECT_HOPS,
+  VIEWER_ORIGIN,
+  isAllowedUpstreamUrl,
+  proxyViewerRequest,
+  sanitizeUpstreamResponse,
+  sanitizeViewerPath,
+} from "./proxy";

--- a/workers/viewer/src/proxy.ts
+++ b/workers/viewer/src/proxy.ts
@@ -13,13 +13,24 @@ export const MAX_REDIRECT_HOPS = 5;
 
 const ALLOWED_METHODS = new Set(["GET", "HEAD"]);
 
+/** HTTP statuses that carry a Location and should be followed manually. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
 /**
  * Reject pathnames that could escape `/demo` via traversal once joined with
  * the origin prefix. Returns the cleaned pathname, or null when unsafe.
  */
 export function sanitizeViewerPath(pathname: string): string | null {
   if (!pathname.startsWith("/")) return null;
-  if (pathname.includes("\\") || pathname.includes("%2e") || pathname.includes("%2E")) {
+  const lower = pathname.toLowerCase();
+  // Block backslash, encoded dots, and encoded slashes so a smuggled
+  // `/foo%2f..%2fsecret` cannot bypass the literal `..` segment check.
+  if (
+    pathname.includes("\\") ||
+    lower.includes("%2e") ||
+    lower.includes("%2f") ||
+    lower.includes("%5c")
+  ) {
     return null;
   }
   const segments = pathname.split("/");
@@ -102,7 +113,9 @@ export async function proxyViewerRequest(
         redirect: "manual",
       });
 
-      if (response.status < 300 || response.status >= 400) {
+      // Pass through non-redirect responses, including 304 Not Modified from
+      // conditional revalidation (If-None-Match / If-Modified-Since).
+      if (!REDIRECT_STATUSES.has(response.status)) {
         return sanitizeUpstreamResponse(response);
       }
 

--- a/workers/viewer/src/proxy.ts
+++ b/workers/viewer/src/proxy.ts
@@ -46,6 +46,9 @@ export function isAllowedUpstreamUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;
+    // Default HTTPS only — non-empty ports (e.g. :8443) are ignored or
+    // remapped by Workers outbound fetch and must not pass the allowlist.
+    if (parsed.port !== "") return false;
     if (!ALLOWED_UPSTREAM_HOSTS.has(parsed.hostname)) return false;
     // Keep redirects under the demo prefix so a 302 to https://geolibre.app/
     // (the marketing site) cannot be served under the viewer hostname.

--- a/workers/viewer/src/proxy.ts
+++ b/workers/viewer/src/proxy.ts
@@ -1,0 +1,124 @@
+// Shared helpers for the web.geolibre.app / viewer.geolibre.app proxy.
+// Kept free of the Worker `export default` so unit tests can import them
+// without Cloudflare runtime types.
+
+/** Origin of record for the viewer static build (GitHub Pages). */
+export const VIEWER_ORIGIN = "https://geolibre.app/demo";
+
+/** Hostnames the upstream may redirect within (never leave geolibre.app). */
+export const ALLOWED_UPSTREAM_HOSTS = new Set(["geolibre.app"]);
+
+/** Cap server-side redirect hops so a misconfigured origin cannot loop us. */
+export const MAX_REDIRECT_HOPS = 5;
+
+const ALLOWED_METHODS = new Set(["GET", "HEAD"]);
+
+/**
+ * Reject pathnames that could escape `/demo` via traversal once joined with
+ * the origin prefix. Returns the cleaned pathname, or null when unsafe.
+ */
+export function sanitizeViewerPath(pathname: string): string | null {
+  if (!pathname.startsWith("/")) return null;
+  if (pathname.includes("\\") || pathname.includes("%2e") || pathname.includes("%2E")) {
+    return null;
+  }
+  const segments = pathname.split("/");
+  if (segments.some((segment) => segment === "..")) return null;
+  return pathname;
+}
+
+/**
+ * Whether a resolved upstream URL is still an HTTPS geolibre.app path under
+ * `/demo` (the only origin this proxy is allowed to fetch).
+ */
+export function isAllowedUpstreamUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    if (!ALLOWED_UPSTREAM_HOSTS.has(parsed.hostname)) return false;
+    // Keep redirects under the demo prefix so a 302 to https://geolibre.app/
+    // (the marketing site) cannot be served under the viewer hostname.
+    return parsed.pathname === "/demo" || parsed.pathname.startsWith("/demo/");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Strip hop-by-hop and credential headers a public static-asset proxy never
+ * needs, and drop Set-Cookie from the origin so the viewer host cannot be
+ * used to plant cookies for geolibre.app.
+ */
+export function sanitizeUpstreamResponse(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.delete("set-cookie");
+  headers.delete("set-cookie2");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Proxy one viewer request to geolibre.app/demo, following only same-site
+ * redirects that stay under `/demo`. Cross-origin (or off-prefix) Locations
+ * become 502 instead of being fetched and re-hosted under the viewer hostname.
+ */
+export async function proxyViewerRequest(
+  request: Request,
+  fetchImpl: FetchLike = fetch,
+): Promise<Response> {
+  if (!ALLOWED_METHODS.has(request.method)) {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    });
+  }
+
+  const url = new URL(request.url);
+  const pathname = sanitizeViewerPath(url.pathname);
+  if (pathname === null) {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  let target = `${VIEWER_ORIGIN}${pathname}${url.search}`;
+  if (!isAllowedUpstreamUrl(target)) {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete("cookie");
+  headers.delete("authorization");
+
+  try {
+    for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+      const response = await fetchImpl(target, {
+        method: request.method,
+        headers,
+        body: null,
+        redirect: "manual",
+      });
+
+      if (response.status < 300 || response.status >= 400) {
+        return sanitizeUpstreamResponse(response);
+      }
+
+      const location = response.headers.get("location");
+      if (!location) {
+        return new Response("Bad Gateway", { status: 502 });
+      }
+
+      const next = new URL(location, target).toString();
+      if (!isAllowedUpstreamUrl(next)) {
+        return new Response("Bad Gateway", { status: 502 });
+      }
+      target = next;
+    }
+    return new Response("Bad Gateway", { status: 502 });
+  } catch {
+    return new Response("Bad Gateway", { status: 502 });
+  }
+}


### PR DESCRIPTION
## Summary
- Rewrite the viewer worker proxy to follow redirects only while they stay under `https://geolibre.app/demo`, refuse path traversal, and allow GET/HEAD only.
- Teach the tiles worker to fetch allowlisted upstreams with the same host-bound redirect policy so OAM / Source Cooperative / OPM / USGS / Protomaps paths cannot be redirected off-origin.
- Add unit coverage for both redirect policies.

## Test plan
- [x] `node --import tsx --test tests/edge-proxy-redirect.test.ts` (6 passing)
- [x] `npm run test:worker` typechecks all workers
- [x] Deploy/preview the viewer worker and confirm a normal asset load still works
- [x] Confirm a mock upstream 302 to `https://evil.example` returns 502 instead of proxying the body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Enforced allowlisted HTTPS upstreams for both viewer and tile proxying using allowed URL prefixes.
  * Hardened viewer path validation against traversal and encoded evasion attempts.
  * Updated redirect handling to follow only safe, in-scope targets within a hop limit; rejects unsafe methods and strips cookies/authorization plus upstream `set-cookie` headers.
* **Bug Fixes**
  * Preserved correct `304 Not Modified` pass-through (including ETag) instead of treating it as a redirect issue.
* **Tests**
  * Expanded coverage for sanitization, allowlist enforcement, redirect success/failure scenarios, and redirect hop caps for both viewer and tiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->