### PR TITLE
test(import): fix stale QGIS nested group name expectation

### DIFF
--- a/tests/qgis-project-import.test.ts
+++ b/tests/qgis-project-import.test.ts
@@ -292,7 +292,7 @@ describe("QGIS project import", () => {
       result.project.layerGroups?.map((group) => [group.name, group.visible]),
       [
         ["Transport", false],
-        ["Transport / Places", false],
+        ["Places", false],
       ],
     );
     const rendered = applyGroupEffects(result.project.layers, result.project.layerGroups ?? []);


### PR DESCRIPTION
## Problem

`main` is red: [CI run 30669858506](https://github.com/opengeos/GeoLibre/actions/runs/30669858506/job/91285127617) fails on one test —
`QGIS project import > inherits visibility from unchecked parent groups`:

```
+ actual - expected
    [ 'Transport', false ],
+   [ 'Places', false ]
-   [ 'Transport / Places', false ]
```

## Cause

A merge race between two PRs:

- #1593 (nested layer groups, cddff5b3) changed `groupDisplayName` in `apps/geolibre-desktop/src/lib/qgis-project-import.ts` so nested QGIS groups keep their own name (`Places`) and record a `parentId`, instead of the old flattened `Transport / Places`. It updated the existing assertions.
- #1584 (bd2883e2) branched before that and merged after, adding a new visibility-inheritance test that still asserted the flattened name.

Each PR was green on its own base; the combination is not.

## Fix

Update the stale expectation to the nested naming. The importer behavior — both the nested names from #1593 and the parent-visibility inheritance from #1584 — is correct and unchanged.

## Verification

- `node --import tsx --test tests/qgis-project-import.test.ts` — 13/13 pass
- `npm run test:frontend` — 4571 pass, 0 fail
- `pre-commit run --files tests/qgis-project-import.test.ts` — passed (includes the npm build hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated project import coverage to reflect the expected separate display of the “Places” nested group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->