### PR TITLE
fix(import): preserve QGIS source paths and group visibility

### DIFF
--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -466,9 +466,9 @@ function layerOrder(document: Document, mapLayers: Element[]): string[] {
 
 function qgisSourcePath(dataSource: string, projectPath: string): string {
   let source = dataSource.split("|", 1)[0]?.trim() ?? "";
+  source = source.replace(/^['"]|['"]$/g, "");
   source = source.replace(/^\/vsicurl(?:_streaming)?\//i, "");
   if (/^\/?vsizip\//i.test(source)) return "";
-  source = source.replace(/^['"]|['"]$/g, "");
   if (/^file:\/\//i.test(source)) {
     try {
       const url = new URL(source);

--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -466,6 +466,7 @@ function layerOrder(document: Document, mapLayers: Element[]): string[] {
 
 function qgisSourcePath(dataSource: string, projectPath: string): string {
   let source = dataSource.split("|", 1)[0]?.trim() ?? "";
+  let parsedFileUrl = false;
   source = source.replace(/^['"]|['"]$/g, "");
   source = source.replace(/^\/vsicurl(?:_streaming)?\//i, "");
   if (/^\/?vsizip\//i.test(source)) return "";
@@ -473,24 +474,26 @@ function qgisSourcePath(dataSource: string, projectPath: string): string {
     try {
       const url = new URL(source);
       const path = decodeURIComponent(url.pathname).replace(/^\/([A-Za-z]:)/, "$1");
+      parsedFileUrl = true;
       source =
         url.hostname && url.hostname.toLowerCase() !== "localhost"
           ? `//${url.hostname}${path}`
           : path;
     } catch {
       const path = source.replace(/^file:\/\//i, "");
-      source = path.startsWith("/") ? path : `//${path}`;
+      source = path.startsWith("/") || /^[A-Za-z]:[/\\]/.test(path) ? path : `//${path}`;
     }
   }
   source = source.replace(/^file:(?:\/\/)?/i, "");
-  if (!isHttpSource(source)) source = source.replace(/[?#].*$/, "");
+  if (!parsedFileUrl && !isHttpSource(source)) source = source.replace(/[?#].*$/, "");
   if (!source || isAbsolutePath(source) || /^[a-z]+:\/\//i.test(source)) return source;
   const directory = /[/\\]/.test(projectPath) ? projectPath.replace(/[/\\][^/\\]*$/, "") : "";
   return normalizeJoinedPath(directory, source);
 }
 
 function sourceExtension(source: string): string {
-  return source.split(/[?#]/, 1)[0]?.split(".").pop()?.toLowerCase() ?? "";
+  const path = isHttpSource(source) ? source.split(/[?#]/, 1)[0] : source;
+  return path?.split(".").pop()?.toLowerCase() ?? "";
 }
 
 function normalizeJoinedPath(directory: string, relative: string): string {

--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -405,11 +405,21 @@ function parseLayerGroups(document: Document): {
       id,
       name,
       collapsed: element.getAttribute("expanded") === "0",
-      visible: element.getAttribute("checked") !== "Qt::Unchecked",
+      visible: qgisGroupVisible(element, root),
       opacity: 1,
     };
   });
   return { groups, ids };
+}
+
+function qgisGroupVisible(element: Element, root: Element): boolean {
+  let current: Element | null = element;
+  while (current) {
+    if (current.getAttribute("checked") === "Qt::Unchecked") return false;
+    if (current === root) break;
+    current = current.parentElement?.closest("layer-tree-group") ?? null;
+  }
+  return true;
 }
 
 function groupDisplayName(element: Element, root: Element): string {
@@ -458,16 +468,22 @@ function qgisSourcePath(dataSource: string, projectPath: string): string {
   let source = dataSource.split("|", 1)[0]?.trim() ?? "";
   source = source.replace(/^\/vsicurl(?:_streaming)?\//i, "");
   if (/^\/?vsizip\//i.test(source)) return "";
-  if (source.startsWith("file://")) {
+  source = source.replace(/^['"]|['"]$/g, "");
+  if (/^file:\/\//i.test(source)) {
     try {
-      source = decodeURIComponent(new URL(source).pathname).replace(/^\/([A-Za-z]:)/, "$1");
+      const url = new URL(source);
+      const path = decodeURIComponent(url.pathname).replace(/^\/([A-Za-z]:)/, "$1");
+      source =
+        url.hostname && url.hostname.toLowerCase() !== "localhost"
+          ? `//${url.hostname}${path}`
+          : path;
     } catch {
-      source = source.slice("file://".length);
+      const path = source.replace(/^file:\/\//i, "");
+      source = path.startsWith("/") ? path : `//${path}`;
     }
   }
   source = source.replace(/^file:(?:\/\/)?/i, "");
-  source = source.replace(/[?#].*$/, "");
-  source = source.replace(/^['"]|['"]$/g, "");
+  if (!isHttpSource(source)) source = source.replace(/[?#].*$/, "");
   if (!source || isAbsolutePath(source) || /^[a-z]+:\/\//i.test(source)) return source;
   const directory = /[/\\]/.test(projectPath) ? projectPath.replace(/[/\\][^/\\]*$/, "") : "";
   return normalizeJoinedPath(directory, source);

--- a/tests/qgis-project-import.test.ts
+++ b/tests/qgis-project-import.test.ts
@@ -236,6 +236,64 @@ describe("QGIS project import", () => {
     );
   });
 
+  it("preserves remote URL credentials when materializing GeoJSON", async () => {
+    const remote = importQgisProject(
+      projectXml({
+        dataSources: [
+          {
+            id: "roads",
+            name: "Remote",
+            source:
+              "/vsicurl/https://example.com/roads.geojson?token=secret&amp;version=2|layername=roads",
+          },
+        ],
+      }),
+      "/work/example.qgs",
+    );
+    const requested: string[] = [];
+    await materializeQgisRemoteLayers(remote, async (input) => {
+      requested.push(String(input));
+      return Response.json({ type: "FeatureCollection", features: [] });
+    });
+
+    assert.deepEqual(requested, ["https://example.com/roads.geojson?token=secret&version=2"]);
+  });
+
+  it("rejects UNC file URLs", () => {
+    const unc = importQgisProject(
+      projectXml({
+        dataSources: [
+          {
+            id: "cities",
+            name: "Network file URL",
+            source: "file://server/share/cities.gpkg",
+          },
+        ],
+      }),
+      "C:\\projects\\example.qgs",
+    );
+    assert.deepEqual(
+      unc.warnings.map((warning) => [warning.layerName, warning.reason]),
+      [["Network file URL", "network-path"]],
+    );
+  });
+
+  it("inherits visibility from unchecked parent groups", () => {
+    const xml = projectXml().replace(
+      'name="Transport" checked="Qt::Checked"',
+      'name="Transport" checked="Qt::Unchecked"',
+    );
+    const result = importQgisProject(xml, "/work/example.qgs");
+
+    assert.deepEqual(
+      result.project.layerGroups?.map((group) => [group.name, group.visible]),
+      [
+        ["Transport", false],
+        ["Transport / Places", false],
+      ],
+    );
+  });
+
   it("normalizes Windows file URLs, query strings, and bare project names", () => {
     const windows = importQgisProject(
       projectXml({

--- a/tests/qgis-project-import.test.ts
+++ b/tests/qgis-project-import.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { applyGroupEffects } from "@geolibre/core";
 import { strToU8, zipSync } from "fflate";
 import { DOMParser } from "linkedom";
 import {
@@ -293,9 +294,11 @@ describe("QGIS project import", () => {
         ["Transport / Places", false],
       ],
     );
+    const rendered = applyGroupEffects(result.project.layers, result.project.layerGroups ?? []);
+    assert.equal(rendered.find((layer) => layer.name === "Cities")?.visible, false);
   });
 
-  it("normalizes Windows file URLs, query strings, and bare project names", () => {
+  it("normalizes Windows file URLs, query strings, encoded delimiters, and bare names", () => {
     const windows = importQgisProject(
       projectXml({
         dataSources: [
@@ -309,6 +312,26 @@ describe("QGIS project import", () => {
       "C:\\projects\\example.qgs",
     );
     assert.equal(windows.project.layers[0].sourcePath, "C:/data/points.csv");
+
+    const encoded = importQgisProject(
+      projectXml({
+        dataSources: [
+          { id: "roads", name: "Encoded delimiter", source: "file:///tmp/a%23b.geojson" },
+        ],
+      }),
+      "/work/example.qgs",
+    );
+    assert.equal(encoded.project.layers[0].sourcePath, "/tmp/a#b.geojson");
+
+    const malformed = importQgisProject(
+      projectXml({
+        dataSources: [
+          { id: "roads", name: "Malformed escape", source: "file://C:/data%zz/roads.geojson" },
+        ],
+      }),
+      "C:\\projects\\example.qgs",
+    );
+    assert.equal(malformed.project.layers[0].sourcePath, "C:/data%zz/roads.geojson");
 
     const browser = importQgisProject(
       projectXml({

--- a/tests/qgis-project-import.test.ts
+++ b/tests/qgis-project-import.test.ts
@@ -244,7 +244,7 @@ describe("QGIS project import", () => {
             id: "roads",
             name: "Remote",
             source:
-              "/vsicurl/https://example.com/roads.geojson?token=secret&amp;version=2|layername=roads",
+              '"/vsicurl/https://example.com/roads.geojson?token=secret&amp;version=2"|layername=roads',
           },
         ],
       }),
@@ -272,6 +272,7 @@ describe("QGIS project import", () => {
       }),
       "C:\\projects\\example.qgs",
     );
+    assert.deepEqual(unc.project.layers, []);
     assert.deepEqual(
       unc.warnings.map((warning) => [warning.layerName, warning.reason]),
       [["Network file URL", "network-path"]],


### PR DESCRIPTION
## Summary

- preserve query parameters on remote QGIS GeoJSON sources, including signed URLs
- retain UNC hosts from `file://server/share/...` sources so network paths are rejected explicitly
- propagate unchecked parent-group visibility into flattened nested groups

## Root cause

The importer normalized remote URLs with the same query stripping used for local file options, discarded the hostname while converting file URLs, and stored only each flattened group's own checked state. Those transformations could break authenticated fetches, treat UNC sources as local paths, and show layers beneath a hidden parent group.

## Validation

- `node --import tsx --test tests/qgis-project-import.test.ts` (13 passed)
- scoped pre-commit hooks for both changed files, including oxfmt, ESLint, and production build
- frontend suite: 4,555 passed, 1 skipped
- worker TypeScript checks
- backend pytest coverage: 313 passed, 20 skipped, 64.77% coverage
- `cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected QGIS layer visibility so nested layers inherit unchecked parent-group states.
  * Improved import handling for quoted, encoded, malformed, remote, and UNC-style file paths.
  * Preserved query credentials in remote GeoJSON URLs and improved source extension detection.
  * Added clearer handling for unsupported network-based file locations.

* **Tests**
  * Expanded coverage for inherited visibility, URL validation, encoded filenames, malformed escapes, and remote URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->