### PR TITLE
fix(mas,ios): drop the network.server entitlement with Earth Engine sign-in

### DIFF
--- a/.github/workflows/mas-store.yml
+++ b/.github/workflows/mas-store.yml
@@ -131,8 +131,19 @@ jobs:
           [[ -d "$app" ]] || { echo "::error::No app bundle at $app"; exit 1; }
           # Confirm the sandbox entitlement made it into the signature before
           # packaging; an unsandboxed binary is an automatic App Review reject.
-          codesign -d --entitlements - --xml "$app" | grep -q "com.apple.security.app-sandbox" \
+          entitlements="$(codesign -d --entitlements - --xml "$app")"
+          grep -q "com.apple.security.app-sandbox" <<<"$entitlements" \
             || { echo "::error::App bundle is missing the app-sandbox entitlement"; exit 1; }
+          # App Review rejected 2.4.0 (guideline 2.4.5) for shipping
+          # network.server without matching functionality. The app now makes
+          # only outgoing connections — the Earth Engine OAuth loopback listener
+          # is compiled out of the `mas` build — so this entitlement must stay
+          # gone. If a future feature genuinely needs to accept an inbound
+          # connection, re-add it here AND justify it in App Review Information.
+          if grep -q "com.apple.security.network.server" <<<"$entitlements"; then
+            echo "::error::App bundle carries com.apple.security.network.server; App Review rejects it without an inbound-connection feature (see mas/Entitlements.mas.plist.template)"
+            exit 1
+          fi
           version="$(node -p "require('./apps/geolibre-desktop/src-tauri/tauri.conf.json').version")"
           pkg="GeoLibre.Desktop_${version}_universal_mas.pkg"
           xcrun productbuild --sign "$APPLE_MAS_INSTALLER_IDENTITY" \

--- a/.github/workflows/mas-store.yml
+++ b/.github/workflows/mas-store.yml
@@ -131,7 +131,8 @@ jobs:
           [[ -d "$app" ]] || { echo "::error::No app bundle at $app"; exit 1; }
           # Confirm the sandbox entitlement made it into the signature before
           # packaging; an unsandboxed binary is an automatic App Review reject.
-          entitlements="$(codesign -d --entitlements - --xml "$app")"
+          entitlements="$(codesign -d --entitlements - --xml "$app")" \
+            || { echo "::error::codesign could not read entitlements from $app"; exit 1; }
           grep -q "com.apple.security.app-sandbox" <<<"$entitlements" \
             || { echo "::error::App bundle is missing the app-sandbox entitlement"; exit 1; }
           # App Review rejected 2.4.0 (guideline 2.4.5) for shipping

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
     email: giswqs@gmail.com
     affiliation: "University of Tennessee, Knoxville, USA"
     orcid: "https://orcid.org/0000-0001-5437-4073"
-version: 2.4.0
-date-released: 2026-07-29
+version: 2.4.1
+date-released: 2026-08-02
 doi: "10.5281/zenodo.20785400"
 repository-code: "https://github.com/opengeos/GeoLibre"
 url: "https://geolibre.app"

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "chrono",
  "duckdb",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "2.4.0"
+version = "2.4.1"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/mas/Entitlements.mas.plist.template
+++ b/apps/geolibre-desktop/src-tauri/mas/Entitlements.mas.plist.template
@@ -16,10 +16,18 @@
 
   - network.client: map tiles, basemap styles, remote GeoJSON/COG/PMTiles,
     collab websocket.
-  - network.server: the Earth Engine OAuth flow listens on a loopback port for
-    the redirect callback.
   - files.user-selected.read-write: open/save project files and datasets picked
     through the file dialogs.
+
+  There is deliberately NO network.server entitlement. The app makes only
+  outgoing connections. The one feature that listened for an inbound connection
+  was Earth Engine sign-in (Google's OAuth loopback-redirect flow binds
+  127.0.0.1 to receive the browser redirect); App Review rejected the 2.4.0
+  submission over it (guideline 2.4.5, submission 76036eca), so the `mas` build
+  compiles that flow out entirely and hides its UI. If you ever add a feature
+  that accepts an inbound connection, adding the entitlement back is not enough
+  — it has to be justified in App Review Information, and mas-store.yml's
+  "no server entitlement" check will fail until this comment is revisited.
 -->
 <plist version="1.0">
 <dict>
@@ -30,8 +38,6 @@
   <key>com.apple.developer.team-identifier</key>
   <string>${APPLE_TEAM_ID}</string>
   <key>com.apple.security.network.client</key>
-  <true/>
-  <key>com.apple.security.network.server</key>
   <true/>
   <key>com.apple.security.files.user-selected.read-write</key>
   <true/>

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1,4 +1,32 @@
+// Earth Engine sign-in uses Google's OAuth loopback-redirect flow, which binds
+// a listener on 127.0.0.1 to accept the browser's redirect. Accepting an
+// inbound connection requires the `com.apple.security.network.server`
+// entitlement, which App Review rejects for an app that otherwise only makes
+// outgoing requests (guideline 2.4.5, submission 76036eca). Both Apple App
+// Store targets therefore compile the whole flow out and hide the Earth Engine
+// UI, so no Apple build ever binds a listening socket: the `mas` (macOS) build,
+// and iOS — which ships through the same review pipeline and has no way to
+// justify a listener either. Every other target (Developer ID macOS, Windows,
+// Linux, Android, web) keeps it. See docs/mac-app-store.md.
+#[cfg(not(any(feature = "mas", target_os = "ios")))]
 mod earth_engine_oauth;
+// App Store stub, mirroring the `native_duckdb` pattern below: the commands stay
+// in the handler list (so a stale panel state or an external plugin gets a clear
+// message instead of an "unknown command" error) but no socket is ever bound.
+#[cfg(any(feature = "mas", target_os = "ios"))]
+mod earth_engine_oauth {
+    const UNAVAILABLE: &str = "Earth Engine sign-in is not available in the App Store build of GeoLibre.";
+
+    #[tauri::command]
+    pub fn start_earth_engine_oauth(_client_id: String) -> Result<serde_json::Value, String> {
+        Err(UNAVAILABLE.to_string())
+    }
+
+    #[tauri::command]
+    pub fn poll_earth_engine_oauth(_state_id: String) -> Result<Option<serde_json::Value>, String> {
+        Err(UNAVAILABLE.to_string())
+    }
+}
 #[cfg(feature = "native-duckdb")]
 mod native_duckdb;
 #[cfg(not(feature = "native-duckdb"))]
@@ -28,9 +56,9 @@ mod native_duckdb {
 #[cfg(all(feature = "mas", feature = "native-duckdb"))]
 compile_error!("the `mas` (Mac App Store) build must not enable `native-duckdb`: DuckDB loads its spatial extension as unsigned native code at runtime, which App Sandbox and App Store guideline 2.5.2 forbid.");
 
-use earth_engine_oauth::{
-    poll_earth_engine_oauth, start_earth_engine_oauth, EarthEngineOAuthState,
-};
+use earth_engine_oauth::{poll_earth_engine_oauth, start_earth_engine_oauth};
+#[cfg(not(any(feature = "mas", target_os = "ios")))]
+use earth_engine_oauth::EarthEngineOAuthState;
 use flate2::read::{GzDecoder, ZlibDecoder};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -255,8 +283,13 @@ pub fn run() {
         .plugin(tauri_plugin_persisted_scope::init())
         .plugin(tauri_plugin_geolocation::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_opener::init())
-        .manage(EarthEngineOAuthState::default());
+        .plugin(tauri_plugin_opener::init());
+
+    // The Earth Engine OAuth loopback listener is compiled out of the Apple App
+    // Store builds (see the module gate at the top of this file); the stub
+    // commands are stateless, so the state goes with it.
+    #[cfg(not(any(feature = "mas", target_os = "ios")))]
+    let builder = builder.manage(EarthEngineOAuthState::default());
 
     // The Martin/sidecar/Jupyter process managers exist only where the commands
     // that spawn those processes do; the MAS build compiles both out together.

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -40,6 +40,7 @@ import {
   PRECIPITATION_PLUGIN_ID,
   REVERSE_GEOCODE_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
+  isEarthEngineAvailable,
   openRightPanel,
 } from "@geolibre/plugins";
 import { Button, cn, Input } from "@geolibre/ui";
@@ -1201,12 +1202,20 @@ export function TopToolbar({
       group: t("toolbar.commandGroup.processing"),
       run: handleOpenPlanetaryComputer,
     },
-    {
-      id: "proc.earth-engine",
-      title: t("toolbar.command.earthEngine"),
-      group: t("toolbar.commandGroup.processing"),
-      run: panels.earthEngine.toggle,
-    },
+    // Earth Engine sign-in needs the Rust loopback OAuth listener, which the
+    // Apple App Store builds (Mac App Store and iOS) compile out so the app
+    // claims no `com.apple.security.network.server` entitlement. Mirrors the
+    // ProcessingMenu gate.
+    ...(isEarthEngineAvailable()
+      ? [
+          {
+            id: "proc.earth-engine",
+            title: t("toolbar.command.earthEngine"),
+            group: t("toolbar.commandGroup.processing"),
+            run: panels.earthEngine.toggle,
+          },
+        ]
+      : []),
     // Controls
     ...MAP_CONTROL_ITEMS.map((control) => ({
       id: `control.${control.id}`,

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -40,7 +40,6 @@ import {
   PRECIPITATION_PLUGIN_ID,
   REVERSE_GEOCODE_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
-  isEarthEngineAvailable,
   openRightPanel,
 } from "@geolibre/plugins";
 import { Button, cn, Input } from "@geolibre/ui";
@@ -132,7 +131,7 @@ import { HelpMenu } from "./toolbar/HelpMenu";
 import { OsmPbfDialogs } from "./toolbar/OsmPbfDialogs";
 import { PluginsMenu } from "./toolbar/PluginsMenu";
 import { PluginToolbarMenus } from "./toolbar/PluginToolbarMenus";
-import { ProcessingMenu } from "./toolbar/ProcessingMenu";
+import { EARTH_ENGINE_AVAILABLE, ProcessingMenu } from "./toolbar/ProcessingMenu";
 import { ProjectFileDialogs } from "./toolbar/ProjectFileDialogs";
 import { ProjectMenu } from "./toolbar/ProjectMenu";
 import { googleEarthUrl, googleMapsUrl } from "../../lib/external-map-links";
@@ -1204,9 +1203,10 @@ export function TopToolbar({
     },
     // Earth Engine sign-in needs the Rust loopback OAuth listener, which the
     // Apple App Store builds (Mac App Store and iOS) compile out so the app
-    // claims no `com.apple.security.network.server` entitlement. Mirrors the
-    // ProcessingMenu gate.
-    ...(isEarthEngineAvailable()
+    // claims no `com.apple.security.network.server` entitlement. Shares the
+    // ProcessingMenu gate's module-level constant rather than recomputing it in
+    // this array, which is rebuilt on every render.
+    ...(EARTH_ENGINE_AVAILABLE
       ? [
           {
             id: "proc.earth-engine",

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -23,6 +23,14 @@ import { isMenuItemVisible } from "../../../lib/ui-profile";
 import { WHITEBOX_MENU_CATALOG } from "../../../lib/whitebox-menu-catalog";
 import type { ToolbarChrome } from "./constants";
 
+// Earth Engine sign-in needs the Rust loopback OAuth listener, which the Apple
+// App Store builds (Mac App Store and iOS) compile out so the app claims no
+// `com.apple.security.network.server` entitlement — App Review rejected it
+// otherwise. Module scope, like IS_MAS_BUILD: the build flag and user agent it
+// reads are fixed for the session, so there is nothing to recompute per render.
+// TopToolbar's command-palette gate reads the same constant.
+export const EARTH_ENGINE_AVAILABLE = isEarthEngineAvailable();
+
 interface ProcessingMenuProps {
   chrome: ToolbarChrome;
   earthEnginePanel: ToolbarPanel;
@@ -73,13 +81,7 @@ export function ProcessingMenu({
   // the browser via WebAssembly, so unlike the sidecar-backed tools it stays
   // available on mobile.
   const showWhitebox = show("processing.whitebox");
-  // Earth Engine sign-in needs the Rust loopback OAuth listener, which the Apple
-  // App Store builds (Mac App Store and iOS) compile out so the app claims no
-  // `com.apple.security.network.server` entitlement — App Review rejected it
-  // otherwise. Evaluated once alongside `mobile`: it reads the same
-  // session-stable user agent.
-  const showEarthEngine =
-    useMemo(() => isEarthEngineAvailable(), []) && show("processing.earthEngine");
+  const showEarthEngine = EARTH_ENGINE_AVAILABLE && show("processing.earthEngine");
 
   // Open the Whitebox toolbox dialog preselected to a specific tool, used by the
   // per-category submenus below. Two store writes: queue the tool, then open.

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -1,4 +1,5 @@
 import { type NetworkToolKind, useAppStore } from "@geolibre/core";
+import { isEarthEngineAvailable } from "@geolibre/plugins";
 import {
   Button,
   DropdownMenu,
@@ -72,6 +73,13 @@ export function ProcessingMenu({
   // the browser via WebAssembly, so unlike the sidecar-backed tools it stays
   // available on mobile.
   const showWhitebox = show("processing.whitebox");
+  // Earth Engine sign-in needs the Rust loopback OAuth listener, which the Apple
+  // App Store builds (Mac App Store and iOS) compile out so the app claims no
+  // `com.apple.security.network.server` entitlement — App Review rejected it
+  // otherwise. Evaluated once alongside `mobile`: it reads the same
+  // session-stable user agent.
+  const showEarthEngine =
+    useMemo(() => isEarthEngineAvailable(), []) && show("processing.earthEngine");
 
   // Open the Whitebox toolbox dialog preselected to a specific tool, used by the
   // per-category submenus below. Two store writes: queue the tool, then open.
@@ -104,7 +112,7 @@ export function ProcessingMenu({
     show("processing.notebook") ||
     show("processing.dashboard") ||
     show("processing.planetaryComputer") ||
-    show("processing.earthEngine");
+    showEarthEngine;
 
   return (
     <DropdownMenu>
@@ -530,7 +538,7 @@ export function ProcessingMenu({
             {t("toolbar.command.planetaryComputer")}
           </DropdownMenuItem>
         )}
-        {show("processing.earthEngine") && (
+        {showEarthEngine && (
           <DropdownMenuItem onSelect={earthEnginePanel.toggle}>
             {t("toolbar.command.earthEngine")}
             {earthEnginePanel.visible ? " ✓" : ""}

--- a/apps/geolibre-desktop/src/lib/is-mobile.ts
+++ b/apps/geolibre-desktop/src/lib/is-mobile.ts
@@ -1,3 +1,5 @@
+import { isIpadDesktopUserAgent } from "@geolibre/core";
+
 /**
  * Whether the app is running on a mobile operating system (Android or iOS).
  *
@@ -27,7 +29,8 @@ export function isMobile(
   maxTouchPoints: number = typeof navigator !== "undefined" ? navigator.maxTouchPoints : 0,
 ): boolean {
   if (MOBILE_UA_PATTERN.test(userAgent)) return true;
-  // iPadOS 13+ requests desktop sites by default and spoofs a macOS UA; a real
-  // Mac reports maxTouchPoints 0/1, an iPad reports >1.
-  return /Macintosh/.test(userAgent) && maxTouchPoints > 1;
+  // iPadOS 13+ requests desktop sites by default and spoofs a macOS UA. Shared
+  // with @geolibre/plugins' Earth Engine availability check so a future
+  // correction to the heuristic lands in both.
+  return isIpadDesktopUserAgent(userAgent, maxTouchPoints);
 }

--- a/docs/mac-app-store.md
+++ b/docs/mac-app-store.md
@@ -38,6 +38,45 @@ Tauri commands with stubs, and `GEOLIBRE_MAS_BUILD=1` hides the matching UI:
   Built-in and bundled drop-in plugins keep working.
 - **In-app update checks** (`GEOLIBRE_STORE_BUILD=1`, same as the Microsoft
   Store MSIX build): a Store app updates only through the Store.
+- **Earth Engine sign-in** (Processing → Earth Engine, and the GeoAgent
+  plugin's Earth Engine overlay). Unlike the items above this is not a sandbox
+  limit but an *entitlement* one — see below.
+
+### Earth Engine and the `network.server` entitlement
+
+Earth Engine sign-in uses Google's OAuth **loopback-redirect** flow for native
+apps: `src-tauri/src/earth_engine_oauth.rs` binds a listener on `127.0.0.1`,
+opens the consent page in the system browser, and accepts the browser's inbound
+redirect to receive the token. Accepting an inbound connection requires
+`com.apple.security.network.server`.
+
+App Review **rejected GeoLibre Desktop 2.4.0** over exactly this (guideline
+2.4.5, submission `76036eca-dc21-45d3-873e-39b015d37036`): an automated analysis
+flags the server entitlement when it cannot find matching functionality, and the
+bind happens lazily inside a Tauri command, so nothing static points at it.
+
+Rather than defend the entitlement in App Review Information, both Apple targets
+drop the feature: the module is gated
+`#[cfg(not(any(feature = "mas", target_os = "ios")))]` and replaced with stub
+commands that bind nothing, so **neither the Mac App Store build nor the iOS app
+ever opens a listening socket**. The entitlement is gone from
+`mas/Entitlements.mas.plist.template`, and `mas-store.yml` fails the build if it
+reappears in the signature. (iOS has no entitlements file — those sandbox keys
+are macOS-only — but it ships through the same review pipeline, so it gets the
+same treatment.)
+
+On the UI side, `isEarthEngineAvailable()`
+(`packages/plugins/src/plugins/earth-engine-auth.ts`) hides the Processing menu
+item and the command-palette entry, and `authenticateEarthEngine` throws early
+if anything else reaches it. It detects the macOS build from the
+`__GEOLIBRE_MAS_BUILD__` define and iOS from the user agent, and only applies
+inside the packaged app — the **web build keeps Earth Engine everywhere**,
+including Safari on iOS, because a browser uses Google's popup/redirect flow and
+binds nothing.
+
+If a future feature genuinely needs to accept an inbound connection, re-adding
+the entitlement is not sufficient on its own: describe the functionality in **App
+Review Information** before submitting, or the automated check rejects it again.
 
 Everything client-side is unchanged and fully functional: MapLibre/deck.gl
 rendering, Add Data for local and remote files, DuckDB-WASM vector reading,
@@ -93,7 +132,8 @@ native code at runtime).
 
 The sandboxed app can be smoke-tested by running the built
 `GeoLibre Desktop.app` directly; `codesign -d --entitlements - --xml` on the
-bundle should show `com.apple.security.app-sandbox`.
+bundle should show `com.apple.security.app-sandbox`, and must **not** show
+`com.apple.security.network.server`.
 
 ## CI: the `mas-store.yml` workflow
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -27,7 +27,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",
         "@carbonplan/zarr-layer": "^0.7.0",
@@ -21957,7 +21957,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^26.2.1",
         "uuid": "^14.0.1",
@@ -22037,7 +22037,8 @@
     },
     "packages/embed": {
       "name": "@geolibre/embed",
-      "version": "2.4.0",
+      "version": "2.4.1",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^7.0.2"
       }
@@ -22079,7 +22080,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@geolibre/core": "*",
         "@maplibre/geojson-vt": "^6.1.1",
@@ -22148,7 +22149,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.7.0",
         "@deck.gl/aggregation-layers": "9.3.7",
@@ -22295,7 +22296,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2",
         "@geolibre/core": "*",
@@ -22367,7 +22368,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-direction": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "description": "GeoLibre: a free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. It runs in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all while keeping your data local and private",
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ export {
   getRuntimeEnvironment,
   getSpatialExtensionPath,
 } from "./runtime-env";
+export { isIpadDesktopUserAgent } from "./platform";
 export {
   GOOGLE_MAPS_API_KEY_HEADER,
   googleMapsApiKeyHeaderValue,

--- a/packages/core/src/platform.ts
+++ b/packages/core/src/platform.ts
@@ -1,0 +1,29 @@
+/**
+ * Platform detection shared across the workspace. Carries no React/MapLibre
+ * dependency so callers stay unit-testable.
+ */
+
+/**
+ * Whether a "Macintosh" user agent is really an iPad.
+ *
+ * iPadOS 13+ requests desktop sites by default and reports a macOS user agent,
+ * so the UA string alone cannot tell an iPad from a Mac. Multi-touch does: a
+ * real Mac reports `maxTouchPoints` 0 or 1, an iPad reports more.
+ *
+ * This lives in `@geolibre/core` because two packages need it and the rule is
+ * an Apple behaviour that could change: the desktop app's `isMobile` (which
+ * hides sidecar-backed tools on mobile) and `@geolibre/plugins`'
+ * `isEarthEngineAvailable` (which hides Earth Engine sign-in on the Apple App
+ * Store builds). Keeping one copy means a future correction lands in both.
+ *
+ * @param userAgent - The user agent string to test.
+ * @param maxTouchPoints - `navigator.maxTouchPoints`, or undefined where the
+ *   runtime does not provide it (Node exposes a `navigator` without it).
+ * @returns True when the UA claims macOS but the device reports multi-touch.
+ */
+export function isIpadDesktopUserAgent(
+  userAgent: string,
+  maxTouchPoints: number | undefined,
+): boolean {
+  return /Macintosh/.test(userAgent) && (maxTouchPoints ?? 0) > 1;
+}

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/embed",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Typed client for GeoLibre's iframe embed API",
   "keywords": [
     "embed",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -183,6 +183,10 @@ export {
   toggleEarthEnginePanel,
 } from "./plugins/maplibre-earth-engine";
 export {
+  EARTH_ENGINE_UNAVAILABLE_MESSAGE,
+  isEarthEngineAvailable,
+} from "./plugins/earth-engine-auth";
+export {
   closeThreeDTilesLayerPanel,
   openThreeDTilesLayerPanel,
   restoreThreeDTilesLayers,

--- a/packages/plugins/src/plugins/earth-engine-auth.ts
+++ b/packages/plugins/src/plugins/earth-engine-auth.ts
@@ -1,5 +1,6 @@
 /// <reference path="../earthengine.d.ts" />
 
+import { isIpadDesktopUserAgent } from "@geolibre/core";
 import { invoke } from "@tauri-apps/api/core";
 
 export const DEFAULT_GEE_OAUTH_CLIENT_ID =
@@ -248,7 +249,7 @@ function isAppleAppStoreRuntime(userAgent?: string, maxTouchPoints?: number): bo
   const ua = userAgent ?? navigator.userAgent;
   const touch = maxTouchPoints ?? navigator.maxTouchPoints;
   if (/iPhone|iPad|iPod/i.test(ua)) return true;
-  return /Macintosh/.test(ua) && touch > 1;
+  return isIpadDesktopUserAgent(ua, touch);
 }
 
 /**

--- a/packages/plugins/src/plugins/earth-engine-auth.ts
+++ b/packages/plugins/src/plugins/earth-engine-auth.ts
@@ -178,6 +178,13 @@ export async function ensureEarthEngineAuthLibraryLoaded(): Promise<void> {
 export async function authenticateEarthEngine(
   oauthClientId: string,
 ): Promise<TauriEarthEngineOAuthToken | null> {
+  // Defence in depth: the UI is hidden in these builds, but a restored panel
+  // state or an external plugin could still reach here, and the Rust command is
+  // a stub that binds nothing.
+  if (!isEarthEngineAvailable()) {
+    throw new Error(EARTH_ENGINE_UNAVAILABLE_MESSAGE);
+  }
+
   if (shouldUseTauriEarthEngineOAuth()) {
     return authenticateEarthEngineViaTauri(oauthClientId);
   }
@@ -219,6 +226,56 @@ export function isTauriProductionOrigin(): boolean {
 export function shouldUseTauriEarthEngineOAuth(): boolean {
   return isTauriProductionOrigin();
 }
+
+// Injected by vite.config.ts; declared locally (module scope, so it does not
+// collide with the app's global declaration in vite-env.d.ts) because this
+// package must stay importable from a plain Node test where the define is
+// absent.
+declare const __GEOLIBRE_MAS_BUILD__: boolean;
+
+/**
+ * Whether this build is one of the Apple App Store targets, which ship without
+ * the Earth Engine OAuth loopback listener.
+ *
+ * The macOS App Store build is identified by its Vite define; iOS by its user
+ * agent, since no define distinguishes it. iPadOS 13+ reports a desktop
+ * "Macintosh" UA, disambiguated from a real Mac by multi-touch — the same rule
+ * as the app's `isMobile`.
+ */
+function isAppleAppStoreRuntime(userAgent?: string, maxTouchPoints?: number): boolean {
+  if (typeof __GEOLIBRE_MAS_BUILD__ !== "undefined" && __GEOLIBRE_MAS_BUILD__) return true;
+  if (typeof navigator === "undefined") return false;
+  const ua = userAgent ?? navigator.userAgent;
+  const touch = maxTouchPoints ?? navigator.maxTouchPoints;
+  if (/iPhone|iPad|iPod/i.test(ua)) return true;
+  return /Macintosh/.test(ua) && touch > 1;
+}
+
+/**
+ * Whether Earth Engine sign-in is available in this build.
+ *
+ * Signing in from a packaged app needs the Rust loopback OAuth listener, which
+ * the Apple App Store builds compile out (see the module gate in
+ * `src-tauri/src/lib.rs`) so the app claims no `network.server` entitlement.
+ * A browser — including Safari on iOS — still uses Google's popup/redirect flow
+ * and keeps Earth Engine, so the check is scoped to the packaged app via
+ * `isTauriProductionOrigin`.
+ *
+ * @param appleAppStore - Override for testing; defaults to the runtime check.
+ * @param packagedApp - Override for testing; defaults to
+ *   `isTauriProductionOrigin()`.
+ * @returns True when the Earth Engine UI and sign-in should be offered.
+ */
+export function isEarthEngineAvailable(
+  appleAppStore: boolean = isAppleAppStoreRuntime(),
+  packagedApp: boolean = isTauriProductionOrigin(),
+): boolean {
+  return !(packagedApp && appleAppStore);
+}
+
+/** The message shown where Earth Engine is compiled out. */
+export const EARTH_ENGINE_UNAVAILABLE_MESSAGE =
+  "Earth Engine sign-in is not available in the App Store build of GeoLibre.";
 
 async function authenticateEarthEngineViaBrowser(oauthClientId: string): Promise<void> {
   const earthEngine = await loadEarthEngine();

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -23,6 +23,7 @@ import {
   errorMessage,
   importMetaEnv,
   installEarthEngineFunctionInfoFallback,
+  isEarthEngineAvailable,
   oauthClientIdValue,
   preloadEarthEngineAuthLibrary,
   projectValue as earthEngineProjectValue,
@@ -377,6 +378,15 @@ function enhanceEarthEngineSignIn(): void {
   const status = details?.querySelector<HTMLElement>(".geoagent-earth-engine-status");
   const clientIdInput = details?.querySelector<HTMLInputElement>(".geoagent-ee-client-id");
   const projectIdInput = details?.querySelector<HTMLInputElement>(".geoagent-ee-project-id");
+  // The Apple App Store builds ship without the loopback OAuth listener that
+  // Earth Engine sign-in needs, so hide the whole section rather than render a
+  // Sign in button that can only throw. Everything inside it is Earth
+  // Engine-specific (status line, OAuth client id, project id), and this is the
+  // GeoAgent counterpart of the ProcessingMenu/TopToolbar gates.
+  if (details && !isEarthEngineAvailable()) {
+    details.hidden = true;
+    return;
+  }
   if (
     !details ||
     !status ||

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from .geolibre import Feature, Layer, Map
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 __all__ = ["Feature", "Layer", "Map", "__version__"]
 
 

--- a/tests/earth-engine-availability.test.ts
+++ b/tests/earth-engine-availability.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isEarthEngineAvailable } from "../packages/plugins/src/plugins/earth-engine-auth";
+
+// Earth Engine sign-in needs the Rust loopback OAuth listener, which binds
+// 127.0.0.1 to receive Google's redirect. Accepting an inbound connection needs
+// the `com.apple.security.network.server` entitlement, and App Review rejected
+// GeoLibre Desktop 2.4.0 over it (guideline 2.4.5). The Apple App Store builds
+// therefore compile the listener out, and this predicate is what keeps the UI
+// from offering a sign-in that cannot work. If it ever returns true for a
+// packaged Apple build again, the entitlement has to come back with it.
+describe("isEarthEngineAvailable", () => {
+  it("is unavailable in a packaged Apple App Store build", () => {
+    assert.equal(isEarthEngineAvailable(true, true), false);
+  });
+
+  it("stays available in every other packaged build (Developer ID, Windows, Linux, Android)", () => {
+    assert.equal(isEarthEngineAvailable(false, true), true);
+  });
+
+  it("stays available in a browser, including Safari on iOS", () => {
+    // Not a packaged app, so Google's popup/redirect flow applies and no
+    // loopback listener is involved — the entitlement never enters into it.
+    assert.equal(isEarthEngineAvailable(true, false), true);
+    assert.equal(isEarthEngineAvailable(false, false), true);
+  });
+
+  it("defaults to available under plain Node, where no Apple runtime is detected", () => {
+    // Both defaults resolve to false without a `navigator` or the Vite define.
+    assert.equal(isEarthEngineAvailable(), true);
+  });
+});

--- a/tests/earth-engine-availability.test.ts
+++ b/tests/earth-engine-availability.test.ts
@@ -26,7 +26,9 @@ describe("isEarthEngineAvailable", () => {
   });
 
   it("defaults to available under plain Node, where no Apple runtime is detected", () => {
-    // Both defaults resolve to false without a `navigator` or the Vite define.
+    // Both defaults resolve to false. Node does expose a global `navigator`
+    // (userAgent "Node.js/<major>"), but it matches none of the Apple UA
+    // patterns, and the Vite define is absent outside a bundled build.
     assert.equal(isEarthEngineAvailable(), true);
   });
 });


### PR DESCRIPTION
## Why

App Review **rejected GeoLibre Desktop 2.4.0** under guideline 2.4.5 (submission `76036eca-dc21-45d3-873e-39b015d37036`): the bundle carried `com.apple.security.network.server` with no functionality the automated analysis could match to it.

The entitlement was **real, not stray**. Earth Engine sign-in uses Google's OAuth loopback-redirect flow for native apps, so `earth_engine_oauth.rs` binds `127.0.0.1:5173` and accepts the browser's inbound redirect to receive the token. The bind happens lazily inside a Tauri command, which is why nothing static pointed at it.

Apple offered two routes — justify the entitlement in App Review Information, or remove it. This PR takes the second: drop the feature from the Apple builds.

## What changed

The Earth Engine OAuth module is gated `#[cfg(not(any(feature = "mas", target_os = "ios")))]` and replaced by stub commands that bind nothing, so **neither the Mac App Store build nor the iOS app ever opens a listening socket**.

This was the only inbound listener left in those builds — `wait_for_port_free` (Jupyter) and `spawn_martin_server` were already `#[cfg(not(feature = "mas"))]`, so nothing else needed touching.

iOS is included because it ships through the same review pipeline. It has no entitlements file (those sandbox keys are macOS-only), so nothing is removed there — but the listener is gone from the binary too.

- Remove `com.apple.security.network.server` from `mas/Entitlements.mas.plist.template`.
- `mas-store.yml` now fails the build if the entitlement reappears in the signature (written as an `if`, not `grep && exit`, which would trip `set -e` on the good path).
- `isEarthEngineAvailable()` hides the Processing menu item and the command-palette entry; `authenticateEarthEngine` throws early if a restored panel state or an external plugin still reaches it.
- Document the rejection and the constraint in `docs/mac-app-store.md`.

## What is *not* affected

Earth Engine is unchanged on **Developer ID macOS, Windows, Linux, Android, and the web build**. A browser uses Google's popup/redirect flow and binds nothing, so Earth Engine still works in **Safari on iOS** — the gate is scoped to the packaged app via `isTauriProductionOrigin()`.

## Verification

- `cargo check` and `cargo check --features mas` — both branches compile clean, no warnings.
- `npm run typecheck` (full build) passes.
- `npm run test:frontend` — 4872 pass / 0 fail, including a new `tests/earth-engine-availability.test.ts` covering the packaged-Apple, other-packaged, and browser cases.
- `pre-commit run --files <changed>` passes.

The iOS `target_os` branch could not be compiled here (the Apple target needs macOS/Xcode); it selects the same stub module as `--features mas`, which is verified.

## Follow-up if the feature is wanted back on Apple platforms

Switching to a **custom URL scheme** redirect (Google supports it for native clients) would keep Earth Engine and still need no `network.server`, at the cost of a new redirect URI in the Google Cloud console plus deep-link wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-aware Earth Engine availability checks.
  - Earth Engine sign-in and related controls are hidden on Mac App Store and iOS builds where unavailable.
  - Improved iPadOS desktop-mode detection.

- **Bug Fixes**
  - Prevented unavailable Earth Engine authentication attempts and clarified the resulting message.
  - Improved App Store package validation and sandbox entitlement checks.

- **Documentation**
  - Updated Mac App Store guidance, feature limitations, and testing expectations.

- **Release**
  - Updated project and package versions to 2.4.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->