### PR TITLE
Add autosave, crash recovery, and project history

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -55,6 +55,7 @@ import { createPortal } from "react-dom";
 import { BROWSER_PANEL_ID, useRegisterBrowserPanel } from "../../hooks/useRegisterBrowserPanel";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
 import { useProjectFileActions } from "../../hooks/useProjectFileActions";
+import { useProjectHistory } from "../../hooks/useProjectHistory";
 import {
   isRasterFileName,
   isTauri,
@@ -151,6 +152,8 @@ import { StoryMapPresenter } from "../storymap/StoryMapPresenter";
 import { DiagnosticsDialog } from "./DiagnosticsDialog";
 import { FileNamePromptDialog } from "./FileNamePromptDialog";
 import { ProjectPluginTrustDialog } from "./ProjectPluginTrustDialog";
+import { ProjectHistoryDialog } from "./ProjectHistoryDialog";
+import { ProjectRecoveryDialog } from "./ProjectRecoveryDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
 import type { LayoutOptions } from "../../hooks/useLayoutOptions";
@@ -579,6 +582,8 @@ export function DesktopShell({
   const activeResizeCleanupRef = useRef<(() => void) | null>(null);
   useEffect(() => () => activeResizeCleanupRef.current?.(), []);
   const mapControllerRef = useRef<MapController | null>(null);
+  const projectHistory = useProjectHistory(mapControllerRef);
+  const [projectHistoryOpen, setProjectHistoryOpen] = useState(false);
   // The place shown in the Wikipedia knowledge card, or null when it is closed.
   // `pendingKnowledgePlace` holds the target while the one-time consent notice
   // is open, so it can be applied only after the user acknowledges it.
@@ -1928,6 +1933,10 @@ export function DesktopShell({
             collaboration={collaboration}
             projectFiles={projectFiles}
             onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+            onOpenProjectHistory={() => {
+              void projectHistory.refresh();
+              setProjectHistoryOpen(true);
+            }}
             onToggleThemeMode={onToggleThemeMode}
             onOpenBasemapExtract={() => setBasemapExtractOpen(true)}
           />
@@ -2329,6 +2338,17 @@ export function DesktopShell({
         diagnostics={diagnostics}
         open={diagnosticsOpen}
         onOpenChange={setDiagnosticsOpen}
+      />
+      <ProjectHistoryDialog
+        open={projectHistoryOpen}
+        onOpenChange={setProjectHistoryOpen}
+        snapshots={projectHistory.snapshots}
+        onRestore={projectHistory.restore}
+      />
+      <ProjectRecoveryDialog
+        snapshot={projectHistory.recoverySnapshot}
+        onRestore={projectHistory.restore}
+        onDiscard={projectHistory.discardRecovery}
       />
       {/* Mounted in the always-rendered shell (not the toolbar) so the bookmark
           export name prompt works even when the toolbar is hidden (`?maponly`). */}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -2343,10 +2343,12 @@ export function DesktopShell({
         open={projectHistoryOpen}
         onOpenChange={setProjectHistoryOpen}
         snapshots={projectHistory.snapshots}
+        restoreError={projectHistory.restoreError}
         onRestore={projectHistory.restore}
       />
       <ProjectRecoveryDialog
         snapshot={projectHistory.recoverySnapshot}
+        restoreError={projectHistory.restoreError}
         onRestore={projectHistory.restore}
         onDiscard={projectHistory.discardRecovery}
         onDismiss={projectHistory.dismissRecovery}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -2349,6 +2349,7 @@ export function DesktopShell({
         snapshot={projectHistory.recoverySnapshot}
         onRestore={projectHistory.restore}
         onDiscard={projectHistory.discardRecovery}
+        onDismiss={projectHistory.dismissRecovery}
       />
       {/* Mounted in the always-rendered shell (not the toolbar) so the bookmark
           export name prompt works even when the toolbar is hidden (`?maponly`). */}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1934,6 +1934,7 @@ export function DesktopShell({
             projectFiles={projectFiles}
             onOpenDiagnostics={() => setDiagnosticsOpen(true)}
             onOpenProjectHistory={() => {
+              projectHistory.clearRestoreError();
               void projectHistory.refresh();
               setProjectHistoryOpen(true);
             }}
@@ -2341,7 +2342,10 @@ export function DesktopShell({
       />
       <ProjectHistoryDialog
         open={projectHistoryOpen}
-        onOpenChange={setProjectHistoryOpen}
+        onOpenChange={(open) => {
+          setProjectHistoryOpen(open);
+          if (!open) projectHistory.clearRestoreError();
+        }}
         snapshots={projectHistory.snapshots}
         restoreError={projectHistory.restoreError}
         onRestore={projectHistory.restore}
@@ -2350,8 +2354,14 @@ export function DesktopShell({
         snapshot={projectHistory.recoverySnapshot}
         restoreError={projectHistory.restoreError}
         onRestore={projectHistory.restore}
-        onDiscard={projectHistory.discardRecovery}
-        onDismiss={projectHistory.dismissRecovery}
+        onDiscard={() => {
+          projectHistory.clearRestoreError();
+          projectHistory.discardRecovery();
+        }}
+        onDismiss={() => {
+          projectHistory.clearRestoreError();
+          projectHistory.dismissRecovery();
+        }}
       />
       {/* Mounted in the always-rendered shell (not the toolbar) so the bookmark
           export name prompt works even when the toolbar is hidden (`?maponly`). */}

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../lib/basemap-presets";
 import { planetaryBasemapLabel, planetaryBasemapSectionKey } from "../../lib/planetary-sections";
 import { buildRemotePmtilesBasemap, isPmtilesStyleUrl } from "../../lib/pmtiles-basemap-url";
+import { clearProjectSnapshots } from "../../lib/project-history-store";
 import { CollapsibleSection } from "../CollapsibleSection";
 import {
   Button,
@@ -200,6 +201,9 @@ export function NewProjectDialog({
       ellipsoidId: selectedPlanetary?.ellipsoidId,
       mapView: selectedBasemapId === LIBERTY_3D_ID ? THREE_D_MAP_VIEW : createDefaultMapView(),
     });
+    void clearProjectSnapshots().catch((error) =>
+      console.error("Could not clear project history for the new project.", error),
+    );
     onProjectCreated?.();
     onOpenChange(false);
     resetForm();
@@ -236,6 +240,9 @@ export function NewProjectDialog({
         ? projectName.trim()
         : templateName;
     loadProject({ ...copy, name: finalName }, null);
+    void clearProjectSnapshots().catch((error) =>
+      console.error("Could not clear project history for the new project.", error),
+    );
     useAppStore.setState({ isDirty: true });
     onProjectCreated?.();
     onOpenChange(false);

--- a/apps/geolibre-desktop/src/components/layout/ProjectHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectHistoryDialog.tsx
@@ -1,0 +1,75 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+import type { ProjectHistorySnapshot } from "../../lib/project-history-store";
+
+interface ProjectHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  snapshots: ProjectHistorySnapshot[];
+  onRestore: (snapshot: ProjectHistorySnapshot) => void;
+}
+
+export function ProjectHistoryDialog({
+  open,
+  onOpenChange,
+  snapshots,
+  onRestore,
+}: ProjectHistoryDialogProps) {
+  const { t, i18n } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t("projectHistory.title")}</DialogTitle>
+          <DialogDescription>{t("projectHistory.description")}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          {snapshots.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              {t("projectHistory.empty")}
+            </p>
+          ) : (
+            snapshots.map((snapshot) => (
+              <div
+                key={snapshot.id}
+                className="flex items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{snapshot.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {new Intl.DateTimeFormat(i18n.language, {
+                      dateStyle: "medium",
+                      timeStyle: "medium",
+                    }).format(new Date(snapshot.createdAt))}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {t("projectHistory.summary", {
+                      count: snapshot.layerCount,
+                      zoom: snapshot.camera.zoom.toFixed(1),
+                    })}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => {
+                    onRestore(snapshot);
+                    onOpenChange(false);
+                  }}
+                >
+                  {t("projectHistory.restore")}
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/ProjectHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectHistoryDialog.tsx
@@ -13,13 +13,15 @@ interface ProjectHistoryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   snapshots: ProjectHistorySnapshot[];
-  onRestore: (snapshot: ProjectHistorySnapshot) => void;
+  restoreError: string | null;
+  onRestore: (snapshot: ProjectHistorySnapshot) => boolean;
 }
 
 export function ProjectHistoryDialog({
   open,
   onOpenChange,
   snapshots,
+  restoreError,
   onRestore,
 }: ProjectHistoryDialogProps) {
   const { t, i18n } = useTranslation();
@@ -31,6 +33,14 @@ export function ProjectHistoryDialog({
           <DialogDescription>{t("projectHistory.description")}</DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
+          {restoreError ? (
+            <p
+              role="alert"
+              className="rounded-md border border-destructive/50 p-3 text-sm text-destructive"
+            >
+              {restoreError}
+            </p>
+          ) : null}
           {snapshots.length === 0 ? (
             <p className="py-8 text-center text-sm text-muted-foreground">
               {t("projectHistory.empty")}
@@ -62,8 +72,7 @@ export function ProjectHistoryDialog({
                 <Button
                   size="sm"
                   onClick={() => {
-                    onRestore(snapshot);
-                    onOpenChange(false);
+                    if (onRestore(snapshot)) onOpenChange(false);
                   }}
                 >
                   {t("projectHistory.restore")}

--- a/apps/geolibre-desktop/src/components/layout/ProjectHistoryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectHistoryDialog.tsx
@@ -52,7 +52,10 @@ export function ProjectHistoryDialog({
                   <p className="truncate text-xs text-muted-foreground">
                     {t("projectHistory.summary", {
                       count: snapshot.layerCount,
-                      zoom: snapshot.camera.zoom.toFixed(1),
+                      zoom: new Intl.NumberFormat(i18n.language, {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      }).format(snapshot.camera.zoom),
                     })}
                   </p>
                 </div>

--- a/apps/geolibre-desktop/src/components/layout/ProjectRecoveryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectRecoveryDialog.tsx
@@ -11,13 +11,15 @@ import type { ProjectHistorySnapshot } from "../../lib/project-history-store";
 
 interface ProjectRecoveryDialogProps {
   snapshot: ProjectHistorySnapshot | null;
-  onRestore: (snapshot: ProjectHistorySnapshot) => void;
+  restoreError: string | null;
+  onRestore: (snapshot: ProjectHistorySnapshot) => boolean;
   onDiscard: () => void;
   onDismiss: () => void;
 }
 
 export function ProjectRecoveryDialog({
   snapshot,
+  restoreError,
   onRestore,
   onDiscard,
   onDismiss,
@@ -32,6 +34,14 @@ export function ProjectRecoveryDialog({
             {t("projectHistory.recoveryDescription", { name: snapshot?.name })}
           </DialogDescription>
         </DialogHeader>
+        {restoreError ? (
+          <p
+            role="alert"
+            className="rounded-md border border-destructive/50 p-3 text-sm text-destructive"
+          >
+            {restoreError}
+          </p>
+        ) : null}
         <div className="flex justify-end gap-2">
           <Button variant="outline" onClick={onDiscard}>
             {t("projectHistory.discard")}

--- a/apps/geolibre-desktop/src/components/layout/ProjectRecoveryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectRecoveryDialog.tsx
@@ -1,0 +1,44 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+import type { ProjectHistorySnapshot } from "../../lib/project-history-store";
+
+interface ProjectRecoveryDialogProps {
+  snapshot: ProjectHistorySnapshot | null;
+  onRestore: (snapshot: ProjectHistorySnapshot) => void;
+  onDiscard: () => void;
+}
+
+export function ProjectRecoveryDialog({
+  snapshot,
+  onRestore,
+  onDiscard,
+}: ProjectRecoveryDialogProps) {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={snapshot !== null} onOpenChange={(open) => !open && onDiscard()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("projectHistory.recoveryTitle")}</DialogTitle>
+          <DialogDescription>
+            {t("projectHistory.recoveryDescription", { name: snapshot?.name })}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onDiscard}>
+            {t("projectHistory.discard")}
+          </Button>
+          <Button onClick={() => snapshot && onRestore(snapshot)}>
+            {t("projectHistory.restore")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/ProjectRecoveryDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ProjectRecoveryDialog.tsx
@@ -13,16 +13,18 @@ interface ProjectRecoveryDialogProps {
   snapshot: ProjectHistorySnapshot | null;
   onRestore: (snapshot: ProjectHistorySnapshot) => void;
   onDiscard: () => void;
+  onDismiss: () => void;
 }
 
 export function ProjectRecoveryDialog({
   snapshot,
   onRestore,
   onDiscard,
+  onDismiss,
 }: ProjectRecoveryDialogProps) {
   const { t } = useTranslation();
   return (
-    <Dialog open={snapshot !== null} onOpenChange={(open) => !open && onDiscard()}>
+    <Dialog open={snapshot !== null} onOpenChange={(open) => !open && onDismiss()}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t("projectHistory.recoveryTitle")}</DialogTitle>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -165,6 +165,7 @@ interface TopToolbarProps {
   // instance — two would not coordinate their in-flight "open recent" aborts.
   projectFiles: ProjectFileActions;
   onOpenDiagnostics: () => void;
+  onOpenProjectHistory: () => void;
   onToggleThemeMode: () => void;
   // Opens the Offline Basemap Extract panel, mounted in DesktopShell over the
   // map so it can stay non-modal (the map is interactive for drawing a bbox).
@@ -182,6 +183,7 @@ export function TopToolbar({
   collaboration,
   projectFiles,
   onOpenDiagnostics,
+  onOpenProjectHistory,
   onToggleThemeMode,
   onOpenBasemapExtract,
 }: TopToolbarProps) {
@@ -1463,6 +1465,7 @@ export function TopToolbar({
               if (error) projectFiles.setActionError(error);
             });
           }}
+          onOpenHistory={onOpenProjectHistory}
           onSave={() => void projectFiles.handleSave()}
           onSaveAs={() => void projectFiles.handleSaveAs()}
           onDuplicate={() => projectFiles.handleDuplicate()}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
@@ -1,4 +1,11 @@
-import { redo, undo, useAppStore } from "@geolibre/core";
+import {
+  canRedoProjectRestore,
+  canUndoProjectRestore,
+  redo,
+  subscribeProjectRestoreHistory,
+  undo,
+  useAppStore,
+} from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   Button,
@@ -22,6 +29,7 @@ import {
   X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useSyncExternalStore } from "react";
 import { useStore } from "zustand";
 import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
 import {
@@ -45,8 +53,20 @@ interface EditMenuProps {
  */
 export function EditMenu({ chrome, mapControllerRef }: EditMenuProps) {
   const { t } = useTranslation();
-  const canUndo = useStore(useAppStore.temporal, (s) => s.pastStates.length > 0);
-  const canRedo = useStore(useAppStore.temporal, (s) => s.futureStates.length > 0);
+  const temporalCanUndo = useStore(useAppStore.temporal, (s) => s.pastStates.length > 0);
+  const temporalCanRedo = useStore(useAppStore.temporal, (s) => s.futureStates.length > 0);
+  const canUndoRestore = useSyncExternalStore(
+    subscribeProjectRestoreHistory,
+    canUndoProjectRestore,
+    canUndoProjectRestore,
+  );
+  const canRedoRestore = useSyncExternalStore(
+    subscribeProjectRestoreHistory,
+    canRedoProjectRestore,
+    canRedoProjectRestore,
+  );
+  const canUndo = temporalCanUndo || canUndoRestore;
+  const canRedo = temporalCanRedo || canRedoRestore;
   const setSelectByExpressionOpen = useAppStore((s) => s.setSelectByExpressionOpen);
   const setSelectByLocationOpen = useAppStore((s) => s.setSelectByLocationOpen);
   // Narrow boolean/number selectors so the menu re-renders only when the

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -47,6 +47,7 @@ interface ProjectMenuProps {
   onOpenGallery: () => void;
   onImportQgisProject: () => void;
   onOpenRecent: (path: string) => void;
+  onOpenHistory: () => void;
   onSave: () => void;
   onSaveAs: () => void;
   onDuplicate?: () => void;
@@ -68,6 +69,7 @@ export function ProjectMenu({
   onOpenGallery,
   onImportQgisProject,
   onOpenRecent,
+  onOpenHistory,
   onSave,
   onSaveAs,
   onDuplicate,
@@ -202,6 +204,12 @@ export function ProjectMenu({
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+        )}
+        {show("project.history") && (
+          <DropdownMenuItem onSelect={onOpenHistory}>
+            <History className="me-2 h-3.5 w-3.5" />
+            {t("toolbar.item.projectHistoryEllipsis")}
+          </DropdownMenuItem>
         )}
         {show("project.import") && (
           <DropdownMenuSub>

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -34,6 +34,7 @@ import { getShareFetch } from "../lib/share-fetch";
 import { resolveShareBaseUrl } from "../lib/share-geolibre";
 import { shareAuthorizedFetch } from "../lib/share-gallery";
 import { normalizeProjectUrl } from "../lib/urls";
+import { recordExplicitProjectSave } from "../lib/project-history-session";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 import {
   importQgisProject,
@@ -714,6 +715,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       openedAt: new Date().toISOString(),
     });
     markSaved();
+    recordExplicitProjectSave();
     return true;
   };
 

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -6,6 +6,7 @@ import {
 } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useTranslation } from "react-i18next";
 import { buildProjectSnapshot } from "../lib/build-project-snapshot";
 import { isEmbedded } from "./embedHost";
 import { isTauri } from "../lib/is-tauri";
@@ -23,14 +24,20 @@ import {
 } from "../lib/project-history-session";
 const AUTOSAVE_DELAY_MS = 3_000;
 
+function currentProjectKey(): string {
+  const { projectPath, projectName } = useAppStore.getState();
+  return projectPath ? `path:${projectPath}` : `unsaved:${projectName}`;
+}
+
 export function useProjectHistory(mapControllerRef: RefObject<MapController | null>) {
+  const { t } = useTranslation();
   const [snapshots, setSnapshots] = useState<ProjectHistorySnapshot[]>([]);
   const [recoverySnapshot, setRecoverySnapshot] = useState<ProjectHistorySnapshot | null>(null);
   const [restoreError, setRestoreError] = useState<string | null>(null);
   const timerRef = useRef<number | null>(null);
   const refresh = useCallback(async () => {
     try {
-      setSnapshots(await listProjectSnapshots());
+      setSnapshots(await listProjectSnapshots(currentProjectKey()));
     } catch (error) {
       console.error("Could not load project history.", error);
     }
@@ -41,7 +48,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     void (async () => {
       try {
         const entries = await listProjectSnapshots();
-        setSnapshots(entries);
+        setSnapshots(entries.filter((entry) => entry.projectKey === currentProjectKey()));
         if (crashRecoveryEnabled) {
           const previousSession = readProjectSessionState();
           const lastSave = readLastExplicitProjectSave();
@@ -70,11 +77,9 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
       timerRef.current = window.setTimeout(() => {
         timerRef.current = null;
         const content = serializeProject(buildProjectSnapshot(mapControllerRef));
-        void addProjectSnapshot(content)
-          .then((result) => {
-            if (result === "added") return refresh();
-          })
-          .catch((error) => console.error("Could not autosave the project.", error));
+        void addProjectSnapshot(content, currentProjectKey()).catch((error) =>
+          console.error("Could not autosave the project.", error),
+        );
       }, AUTOSAVE_DELAY_MS);
     });
     return () => {
@@ -91,23 +96,21 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
         const before = buildProjectSnapshot(mapControllerRef);
         const beforePath = useAppStore.getState().projectPath;
         const restored = parseProject(snapshot.content);
-        useAppStore.getState().loadProject(restored, null, {
+        useAppStore.getState().loadProject(restored, beforePath, {
           rememberRecent: false,
           presenting: false,
         });
-        registerProjectRestoreHistory(before, beforePath, restored);
+        registerProjectRestoreHistory(before, beforePath, restored, beforePath);
         useAppStore.setState({ isDirty: true });
         setRecoverySnapshot(null);
         return true;
       } catch (error) {
         console.error("Could not restore the project snapshot.", error);
-        setRestoreError(
-          error instanceof Error ? error.message : "Could not restore the project snapshot.",
-        );
+        setRestoreError(t("projectHistory.restoreError"));
         return false;
       }
     },
-    [mapControllerRef],
+    [mapControllerRef, t],
   );
 
   const discardRecovery = useCallback(() => {
@@ -120,6 +123,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
   }, [recoverySnapshot, refresh]);
 
   const dismissRecovery = useCallback(() => setRecoverySnapshot(null), []);
+  const clearRestoreError = useCallback(() => setRestoreError(null), []);
 
   return {
     snapshots,
@@ -129,5 +133,6 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     restore,
     discardRecovery,
     dismissRecovery,
+    clearRestoreError,
   };
 }

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -1,57 +1,74 @@
-import { parseProject, serializeProject, useAppStore } from "@geolibre/core";
+import {
+  parseProject,
+  registerProjectRestoreHistory,
+  serializeProject,
+  useAppStore,
+} from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { buildProjectSnapshot } from "../lib/build-project-snapshot";
+import { projectChanged } from "../lib/project-broadcast-changed";
 import {
   addProjectSnapshot,
-  clearProjectSnapshots,
   deleteProjectSnapshot,
   listProjectSnapshots,
   type ProjectHistorySnapshot,
 } from "../lib/project-history-store";
-
-const SESSION_KEY = "geolibre-project-session";
-const LAST_SAVE_KEY = "geolibre-project-last-explicit-save";
+import {
+  markProjectSession,
+  readLastExplicitProjectSave,
+  readProjectSessionState,
+} from "../lib/project-history-session";
 const AUTOSAVE_DELAY_MS = 3_000;
 
 export function useProjectHistory(mapControllerRef: RefObject<MapController | null>) {
   const [snapshots, setSnapshots] = useState<ProjectHistorySnapshot[]>([]);
   const [recoverySnapshot, setRecoverySnapshot] = useState<ProjectHistorySnapshot | null>(null);
   const timerRef = useRef<number | null>(null);
-  const lastGenerationRef = useRef(useAppStore.getState().projectGeneration);
-  const refresh = useCallback(async () => setSnapshots(await listProjectSnapshots()), []);
+  const refresh = useCallback(async () => {
+    try {
+      setSnapshots(await listProjectSnapshots());
+    } catch (error) {
+      console.error("Could not load project history.", error);
+    }
+  }, []);
 
   useEffect(() => {
     void (async () => {
-      const entries = await listProjectSnapshots();
-      setSnapshots(entries);
-      const previousSession = localStorage.getItem(SESSION_KEY);
-      const lastSave = localStorage.getItem(LAST_SAVE_KEY);
-      const latest = entries[0];
-      if (previousSession === "open" && latest && (!lastSave || latest.createdAt > lastSave)) {
-        setRecoverySnapshot(latest);
+      try {
+        const entries = await listProjectSnapshots();
+        setSnapshots(entries);
+        const previousSession = readProjectSessionState();
+        const lastSave = readLastExplicitProjectSave();
+        const latest = entries[0];
+        if (previousSession === "open" && latest && (!lastSave || latest.createdAt > lastSave)) {
+          setRecoverySnapshot(latest);
+        }
+      } catch (error) {
+        console.error("Could not initialize project recovery.", error);
+      } finally {
+        markProjectSession("open");
       }
-      localStorage.setItem(SESSION_KEY, "open");
     })();
 
-    const markClean = () => localStorage.setItem(SESSION_KEY, "closed");
+    const markClean = () => markProjectSession("closed");
     window.addEventListener("pagehide", markClean);
     const unsubscribe = useAppStore.subscribe((state, previous) => {
-      if (!state.isDirty && previous.isDirty) {
-        localStorage.setItem(LAST_SAVE_KEY, new Date().toISOString());
+      if (
+        !state.isDirty ||
+        (!projectChanged(state, previous) && state.mapView === previous.mapView)
+      ) {
+        return;
       }
-      if (state.projectGeneration !== lastGenerationRef.current) {
-        lastGenerationRef.current = state.projectGeneration;
-        if (state.projectPath === null && state.layers.length === 0) {
-          void clearProjectSnapshots().then(refresh);
-        }
-      }
-      if (!state.isDirty) return;
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
       timerRef.current = window.setTimeout(() => {
         timerRef.current = null;
         const content = serializeProject(buildProjectSnapshot(mapControllerRef));
-        void addProjectSnapshot(content).then(refresh).catch(console.error);
+        void addProjectSnapshot(content)
+          .then((result) => {
+            if (result === "added") return refresh();
+          })
+          .catch((error) => console.error("Could not autosave the project.", error));
       }, AUTOSAVE_DELAY_MS);
     });
     return () => {
@@ -61,19 +78,36 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     };
   }, [mapControllerRef, refresh]);
 
-  const restore = useCallback((snapshot: ProjectHistorySnapshot) => {
-    useAppStore.getState().loadProject(parseProject(snapshot.content), null, {
-      rememberRecent: false,
-      presenting: false,
-    });
-    useAppStore.setState({ isDirty: true });
-    setRecoverySnapshot(null);
-  }, []);
+  const restore = useCallback(
+    (snapshot: ProjectHistorySnapshot) => {
+      try {
+        const before = buildProjectSnapshot(mapControllerRef);
+        const beforePath = useAppStore.getState().projectPath;
+        const restored = parseProject(snapshot.content);
+        useAppStore.getState().loadProject(restored, null, {
+          rememberRecent: false,
+          presenting: false,
+        });
+        registerProjectRestoreHistory(before, beforePath, restored);
+        useAppStore.setState({ isDirty: true });
+        setRecoverySnapshot(null);
+      } catch (error) {
+        console.error("Could not restore the project snapshot.", error);
+      }
+    },
+    [mapControllerRef],
+  );
 
   const discardRecovery = useCallback(() => {
-    if (recoverySnapshot) void deleteProjectSnapshot(recoverySnapshot.id).then(refresh);
+    if (recoverySnapshot) {
+      void deleteProjectSnapshot(recoverySnapshot.id)
+        .then(refresh)
+        .catch((error) => console.error("Could not discard the recovery snapshot.", error));
+    }
     setRecoverySnapshot(null);
   }, [recoverySnapshot, refresh]);
 
-  return { snapshots, recoverySnapshot, refresh, restore, discardRecovery };
+  const dismissRecovery = useCallback(() => setRecoverySnapshot(null), []);
+
+  return { snapshots, recoverySnapshot, refresh, restore, discardRecovery, dismissRecovery };
 }

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -1,0 +1,79 @@
+import { parseProject, serializeProject, useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { buildProjectSnapshot } from "../lib/build-project-snapshot";
+import {
+  addProjectSnapshot,
+  clearProjectSnapshots,
+  deleteProjectSnapshot,
+  listProjectSnapshots,
+  type ProjectHistorySnapshot,
+} from "../lib/project-history-store";
+
+const SESSION_KEY = "geolibre-project-session";
+const LAST_SAVE_KEY = "geolibre-project-last-explicit-save";
+const AUTOSAVE_DELAY_MS = 3_000;
+
+export function useProjectHistory(mapControllerRef: RefObject<MapController | null>) {
+  const [snapshots, setSnapshots] = useState<ProjectHistorySnapshot[]>([]);
+  const [recoverySnapshot, setRecoverySnapshot] = useState<ProjectHistorySnapshot | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const lastGenerationRef = useRef(useAppStore.getState().projectGeneration);
+  const refresh = useCallback(async () => setSnapshots(await listProjectSnapshots()), []);
+
+  useEffect(() => {
+    void (async () => {
+      const entries = await listProjectSnapshots();
+      setSnapshots(entries);
+      const previousSession = localStorage.getItem(SESSION_KEY);
+      const lastSave = localStorage.getItem(LAST_SAVE_KEY);
+      const latest = entries[0];
+      if (previousSession === "open" && latest && (!lastSave || latest.createdAt > lastSave)) {
+        setRecoverySnapshot(latest);
+      }
+      localStorage.setItem(SESSION_KEY, "open");
+    })();
+
+    const markClean = () => localStorage.setItem(SESSION_KEY, "closed");
+    window.addEventListener("pagehide", markClean);
+    const unsubscribe = useAppStore.subscribe((state, previous) => {
+      if (!state.isDirty && previous.isDirty) {
+        localStorage.setItem(LAST_SAVE_KEY, new Date().toISOString());
+      }
+      if (state.projectGeneration !== lastGenerationRef.current) {
+        lastGenerationRef.current = state.projectGeneration;
+        if (state.projectPath === null && state.layers.length === 0) {
+          void clearProjectSnapshots().then(refresh);
+        }
+      }
+      if (!state.isDirty) return;
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = null;
+        const content = serializeProject(buildProjectSnapshot(mapControllerRef));
+        void addProjectSnapshot(content).then(refresh).catch(console.error);
+      }, AUTOSAVE_DELAY_MS);
+    });
+    return () => {
+      unsubscribe();
+      window.removeEventListener("pagehide", markClean);
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    };
+  }, [mapControllerRef, refresh]);
+
+  const restore = useCallback((snapshot: ProjectHistorySnapshot) => {
+    useAppStore.getState().loadProject(parseProject(snapshot.content), null, {
+      rememberRecent: false,
+      presenting: false,
+    });
+    useAppStore.setState({ isDirty: true });
+    setRecoverySnapshot(null);
+  }, []);
+
+  const discardRecovery = useCallback(() => {
+    if (recoverySnapshot) void deleteProjectSnapshot(recoverySnapshot.id).then(refresh);
+    setRecoverySnapshot(null);
+  }, [recoverySnapshot, refresh]);
+
+  return { snapshots, recoverySnapshot, refresh, restore, discardRecovery };
+}

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -7,6 +7,8 @@ import {
 import type { MapController } from "@geolibre/map";
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { buildProjectSnapshot } from "../lib/build-project-snapshot";
+import { isEmbedded } from "./embedHost";
+import { isTauri } from "../lib/is-tauri";
 import { projectChanged } from "../lib/project-broadcast-changed";
 import {
   addProjectSnapshot,
@@ -34,25 +36,28 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
   }, []);
 
   useEffect(() => {
+    const crashRecoveryEnabled = !isTauri() && !isEmbedded();
     void (async () => {
       try {
         const entries = await listProjectSnapshots();
         setSnapshots(entries);
-        const previousSession = readProjectSessionState();
-        const lastSave = readLastExplicitProjectSave();
-        const latest = entries[0];
-        if (previousSession === "open" && latest && (!lastSave || latest.createdAt > lastSave)) {
-          setRecoverySnapshot(latest);
+        if (crashRecoveryEnabled) {
+          const previousSession = readProjectSessionState();
+          const lastSave = readLastExplicitProjectSave();
+          const latest = entries[0];
+          if (previousSession === "open" && latest && (!lastSave || latest.createdAt > lastSave)) {
+            setRecoverySnapshot(latest);
+          }
         }
       } catch (error) {
         console.error("Could not initialize project recovery.", error);
       } finally {
-        markProjectSession("open");
+        if (crashRecoveryEnabled) markProjectSession("open");
       }
     })();
 
     const markClean = () => markProjectSession("closed");
-    window.addEventListener("pagehide", markClean);
+    if (crashRecoveryEnabled) window.addEventListener("pagehide", markClean);
     const unsubscribe = useAppStore.subscribe((state, previous) => {
       if (
         !state.isDirty ||
@@ -73,7 +78,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     });
     return () => {
       unsubscribe();
-      window.removeEventListener("pagehide", markClean);
+      if (crashRecoveryEnabled) window.removeEventListener("pagehide", markClean);
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
     };
   }, [mapControllerRef, refresh]);

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -26,6 +26,7 @@ const AUTOSAVE_DELAY_MS = 3_000;
 export function useProjectHistory(mapControllerRef: RefObject<MapController | null>) {
   const [snapshots, setSnapshots] = useState<ProjectHistorySnapshot[]>([]);
   const [recoverySnapshot, setRecoverySnapshot] = useState<ProjectHistorySnapshot | null>(null);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
   const timerRef = useRef<number | null>(null);
   const refresh = useCallback(async () => {
     try {
@@ -85,6 +86,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
 
   const restore = useCallback(
     (snapshot: ProjectHistorySnapshot) => {
+      setRestoreError(null);
       try {
         const before = buildProjectSnapshot(mapControllerRef);
         const beforePath = useAppStore.getState().projectPath;
@@ -96,8 +98,13 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
         registerProjectRestoreHistory(before, beforePath, restored);
         useAppStore.setState({ isDirty: true });
         setRecoverySnapshot(null);
+        return true;
       } catch (error) {
         console.error("Could not restore the project snapshot.", error);
+        setRestoreError(
+          error instanceof Error ? error.message : "Could not restore the project snapshot.",
+        );
+        return false;
       }
     },
     [mapControllerRef],
@@ -114,5 +121,13 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
 
   const dismissRecovery = useCallback(() => setRecoverySnapshot(null), []);
 
-  return { snapshots, recoverySnapshot, refresh, restore, discardRecovery, dismissRecovery };
+  return {
+    snapshots,
+    recoverySnapshot,
+    restoreError,
+    refresh,
+    restore,
+    discardRecovery,
+    dismissRecovery,
+  };
 }

--- a/apps/geolibre-desktop/src/hooks/useUndoRedoShortcuts.ts
+++ b/apps/geolibre-desktop/src/hooks/useUndoRedoShortcuts.ts
@@ -1,4 +1,10 @@
-import { redo, undo, useAppStore } from "@geolibre/core";
+import {
+  canRedoProjectRestore,
+  canUndoProjectRestore,
+  redo,
+  undo,
+  useAppStore,
+} from "@geolibre/core";
 import { useEffect } from "react";
 
 /** True when focus is in a text-editing surface (let the browser handle undo). */
@@ -27,10 +33,10 @@ export function useUndoRedoShortcuts(): void {
       // Only consume the event when there is actually something to do, so an
       // empty stack doesn't swallow the browser/OS shortcut (e.g. Cmd+Y).
       const temporal = useAppStore.temporal.getState();
-      if (isRedo && temporal.futureStates.length > 0) {
+      if (isRedo && (temporal.futureStates.length > 0 || canRedoProjectRestore())) {
         e.preventDefault();
         redo();
-      } else if (isUndo && temporal.pastStates.length > 0) {
+      } else if (isUndo && (temporal.pastStates.length > 0 || canUndoProjectRestore())) {
         e.preventDefault();
         undo();
       }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1,4 +1,14 @@
 {
+  "projectHistory": {
+    "title": "Project History",
+    "description": "Browse autosaved snapshots stored on this device.",
+    "empty": "No autosaved snapshots yet.",
+    "summary": "{{count}} layers · zoom {{zoom}}",
+    "restore": "Restore",
+    "discard": "Discard",
+    "recoveryTitle": "Recover unsaved work?",
+    "recoveryDescription": "GeoLibre did not close cleanly. A newer autosave of “{{name}}” is available."
+  },
   "browser": {
     "title": "Browser",
     "services": "Services",
@@ -2278,6 +2288,7 @@
       "urlEllipsis": "URL...",
       "galleryEllipsis": "Gallery...",
       "openRecent": "Open Recent",
+      "projectHistoryEllipsis": "History...",
       "noRecentProjects": "No recent projects",
       "removeFromRecent": "Remove {{name}} from recent projects",
       "clearRecentProjects": "Clear Recent Projects",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -6,6 +6,7 @@
     "summary": "{{count}} layers · zoom {{zoom}}",
     "restore": "Restore",
     "discard": "Discard",
+    "restoreError": "Could not restore this snapshot. It may be damaged or incompatible with this GeoLibre version.",
     "recoveryTitle": "Recover unsaved work?",
     "recoveryDescription": "GeoLibre did not close cleanly. A newer autosave of “{{name}}” is available."
   },

--- a/apps/geolibre-desktop/src/lib/project-history-session.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-session.ts
@@ -1,9 +1,32 @@
 const SESSION_KEY = "geolibre-project-session";
+const TAB_KEY = "geolibre-project-session-tab";
 const LAST_SAVE_KEY = "geolibre-project-last-explicit-save";
+
+function currentTabId(): string {
+  let id = sessionStorage.getItem(TAB_KEY);
+  if (!id) {
+    id =
+      globalThis.crypto?.randomUUID?.() ??
+      `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    sessionStorage.setItem(TAB_KEY, id);
+  }
+  return id;
+}
+
+function readSessions(): Record<string, "open" | "closed"> {
+  const stored = localStorage.getItem(SESSION_KEY);
+  if (!stored) return {};
+  if (stored === "open" || stored === "closed") return { legacy: stored };
+  try {
+    return JSON.parse(stored) as Record<string, "open" | "closed">;
+  } catch {
+    return {};
+  }
+}
 
 export function readProjectSessionState(): string | null {
   try {
-    return localStorage.getItem(SESSION_KEY);
+    return Object.values(readSessions()).includes("open") ? "open" : "closed";
   } catch (error) {
     console.error("Could not read the project session state.", error);
     return null;
@@ -21,7 +44,10 @@ export function readLastExplicitProjectSave(): string | null {
 
 export function markProjectSession(state: "open" | "closed"): void {
   try {
-    localStorage.setItem(SESSION_KEY, state);
+    const sessions = readSessions();
+    delete sessions.legacy;
+    sessions[currentTabId()] = state;
+    localStorage.setItem(SESSION_KEY, JSON.stringify(sessions));
   } catch (error) {
     console.error("Could not persist the project session state.", error);
   }

--- a/apps/geolibre-desktop/src/lib/project-history-session.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-session.ts
@@ -1,0 +1,36 @@
+const SESSION_KEY = "geolibre-project-session";
+const LAST_SAVE_KEY = "geolibre-project-last-explicit-save";
+
+export function readProjectSessionState(): string | null {
+  try {
+    return localStorage.getItem(SESSION_KEY);
+  } catch (error) {
+    console.error("Could not read the project session state.", error);
+    return null;
+  }
+}
+
+export function readLastExplicitProjectSave(): string | null {
+  try {
+    return localStorage.getItem(LAST_SAVE_KEY);
+  } catch (error) {
+    console.error("Could not read the last project save time.", error);
+    return null;
+  }
+}
+
+export function markProjectSession(state: "open" | "closed"): void {
+  try {
+    localStorage.setItem(SESSION_KEY, state);
+  } catch (error) {
+    console.error("Could not persist the project session state.", error);
+  }
+}
+
+export function recordExplicitProjectSave(): void {
+  try {
+    localStorage.setItem(LAST_SAVE_KEY, new Date().toISOString());
+  } catch (error) {
+    console.error("Could not persist the last project save time.", error);
+  }
+}

--- a/apps/geolibre-desktop/src/lib/project-history-store.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-store.ts
@@ -61,8 +61,17 @@ function openDatabase(): Promise<IDBDatabase> {
         }
       }
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      request.result.onversionchange = () => request.result.close();
+      resolve(request.result);
+    };
     request.onerror = () => reject(request.error ?? new Error("Could not open project history."));
+    request.onblocked = () =>
+      reject(
+        new Error(
+          "Project history is blocked by another GeoLibre tab. Close or reload other tabs and try again.",
+        ),
+      );
   });
 }
 

--- a/apps/geolibre-desktop/src/lib/project-history-store.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-store.ts
@@ -1,0 +1,129 @@
+import { parseProject, type GeoLibreProject } from "@geolibre/core";
+
+const DB_NAME = "geolibre-project-history";
+const DB_VERSION = 1;
+const STORE_NAME = "snapshots";
+const MAX_SNAPSHOTS = 20;
+const MAX_TOTAL_BYTES = 50 * 1024 * 1024;
+const MAX_SNAPSHOT_BYTES = 10 * 1024 * 1024;
+
+export interface ProjectHistorySnapshot {
+  id: string;
+  createdAt: string;
+  content: string;
+  size: number;
+  name: string;
+  layerCount: number;
+  basemap: string;
+  camera: GeoLibreProject["mapView"];
+}
+
+function available(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Could not open project history."));
+  });
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Project history request failed."));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error("Project history transaction failed."));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("Project history transaction was aborted."));
+  });
+}
+
+export async function listProjectSnapshots(): Promise<ProjectHistorySnapshot[]> {
+  if (!available()) return [];
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const snapshots = await requestResult(
+      transaction.objectStore(STORE_NAME).getAll() as IDBRequest<ProjectHistorySnapshot[]>,
+    );
+    return snapshots.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  } finally {
+    db.close();
+  }
+}
+
+export async function addProjectSnapshot(content: string): Promise<boolean> {
+  if (!available()) return false;
+  const size = new Blob([content]).size;
+  if (size > MAX_SNAPSHOT_BYTES) return false;
+  const project = parseProject(content);
+  const existing = await listProjectSnapshots();
+  if (existing[0]?.content === content) return false;
+  const snapshot: ProjectHistorySnapshot = {
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+    content,
+    size,
+    name: project.name,
+    layerCount: project.layers.length,
+    basemap: project.basemapStyleUrl,
+    camera: project.mapView,
+  };
+  const retained = [snapshot, ...existing];
+  let total = 0;
+  const keepIds = new Set<string>();
+  for (const entry of retained) {
+    if (keepIds.size >= MAX_SNAPSHOTS || total + entry.size > MAX_TOTAL_BYTES) continue;
+    keepIds.add(entry.id);
+    total += entry.size;
+  }
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    store.put(snapshot);
+    existing.filter((entry) => !keepIds.has(entry.id)).forEach((entry) => store.delete(entry.id));
+    await transactionDone(transaction);
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
+export async function deleteProjectSnapshot(id: string): Promise<void> {
+  if (!available()) return;
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    transaction.objectStore(STORE_NAME).delete(id);
+    await transactionDone(transaction);
+  } finally {
+    db.close();
+  }
+}
+
+export async function clearProjectSnapshots(): Promise<void> {
+  if (!available()) return;
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    transaction.objectStore(STORE_NAME).clear();
+    await transactionDone(transaction);
+  } finally {
+    db.close();
+  }
+}

--- a/apps/geolibre-desktop/src/lib/project-history-store.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-store.ts
@@ -18,6 +18,7 @@ export interface ProjectHistorySnapshot {
   basemap: string;
   camera: GeoLibreProject["mapView"];
   contentHash?: string;
+  projectKey?: string;
 }
 
 type ProjectHistoryMetadata = Omit<ProjectHistorySnapshot, "content">;
@@ -32,6 +33,7 @@ function snapshotMetadata(snapshot: ProjectHistorySnapshot): ProjectHistoryMetad
     basemap: snapshot.basemap,
     camera: snapshot.camera,
     contentHash: snapshot.contentHash,
+    projectKey: snapshot.projectKey,
   };
 }
 
@@ -42,6 +44,12 @@ function available(): boolean {
 function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
+    let settled = false;
+    const rejectOnce = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
     request.onupgradeneeded = () => {
       if (!request.result.objectStoreNames.contains(STORE_NAME)) {
         request.result.createObjectStore(STORE_NAME, { keyPath: "id" });
@@ -62,12 +70,19 @@ function openDatabase(): Promise<IDBDatabase> {
       }
     };
     request.onsuccess = () => {
-      request.result.onversionchange = () => request.result.close();
-      resolve(request.result);
+      const db = request.result;
+      db.onversionchange = () => db.close();
+      if (settled) {
+        db.close();
+        return;
+      }
+      settled = true;
+      resolve(db);
     };
-    request.onerror = () => reject(request.error ?? new Error("Could not open project history."));
+    request.onerror = () =>
+      rejectOnce(request.error ?? new Error("Could not open project history."));
     request.onblocked = () =>
-      reject(
+      rejectOnce(
         new Error(
           "Project history is blocked by another GeoLibre tab. Close or reload other tabs and try again.",
         ),
@@ -92,7 +107,7 @@ function transactionDone(transaction: IDBTransaction): Promise<void> {
   });
 }
 
-export async function listProjectSnapshots(): Promise<ProjectHistorySnapshot[]> {
+export async function listProjectSnapshots(projectKey?: string): Promise<ProjectHistorySnapshot[]> {
   if (!available()) return [];
   const db = await openDatabase();
   try {
@@ -100,7 +115,9 @@ export async function listProjectSnapshots(): Promise<ProjectHistorySnapshot[]> 
     const snapshots = await requestResult(
       transaction.objectStore(STORE_NAME).getAll() as IDBRequest<ProjectHistorySnapshot[]>,
     );
-    return snapshots.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    return snapshots
+      .filter((snapshot) => projectKey === undefined || snapshot.projectKey === projectKey)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   } finally {
     db.close();
   }
@@ -122,7 +139,26 @@ async function listProjectSnapshotMetadata(): Promise<ProjectHistoryMetadata[]> 
 
 export type AddProjectSnapshotResult = "added" | "duplicate" | "too-large";
 
-export async function addProjectSnapshot(content: string): Promise<AddProjectSnapshotResult> {
+function hashContent(content: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < content.length; index += 1) {
+    hash ^= content.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function createSnapshotId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+export async function addProjectSnapshot(
+  content: string,
+  projectKey?: string,
+): Promise<AddProjectSnapshotResult> {
   if (!available()) return "duplicate";
   const size = new Blob([content]).size;
   if (size > MAX_SNAPSHOT_BYTES) {
@@ -132,14 +168,11 @@ export async function addProjectSnapshot(content: string): Promise<AddProjectSna
     return "too-large";
   }
   const project = parseProject(content);
-  const contentHash = Array.from(
-    new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(content))),
-    (byte) => byte.toString(16).padStart(2, "0"),
-  ).join("");
+  const contentHash = hashContent(content);
   const existing = await listProjectSnapshotMetadata();
   if (existing[0]?.contentHash === contentHash) return "duplicate";
   const snapshot: ProjectHistorySnapshot = {
-    id: crypto.randomUUID(),
+    id: createSnapshotId(),
     createdAt: new Date().toISOString(),
     content,
     size,
@@ -148,6 +181,7 @@ export async function addProjectSnapshot(content: string): Promise<AddProjectSna
     basemap: project.basemapStyleUrl,
     camera: project.mapView,
     contentHash,
+    projectKey,
   };
   const retained = [snapshot, ...existing];
   let total = 0;

--- a/apps/geolibre-desktop/src/lib/project-history-store.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-store.ts
@@ -1,8 +1,9 @@
 import { parseProject, type GeoLibreProject } from "@geolibre/core";
 
 const DB_NAME = "geolibre-project-history";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = "snapshots";
+const METADATA_STORE_NAME = "snapshot-metadata";
 const MAX_SNAPSHOTS = 20;
 const MAX_TOTAL_BYTES = 50 * 1024 * 1024;
 const MAX_SNAPSHOT_BYTES = 10 * 1024 * 1024;
@@ -16,6 +17,22 @@ export interface ProjectHistorySnapshot {
   layerCount: number;
   basemap: string;
   camera: GeoLibreProject["mapView"];
+  contentHash?: string;
+}
+
+type ProjectHistoryMetadata = Omit<ProjectHistorySnapshot, "content">;
+
+function snapshotMetadata(snapshot: ProjectHistorySnapshot): ProjectHistoryMetadata {
+  return {
+    id: snapshot.id,
+    createdAt: snapshot.createdAt,
+    size: snapshot.size,
+    name: snapshot.name,
+    layerCount: snapshot.layerCount,
+    basemap: snapshot.basemap,
+    camera: snapshot.camera,
+    contentHash: snapshot.contentHash,
+  };
 }
 
 function available(): boolean {
@@ -28,6 +45,20 @@ function openDatabase(): Promise<IDBDatabase> {
     request.onupgradeneeded = () => {
       if (!request.result.objectStoreNames.contains(STORE_NAME)) {
         request.result.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+      if (!request.result.objectStoreNames.contains(METADATA_STORE_NAME)) {
+        const metadataStore = request.result.createObjectStore(METADATA_STORE_NAME, {
+          keyPath: "id",
+        });
+        if (request.transaction && request.result.objectStoreNames.contains(STORE_NAME)) {
+          const cursorRequest = request.transaction.objectStore(STORE_NAME).openCursor();
+          cursorRequest.onsuccess = () => {
+            const cursor = cursorRequest.result;
+            if (!cursor) return;
+            metadataStore.put(snapshotMetadata(cursor.value as ProjectHistorySnapshot));
+            cursor.continue();
+          };
+        }
       }
     };
     request.onsuccess = () => resolve(request.result);
@@ -66,13 +97,38 @@ export async function listProjectSnapshots(): Promise<ProjectHistorySnapshot[]> 
   }
 }
 
-export async function addProjectSnapshot(content: string): Promise<boolean> {
-  if (!available()) return false;
+async function listProjectSnapshotMetadata(): Promise<ProjectHistoryMetadata[]> {
+  if (!available()) return [];
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(METADATA_STORE_NAME, "readonly");
+    const entries = await requestResult(
+      transaction.objectStore(METADATA_STORE_NAME).getAll() as IDBRequest<ProjectHistoryMetadata[]>,
+    );
+    return entries.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  } finally {
+    db.close();
+  }
+}
+
+export type AddProjectSnapshotResult = "added" | "duplicate" | "too-large";
+
+export async function addProjectSnapshot(content: string): Promise<AddProjectSnapshotResult> {
+  if (!available()) return "duplicate";
   const size = new Blob([content]).size;
-  if (size > MAX_SNAPSHOT_BYTES) return false;
+  if (size > MAX_SNAPSHOT_BYTES) {
+    console.warn(
+      `Project autosave skipped: snapshot is ${size} bytes, above the ${MAX_SNAPSHOT_BYTES}-byte limit.`,
+    );
+    return "too-large";
+  }
   const project = parseProject(content);
-  const existing = await listProjectSnapshots();
-  if (existing[0]?.content === content) return false;
+  const contentHash = Array.from(
+    new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(content))),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+  const existing = await listProjectSnapshotMetadata();
+  if (existing[0]?.contentHash === contentHash) return "duplicate";
   const snapshot: ProjectHistorySnapshot = {
     id: crypto.randomUUID(),
     createdAt: new Date().toISOString(),
@@ -82,23 +138,31 @@ export async function addProjectSnapshot(content: string): Promise<boolean> {
     layerCount: project.layers.length,
     basemap: project.basemapStyleUrl,
     camera: project.mapView,
+    contentHash,
   };
   const retained = [snapshot, ...existing];
   let total = 0;
   const keepIds = new Set<string>();
   for (const entry of retained) {
-    if (keepIds.size >= MAX_SNAPSHOTS || total + entry.size > MAX_TOTAL_BYTES) continue;
+    if (keepIds.size >= MAX_SNAPSHOTS || total + entry.size > MAX_TOTAL_BYTES) break;
     keepIds.add(entry.id);
     total += entry.size;
   }
   const db = await openDatabase();
   try {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const transaction = db.transaction([STORE_NAME, METADATA_STORE_NAME], "readwrite");
     const store = transaction.objectStore(STORE_NAME);
+    const metadataStore = transaction.objectStore(METADATA_STORE_NAME);
     store.put(snapshot);
-    existing.filter((entry) => !keepIds.has(entry.id)).forEach((entry) => store.delete(entry.id));
+    metadataStore.put(snapshotMetadata(snapshot));
+    existing
+      .filter((entry) => !keepIds.has(entry.id))
+      .forEach((entry) => {
+        store.delete(entry.id);
+        metadataStore.delete(entry.id);
+      });
     await transactionDone(transaction);
-    return true;
+    return "added";
   } finally {
     db.close();
   }
@@ -108,8 +172,9 @@ export async function deleteProjectSnapshot(id: string): Promise<void> {
   if (!available()) return;
   const db = await openDatabase();
   try {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const transaction = db.transaction([STORE_NAME, METADATA_STORE_NAME], "readwrite");
     transaction.objectStore(STORE_NAME).delete(id);
+    transaction.objectStore(METADATA_STORE_NAME).delete(id);
     await transactionDone(transaction);
   } finally {
     db.close();
@@ -120,8 +185,9 @@ export async function clearProjectSnapshots(): Promise<void> {
   if (!available()) return;
   const db = await openDatabase();
   try {
-    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const transaction = db.transaction([STORE_NAME, METADATA_STORE_NAME], "readwrite");
     transaction.objectStore(STORE_NAME).clear();
+    transaction.objectStore(METADATA_STORE_NAME).clear();
     await transactionDone(transaction);
   } finally {
     db.close();

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -257,6 +257,12 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
     tier: "basic",
   },
   {
+    id: "project.history",
+    menuId: "project",
+    labelKey: "toolbar.item.projectHistoryEllipsis",
+    tier: "basic",
+  },
+  {
     id: "project.import",
     menuId: "project",
     labelKey: "toolbar.menu.import",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,8 +30,12 @@ export {
 } from "./storymap-io";
 export {
   clearHistory,
+  canRedoProjectRestore,
+  canUndoProjectRestore,
   DEFAULT_COLLABORATION_STATE,
   projectPathLabel,
+  registerProjectRestoreHistory,
+  subscribeProjectRestoreHistory,
   redo,
   undo,
   useAppStore,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -2131,6 +2131,10 @@ export const useAppStore = create<AppState>()(
           const before = useAppStore.temporal.getState().pastStates;
           debounced(...args);
           if (useAppStore.temporal.getState().pastStates !== before) {
+            if (!applyingProjectRestoreHistory && projectRestoreRedo) {
+              projectRestoreRedo = null;
+              notifyProjectRestoreHistory();
+            }
             pruneHistoryBySize();
           }
         };
@@ -2207,19 +2211,21 @@ export function undo(): void {
   const temporal = useAppStore.temporal.getState();
   if (temporal.pastStates.length === 0 && projectRestoreUndo) {
     const entry = projectRestoreUndo;
-    projectRestoreUndo = null;
     applyingProjectRestoreHistory = true;
     try {
       useAppStore.getState().loadProject(entry.before, entry.beforePath, {
         rememberRecent: false,
         presenting: false,
       });
+      projectRestoreUndo = null;
+      useAppStore.setState({ isDirty: true });
+      projectRestoreRedo = entry;
+      notifyProjectRestoreHistory();
+    } catch (error) {
+      console.error("Could not undo the project snapshot restore.", error);
     } finally {
       applyingProjectRestoreHistory = false;
     }
-    useAppStore.setState({ isDirty: true });
-    projectRestoreRedo = entry;
-    notifyProjectRestoreHistory();
     return;
   }
   if (temporal.pastStates.length === 0) return; // nothing to undo; stay clean
@@ -2234,19 +2240,21 @@ export function redo(): void {
   const temporal = useAppStore.temporal.getState();
   if (temporal.futureStates.length === 0 && projectRestoreRedo) {
     const entry = projectRestoreRedo;
-    projectRestoreRedo = null;
     applyingProjectRestoreHistory = true;
     try {
       useAppStore.getState().loadProject(entry.after, null, {
         rememberRecent: false,
         presenting: false,
       });
+      projectRestoreRedo = null;
+      useAppStore.setState({ isDirty: true });
+      projectRestoreUndo = entry;
+      notifyProjectRestoreHistory();
+    } catch (error) {
+      console.error("Could not redo the project snapshot restore.", error);
     } finally {
       applyingProjectRestoreHistory = false;
     }
-    useAppStore.setState({ isDirty: true });
-    projectRestoreUndo = entry;
-    notifyProjectRestoreHistory();
     return;
   }
   if (temporal.futureStates.length === 0) return; // nothing to redo; stay clean

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -849,6 +849,50 @@ function fitGrid(total: number, preferredCols: number): { rows: number; cols: nu
 /** Cancels the active history coalesce window (assigned by zundo's handleSet). */
 let cancelHistoryCoalesce: () => void = () => {};
 
+interface ProjectRestoreHistoryEntry {
+  before: GeoLibreProject;
+  beforePath: string | null;
+  after: GeoLibreProject;
+}
+
+let projectRestoreUndo: ProjectRestoreHistoryEntry | null = null;
+let projectRestoreRedo: ProjectRestoreHistoryEntry | null = null;
+let applyingProjectRestoreHistory = false;
+const projectRestoreHistoryListeners = new Set<() => void>();
+
+function notifyProjectRestoreHistory(): void {
+  projectRestoreHistoryListeners.forEach((listener) => listener());
+}
+
+export function subscribeProjectRestoreHistory(listener: () => void): () => void {
+  projectRestoreHistoryListeners.add(listener);
+  return () => projectRestoreHistoryListeners.delete(listener);
+}
+
+export function canUndoProjectRestore(): boolean {
+  return projectRestoreUndo !== null;
+}
+
+export function canRedoProjectRestore(): boolean {
+  return projectRestoreRedo !== null;
+}
+
+/**
+ * Register a whole-project restore as one undoable operation. The regular
+ * temporal history intentionally tracks only editing fields, while restoring a
+ * history snapshot also changes project metadata, camera, plugins, and other
+ * serialized state, so it needs a full canonical project pair.
+ */
+export function registerProjectRestoreHistory(
+  before: GeoLibreProject,
+  beforePath: string | null,
+  after: GeoLibreProject,
+): void {
+  projectRestoreUndo = { before, beforePath, after };
+  projectRestoreRedo = null;
+  notifyProjectRestoreHistory();
+}
+
 /**
  * Drop the oldest undo snapshots once their combined feature payload exceeds the
  * configured budget, bounding the memory held by history when a large vector
@@ -2161,6 +2205,23 @@ function finishHistoryStep(previousBasemapStyleUrl: string): void {
  */
 export function undo(): void {
   const temporal = useAppStore.temporal.getState();
+  if (temporal.pastStates.length === 0 && projectRestoreUndo) {
+    const entry = projectRestoreUndo;
+    projectRestoreUndo = null;
+    applyingProjectRestoreHistory = true;
+    try {
+      useAppStore.getState().loadProject(entry.before, entry.beforePath, {
+        rememberRecent: false,
+        presenting: false,
+      });
+    } finally {
+      applyingProjectRestoreHistory = false;
+    }
+    useAppStore.setState({ isDirty: true });
+    projectRestoreRedo = entry;
+    notifyProjectRestoreHistory();
+    return;
+  }
   if (temporal.pastStates.length === 0) return; // nothing to undo; stay clean
   cancelHistoryCoalesce(); // break any in-flight burst so the next edit records
   const previousBasemapStyleUrl = useAppStore.getState().basemapStyleUrl;
@@ -2171,6 +2232,23 @@ export function undo(): void {
 /** Step the history forward one entry and mark the project dirty. */
 export function redo(): void {
   const temporal = useAppStore.temporal.getState();
+  if (temporal.futureStates.length === 0 && projectRestoreRedo) {
+    const entry = projectRestoreRedo;
+    projectRestoreRedo = null;
+    applyingProjectRestoreHistory = true;
+    try {
+      useAppStore.getState().loadProject(entry.after, null, {
+        rememberRecent: false,
+        presenting: false,
+      });
+    } finally {
+      applyingProjectRestoreHistory = false;
+    }
+    useAppStore.setState({ isDirty: true });
+    projectRestoreUndo = entry;
+    notifyProjectRestoreHistory();
+    return;
+  }
   if (temporal.futureStates.length === 0) return; // nothing to redo; stay clean
   cancelHistoryCoalesce(); // break any in-flight burst so the next edit records
   const previousBasemapStyleUrl = useAppStore.getState().basemapStyleUrl;
@@ -2182,4 +2260,9 @@ export function redo(): void {
 export function clearHistory(): void {
   cancelHistoryCoalesce(); // reset any in-flight burst so the next edit records
   useAppStore.temporal.getState().clear();
+  if (!applyingProjectRestoreHistory) {
+    projectRestoreUndo = null;
+    projectRestoreRedo = null;
+    notifyProjectRestoreHistory();
+  }
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -853,6 +853,7 @@ interface ProjectRestoreHistoryEntry {
   before: GeoLibreProject;
   beforePath: string | null;
   after: GeoLibreProject;
+  afterPath: string | null;
 }
 
 let projectRestoreUndo: ProjectRestoreHistoryEntry | null = null;
@@ -887,8 +888,9 @@ export function registerProjectRestoreHistory(
   before: GeoLibreProject,
   beforePath: string | null,
   after: GeoLibreProject,
+  afterPath: string | null = null,
 ): void {
-  projectRestoreUndo = { before, beforePath, after };
+  projectRestoreUndo = { before, beforePath, after, afterPath };
   projectRestoreRedo = null;
   notifyProjectRestoreHistory();
 }
@@ -2242,7 +2244,7 @@ export function redo(): void {
     const entry = projectRestoreRedo;
     applyingProjectRestoreHistory = true;
     try {
-      useAppStore.getState().loadProject(entry.after, null, {
+      useAppStore.getState().loadProject(entry.after, entry.afterPath, {
         rememberRecent: false,
         presenting: false,
       });

--- a/tests/undo-redo.test.ts
+++ b/tests/undo-redo.test.ts
@@ -174,7 +174,12 @@ describe("project restore history", () => {
     const before = createEmptyProject("Before restore");
     const after = createEmptyProject("Restored snapshot");
     useAppStore.getState().loadProject(after, null, { rememberRecent: false, presenting: false });
-    registerProjectRestoreHistory(before, "/tmp/before.geolibre.json", after);
+    registerProjectRestoreHistory(
+      before,
+      "/tmp/before.geolibre.json",
+      after,
+      "/tmp/before.geolibre.json",
+    );
 
     undo();
     assert.equal(useAppStore.getState().projectName, "Before restore");
@@ -183,7 +188,7 @@ describe("project restore history", () => {
 
     redo();
     assert.equal(useAppStore.getState().projectName, "Restored snapshot");
-    assert.equal(useAppStore.getState().projectPath, null);
+    assert.equal(useAppStore.getState().projectPath, "/tmp/before.geolibre.json");
     assert.equal(useAppStore.getState().isDirty, true);
   });
 

--- a/tests/undo-redo.test.ts
+++ b/tests/undo-redo.test.ts
@@ -186,6 +186,20 @@ describe("project restore history", () => {
     assert.equal(useAppStore.getState().projectPath, null);
     assert.equal(useAppStore.getState().isDirty, true);
   });
+
+  it("invalidates restore redo when a normal edit follows undo", () => {
+    const before = createEmptyProject("Before restore");
+    const after = createEmptyProject("Restored snapshot");
+    useAppStore.getState().loadProject(after, null, { rememberRecent: false, presenting: false });
+    registerProjectRestoreHistory(before, null, after);
+
+    undo();
+    useAppStore.getState().setBasemapOpacity(0.5);
+    redo();
+
+    assert.equal(useAppStore.getState().projectName, "Before restore");
+    assert.equal(useAppStore.getState().basemapOpacity, 0.5);
+  });
 });
 
 describe("history size budget (issue #341)", () => {

--- a/tests/undo-redo.test.ts
+++ b/tests/undo-redo.test.ts
@@ -8,7 +8,13 @@ import {
   setMaxHistoryFeatureCount,
   trimHistoryBySize,
 } from "../packages/core/src/history";
-import { clearHistory, redo, undo, useAppStore } from "../packages/core/src/store";
+import {
+  clearHistory,
+  redo,
+  registerProjectRestoreHistory,
+  undo,
+  useAppStore,
+} from "../packages/core/src/store";
 import { createEmptyProject } from "../packages/core/src/project";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -155,6 +161,30 @@ describe("store history tracking", () => {
     useAppStore.getState().setPointerCoords([1, 2]);
     useAppStore.getState().setAttributeFilter("abc");
     assert.equal(pastLen(), before);
+  });
+});
+
+describe("project restore history", () => {
+  beforeEach(() => {
+    setHistoryCoalesceMs(0);
+    useAppStore.getState().newProject({ name: "reset" });
+  });
+
+  it("undoes and redoes a whole-project snapshot restore", () => {
+    const before = createEmptyProject("Before restore");
+    const after = createEmptyProject("Restored snapshot");
+    useAppStore.getState().loadProject(after, null, { rememberRecent: false, presenting: false });
+    registerProjectRestoreHistory(before, "/tmp/before.geolibre.json", after);
+
+    undo();
+    assert.equal(useAppStore.getState().projectName, "Before restore");
+    assert.equal(useAppStore.getState().projectPath, "/tmp/before.geolibre.json");
+    assert.equal(useAppStore.getState().isDirty, true);
+
+    redo();
+    assert.equal(useAppStore.getState().projectName, "Restored snapshot");
+    assert.equal(useAppStore.getState().projectPath, null);
+    assert.equal(useAppStore.getState().isDirty, true);
   });
 });
 


### PR DESCRIPTION
## Summary

- autosave canonical project snapshots to a bounded IndexedDB ring buffer after a 3-second debounce
- offer recovery when a newer autosave follows an unclean session
- add Project > History for browsing and restoring timestamped snapshots
- clear recovery history when starting a blank new project

Snapshots are capped at 10 MB each, 20 entries, and 50 MB total. Identical serialized states are skipped, and autosave never writes to the user project file.

## Verification

- `npm run build`
- `npm run lint -- --quiet`
- `npm run test:frontend` (4,629 passed, 1 skipped)
- `pre-commit run --files ...`
- Playwright browser verification in light and dark themes, including snapshot creation and restoring an earlier project name

Fixes #1522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Project History access through the Project menu.
  * Browse saved snapshots with dates and metadata.
  * Restore snapshots or discard recoverable sessions.
  * Automatically save unsaved changes for recovery.
  * Undo and redo now support whole-project restorations.
  * New projects and templates clear previous history.
  * Added localized messaging for history, restoration, and recovery actions.
  * Snapshot storage avoids duplicates and retains history within configured limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->