### PR TITLE
fix: scrub widgets, comments, and legend when layers disappear

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,11 @@ export * from "./layer-style-clipboard";
 export * from "./layer-groups";
 export { createSampleStoryMap } from "./storymap-sample";
 export {
+  scrubWidgetsForRemovedLayers,
+  scrubCommentsForRemovedLayers,
+  scrubLegendForRemovedLayers,
+} from "./layer-ref-scrub";
+export {
   serializeStoryMapJson,
   parseStoryMapJson,
   serializeStoryMapCsv,

--- a/packages/core/src/layer-ref-scrub.ts
+++ b/packages/core/src/layer-ref-scrub.ts
@@ -65,8 +65,7 @@ export function scrubLegendForRemovedLayers(
   // --- overrides ---
   const overrides: Record<string, (typeof legend.overrides)[string]> = {};
   for (const [key, value] of Object.entries(legend.overrides)) {
-    const isRemoved =
-      removed.has(key) || [...removed].some((id) => key.startsWith(`${id}::`));
+    const isRemoved = removed.has(key) || [...removed].some((id) => key.startsWith(`${id}::`));
     if (isRemoved) {
       changed = true;
     } else {

--- a/packages/core/src/layer-ref-scrub.ts
+++ b/packages/core/src/layer-ref-scrub.ts
@@ -1,0 +1,98 @@
+import type { DashboardWidget, LegendConfig, ProjectComment } from "./types";
+
+/**
+ * Normalize the removed-layer-ids argument into a Set for uniform lookup.
+ */
+export function removedLayerIdSet(layerIds: string | Iterable<string>): Set<string> {
+  if (typeof layerIds === "string") return new Set([layerIds]);
+  if (layerIds instanceof Set) return layerIds as Set<string>;
+  return new Set(layerIds);
+}
+
+/**
+ * Filter out dashboard widgets whose `layerId` references a removed layer.
+ * Returns the same array reference when nothing changes.
+ */
+export function scrubWidgetsForRemovedLayers(
+  widgets: DashboardWidget[],
+  layerIds: string | Iterable<string>,
+): DashboardWidget[] {
+  const removed = removedLayerIdSet(layerIds);
+  if (removed.size === 0 || widgets.length === 0) return widgets;
+  const filtered = widgets.filter((w) => !removed.has(w.layerId));
+  return filtered.length === widgets.length ? widgets : filtered;
+}
+
+/**
+ * Drop comments whose anchor is a feature on a removed layer.
+ * Point-anchored comments are always kept.
+ * Returns the same array reference when nothing changes.
+ */
+export function scrubCommentsForRemovedLayers(
+  comments: ProjectComment[],
+  layerIds: string | Iterable<string>,
+): ProjectComment[] {
+  const removed = removedLayerIdSet(layerIds);
+  if (removed.size === 0 || comments.length === 0) return comments;
+  const filtered = comments.filter(
+    (c) => !(c.anchor.type === "feature" && removed.has(c.anchor.layerId)),
+  );
+  return filtered.length === comments.length ? comments : filtered;
+}
+
+/**
+ * Scrub legend config of references to removed layers:
+ * - `order`: filter out removed layer ids
+ * - `overrides`: drop keys that equal a removed id OR start with `${id}::`
+ * - `customEntries`: drop keys that equal a removed layer id but KEEP keys
+ *   starting with `custom:`
+ *
+ * Returns the same reference when nothing changes.
+ */
+export function scrubLegendForRemovedLayers(
+  legend: LegendConfig,
+  layerIds: string | Iterable<string>,
+): LegendConfig {
+  const removed = removedLayerIdSet(layerIds);
+  if (removed.size === 0) return legend;
+
+  let changed = false;
+
+  // --- order ---
+  const order = legend.order.filter((id) => !removed.has(id));
+  if (order.length !== legend.order.length) changed = true;
+
+  // --- overrides ---
+  const overrides: Record<string, (typeof legend.overrides)[string]> = {};
+  for (const [key, value] of Object.entries(legend.overrides)) {
+    const isRemoved =
+      removed.has(key) || [...removed].some((id) => key.startsWith(`${id}::`));
+    if (isRemoved) {
+      changed = true;
+    } else {
+      overrides[key] = value;
+    }
+  }
+
+  // --- customEntries ---
+  let customEntries = legend.customEntries;
+  if (customEntries) {
+    const nextCustom: Record<string, (typeof customEntries)[string]> = {};
+    for (const [key, value] of Object.entries(customEntries)) {
+      if (key.startsWith("custom:")) {
+        nextCustom[key] = value;
+      } else if (removed.has(key)) {
+        changed = true;
+      } else {
+        nextCustom[key] = value;
+      }
+    }
+    if (changed || Object.keys(nextCustom).length !== Object.keys(customEntries).length) {
+      customEntries = Object.keys(nextCustom).length > 0 ? nextCustom : undefined;
+      changed = true;
+    }
+  }
+
+  if (!changed) return legend;
+  return { ...legend, order, overrides, customEntries };
+}

--- a/packages/core/src/layer-ref-scrub.ts
+++ b/packages/core/src/layer-ref-scrub.ts
@@ -65,8 +65,8 @@ export function scrubLegendForRemovedLayers(
   // --- overrides ---
   const overrides: Record<string, (typeof legend.overrides)[string]> = {};
   for (const [key, value] of Object.entries(legend.overrides)) {
-    const isRemoved = removed.has(key) || [...removed].some((id) => key.startsWith(`${id}::`));
-    if (isRemoved) {
+    const base = key.includes("::") ? key.slice(0, key.indexOf("::")) : key;
+    if (removed.has(base)) {
       changed = true;
     } else {
       overrides[key] = value;
@@ -76,17 +76,18 @@ export function scrubLegendForRemovedLayers(
   // --- customEntries ---
   let customEntries = legend.customEntries;
   if (customEntries) {
+    let customEntriesChanged = false;
     const nextCustom: Record<string, (typeof customEntries)[string]> = {};
     for (const [key, value] of Object.entries(customEntries)) {
       if (key.startsWith("custom:")) {
         nextCustom[key] = value;
       } else if (removed.has(key)) {
-        changed = true;
+        customEntriesChanged = true;
       } else {
         nextCustom[key] = value;
       }
     }
-    if (changed || Object.keys(nextCustom).length !== Object.keys(customEntries).length) {
+    if (customEntriesChanged) {
       customEntries = Object.keys(nextCustom).length > 0 ? nextCustom : undefined;
       changed = true;
     }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1528,9 +1528,12 @@ export function applyProjectToStore(project: GeoLibreProject): {
 
   const orphanIds = new Set([...allReferencedIds].filter((id) => !existingLayerIds.has(id)));
 
-  const scrubbedWidgets = orphanIds.size > 0 ? scrubWidgetsForRemovedLayers(widgets, orphanIds) : widgets;
-  const scrubbedComments = orphanIds.size > 0 ? scrubCommentsForRemovedLayers(comments, orphanIds) : comments;
-  const scrubbedLegend = orphanIds.size > 0 ? scrubLegendForRemovedLayers(legend, orphanIds) : legend;
+  const scrubbedWidgets =
+    orphanIds.size > 0 ? scrubWidgetsForRemovedLayers(widgets, orphanIds) : widgets;
+  const scrubbedComments =
+    orphanIds.size > 0 ? scrubCommentsForRemovedLayers(comments, orphanIds) : comments;
+  const scrubbedLegend =
+    orphanIds.size > 0 ? scrubLegendForRemovedLayers(legend, orphanIds) : legend;
 
   return {
     projectName: project.name,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -52,6 +52,11 @@ import {
 import { DEFAULT_LAYER_GROUP_OPACITY, normalizeGroupContiguity } from "./layer-groups";
 import { normalizeStyleLibraryEntries } from "./style-library";
 import { getEllipsoid } from "./ellipsoids";
+import {
+  scrubWidgetsForRemovedLayers,
+  scrubCommentsForRemovedLayers,
+  scrubLegendForRemovedLayers,
+} from "./layer-ref-scrub";
 
 /** Placeholder name a project carries before the user names it. */
 export const DEFAULT_PROJECT_NAME = "Untitled Project";
@@ -1495,6 +1500,38 @@ export function applyProjectToStore(project: GeoLibreProject): {
     normalizeSecondaryMapViews(project.secondaryMapViews),
     { mapView },
   );
+
+  // Scrub cross-references that point at layers not present in the loaded
+  // project (orphans from hand-editing or a partial project file).
+  const existingLayerIds = new Set(normalizedLayers.map((l) => l.id));
+  const widgets = normalizeWidgets(project.widgets) ?? [];
+  const comments = normalizeProjectComments(project.comments);
+  const legend = normalizeLegendConfig(project.legend) ?? {
+    ...DEFAULT_LEGEND_CONFIG,
+  };
+
+  const allReferencedIds = new Set<string>();
+  for (const w of widgets) allReferencedIds.add(w.layerId);
+  for (const c of comments) {
+    if (c.anchor.type === "feature") allReferencedIds.add(c.anchor.layerId);
+  }
+  for (const id of legend.order) allReferencedIds.add(id);
+  for (const key of Object.keys(legend.overrides)) {
+    const base = key.includes("::") ? key.slice(0, key.indexOf("::")) : key;
+    allReferencedIds.add(base);
+  }
+  if (legend.customEntries) {
+    for (const key of Object.keys(legend.customEntries)) {
+      if (!key.startsWith("custom:")) allReferencedIds.add(key);
+    }
+  }
+
+  const orphanIds = new Set([...allReferencedIds].filter((id) => !existingLayerIds.has(id)));
+
+  const scrubbedWidgets = orphanIds.size > 0 ? scrubWidgetsForRemovedLayers(widgets, orphanIds) : widgets;
+  const scrubbedComments = orphanIds.size > 0 ? scrubCommentsForRemovedLayers(comments, orphanIds) : comments;
+  const scrubbedLegend = orphanIds.size > 0 ? scrubLegendForRemovedLayers(legend, orphanIds) : legend;
+
   return {
     projectName: project.name,
     mapView,
@@ -1505,19 +1542,17 @@ export function applyProjectToStore(project: GeoLibreProject): {
     layerGroups,
     preferences: normalizeProjectPreferences(project.preferences),
     projectPlugins: normalizeProjectPlugins(project.plugins),
-    legend: normalizeLegendConfig(project.legend) ?? {
-      ...DEFAULT_LEGEND_CONFIG,
-    },
+    legend: scrubbedLegend,
     storymap: normalizeStoryMap(project.storymap),
     models: normalizeModels(project.models) ?? [],
     processingHistory: normalizeProcessingHistory(project.processingHistory) ?? [],
-    widgets: normalizeWidgets(project.widgets) ?? [],
+    widgets: scrubbedWidgets,
     dashboardColumns: normalizeDashboardColumns(project.dashboardColumns),
     mapLayout,
     secondaryMapViews,
     primaryMapLabel: normalizeString(project.primaryMapLabel),
     projectStyleLibrary: normalizeStyleLibraryEntries(project.styleLibrary),
-    comments: normalizeProjectComments(project.comments),
+    comments: scrubbedComments,
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -753,7 +753,6 @@ function sameCamera(a: MapViewState, b: MapViewState): boolean {
   );
 }
 
-
 /**
  * Strip storymap chapter enter/exit opacity rows that reference any of the
  * removed layer ids. Returns the same reference when nothing changes so
@@ -1954,9 +1953,7 @@ export const useAppStore = create<AppState>()(
             comments: removeChildren
               ? scrubCommentsForRemovedLayers(s.comments, removedIds)
               : s.comments,
-            legend: removeChildren
-              ? scrubLegendForRemovedLayers(s.legend, removedIds)
-              : s.legend,
+            legend: removeChildren ? scrubLegendForRemovedLayers(s.legend, removedIds) : s.legend,
             selectedLayerId: selectionRemoved
               ? (layers[layers.length - 1]?.id ?? null)
               : s.selectedLayerId,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -63,6 +63,12 @@ import {
   type CommentReply,
   type ProjectComment,
 } from "./types";
+import {
+  removedLayerIdSet,
+  scrubWidgetsForRemovedLayers,
+  scrubCommentsForRemovedLayers,
+  scrubLegendForRemovedLayers,
+} from "./layer-ref-scrub";
 import { hasSimpleStyleProperties } from "./vector-color";
 import {
   applyCopiedLayerStyle,
@@ -747,11 +753,6 @@ function sameCamera(a: MapViewState, b: MapViewState): boolean {
   );
 }
 
-function removedLayerIdSet(layerIds: string | Iterable<string>): Set<string> {
-  if (typeof layerIds === "string") return new Set([layerIds]);
-  if (layerIds instanceof Set) return layerIds;
-  return new Set(layerIds);
-}
 
 /**
  * Strip storymap chapter enter/exit opacity rows that reference any of the
@@ -1618,6 +1619,9 @@ export const useAppStore = create<AppState>()(
           // Drop storymap chapter enter/exit opacity rows that pointed at the
           // removed layer so they do not keep a dangling id across save/reload.
           storymap: scrubStorymapLayerRefs(s.storymap, id),
+          widgets: scrubWidgetsForRemovedLayers(s.widgets, id),
+          comments: scrubCommentsForRemovedLayers(s.comments, id),
+          legend: scrubLegendForRemovedLayers(s.legend, id),
           selectedLayerId:
             s.selectedLayerId === id
               ? (s.layers.find((l) => l.id !== id)?.id ?? null)
@@ -1944,6 +1948,15 @@ export const useAppStore = create<AppState>()(
               ? scrubSecondaryPaneLayerVisibility(s.secondaryMapViews, removedIds)
               : s.secondaryMapViews,
             storymap: removeChildren ? scrubStorymapLayerRefs(s.storymap, removedIds) : s.storymap,
+            widgets: removeChildren
+              ? scrubWidgetsForRemovedLayers(s.widgets, removedIds)
+              : s.widgets,
+            comments: removeChildren
+              ? scrubCommentsForRemovedLayers(s.comments, removedIds)
+              : s.comments,
+            legend: removeChildren
+              ? scrubLegendForRemovedLayers(s.legend, removedIds)
+              : s.legend,
             selectedLayerId: selectionRemoved
               ? (layers[layers.length - 1]?.id ?? null)
               : s.selectedLayerId,

--- a/tests/layer-ref-scrub.test.ts
+++ b/tests/layer-ref-scrub.test.ts
@@ -1,0 +1,339 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_LEGEND_CONFIG,
+  applyProjectToStore,
+  createEmptyProject,
+  scrubWidgetsForRemovedLayers,
+  scrubCommentsForRemovedLayers,
+  scrubLegendForRemovedLayers,
+  useAppStore,
+  type DashboardWidget,
+  type LegendConfig,
+  type ProjectComment,
+} from "@geolibre/core";
+import { geojsonLayer } from "./helpers/layer-fixtures";
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure scrub helpers
+// ---------------------------------------------------------------------------
+
+describe("scrubWidgetsForRemovedLayers", () => {
+  it("removes widgets whose layerId is in the removed set", () => {
+    const widgets: DashboardWidget[] = [
+      { id: "w1", layerId: "gone", type: "histogram", field: "x" },
+      { id: "w2", layerId: "keep", type: "bar", category: "y" },
+    ];
+    const result = scrubWidgetsForRemovedLayers(widgets, "gone");
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "w2");
+  });
+
+  it("returns same reference when nothing changes", () => {
+    const widgets: DashboardWidget[] = [
+      { id: "w1", layerId: "keep", type: "histogram", field: "x" },
+    ];
+    const result = scrubWidgetsForRemovedLayers(widgets, "other");
+    assert.equal(result, widgets);
+  });
+
+  it("handles multiple removed ids", () => {
+    const widgets: DashboardWidget[] = [
+      { id: "w1", layerId: "a", type: "histogram", field: "x" },
+      { id: "w2", layerId: "b", type: "bar", category: "y" },
+      { id: "w3", layerId: "c", type: "pie", category: "z" },
+    ];
+    const result = scrubWidgetsForRemovedLayers(widgets, new Set(["a", "c"]));
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "w2");
+  });
+});
+
+describe("scrubCommentsForRemovedLayers", () => {
+  const pointComment: ProjectComment = {
+    id: "c-point",
+    anchor: { type: "point", lngLat: [0, 0] },
+    author: { name: "A", color: "#f00" },
+    body: "map note",
+    createdAt: "2026-01-01T00:00:00Z",
+    resolved: false,
+    replies: [],
+  };
+
+  const featureComment: ProjectComment = {
+    id: "c-feat",
+    anchor: { type: "feature", layerId: "gone", featureId: "f1" },
+    author: { name: "B", color: "#0f0" },
+    body: "on feature",
+    createdAt: "2026-01-01T00:00:00Z",
+    resolved: false,
+    replies: [],
+  };
+
+  const keepFeatureComment: ProjectComment = {
+    id: "c-feat-keep",
+    anchor: { type: "feature", layerId: "keep", featureId: "f2" },
+    author: { name: "C", color: "#00f" },
+    body: "different layer",
+    createdAt: "2026-01-01T00:00:00Z",
+    resolved: false,
+    replies: [],
+  };
+
+  it("drops feature comments on removed layers but keeps point comments", () => {
+    const comments = [pointComment, featureComment, keepFeatureComment];
+    const result = scrubCommentsForRemovedLayers(comments, "gone");
+    assert.equal(result.length, 2);
+    assert.equal(result[0].id, "c-point");
+    assert.equal(result[1].id, "c-feat-keep");
+  });
+
+  it("returns same reference when nothing changes", () => {
+    const comments = [pointComment, keepFeatureComment];
+    const result = scrubCommentsForRemovedLayers(comments, "gone");
+    assert.equal(result, comments);
+  });
+});
+
+describe("scrubLegendForRemovedLayers", () => {
+  it("removes layer id from order", () => {
+    const legend: LegendConfig = {
+      ...DEFAULT_LEGEND_CONFIG,
+      order: ["a", "gone", "b"],
+      overrides: {},
+    };
+    const result = scrubLegendForRemovedLayers(legend, "gone");
+    assert.deepEqual(result.order, ["a", "b"]);
+  });
+
+  it("drops overrides keyed by removed id or starting with id::", () => {
+    const legend: LegendConfig = {
+      ...DEFAULT_LEGEND_CONFIG,
+      order: [],
+      overrides: {
+        gone: { label: "x" },
+        "gone::0": { hidden: true },
+        "gone::1": { label: "y" },
+        keep: { label: "z" },
+        "keep::0": { label: "w" },
+      },
+    };
+    const result = scrubLegendForRemovedLayers(legend, "gone");
+    assert.deepEqual(Object.keys(result.overrides), ["keep", "keep::0"]);
+  });
+
+  it("drops customEntries keyed by removed layer id but keeps custom: keys", () => {
+    const legend: LegendConfig = {
+      ...DEFAULT_LEGEND_CONFIG,
+      order: [],
+      overrides: {},
+      customEntries: {
+        gone: { items: [{ color: "#f00", label: "A" }] },
+        "custom:my-legend": { items: [{ color: "#0f0", label: "B" }] },
+        keep: { items: [{ color: "#00f", label: "C" }] },
+      },
+    };
+    const result = scrubLegendForRemovedLayers(legend, "gone");
+    assert.deepEqual(Object.keys(result.customEntries!), ["custom:my-legend", "keep"]);
+  });
+
+  it("returns same reference when nothing changes", () => {
+    const legend: LegendConfig = {
+      ...DEFAULT_LEGEND_CONFIG,
+      order: ["keep"],
+      overrides: { keep: { label: "hi" } },
+    };
+    const result = scrubLegendForRemovedLayers(legend, "gone");
+    assert.equal(result, legend);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store integration tests: removeLayer
+// ---------------------------------------------------------------------------
+
+describe("removeLayer cross-ref scrub", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Scrub test" });
+  });
+
+  it("drops widgets referencing the removed layer", () => {
+    const store = useAppStore.getState();
+    store.addLayer(geojsonLayer({ id: "keep", name: "keep" }));
+    store.addLayer(geojsonLayer({ id: "gone", name: "gone" }));
+    store.addWidget({ id: "w1", layerId: "gone", type: "histogram", field: "x" });
+    store.addWidget({ id: "w2", layerId: "keep", type: "bar", category: "y" });
+
+    useAppStore.getState().removeLayer("gone");
+    const widgets = useAppStore.getState().widgets;
+    assert.equal(widgets.length, 1);
+    assert.equal(widgets[0].id, "w2");
+  });
+
+  it("drops feature-anchored comments on the removed layer", () => {
+    const store = useAppStore.getState();
+    store.addLayer(geojsonLayer({ id: "keep", name: "keep" }));
+    store.addLayer(geojsonLayer({ id: "gone", name: "gone" }));
+    store.addComment({
+      id: "c1",
+      anchor: { type: "feature", layerId: "gone", featureId: "f1" },
+      author: { name: "A", color: "#f00" },
+      body: "gone",
+      createdAt: "2026-01-01T00:00:00Z",
+      resolved: false,
+      replies: [],
+    });
+    store.addComment({
+      id: "c2",
+      anchor: { type: "point", lngLat: [0, 0] },
+      author: { name: "B", color: "#0f0" },
+      body: "stays",
+      createdAt: "2026-01-01T00:00:00Z",
+      resolved: false,
+      replies: [],
+    });
+
+    useAppStore.getState().removeLayer("gone");
+    const comments = useAppStore.getState().comments;
+    assert.equal(comments.length, 1);
+    assert.equal(comments[0].id, "c2");
+  });
+
+  it("scrubs legend order, overrides, and customEntries", () => {
+    const store = useAppStore.getState();
+    store.addLayer(geojsonLayer({ id: "keep", name: "keep" }));
+    store.addLayer(geojsonLayer({ id: "gone", name: "gone" }));
+    store.setLegend({
+      ...DEFAULT_LEGEND_CONFIG,
+      order: ["gone", "keep"],
+      overrides: { gone: { label: "x" }, "gone::0": { hidden: true }, keep: { label: "y" } },
+      customEntries: {
+        gone: { items: [{ color: "#f00", label: "A" }] },
+        "custom:standalone": { items: [{ color: "#0f0", label: "B" }] },
+      },
+    });
+
+    useAppStore.getState().removeLayer("gone");
+    const legend = useAppStore.getState().legend;
+    assert.deepEqual(legend.order, ["keep"]);
+    assert.deepEqual(Object.keys(legend.overrides), ["keep"]);
+    assert.deepEqual(Object.keys(legend.customEntries!), ["custom:standalone"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Store integration tests: removeLayerGroup
+// ---------------------------------------------------------------------------
+
+describe("removeLayerGroup cross-ref scrub", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Group scrub" });
+  });
+
+  it("scrubs widgets and comments when group deletes children", () => {
+    const store = useAppStore.getState();
+    const groupId = store.addLayerGroup("G");
+    store.addLayer({ ...geojsonLayer({ id: "child", name: "child" }), groupId });
+    store.addLayer(geojsonLayer({ id: "keep", name: "keep" }));
+    store.addWidget({ id: "w1", layerId: "child", type: "histogram", field: "x" });
+    store.addWidget({ id: "w2", layerId: "keep", type: "bar", category: "y" });
+    store.addComment({
+      id: "c1",
+      anchor: { type: "feature", layerId: "child", featureId: "f1" },
+      author: { name: "A", color: "#f00" },
+      body: "bye",
+      createdAt: "2026-01-01T00:00:00Z",
+      resolved: false,
+      replies: [],
+    });
+
+    useAppStore.getState().removeLayerGroup(groupId, { removeChildren: true });
+    assert.equal(useAppStore.getState().widgets.length, 1);
+    assert.equal(useAppStore.getState().widgets[0].id, "w2");
+    assert.equal(useAppStore.getState().comments.length, 0);
+  });
+
+  it("does not scrub widgets/comments when group keeps children", () => {
+    const store = useAppStore.getState();
+    const groupId = store.addLayerGroup("G");
+    store.addLayer({ ...geojsonLayer({ id: "child", name: "child" }), groupId });
+    store.addWidget({ id: "w1", layerId: "child", type: "histogram", field: "x" });
+    store.addComment({
+      id: "c1",
+      anchor: { type: "feature", layerId: "child", featureId: "f1" },
+      author: { name: "A", color: "#f00" },
+      body: "stays",
+      createdAt: "2026-01-01T00:00:00Z",
+      resolved: false,
+      replies: [],
+    });
+
+    useAppStore.getState().removeLayerGroup(groupId, { removeChildren: false });
+    assert.equal(useAppStore.getState().widgets.length, 1);
+    assert.equal(useAppStore.getState().comments.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyProjectToStore orphan scrub
+// ---------------------------------------------------------------------------
+
+describe("applyProjectToStore orphan ref scrub", () => {
+  it("drops widgets referencing non-existent layers", () => {
+    const project = createEmptyProject("Test");
+    project.layers = [geojsonLayer({ id: "real", name: "real" })];
+    project.widgets = [
+      { id: "w1", layerId: "real", type: "histogram", field: "x" },
+      { id: "w2", layerId: "orphan", type: "bar", category: "y" },
+    ];
+    const applied = applyProjectToStore(project);
+    assert.equal(applied.widgets.length, 1);
+    assert.equal(applied.widgets[0].id, "w1");
+  });
+
+  it("drops feature comments referencing non-existent layers but keeps point comments", () => {
+    const project = createEmptyProject("Test");
+    project.layers = [geojsonLayer({ id: "real", name: "real" })];
+    project.comments = [
+      {
+        id: "c1",
+        anchor: { type: "feature", layerId: "orphan", featureId: "f1" },
+        author: { name: "A", color: "#f00" },
+        body: "orphan",
+        createdAt: "2026-01-01T00:00:00Z",
+        resolved: false,
+        replies: [],
+      },
+      {
+        id: "c2",
+        anchor: { type: "point", lngLat: [10, 20] },
+        author: { name: "B", color: "#0f0" },
+        body: "kept",
+        createdAt: "2026-01-01T00:00:00Z",
+        resolved: false,
+        replies: [],
+      },
+    ];
+    const applied = applyProjectToStore(project);
+    assert.equal(applied.comments.length, 1);
+    assert.equal(applied.comments[0].id, "c2");
+  });
+
+  it("scrubs legend keys referencing non-existent layers but keeps custom: entries", () => {
+    const project = createEmptyProject("Test");
+    project.layers = [geojsonLayer({ id: "real", name: "real" })];
+    project.legend = {
+      ...DEFAULT_LEGEND_CONFIG,
+      order: ["orphan", "real"],
+      overrides: { orphan: { label: "x" }, "orphan::0": { hidden: true }, real: { label: "y" } },
+      customEntries: {
+        orphan: { items: [{ color: "#f00", label: "A" }] },
+        "custom:standalone": { items: [{ color: "#0f0", label: "B" }] },
+      },
+    };
+    const applied = applyProjectToStore(project);
+    assert.deepEqual(applied.legend.order, ["real"]);
+    assert.deepEqual(Object.keys(applied.legend.overrides), ["real"]);
+    assert.deepEqual(Object.keys(applied.legend.customEntries!), ["custom:standalone"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Drop dashboard widgets, feature-anchored comments, and legend order/overrides that still point at a deleted layer (and the same on group delete with children).
- Apply the same membership scrub in `applyProjectToStore` so hand-edited or collab projects cannot keep orphan refs forever.
- Point-anchored comments and `custom:` legend entries are preserved.

## Test plan
- [x] `node --import tsx --test tests/layer-ref-scrub.test.ts`
- [x] Delete a layer used by a dashboard widget / feature comment / legend override and confirm the dangling refs are gone after save/reload
- [x] Delete a group with children that widgets reference and confirm scrub
- [x] Load a project JSON with orphan widget `layerId`s and confirm apply drops them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed layers are now fully cleared from widgets, comments, legend ordering, and legend overrides.
  * Loading projects now automatically removes references to missing layers.
  * Deleting layers or layer groups now cleans up related dashboard and map configuration.
  * Preserved point comments and custom legend entries during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->