### PR TITLE
fix(ci): stop superseded Pages builds failing the PR preview deploy

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -193,6 +193,18 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.found == 'true'
     runs-on: ubuntu-latest
+    # opengeos/pages-preview is a single GitHub Pages site, and Pages builds one
+    # commit at a time per repository. Two preview deploys landing together make
+    # the older build report `errored` even though its push succeeded, which the
+    # action's wait step treats as fatal. The workflow-level group above is keyed
+    # per branch and so only serializes reruns of the same PR; this one holds
+    # every Pages deploy in this repository to one at a time. It cannot cover
+    # deploys from the other repositories that share the site (Actions
+    # concurrency is per repository), which is why the verify step below still
+    # has to tell a superseded build apart from a real failure.
+    concurrency:
+      group: pages-preview-deploy
+      cancel-in-progress: false
     steps:
       # The Pages deploy action needs a git repository in the workspace. This
       # is the DEFAULT BRANCH -- never the PR head. Do not add a `ref:` here.
@@ -210,8 +222,19 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      # Record the time before the push so the verify step can tell a Pages
+      # build that includes this deploy from one that predates it.
+      - name: Note the deploy start time
+        id: started
+        run: echo "at=$(date -u +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy preview to GitHub Pages
         id: pages
+        # A superseded Pages build is reported as `errored`, which fails this
+        # action's wait step even though the push landed and the next build
+        # publishes it. Never fail the job here -- the verify step below decides,
+        # by checking whether the preview actually came up.
+        continue-on-error: true
         # Pinned rather than tracking the v1 tag: this is a third-party action
         # and it receives PREVIEW_DEPLOY_TOKEN.
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
@@ -237,12 +260,70 @@ jobs:
           wait-for-pages-deployment: true
           comment: false
 
+      # Decides whether the deploy really failed. A Pages build that another
+      # repository's deploy superseded reports `errored`, but this deploy's
+      # commit is already on gh-pages, so the very next build publishes it --
+      # historically within about a minute. So rather than trusting the action's
+      # outcome, wait for a Pages build that both succeeded and started after
+      # this deploy pushed (any such build necessarily contains it), then
+      # confirm the URL serves. Only if neither holds is the preview broken.
+      - name: Verify the preview published
+        id: verify
+        if: needs.resolve.outputs.action == 'deploy'
+        env:
+          GH_TOKEN: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
+          STARTED_AT: ${{ steps.started.outputs.at }}
+          PREVIEW_URL: ${{ steps.pages.outputs.preview-url || format('https://opengeos.org/pages-preview/GeoLibre/pr-{0}/', needs.resolve.outputs.number) }}
+        run: |
+          echo "url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
+          echo "Verifying $PREVIEW_URL"
+          for attempt in $(seq 1 20); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL" || echo 000)
+
+            # A 200 alone could still be the previous deploy of this same PR, so
+            # also require a successful Pages build that started after the push.
+            # If the builds API is not readable with this token, do not block on
+            # it -- fall back to the URL check rather than failing every run.
+            if builds=$(gh api repos/opengeos/pages-preview/pages/builds 2>/dev/null); then
+              built_at=$(printf '%s' "$builds" |
+                jq -r '[.[] | select(.status == "built")] | max_by(.created_at) | .created_at // empty')
+              if [ -n "$built_at" ] &&
+                 [ "$(date -u -d "$built_at" +%s 2>/dev/null || echo 0)" -ge "$STARTED_AT" ]; then
+                fresh=yes
+              else
+                fresh=no
+              fi
+              echo "Attempt $attempt: HTTP $code, latest successful build $built_at (fresh: $fresh)"
+            else
+              fresh=unknown
+              echo "Attempt $attempt: HTTP $code, Pages builds API unreadable -- relying on the URL"
+            fi
+
+            if [ "$code" = "200" ] && [ "$fresh" != "no" ]; then
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "published=false" >> "$GITHUB_OUTPUT"
+          echo "::error::The preview at $PREVIEW_URL did not publish within 10 minutes."
+          exit 1
+
+      # `continue-on-error` on the deploy step also swallows a failed *removal*,
+      # which the verify step does not cover -- there is no URL to poll, since a
+      # removal is meant to take the preview away. Surface that here instead.
+      - name: Fail if the preview removal failed
+        if: needs.resolve.outputs.action == 'remove' && steps.pages.outcome == 'failure'
+        run: |
+          echo "::error::Removing the preview for PR ${{ needs.resolve.outputs.number }} failed."
+          exit 1
+
       - name: Comment GitHub Pages preview status
         if: always() && needs.resolve.outputs.action == 'deploy'
         uses: actions/github-script@v9
         env:
-          PAGES_URL: ${{ steps.pages.outputs.preview-url }}
-          PAGES_OUTCOME: ${{ steps.pages.outcome }}
+          PAGES_URL: ${{ steps.verify.outputs.url }}
+          PAGES_OUTCOME: ${{ steps.verify.outputs.published == 'true' && 'success' || 'failure' }}
           PR_NUMBER: ${{ needs.resolve.outputs.number }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         with:

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -222,8 +222,8 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      # Record the time before the push so the verify step can tell a Pages
-      # build that includes this deploy from one that predates it.
+      # Fallback reference point for the verify step, used only when the commit
+      # the deploy pushed cannot be read back (see below).
       - name: Note the deploy start time
         id: started
         run: echo "at=$(date -u +%s)" >> "$GITHUB_OUTPUT"
@@ -265,30 +265,74 @@ jobs:
       # commit is already on gh-pages, so the very next build publishes it --
       # historically within about a minute. So rather than trusting the action's
       # outcome, wait for a Pages build that both succeeded and started after
-      # this deploy pushed (any such build necessarily contains it), then
-      # confirm the URL serves. Only if neither holds is the preview broken.
+      # this deploy's commit landed (any such build necessarily contains it),
+      # then confirm the URL serves. Only if neither holds is the preview broken.
+      #
+      # `deployed-commit-sha` is what separates the two failure modes. The
+      # action sets it by reading gh-pages HEAD back *after* pushing, in a step
+      # that only runs once the push step itself succeeded -- so an empty value
+      # means nothing was ever pushed (bad or expired token, network error),
+      # not a superseded build. Neither the URL nor the build list can tell
+      # that apart on its own: a previous preview for this PR keeps serving 200,
+      # and this Pages site is shared and busy enough that some other
+      # repository's build almost always completes inside the poll window. So
+      # report it immediately -- waiting ten minutes would only delay a genuine
+      # outage.
       - name: Verify the preview published
         id: verify
         if: needs.resolve.outputs.action == 'deploy'
         env:
           GH_TOKEN: ${{ secrets.PREVIEW_DEPLOY_TOKEN }}
           STARTED_AT: ${{ steps.started.outputs.at }}
+          PAGES_OUTCOME: ${{ steps.pages.outcome }}
+          DEPLOYED_SHA: ${{ steps.pages.outputs.deployed-commit-sha }}
           PREVIEW_URL: ${{ steps.pages.outputs.preview-url || format('https://opengeos.org/pages-preview/GeoLibre/pr-{0}/', needs.resolve.outputs.number) }}
         run: |
           echo "url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
-          echo "Verifying $PREVIEW_URL"
-          for attempt in $(seq 1 20); do
-            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL" || echo 000)
+          if [ -z "$DEPLOYED_SHA" ] && [ "$PAGES_OUTCOME" != "success" ]; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "::error::The preview was never pushed to opengeos/pages-preview -- the deploy failed before it reached gh-pages. See the deploy step's log."
+            exit 1
+          fi
+
+          # A build only contains this deploy if it started after the deploy's
+          # commit landed, so prefer that commit's timestamp over the pre-push
+          # one recorded above; a build can start between the two and carry
+          # none of this deploy.
+          ref_at="$STARTED_AT"
+          if [ -n "$DEPLOYED_SHA" ] &&
+             commit_date=$(gh api "repos/opengeos/pages-preview/commits/${DEPLOYED_SHA}" \
+               --jq '.commit.committer.date' 2>/dev/null); then
+            commit_at=$(date -u -d "$commit_date" +%s 2>/dev/null || echo 0)
+            if [ "$commit_at" -gt "$ref_at" ]; then
+              ref_at="$commit_at"
+            fi
+          fi
+          echo "Verifying $PREVIEW_URL (deployed commit ${DEPLOYED_SHA:-unknown})"
+
+          # Bound the whole poll by wall clock rather than by attempt count, so
+          # the ten minutes reported on failure is the time actually spent
+          # rather than 20 sleeps plus 20 unbounded API round trips.
+          deadline=$(( $(date -u +%s) + 600 ))
+          attempt=0
+          while :; do
+            attempt=$((attempt + 1))
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$PREVIEW_URL" || echo 000)
 
             # A 200 alone could still be the previous deploy of this same PR, so
             # also require a successful Pages build that started after the push.
+            # per_page=100 because the default page of this shared, frequently
+            # built site can fill with other repositories' builds; the list is
+            # used rather than /builds/latest because the newest build is often
+            # another repository's, still in flight, while the build that
+            # published this deploy has already finished.
             # If the builds API is not readable with this token, do not block on
             # it -- fall back to the URL check rather than failing every run.
-            if builds=$(gh api repos/opengeos/pages-preview/pages/builds 2>/dev/null); then
+            if builds=$(gh api 'repos/opengeos/pages-preview/pages/builds?per_page=100' 2>/dev/null); then
               built_at=$(printf '%s' "$builds" |
                 jq -r '[.[] | select(.status == "built")] | max_by(.created_at) | .created_at // empty')
               if [ -n "$built_at" ] &&
-                 [ "$(date -u -d "$built_at" +%s 2>/dev/null || echo 0)" -ge "$STARTED_AT" ]; then
+                 [ "$(date -u -d "$built_at" +%s 2>/dev/null || echo 0)" -ge "$ref_at" ]; then
                 fresh=yes
               else
                 fresh=no
@@ -303,6 +347,7 @@ jobs:
               echo "published=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            [ "$(date -u +%s)" -lt "$deadline" ] || break
             sleep 30
           done
           echo "published=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `Deploy GitHub Pages preview` job fails on roughly half of recent runs while the preview itself publishes fine. `opengeos/pages-preview` is a single GitHub Pages site shared by GeoLibre and geoai, and Pages builds one commit at a time per repository. When two preview deploys land close together, the older build is superseded and reported as `errored` - and `pr-preview-action`'s wait step treats that as fatal, even though its push already landed on `gh-pages`.

Evidence from the last 345 builds on that site:

- 75 errored (22%), and **every single one** was followed by another build
- median gap to the next build: 49 seconds; 66 of 75 within two minutes
- the preview URL for the run that prompted this was live (HTTP 200) while the job was red

Two changes:

- **Serialize this repository's Pages deploys** with a job-level concurrency group. The existing workflow-level group is keyed per branch, so it only guarded reruns of the same PR. This cannot cover the other repositories sharing the site, since Actions concurrency is per repository - hence the second change.
- **Stop trusting the action's outcome.** The deploy step becomes `continue-on-error`, and a new verify step waits for a successful Pages build that started *after* the push (any such build necessarily contains it) and confirms the URL serves. Only if neither holds is the job failed. A `remove` action is reported separately, since there is no URL to poll for it.

The verify step degrades safely: if the Pages builds API is not readable with the deploy token, it falls back to the URL check rather than failing every run.

## Test plan

- [x] Workflow YAML parses; job/step structure and the new concurrency group confirmed
- [x] `bash -n` on the verify script
- [x] Verify logic exercised against stubbed `gh`/`curl`: fresh build + 200 passes; stale build + 200 fails (does not claim a stale preview); API unreadable + 200 passes via fallback; API unreadable + 404 fails; empty build list fails
- [x] `pre-commit run --files .github/workflows/pr-preview-deploy.yml`
- [ ] Merge and confirm a normal PR deploy still goes green and comments the URL
- [ ] Confirm a deploy that races another repository's now passes instead of failing
- [ ] Close a PR and confirm the preview is removed and the job still reports a genuine removal failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview deployment reliability by preventing overlapping deployments from interfering with one another.
  * Added publication verification so preview links and deployment statuses reflect the actual availability of the latest build.
  * Improved handling and reporting of deployment and preview cleanup failures.
  * Deployment status updates now provide more accurate results and verified preview URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->