### PR TITLE
Allow all values in categorized styles

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -100,6 +100,7 @@ import {
   getPropertyValues,
   isCategoricalProperty,
   isNumericProperty,
+  MAX_MANUAL_CATEGORIZED_VALUES,
   proportionalSizeBounds,
 } from "../../lib/vector-style-classification";
 import { buildStyleSuggestions, type StyleSuggestion } from "../../lib/style-suggestions";
@@ -585,7 +586,7 @@ function normalizeVectorStyleClassCount(mode: VectorStyleMode, value: number): n
   return clampClassCount(
     value,
     mode === "categorized" ? 1 : 2,
-    mode === "categorized" ? Number.POSITIVE_INFINITY : 12,
+    mode === "categorized" ? MAX_MANUAL_CATEGORIZED_VALUES : 12,
   );
 }
 
@@ -1470,9 +1471,10 @@ export function StylePanel({
       loadedVectorPropertyValues?.layerId === layer.id
         ? loadedVectorPropertyValues.byProperty[draftVectorStyleProperty]
         : undefined;
-    return countCategorizedValues(
+    const count = countCategorizedValues(
       loadedValues ?? getPropertyValues(layer, draftVectorStyleProperty),
     );
+    return count <= MAX_MANUAL_CATEGORIZED_VALUES ? count : 0;
     // The calculation reads only these stable layer fields. Depending on the
     // whole layer object would rescan on every unrelated style edit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1843,7 +1845,7 @@ export function StylePanel({
         ? draftVectorStyleClassCount === currentCategoryCount
           ? nextCategoryCount
           : Math.min(draftVectorStyleClassCount, nextCategoryCount)
-        : draftVectorStyleClassCount;
+        : Math.min(draftVectorStyleClassCount, 12);
     setDraftVectorStyleProperty(property);
     setDraftVectorStyleClassCount(classCount);
     regenerateDraftVectorStyleStops(
@@ -2463,6 +2465,10 @@ export function StylePanel({
                     {classCount}
                   </option>
                 ))}
+              {draftVectorStyleClassCount > 12 &&
+                draftVectorStyleClassCount !== categorizedValueCount && (
+                  <option value={draftVectorStyleClassCount}>{draftVectorStyleClassCount}</option>
+                )}
               {draftVectorStyleMode === "categorized" && categorizedValueCount > 0 && (
                 <option value="all">
                   {t("style.symbology.allClasses", {

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1460,6 +1460,41 @@ export function StylePanel({
   // hook order stays stable.
   const builderFeatures = useMemo(() => layer?.geojson?.features ?? [], [layer]);
   const builderFieldNames = useMemo(() => (layer ? getAttributePropertyNames(layer) : []), [layer]);
+  const categorizedValueCount = useMemo(() => {
+    if (!layer || draftVectorStyleMode !== "categorized") return 0;
+    const valuesAreSampled =
+      !layer.geojson &&
+      (layer.type === "vector-tiles" || layer.type === "pmtiles" || layer.type === "mbtiles");
+    if (valuesAreSampled) return 0;
+    const loadedValues =
+      loadedVectorPropertyValues?.layerId === layer.id
+        ? loadedVectorPropertyValues.byProperty[draftVectorStyleProperty]
+        : undefined;
+    return countCategorizedValues(
+      loadedValues ?? getPropertyValues(layer, draftVectorStyleProperty),
+    );
+    // The calculation reads only these stable layer fields. Depending on the
+    // whole layer object would rescan on every unrelated style edit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    draftVectorStyleMode,
+    draftVectorStyleProperty,
+    layer?.geojson,
+    layer?.id,
+    layer?.type,
+    loadedVectorPropertyValues,
+  ]);
+
+  useEffect(() => {
+    if (
+      draftVectorStyleMode !== "categorized" ||
+      categorizedValueCount === 0 ||
+      draftVectorStyleClassCount <= categorizedValueCount
+    ) {
+      return;
+    }
+    setDraftVectorStyleClassCount(categorizedValueCount);
+  }, [categorizedValueCount, draftVectorStyleClassCount, draftVectorStyleMode]);
   // Zoom and variables snapshot the camera via getState() when the builder
   // opens instead of subscribing: the dialog is modal (the map cannot move
   // while it is open), and mapView subscriptions would re-render this whole
@@ -2084,13 +2119,6 @@ export function StylePanel({
   const vectorClassCountOptions = VECTOR_STYLE_CLASS_COUNTS.filter((classCount) =>
     draftVectorStyleMode === "categorized" ? true : classCount >= 2,
   );
-  const categorizedValueCount =
-    draftVectorStyleMode === "categorized"
-      ? countCategorizedValues(
-          draftVectorPropertyValues ?? getPropertyValues(layer, draftVectorStyleProperty),
-        )
-      : 0;
-
   // --- Rule-based renderer (immediate writes to style.vectorRules) ---
   const currentRules = styleValue(style, "vectorRules");
   const concreteRules = currentRules.filter((rule) => !rule.isElse);

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1791,11 +1791,30 @@ export function StylePanel({
     }
   };
   const updateDraftVectorStyleProperty = (property: string) => {
+    const currentCategoryCount =
+      draftVectorStyleMode === "categorized"
+        ? countCategorizedValues(
+            draftVectorPropertyValues ?? getPropertyValues(layer, draftVectorStyleProperty),
+          )
+        : 0;
+    const nextCategoryCount =
+      draftVectorStyleMode === "categorized"
+        ? countCategorizedValues(
+            matchingPropertyValues(property) ?? getPropertyValues(layer, property),
+          )
+        : 0;
+    const classCount =
+      nextCategoryCount > 0
+        ? draftVectorStyleClassCount === currentCategoryCount
+          ? nextCategoryCount
+          : Math.min(draftVectorStyleClassCount, nextCategoryCount)
+        : draftVectorStyleClassCount;
     setDraftVectorStyleProperty(property);
+    setDraftVectorStyleClassCount(classCount);
     regenerateDraftVectorStyleStops(
       draftVectorStyleMode,
       property,
-      draftVectorStyleClassCount,
+      classCount,
       draftVectorStyleColorRamp,
       draftVectorStyleClassificationScheme,
     );

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -582,6 +582,33 @@ function createDefaultStops(
   return styleValue(DEFAULT_LAYER_STYLE, "vectorStyleStops");
 }
 
+/**
+ * Count the distinct values a property offers as categorized stops, or 0 when
+ * that count is not known to be complete.
+ *
+ * A tiled source only exposes the features MapLibre has currently rendered, so
+ * its distinct values are a viewport sample that changes as the map pans. Add
+ * Vector Layer datasets are the exception: they render as tiles but their
+ * values come back complete from DuckDB, which is why the property-value
+ * loading effect keys on `metadata.sourceKind === "maplibre-gl-vector"` rather
+ * than on `layer.type`. Counts past the manual ceiling also report 0, so the
+ * panel never offers to render more category rows than it can.
+ */
+function completeCategorizedValueCount(
+  layer: GeoLibreLayer | undefined,
+  property: string,
+  loadedValues: unknown[] | undefined,
+): number {
+  if (!layer || !property) return 0;
+  const valuesAreSampled =
+    !layer.geojson &&
+    layer.metadata.sourceKind !== "maplibre-gl-vector" &&
+    (layer.type === "vector-tiles" || layer.type === "pmtiles" || layer.type === "mbtiles");
+  if (valuesAreSampled) return 0;
+  const count = countCategorizedValues(loadedValues ?? getPropertyValues(layer, property));
+  return count <= MAX_MANUAL_CATEGORIZED_VALUES ? count : 0;
+}
+
 function normalizeVectorStyleClassCount(mode: VectorStyleMode, value: number): number {
   return clampClassCount(
     value,
@@ -1026,6 +1053,13 @@ export function StylePanel({
   const [draftVectorStyleClassCount, setDraftVectorStyleClassCount] = useState(
     DEFAULT_LAYER_STYLE.vectorStyleClassCount,
   );
+  // "All categories" is a draft-only selection: the applied style records the
+  // class count it resolved to, so the panel seeds this flag from that count and
+  // then keeps it as the source of truth. Re-deriving it from
+  // `classCount === categorizedValueCount` would confuse "All" with a literal
+  // count that happens to match, and the two behave differently once the
+  // attribute changes underneath them.
+  const [draftVectorStyleAllCategories, setDraftVectorStyleAllCategories] = useState(false);
   const [draftVectorStyleColorRamp, setDraftVectorStyleColorRamp] = useState(
     DEFAULT_LAYER_STYLE.vectorStyleColorRamp,
   );
@@ -1104,6 +1138,7 @@ export function StylePanel({
       setDraftVectorStyleMode(DEFAULT_LAYER_STYLE.vectorStyleMode);
       setDraftVectorStyleProperty(DEFAULT_LAYER_STYLE.vectorStyleProperty);
       setDraftVectorStyleClassCount(DEFAULT_LAYER_STYLE.vectorStyleClassCount);
+      setDraftVectorStyleAllCategories(false);
       setDraftVectorStyleColorRamp(DEFAULT_LAYER_STYLE.vectorStyleColorRamp);
       setDraftVectorStyleClassificationScheme(DEFAULT_LAYER_STYLE.vectorStyleClassificationScheme);
       setDraftVectorStyleStops(DEFAULT_LAYER_STYLE.vectorStyleStops);
@@ -1124,12 +1159,21 @@ export function StylePanel({
     setDraftHeightExpression(styleValue(layer.style, "extrusionHeightExpression"));
     const vectorStyleMode = styleValue(layer.style, "vectorStyleMode");
     setDraftVectorStyleMode(vectorStyleMode);
-    setDraftVectorStyleProperty(styleValue(layer.style, "vectorStyleProperty"));
-    setDraftVectorStyleClassCount(
-      normalizeVectorStyleClassCount(
-        vectorStyleMode,
-        styleValue(layer.style, "vectorStyleClassCount"),
-      ),
+    const vectorStyleProperty = styleValue(layer.style, "vectorStyleProperty");
+    setDraftVectorStyleProperty(vectorStyleProperty);
+    const vectorStyleClassCount = normalizeVectorStyleClassCount(
+      vectorStyleMode,
+      styleValue(layer.style, "vectorStyleClassCount"),
+    );
+    setDraftVectorStyleClassCount(vectorStyleClassCount);
+    // Values that load asynchronously are not available yet, so a re-opened
+    // panel recognizes "All" only for layers whose features are already in the
+    // store — elsewhere the resolved number stays selected until the user picks
+    // "All" again.
+    setDraftVectorStyleAllCategories(
+      vectorStyleMode === "categorized" &&
+        vectorStyleClassCount ===
+          completeCategorizedValueCount(layer, vectorStyleProperty, undefined),
     );
     setDraftVectorStyleColorRamp(styleValue(layer.style, "vectorStyleColorRamp"));
     setDraftVectorStyleClassificationScheme(
@@ -1461,42 +1505,48 @@ export function StylePanel({
   // hook order stays stable.
   const builderFeatures = useMemo(() => layer?.geojson?.features ?? [], [layer]);
   const builderFieldNames = useMemo(() => (layer ? getAttributePropertyNames(layer) : []), [layer]);
-  const categorizedValueCount = useMemo(() => {
-    if (!layer || draftVectorStyleMode !== "categorized") return 0;
-    const valuesAreSampled =
-      !layer.geojson &&
-      (layer.type === "vector-tiles" || layer.type === "pmtiles" || layer.type === "mbtiles");
-    if (valuesAreSampled) return 0;
-    const loadedValues =
-      loadedVectorPropertyValues?.layerId === layer.id
-        ? loadedVectorPropertyValues.byProperty[draftVectorStyleProperty]
-        : undefined;
-    const count = countCategorizedValues(
-      loadedValues ?? getPropertyValues(layer, draftVectorStyleProperty),
-    );
-    return count <= MAX_MANUAL_CATEGORIZED_VALUES ? count : 0;
-    // The calculation reads only these stable layer fields. Depending on the
-    // whole layer object would rescan on every unrelated style edit.
+  const countCompleteCategorizedValues = useCallback(
+    (property: string): number =>
+      completeCategorizedValueCount(
+        layer,
+        property,
+        layer && loadedVectorPropertyValues?.layerId === layer.id
+          ? loadedVectorPropertyValues.byProperty[property]
+          : undefined,
+      ),
+    // The count reads only these stable layer fields. Depending on the whole
+    // layer object would rescan every feature on any unrelated style edit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    draftVectorStyleMode,
-    draftVectorStyleProperty,
-    layer?.geojson,
-    layer?.id,
-    layer?.type,
-    loadedVectorPropertyValues,
-  ]);
+    [
+      layer?.geojson,
+      layer?.id,
+      layer?.metadata.sourceKind,
+      layer?.type,
+      loadedVectorPropertyValues,
+    ],
+  );
+  const categorizedValueCount = useMemo(
+    () =>
+      draftVectorStyleMode === "categorized"
+        ? countCompleteCategorizedValues(draftVectorStyleProperty)
+        : 0,
+    [countCompleteCategorizedValues, draftVectorStyleMode, draftVectorStyleProperty],
+  );
 
+  // The distinct-value count can land after the attribute was picked (DuckDB
+  // loads values asynchronously), so reconcile the class count once it arrives:
+  // "All" follows the new attribute's count, an explicit count only shrinks to
+  // fit. Tracking the "All" selection as its own flag — rather than inferring it
+  // from `classCount === categorizedValueCount` — is what makes the two cases
+  // distinguishable when the counts happen to coincide.
   useEffect(() => {
-    if (
-      draftVectorStyleMode !== "categorized" ||
-      categorizedValueCount === 0 ||
-      draftVectorStyleClassCount <= categorizedValueCount
-    ) {
-      return;
-    }
-    setDraftVectorStyleClassCount(categorizedValueCount);
-  }, [categorizedValueCount, draftVectorStyleClassCount, draftVectorStyleMode]);
+    if (draftVectorStyleMode !== "categorized" || categorizedValueCount === 0) return;
+    setDraftVectorStyleClassCount((current) =>
+      draftVectorStyleAllCategories || current > categorizedValueCount
+        ? categorizedValueCount
+        : current,
+    );
+  }, [categorizedValueCount, draftVectorStyleAllCategories, draftVectorStyleMode]);
   // Zoom and variables snapshot the camera via getState() when the builder
   // opens instead of subscribing: the dialog is modal (the map cannot move
   // while it is open), and mapView subscriptions would re-render this whole
@@ -1802,6 +1852,7 @@ export function StylePanel({
     draftHeightExpression !== styleValue(style, "extrusionHeightExpression");
   const updateDraftVectorStyleMode = (mode: VectorStyleMode) => {
     setDraftVectorStyleMode(mode);
+    setDraftVectorStyleAllCategories(false);
     setVectorStyleError(null);
     if (mode === "graduated" || mode === "categorized") {
       const classCount = normalizeVectorStyleClassCount(mode, draftVectorStyleClassCount);
@@ -1828,21 +1879,14 @@ export function StylePanel({
     }
   };
   const updateDraftVectorStyleProperty = (property: string) => {
-    const currentCategoryCount =
-      draftVectorStyleMode === "categorized"
-        ? countCategorizedValues(
-            draftVectorPropertyValues ?? getPropertyValues(layer, draftVectorStyleProperty),
-          )
-        : 0;
+    // The new attribute's count is 0 when its values have yet to load; keep the
+    // count within the plain options until then and let the reconcile effect
+    // above re-apply "All" once the real count arrives.
     const nextCategoryCount =
-      draftVectorStyleMode === "categorized"
-        ? countCategorizedValues(
-            matchingPropertyValues(property) ?? getPropertyValues(layer, property),
-          )
-        : 0;
+      draftVectorStyleMode === "categorized" ? countCompleteCategorizedValues(property) : 0;
     const classCount =
       nextCategoryCount > 0
-        ? draftVectorStyleClassCount === currentCategoryCount
+        ? draftVectorStyleAllCategories
           ? nextCategoryCount
           : Math.min(draftVectorStyleClassCount, nextCategoryCount)
         : Math.min(draftVectorStyleClassCount, 12);
@@ -1856,9 +1900,10 @@ export function StylePanel({
       draftVectorStyleClassificationScheme,
     );
   };
-  const updateDraftVectorStyleClassCount = (value: number) => {
+  const updateDraftVectorStyleClassCount = (value: number, allCategories = false) => {
     const classCount = normalizeVectorStyleClassCount(draftVectorStyleMode, value);
     setDraftVectorStyleClassCount(classCount);
+    setDraftVectorStyleAllCategories(allCategories);
     regenerateDraftVectorStyleStops(
       draftVectorStyleMode,
       draftVectorStyleProperty,
@@ -2121,6 +2166,10 @@ export function StylePanel({
   const vectorClassCountOptions = VECTOR_STYLE_CLASS_COUNTS.filter((classCount) =>
     draftVectorStyleMode === "categorized" ? true : classCount >= 2,
   );
+  // The "All (N)" option only renders while a complete count is known, so the
+  // selection falls back to the plain class count whenever it is not — keeping
+  // the controlled <select> value on an option that actually exists.
+  const allCategoriesSelected = draftVectorStyleAllCategories && categorizedValueCount > 0;
   // --- Rule-based renderer (immediate writes to style.vectorRules) ---
   const currentRules = styleValue(style, "vectorRules");
   const concreteRules = currentRules.filter((rule) => !rule.isElse);
@@ -2342,6 +2391,7 @@ export function StylePanel({
     setDraftVectorStyleMode(mode);
     setDraftVectorStyleProperty(property);
     setDraftVectorStyleClassCount(classCount);
+    setDraftVectorStyleAllCategories(false);
     setDraftVectorStyleClassificationScheme(classificationScheme);
     setDraftVectorStyleStops(stops);
     setVectorStyleError(null);
@@ -2447,32 +2497,30 @@ export function StylePanel({
             <Label htmlFor="vectorStyleClassCount">{t("style.symbology.classes")}</Label>
             <Select
               id="vectorStyleClassCount"
-              value={
-                categorizedValueCount > 0 && draftVectorStyleClassCount === categorizedValueCount
-                  ? "all"
-                  : String(draftVectorStyleClassCount)
-              }
+              value={allCategoriesSelected ? "all" : String(draftVectorStyleClassCount)}
               onChange={(event) =>
                 updateDraftVectorStyleClassCount(
                   event.target.value === "all" ? categorizedValueCount : Number(event.target.value),
+                  event.target.value === "all",
                 )
               }
             >
               {vectorClassCountOptions
-                .filter((classCount) => classCount !== categorizedValueCount)
+                .filter(
+                  (classCount) => !(allCategoriesSelected && classCount === categorizedValueCount),
+                )
                 .map((classCount) => (
                   <option key={classCount} value={classCount}>
                     {classCount}
                   </option>
                 ))}
-              {draftVectorStyleClassCount > 12 &&
-                draftVectorStyleClassCount !== categorizedValueCount && (
-                  <option value={draftVectorStyleClassCount}>{draftVectorStyleClassCount}</option>
-                )}
+              {draftVectorStyleClassCount > 12 && !allCategoriesSelected && (
+                <option value={draftVectorStyleClassCount}>{draftVectorStyleClassCount}</option>
+              )}
               {draftVectorStyleMode === "categorized" && categorizedValueCount > 0 && (
                 <option value="all">
                   {t("style.symbology.allClasses", {
-                    count: categorizedValueCount,
+                    total: categorizedValueCount,
                   })}
                 </option>
               )}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -96,6 +96,7 @@ import {
   clampClassCount,
   createCategorizedStops,
   createGraduatedStops,
+  countCategorizedValues,
   getPropertyValues,
   isCategoricalProperty,
   isNumericProperty,
@@ -581,7 +582,11 @@ function createDefaultStops(
 }
 
 function normalizeVectorStyleClassCount(mode: VectorStyleMode, value: number): number {
-  return clampClassCount(value, mode === "categorized" ? 1 : 2);
+  return clampClassCount(
+    value,
+    mode === "categorized" ? 1 : 2,
+    mode === "categorized" ? Number.POSITIVE_INFINITY : 12,
+  );
 }
 
 function defaultClassificationScheme(mode: VectorStyleMode): string {
@@ -2060,6 +2065,12 @@ export function StylePanel({
   const vectorClassCountOptions = VECTOR_STYLE_CLASS_COUNTS.filter((classCount) =>
     draftVectorStyleMode === "categorized" ? true : classCount >= 2,
   );
+  const categorizedValueCount =
+    draftVectorStyleMode === "categorized"
+      ? countCategorizedValues(
+          draftVectorPropertyValues ?? getPropertyValues(layer, draftVectorStyleProperty),
+        )
+      : 0;
 
   // --- Rule-based renderer (immediate writes to style.vectorRules) ---
   const currentRules = styleValue(style, "vectorRules");
@@ -2387,14 +2398,31 @@ export function StylePanel({
             <Label htmlFor="vectorStyleClassCount">{t("style.symbology.classes")}</Label>
             <Select
               id="vectorStyleClassCount"
-              value={String(draftVectorStyleClassCount)}
-              onChange={(event) => updateDraftVectorStyleClassCount(Number(event.target.value))}
+              value={
+                categorizedValueCount > 0 && draftVectorStyleClassCount === categorizedValueCount
+                  ? "all"
+                  : String(draftVectorStyleClassCount)
+              }
+              onChange={(event) =>
+                updateDraftVectorStyleClassCount(
+                  event.target.value === "all" ? categorizedValueCount : Number(event.target.value),
+                )
+              }
             >
-              {vectorClassCountOptions.map((classCount) => (
-                <option key={classCount} value={classCount}>
-                  {classCount}
+              {vectorClassCountOptions
+                .filter((classCount) => classCount !== categorizedValueCount)
+                .map((classCount) => (
+                  <option key={classCount} value={classCount}>
+                    {classCount}
+                  </option>
+                ))}
+              {draftVectorStyleMode === "categorized" && categorizedValueCount > 0 && (
+                <option value="all">
+                  {t("style.symbology.allClasses", {
+                    count: categorizedValueCount,
+                  })}
                 </option>
-              ))}
+              )}
             </Select>
           </div>
           <div className="space-y-2">

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -4307,6 +4307,7 @@
       "styleType": "نوع النمط",
       "attribute": "السمة",
       "classes": "الفئات",
+      "allClasses": "الكل ({{total}})",
       "scheme": "أسلوب التصنيف",
       "stops": "نقاط التوقف",
       "categories": "الأصناف",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -4040,6 +4040,7 @@
       "styleType": "Stiltyp",
       "attribute": "Attribut",
       "classes": "Klassen",
+      "allClasses": "Alle ({{total}})",
       "scheme": "Schema",
       "stops": "Stopps",
       "categories": "Kategorien",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4259,7 +4259,7 @@
       "styleType": "Style type",
       "attribute": "Attribute",
       "classes": "Classes",
-      "allClasses": "All ({{count}})",
+      "allClasses": "All ({{total}})",
       "scheme": "Scheme",
       "stops": "Stops",
       "categories": "Categories",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4259,6 +4259,7 @@
       "styleType": "Style type",
       "attribute": "Attribute",
       "classes": "Classes",
+      "allClasses": "All ({{count}})",
       "scheme": "Scheme",
       "stops": "Stops",
       "categories": "Categories",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -4040,6 +4040,7 @@
       "styleType": "Tipo de estilo",
       "attribute": "Atributo",
       "classes": "Clases",
+      "allClasses": "Todas ({{total}})",
       "scheme": "Esquema",
       "stops": "Paradas",
       "categories": "Categorías",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -4040,6 +4040,7 @@
       "styleType": "Type de style",
       "attribute": "Attribut",
       "classes": "Classes",
+      "allClasses": "Toutes ({{total}})",
       "scheme": "Schéma",
       "stops": "Paliers",
       "categories": "Catégories",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -4040,6 +4040,7 @@
       "styleType": "शैली प्रकार",
       "attribute": "एट्रिब्यूट",
       "classes": "वर्ग",
+      "allClasses": "सभी ({{total}})",
       "scheme": "योजना",
       "stops": "स्टॉप्स",
       "categories": "श्रेणियां",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -3973,6 +3973,7 @@
       "styleType": "Jenis gaya",
       "attribute": "Atribut",
       "classes": "Kelas",
+      "allClasses": "Semua ({{total}})",
       "scheme": "Skema",
       "stops": "Titik henti",
       "categories": "Kategori",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -4040,6 +4040,7 @@
       "styleType": "Tipo di stile",
       "attribute": "Attributo",
       "classes": "Classi",
+      "allClasses": "Tutte ({{total}})",
       "scheme": "Schema",
       "stops": "Soglie",
       "categories": "Categorie",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -3973,6 +3973,7 @@
       "styleType": "スタイルタイプ",
       "attribute": "属性",
       "classes": "クラス数",
+      "allClasses": "すべて（{{total}}）",
       "scheme": "分類方法",
       "stops": "区分点",
       "categories": "カテゴリ",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -4040,6 +4040,7 @@
       "styleType": "სტილის ტიპი",
       "attribute": "ატრიბუტი",
       "classes": "კლასები",
+      "allClasses": "ყველა ({{total}})",
       "scheme": "სქემა",
       "stops": "საფეხურები",
       "categories": "კატეგორიები",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -3973,6 +3973,7 @@
       "styleType": "스타일 유형",
       "attribute": "속성",
       "classes": "클래스 수",
+      "allClasses": "전체({{total}})",
       "scheme": "분류 방식",
       "stops": "구분점",
       "categories": "카테고리",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -4040,6 +4040,7 @@
       "styleType": "Stijltype",
       "attribute": "Attribuut",
       "classes": "Klassen",
+      "allClasses": "Alle ({{total}})",
       "scheme": "Schema",
       "stops": "Stops",
       "categories": "Categorieën",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -4040,6 +4040,7 @@
       "styleType": "Tipo de estilo",
       "attribute": "Atributo",
       "classes": "Classes",
+      "allClasses": "Todas ({{total}})",
       "scheme": "Esquema",
       "stops": "Limites",
       "categories": "Categorias",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -4174,6 +4174,7 @@
       "styleType": "Тип стиля",
       "attribute": "Атрибут",
       "classes": "Классы",
+      "allClasses": "Все ({{total}})",
       "scheme": "Схема",
       "stops": "Границы",
       "categories": "Категории",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -4040,6 +4040,7 @@
       "styleType": "Stil türü",
       "attribute": "Öznitelik",
       "classes": "Sınıflar",
+      "allClasses": "Tümü ({{total}})",
       "scheme": "Şema",
       "stops": "Duraklar",
       "categories": "Kategoriler",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -3973,6 +3973,7 @@
       "styleType": "样式类型",
       "attribute": "属性",
       "classes": "分类数",
+      "allClasses": "全部（{{total}}）",
       "scheme": "分级方案",
       "stops": "分级点",
       "categories": "类别",

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -115,6 +115,10 @@ export function createGraduatedStops(
 
 /**
  * Create categorized color stops from GeoJSON or separately loaded property values.
+ *
+ * Automatic style suggestions intentionally recognize at most
+ * {@link MAX_CATEGORICAL_VALUES} distinct values so suggested legends stay
+ * compact. Manual categorized styling can request every distinct value.
  */
 export function createCategorizedStops(
   layer: ClassifiableLayer,

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -22,6 +22,9 @@ const CLASSIFICATION_FALLBACK_COLORS = [
   "#0891b2",
 ];
 
+/** Maximum categorized rows the manual Style panel may render at once. */
+export const MAX_MANUAL_CATEGORIZED_VALUES = 256;
+
 /** Return the non-null values of a GeoJSON property. */
 export function getPropertyValues(layer: ClassifiableLayer, property: string): unknown[] {
   if (!property) return [];
@@ -151,7 +154,7 @@ export function createCategorizedStops(
     }
   }
 
-  const count = clampClassCount(classCount, 1, Number.POSITIVE_INFINITY);
+  const count = clampClassCount(classCount, 1, MAX_MANUAL_CATEGORIZED_VALUES);
   const sortedCategories = Array.from(categories.values()).sort((a, b) => {
     if (classificationScheme === "alphabetical") {
       return String(a.value).localeCompare(String(b.value), undefined, {

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -43,9 +43,21 @@ export function numericBounds(values: number[]): { min: number; max: number } {
 }
 
 /** Clamp a requested class count to the supported range. */
-export function clampClassCount(value: number, min: number): number {
+export function clampClassCount(value: number, min: number, max = 12): number {
   if (!Number.isFinite(value)) return min;
-  return Math.min(12, Math.max(min, Math.round(value)));
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+/** Count distinct scalar values that can be used as categorized stops. */
+export function countCategorizedValues(values: unknown[]): number {
+  const categories = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== "string" && (typeof value !== "number" || !Number.isFinite(value))) {
+      continue;
+    }
+    categories.add(`${typeof value}:${String(value)}`);
+  }
+  return categories.size;
 }
 
 /** Convert a scalar numeric property value without coercing blanks or non-scalars. */
@@ -137,7 +149,7 @@ export function createCategorizedStops(
     }
   }
 
-  const count = clampClassCount(classCount, 1);
+  const count = clampClassCount(classCount, 1, Number.POSITIVE_INFINITY);
   const sortedCategories = Array.from(categories.values()).sort((a, b) => {
     if (classificationScheme === "alphabetical") {
       return String(a.value).localeCompare(String(b.value), undefined, {

--- a/apps/geolibre-desktop/src/lib/vector-style-classification.ts
+++ b/apps/geolibre-desktop/src/lib/vector-style-classification.ts
@@ -48,16 +48,16 @@ export function clampClassCount(value: number, min: number, max = 12): number {
   return Math.min(max, Math.max(min, Math.round(value)));
 }
 
+/** Return the stable identity of a scalar that can be used as a categorized stop. */
+function categorizedValueKey(value: unknown): string | null {
+  if (typeof value === "string") return `string:${value}`;
+  if (typeof value === "number" && Number.isFinite(value)) return `number:${String(value)}`;
+  return null;
+}
+
 /** Count distinct scalar values that can be used as categorized stops. */
 export function countCategorizedValues(values: unknown[]): number {
-  const categories = new Set<string>();
-  for (const value of values) {
-    if (typeof value !== "string" && (typeof value !== "number" || !Number.isFinite(value))) {
-      continue;
-    }
-    categories.add(`${typeof value}:${String(value)}`);
-  }
-  return categories.size;
+  return new Set(values.map(categorizedValueKey).filter((key) => key !== null)).size;
 }
 
 /** Convert a scalar numeric property value without coercing blanks or non-scalars. */
@@ -133,16 +133,14 @@ export function createCategorizedStops(
     }
   >();
   for (const value of propertyValues ?? getPropertyValues(layer, property)) {
-    if (typeof value !== "string" && (typeof value !== "number" || !Number.isFinite(value))) {
-      continue;
-    }
-    const key = `${typeof value}:${String(value)}`;
+    const key = categorizedValueKey(value);
+    if (key === null) continue;
     const category = categories.get(key);
     if (category) {
       category.count += 1;
     } else {
       categories.set(key, {
-        value,
+        value: value as string | number,
         count: 1,
         firstSeen: categories.size,
       });

--- a/tests/vector-style-classification.test.ts
+++ b/tests/vector-style-classification.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   createCategorizedStops,
   createGraduatedStops,
+  countCategorizedValues,
   proportionalSizeBounds,
 } from "../apps/geolibre-desktop/src/lib/vector-style-classification";
 
@@ -78,6 +79,24 @@ describe("vector style classification", () => {
       stops.map((stop) => stop.value),
       [1, 2],
     );
+  });
+
+  it("counts distinct categorized values by scalar type", () => {
+    assert.equal(countCategorizedValues(["1", 1, "1", null, Number.NaN, {}]), 2);
+  });
+
+  it("creates more than twelve categorized stops when all values are requested", () => {
+    const values = Array.from({ length: 14 }, (_, index) => `category-${index + 1}`);
+    const stops = createCategorizedStops(
+      tiledLayer,
+      "category",
+      values.length,
+      "viridis",
+      "alphabetical",
+      values,
+    );
+
+    assert.equal(stops.length, 14);
   });
 
   it("keeps adjacent high-magnitude breaks distinct", () => {

--- a/tests/vector-style-classification.test.ts
+++ b/tests/vector-style-classification.test.ts
@@ -4,6 +4,7 @@ import {
   createCategorizedStops,
   createGraduatedStops,
   countCategorizedValues,
+  MAX_MANUAL_CATEGORIZED_VALUES,
   proportionalSizeBounds,
 } from "../apps/geolibre-desktop/src/lib/vector-style-classification";
 
@@ -97,6 +98,23 @@ describe("vector style classification", () => {
     );
 
     assert.equal(stops.length, 14);
+  });
+
+  it("bounds manual categorized stops to the editor safety limit", () => {
+    const values = Array.from(
+      { length: MAX_MANUAL_CATEGORIZED_VALUES + 10 },
+      (_, index) => `category-${index + 1}`,
+    );
+    const stops = createCategorizedStops(
+      tiledLayer,
+      "category",
+      values.length,
+      "viridis",
+      "first-values",
+      values,
+    );
+
+    assert.equal(stops.length, MAX_MANUAL_CATEGORIZED_VALUES);
   });
 
   it("keeps adjacent high-magnitude breaks distinct", () => {


### PR DESCRIPTION
## Summary

- detect the distinct scalar values for the selected categorized attribute
- offer an `All (N)` class-count choice without raising the 12-class limit for graduated styles
- allow categorized stop generation beyond 12 values

## Verification

- reproduced with the `OTEX` field in the dataset from discussion 1608
- confirmed `All (14)` creates 14 category rows in light and dark themes
- `npm run test:frontend`
- `npm run build`
- `npm run lint`

Related to https://github.com/opengeos/GeoLibre/discussions/1608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Categorized styling includes a localized “All” option showing the total available classes.
  * Supports up to 256 categories for manual categorized styles.
  * Preserves “All” selections when switching properties where possible.
  * Filters duplicate numeric categories for clearer selections.
  * Adjusts available class counts to match the data.
* **Bug Fixes**
  * Improves counting of distinct valid numeric and text values.
  * Excludes invalid or unsupported values from class counts.
  * Keeps graduated styling class counts capped at 12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->