### PR TITLE
fix: drop benign ResizeObserver loop errors from diagnostics

### DIFF
--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -77,6 +77,15 @@ const BENIGN_CONSOLE_WARNINGS = [
   "WARNING: Multiple instances of Three.js being imported.",
 ];
 
+// ResizeObserver reports a delivery-cycle guard through window.onerror even
+// though no application exception was thrown. The browser defers the remaining
+// notifications to the next frame, so recording it as a runtime error produces
+// noisy `/:0:0` diagnostics during ordinary panel and map resizing.
+const BENIGN_WINDOW_ERRORS = [
+  "ResizeObserver loop completed with undelivered notifications.",
+  "ResizeObserver loop limit exceeded",
+];
+
 /** Whether a console.warn message is a known-benign warning to drop entirely. */
 function isBenignConsoleWarning(args: unknown[]): boolean {
   return (
@@ -510,6 +519,12 @@ export function installDiagnosticsCapture(): () => void {
   };
 
   const handleWindowError = (event: ErrorEvent) => {
+    if (BENIGN_WINDOW_ERRORS.includes(event.message)) {
+      // Suppress Chromium/WebKit's console error as well as the diagnostics
+      // entry. ResizeObserver will deliver the deferred notification next frame.
+      event.preventDefault();
+      return;
+    }
     appendDiagnostic({
       category: "runtime",
       level: "error",

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -195,6 +195,45 @@ describe("diagnostics startup transient suppression", () => {
     };
   }
 
+  function windowErrorEvent(message: string) {
+    let prevented = false;
+    return {
+      event: {
+        message,
+        filename: "https://web.geolibre.app/",
+        lineno: 0,
+        colno: 0,
+        preventDefault: () => {
+          prevented = true;
+        },
+      },
+      wasPrevented: () => prevented,
+    };
+  }
+
+  it("suppresses benign ResizeObserver delivery-loop errors", () => {
+    install();
+    for (const message of [
+      "ResizeObserver loop completed with undelivered notifications.",
+      "ResizeObserver loop limit exceeded",
+    ]) {
+      const { event, wasPrevented } = windowErrorEvent(message);
+      listeners.get("error")?.(event);
+      assert.equal(wasPrevented(), true);
+    }
+    assert.equal(getDiagnosticsSnapshot().totalCount, 0);
+  });
+
+  it("still records genuine window errors", () => {
+    install();
+    const { event, wasPrevented } = windowErrorEvent("ResizeObserver callback failed");
+    listeners.get("error")?.(event);
+    assert.equal(wasPrevented(), false);
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.message, "ResizeObserver callback failed");
+    assert.equal(record.level, "error");
+  });
+
   it("swallows a benign startup fetch rejection under Tauri", () => {
     win.__TAURI_INTERNALS__ = {};
     install();


### PR DESCRIPTION
## Summary
- Suppress the two ResizeObserver delivery-cycle guard messages ("loop completed with undelivered notifications" and "loop limit exceeded") in the window error handler, so they no longer land in the diagnostics panel as `/:0:0` runtime errors during ordinary panel and map resizing.
- Call `preventDefault()` on those events so the browser's own console error is suppressed too; the observer still delivers the deferred notification on the next frame.
- Genuine errors whose message merely mentions ResizeObserver are still recorded unchanged.

## Test plan
- [x] `node --import tsx --test tests/diagnostics.test.ts` (new cases: benign guard messages suppressed, real errors still recorded)
- [x] `pre-commit run --files apps/geolibre-desktop/src/lib/diagnostics.ts tests/diagnostics.test.ts`
- [ ] Resize the map and side panels in the running app and confirm the diagnostics panel stays clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented benign browser ResizeObserver warnings from appearing in the console or diagnostic reports.
  * Preserved existing handling and reporting for genuine runtime errors.

* **Tests**
  * Added coverage to verify filtering of ResizeObserver warnings and recording of other window errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->