### PR TITLE
Preserve KMZ custom icons and formatted descriptions

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -83,7 +83,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.4",
+    "maplibre-gl-vector": "^0.10.5",
     "openai": "^7.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1925,6 +1925,28 @@ body,
   scrollbar-width: thin;
 }
 
+.geolibre-kml-description table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.geolibre-kml-description td,
+.geolibre-kml-description th {
+  border-top: 1px solid hsl(var(--border));
+  padding: 0.25rem 0.375rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.geolibre-kml-description tr:nth-child(even) {
+  background: hsl(var(--muted) / 0.55);
+}
+
+.geolibre-kml-description a {
+  color: hsl(var(--primary));
+  text-decoration: underline;
+}
+
 .geolibre-identify-popup .maplibregl-popup-close-button {
   color: hsl(var(--muted-foreground));
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1934,7 +1934,7 @@ body,
 .geolibre-kml-description th {
   border-top: 1px solid hsl(var(--border));
   padding: 0.25rem 0.375rem;
-  text-align: left;
+  text-align: start;
   vertical-align: top;
 }
 

--- a/apps/geolibre-desktop/src/lib/kml.ts
+++ b/apps/geolibre-desktop/src/lib/kml.ts
@@ -29,8 +29,6 @@ interface KmlStyle {
   "marker-opacity"?: number;
   /** Archive-relative/remote KML icon reference, resolved by the KMZ loader. */
   __geolibre_kml_icon_href?: string;
-  /** KML IconStyle scale multiplier. */
-  __geolibre_kml_icon_scale?: number;
 }
 
 /**
@@ -505,8 +503,6 @@ function styleFromElement(element: Element): KmlStyle {
     const icon = directChild(iconStyle, "Icon");
     const href = icon ? childText(icon, "href") : undefined;
     if (href) style.__geolibre_kml_icon_href = href;
-    const scale = Number(childText(iconStyle, "scale"));
-    if (Number.isFinite(scale) && scale > 0) style.__geolibre_kml_icon_scale = scale;
   }
 
   return style;

--- a/apps/geolibre-desktop/src/lib/kml.ts
+++ b/apps/geolibre-desktop/src/lib/kml.ts
@@ -27,6 +27,10 @@ interface KmlStyle {
   // that the spec has no key for, so it is round-tripped here and wired into
   // circle-opacity by the map package.
   "marker-opacity"?: number;
+  /** Archive-relative/remote KML icon reference, resolved by the KMZ loader. */
+  __geolibre_kml_icon_href?: string;
+  /** KML IconStyle scale multiplier. */
+  __geolibre_kml_icon_scale?: number;
 }
 
 /**
@@ -498,6 +502,11 @@ function styleFromElement(element: Element): KmlStyle {
       style["marker-color"] = color.color;
       style["marker-opacity"] = color.opacity;
     }
+    const icon = directChild(iconStyle, "Icon");
+    const href = icon ? childText(icon, "href") : undefined;
+    if (href) style.__geolibre_kml_icon_href = href;
+    const scale = Number(childText(iconStyle, "scale"));
+    if (Number.isFinite(scale) && scale > 0) style.__geolibre_kml_icon_scale = scale;
   }
 
   return style;

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1200,7 +1200,7 @@ async function kmzVectorFeatures(
     kmlFiles.map((file) =>
       loadKmlFile(file, options).then(
         async (collection): Promise<FeatureCollection | null> => {
-          await resolveKmzFeatureIcons(collection, entries);
+          await resolveKmzFeatureIcons(collection, entries, file.name);
           return collection;
         },
         (error): null => {
@@ -1231,16 +1231,24 @@ const KML_ICON_URL_PROPERTY = "__geolibre_kml_icon_url";
 async function resolveKmzFeatureIcons(
   collection: FeatureCollection,
   entries: Record<string, Uint8Array>,
+  kmlEntryName: string,
 ): Promise<void> {
   const resolved = new Map<string, Promise<string | null>>();
   const iconUrl = (href: string): Promise<string | null> => {
     const cached = resolved.get(href);
     if (cached) return cached;
     const promise = (async () => {
-      const key = findArchiveEntryKey(entries, href);
-      if (!key) return null;
+      const key = findArchiveEntryKey(entries, resolveArchiveRelativeHref(kmlEntryName, href));
+      if (!key) {
+        console.warn(`Could not resolve embedded KMZ icon: ${href}`);
+        return null;
+      }
       const mime = imageMimeFromName(key);
       if (!mime.startsWith("image/") || mime === "image/svg+xml") return null;
+      if (entries[key].byteLength > MAX_OVERLAY_IMAGE_BYTES) {
+        console.warn(`Skipping oversized embedded KMZ icon: ${key}`);
+        return null;
+      }
       return bytesToDataUrl(entries[key], mime);
     })();
     resolved.set(href, promise);
@@ -1257,6 +1265,17 @@ async function resolveKmzFeatureIcons(
       if (url) properties[KML_ICON_URL_PROPERTY] = url;
     }),
   );
+}
+
+function resolveArchiveRelativeHref(owner: string, href: string): string {
+  if (/^[a-z][a-z\d+.-]*:/i.test(href) || href.startsWith("//")) return href;
+  const parts = href.startsWith("/") ? [] : owner.replaceAll("\\", "/").split("/").slice(0, -1);
+  for (const part of href.replaceAll("\\", "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") parts.pop();
+    else parts.push(part);
+  }
+  return parts.join("/");
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1192,13 +1192,17 @@ async function modelsFromKml(text: string, path: string): Promise<LoadedModel[]>
 // loaded.
 async function kmzVectorFeatures(
   kmlFiles: DuckDbVectorFile[],
+  entries: Record<string, Uint8Array>,
   options?: DuckDbVectorLoadOptions,
 ): Promise<FeatureCollection> {
   let cancellation: unknown;
   const settled = await Promise.all(
     kmlFiles.map((file) =>
       loadKmlFile(file, options).then(
-        (collection): FeatureCollection | null => collection,
+        async (collection): Promise<FeatureCollection | null> => {
+          await resolveKmzFeatureIcons(collection, entries);
+          return collection;
+        },
         (error): null => {
           if (isVectorLoadCancelled(error)) {
             cancellation = error;
@@ -1218,6 +1222,41 @@ async function kmzVectorFeatures(
   );
   if (collections.length === 0 && cancellation) throw cancellation;
   return mergeFeatureCollections(collections);
+}
+
+const KML_ICON_HREF_PROPERTY = "__geolibre_kml_icon_href";
+const KML_ICON_URL_PROPERTY = "__geolibre_kml_icon_url";
+
+/** Replace archive-relative KML icon hrefs with persistent inline raster URLs. */
+async function resolveKmzFeatureIcons(
+  collection: FeatureCollection,
+  entries: Record<string, Uint8Array>,
+): Promise<void> {
+  const resolved = new Map<string, Promise<string | null>>();
+  const iconUrl = (href: string): Promise<string | null> => {
+    const cached = resolved.get(href);
+    if (cached) return cached;
+    const promise = (async () => {
+      const key = findArchiveEntryKey(entries, href);
+      if (!key) return null;
+      const mime = imageMimeFromName(key);
+      if (!mime.startsWith("image/") || mime === "image/svg+xml") return null;
+      return bytesToDataUrl(entries[key], mime);
+    })();
+    resolved.set(href, promise);
+    return promise;
+  };
+
+  await Promise.all(
+    collection.features.map(async (feature) => {
+      const properties = feature.properties;
+      const href = properties?.[KML_ICON_HREF_PROPERTY];
+      if (!properties || typeof href !== "string") return;
+      const url = await iconUrl(href);
+      delete properties[KML_ICON_HREF_PROPERTY];
+      if (url) properties[KML_ICON_URL_PROPERTY] = url;
+    }),
+  );
 }
 
 /**
@@ -1262,7 +1301,7 @@ async function loadKmzLayers(
   // purely-declined file rather than surfacing a generic error).
   let cancellation: unknown;
   try {
-    const features = await kmzVectorFeatures(kmlFiles, options);
+    const features = await kmzVectorFeatures(kmlFiles, entries, options);
     if (features.features.length > 0) layers.push({ data: features, path });
   } catch (error) {
     if (!isVectorLoadCancelled(error)) throw error;

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.4",
+        "maplibre-gl-vector": "^0.10.5",
         "openai": "^7.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17283,9 +17283,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.4.tgz",
-      "integrity": "sha512-BWTf82ZtCgF+YY85SR4wl14E587sgMFDj0GonW+nwBNoUe37W6BESCSEJwdSI+OV3hduROASuSFBjGIW3/kcBQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.5.tgz",
+      "integrity": "sha512-dowVyifaYkuXGFfKXaQFtnPITwvbXcUrUmdgnIVAPnegTWRDKjmCTMnZQS7jafFTuulN3H3o4nQ7Lk4rz42esw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -21921,7 +21921,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.4",
+        "maplibre-gl-vector": "^0.10.5",
         "netcdfjs": "^4.0.0",
         "pbf": "^5.1.2",
         "pmtiles": "^4.4.1",

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -129,7 +129,9 @@ function createIdentifyPopupElement(
     // thumbnail) as an actual thumbnail rather than a multi-kilobyte string.
     // Match base64 raster images only, excluding SVG (which can carry scripts)
     // so an untrusted GeoJSON value can't smuggle one in.
-    if (typeof value === "string" && /^data:image\/(?!svg)[\w.+-]+;base64,/i.test(value)) {
+    if (key === "description" && typeof value === "string" && /<[^>]+>/.test(value)) {
+      appendSanitizedKmlDescription(valueCell, value);
+    } else if (typeof value === "string" && /^data:image\/(?!svg)[\w.+-]+;base64,/i.test(value)) {
       const image = document.createElement("img");
       image.src = value;
       image.alt = key;
@@ -151,7 +153,9 @@ function createIdentifyPopupElement(
   // show a second copy of the same photo in the same small box. Filter before
   // the empty-state check so a feature whose only property is `photo_full` still
   // reports "No attributes" rather than rendering an empty panel.
-  const entries = Object.entries(properties).filter(([key]) => key !== PHOTO_FULL_KEY);
+  const entries = Object.entries(properties).filter(
+    ([key]) => key !== PHOTO_FULL_KEY && !key.startsWith("__geolibre_"),
+  );
   if (entries.length === 0 && featureId == null) {
     const empty = document.createElement("div");
     empty.className = "text-muted-foreground";
@@ -162,6 +166,57 @@ function createIdentifyPopupElement(
   }
 
   return root;
+}
+
+const KML_DESCRIPTION_TAGS = new Set([
+  "a",
+  "b",
+  "br",
+  "div",
+  "em",
+  "i",
+  "p",
+  "span",
+  "strong",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+]);
+
+/** Render useful KML description markup while dropping scripts and attributes. */
+function appendSanitizedKmlDescription(target: HTMLElement, html: string): void {
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+  const copy = (node: Node, parent: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      parent.appendChild(document.createTextNode(node.textContent ?? ""));
+      return;
+    }
+    if (!(node instanceof Element)) return;
+    const tag = node.localName.toLowerCase();
+    if (tag === "script" || tag === "style" || tag === "head" || tag === "meta") return;
+    if (!KML_DESCRIPTION_TAGS.has(tag)) {
+      for (const child of node.childNodes) copy(child, parent);
+      return;
+    }
+    const element = document.createElement(tag);
+    if (tag === "a") {
+      const href = node.getAttribute("href")?.trim();
+      if (href && /^(https?:|mailto:)/i.test(href)) {
+        element.setAttribute("href", href);
+        element.setAttribute("target", "_blank");
+        element.setAttribute("rel", "noopener noreferrer");
+      }
+    }
+    for (const child of node.childNodes) copy(child, element);
+    parent.appendChild(element);
+  };
+  const content = document.createElement("div");
+  content.className = "geolibre-kml-description";
+  for (const child of parsed.body.childNodes) copy(child, content);
+  target.appendChild(content);
 }
 
 function createIdentifyMessagePopupElement(layerName: string, message: string): HTMLElement {
@@ -526,6 +581,7 @@ function identifyStyleLayerIds(layer: GeoLibreLayer): string[] {
     ...nativeIdentifyLayerIds(layer),
     ...nativeIdentifyLayerIds(layer).map(externalExtrusionLayerId),
     ...mbtilesStyleLayerIds(layer),
+    markerLayerId(layer.id),
     circleLayerId(layer.id),
     lineLayerId(layer.id),
     fillExtrusionLayerId(layer.id),

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -125,12 +125,18 @@ function createIdentifyPopupElement(
 
     const valueCell = document.createElement("div");
     valueCell.className = "break-words text-foreground";
-    // Render inline image data URLs (e.g. a geotagged-photo or field-collection
-    // thumbnail) as an actual thumbnail rather than a multi-kilobyte string.
-    // Match base64 raster images only, excluding SVG (which can carry scripts)
-    // so an untrusted GeoJSON value can't smuggle one in.
-    if (key === "description" && typeof value === "string" && /<[^>]+>/.test(value)) {
+    // Render known KML description structures as sanitized markup. Requiring a
+    // supported tag keeps ordinary text such as "Elevation <500m>" intact.
+    if (
+      key === "description" &&
+      typeof value === "string" &&
+      /<(?:a|b|br|div|em|i|p|span|strong|table|tbody|td|th|thead|tr)\b/i.test(value)
+    ) {
       appendSanitizedKmlDescription(valueCell, value);
+      // Render inline image data URLs (e.g. a geotagged-photo or field-collection
+      // thumbnail) as an actual thumbnail rather than a multi-kilobyte string.
+      // Match base64 raster images only, excluding SVG (which can carry scripts)
+      // so an untrusted GeoJSON value can't smuggle one in.
     } else if (typeof value === "string" && /^data:image\/(?!svg)[\w.+-]+;base64,/i.test(value)) {
       const image = document.createElement("img");
       image.src = value;

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -56,7 +56,12 @@ import {
 import { ensureGeneratedImageHandler } from "./generated-images";
 import { prepareFillPattern } from "./fill-patterns";
 import { prepareLineDecoration } from "./line-decorations";
-import { markerIconSizeValue, prepareMarker } from "./markers";
+import {
+  KML_ICON_URL_PROPERTY,
+  markerIconSizeValue,
+  prepareKmlFeatureIcons,
+  prepareMarker,
+} from "./markers";
 import { isPlaceholderLayer } from "./placeholders";
 import {
   circlePaint,
@@ -1859,6 +1864,7 @@ function applyVectorDataRenderLayers(
   ensureGeneratedImageHandler(map);
   const fillPatternId = prepareFillPattern(layer.style);
   const markerImageId = prepareMarker(layer.style);
+  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!);
   // Derived companion symbology (inverted mask, geometry generator, dedup
   // labels) is built from the raw features, so no MapLibre filter applies to
   // it. While a Time Slider window or a rule-based visibility filter is
@@ -2149,7 +2155,7 @@ function applyVectorDataRenderLayers(
       layer,
       hasTextMarkers ? nonTextMarkerPointFilter : pointGeometryFilter,
     );
-    if (markerImageId) {
+    if (markerImageId || kmlIconImage) {
       removeIfExists(map, circleLayerId(layer.id));
       ensureLayer(
         map,
@@ -2161,10 +2167,12 @@ function applyVectorDataRenderLayers(
           ...styleLayerZoomRange(layer.style),
           filter: pointFilter,
           layout: {
-            "icon-image": markerImageId,
+            "icon-image": (kmlIconImage ?? markerImageId) as string,
             // The sprite is baked at its display size, so icon-size stays 1
             // unless proportional sizing scales it per feature.
-            "icon-size": markerIconSizeValue(layer.style) as PropertyValueSpecification<number>,
+            "icon-size": (kmlIconImage
+              ? 1
+              : markerIconSizeValue(layer.style)) as PropertyValueSpecification<number>,
             "icon-allow-overlap": true,
             "icon-ignore-placement": true,
             visibility,
@@ -2173,6 +2181,27 @@ function applyVectorDataRenderLayers(
         },
         beforeId,
       );
+      if (kmlIconImage && !markerImageId) {
+        // Features without a KML icon still use the ordinary circle renderer.
+        ensureLayer(
+          map,
+          circleLayerId(layer.id),
+          {
+            id: circleLayerId(layer.id),
+            type: "circle",
+            ...sourceSpec,
+            ...styleLayerZoomRange(layer.style),
+            filter: withFeatureFilters(layer, [
+              "all",
+              hasTextMarkers ? nonTextMarkerPointFilter : pointGeometryFilter,
+              ["!", ["has", KML_ICON_URL_PROPERTY]],
+            ] as maplibregl.FilterSpecification),
+            paint: circlePaint(layer.style, opacity),
+            layout: { visibility },
+          },
+          beforeId,
+        );
+      }
     } else {
       removeIfExists(map, markerLayerId(layer.id));
       ensureLayer(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1864,7 +1864,7 @@ function applyVectorDataRenderLayers(
   ensureGeneratedImageHandler(map);
   const fillPatternId = prepareFillPattern(layer.style);
   const markerImageId = prepareMarker(layer.style);
-  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!);
+  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!, markerImageId ?? "");
   // Derived companion symbology (inverted mask, geometry generator, dedup
   // labels) is built from the raw features, so no MapLibre filter applies to
   // it. While a Time Slider window or a rule-based visibility filter is
@@ -2171,7 +2171,7 @@ function applyVectorDataRenderLayers(
             // The sprite is baked at its display size, so icon-size stays 1
             // unless proportional sizing scales it per feature.
             "icon-size": (kmlIconImage
-              ? 1
+              ? ["case", ["has", KML_ICON_URL_PROPERTY], 1, markerIconSizeValue(layer.style)]
               : markerIconSizeValue(layer.style)) as PropertyValueSpecification<number>,
             "icon-allow-overlap": true,
             "icon-ignore-placement": true,

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -19,7 +19,6 @@ const MARKER_PIXEL_RATIO = 2;
 const MIN_MARKER_SIZE = 6;
 const MAX_MARKER_SIZE = 96;
 export const KML_ICON_URL_PROPERTY = "__geolibre_kml_icon_url";
-export const KML_ICON_SCALE_PROPERTY = "__geolibre_kml_icon_scale";
 
 const BUILTIN_SHAPES: ReadonlySet<MarkerShape> = new Set([
   "circle",
@@ -231,7 +230,10 @@ function loadRasterMarker(url: string): Promise<GeneratedImageResult | null> {
  * Register embedded KMZ raster icons and return an icon-image expression for
  * the features that carry them.
  */
-export function prepareKmlFeatureIcons(collection: GeoJSON.FeatureCollection): unknown[] | null {
+export function prepareKmlFeatureIcons(
+  collection: GeoJSON.FeatureCollection,
+  fallbackImage = "",
+): unknown[] | null {
   const matches: unknown[] = [];
   const seen = new Set<string>();
   for (const feature of collection.features) {
@@ -242,5 +244,7 @@ export function prepareKmlFeatureIcons(collection: GeoJSON.FeatureCollection): u
     registerGeneratedImage(id, () => loadRasterMarker(url));
     matches.push(url, id);
   }
-  return matches.length ? ["match", ["get", KML_ICON_URL_PROPERTY], ...matches, ""] : null;
+  return matches.length
+    ? ["match", ["get", KML_ICON_URL_PROPERTY], ...matches, fallbackImage]
+    : null;
 }

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -18,6 +18,8 @@ const MARKER_PIXEL_RATIO = 2;
 // enormous canvas; the rendered size is set via the marker image's own pixels.
 const MIN_MARKER_SIZE = 6;
 const MAX_MARKER_SIZE = 96;
+export const KML_ICON_URL_PROPERTY = "__geolibre_kml_icon_url";
+export const KML_ICON_SCALE_PROPERTY = "__geolibre_kml_icon_scale";
 
 const BUILTIN_SHAPES: ReadonlySet<MarkerShape> = new Set([
   "circle",
@@ -212,4 +214,33 @@ export function prepareMarker(style: LayerStyle): string | null {
   const id = `geolibre-marker-${shape}-${color.replace("#", "")}-${size}`;
   registerGeneratedImage(id, () => drawBuiltinMarker(shape, color, size));
   return id;
+}
+
+function loadRasterMarker(url: string): Promise<GeneratedImageResult | null> {
+  if (!/^data:image\/(?!svg)[\w.+-]+;base64,/i.test(url)) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.decoding = "async";
+    image.onload = () => resolve({ image, pixelRatio: 2 });
+    image.onerror = () => resolve(null);
+    image.src = url;
+  });
+}
+
+/**
+ * Register embedded KMZ raster icons and return an icon-image expression for
+ * the features that carry them.
+ */
+export function prepareKmlFeatureIcons(collection: GeoJSON.FeatureCollection): unknown[] | null {
+  const matches: unknown[] = [];
+  const seen = new Set<string>();
+  for (const feature of collection.features) {
+    const url = feature.properties?.[KML_ICON_URL_PROPERTY];
+    if (typeof url !== "string" || seen.has(url)) continue;
+    seen.add(url);
+    const id = `geolibre-kml-icon-${hashText(url)}`;
+    registerGeneratedImage(id, () => loadRasterMarker(url));
+    matches.push(url, id);
+  }
+  return matches.length ? ["match", ["get", KML_ICON_URL_PROPERTY], ...matches, ""] : null;
 }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.4",
+    "maplibre-gl-vector": "^0.10.5",
     "netcdfjs": "^4.0.0",
     "pbf": "^5.1.2",
     "pmtiles": "^4.4.1",


### PR DESCRIPTION
## Summary

- consume `maplibre-gl-vector` v0.10.5 for KMZ icon and description support in the Vector Layer control
- preserve embedded raster icons in GeoLibre’s native KMZ drag-and-drop path
- render sanitized KML description tables and links in Identify popups
- include marker symbol layers in feature identification

Addresses discussion #1577.

Upstream: opengeos/maplibre-gl-vector#53

## Validation

- tested `Kinetic_Activities_Last_30_Days.kmz` through Vector Layer and drag-and-drop
- verified custom icons and formatted point popups in light and dark themes with Playwright
- `conda run -n geo pre-commit run --files ...`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved KML/KMZ map icons with embedded archive images, caching, scaling, and fallback markers.
  - KML descriptions now display formatted content in identify popups.
- **Bug Fixes**
  - Improved KMZ icon resolution and rendering reliability.
  - Internal metadata and full-resolution photo data are excluded from feature details.
  - Popup links and HTML content are handled more safely.
- **Style**
  - Added readable styling for KML description tables, links, borders, spacing, and alternating rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->