### PR TITLE
fix: resolve relative style/tileset URLs for OGC vector tiles

### DIFF
--- a/apps/geolibre-desktop/src/lib/ogc-json.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-json.ts
@@ -80,6 +80,38 @@ async function responseStatusError(response: Response): Promise<Error> {
 }
 
 /**
+ * Throws when a 2xx JSON document is really an Esri error report.
+ *
+ * ArcGIS answers a missing, renamed, or token-protected service with HTTP
+ * **200** and `{"error":{"code":404,"message":"Requested Service not
+ * available."}}`, so `response.ok` is true and the body parses cleanly. Left
+ * undetected it reaches the caller as a valid-but-empty document and surfaces
+ * as a misleading downstream complaint ("no source layers") instead of the
+ * actual cause.
+ *
+ * The shape is checked, not just the key: a legitimate document is free to
+ * carry an `error` property of some other form, so an object with a `message`
+ * or a numeric `code` is required before the document is rejected.
+ */
+function assertNoServiceError(doc: unknown): void {
+  const error = (doc as { error?: unknown } | null | undefined)?.error;
+  if (!error || typeof error !== "object" || Array.isArray(error)) return;
+  const { message, code, details } = error as {
+    message?: unknown;
+    code?: unknown;
+    details?: unknown;
+  };
+  const hasMessage = typeof message === "string" && message.trim() !== "";
+  if (!hasMessage && typeof code !== "number") return;
+  // `details` is an array of extra lines; append it when it adds anything.
+  const detail = Array.isArray(details)
+    ? details.filter((line): line is string => typeof line === "string" && line.trim() !== "")
+    : [];
+  const text = hasMessage ? (message as string).trim() : `Service error ${String(code)}`;
+  throw new Error([text, ...detail].join(" ").slice(0, 300));
+}
+
+/**
  * Fetches and parses a remote JSON document, working around cross-origin limits
  * (see the module comment). When the caller passes a `signal` it owns the
  * deadline (callers that issue several requests share one across them);
@@ -106,7 +138,11 @@ export async function fetchOgcJson(
     try {
       const bytes = await Promise.race([bytesPromise, rejectOnAbort(abort)]);
       const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-      return JSON.parse(new TextDecoder().decode(array));
+      const doc = JSON.parse(new TextDecoder().decode(array));
+      // `normalizeFetchError` passes an Error through unchanged, so the service
+      // error message survives the catch below.
+      assertNoServiceError(doc);
+      return doc;
     } catch (error) {
       throw normalizeFetchError(error);
     }
@@ -122,5 +158,7 @@ export async function fetchOgcJson(
   if (!response.ok) {
     throw await responseStatusError(response);
   }
-  return response.json();
+  const doc = await response.json();
+  assertNoServiceError(doc);
+  return doc;
 }

--- a/apps/geolibre-desktop/src/lib/ogc-json.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-json.ts
@@ -90,8 +90,10 @@ async function responseStatusError(response: Response): Promise<Error> {
  * actual cause.
  *
  * The shape is checked, not just the key: a legitimate document is free to
- * carry an `error` property of some other form, so an object with a `message`
- * or a numeric `code` is required before the document is rejected.
+ * carry an `error` property of some other form, so a `message` or a reported
+ * `code` is required before the document is rejected. `code: 0` conventionally
+ * means success, so it is not on its own a failure; a string code
+ * (`{"code":"NotFound"}`) is as much a report as a numeric one.
  */
 function assertNoServiceError(doc: unknown): void {
   const error = (doc as { error?: unknown } | null | undefined)?.error;
@@ -102,12 +104,14 @@ function assertNoServiceError(doc: unknown): void {
     details?: unknown;
   };
   const hasMessage = typeof message === "string" && message.trim() !== "";
-  if (!hasMessage && typeof code !== "number") return;
+  const hasCode =
+    (typeof code === "number" && code !== 0) || (typeof code === "string" && code.trim() !== "");
+  if (!hasMessage && !hasCode) return;
   // `details` is an array of extra lines; append it when it adds anything.
   const detail = Array.isArray(details)
     ? details.filter((line): line is string => typeof line === "string" && line.trim() !== "")
     : [];
-  const text = hasMessage ? (message as string).trim() : `Service error ${String(code)}`;
+  const text = hasMessage ? message.trim() : `Service error ${String(code).trim()}`;
   throw new Error([text, ...detail].join(" ").slice(0, 300));
 }
 

--- a/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/ogc-vector-tiles.ts
@@ -72,6 +72,12 @@ function asBounds(value: unknown): [number, number, number, number] | undefined 
   return undefined;
 }
 
+/** Whether a reference already carries a scheme (or is protocol-relative), and
+ * so needs no resolution against the document it was read from. */
+function isAbsoluteUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value) || value.startsWith("//");
+}
+
 /** Non-empty string tile templates from an unknown `tiles` value. */
 function asTiles(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
@@ -251,6 +257,19 @@ export function tileJsonConfig(
   ) {
     config.center = center as number[];
   }
+  // An Esri `VectorTileServer` document is TileJSON-shaped enough to read
+  // (`name`, `maxzoom`) but lists its tiles relatively — `tile/{z}/{y}/{x}.pbf`.
+  // MapLibre would resolve those against the app origin, so when the document
+  // carries relative templates, hand it explicit absolute `tiles` instead of the
+  // document URL. Absolute templates are left alone so a conforming TileJSON
+  // keeps being loaded by MapLibre itself (it re-reads more than is copied here).
+  const tiles = asTiles(tilejson.tiles);
+  if (tiles?.some((tile) => !isAbsoluteUrl(tile))) {
+    config.tiles = tiles.map((tile) =>
+      normalizeTilePlaceholders(resolveDocumentUrl(tile, tilejsonUrl)),
+    );
+    delete config.url;
+  }
   const sourceLayers = vectorLayerIds(tilejson);
   if (sourceLayers.length > 0) config.sourceLayers = sourceLayers;
   return config;
@@ -261,6 +280,35 @@ export function tileJsonConfig(
  * verbatim and silently fail to load. */
 function normalizeTilePlaceholders(url: string): string {
   return url.replace(/\{z\}/gi, "{z}").replace(/\{x\}/gi, "{x}").replace(/\{y\}/gi, "{y}");
+}
+
+/**
+ * Resolves a reference taken out of a fetched document against that document's
+ * own URL.
+ *
+ * Style and service documents routinely use relative references: every Esri
+ * vector tile style declares its tileset as `{"type":"vector","url":"../../"}`,
+ * and an Esri `VectorTileServer` document lists `tiles:
+ * ["tile/{z}/{y}/{x}.pbf"]`. MapLibre resolves whatever it is handed against
+ * the *app* origin rather than the document it came from, so passing such a
+ * value through verbatim requests the wrong host entirely — the layer is added
+ * and then silently renders nothing (GeoLibre#1639).
+ *
+ * `URL` percent-encodes the `{`/`}` of a tile template, which would defeat
+ * MapLibre's placeholder substitution, so the braces are restored afterwards.
+ *
+ * @param value - The (possibly relative) reference read from the document.
+ * @param baseUrl - The URL the document was fetched from.
+ * @returns The absolute URL, or the trimmed input when it cannot be resolved.
+ */
+export function resolveDocumentUrl(value: string, baseUrl?: string): string {
+  const trimmed = value.trim();
+  if (trimmed === "" || !baseUrl) return trimmed;
+  try {
+    return new URL(trimmed, baseUrl).toString().replace(/%7B/gi, "{").replace(/%7D/gi, "}");
+  } catch {
+    return trimmed;
+  }
 }
 
 /**
@@ -324,12 +372,49 @@ export async function resolveOgcVectorTiles(input: {
     }
     if (vector) {
       // Fall back to the style's own vector source only when no tiles input was
-      // given...
+      // given. Both forms are resolved against the style URL first: they are
+      // routinely relative (see `resolveDocumentUrl`).
       if (!config.url && !config.tiles) {
         if (typeof vector.source.url === "string") {
-          config.url = vector.source.url;
+          const sourceUrl = resolveDocumentUrl(vector.source.url, styleUrl);
+          config.url = sourceUrl || undefined;
+          // The style only names the tileset; the document it points at holds
+          // the tile templates and zoom range. Read it so a non-TileJSON
+          // service (Esri's `VectorTileServer`) still yields usable absolute
+          // tiles. Best-effort: the style's own metadata below still applies if
+          // this fails, so a fetch error must not block adding the layer.
+          if (sourceUrl) {
+            const tileset = await fetchOgcJson(sourceUrl, signal).catch((error) => {
+              if (input.signal?.aborted) throw error;
+              return null;
+            });
+            if (tileset && typeof tileset === "object") {
+              // Style-derived source layers and name stay authoritative
+              // (manual > style > TileJSON), so the tileset must not clobber
+              // them. `url` is assigned rather than spread: `tileJsonConfig`
+              // *drops* it when it emits explicit `tiles`, and a spread would
+              // leave the stale value behind — a MapLibre vector source given
+              // both `url` and `tiles` is invalid.
+              const {
+                sourceLayers: tilesetLayers,
+                name: tilesetName,
+                url: tilesetUrl,
+                ...tilesetConfig
+              } = tileJsonConfig(tileset as Record<string, unknown>, sourceUrl);
+              config = {
+                ...config,
+                ...tilesetConfig,
+                url: tilesetUrl,
+                name: config.name ?? tilesetName,
+                sourceLayers:
+                  config.sourceLayers.length > 0 ? config.sourceLayers : (tilesetLayers ?? []),
+              };
+            }
+          }
         } else {
-          config.tiles = asTiles(vector.source.tiles)?.map(normalizeTilePlaceholders);
+          config.tiles = asTiles(vector.source.tiles)?.map((tile) =>
+            normalizeTilePlaceholders(resolveDocumentUrl(tile, styleUrl)),
+          );
         }
       }
       // ...but always fill a missing zoom range / bounds from the style, even

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -253,6 +253,35 @@ async function addArcGISFeatureLayerAsGeoJson(
   return id;
 }
 
+/** The JSON error envelope ArcGIS returns, usually with an HTTP 200 status. */
+interface ArcGISErrorEnvelope {
+  message?: string;
+  details?: unknown;
+}
+
+/**
+ * The most specific text available from an ArcGIS error envelope.
+ *
+ * `message` is frequently an empty string, with the only useful text in
+ * `details` — asking a hosted FeatureServer for a layer id it does not have
+ * answers `{"code":400,"message":"","details":["The requested layer (layerId:
+ * 0) was not found."]}`. Reading `message` alone drops that and reports the
+ * generic fallback, which says nothing about what to correct.
+ *
+ * @param error - The `error` member of an ArcGIS JSON response.
+ * @param fallback - The message to use when the envelope carries no text.
+ */
+function arcgisErrorMessage(error: ArcGISErrorEnvelope | undefined, fallback: string): string {
+  const message = typeof error?.message === "string" ? error.message.trim() : "";
+  if (message) return message;
+  const details = Array.isArray(error?.details)
+    ? error.details.filter(
+        (detail): detail is string => typeof detail === "string" && detail.trim() !== "",
+      )
+    : [];
+  return details.length > 0 ? details.join(" ").trim() : fallback;
+}
+
 /**
  * Fetch and validate a GeoJSON FeatureCollection from an ArcGIS query URL.
  *
@@ -281,7 +310,7 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
     );
   }
   let json: FeatureCollection & {
-    error?: { message?: string };
+    error?: ArcGISErrorEnvelope;
     exceededTransferLimit?: boolean;
   };
   try {
@@ -290,7 +319,7 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
     throw new Error("The ArcGIS feature layer did not return GeoJSON features.");
   }
   if (json.error) {
-    throw new Error(json.error.message || "ArcGIS feature query failed.");
+    throw new Error(arcgisErrorMessage(json.error, "ArcGIS feature query failed."));
   }
   if (json.type !== "FeatureCollection" || !Array.isArray(json.features)) {
     throw new Error("The ArcGIS feature layer did not return GeoJSON features.");
@@ -378,10 +407,10 @@ async function fetchArcGISJson<T>(
     });
   }
   const json = (await response.json()) as T & {
-    error?: { message?: string };
+    error?: ArcGISErrorEnvelope;
   };
   if (json.error) {
-    throw new Error(json.error.message || "ArcGIS service request failed.", {
+    throw new Error(arcgisErrorMessage(json.error, "ArcGIS service request failed."), {
       cause,
     });
   }

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -149,6 +149,32 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.equal(useAppStore.getState().layers.length, 0);
   });
 
+  // ArcGIS routinely leaves `message` empty and puts the only useful text in
+  // `details` — asking a hosted FeatureServer for a layer id it does not have
+  // answers `{"code":400,"message":"","details":["The requested layer (layerId:
+  // 0) was not found."]}`. Reporting the generic fallback instead hides the one
+  // thing the user needs to correct.
+  it("surfaces error `details` when the service leaves `message` empty", async () => {
+    globalThis.fetch = (async () =>
+      jsonResponse({
+        error: {
+          code: 400,
+          message: "",
+          details: ["The requested layer (layerId: 0) was not found."],
+        },
+      })) as typeof fetch;
+
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      }),
+      /The requested layer \(layerId: 0\) was not found\./,
+    );
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
   it("rejects an HTML login page returned with a 200 status", async () => {
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();

--- a/tests/ogc-vector-tiles.test.ts
+++ b/tests/ogc-vector-tiles.test.ts
@@ -4,11 +4,33 @@ import { describe, it } from "node:test";
 import {
   firstVectorSource,
   hasTilePlaceholders,
+  resolveDocumentUrl,
   resolveOgcVectorTiles,
   styleSourceLayers,
   tileJsonConfig,
   unionCollectionBounds,
 } from "../apps/geolibre-desktop/src/lib/ogc-vector-tiles";
+
+/**
+ * Installs a `globalThis.fetch` stub answering from a URL → document map, and
+ * returns the URLs requested plus a restore function.
+ */
+function stubFetch(responses: Record<string, unknown>) {
+  const original = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = String(input);
+    calls.push(url);
+    const body = responses[url];
+    return Promise.resolve({
+      ok: body !== undefined,
+      status: body !== undefined ? 200 : 404,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body ?? {},
+    } as Response);
+  }) as typeof fetch;
+  return { calls, restore: () => void (globalThis.fetch = original) };
+}
 
 describe("hasTilePlaceholders", () => {
   it("recognizes a MapLibre {z}/{x}/{y} template", () => {
@@ -136,6 +158,125 @@ describe("resolveOgcVectorTiles (template path)", () => {
     });
     assert.ok(Array.isArray(config.sourceLayers));
     assert.equal(config.sourceLayers.length, 0);
+  });
+});
+
+describe("resolveDocumentUrl", () => {
+  const style =
+    "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/resources/styles/root.json";
+
+  it("resolves an Esri style's relative source url against the style URL", () => {
+    assert.equal(
+      resolveDocumentUrl("../../", style),
+      "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/",
+    );
+  });
+
+  it("keeps {z}/{y}/{x} braces unescaped so MapLibre can substitute them", () => {
+    assert.equal(
+      resolveDocumentUrl(
+        "tile/{z}/{y}/{x}.pbf",
+        "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/",
+      ),
+      "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/tile/{z}/{y}/{x}.pbf",
+    );
+  });
+
+  it("leaves an absolute URL and passes through when there is no base", () => {
+    assert.equal(resolveDocumentUrl("https://ex.com/a.json", style), "https://ex.com/a.json");
+    assert.equal(resolveDocumentUrl("../../", undefined), "../../");
+  });
+});
+
+// An Esri `VectorTileServer` document is not conforming TileJSON: its `tiles`
+// are relative to the service. MapLibre would resolve them against the app
+// origin, so the resolver must emit absolute templates instead (GeoLibre#1639).
+describe("tileJsonConfig (relative tiles)", () => {
+  const serviceUrl =
+    "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/";
+
+  it("emits absolute tiles and drops the document url", () => {
+    const config = tileJsonConfig(
+      { name: "Svc", maxzoom: 22, tiles: ["tile/{z}/{y}/{x}.pbf"] },
+      serviceUrl,
+    );
+    assert.deepEqual(config.tiles, [`${serviceUrl}tile/{z}/{y}/{x}.pbf`]);
+    assert.equal(config.url, undefined);
+    assert.equal(config.maxzoom, 22);
+  });
+
+  it("leaves a conforming TileJSON to be loaded by MapLibre itself", () => {
+    const config = tileJsonConfig(
+      { tilejson: "3.0.0", tiles: ["https://ex.com/{z}/{x}/{y}.pbf"] },
+      "https://ex.com/tiles.json",
+    );
+    assert.equal(config.url, "https://ex.com/tiles.json");
+    assert.equal(config.tiles, undefined);
+  });
+});
+
+// The reported failure: an Esri vector tile service added by its style URL was
+// handed MapLibre the style's verbatim relative `"url": "../../"`, which
+// resolves against the app origin — the layer was added and rendered nothing.
+describe("resolveOgcVectorTiles (Esri style URL)", () => {
+  const styleUrl =
+    "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/resources/styles/root.json";
+  const serviceUrl =
+    "https://tiles.arcgis.com/tiles/org/arcgis/rest/services/Svc/VectorTileServer/";
+
+  it("resolves the relative source url and reads the service's tiles", async () => {
+    const { calls, restore } = stubFetch({
+      [styleUrl]: {
+        name: "Svc",
+        sources: { esri: { type: "vector", url: "../../" } },
+        layers: [{ id: "a", source: "esri", "source-layer": "Boundaries" }],
+      },
+      [serviceUrl]: { name: "Service", maxzoom: 16, tiles: ["tile/{z}/{y}/{x}.pbf"] },
+    });
+    try {
+      const config = await resolveOgcVectorTiles({ tilesUrl: "", styleUrl });
+      assert.deepEqual(config.tiles, [`${serviceUrl}tile/{z}/{y}/{x}.pbf`]);
+      // A vector source with both `url` and `tiles` is invalid in MapLibre.
+      assert.equal(config.url, undefined);
+      assert.deepEqual(config.sourceLayers, ["Boundaries"]);
+      assert.equal(config.maxzoom, 16);
+      // The style's own name wins over the service's (manual > style > TileJSON).
+      assert.equal(config.name, "Svc");
+      assert.ok(calls.includes(serviceUrl));
+    } finally {
+      restore();
+    }
+  });
+
+  it("still adds the layer when the tileset document cannot be read", async () => {
+    const { restore } = stubFetch({
+      [styleUrl]: {
+        sources: { esri: { type: "vector", url: "../../" } },
+        layers: [{ id: "a", source: "esri", "source-layer": "Boundaries" }],
+      },
+    });
+    try {
+      const config = await resolveOgcVectorTiles({ tilesUrl: "", styleUrl });
+      // Falls back to the resolved absolute service URL rather than "../../".
+      assert.equal(config.url, serviceUrl);
+      assert.deepEqual(config.sourceLayers, ["Boundaries"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("surfaces an Esri HTTP 200 error body instead of a bare 'no layers'", async () => {
+    const { restore } = stubFetch({
+      [styleUrl]: { error: { code: 404, message: "Requested Service not available." } },
+    });
+    try {
+      await assert.rejects(
+        resolveOgcVectorTiles({ tilesUrl: "", styleUrl }),
+        /Requested Service not available/,
+      );
+    } finally {
+      restore();
+    }
   });
 });
 

--- a/tests/ogc-vector-tiles.test.ts
+++ b/tests/ogc-vector-tiles.test.ts
@@ -278,6 +278,43 @@ describe("resolveOgcVectorTiles (Esri style URL)", () => {
       restore();
     }
   });
+
+  // A host can report a failure with a bare code and no usable `message` (498
+  // is Esri's invalid-token code), and some use string codes. Both must still
+  // be recognized as errors rather than passed on as an empty document.
+  it("reports a coded error that carries no message", async () => {
+    for (const code of [498, "NotFound"]) {
+      const { restore } = stubFetch({ [styleUrl]: { error: { code } } });
+      try {
+        await assert.rejects(
+          resolveOgcVectorTiles({ tilesUrl: "", styleUrl }),
+          new RegExp(`Service error ${code}`),
+        );
+      } finally {
+        restore();
+      }
+    }
+  });
+
+  // `code: 0` conventionally means success, so it must not be read as a
+  // failure — only a real code or a message makes the document an error report.
+  it("does not treat a zero code or an unrelated `error` value as a failure", async () => {
+    for (const error of [{ code: 0 }, "not an envelope", ["nope"], null]) {
+      const { restore } = stubFetch({
+        [styleUrl]: {
+          error,
+          sources: { s: { type: "vector", tiles: ["https://ex.com/{z}/{x}/{y}.pbf"] } },
+          layers: [{ id: "a", source: "s", "source-layer": "roads" }],
+        },
+      });
+      try {
+        const config = await resolveOgcVectorTiles({ tilesUrl: "", styleUrl });
+        assert.deepEqual(config.sourceLayers, ["roads"]);
+      } finally {
+        restore();
+      }
+    }
+  });
 });
 
 // Exercises the full resolver against a stubbed OGC API: a TileJSON without


### PR DESCRIPTION
Investigated from [discussion #1639](https://github.com/opengeos/GeoLibre/discussions/1639#discussioncomment-17867511) — "connected to the portal but no data gets sent."

The reporter's own URL turned out to be a service that doesn't exist (they'd constructed a `VectorTileServer` path under an org that only publishes it as a `MapServer`/`FeatureServer`). But reproducing it surfaced two real bugs, and the first one is why adding *any* Esri vector tile service by style URL has been silently broken.

## 1. Relative style/tileset URLs were never resolved

Every Esri vector tile style declares its tileset relatively:

```json
"sources": { "esri": { "type": "vector", "url": "../../" } }
```

`resolveOgcVectorTiles` copied that verbatim into the MapLibre source (`ogc-vector-tiles.ts:329-330`). MapLibre resolves what it is handed against the **app** origin, not the document it came from, so the source pointed at the GeoLibre origin and never issued a tile request. The `tiles` form of a style source had the same flaw, as does an Esri `VectorTileServer` document, whose `tiles` are `["tile/{z}/{y}/{x}.pbf"]`.

Both forms are now resolved against the document they were read from. Because the document behind a style's source URL may not be conforming TileJSON, it is read so a service like Esri's still yields usable absolute templates. `URL` percent-encodes `{`/`}` — which would defeat MapLibre's placeholder substitution — so the braces are restored after resolution.

Conforming TileJSON with absolute `tiles` is untouched: it keeps being handed to MapLibre as a `url`, which re-reads more than is copied out here.

## 2. Esri's HTTP 200 error bodies were invisible

ArcGIS reports a missing, renamed, or token-protected service as **HTTP 200** with:

```json
{"error":{"code":404,"message":"Requested Service not available."}}
```

`fetchOgcJson` only checked `response.ok`, so the body parsed cleanly and reached the caller as a valid-but-empty document. The dialog then complained "no source layers" — hiding the real cause and sending the reporter looking for a nonexistent client-side problem (they'd been told the server was blocking WebKit as a scraper; it isn't, and CORS is fine).

The shape is checked rather than just the key, so a legitimate document carrying an `error` property of some other form isn't misread. This also benefits OGC API - Features, which shares the fetch.

## Verification

Real browser (production build + `vite preview`, Playwright), adding `World_Basemap_v2/VectorTileServer/resources/styles/root.json` via Add Data → OGC Vector Tiles with the tiles field blank:

| | tile requests | resolved against localhost | non-OK | rendered |
|---|---|---|---|---|
| before | **0** | 0 | 0 | nothing, no error |
| after | **10** | 0 | 0 | ✅ Diagnostics: 0 |

Against the live service, the resolver now returns
`https://basemaps.arcgis.com/.../VectorTileServer/tile/{z}/{y}/{x}.pbf` (verified serving 159 kB of MVT) plus 115 source layers, and the reporter's dead URL now fails with `Requested Service not available.` instead of "no source layers".

`npm run test:frontend` 4836 pass / 0 fail, `npm run typecheck` clean, `pre-commit run --files` clean. Adds 8 tests covering brace-safe resolution, the Esri style path, the tileset-unreadable fallback, the `url`+`tiles` mutual exclusion, and the 200-error surfacing.

## Follow-ups not in this PR

- Add Data → ArcGIS has no MapServer/ImageServer option, so pasting one fails with a misleading "Enter an ArcGIS FeatureServer layer URL." even though `earthdata-gis-api.ts` already knows how to build `export` raster templates for them.
- `BrowserPanel.tsx:445-450` discards the real error message in favour of a generic "add failed".
- An Esri service's `fullExtent` (Web Mercator) could fill `bounds` so zoom-to-layer works on these layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of service errors returned with successful HTTP responses, displaying clearer error details.
  * Fixed relative map and tile URLs so referenced resources load correctly across supported connection methods.
  * Improved compatibility with TileJSON and Esri style-based vector sources.
  * Added fallback behavior when optional service metadata cannot be retrieved.
  * Improved ArcGIS error reporting by displaying available message and detail information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->