### PR TITLE
Keep KML icons independent from background controls

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2160,7 +2160,7 @@ export class MapController {
       // GeoLibre-owned companion symbol layer, not one of the control's native
       // layer ids. Include it here so Background visibility/opacity does not
       // mistake the icons for basemap symbols.
-      if (layer.type === "geojson") {
+      if (layer.metadata.sourceKind === "maplibre-gl-vector") {
         candidates.push({ id: markerLayerId(layer.id), suffix: "Markers" });
       }
       return candidates;

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -31,6 +31,7 @@ import {
   highlightLineLayerId,
   highlightSourceId,
   lineLayerId,
+  markerLayerId,
   sourceId,
 } from "./geojson-loader";
 import {
@@ -2152,9 +2153,17 @@ export class MapController {
   }> {
     const nativeLayerIds = layer.metadata.nativeLayerIds;
     if (Array.isArray(nativeLayerIds) && nativeLayerIds.length > 0) {
-      return nativeLayerIds
+      const candidates = nativeLayerIds
         .filter((id): id is string => typeof id === "string")
         .map((id) => ({ id, suffix: nativeLayerSuffix(id) }));
+      // KML/KMZ icons loaded through the Vector Layer control render in a
+      // GeoLibre-owned companion symbol layer, not one of the control's native
+      // layer ids. Include it here so Background visibility/opacity does not
+      // mistake the icons for basemap symbols.
+      if (layer.type === "geojson") {
+        candidates.push({ id: markerLayerId(layer.id), suffix: "Markers" });
+      }
+      return candidates;
     }
 
     if (layer.type === "geojson") {
@@ -2163,6 +2172,7 @@ export class MapController {
         { id: fillLayerId(layer.id), suffix: "Polygons" },
         { id: lineLayerId(layer.id), suffix: "Lines" },
         { id: circleLayerId(layer.id), suffix: "Points" },
+        { id: markerLayerId(layer.id), suffix: "Markers" },
       ];
     }
 

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -576,29 +576,31 @@ describe("MapController basemap controls", () => {
   });
 
   it("keeps KML marker symbols independent from basemap visibility and opacity", () => {
-    const { map, fake } = makeFakeMap();
-    const controller = controllerWith(map);
-    controller.syncLayers([controlVectorLayer("kml")]);
-    fake.layers.set(markerId("kml"), {
-      id: markerId("kml"),
-      type: "symbol",
-      paint: { "icon-opacity": 1 },
-    });
-    fake.order.push(markerId("kml"));
+    for (const type of ["geojson", "vector-tiles"] as const) {
+      const { map, fake } = makeFakeMap();
+      const controller = controllerWith(map);
+      controller.syncLayers([controlVectorLayer("kml", { type })]);
+      fake.layers.set(markerId("kml"), {
+        id: markerId("kml"),
+        type: "symbol",
+        paint: { "icon-opacity": 1 },
+      });
+      fake.order.push(markerId("kml"));
 
-    assert.ok(!controller.getBasemapStyleLayerIds().includes(markerId("kml")));
+      assert.ok(!controller.getBasemapStyleLayerIds().includes(markerId("kml")));
 
-    controller.setBasemapVisible(false);
-    controller.setBasemapOpacity(0.25);
+      controller.setBasemapVisible(false);
+      controller.setBasemapOpacity(0.25);
 
-    assert.ok(
-      !fake.calls.some(
-        (call) =>
-          call.args[0] === markerId("kml") &&
-          (call.method === "setLayoutProperty" || call.method === "setPaintProperty"),
-      ),
-      "background controls do not update the KML marker symbol",
-    );
+      assert.ok(
+        !fake.calls.some(
+          (call) =>
+            call.args[0] === markerId("kml") &&
+            (call.method === "setLayoutProperty" || call.method === "setPaintProperty"),
+        ),
+        `background controls do not update the ${type} KML marker symbol`,
+      );
+    }
   });
 
   it("scales basemap opacity from the layer's original paint value", () => {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -264,6 +264,7 @@ function controlVectorLayer(id: string, patch: Partial<GeoLibreLayer> = {}): Geo
 }
 
 const circleId = (id: string) => `layer-${id}-circle`;
+const markerId = (id: string) => `layer-${id}-marker`;
 const rasterId = (id: string) => `layer-${id}-raster`;
 const srcId = (id: string) => `source-${id}`;
 
@@ -572,6 +573,32 @@ describe("MapController basemap controls", () => {
     const ids = controller.getBasemapStyleLayerIds();
     assert.ok(ids.includes("basemap-bg"));
     assert.ok(!ids.includes(circleId("a")), "user layers are not basemap layers");
+  });
+
+  it("keeps KML marker symbols independent from basemap visibility and opacity", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    controller.syncLayers([controlVectorLayer("kml")]);
+    fake.layers.set(markerId("kml"), {
+      id: markerId("kml"),
+      type: "symbol",
+      paint: { "icon-opacity": 1 },
+    });
+    fake.order.push(markerId("kml"));
+
+    assert.ok(!controller.getBasemapStyleLayerIds().includes(markerId("kml")));
+
+    controller.setBasemapVisible(false);
+    controller.setBasemapOpacity(0.25);
+
+    assert.ok(
+      !fake.calls.some(
+        (call) =>
+          call.args[0] === markerId("kml") &&
+          (call.method === "setLayoutProperty" || call.method === "setPaintProperty"),
+      ),
+      "background controls do not update the KML marker symbol",
+    );
   });
 
   it("scales basemap opacity from the layer's original paint value", () => {


### PR DESCRIPTION
## Summary

- classify GeoLibre-owned KML/KMZ marker companion layers as vector layer style layers
- prevent Background visibility and opacity controls from changing custom KML/KMZ icons
- add regression coverage for Vector Layer control imports

Addresses https://github.com/opengeos/GeoLibre/discussions/1577#discussioncomment-17856641.

## Validation

- reproduced with `Kinetic_Activities_Last_30_Days.kmz`
- verified Background visibility and zero opacity in light and dark themes with Playwright
- `node --import tsx --test tests/map-controller.test.ts`
- `npm run build`
- `pre-commit run --files packages/map/src/map-controller.ts tests/map-controller.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map layer handling for GeoLibre markers.
  * KML/KMZ marker symbols are now excluded from basemap visibility and opacity updates.
  * GeoJSON layers now correctly include associated marker layers when determining applicable style layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->