### PR TITLE
fix(layers): truncate long layer names

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2700,6 +2700,8 @@ export function LayerPanel({
                         ? "border-primary bg-primary/5"
                         : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
                     } ${draggedLayerId === layer.id ? "opacity-50" : ""} ${
+                      // width:auto lets the browser subtract the group margin;
+                      // combining ms-4 with w-full would overflow the panel.
                       group ? "ms-4" : "w-full"
                     }`}
                     onDragOver={(e) => handleLayerDragOver(e, layer.id)}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2538,8 +2538,11 @@ export function LayerPanel({
           </Button>
         </div>
       </div>
-      <ScrollArea className="flex-1">
-        <div className="space-y-1 p-2">
+      <ScrollArea
+        className="flex-1"
+        viewportClassName="[&>div]:!block [&>div]:!w-full [&>div]:!min-w-0"
+      >
+        <div className="w-full min-w-0 space-y-1 p-2">
           {layers.length === 0 && (
             <p className="px-2 py-4 text-xs text-muted-foreground">
               {isBeginnerProfile ? t("layers.emptyBeginner") : t("layers.empty")}
@@ -2690,7 +2693,7 @@ export function LayerPanel({
                     data-layer-card=""
                     data-testid="layer-row"
                     data-layer-name={layer.name}
-                    className={`relative rounded-md border p-2 transition-colors ${
+                    className={`relative w-full min-w-0 max-w-full overflow-hidden rounded-md border p-2 transition-colors ${
                       selectedLayerId === layer.id
                         ? "border-primary bg-primary/5"
                         : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
@@ -2713,7 +2716,7 @@ export function LayerPanel({
                       draggedDisplayIndex < displayIndex && (
                         <div className="pointer-events-none absolute -bottom-1 left-2 right-2 h-1 rounded-full bg-primary shadow-[0_0_0_2px_hsl(var(--background))]" />
                       )}
-                    <div className="flex items-center gap-1">
+                    <div className="flex min-w-0 items-center gap-1">
                       <span
                         role="button"
                         tabIndex={0}
@@ -2769,7 +2772,7 @@ export function LayerPanel({
                         />
                       ) : (
                         <span
-                          className={`flex-1 truncate text-sm font-medium ${
+                          className={`min-w-0 flex-1 truncate text-sm font-medium ${
                             groupHidden ? "text-muted-foreground" : ""
                           }`}
                           title={
@@ -2785,7 +2788,7 @@ export function LayerPanel({
                           {layer.name}
                         </span>
                       )}
-                      <span className="text-[10px] uppercase text-muted-foreground">
+                      <span className="shrink-0 text-[10px] uppercase text-muted-foreground">
                         {layerTypeLabel(layer, t)}
                       </span>
                     </div>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2543,7 +2543,7 @@ export function LayerPanel({
         // Radix measures scroll content with an injected display:table
         // wrapper. Opt this viewport into block sizing so long layer names
         // cannot establish a wider min-content table.
-        viewportClassName="[&>div]:!block [&>div]:!w-full [&>div]:!min-w-0"
+        viewportClassName="[&>div]:block! [&>div]:w-full! [&>div]:min-w-0!"
       >
         <div className="w-full min-w-0 space-y-1 p-2">
           {layers.length === 0 && (
@@ -2696,11 +2696,13 @@ export function LayerPanel({
                     data-layer-card=""
                     data-testid="layer-row"
                     data-layer-name={layer.name}
-                    className={`relative w-full min-w-0 max-w-full rounded-md border p-2 transition-colors ${
+                    className={`relative min-w-0 max-w-full rounded-md border p-2 transition-colors ${
                       selectedLayerId === layer.id
                         ? "border-primary bg-primary/5"
                         : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
-                    } ${draggedLayerId === layer.id ? "opacity-50" : ""} ${group ? "ms-4" : ""}`}
+                    } ${draggedLayerId === layer.id ? "opacity-50" : ""} ${
+                      group ? "ms-4" : "w-full"
+                    }`}
                     onDragOver={(e) => handleLayerDragOver(e, layer.id)}
                     onDrop={(e) => handleLayerDrop(e, layer.id, displayIndex)}
                     onDragEnd={resetDragState}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2243,7 +2243,7 @@ export function LayerPanel({
         data-group-header=""
         data-testid="layer-group-header"
         data-group-name={group.name}
-        className={`rounded-md border p-2 transition-colors ${
+        className={`w-full min-w-0 max-w-full rounded-md border p-2 transition-colors ${
           isDropTarget
             ? "border-primary bg-primary/10"
             : "border-border bg-muted/30 hover:border-muted-foreground/40"
@@ -2251,7 +2251,7 @@ export function LayerPanel({
         onDragOver={(e) => handleGroupHeaderDragOver(e, group.id)}
         onDrop={(e) => handleGroupHeaderDrop(e, group.id)}
       >
-        <div className="flex items-center gap-1">
+        <div className="flex min-w-0 items-center gap-1">
           <button
             type="button"
             className="rounded p-0.5 text-muted-foreground hover:bg-muted"
@@ -2314,7 +2314,7 @@ export function LayerPanel({
             />
           ) : (
             <span
-              className="flex-1 truncate text-sm font-semibold"
+              className="min-w-0 flex-1 truncate text-sm font-semibold"
               title={t("layers.doubleClickToRename")}
               onDoubleClick={(e: ReactMouseEvent) => {
                 e.stopPropagation();
@@ -2539,11 +2539,10 @@ export function LayerPanel({
         </div>
       </div>
       <ScrollArea
-        className="flex-1"
+        className="flex-1 [&_[data-radix-scroll-area-viewport]>div]:block! [&_[data-radix-scroll-area-viewport]>div]:w-full! [&_[data-radix-scroll-area-viewport]>div]:min-w-0!"
         // Radix measures scroll content with an injected display:table
         // wrapper. Opt this viewport into block sizing so long layer names
         // cannot establish a wider min-content table.
-        viewportClassName="[&>div]:block! [&>div]:w-full! [&>div]:min-w-0!"
       >
         <div className="w-full min-w-0 space-y-1 p-2">
           {layers.length === 0 && (

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2540,6 +2540,9 @@ export function LayerPanel({
       </div>
       <ScrollArea
         className="flex-1"
+        // Radix measures scroll content with an injected display:table
+        // wrapper. Opt this viewport into block sizing so long layer names
+        // cannot establish a wider min-content table.
         viewportClassName="[&>div]:!block [&>div]:!w-full [&>div]:!min-w-0"
       >
         <div className="w-full min-w-0 space-y-1 p-2">
@@ -2693,7 +2696,7 @@ export function LayerPanel({
                     data-layer-card=""
                     data-testid="layer-row"
                     data-layer-name={layer.name}
-                    className={`relative w-full min-w-0 max-w-full overflow-hidden rounded-md border p-2 transition-colors ${
+                    className={`relative w-full min-w-0 max-w-full rounded-md border p-2 transition-colors ${
                       selectedLayerId === layer.id
                         ? "border-primary bg-primary/5"
                         : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"

--- a/e2e/layer-panel.spec.ts
+++ b/e2e/layer-panel.spec.ts
@@ -48,3 +48,35 @@ test("reorders layers and removes one through the confirm dialog", async ({ page
   await expect(layerRow(page, "aaa")).toHaveCount(0);
   await expect(layerRow(page, "bbb")).toBeVisible();
 });
+
+test("long layer names truncate without widening the layer panel", async ({ page }) => {
+  await waitForMap(page);
+  await dropGeoJson(page, "short-name", FIXTURE_TEXT);
+
+  const row = layerRow(page, "short-name");
+  await row.getByTitle("Double-click to rename").dblclick();
+  const renameInput = page.getByRole("textbox", { name: "Rename short-name" });
+  await renameInput.fill(
+    "This is an exceptionally long vector layer name that should truncate cleanly",
+  );
+  await renameInput.press("Enter");
+
+  const renamedRow = layerRow(
+    page,
+    "This is an exceptionally long vector layer name that should truncate cleanly",
+  );
+  const panel = page.getByRole("complementary", { name: "Layers" });
+  const name = renamedRow.getByTitle("Double-click to rename");
+
+  await expect(renamedRow).toBeVisible();
+  await expect(name).toHaveCSS("text-overflow", "ellipsis");
+  await expect
+    .poll(async () => {
+      const [rowBox, panelBox] = await Promise.all([renamedRow.boundingBox(), panel.boundingBox()]);
+      return Boolean(rowBox && panelBox && rowBox.x + rowBox.width <= panelBox.x + panelBox.width);
+    })
+    .toBe(true);
+  await expect
+    .poll(() => name.evaluate((element) => element.scrollWidth > element.clientWidth))
+    .toBe(true);
+});

--- a/e2e/layer-panel.spec.ts
+++ b/e2e/layer-panel.spec.ts
@@ -54,6 +54,9 @@ test("long layer names truncate without widening the layer panel", async ({ page
   await dropGeoJson(page, "short-name", FIXTURE_TEXT);
 
   const row = layerRow(page, "short-name");
+  const panel = page.getByRole("complementary", { name: "Layers" });
+  const panelBoxBefore = await panel.boundingBox();
+  expect(panelBoxBefore).not.toBeNull();
   await row.getByTitle("Double-click to rename").dblclick();
   const renameInput = page.getByRole("textbox", { name: "Rename short-name" });
   await renameInput.fill(
@@ -65,15 +68,28 @@ test("long layer names truncate without widening the layer panel", async ({ page
     page,
     "This is an exceptionally long vector layer name that should truncate cleanly",
   );
-  const panel = page.getByRole("complementary", { name: "Layers" });
   const name = renamedRow.getByTitle("Double-click to rename");
 
   await expect(renamedRow).toBeVisible();
   await expect(name).toHaveCSS("text-overflow", "ellipsis");
   await expect
     .poll(async () => {
-      const [rowBox, panelBox] = await Promise.all([renamedRow.boundingBox(), panel.boundingBox()]);
-      return Boolean(rowBox && panelBox && rowBox.x + rowBox.width <= panelBox.x + panelBox.width);
+      const [rowBox, panelBox, viewportWidth] = await Promise.all([
+        renamedRow.boundingBox(),
+        panel.boundingBox(),
+        page.evaluate(() => window.innerWidth),
+      ]);
+      return Boolean(
+        rowBox &&
+        panelBox &&
+        panelBoxBefore &&
+        panelBox.x === panelBoxBefore.x &&
+        panelBox.width === panelBoxBefore.width &&
+        panelBox.x >= 0 &&
+        panelBox.x + panelBox.width <= viewportWidth &&
+        rowBox.x >= panelBox.x &&
+        rowBox.x + rowBox.width <= panelBox.x + panelBox.width,
+      );
     })
     .toBe(true);
   await expect

--- a/e2e/layer-panel.spec.ts
+++ b/e2e/layer-panel.spec.ts
@@ -69,26 +69,38 @@ test("long layer names truncate without widening the layer panel", async ({ page
     "This is an exceptionally long vector layer name that should truncate cleanly",
   );
   const name = renamedRow.getByTitle("Double-click to rename");
+  const typeBadge = renamedRow.getByText("vector", { exact: true });
+  const opacitySlider = renamedRow.getByRole("slider");
 
   await expect(renamedRow).toBeVisible();
   await expect(name).toHaveCSS("text-overflow", "ellipsis");
+  await expect(typeBadge).toBeVisible();
+  await expect(opacitySlider).toBeVisible();
   await expect
     .poll(async () => {
-      const [rowBox, panelBox, viewportWidth] = await Promise.all([
+      const [rowBox, panelBox, typeBadgeBox, opacitySliderBox, viewportWidth] = await Promise.all([
         renamedRow.boundingBox(),
         panel.boundingBox(),
+        typeBadge.boundingBox(),
+        opacitySlider.boundingBox(),
         page.evaluate(() => window.innerWidth),
       ]);
       return Boolean(
         rowBox &&
         panelBox &&
+        typeBadgeBox &&
+        opacitySliderBox &&
         panelBoxBefore &&
         panelBox.x === panelBoxBefore.x &&
         panelBox.width === panelBoxBefore.width &&
         panelBox.x >= 0 &&
         panelBox.x + panelBox.width <= viewportWidth &&
         rowBox.x >= panelBox.x &&
-        rowBox.x + rowBox.width <= panelBox.x + panelBox.width,
+        rowBox.x + rowBox.width <= panelBox.x + panelBox.width &&
+        typeBadgeBox.x >= rowBox.x &&
+        typeBadgeBox.x + typeBadgeBox.width <= rowBox.x + rowBox.width &&
+        opacitySliderBox.x >= rowBox.x &&
+        opacitySliderBox.x + opacitySliderBox.width <= rowBox.x + rowBox.width,
       );
     })
     .toBe(true);

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -10,18 +10,22 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
    * ref would not give them a stable element to read).
    */
   viewportRef?: React.RefObject<HTMLDivElement | null>;
+  viewportClassName?: string;
 };
 
 export const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   ScrollAreaProps
->(({ className, children, viewportRef, ...props }, ref) => (
+>(({ className, children, viewportRef, viewportClassName, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport ref={viewportRef} className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport
+      ref={viewportRef}
+      className={cn("h-full w-full rounded-[inherit]", viewportClassName)}
+    >
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -10,22 +10,18 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
    * ref would not give them a stable element to read).
    */
   viewportRef?: React.RefObject<HTMLDivElement | null>;
-  viewportClassName?: string;
 };
 
 export const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   ScrollAreaProps
->(({ className, children, viewportRef, viewportClassName, ...props }, ref) => (
+>(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport
-      ref={viewportRef}
-      className={cn("h-full w-full rounded-[inherit]", viewportClassName)}
-    >
+    <ScrollAreaPrimitive.Viewport ref={viewportRef} className="h-full w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
## Summary

- constrain the Layers scroll viewport so long content cannot widen the panel
- allow layer names to shrink and truncate while preserving the type badge and opacity controls
- add a Playwright regression test for long renamed layers

## Verification

- `npm run build`
- `npx playwright test e2e/layer-panel.spec.ts --grep "long layer names"`
- `pre-commit run --files apps/geolibre-desktop/src/components/panels/LayerPanel.tsx packages/ui/src/components/scroll-area.tsx e2e/layer-panel.spec.ts`
- verified with `us_cities.geojson` in light and dark themes at default and narrowed Layers panel widths

Fixes #1586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented horizontal overflow in the layer panel.
  - Long layer names now truncate with an ellipsis while keeping layer type labels visible.
  - Preserved panel dimensions and ensured content remains within the scroll area.

- **Tests**
  - Added end-to-end coverage for exceptionally long layer names and panel layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->