### PR TITLE
feat(python): add leafmap-parity data and layer helpers

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -28,7 +28,8 @@ conda install -c conda-forge geolibre
 
 Optional extras for `add_geojson()` from a GeoDataFrame and for reading **local**
 vector files with `add_vector()` / `add_geoparquet()` / `add_flatgeobuf()` /
-`add_shp()` (remote URLs for those formats need no extras):
+`add_shp()` / `add_kml()` / `add_gpkg()` (remote URLs for those formats need no
+extras):
 
 ```bash
 pip install "geolibre[all]"   # adds GeoPandas and Shapely
@@ -286,13 +287,14 @@ UI edits flow back the same way.
 
 !!! warning "URL fetching"
 
-    `add_geojson(url)` fetches the URL from the **kernel**, following redirects,
-    so a notebook can reach any host the kernel can (including private and
-    link-local addresses such as cloud metadata endpoints). This is intended for
-    single-user local notebooks, where you already control the kernel. Private
-    and localhost URLs are intentionally allowed so you can load from a local
-    tile server. Do not load untrusted `.geolibre.json` projects or URLs on a
-    shared/multi-tenant kernel.
+    `add_geojson(url)`, `add_csv(url)` / `add_xy_data(url)`, and `add_wfs()`
+    fetch the URL from the **kernel**, following redirects, so a notebook can
+    reach any host the kernel can. Every hop is checked, and a URL that resolves
+    to a non-public address (private, loopback, or link-local — including cloud
+    metadata endpoints such as `169.254.169.254`) is refused; responses are
+    capped at 50 MB. Tile and service layers are fetched by the **browser**
+    instead, so those can still point at a local server. Do not load untrusted
+    `.geolibre.json` projects or URLs on a shared/multi-tenant kernel.
 
 ## Building from source
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -73,6 +73,8 @@ Add markers and data-driven symbology without precomputing styles:
 ```python
 m.add_marker(-122.4, 37.8, properties={"name": "San Francisco"})
 m.add_marker_cluster([(-122.4, 37.8), (-122.3, 37.9), (-122.5, 37.7)])
+m.add_heatmap([(-122.4, 37.8), (-122.3, 37.9)], radius=35)
+m.add_csv("cities.csv", x="longitude", y="latitude", name="Cities")
 m.add_choropleth(
     "https://example.com/counties.geojson",
     column="population",
@@ -185,11 +187,14 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `get_view()` / `get_center()` / `get_bounds()` | Read the live camera / center / viewport bounds. |
 | `fly_to(lng, lat, zoom=, bearing=, pitch=, duration=)` | Animate the camera. |
 | `fit_bounds([w, s, e, n])` | Fit the camera to a bounding box. |
+| `zoom_to_bounds([w, s, e, n])` / `zoom_to_layer(layer)` | Leafmap-style view helpers; layers may be addressed by id, name, or handle. |
 | `identify(lng, lat, layer_id=None)` | Query rendered features at a point. |
 | `get_features(layer_id)` | A layer's features as `Feature` objects. |
 | `get_selected_features(as_gdf=False)` | The feature(s) selected in the app, as `Feature` objects (or a GeoDataFrame). |
 | `get_drawn_features(as_gdf=False)` / `user_rois` | Features drawn with the Geo Editor; `user_rois` returns them as a FeatureCollection. |
 | `layers` / `get_layer(id)` | `Layer` handles (read state; set `name`/`visible`/`opacity`, `set_style`, `get_features`, `zoom_to`, `remove`). |
+| `layer_names` / `find_layer(name)` / `find_layer_index(name)` | Inspect layers by display name. |
+| `set_layer_visibility(layer, visible)` / `set_layer_opacity(layer, opacity)` | Change a layer by id, name, or handle. |
 | `list_algorithms()` | Available processing algorithms (`id`, `parameters`, …). |
 | `run_algorithm(id, parameters=None, timeout=)` | Run an algorithm; returns `{logs, resultLayerIds}`. |
 | `to_image(path=None, timeout=)` | Capture the map as PNG bytes, or write to `path`. |
@@ -203,16 +208,20 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | --- | --- |
 | `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. |
 | `add_geojson(data, name=, **style)` | Add GeoJSON from a dict, file path, URL, JSON string, or GeoDataFrame. |
+| `add_gdf(gdf, name=, column=None, **style)` | Add a GeoDataFrame, optionally as a choropleth. |
+| `add_csv(data, x="longitude", y="latitude", name=, **style)` / `add_xy_data(...)` | Add points from a CSV path, URL, text, DataFrame, or row mappings. |
 | `add_marker(lng, lat, name=, properties=, **style)` | Add a single point marker (shown as a circle; `properties` appear on click). |
 | `add_markers(points, name=, **style)` | Add point markers from `(lng, lat)` pairs, `{lng/lon/x, lat/y, …}` dicts, GeoJSON, or a GeoDataFrame. |
 | `add_circle_markers(points, name=, radius=, **style)` | Add circle markers with an explicit `radius`. |
 | `add_marker_cluster(points, name=, cluster_radius=, cluster_max_zoom=, **style)` | Add clustered point markers. |
+| `add_heatmap(points, name=, radius=, intensity=, **style)` | Add point data using the density heatmap renderer. |
 | `add_choropleth(data, column, name=, class_count=, colormap=, scheme=, **style)` | Add a GeoJSON layer with graduated symbology computed from a numeric `column`. |
 | `add_data(data, column=None, name=, **kwargs)` | Add data; a choropleth when `column` is given, else a plain GeoJSON layer (leafmap parity). |
 | `add_vector(data, name=, render_mode=, data_format=, source_layer=, **style)` | Add a vector dataset from a URL (GeoParquet, FlatGeobuf, zipped Shapefile, GeoJSON, …) or a local file (read via GeoPandas and inlined). |
 | `add_geoparquet(data, name=, **style)` | Add a GeoParquet dataset (URL or local file). |
 | `add_flatgeobuf(data, name=, **style)` | Add a FlatGeobuf dataset (URL or local file). |
 | `add_shp(data, name=, **style)` | Add a Shapefile (zipped URL or local `.shp`). |
+| `add_kml(data, name=, **style)` / `add_gpkg(data, name=, layer=None, **style)` | Add KML/KMZ or GeoPackage data. |
 | `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add a vector tile layer from a TileJSON endpoint. |
 | `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |

--- a/python/README.md
+++ b/python/README.md
@@ -104,8 +104,8 @@ m.to_project()["mapView"]["center"]
   use that same remote path; `Map(server_proxy=False)` forces the direct path.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)` and for reading **local** vector files
-  (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`), which the kernel
-  reads and inlines as GeoJSON. Remote URLs for the same formats stream through
+  (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`/`add_kml`/`add_gpkg`),
+  which the kernel reads and inlines as GeoJSON. Remote URLs for the same formats stream through
   the in-browser vector control and need no extras.
 - `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large
   dataset is held in memory and re-synced on every project update. For very large

--- a/python/README.md
+++ b/python/README.md
@@ -66,8 +66,11 @@ m.to_project()["mapView"]["center"]
 | --- | --- |
 | `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. `layout` is `"embed"`, `"full"`, or `"maponly"`. |
 | `add_geojson(data, name=, **style)` | Add GeoJSON (dict, path, URL, JSON, or GeoDataFrame). |
+| `add_gdf(gdf, name=, column=None, **style)` | Add a GeoDataFrame, optionally as a choropleth. |
+| `add_csv` / `add_xy_data` `(data, x=, y=, name=, **style)` | Add points from CSV, a DataFrame, or row mappings. |
+| `add_heatmap(points, name=, radius=, intensity=, **style)` | Add a point density heatmap. |
 | `add_vector(data, name=, render_mode=, data_format=, source_layer=, **style)` | Add a vector dataset from a URL (GeoParquet, FlatGeobuf, zipped Shapefile, GeoJSON) or a local file (read via GeoPandas, inlined). |
-| `add_geoparquet` / `add_flatgeobuf` / `add_shp` `(data, name=, **style)` | Format-specific wrappers over `add_vector`. |
+| `add_geoparquet` / `add_flatgeobuf` / `add_shp` / `add_kml` / `add_gpkg` | Format-specific wrappers over `add_vector`. |
 | `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add vector tiles from a TileJSON endpoint. |
 | `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
@@ -81,6 +84,8 @@ m.to_project()["mapView"]["center"]
 | `add_basemap(basemap)` | Set the background basemap. |
 | `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
 | `set_center_zoom(lng, lat, zoom=None)` | Alias of `set_center` (leafmap compatibility). |
+| `zoom_to_bounds(bounds)` / `zoom_to_layer(layer)` | Fit the view to bounds or a layer id/name/handle. |
+| `layer_names` / `find_layer(name)` / `set_layer_visibility` / `set_layer_opacity` | Inspect and update layers conveniently. |
 | `remove_layer(layer_id)` / `clear_layers()` | Remove layers. |
 | `to_project()` / `load_project(src)` / `save_project(path)` | Project I/O. |
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import base64
 import copy
+import csv
 import html as _html
+import io
 import json
 import math
 import os
 import pathlib
 import re
 import time
+import urllib.request
 import uuid
 import warnings
 from typing import Any, Callable
@@ -40,7 +43,11 @@ _VALID_ORIENTATIONS = frozenset({"vertical", "horizontal"})
 _VALID_LEGEND_SHAPES = frozenset({"square", "circle", "line"})
 
 
-def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, Any]:
+def _read_local_vector(
+    path: Any,
+    data_format: str | None = None,
+    source_layer: str | None = None,
+) -> dict[str, Any]:
     """Read a local vector file into a GeoJSON FeatureCollection via GeoPandas.
 
     The browser cannot read a file that lives on the kernel host, so a local
@@ -54,6 +61,8 @@ def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, A
         data_format: Optional format hint (e.g. ``"parquet"``) that overrides
             filename-suffix detection, so a GeoParquet file saved under a
             non-standard name still uses the dedicated Parquet reader.
+        source_layer: Optional layer/table name for a multi-layer container such
+            as a GeoPackage.
 
     Returns:
         A GeoJSON FeatureCollection dict in EPSG:4326.
@@ -82,7 +91,7 @@ def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, A
     if is_parquet:
         gdf = geopandas.read_parquet(file_path)
     else:
-        gdf = geopandas.read_file(file_path)
+        gdf = geopandas.read_file(file_path, **({"layer": source_layer} if source_layer else {}))
     if gdf.crs is not None:
         gdf = gdf.to_crs(epsg=4326)
     # Round-trip through GeoPandas' own GeoJSON writer so numpy/datetime property
@@ -557,7 +566,27 @@ class Map(anywidget.AnyWidget):
         timeout: float = 10.0,
     ) -> None:
         """Fit the camera to ``[west, south, east, north]``."""
-        self.request("fitBounds", {"bounds": [float(b) for b in bounds]}, timeout=timeout)
+        values = [float(b) for b in bounds]
+        if len(values) != 4:
+            raise ValueError("bounds must contain [west, south, east, north]")
+        west, south, east, north = values
+        if west > east or south > north:
+            raise ValueError("bounds must satisfy west <= east and south <= north")
+        self.request("fitBounds", {"bounds": values}, timeout=timeout)
+
+    def zoom_to_bounds(
+        self,
+        bounds: list[float] | tuple[float, float, float, float],
+        *,
+        timeout: float = 10.0,
+    ) -> None:
+        """Fit the map to bounds (leafmap-style alias of :meth:`fit_bounds`)."""
+        self.fit_bounds(bounds, timeout=timeout)
+
+    def zoom_to_layer(self, layer: str | Layer, *, timeout: float = 10.0) -> None:
+        """Fit the map to a layer, addressed by id, name, or layer handle."""
+        resolved = self._resolve_layer(layer)
+        self.request("zoomToLayer", {"layerId": resolved.id}, timeout=timeout)
 
     def identify(
         self,
@@ -837,6 +866,11 @@ class Map(anywidget.AnyWidget):
             if isinstance(layer, dict) and "id" in layer
         ]
 
+    @property
+    def layer_names(self) -> list[str]:
+        """Return layer display names in map order."""
+        return [str(layer.name) for layer in self.layers]
+
     def get_layer(self, layer_id: str) -> Layer:
         """Return a :class:`Layer` handle for ``layer_id``.
 
@@ -847,6 +881,38 @@ class Map(anywidget.AnyWidget):
             if isinstance(layer, dict) and layer.get("id") == layer_id:
                 return Layer(self, layer_id)
         raise ValueError(f"No layer with id {layer_id!r}")
+
+    def find_layer(self, name: str) -> Layer | None:
+        """Return the first layer named ``name``, or ``None`` when absent."""
+        return next((layer for layer in self.layers if layer.name == name), None)
+
+    def find_layer_index(self, name: str) -> int:
+        """Return the index of the first layer named ``name``, or ``-1``."""
+        return next((i for i, layer in enumerate(self.layers) if layer.name == name), -1)
+
+    def _resolve_layer(self, layer: str | Layer) -> Layer:
+        """Resolve a layer handle, id, or display name to a live layer."""
+        if isinstance(layer, Layer):
+            if layer._map is not self:
+                raise ValueError("Layer belongs to a different map")
+            # Access verifies that a stale handle has not been removed.
+            layer._layer()
+            return layer
+        try:
+            return self.get_layer(str(layer))
+        except ValueError:
+            match = self.find_layer(str(layer))
+            if match is not None:
+                return match
+        raise ValueError(f"No layer with id or name {layer!r}")
+
+    def set_layer_visibility(self, layer: str | Layer, visible: bool = True) -> None:
+        """Show or hide a layer addressed by id, name, or layer handle."""
+        self._resolve_layer(layer).visible = visible
+
+    def set_layer_opacity(self, layer: str | Layer, opacity: float) -> None:
+        """Set a layer's opacity in ``[0, 1]``."""
+        self._resolve_layer(layer).opacity = opacity
 
     def _mutate_layer(self, layer_id: str, mutate: Callable[[dict[str, Any]], None]) -> None:
         """Apply an in-place mutation to one layer through the project trait."""
@@ -886,6 +952,40 @@ class Map(anywidget.AnyWidget):
         )
         fc = _project.load_featurecollection(data)
         return self._add_layer(_project.geojson_layer(name, fc, source_url=source_url, **style))
+
+    def add_gdf(
+        self,
+        gdf: Any,
+        name: str = "GeoDataFrame",
+        *,
+        column: str | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a GeoDataFrame, optionally styled by a numeric column."""
+        if not hasattr(gdf, "__geo_interface__"):
+            raise TypeError("gdf must provide a __geo_interface__")
+        return self.add_data(gdf, column=column, name=name, **style)
+
+    def add_kml(self, data: Any, name: str = "KML", **style: Any) -> str:
+        """Add a local or remote KML/KMZ dataset."""
+        return self.add_vector(data, name=name, data_format="kml", **style)
+
+    def add_gpkg(
+        self,
+        data: Any,
+        name: str = "GeoPackage",
+        *,
+        layer: str | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a local or remote GeoPackage, optionally selecting a table."""
+        return self.add_vector(
+            data,
+            name=name,
+            data_format="gpkg",
+            source_layer=layer,
+            **style,
+        )
 
     # -- markers ---------------------------------------------------------
 
@@ -1071,6 +1171,79 @@ class Map(anywidget.AnyWidget):
         style.setdefault("clusterRadius", int(cluster_radius))
         style.setdefault("clusterMaxZoom", int(cluster_max_zoom))
         return self.add_markers(points, name=name, **style)
+
+    def add_heatmap(
+        self,
+        points: Any,
+        name: str = "Heatmap",
+        *,
+        radius: float = 30,
+        intensity: float = 1,
+        **style: Any,
+    ) -> str:
+        """Add point data using GeoLibre's density heatmap renderer."""
+        if float(radius) <= 0:
+            raise ValueError("radius must be greater than zero")
+        if float(intensity) < 0:
+            raise ValueError("intensity must be non-negative")
+        style.setdefault("pointRenderer", "heatmap")
+        style.setdefault("heatmapRadius", float(radius))
+        style.setdefault("heatmapIntensity", float(intensity))
+        return self.add_markers(points, name=name, **style)
+
+    @staticmethod
+    def _tabular_records(data: Any) -> list[dict[str, Any]]:
+        """Convert a DataFrame, CSV path/URL/text, or row iterable to records."""
+        if hasattr(data, "to_dict"):
+            try:
+                records = data.to_dict(orient="records")
+            except TypeError:
+                records = data.to_dict("records")
+            if isinstance(records, list):
+                return [dict(row) for row in records]
+        if isinstance(data, (str, os.PathLike)):
+            source = str(data)
+            if source.startswith(("http://", "https://")):
+                with urllib.request.urlopen(source, timeout=30) as response:  # noqa: S310
+                    text = response.read().decode("utf-8-sig")
+            else:
+                path = pathlib.Path(source).expanduser()
+                text = path.read_text(encoding="utf-8-sig") if path.exists() else source
+            return [dict(row) for row in csv.DictReader(io.StringIO(text))]
+        return [dict(row) for row in data]
+
+    def add_xy_data(
+        self,
+        data: Any,
+        x: str = "longitude",
+        y: str = "latitude",
+        name: str = "XY Data",
+        **style: Any,
+    ) -> str:
+        """Add points from a DataFrame, CSV path/URL/text, or row mappings."""
+        records = self._tabular_records(data)
+        points: list[dict[str, Any]] = []
+        for index, row in enumerate(records, start=1):
+            if x not in row or y not in row:
+                raise ValueError(f"Row {index} is missing coordinate columns {x!r} and/or {y!r}")
+            point = {key: value for key, value in row.items() if key not in (x, y)}
+            try:
+                point.update(lng=float(row[x]), lat=float(row[y]))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Row {index} has invalid coordinates") from exc
+            points.append(point)
+        return self.add_markers(points, name=name, **style)
+
+    def add_csv(
+        self,
+        data: Any,
+        x: str = "longitude",
+        y: str = "latitude",
+        name: str = "CSV",
+        **style: Any,
+    ) -> str:
+        """Add a CSV containing longitude and latitude columns."""
+        return self.add_xy_data(data, x=x, y=y, name=name, **style)
 
     # -- choropleth ------------------------------------------------------
 
@@ -1492,17 +1665,16 @@ class Map(anywidget.AnyWidget):
                     stacklevel=2,
                 )
             return self.add_geojson(data, name=name, **style)
-        # A local file is read and inlined as GeoJSON; render_mode and
-        # source_layer only apply to the in-browser vector control (remote URLs),
-        # so flag them as no-ops here rather than dropping them silently.
-        if render_mode != "geojson" or source_layer is not None:
+        # A local file is read and inlined as GeoJSON. Tile rendering is a
+        # browser-only option, while source_layer is forwarded to GeoPandas for
+        # multi-layer containers such as GeoPackage.
+        if render_mode != "geojson":
             warnings.warn(
-                "render_mode and source_layer are ignored for local files; they "
-                "only apply to remote URLs handled by the in-browser vector "
-                "control.",
+                "render_mode is ignored for local files; it only applies to "
+                "remote URLs handled by the in-browser vector control.",
                 stacklevel=2,
             )
-        fc = _read_local_vector(data, data_format=data_format)
+        fc = _read_local_vector(data, data_format=data_format, source_layer=source_layer)
         return self._add_layer(_project.geojson_layer(name, fc, **style))
 
     def add_geoparquet(self, data: Any, name: str = "GeoParquet", **style: Any) -> str:
@@ -2200,7 +2372,10 @@ class Layer:
 
     @opacity.setter
     def opacity(self, value: float) -> None:
-        self._map._mutate_layer(self._id, lambda layer: layer.update(opacity=float(value)))
+        opacity = float(value)
+        if not math.isfinite(opacity) or not 0 <= opacity <= 1:
+            raise ValueError("opacity must be a finite number between 0 and 1")
+        self._map._mutate_layer(self._id, lambda layer: layer.update(opacity=opacity))
 
     @property
     def style(self) -> dict[str, Any]:
@@ -2221,7 +2396,7 @@ class Layer:
 
     def zoom_to(self, *, timeout: float = 10.0) -> None:
         """Fit the map camera to this layer's extent."""
-        self._map.request("zoomToLayer", {"layerId": self._id}, timeout=timeout)
+        self._map.zoom_to_layer(self, timeout=timeout)
 
     def remove(self) -> None:
         """Remove this layer from the map."""

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -13,10 +13,10 @@ import os
 import pathlib
 import re
 import time
-import urllib.request
 import uuid
 import warnings
 from typing import Any, Callable
+from urllib.error import URLError
 
 import anywidget
 import traitlets
@@ -41,6 +41,15 @@ _VALID_THEMES = frozenset({"light", "dark"})
 _VALID_CONTROL_POSITIONS = _project.CONTROL_POSITIONS
 _VALID_ORIENTATIONS = frozenset({"vertical", "horizontal"})
 _VALID_LEGEND_SHAPES = frozenset({"square", "circle", "line"})
+
+# CSV/tabular input is inlined into the project exactly like GeoJSON is, so the
+# same 50 MB ceiling applies to a fetched response or a local file.
+_MAX_TABULAR_BYTES = _project._MAX_GEOJSON_BYTES
+
+# Column name for CSV fields beyond the header row. csv.DictReader's default
+# restkey is ``None``, which would put a non-string key in the feature
+# properties and break JSON serialization on the way to the widget.
+_CSV_RESTKEY = "_extra"
 
 
 def _read_local_vector(
@@ -89,6 +98,13 @@ def _read_local_vector(
         file_path.suffix.lower() in (".parquet", ".geoparquet", ".pq")
     )
     if is_parquet:
+        # read_parquet has no layer concept, so a source_layer here is a no-op.
+        if source_layer is not None:
+            warnings.warn(
+                "source_layer is ignored for (Geo)Parquet files; it only applies "
+                "to multi-layer containers such as GeoPackage.",
+                stacklevel=2,
+            )
         gdf = geopandas.read_parquet(file_path)
     else:
         gdf = geopandas.read_file(file_path, **({"layer": source_layer} if source_layer else {}))
@@ -569,6 +585,8 @@ class Map(anywidget.AnyWidget):
         values = [float(b) for b in bounds]
         if len(values) != 4:
             raise ValueError("bounds must contain [west, south, east, north]")
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("bounds must contain finite numbers")
         west, south, east, north = values
         if west > east or south > north:
             raise ValueError("bounds must satisfy west <= east and south <= north")
@@ -1182,10 +1200,12 @@ class Map(anywidget.AnyWidget):
         **style: Any,
     ) -> str:
         """Add point data using GeoLibre's density heatmap renderer."""
-        if float(radius) <= 0:
-            raise ValueError("radius must be greater than zero")
-        if float(intensity) < 0:
-            raise ValueError("intensity must be non-negative")
+        # NaN and infinity slip past the comparisons below, so check finiteness
+        # first rather than storing an unusable renderer setting.
+        if not math.isfinite(float(radius)) or float(radius) <= 0:
+            raise ValueError("radius must be a finite number greater than zero")
+        if not math.isfinite(float(intensity)) or float(intensity) < 0:
+            raise ValueError("intensity must be a finite non-negative number")
         style.setdefault("pointRenderer", "heatmap")
         style.setdefault("heatmapRadius", float(radius))
         style.setdefault("heatmapIntensity", float(intensity))
@@ -1204,12 +1224,31 @@ class Map(anywidget.AnyWidget):
         if isinstance(data, (str, os.PathLike)):
             source = str(data)
             if source.startswith(("http://", "https://")):
-                with urllib.request.urlopen(source, timeout=30) as response:  # noqa: S310
-                    text = response.read().decode("utf-8-sig")
+                # Same defences as the remote GeoJSON fetch in project.py: reject
+                # non-public hosts up front, re-check every redirect hop through
+                # the shared opener, and bound the response. read(limit + 1)
+                # detects an over-limit body without buffering the whole thing.
+                _project._assert_public_url(source)
+                try:
+                    with _project._GEOJSON_OPENER.open(  # noqa: S310 - user URL
+                        source, timeout=30
+                    ) as response:
+                        raw = response.read(_MAX_TABULAR_BYTES + 1)
+                except (URLError, TimeoutError) as exc:
+                    raise ValueError(f"Could not load CSV from URL: {source}") from exc
+                if len(raw) > _MAX_TABULAR_BYTES:
+                    raise ValueError("CSV response exceeds the 50 MB size limit")
+                text = raw.decode("utf-8-sig")
             else:
                 path = pathlib.Path(source).expanduser()
-                text = path.read_text(encoding="utf-8-sig") if path.exists() else source
-            return [dict(row) for row in csv.DictReader(io.StringIO(text))]
+                if path.exists():
+                    if path.stat().st_size > _MAX_TABULAR_BYTES:
+                        raise ValueError(f"CSV file exceeds the 50 MB size limit: {source}")
+                    text = path.read_text(encoding="utf-8-sig")
+                else:
+                    text = source
+            reader = csv.DictReader(io.StringIO(text), restkey=_CSV_RESTKEY)
+            return [dict(row) for row in reader]
         return [dict(row) for row in data]
 
     def add_xy_data(
@@ -1228,9 +1267,14 @@ class Map(anywidget.AnyWidget):
                 raise ValueError(f"Row {index} is missing coordinate columns {x!r} and/or {y!r}")
             point = {key: value for key, value in row.items() if key not in (x, y)}
             try:
-                point.update(lng=float(row[x]), lat=float(row[y]))
+                lng, lat = float(row[x]), float(row[y])
             except (TypeError, ValueError) as exc:
                 raise ValueError(f"Row {index} has invalid coordinates") from exc
+            # float() happily parses "nan"/"inf", which would produce a feature
+            # with coordinates no renderer can place.
+            if not math.isfinite(lng) or not math.isfinite(lat):
+                raise ValueError(f"Row {index} has invalid coordinates")
+            point.update(lng=lng, lat=lat)
             points.append(point)
         return self.add_markers(points, name=name, **style)
 

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+import types
+
 import pytest
 
 import geolibre.geolibre as gmod
@@ -192,6 +195,21 @@ def test_add_gpkg_forwards_local_source_layer(monkeypatch, m):
     }
 
 
+def test_read_local_vector_warns_on_parquet_source_layer(monkeypatch, tmp_path):
+    class _FakeGdf:
+        crs = None
+
+        def to_json(self):
+            return '{"type": "FeatureCollection", "features": []}'
+
+    path = tmp_path / "data.parquet"
+    path.write_bytes(b"")
+    fake_geopandas = types.SimpleNamespace(read_parquet=lambda _p: _FakeGdf())
+    monkeypatch.setitem(sys.modules, "geopandas", fake_geopandas)
+    with pytest.warns(UserWarning, match="source_layer is ignored"):
+        gmod._read_local_vector(path, source_layer="roads")
+
+
 def test_add_vector_geo_interface_inlined(m):
     class Fake:
         __geo_interface__ = {"type": "FeatureCollection", "features": []}
@@ -324,6 +342,12 @@ def test_add_heatmap_validates_parameters(m):
         m.add_heatmap([(0, 0)], radius=0)
     with pytest.raises(ValueError, match="intensity"):
         m.add_heatmap([(0, 0)], intensity=-1)
+    with pytest.raises(ValueError, match="radius"):
+        m.add_heatmap([(0, 0)], radius=float("nan"))
+    with pytest.raises(ValueError, match="radius"):
+        m.add_heatmap([(0, 0)], radius=float("inf"))
+    with pytest.raises(ValueError, match="intensity"):
+        m.add_heatmap([(0, 0)], intensity=float("nan"))
 
 
 def test_add_xy_data_from_records(m):
@@ -348,6 +372,29 @@ def test_add_xy_data_rejects_missing_or_invalid_coordinates(m):
         m.add_xy_data([{"longitude": 1}])
     with pytest.raises(ValueError, match="invalid coordinates"):
         m.add_xy_data([{"longitude": "nope", "latitude": 1}])
+    with pytest.raises(ValueError, match="invalid coordinates"):
+        m.add_xy_data([{"longitude": "nan", "latitude": 1}])
+    with pytest.raises(ValueError, match="invalid coordinates"):
+        m.add_xy_data([{"longitude": 1, "latitude": float("inf")}])
+
+
+def test_add_csv_keeps_extra_fields_under_a_string_key(m):
+    m.add_csv("longitude,latitude\n-100,40,spill\n")
+    properties = _last_layer(m)["geojson"]["features"][0]["properties"]
+    assert properties == {gmod._CSV_RESTKEY: ["spill"]}
+
+
+def test_add_csv_rejects_non_public_url(m):
+    with pytest.raises(ValueError, match="non-public address"):
+        m.add_csv("http://127.0.0.1/points.csv")
+
+
+def test_add_csv_rejects_oversized_file(monkeypatch, tmp_path, m):
+    path = tmp_path / "points.csv"
+    path.write_text("longitude,latitude\n-100,40\n", encoding="utf-8")
+    monkeypatch.setattr(gmod, "_MAX_TABULAR_BYTES", 4)
+    with pytest.raises(ValueError, match="size limit"):
+        m.add_csv(str(path))
 
 
 def test_add_gdf_requires_geo_interface(m):

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -91,6 +91,15 @@ def test_add_flatgeobuf_sets_format(m):
     assert _last_layer(m)["metadata"]["vectorState"]["format"] == "flatgeobuf"
 
 
+def test_format_convenience_methods(m):
+    m.add_kml("https://e/data.kml")
+    assert _last_layer(m)["metadata"]["vectorState"]["format"] == "kml"
+    m.add_gpkg("https://e/data.gpkg", layer="roads")
+    layer = _last_layer(m)
+    assert layer["metadata"]["vectorState"]["format"] == "gpkg"
+    assert layer["metadata"]["vectorState"]["sourceLayer"] == "roads"
+
+
 def test_add_vector_tiles(m):
     m.add_vector_tiles("https://e/tiles.json", source_layer="x")
     layer = _last_layer(m)
@@ -142,9 +151,10 @@ def test_add_vector_local_file_inlined(monkeypatch, m):
     fake_fc = {"type": "FeatureCollection", "features": []}
     captured = {}
 
-    def fake_read(path, data_format=None):
+    def fake_read(path, data_format=None, source_layer=None):
         captured["path"] = path
         captured["data_format"] = data_format
+        captured["source_layer"] = source_layer
         return fake_fc
 
     monkeypatch.setattr(gmod, "_read_local_vector", fake_read)
@@ -156,10 +166,30 @@ def test_add_vector_local_file_inlined(monkeypatch, m):
     assert captured["data_format"] == "parquet"
 
 
-def test_add_vector_local_file_warns_on_ignored_kwargs(monkeypatch, m):
-    monkeypatch.setattr(gmod, "_read_local_vector", lambda _p, data_format=None: {"type": "x"})
+def test_add_vector_local_file_warns_on_ignored_render_mode(monkeypatch, m):
+    monkeypatch.setattr(
+        gmod,
+        "_read_local_vector",
+        lambda _p, data_format=None, source_layer=None: {"type": "x"},
+    )
     with pytest.warns(UserWarning, match="ignored for local files"):
-        m.add_vector("/data/parcels.shp", source_layer="layer0")
+        m.add_vector("/data/parcels.shp", render_mode="tiles")
+
+
+def test_add_gpkg_forwards_local_source_layer(monkeypatch, m):
+    captured = {}
+
+    def fake_read(path, data_format=None, source_layer=None):
+        captured.update(path=path, data_format=data_format, source_layer=source_layer)
+        return {"type": "FeatureCollection", "features": []}
+
+    monkeypatch.setattr(gmod, "_read_local_vector", fake_read)
+    m.add_gpkg("/data/maps.gpkg", layer="roads")
+    assert captured == {
+        "path": "/data/maps.gpkg",
+        "data_format": "gpkg",
+        "source_layer": "roads",
+    }
 
 
 def test_add_vector_geo_interface_inlined(m):
@@ -278,7 +308,51 @@ def test_add_markers_from_geojson(m):
 
 def test_add_circle_markers_sets_radius(m):
     m.add_circle_markers([(0, 0)], radius=12)
-    assert _last_layer(m)["style"]["circleRadius"] == 12.0
+    assert _last_layer(m)["style"]["circleRadius"] == 12
+
+
+def test_add_heatmap_sets_renderer(m):
+    m.add_heatmap([(0, 0), (1, 1)], radius=42, intensity=1.5)
+    style = _last_layer(m)["style"]
+    assert style["pointRenderer"] == "heatmap"
+    assert style["heatmapRadius"] == 42
+    assert style["heatmapIntensity"] == 1.5
+
+
+def test_add_heatmap_validates_parameters(m):
+    with pytest.raises(ValueError, match="radius"):
+        m.add_heatmap([(0, 0)], radius=0)
+    with pytest.raises(ValueError, match="intensity"):
+        m.add_heatmap([(0, 0)], intensity=-1)
+
+
+def test_add_xy_data_from_records(m):
+    m.add_xy_data(
+        [{"lon": "-100", "lat": "40", "city": "A"}],
+        x="lon",
+        y="lat",
+    )
+    feature = _last_layer(m)["geojson"]["features"][0]
+    assert feature["geometry"]["coordinates"] == [-100.0, 40.0]
+    assert feature["properties"] == {"city": "A"}
+
+
+def test_add_csv_from_text(m):
+    m.add_csv("longitude,latitude,name\n-100,40,A\n")
+    feature = _last_layer(m)["geojson"]["features"][0]
+    assert feature["properties"]["name"] == "A"
+
+
+def test_add_xy_data_rejects_missing_or_invalid_coordinates(m):
+    with pytest.raises(ValueError, match="missing coordinate"):
+        m.add_xy_data([{"longitude": 1}])
+    with pytest.raises(ValueError, match="invalid coordinates"):
+        m.add_xy_data([{"longitude": "nope", "latitude": 1}])
+
+
+def test_add_gdf_requires_geo_interface(m):
+    with pytest.raises(TypeError, match="__geo_interface__"):
+        m.add_gdf([{"x": 1}])
 
 
 def test_add_marker_cluster_enables_clustering(m):

--- a/python/tests/test_scripting.py
+++ b/python/tests/test_scripting.py
@@ -382,7 +382,7 @@ def test_layer_lookup_and_map_mutators(m):
     assert m.find_layer_index("B") == 1
     assert m.find_layer_index("missing") == -1
 
-    m.set_layer_visibility("A", False)
+    m.set_layer_visibility("A", visible=False)
     m.set_layer_opacity(first_id, 0.25)
     assert m.get_layer(first_id).visible is False
     assert m.get_layer(first_id).opacity == 0.25
@@ -392,6 +392,8 @@ def test_layer_opacity_validation(m):
     layer_id = m.add_geojson({"type": "FeatureCollection", "features": []})
     with pytest.raises(ValueError, match="between 0 and 1"):
         m.get_layer(layer_id).opacity = 2
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        m.get_layer(layer_id).opacity = -0.1
 
 
 def test_layer_setters_mutate_project_and_bump_seq(m):
@@ -455,6 +457,10 @@ def test_fit_bounds_validates_shape_and_order(m):
         m.fit_bounds([0, 1])
     with pytest.raises(ValueError, match="west <= east"):
         m.fit_bounds([10, 0, -10, 1])
+    with pytest.raises(ValueError, match="south <= north"):
+        m.fit_bounds([-10, 5, 10, -5])
+    with pytest.raises(ValueError, match="finite"):
+        m.fit_bounds([-10, -5, float("nan"), 5])
 
 
 def test_stale_layer_access_raises(m):

--- a/python/tests/test_scripting.py
+++ b/python/tests/test_scripting.py
@@ -373,6 +373,27 @@ def test_get_layer_unknown_raises(m):
         m.get_layer("missing")
 
 
+def test_layer_lookup_and_map_mutators(m):
+    first_id = m.add_geojson({"type": "FeatureCollection", "features": []}, name="A")
+    m.add_geojson({"type": "FeatureCollection", "features": []}, name="B")
+    assert m.layer_names == ["A", "B"]
+    assert m.find_layer("A").id == first_id
+    assert m.find_layer("missing") is None
+    assert m.find_layer_index("B") == 1
+    assert m.find_layer_index("missing") == -1
+
+    m.set_layer_visibility("A", False)
+    m.set_layer_opacity(first_id, 0.25)
+    assert m.get_layer(first_id).visible is False
+    assert m.get_layer(first_id).opacity == 0.25
+
+
+def test_layer_opacity_validation(m):
+    layer_id = m.add_geojson({"type": "FeatureCollection", "features": []})
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        m.get_layer(layer_id).opacity = 2
+
+
 def test_layer_setters_mutate_project_and_bump_seq(m):
     layer_id = m.add_geojson({"type": "FeatureCollection", "features": []}, name="A")
     layer = m.get_layer(layer_id)
@@ -411,6 +432,29 @@ def test_layer_zoom_to_sends_command(m, monkeypatch):
     m.get_layer(layer_id).zoom_to()
     assert captured["method"] == "zoomToLayer"
     assert captured["params"] == {"layerId": layer_id}
+
+
+def test_zoom_aliases_send_commands(m, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        m,
+        "request",
+        lambda method, params=None, **_k: calls.append((method, params)),
+    )
+    layer_id = m.add_geojson({"type": "FeatureCollection", "features": []}, name="A")
+    m.zoom_to_bounds([-10, -5, 10, 5])
+    m.zoom_to_layer("A")
+    assert calls == [
+        ("fitBounds", {"bounds": [-10.0, -5.0, 10.0, 5.0]}),
+        ("zoomToLayer", {"layerId": layer_id}),
+    ]
+
+
+def test_fit_bounds_validates_shape_and_order(m):
+    with pytest.raises(ValueError, match="contain"):
+        m.fit_bounds([0, 1])
+    with pytest.raises(ValueError, match="west <= east"):
+        m.fit_bounds([10, 0, -10, 1])
 
 
 def test_stale_layer_access_raises(m):


### PR DESCRIPTION
## Summary
- Add leafmap-style data helpers to the `geolibre` Python widget: `add_gdf`, `add_csv` / `add_xy_data`, `add_heatmap`, and the `add_kml` / `add_gpkg` format wrappers.
- Add layer conveniences: `layer_names`, `find_layer`, `find_layer_index`, `set_layer_visibility`, `set_layer_opacity`, `zoom_to_bounds`, and `zoom_to_layer`, all accepting a layer id, display name, or handle.
- Forward `source_layer` to GeoPandas for local multi-layer containers (GeoPackage) instead of warning that it is ignored, and validate `fit_bounds` shape/order plus layer `opacity` range so bad input raises rather than producing a broken view.

## Test plan
- [x] `pytest` in `python/` (173 passed, 2 skipped)
- [x] `pre-commit run --files <changed files>` clean, including the npm build hook
- [ ] Smoke test in a notebook: `m.add_csv(...)`, `m.add_heatmap(...)`, `m.zoom_to_layer("<name>")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GeoDataFrame, KML, GeoPackage, CSV, XY data, and heatmap layers.
  * Added layer lookup, visibility, opacity, and zoom controls.
  * Added source-layer selection for local vector data.
  * Added bounds-based map zooming and input validation.

* **Documentation**
  * Expanded Python API reference and quickstart examples for new layer and map controls.
  * Documented URL redirect handling, public-destination restrictions, and 50 MB download limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->