### PR TITLE
fix(desktop): route built-in GeoLens through native HTTP

### DIFF
--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -29,7 +29,7 @@
       "allow": [{ "url": "http://*" }, { "url": "https://*" }]
     },
     {
-      "comment": "Hosts routed through the native HTTP client to bypass the WebView's CORS. Geocoding (place search / reverse geocode): public Nominatim's CDN intermittently omits the CORS header on cached responses (rejected as 'Search failed'), and the native client can send the User-Agent Nominatim's policy requires — keep the geocoder hosts in sync with the GEOCODING_PROVIDERS registry / lib/geocoding-fetch.ts. share.geolibre.app (project Share + gallery): its CORS policy allows the web origin but not the Tauri WebView origin, so browser fetches fail as 'Could not reach share.geolibre.app' — see lib/share-fetch.ts. Any other host (custom/self-hosted geocoder, third-party project URL) falls back to the browser fetch.",
+      "comment": "Hosts routed through the native HTTP client to bypass the WebView's CORS. Geocoding (place search / reverse geocode): public Nominatim's CDN intermittently omits the CORS header on cached responses (rejected as 'Search failed'), and the native client can send the User-Agent Nominatim's policy requires — keep the geocoder hosts in sync with the GEOCODING_PROVIDERS registry / lib/geocoding-fetch.ts. share.geolibre.app (project Share + gallery) and datasets.geolibre.app (the built-in GeoLens service) have origin-restricted CORS policies that may not include the Tauri WebView origin — see lib/share-fetch.ts and lib/geolens-fetch.ts. Any custom/self-hosted service falls back to the browser fetch.",
       "identifier": "http:default",
       "allow": [
         { "url": "https://nominatim.openstreetmap.org/*" },
@@ -37,7 +37,8 @@
         { "url": "https://geocode.arcgis.com/*" },
         { "url": "https://api.mapbox.com/*" },
         { "url": "https://maps.googleapis.com/*" },
-        { "url": "https://share.geolibre.app/*" }
+        { "url": "https://share.geolibre.app/*" },
+        { "url": "https://datasets.geolibre.app/*" }
       ]
     }
   ]

--- a/apps/geolibre-desktop/src/lib/geolens-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/geolens-fetch.ts
@@ -1,24 +1,45 @@
 import {
   createGeoLensHostFetch,
+  GEOLENS_SAMPLE_SERVERS,
   setGeoLensFetch,
   type GeoLensFetch,
   type GeoLensHttpResponse,
 } from "@geolibre/plugins";
 
-/** The public service bundled into the GeoLens server picker. */
-const GEOLIBRE_DATASETS_HOST = "datasets.geolibre.app";
+/** Domain suffix of the GeoLens deployments GeoLibre operates. */
+const GEOLIBRE_HOST_SUFFIX = ".geolibre.app";
+
+/**
+ * Hosts of the GeoLibre-operated servers in the GeoLens picker, derived from
+ * the sample-server registry so the two cannot drift (the same approach
+ * `geocoding-fetch.ts` takes with `GEOCODING_PROVIDERS`). The suffix filter is
+ * what keeps this to *our* deployments: the picker also offers a third-party
+ * demo server, which must stay on the browser `fetch` and outside the native
+ * client's reach. The Tauri capability scope (`src-tauri/capabilities/
+ * default.json`, `http:default`) must list the same hosts.
+ */
+const NATIVE_FETCH_HOSTS = new Set(
+  GEOLENS_SAMPLE_SERVERS.flatMap((server) => {
+    try {
+      const { host } = new URL(server.baseUrl);
+      return host.endsWith(GEOLIBRE_HOST_SUFFIX) ? [host] : [];
+    } catch {
+      return [];
+    }
+  }),
+);
 
 /**
  * Build the desktop GeoLens transport.
  *
- * Only the built-in GeoLibre datasets host goes through Tauri's native HTTP
+ * Only the GeoLibre-operated datasets hosts go through Tauri's native HTTP
  * client, so production WebView origins are not blocked when the service's
- * CORS allowlist changes. Custom/self-hosted GeoLens deployments remain on
+ * CORS allowlist changes. Custom and self-hosted GeoLens deployments remain on
  * browser fetch and therefore stay outside the Tauri capability scope.
  */
 export async function installNativeGeoLensFetch(): Promise<void> {
   const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
   const nativeFetch: GeoLensFetch = (url, init) =>
     tauriFetch(url, init as RequestInit) as unknown as Promise<GeoLensHttpResponse>;
-  setGeoLensFetch(createGeoLensHostFetch(GEOLIBRE_DATASETS_HOST, nativeFetch));
+  setGeoLensFetch(createGeoLensHostFetch(NATIVE_FETCH_HOSTS, nativeFetch));
 }

--- a/apps/geolibre-desktop/src/lib/geolens-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/geolens-fetch.ts
@@ -1,0 +1,24 @@
+import {
+  createGeoLensHostFetch,
+  setGeoLensFetch,
+  type GeoLensFetch,
+  type GeoLensHttpResponse,
+} from "@geolibre/plugins";
+
+/** The public service bundled into the GeoLens server picker. */
+const GEOLIBRE_DATASETS_HOST = "datasets.geolibre.app";
+
+/**
+ * Build the desktop GeoLens transport.
+ *
+ * Only the built-in GeoLibre datasets host goes through Tauri's native HTTP
+ * client, so production WebView origins are not blocked when the service's
+ * CORS allowlist changes. Custom/self-hosted GeoLens deployments remain on
+ * browser fetch and therefore stay outside the Tauri capability scope.
+ */
+export async function installNativeGeoLensFetch(): Promise<void> {
+  const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");
+  const nativeFetch: GeoLensFetch = (url, init) =>
+    tauriFetch(url, init as RequestInit) as unknown as Promise<GeoLensHttpResponse>;
+  setGeoLensFetch(createGeoLensHostFetch(GEOLIBRE_DATASETS_HOST, nativeFetch));
+}

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -73,6 +73,14 @@ if (isTauri()) {
       // path this fixes); surface it rather than swallow the rejection.
       console.error("[GeoLibre] Failed to install native share fetch", error);
     });
+  // GeoLens sends X-Api-Key, which preflights in a WebView. Keep the built-in
+  // datasets.geolibre.app connection working even when its CORS origin
+  // allowlist does not include the packaged desktop origin.
+  void import("./lib/geolens-fetch")
+    .then(({ installNativeGeoLensFetch }) => installNativeGeoLensFetch())
+    .catch((error: unknown) => {
+      console.error("[GeoLibre] Failed to install native GeoLens fetch", error);
+    });
 }
 // Recover from chunks orphaned by a web redeploy (stale lazy import → 404). A
 // no-op in the desktop build, whose chunks are bundled locally.

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -446,6 +446,14 @@ export {
   type HuggingFaceLabels,
 } from "./plugins/maplibre-huggingface";
 export {
+  createGeoLensHostFetch,
+  defaultGeoLensFetch,
+  resetGeoLensFetch,
+  setGeoLensFetch,
+  type GeoLensFetch,
+  type GeoLensHttpResponse,
+} from "./plugins/geolens-api";
+export {
   DEFAULT_GEOLENS_LABELS,
   DEFAULT_GEOLENS_FEATURE_LIMIT,
   GEOLENS_FEATURES_SOURCE_KIND,

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -127,9 +127,49 @@ export type GeoLensFetch = (
   },
 ) => Promise<GeoLensHttpResponse>;
 
-/** The default transport: the platform `fetch`. */
-export const defaultGeoLensFetch: GeoLensFetch = (url, init) =>
+/**
+ * The active default transport.
+ *
+ * Browser builds keep the platform `fetch`. The desktop host may replace this
+ * with Tauri's native HTTP transport for the built-in GeoLens service, whose
+ * origin allowlist cannot reliably cover every WebView origin.
+ */
+let geoLensFetch: GeoLensFetch = (url, init) =>
   fetch(url, init) as unknown as Promise<GeoLensHttpResponse>;
+
+/** The default transport used by the plugin, resolved lazily for host overrides. */
+export const defaultGeoLensFetch: GeoLensFetch = (url, init) => geoLensFetch(url, init);
+
+/** Override the plugin's default transport (used by the desktop host and tests). */
+export function setGeoLensFetch(fetchImpl: GeoLensFetch): void {
+  geoLensFetch = fetchImpl;
+}
+
+/** Restore the platform-fetch transport (used to isolate tests). */
+export function resetGeoLensFetch(): void {
+  geoLensFetch = (url, init) => fetch(url, init) as unknown as Promise<GeoLensHttpResponse>;
+}
+
+/**
+ * Route one host through a special transport and leave every other GeoLens
+ * deployment on the fallback transport.
+ */
+export function createGeoLensHostFetch(
+  nativeHost: string,
+  nativeFetch: GeoLensFetch,
+  fallbackFetch: GeoLensFetch = (url, init) =>
+    fetch(url, init) as unknown as Promise<GeoLensHttpResponse>,
+): GeoLensFetch {
+  return (url, init) => {
+    let host: string | null = null;
+    try {
+      host = new URL(url).host;
+    } catch {
+      // The client validates HTTP(S) URLs before calling its transport.
+    }
+    return (host === nativeHost ? nativeFetch : fallbackFetch)(url, init);
+  };
+}
 
 /** Only http(s) URLs may ever reach the map or a token mint. */
 const HTTP_URL_RE = /^https?:\/\//i;

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -151,15 +151,16 @@ export function resetGeoLensFetch(): void {
 }
 
 /**
- * Route one host through a special transport and leave every other GeoLens
- * deployment on the fallback transport.
+ * Route the given hosts through a special transport and leave every other
+ * GeoLens deployment on the fallback transport.
  */
 export function createGeoLensHostFetch(
-  nativeHost: string,
+  nativeHosts: Iterable<string>,
   nativeFetch: GeoLensFetch,
   fallbackFetch: GeoLensFetch = (url, init) =>
     fetch(url, init) as unknown as Promise<GeoLensHttpResponse>,
 ): GeoLensFetch {
+  const hosts = new Set(nativeHosts);
   return (url, init) => {
     let host: string | null = null;
     try {
@@ -167,7 +168,7 @@ export function createGeoLensHostFetch(
     } catch {
       // The client validates HTTP(S) URLs before calling its transport.
     }
-    return (host === nativeHost ? nativeFetch : fallbackFetch)(url, init);
+    return (host && hosts.has(host) ? nativeFetch : fallbackFetch)(url, init);
   };
 }
 

--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -127,6 +127,10 @@ export type GeoLensFetch = (
   },
 ) => Promise<GeoLensHttpResponse>;
 
+/** The platform `fetch`, narrowed to the subset of `Response` this client uses. */
+const platformGeoLensFetch: GeoLensFetch = (url, init) =>
+  fetch(url, init) as unknown as Promise<GeoLensHttpResponse>;
+
 /**
  * The active default transport.
  *
@@ -134,8 +138,7 @@ export type GeoLensFetch = (
  * with Tauri's native HTTP transport for the built-in GeoLens service, whose
  * origin allowlist cannot reliably cover every WebView origin.
  */
-let geoLensFetch: GeoLensFetch = (url, init) =>
-  fetch(url, init) as unknown as Promise<GeoLensHttpResponse>;
+let geoLensFetch: GeoLensFetch = platformGeoLensFetch;
 
 /** The default transport used by the plugin, resolved lazily for host overrides. */
 export const defaultGeoLensFetch: GeoLensFetch = (url, init) => geoLensFetch(url, init);
@@ -147,7 +150,7 @@ export function setGeoLensFetch(fetchImpl: GeoLensFetch): void {
 
 /** Restore the platform-fetch transport (used to isolate tests). */
 export function resetGeoLensFetch(): void {
-  geoLensFetch = (url, init) => fetch(url, init) as unknown as Promise<GeoLensHttpResponse>;
+  geoLensFetch = platformGeoLensFetch;
 }
 
 /**
@@ -157,8 +160,7 @@ export function resetGeoLensFetch(): void {
 export function createGeoLensHostFetch(
   nativeHosts: Iterable<string>,
   nativeFetch: GeoLensFetch,
-  fallbackFetch: GeoLensFetch = (url, init) =>
-    fetch(url, init) as unknown as Promise<GeoLensHttpResponse>,
+  fallbackFetch: GeoLensFetch = platformGeoLensFetch,
 ): GeoLensFetch {
   const hosts = new Set(nativeHosts);
   return (url, init) => {

--- a/tests/geolens-fetch.test.ts
+++ b/tests/geolens-fetch.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  createGeoLensHostFetch,
+  defaultGeoLensFetch,
+  resetGeoLensFetch,
+  setGeoLensFetch,
+  type GeoLensFetch,
+} from "../packages/plugins/src/plugins/geolens-api";
+
+describe("GeoLens fetch override", () => {
+  afterEach(() => resetGeoLensFetch());
+
+  it("resolves the default transport lazily so the desktop host can override it", async () => {
+    let seen = "";
+    const override: GeoLensFetch = async (url) => {
+      seen = url;
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+    setGeoLensFetch(override);
+
+    await defaultGeoLensFetch("https://datasets.geolibre.app/api/search/datasets/");
+    assert.equal(seen, "https://datasets.geolibre.app/api/search/datasets/");
+  });
+
+  it("uses native HTTP only for datasets.geolibre.app", async () => {
+    const calls: string[] = [];
+    const response = { ok: true, status: 200, json: async () => ({}) };
+    const nativeFetch: GeoLensFetch = async (url) => {
+      calls.push(`native:${url}`);
+      return response;
+    };
+    const browserFetch: GeoLensFetch = async (url) => {
+      calls.push(`browser:${url}`);
+      return response;
+    };
+    const fetchImpl = createGeoLensHostFetch("datasets.geolibre.app", nativeFetch, browserFetch);
+
+    await fetchImpl("https://datasets.geolibre.app/api/search/datasets/");
+    await fetchImpl("https://demo.getgeolens.com/api/search/datasets/");
+
+    assert.deepEqual(calls, [
+      "native:https://datasets.geolibre.app/api/search/datasets/",
+      "browser:https://demo.getgeolens.com/api/search/datasets/",
+    ]);
+  });
+});

--- a/tests/geolens-fetch.test.ts
+++ b/tests/geolens-fetch.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { afterEach, describe, it } from "node:test";
 import {
   createGeoLensHostFetch,
@@ -54,9 +55,42 @@ describe("GeoLens fetch override", () => {
    * reach it, so keep the two in sync.
    */
   it("offers exactly one GeoLibre-operated sample server", () => {
-    const geoLibreHosts = GEOLENS_SAMPLE_SERVERS.map((server) => new URL(server.baseUrl).host)
-      .filter((host) => host.endsWith(".geolibre.app"))
-      .sort();
-    assert.deepEqual(geoLibreHosts, ["datasets.geolibre.app"]);
+    assert.deepEqual(geoLibreSampleHosts(), ["datasets.geolibre.app"]);
+  });
+
+  /**
+   * The other half of that contract: every host `geolens-fetch.ts` routes to
+   * the native client must be inside the Tauri `http:default` scope. Narrowing
+   * or dropping the capability entry would otherwise leave the transport
+   * selecting a client the capability forbids — a runtime failure the
+   * registry-only assertion above cannot see.
+   */
+  it("keeps every natively-routed GeoLens host in the Tauri capability scope", () => {
+    const capabilities = JSON.parse(
+      readFileSync(
+        new URL("../apps/geolibre-desktop/src-tauri/capabilities/default.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { permissions: ({ identifier: string; allow?: { url?: string }[] } | string)[] };
+    const httpScope = capabilities.permissions.find(
+      (permission) => typeof permission === "object" && permission.identifier === "http:default",
+    );
+    assert.ok(httpScope && typeof httpScope === "object", "no http:default permission");
+
+    const allowedHosts = new Set(
+      (httpScope.allow ?? []).flatMap((entry) =>
+        entry.url ? [new URL(entry.url.replace(/\*$/, "")).host] : [],
+      ),
+    );
+    for (const host of geoLibreSampleHosts()) {
+      assert.ok(allowedHosts.has(host), `${host} is missing from the http:default scope`);
+    }
   });
 });
+
+/** GeoLibre-operated GeoLens hosts, derived exactly as `geolens-fetch.ts` does. */
+function geoLibreSampleHosts(): string[] {
+  return GEOLENS_SAMPLE_SERVERS.map((server) => new URL(server.baseUrl).host)
+    .filter((host) => host.endsWith(".geolibre.app"))
+    .sort();
+}

--- a/tests/geolens-fetch.test.ts
+++ b/tests/geolens-fetch.test.ts
@@ -7,6 +7,7 @@ import {
   setGeoLensFetch,
   type GeoLensFetch,
 } from "../packages/plugins/src/plugins/geolens-api";
+import { GEOLENS_SAMPLE_SERVERS } from "../packages/plugins/src/plugins/maplibre-geolens";
 
 describe("GeoLens fetch override", () => {
   afterEach(() => resetGeoLensFetch());
@@ -23,7 +24,7 @@ describe("GeoLens fetch override", () => {
     assert.equal(seen, "https://datasets.geolibre.app/api/search/datasets/");
   });
 
-  it("uses native HTTP only for datasets.geolibre.app", async () => {
+  it("uses native HTTP only for the listed hosts", async () => {
     const calls: string[] = [];
     const response = { ok: true, status: 200, json: async () => ({}) };
     const nativeFetch: GeoLensFetch = async (url) => {
@@ -34,7 +35,7 @@ describe("GeoLens fetch override", () => {
       calls.push(`browser:${url}`);
       return response;
     };
-    const fetchImpl = createGeoLensHostFetch("datasets.geolibre.app", nativeFetch, browserFetch);
+    const fetchImpl = createGeoLensHostFetch(["datasets.geolibre.app"], nativeFetch, browserFetch);
 
     await fetchImpl("https://datasets.geolibre.app/api/search/datasets/");
     await fetchImpl("https://demo.getgeolens.com/api/search/datasets/");
@@ -43,5 +44,19 @@ describe("GeoLens fetch override", () => {
       "native:https://datasets.geolibre.app/api/search/datasets/",
       "browser:https://demo.getgeolens.com/api/search/datasets/",
     ]);
+  });
+
+  /**
+   * The desktop transport derives its native-fetch hosts from this registry by
+   * `.geolibre.app` suffix, and the Tauri capability scope must list the same
+   * hosts. A GeoLibre-operated server added here without a matching
+   * `http:default` entry would be routed to a client that is not allowed to
+   * reach it, so keep the two in sync.
+   */
+  it("offers exactly one GeoLibre-operated sample server", () => {
+    const geoLibreHosts = GEOLENS_SAMPLE_SERVERS.map((server) => new URL(server.baseUrl).host)
+      .filter((host) => host.endsWith(".geolibre.app"))
+      .sort();
+    assert.deepEqual(geoLibreHosts, ["datasets.geolibre.app"]);
   });
 });


### PR DESCRIPTION
## Summary
- The GeoLens client sends `X-Api-Key`, which forces a CORS preflight in the Tauri WebView. The bundled `datasets.geolibre.app` service then fails whenever its origin allowlist does not cover the packaged desktop origin.
- The desktop shell now installs a GeoLens transport that routes only `datasets.geolibre.app` through Tauri's native HTTP client, mirroring the existing native geocoding and Share fetch overrides. Custom and self-hosted GeoLens deployments stay on browser fetch and remain outside the Tauri capability scope.
- `@geolibre/plugins` gained a settable default transport plus a host-scoped fetch factory so the host can install the override without the plugin depending on Tauri.

## Test plan
- [x] `node --import tsx --test tests/geolens-fetch.test.ts`
- [x] `npm run test:frontend` (4631 pass, 1 skipped)
- [x] `pre-commit run --files <changed paths>` (includes the npm build hook)
- [ ] In `npm run tauri:dev`, open the GeoLens plugin against the built-in datasets service and confirm search and layer add succeed
- [ ] In the same build, point GeoLens at a custom server URL and confirm it still works through browser fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoLens requests in the desktop app now use native networking for built-in GeoLibre services.
  * Custom and self-hosted deployments continue using browser-based networking.
  * Added configurable GeoLens transport routing for improved compatibility.

* **Bug Fixes**
  * Native networking setup failures are handled safely without affecting other builds.
  * Invalid or unsupported service addresses continue using the standard browser connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->