### PR TITLE
fix(sidecar): bound Sedona SQL with a statement timeout

### DIFF
--- a/backend/geolibre_server/geolibre_server/app/sql.py
+++ b/backend/geolibre_server/geolibre_server/app/sql.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from geolibre_server import sedona_ops
-from geolibre_server.sedona_ops import SqlInputTooLarge
+from geolibre_server.sedona_ops import SqlInputTooLarge, SqlTimeout
 
 router = APIRouter(prefix="/sql", tags=["sql"])
 logger = logging.getLogger(__name__)
@@ -77,6 +77,8 @@ def sql_run(request: SqlRunRequest) -> dict[str, Any]:
             request.sql,
             [{"name": layer.name, "geojson": layer.geojson} for layer in request.layers],
         )
+    except SqlTimeout as exc:
+        raise HTTPException(status_code=504, detail=str(exc)) from exc
     except SqlInputTooLarge as exc:
         raise HTTPException(status_code=413, detail=str(exc)) from exc
     except ValueError as exc:

--- a/backend/geolibre_server/geolibre_server/sedona_ops.py
+++ b/backend/geolibre_server/geolibre_server/sedona_ops.py
@@ -165,7 +165,8 @@ def run_sql(sql: str, layers: Optional[list[dict]] = None) -> dict:
             r = r.limit(MAX_FEATURES + 1)
             return r.to_pandas()
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        try:
             future = pool.submit(_execute)
             try:
                 frame = future.result(timeout=timeout_secs)
@@ -179,6 +180,8 @@ def run_sql(sql: str, layers: Optional[list[dict]] = None) -> dict:
                 raise SqlTimeout(
                     f"Spatial SQL timed out after {int(timeout_secs)} seconds"
                 ) from None
+        finally:
+            pool.shutdown(wait=False)
         if len(frame) > MAX_FEATURES:
             # Input registration already caps each layer, but a query can still
             # expand rows (cross joins, generate_series, etc.). Bound the

--- a/backend/geolibre_server/geolibre_server/sedona_ops.py
+++ b/backend/geolibre_server/geolibre_server/sedona_ops.py
@@ -15,12 +15,19 @@ below to status codes. SedonaDB is imported lazily so ``/sql/status`` can report
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import math
 import re
 from typing import Any, Optional
 
 WGS84 = "EPSG:4326"
+
+# Wall-clock budget for a single SQL statement (execute + materialise). Mirrors
+# the PostGIS ``_STATEMENT_TIMEOUT_MS`` so both engines expose a consistent cap.
+# Uses ``concurrent.futures`` rather than SedonaDB/DataFusion session config
+# because the Rust engine exposes no timeout knob to Python today.
+_STATEMENT_TIMEOUT_MS = 60_000
 
 # Layer/view names must be plain SQL identifiers. The frontend already sanitises
 # them, but `/sql/run` is an HTTP boundary that can be called directly, so the
@@ -39,6 +46,10 @@ class SqlInputTooLarge(ValueError):
     A :class:`ValueError` subclass so generic callers treat it as bad input,
     while the sidecar can catch it specifically to return HTTP 413.
     """
+
+
+class SqlTimeout(Exception):
+    """Raised when a SQL statement exceeds :data:`_STATEMENT_TIMEOUT_MS`."""
 
 
 def _import_sedona() -> Any:
@@ -147,14 +158,27 @@ def run_sql(sql: str, layers: Optional[list[dict]] = None) -> dict:
             gdf = gpd.GeoDataFrame.from_features(features, crs=WGS84)
             connection.create_data_frame(gdf).to_view(name)
 
-        result = connection.sql(sql)
-        # Cap before materializing: to_pandas() would otherwise hold an
-        # unbounded cross-join / generate_series expansion in memory. Fetch one
-        # past the limit so overflow still raises SqlInputTooLarge.
-        result = result.limit(MAX_FEATURES + 1)
-        # to_pandas() returns a GeoDataFrame when the result has a geometry
-        # column, otherwise a plain DataFrame.
-        frame = result.to_pandas()
+        timeout_secs = _STATEMENT_TIMEOUT_MS / 1000
+
+        def _execute():
+            r = connection.sql(sql)
+            r = r.limit(MAX_FEATURES + 1)
+            return r.to_pandas()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(_execute)
+            try:
+                frame = future.result(timeout=timeout_secs)
+            except concurrent.futures.TimeoutError:
+                close = getattr(connection, "close", None)
+                if callable(close):
+                    try:
+                        close()
+                    except Exception:  # noqa: BLE001
+                        pass
+                raise SqlTimeout(
+                    f"Spatial SQL timed out after {int(timeout_secs)} seconds"
+                ) from None
         if len(frame) > MAX_FEATURES:
             # Input registration already caps each layer, but a query can still
             # expand rows (cross joins, generate_series, etc.). Bound the

--- a/backend/geolibre_server/tests/test_sql.py
+++ b/backend/geolibre_server/tests/test_sql.py
@@ -3,6 +3,7 @@ from fastapi import HTTPException
 
 from geolibre_server import sedona_ops
 from geolibre_server.app.sql import SqlRunRequest, sql_run, sql_status
+from geolibre_server.sedona_ops import SqlTimeout
 
 try:
     import sedona.db  # noqa: F401
@@ -172,3 +173,43 @@ def test_run_rejects_oversized_result(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc.value.status_code == 413
     assert "Query result exceeds" in str(exc.value.detail)
     assert limited_to == [sedona_ops.MAX_FEATURES + 1]
+
+
+def test_statement_timeout_constant_exists() -> None:
+    """The wall-clock timeout constant must be defined and positive."""
+    assert hasattr(sedona_ops, "_STATEMENT_TIMEOUT_MS")
+    assert sedona_ops._STATEMENT_TIMEOUT_MS > 0
+
+
+def test_sql_timeout_maps_to_504(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A SqlTimeout from run_sql is surfaced as HTTP 504."""
+    monkeypatch.setattr(sedona_ops, "sedonadb_import_error", lambda: None)
+
+    def _boom(*_a, **_kw):
+        raise SqlTimeout("Spatial SQL timed out after 60 seconds")
+
+    monkeypatch.setattr(sedona_ops, "run_sql", _boom)
+    with pytest.raises(HTTPException) as exc:
+        sql_run(SqlRunRequest(sql="SELECT pg_sleep(999)"))
+    assert exc.value.status_code == 504
+    assert "timed out" in str(exc.value.detail)
+
+
+def test_run_sql_raises_timeout_on_slow_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_sql raises SqlTimeout when the query exceeds the budget."""
+    import time
+
+    monkeypatch.setattr(sedona_ops, "_STATEMENT_TIMEOUT_MS", 100)
+
+    class _FakeConnection:
+        def sql(self, statement):  # noqa: ARG002
+            time.sleep(5)
+
+        def close(self):
+            pass
+
+    fake_mod = type("M", (), {"connect": staticmethod(lambda: _FakeConnection())})()
+    monkeypatch.setattr(sedona_ops, "_import_sedona", lambda: fake_mod)
+
+    with pytest.raises(SqlTimeout, match="timed out"):
+        sedona_ops.run_sql("SELECT 1")

--- a/backend/geolibre_server/tests/test_sql.py
+++ b/backend/geolibre_server/tests/test_sql.py
@@ -176,9 +176,9 @@ def test_run_rejects_oversized_result(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_statement_timeout_constant_exists() -> None:
-    """The wall-clock timeout constant must be defined and positive."""
+    """The wall-clock timeout constant must equal the documented 60-second contract."""
     assert hasattr(sedona_ops, "_STATEMENT_TIMEOUT_MS")
-    assert sedona_ops._STATEMENT_TIMEOUT_MS > 0
+    assert sedona_ops._STATEMENT_TIMEOUT_MS == 60_000
 
 
 def test_sql_timeout_maps_to_504(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Mirror PostGIS's 60s statement budget for Sedona `/sql/run` so a heavy query cannot pin a FastAPI worker indefinitely.
- Time out `connection.sql` / `to_pandas` via a bounded executor and map `SqlTimeout` to HTTP 504.

## Test plan
- [x] `uv run --project backend/geolibre_server --extra test pytest backend/geolibre_server/tests/test_sql.py -q`
- [x] Run a normal Sedona query and confirm it still succeeds
- [x] Force a slow path (or the unit timeout stub) and confirm 504 with a stable message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- SQL queries that run longer than 60 seconds now time out automatically.
- Timed-out requests return an HTTP 504 response instead of waiting indefinitely.
- Database connections are closed when possible after a timeout.
- Successfully completed queries continue to enforce result limits, helping prevent excessively large responses.
- Improved handling of slow or unresponsive SQL operations provides more predictable request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->