### PR TITLE
Add nested layer groups

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -568,6 +568,7 @@ export function LayerPanel({
   const setLayerGroupOpacity = useAppStore((s) => s.setLayerGroupOpacity);
   const toggleLayerGroupCollapsed = useAppStore((s) => s.toggleLayerGroupCollapsed);
   const moveLayerToGroup = useAppStore((s) => s.moveLayerToGroup);
+  const moveLayerGroupToGroup = useAppStore((s) => s.moveLayerGroupToGroup);
   const reorderLayerGroup = useAppStore((s) => s.reorderLayerGroup);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectLayer = useAppStore((s) => s.selectLayer);
@@ -773,6 +774,52 @@ export function LayerPanel({
   const groupById = useMemo(
     () => new Map(layerGroups.map((g) => [g.id, g] as const)),
     [layerGroups],
+  );
+  const groupDepth = useCallback(
+    (group: LayerGroup) => {
+      let depth = 0;
+      let parentId = group.parentId;
+      const visited = new Set([group.id]);
+      while (parentId && !visited.has(parentId)) {
+        visited.add(parentId);
+        const parent = groupById.get(parentId);
+        if (!parent) break;
+        depth += 1;
+        parentId = parent.parentId;
+      }
+      return depth;
+    },
+    [groupById],
+  );
+  const hasCollapsedAncestor = useCallback(
+    (group: LayerGroup) => {
+      let parentId = group.parentId;
+      const visited = new Set([group.id]);
+      while (parentId && !visited.has(parentId)) {
+        visited.add(parentId);
+        const parent = groupById.get(parentId);
+        if (!parent) return false;
+        if (parent.collapsed) return true;
+        parentId = parent.parentId;
+      }
+      return false;
+    },
+    [groupById],
+  );
+  const groupMoveTargets = useCallback(
+    (group: LayerGroup) =>
+      layerGroups.filter((candidate) => {
+        if (candidate.id === group.id) return false;
+        let parentId: string | undefined = candidate.parentId;
+        const visited = new Set<string>();
+        while (parentId && !visited.has(parentId)) {
+          if (parentId === group.id) return false;
+          visited.add(parentId);
+          parentId = groupById.get(parentId)?.parentId;
+        }
+        return true;
+      }),
+    [groupById, layerGroups],
   );
   const firstMemberIdByGroup = useMemo(() => {
     const map = new Map<string, string>();
@@ -1024,7 +1071,10 @@ export function LayerPanel({
       clearRefreshStatusTimer(layer.id);
       setRefreshStatuses((current) => ({
         ...current,
-        [layer.id]: { type: "success", message: t("layers.styleCopied", { name: layer.name }) },
+        [layer.id]: {
+          type: "success",
+          message: t("layers.styleCopied", { name: layer.name }),
+        },
       }));
       scheduleStatusClear(layer.id);
     },
@@ -1042,7 +1092,10 @@ export function LayerPanel({
       clearRefreshStatusTimer(layer.id);
       setRefreshStatuses((current) => ({
         ...current,
-        [layer.id]: { type: "success", message: t("layers.stylePasted", { name: sourceName }) },
+        [layer.id]: {
+          type: "success",
+          message: t("layers.stylePasted", { name: sourceName }),
+        },
       }));
       scheduleStatusClear(layer.id);
     },
@@ -1085,7 +1138,10 @@ export function LayerPanel({
         setRefreshStatuses((current) => ({
           ...current,
           [layer.id]: result.ok
-            ? { type: "success", message: t("layers.savedToLibrary", { name: layer.name }) }
+            ? {
+                type: "success",
+                message: t("layers.savedToLibrary", { name: layer.name }),
+              }
             : {
                 type: "error",
                 message:
@@ -1346,7 +1402,10 @@ export function LayerPanel({
       fileMeta: {
         defaultName: string;
         filters: { name: string; extensions: string[] }[];
-        browserTypes: { description: string; accept: Record<string, string[]> }[];
+        browserTypes: {
+          description: string;
+          accept: Record<string, string[]>;
+        }[];
         mimeType: string;
       },
     ) => {
@@ -1470,7 +1529,12 @@ export function LayerPanel({
         {
           defaultName: `${sanitizeExportFileName(layer.name)}.qml`,
           filters: [{ name: "QGIS QML", extensions: ["qml"] }],
-          browserTypes: [{ description: "QGIS QML", accept: { "application/xml": [".qml"] } }],
+          browserTypes: [
+            {
+              description: "QGIS QML",
+              accept: { "application/xml": [".qml"] },
+            },
+          ],
           mimeType: "application/xml",
         },
       ),
@@ -1809,7 +1873,9 @@ export function LayerPanel({
       }
       extent = { min, max };
     }
-    const binding = buildTimeBindingFromRecords(bindRecords, bindProperty, { extent });
+    const binding = buildTimeBindingFromRecords(bindRecords, bindProperty, {
+      extent,
+    });
     if (!binding) {
       // Keep the dialog open and explain why, rather than closing silently.
       setBindError(t("layers.bindNoTimestamps"));
@@ -2240,6 +2306,7 @@ export function LayerPanel({
   };
 
   const renderGroupHeader = (group: LayerGroup) => {
+    if (hasCollapsedAncestor(group)) return null;
     const isDropTarget = dropTargetGroupId === group.id;
     // Empty folders have no members in the flat `layers` array, so
     // reorderLayerGroup cannot move them; disable the reorder actions for them.
@@ -2249,6 +2316,7 @@ export function LayerPanel({
         data-group-header=""
         data-testid="layer-group-header"
         data-group-name={group.name}
+        style={{ marginInlineStart: `${groupDepth(group)}rem` }}
         className={`rounded-md border p-2 transition-colors ${
           isDropTarget
             ? "border-primary bg-primary/10"
@@ -2353,6 +2421,31 @@ export function LayerPanel({
                 <Pencil className="me-2 h-3.5 w-3.5" />
                 {t("layers.renameGroup")}
               </DropdownMenuItem>
+              {groupMoveTargets(group).length > 0 && (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Folder className="h-3.5 w-3.5" />
+                    {t("layers.moveToGroup")}
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {groupMoveTargets(group).map((target) => (
+                      <DropdownMenuItem
+                        key={target.id}
+                        disabled={group.parentId === target.id}
+                        onSelect={() => moveLayerGroupToGroup(group.id, target.id)}
+                      >
+                        {target.name}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              )}
+              {group.parentId && (
+                <DropdownMenuItem onSelect={() => moveLayerGroupToGroup(group.id, null)}>
+                  <FolderMinus className="me-2 h-3.5 w-3.5" />
+                  {t("layers.removeFromGroup")}
+                </DropdownMenuItem>
+              )}
               {/* Action items below omit preventDefault so Radix dismisses the
                   menu on select; only the rename item above keeps it, so the
                   menu's close does not race its input autofocus. */}
@@ -2558,6 +2651,7 @@ export function LayerPanel({
             const group = layer.groupId ? groupById.get(layer.groupId) : undefined;
             const isFirstOfGroup = group ? firstMemberIdByGroup.get(group.id) === layer.id : false;
             const groupCollapsed = group?.collapsed ?? false;
+            const groupAncestorCollapsed = group ? hasCollapsedAncestor(group) : false;
             // When the parent group is hidden, a layer whose own visibility
             // toggle is still on is not rendered — a surprising state. Grey its
             // name out as a cue that the group-level setting is what's hiding
@@ -2691,7 +2785,7 @@ export function LayerPanel({
             return (
               <Fragment key={layer.id}>
                 {isFirstOfGroup && group && renderGroupHeader(group)}
-                {!groupCollapsed && (
+                {!groupCollapsed && !groupAncestorCollapsed && (
                   <div
                     data-layer-card=""
                     data-testid="layer-row"
@@ -2701,6 +2795,7 @@ export function LayerPanel({
                         ? "border-primary bg-primary/5"
                         : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
                     } ${draggedLayerId === layer.id ? "opacity-50" : ""} ${group ? "ms-4" : ""}`}
+                    style={group ? { marginInlineStart: `${groupDepth(group) + 1}rem` } : undefined}
                     onDragOver={(e) => handleLayerDragOver(e, layer.id)}
                     onDrop={(e) => handleLayerDrop(e, layer.id, displayIndex)}
                     onDragEnd={resetDragState}
@@ -2757,7 +2852,9 @@ export function LayerPanel({
                           type="text"
                           className="flex-1 min-w-0 rounded border border-input bg-background px-1 py-0.5 text-sm font-medium outline-none focus:ring-1 focus:ring-ring"
                           value={editingName}
-                          aria-label={t("layers.renameNamed", { name: layer.name })}
+                          aria-label={t("layers.renameNamed", {
+                            name: layer.name,
+                          })}
                           onChange={(e) => setEditingName(e.target.value)}
                           onClick={(e: ReactMouseEvent) => e.stopPropagation()}
                           onFocus={(e) => e.currentTarget.select()}
@@ -3059,7 +3156,10 @@ export function LayerPanel({
                                       runLayerQuickTool(
                                         layer,
                                         "buffer",
-                                        { distance: preset.distance, units: preset.units },
+                                        {
+                                          distance: preset.distance,
+                                          units: preset.units,
+                                        },
                                         t("quickAnalysis.bufferOfLayerName", {
                                           name: layer.name,
                                           distance: formatQuickDistance(preset),
@@ -3079,7 +3179,9 @@ export function LayerPanel({
                                       layer,
                                       "centroids",
                                       {},
-                                      t("quickAnalysis.centroidsLayerName", { name: layer.name }),
+                                      t("quickAnalysis.centroidsLayerName", {
+                                        name: layer.name,
+                                      }),
                                     )
                                   }
                                 >
@@ -3091,7 +3193,9 @@ export function LayerPanel({
                                       layer,
                                       "convex-hull",
                                       {},
-                                      t("quickAnalysis.convexHullLayerName", { name: layer.name }),
+                                      t("quickAnalysis.convexHullLayerName", {
+                                        name: layer.name,
+                                      }),
                                     )
                                   }
                                 >
@@ -3103,7 +3207,9 @@ export function LayerPanel({
                                       layer,
                                       "bounding-box",
                                       {},
-                                      t("quickAnalysis.boundingBoxLayerName", { name: layer.name }),
+                                      t("quickAnalysis.boundingBoxLayerName", {
+                                        name: layer.name,
+                                      }),
                                     )
                                   }
                                 >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -830,11 +830,50 @@ export function LayerPanel({
     }
     return map;
   }, [visibleLayers]);
+  const descendantLayerAnchorByGroup = useMemo(() => {
+    const result = new Map<string, string>();
+    const displayGroupIds = visibleLayers
+      .map((layer) => layer.groupId)
+      .filter((id): id is string => Boolean(id && groupById.has(id)));
+    for (const group of layerGroups) {
+      if (firstMemberIdByGroup.has(group.id)) continue;
+      const anchor = displayGroupIds.find((candidateId) => {
+        let parentId = groupById.get(candidateId)?.parentId;
+        const visited = new Set<string>();
+        while (parentId && !visited.has(parentId)) {
+          if (parentId === group.id) return true;
+          visited.add(parentId);
+          parentId = groupById.get(parentId)?.parentId;
+        }
+        return false;
+      });
+      if (anchor) result.set(group.id, anchor);
+    }
+    return result;
+  }, [firstMemberIdByGroup, groupById, layerGroups, visibleLayers]);
+  const organizerHeadersByAnchor = useMemo(() => {
+    const result = new Map<string, LayerGroup[]>();
+    for (const group of layerGroups) {
+      const anchor = descendantLayerAnchorByGroup.get(group.id);
+      if (!anchor) continue;
+      const headers = result.get(anchor) ?? [];
+      headers.push(group);
+      result.set(anchor, headers);
+    }
+    for (const headers of result.values()) {
+      headers.sort((a, b) => groupDepth(a) - groupDepth(b));
+    }
+    return result;
+  }, [descendantLayerAnchorByGroup, groupDepth, layerGroups]);
   // Empty folders have no member to anchor them, so they render pinned at the
   // top of the panel where they are easy to drop layers into.
   const emptyGroups = useMemo(
-    () => layerGroups.filter((g) => !firstMemberIdByGroup.has(g.id)),
-    [layerGroups, firstMemberIdByGroup],
+    () =>
+      layerGroups.filter(
+        (group) =>
+          !firstMemberIdByGroup.has(group.id) && !descendantLayerAnchorByGroup.has(group.id),
+      ),
+    [descendantLayerAnchorByGroup, firstMemberIdByGroup, layerGroups],
   );
   // Resize the metadata dialog from its bottom-end grip. The dialog is centred
   // via a -50% transform, so each edge moves by half the size change; growing
@@ -2308,9 +2347,9 @@ export function LayerPanel({
   const renderGroupHeader = (group: LayerGroup) => {
     if (hasCollapsedAncestor(group)) return null;
     const isDropTarget = dropTargetGroupId === group.id;
-    // Empty folders have no members in the flat `layers` array, so
-    // reorderLayerGroup cannot move them; disable the reorder actions for them.
-    const canReorderGroup = firstMemberIdByGroup.has(group.id);
+    const canReorderGroup =
+      firstMemberIdByGroup.has(group.id) || descendantLayerAnchorByGroup.has(group.id);
+    const moveTargets = groupMoveTargets(group);
     return (
       <div
         data-group-header=""
@@ -2421,14 +2460,14 @@ export function LayerPanel({
                 <Pencil className="me-2 h-3.5 w-3.5" />
                 {t("layers.renameGroup")}
               </DropdownMenuItem>
-              {groupMoveTargets(group).length > 0 && (
+              {moveTargets.length > 0 && (
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>
                     <Folder className="h-3.5 w-3.5" />
                     {t("layers.moveToGroup")}
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
-                    {groupMoveTargets(group).map((target) => (
+                    {moveTargets.map((target) => (
                       <DropdownMenuItem
                         key={target.id}
                         disabled={group.parentId === target.id}
@@ -2784,6 +2823,13 @@ export function LayerPanel({
             const isRefreshing = refreshStatus?.type === "refreshing";
             return (
               <Fragment key={layer.id}>
+                {isFirstOfGroup &&
+                  group &&
+                  organizerHeadersByAnchor
+                    .get(group.id)
+                    ?.map((organizer) => (
+                      <Fragment key={organizer.id}>{renderGroupHeader(organizer)}</Fragment>
+                    ))}
                 {isFirstOfGroup && group && renderGroupHeader(group)}
                 {!groupCollapsed && !groupAncestorCollapsed && (
                   <div

--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -79,7 +79,9 @@ export async function materializeQgisRemoteLayers(
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
       try {
-        const response = await fetcher(sourcePath, { signal: controller.signal });
+        const response = await fetcher(sourcePath, {
+          signal: controller.signal,
+        });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = (await response.json()) as unknown;
         if (!isFeatureCollection(data))
@@ -404,6 +406,12 @@ function parseLayerGroups(document: Document): {
     return {
       id,
       name,
+      ...(element.parentElement?.closest("layer-tree-group") &&
+      element.parentElement.closest("layer-tree-group") !== root
+        ? {
+            parentId: ids.get(element.parentElement.closest("layer-tree-group")!),
+          }
+        : {}),
       collapsed: element.getAttribute("expanded") === "0",
       visible: element.getAttribute("checked") !== "Qt::Unchecked",
       opacity: 1,
@@ -413,14 +421,8 @@ function parseLayerGroups(document: Document): {
 }
 
 function groupDisplayName(element: Element, root: Element): string {
-  const names: string[] = [];
-  let current: Element | null = element;
-  while (current && current !== root) {
-    const name = current.getAttribute("name")?.trim();
-    if (name) names.unshift(name);
-    current = current.parentElement?.closest("layer-tree-group") ?? null;
-  }
-  return names.join(" / ") || "Group";
+  if (element === root) return "Group";
+  return element.getAttribute("name")?.trim() || "Group";
 }
 
 function layerGroupAssignments(document: Document, ids: Map<Element, string>): Map<string, string> {

--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -403,14 +403,12 @@ function parseLayerGroups(document: Document): {
     const name = groupDisplayName(element, root);
     const id = `qgis-group-${index}-${slug(name)}`;
     ids.set(element, id);
+    const parentGroupElement = element.parentElement?.closest("layer-tree-group");
     return {
       id,
       name,
-      ...(element.parentElement?.closest("layer-tree-group") &&
-      element.parentElement.closest("layer-tree-group") !== root
-        ? {
-            parentId: ids.get(element.parentElement.closest("layer-tree-group")!),
-          }
+      ...(parentGroupElement && parentGroupElement !== root
+        ? { parentId: ids.get(parentGroupElement) }
         : {}),
       collapsed: element.getAttribute("expanded") === "0",
       visible: element.getAttribute("checked") !== "Qt::Unchecked",

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -93,10 +93,17 @@ export function applyGroupEffects(layers: GeoLibreLayer[], groups: LayerGroup[])
   const groupById = new Map(groups.map((g) => [g.id, g]));
   return layers.map((layer) => {
     if (!layer.groupId) return layer;
-    const group = groupById.get(layer.groupId);
+    let group = groupById.get(layer.groupId);
     if (!group) return layer;
-    const visible = layer.visible && group.visible;
-    const opacity = layer.opacity * group.opacity;
+    let visible = layer.visible;
+    let opacity = layer.opacity;
+    const visited = new Set<string>();
+    while (group && !visited.has(group.id)) {
+      visited.add(group.id);
+      visible = visible && group.visible;
+      opacity *= group.opacity;
+      group = group.parentId ? groupById.get(group.parentId) : undefined;
+    }
     if (visible === layer.visible && opacity === layer.opacity) return layer;
     return { ...layer, visible, opacity };
   });

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -190,12 +190,29 @@ function normalizeLayerGroups(value: unknown): LayerGroup[] {
     groups.push({
       id,
       name: typeof candidate.name === "string" ? candidate.name : id,
+      ...(typeof candidate.parentId === "string" && candidate.parentId.trim()
+        ? { parentId: candidate.parentId.trim() }
+        : {}),
       collapsed: candidate.collapsed === true,
       visible: candidate.visible !== false,
       opacity,
     });
   }
-  return groups;
+  const ids = new Set(groups.map((group) => group.id));
+  const byId = new Map(groups.map((group) => [group.id, group]));
+  return groups.map((group) => {
+    if (!group.parentId || !ids.has(group.parentId) || group.parentId === group.id) {
+      return group.parentId ? { ...group, parentId: undefined } : group;
+    }
+    let id: string | undefined = group.parentId;
+    const seen = new Set([group.id]);
+    while (id) {
+      if (seen.has(id)) return { ...group, parentId: undefined };
+      seen.add(id);
+      id = byId.get(id)?.parentId;
+    }
+    return group;
+  });
 }
 
 /**
@@ -1340,7 +1357,9 @@ export function applyProjectToStore(project: GeoLibreProject): {
     layerGroups,
     preferences: normalizeProjectPreferences(project.preferences),
     projectPlugins: normalizeProjectPlugins(project.plugins),
-    legend: normalizeLegendConfig(project.legend) ?? { ...DEFAULT_LEGEND_CONFIG },
+    legend: normalizeLegendConfig(project.legend) ?? {
+      ...DEFAULT_LEGEND_CONFIG,
+    },
     storymap: normalizeStoryMap(project.storymap),
     models: normalizeModels(project.models) ?? [],
     processingHistory: normalizeProcessingHistory(project.processingHistory) ?? [],

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1817,9 +1817,21 @@ export const useAppStore = create<AppState>()(
 
       reorderLayerGroup: (id, direction) =>
         set((s) => {
+          const groupIds = new Set([id]);
+          let foundDescendant = true;
+          while (foundDescendant) {
+            foundDescendant = false;
+            for (const group of s.layerGroups) {
+              if (group.parentId && groupIds.has(group.parentId) && !groupIds.has(group.id)) {
+                groupIds.add(group.id);
+                foundDescendant = true;
+              }
+            }
+          }
           // Build the top-level units in store (render) order: each ungrouped
           // layer is its own unit, and a group's contiguous members form one
-          // unit. Reordering swaps the whole group block past its neighbor.
+          // unit. A nested organizer group may have no direct layers, so its
+          // block includes every unit belonging to a descendant group.
           const units: { key: string; layers: GeoLibreLayer[] }[] = [];
           for (const layer of s.layers) {
             const key = layer.groupId ?? `layer:${layer.id}`;
@@ -1827,13 +1839,21 @@ export const useAppStore = create<AppState>()(
             if (last && last.key === key) last.layers.push(layer);
             else units.push({ key, layers: [layer] });
           }
-          const unitIndex = units.findIndex((u) => u.key === id);
-          if (unitIndex < 0) return s; // empty group: nothing to move
-          const target = direction === "up" ? unitIndex + 1 : unitIndex - 1;
-          if (target < 0 || target >= units.length) return s;
-          const [unit] = units.splice(unitIndex, 1);
-          units.splice(target, 0, unit);
-          return { layers: units.flatMap((u) => u.layers), isDirty: true };
+          const matching = units
+            .map((unit, index) => (groupIds.has(unit.key) ? index : -1))
+            .filter((index) => index >= 0);
+          if (matching.length === 0) return s;
+          const first = matching[0];
+          const last = matching[matching.length - 1];
+          const neighbor = direction === "up" ? last + 1 : first - 1;
+          if (neighbor < 0 || neighbor >= units.length) return s;
+          const block = units.filter((unit) => groupIds.has(unit.key));
+          const remaining = units.filter((unit) => !groupIds.has(unit.key));
+          const neighborKey = units[neighbor].key;
+          const neighborIndex = remaining.findIndex((unit) => unit.key === neighborKey);
+          const insertAt = direction === "up" ? neighborIndex + 1 : neighborIndex;
+          remaining.splice(insertAt, 0, ...block);
+          return { layers: remaining.flatMap((u) => u.layers), isDirty: true };
         }),
 
       newProject: (options = {}) => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -614,6 +614,7 @@ export interface AppState {
     groupId: string | null,
     beforeLayerId?: string | null,
   ) => void;
+  moveLayerGroupToGroup: (id: string, parentId: string | null) => void;
   reorderLayerGroup: (id: string, direction: "up" | "down") => void;
 }
 
@@ -739,7 +740,12 @@ function clampGridDim(value: number): number {
  */
 function fitGrid(total: number, preferredCols: number): { rows: number; cols: number } {
   if (total <= 1) return { rows: 1, cols: 1 };
-  let best: { rows: number; cols: number; empty: number; score: number } | null = null;
+  let best: {
+    rows: number;
+    cols: number;
+    empty: number;
+    score: number;
+  } | null = null;
   for (let rows = 1; rows <= MAX_MAP_GRID_DIM; rows++) {
     for (let cols = 1; cols <= MAX_MAP_GRID_DIM; cols++) {
       const capacity = rows * cols;
@@ -1051,7 +1057,11 @@ export const useAppStore = create<AppState>()(
           isDirty: shouldMarkDirty || s.isDirty,
         })),
       selectLayer: (id) =>
-        set({ selectedLayerId: id, selectedFeatureId: null, selectedFeatureIds: [] }),
+        set({
+          selectedLayerId: id,
+          selectedFeatureId: null,
+          selectedFeatureIds: [],
+        }),
       selectFeature: (id) => set({ selectedFeatureId: id, selectedFeatureIds: id ? [id] : [] }),
       selectFeatures: (ids, anchorId) =>
         set({
@@ -1557,7 +1567,9 @@ export const useAppStore = create<AppState>()(
           style: initialLayerStyle({
             geojson,
             layers: get().layers,
-            overrides: { simpleStyleEnabled: hasSimpleStyleProperties(geojson) },
+            overrides: {
+              simpleStyleEnabled: hasSimpleStyleProperties(geojson),
+            },
           }),
           metadata: {},
           geojson,
@@ -1573,7 +1585,11 @@ export const useAppStore = create<AppState>()(
           id,
           name,
           type: "image",
-          source: { type: "image", url: source.url, coordinates: source.coordinates },
+          source: {
+            type: "image",
+            url: source.url,
+            coordinates: source.coordinates,
+          },
           visible: options?.visible ?? true,
           opacity: options?.opacity ?? 1,
           style: { ...DEFAULT_LAYER_STYLE },
@@ -1669,15 +1685,34 @@ export const useAppStore = create<AppState>()(
       removeLayerGroup: (id, options) =>
         set((s) => {
           const removeChildren = options?.removeChildren ?? false;
-          const removedIds = new Set(s.layers.filter((l) => l.groupId === id).map((l) => l.id));
+          const removedGroup = s.layerGroups.find((g) => g.id === id);
+          if (!removedGroup) return s;
+          const groupIds = new Set([id]);
+          if (removeChildren) {
+            let changed = true;
+            while (changed) {
+              changed = false;
+              for (const group of s.layerGroups) {
+                if (group.parentId && groupIds.has(group.parentId) && !groupIds.has(group.id)) {
+                  groupIds.add(group.id);
+                  changed = true;
+                }
+              }
+            }
+          }
+          const removedIds = new Set(
+            s.layers.filter((l) => l.groupId && groupIds.has(l.groupId)).map((l) => l.id),
+          );
           const layers = removeChildren
-            ? s.layers.filter((l) => l.groupId !== id)
+            ? s.layers.filter((l) => !l.groupId || !groupIds.has(l.groupId))
             : s.layers.map((l) => (l.groupId === id ? { ...l, groupId: undefined } : l));
           const selectionRemoved =
             removeChildren && s.selectedLayerId !== null && removedIds.has(s.selectedLayerId);
           return {
             layers,
-            layerGroups: s.layerGroups.filter((g) => g.id !== id),
+            layerGroups: s.layerGroups
+              .filter((g) => !groupIds.has(g.id))
+              .map((g) => (g.parentId === id ? { ...g, parentId: removedGroup.parentId } : g)),
             selectedLayerId: selectionRemoved
               ? (layers[layers.length - 1]?.id ?? null)
               : s.selectedLayerId,
@@ -1752,6 +1787,32 @@ export const useAppStore = create<AppState>()(
           );
           if (unchanged) return s;
           return { layers: normalized, isDirty: true };
+        }),
+
+      moveLayerGroupToGroup: (id, parentId) =>
+        set((s) => {
+          if (parentId === id) return s;
+          const group = s.layerGroups.find((g) => g.id === id);
+          if (!group) return s;
+          if (parentId && !s.layerGroups.some((g) => g.id === parentId)) return s;
+          // Walking upward from the proposed parent must never reach the group
+          // being moved, otherwise the assignment would create a cycle.
+          const byId = new Map(s.layerGroups.map((g) => [g.id, g]));
+          let ancestorId = parentId ?? undefined;
+          const visited = new Set<string>();
+          while (ancestorId && !visited.has(ancestorId)) {
+            if (ancestorId === id) return s;
+            visited.add(ancestorId);
+            ancestorId = byId.get(ancestorId)?.parentId;
+          }
+          const nextParentId = parentId ?? undefined;
+          if (group.parentId === nextParentId) return s;
+          return {
+            layerGroups: s.layerGroups.map((g) =>
+              g.id === id ? { ...g, parentId: nextParentId } : g,
+            ),
+            isDirty: true,
+          };
         }),
 
       reorderLayerGroup: (id, direction) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -939,7 +939,8 @@ export interface AddTileLayerOptions {
 
 /**
  * A named, collapsible folder in the layer panel that organizes a contiguous
- * run of layers (single-level nesting; groups never contain other groups).
+ * run of layers. Groups may be nested by referencing another group as their
+ * parent; the root groups omit `parentId`.
  *
  * The group's `visible` flag and `opacity` multiplier are folded into each
  * child layer's effective render state by `applyGroupEffects` before the map
@@ -948,6 +949,8 @@ export interface AddTileLayerOptions {
 export interface LayerGroup {
   id: string;
   name: string;
+  /** Parent folder id, or undefined when this folder is at the panel root. */
+  parentId?: string;
   /** When true, the group's children are hidden in the panel (not on the map). */
   collapsed: boolean;
   /** Group-level visibility; ANDed with each child layer's own visibility. */

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -253,6 +253,20 @@ describe("layer group store actions", () => {
     );
   });
 
+  it("reorders an organizer group using its descendant layer blocks", () => {
+    const childLayer = useAppStore.getState().addGeoJsonLayer("Child", emptyFC);
+    const neighbor = useAppStore.getState().addGeoJsonLayer("Neighbor", emptyFC);
+    const parent = useAppStore.getState().addLayerGroup("Parent");
+    const child = useAppStore.getState().addLayerGroup("Child group", [childLayer]);
+    useAppStore.getState().moveLayerGroupToGroup(child, parent);
+
+    useAppStore.getState().reorderLayerGroup(parent, "up");
+    assert.deepEqual(
+      useAppStore.getState().layers.map((candidate) => candidate.id),
+      [neighbor, childLayer],
+    );
+  });
+
   it("ungroups children by default but can delete them", () => {
     const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
     const gid = useAppStore.getState().addLayerGroup("G", [a]);

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -116,6 +116,17 @@ describe("applyGroupEffects", () => {
     const result = applyGroupEffects(layers, [group("g")]);
     assert.equal(result[0], layers[0]);
   });
+
+  it("inherits visibility and opacity through nested groups", () => {
+    const layers = [layer("a", { groupId: "child", opacity: 0.8 })];
+    const groups = [
+      group("parent", { opacity: 0.5, visible: false }),
+      group("child", { parentId: "parent", opacity: 0.25 }),
+    ];
+    const result = applyGroupEffects(layers, groups);
+    assert.equal(result[0].visible, false);
+    assert.equal(result[0].opacity, 0.1);
+  });
 });
 
 describe("normalizeGroupContiguity", () => {
@@ -194,6 +205,42 @@ describe("layer group store actions", () => {
     assert.equal(useAppStore.getState().layers.find((l) => l.id === a)?.groupId, undefined);
   });
 
+  it("nests groups, rejects cycles, and promotes children when ungrouping", () => {
+    const parent = useAppStore.getState().addLayerGroup("Parent");
+    const child = useAppStore.getState().addLayerGroup("Child");
+    const grandchild = useAppStore.getState().addLayerGroup("Grandchild");
+    useAppStore.getState().moveLayerGroupToGroup(child, parent);
+    useAppStore.getState().moveLayerGroupToGroup(grandchild, child);
+    assert.equal(useAppStore.getState().layerGroups.find((g) => g.id === child)?.parentId, parent);
+    assert.equal(
+      useAppStore.getState().layerGroups.find((g) => g.id === grandchild)?.parentId,
+      child,
+    );
+
+    useAppStore.getState().moveLayerGroupToGroup(parent, grandchild);
+    assert.equal(
+      useAppStore.getState().layerGroups.find((g) => g.id === parent)?.parentId,
+      undefined,
+    );
+
+    useAppStore.getState().removeLayerGroup(child);
+    assert.equal(
+      useAppStore.getState().layerGroups.find((g) => g.id === grandchild)?.parentId,
+      parent,
+    );
+  });
+
+  it("deletes a nested group's full subtree and its layers", () => {
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    const b = useAppStore.getState().addGeoJsonLayer("B", emptyFC);
+    const parent = useAppStore.getState().addLayerGroup("Parent", [a]);
+    const child = useAppStore.getState().addLayerGroup("Child", [b]);
+    useAppStore.getState().moveLayerGroupToGroup(child, parent);
+    useAppStore.getState().removeLayerGroup(parent, { removeChildren: true });
+    assert.equal(useAppStore.getState().layerGroups.length, 0);
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
   it("reorders a group block past a neighboring layer", () => {
     const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
     const b = useAppStore.getState().addGeoJsonLayer("B", emptyFC);
@@ -267,7 +314,10 @@ describe("layer group store actions", () => {
 describe("layer group serialization", () => {
   it("round-trips groups through projectFromStore and parseProject", () => {
     const layers = [layer("a", { groupId: "g" }), layer("b")];
-    const groups = [group("g", { name: "Folder", opacity: 0.5 })];
+    const groups = [
+      group("parent", { name: "Parent" }),
+      group("g", { name: "Folder", parentId: "parent", opacity: 0.5 }),
+    ];
     const project = projectFromStore({
       projectName: "P",
       mapView: { center: [0, 0], zoom: 1, bearing: 0, pitch: 0 },
@@ -280,9 +330,10 @@ describe("layer group serialization", () => {
       metadata: {},
     });
     const parsed = parseProject(serializeProject(project));
-    assert.equal(parsed.layerGroups?.length, 1);
-    assert.equal(parsed.layerGroups?.[0].name, "Folder");
-    assert.equal(parsed.layerGroups?.[0].opacity, 0.5);
+    assert.equal(parsed.layerGroups?.length, 2);
+    assert.equal(parsed.layerGroups?.[1].name, "Folder");
+    assert.equal(parsed.layerGroups?.[1].parentId, "parent");
+    assert.equal(parsed.layerGroups?.[1].opacity, 0.5);
     assert.equal(parsed.layers.find((l) => l.id === "a")?.groupId, "g");
   });
 

--- a/tests/qgis-project-import.test.ts
+++ b/tests/qgis-project-import.test.ts
@@ -125,8 +125,9 @@ describe("QGIS project import", () => {
     assert.deepEqual(result.project.mapView.center, [-95.5, 37]);
     assert.deepEqual(
       result.project.layerGroups?.map((group) => group.name),
-      ["Transport", "Transport / Places"],
+      ["Transport", "Places"],
     );
+    assert.equal(result.project.layerGroups?.[1].parentId, result.project.layerGroups?.[0].id);
     assert.deepEqual(
       result.project.layers.map((layer) => layer.name),
       ["Cities", "Roads"],
@@ -277,7 +278,9 @@ describe("QGIS project import", () => {
   });
 
   it("rejects oversized QGS members before decompressing them", () => {
-    const oversized = zipSync({ "project.qgs": new Uint8Array(25 * 1024 * 1024 + 1) });
+    const oversized = zipSync({
+      "project.qgs": new Uint8Array(25 * 1024 * 1024 + 1),
+    });
     assert.throws(
       () => importQgisProject(oversized, "/work/example.qgz"),
       /too large to import safely/,


### PR DESCRIPTION
## Summary

- allow layer groups to be moved into other groups with cycle-safe parent relationships
- inherit visibility, opacity, collapse, deletion, and project persistence through nested groups
- preserve nested folders when importing QGIS projects

## Verification

- `node --import tsx --test tests/layer-groups.test.ts tests/qgis-project-import.test.ts`
- `pre-commit run --files apps/geolibre-desktop/src/components/panels/LayerPanel.tsx apps/geolibre-desktop/src/lib/qgis-project-import.ts packages/core/src/layer-groups.ts packages/core/src/project.ts packages/core/src/store.ts packages/core/src/types.ts tests/layer-groups.test.ts tests/qgis-project-import.test.ts`
- browser tested creating, nesting, collapsing, and expanding groups in light and dark themes

Fixes #1589