### PR TITLE
Convert Whitebox raster outputs to COGs

### DIFF
--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -44,6 +44,38 @@ WHITEBOX_RUNTIME_PACKAGE = os.environ.get(
 )
 WHITEBOX_PYTHON_VERSION = os.environ.get("GEOLIBRE_WHITEBOX_PYTHON_VERSION", "3.12")
 
+_ENSURE_COG_SCRIPT = """
+import json, os, sys
+
+from rio_cogeo.cogeo import cog_translate, cog_validate
+from rio_cogeo.profiles import cog_profiles
+
+path = sys.argv[1]
+valid, _, _ = cog_validate(path, quiet=True)
+if valid:
+    print(json.dumps({"converted": False}))
+    raise SystemExit(0)
+
+temporary = path + ".geolibre-cog.tmp"
+try:
+    cog_translate(
+        path,
+        temporary,
+        cog_profiles.get("deflate"),
+        in_memory=False,
+        quiet=True,
+        use_cog_driver=False,
+    )
+    valid, errors, _ = cog_validate(temporary, quiet=True)
+    if not valid:
+        raise RuntimeError("COG validation failed: " + "; ".join(errors))
+    os.replace(temporary, path)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+print(json.dumps({"converted": True}))
+"""
+
 
 def _whitebox_run_timeout_secs() -> int:
     """Return the wall-clock timeout for a single Whitebox tool run.
@@ -915,6 +947,51 @@ def _extract_outputs(
     return outputs
 
 
+def _raster_output_paths(args: dict[str, Any], tool: dict[str, Any] | None) -> list[str]:
+    """Return existing filesystem paths declared as raster outputs."""
+    paths: list[str] = []
+    for param in (tool or {}).get("params", []):
+        if not isinstance(param, dict) or str(param.get("kind") or "") != "raster_out":
+            continue
+        value = args.get(str(param.get("name") or ""))
+        if isinstance(value, str) and value.strip() and Path(value).is_file():
+            paths.append(value)
+    return paths
+
+
+def _ensure_raster_outputs_are_cogs(
+    args: dict[str, Any],
+    tool: dict[str, Any] | None,
+    on_message: Callable[[str], None],
+) -> None:
+    """Convert striped Whitebox raster outputs to valid COGs in place."""
+    paths = _raster_output_paths(args, tool)
+    if not paths:
+        return
+    python = conversion._runtime_python()
+    for path in paths:
+        completed = subprocess.run(
+            [python, "-c", _ENSURE_COG_SCRIPT, path],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=_clean_env(),
+            timeout=conversion.CONVERSION_RUN_TIMEOUT_SECS,
+            **_subprocess_startup_kwargs(),
+        )
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(f"Could not optimize Whitebox raster output: {detail}")
+        try:
+            converted = bool(json.loads(completed.stdout.strip()).get("converted"))
+        except (json.JSONDecodeError, AttributeError):
+            converted = True
+        if converted:
+            on_message(f"Converted {Path(path).name} to a Cloud Optimized GeoTIFF.")
+
+
 def _job_update(job_id: str, **patch: Any) -> None:
     """Update an in-memory Whitebox job."""
     with _JOBS_LOCK:
@@ -955,6 +1032,11 @@ def _run_job(job_id: str, request: WhiteboxRunRequest) -> None:
             working_directory=working_directory,
         )
         result = _parse_json_maybe(raw_result)
+        _ensure_raster_outputs_are_cogs(
+            args,
+            request.tool,
+            lambda message: _append_job_message(job_id, message),
+        )
         _job_update(
             job_id,
             status="succeeded",

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -45,13 +45,14 @@ WHITEBOX_RUNTIME_PACKAGE = os.environ.get(
 WHITEBOX_PYTHON_VERSION = os.environ.get("GEOLIBRE_WHITEBOX_PYTHON_VERSION", "3.12")
 
 _ENSURE_COG_SCRIPT = """
-import json, os, sys
+import json, os, stat, sys
 
 from rio_cogeo.cogeo import cog_translate, cog_validate
 from rio_cogeo.profiles import cog_profiles
 
 path = sys.argv[1]
 temporary = sys.argv[2]
+original_mode = stat.S_IMODE(os.stat(path).st_mode)
 valid, _, _ = cog_validate(path, quiet=True)
 if valid:
     print("{marker}" + json.dumps({"converted": False}))
@@ -68,6 +69,7 @@ cog_translate(
 valid, errors, _ = cog_validate(temporary, quiet=True)
 if not valid:
     raise RuntimeError("COG validation failed: " + "; ".join(errors))
+os.chmod(temporary, original_mode)
 os.replace(temporary, path)
 print("{marker}" + json.dumps({"converted": True}))
 """.replace("{marker}", conversion._RESULT_MARKER)

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -51,28 +51,24 @@ from rio_cogeo.cogeo import cog_translate, cog_validate
 from rio_cogeo.profiles import cog_profiles
 
 path = sys.argv[1]
+temporary = sys.argv[2]
 valid, _, _ = cog_validate(path, quiet=True)
 if valid:
     print(json.dumps({"converted": False}))
     raise SystemExit(0)
 
-temporary = path + ".geolibre-cog.tmp"
-try:
-    cog_translate(
-        path,
-        temporary,
-        cog_profiles.get("deflate"),
-        in_memory=False,
-        quiet=True,
-        use_cog_driver=False,
-    )
-    valid, errors, _ = cog_validate(temporary, quiet=True)
-    if not valid:
-        raise RuntimeError("COG validation failed: " + "; ".join(errors))
-    os.replace(temporary, path)
-finally:
-    if os.path.exists(temporary):
-        os.unlink(temporary)
+cog_translate(
+    path,
+    temporary,
+    cog_profiles.get("deflate"),
+    in_memory=False,
+    quiet=True,
+    use_cog_driver=False,
+)
+valid, errors, _ = cog_validate(temporary, quiet=True)
+if not valid:
+    raise RuntimeError("COG validation failed: " + "; ".join(errors))
+os.replace(temporary, path)
 print(json.dumps({"converted": True}))
 """
 
@@ -963,6 +959,7 @@ def _ensure_raster_outputs_are_cogs(
     args: dict[str, Any],
     tool: dict[str, Any] | None,
     on_message: Callable[[str], None],
+    temp_paths: list[Path],
 ) -> None:
     """Convert striped Whitebox raster outputs to valid COGs in place."""
     paths = _raster_output_paths(args, tool)
@@ -970,8 +967,18 @@ def _ensure_raster_outputs_are_cogs(
         return
     python = conversion._runtime_python()
     for path in paths:
+        output_path = Path(path)
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=f".{output_path.name}.",
+            suffix=".geolibre-cog.tmp",
+            dir=output_path.parent,
+        )
+        os.close(descriptor)
+        temporary_path = Path(temporary)
+        temporary_path.unlink()
+        temp_paths.append(temporary_path)
         completed = subprocess.run(
-            [python, "-c", _ENSURE_COG_SCRIPT, path],
+            [python, "-c", _ENSURE_COG_SCRIPT, path, temporary],
             check=False,
             capture_output=True,
             text=True,
@@ -985,9 +992,9 @@ def _ensure_raster_outputs_are_cogs(
             detail = completed.stderr.strip() or completed.stdout.strip()
             raise RuntimeError(f"Could not optimize Whitebox raster output: {detail}")
         try:
-            converted = bool(json.loads(completed.stdout.strip()).get("converted"))
+            converted = bool(json.loads(completed.stdout.splitlines()[-1]).get("converted"))
         except (json.JSONDecodeError, AttributeError):
-            converted = True
+            converted = False
         if converted:
             on_message(f"Converted {Path(path).name} to a Cloud Optimized GeoTIFF.")
 
@@ -1036,6 +1043,7 @@ def _run_job(job_id: str, request: WhiteboxRunRequest) -> None:
             args,
             request.tool,
             lambda message: _append_job_message(job_id, message),
+            temp_paths,
         )
         _job_update(
             job_id,

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -54,7 +54,7 @@ path = sys.argv[1]
 temporary = sys.argv[2]
 valid, _, _ = cog_validate(path, quiet=True)
 if valid:
-    print(json.dumps({"converted": False}))
+    print("{marker}" + json.dumps({"converted": False}))
     raise SystemExit(0)
 
 cog_translate(
@@ -69,8 +69,8 @@ valid, errors, _ = cog_validate(temporary, quiet=True)
 if not valid:
     raise RuntimeError("COG validation failed: " + "; ".join(errors))
 os.replace(temporary, path)
-print(json.dumps({"converted": True}))
-"""
+print("{marker}" + json.dumps({"converted": True}))
+""".replace("{marker}", conversion._RESULT_MARKER)
 
 
 def _whitebox_run_timeout_secs() -> int:
@@ -991,10 +991,16 @@ def _ensure_raster_outputs_are_cogs(
         if completed.returncode != 0:
             detail = completed.stderr.strip() or completed.stdout.strip()
             raise RuntimeError(f"Could not optimize Whitebox raster output: {detail}")
-        try:
-            converted = bool(json.loads(completed.stdout.splitlines()[-1]).get("converted"))
-        except (json.JSONDecodeError, AttributeError):
-            converted = False
+        converted = False
+        for line in completed.stdout.splitlines():
+            if not line.startswith(conversion._RESULT_MARKER):
+                continue
+            try:
+                converted = bool(
+                    json.loads(line[len(conversion._RESULT_MARKER) :]).get("converted")
+                )
+            except (json.JSONDecodeError, AttributeError):
+                pass
         if converted:
             on_message(f"Converted {Path(path).name} to a Cloud Optimized GeoTIFF.")
 

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -975,7 +975,6 @@ def _ensure_raster_outputs_are_cogs(
         )
         os.close(descriptor)
         temporary_path = Path(temporary)
-        temporary_path.unlink()
         temp_paths.append(temporary_path)
         completed = subprocess.run(
             [python, "-c", _ENSURE_COG_SCRIPT, path, temporary],

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -190,6 +190,25 @@ def test_ensure_raster_outputs_does_not_announce_existing_cog(monkeypatch, tmp_p
     assert messages == []
 
 
+def test_ensure_raster_outputs_surfaces_conversion_failure(monkeypatch, tmp_path):
+    raster = tmp_path / "result.tif"
+    raster.write_bytes(b"striped")
+    monkeypatch.setattr(whitebox.conversion, "_runtime_python", lambda: "/python")
+    monkeypatch.setattr(
+        whitebox.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 1, "", "conversion failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="Could not optimize.*conversion failed"):
+        whitebox._ensure_raster_outputs_are_cogs(
+            {"output": str(raster)},
+            {"params": [{"name": "output", "kind": "raster_out"}]},
+            lambda message: None,
+            [],
+        )
+
+
 def test_ensure_raster_outputs_converts_real_striped_geotiff(monkeypatch, tmp_path):
     numpy = pytest.importorskip("numpy")
     rasterio = pytest.importorskip("rasterio")

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -7,6 +7,9 @@ back to the client, mirroring conversion.py/raster.py.
 
 from __future__ import annotations
 
+import json
+import subprocess
+
 import pytest
 from fastapi import HTTPException
 
@@ -111,3 +114,62 @@ def test_run_job_does_not_leak_error(monkeypatch):
     finally:
         with whitebox._JOBS_LOCK:
             whitebox._JOBS.pop(job_id, None)
+
+
+def test_raster_output_paths_only_returns_declared_existing_rasters(tmp_path):
+    raster = tmp_path / "result.tif"
+    raster.write_bytes(b"tiff")
+    vector = tmp_path / "result.geojson"
+    vector.write_text("{}", encoding="utf-8")
+    args = {"raster": str(raster), "vector": str(vector), "missing": str(tmp_path / "x.tif")}
+    tool = {
+        "params": [
+            {"name": "raster", "kind": "raster_out"},
+            {"name": "vector", "kind": "vector_out"},
+            {"name": "missing", "kind": "raster_out"},
+        ]
+    }
+
+    assert whitebox._raster_output_paths(args, tool) == [str(raster)]
+
+
+def test_ensure_raster_outputs_converts_striped_tiff(monkeypatch, tmp_path):
+    raster = tmp_path / "result.tif"
+    raster.write_bytes(b"striped")
+    messages = []
+    monkeypatch.setattr(whitebox.conversion, "_runtime_python", lambda: "/python")
+
+    def _run(command, **kwargs):
+        assert command[-1] == str(raster)
+        return subprocess.CompletedProcess(command, 0, json.dumps({"converted": True}), "")
+
+    monkeypatch.setattr(whitebox.subprocess, "run", _run)
+    whitebox._ensure_raster_outputs_are_cogs(
+        {"output": str(raster)},
+        {"params": [{"name": "output", "kind": "raster_out"}]},
+        messages.append,
+    )
+
+    assert messages == ["Converted result.tif to a Cloud Optimized GeoTIFF."]
+
+
+def test_ensure_raster_outputs_does_not_announce_existing_cog(monkeypatch, tmp_path):
+    raster = tmp_path / "result.tif"
+    raster.write_bytes(b"cog")
+    messages = []
+    monkeypatch.setattr(whitebox.conversion, "_runtime_python", lambda: "/python")
+    monkeypatch.setattr(
+        whitebox.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command, 0, json.dumps({"converted": False}), ""
+        ),
+    )
+
+    whitebox._ensure_raster_outputs_are_cogs(
+        {"output": str(raster)},
+        {"params": [{"name": "output", "kind": "raster_out"}]},
+        messages.append,
+    )
+
+    assert messages == []

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -142,7 +142,12 @@ def test_ensure_raster_outputs_converts_striped_tiff(monkeypatch, tmp_path):
 
     def _run(command, **kwargs):
         assert command[-2] == str(raster)
-        return subprocess.CompletedProcess(command, 0, json.dumps({"converted": True}), "")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            whitebox.conversion._RESULT_MARKER + json.dumps({"converted": True}),
+            "",
+        )
 
     monkeypatch.setattr(whitebox.subprocess, "run", _run)
     temp_paths = []
@@ -168,7 +173,10 @@ def test_ensure_raster_outputs_does_not_announce_existing_cog(monkeypatch, tmp_p
         whitebox.subprocess,
         "run",
         lambda command, **kwargs: subprocess.CompletedProcess(
-            command, 0, json.dumps({"converted": False}), ""
+            command,
+            0,
+            whitebox.conversion._RESULT_MARKER + json.dumps({"converted": False}),
+            "",
         ),
     )
 

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -197,14 +197,14 @@ def test_ensure_raster_outputs_surfaces_conversion_failure(monkeypatch, tmp_path
     monkeypatch.setattr(
         whitebox.subprocess,
         "run",
-        lambda command, **kwargs: subprocess.CompletedProcess(command, 1, "", "conversion failed"),
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 1, "", "conversion failed"),
     )
 
-    with pytest.raises(RuntimeError, match="Could not optimize.*conversion failed"):
+    with pytest.raises(RuntimeError, match=r"Could not optimize.*conversion failed"):
         whitebox._ensure_raster_outputs_are_cogs(
             {"output": str(raster)},
             {"params": [{"name": "output", "kind": "raster_out"}]},
-            lambda message: None,
+            lambda _message: None,
             [],
         )
 
@@ -229,6 +229,7 @@ def test_ensure_raster_outputs_converts_real_striped_geotiff(monkeypatch, tmp_pa
         dataset.write(numpy.zeros((1, 1024, 1024), dtype="uint8"))
 
     assert cog_validate(raster, quiet=True)[0] is False
+    original_mode = raster.stat().st_mode
     monkeypatch.setattr(whitebox.conversion, "_runtime_python", lambda: sys.executable)
     messages = []
     temp_paths = []
@@ -240,5 +241,6 @@ def test_ensure_raster_outputs_converts_real_striped_geotiff(monkeypatch, tmp_pa
     )
 
     assert cog_validate(raster, quiet=True)[0] is True
+    assert raster.stat().st_mode == original_mode
     assert messages == ["Converted striped.tif to a Cloud Optimized GeoTIFF."]
     assert all(not path.exists() for path in temp_paths)

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 
 import pytest
 from fastapi import HTTPException
@@ -140,17 +141,22 @@ def test_ensure_raster_outputs_converts_striped_tiff(monkeypatch, tmp_path):
     monkeypatch.setattr(whitebox.conversion, "_runtime_python", lambda: "/python")
 
     def _run(command, **kwargs):
-        assert command[-1] == str(raster)
+        assert command[-2] == str(raster)
         return subprocess.CompletedProcess(command, 0, json.dumps({"converted": True}), "")
 
     monkeypatch.setattr(whitebox.subprocess, "run", _run)
+    temp_paths = []
     whitebox._ensure_raster_outputs_are_cogs(
         {"output": str(raster)},
         {"params": [{"name": "output", "kind": "raster_out"}]},
         messages.append,
+        temp_paths,
     )
 
     assert messages == ["Converted result.tif to a Cloud Optimized GeoTIFF."]
+    assert len(temp_paths) == 1
+    assert temp_paths[0].parent == tmp_path
+    assert temp_paths[0].name != "result.tif.geolibre-cog.tmp"
 
 
 def test_ensure_raster_outputs_does_not_announce_existing_cog(monkeypatch, tmp_path):
@@ -170,6 +176,42 @@ def test_ensure_raster_outputs_does_not_announce_existing_cog(monkeypatch, tmp_p
         {"output": str(raster)},
         {"params": [{"name": "output", "kind": "raster_out"}]},
         messages.append,
+        [],
     )
 
     assert messages == []
+
+
+def test_ensure_raster_outputs_converts_real_striped_geotiff(monkeypatch, tmp_path):
+    numpy = pytest.importorskip("numpy")
+    rasterio = pytest.importorskip("rasterio")
+    pytest.importorskip("rio_cogeo")
+    from rio_cogeo.cogeo import cog_validate
+
+    raster = tmp_path / "striped.tif"
+    with rasterio.open(
+        raster,
+        "w",
+        driver="GTiff",
+        width=1024,
+        height=1024,
+        count=1,
+        dtype="uint8",
+        transform=rasterio.transform.from_origin(0, 32, 1, 1),
+    ) as dataset:
+        dataset.write(numpy.zeros((1, 1024, 1024), dtype="uint8"))
+
+    assert cog_validate(raster, quiet=True)[0] is False
+    monkeypatch.setattr(whitebox.conversion, "_runtime_python", lambda: sys.executable)
+    messages = []
+    temp_paths = []
+    whitebox._ensure_raster_outputs_are_cogs(
+        {"output": str(raster)},
+        {"params": [{"name": "output", "kind": "raster_out"}]},
+        messages.append,
+        temp_paths,
+    )
+
+    assert cog_validate(raster, quiet=True)[0] is True
+    assert messages == ["Converted striped.tif to a Cloud Optimized GeoTIFF."]
+    assert all(not path.exists() for path in temp_paths)

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -698,7 +698,7 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
     if (entry.kind === "raster") {
       const cog = await ensureWhiteboxRasterCog(bytes);
       out[entry.name] = cog;
-      if (cog !== bytes) stdout.push(`Converted ${entry.file} to a Cloud Optimized GeoTIFF.`);
+      stdout.push(`Converted ${entry.file} to a Cloud Optimized GeoTIFF.`);
       continue;
     }
     if (entry.kind === "bytes") {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -6,6 +6,7 @@
 // algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB memory and
 // single-threaded execution (use the sidecar for very large data).
 import type { FeatureCollection } from "geojson";
+import { convertGeoTiffToCog, isTiledGeoTiff } from "./cog-convert";
 import { normalizeVectorOutputFormat } from "./sidecar-client";
 import type {
   RunWhiteboxToolRequest,
@@ -545,6 +546,15 @@ const SUBSET_OUTPUT_TOOL_IDS = new Set([
 ]);
 
 /**
+ * Ensure a browser-run Whitebox raster can be streamed by GeoLibre's raster
+ * renderer. Whitebox tools may emit striped GeoTIFFs just like the Python
+ * runtime, so normalize only those outputs and preserve existing tiled COGs.
+ */
+export async function ensureWhiteboxRasterCog(bytes: Uint8Array): Promise<Uint8Array> {
+  return (await isTiledGeoTiff(bytes)) ? bytes : convertGeoTiffToCog(bytes);
+}
+
+/**
  * Run a Whitebox tool in the browser via WASM. Mirrors `runWhiteboxTool` but
  * executes locally and returns an already-completed {@link WhiteboxJob}. Output
  * values are inline: a `FeatureCollection` for `vector_out`, or a `Uint8Array`
@@ -556,13 +566,14 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
   const input: Record<string, Uint8Array> = {};
   const args: string[] = [];
   // How each output file is turned into a job output: "geojson" is parsed into a
-  // FeatureCollection (a map layer); "bytes" is returned raw (a raster COG, a
-  // file_out blob, or a CRS-preserving vector file to download); "shapefile" is
-  // zipped with its sidecars first.
+  // FeatureCollection (a map layer); "raster" is normalized to a COG before it
+  // reaches the map; "bytes" is returned raw (a file_out blob or a
+  // CRS-preserving vector file to download); "shapefile" is zipped with its
+  // sidecars first.
   const outputs: {
     name: string;
     file: string;
-    kind: "geojson" | "bytes" | "shapefile";
+    kind: "geojson" | "raster" | "bytes" | "shapefile";
   }[] = [];
   // Defensive: validate the requested format so a bad value (e.g. a stale
   // output path from switching sidecar/WASM modes) degrades to GeoJSON instead
@@ -643,7 +654,7 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
       const ext =
         kind === "file_out" ? fileOutputTargetExtension(param, request.parameters[name]) : "tif";
       const file = `${outputBaseName(request.tool_id, name)}.${ext}`;
-      outputs.push({ name, file, kind: "bytes" });
+      outputs.push({ name, file, kind: kind === "raster_out" ? "raster" : "bytes" });
       args.push(`--${name}=/work/${file}`);
     } else {
       const value = request.parameters[name];
@@ -682,6 +693,12 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
     }
     const bytes = files[entry.file];
     if (!bytes) continue;
+    if (entry.kind === "raster") {
+      const cog = await ensureWhiteboxRasterCog(bytes);
+      out[entry.name] = cog;
+      if (cog !== bytes) stdout.push(`Converted ${entry.file} to a Cloud Optimized GeoTIFF.`);
+      continue;
+    }
     if (entry.kind === "bytes") {
       out[entry.name] = bytes;
       continue;

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -6,7 +6,7 @@
 // algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB memory and
 // single-threaded execution (use the sidecar for very large data).
 import type { FeatureCollection } from "geojson";
-import { convertGeoTiffToCog, isTiledGeoTiff } from "./cog-convert";
+import { convertGeoTiffToCog } from "./cog-convert";
 import { normalizeVectorOutputFormat } from "./sidecar-client";
 import type {
   RunWhiteboxToolRequest,
@@ -548,10 +548,12 @@ const SUBSET_OUTPUT_TOOL_IDS = new Set([
 /**
  * Ensure a browser-run Whitebox raster can be streamed by GeoLibre's raster
  * renderer. Whitebox tools may emit striped GeoTIFFs just like the Python
- * runtime, so normalize only those outputs and preserve existing tiled COGs.
+ * runtime. The browser converter does not expose full COG validation, and a
+ * tiled GeoTIFF is not necessarily cloud optimized, so re-encode every declared
+ * raster output instead of treating tile layout alone as proof of conformance.
  */
 export async function ensureWhiteboxRasterCog(bytes: Uint8Array): Promise<Uint8Array> {
-  return (await isTiledGeoTiff(bytes)) ? bytes : convertGeoTiffToCog(bytes);
+  return convertGeoTiffToCog(bytes);
 }
 
 /**

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -104,6 +104,7 @@ describe("convertGeoTiffToCog", () => {
   });
 
   it("normalizes every Whitebox WASM output because tiling alone does not prove COG conformance", async () => {
+    assert.equal(await isTiledGeoTiff(stripedTiff), false);
     const converted = await ensureWhiteboxRasterCog(stripedTiff);
 
     assert.equal(await isTiledGeoTiff(converted), true);

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -10,6 +10,7 @@ import {
   isTiledGeoTiff,
   readGeoTiffInfo,
 } from "../packages/processing/src/cog-convert";
+import { ensureWhiteboxRasterCog } from "../packages/processing/src/wasm-client";
 
 // A tiny 32x32 Int16 GeoTIFF written striped (not tiled) by rasterio, the kind
 // of file desktop GIS tools export and that the raster panel cannot render
@@ -100,5 +101,13 @@ describe("convertGeoTiffToCog", () => {
       deflate.byteLength < none.byteLength,
       `deflate (${deflate.byteLength}) should be smaller than none (${none.byteLength})`,
     );
+  });
+
+  it("normalizes striped Whitebox WASM output and preserves an existing COG", async () => {
+    const converted = await ensureWhiteboxRasterCog(stripedTiff);
+
+    assert.equal(await isTiledGeoTiff(converted), true);
+    assert.notEqual(converted, stripedTiff);
+    assert.equal(await ensureWhiteboxRasterCog(converted), converted);
   });
 });

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -103,11 +103,13 @@ describe("convertGeoTiffToCog", () => {
     );
   });
 
-  it("normalizes striped Whitebox WASM output and preserves an existing COG", async () => {
+  it("normalizes every Whitebox WASM output because tiling alone does not prove COG conformance", async () => {
     const converted = await ensureWhiteboxRasterCog(stripedTiff);
 
     assert.equal(await isTiledGeoTiff(converted), true);
     assert.notEqual(converted, stripedTiff);
-    assert.equal(await ensureWhiteboxRasterCog(converted), converted);
+    const revalidated = await ensureWhiteboxRasterCog(converted);
+    assert.equal(await isTiledGeoTiff(revalidated), true);
+    assert.notEqual(revalidated, converted);
   });
 });


### PR DESCRIPTION
Fixes #1583

## Summary
- validate every sidecar Whitebox raster output before completing the job
- convert striped GeoTIFF outputs to compressed COGs atomically with job-unique temporary files
- normalize striped Whitebox WASM raster bytes to COGs in the web version before adding them to the map
- preserve already-valid COGs in both execution modes and report conversions in the job log
- add focused unit and real striped-GeoTIFF integration coverage

## Verification
- reproduced Multidirectional Hillshade with `dem.tif` as a striped GeoTIFF
- confirmed the completed sidecar job produces a rio-cogeo-valid 512x512 tiled COG
- loaded the converted hillshade in GeoLibre in light and dark themes with no browser errors
- confirmed the web/WASM normalizer converts striped fixture bytes and preserves existing COG bytes
- backend Whitebox tests: 10 passed
- frontend tests: 4,560 passed, 1 skipped
- `npm run build`
- `pre-commit run --files ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically converts Whitebox raster outputs into Cloud Optimized GeoTIFFs (COGs).
  * Applies the same conversion to raster outputs from browser-based processing.
  * Preserves non-raster outputs and reports conversion progress when files are changed.

* **Bug Fixes**
  * Improves compatibility and performance for generated raster files.
  * Cleans up temporary files and clearly reports conversion failures.

* **Tests**
  * Added coverage for conversion, validation, messaging, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->