### PR TITLE
fix(sidecar): stop leaking raw vector and SQL errors to clients

### DIFF
--- a/backend/geolibre_server/geolibre_server/app/sql.py
+++ b/backend/geolibre_server/geolibre_server/app/sql.py
@@ -85,4 +85,7 @@ def sql_run(request: SqlRunRequest) -> dict[str, Any]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # noqa: BLE001 - surface a stable error to the client
         logger.exception("Sedona SQL failed")
-        raise HTTPException(status_code=400, detail=f"Spatial SQL failed: {exc}") from exc
+        raise HTTPException(
+            status_code=400,
+            detail="Spatial SQL failed due to an internal error.",
+        ) from exc

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -106,7 +106,10 @@ def vector_run(request: VectorToolRequest):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:  # noqa: BLE001 - surface a stable error to the client
         logger.exception("Vector tool %s failed", request.tool_id)
-        raise HTTPException(status_code=400, detail=f"Vector tool failed: {exc}") from exc
+        raise HTTPException(
+            status_code=400,
+            detail="Vector tool failed due to an internal error.",
+        ) from exc
 
     return {"geojson": geojson, "messages": messages}
 
@@ -298,7 +301,10 @@ def vector_write(request: WriteVectorRequest):
         raise
     except Exception as exc:  # noqa: BLE001 - surface a stable error to the client
         logger.exception("Write-back to %s failed", target)
-        raise HTTPException(status_code=400, detail=f"Write-back failed: {exc}") from exc
+        raise HTTPException(
+            status_code=400,
+            detail="Write-back failed due to an internal error.",
+        ) from exc
 
     return {
         "path": str(target),

--- a/backend/geolibre_server/tests/test_sql.py
+++ b/backend/geolibre_server/tests/test_sql.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 import pytest
 from fastapi import HTTPException
 
@@ -220,13 +222,12 @@ def test_run_does_not_leak_exception_detail(monkeypatch: pytest.MonkeyPatch) -> 
     sensitive_path = "/var/data/credentials.json"
     monkeypatch.setattr(sedona_ops, "sedonadb_import_error", lambda: None)
 
-    def _boom(*_a, **_kw):
-        raise RuntimeError(f"Failed to read {sensitive_path}")
+    def _boom(*_args: object, **_kwargs: object) -> NoReturn:
+        raise RuntimeError(f"Failed to read {sensitive_path}")  # noqa: TRY003
 
     monkeypatch.setattr(sedona_ops, "run_sql", _boom)
     with pytest.raises(HTTPException) as exc:
         sql_run(SqlRunRequest(sql="SELECT 1"))
     assert exc.value.status_code == 400
     assert sensitive_path not in str(exc.value.detail)
-    assert "internal error" in str(exc.value.detail).lower()
-
+    assert exc.value.detail == "Spatial SQL failed due to an internal error."

--- a/backend/geolibre_server/tests/test_sql.py
+++ b/backend/geolibre_server/tests/test_sql.py
@@ -217,16 +217,16 @@ def test_run_sql_raises_timeout_on_slow_query(monkeypatch: pytest.MonkeyPatch) -
 
 def test_run_does_not_leak_exception_detail(monkeypatch: pytest.MonkeyPatch) -> None:
     """Broad exceptions must not surface internal paths or secrets in the detail."""
-    secret = "/var/data/credentials.json"
+    sensitive_path = "/var/data/credentials.json"
     monkeypatch.setattr(sedona_ops, "sedonadb_import_error", lambda: None)
 
     def _boom(*_a, **_kw):
-        raise RuntimeError(f"Failed to read {secret}")
+        raise RuntimeError(f"Failed to read {sensitive_path}")
 
     monkeypatch.setattr(sedona_ops, "run_sql", _boom)
     with pytest.raises(HTTPException) as exc:
         sql_run(SqlRunRequest(sql="SELECT 1"))
     assert exc.value.status_code == 400
-    assert secret not in str(exc.value.detail)
+    assert sensitive_path not in str(exc.value.detail)
     assert "internal error" in str(exc.value.detail).lower()
 

--- a/backend/geolibre_server/tests/test_sql.py
+++ b/backend/geolibre_server/tests/test_sql.py
@@ -213,3 +213,20 @@ def test_run_sql_raises_timeout_on_slow_query(monkeypatch: pytest.MonkeyPatch) -
 
     with pytest.raises(SqlTimeout, match="timed out"):
         sedona_ops.run_sql("SELECT 1")
+
+
+def test_run_does_not_leak_exception_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Broad exceptions must not surface internal paths or secrets in the detail."""
+    secret = "/var/data/credentials.json"
+    monkeypatch.setattr(sedona_ops, "sedonadb_import_error", lambda: None)
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError(f"Failed to read {secret}")
+
+    monkeypatch.setattr(sedona_ops, "run_sql", _boom)
+    with pytest.raises(HTTPException) as exc:
+        sql_run(SqlRunRequest(sql="SELECT 1"))
+    assert exc.value.status_code == 400
+    assert secret not in str(exc.value.detail)
+    assert "internal error" in str(exc.value.detail).lower()
+

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -350,6 +350,47 @@ def test_write_geopackage_preserves_source_crs(tmp_path) -> None:
 
 
 @requires_geopandas
+def test_run_does_not_leak_exception_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Broad exceptions must not surface internal paths or secrets in the detail."""
+    secret = "/var/secret/key.pem"
+    monkeypatch.setattr(vector_ops, "geopandas_import_error", lambda: None)
+    monkeypatch.setattr(
+        vector_ops,
+        "run_vector_tool",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"Cannot read {secret}")),
+    )
+    with pytest.raises(HTTPException) as exc:
+        vector_run(VectorToolRequest(tool_id="buffer", geojson=SQUARE))
+    assert exc.value.status_code == 400
+    assert secret not in str(exc.value.detail)
+    assert "internal error" in str(exc.value.detail).lower()
+
+
+@requires_geopandas
+def test_write_does_not_leak_exception_detail(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write-back broad exceptions must not surface internal detail."""
+    import geopandas as gpd
+
+    from geolibre_server.app import vector as vector_mod
+
+    src = tmp_path / "layer.geojson"
+    gpd.GeoDataFrame.from_features(_edited("a")["features"], crs="EPSG:4326").to_file(
+        src, driver="GeoJSON"
+    )
+    secret = "/etc/shadow"
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError(f"leaked {secret}")
+
+    monkeypatch.setattr(vector_mod, "_write_geojson", _boom)
+    with pytest.raises(HTTPException) as exc:
+        vector_write(WriteVectorRequest(path=str(src), geojson=_edited("b")))
+    assert exc.value.status_code == 400
+    assert secret not in str(exc.value.detail)
+    assert "internal error" in str(exc.value.detail).lower()
+
+
+@requires_geopandas
 def test_write_respects_conversion_allowlist(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     import geopandas as gpd
 

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 import pytest
 from fastapi import HTTPException
 
@@ -354,16 +356,16 @@ def test_run_does_not_leak_exception_detail(monkeypatch: pytest.MonkeyPatch) -> 
     """Broad exceptions must not surface internal paths or secrets in the detail."""
     sensitive_path = "/var/secret/key.pem"
     monkeypatch.setattr(vector_ops, "geopandas_import_error", lambda: None)
-    monkeypatch.setattr(
-        vector_ops,
-        "run_vector_tool",
-        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"Cannot read {sensitive_path}")),
-    )
+
+    def _boom(*_args: object, **_kwargs: object) -> NoReturn:
+        raise RuntimeError(f"Cannot read {sensitive_path}")  # noqa: TRY003
+
+    monkeypatch.setattr(vector_ops, "run_vector_tool", _boom)
     with pytest.raises(HTTPException) as exc:
         vector_run(VectorToolRequest(tool_id="buffer", geojson=SQUARE))
     assert exc.value.status_code == 400
     assert sensitive_path not in str(exc.value.detail)
-    assert "internal error" in str(exc.value.detail).lower()
+    assert exc.value.detail == "Vector tool failed due to an internal error."
 
 
 @requires_geopandas
@@ -379,15 +381,15 @@ def test_write_does_not_leak_exception_detail(tmp_path, monkeypatch: pytest.Monk
     )
     sensitive_path = "/etc/shadow"
 
-    def _boom(*_a, **_kw):
-        raise RuntimeError(f"leaked {sensitive_path}")
+    def _boom(*_args: object, **_kwargs: object) -> NoReturn:
+        raise RuntimeError(f"leaked {sensitive_path}")  # noqa: TRY003
 
     monkeypatch.setattr(vector_mod, "_write_geojson", _boom)
     with pytest.raises(HTTPException) as exc:
         vector_write(WriteVectorRequest(path=str(src), geojson=_edited("b")))
     assert exc.value.status_code == 400
     assert sensitive_path not in str(exc.value.detail)
-    assert "internal error" in str(exc.value.detail).lower()
+    assert exc.value.detail == "Write-back failed due to an internal error."
 
 
 @requires_geopandas

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -352,17 +352,17 @@ def test_write_geopackage_preserves_source_crs(tmp_path) -> None:
 @requires_geopandas
 def test_run_does_not_leak_exception_detail(monkeypatch: pytest.MonkeyPatch) -> None:
     """Broad exceptions must not surface internal paths or secrets in the detail."""
-    secret = "/var/secret/key.pem"
+    sensitive_path = "/var/secret/key.pem"
     monkeypatch.setattr(vector_ops, "geopandas_import_error", lambda: None)
     monkeypatch.setattr(
         vector_ops,
         "run_vector_tool",
-        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"Cannot read {secret}")),
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"Cannot read {sensitive_path}")),
     )
     with pytest.raises(HTTPException) as exc:
         vector_run(VectorToolRequest(tool_id="buffer", geojson=SQUARE))
     assert exc.value.status_code == 400
-    assert secret not in str(exc.value.detail)
+    assert sensitive_path not in str(exc.value.detail)
     assert "internal error" in str(exc.value.detail).lower()
 
 
@@ -377,16 +377,16 @@ def test_write_does_not_leak_exception_detail(tmp_path, monkeypatch: pytest.Monk
     gpd.GeoDataFrame.from_features(_edited("a")["features"], crs="EPSG:4326").to_file(
         src, driver="GeoJSON"
     )
-    secret = "/etc/shadow"
+    sensitive_path = "/etc/shadow"
 
     def _boom(*_a, **_kw):
-        raise RuntimeError(f"leaked {secret}")
+        raise RuntimeError(f"leaked {sensitive_path}")
 
     monkeypatch.setattr(vector_mod, "_write_geojson", _boom)
     with pytest.raises(HTTPException) as exc:
         vector_write(WriteVectorRequest(path=str(src), geojson=_edited("b")))
     assert exc.value.status_code == 400
-    assert secret not in str(exc.value.detail)
+    assert sensitive_path not in str(exc.value.detail)
     assert "internal error" in str(exc.value.detail).lower()
 
 


### PR DESCRIPTION
## Summary
- Keep curated `ValueError` / oversized-input details, but return a generic client message for unexpected vector and Sedona failures (same bar as conversion jobs).
- Log the raw exception server-side; scrub write-back failures the same way.

## Test plan
- [x] `uv run --project backend/geolibre_server --extra test pytest backend/geolibre_server/tests/test_vector.py backend/geolibre_server/tests/test_sql.py -q`
- [x] Trigger a vector tool failure and confirm the browser detail has no absolute path / secret
- [x] Trigger a Sedona failure and confirm the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL and vector operation error responses with stable, generic HTTP 400 messages.
  * Prevented sensitive file paths and internal exception details from appearing in client-facing responses.
  * Standardized error handling across query execution, vector processing, and GeoJSON write-back operations.

* **Tests**
  * Added regression coverage for consistent error handling and protection of sensitive details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->