### PR TITLE
fix(layers): hide control vectors with groups

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -881,11 +881,17 @@ export function LayerPanel({
       : 0
     : null;
   const backgroundSelected = selectedLayerId === BACKGROUND_SELECTION_ID;
-  const allLayersVisible = basemapVisible && layers.every((layer) => layer.visible);
+  const allLayersVisible =
+    basemapVisible &&
+    layers.every((layer) => layer.visible) &&
+    layerGroups.every((group) => group.visible);
   const toggleAllLayers = () => {
     const nextVisible = !allLayersVisible;
     for (const layer of layers) {
       setLayerVisibility(layer.id, nextVisible);
+    }
+    for (const group of layerGroups) {
+      setLayerGroupVisibility(group.id, nextVisible);
     }
     setBasemapVisible(nextVisible);
   };

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -456,6 +456,13 @@ function syncExternalNativeLayer(
 
     for (const nativeLayerId of nativeLayerIds) {
       moveLayer(map, nativeLayerId, beforeId);
+      // The owning control mirrors direct per-layer visibility changes from
+      // the store, but effective state such as a hidden parent group never
+      // mutates the child's stored `visible` flag. Apply the effective value
+      // to ordinary native MapLibre layers here so group visibility reaches
+      // control-rendered vectors too. MapLibre custom layers also accept the
+      // standard layout visibility property.
+      setNativeLayerVisibility(map, nativeLayerId, layer.visible ? "visible" : "none");
       // Control-painted vector layers (e.g. Add Vector Layer's circle/fill/line
       // layers) still honor a Time Slider window and the rule-based
       // hide-unmatched filter: filtering is independent of the paint the

--- a/tests/vector-control-symbology.test.ts
+++ b/tests/vector-control-symbology.test.ts
@@ -82,6 +82,24 @@ function radiusCalls(calls: MapCall[], layerId: string): MapCall[] {
 }
 
 describe("vector-control point symbology overlay (#1311)", () => {
+  it("applies effective visibility to a control-rendered vector layer", () => {
+    const { map, calls } = makeVectorControlMapStub("vech");
+    const layer = vectorControlLayer("vech", { visible: false });
+
+    syncLayer(map as never, layer);
+
+    assert.ok(
+      calls.some(
+        (c) =>
+          c.method === "setLayoutProperty" &&
+          c.args[0] === "vech-circle" &&
+          c.args[1] === "visibility" &&
+          c.args[2] === "none",
+      ),
+      "expected effective group visibility to hide the control's native layer",
+    );
+  });
+
   it("renders a GeoLibre marker symbol layer and hides the control's circle", () => {
     const { map, calls } = makeVectorControlMapStub("vecm");
     const layer = vectorControlLayer("vecm", {


### PR DESCRIPTION
## Summary

- apply effective group visibility to control-rendered native MapLibre layers
- include layer groups in the Layers toolbar show-all and hide-all action
- keep each child layer's stored visibility independent when toggling a group directly
- add a regression test for hidden Add Vector Layer output

## Verification

- loaded `us_cities.geojson` through Add Vector Layer
- moved two visible vector layers into a hidden group and confirmed both disappear
- confirmed the toolbar show-all and hide-all action updates the group, child layers, and basemap together
- verified in light and dark themes
- ran the focused vector-control symbology test suite
- ran the production build and pre-commit hooks

Related to https://github.com/opengeos/GeoLibre/discussions/1587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed visibility synchronization for custom and native map layers.
  - Layers configured as hidden now correctly remain hidden after reordering.
  - Unsupported visibility updates are safely ignored.
  - “Show/hide all layers” now correctly includes layer groups and the basemap.

- **Tests**
  - Added regression coverage for hidden vector layers rendered by controls.
  - Added coverage confirming hidden layers retain the correct native visibility state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->