### PR TITLE
fix(workers): harden Vite proxy and github-raw redirect fetches

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -94,6 +94,7 @@
     "shpjs": "^6.2.0",
     "sql.js": "^1.14.0",
     "three": "^0.185.1",
+    "undici": "^7.29.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -94,7 +94,6 @@
     "shpjs": "^6.2.0",
     "sql.js": "^1.14.0",
     "three": "^0.185.1",
-    "undici": "^7.29.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -110,6 +109,7 @@
     "postcss": "^8.5.23",
     "tailwindcss": "^4.3.0",
     "typescript": "^7.0.2",
+    "undici": "^7.29.0",
     "vite": "^8.1.5",
     "vite-plugin-pwa": "^1.3.0"
   }

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -88,7 +88,8 @@ export function isPrivateHost(host: string): boolean {
 
   if (isIpv4Literal(bare)) {
     const octets = bare.split(".").map(Number);
-    if (octets.some((o) => o > 255)) return false;
+    // Fail closed: unclassifiable / out-of-range literals are treated as blocked.
+    if (octets.some((o) => o > 255)) return true;
     return isPrivateIPv4(octets);
   }
 
@@ -150,8 +151,13 @@ function isPrivateIPv6(addr: string): boolean {
 /**
  * Resolve `hostname` (when it is a DNS name) and refuse if any returned
  * address is private/reserved. IP literals are checked synchronously.
+ *
+ * `lookup` is injectable so unit tests can cover the DNS branch offline.
  */
-export async function assertResolvedPublicHost(hostname: string): Promise<void> {
+export async function assertResolvedPublicHost(
+  hostname: string,
+  lookup: typeof dnsLookup = dnsLookup,
+): Promise<void> {
   const bare = stripIpv6Brackets(hostname);
   if (isIpLiteral(bare)) {
     if (isPrivateHost(bare)) {
@@ -162,7 +168,7 @@ export async function assertResolvedPublicHost(hostname: string): Promise<void> 
   if (isPrivateHost(bare)) {
     throw new Error(`Blocked private/reserved address: ${hostname}`);
   }
-  const results = await dnsLookup(bare, { all: true, verbatim: true });
+  const results = await lookup(bare, { all: true, verbatim: true });
   if (results.length === 0) {
     throw new Error(`DNS lookup returned no addresses for ${hostname}`);
   }
@@ -176,45 +182,50 @@ export async function assertResolvedPublicHost(hostname: string): Promise<void> 
 /**
  * undici Agent whose DNS lookup validates every address and only hands the
  * connector a previously-checked public address — closing the rebinding
- * window between a pre-check and connect.
+ * window between check and connect. This lookup is the authoritative SSRF
+ * gate for production fetches (no separate pre-resolve).
  */
 const guardedDispatcher = new Agent({
   connect: {
     lookup(hostname, options, callback) {
-      dnsLookupCallback(hostname, { all: true, verbatim: true, ...options }, (err, addresses) => {
-        if (err) {
-          callback(err as NodeJS.ErrnoException, "", 4);
-          return;
-        }
-        const list = Array.isArray(addresses)
-          ? addresses
-          : [{ address: String(addresses), family: 4 as const }];
-        if (list.length === 0) {
-          callback(
-            Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), {
-              code: "ENOTFOUND",
-            }),
-            "",
-            4,
-          );
-          return;
-        }
-        for (const entry of list) {
-          if (isPrivateHost(entry.address)) {
+      // Force all-address mode after spreading connector options so the
+      // caller cannot downgrade us to the single-address callback form.
+      dnsLookupCallback(
+        hostname,
+        { ...options, all: true, verbatim: true },
+        (err, addresses) => {
+          if (err) {
+            callback(err as NodeJS.ErrnoException, "", 4);
+            return;
+          }
+          const list = addresses as Array<{ address: string; family: number }>;
+          if (!Array.isArray(list) || list.length === 0) {
             callback(
-              Object.assign(
-                new Error(`Blocked private/reserved address: ${hostname} → ${entry.address}`),
-                { code: "ENOTFOUND" },
-              ),
+              Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), {
+                code: "ENOTFOUND",
+              }),
               "",
               4,
             );
             return;
           }
-        }
-        const chosen = list[0];
-        callback(null, chosen.address, chosen.family);
-      });
+          for (const entry of list) {
+            if (isPrivateHost(entry.address)) {
+              callback(
+                Object.assign(
+                  new Error(`Blocked private/reserved address: ${hostname} → ${entry.address}`),
+                  { code: "ENOTFOUND" },
+                ),
+                "",
+                4,
+              );
+              return;
+            }
+          }
+          const chosen = list[0];
+          callback(null, chosen.address, chosen.family);
+        },
+      );
     },
   },
 });
@@ -228,13 +239,11 @@ function mergeAbortSignals(timeoutMs: number, caller?: AbortSignal | null): Abor
 }
 
 /**
- * Fetch `targetUrl` with manual redirect following, DNS-resolved SSRF checks,
- * a per-hop timeout, and (by default) a dispatcher that pins connects to
- * validated addresses. Returns the final Response or throws on disallowed
- * targets / too many hops.
+ * Fetch `targetUrl` with manual redirect following, a per-hop timeout, and
+ * (by default) a dispatcher that pins connects to validated public addresses.
  *
- * `options.fetchImpl` is for tests; production callers leave it unset so the
- * undici agent with the validating DNS lookup is used.
+ * DNS SSRF checks happen inside `guardedDispatcher.lookup` for production
+ * fetches. Inject `fetchImpl` for offline unit tests (no real DNS/connect).
  */
 export async function fetchWithGuard(
   targetUrl: string,
@@ -250,12 +259,6 @@ export async function fetchWithGuard(
 
   let current = targetUrl;
   for (let hop = 0; hop <= PROXY_MAX_REDIRECT_HOPS; hop++) {
-    // Production always resolves so DNS-rebinding hosts are refused. Injected
-    // fetchImpl (unit tests) skips the lookup so offline mocks stay offline.
-    if (!fetchImpl) {
-      await assertResolvedPublicHost(new URL(current).hostname);
-    }
-
     const { signal: callerSignal, ...rest } = init;
     const signal = mergeAbortSignals(timeoutMs, callerSignal ?? null);
     const response = fetchImpl
@@ -348,9 +351,12 @@ export async function proxyBinaryRequestGuarded(
   try {
     response = await fetchWithGuard(target, { headers });
   } catch (err) {
+    // Do not echo err.message — resolved private IPs / undici connect details
+    // would turn this proxy into an internal-network disclosure oracle.
+    console.warn("[vite-proxy-guard] upstream fetch blocked or failed:", err);
     res.statusCode = 502;
     res.setHeader("content-type", "text/plain");
-    res.end(err instanceof Error ? err.message : "Upstream fetch failed");
+    res.end("Upstream fetch failed");
     return;
   }
 
@@ -359,9 +365,10 @@ export async function proxyBinaryRequestGuarded(
   try {
     body = await readBodyWithLimit(response);
   } catch (err) {
+    console.warn("[vite-proxy-guard] upstream body rejected:", err);
     res.statusCode = 502;
     res.setHeader("content-type", "text/plain");
-    res.end(err instanceof Error ? err.message : "Upstream response exceeds size limit");
+    res.end("Upstream response exceeds size limit");
     return;
   }
 

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -190,7 +190,13 @@ const guardedDispatcher = new Agent({
           ? addresses
           : [{ address: String(addresses), family: 4 as const }];
         if (list.length === 0) {
-          callback(Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), { code: "ENOTFOUND" }), "", 4);
+          callback(
+            Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), {
+              code: "ENOTFOUND",
+            }),
+            "",
+            4,
+          );
           return;
         }
         for (const entry of list) {
@@ -213,10 +219,7 @@ const guardedDispatcher = new Agent({
   },
 });
 
-function mergeAbortSignals(
-  timeoutMs: number,
-  caller?: AbortSignal | null,
-): AbortSignal {
+function mergeAbortSignals(timeoutMs: number, caller?: AbortSignal | null): AbortSignal {
   const timeout = AbortSignal.timeout(timeoutMs);
   if (!caller) return timeout;
   const any = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -2,23 +2,31 @@
  * SSRF guard for the Vite dev-server `__geolibre_*_proxy` binary proxies.
  *
  * Validates that a target URL is a public HTTP(S) address (not loopback,
- * private RFC-1918, link-local, metadata, or IPv6 ULA/loopback) and follows
- * redirects manually, re-validating each hop against the same rules.
+ * private RFC-1918, link-local, metadata, or IPv6 ULA/loopback), resolves
+ * DNS names and checks every returned address before connecting (with a
+ * custom undici lookup that pins the connection to a validated address),
+ * and follows redirects manually while re-validating each hop.
  *
  * Exported so `tests/` can import and exercise the guard without pulling in
  * the full vite.config.
  */
 
+import { lookup as dnsLookupCallback } from "node:dns";
+import { lookup as dnsLookup } from "node:dns/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { Agent, fetch as undiciFetch } from "undici";
 
-const PROXY_MAX_REDIRECT_HOPS = 5;
-const PROXY_MAX_BODY_BYTES = 50 * 1024 * 1024; // 50 MB
+export const PROXY_MAX_REDIRECT_HOPS = 5;
+export const PROXY_MAX_BODY_BYTES = 50 * 1024 * 1024; // 50 MB
+export const PROXY_FETCH_TIMEOUT_MS = 30_000;
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 /**
  * Returns an error message if `urlString` is not a safe public HTTP(S) URL,
- * or `null` when it is acceptable.
+ * or `null` when it is acceptable. This only inspects the literal hostname;
+ * call {@link assertResolvedPublicHost} before connecting so DNS names that
+ * resolve to private addresses are also refused.
  */
 export function validatePublicUrl(urlString: string): string | null {
   let parsed: URL;
@@ -33,9 +41,13 @@ export function validatePublicUrl(urlString: string): string | null {
   if (parsed.username || parsed.password) {
     return "URLs with credentials are not allowed";
   }
+  // Non-default ports are remapped/ignored differently across runtimes; keep
+  // the allowlist on the default http/https ports only.
+  if (parsed.port !== "") {
+    return `Blocked non-default port: ${parsed.port}`;
+  }
   const hostname = parsed.hostname;
-  // Strip IPv6 brackets for address checks.
-  const bare = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+  const bare = stripIpv6Brackets(hostname);
 
   if (isPrivateHost(bare)) {
     return `Blocked private/reserved address: ${hostname}`;
@@ -51,28 +63,40 @@ export function assertPublicHttpUrl(urlString: string): void {
   if (err) throw new Error(err);
 }
 
-function isPrivateHost(host: string): boolean {
-  // Loopback names
-  if (host === "localhost" || host.endsWith(".localhost")) return true;
+function stripIpv6Brackets(host: string): string {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+}
 
-  // IPv4 checks
-  const ipv4Parts = host.split(".");
-  if (ipv4Parts.length === 4 && ipv4Parts.every((p) => /^\d{1,3}$/.test(p))) {
-    const octets = ipv4Parts.map(Number);
-    if (octets.some((o) => o > 255)) return false; // not a valid IPv4, let DNS decide
+function isIpv4Literal(host: string): boolean {
+  const parts = host.split(".");
+  return parts.length === 4 && parts.every((p) => /^\d{1,3}$/.test(p));
+}
+
+function isIpv6Literal(host: string): boolean {
+  return host.includes(":");
+}
+
+/** True when `host` is a literal IPv4/IPv6 address (not a DNS name). */
+export function isIpLiteral(host: string): boolean {
+  const bare = stripIpv6Brackets(host);
+  return isIpv4Literal(bare) || isIpv6Literal(bare);
+}
+
+export function isPrivateHost(host: string): boolean {
+  const bare = stripIpv6Brackets(host);
+  if (bare === "localhost" || bare.endsWith(".localhost")) return true;
+
+  if (isIpv4Literal(bare)) {
+    const octets = bare.split(".").map(Number);
+    if (octets.some((o) => o > 255)) return false;
     return isPrivateIPv4(octets);
   }
 
-  // IPv6 checks (bare, already stripped of brackets)
-  if (host.includes(":")) {
-    return isPrivateIPv6(host);
+  if (isIpv6Literal(bare)) {
+    return isPrivateIPv6(bare);
   }
 
-  // DNS names like "metadata.google.internal" — block if they resolve to a
-  // known cloud metadata hostname pattern (the actual resolution to 169.254.*
-  // is caught by IPv4 checks when the caller resolves, but we block the name
-  // too for defence in depth).
-  if (host === "metadata.google.internal") return true;
+  if (bare === "metadata.google.internal") return true;
 
   return false;
 }
@@ -87,6 +111,7 @@ function isPrivateIPv4(octets: number[]): boolean {
   if (a === 0) return true; // 0.0.0.0/8 "this" network
   if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
   if (a === 192 && b === 0 && octets[2] === 0) return true; // 192.0.0.0/24 IETF protocol
+  if (a === 192 && b === 0 && octets[2] === 2) return true; // 192.0.2.0/24 TEST-NET-1
   if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
   if (a === 198 && b === 51 && octets[2] === 100) return true; // 198.51.100.0/24 documentation
   if (a === 203 && b === 0 && octets[2] === 113) return true; // 203.0.113.0/24 documentation
@@ -97,13 +122,11 @@ function isPrivateIPv4(octets: number[]): boolean {
 function isPrivateIPv6(addr: string): boolean {
   const lower = addr.toLowerCase();
 
-  // Handle ::ffff:a.b.c.d mapped IPv4 (dotted-quad form)
   const mappedDotted = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(lower);
   if (mappedDotted) {
     return isPrivateIPv4(mappedDotted[1].split(".").map(Number));
   }
 
-  // Handle ::ffff:HHHH:HHHH mapped IPv4 (hex form — Node.js normalizes to this)
   const mappedHex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(lower);
   if (mappedHex) {
     const hi = parseInt(mappedHex[1], 16);
@@ -113,22 +136,133 @@ function isPrivateIPv6(addr: string): boolean {
 
   if (lower === "::1") return true; // loopback
   if (lower === "::") return true; // unspecified
-  if (lower.startsWith("fe80:") || lower.startsWith("fe80::")) return true; // link-local
-  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // ULA fc00::/7
+
+  // Link-local is fe80::/10 (first hextet 0xfe80–0xfebf), not merely "fe80:".
+  const firstHextet = parseInt(lower.split(":")[0] || "", 16);
+  if (Number.isFinite(firstHextet) && (firstHextet & 0xffc0) === 0xfe80) return true;
+
+  // ULA fc00::/7
+  if (Number.isFinite(firstHextet) && (firstHextet & 0xfe00) === 0xfc00) return true;
 
   return false;
 }
 
 /**
- * Fetch `targetUrl` with manual redirect following, re-validating each hop.
- * Returns the final Response or throws on disallowed targets / too many hops.
+ * Resolve `hostname` (when it is a DNS name) and refuse if any returned
+ * address is private/reserved. IP literals are checked synchronously.
  */
-export async function fetchWithGuard(targetUrl: string, init: RequestInit = {}): Promise<Response> {
+export async function assertResolvedPublicHost(hostname: string): Promise<void> {
+  const bare = stripIpv6Brackets(hostname);
+  if (isIpLiteral(bare)) {
+    if (isPrivateHost(bare)) {
+      throw new Error(`Blocked private/reserved address: ${hostname}`);
+    }
+    return;
+  }
+  if (isPrivateHost(bare)) {
+    throw new Error(`Blocked private/reserved address: ${hostname}`);
+  }
+  const results = await dnsLookup(bare, { all: true, verbatim: true });
+  if (results.length === 0) {
+    throw new Error(`DNS lookup returned no addresses for ${hostname}`);
+  }
+  for (const { address } of results) {
+    if (isPrivateHost(address)) {
+      throw new Error(`Blocked private/reserved address: ${hostname} → ${address}`);
+    }
+  }
+}
+
+/**
+ * undici Agent whose DNS lookup validates every address and only hands the
+ * connector a previously-checked public address — closing the rebinding
+ * window between a pre-check and connect.
+ */
+const guardedDispatcher = new Agent({
+  connect: {
+    lookup(hostname, options, callback) {
+      dnsLookupCallback(hostname, { all: true, verbatim: true, ...options }, (err, addresses) => {
+        if (err) {
+          callback(err as NodeJS.ErrnoException, "", 4);
+          return;
+        }
+        const list = Array.isArray(addresses)
+          ? addresses
+          : [{ address: String(addresses), family: 4 as const }];
+        if (list.length === 0) {
+          callback(Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), { code: "ENOTFOUND" }), "", 4);
+          return;
+        }
+        for (const entry of list) {
+          if (isPrivateHost(entry.address)) {
+            callback(
+              Object.assign(
+                new Error(`Blocked private/reserved address: ${hostname} → ${entry.address}`),
+                { code: "ENOTFOUND" },
+              ),
+              "",
+              4,
+            );
+            return;
+          }
+        }
+        const chosen = list[0];
+        callback(null, chosen.address, chosen.family);
+      });
+    },
+  },
+});
+
+function mergeAbortSignals(
+  timeoutMs: number,
+  caller?: AbortSignal | null,
+): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  if (!caller) return timeout;
+  const any = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+  if (typeof any === "function") return any([timeout, caller]);
+  return timeout;
+}
+
+/**
+ * Fetch `targetUrl` with manual redirect following, DNS-resolved SSRF checks,
+ * a per-hop timeout, and (by default) a dispatcher that pins connects to
+ * validated addresses. Returns the final Response or throws on disallowed
+ * targets / too many hops.
+ *
+ * `options.fetchImpl` is for tests; production callers leave it unset so the
+ * undici agent with the validating DNS lookup is used.
+ */
+export async function fetchWithGuard(
+  targetUrl: string,
+  init: RequestInit = {},
+  options: {
+    timeoutMs?: number;
+    fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  } = {},
+): Promise<Response> {
   assertPublicHttpUrl(targetUrl);
+  const timeoutMs = options.timeoutMs ?? PROXY_FETCH_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl;
 
   let current = targetUrl;
   for (let hop = 0; hop <= PROXY_MAX_REDIRECT_HOPS; hop++) {
-    const response = await fetch(current, { ...init, redirect: "manual" });
+    // Production always resolves so DNS-rebinding hosts are refused. Injected
+    // fetchImpl (unit tests) skips the lookup so offline mocks stay offline.
+    if (!fetchImpl) {
+      await assertResolvedPublicHost(new URL(current).hostname);
+    }
+
+    const { signal: callerSignal, ...rest } = init;
+    const signal = mergeAbortSignals(timeoutMs, callerSignal ?? null);
+    const response = fetchImpl
+      ? await fetchImpl(current, { ...rest, signal, redirect: "manual" })
+      : ((await undiciFetch(current, {
+          ...rest,
+          signal,
+          redirect: "manual",
+          dispatcher: guardedDispatcher,
+        })) as unknown as Response);
     if (!REDIRECT_STATUSES.has(response.status)) {
       return response;
     }
@@ -142,9 +276,44 @@ export async function fetchWithGuard(targetUrl: string, init: RequestInit = {}):
 }
 
 /**
+ * Read an upstream body while enforcing {@link PROXY_MAX_BODY_BYTES}. Checks
+ * Content-Length early when present and aborts mid-stream if the running
+ * total exceeds the cap.
+ */
+export async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number = PROXY_MAX_BODY_BYTES,
+): Promise<Buffer> {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error("Upstream response exceeds size limit");
+  }
+
+  if (!response.body) {
+    return Buffer.alloc(0);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new Error("Upstream response exceeds size limit");
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c)));
+}
+
+/**
  * Hardened version of the Vite dev-server binary proxy handler. Validates the
- * target URL against SSRF rules, follows redirects manually, and caps the
- * response body size.
+ * target URL against SSRF rules (including DNS resolution), follows redirects
+ * manually, and caps the response body size while streaming.
  */
 export async function proxyBinaryRequestGuarded(
   req: IncomingMessage,
@@ -183,14 +352,15 @@ export async function proxyBinaryRequestGuarded(
   }
 
   const contentType = response.headers.get("content-type") ?? "application/octet-stream";
-  const buf = await response.arrayBuffer();
-  if (buf.byteLength > PROXY_MAX_BODY_BYTES) {
+  let body: Buffer;
+  try {
+    body = await readBodyWithLimit(response);
+  } catch (err) {
     res.statusCode = 502;
     res.setHeader("content-type", "text/plain");
-    res.end("Upstream response exceeds size limit");
+    res.end(err instanceof Error ? err.message : "Upstream response exceeds size limit");
     return;
   }
-  const body = Buffer.from(buf);
 
   res.statusCode = response.status;
   res.setHeader("access-control-allow-origin", "*");

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -123,10 +123,7 @@ function isPrivateIPv6(addr: string): boolean {
  * Fetch `targetUrl` with manual redirect following, re-validating each hop.
  * Returns the final Response or throws on disallowed targets / too many hops.
  */
-export async function fetchWithGuard(
-  targetUrl: string,
-  init: RequestInit = {},
-): Promise<Response> {
+export async function fetchWithGuard(targetUrl: string, init: RequestInit = {}): Promise<Response> {
   assertPublicHttpUrl(targetUrl);
 
   let current = targetUrl;

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -239,14 +239,19 @@ function mergeAbortSignals(timeoutMs: number, caller?: AbortSignal | null): Abor
  * (by default) a dispatcher that pins connects to validated public addresses.
  *
  * DNS SSRF checks happen inside `guardedDispatcher.lookup` for production
- * fetches. Inject `fetchImpl` for offline unit tests (no real DNS/connect).
+ * fetches. Inject `fetchImpl` only for offline unit tests — that path still
+ * runs {@link assertResolvedPublicHost} so a custom fetch cannot skip the
+ * DNS-rebinding check.
  */
 export async function fetchWithGuard(
   targetUrl: string,
   init: RequestInit = {},
   options: {
     timeoutMs?: number;
+    /** Test-only fetch substitute. Still resolves+validates the hostname. */
     fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+    /** Test-only DNS override used with `fetchImpl`. */
+    lookup?: typeof dnsLookup;
   } = {},
 ): Promise<Response> {
   assertPublicHttpUrl(targetUrl);
@@ -257,14 +262,19 @@ export async function fetchWithGuard(
   for (let hop = 0; hop <= PROXY_MAX_REDIRECT_HOPS; hop++) {
     const { signal: callerSignal, ...rest } = init;
     const signal = mergeAbortSignals(timeoutMs, callerSignal ?? null);
-    const response = fetchImpl
-      ? await fetchImpl(current, { ...rest, signal, redirect: "manual" })
-      : ((await undiciFetch(current, {
-          ...rest,
-          signal,
-          redirect: "manual",
-          dispatcher: guardedDispatcher,
-        })) as unknown as Response);
+    let response: Response;
+    if (fetchImpl) {
+      // No undici dispatcher on this path — resolve+validate before fetching.
+      await assertResolvedPublicHost(new URL(current).hostname, options.lookup);
+      response = await fetchImpl(current, { ...rest, signal, redirect: "manual" });
+    } else {
+      response = (await undiciFetch(current, {
+        ...rest,
+        signal,
+        redirect: "manual",
+        dispatcher: guardedDispatcher,
+      })) as unknown as Response;
+    }
     if (!REDIRECT_STATUSES.has(response.status)) {
       return response;
     }

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -190,42 +190,38 @@ const guardedDispatcher = new Agent({
     lookup(hostname, options, callback) {
       // Force all-address mode after spreading connector options so the
       // caller cannot downgrade us to the single-address callback form.
-      dnsLookupCallback(
-        hostname,
-        { ...options, all: true, verbatim: true },
-        (err, addresses) => {
-          if (err) {
-            callback(err as NodeJS.ErrnoException, "", 4);
-            return;
-          }
-          const list = addresses as Array<{ address: string; family: number }>;
-          if (!Array.isArray(list) || list.length === 0) {
+      dnsLookupCallback(hostname, { ...options, all: true, verbatim: true }, (err, addresses) => {
+        if (err) {
+          callback(err as NodeJS.ErrnoException, "", 4);
+          return;
+        }
+        const list = addresses as Array<{ address: string; family: number }>;
+        if (!Array.isArray(list) || list.length === 0) {
+          callback(
+            Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), {
+              code: "ENOTFOUND",
+            }),
+            "",
+            4,
+          );
+          return;
+        }
+        for (const entry of list) {
+          if (isPrivateHost(entry.address)) {
             callback(
-              Object.assign(new Error(`DNS lookup returned no addresses for ${hostname}`), {
-                code: "ENOTFOUND",
-              }),
+              Object.assign(
+                new Error(`Blocked private/reserved address: ${hostname} → ${entry.address}`),
+                { code: "ENOTFOUND" },
+              ),
               "",
               4,
             );
             return;
           }
-          for (const entry of list) {
-            if (isPrivateHost(entry.address)) {
-              callback(
-                Object.assign(
-                  new Error(`Blocked private/reserved address: ${hostname} → ${entry.address}`),
-                  { code: "ENOTFOUND" },
-                ),
-                "",
-                4,
-              );
-              return;
-            }
-          }
-          const chosen = list[0];
-          callback(null, chosen.address, chosen.family);
-        },
-      );
+        }
+        const chosen = list[0];
+        callback(null, chosen.address, chosen.family);
+      });
     },
   },
 });

--- a/apps/geolibre-desktop/vite-proxy-guard.ts
+++ b/apps/geolibre-desktop/vite-proxy-guard.ts
@@ -1,0 +1,208 @@
+/**
+ * SSRF guard for the Vite dev-server `__geolibre_*_proxy` binary proxies.
+ *
+ * Validates that a target URL is a public HTTP(S) address (not loopback,
+ * private RFC-1918, link-local, metadata, or IPv6 ULA/loopback) and follows
+ * redirects manually, re-validating each hop against the same rules.
+ *
+ * Exported so `tests/` can import and exercise the guard without pulling in
+ * the full vite.config.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+const PROXY_MAX_REDIRECT_HOPS = 5;
+const PROXY_MAX_BODY_BYTES = 50 * 1024 * 1024; // 50 MB
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Returns an error message if `urlString` is not a safe public HTTP(S) URL,
+ * or `null` when it is acceptable.
+ */
+export function validatePublicUrl(urlString: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return "Malformed URL";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return "Only http/https URLs are allowed";
+  }
+  if (parsed.username || parsed.password) {
+    return "URLs with credentials are not allowed";
+  }
+  const hostname = parsed.hostname;
+  // Strip IPv6 brackets for address checks.
+  const bare = hostname.startsWith("[") ? hostname.slice(1, -1) : hostname;
+
+  if (isPrivateHost(bare)) {
+    return `Blocked private/reserved address: ${hostname}`;
+  }
+  return null;
+}
+
+/**
+ * Throws if `urlString` is not a safe, publicly-routable HTTP(S) URL.
+ */
+export function assertPublicHttpUrl(urlString: string): void {
+  const err = validatePublicUrl(urlString);
+  if (err) throw new Error(err);
+}
+
+function isPrivateHost(host: string): boolean {
+  // Loopback names
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+
+  // IPv4 checks
+  const ipv4Parts = host.split(".");
+  if (ipv4Parts.length === 4 && ipv4Parts.every((p) => /^\d{1,3}$/.test(p))) {
+    const octets = ipv4Parts.map(Number);
+    if (octets.some((o) => o > 255)) return false; // not a valid IPv4, let DNS decide
+    return isPrivateIPv4(octets);
+  }
+
+  // IPv6 checks (bare, already stripped of brackets)
+  if (host.includes(":")) {
+    return isPrivateIPv6(host);
+  }
+
+  // DNS names like "metadata.google.internal" — block if they resolve to a
+  // known cloud metadata hostname pattern (the actual resolution to 169.254.*
+  // is caught by IPv4 checks when the caller resolves, but we block the name
+  // too for defence in depth).
+  if (host === "metadata.google.internal") return true;
+
+  return false;
+}
+
+function isPrivateIPv4(octets: number[]): boolean {
+  const [a, b] = octets;
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local / cloud metadata
+  if (a === 0) return true; // 0.0.0.0/8 "this" network
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 192 && b === 0 && octets[2] === 0) return true; // 192.0.0.0/24 IETF protocol
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && octets[2] === 100) return true; // 198.51.100.0/24 documentation
+  if (a === 203 && b === 0 && octets[2] === 113) return true; // 203.0.113.0/24 documentation
+  if (a >= 224) return true; // 224.0.0.0+ multicast + reserved
+  return false;
+}
+
+function isPrivateIPv6(addr: string): boolean {
+  const lower = addr.toLowerCase();
+
+  // Handle ::ffff:a.b.c.d mapped IPv4 (dotted-quad form)
+  const mappedDotted = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(lower);
+  if (mappedDotted) {
+    return isPrivateIPv4(mappedDotted[1].split(".").map(Number));
+  }
+
+  // Handle ::ffff:HHHH:HHHH mapped IPv4 (hex form — Node.js normalizes to this)
+  const mappedHex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(lower);
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16);
+    const lo = parseInt(mappedHex[2], 16);
+    return isPrivateIPv4([(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff]);
+  }
+
+  if (lower === "::1") return true; // loopback
+  if (lower === "::") return true; // unspecified
+  if (lower.startsWith("fe80:") || lower.startsWith("fe80::")) return true; // link-local
+  if (lower.startsWith("fc") || lower.startsWith("fd")) return true; // ULA fc00::/7
+
+  return false;
+}
+
+/**
+ * Fetch `targetUrl` with manual redirect following, re-validating each hop.
+ * Returns the final Response or throws on disallowed targets / too many hops.
+ */
+export async function fetchWithGuard(
+  targetUrl: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  assertPublicHttpUrl(targetUrl);
+
+  let current = targetUrl;
+  for (let hop = 0; hop <= PROXY_MAX_REDIRECT_HOPS; hop++) {
+    const response = await fetch(current, { ...init, redirect: "manual" });
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return response;
+    }
+    const location = response.headers.get("location");
+    if (!location) return response;
+    const next = new URL(location, current).toString();
+    assertPublicHttpUrl(next);
+    current = next;
+  }
+  throw new Error("Too many proxy redirects");
+}
+
+/**
+ * Hardened version of the Vite dev-server binary proxy handler. Validates the
+ * target URL against SSRF rules, follows redirects manually, and caps the
+ * response body size.
+ */
+export async function proxyBinaryRequestGuarded(
+  req: IncomingMessage,
+  res: ServerResponse,
+  proxyPath: string,
+): Promise<void> {
+  const requestUrl = new URL(req.url ?? "", `http://localhost${proxyPath}`);
+  const target = requestUrl.searchParams.get("url");
+  if (!target || !/^https?:\/\//i.test(target)) {
+    res.statusCode = 400;
+    res.setHeader("content-type", "text/plain");
+    res.end("Missing or invalid target URL");
+    return;
+  }
+
+  const urlErr = validatePublicUrl(target);
+  if (urlErr) {
+    res.statusCode = 502;
+    res.setHeader("content-type", "text/plain");
+    res.end(urlErr);
+    return;
+  }
+
+  const headers = new Headers();
+  const range = req.headers.range;
+  if (range) headers.set("range", range);
+
+  let response: Response;
+  try {
+    response = await fetchWithGuard(target, { headers });
+  } catch (err) {
+    res.statusCode = 502;
+    res.setHeader("content-type", "text/plain");
+    res.end(err instanceof Error ? err.message : "Upstream fetch failed");
+    return;
+  }
+
+  const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+  const buf = await response.arrayBuffer();
+  if (buf.byteLength > PROXY_MAX_BODY_BYTES) {
+    res.statusCode = 502;
+    res.setHeader("content-type", "text/plain");
+    res.end("Upstream response exceeds size limit");
+    return;
+  }
+  const body = Buffer.from(buf);
+
+  res.statusCode = response.status;
+  res.setHeader("access-control-allow-origin", "*");
+  res.setHeader("cache-control", "public, max-age=3600");
+  res.setHeader("content-type", contentType);
+  for (const header of ["accept-ranges", "content-range"]) {
+    const value = response.headers.get(header);
+    if (value) res.setHeader(header, value);
+  }
+  res.setHeader("content-length", String(body.byteLength));
+  res.end(body);
+}

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -11,6 +11,7 @@ import { bundledPlugins } from "./vite-plugins/bundled-plugins";
 import { copyCesiumAssets } from "./vite-plugins/copy-cesium-assets";
 import { copyRtlText } from "./vite-plugins/copy-rtl-text";
 import { copyVectorOps } from "./vite-plugins/copy-vector-ops";
+import { proxyBinaryRequestGuarded } from "./vite-proxy-guard";
 
 const GEOAGENT_BROWSER_BUNDLE = "maplibre-gl-geoagent/dist/browser-";
 const EARTH_ENGINE_CONTROL_BUNDLE = "maplibre-gl-earth-engine/dist/";
@@ -376,7 +377,7 @@ function wmsProxyPlugin(): Plugin {
       });
       server.middlewares.use(WFS_PROXY_PATH, async (req, res) => {
         try {
-          await proxyBinaryRequest(req, res, WFS_PROXY_PATH);
+          await proxyBinaryRequestGuarded(req, res, WFS_PROXY_PATH);
         } catch (error) {
           const message = error instanceof Error ? error.message : "WFS proxy request failed";
           res.statusCode = 502;
@@ -386,7 +387,7 @@ function wmsProxyPlugin(): Plugin {
       });
       server.middlewares.use(GPX_PROXY_PATH, async (req, res) => {
         try {
-          await proxyBinaryRequest(req, res, GPX_PROXY_PATH);
+          await proxyBinaryRequestGuarded(req, res, GPX_PROXY_PATH);
         } catch (error) {
           const message = error instanceof Error ? error.message : "GPX proxy request failed";
           res.statusCode = 502;
@@ -396,7 +397,7 @@ function wmsProxyPlugin(): Plugin {
       });
       server.middlewares.use(RASTER_PROXY_PATH, async (req, res) => {
         try {
-          await proxyBinaryRequest(req, res, RASTER_PROXY_PATH);
+          await proxyBinaryRequestGuarded(req, res, RASTER_PROXY_PATH);
         } catch (error) {
           const message = error instanceof Error ? error.message : "Raster proxy request failed";
           res.statusCode = 502;
@@ -637,46 +638,7 @@ function safeDecodeURIComponent(value: string): string {
 }
 
 async function proxyWmsRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  await proxyBinaryRequest(req, res, WMS_PROXY_PATH);
-}
-
-async function proxyBinaryRequest(
-  req: IncomingMessage,
-  res: ServerResponse,
-  proxyPath: string,
-): Promise<void> {
-  const requestUrl = new URL(req.url ?? "", `http://localhost${proxyPath}`);
-  const target = requestUrl.searchParams.get("url");
-  if (!target || !/^https?:\/\//i.test(target)) {
-    res.statusCode = 400;
-    res.setHeader("content-type", "text/plain");
-    res.end("Missing or invalid target URL");
-    return;
-  }
-
-  const headers = new Headers();
-  const range = req.headers.range;
-  if (range) headers.set("range", range);
-
-  const response = await fetch(target, { headers });
-  const contentType = response.headers.get("content-type") ?? "application/octet-stream";
-  const body = Buffer.from(await response.arrayBuffer());
-
-  res.statusCode = response.status;
-  res.setHeader("access-control-allow-origin", "*");
-  res.setHeader("cache-control", "public, max-age=3600");
-  res.setHeader("content-type", contentType);
-  for (const header of ["accept-ranges", "content-range"]) {
-    const value = response.headers.get(header);
-    if (value) res.setHeader(header, value);
-  }
-  // Derive content-length from the buffered body, never the upstream header:
-  // fetch() transparently decompresses gzip/br responses, so the upstream
-  // content-length (the compressed size) would be smaller than the body we
-  // send and truncate it in the browser. The buffer length is correct for both
-  // full (200) and partial (206 + content-range) responses.
-  res.setHeader("content-length", String(body.byteLength));
-  res.end(body);
+  await proxyBinaryRequestGuarded(req, res, WMS_PROXY_PATH);
 }
 
 // Installable, offline-capable web build. See docs/architecture.md (Offline /

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
         "shpjs": "^6.2.0",
         "sql.js": "^1.14.0",
         "three": "^0.185.1",
+        "undici": "^7.29.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -266,6 +267,15 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "apps/geolibre-desktop/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,6 @@
         "shpjs": "^6.2.0",
         "sql.js": "^1.14.0",
         "three": "^0.185.1",
-        "undici": "^7.29.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -123,6 +122,7 @@
         "postcss": "^8.5.23",
         "tailwindcss": "^4.3.0",
         "typescript": "^7.0.2",
+        "undici": "^7.29.0",
         "vite": "^8.1.5",
         "vite-plugin-pwa": "^1.3.0"
       }
@@ -273,6 +273,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -11,6 +11,11 @@ import {
   fetchAllowlistedUpstream,
   isAllowedTilesUpstreamUrl,
 } from "../workers/tiles/src/allowlisted-fetch";
+import {
+  assertPublicHttpUrl,
+  validatePublicUrl,
+  fetchWithGuard,
+} from "../apps/geolibre-desktop/vite-proxy-guard";
 
 describe("viewer proxy path sanitization", () => {
   it("accepts normal asset paths and rejects traversal", () => {
@@ -200,5 +205,177 @@ describe("tiles allowlisted fetch", () => {
     );
     assert.equal(response.status, 304);
     assert.equal(response.headers.get("etag"), '"tile-abc"');
+  });
+
+  it("accepts raw.githubusercontent.com and rejects evil redirect from it", async () => {
+    assert.equal(
+      isAllowedTilesUpstreamUrl("https://raw.githubusercontent.com/owner/repo/main/file.geojson"),
+      true,
+    );
+    assert.equal(isAllowedTilesUpstreamUrl("https://raw.githubusercontent.com/"), true);
+    assert.equal(isAllowedTilesUpstreamUrl("https://evil.githubusercontent.com/x"), false);
+
+    const fetchImpl: typeof fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://evil.example/steal" },
+      });
+    await assert.rejects(
+      () =>
+        fetchAllowlistedUpstream(
+          "https://raw.githubusercontent.com/owner/repo/main/data.geojson",
+          {},
+          fetchImpl,
+        ),
+      /non-allowlisted/,
+    );
+  });
+});
+
+describe("Vite proxy guard — validatePublicUrl", () => {
+  it("accepts public HTTP(S) URLs", () => {
+    assert.equal(validatePublicUrl("https://example.com/tiles"), null);
+    assert.equal(validatePublicUrl("http://example.com/data"), null);
+    assert.equal(validatePublicUrl("https://8.8.8.8/dns"), null);
+  });
+
+  it("rejects non-HTTP protocols", () => {
+    assert.notEqual(validatePublicUrl("ftp://example.com"), null);
+    assert.notEqual(validatePublicUrl("file:///etc/passwd"), null);
+    assert.notEqual(validatePublicUrl("data:text/html,<h1>hi</h1>"), null);
+  });
+
+  it("rejects URLs with credentials", () => {
+    assert.notEqual(validatePublicUrl("https://user:pass@example.com"), null);
+    assert.notEqual(validatePublicUrl("https://user@example.com"), null);
+  });
+
+  it("rejects localhost and .localhost", () => {
+    assert.notEqual(validatePublicUrl("http://localhost/secret"), null);
+    assert.notEqual(validatePublicUrl("http://foo.localhost/bar"), null);
+  });
+
+  it("rejects loopback IPv4 (127.0.0.0/8)", () => {
+    assert.notEqual(validatePublicUrl("http://127.0.0.1/admin"), null);
+    assert.notEqual(validatePublicUrl("http://127.0.0.2/x"), null);
+    assert.notEqual(validatePublicUrl("http://127.255.255.255"), null);
+  });
+
+  it("rejects private RFC-1918 ranges", () => {
+    assert.notEqual(validatePublicUrl("http://10.0.0.1"), null);
+    assert.notEqual(validatePublicUrl("http://172.16.0.1"), null);
+    assert.notEqual(validatePublicUrl("http://172.31.255.255"), null);
+    assert.notEqual(validatePublicUrl("http://192.168.1.1"), null);
+  });
+
+  it("rejects link-local / cloud metadata 169.254.x.x", () => {
+    assert.notEqual(validatePublicUrl("http://169.254.169.254/latest/meta-data/"), null);
+    assert.notEqual(validatePublicUrl("http://169.254.0.1"), null);
+  });
+
+  it("rejects 0.0.0.0/8 and multicast/reserved (224+)", () => {
+    assert.notEqual(validatePublicUrl("http://0.0.0.0"), null);
+    assert.notEqual(validatePublicUrl("http://224.0.0.1"), null);
+    assert.notEqual(validatePublicUrl("http://255.255.255.255"), null);
+  });
+
+  it("rejects CGNAT (100.64.0.0/10) and benchmarking (198.18.0.0/15)", () => {
+    assert.notEqual(validatePublicUrl("http://100.64.0.1"), null);
+    assert.notEqual(validatePublicUrl("http://100.127.255.254"), null);
+    assert.notEqual(validatePublicUrl("http://198.18.0.1"), null);
+    assert.notEqual(validatePublicUrl("http://198.19.255.254"), null);
+  });
+
+  it("rejects IPv6 loopback, link-local, and ULA", () => {
+    assert.notEqual(validatePublicUrl("http://[::1]"), null);
+    assert.notEqual(validatePublicUrl("http://[::]"), null);
+    assert.notEqual(validatePublicUrl("http://[fe80::1]"), null);
+    assert.notEqual(validatePublicUrl("http://[fd00::1]"), null);
+    assert.notEqual(validatePublicUrl("http://[fc00::1]"), null);
+  });
+
+  it("rejects IPv4-mapped IPv6 private addresses", () => {
+    assert.notEqual(validatePublicUrl("http://[::ffff:127.0.0.1]"), null);
+    assert.notEqual(validatePublicUrl("http://[::ffff:169.254.169.254]"), null);
+    assert.notEqual(validatePublicUrl("http://[::ffff:10.0.0.1]"), null);
+  });
+
+  it("rejects metadata.google.internal", () => {
+    assert.notEqual(validatePublicUrl("http://metadata.google.internal/v1/"), null);
+  });
+
+  it("allows non-private 172.x addresses outside 172.16-31", () => {
+    assert.equal(validatePublicUrl("http://172.15.0.1"), null);
+    assert.equal(validatePublicUrl("http://172.32.0.1"), null);
+  });
+});
+
+describe("Vite proxy guard — assertPublicHttpUrl", () => {
+  it("throws on private URLs", () => {
+    assert.throws(() => assertPublicHttpUrl("http://127.0.0.1"), /private|reserved|Blocked/i);
+    assert.throws(
+      () => assertPublicHttpUrl("http://169.254.169.254/latest/meta-data/"),
+      /private|reserved|Blocked/i,
+    );
+  });
+
+  it("does not throw on public URLs", () => {
+    assert.doesNotThrow(() => assertPublicHttpUrl("https://example.com/tiles"));
+    assert.doesNotThrow(() => assertPublicHttpUrl("https://8.8.8.8/dns"));
+  });
+});
+
+describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
+  it("follows a public redirect and refuses a private-address redirect", async () => {
+    const originalFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        assert.equal((init as Record<string, string> | undefined)?.redirect, "manual");
+        if (url === "https://example.com/a") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://example.com/b" },
+          });
+        }
+        if (url === "https://example.com/b") {
+          return new Response("ok", { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }) as typeof fetch;
+
+      const resp = await fetchWithGuard("https://example.com/a");
+      assert.equal(resp.status, 200);
+      assert.equal(await resp.text(), "ok");
+
+      globalThis.fetch = (async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "http://169.254.169.254/latest/meta-data/" },
+        })) as typeof fetch;
+
+      await assert.rejects(() => fetchWithGuard("https://example.com/evil"), /Blocked/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("caps redirect hops", async () => {
+    const originalFetch = globalThis.fetch;
+    let hops = 0;
+    try {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        hops++;
+        return new Response(null, {
+          status: 302,
+          headers: { location: `${String(input)}?n=${hops}` },
+        });
+      }) as typeof fetch;
+
+      await assert.rejects(() => fetchWithGuard("https://example.com/loop"), /Too many/);
+      assert.equal(hops, 6); // 0..5 inclusive = 6 fetches
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -13,8 +13,11 @@ import {
 } from "../workers/tiles/src/allowlisted-fetch";
 import {
   assertPublicHttpUrl,
-  validatePublicUrl,
+  assertResolvedPublicHost,
   fetchWithGuard,
+  PROXY_MAX_BODY_BYTES,
+  readBodyWithLimit,
+  validatePublicUrl,
 } from "../apps/geolibre-desktop/vite-proxy-guard";
 
 describe("viewer proxy path sanitization", () => {
@@ -250,6 +253,11 @@ describe("Vite proxy guard — validatePublicUrl", () => {
     assert.notEqual(validatePublicUrl("https://user@example.com"), null);
   });
 
+  it("rejects non-default ports", () => {
+    assert.notEqual(validatePublicUrl("https://example.com:8443/tiles"), null);
+    assert.notEqual(validatePublicUrl("http://8.8.8.8:8080/dns"), null);
+  });
+
   it("rejects localhost and .localhost", () => {
     assert.notEqual(validatePublicUrl("http://localhost/secret"), null);
     assert.notEqual(validatePublicUrl("http://foo.localhost/bar"), null);
@@ -279,17 +287,22 @@ describe("Vite proxy guard — validatePublicUrl", () => {
     assert.notEqual(validatePublicUrl("http://255.255.255.255"), null);
   });
 
-  it("rejects CGNAT (100.64.0.0/10) and benchmarking (198.18.0.0/15)", () => {
+  it("rejects CGNAT, benchmarking, and all three TEST-NET ranges", () => {
     assert.notEqual(validatePublicUrl("http://100.64.0.1"), null);
     assert.notEqual(validatePublicUrl("http://100.127.255.254"), null);
     assert.notEqual(validatePublicUrl("http://198.18.0.1"), null);
     assert.notEqual(validatePublicUrl("http://198.19.255.254"), null);
+    assert.notEqual(validatePublicUrl("http://192.0.2.1"), null); // TEST-NET-1
+    assert.notEqual(validatePublicUrl("http://198.51.100.1"), null); // TEST-NET-2
+    assert.notEqual(validatePublicUrl("http://203.0.113.1"), null); // TEST-NET-3
   });
 
-  it("rejects IPv6 loopback, link-local, and ULA", () => {
+  it("rejects IPv6 loopback, full fe80::/10 link-local, and ULA", () => {
     assert.notEqual(validatePublicUrl("http://[::1]"), null);
     assert.notEqual(validatePublicUrl("http://[::]"), null);
     assert.notEqual(validatePublicUrl("http://[fe80::1]"), null);
+    assert.notEqual(validatePublicUrl("http://[fe90::1]"), null); // still in fe80::/10
+    assert.notEqual(validatePublicUrl("http://[febf::1]"), null); // top of fe80::/10
     assert.notEqual(validatePublicUrl("http://[fd00::1]"), null);
     assert.notEqual(validatePublicUrl("http://[fc00::1]"), null);
   });
@@ -325,57 +338,94 @@ describe("Vite proxy guard — assertPublicHttpUrl", () => {
   });
 });
 
+describe("Vite proxy guard — assertResolvedPublicHost", () => {
+  it("rejects private IP literals without DNS", async () => {
+    await assert.rejects(() => assertResolvedPublicHost("127.0.0.1"), /Blocked/);
+    await assert.rejects(() => assertResolvedPublicHost("169.254.169.254"), /Blocked/);
+  });
+
+  it("accepts a public IP literal", async () => {
+    await assertResolvedPublicHost("8.8.8.8");
+  });
+});
+
+describe("Vite proxy guard — readBodyWithLimit", () => {
+  it("rejects an oversized Content-Length before reading", async () => {
+    const response = new Response("ignored", {
+      headers: { "content-length": String(PROXY_MAX_BODY_BYTES + 1) },
+    });
+    await assert.rejects(() => readBodyWithLimit(response), /size limit/);
+  });
+
+  it("aborts when streamed bytes exceed the limit", async () => {
+    const chunk = new Uint8Array(1024).fill(1);
+    let remaining = 3;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (remaining-- > 0) {
+          controller.enqueue(chunk);
+        } else {
+          controller.close();
+        }
+      },
+    });
+    const response = new Response(stream);
+    await assert.rejects(() => readBodyWithLimit(response, 1500), /size limit/);
+  });
+
+  it("returns the full body when under the limit", async () => {
+    const response = new Response("hello", { headers: { "content-length": "5" } });
+    const buf = await readBodyWithLimit(response, 100);
+    assert.equal(buf.toString("utf8"), "hello");
+  });
+});
+
 describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
   it("follows a public redirect and refuses a private-address redirect", async () => {
-    const originalFetch = globalThis.fetch;
-    try {
-      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = String(input);
-        assert.equal((init as Record<string, string> | undefined)?.redirect, "manual");
-        if (url === "https://example.com/a") {
-          return new Response(null, {
-            status: 302,
-            headers: { location: "https://example.com/b" },
-          });
-        }
-        if (url === "https://example.com/b") {
-          return new Response("ok", { status: 200 });
-        }
-        return new Response("unexpected", { status: 500 });
-      }) as typeof fetch;
-
-      const resp = await fetchWithGuard("https://example.com/a");
-      assert.equal(resp.status, 200);
-      assert.equal(await resp.text(), "ok");
-
-      globalThis.fetch = (async () =>
-        new Response(null, {
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      assert.equal(init?.redirect, "manual");
+      if (url === "https://example.com/a") {
+        return new Response(null, {
           status: 302,
-          headers: { location: "http://169.254.169.254/latest/meta-data/" },
-        })) as typeof fetch;
+          headers: { location: "https://example.com/b" },
+        });
+      }
+      if (url === "https://example.com/b") {
+        return new Response("ok", { status: 200 });
+      }
+      return new Response("unexpected", { status: 500 });
+    };
 
-      await assert.rejects(() => fetchWithGuard("https://example.com/evil"), /Blocked/);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    const resp = await fetchWithGuard("https://example.com/a", {}, { fetchImpl });
+    assert.equal(resp.status, 200);
+    assert.equal(await resp.text(), "ok");
+
+    const evil: typeof fetch = async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data/" },
+      });
+    await assert.rejects(
+      () => fetchWithGuard("https://example.com/evil", {}, { fetchImpl: evil }),
+      /Blocked/,
+    );
   });
 
   it("caps redirect hops", async () => {
-    const originalFetch = globalThis.fetch;
     let hops = 0;
-    try {
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        hops++;
-        return new Response(null, {
-          status: 302,
-          headers: { location: `${String(input)}?n=${hops}` },
-        });
-      }) as typeof fetch;
+    const fetchImpl: typeof fetch = async (input) => {
+      hops++;
+      return new Response(null, {
+        status: 302,
+        headers: { location: `${String(input)}?n=${hops}` },
+      });
+    };
 
-      await assert.rejects(() => fetchWithGuard("https://example.com/loop"), /Too many/);
-      assert.equal(hops, 6); // 0..5 inclusive = 6 fetches
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await assert.rejects(
+      () => fetchWithGuard("https://example.com/loop", {}, { fetchImpl }),
+      /Too many/,
+    );
+    assert.equal(hops, 6); // 0..5 inclusive = 6 fetches
   });
 });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -424,7 +424,8 @@ describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
         headers: { location: "http://169.254.169.254/latest/meta-data/" },
       });
     await assert.rejects(
-      () => fetchWithGuard("https://example.com/evil", {}, { fetchImpl: evil, lookup: publicLookup }),
+      () =>
+        fetchWithGuard("https://example.com/evil", {}, { fetchImpl: evil, lookup: publicLookup }),
       /Blocked/,
     );
   });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -392,6 +392,8 @@ describe("Vite proxy guard — readBodyWithLimit", () => {
 });
 
 describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
+  const publicLookup = (async () => [{ address: "93.184.216.34", family: 4 as const }]) as never;
+
   it("follows a public redirect and refuses a private-address redirect", async () => {
     const fetchImpl: typeof fetch = async (input, init) => {
       const url = String(input);
@@ -408,7 +410,11 @@ describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
       return new Response("unexpected", { status: 500 });
     };
 
-    const resp = await fetchWithGuard("https://example.com/a", {}, { fetchImpl });
+    const resp = await fetchWithGuard(
+      "https://example.com/a",
+      {},
+      { fetchImpl, lookup: publicLookup },
+    );
     assert.equal(resp.status, 200);
     assert.equal(await resp.text(), "ok");
 
@@ -418,7 +424,7 @@ describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
         headers: { location: "http://169.254.169.254/latest/meta-data/" },
       });
     await assert.rejects(
-      () => fetchWithGuard("https://example.com/evil", {}, { fetchImpl: evil }),
+      () => fetchWithGuard("https://example.com/evil", {}, { fetchImpl: evil, lookup: publicLookup }),
       /Blocked/,
     );
   });
@@ -434,9 +440,23 @@ describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
     };
 
     await assert.rejects(
-      () => fetchWithGuard("https://example.com/loop", {}, { fetchImpl }),
+      () => fetchWithGuard("https://example.com/loop", {}, { fetchImpl, lookup: publicLookup }),
       /Too many/,
     );
     assert.equal(hops, PROXY_MAX_REDIRECT_HOPS + 1);
+  });
+
+  it("still resolves DNS when a test fetchImpl is injected", async () => {
+    let called = false;
+    const fetchImpl: typeof fetch = async () => {
+      called = true;
+      return new Response("should not run", { status: 200 });
+    };
+    const lookup = (async () => [{ address: "10.0.0.5", family: 4 as const }]) as never;
+    await assert.rejects(
+      () => fetchWithGuard("https://evil.example/x", {}, { fetchImpl, lookup }),
+      /10\.0\.0\.5/,
+    );
+    assert.equal(called, false);
   });
 });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -16,6 +16,7 @@ import {
   assertResolvedPublicHost,
   fetchWithGuard,
   PROXY_MAX_BODY_BYTES,
+  PROXY_MAX_REDIRECT_HOPS,
   readBodyWithLimit,
   validatePublicUrl,
 } from "../apps/geolibre-desktop/vite-proxy-guard";
@@ -254,8 +255,8 @@ describe("Vite proxy guard — validatePublicUrl", () => {
   });
 
   it("rejects non-default ports", () => {
-    assert.notEqual(validatePublicUrl("https://example.com:8443/tiles"), null);
-    assert.notEqual(validatePublicUrl("http://8.8.8.8:8080/dns"), null);
+    assert.match(validatePublicUrl("https://example.com:8443/tiles") ?? "", /port/i);
+    assert.match(validatePublicUrl("http://8.8.8.8:8080/dns") ?? "", /port/i);
   });
 
   it("rejects localhost and .localhost", () => {
@@ -347,6 +348,19 @@ describe("Vite proxy guard — assertResolvedPublicHost", () => {
   it("accepts a public IP literal", async () => {
     await assertResolvedPublicHost("8.8.8.8");
   });
+
+  it("rejects a DNS name that resolves to a private address", async () => {
+    const lookup = (async () => [{ address: "10.0.0.5", family: 4 as const }]) as never;
+    await assert.rejects(
+      () => assertResolvedPublicHost("evil.example", lookup),
+      /10\.0\.0\.5/,
+    );
+  });
+
+  it("rejects an empty DNS result", async () => {
+    const lookup = (async () => []) as never;
+    await assert.rejects(() => assertResolvedPublicHost("empty.example", lookup), /no addresses/);
+  });
 });
 
 describe("Vite proxy guard — readBodyWithLimit", () => {
@@ -426,6 +440,6 @@ describe("Vite proxy guard — fetchWithGuard redirect policy", () => {
       () => fetchWithGuard("https://example.com/loop", {}, { fetchImpl }),
       /Too many/,
     );
-    assert.equal(hops, 6); // 0..5 inclusive = 6 fetches
+    assert.equal(hops, PROXY_MAX_REDIRECT_HOPS + 1);
   });
 });

--- a/tests/edge-proxy-redirect.test.ts
+++ b/tests/edge-proxy-redirect.test.ts
@@ -351,10 +351,7 @@ describe("Vite proxy guard — assertResolvedPublicHost", () => {
 
   it("rejects a DNS name that resolves to a private address", async () => {
     const lookup = (async () => [{ address: "10.0.0.5", family: 4 as const }]) as never;
-    await assert.rejects(
-      () => assertResolvedPublicHost("evil.example", lookup),
-      /10\.0\.0\.5/,
-    );
+    await assert.rejects(() => assertResolvedPublicHost("evil.example", lookup), /10\.0\.0\.5/);
   });
 
   it("rejects an empty DNS result", async () => {

--- a/workers/tiles/src/allowlisted-fetch.ts
+++ b/workers/tiles/src/allowlisted-fetch.ts
@@ -18,6 +18,7 @@ export const TILES_ALLOWED_URL_PREFIXES = [
   "https://source.coop/",
   "https://build.protomaps.com/",
   "https://planetarymaps.usgs.gov/",
+  "https://raw.githubusercontent.com/",
 ] as const;
 
 /** @deprecated Prefer {@link TILES_ALLOWED_URL_PREFIXES}; kept for tests/docs. */

--- a/workers/tiles/src/index.ts
+++ b/workers/tiles/src/index.ts
@@ -659,7 +659,7 @@ export default {
         const rawUrl = new URL(
           `https://raw.githubusercontent.com/${parts[0]}/${parts[1]}/${parts.slice(3).join("/")}`,
         );
-        originResponse = await fetch(rawUrl.toString(), {
+        originResponse = await fetchAllowlistedUpstream(rawUrl.toString(), {
           headers: { accept: "application/octet-stream" },
         });
       } catch {


### PR DESCRIPTION
## Summary
- Guard the Vite `__geolibre_*_proxy` helpers against private/metadata targets and redirect pivots (manual hops + re-validate).
- Fetch tiles `/github-raw` through `fetchAllowlistedUpstream` with `raw.githubusercontent.com` on the prefix allowlist.

## Test plan
- [x] `node --import tsx --test tests/edge-proxy-redirect.test.ts`
- [x] Hit a Vite proxy with a public URL and confirm it still works in `npm run dev`
- [x] Confirm a private/metadata `url=` is refused
- [x] Confirm github-raw still serves an allowlisted raw file and refuses an evil redirect Location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protected proxy handling for map services, GPX files, raster imagery, and other binary resources.
  * Added support for retrieving approved raw GitHub-hosted files through the tile service.
* **Bug Fixes**
  * Blocked requests to private, local, reserved, and metadata endpoints.
  * Added validation for redirects, with unsafe destinations rejected and redirect chains limited.
  * Improved handling of failed, timed-out, or oversized upstream responses.
  * Preserved supported range requests and relevant upstream response headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->