### PR TITLE
fix(gps): close NMEA connection lifecycle races

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -538,9 +538,12 @@ export function GpsTrackingDialog({
   }, []);
 
   /** Close the NMEA connection, if any, and clear its readout. */
-  const disconnectNmea = useCallback(async () => {
-    // Any connect still in flight is now stale; see connectGenerationRef.
-    connectGenerationRef.current += 1;
+  /**
+   * Release the live connection and clear its readout, leaving the generation
+   * alone. Split from {@link disconnectNmea} so a connect attempt can close a
+   * previous connection without invalidating the generation it just claimed.
+   */
+  const closeNmea = useCallback(async () => {
     const conn = nmeaConnRef.current;
     nmeaConnRef.current = null;
     setNmeaLabel(null);
@@ -559,6 +562,12 @@ export function GpsTrackingDialog({
     }
   }, []);
 
+  /** Abandon any in-flight connect as well as closing the live connection. */
+  const disconnectNmea = useCallback(async () => {
+    connectGenerationRef.current += 1;
+    await closeNmea();
+  }, [closeNmea]);
+
   /**
    * Open an NMEA receiver and start tracking from it. Both transports show a
    * browser device chooser, so this must run from a user gesture; a dismissed
@@ -568,20 +577,29 @@ export function GpsTrackingDialog({
     async (transport: NmeaTransport) => {
       setError(null);
       setNotice(null);
-      // Supersede any earlier attempt, then claim this attempt's indicator and
-      // generation. Claiming after the disconnect matters: disconnectNmea
-      // resets `connecting`, so setting it first would wipe it immediately.
-      // disconnectNmea swallows close failures, so it cannot reject here.
-      await disconnectNmea();
-      setConnecting(transport);
-      const generation = connectGenerationRef.current;
+      // Claim a generation synchronously, before the first await: closing the
+      // previous connection suspends, and two invocations that both captured
+      // afterwards would read the same value and both believe they are current.
+      const generation = ++connectGenerationRef.current;
       const isStale = () => generation !== connectGenerationRef.current;
+      // Closes the previous connection without invalidating the generation
+      // just claimed, and cannot reject (closeNmea swallows close failures).
+      await closeNmea();
+      if (isStale()) return;
+      setConnecting(transport);
       try {
         const handlers = {
-          onFix: handleFix,
+          // Both callbacks are generation-guarded: the transport starts reading
+          // before this function commits the connection, so a superseded
+          // attempt could otherwise re-create overlays teardown had cleared, or
+          // tear down a newer connection that replaced it.
+          onFix: (fix: GpsFix) => {
+            if (!isStale()) handleFix(fix);
+          },
           // A dropped device or a read failure stops the session rather than
           // leaving a stale position on the map.
           onError: (err: NmeaError) => {
+            if (isStale()) return;
             setError(nmeaErrorText(err, t));
             setTracking(false);
             void disconnectNmea();
@@ -615,7 +633,7 @@ export function GpsTrackingDialog({
         if (!isStale()) setConnecting(null);
       }
     },
-    [baudRate, disconnectNmea, handleFix, t],
+    [baudRate, closeNmea, disconnectNmea, handleFix, t],
   );
 
   // Poll the assembler's counters while connected so the readout shows the

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -547,11 +547,6 @@ export function GpsTrackingDialog({
     nmeaConnRef.current = null;
     setNmeaLabel(null);
     setNmeaStats(null);
-    // Clearing the indicator belongs here rather than only in connectNmea's
-    // `finally`: an attempt abandoned by a source change or a stop is stale by
-    // the time it resolves, so that `finally` deliberately skips it, and the
-    // buttons would stay disabled showing "Connecting…" for the session.
-    setConnecting(null);
     try {
       await conn?.close();
     } catch {
@@ -564,6 +559,12 @@ export function GpsTrackingDialog({
   /** Abandon any in-flight connect as well as closing the live connection. */
   const disconnectNmea = useCallback(async () => {
     connectGenerationRef.current += 1;
+    // Clearing the indicator belongs on the abandon path rather than in
+    // connectNmea's `finally`: an attempt abandoned by a source change or a
+    // stop is stale by the time it resolves, so that `finally` deliberately
+    // skips it, and the buttons would stay disabled showing "Connecting…" for
+    // the rest of the session.
+    setConnecting(null);
     await closeNmea();
   }, [closeNmea]);
 
@@ -581,11 +582,15 @@ export function GpsTrackingDialog({
       // afterwards would read the same value and both believe they are current.
       const generation = ++connectGenerationRef.current;
       const isStale = () => generation !== connectGenerationRef.current;
+      // Show the indicator before the first await, so there is no window in
+      // which an attempt is in flight but the buttons look idle — closing a
+      // live connection below can take real time. closeNmea deliberately does
+      // not clear it; only the abandon path (disconnectNmea) does.
+      setConnecting(transport);
       // Closes the previous connection without invalidating the generation
       // just claimed, and cannot reject (closeNmea swallows close failures).
       await closeNmea();
       if (isStale()) return;
-      setConnecting(transport);
       try {
         const handlers = {
           // Both callbacks are generation-guarded: the transport starts reading

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -537,7 +537,6 @@ export function GpsTrackingDialog({
     });
   }, []);
 
-  /** Close the NMEA connection, if any, and clear its readout. */
   /**
    * Release the live connection and clear its readout, leaving the generation
    * alone. Split from {@link disconnectNmea} so a connect attempt can close a

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -282,6 +282,14 @@ export function GpsTrackingDialog({
   const [nmeaStats, setNmeaStats] = useState<NmeaStreamStats | null>(null);
   const [connecting, setConnecting] = useState<NmeaTransport | null>(null);
   const nmeaConnRef = useRef<NmeaConnection | null>(null);
+  /**
+   * Bumped whenever an in-flight connect is superseded — by another connect, a
+   * source change, stopping, or unmount. A Bluetooth `gatt.connect()` can stay
+   * pending for seconds, and nothing stops the user abandoning it meanwhile, so
+   * a late success must close itself rather than silently reactivating a
+   * session the user believes is over (or leaking a port opened after unmount).
+   */
+  const connectGenerationRef = useRef(0);
 
   const markerRef = useRef<maplibregl.Marker | null>(null);
   const markerArrowRef = useRef<HTMLDivElement | null>(null);
@@ -511,7 +519,10 @@ export function GpsTrackingDialog({
     () => () => {
       clearMapArtifacts();
       useAppStore.getState().setGpsStatus(null);
-      // Release the serial port / GATT server so a re-mount can reopen it.
+      // Release the serial port / GATT server so a re-mount can reopen it, and
+      // mark any in-flight connect stale so one that resolves after this closes
+      // itself instead of leaking a device nothing will ever release.
+      connectGenerationRef.current += 1;
       void nmeaConnRef.current?.close();
       nmeaConnRef.current = null;
     },
@@ -528,6 +539,8 @@ export function GpsTrackingDialog({
 
   /** Close the NMEA connection, if any, and clear its readout. */
   const disconnectNmea = useCallback(async () => {
+    // Any connect still in flight is now stale; see connectGenerationRef.
+    connectGenerationRef.current += 1;
     const conn = nmeaConnRef.current;
     nmeaConnRef.current = null;
     setNmeaLabel(null);
@@ -551,8 +564,12 @@ export function GpsTrackingDialog({
       setError(null);
       setNotice(null);
       setConnecting(transport);
+      // Supersede any earlier attempt, then claim this attempt's generation.
+      // disconnectNmea swallows close failures, so it cannot reject here.
+      await disconnectNmea();
+      const generation = connectGenerationRef.current;
+      const isStale = () => generation !== connectGenerationRef.current;
       try {
-        await disconnectNmea();
         const handlers = {
           onFix: handleFix,
           // A dropped device or a read failure stops the session rather than
@@ -567,18 +584,26 @@ export function GpsTrackingDialog({
           transport === "serial"
             ? await connectSerialNmea({ baudRate }, handlers)
             : await connectBluetoothNmea(handlers);
+        if (isStale()) {
+          // The user moved on while the device was still opening: release it
+          // rather than resurrecting a session they already abandoned.
+          await conn.close();
+          return;
+        }
         nmeaConnRef.current = conn;
         setNmeaLabel(conn.label);
         setNmeaStats(conn.stats());
         setTracking(true);
       } catch (err) {
+        if (isStale()) return;
         if (err instanceof NmeaError) {
           if (!err.cancelled) setError(nmeaErrorText(err, t));
         } else {
           setError(err instanceof Error ? err.message : t("gps.nmeaConnectFailed"));
         }
       } finally {
-        setConnecting(null);
+        // A superseded attempt must not clear the newer attempt's indicator.
+        if (!isStale()) setConnecting(null);
       }
     },
     [baudRate, disconnectNmea, handleFix, t],

--- a/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/GpsTrackingDialog.tsx
@@ -545,6 +545,11 @@ export function GpsTrackingDialog({
     nmeaConnRef.current = null;
     setNmeaLabel(null);
     setNmeaStats(null);
+    // Clearing the indicator belongs here rather than only in connectNmea's
+    // `finally`: an attempt abandoned by a source change or a stop is stale by
+    // the time it resolves, so that `finally` deliberately skips it, and the
+    // buttons would stay disabled showing "Connecting…" for the session.
+    setConnecting(null);
     try {
       await conn?.close();
     } catch {
@@ -563,10 +568,12 @@ export function GpsTrackingDialog({
     async (transport: NmeaTransport) => {
       setError(null);
       setNotice(null);
-      setConnecting(transport);
-      // Supersede any earlier attempt, then claim this attempt's generation.
+      // Supersede any earlier attempt, then claim this attempt's indicator and
+      // generation. Claiming after the disconnect matters: disconnectNmea
+      // resets `connecting`, so setting it first would wipe it immediately.
       // disconnectNmea swallows close failures, so it cannot reject here.
       await disconnectNmea();
+      setConnecting(transport);
       const generation = connectGenerationRef.current;
       const isStale = () => generation !== connectGenerationRef.current;
       try {
@@ -602,7 +609,9 @@ export function GpsTrackingDialog({
           setError(err instanceof Error ? err.message : t("gps.nmeaConnectFailed"));
         }
       } finally {
-        // A superseded attempt must not clear the newer attempt's indicator.
+        // A superseded attempt must not clear the newer attempt's indicator;
+        // one abandoned by a source change or a stop already had it reset by
+        // disconnectNmea itself.
         if (!isStale()) setConnecting(null);
       }
     },

--- a/apps/geolibre-desktop/src/lib/nmea-source.ts
+++ b/apps/geolibre-desktop/src/lib/nmea-source.ts
@@ -248,7 +248,13 @@ export async function connectSerialNmea(
     try {
       for (;;) {
         const { value, done } = await reader.read();
-        if (done) break;
+        // `closed` is re-checked here, not just at the error dispatch below: a
+        // read that resolved just before close() runs would otherwise deliver a
+        // fix afterwards, and handleFix re-creates the marker and map sources
+        // that teardown has already removed, leaving a stray overlay behind.
+        // The Bluetooth transport gets this for free, since removing the
+        // listener in close() is synchronous.
+        if (done || closed) break;
         if (!value) continue;
         buffer = consumeChunk(decoder.decode(value, { stream: true }), buffer, assembler, onFix);
       }

--- a/tests/nmea-source.test.ts
+++ b/tests/nmea-source.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { nmeaChecksum } from "../apps/geolibre-desktop/src/lib/nmea";
+import type { GpsFix } from "../apps/geolibre-desktop/src/lib/gps-tracking";
+import {
+  connectSerialNmea,
+  NmeaError,
+  serialNmeaSupported,
+} from "../apps/geolibre-desktop/src/lib/nmea-source";
+
+const sentence = (payload: string) => `$${payload}*${nmeaChecksum(payload)}\r\n`;
+
+/** One complete 1 Hz epoch at the given `hhmmss.ss`. */
+function epoch(time: string): string {
+  return (
+    sentence(`GNGGA,${time},3557.5432,N,08355.1234,W,1,09,0.92,268.4,M,-33.2,M,,`) +
+    sentence(`GNRMC,${time},A,3557.5432,N,08355.1234,W,4.5,187.3,010826,,,A`)
+  );
+}
+
+interface FakePort {
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  closeCalls: number;
+}
+
+/**
+ * Install a fake `navigator.serial` whose port streams whatever the test
+ * enqueues. Only the browser API boundary is faked; the transport, the parser,
+ * and the assembler all run for real.
+ */
+function installFakeSerial(): { port: () => FakePort; restore: () => void } {
+  let fake: FakePort | undefined;
+  const makePort = () => {
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+    const port = {
+      open: async () => {},
+      close: async () => {
+        if (fake) fake.closeCalls += 1;
+      },
+      get readable() {
+        return stream;
+      },
+    };
+    fake = { controller, closeCalls: 0 };
+    return port;
+  };
+  const previous = Object.getOwnPropertyDescriptor(globalThis.navigator, "serial");
+  Object.defineProperty(globalThis.navigator, "serial", {
+    configurable: true,
+    value: { requestPort: async () => makePort() },
+  });
+  return {
+    port: () => {
+      assert.ok(fake, "no port was requested");
+      return fake;
+    },
+    restore: () => {
+      if (previous) Object.defineProperty(globalThis.navigator, "serial", previous);
+      else Reflect.deleteProperty(globalThis.navigator as object, "serial");
+    },
+  };
+}
+
+const encode = (text: string) => new TextEncoder().encode(text);
+const settle = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+describe("connectSerialNmea", () => {
+  it("reports Web Serial support from the presence of navigator.serial", () => {
+    const serial = installFakeSerial();
+    try {
+      assert.equal(serialNmeaSupported(), true);
+    } finally {
+      serial.restore();
+    }
+  });
+
+  it("streams fixes assembled from the sentences the port emits", async () => {
+    const serial = installFakeSerial();
+    try {
+      const fixes: GpsFix[] = [];
+      const conn = await connectSerialNmea(
+        { baudRate: 9600 },
+        { onFix: (f) => fixes.push(f), onError: () => {} },
+      );
+      // The second epoch's first sentence is what closes the first epoch.
+      serial.port().controller.enqueue(encode(epoch("174512.00") + epoch("174513.00")));
+      await settle();
+      assert.equal(fixes.length, 1, "one completed epoch");
+      assert.ok(Math.abs(fixes[0].lat - 35.9590533) < 1e-6);
+      assert.ok(Math.abs(fixes[0].speed! - 2.315) < 1e-3, "carried RMC speed");
+      assert.equal(conn.stats().fixes, 1);
+      await conn.close();
+    } finally {
+      serial.restore();
+    }
+  });
+
+  it("delivers no further fix once close() has been called", async () => {
+    const serial = installFakeSerial();
+    try {
+      const fixes: GpsFix[] = [];
+      const conn = await connectSerialNmea(
+        { baudRate: 9600 },
+        { onFix: (f) => fixes.push(f), onError: () => {} },
+      );
+      serial.port().controller.enqueue(encode(epoch("174512.00") + epoch("174513.00")));
+      await settle();
+      const delivered = fixes.length;
+      assert.equal(delivered, 1, "precondition: the stream is live");
+
+      // Enqueue data that would complete another fix and close in the same turn,
+      // so the pending read() resolves only after close() has set its flag. The
+      // contract is that close() never delivers another fix: a late one would
+      // re-create the map overlays that teardown has already removed.
+      serial.port().controller.enqueue(encode(epoch("174514.00") + epoch("174515.00")));
+      await conn.close();
+      await settle();
+      assert.equal(fixes.length, delivered, "no fix arrived after close()");
+    } finally {
+      serial.restore();
+    }
+  });
+
+  it("is safe to close twice and releases the port once", async () => {
+    const serial = installFakeSerial();
+    try {
+      const conn = await connectSerialNmea(
+        { baudRate: 9600 },
+        { onFix: () => {}, onError: () => {} },
+      );
+      await conn.close();
+      await conn.close();
+      assert.equal(serial.port().closeCalls, 1);
+    } finally {
+      serial.restore();
+    }
+  });
+
+  it("classifies a dismissed port chooser as cancelled rather than a failure", async () => {
+    const previous = Object.getOwnPropertyDescriptor(globalThis.navigator, "serial");
+    Object.defineProperty(globalThis.navigator, "serial", {
+      configurable: true,
+      value: {
+        requestPort: async () => {
+          // What Chromium throws when the user dismisses the port picker.
+          const err = new Error("No port selected by the user.");
+          err.name = "NotFoundError";
+          throw err;
+        },
+      },
+    });
+    try {
+      await assert.rejects(
+        connectSerialNmea({ baudRate: 9600 }, { onFix: () => {}, onError: () => {} }),
+        (err: unknown) => err instanceof NmeaError && err.cancelled && err.code === "cancelled",
+      );
+    } finally {
+      if (previous) Object.defineProperty(globalThis.navigator, "serial", previous);
+      else Reflect.deleteProperty(globalThis.navigator as object, "serial");
+    }
+  });
+});

--- a/tests/nmea-source.test.ts
+++ b/tests/nmea-source.test.ts
@@ -23,6 +23,26 @@ interface FakePort {
   closeCalls: number;
 }
 
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+/**
+ * Replace the whole `navigator` global rather than mutating the real one,
+ * matching the convention in tests/geolocation.test.ts. That keeps the stub
+ * from depending on the runtime providing an extensible `navigator`.
+ */
+function setSerialApi(serial: unknown): void {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: "node", serial },
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreNavigator(): void {
+  if (originalNavigator) Object.defineProperty(globalThis, "navigator", originalNavigator);
+  else Reflect.deleteProperty(globalThis, "navigator");
+}
+
 /**
  * Install a fake `navigator.serial` whose port streams whatever the test
  * enqueues. Only the browser API boundary is faked; the transport, the parser,
@@ -49,20 +69,13 @@ function installFakeSerial(): { port: () => FakePort; restore: () => void } {
     fake = { controller, closeCalls: 0 };
     return port;
   };
-  const previous = Object.getOwnPropertyDescriptor(globalThis.navigator, "serial");
-  Object.defineProperty(globalThis.navigator, "serial", {
-    configurable: true,
-    value: { requestPort: async () => makePort() },
-  });
+  setSerialApi({ requestPort: async () => makePort() });
   return {
     port: () => {
       assert.ok(fake, "no port was requested");
       return fake;
     },
-    restore: () => {
-      if (previous) Object.defineProperty(globalThis.navigator, "serial", previous);
-      else Reflect.deleteProperty(globalThis.navigator as object, "serial");
-    },
+    restore: restoreNavigator,
   };
 }
 
@@ -142,16 +155,12 @@ describe("connectSerialNmea", () => {
   });
 
   it("classifies a dismissed port chooser as cancelled rather than a failure", async () => {
-    const previous = Object.getOwnPropertyDescriptor(globalThis.navigator, "serial");
-    Object.defineProperty(globalThis.navigator, "serial", {
-      configurable: true,
-      value: {
-        requestPort: async () => {
-          // What Chromium throws when the user dismisses the port picker.
-          const err = new Error("No port selected by the user.");
-          err.name = "NotFoundError";
-          throw err;
-        },
+    setSerialApi({
+      requestPort: async () => {
+        // What Chromium throws when the user dismisses the port picker.
+        const err = new Error("No port selected by the user.");
+        err.name = "NotFoundError";
+        throw err;
       },
     });
     try {
@@ -160,8 +169,7 @@ describe("connectSerialNmea", () => {
         (err: unknown) => err instanceof NmeaError && err.cancelled && err.code === "cancelled",
       );
     } finally {
-      if (previous) Object.defineProperty(globalThis.navigator, "serial", previous);
-      else Reflect.deleteProperty(globalThis.navigator as object, "serial");
+      restoreNavigator();
     }
   });
 });


### PR DESCRIPTION
Follow-up to #1624. Two review comments landed on that PR after it was merged, so they are fixed here instead. Both are timing-dependent, but each leaves something durable behind: an orphaned live connection, or a map overlay nothing cleans up.

## 1. A fix could arrive after `close()`

The serial read loop re-checked `closed` only at the error dispatch, not after `reader.read()` resolved:

```ts
const { value, done } = await reader.read();
if (done) break;                  // <- no `closed` check
```

`close()` sets `closed = true` and *then* awaits `reader.cancel()`, so a read that had already resolved runs its continuation afterwards and calls `onFix`. In the dialog that reaches `handleFix`, which re-creates the marker and the accuracy/track sources that teardown had just removed — a stray overlay that lingers until tracking is toggled again. It also contradicted the documented contract on `NmeaConnection.close()` ("guaranteed not to deliver another fix once it has been called").

The Bluetooth transport was already correct here, because removing the listener in `close()` is synchronous. That asymmetry is what made the serial gap visible.

## 2. An abandoned connect could reactivate itself

`connectNmea` had no way to notice it had been superseded. `connectBluetoothNmea` can sit in `gatt.connect()` for several seconds, and nothing prevents the user from switching the source back to "This device", stopping, or closing the panel meanwhile — `NmeaControls` simply unmounts, so there is not even a visible way to cancel.

When the stale attempt finally resolved it unconditionally ran `nmeaConnRef.current = conn` / `setNmeaLabel(...)` / `setTracking(true)`, reviving a session the UI no longer offers any way to disconnect. After unmount it was worse: the teardown effect had already closed and cleared the ref, so the newly opened port was leaked with nothing left to close it.

Attempts now carry a generation that `disconnectNmea`, source changes, stopping, and unmount all bump. A superseded attempt closes its own connection and touches no state — including not clearing a newer attempt's "Connecting…" indicator.

## Tests

First coverage for the transport layer itself (`tests/nmea-source.test.ts`), faking only `navigator.serial` so the parser, assembler, and connection lifecycle all run for real: fix streaming, the close race, idempotent close, and chooser-cancellation classification.

The close-race test is a genuine regression test — I confirmed it fails against the previous loop and passes with the guard, rather than assuming it would.

Full suite green at 4725 passing; build and pre-commit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPS connection handling when attempts are canceled, replaced, or interrupted.
  * Prevented stale attempts from restoring abandoned sessions or displaying outdated errors.
  * Stopped GPS data from being emitted after a connection is closed.
  * Improved handling of dismissed device-selection prompts and repeated port closures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->