### PR TITLE
Follow-up: notebook style review fixes

### DIFF
--- a/apps/geolibre-desktop/src/lib/pyodide/console_api.py
+++ b/apps/geolibre-desktop/src/lib/pyodide/console_api.py
@@ -197,8 +197,11 @@ class _GeoLibre:
         fc = _coerce_featurecollection(data)
         return _js.addGeoJsonLayer(_to_js({"name": name, "geojson": fc, "style": style}))
 
-    async def load_geojson(self, url, name="GeoJSON"):
-        """Fetch a GeoJSON URL and add it as a layer (async). Returns the id."""
+    async def load_geojson(self, url, name="GeoJSON", **style):
+        """Fetch a GeoJSON URL and add it as a layer (async). Returns the id.
+
+        Takes the same style overrides as :meth:`add_geojson`.
+        """
         from pyodide.http import pyfetch
 
         response = await pyfetch(url)
@@ -207,7 +210,7 @@ class _GeoLibre:
         if not response.ok:
             raise RuntimeError(f"Failed to fetch {url!r}: HTTP {response.status}")
         fc = _coerce_featurecollection(await response.json())
-        return _js.addGeoJsonLayer(_to_js({"name": name, "geojson": fc}))
+        return _js.addGeoJsonLayer(_to_js({"name": name, "geojson": fc, "style": style}))
 
     def remove_layer(self, layer_id):
         """Remove a layer by id."""

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -36,11 +36,6 @@ m.add_geojson(
 )  # GeoDataFrame, dict, or JSON string
 m.fit_bounds([-123, 37, -122, 38])
 m.set_basemap("https://…/style.json")
-
-# Layer-targeted calls take a layer id. This client is fire-and-forget, so
-# `add_geojson` does not hand one back — see the note below.
-m.set_visibility(layer_id, False)
-m.remove_layer(layer_id)
 ```
 
 Calls are **fire-and-forget**: each posts a command to the host app over the
@@ -51,9 +46,13 @@ client source: `backend/geolibre_server/notebook_client.py`.
 
 > Read-back queries (e.g. `get_center`) are not exposed by this fire-and-forget
 > client; they need the blocking request/reply path the `geolibre` widget uses.
-> Layer ids come from the same path: this client's `add_geojson` returns
-> `None`, while the widget's ([`geolibre` package](python.md)) returns the new
-> layer's id — which is what the id-taking calls above expect.
+
+The client also has layer-targeted calls — `set_visibility(layer_id, visible)`,
+`set_opacity`, `set_style`, `remove_layer`, `zoom_to_layer` — but they are left
+out of the snippet above because there is no way to obtain a `layer_id` here:
+being fire-and-forget, this client's `add_geojson` returns `None`. Use them with
+an id from the blocking [`geolibre` widget](python.md), whose `add_geojson`
+returns the new layer's id.
 
 ## Driving the map from an external client (VS Code, …)
 

--- a/docs/user-guide/python-console.md
+++ b/docs/user-guide/python-console.md
@@ -124,7 +124,7 @@ is available this way.
 | `set_basemap(url)` | Set the basemap style (an http(s) or root-relative URL). |
 | `identify(lng, lat, layer_id=None)` | Query rendered features at a point (like a click). |
 | `add_geojson(data, name=, **style)` | Add a layer from a GeoJSON dict / geometry / `__geo_interface__`, with optional inline style overrides; returns the layer id. |
-| `await load_geojson(url, name=)` | Fetch a GeoJSON URL and add it; returns the layer id. |
+| `await load_geojson(url, name=, **style)` | Fetch a GeoJSON URL and add it, with the same optional inline style overrides; returns the layer id. |
 | `layers` | List of [`Layer`](#layer) objects, in draw order. |
 | `get_layer(layer_id)` | The `Layer` with that id (raises if absent). |
 | `remove_layer(layer_id)` | Remove a layer by id. |

--- a/tests/scripting-style-params.test.ts
+++ b/tests/scripting-style-params.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
-import { beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import { useAppStore } from "@geolibre/core";
+import { setHistoryCoalesceMs } from "../packages/core/src/history";
 import { styleParamPatch } from "../apps/geolibre-desktop/src/lib/scripting/style-params";
 
 // The notebook client's `add_geojson(gdf, **style)` always sends a `style`
@@ -39,27 +40,56 @@ describe("styleParamPatch", () => {
   });
 });
 
+/** What the `addGeoJsonLayer` handler does with a raw `style` param. */
+function addGeoJsonCommand(name: string, style: unknown): string {
+  const layerId = useAppStore.getState().addGeoJsonLayer(name, FC);
+  const patch = styleParamPatch(style);
+  if (patch) useAppStore.getState().setLayerStyle(layerId, patch);
+  return layerId;
+}
+
 describe("addGeoJsonLayer command styling", () => {
   beforeEach(() => {
+    // 0 so each store write is its own history entry: with the app's default
+    // coalesce window the two writes of a styled add would merge and the guard
+    // below would pass whether or not it works.
+    setHistoryCoalesceMs(0);
     useAppStore.getState().newProject({ name: "Scripting" });
     useAppStore.temporal.getState().clear();
   });
 
+  afterEach(() => {
+    setHistoryCoalesceMs(400);
+  });
+
   it("merges an inline style into the new layer", () => {
-    const layerId = useAppStore.getState().addGeoJsonLayer("Styled", FC);
-    const style = styleParamPatch({ fillColor: "#facc15", strokeColor: "#d97706" });
-    assert.ok(style);
-    useAppStore.getState().setLayerStyle(layerId, style);
+    const layerId = addGeoJsonCommand("Styled", {
+      fillColor: "#facc15",
+      strokeColor: "#d97706",
+    });
 
     const layer = useAppStore.getState().layers.find((item) => item.id === layerId);
     assert.equal(layer?.style?.fillColor, "#facc15");
     assert.equal(layer?.style?.strokeColor, "#d97706");
   });
 
-  it("costs a single undo step when no style kwargs were passed", () => {
-    const layerId = useAppStore.getState().addGeoJsonLayer("Plain", FC);
-    const style = styleParamPatch({});
-    if (style) useAppStore.getState().setLayerStyle(layerId, style);
+  it("writes nothing extra when no style kwargs were passed", () => {
+    const layerId = addGeoJsonCommand("Plain", {});
+
+    assert.equal(useAppStore.temporal.getState().pastStates.length, 1);
+    useAppStore.temporal.getState().undo();
+    assert.equal(
+      useAppStore.getState().layers.find((item) => item.id === layerId),
+      undefined,
+    );
+  });
+
+  it("coalesces a styled add into one undo step at the app's window", () => {
+    // The two writes land in the same tick, so the leading debounce in the
+    // store's `handleSet` records only the first: one Ctrl+Z removes the
+    // styled layer outright rather than leaving an unstyled one behind.
+    setHistoryCoalesceMs(400);
+    const layerId = addGeoJsonCommand("Styled", { fillColor: "#facc15" });
 
     assert.equal(useAppStore.temporal.getState().pastStates.length, 1);
     useAppStore.temporal.getState().undo();

--- a/tests/scripting-style-params.test.ts
+++ b/tests/scripting-style-params.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { useAppStore } from "@geolibre/core";
-import { setHistoryCoalesceMs } from "../packages/core/src/history";
+import { getHistoryCoalesceMs, setHistoryCoalesceMs } from "../packages/core/src/history";
 import { styleParamPatch } from "../apps/geolibre-desktop/src/lib/scripting/style-params";
 
 // The notebook client's `add_geojson(gdf, **style)` always sends a `style`
@@ -40,6 +40,11 @@ describe("styleParamPatch", () => {
   });
 });
 
+// Captured before any test changes it, so the app's real window is what the
+// coalescing case exercises and what cleanup restores — not a copy of it that
+// would go stale if the default moved.
+const APP_COALESCE_MS = getHistoryCoalesceMs();
+
 /** What the `addGeoJsonLayer` handler does with a raw `style` param. */
 function addGeoJsonCommand(name: string, style: unknown): string {
   const layerId = useAppStore.getState().addGeoJsonLayer(name, FC);
@@ -59,7 +64,7 @@ describe("addGeoJsonLayer command styling", () => {
   });
 
   afterEach(() => {
-    setHistoryCoalesceMs(400);
+    setHistoryCoalesceMs(APP_COALESCE_MS);
   });
 
   it("merges an inline style into the new layer", () => {
@@ -88,7 +93,7 @@ describe("addGeoJsonLayer command styling", () => {
     // The two writes land in the same tick, so the leading debounce in the
     // store's `handleSet` records only the first: one Ctrl+Z removes the
     // styled layer outright rather than leaving an unstyled one behind.
-    setHistoryCoalesceMs(400);
+    setHistoryCoalesceMs(APP_COALESCE_MS);
     const layerId = addGeoJsonCommand("Styled", { fillColor: "#facc15" });
 
     assert.equal(useAppStore.temporal.getState().pastStates.length, 1);


### PR DESCRIPTION
Follow-up to #1619, which merged while the second round of review comments was still being worked. Addresses all three.

## Changes

- **`docs/notebook.md`** — the scripting snippet used a `layer_id` it never defined. #1619 annotated it; the reviewer was right that this only made the example read as self-contradictory, since the fire-and-forget client can never produce an id. The id-taking calls (`set_visibility`, `set_opacity`, `set_style`, `remove_layer`, `zoom_to_layer`) are now out of the snippet and described in prose below it, pointing at the blocking `geolibre` widget whose `add_geojson` returns the id.
- **`console_api.py`** — `load_geojson` now takes the same `**style` kwargs as `add_geojson`, so both console entry points style in one call.
- **`tests/scripting-style-params.test.ts`** — the "no extra write" test ran at the app's default 400 ms history coalesce window, where the two store writes merge, so it passed whether or not the guard worked. It now sets the window to 0; mutating `styleParamPatch` to return `{}` unguarded makes it fail, so the guard is genuinely under test. Added a case at the default window pinning the UX the reviewer asked about: a styled `add_geojson` coalesces into **one** undo entry, so a single Ctrl+Z removes the layer rather than leaving an unstyled one behind.

## Verification

`npm run test:frontend` (4661 tests, 0 failures), `npm run lint`, `npm run build`, and `pre-commit run --files` on the changed files all pass.

## Left open

One thread on #1619 is still open by design: the Claude bot flagged that style kwargs reach `setLayerStyle` with no key/type validation. That is a deliberate pass-through shared by `setStyle`, the console, and the widget — validating only `add_geojson` would make the surfaces disagree. A real fix is a shared style-key schema at the scripting boundary, which is bigger than either PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for applying custom styles when loading GeoJSON layers through scripting.
  * Styled GeoJSON layers now appear with the requested visual formatting immediately after being added.

* **Documentation**
  * Clarified scripting guidance for layer-targeted methods and explained when layer IDs are available.
  * Documented optional inline style overrides for GeoJSON loading.

* **Bug Fixes**
  * Improved undo history behavior so styled layer additions are grouped into a single undo step.
  * Ensured adding a GeoJSON layer without styles still creates a single undoable action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->