### PR TITLE
fix: keep the Vite dev watcher out of src-tauri

### DIFF
--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -901,6 +901,20 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    watch: {
+      // Never watch the Rust side. `tauri dev` runs this dev server as its
+      // `beforeDevCommand` and then starts cargo in the same tree, so the
+      // watcher would otherwise crawl `src-tauri/target/` while cargo is
+      // writing into it. On Windows that is fatal: chokidar's fs.watch on a
+      // build artifact cargo still holds open throws EBUSY (`errno -4082`) out
+      // of `NodeFsHandler._addToNodeFs`, which is an unhandled error — vite
+      // exits non-zero and tauri reports only `The "beforeDevCommand"
+      // terminated with a non-zero status code` (see the libsqlite3-sys
+      // `*-sqlite3.o` failure). Nothing under src-tauri feeds the frontend
+      // bundle, so there is no HMR to lose. These are appended to Vite's own
+      // defaults (node_modules, .git), not a replacement for them.
+      ignored: ["**/src-tauri/**"],
+    },
   },
   worker: {
     format: "es",


### PR DESCRIPTION
## Summary
- `tauri dev` launches the Vite dev server as its `beforeDevCommand` and then starts cargo in the same tree, so Vite's watcher crawled `src-tauri/target/` while cargo was still writing into it. On Windows, `fs.watch` on a build artifact cargo holds open throws an unhandled `EBUSY` (`errno -4082`) out of chokidar's `NodeFsHandler._addToNodeFs`; Vite exits non-zero and Tauri reports only `The "beforeDevCommand" terminated with a non-zero status code`, which hides the real cause.
- Adds `server.watch.ignored: ["**/src-tauri/**"]`. Vite appends this to its own defaults (`node_modules`, `.git`) rather than replacing them.
- No HMR is lost on any platform: every frontend reference to `src-tauri` is a comment (SYNC notes pointing at `lib.rs` and the capability JSONs), so it was never in the module graph. Tauri watches the Rust sources itself for the cargo rebuild. On Linux this also stops a warm `target/` (about 95k files here) from consuming inotify watches, which is the usual source of `ENOSPC: System limit for number of file watchers reached` under the common 8192/65536 distro defaults.

## Test plan
- [x] `pre-commit run --files apps/geolibre-desktop/vite.config.ts` passes, including the `npm build` hook
- [x] `npx vite` in `apps/geolibre-desktop` still boots and binds on 5173
- [ ] `npm run tauri:dev` completes the cargo build and opens the window on Windows
- [ ] `npm run tauri:dev` still works on Linux and macOS, and editing a file under `src-tauri/src/` still triggers a cargo rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented frontend development watcher errors caused by Rust build artifacts.
  * Improved development server stability by excluding backend-generated files from watch events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->