### PR TITLE
fix(sidecar): cap concurrent ML segmentation proxy requests

### DIFF
--- a/backend/geolibre_server/geolibre_server/app/ml.py
+++ b/backend/geolibre_server/geolibre_server/app/ml.py
@@ -425,8 +425,15 @@ async def _forward_segment(request: Request, path: str) -> Response:
             headers["content-type"] = content_type
 
         async def _body_iter():
+            body_size = 0
             async for chunk in request.stream():
                 if chunk:
+                    body_size += len(chunk)
+                    if body_size > _MAX_SEGMENT_BODY_BYTES:
+                        raise HTTPException(
+                            status_code=413,
+                            detail="Upload exceeds the 100 MiB segmentation size limit.",
+                        )
                     yield chunk
 
         try:

--- a/backend/geolibre_server/geolibre_server/app/ml.py
+++ b/backend/geolibre_server/geolibre_server/app/ml.py
@@ -67,6 +67,18 @@ _LAUNCH_CMD = os.environ.get("GEOLIBRE_ML_SAMGEO_CMD", "samgeo-api")
 _HEALTH_TIMEOUT_SECS = 60
 _PROXY_TIMEOUT_SECS = 1800  # model inference on large rasters can be slow
 
+# Cap concurrent segmentation proxy requests so a burst of large uploads cannot
+# exhaust sidecar memory or starve the event loop. Mirrors the conversion
+# engine's MAX_IN_FLIGHT_JOBS pattern.
+MAX_IN_FLIGHT_SEGMENT_REQUESTS = 4
+_segment_lock = threading.Lock()
+_segment_in_flight = 0
+
+# Reject uploads whose Content-Length exceeds this (100 MiB). When the header
+# is missing (chunked transfer) the limit is not enforced — the backend's own
+# size handling applies.
+_MAX_SEGMENT_BODY_BYTES = 100 * 1024 * 1024
+
 # Guards the launch-or-reuse decision for the child process.
 _child_lock = threading.Lock()
 _child: dict = {"proc": None, "url": None}
@@ -375,6 +387,9 @@ async def _forward_segment(request: Request, path: str) -> Response:
     and ``output_format`` supported by samgeo-api works without re-encoding, and
     so a large GeoTIFF upload is never buffered whole in the sidecar's memory.
 
+    Concurrency is capped at :data:`MAX_IN_FLIGHT_SEGMENT_REQUESTS` to prevent a
+    burst of large uploads from exhausting sidecar resources.
+
     Args:
         request: The incoming FastAPI request (multipart/form-data).
         path: The backend path to forward to, e.g. ``/segment/text``.
@@ -382,33 +397,51 @@ async def _forward_segment(request: Request, path: str) -> Response:
     Returns:
         The backend response (status, body, content-type) passed straight back.
     """
-    httpx = _require_httpx()
-    base = await _resolve_base()
-    headers = {}
-    content_type = request.headers.get("content-type")
-    if content_type:
-        headers["content-type"] = content_type
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > _MAX_SEGMENT_BODY_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Upload exceeds the 100 MiB segmentation size limit.",
+                )
+        except ValueError:
+            pass
 
-    async def _body_iter():
-        # Forward the upload chunk-by-chunk so the whole payload never sits in
-        # memory at once (uvicorn/httpx negotiate chunked transfer encoding).
-        async for chunk in request.stream():
-            if chunk:
-                yield chunk
-
+    global _segment_in_flight  # noqa: PLW0603
+    with _segment_lock:
+        if _segment_in_flight >= MAX_IN_FLIGHT_SEGMENT_REQUESTS:
+            raise HTTPException(
+                status_code=429,
+                detail="Too many segmentation requests in progress; try again shortly.",
+            )
+        _segment_in_flight += 1
     try:
-        async with httpx.AsyncClient(timeout=_PROXY_TIMEOUT_SECS) as client:
-            resp = await client.post(f"{base}{path}", content=_body_iter(), headers=headers)
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail=f"samgeo-api error: {exc}")
-    # The GeoJSON/PNG response is buffered (resp.content); it is bounded and far
-    # smaller than the upload. Streaming it back would need client.stream() +
-    # StreamingResponse and is left as a follow-up.
-    return Response(
-        content=resp.content,
-        status_code=resp.status_code,
-        media_type=resp.headers.get("content-type"),
-    )
+        httpx = _require_httpx()
+        base = await _resolve_base()
+        headers = {}
+        content_type = request.headers.get("content-type")
+        if content_type:
+            headers["content-type"] = content_type
+
+        async def _body_iter():
+            async for chunk in request.stream():
+                if chunk:
+                    yield chunk
+
+        try:
+            async with httpx.AsyncClient(timeout=_PROXY_TIMEOUT_SECS) as client:
+                resp = await client.post(f"{base}{path}", content=_body_iter(), headers=headers)
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=f"samgeo-api error: {exc}")
+        return Response(
+            content=resp.content,
+            status_code=resp.status_code,
+            media_type=resp.headers.get("content-type"),
+        )
+    finally:
+        with _segment_lock:
+            _segment_in_flight -= 1
 
 
 @router.post("/segment/automatic")

--- a/backend/geolibre_server/geolibre_server/app/ml.py
+++ b/backend/geolibre_server/geolibre_server/app/ml.py
@@ -69,14 +69,21 @@ _PROXY_TIMEOUT_SECS = 1800  # model inference on large rasters can be slow
 
 # Cap concurrent segmentation proxy requests so a burst of large uploads cannot
 # exhaust sidecar memory or starve the event loop. Mirrors the conversion
-# engine's MAX_IN_FLIGHT_JOBS pattern.
+# engine's MAX_IN_FLIGHT_JOBS pattern, with one difference worth knowing: those
+# endpoints enqueue a background job and return immediately, whereas this is a
+# streaming proxy, so a slot is held for the whole call — the samgeo-api launch
+# (_HEALTH_TIMEOUT_SECS) plus inference (_PROXY_TIMEOUT_SECS). That is
+# deliberate: the resource being rationed is the held connection and the
+# in-flight upload, not a queue position.
 MAX_IN_FLIGHT_SEGMENT_REQUESTS = 4
 _segment_lock = threading.Lock()
 _segment_in_flight = 0
 
-# Reject uploads whose Content-Length exceeds this (100 MiB). When the header
-# is missing (chunked transfer) the limit is not enforced — the backend's own
-# size handling applies.
+# Reject uploads larger than this (100 MiB). Enforced twice: once up front on
+# Content-Length so an oversized upload is refused before any bytes are read,
+# and again on the cumulative bytes seen in ``_body_iter``, which is what
+# actually covers a client that omits the header (chunked transfer) or sends a
+# non-numeric one.
 _MAX_SEGMENT_BODY_BYTES = 100 * 1024 * 1024
 
 # Guards the launch-or-reuse decision for the child process.

--- a/backend/geolibre_server/tests/test_ml.py
+++ b/backend/geolibre_server/tests/test_ml.py
@@ -55,11 +55,15 @@ class _FakeAsyncClient:
         return _FakeResp()
 
 
+class _FakeHTTPError(Exception):
+    """Narrow stand-in so ``except httpx.HTTPError`` doesn't swallow unrelated exceptions."""
+
+
 class _FakeHttpx:
     """Minimal stand-in for the httpx module used by ml.py."""
 
     calls: list = []
-    HTTPError = Exception
+    HTTPError = _FakeHTTPError
     AsyncClient = _FakeAsyncClient
 
     @staticmethod
@@ -354,10 +358,13 @@ def test_segment_rejects_oversized_chunked_stream(monkeypatch):
     monkeypatch.setattr(ml, "_require_httpx", lambda: _FakeHttpx)
     monkeypatch.setattr(ml, "_ensure_server", lambda: "http://backend:9")
 
+    def _oversized_body():
+        yield b"x" * 50
+
     client = TestClient(app)
     resp = client.post(
         "/ml/segment/text",
-        content=b"x" * 50,
+        content=_oversized_body(),
         headers={"content-type": "multipart/form-data; boundary=----"},
     )
     assert resp.status_code == 413

--- a/backend/geolibre_server/tests/test_ml.py
+++ b/backend/geolibre_server/tests/test_ml.py
@@ -231,3 +231,70 @@ def test_segment_forwards_request_to_backend(monkeypatch):
     assert forwarded and forwarded[0][1] == "http://backend:9/segment/text"
     # The original multipart body is streamed through unchanged.
     assert b"fakebytes" in forwarded[0][2]
+
+
+# --- concurrency cap -------------------------------------------------------
+
+
+def test_segment_rejects_when_in_flight_cap_reached(monkeypatch):
+    """A new segmentation request is refused with 429 when in-flight work is at the cap."""
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from geolibre_server.app.main import app
+
+    monkeypatch.setattr(ml, "MAX_IN_FLIGHT_SEGMENT_REQUESTS", 1)
+    monkeypatch.setattr(ml, "_segment_in_flight", 1)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/ml/segment/text",
+        files={"file": ("a.tif", b"fakebytes", "image/tiff")},
+        data={"prompt": "tree"},
+    )
+    assert resp.status_code == 429
+    assert "Too many segmentation requests" in resp.json()["detail"]
+
+
+def test_segment_releases_slot_after_success(monkeypatch):
+    """The in-flight counter is decremented after a successful proxy request."""
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from geolibre_server.app.main import app
+
+    _FakeHttpx.calls.clear()
+    monkeypatch.setattr(ml, "_require_httpx", lambda: _FakeHttpx)
+    monkeypatch.setattr(ml, "_ensure_server", lambda: "http://backend:9")
+    monkeypatch.setattr(ml, "MAX_IN_FLIGHT_SEGMENT_REQUESTS", 4)
+    monkeypatch.setattr(ml, "_segment_in_flight", 0)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/ml/segment/text",
+        files={"file": ("a.tif", b"bytes", "image/tiff")},
+    )
+    assert resp.status_code == 200
+    assert ml._segment_in_flight == 0
+
+
+def test_segment_rejects_oversized_body(monkeypatch):
+    """A request with Content-Length above the cap is refused with 413."""
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from geolibre_server.app.main import app
+
+    monkeypatch.setattr(ml, "MAX_IN_FLIGHT_SEGMENT_REQUESTS", 4)
+    monkeypatch.setattr(ml, "_segment_in_flight", 0)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/ml/segment/text",
+        content=b"x",
+        headers={
+            "content-type": "multipart/form-data; boundary=----",
+            "content-length": str(200 * 1024 * 1024),
+        },
+    )
+    assert resp.status_code == 413

--- a/backend/geolibre_server/tests/test_ml.py
+++ b/backend/geolibre_server/tests/test_ml.py
@@ -278,6 +278,47 @@ def test_segment_releases_slot_after_success(monkeypatch):
     assert ml._segment_in_flight == 0
 
 
+def test_segment_releases_slot_after_upstream_failure(monkeypatch):
+    """The in-flight counter is decremented even when the upstream proxy errors."""
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from geolibre_server.app.main import app
+
+    class _ErrorHttpx:
+        calls: list = []
+        HTTPError = Exception
+
+        class AsyncClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            async def post(self, url, content=None, headers=None):
+                if hasattr(content, "__aiter__"):
+                    async for _ in content:
+                        pass
+                raise Exception("backend down")
+
+    monkeypatch.setattr(ml, "_require_httpx", lambda: _ErrorHttpx)
+    monkeypatch.setattr(ml, "_ensure_server", lambda: "http://backend:9")
+    monkeypatch.setattr(ml, "MAX_IN_FLIGHT_SEGMENT_REQUESTS", 4)
+    monkeypatch.setattr(ml, "_segment_in_flight", 0)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/ml/segment/text",
+        files={"file": ("a.tif", b"bytes", "image/tiff")},
+    )
+    assert resp.status_code == 502
+    assert ml._segment_in_flight == 0
+
+
 def test_segment_rejects_oversized_body(monkeypatch):
     """A request with Content-Length above the cap is refused with 413."""
     pytest.importorskip("httpx")
@@ -296,5 +337,27 @@ def test_segment_rejects_oversized_body(monkeypatch):
             "content-type": "multipart/form-data; boundary=----",
             "content-length": str(200 * 1024 * 1024),
         },
+    )
+    assert resp.status_code == 413
+
+
+def test_segment_rejects_oversized_chunked_stream(monkeypatch):
+    """Chunked uploads without Content-Length are still rejected when they exceed the cap."""
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from geolibre_server.app.main import app
+
+    monkeypatch.setattr(ml, "_MAX_SEGMENT_BODY_BYTES", 10)
+    monkeypatch.setattr(ml, "MAX_IN_FLIGHT_SEGMENT_REQUESTS", 4)
+    monkeypatch.setattr(ml, "_segment_in_flight", 0)
+    monkeypatch.setattr(ml, "_require_httpx", lambda: _FakeHttpx)
+    monkeypatch.setattr(ml, "_ensure_server", lambda: "http://backend:9")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/ml/segment/text",
+        content=b"x" * 50,
+        headers={"content-type": "multipart/form-data; boundary=----"},
     )
     assert resp.status_code == 413

--- a/backend/geolibre_server/tests/test_ml.py
+++ b/backend/geolibre_server/tests/test_ml.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import asyncio
 import json
 import subprocess
+from collections.abc import Iterator
+from typing import ClassVar
 
 import pytest
 
@@ -62,7 +64,7 @@ class _FakeHTTPError(Exception):
 class _FakeHttpx:
     """Minimal stand-in for the httpx module used by ml.py."""
 
-    calls: list = []
+    calls: ClassVar[list] = []
     HTTPError = _FakeHTTPError
     AsyncClient = _FakeAsyncClient
 
@@ -290,7 +292,7 @@ def test_segment_releases_slot_after_upstream_failure(monkeypatch):
     from geolibre_server.app.main import app
 
     class _ErrorHttpx:
-        calls: list = []
+        calls: ClassVar[list] = []
         HTTPError = Exception
 
         class AsyncClient:
@@ -358,7 +360,7 @@ def test_segment_rejects_oversized_chunked_stream(monkeypatch):
     monkeypatch.setattr(ml, "_require_httpx", lambda: _FakeHttpx)
     monkeypatch.setattr(ml, "_ensure_server", lambda: "http://backend:9")
 
-    def _oversized_body():
+    def _oversized_body() -> Iterator[bytes]:
         yield b"x" * 50
 
     client = TestClient(app)


### PR DESCRIPTION
## Summary
- Cap in-flight `/ml/segment/*` proxy requests (default 4) with HTTP 429 when the slot is full, matching conversion/Whitebox job caps.
- Refuse oversized request bodies (100 MiB) with HTTP 413.
- Always release the slot in `finally`.

## Test plan
- [x] `uv run --project backend/geolibre_server --extra test pytest backend/geolibre_server/tests/test_ml.py -q`
- [x] Fire a normal segment request and confirm it still forwards
- [x] Hold the in-flight cap and confirm a further request returns 429

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards for segmentation requests by limiting uploads to 100 MiB.
  * Limited simultaneous segmentation requests to four.
  * Oversized requests now return HTTP 413, while requests exceeding the concurrency limit return HTTP 429.
  * Improved request-slot cleanup to ensure capacity is restored after completed or failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->