### PR TITLE
fix: load vector URLs through native HTTP

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -84,7 +84,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.6",
+    "maplibre-gl-vector": "^0.10.7",
     "openai": "^7.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -84,7 +84,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.5",
+    "maplibre-gl-vector": "^0.10.6",
     "openai": "^7.0.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1011,12 +1011,35 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     // presence to auto-discover shapefile sidecars instead of forcing the user
     // to select every component, and to capture the file's path for restore.
     pickVectorFilesWithSidecars: isTauriRuntime() ? pickVectorFilesWithSidecars : undefined,
-    fetchVectorUrl: isTauriRuntime()
-      ? async (url: string) => {
+    fetchVectorUrl: async (url: string) => {
+      if (isTauriRuntime()) {
+        try {
           const bytes = await fetchUrlBytes(url, { context: "Add Vector Layer" });
-          return new Blob([new Uint8Array(bytes)]);
+          const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+          return new Blob([array as Uint8Array<ArrayBuffer>]);
+        } catch {
+          // The shared native command has a short, tile-oriented timeout.
+          // Preserve the former browser path for large CORS-enabled datasets.
+          try {
+            const response = await fetch(url);
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status} ${response.statusText}`);
+            }
+            return response.blob();
+          } catch {
+            // GitHub's /raw route rejects browser CORS, so fall through to the
+            // same guarded proxy used by the web build.
+          }
         }
-      : undefined,
+      }
+      const proxyUrl = githubRawVectorProxyUrl(url);
+      if (!proxyUrl) return null;
+      const response = await fetch(proxyUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      return response.blob();
+    },
     readLocalVectorFile: readVectorFileWithSidecars,
     exportTextFile: (filename: string, content: string, options?: GeoLibreFileDialogOptions) => {
       const description = options?.description ?? "GeoJSON";
@@ -1284,6 +1307,27 @@ async function fetchArrayBuffer(url: string): Promise<ArrayBuffer> {
 function isTauriRuntime(): boolean {
   if (typeof window === "undefined") return false;
   return Boolean((window as TauriRuntimeWindow).__TAURI_INTERNALS__);
+}
+
+const GITHUB_RAW_VECTOR_PROXY = "https://tiles.geolibre.app/github-raw";
+
+function githubRawVectorProxyUrl(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.hostname !== "github.com" ||
+    !/^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/raw\/.+$/.test(url.pathname)
+  ) {
+    return null;
+  }
+  const proxy = new URL(GITHUB_RAW_VECTOR_PROXY);
+  proxy.searchParams.set("url", url.href);
+  return proxy.href;
 }
 
 function setExternalPluginsLoaded(loaded: boolean): void {

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1011,6 +1011,12 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     // presence to auto-discover shapefile sidecars instead of forcing the user
     // to select every component, and to capture the file's path for restore.
     pickVectorFilesWithSidecars: isTauriRuntime() ? pickVectorFilesWithSidecars : undefined,
+    fetchVectorUrl: isTauriRuntime()
+      ? async (url: string) => {
+          const bytes = await fetchUrlBytes(url, { context: "Add Vector Layer" });
+          return new Blob([new Uint8Array(bytes)]);
+        }
+      : undefined,
     readLocalVectorFile: readVectorFileWithSidecars,
     exportTextFile: (filename: string, content: string, options?: GeoLibreFileDialogOptions) => {
       const description = options?.description ?? "GeoJSON";

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.6",
+        "maplibre-gl-vector": "^0.10.7",
         "openai": "^7.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17561,9 +17561,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.6.tgz",
-      "integrity": "sha512-Zz9l3chCtffwZZj1RIS5c6+qhJoeTAqwD9Y1SiGytc+xNW9hIGotxx7PUC/lkjtvfbMtbZk32DdQ4ArwuQWAOg==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.7.tgz",
+      "integrity": "sha512-5qBVgpk9MBW5TOkgxZbCdiZwEB0oHbe9EnHSSi6BNKZ3Q999T1Jib0NnobOrvpGzRtv7JwwiUlQhAIzuIJdHdA==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -22223,7 +22223,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.6",
+        "maplibre-gl-vector": "^0.10.7",
         "netcdfjs": "^4.0.0",
         "pbf": "^5.1.2",
         "pmtiles": "^4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.5",
+        "maplibre-gl-vector": "^0.10.6",
         "openai": "^7.0.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17561,9 +17561,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.5.tgz",
-      "integrity": "sha512-dowVyifaYkuXGFfKXaQFtnPITwvbXcUrUmdgnIVAPnegTWRDKjmCTMnZQS7jafFTuulN3H3o4nQ7Lk4rz42esw==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.6.tgz",
+      "integrity": "sha512-Zz9l3chCtffwZZj1RIS5c6+qhJoeTAqwD9Y1SiGytc+xNW9hIGotxx7PUC/lkjtvfbMtbZk32DdQ4ArwuQWAOg==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -22223,7 +22223,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.5",
+        "maplibre-gl-vector": "^0.10.6",
         "netcdfjs": "^4.0.0",
         "pbf": "^5.1.2",
         "pmtiles": "^4.4.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.6",
+    "maplibre-gl-vector": "^0.10.7",
     "netcdfjs": "^4.0.0",
     "pbf": "^5.1.2",
     "pmtiles": "^4.4.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.5",
+    "maplibre-gl-vector": "^0.10.6",
     "netcdfjs": "^4.0.0",
     "pbf": "^5.1.2",
     "pmtiles": "^4.4.1",

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -461,7 +461,7 @@ function readEmbeddedVectorGeoJSON(value: unknown): FeatureCollection | null {
 async function ensureVectorControl(app: GeoLibreAppAPI): Promise<VectorControl | null> {
   const VectorControlClass = await getVectorControlClass();
 
-  vectorControl ??= createVectorControl(VectorControlClass);
+  vectorControl ??= createVectorControl(VectorControlClass, app);
 
   if (!vectorControlMounted) {
     const added = app.addMapControl(vectorControl, vectorControlPosition);
@@ -530,7 +530,10 @@ function getVectorControlClass(): Promise<VectorControlConstructor> {
   return vectorControlClassPromise;
 }
 
-function createVectorControl(VectorControlClass: VectorControlConstructor): VectorControl {
+function createVectorControl(
+  VectorControlClass: VectorControlConstructor,
+  app: GeoLibreAppAPI,
+): VectorControl {
   const control = new VectorControlClass({
     className: "geolibre-vector-control",
     collapsed: true,
@@ -545,6 +548,9 @@ function createVectorControl(VectorControlClass: VectorControlConstructor): Vect
     // The panel doubles as the Add Vector Layer dialog, so it stays open
     // until the user closes it; clicking the map must not collapse it.
     closeOnOutsideClick: false,
+    // Desktop routes arbitrary remote datasets through its guarded native
+    // downloader, bypassing WebView CORS. The browser build leaves this unset.
+    ...(app.fetchVectorUrl ? { urlLoader: app.fetchVectorUrl } : {}),
     // Skip the remote spatial-extension install in offline/sandboxed
     // environments when a local extension path is configured.
     spatialExtensionPath: getSpatialExtensionPath(),

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -535,7 +535,7 @@ export interface GeoLibreAppAPI {
    * Desktop-native downloader for Add Vector Layer URL sources. The web app
    * leaves this unset so the control uses ordinary browser networking.
    */
-  fetchVectorUrl?: (url: string) => Promise<Blob>;
+  fetchVectorUrl?: (url: string) => Promise<Blob | null>;
   /**
    * Read a local vector file back into a File (with any shapefile sidecars) from
    * the absolute path persisted on a layer's `sourcePath`, so the Add Vector

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -530,6 +530,12 @@ export interface GeoLibreAppAPI {
    * dialog is cancelled.
    */
   pickVectorFilesWithSidecars?: () => Promise<GeoLibrePickedVectorFile[]>;
+
+  /**
+   * Desktop-native downloader for Add Vector Layer URL sources. The web app
+   * leaves this unset so the control uses ordinary browser networking.
+   */
+  fetchVectorUrl?: (url: string) => Promise<Blob>;
   /**
    * Read a local vector file back into a File (with any shapefile sidecars) from
    * the absolute path persisted on a layer's `sourcePath`, so the Add Vector

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -322,6 +322,7 @@ function isAllowedOamOrigin(origin: string | null): boolean {
   } catch {
     return false;
   }
+  if (protocol === "tauri:" && hostname === "localhost") return true;
   if (protocol === "https:") {
     if (hostname === "geolibre.app" || hostname.endsWith(".geolibre.app")) {
       return true;

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -105,6 +105,13 @@ const SOURCE_COOP_PRODUCTS_PATH =
 // The catalog changes when products are published, so cache briefly at the edge.
 const SOURCE_COOP_CACHE_CONTROL = "public, max-age=300";
 
+// GitHub repository files are served without a usable CORS header on the
+// `github.com/<owner>/<repo>/raw/...` route. This named proxy accepts only that
+// path shape and only from GeoLibre origins, then streams the response without
+// buffering it in Worker memory.
+const GITHUB_RAW_PATH = "/github-raw";
+const GITHUB_RAW_REPOSITORY_PATH = /^\/[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}\/raw\/.+$/;
+
 // A USGS Astrogeology WMS layer to reproject. `map` and `layer` are the only
 // caller-influenced parts of the upstream request, and both come from this
 // allowlist — the Worker never forwards a client-supplied WMS parameter.
@@ -505,6 +512,7 @@ export default {
           `    Datasets: ${Object.keys(WMS_DATASETS).join(", ")}\n` +
           "  OpenAerialMap search: /oam/meta?bbox=...&limit=...\n" +
           "  Source Cooperative metadata: /source-coop/products/... , /source-coop/feed\n" +
+          "  GitHub repository file: /github-raw?url=https://github.com/.../raw/...\n" +
           "  PMTiles range proxy: /pmtiles/<name>.pmtiles (Range header required)\n",
         { status: 200, headers: { "content-type": "text/plain; charset=utf-8" } },
       );
@@ -570,6 +578,49 @@ export default {
     // web build reads it through here (see SOURCE_COOP_PREFIX above).
     if (url.pathname.startsWith(SOURCE_COOP_PREFIX)) {
       return handleSourceCoop(request, url.pathname);
+    }
+
+    if (url.pathname === GITHUB_RAW_PATH) {
+      if (!isAllowedOamOrigin(request.headers.get("origin"))) {
+        return new Response("Forbidden", { status: 403, headers: CORS_HEADERS });
+      }
+      const source = url.searchParams.get("url");
+      let upstream: URL;
+      try {
+        upstream = new URL(source ?? "");
+      } catch {
+        return new Response("Bad Request", { status: 400, headers: CORS_HEADERS });
+      }
+      if (
+        upstream.protocol !== "https:" ||
+        upstream.hostname !== "github.com" ||
+        upstream.search !== "" ||
+        !GITHUB_RAW_REPOSITORY_PATH.test(upstream.pathname)
+      ) {
+        return new Response("Bad Request", { status: 400, headers: CORS_HEADERS });
+      }
+      let originResponse: Response;
+      try {
+        const parts = upstream.pathname.split("/").filter(Boolean);
+        const rawUrl = new URL(
+          `https://raw.githubusercontent.com/${parts[0]}/${parts[1]}/${parts.slice(3).join("/")}`,
+        );
+        originResponse = await fetch(rawUrl.toString(), {
+          headers: { accept: "application/octet-stream" },
+        });
+      } catch {
+        return new Response("Bad Gateway", { status: 502, headers: CORS_HEADERS });
+      }
+      const headers = new Headers(CORS_HEADERS);
+      for (const key of ["content-type", "content-length", "content-disposition", "etag"]) {
+        const value = originResponse.headers.get(key);
+        if (value) headers.set(key, value);
+      }
+      headers.set("cache-control", originResponse.ok ? "public, max-age=300" : "no-store");
+      return new Response(originResponse.body, {
+        status: originResponse.status,
+        headers,
+      });
     }
 
     const pmtilesMatch = PMTILES_PATH.exec(url.pathname);


### PR DESCRIPTION
## Summary

- route GitHub repository file URLs through an origin-gated, GitHub-only streaming proxy in the web build
- route Add Vector Layer downloads through guarded native HTTP in GeoLibre Desktop, with browser fallback for slow CORS-enabled datasets
- preserve direct browser loading for non-GitHub URLs
- update maplibre-gl-vector to 0.10.7 for optional host-provided URL loading

## Verification

- loaded the issue sample KMZ from its GitHub URL and confirmed all 4 features in the web build
- verified the layer in light and dark themes with Playwright
- verified the deployed proxy returns byte-identical KMZ data
- `npm run build`
- `npm run test:frontend`
- `npm run lint`
- `npm run typecheck -w geolibre-tiles-worker`
- changed-file pre-commit checks

Upstream: opengeos/maplibre-gl-vector#55 and opengeos/maplibre-gl-vector#57
Release: https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.10.7

Fixes #1592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop users can load remote vector datasets more reliably through native network handling.
  * Added secure retrieval for approved GitHub-hosted vector resources.
  * Added a documented GitHub raw-file proxy with CORS and caching support.

* **Bug Fixes**
  * Improved fallback behavior when native or browser-based downloads are unavailable.
  * Invalid, unauthorized, or failed remote requests now return clear error responses.
  * Added support for Tauri localhost origins when accessing remote vector resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->