### PR TITLE
fix: surface notebook runtime dir failures and reclaim port 8766 on Windows

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1655,6 +1655,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-persisted-scope",
  "webkit2gtk-sys",
+ "windows-sys 0.61.2",
  "zip 8.6.0",
 ]
 

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -80,3 +80,15 @@ reqwest = { version = "0.12", default-features = false, features = ["native-tls"
 # Runtime WebKitGTK version check (already an indirect dep via tauri/wry).
 [target."cfg(target_os = \"linux\")".dependencies]
 webkit2gtk-sys = "2"
+
+# Reclaiming port 8766 from a Jupyter server orphaned by a previous session
+# (issue #1643): the IP Helper TCP table names the process that owns the
+# listening socket, and the process APIs let us check its image path before
+# terminating it. Windows has no /proc, so the Linux path cannot be reused.
+# Already an indirect dep via tauri, so this adds no new crate to the build.
+[target."cfg(target_os = \"windows\")".dependencies]
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_System_Threading",
+] }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2198,8 +2198,13 @@ fn stop_jupyter_server_blocking(app: tauri::AppHandle) -> Result<(), String> {
     // clean up after is already gone by now: returning an error here would
     // leave the frontend believing the server it just stopped is still running
     // (stopJupyterServer only clears its state once this invoke resolves).
-    if let Ok(runtime_dir) = app_runtime_dir(&app) {
-        let _ = terminate_jupyter_listeners_on_port(JUPYTER_PORT, &runtime_dir);
+    // Best-effort, but not silent: skipping the backstop is what a later
+    // "stale Jupyter still holding the port" report would trace back to.
+    match app_runtime_dir(&app) {
+        Ok(runtime_dir) => {
+            let _ = terminate_jupyter_listeners_on_port(JUPYTER_PORT, &runtime_dir);
+        }
+        Err(error) => eprintln!("Jupyter: skipping the port {JUPYTER_PORT} backstop ({error})."),
     }
     Ok(())
 }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2750,20 +2750,19 @@ fn terminate_jupyter_listeners_on_port(
     port: u16,
     runtime_dir: &std::path::Path,
 ) -> Result<(), String> {
-    for pid in listening_tcp_pids(port)? {
-        let Some(image) = process_image_path(pid) else {
-            continue;
-        };
-        if path_is_under(&image, runtime_dir) {
-            terminate_windows_pid(pid);
-        }
+    for pid in listening_tcp_pids(port) {
+        terminate_listener_under(pid, runtime_dir);
     }
     Ok(())
 }
 
-// PIDs of the processes listening on `port`, over both IPv4 and IPv6.
+// PIDs of the processes listening on `port`, over both IPv4 and IPv6. The two
+// families are read independently: a machine with IPv6 disabled outright can
+// fail the second read, and letting that discard the IPv4 result would drop the
+// orphan we are here to reclaim (Jupyter binds 127.0.0.1, so it is nearly
+// always the IPv4 table that holds it).
 #[cfg(all(target_os = "windows", not(feature = "mas")))]
-fn listening_tcp_pids(port: u16) -> Result<HashSet<u32>, String> {
+fn listening_tcp_pids(port: u16) -> HashSet<u32> {
     use windows_sys::Win32::NetworkManagement::IpHelper::{
         MIB_TCP6ROW_OWNER_PID, MIB_TCPROW_OWNER_PID,
     };
@@ -2774,19 +2773,25 @@ fn listening_tcp_pids(port: u16) -> Result<HashSet<u32>, String> {
     const AF_INET6: u32 = 23;
 
     let mut pids = HashSet::new();
-    collect_owner_pids::<MIB_TCPROW_OWNER_PID>(
-        &extended_tcp_table(AF_INET)?,
-        port,
-        |row| (row.dwLocalPort, row.dwOwningPid),
-        &mut pids,
-    );
-    collect_owner_pids::<MIB_TCP6ROW_OWNER_PID>(
-        &extended_tcp_table(AF_INET6)?,
-        port,
-        |row| (row.dwLocalPort, row.dwOwningPid),
-        &mut pids,
-    );
-    Ok(pids)
+    match extended_tcp_table(AF_INET) {
+        Ok(table) => collect_owner_pids::<MIB_TCPROW_OWNER_PID>(
+            &table,
+            port,
+            |row| (row.dwLocalPort, row.dwOwningPid),
+            &mut pids,
+        ),
+        Err(error) => eprintln!("Jupyter: {error}"),
+    }
+    match extended_tcp_table(AF_INET6) {
+        Ok(table) => collect_owner_pids::<MIB_TCP6ROW_OWNER_PID>(
+            &table,
+            port,
+            |row| (row.dwLocalPort, row.dwOwningPid),
+            &mut pids,
+        ),
+        Err(error) => eprintln!("Jupyter: {error}"),
+    }
+    pids
 }
 
 // Walk one MIB_TCP*TABLE_OWNER_PID and collect the PIDs listening on `port`.
@@ -2877,22 +2882,38 @@ fn extended_tcp_table(family: u32) -> Result<Vec<u32>, String> {
     Err("Could not read the TCP listener table: it kept growing between calls.".to_string())
 }
 
-// Full path of the executable backing `pid`, or None when the process has
-// already exited or we may not inspect it.
+// Terminate `pid`, but only if its executable lives inside `runtime_dir`. Does
+// nothing when the process has already exited or we may not touch it.
+//
+// The image check and the kill deliberately share ONE handle. An open handle
+// pins the process object, so the PID cannot be recycled onto some unrelated
+// process in between -- re-opening by PID to terminate would leave exactly that
+// window, and the whole point of the image check is that we never kill a
+// process that is not ours.
+//
+// Windows has no SIGTERM, so unlike the Linux path there is no graceful step to
+// try first: an orphan from a previous session has no channel we can ask it to
+// shut down through.
 #[cfg(all(target_os = "windows", not(feature = "mas")))]
-fn process_image_path(pid: u32) -> Option<PathBuf> {
+fn terminate_listener_under(pid: u32, runtime_dir: &Path) {
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
-        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
-        PROCESS_QUERY_LIMITED_INFORMATION,
+        OpenProcess, QueryFullProcessImageNameW, TerminateProcess, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
     };
 
-    // SAFETY: a query-only handle, closed on every path below.
-    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    // SAFETY: one handle for both the query and the kill; closed on every path.
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE,
+            0,
+            pid,
+        )
+    };
     if process.is_null() {
-        return None;
+        return;
     }
     // Sized for an extended-length path rather than MAX_PATH, so a deeply
     // nested app-data directory is not silently truncated into a non-match.
@@ -2908,28 +2929,15 @@ fn process_image_path(pid: u32) -> Option<PathBuf> {
             &mut length,
         )
     };
-    let _ = unsafe { CloseHandle(process) };
-    if queried == 0 {
-        return None;
+    if queried != 0 {
+        let image = PathBuf::from(OsString::from_wide(
+            &buffer[..(length as usize).min(buffer.len())],
+        ));
+        if path_is_under(&image, runtime_dir) {
+            // SAFETY: the same handle, opened with PROCESS_TERMINATE above.
+            let _ = unsafe { TerminateProcess(process, 1) };
+        }
     }
-    Some(PathBuf::from(OsString::from_wide(
-        &buffer[..(length as usize).min(buffer.len())],
-    )))
-}
-
-// Windows has no SIGTERM, so there is no graceful step to try first: an orphan
-// from a previous session has no channel we can ask it to shut down through.
-#[cfg(all(target_os = "windows", not(feature = "mas")))]
-fn terminate_windows_pid(pid: u32) {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
-
-    // SAFETY: a terminate-only handle, closed immediately after use.
-    let process = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
-    if process.is_null() {
-        return;
-    }
-    let _ = unsafe { TerminateProcess(process, 1) };
     let _ = unsafe { CloseHandle(process) };
 }
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2675,7 +2675,30 @@ fn configure_sidecar_process_impl(command: &mut Command) {
 }
 
 #[cfg(all(not(unix), not(feature = "mas")))]
-fn configure_sidecar_process_impl(_command: &mut Command) {}
+fn configure_sidecar_process_impl(command: &mut Command) {
+    hide_console_window(command);
+}
+
+/// Keep a spawned console program from opening a console window.
+///
+/// Release builds are GUI-subsystem (`windows_subsystem = "windows"`), so they
+/// have no console of their own. Spawning `uv.exe` (a console program) then
+/// makes Windows allocate a fresh console *window* for it, which appears on the
+/// user's desktop and stays for as long as the child runs -- for the Notebook
+/// panel that is the whole session. `CREATE_NO_WINDOW` runs the child without
+/// one. Output is unaffected: every caller already pipes stdout/stderr and
+/// drains them (see CapturedOutput).
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn hide_console_window(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+    command.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(all(not(target_os = "windows"), not(feature = "mas")))]
+fn hide_console_window(_command: &mut Command) {}
 
 #[cfg(not(feature = "mas"))]
 fn terminate_sidecar_child(child: &mut Child) {
@@ -3215,6 +3238,9 @@ fn install_managed_uv(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         command.arg(&script);
         command
     };
+    // First run only, but it is the one that would flash a PowerShell window
+    // across the user's desktop while uv installs.
+    hide_console_window(&mut command);
     let output = command
         .env("UV_UNMANAGED_INSTALL", &uv_dir)
         .output()
@@ -3527,6 +3553,10 @@ fn spawn_martin_server(
     {
         command.env("DEFAULT_SRID", default_srid);
     }
+
+    // Martin is a console program too, and it runs for as long as the PostGIS
+    // connection is open.
+    hide_console_window(&mut command);
 
     drop(listener);
     let mut child = command

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2952,10 +2952,20 @@ fn tcp_table_port(value: u32) -> u16 {
 // case folded, because Windows paths are case-insensitive and the image path
 // the OS reports need not spell the directory the way we built it. The trailing
 // separator is what keeps `...\runtime` from matching `...\runtime-old`.
+//
+// Folding is ASCII-only on purpose. What actually varies between the path we
+// built and the one the OS reports is the drive letter and the segments we
+// wrote ourselves, all ASCII; the rest (a user's name in the profile path) is
+// byte-identical on both sides. Unicode `to_lowercase` would buy nothing there
+// and can change a string's length (Turkish dotless I, sharp S), which would
+// misalign the prefix comparison.
 #[cfg(any(all(target_os = "windows", not(feature = "mas")), test))]
 fn path_is_under(path: &Path, root: &Path) -> bool {
     fn normalize(value: &Path) -> String {
-        value.to_string_lossy().replace('/', "\\").to_lowercase()
+        value
+            .to_string_lossy()
+            .replace('/', "\\")
+            .to_ascii_lowercase()
     }
 
     let root = normalize(root);
@@ -4614,6 +4624,16 @@ mod tests {
         assert!(!path_is_under(
             std::path::Path::new(r"C:\Program Files\Python312\python.exe"),
             root
+        ));
+        // A non-ASCII profile name survives the fold: ASCII case folding leaves
+        // it byte-identical on both sides, where Unicode lowercasing could
+        // change its length and misalign the prefix.
+        let unicode_root = std::path::Path::new(r"C:\Users\İŞIL\AppData\Roaming\runtime");
+        assert!(path_is_under(
+            std::path::Path::new(
+                r"C:\Users\İŞIL\AppData\Roaming\runtime\jupyter-server\python.exe"
+            ),
+            unicode_root
         ));
         // The directory itself is not "inside" itself, and an empty root never
         // matches (which would otherwise make every listener look like ours).

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1858,11 +1858,7 @@ fn start_geolibre_sidecar_blocking(app: tauri::AppHandle) -> Result<SidecarServe
 
     let uv = ensure_managed_uv(&app)?;
     let project_dir = sidecar_project_dir(&app)?;
-    let runtime_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
-        .join("runtime");
+    let runtime_dir = app_runtime_dir(&app)?;
     // A value already in the environment wins, so a desktop user who does want
     // the allowlist can narrow it by launching the app with it set.
     let postgis_hosts = env::var(POSTGIS_HOSTS_ENV)
@@ -2030,12 +2026,14 @@ fn start_jupyter_server_blocking(app: tauri::AppHandle) -> Result<JupyterServerI
         }
     }
 
+    let runtime_dir = app_runtime_dir(&app)?;
+
     // A Jupyter server from a previous app session may still hold the port. We
     // can't reuse it (its per-launch token is unknown to us), and because we
     // spawn with `--ServerApp.port_retries=0`, a new server would fail to bind
     // and exit 1 ("exited before it was ready") while the orphan lingers. Clear
     // any stale listener and wait for the port to free before spawning.
-    let _ = terminate_jupyter_listeners_on_port(JUPYTER_PORT);
+    let _ = terminate_jupyter_listeners_on_port(JUPYTER_PORT, &runtime_dir);
     // Best-effort here: if the port never frees, the spawn below fails with
     // Jupyter's own bind error, which is already reported to the user.
     let _ = wait_for_port_free(JUPYTER_PORT);
@@ -2043,14 +2041,19 @@ fn start_jupyter_server_blocking(app: tauri::AppHandle) -> Result<JupyterServerI
     let uv = ensure_managed_uv(&app)?;
     let project_dir = sidecar_project_dir(&app)?;
     let config_path = project_dir.join("jupyter_server_config.py");
-    let runtime_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
-        .join("runtime");
-    // Notebooks are saved here (the JupyterLab file browser root).
+    // Notebooks are saved here (the JupyterLab file browser root). Jupyter is
+    // launched with `--ServerApp.root_dir` pointing at this directory and
+    // refuses to start when it is missing, so a creation failure has to surface
+    // here. Swallowing it reached the user several steps later as an opaque
+    // "Bad config encountered during initialization: No such directory"
+    // (issue #1642).
     let notebooks_dir = runtime_dir.join("notebooks");
-    let _ = fs::create_dir_all(&notebooks_dir);
+    fs::create_dir_all(&notebooks_dir).map_err(|error| {
+        format!(
+            "Could not create the notebooks directory {}: {error}",
+            notebooks_dir.display()
+        )
+    })?;
     // Seed the starter Welcome notebook (the same one bundled into JupyterLite on
     // web) on first run only, so we never clobber a user's edits.
     let welcome_dest = notebooks_dir.join("Welcome.ipynb");
@@ -2065,7 +2068,12 @@ fn start_jupyter_server_blocking(app: tauri::AppHandle) -> Result<JupyterServerI
     // the kernel's PYTHONPATH (so `import geolibre` works regardless of where the
     // notebook lives).
     let lib_dir = runtime_dir.join("notebook-lib");
-    let _ = fs::create_dir_all(&lib_dir);
+    fs::create_dir_all(&lib_dir).map_err(|error| {
+        format!(
+            "Could not create the notebook library directory {}: {error}",
+            lib_dir.display()
+        )
+    })?;
     let _ = fs::copy(
         project_dir.join("notebook_client.py"),
         lib_dir.join("geolibre.py"),
@@ -2180,10 +2188,22 @@ fn stop_jupyter_server_blocking(app: tauri::AppHandle) -> Result<(), String> {
     if let Ok(mut token) = state.token.lock() {
         *token = None;
     }
-    // Backstop: reap anything still bound to the port (no-op on non-unix and
-    // when nothing is listening).
-    terminate_jupyter_listeners_on_port(JUPYTER_PORT)?;
+    // Backstop: reap anything still bound to the port (no-op when nothing of
+    // ours is listening).
+    terminate_jupyter_listeners_on_port(JUPYTER_PORT, &app_runtime_dir(&app)?)?;
     Ok(())
+}
+
+/// Directory holding everything the app installs at runtime (the managed uv, its
+/// caches and project environments, and the notebook root). Lives under the
+/// per-user app data directory, so nothing outside it belongs to us.
+#[cfg(not(feature = "mas"))]
+fn app_runtime_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
+        .join("runtime"))
 }
 
 #[cfg(not(feature = "mas"))]
@@ -2678,19 +2698,254 @@ fn terminate_sidecar_listeners_on_port(port: u16) -> Result<(), String> {
 // non-graceful exit of a previous app session). Recognized by its cmdline so we
 // never touch an unrelated jupyter (the user's own JupyterHub, etc.).
 #[cfg(all(target_os = "linux", not(feature = "mas")))]
-fn terminate_jupyter_listeners_on_port(port: u16) -> Result<(), String> {
+fn terminate_jupyter_listeners_on_port(
+    port: u16,
+    _runtime_dir: &std::path::Path,
+) -> Result<(), String> {
     terminate_listeners_on_port(port, is_geolibre_jupyter_process)
 }
 
-// Known gap: this is a no-op on macOS/Windows (the /proc-based listener lookup is
-// Linux-only). The current session's child is still reaped on exit via
-// JupyterProcess::Drop, but an orphan left by a *previous* crashed session can
-// keep holding the port there, in which case the next launch fails to bind and
-// surfaces "exited before it was ready". A cross-platform port-owner lookup
-// (e.g. lsof on macOS) would be needed to close this.
-#[cfg(all(not(target_os = "linux"), not(feature = "mas")))]
-fn terminate_jupyter_listeners_on_port(_port: u16) -> Result<(), String> {
+// Known gap: still a no-op on macOS (there is no /proc, and the Windows IP
+// Helper route below does not exist either). The current session's child is
+// reaped on exit via JupyterProcess::Drop, but an orphan left by a *previous*
+// crashed session can keep holding the port, in which case the next launch
+// fails to bind and surfaces "exited before it was ready". An lsof-based
+// port-owner lookup would be needed to close this.
+#[cfg(all(
+    not(target_os = "linux"),
+    not(target_os = "windows"),
+    not(feature = "mas")
+))]
+fn terminate_jupyter_listeners_on_port(
+    _port: u16,
+    _runtime_dir: &std::path::Path,
+) -> Result<(), String> {
     Ok(())
+}
+
+// Windows equivalent of the Linux reaper (issue #1643): an orphaned Jupyter
+// server from a crashed session keeps holding 8766, and every later launch dies
+// with "the port 8766 is already in use" until the user kills it by hand.
+//
+// There is no /proc here, so the owner of the listening socket comes from the IP
+// Helper TCP table, and "is it ours?" is answered by the process image path: we
+// only ever terminate a listener whose executable lives inside this user's own
+// GeoLibre runtime directory (the uv-managed environment under
+// `%APPDATA%\org.geolibre.desktop\runtime\`). A Jupyter the user installed
+// themselves lives outside it and is left alone. The sidecar's port keeps its
+// no-op: unlike Jupyter it already reports an actionable message of its own
+// when the port stays busy (see start_geolibre_sidecar_blocking).
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn terminate_jupyter_listeners_on_port(
+    port: u16,
+    runtime_dir: &std::path::Path,
+) -> Result<(), String> {
+    for pid in listening_tcp_pids(port)? {
+        let Some(image) = process_image_path(pid) else {
+            continue;
+        };
+        if path_is_under(&image, runtime_dir) {
+            terminate_windows_pid(pid);
+        }
+    }
+    Ok(())
+}
+
+// PIDs of the processes listening on `port`, over both IPv4 and IPv6.
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn listening_tcp_pids(port: u16) -> Result<HashSet<u32>, String> {
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        MIB_TCP6ROW_OWNER_PID, MIB_TCPROW_OWNER_PID,
+    };
+
+    // The address families as GetExtendedTcpTable wants them: a plain u32, not
+    // the u16 `ADDRESS_FAMILY` the WinSock module exports.
+    const AF_INET: u32 = 2;
+    const AF_INET6: u32 = 23;
+
+    let mut pids = HashSet::new();
+    collect_owner_pids::<MIB_TCPROW_OWNER_PID>(
+        &extended_tcp_table(AF_INET)?,
+        port,
+        |row| (row.dwLocalPort, row.dwOwningPid),
+        &mut pids,
+    );
+    collect_owner_pids::<MIB_TCP6ROW_OWNER_PID>(
+        &extended_tcp_table(AF_INET6)?,
+        port,
+        |row| (row.dwLocalPort, row.dwOwningPid),
+        &mut pids,
+    );
+    Ok(pids)
+}
+
+// Walk one MIB_TCP*TABLE_OWNER_PID and collect the PIDs listening on `port`.
+// Both the IPv4 and IPv6 tables have the same shape -- a DWORD entry count
+// followed by the rows -- so the row type and the two fields we need are the
+// only things that differ.
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn collect_owner_pids<Row>(
+    buffer: &[u32],
+    port: u16,
+    fields: fn(&Row) -> (u32, u32),
+    pids: &mut HashSet<u32>,
+) {
+    use std::mem::{size_of, size_of_val};
+
+    if buffer.is_empty() {
+        return;
+    }
+    let base = buffer.as_ptr();
+    // SAFETY: `buffer` is a u32-aligned allocation that GetExtendedTcpTable
+    // filled for this table class, and it holds at least the leading entry
+    // count. Every row type here has 4-byte alignment, so the rows -- which
+    // start one DWORD in -- are aligned too. The walk is capped at the number
+    // of rows the allocation can actually hold, so an entry count that
+    // disagrees with the reported size cannot read past the end.
+    let count = unsafe { *base } as usize;
+    let capacity = (size_of_val(buffer) - size_of::<u32>()) / size_of::<Row>();
+    let rows = unsafe { base.add(1) }.cast::<Row>();
+    for index in 0..count.min(capacity) {
+        let (local_port, owning_pid) = fields(unsafe { &*rows.add(index) });
+        if tcp_table_port(local_port) == port {
+            pids.insert(owning_pid);
+        }
+    }
+}
+
+// Read the TCP listener table for one address family into a u32-aligned buffer.
+// GetExtendedTcpTable reports the size it needs on the first (null) call, but
+// the table can grow between that call and the read, so retry a bounded number
+// of times rather than trusting the first answer.
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn extended_tcp_table(family: u32) -> Result<Vec<u32>, String> {
+    use std::mem::size_of;
+    use windows_sys::Win32::NetworkManagement::IpHelper::{
+        GetExtendedTcpTable, TCP_TABLE_OWNER_PID_LISTENER,
+    };
+
+    const NO_ERROR: u32 = 0;
+    const ERROR_INSUFFICIENT_BUFFER: u32 = 122;
+    const ATTEMPTS: usize = 8;
+
+    let mut size: u32 = 0;
+    let mut buffer: Vec<u32> = Vec::new();
+    for _ in 0..ATTEMPTS {
+        // SAFETY: the pointer and `size` describe the same allocation (null and
+        // zero on the sizing call, which is what the API asks for), and the API
+        // only writes within `size` bytes.
+        let result = unsafe {
+            GetExtendedTcpTable(
+                if buffer.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    buffer.as_mut_ptr().cast()
+                },
+                &mut size,
+                0, // unsorted: we look up a single port
+                family,
+                TCP_TABLE_OWNER_PID_LISTENER,
+                0,
+            )
+        };
+        match result {
+            NO_ERROR => return Ok(buffer),
+            ERROR_INSUFFICIENT_BUFFER => {
+                if size == 0 {
+                    return Ok(Vec::new());
+                }
+                buffer = vec![0u32; (size as usize).div_ceil(size_of::<u32>())];
+            }
+            other => {
+                return Err(format!(
+                    "Could not read the TCP listener table for address family {family}: \
+                     Windows error {other}."
+                ))
+            }
+        }
+    }
+    Err("Could not read the TCP listener table: it kept growing between calls.".to_string())
+}
+
+// Full path of the executable backing `pid`, or None when the process has
+// already exited or we may not inspect it.
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn process_image_path(pid: u32) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32,
+        PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // SAFETY: a query-only handle, closed on every path below.
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if process.is_null() {
+        return None;
+    }
+    // Sized for an extended-length path rather than MAX_PATH, so a deeply
+    // nested app-data directory is not silently truncated into a non-match.
+    let mut buffer = vec![0u16; 32_768];
+    let mut length = buffer.len() as u32;
+    // SAFETY: `buffer` holds `length` u16s; on success the API sets `length` to
+    // the number it wrote, which is never more than the value passed in.
+    let queried = unsafe {
+        QueryFullProcessImageNameW(
+            process,
+            PROCESS_NAME_WIN32,
+            buffer.as_mut_ptr(),
+            &mut length,
+        )
+    };
+    let _ = unsafe { CloseHandle(process) };
+    if queried == 0 {
+        return None;
+    }
+    Some(PathBuf::from(OsString::from_wide(
+        &buffer[..(length as usize).min(buffer.len())],
+    )))
+}
+
+// Windows has no SIGTERM, so there is no graceful step to try first: an orphan
+// from a previous session has no channel we can ask it to shut down through.
+#[cfg(all(target_os = "windows", not(feature = "mas")))]
+fn terminate_windows_pid(pid: u32) {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+
+    // SAFETY: a terminate-only handle, closed immediately after use.
+    let process = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if process.is_null() {
+        return;
+    }
+    let _ = unsafe { TerminateProcess(process, 1) };
+    let _ = unsafe { CloseHandle(process) };
+}
+
+// MIB_TCP*ROW_OWNER_PID keeps the local port in the low word of a DWORD, in
+// network byte order.
+#[cfg(any(all(target_os = "windows", not(feature = "mas")), test))]
+fn tcp_table_port(value: u32) -> u16 {
+    u16::from_be((value & 0xFFFF) as u16)
+}
+
+// Whether `path` sits inside `root`. Compared with separators normalized and
+// case folded, because Windows paths are case-insensitive and the image path
+// the OS reports need not spell the directory the way we built it. The trailing
+// separator is what keeps `...\runtime` from matching `...\runtime-old`.
+#[cfg(any(all(target_os = "windows", not(feature = "mas")), test))]
+fn path_is_under(path: &Path, root: &Path) -> bool {
+    fn normalize(value: &Path) -> String {
+        value.to_string_lossy().replace('/', "\\").to_lowercase()
+    }
+
+    let root = normalize(root);
+    let root = root.trim_end_matches('\\');
+    if root.is_empty() {
+        return false;
+    }
+    normalize(path).starts_with(&format!("{root}\\"))
 }
 
 // Kill the processes listening on `port` that `is_ours` recognizes (SIGTERM then
@@ -2904,12 +3159,7 @@ fn ensure_managed_uv(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 
 #[cfg(not(feature = "mas"))]
 fn install_managed_uv(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    let uv_dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
-        .join("runtime")
-        .join("uv-bin");
+    let uv_dir = app_runtime_dir(app)?.join("uv-bin");
     let uv = uv_dir.join(uv_executable_name());
     if uv.exists() {
         return Ok(uv);
@@ -3656,7 +3906,7 @@ mod tests {
     use super::{
         client_cert_is_pkcs12, client_cert_password_without_path, ensure_fetchable_url,
         is_allowed_local_vector_path, is_allowed_project_path, is_disallowed_ip,
-        is_safe_absolute_path,
+        is_safe_absolute_path, path_is_under, tcp_table_port,
     };
     #[cfg(target_os = "linux")]
     use super::{linux_uses_nvidia_renderer, nvidia_is_primary_gpu};
@@ -4299,5 +4549,60 @@ mod tests {
             "settle blocked for {:?}",
             started.elapsed()
         );
+    }
+
+    // The Windows reaper reads the local port out of a DWORD that holds it in
+    // network byte order in its low word. Getting this wrong would match the
+    // wrong listener (or none), so pin the decoding here -- these are pure
+    // functions, so the check runs on every platform even though their only
+    // caller is Windows-only.
+    #[test]
+    fn decodes_a_network_order_port_from_the_tcp_table() {
+        // 8766 = 0x223E; network byte order puts 0x22 first, so the DWORD's low
+        // word reads 0x3E22, and the high word is padding the API does not use.
+        assert_eq!(tcp_table_port(0x0000_3E22), 8766);
+        assert_eq!(tcp_table_port(0xDEAD_3E22), 8766);
+        assert_eq!(tcp_table_port(0x0000_223E), 0x3E22);
+    }
+
+    // The image-path guard is what keeps the reaper from killing a Jupyter the
+    // user installed themselves: only executables under our own runtime
+    // directory are ours to terminate.
+    #[test]
+    fn recognizes_only_paths_inside_the_runtime_directory() {
+        let root =
+            std::path::Path::new(r"C:\Users\me\AppData\Roaming\org.geolibre.desktop\runtime");
+        assert!(path_is_under(
+            std::path::Path::new(
+                r"C:\Users\me\AppData\Roaming\org.geolibre.desktop\runtime\jupyter-server\Scripts\python.exe"
+            ),
+            root
+        ));
+        // Case and separator differences are not a mismatch on Windows.
+        assert!(path_is_under(
+            std::path::Path::new(
+                r"c:\users\me\appdata\roaming\org.geolibre.desktop\RUNTIME/uv-bin/uv.exe"
+            ),
+            root
+        ));
+        // A sibling directory sharing the prefix is not inside it.
+        assert!(!path_is_under(
+            std::path::Path::new(
+                r"C:\Users\me\AppData\Roaming\org.geolibre.desktop\runtime-old\jupyter-server\python.exe"
+            ),
+            root
+        ));
+        // The user's own Python is left alone.
+        assert!(!path_is_under(
+            std::path::Path::new(r"C:\Program Files\Python312\python.exe"),
+            root
+        ));
+        // The directory itself is not "inside" itself, and an empty root never
+        // matches (which would otherwise make every listener look like ours).
+        assert!(!path_is_under(root, root));
+        assert!(!path_is_under(
+            std::path::Path::new(r"C:\anything"),
+            std::path::Path::new("")
+        ));
     }
 }

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2067,13 +2067,18 @@ fn start_jupyter_server_blocking(app: tauri::AppHandle) -> Result<JupyterServerI
     // it out of the bundled backend resource into a dedicated lib dir placed on
     // the kernel's PYTHONPATH (so `import geolibre` works regardless of where the
     // notebook lives).
+    // Not fatal, unlike the notebooks root: Jupyter starts fine without this
+    // one, and losing it only costs `import geolibre` inside the notebooks. So
+    // report it rather than failing the whole panel -- but do report it, since
+    // silently discarding the result is what made #1642 so hard to read.
     let lib_dir = runtime_dir.join("notebook-lib");
-    fs::create_dir_all(&lib_dir).map_err(|error| {
-        format!(
-            "Could not create the notebook library directory {}: {error}",
+    if let Err(error) = fs::create_dir_all(&lib_dir) {
+        eprintln!(
+            "Jupyter: could not create the notebook library directory {} ({error}); \
+             `import geolibre` will not resolve in notebooks.",
             lib_dir.display()
-        )
-    })?;
+        );
+    }
     let _ = fs::copy(
         project_dir.join("notebook_client.py"),
         lib_dir.join("geolibre.py"),
@@ -2189,8 +2194,13 @@ fn stop_jupyter_server_blocking(app: tauri::AppHandle) -> Result<(), String> {
         *token = None;
     }
     // Backstop: reap anything still bound to the port (no-op when nothing of
-    // ours is listening).
-    terminate_jupyter_listeners_on_port(JUPYTER_PORT, &app_runtime_dir(&app)?)?;
+    // ours is listening). Best-effort, because the child this call exists to
+    // clean up after is already gone by now: returning an error here would
+    // leave the frontend believing the server it just stopped is still running
+    // (stopJupyterServer only clears its state once this invoke resolves).
+    if let Ok(runtime_dir) = app_runtime_dir(&app) {
+        let _ = terminate_jupyter_listeners_on_port(JUPYTER_PORT, &runtime_dir);
+    }
     Ok(())
 }
 

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -76,7 +76,9 @@ ENV_RELAY_TOKEN = "GEOLIBRE_RELAY_TOKEN"
 COMMAND_TYPE = "geolibre:command"
 
 # Origins allowed to open the relay WebSocket: the Tauri webview (tauri:// on
-# macOS/Linux, https://tauri.localhost on Windows) and any loopback dev origin.
+# macOS/Linux, http://tauri.localhost on Windows, or https:// there if
+# useHttpsScheme is ever turned on) and any loopback dev origin. Matching is on
+# host and scheme separately, so both Windows schemes are already covered.
 # This mirrors the `frame-ancestors` list in jupyter_server_config.py — the app
 # that may embed this server is exactly the app that may drive the map.
 _ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "tauri.localhost"})

--- a/backend/geolibre_server/jupyter_server_config.py
+++ b/backend/geolibre_server/jupyter_server_config.py
@@ -5,7 +5,7 @@ environment and embeds it in an ``<iframe>`` beside the map. By default Jupyter
 Server only allows itself to be framed by its own origin
 (``Content-Security-Policy: frame-ancestors 'self'``), which would block the
 GeoLibre webview (a different origin: ``tauri://localhost`` /
-``https://tauri.localhost``). This config relaxes ``frame-ancestors`` to the
+``http://tauri.localhost``). This config relaxes ``frame-ancestors`` to the
 loopback / Tauri webview origins so the panel can host it.
 
 The server is bound to ``127.0.0.1`` and protected by a per-launch token
@@ -17,11 +17,19 @@ build, which embeds the in-browser JupyterLite site instead.
 """
 
 # Origins permitted to embed this server in an iframe. Covers the Tauri webview
-# (macOS/Linux use the tauri:// scheme; Windows uses https://tauri.localhost)
 # and any loopback dev origin.
+#
+# Windows needs BOTH schemes of tauri.localhost. Tauri v1 served the webview
+# from https://tauri.localhost, but v2's `app.windows[].useHttpsScheme` defaults
+# to false, so the real origin there is http://tauri.localhost. Listing only the
+# https form left the panel showing Chromium's "127.0.0.1 refused to connect."
+# on Windows -- the server was healthy and listening, its CSP just refused to be
+# framed by the app. macOS and Linux were unaffected: they use tauri://localhost.
+# Keep https here too, so flipping useHttpsScheme on cannot silently break this
+# again.
 _FRAME_ANCESTORS = (
     "frame-ancestors 'self' "
-    "tauri://localhost https://tauri.localhost "
+    "tauri://localhost http://tauri.localhost https://tauri.localhost "
     "http://localhost:* http://127.0.0.1:*"
 )
 

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -150,6 +150,9 @@ def test_normalize_command_rejects_malformed_payloads(payload):
         None,
         "",
         "tauri://localhost",
+        # Windows: http is the real scheme (Tauri v2's useHttpsScheme defaults
+        # to false); https covers it being turned on.
+        "http://tauri.localhost",
         "https://tauri.localhost",
         "http://localhost:5173",
         "http://127.0.0.1:8766",

--- a/backend/geolibre_server/tests/test_jupyter_server_config.py
+++ b/backend/geolibre_server/tests/test_jupyter_server_config.py
@@ -1,0 +1,90 @@
+"""Tests for the bundled Jupyter Server config the desktop Notebook panel uses.
+
+The panel embeds this server in an ``<iframe>`` from the Tauri webview's origin,
+so the ``frame-ancestors`` list in the config is the single thing standing
+between a healthy server and Chromium's "127.0.0.1 refused to connect." in the
+panel. It is also easy to get wrong per-platform and impossible to notice from
+the server side, since a refused frame looks like a perfectly healthy server in
+every log -- hence these tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "jupyter_server_config.py"
+
+
+class _Section:
+    """Auto-vivifying stand-in for a traitlets Config section."""
+
+    def __init__(self):
+        self._values = {}
+
+    def __getattr__(self, name):
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return self._values.setdefault(name, _Section())
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            super().__setattr__(name, value)
+        else:
+            self._values[name] = value
+
+
+@pytest.fixture(scope="module")
+def config():
+    """Evaluate the real config file with a stubbed ``get_config``.
+
+    Executing it rather than reading its text means the assertions below cover
+    the value Jupyter would actually serve, not the spelling of a literal.
+    """
+    section = _Section()
+    namespace = {"get_config": lambda: section, "__file__": str(CONFIG_PATH)}
+    exec(compile(CONFIG_PATH.read_text(encoding="utf-8"), str(CONFIG_PATH), "exec"), namespace)
+    return section
+
+
+@pytest.fixture(scope="module")
+def frame_ancestors(config):
+    policy = config.ServerApp.tornado_settings["headers"]["Content-Security-Policy"]
+    directive, _, value = policy.partition(" ")
+    assert directive == "frame-ancestors", policy
+    return value.split()
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        # macOS and Linux.
+        "tauri://localhost",
+        # Windows. Tauri v2's `useHttpsScheme` defaults to false, so the real
+        # origin is the http one; v1 served https, and the config listed only
+        # that, which is what broke the panel on Windows. Both stay listed so
+        # turning `useHttpsScheme` on cannot silently break it again.
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+        # Dev servers and the loopback the server itself is bound to.
+        "http://localhost:*",
+        "http://127.0.0.1:*",
+    ],
+)
+def test_permits_every_origin_the_panel_can_be_embedded_from(frame_ancestors, origin):
+    assert origin in frame_ancestors
+
+
+def test_does_not_open_framing_to_the_whole_web(frame_ancestors):
+    # A stray `*` or `https:` here would let any site frame a token-bearing
+    # local server, so the list must stay an explicit allowlist.
+    assert "*" not in frame_ancestors
+    assert "https:" not in frame_ancestors
+    assert "http:" not in frame_ancestors
+
+
+def test_never_opens_a_browser_on_the_host(config):
+    # The app embeds the URL itself; a spawned browser would leak the token
+    # into the user's normal profile and history.
+    assert config.ServerApp.open_browser is False

--- a/tests/nmea.test.ts
+++ b/tests/nmea.test.ts
@@ -252,7 +252,12 @@ describe("NmeaAssembler", () => {
     const next = GGA.replace("174512.00", "174513.00");
     // Rebuild the checksum after mutating the payload.
     const nextGga = sentence(next.slice(1, next.lastIndexOf("*")));
-    const fixes = run([GGA, RMC, nextGga]);
+    // The second epoch gets its own RMC. An epoch resets on flush, so the date
+    // does not carry over from the first one, and a date-less epoch would be
+    // stamped against today's UTC day -- which made the assertion below pass
+    // only on the day it was written.
+    const nextRmc = sentence(RMC.slice(1, RMC.lastIndexOf("*")).replace("174512.00", "174513.00"));
+    const fixes = run([GGA, RMC, nextGga, nextRmc]);
     assert.equal(fixes.length, 2);
     assert.equal(new Date(fixes[0]!.timestamp).toISOString(), "2026-08-01T17:45:12.000Z");
     assert.equal(new Date(fixes[1]!.timestamp).toISOString(), "2026-08-01T17:45:13.000Z");


### PR DESCRIPTION
Fixes #1642
Fixes #1643

Two Notebook panel startup failures reported on Windows 11. Both reached the user as the same opaque message: "Jupyter server exited before it was ready".

## #1642 - swallowed `create_dir_all`

`start_jupyter_server_blocking` created the notebook root and the notebook lib directory with `let _ = fs::create_dir_all(...)`, then launched Jupyter with `--ServerApp.root_dir` pointing at the notebook root regardless. When creation had actually failed, Jupyter's own config validation was the first thing to complain, several steps later, with `Bad config encountered during initialization: No such directory: '...\runtime\notebooks'`.

Both results are now propagated and name the directory that could not be created, so the failure is reported where it happens.

## #1643 - stale server holding port 8766

`terminate_jupyter_listeners_on_port` was a no-op everywhere except Linux, where it reaps an orphaned server by walking `/proc`. On Windows a Jupyter server orphaned by a previous session kept holding 8766, and because the app spawns with `--ServerApp.port_retries=0`, every later launch failed to bind until the user found and killed the process by hand.

Windows now has an equivalent path:

- `GetExtendedTcpTable` with `TCP_TABLE_OWNER_PID_LISTENER` gives the PID owning the listening socket, over IPv4 and IPv6.
- `QueryFullProcessImageNameW` gives that process's executable path, and only a listener whose image lives **inside this user's own GeoLibre runtime directory** (`%APPDATA%\org.geolibre.desktop\runtime\`, where the uv-managed environments live) is terminated. A Jupyter the user installed themselves sits outside it and is never touched.
- `TerminateProcess` does the reclaim. Windows has no SIGTERM, so unlike the Linux path there is no graceful step to try first.

The existing `wait_for_port_free` then covers the release window before the spawn, unchanged.

macOS keeps the no-op; the comment now says so instead of lumping it together with Windows.

`windows-sys` is added as a Windows-only dependency. It is already an indirect dependency via tauri, so `Cargo.lock` gains only the dependency edge, no new crate.

Supporting change: the runtime directory is resolved once through a shared `app_runtime_dir` helper, since the reaper needs it too. The three places that previously spelled `app_data_dir()?.join("runtime")` by hand now call it.

## Verification

- `cargo check` and `cargo fmt --check` clean; `cargo test --lib` passes (34 tests).
- Two new unit tests cover the parts of the Windows path that are pure logic, so they run on every platform: the network-byte-order port decode out of the TCP table row, and the image-path guard (case and separator insensitivity, `runtime` not matching `runtime-old`, an empty root never matching, a user-installed Python not matching).
- The Windows FFI was type-checked against the real `windows-sys` 0.61 for `x86_64-pc-windows-gnu`, and `cargo clippy` on it is clean.
- The desktop app was built and launched on Linux with the change.
- I could not exercise the Windows reclaim itself, having no Windows machine here. I have added the `test-build` label so the Windows bundle job compiles and packages this branch; the runtime behaviour on Windows would benefit from a check by someone who can reproduce the original repro.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability by consistently managing application runtime files and directories.
  * Added cleanup for stale Jupyter processes that may prevent startup on Windows.
  * Enhanced health checks by capturing background service output.
  * Improved handling and reporting of directory-creation and service-startup errors.
  * Fixed NMEA epoch parsing when date information changes between sentence groups.
* **Chores**
  * Strengthened runtime-path handling across Jupyter, sidecar services, and tool installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## One unrelated commit

`c639d419` fixes `tests/nmea.test.ts`, which is not part of either issue. It is here because it is what turned CI red on this branch: "splits epochs when the time field advances" fed a single RMC and then a second GGA, so the second epoch carried no date and `epochTimestamp` stamped it against the host's current UTC day. The hardcoded `2026-08-01` expectation could therefore only pass on the day the test was written. The fix gives the second epoch its own RMC, which is also closer to what a real receiver sends. Happy to split it out if you would rather it landed on its own.


## Two more Windows defects, found by testing this PR's own artifact

Installing the Windows build from this PR showed the Notebook panel still failing, in a way neither issue describes. Both causes are pre-existing and were simply unreachable before: you cannot notice a framing refusal until the server gets far enough to be framed.

**The panel showed "127.0.0.1 refused to connect." with a healthy server behind it.** uv was still running and the Rust health check had already returned 200 from `127.0.0.1:8766` (the panel only sets the iframe `src` after `start_jupyter_server` resolves). What was refused was the *framing*, not the connection: `jupyter_server_config.py` allowed `frame-ancestors ... https://tauri.localhost`, which was the webview origin under Tauri v1. Tauri v2's `app.windows[].useHttpsScheme` defaults to `false` (`tauri-utils` `config.rs`), so the real origin on Windows is `http://tauri.localhost`, and Jupyter's CSP refused it. macOS and Linux never hit this: they use `tauri://localhost`, which was listed. Both schemes are allowed now, so enabling `useHttpsScheme` later cannot break it again either.

The app-side CSP in `tauri.conf.json` was never the problem; it already allows `frame-src http://127.0.0.1:*`.

**A console window appeared and stayed for the whole session.** Release builds are GUI-subsystem (`windows_subsystem = "windows"`) and so have no console of their own, which makes Windows allocate a console *window* for any console program they spawn. `configure_sidecar_process_impl` was a no-op off unix, so `uv.exe` (sidecar and Jupyter), the PowerShell uv installer, and Martin all got one. They now spawn with `CREATE_NO_WINDOW`; output is unaffected, since those callers already pipe and drain stdout/stderr.

`backend/geolibre_server/tests/test_jupyter_server_config.py` evaluates the real config file and asserts every origin the panel can be embedded from, plus that the list stays an explicit allowlist. A refused frame looks like a perfectly healthy server from the server side and leaves nothing in any log, so it needs a test rather than an eye.
