### PR TITLE
fix: add notebook layer read-back

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -3,6 +3,7 @@ import type { MapController } from "@geolibre/map";
 import { subscribeJupyterServer } from "../lib/jupyter";
 import {
   type RelayCommand,
+  type RelayResult,
   parseRelayMessage,
   relayReconnectDelay,
   relaySocketUrl,
@@ -45,7 +46,7 @@ export function useJupyterRelay(mapControllerRef: RefObject<MapController | null
     // server can never resurrect the reconnect loop after we moved on.
     let generation = 0;
 
-    const reply = (activeSocket: WebSocket, payload: object) => {
+    const reply = (activeSocket: WebSocket, payload: RelayResult) => {
       if (activeSocket.readyState !== WebSocket.OPEN) return;
       try {
         activeSocket.send(JSON.stringify(payload));

--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -44,17 +44,47 @@ export function useJupyterRelay(mapControllerRef: RefObject<MapController | null
     // server can never resurrect the reconnect loop after we moved on.
     let generation = 0;
 
-    const run = async (command: RelayCommand) => {
+    const run = async (command: RelayCommand, activeSocket: WebSocket) => {
       // Own-property only, so an inherited member ("constructor", …) can never be
       // invoked as a command.
       if (!Object.hasOwn(handlers, command.method)) {
         console.warn(`Jupyter relay: unknown command "${command.method}"`);
+        if (command.requestId) {
+          activeSocket.send(
+            JSON.stringify({
+              type: "geolibre:result",
+              requestId: command.requestId,
+              ok: false,
+              error: `Unknown command "${command.method}"`,
+            }),
+          );
+        }
         return;
       }
       try {
-        await handlers[command.method](command.params);
+        const value = await handlers[command.method](command.params);
+        if (command.requestId) {
+          activeSocket.send(
+            JSON.stringify({
+              type: "geolibre:result",
+              requestId: command.requestId,
+              ok: true,
+              value,
+            }),
+          );
+        }
       } catch (error) {
         console.error(`Jupyter relay: command "${command.method}" failed`, error);
+        if (command.requestId) {
+          activeSocket.send(
+            JSON.stringify({
+              type: "geolibre:result",
+              requestId: command.requestId,
+              ok: false,
+              error: error instanceof Error ? error.message : String(error),
+            }),
+          );
+        }
       }
     };
 
@@ -96,7 +126,7 @@ export function useJupyterRelay(mapControllerRef: RefObject<MapController | null
         };
         next.onmessage = (event: MessageEvent) => {
           const command = parseRelayMessage(event.data);
-          if (command) void run(command);
+          if (command) void run(command, next);
         };
         next.onclose = () => {
           if (generation !== mine) return;

--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -4,6 +4,7 @@ import { subscribeJupyterServer } from "../lib/jupyter";
 import {
   type RelayCommand,
   type RelayResult,
+  encodeRelayResult,
   parseRelayMessage,
   relayReconnectDelay,
   relaySocketUrl,
@@ -49,7 +50,7 @@ export function useJupyterRelay(mapControllerRef: RefObject<MapController | null
     const reply = (activeSocket: WebSocket, payload: RelayResult) => {
       if (activeSocket.readyState !== WebSocket.OPEN) return;
       try {
-        activeSocket.send(JSON.stringify(payload));
+        activeSocket.send(encodeRelayResult(payload));
       } catch (error) {
         console.warn("Jupyter relay: could not return a command result", error);
       }

--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -6,6 +6,7 @@ import {
   parseRelayMessage,
   relayReconnectDelay,
   relaySocketUrl,
+  runRelayCommand,
 } from "../lib/jupyter-relay";
 import { createScriptingHandlers } from "../lib/scripting/scriptingApi";
 
@@ -54,41 +55,8 @@ export function useJupyterRelay(mapControllerRef: RefObject<MapController | null
     };
 
     const run = async (command: RelayCommand, activeSocket: WebSocket) => {
-      // Own-property only, so an inherited member ("constructor", …) can never be
-      // invoked as a command.
-      if (!Object.hasOwn(handlers, command.method)) {
-        console.warn(`Jupyter relay: unknown command "${command.method}"`);
-        if (command.requestId) {
-          reply(activeSocket, {
-            type: "geolibre:result",
-            requestId: command.requestId,
-            ok: false,
-            error: `Unknown command "${command.method}"`,
-          });
-        }
-        return;
-      }
-      try {
-        const value = await handlers[command.method](command.params);
-        if (command.requestId) {
-          reply(activeSocket, {
-            type: "geolibre:result",
-            requestId: command.requestId,
-            ok: true,
-            value,
-          });
-        }
-      } catch (error) {
-        console.error(`Jupyter relay: command "${command.method}" failed`, error);
-        if (command.requestId) {
-          reply(activeSocket, {
-            type: "geolibre:result",
-            requestId: command.requestId,
-            ok: false,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
+      const result = await runRelayCommand(handlers, command);
+      if (result) reply(activeSocket, result);
     };
 
     const close = () => {

--- a/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
+++ b/apps/geolibre-desktop/src/hooks/useJupyterRelay.ts
@@ -44,46 +44,49 @@ export function useJupyterRelay(mapControllerRef: RefObject<MapController | null
     // server can never resurrect the reconnect loop after we moved on.
     let generation = 0;
 
+    const reply = (activeSocket: WebSocket, payload: object) => {
+      if (activeSocket.readyState !== WebSocket.OPEN) return;
+      try {
+        activeSocket.send(JSON.stringify(payload));
+      } catch (error) {
+        console.warn("Jupyter relay: could not return a command result", error);
+      }
+    };
+
     const run = async (command: RelayCommand, activeSocket: WebSocket) => {
       // Own-property only, so an inherited member ("constructor", …) can never be
       // invoked as a command.
       if (!Object.hasOwn(handlers, command.method)) {
         console.warn(`Jupyter relay: unknown command "${command.method}"`);
         if (command.requestId) {
-          activeSocket.send(
-            JSON.stringify({
-              type: "geolibre:result",
-              requestId: command.requestId,
-              ok: false,
-              error: `Unknown command "${command.method}"`,
-            }),
-          );
+          reply(activeSocket, {
+            type: "geolibre:result",
+            requestId: command.requestId,
+            ok: false,
+            error: `Unknown command "${command.method}"`,
+          });
         }
         return;
       }
       try {
         const value = await handlers[command.method](command.params);
         if (command.requestId) {
-          activeSocket.send(
-            JSON.stringify({
-              type: "geolibre:result",
-              requestId: command.requestId,
-              ok: true,
-              value,
-            }),
-          );
+          reply(activeSocket, {
+            type: "geolibre:result",
+            requestId: command.requestId,
+            ok: true,
+            value,
+          });
         }
       } catch (error) {
         console.error(`Jupyter relay: command "${command.method}" failed`, error);
         if (command.requestId) {
-          activeSocket.send(
-            JSON.stringify({
-              type: "geolibre:result",
-              requestId: command.requestId,
-              ok: false,
-              error: error instanceof Error ? error.message : String(error),
-            }),
-          );
+          reply(activeSocket, {
+            type: "geolibre:result",
+            requestId: command.requestId,
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
       }
     };

--- a/apps/geolibre-desktop/src/lib/jupyter-relay.ts
+++ b/apps/geolibre-desktop/src/lib/jupyter-relay.ts
@@ -120,6 +120,32 @@ export async function runRelayCommand(
   }
 }
 
+/**
+ * Serialize a result for the wire, degrading to an error rather than nothing.
+ *
+ * A handler can in principle resolve with a value `JSON.stringify` refuses (a
+ * circular structure, a BigInt). Sending no frame at all would leave the kernel
+ * waiting out the relay's whole result timeout for a generic 504, so send a
+ * failure the caller can actually read.
+ *
+ * @param result - The reply to encode.
+ * @returns The JSON frame to send.
+ */
+export function encodeRelayResult(result: RelayResult): string {
+  try {
+    return JSON.stringify(result);
+  } catch (error) {
+    return JSON.stringify({
+      type: "geolibre:result",
+      requestId: result.requestId,
+      ok: false,
+      error: `Result could not be serialized: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    } satisfies RelayResult);
+  }
+}
+
 /** Reconnect backoff (ms) after a dropped socket, capped so it stays responsive. */
 export const RELAY_RECONNECT_MIN_MS = 1_000;
 export const RELAY_RECONNECT_MAX_MS = 15_000;

--- a/apps/geolibre-desktop/src/lib/jupyter-relay.ts
+++ b/apps/geolibre-desktop/src/lib/jupyter-relay.ts
@@ -11,6 +11,7 @@ import type { JupyterServerInfo } from "./jupyter";
 
 /** One scripting command relayed from a kernel, in the shared bridge envelope. */
 export interface RelayCommand {
+  requestId: string;
   method: string;
   params: Record<string, unknown>;
 }
@@ -51,14 +52,23 @@ export function parseRelayMessage(data: unknown): RelayCommand | null {
     return null;
   }
   if (!payload || typeof payload !== "object") return null;
-  const message = payload as { type?: unknown; method?: unknown; params?: unknown };
+  const message = payload as {
+    type?: unknown;
+    requestId?: unknown;
+    method?: unknown;
+    params?: unknown;
+  };
   if (message.type !== "geolibre:command") return null;
   if (typeof message.method !== "string" || !message.method) return null;
   const params =
     message.params && typeof message.params === "object" && !Array.isArray(message.params)
       ? (message.params as Record<string, unknown>)
       : {};
-  return { method: message.method, params };
+  return {
+    requestId: typeof message.requestId === "string" ? message.requestId : "",
+    method: message.method,
+    params,
+  };
 }
 
 /** Reconnect backoff (ms) after a dropped socket, capped so it stays responsive. */

--- a/apps/geolibre-desktop/src/lib/jupyter-relay.ts
+++ b/apps/geolibre-desktop/src/lib/jupyter-relay.ts
@@ -1,4 +1,5 @@
 import type { JupyterServerInfo } from "./jupyter";
+import type { ScriptingHandlers } from "./scripting/scriptingApi";
 
 // Wire format for the desktop Jupyter map-command relay
 // (backend/geolibre_server/geolibre_server/jupyter_relay.py). The relay lets a
@@ -69,6 +70,54 @@ export function parseRelayMessage(data: unknown): RelayCommand | null {
     method: message.method,
     params,
   };
+}
+
+/** The correlated reply the app sends back for a command carrying a requestId. */
+export type RelayResult =
+  | { type: "geolibre:result"; requestId: string; ok: true; value: unknown }
+  | { type: "geolibre:result"; requestId: string; ok: false; error: string };
+
+/**
+ * Run one relayed command against the scripting handlers and build its reply.
+ *
+ * @param handlers - The scripting command surface (`createScriptingHandlers`).
+ * @param command - The parsed command to run.
+ * @returns The result to send back, or null for a fire-and-forget command (empty
+ *   `requestId`) — the handler still ran, there is just nothing to correlate.
+ */
+export async function runRelayCommand(
+  handlers: ScriptingHandlers,
+  command: RelayCommand,
+): Promise<RelayResult | null> {
+  // Own-property only, so an inherited member ("constructor", …) can never be
+  // invoked as a command.
+  if (!Object.hasOwn(handlers, command.method)) {
+    console.warn(`Jupyter relay: unknown command "${command.method}"`);
+    return command.requestId
+      ? {
+          type: "geolibre:result",
+          requestId: command.requestId,
+          ok: false,
+          error: `Unknown command "${command.method}"`,
+        }
+      : null;
+  }
+  try {
+    const value = await handlers[command.method](command.params);
+    return command.requestId
+      ? { type: "geolibre:result", requestId: command.requestId, ok: true, value }
+      : null;
+  } catch (error) {
+    console.error(`Jupyter relay: command "${command.method}" failed`, error);
+    return command.requestId
+      ? {
+          type: "geolibre:result",
+          requestId: command.requestId,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      : null;
+  }
 }
 
 /** Reconnect backoff (ms) after a dropped socket, capped so it stays responsive. */

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -96,6 +96,10 @@ _listeners: list[GeoLibreRelaySocket] = []
 # enter this mapping.
 _pending_results: dict[str, Future[dict[str, Any]]] = {}
 
+# Which window each in-flight correlated request was dispatched to, so closing
+# that window can fail its requests at once instead of waiting out the timeout.
+_pending_owners: dict[str, GeoLibreRelaySocket] = {}
+
 #: How long a correlated POST waits for the app's result before answering 504.
 #: The kernel client's own socket timeout (``_RELAY_TIMEOUT_SECONDS + 1`` in
 #: ``notebook_client.py``) must stay longer than this, so the precise 504 message
@@ -196,16 +200,8 @@ def _drop_listener(socket: GeoLibreRelaySocket) -> None:
         _listeners.remove(socket)
 
 
-def _broadcast(message: dict[str, Any], *, limit: int | None = None) -> int:
-    """Send ``message`` to open app sockets; return how many received it.
-
-    Args:
-        message: The envelope to encode and send.
-        limit: Stop after this many windows received it. ``limit=1`` delivers to
-            the oldest connected window, which is stable for as long as that
-            window stays open, so a mutation and the read-back that follows it
-            reach the same map.
-    """
+def _broadcast(message: dict[str, Any]) -> int:
+    """Send ``message`` to every open app socket; return how many received it."""
     encoded = json.dumps(message)
     delivered = 0
     # Copy: write_message on a closed socket raises and we drop it from the list.
@@ -216,9 +212,25 @@ def _broadcast(message: dict[str, Any], *, limit: int | None = None) -> int:
             _drop_listener(socket)
             continue
         delivered += 1
-        if limit is not None and delivered >= limit:
-            break
     return delivered
+
+
+def _dispatch_one(message: dict[str, Any]) -> GeoLibreRelaySocket | None:
+    """Send ``message`` to exactly one app window; return the one that took it.
+
+    That is the oldest still-open window, a choice that is stable for as long as
+    it stays open, so a mutation and the read-back that follows it reach the same
+    map. Returns None when no window could be written to.
+    """
+    encoded = json.dumps(message)
+    for socket in list(_listeners):
+        try:
+            socket.write_message(encoded)
+        except Exception:  # noqa: BLE001 - a dead peer must not fail the request
+            _drop_listener(socket)
+            continue
+        return socket
+    return None
 
 
 class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHandler):
@@ -255,8 +267,23 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
             future.set_result(result)
 
     def on_close(self) -> None:
-        """Unregister this app window."""
+        """Unregister this app window and fail anything it still owed."""
         _drop_listener(self)
+        # A correlated command runs in exactly one window. When that window is
+        # this one, nothing can answer it any more, so say so now rather than
+        # making the kernel sit out RESULT_TIMEOUT_SECONDS for a certain 504.
+        for request_id, owner in list(_pending_owners.items()):
+            if owner is not self:
+                continue
+            future = _pending_results.get(request_id)
+            if future is not None and not future.done():
+                future.set_result(
+                    {
+                        "requestId": request_id,
+                        "ok": False,
+                        "error": "The GeoLibre window running this command closed.",
+                    }
+                )
 
 
 class GeoLibreRelayCommandHandler(APIHandler):
@@ -281,20 +308,22 @@ class GeoLibreRelayCommandHandler(APIHandler):
         try:
             # A correlated mutation must execute in only one app window; its
             # returned layer id then always belongs to the window that handled
-            # it. `_listeners` is ordered, so "one window" is consistently the
-            # oldest connected one and a later read-back finds what the mutation
-            # created. Fire-and-forget commands retain the historical broadcast.
-            delivered = _broadcast(message, limit=1)
-            if not delivered:
+            # it. Fire-and-forget commands retain the historical broadcast.
+            owner = _dispatch_one(message)
+            if owner is None:
                 self.finish(json.dumps({"delivered": 0}))
                 return
+            # No await between the dispatch and this record, so the window's
+            # on_close can never miss the request it is now responsible for.
+            _pending_owners[request_id] = owner
             try:
                 result = await wait_for(future, RESULT_TIMEOUT_SECONDS)
             except (TimeoutError, AsyncTimeoutError) as error:
                 raise web.HTTPError(504, "GeoLibre did not return a result in time.") from error
-            self.finish(json.dumps({"delivered": delivered, **result}))
+            self.finish(json.dumps({"delivered": 1, **result}))
         finally:
             _pending_results.pop(request_id, None)
+            _pending_owners.pop(request_id, None)
 
 
 class GeoLibreRelayStatusHandler(APIHandler):

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -82,16 +82,24 @@ COMMAND_TYPE = "geolibre:command"
 _ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "tauri.localhost"})
 _ALLOWED_ORIGIN_SCHEMES = frozenset({"http", "https", "tauri"})
 
-# Open app-side sockets. Module level (not per-handler) because every handler
-# instance is created per request: the POST handler needs the set the WebSocket
-# handlers registered themselves in.
-_listeners: set[GeoLibreRelaySocket] = set()
+# Open app-side sockets, oldest connection first. Module level (not per-handler)
+# because every handler instance is created per request: the POST handler needs
+# the list the WebSocket handlers registered themselves in. Ordered (a list, not
+# a set) because single-window dispatch below takes the first entry: with a set
+# that would be whatever the hash table happens to yield, so a correlated
+# read-back could land in a different window than the mutation it follows up on
+# once a second window connects.
+_listeners: list[GeoLibreRelaySocket] = []
 
 # Correlated read-back requests waiting for the app-side socket to execute a
 # scripting handler. Fire-and-forget commands keep an empty requestId and never
 # enter this mapping.
 _pending_results: dict[str, Future[dict[str, Any]]] = {}
 
+#: How long a correlated POST waits for the app's result before answering 504.
+#: The kernel client's own socket timeout (``_RELAY_TIMEOUT_SECONDS + 1`` in
+#: ``notebook_client.py``) must stay longer than this, so the precise 504 message
+#: reaches the notebook instead of the client's generic "could not be reached".
 RESULT_TIMEOUT_SECONDS = 5.0
 
 
@@ -182,16 +190,30 @@ def relay_base_url(host: str, port: int, base_url: str) -> str:
     return f"http://{host}:{port}" + url_path_join(base_url, RELAY_PATH)
 
 
+def _drop_listener(socket: GeoLibreRelaySocket) -> None:
+    """Unregister a socket, tolerating one that is already gone."""
+    if socket in _listeners:
+        _listeners.remove(socket)
+
+
 def _broadcast(message: dict[str, Any], *, limit: int | None = None) -> int:
-    """Send ``message`` to open app sockets; return how many received it."""
+    """Send ``message`` to open app sockets; return how many received it.
+
+    Args:
+        message: The envelope to encode and send.
+        limit: Stop after this many windows received it. ``limit=1`` delivers to
+            the oldest connected window, which is stable for as long as that
+            window stays open, so a mutation and the read-back that follows it
+            reach the same map.
+    """
     encoded = json.dumps(message)
     delivered = 0
-    # Copy: write_message on a closed socket raises and we drop it from the set.
+    # Copy: write_message on a closed socket raises and we drop it from the list.
     for socket in list(_listeners):
         try:
             socket.write_message(encoded)
         except Exception:  # noqa: BLE001 - a dead peer must not fail the request
-            _listeners.discard(socket)
+            _drop_listener(socket)
             continue
         delivered += 1
         if limit is not None and delivered >= limit:
@@ -218,7 +240,8 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
 
     def open(self, *args: Any, **kwargs: Any) -> None:
         """Register this app window as a command listener."""
-        _listeners.add(self)
+        if self not in _listeners:
+            _listeners.append(self)
         self.write_message(json.dumps({"type": "geolibre:relay-ready"}))
 
     def on_message(self, message: str) -> None:
@@ -233,7 +256,7 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
 
     def on_close(self) -> None:
         """Unregister this app window."""
-        _listeners.discard(self)
+        _drop_listener(self)
 
 
 class GeoLibreRelayCommandHandler(APIHandler):
@@ -258,7 +281,9 @@ class GeoLibreRelayCommandHandler(APIHandler):
         try:
             # A correlated mutation must execute in only one app window; its
             # returned layer id then always belongs to the window that handled
-            # it. Fire-and-forget commands retain the historical broadcast.
+            # it. `_listeners` is ordered, so "one window" is consistently the
+            # oldest connected one and a later read-back finds what the mutation
+            # created. Fire-and-forget commands retain the historical broadcast.
             delivered = _broadcast(message, limit=1)
             if not delivered:
                 self.finish(json.dumps({"delivered": 0}))

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -200,19 +200,21 @@ def _drop_listener(socket: GeoLibreRelaySocket) -> None:
         _listeners.remove(socket)
 
 
+def _try_write(socket: GeoLibreRelaySocket, encoded: str) -> bool:
+    """Write to one app socket, dropping it if the peer is gone."""
+    try:
+        socket.write_message(encoded)
+    except Exception:  # noqa: BLE001 - a dead peer must not fail the request
+        _drop_listener(socket)
+        return False
+    return True
+
+
 def _broadcast(message: dict[str, Any]) -> int:
     """Send ``message`` to every open app socket; return how many received it."""
     encoded = json.dumps(message)
-    delivered = 0
-    # Copy: write_message on a closed socket raises and we drop it from the list.
-    for socket in list(_listeners):
-        try:
-            socket.write_message(encoded)
-        except Exception:  # noqa: BLE001 - a dead peer must not fail the request
-            _drop_listener(socket)
-            continue
-        delivered += 1
-    return delivered
+    # Copy: _try_write drops a dead socket from the list we are walking.
+    return sum(_try_write(socket, encoded) for socket in list(_listeners))
 
 
 def _dispatch_one(message: dict[str, Any]) -> GeoLibreRelaySocket | None:
@@ -224,12 +226,8 @@ def _dispatch_one(message: dict[str, Any]) -> GeoLibreRelaySocket | None:
     """
     encoded = json.dumps(message)
     for socket in list(_listeners):
-        try:
-            socket.write_message(encoded)
-        except Exception:  # noqa: BLE001 - a dead peer must not fail the request
-            _drop_listener(socket)
-            continue
-        return socket
+        if _try_write(socket, encoded):
+            return socket
     return None
 
 
@@ -261,6 +259,11 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
         try:
             result = normalize_result(json.loads(message))
         except (ValueError, json.JSONDecodeError):
+            return
+        # Only the window a request was dispatched to may answer it. Nothing else
+        # can learn the id today, but the single-authoritative-window guarantee
+        # this file builds up is worth enforcing where it is actually consumed.
+        if _pending_owners.get(result["requestId"]) is not self:
             return
         future = _pending_results.get(result["requestId"])
         if future is not None and not future.done():

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -14,7 +14,9 @@ being *displayed*, only on which server the kernel belongs to:
 ``POST {base_url}geolibre/relay/command``
     Send one scripting command (the kernel side). Responds with
     ``{"delivered": n}`` — the number of connected app windows it reached, so the
-    client can warn instead of failing silently.
+    client can warn instead of failing silently. When the command carries a
+    non-empty request id, the response also waits for and includes the app's
+    correlated ``ok``/``value`` or ``ok``/``error`` result.
 ``GET {base_url}geolibre/relay/socket`` (WebSocket)
     Subscribe to commands (the app side). Every posted command is broadcast to
     all open sockets.
@@ -42,6 +44,7 @@ from __future__ import annotations
 
 import json
 import os
+from asyncio import Future, wait_for
 from typing import Any
 from urllib.parse import urlparse
 
@@ -81,6 +84,13 @@ _ALLOWED_ORIGIN_SCHEMES = frozenset({"http", "https", "tauri"})
 # instance is created per request: the POST handler needs the set the WebSocket
 # handlers registered themselves in.
 _listeners: set[GeoLibreRelaySocket] = set()
+
+# Correlated read-back requests waiting for the app-side socket to execute a
+# scripting handler. Fire-and-forget commands keep an empty requestId and never
+# enter this mapping.
+_pending_results: dict[str, Future[dict[str, Any]]] = {}
+
+RESULT_TIMEOUT_SECONDS = 5.0
 
 
 def is_allowed_origin(origin: str | None) -> bool:
@@ -130,6 +140,27 @@ def normalize_command(payload: Any) -> dict[str, Any]:
         "method": method,
         "params": params,
     }
+
+
+def normalize_result(payload: Any) -> dict[str, Any]:
+    """Validate an app-side scripting result sent over the relay socket."""
+    if not isinstance(payload, dict) or payload.get("type") != "geolibre:result":
+        raise ValueError("Expected a GeoLibre result object.")
+    request_id = payload.get("requestId")
+    if not isinstance(request_id, str) or not request_id:
+        raise ValueError("Missing a non-empty 'requestId'.")
+    ok = payload.get("ok")
+    if not isinstance(ok, bool):
+        raise ValueError("Missing boolean 'ok'.")
+    result: dict[str, Any] = {
+        "requestId": request_id,
+        "ok": ok,
+    }
+    if ok:
+        result["value"] = payload.get("value")
+    else:
+        result["error"] = str(payload.get("error") or "GeoLibre command failed.")
+    return result
 
 
 def relay_base_url(host: str, port: int, base_url: str) -> str:
@@ -187,7 +218,14 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
         self.write_message(json.dumps({"type": "geolibre:relay-ready"}))
 
     def on_message(self, message: str) -> None:
-        """Ignore app→relay traffic: commands are fire-and-forget today."""
+        """Resolve a correlated kernel request with the app's command result."""
+        try:
+            result = normalize_result(json.loads(message))
+        except (ValueError, json.JSONDecodeError):
+            return
+        future = _pending_results.get(result["requestId"])
+        if future is not None and not future.done():
+            future.set_result(result)
 
     def on_close(self) -> None:
         """Unregister this app window."""
@@ -198,13 +236,33 @@ class GeoLibreRelayCommandHandler(APIHandler):
     """The kernel side: posts one command to every connected app window."""
 
     @web.authenticated
-    def post(self) -> None:
+    async def post(self) -> None:
         """Relay the posted command and report how many windows received it."""
         try:
             message = normalize_command(json.loads(self.request.body or b"{}"))
         except (ValueError, json.JSONDecodeError) as error:
             raise web.HTTPError(400, str(error)) from error
-        self.finish(json.dumps({"delivered": _broadcast(message)}))
+        request_id = message["requestId"]
+        if not request_id:
+            self.finish(json.dumps({"delivered": _broadcast(message)}))
+            return
+
+        if request_id in _pending_results:
+            raise web.HTTPError(409, "Duplicate requestId.")
+        future: Future[dict[str, Any]] = Future()
+        _pending_results[request_id] = future
+        try:
+            delivered = _broadcast(message)
+            if not delivered:
+                self.finish(json.dumps({"delivered": 0}))
+                return
+            try:
+                result = await wait_for(future, RESULT_TIMEOUT_SECONDS)
+            except TimeoutError as error:
+                raise web.HTTPError(504, "GeoLibre did not return a result in time.") from error
+            self.finish(json.dumps({"delivered": delivered, **result}))
+        finally:
+            _pending_results.pop(request_id, None)
 
 
 class GeoLibreRelayStatusHandler(APIHandler):

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import json
 import os
 from asyncio import Future, wait_for
+from asyncio import TimeoutError as AsyncTimeoutError
 from typing import Any
 from urllib.parse import urlparse
 
@@ -59,6 +60,7 @@ __all__ = [
     "RELAY_PATH",
     "is_allowed_origin",
     "normalize_command",
+    "normalize_result",
     "relay_base_url",
 ]
 
@@ -180,8 +182,8 @@ def relay_base_url(host: str, port: int, base_url: str) -> str:
     return f"http://{host}:{port}" + url_path_join(base_url, RELAY_PATH)
 
 
-def _broadcast(message: dict[str, Any]) -> int:
-    """Send ``message`` to every open app socket; return how many received it."""
+def _broadcast(message: dict[str, Any], *, limit: int | None = None) -> int:
+    """Send ``message`` to open app sockets; return how many received it."""
     encoded = json.dumps(message)
     delivered = 0
     # Copy: write_message on a closed socket raises and we drop it from the set.
@@ -192,6 +194,8 @@ def _broadcast(message: dict[str, Any]) -> int:
             _listeners.discard(socket)
             continue
         delivered += 1
+        if limit is not None and delivered >= limit:
+            break
     return delivered
 
 
@@ -252,13 +256,16 @@ class GeoLibreRelayCommandHandler(APIHandler):
         future: Future[dict[str, Any]] = Future()
         _pending_results[request_id] = future
         try:
-            delivered = _broadcast(message)
+            # A correlated mutation must execute in only one app window; its
+            # returned layer id then always belongs to the window that handled
+            # it. Fire-and-forget commands retain the historical broadcast.
+            delivered = _broadcast(message, limit=1)
             if not delivered:
                 self.finish(json.dumps({"delivered": 0}))
                 return
             try:
                 result = await wait_for(future, RESULT_TIMEOUT_SECONDS)
-            except TimeoutError as error:
+            except (TimeoutError, AsyncTimeoutError) as error:
                 raise web.HTTPError(504, "GeoLibre did not return a result in time.") from error
             self.finish(json.dumps({"delivered": delivered, **result}))
         finally:

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -71,6 +71,8 @@ from IPython.display import Javascript, display
 __all__ = [
     "GeoLibreNotConnectedError",
     "GeoLibreNotConnectedWarning",
+    "GeoLibreTimeoutError",
+    "GeoLibreTimeoutWarning",
     "HostMap",
     "Map",
     "connect",
@@ -102,14 +104,35 @@ class GeoLibreNotConnectedWarning(UserWarning):
     """Warned when a map command could not be delivered to a GeoLibre window."""
 
 
+class GeoLibreTimeoutWarning(UserWarning):
+    """Warned when a command was accepted but its result did not arrive in time.
+
+    The command is running in a GeoLibre window; only its return value is lost.
+    Distinct from :class:`GeoLibreNotConnectedWarning`, which means the command
+    reached no window at all.
+    """
+
+
 class GeoLibreNotConnectedError(RuntimeError):
-    """Raised when a read-back command found no GeoLibre window to run it.
+    """Raised when a read-back command never reached a GeoLibre window.
+
+    Covers both "no window is subscribed" and "the relay itself could not be
+    reached" — in either case nothing ran, so a caller is free to retry.
 
     Only the read-back calls (:meth:`HostMap.list_layers`,
     :meth:`HostMap.get_layer`) raise this: they have nothing to return without a
     window. Mutations degrade to the fire-and-forget transport and warn with
     :class:`GeoLibreNotConnectedWarning` instead. Subclasses ``RuntimeError``, so
     code that already catches that keeps working.
+    """
+
+
+class GeoLibreTimeoutError(RuntimeError):
+    """Raised when a window took a command but did not return a result in time.
+
+    The opposite of :class:`GeoLibreNotConnectedError` in the way that matters
+    for retries: the command *was* dispatched and is probably still running, so
+    sending it again risks doing the work twice.
     """
 
 
@@ -205,8 +228,22 @@ def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = N
             request, timeout=_RELAY_TIMEOUT_SECONDS + 1
         ) as response:
             payload = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, OSError, ValueError) as error:
+    except urllib.error.HTTPError as error:
+        # 504: a window took the command and is likely still running it, which is
+        # a different situation for the caller than "nothing ran". Other statuses
+        # (400 malformed, 409 duplicate id) are bugs and stay loud.
+        if error.code == 504:
+            raise GeoLibreTimeoutError(
+                f"GeoLibre did not return a result within {_RELAY_TIMEOUT_SECONDS:.0f}s. "
+                "The command is still running in the app."
+            ) from error
         raise RuntimeError(f"GeoLibre read-back failed: {_relay_failure_reason(error)}") from error
+    except (urllib.error.URLError, OSError, ValueError) as error:
+        # The relay never answered, so nothing was dispatched: the same situation
+        # for a caller as no window being connected.
+        raise GeoLibreNotConnectedError(
+            f"GeoLibre read-back failed: {_relay_failure_reason(error)}"
+        ) from error
     if not payload.get("delivered"):
         raise GeoLibreNotConnectedError(f"No GeoLibre window is connected. {_NOT_CONNECTED_HINT}")
     if not payload.get("ok"):
@@ -472,10 +509,12 @@ class HostMap:
                 ``fillColor="#facc15"`` or ``strokeColor="#d97706"``).
 
         Returns:
-            The new layer's id on desktop, or None when the id is unavailable —
-            on JupyterLite, and on desktop when no window held the relay socket
-            (the layer is still sent over the display transport, with a
-            :class:`GeoLibreNotConnectedWarning`).
+            The new layer's id on desktop, or None when the id is unavailable:
+            on JupyterLite; on desktop when the command reached no window (it is
+            re-sent over the display transport, with a
+            :class:`GeoLibreNotConnectedWarning`); and on desktop when a window
+            took it but did not answer in time (:class:`GeoLibreTimeoutWarning`
+            — the layer is still being added, so it is not re-sent).
         """
         params = {
             "name": name,
@@ -490,12 +529,24 @@ class HostMap:
             try:
                 value = _request_from_relay(url, "addGeoJsonLayer", params)
             except GeoLibreNotConnectedError:
-                # Nothing held the relay socket. Every other mutation degrades to
-                # the display transport here (which still reaches the embedded
-                # Notebook panel) and warns, so adding a layer must not be the
-                # one call that hard-fails. The id is then unavailable, exactly
-                # as on JupyterLite. A handler error still raises.
+                # Nothing ran. Every other mutation degrades to the display
+                # transport here (which still reaches the embedded Notebook
+                # panel) and warns, so adding a layer must not be the one call
+                # that hard-fails. The id is then unavailable, exactly as on
+                # JupyterLite. A handler error still raises.
                 _send("addGeoJsonLayer", params)
+                return None
+            except GeoLibreTimeoutError as error:
+                # A window DID take this command — a big FeatureCollection can
+                # outrun the relay's result timeout — and is probably still
+                # adding the layer. Re-sending would add it twice, so give up on
+                # the id alone and say what happened.
+                warnings.warn(
+                    f"GeoLibre: {error} The layer is most likely being added; "
+                    "its id is unavailable. Use list_layers() to find it.",
+                    GeoLibreTimeoutWarning,
+                    stacklevel=3,
+                )
                 return None
             if not isinstance(value, str) or not value:
                 # Fail loudly rather than handing back an id ("None") that no

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -69,6 +69,7 @@ from typing import Any
 from IPython.display import Javascript, display
 
 __all__ = [
+    "GeoLibreNotConnectedError",
     "GeoLibreNotConnectedWarning",
     "HostMap",
     "Map",
@@ -99,6 +100,17 @@ _NOT_CONNECTED_HINT = (
 
 class GeoLibreNotConnectedWarning(UserWarning):
     """Warned when a map command could not be delivered to a GeoLibre window."""
+
+
+class GeoLibreNotConnectedError(RuntimeError):
+    """Raised when a read-back command found no GeoLibre window to run it.
+
+    Only the read-back calls (:meth:`HostMap.list_layers`,
+    :meth:`HostMap.get_layer`) raise this: they have nothing to return without a
+    window. Mutations degrade to the fire-and-forget transport and warn with
+    :class:`GeoLibreNotConnectedWarning` instead. Subclasses ``RuntimeError``, so
+    code that already catches that keeps working.
+    """
 
 
 def _relay_url() -> str | None:
@@ -196,7 +208,7 @@ def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = N
     except (urllib.error.URLError, OSError, ValueError) as error:
         raise RuntimeError(f"GeoLibre read-back failed: {_relay_failure_reason(error)}") from error
     if not payload.get("delivered"):
-        raise RuntimeError(f"No GeoLibre window is connected. {_NOT_CONNECTED_HINT}")
+        raise GeoLibreNotConnectedError(f"No GeoLibre window is connected. {_NOT_CONNECTED_HINT}")
     if not payload.get("ok"):
         raise RuntimeError(str(payload.get("error") or "GeoLibre command failed."))
     return payload.get("value")
@@ -458,6 +470,12 @@ class HostMap:
             name: Layer display name.
             **style: Style overrides applied when the layer is created (e.g.
                 ``fillColor="#facc15"`` or ``strokeColor="#d97706"``).
+
+        Returns:
+            The new layer's id on desktop, or None when the id is unavailable —
+            on JupyterLite, and on desktop when no window held the relay socket
+            (the layer is still sent over the display transport, with a
+            :class:`GeoLibreNotConnectedWarning`).
         """
         params = {
             "name": name,
@@ -469,7 +487,16 @@ class HostMap:
         # where a synchronous Python call cannot wait on the browser event loop.
         url = _relay_url()
         if url is not None:
-            value = _request_from_relay(url, "addGeoJsonLayer", params)
+            try:
+                value = _request_from_relay(url, "addGeoJsonLayer", params)
+            except GeoLibreNotConnectedError:
+                # Nothing held the relay socket. Every other mutation degrades to
+                # the display transport here (which still reaches the embedded
+                # Notebook panel) and warns, so adding a layer must not be the
+                # one call that hard-fails. The id is then unavailable, exactly
+                # as on JupyterLite. A handler error still raises.
+                _send("addGeoJsonLayer", params)
+                return None
             if not isinstance(value, str) or not value:
                 # Fail loudly rather than handing back an id ("None") that no
                 # later set_style/remove_layer call could ever resolve.

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -467,8 +467,9 @@ class HostMap:
         # Desktop kernels have a correlated request/reply relay, so return the
         # new layer id. JupyterLite retains its display/postMessage transport,
         # where a synchronous Python call cannot wait on the browser event loop.
-        if _relay_url() is not None:
-            value = _request("addGeoJsonLayer", params)
+        url = _relay_url()
+        if url is not None:
+            value = _request_from_relay(url, "addGeoJsonLayer", params)
             if not isinstance(value, str) or not value:
                 # Fail loudly rather than handing back an id ("None") that no
                 # later set_style/remove_layer call could ever resolve.

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -571,11 +571,13 @@ class HostMap:
                 # outrun the relay's result timeout — and is probably still
                 # adding the layer. Re-sending would add it twice, so give up on
                 # the id alone and say what happened.
+                # stacklevel=2, not the 3 _send uses: this warn() is already in
+                # the HostMap method, so the user's cell is one frame up, not two.
                 warnings.warn(
                     f"GeoLibre: {error} The layer is most likely being added; "
                     "its id is unavailable. Use list_layers() to find it.",
                     GeoLibreTimeoutWarning,
-                    stacklevel=3,
+                    stacklevel=2,
                 )
                 return None
             if not isinstance(value, str) or not value:

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -124,7 +124,17 @@ class GeoLibreNotConnectedError(RuntimeError):
     window. Mutations degrade to the fire-and-forget transport and warn with
     :class:`GeoLibreNotConnectedWarning` instead. Subclasses ``RuntimeError``, so
     code that already catches that keeps working.
+
+    Attributes:
+        relay_reason: Why the relay endpoint itself did not answer, or None when
+            it answered and simply had no window to hand the command to. A
+            caller degrading to another transport uses this to skip a retry that
+            would only burn a second timeout.
     """
+
+    def __init__(self, message: str, *, relay_reason: str | None = None) -> None:
+        super().__init__(message)
+        self.relay_reason = relay_reason
 
 
 class GeoLibreTimeoutError(RuntimeError):
@@ -240,9 +250,11 @@ def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = N
         raise RuntimeError(f"GeoLibre read-back failed: {_relay_failure_reason(error)}") from error
     except (urllib.error.URLError, OSError, ValueError) as error:
         # The relay never answered, so nothing was dispatched: the same situation
-        # for a caller as no window being connected.
+        # for a caller as no window being connected. Carry the reason so a caller
+        # that degrades to another transport can skip re-asking the relay.
+        reason = _relay_failure_reason(error)
         raise GeoLibreNotConnectedError(
-            f"GeoLibre read-back failed: {_relay_failure_reason(error)}"
+            f"GeoLibre read-back failed: {reason}", relay_reason=reason
         ) from error
     if not payload.get("delivered"):
         raise GeoLibreNotConnectedError(f"No GeoLibre window is connected. {_NOT_CONNECTED_HINT}")
@@ -319,7 +331,9 @@ def is_connected() -> bool:
     return bool(payload.get("listeners"))
 
 
-def _send(method: str, params: dict[str, Any] | None = None) -> None:
+def _send(
+    method: str, params: dict[str, Any] | None = None, *, known_failure: str | None = None
+) -> None:
     """Post one scripting command to the host GeoLibre app.
 
     Prefers the relay (works from any Jupyter frontend, and reports delivery);
@@ -329,6 +343,14 @@ def _send(method: str, params: dict[str, Any] | None = None) -> None:
 
     Warns with :class:`GeoLibreNotConnectedWarning` when the command provably did
     not reach a map, so a disconnected setup never looks like a silent success.
+
+    Args:
+        method: The scripting command name.
+        params: The command's parameters.
+        known_failure: A relay failure an earlier call in this same command
+            already established. Skips the relay POST — which would only wait out
+            a second timeout against an endpoint just proven unresponsive — and
+            goes straight to the display transport, warning with this reason.
     """
     message = {
         "type": "geolibre:command",
@@ -338,7 +360,10 @@ def _send(method: str, params: dict[str, Any] | None = None) -> None:
     }
     url = _relay_url()
     if url is not None:
-        delivered, error = _post_to_relay(url, message)
+        if known_failure is None:
+            delivered, error = _post_to_relay(url, message)
+        else:
+            delivered, error = 0, known_failure
         if delivered:
             return
         # Last-ditch: an app old enough to lack the relay socket still listens on
@@ -528,13 +553,18 @@ class HostMap:
         if url is not None:
             try:
                 value = _request_from_relay(url, "addGeoJsonLayer", params)
-            except GeoLibreNotConnectedError:
+            except GeoLibreNotConnectedError as error:
                 # Nothing ran. Every other mutation degrades to the display
                 # transport here (which still reaches the embedded Notebook
                 # panel) and warns, so adding a layer must not be the one call
                 # that hard-fails. The id is then unavailable, exactly as on
                 # JupyterLite. A handler error still raises.
-                _send("addGeoJsonLayer", params)
+                #
+                # relay_reason is set only when the relay endpoint itself did not
+                # answer; passing it through skips a second POST that would wait
+                # out another full timeout, keeping this no worse than the single
+                # attempt every other mutation makes.
+                _send("addGeoJsonLayer", params, known_failure=error.relay_reason)
                 return None
             except GeoLibreTimeoutError as error:
                 # A window DID take this command — a big FeatureCollection can

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -14,12 +14,12 @@ mutates a whole project model and renders its own app). Marker/choropleth helper
 here build GeoJSON and add it through the same layer command, so no extra bridge
 commands are needed.
 
-It is **fire-and-forget**: each call posts a command and returns immediately
-without waiting for a reply, so it behaves identically in JupyterLite (a
-browser/WebAssembly kernel) and a real JupyterLab server, with no
-``anywidget``/comm dependency. Consequently *read-back* queries (``get_view``,
-``identify``, ``list_layers``, …) are not available here — they need the blocking
-request/reply path the ``geolibre`` widget uses.
+Mutation calls are fire-and-forget except ``add_geojson`` on desktop, which uses
+the relay's correlated request/reply path to return the new layer id. The same
+path powers ``list_layers`` and ``get_layer`` against the live map. JupyterLite
+continues to use browser ``postMessage`` without a comm dependency; synchronous
+read-back is unavailable there because blocking the Python call would also block
+the browser event loop that has to deliver its result.
 
 Two transports carry those commands, picked per call:
 
@@ -44,7 +44,8 @@ Usage::
 
     m = geolibre.connect()
     m.fly_to(-122.4, 37.8, zoom=11)
-    m.add_geojson(gdf, name="My layer")          # GeoDataFrame, dict, or JSON
+    layer_id = m.add_geojson(gdf, name="My layer")  # returns an id on desktop
+    m.get_layer(layer_id)
     m.add_markers([(-122.4, 37.8), (-73.9, 40.7)], name="Cities")
 
 Canonical source: ``backend/geolibre_server/notebook_client.py``. The web build
@@ -60,6 +61,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+import uuid
 import warnings
 from collections.abc import Iterable, Sequence
 from typing import Any
@@ -139,6 +141,49 @@ def _post_to_relay(url: str, message: dict[str, Any]) -> tuple[int, str | None]:
         return 0, f"the local GeoLibre relay could not be reached ({error})"
     delivered = payload.get("delivered")
     return (delivered if isinstance(delivered, int) else 0), None
+
+
+def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = None) -> Any:
+    """Run one scripting command and return its correlated result."""
+    message = {
+        "type": "geolibre:command",
+        "requestId": uuid.uuid4().hex,
+        "method": method,
+        "params": params or {},
+    }
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get(_RELAY_TOKEN_ENV, "").strip()
+    if token:
+        headers["Authorization"] = f"token {token}"
+    request = urllib.request.Request(  # noqa: S310 - fixed http:// loopback URL
+        f"{url}/command",
+        data=json.dumps(message).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - see above
+            request, timeout=_RELAY_TIMEOUT_SECONDS + 1
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as error:
+        raise RuntimeError(f"The local GeoLibre relay could not be reached: {error}") from error
+    if not payload.get("delivered"):
+        raise RuntimeError(f"No GeoLibre window is connected. {_NOT_CONNECTED_HINT}")
+    if not payload.get("ok"):
+        raise RuntimeError(str(payload.get("error") or "GeoLibre command failed."))
+    return payload.get("value")
+
+
+def _request(method: str, params: dict[str, Any] | None = None) -> Any:
+    """Run a read-back command through the desktop relay."""
+    url = _relay_url()
+    if url is None:
+        raise RuntimeError(
+            "GeoLibre read-back requires the desktop Notebook server relay. "
+            "It is not available in this kernel."
+        )
+    return _request_from_relay(url, method, params)
 
 
 def _post_message_via_display(message: dict[str, Any]) -> None:
@@ -361,7 +406,19 @@ class HostMap:
 
     # -- layers ---------------------------------------------------------------
 
-    def add_geojson(self, data: Any, name: str = "GeoJSON", **style: Any) -> None:
+    def list_layers(self) -> list[dict[str, Any]]:
+        """Return live layer metadata in draw order."""
+        value = _request("listLayers")
+        return value if isinstance(value, list) else []
+
+    def get_layer(self, layer_id: str) -> dict[str, Any]:
+        """Return live metadata for one layer id (raises if absent)."""
+        for layer in self.list_layers():
+            if layer.get("id") == layer_id:
+                return layer
+        raise ValueError(f"No layer with id {layer_id!r}")
+
+    def add_geojson(self, data: Any, name: str = "GeoJSON", **style: Any) -> str | None:
         """Add a GeoJSON layer.
 
         Args:
@@ -371,14 +428,19 @@ class HostMap:
             **style: Style overrides applied when the layer is created (e.g.
                 ``fillColor="#facc15"`` or ``strokeColor="#d97706"``).
         """
-        _send(
-            "addGeoJsonLayer",
-            {
-                "name": name,
-                "geojson": _to_featurecollection(data),
-                "style": dict(style),
-            },
-        )
+        params = {
+            "name": name,
+            "geojson": _to_featurecollection(data),
+            "style": dict(style),
+        }
+        # Desktop kernels have a correlated request/reply relay, so return the
+        # new layer id. JupyterLite retains its display/postMessage transport,
+        # where a synchronous Python call cannot wait on the browser event loop.
+        if _relay_url() is not None:
+            value = _request("addGeoJsonLayer", params)
+            return str(value)
+        _send("addGeoJsonLayer", params)
+        return None
 
     def add_marker(
         self, lng: float, lat: float, *, name: str = "Marker", **properties: Any

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -83,6 +83,11 @@ _RELAY_TOKEN_ENV = "GEOLIBRE_RELAY_TOKEN"
 
 # Loopback round-trip to the local app. Short: a hung relay must not stall a
 # notebook, and the caller only loses a fire-and-forget command.
+#
+# Read-back calls wait one second longer than this (see _request_from_relay), so
+# they stay above the relay's own RESULT_TIMEOUT_SECONDS (5.0, in
+# geolibre_server/jupyter_relay.py) and surface its precise 504 rather than
+# timing out here first. Keep the two in step if either moves.
 _RELAY_TIMEOUT_SECONDS = 5.0
 
 _NOT_CONNECTED_HINT = (
@@ -129,9 +134,35 @@ def _post_to_relay(url: str, message: dict[str, Any]) -> tuple[int, str | None]:
         ) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError) as error:
-        return 0, f"the local GeoLibre relay could not be reached ({error})"
+        return 0, _relay_failure_reason(error)
     delivered = payload.get("delivered")
     return (delivered if isinstance(delivered, int) else 0), None
+
+
+def _relay_failure_reason(error: Exception) -> str:
+    """Describe a failed relay call, in the terms that actually apply.
+
+    An :class:`urllib.error.HTTPError` means the relay *was* reached and answered
+    with an error status (400 for a malformed command, 409 for a duplicate
+    request id, 504 when the app did not return a result in time); saying it
+    "could not be reached" would send a reader looking in the wrong place.
+    """
+    if isinstance(error, urllib.error.HTTPError):
+        return f"the local GeoLibre relay returned HTTP {error.code} ({_http_error_detail(error)})"
+    return f"the local GeoLibre relay could not be reached ({error})"
+
+
+def _http_error_detail(error: urllib.error.HTTPError) -> str:
+    """Best-effort human message from a relay error response."""
+    try:
+        payload = json.loads(error.read().decode("utf-8"))
+    except (OSError, ValueError):
+        payload = None
+    if isinstance(payload, dict):
+        message = payload.get("message") or payload.get("reason")
+        if isinstance(message, str) and message:
+            return message
+    return str(error.reason or error)
 
 
 def _relay_request(url: str, message: dict[str, Any]) -> urllib.request.Request:
@@ -163,7 +194,7 @@ def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = N
         ) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, OSError, ValueError) as error:
-        raise RuntimeError(f"The local GeoLibre relay could not be reached: {error}") from error
+        raise RuntimeError(f"GeoLibre read-back failed: {_relay_failure_reason(error)}") from error
     if not payload.get("delivered"):
         raise RuntimeError(f"No GeoLibre window is connected. {_NOT_CONNECTED_HINT}")
     if not payload.get("ok"):
@@ -405,7 +436,11 @@ class HostMap:
     def list_layers(self) -> list[dict[str, Any]]:
         """Return live layer metadata in draw order."""
         value = _request("listLayers")
-        return value if isinstance(value, list) else []
+        if not isinstance(value, list):
+            # A successful reply that is not a list means the app's handler is
+            # broken; returning [] would read as "the map has no layers".
+            raise RuntimeError(f"GeoLibre returned an unexpected layer list: {value!r}")
+        return value
 
     def get_layer(self, layer_id: str) -> dict[str, Any]:
         """Return live metadata for one layer id (raises if absent)."""
@@ -434,7 +469,11 @@ class HostMap:
         # where a synchronous Python call cannot wait on the browser event loop.
         if _relay_url() is not None:
             value = _request("addGeoJsonLayer", params)
-            return str(value)
+            if not isinstance(value, str) or not value:
+                # Fail loudly rather than handing back an id ("None") that no
+                # later set_style/remove_layer call could ever resolve.
+                raise RuntimeError(f"GeoLibre returned an unexpected layer id: {value!r}")
+            return value
         _send("addGeoJsonLayer", params)
         return None
 

--- a/backend/geolibre_server/notebook_client.py
+++ b/backend/geolibre_server/notebook_client.py
@@ -122,16 +122,7 @@ def _post_to_relay(url: str, message: dict[str, Any]) -> tuple[int, str | None]:
         ``(delivered, error)`` — how many app windows received the command, and a
         human-readable reason when the relay itself could not be reached.
     """
-    headers = {"Content-Type": "application/json"}
-    token = os.environ.get(_RELAY_TOKEN_ENV, "").strip()
-    if token:
-        headers["Authorization"] = f"token {token}"
-    request = urllib.request.Request(  # noqa: S310 - fixed http:// loopback URL
-        f"{url}/command",
-        data=json.dumps(message).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
+    request = _relay_request(url, message)
     try:
         with urllib.request.urlopen(  # noqa: S310 - see above
             request, timeout=_RELAY_TIMEOUT_SECONDS
@@ -143,6 +134,20 @@ def _post_to_relay(url: str, message: dict[str, Any]) -> tuple[int, str | None]:
     return (delivered if isinstance(delivered, int) else 0), None
 
 
+def _relay_request(url: str, message: dict[str, Any]) -> urllib.request.Request:
+    """Build an authenticated command request for the loopback relay."""
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get(_RELAY_TOKEN_ENV, "").strip()
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return urllib.request.Request(  # noqa: S310 - fixed http:// loopback URL
+        f"{url}/command",
+        data=json.dumps(message).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+
+
 def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = None) -> Any:
     """Run one scripting command and return its correlated result."""
     message = {
@@ -151,16 +156,7 @@ def _request_from_relay(url: str, method: str, params: dict[str, Any] | None = N
         "method": method,
         "params": params or {},
     }
-    headers = {"Content-Type": "application/json"}
-    token = os.environ.get(_RELAY_TOKEN_ENV, "").strip()
-    if token:
-        headers["Authorization"] = f"token {token}"
-    request = urllib.request.Request(  # noqa: S310 - fixed http:// loopback URL
-        f"{url}/command",
-        data=json.dumps(message).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
+    request = _relay_request(url, message)
     try:
         with urllib.request.urlopen(  # noqa: S310 - see above
             request, timeout=_RELAY_TIMEOUT_SECONDS + 1

--- a/backend/geolibre_server/notebook_examples/Welcome.ipynb
+++ b/backend/geolibre_server/notebook_examples/Welcome.ipynb
@@ -124,7 +124,7 @@
    "source": [
     "## More\n",
     "\n",
-    "Other methods: `set_view`, `zoom_to_layer`, `set_basemap`, `set_visibility`, `set_opacity`, `set_style`, `remove_layer`, `run_algorithm`. These are fire-and-forget map commands; read-back queries (e.g. `get_view`) are not available in this lightweight client. See the [Notebook panel docs](https://geolibre.org/notebook/)."
+    "Other methods: `set_view`, `zoom_to_layer`, `set_basemap`, `set_visibility`, `set_opacity`, `set_style`, `remove_layer`, `run_algorithm`. In the desktop app, `add_geojson` returns a layer id, and `list_layers()` / `get_layer(layer_id)` read metadata from the live map. See the [Notebook panel docs](https://geolibre.org/notebook/)."
    ]
   }
  ],

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -36,10 +36,14 @@ class FakeSocket:
 def _isolate_listeners():
     """Keep each test's listener set independent of the module-level one."""
     saved = set(jupyter_relay._listeners)
+    saved_pending = dict(jupyter_relay._pending_results)
     jupyter_relay._listeners.clear()
+    jupyter_relay._pending_results.clear()
     yield
     jupyter_relay._listeners.clear()
     jupyter_relay._listeners.update(saved)
+    jupyter_relay._pending_results.clear()
+    jupyter_relay._pending_results.update(saved_pending)
 
 
 # -- the command envelope ----------------------------------------------------
@@ -62,6 +66,45 @@ def test_normalize_command_keeps_a_string_request_id():
 
 def test_normalize_command_defaults_missing_params_to_an_empty_object():
     assert jupyter_relay.normalize_command({"method": "getView"})["params"] == {}
+
+
+def test_normalize_result_keeps_a_success_value():
+    assert jupyter_relay.normalize_result(
+        {
+            "type": "geolibre:result",
+            "requestId": "abc",
+            "ok": True,
+            "value": [{"id": "layer-1"}],
+        }
+    ) == {
+        "requestId": "abc",
+        "ok": True,
+        "value": [{"id": "layer-1"}],
+    }
+
+
+def test_normalize_result_keeps_an_error_message():
+    assert jupyter_relay.normalize_result(
+        {
+            "type": "geolibre:result",
+            "requestId": "abc",
+            "ok": False,
+            "error": "No layer",
+        }
+    ) == {"requestId": "abc", "ok": False, "error": "No layer"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"type": "geolibre:result", "requestId": "", "ok": True},
+        {"type": "geolibre:result", "requestId": "abc", "ok": "yes"},
+    ],
+)
+def test_normalize_result_rejects_malformed_payloads(payload):
+    with pytest.raises(ValueError):
+        jupyter_relay.normalize_result(payload)
 
 
 @pytest.mark.parametrize(

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -207,6 +207,19 @@ def test_broadcast_with_no_listeners_reports_zero():
     assert jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"}) == 0
 
 
+def test_limited_broadcast_reaches_only_one_listener():
+    first, second = FakeSocket(), FakeSocket()
+    jupyter_relay._listeners.update({first, second})
+
+    delivered = jupyter_relay._broadcast(
+        {"type": "geolibre:command", "method": "listLayers"},
+        limit=1,
+    )
+
+    assert delivered == 1
+    assert len(first.received) + len(second.received) == 1
+
+
 # -- extension load ----------------------------------------------------------
 
 

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -8,6 +8,7 @@ environment it publishes to kernels, and the broadcast bookkeeping itself.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
@@ -37,13 +38,17 @@ def _isolate_listeners():
     """Keep each test's listener list independent of the module-level one."""
     saved = list(jupyter_relay._listeners)
     saved_pending = dict(jupyter_relay._pending_results)
+    saved_owners = dict(jupyter_relay._pending_owners)
     jupyter_relay._listeners.clear()
     jupyter_relay._pending_results.clear()
+    jupyter_relay._pending_owners.clear()
     yield
     jupyter_relay._listeners.clear()
     jupyter_relay._listeners.extend(saved)
     jupyter_relay._pending_results.clear()
     jupyter_relay._pending_results.update(saved_pending)
+    jupyter_relay._pending_owners.clear()
+    jupyter_relay._pending_owners.update(saved_owners)
 
 
 # -- the command envelope ----------------------------------------------------
@@ -207,20 +212,20 @@ def test_broadcast_with_no_listeners_reports_zero():
     assert jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"}) == 0
 
 
-def test_limited_broadcast_reaches_only_one_listener():
+# -- single-window dispatch (correlated read-back) ---------------------------
+
+
+def test_dispatch_one_reaches_only_one_listener():
     first, second = FakeSocket(), FakeSocket()
     jupyter_relay._listeners.extend([first, second])
 
-    delivered = jupyter_relay._broadcast(
-        {"type": "geolibre:command", "method": "listLayers"},
-        limit=1,
-    )
+    owner = jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"})
 
-    assert delivered == 1
+    assert owner is first
     assert len(first.received) + len(second.received) == 1
 
 
-def test_limited_broadcast_keeps_picking_the_same_window():
+def test_dispatch_one_keeps_picking_the_same_window():
     # A mutation and the read-back that follows it must reach the same map, so
     # the single-window pick has to be the oldest connection every time — not
     # whichever one an unordered set happened to yield.
@@ -228,24 +233,50 @@ def test_limited_broadcast_keeps_picking_the_same_window():
     jupyter_relay._listeners.extend([first, second])
 
     for method in ("addGeoJsonLayer", "listLayers"):
-        jupyter_relay._broadcast({"type": "geolibre:command", "method": method}, limit=1)
+        jupyter_relay._dispatch_one({"type": "geolibre:command", "method": method})
 
     assert len(first.received) == 2
     assert second.received == []
 
 
-def test_limited_broadcast_falls_through_a_dead_first_window():
+def test_dispatch_one_falls_through_a_dead_first_window():
     dead, alive = FakeSocket(fails=True), FakeSocket()
     jupyter_relay._listeners.extend([dead, alive])
 
-    delivered = jupyter_relay._broadcast(
-        {"type": "geolibre:command", "method": "listLayers"},
-        limit=1,
-    )
+    owner = jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"})
 
-    assert delivered == 1
+    assert owner is alive
     assert len(alive.received) == 1
     assert jupyter_relay._listeners == [alive]
+
+
+def test_dispatch_one_reports_no_window():
+    assert jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"}) is None
+
+
+def test_closing_the_owning_window_fails_its_request_at_once():
+    # Without this the kernel would sit out the full RESULT_TIMEOUT_SECONDS for
+    # an answer the relay already knows can never arrive.
+    loop = asyncio.new_event_loop()
+    try:
+        socket, other = FakeSocket(), FakeSocket()
+        future, untouched = loop.create_future(), loop.create_future()
+        jupyter_relay._listeners.extend([socket, other])
+        jupyter_relay._pending_results.update({"mine": future, "theirs": untouched})
+        jupyter_relay._pending_owners.update({"mine": socket, "theirs": other})
+
+        jupyter_relay.GeoLibreRelaySocket.on_close(socket)
+
+        assert jupyter_relay._listeners == [other]
+        assert future.result() == {
+            "requestId": "mine",
+            "ok": False,
+            "error": "The GeoLibre window running this command closed.",
+        }
+        # Another window's in-flight request is none of this socket's business.
+        assert not untouched.done()
+    finally:
+        loop.close()
 
 
 # -- extension load ----------------------------------------------------------

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -254,6 +254,27 @@ def test_dispatch_one_reports_no_window():
     assert jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"}) is None
 
 
+def test_only_the_owning_window_may_answer_a_request():
+    loop = asyncio.new_event_loop()
+    try:
+        owner, other = FakeSocket(), FakeSocket()
+        future = loop.create_future()
+        jupyter_relay._listeners.extend([owner, other])
+        jupyter_relay._pending_results["mine"] = future
+        jupyter_relay._pending_owners["mine"] = owner
+        reply = json.dumps(
+            {"type": "geolibre:result", "requestId": "mine", "ok": True, "value": "layer-1"}
+        )
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(other, reply)
+        assert not future.done()
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(owner, reply)
+        assert future.result()["value"] == "layer-1"
+    finally:
+        loop.close()
+
+
 def test_closing_the_owning_window_fails_its_request_at_once():
     # Without this the kernel would sit out the full RESULT_TIMEOUT_SECONDS for
     # an answer the relay already knows can never arrive.

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -112,6 +112,20 @@ def test_normalize_result_rejects_malformed_payloads(payload):
         jupyter_relay.normalize_result(payload)
 
 
+def test_the_client_outwaits_this_modules_result_timeout():
+    # notebook_client's read-back waits _RELAY_TIMEOUT_SECONDS + 1 (see
+    # _request_from_relay). That has to stay above the budget here, or the
+    # kernel's own socket gives up first and the precise 504 -> GeoLibreTimeoutError
+    # ("still running in the app") degrades into GeoLibreNotConnectedError
+    # ("could not be reached"), which is both wrong and differently handled.
+    # The two constants live in separate modules, so pin their ordering here.
+    notebook_client = pytest.importorskip(
+        "notebook_client", reason="the notebook client renders IPython displays"
+    )
+
+    assert notebook_client._RELAY_TIMEOUT_SECONDS + 1 > jupyter_relay.RESULT_TIMEOUT_SECONDS
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -34,14 +34,14 @@ class FakeSocket:
 
 @pytest.fixture(autouse=True)
 def _isolate_listeners():
-    """Keep each test's listener set independent of the module-level one."""
-    saved = set(jupyter_relay._listeners)
+    """Keep each test's listener list independent of the module-level one."""
+    saved = list(jupyter_relay._listeners)
     saved_pending = dict(jupyter_relay._pending_results)
     jupyter_relay._listeners.clear()
     jupyter_relay._pending_results.clear()
     yield
     jupyter_relay._listeners.clear()
-    jupyter_relay._listeners.update(saved)
+    jupyter_relay._listeners.extend(saved)
     jupyter_relay._pending_results.clear()
     jupyter_relay._pending_results.update(saved_pending)
 
@@ -181,7 +181,7 @@ def test_relay_base_url_falls_back_to_loopback(host):
 
 def test_broadcast_reaches_every_listener_and_counts_them():
     first, second = FakeSocket(), FakeSocket()
-    jupyter_relay._listeners.update({first, second})
+    jupyter_relay._listeners.extend([first, second])
 
     delivered = jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"})
 
@@ -192,7 +192,7 @@ def test_broadcast_reaches_every_listener_and_counts_them():
 
 def test_broadcast_drops_a_dead_listener_instead_of_failing():
     alive, dead = FakeSocket(), FakeSocket(fails=True)
-    jupyter_relay._listeners.update({alive, dead})
+    jupyter_relay._listeners.extend([alive, dead])
 
     delivered = jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"})
 
@@ -209,7 +209,7 @@ def test_broadcast_with_no_listeners_reports_zero():
 
 def test_limited_broadcast_reaches_only_one_listener():
     first, second = FakeSocket(), FakeSocket()
-    jupyter_relay._listeners.update({first, second})
+    jupyter_relay._listeners.extend([first, second])
 
     delivered = jupyter_relay._broadcast(
         {"type": "geolibre:command", "method": "listLayers"},
@@ -218,6 +218,34 @@ def test_limited_broadcast_reaches_only_one_listener():
 
     assert delivered == 1
     assert len(first.received) + len(second.received) == 1
+
+
+def test_limited_broadcast_keeps_picking_the_same_window():
+    # A mutation and the read-back that follows it must reach the same map, so
+    # the single-window pick has to be the oldest connection every time — not
+    # whichever one an unordered set happened to yield.
+    first, second = FakeSocket(), FakeSocket()
+    jupyter_relay._listeners.extend([first, second])
+
+    for method in ("addGeoJsonLayer", "listLayers"):
+        jupyter_relay._broadcast({"type": "geolibre:command", "method": method}, limit=1)
+
+    assert len(first.received) == 2
+    assert second.received == []
+
+
+def test_limited_broadcast_falls_through_a_dead_first_window():
+    dead, alive = FakeSocket(fails=True), FakeSocket()
+    jupyter_relay._listeners.extend([dead, alive])
+
+    delivered = jupyter_relay._broadcast(
+        {"type": "geolibre:command", "method": "listLayers"},
+        limit=1,
+    )
+
+    assert delivered == 1
+    assert len(alive.received) == 1
+    assert jupyter_relay._listeners == [alive]
 
 
 # -- extension load ----------------------------------------------------------

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -273,13 +273,16 @@ def test_add_geojson_does_not_resend_after_a_result_timeout(relay, displays):
         "http://127.0.0.1:8766/geolibre/relay/command", 504, "Gateway Timeout", {}, None
     )
 
-    with pytest.warns(notebook_client.GeoLibreTimeoutWarning, match="still running"):
+    with pytest.warns(notebook_client.GeoLibreTimeoutWarning, match="still running") as caught:
         layer_id = notebook_client.HostMap().add_geojson(
             {"type": "FeatureCollection", "features": []}
         )
 
     assert layer_id is None
     assert displays == []
+    # The warning must blame the caller's line, not notebook_client's internals,
+    # so it points at the user's cell and repeats per cell.
+    assert caught[0].filename == __file__
 
 
 def test_add_geojson_falls_back_when_the_relay_is_unreachable(relay, displays):

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -48,12 +48,20 @@ def relay(monkeypatch):
         body = (
             {"listeners": Relay.listeners}
             if request.full_url.endswith("/status")
-            else {"delivered": Relay.listeners}
+            else _command_response(request, Relay.listeners)
         )
         return FakeResponse(json.dumps(body).encode())
 
     monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
     return Relay
+
+
+def _command_response(request, listeners):
+    message = json.loads(request.data)
+    response = {"delivered": listeners}
+    if message.get("requestId"):
+        response.update({"ok": True, "value": f"result-for-{message['method']}"})
+    return response
 
 
 @pytest.fixture
@@ -173,9 +181,13 @@ def test_is_connected_without_a_relay_follows_the_kernel_kind(monkeypatch):
 
 
 def test_add_geojson_wraps_a_bare_geometry(relay, displays):
-    notebook_client.HostMap().add_geojson({"type": "Point", "coordinates": [1, 2]}, name="Pin")
+    layer_id = notebook_client.HostMap().add_geojson(
+        {"type": "Point", "coordinates": [1, 2]}, name="Pin"
+    )
 
     params = json.loads(relay.calls[0].data)["params"]
+    assert json.loads(relay.calls[0].data)["requestId"]
+    assert layer_id == "result-for-addGeoJsonLayer"
     assert params["name"] == "Pin"
     assert params["geojson"]["features"][0]["geometry"]["coordinates"] == [1, 2]
     assert params["style"] == {}
@@ -202,3 +214,31 @@ def test_add_markers_builds_a_point_collection(relay, displays):
     features = json.loads(relay.calls[0].data)["params"]["geojson"]["features"]
     assert [f["geometry"]["coordinates"] for f in features] == [[-122.4, 37.8], [1.0, 2.0]]
     assert features[1]["properties"] == {"kind": "x"}
+
+
+def test_list_layers_returns_live_metadata(relay, monkeypatch):
+    layers = [{"id": "cities", "name": "Cities", "type": "geojson"}]
+    monkeypatch.setattr(
+        notebook_client,
+        "_request",
+        lambda method, params=None: layers if method == "listLayers" else None,
+    )
+
+    assert notebook_client.HostMap().list_layers() == layers
+
+
+def test_get_layer_returns_a_matching_layer(monkeypatch):
+    layers = [
+        {"id": "roads", "name": "Roads", "type": "geojson"},
+        {"id": "cities", "name": "Cities", "type": "geojson"},
+    ]
+    monkeypatch.setattr(notebook_client.HostMap, "list_layers", lambda self: layers)
+
+    assert notebook_client.HostMap().get_layer("cities") == layers[1]
+
+
+def test_get_layer_raises_for_an_unknown_id(monkeypatch):
+    monkeypatch.setattr(notebook_client.HostMap, "list_layers", lambda self: [])
+
+    with pytest.raises(ValueError, match="missing"):
+        notebook_client.HostMap().get_layer("missing")

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -252,6 +252,31 @@ def test_list_layers_raises_on_a_non_list_result(relay, monkeypatch):
         notebook_client.HostMap().list_layers()
 
 
+def test_add_geojson_falls_back_when_no_window_is_connected(relay, displays):
+    # Every other mutation degrades to the display transport (which still reaches
+    # the embedded Notebook panel) rather than failing, so this must too.
+    relay.listeners = 0
+
+    with pytest.warns(notebook_client.GeoLibreNotConnectedWarning):
+        layer_id = notebook_client.HostMap().add_geojson(
+            {"type": "FeatureCollection", "features": []}
+        )
+
+    assert layer_id is None
+    assert len(displays) == 1
+
+
+def test_add_geojson_still_raises_when_the_handler_fails(relay, monkeypatch):
+    # Only the not-connected case degrades; a real handler error must surface.
+    def fail(url, method, params=None):
+        raise RuntimeError("layerId must be a non-empty string")
+
+    monkeypatch.setattr(notebook_client, "_request_from_relay", fail)
+
+    with pytest.raises(RuntimeError, match="layerId"):
+        notebook_client.HostMap().add_geojson({"type": "FeatureCollection", "features": []})
+
+
 def test_add_geojson_raises_on_a_missing_layer_id(relay, monkeypatch):
     # str(None) would hand back "None", an id no later call could ever resolve.
     monkeypatch.setattr(

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -254,7 +254,9 @@ def test_list_layers_raises_on_a_non_list_result(relay, monkeypatch):
 
 def test_add_geojson_raises_on_a_missing_layer_id(relay, monkeypatch):
     # str(None) would hand back "None", an id no later call could ever resolve.
-    monkeypatch.setattr(notebook_client, "_request", lambda method, params=None: None)
+    monkeypatch.setattr(
+        notebook_client, "_request_from_relay", lambda url, method, params=None: None
+    )
 
     with pytest.raises(RuntimeError, match="unexpected layer id"):
         notebook_client.HostMap().add_geojson({"type": "FeatureCollection", "features": []})

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -266,6 +266,45 @@ def test_add_geojson_falls_back_when_no_window_is_connected(relay, displays):
     assert len(displays) == 1
 
 
+def test_add_geojson_does_not_resend_after_a_result_timeout(relay, displays):
+    # A window took the command (504 from the relay) and is probably still adding
+    # the layer, so re-sending it would add a duplicate. Only the id is lost.
+    relay.error = urllib.error.HTTPError(
+        "http://127.0.0.1:8766/geolibre/relay/command", 504, "Gateway Timeout", {}, None
+    )
+
+    with pytest.warns(notebook_client.GeoLibreTimeoutWarning, match="still running"):
+        layer_id = notebook_client.HostMap().add_geojson(
+            {"type": "FeatureCollection", "features": []}
+        )
+
+    assert layer_id is None
+    assert displays == []
+
+
+def test_add_geojson_falls_back_when_the_relay_is_unreachable(relay, displays):
+    # Nothing was dispatched, so re-sending is safe — and is what every other
+    # mutation does.
+    relay.error = urllib.error.URLError("connection refused")
+
+    with pytest.warns(notebook_client.GeoLibreNotConnectedWarning):
+        layer_id = notebook_client.HostMap().add_geojson(
+            {"type": "FeatureCollection", "features": []}
+        )
+
+    assert layer_id is None
+    assert len(displays) == 1
+
+
+def test_read_back_timeout_raises_rather_than_reporting_no_layers(relay):
+    relay.error = urllib.error.HTTPError(
+        "http://127.0.0.1:8766/geolibre/relay/command", 504, "Gateway Timeout", {}, None
+    )
+
+    with pytest.raises(notebook_client.GeoLibreTimeoutError, match="still running"):
+        notebook_client.HostMap().list_layers()
+
+
 def test_add_geojson_still_raises_when_the_handler_fails(relay, monkeypatch):
     # Only the not-connected case degrades; a real handler error must surface.
     def fail(url, method, params=None):
@@ -291,20 +330,21 @@ def test_add_geojson_raises_on_a_missing_layer_id(relay, monkeypatch):
 
 
 def test_read_back_reports_an_answered_error_status_as_such(relay):
-    # The relay answered (504 = the app did not return a result in time), so the
-    # message must not send the reader looking for an unreachable server.
+    # The relay answered (400 = it rejected the command), so the message must not
+    # send the reader looking for an unreachable server. 504 is its own case, see
+    # test_read_back_timeout_raises_rather_than_reporting_no_layers.
     relay.error = urllib.error.HTTPError(
         "http://127.0.0.1:8766/geolibre/relay/command",
-        504,
-        "Gateway Timeout",
+        400,
+        "Bad Request",
         {},
-        io.BytesIO(json.dumps({"message": "GeoLibre did not return a result in time."}).encode()),
+        io.BytesIO(json.dumps({"message": "Missing a non-empty 'method'."}).encode()),
     )
 
-    with pytest.raises(RuntimeError, match="returned HTTP 504") as excinfo:
+    with pytest.raises(RuntimeError, match="returned HTTP 400") as excinfo:
         notebook_client.HostMap().list_layers()
 
-    assert "did not return a result in time" in str(excinfo.value)
+    assert "Missing a non-empty" in str(excinfo.value)
     assert "could not be reached" not in str(excinfo.value)
 
 

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -242,3 +242,47 @@ def test_get_layer_raises_for_an_unknown_id(monkeypatch):
 
     with pytest.raises(ValueError, match="missing"):
         notebook_client.HostMap().get_layer("missing")
+
+
+def test_list_layers_raises_on_a_non_list_result(relay, monkeypatch):
+    # An empty list would read as "the map has no layers" and hide the bug.
+    monkeypatch.setattr(notebook_client, "_request", lambda method, params=None: {"oops": True})
+
+    with pytest.raises(RuntimeError, match="unexpected layer list"):
+        notebook_client.HostMap().list_layers()
+
+
+def test_add_geojson_raises_on_a_missing_layer_id(relay, monkeypatch):
+    # str(None) would hand back "None", an id no later call could ever resolve.
+    monkeypatch.setattr(notebook_client, "_request", lambda method, params=None: None)
+
+    with pytest.raises(RuntimeError, match="unexpected layer id"):
+        notebook_client.HostMap().add_geojson({"type": "FeatureCollection", "features": []})
+
+
+# -- relay failures ----------------------------------------------------------
+
+
+def test_read_back_reports_an_answered_error_status_as_such(relay):
+    # The relay answered (504 = the app did not return a result in time), so the
+    # message must not send the reader looking for an unreachable server.
+    relay.error = urllib.error.HTTPError(
+        "http://127.0.0.1:8766/geolibre/relay/command",
+        504,
+        "Gateway Timeout",
+        {},
+        io.BytesIO(json.dumps({"message": "GeoLibre did not return a result in time."}).encode()),
+    )
+
+    with pytest.raises(RuntimeError, match="returned HTTP 504") as excinfo:
+        notebook_client.HostMap().list_layers()
+
+    assert "did not return a result in time" in str(excinfo.value)
+    assert "could not be reached" not in str(excinfo.value)
+
+
+def test_read_back_reports_an_unreachable_relay_as_such(relay):
+    relay.error = urllib.error.URLError("connection refused")
+
+    with pytest.raises(RuntimeError, match="could not be reached"):
+        notebook_client.HostMap().list_layers()

--- a/backend/geolibre_server/tests/test_notebook_client.py
+++ b/backend/geolibre_server/tests/test_notebook_client.py
@@ -294,6 +294,20 @@ def test_add_geojson_falls_back_when_the_relay_is_unreachable(relay, displays):
 
     assert layer_id is None
     assert len(displays) == 1
+    # One POST, not two: re-asking an endpoint that just failed to answer would
+    # wait out a second full timeout on top of the read-back's.
+    assert len(relay.calls) == 1
+
+
+def test_add_geojson_still_retries_the_relay_when_it_is_merely_unsubscribed(relay, displays):
+    # Here the relay answered (delivered: 0), so it is up and the second POST is
+    # immediate — worth making, since a window may have connected in between.
+    relay.listeners = 0
+
+    with pytest.warns(notebook_client.GeoLibreNotConnectedWarning):
+        notebook_client.HostMap().add_geojson({"type": "FeatureCollection", "features": []})
+
+    assert len(relay.calls) == 2
 
 
 def test_read_back_timeout_raises_rather_than_reporting_no_layers(relay):

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -42,9 +42,9 @@ m.set_basemap("https://…/style.json")
 
 Most mutation calls are **fire-and-forget**. On desktop, `add_geojson` uses the
 relay's correlated request/reply path and returns the new layer id. The same
-path exposes `list_layers()`, which returns each live layer's id, name, type,
-visibility, and opacity, and `get_layer(layer_id)`, which returns one matching
-layer or raises `ValueError`. The id can be passed directly to
+path exposes `list_layers()`, which returns one dict per live layer with `id`,
+`name`, `type`, `visible`, and `opacity`, and `get_layer(layer_id)`, which
+returns one matching layer or raises `ValueError`. The id can be passed directly to
 `set_visibility`, `set_opacity`, `set_style`, `remove_layer`, or
 `zoom_to_layer`.
 

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -57,11 +57,20 @@ fire-and-forget command — including `add_marker`/`add_markers` — still reach
 every connected window. This is only visible if you attach two GeoLibre windows
 to one Jupyter server.
 
-If no window is connected when `add_geojson` runs, it behaves like every other
-mutation — the layer goes out over the display transport, you get a
-`GeoLibreNotConnectedWarning`, and the return value is `None` rather than an id.
-The read-back calls have nothing to return in that situation, so they raise
-`GeoLibreNotConnectedError` (a `RuntimeError`) instead.
+`add_geojson` returns `None` instead of an id in two situations, and never
+fails outright in either:
+
+- **Nothing received the command** (no window connected, or the relay itself
+  unreachable). It behaves like every other mutation — the layer goes out over
+  the display transport with a `GeoLibreNotConnectedWarning`.
+- **A window took it but did not answer within 5s**, which a large
+  `FeatureCollection` can do. You get a `GeoLibreTimeoutWarning`; the layer is
+  still being added, so it is deliberately *not* re-sent (that would add it
+  twice) — find it with `list_layers()`.
+
+The read-back calls have nothing to return in either situation, so they raise
+`GeoLibreNotConnectedError` / `GeoLibreTimeoutError` (both `RuntimeError`)
+instead.
 
 Synchronous read-back is desktop-only. JupyterLite uses browser `postMessage`;
 blocking its Python call would also block the browser event loop that must

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -28,31 +28,30 @@ import geolibre
 
 m = geolibre.connect()          # or geolibre.Map()
 m.fly_to(-122.4, 37.8, zoom=11) # animate the live map in the left pane
-m.add_geojson(
+layer_id = m.add_geojson(
     gdf,
     name="My layer",
     fillColor="#facc15",
     strokeColor="#d97706",
-)  # GeoDataFrame, dict, or JSON string
+)  # GeoDataFrame, dict, or JSON string; returns an id on desktop
+m.get_layer(layer_id)
+m.list_layers()
 m.fit_bounds([-123, 37, -122, 38])
 m.set_basemap("https://…/style.json")
 ```
 
-Calls are **fire-and-forget**: each posts a command to the host app over the
-shared scripting protocol (the same `createScriptingHandlers` surface used by the
-in-app Python console and the Jupyter widget) and returns immediately, so the
-client behaves identically on the in-browser kernel and a real server. Canonical
-client source: `backend/geolibre_server/notebook_client.py`.
+Most mutation calls are **fire-and-forget**. On desktop, `add_geojson` uses the
+relay's correlated request/reply path and returns the new layer id. The same
+path exposes `list_layers()`, which returns each live layer's id, name, type,
+visibility, and opacity, and `get_layer(layer_id)`, which returns one matching
+layer or raises `ValueError`. The id can be passed directly to
+`set_visibility`, `set_opacity`, `set_style`, `remove_layer`, or
+`zoom_to_layer`.
 
-> Read-back queries (e.g. `get_center`) are not exposed by this fire-and-forget
-> client; they need the blocking request/reply path the `geolibre` widget uses.
-
-The client also has layer-targeted calls — `set_visibility(layer_id, visible)`,
-`set_opacity`, `set_style`, `remove_layer`, `zoom_to_layer` — but they are left
-out of the snippet above because there is no way to obtain a `layer_id` here:
-being fire-and-forget, this client's `add_geojson` returns `None`. Use them with
-an id from the blocking [`geolibre` widget](python.md), whose `add_geojson`
-returns the new layer's id.
+Synchronous read-back is desktop-only. JupyterLite uses browser `postMessage`;
+blocking its Python call would also block the browser event loop that must
+deliver the result. Canonical client source:
+`backend/geolibre_server/notebook_client.py`.
 
 ## Driving the map from an external client (VS Code, …)
 

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -57,6 +57,12 @@ fire-and-forget command — including `add_marker`/`add_markers` — still reach
 every connected window. This is only visible if you attach two GeoLibre windows
 to one Jupyter server.
 
+If no window is connected when `add_geojson` runs, it behaves like every other
+mutation — the layer goes out over the display transport, you get a
+`GeoLibreNotConnectedWarning`, and the return value is `None` rather than an id.
+The read-back calls have nothing to return in that situation, so they raise
+`GeoLibreNotConnectedError` (a `RuntimeError`) instead.
+
 Synchronous read-back is desktop-only. JupyterLite uses browser `postMessage`;
 blocking its Python call would also block the browser event loop that must
 deliver the result. Canonical client source:

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -48,6 +48,15 @@ returns one matching layer or raises `ValueError`. The id can be passed directly
 `set_visibility`, `set_opacity`, `set_style`, `remove_layer`, or
 `zoom_to_layer`.
 
+These three are also the only commands that do **not** fan out: a correlated
+request/reply can have exactly one authoritative responder, so `add_geojson`,
+`list_layers`, and `get_layer` run in a single app window (the one that
+connected first) and consistently keep using it, which is what makes an id
+returned by `add_geojson` resolvable by a later `get_layer`. Every
+fire-and-forget command — including `add_marker`/`add_markers` — still reaches
+every connected window. This is only visible if you attach two GeoLibre windows
+to one Jupyter server.
+
 Synchronous read-back is desktop-only. JupyterLite uses browser `postMessage`;
 blocking its Python call would also block the browser event loop that must
 deliver the result. Canonical client source:

--- a/tests/jupyter-relay.test.ts
+++ b/tests/jupyter-relay.test.ts
@@ -56,7 +56,7 @@ describe("parseRelayMessage", () => {
         params: { zoom: 4 },
       }),
     );
-    assert.deepEqual(command, { method: "flyTo", params: { zoom: 4 } });
+    assert.deepEqual(command, { requestId: "", method: "flyTo", params: { zoom: 4 } });
   });
 
   it("defaults missing or non-object params to an empty object", () => {
@@ -65,7 +65,19 @@ describe("parseRelayMessage", () => {
         JSON.stringify({ type: "geolibre:command", method: "x", params }),
       );
       assert.deepEqual(command?.params, {});
+      assert.equal(command?.requestId, "");
     }
+  });
+
+  it("preserves a correlated request id", () => {
+    const command = parseRelayMessage(
+      JSON.stringify({
+        type: "geolibre:command",
+        requestId: "request-1",
+        method: "listLayers",
+      }),
+    );
+    assert.equal(command?.requestId, "request-1");
   });
 
   it("ignores the relay's ready greeting", () => {

--- a/tests/jupyter-relay.test.ts
+++ b/tests/jupyter-relay.test.ts
@@ -6,7 +6,9 @@ import {
   parseRelayMessage,
   relayReconnectDelay,
   relaySocketUrl,
+  runRelayCommand,
 } from "../apps/geolibre-desktop/src/lib/jupyter-relay";
+import type { ScriptingHandlers } from "../apps/geolibre-desktop/src/lib/scripting/scriptingApi";
 
 // The wire format the app shares with the desktop Jupyter map-command relay
 // (backend/geolibre_server/geolibre_server/jupyter_relay.py), which is what lets
@@ -94,6 +96,103 @@ describe("parseRelayMessage", () => {
     assert.equal(parseRelayMessage("not json"), null);
     assert.equal(parseRelayMessage(new ArrayBuffer(4)), null);
     assert.equal(parseRelayMessage(null), null);
+  });
+});
+
+describe("runRelayCommand", () => {
+  // The reply this builds is what the relay's correlated request/reply path
+  // returns to the kernel, so `list_layers()` / `add_geojson()` read-back in the
+  // notebook client is exactly these payloads.
+  const handlers = {
+    listLayers: () => [{ id: "layer-1" }],
+    addGeoJsonLayer: async () => "layer-2",
+    boom: () => {
+      throw new Error("handler exploded");
+    },
+  } as unknown as ScriptingHandlers;
+
+  /** Run without the hook's diagnostics polluting the test output. */
+  const quietly = async <T>(run: () => Promise<T>): Promise<T> => {
+    const { warn, error } = console;
+    console.warn = () => {};
+    console.error = () => {};
+    try {
+      return await run();
+    } finally {
+      console.warn = warn;
+      console.error = error;
+    }
+  };
+
+  it("returns the handler's value under the request id", async () => {
+    const result = await runRelayCommand(handlers, {
+      requestId: "request-1",
+      method: "listLayers",
+      params: {},
+    });
+    assert.deepEqual(result, {
+      type: "geolibre:result",
+      requestId: "request-1",
+      ok: true,
+      value: [{ id: "layer-1" }],
+    });
+  });
+
+  it("awaits an async handler", async () => {
+    const result = await runRelayCommand(handlers, {
+      requestId: "request-2",
+      method: "addGeoJsonLayer",
+      params: {},
+    });
+    assert.deepEqual(result, {
+      type: "geolibre:result",
+      requestId: "request-2",
+      ok: true,
+      value: "layer-2",
+    });
+  });
+
+  it("reports a handler failure as ok:false", async () => {
+    const result = await quietly(() =>
+      runRelayCommand(handlers, { requestId: "request-3", method: "boom", params: {} }),
+    );
+    assert.deepEqual(result, {
+      type: "geolibre:result",
+      requestId: "request-3",
+      ok: false,
+      error: "handler exploded",
+    });
+  });
+
+  it("reports an unknown command as ok:false rather than hanging the caller", async () => {
+    const result = await quietly(() =>
+      runRelayCommand(handlers, { requestId: "request-4", method: "nope", params: {} }),
+    );
+    assert.deepEqual(result, {
+      type: "geolibre:result",
+      requestId: "request-4",
+      ok: false,
+      error: 'Unknown command "nope"',
+    });
+  });
+
+  it("never dispatches an inherited member as a command", async () => {
+    const result = await quietly(() =>
+      runRelayCommand(handlers, { requestId: "request-5", method: "constructor", params: {} }),
+    );
+    assert.equal(result?.ok, false);
+  });
+
+  it("replies with nothing for a fire-and-forget command", async () => {
+    // An empty requestId means the kernel is not waiting; the handler still runs.
+    let ran = false;
+    const spy = { ping: () => (ran = true) } as unknown as ScriptingHandlers;
+    assert.equal(await runRelayCommand(spy, { requestId: "", method: "ping", params: {} }), null);
+    assert.equal(ran, true);
+    assert.equal(
+      await quietly(() => runRelayCommand(spy, { requestId: "", method: "boom", params: {} })),
+      null,
+    );
   });
 });
 

--- a/tests/jupyter-relay.test.ts
+++ b/tests/jupyter-relay.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   RELAY_RECONNECT_MAX_MS,
   RELAY_RECONNECT_MIN_MS,
+  encodeRelayResult,
   parseRelayMessage,
   relayReconnectDelay,
   relaySocketUrl,
@@ -193,6 +194,36 @@ describe("runRelayCommand", () => {
       await quietly(() => runRelayCommand(spy, { requestId: "", method: "boom", params: {} })),
       null,
     );
+  });
+});
+
+describe("encodeRelayResult", () => {
+  it("encodes an ordinary result unchanged", () => {
+    const result = {
+      type: "geolibre:result",
+      requestId: "request-1",
+      ok: true,
+      value: [{ id: "layer-1" }],
+    } as const;
+    assert.deepEqual(JSON.parse(encodeRelayResult(result)), result);
+  });
+
+  it("degrades an unserializable value to a readable failure", () => {
+    // Sending nothing would leave the kernel waiting out the relay's whole
+    // result timeout for a generic 504.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const frame = JSON.parse(
+      encodeRelayResult({
+        type: "geolibre:result",
+        requestId: "request-2",
+        ok: true,
+        value: circular,
+      }),
+    );
+    assert.equal(frame.requestId, "request-2");
+    assert.equal(frame.ok, false);
+    assert.match(frame.error, /could not be serialized/);
   });
 });
 


### PR DESCRIPTION
## Summary

- add correlated request/reply support to the desktop Jupyter relay
- return the new layer id from notebook `add_geojson` and expose `list_layers()` / `get_layer()`
- document desktop read-back support and cover the protocol and client behavior with tests

## Verification

- `51 passed` in the focused Python relay/client suites
- `13 passed` in `tests/jupyter-relay.test.ts`
- full pre-commit gate, including npm build, lint, formatting, and notebook checks
- loaded `us_cities.geojson` (109 features) in the browser and verified both dark and light themes with zero console errors

Fixes #1616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Desktop notebook operations now return correlated results and clear error information.
  - Added live layer discovery and retrieval.
  - Adding GeoJSON now returns the created layer ID in the desktop app.

- **Bug Fixes**
  - Improved handling of unknown commands, failed operations, duplicate requests, malformed results, disconnected windows, and timeouts.
  - Ensured requests reach the correct desktop app window.

- **Documentation**
  - Updated notebook guidance and examples for layer read-back.
  - Clarified that JupyterLite continues to use fire-and-forget operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->