### PR TITLE
fix(settings): contain mobile dialog content

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1460,11 +1460,11 @@ export function SettingsDialog({
             <DialogTitle>{t("settings.title")}</DialogTitle>
             <DialogDescription>{t("settings.description")}</DialogDescription>
           </DialogHeader>
-          <div className="grid min-h-0 grid-cols-1 md:grid-cols-[12rem_1fr]">
-            <nav className="flex gap-1 border-b p-3 md:flex-col md:border-b-0 md:border-e">
+          <div className="grid min-h-0 min-w-0 grid-cols-1 md:grid-cols-[12rem_1fr]">
+            <nav className="flex min-w-0 gap-1 overflow-x-auto border-b p-3 md:flex-col md:overflow-x-visible md:border-b-0 md:border-e">
               {SECTION_ITEMS.filter((item) => isSectionVisible(item.id)).map(renderSectionButton)}
             </nav>
-            <div className="min-h-0 overflow-y-auto p-6">
+            <div className="min-h-0 min-w-0 overflow-y-auto p-6">
               {effectiveSection === "map" ? (
                 <div className="space-y-5">
                   <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
## Summary

- constrain the Settings content grid to the dialog width on narrow screens
- make the section navigation horizontally scrollable on mobile
- keep Settings section content from expanding beyond the viewport

## Verification

- reproduced and verified at a 393 x 852 viewport
- verified AI Providers in English and Chinese
- verified light and dark themes
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx`

Fixes #1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the Settings dialog layout across different screen sizes.
  * Preserved horizontal scrolling for mobile navigation and vertical scrolling for desktop navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->