### PR TITLE
fix(gps): stream Android fixes at GNSS rate and keep follow mode reachable

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -242,6 +242,19 @@ export function GpsTrackingDialog({
   const getMap = useCallback(() => mapControllerRef.current?.getMap() ?? null, [mapControllerRef]);
 
   /**
+   * Center the map on a fix. The first recenter of a session also zooms in;
+   * later ones only pan, so following doesn't fight the user's chosen zoom.
+   */
+  const recenterOnFix = useCallback((map: maplibregl.Map, fix: GpsFix) => {
+    map.easeTo({
+      center: [fix.lng, fix.lat],
+      duration: 500,
+      ...(zoomedRef.current ? {} : { zoom: Math.max(map.getZoom(), 15) }),
+    });
+    zoomedRef.current = true;
+  }, []);
+
+  /**
    * Toggle follow mode. The ref moves first so a fix arriving before the
    * re-render doesn't recenter a map the user has just panned away from, and
    * switching it back on recenters immediately instead of leaving the map
@@ -254,9 +267,9 @@ export function GpsTrackingDialog({
       if (!next) return;
       const map = getMap();
       const fix = lastFixRef.current;
-      if (map && fix) map.easeTo({ center: [fix.lng, fix.lat], duration: 500 });
+      if (map && fix) recenterOnFix(map, fix);
     },
-    [getMap],
+    [getMap, recenterOnFix],
   );
 
   const handleFix = useCallback(
@@ -313,17 +326,10 @@ export function GpsTrackingDialog({
         }
         if (fix.heading != null) markerRef.current.setRotation(fix.heading);
 
-        if (followRef.current) {
-          map.easeTo({
-            center: [fix.lng, fix.lat],
-            duration: 500,
-            ...(zoomedRef.current ? {} : { zoom: Math.max(map.getZoom(), 15) }),
-          });
-          zoomedRef.current = true;
-        }
+        if (followRef.current) recenterOnFix(map, fix);
       }
     },
-    [getMap, setGpsStatus],
+    [getMap, recenterOnFix, setGpsStatus],
   );
 
   // The watchPosition subscription follows `tracking`. On Tauri mobile this
@@ -583,7 +589,10 @@ export function GpsTrackingDialog({
           stats={stats}
           capturedCount={capturedCount}
           follow={follow}
-          onToggleFollow={() => setFollowMode(!follow)}
+          // Flip the ref, not the rendered `follow`: a drag that has just
+          // turned follow off updates the ref synchronously but the state only
+          // on the next render, so `!follow` could re-disable it instead.
+          onToggleFollow={() => setFollowMode(!followRef.current)}
           onCapture={handleCapturePoint}
           onPause={() => changeRecording("paused")}
           onResume={handleResumeRecording}

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@geolibre/ui";
 import {
   Circle,
+  Crosshair,
   Download,
   LocateFixed,
   MapPin,
@@ -240,6 +241,24 @@ export function GpsTrackingDialog({
 
   const getMap = useCallback(() => mapControllerRef.current?.getMap() ?? null, [mapControllerRef]);
 
+  /**
+   * Toggle follow mode. The ref moves first so a fix arriving before the
+   * re-render doesn't recenter a map the user has just panned away from, and
+   * switching it back on recenters immediately instead of leaving the map
+   * where it was until the next fix.
+   */
+  const setFollowMode = useCallback(
+    (next: boolean) => {
+      followRef.current = next;
+      setFollow(next);
+      if (!next) return;
+      const map = getMap();
+      const fix = lastFixRef.current;
+      if (map && fix) map.easeTo({ center: [fix.lng, fix.lat], duration: 500 });
+    },
+    [getMap],
+  );
+
   const handleFix = useCallback(
     (fix: GpsFix) => {
       lastFixRef.current = fix;
@@ -353,7 +372,7 @@ export function GpsTrackingDialog({
   // subscriptions for the whole session.
   useEffect(() => {
     if (!tracking) return;
-    const onDragStart = () => setFollow(false);
+    const onDragStart = () => setFollowMode(false);
     // Gated on the source actually being gone, so the frequent styledata
     // events fired by ordinary style mutations cost one getSource() check.
     const onStyleData = () => {
@@ -381,7 +400,7 @@ export function GpsTrackingDialog({
       map?.off("dragstart", onDragStart);
       map?.off("styledata", onStyleData);
     };
-  }, [tracking, getMap]);
+  }, [tracking, getMap, setFollowMode]);
 
   const clearMapArtifacts = useCallback(() => {
     markerRef.current?.remove();
@@ -563,6 +582,8 @@ export function GpsTrackingDialog({
           recording={recording}
           stats={stats}
           capturedCount={capturedCount}
+          follow={follow}
+          onToggleFollow={() => setFollowMode(!follow)}
           onCapture={handleCapturePoint}
           onPause={() => changeRecording("paused")}
           onResume={handleResumeRecording}
@@ -588,7 +609,7 @@ export function GpsTrackingDialog({
                       <input
                         type="checkbox"
                         checked={follow}
-                        onChange={(e) => setFollow(e.target.checked)}
+                        onChange={(e) => setFollowMode(e.target.checked)}
                       />
                       {t("gps.follow")}
                     </label>
@@ -801,6 +822,8 @@ interface FloatingPanelProps {
   recording: RecordingState;
   stats: { distanceM: number; durationS: number; pointCount: number };
   capturedCount: number;
+  follow: boolean;
+  onToggleFollow: () => void;
   onCapture: () => void;
   onPause: () => void;
   onResume: () => void;
@@ -811,12 +834,19 @@ interface FloatingPanelProps {
  * Compact live readout shown while GPS is on and the dialog is closed, so the
  * map stays fully visible in the field. Anchored to the trailing corner to
  * avoid the Field Collection quick-open button at bottom center.
+ *
+ * Carries its own follow toggle: panning the map turns follow off (QGIS-style),
+ * and in the field the dialog is usually closed, so without it the only way
+ * back is to reopen the dialog — which reads as "keep map centered does
+ * nothing".
  */
 function FloatingPanel({
   fix,
   recording,
   stats,
   capturedCount,
+  follow,
+  onToggleFollow,
   onCapture,
   onPause,
   onResume,
@@ -854,6 +884,15 @@ function FloatingPanel({
         <Button size="sm" variant="outline" disabled={!fix} onClick={onCapture}>
           <MapPin className="me-1 h-3.5 w-3.5" />
           {t("gps.capturePoint")}
+        </Button>
+        <Button
+          size="sm"
+          variant={follow ? "default" : "outline"}
+          aria-label={t("gps.follow")}
+          aria-pressed={follow}
+          onClick={onToggleFollow}
+        >
+          <Crosshair className="h-3.5 w-3.5" />
         </Button>
         {recording === "recording" && (
           <Button size="sm" variant="outline" aria-label={t("gps.pause")} onClick={onPause}>

--- a/apps/geolibre-desktop/src/lib/geolocation.ts
+++ b/apps/geolibre-desktop/src/lib/geolocation.ts
@@ -59,14 +59,51 @@ function fromPlugin(p: PluginPosition): GeolocationPosition {
  * The browser's `PositionOptions` are all optional; the plugin's require every
  * field. Fill in browser-equivalent defaults (accuracy off, no cached fix). The
  * `timeout` default is finite because the plugin can't take the browser's
- * `Infinity`; it's ignored on Android for a one-shot read and only bounds the
- * per-update wait for a watch.
+ * `Infinity`; it's ignored on Android for a one-shot read.
  */
 function toPluginOptions(o?: PositionOptions): PluginPositionOptions {
   return {
     enableHighAccuracy: o?.enableHighAccuracy ?? false,
     timeout: o?.timeout ?? 30000,
     maximumAge: o?.maximumAge ?? 0,
+  };
+}
+
+/** Extra knobs {@link watchPosition} accepts on top of the browser options. */
+export interface WatchOptions extends PositionOptions {
+  /**
+   * Android only: how often, in milliseconds, to ask the fused location
+   * provider for a new fix. Defaults to {@link NATIVE_WATCH_INTERVAL_MS}.
+   */
+  nativeIntervalMs?: number;
+}
+
+/**
+ * Requested interval between native watch fixes. 1 s is the rate a GNSS
+ * receiver produces fixes at, so a live tracker moves smoothly rather than in
+ * jumps.
+ */
+export const NATIVE_WATCH_INTERVAL_MS = 1000;
+
+/**
+ * Options for a *native watch*, where `timeout` means something different from
+ * the browser's.
+ *
+ * The Android bridge feeds `timeout` straight into `LocationRequest.Builder`
+ * as the update interval (and as the min interval / max batching delay), so
+ * leaving it at the one-shot default asks the fused provider for one fix every
+ * 30 s — the live position freezes between updates and "keep map centered"
+ * looks like it does nothing. The browser meaning of `timeout` (how long to
+ * wait before erroring) is unrelated, so it is deliberately not reused here:
+ * the update interval comes from `nativeIntervalMs` alone. Ignored on iOS,
+ * which streams from `CLLocationManager`.
+ *
+ * Exported for tests; the native path can't run under `node --test`.
+ */
+export function nativeWatchOptions(o?: WatchOptions): PluginPositionOptions {
+  return {
+    ...toPluginOptions(o),
+    timeout: o?.nativeIntervalMs ?? NATIVE_WATCH_INTERVAL_MS,
   };
 }
 
@@ -118,13 +155,13 @@ export async function getCurrentPosition(options?: PositionOptions): Promise<Geo
 export async function watchPosition(
   onFix: (pos: GeolocationPosition) => void,
   onError: (err: GeolocationError) => void,
-  options?: PositionOptions,
+  options?: WatchOptions,
 ): Promise<() => void> {
   if (nativeGeolocationAvailable()) {
     await ensureNativePermission();
     const { watchPosition: nativeWatch, clearWatch } =
       await import("@tauri-apps/plugin-geolocation");
-    const id = await nativeWatch(toPluginOptions(options), (pos, err) => {
+    const id = await nativeWatch(nativeWatchOptions(options), (pos, err) => {
       if (pos) onFix(fromPlugin(pos));
       // A watch error after start is treated as transient (signal loss): keep
       // watching. Up-front permission refusal already rejected above.

--- a/tests/geolocation.test.ts
+++ b/tests/geolocation.test.ts
@@ -79,10 +79,11 @@ describe("nativeGeolocationAvailable", () => {
 // a fix twice a minute (the live position and "keep map centered" both freeze
 // in between). These lock the watch to a GNSS-rate interval.
 describe("nativeWatchOptions", () => {
-  it("asks for a fix at the native watch interval, not the one-shot timeout", () => {
+  it("asks for a fix every second, not at the one-shot timeout", () => {
     const opts = nativeWatchOptions({ enableHighAccuracy: true, maximumAge: 0 });
-    assert.equal(opts.timeout, NATIVE_WATCH_INTERVAL_MS);
-    assert.ok(NATIVE_WATCH_INTERVAL_MS <= 1000);
+    // A literal, not NATIVE_WATCH_INTERVAL_MS: comparing the constant with
+    // itself would hold however far the default drifted from a GNSS fix rate.
+    assert.equal(opts.timeout, 1000);
   });
 
   it("ignores the browser timeout, which means something else entirely", () => {

--- a/tests/geolocation.test.ts
+++ b/tests/geolocation.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, it } from "node:test";
 import {
   GeolocationError,
   getCurrentPosition,
+  NATIVE_WATCH_INTERVAL_MS,
   nativeGeolocationAvailable,
+  nativeWatchOptions,
   watchPosition,
 } from "../apps/geolibre-desktop/src/lib/geolocation";
 
@@ -69,6 +71,32 @@ describe("nativeGeolocationAvailable", () => {
     setWindow(true);
     setNavigator(undefined, "Mozilla/5.0 (X11; Linux x86_64)");
     assert.equal(nativeGeolocationAvailable(), false);
+  });
+});
+
+// The Android bridge feeds the plugin's `timeout` into LocationRequest as the
+// update interval, so a watch that inherits the one-shot 30 s default only gets
+// a fix twice a minute (the live position and "keep map centered" both freeze
+// in between). These lock the watch to a GNSS-rate interval.
+describe("nativeWatchOptions", () => {
+  it("asks for a fix at the native watch interval, not the one-shot timeout", () => {
+    const opts = nativeWatchOptions({ enableHighAccuracy: true, maximumAge: 0 });
+    assert.equal(opts.timeout, NATIVE_WATCH_INTERVAL_MS);
+    assert.ok(NATIVE_WATCH_INTERVAL_MS <= 1000);
+  });
+
+  it("ignores the browser timeout, which means something else entirely", () => {
+    const opts = nativeWatchOptions({ timeout: 30000, enableHighAccuracy: true, maximumAge: 0 });
+    assert.equal(opts.timeout, NATIVE_WATCH_INTERVAL_MS);
+  });
+
+  it("honors an explicit native interval and preserves the other options", () => {
+    const opts = nativeWatchOptions({
+      enableHighAccuracy: true,
+      maximumAge: 5000,
+      nativeIntervalMs: 250,
+    });
+    assert.deepEqual(opts, { enableHighAccuracy: true, maximumAge: 5000, timeout: 250 });
   });
 });
 
@@ -151,6 +179,25 @@ describe("watchPosition (browser path)", () => {
       },
     );
     assert.equal(denied, true);
+  });
+
+  it("keeps the caller's browser timeout, which is unrelated to the native interval", async () => {
+    setWindow(false);
+    let seen: PositionOptions | undefined;
+    setNavigator({
+      getCurrentPosition: () => {},
+      watchPosition: (_ok, _err, opts) => {
+        seen = opts;
+        return 1;
+      },
+      clearWatch: () => {},
+    });
+    await watchPosition(
+      () => {},
+      () => {},
+      { enableHighAccuracy: true, maximumAge: 0, timeout: 20000 },
+    );
+    assert.equal(seen?.timeout, 20000);
   });
 
   it("rejects when starting a watch with no geolocation source", async () => {


### PR DESCRIPTION
## Problem

GPS tracking on the Android build updates the position only every ~20-30 s instead of continuously, and "Keep map centered on my position" appears to do nothing.

## Root cause

The Android bridge in the vendored `tauri-plugin-geolocation` feeds the plugin's `timeout` option straight into `LocationRequest.Builder` — as the update interval, the min update interval, *and* the max batching delay:

```kotlin
val locationRequest = LocationRequest.Builder(timeout)
    .setMaxUpdateDelayMillis(timeout)
    .setMinUpdateIntervalMillis(timeout)
```

`lib/geolocation.ts` filled in a browser-equivalent `timeout` default of 30000 ms for the plugin (the browser meaning is "how long to wait before erroring", which is unrelated), and the GPS Tracking dialog does not pass one. So the fused location provider was asked for one fix every 30 s, with permission to batch. The live marker, the readout, and the follow-mode `easeTo` all froze in between, which reads as follow doing nothing while you walk.

iOS is unaffected (`CLLocationManager.startUpdatingLocation` streams), and so is the browser/desktop path (`navigator.geolocation`).

## Fix

- `watchPosition` now gives the native watch its own update interval (`NATIVE_WATCH_INTERVAL_MS`, 1 s — the rate a GNSS receiver produces fixes at), overridable per call via `nativeIntervalMs`. The browser `timeout` keeps its own meaning and is passed through untouched on the `navigator.geolocation` path.
- Follow mode had no field-facing control: panning the map turns it off (QGIS-style), but the only toggle lives in the dialog, which is closed while you are out collecting — so once it switched off there was no way back without reopening the dialog. The floating panel now carries a follow toggle that shows its state, and re-enabling recenters immediately instead of waiting for the next fix. The ref is also updated before the state so a fix arriving mid-pan cannot snap the map back.

## Verification

- `tests/geolocation.test.ts`: new `nativeWatchOptions` cases lock the watch to the GNSS-rate interval and assert the browser `timeout` is neither reused for it nor clobbered on the browser path. Full frontend suite passes (4422/4422).
- Drove the real web build in Chromium with a simulated moving device: the map center follows each fix, a user pan flips the panel toggle to unpressed and subsequent fixes are ignored, clicking the toggle recenters on the last fix immediately, and following resumes.
- `npm run typecheck` and `pre-commit run --files` clean.

The Android update rate itself needs an APK rebuild to confirm on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a follow-mode toggle for GPS tracking that keeps the map centered on the latest location.
  * Re-enabling follow mode immediately recenters the map on the latest location.
  * Follow mode is available in both the tracking dialog and floating panel, with clear active and inactive states.

* **Bug Fixes**
  * Manual map movement automatically disables follow mode.
  * Improved mobile GPS update timing with consistent one-second location intervals.
  * Preserved browser location timeout behavior while supporting native tracking intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->