### PR TITLE
fix: clear select/load dialog layer ids when layers are removed

### DIFF
--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1625,6 +1625,15 @@ export const useAppStore = create<AppState>()(
           selectedFeatureId: s.selectedLayerId === id ? null : s.selectedFeatureId,
           selectedFeatureIds: s.selectedLayerId === id ? [] : s.selectedFeatureIds,
           identifyLayerId: s.identifyLayerId === id ? null : s.identifyLayerId,
+          ui: {
+            ...s.ui,
+            selectByExpressionLayerId:
+              s.ui.selectByExpressionLayerId === id ? null : s.ui.selectByExpressionLayerId,
+            selectByLocationLayerId:
+              s.ui.selectByLocationLayerId === id ? null : s.ui.selectByLocationLayerId,
+            loadEditorFeaturesLayerId:
+              s.ui.loadEditorFeaturesLayerId === id ? null : s.ui.loadEditorFeaturesLayerId,
+          },
           isDirty: true,
         })),
 
@@ -1953,6 +1962,24 @@ export const useAppStore = create<AppState>()(
               s.identifyLayerId !== null && removedIds.has(s.identifyLayerId)
                 ? null
                 : s.identifyLayerId,
+            ui: {
+              ...s.ui,
+              selectByExpressionLayerId:
+                s.ui.selectByExpressionLayerId !== null &&
+                removedIds.has(s.ui.selectByExpressionLayerId)
+                  ? null
+                  : s.ui.selectByExpressionLayerId,
+              selectByLocationLayerId:
+                s.ui.selectByLocationLayerId !== null &&
+                removedIds.has(s.ui.selectByLocationLayerId)
+                  ? null
+                  : s.ui.selectByLocationLayerId,
+              loadEditorFeaturesLayerId:
+                s.ui.loadEditorFeaturesLayerId !== null &&
+                removedIds.has(s.ui.loadEditorFeaturesLayerId)
+                  ? null
+                  : s.ui.loadEditorFeaturesLayerId,
+            },
             isDirty: true,
           };
         }),
@@ -2129,6 +2156,8 @@ export const useAppStore = create<AppState>()(
             selectByExpressionLayerId: null,
             selectByLocationOpen: false,
             selectByLocationLayerId: null,
+            loadEditorFeaturesOpen: false,
+            loadEditorFeaturesLayerId: null,
           },
         }));
         clearHistory();
@@ -2180,6 +2209,8 @@ export const useAppStore = create<AppState>()(
             selectByExpressionLayerId: null,
             selectByLocationOpen: false,
             selectByLocationLayerId: null,
+            loadEditorFeaturesOpen: false,
+            loadEditorFeaturesLayerId: null,
           },
         }));
         clearHistory();

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1962,24 +1962,26 @@ export const useAppStore = create<AppState>()(
               s.identifyLayerId !== null && removedIds.has(s.identifyLayerId)
                 ? null
                 : s.identifyLayerId,
-            ui: {
-              ...s.ui,
-              selectByExpressionLayerId:
-                s.ui.selectByExpressionLayerId !== null &&
-                removedIds.has(s.ui.selectByExpressionLayerId)
-                  ? null
-                  : s.ui.selectByExpressionLayerId,
-              selectByLocationLayerId:
-                s.ui.selectByLocationLayerId !== null &&
-                removedIds.has(s.ui.selectByLocationLayerId)
-                  ? null
-                  : s.ui.selectByLocationLayerId,
-              loadEditorFeaturesLayerId:
-                s.ui.loadEditorFeaturesLayerId !== null &&
-                removedIds.has(s.ui.loadEditorFeaturesLayerId)
-                  ? null
-                  : s.ui.loadEditorFeaturesLayerId,
-            },
+            ui: removeChildren
+              ? {
+                  ...s.ui,
+                  selectByExpressionLayerId:
+                    s.ui.selectByExpressionLayerId !== null &&
+                    removedIds.has(s.ui.selectByExpressionLayerId)
+                      ? null
+                      : s.ui.selectByExpressionLayerId,
+                  selectByLocationLayerId:
+                    s.ui.selectByLocationLayerId !== null &&
+                    removedIds.has(s.ui.selectByLocationLayerId)
+                      ? null
+                      : s.ui.selectByLocationLayerId,
+                  loadEditorFeaturesLayerId:
+                    s.ui.loadEditorFeaturesLayerId !== null &&
+                    removedIds.has(s.ui.loadEditorFeaturesLayerId)
+                      ? null
+                      : s.ui.loadEditorFeaturesLayerId,
+                }
+              : s.ui,
             isDirty: true,
           };
         }),

--- a/tests/ui-layer-pointers.test.ts
+++ b/tests/ui-layer-pointers.test.ts
@@ -70,6 +70,21 @@ describe("UI layer pointer cleanup", () => {
       assert.equal(ui.selectByLocationLayerId, null);
       assert.equal(ui.loadEditorFeaturesLayerId, null);
     });
+
+    it("preserves pointers when removeChildren is false", () => {
+      const store = useAppStore.getState();
+      const groupId = store.addLayerGroup("G");
+      store.addLayer(geojsonLayer({ id: "child", groupId }));
+      store.setSelectByExpressionOpen(true, "child");
+      store.setSelectByLocationOpen(true, "child");
+      store.setLoadEditorFeaturesOpen(true, "child");
+
+      useAppStore.getState().removeLayerGroup(groupId, { removeChildren: false });
+      const ui = useAppStore.getState().ui;
+      assert.equal(ui.selectByExpressionLayerId, "child");
+      assert.equal(ui.selectByLocationLayerId, "child");
+      assert.equal(ui.loadEditorFeaturesLayerId, "child");
+    });
   });
 
   describe("newProject/loadProject clear load-editor-features state", () => {

--- a/tests/ui-layer-pointers.test.ts
+++ b/tests/ui-layer-pointers.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import { useAppStore } from "@geolibre/core";
+import { geojsonLayer } from "./helpers/layer-fixtures";
+
+describe("UI layer pointer cleanup", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Pointer cleanup" });
+  });
+
+  describe("removeLayer clears dialog layer ids", () => {
+    it("clears selectByExpressionLayerId", () => {
+      const store = useAppStore.getState();
+      store.addLayer(geojsonLayer({ id: "target" }));
+      store.setSelectByExpressionOpen(true, "target");
+      assert.equal(useAppStore.getState().ui.selectByExpressionLayerId, "target");
+
+      useAppStore.getState().removeLayer("target");
+      assert.equal(useAppStore.getState().ui.selectByExpressionLayerId, null);
+    });
+
+    it("clears selectByLocationLayerId", () => {
+      const store = useAppStore.getState();
+      store.addLayer(geojsonLayer({ id: "target" }));
+      store.setSelectByLocationOpen(true, "target");
+      assert.equal(useAppStore.getState().ui.selectByLocationLayerId, "target");
+
+      useAppStore.getState().removeLayer("target");
+      assert.equal(useAppStore.getState().ui.selectByLocationLayerId, null);
+    });
+
+    it("clears loadEditorFeaturesLayerId", () => {
+      const store = useAppStore.getState();
+      store.addLayer(geojsonLayer({ id: "target" }));
+      store.setLoadEditorFeaturesOpen(true, "target");
+      assert.equal(useAppStore.getState().ui.loadEditorFeaturesLayerId, "target");
+
+      useAppStore.getState().removeLayer("target");
+      assert.equal(useAppStore.getState().ui.loadEditorFeaturesLayerId, null);
+    });
+
+    it("does not clear pointers for unrelated layers", () => {
+      const store = useAppStore.getState();
+      store.addLayer(geojsonLayer({ id: "keep", name: "Keep" }));
+      store.addLayer(geojsonLayer({ id: "gone", name: "Gone" }));
+      store.setSelectByExpressionOpen(true, "keep");
+      store.setSelectByLocationOpen(true, "keep");
+      store.setLoadEditorFeaturesOpen(true, "keep");
+
+      useAppStore.getState().removeLayer("gone");
+      const ui = useAppStore.getState().ui;
+      assert.equal(ui.selectByExpressionLayerId, "keep");
+      assert.equal(ui.selectByLocationLayerId, "keep");
+      assert.equal(ui.loadEditorFeaturesLayerId, "keep");
+    });
+  });
+
+  describe("removeLayerGroup clears dialog layer ids", () => {
+    it("clears pointers when group children are removed", () => {
+      const store = useAppStore.getState();
+      const groupId = store.addLayerGroup("G");
+      store.addLayer(geojsonLayer({ id: "child", groupId }));
+      store.setSelectByExpressionOpen(true, "child");
+      store.setSelectByLocationOpen(true, "child");
+      store.setLoadEditorFeaturesOpen(true, "child");
+
+      useAppStore.getState().removeLayerGroup(groupId, { removeChildren: true });
+      const ui = useAppStore.getState().ui;
+      assert.equal(ui.selectByExpressionLayerId, null);
+      assert.equal(ui.selectByLocationLayerId, null);
+      assert.equal(ui.loadEditorFeaturesLayerId, null);
+    });
+  });
+
+  describe("newProject/loadProject clear load-editor-features state", () => {
+    it("newProject clears loadEditorFeaturesOpen and layerId", () => {
+      const store = useAppStore.getState();
+      store.addLayer(geojsonLayer({ id: "target" }));
+      store.setLoadEditorFeaturesOpen(true, "target");
+      assert.equal(useAppStore.getState().ui.loadEditorFeaturesOpen, true);
+
+      useAppStore.getState().newProject();
+      const ui = useAppStore.getState().ui;
+      assert.equal(ui.loadEditorFeaturesOpen, false);
+      assert.equal(ui.loadEditorFeaturesLayerId, null);
+    });
+
+    it("loadProject clears loadEditorFeaturesOpen and layerId", () => {
+      const store = useAppStore.getState();
+      store.addLayer(geojsonLayer({ id: "target" }));
+      store.setLoadEditorFeaturesOpen(true, "target");
+      assert.equal(useAppStore.getState().ui.loadEditorFeaturesOpen, true);
+
+      useAppStore.getState().loadProject({ name: "Loaded", layers: [], version: 1 });
+      const ui = useAppStore.getState().ui;
+      assert.equal(ui.loadEditorFeaturesOpen, false);
+      assert.equal(ui.loadEditorFeaturesLayerId, null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Null `ui.selectByExpressionLayerId`, `ui.selectByLocationLayerId`, and `ui.loadEditorFeaturesLayerId` on layer/group delete the same way `identifyLayerId` already is.
- Also reset Load-Features open state on new/load project for consistency with the select-by dialogs.

## Test plan
- [x] `node --import tsx --test tests/ui-layer-pointers.test.ts`
- [x] Open Select-by-Expression for a layer, delete that layer, reopen the dialog and confirm it does not keep the gone id
- [x] Same for Select-by-Location and Load Features into Editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed layers and layer groups now correctly clear related UI selections.
  * Loading or creating a project now closes the feature-loading dialog and resets its layer selection.
  * Unrelated layer selections are preserved during cleanup.

* **Tests**
  * Added coverage for layer removal, group deletion, and project reset or loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->