### PR TITLE
Fix laggy globe dragging with atmospheric effects

### DIFF
--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1114,7 +1114,6 @@ export const MapCanvas = memo(function MapCanvas({
     map.on("projectiontransition", updateProjection);
     map.on("load", () => {
       const state = useAppStore.getState();
-      mc.waitAndSyncLayers(applyGroupEffects(state.layers, state.layerGroups));
       mc.setBasemapVisible(state.basemapVisible);
       mc.setBasemapOpacity(state.basemapOpacity);
       mc.highlightFeature(

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1185,7 +1185,6 @@ export const MapCanvas = memo(function MapCanvas({
     prevBasemap.current = basemapStyleUrl;
     map.once("style.load", () => {
       const state = useAppStore.getState();
-      controller.current?.waitAndSyncLayers(applyGroupEffects(state.layers, state.layerGroups));
       controller.current?.setBasemapVisible(state.basemapVisible);
       controller.current?.setBasemapOpacity(state.basemapOpacity);
       controller.current?.highlightFeature(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -3489,7 +3489,7 @@ function ensureLayer(
   map.addLayer(addSpec, validBeforeId);
 }
 
-function styleValuesEqual(current: unknown, next: unknown): boolean {
+export function styleValuesEqual(current: unknown, next: unknown): boolean {
   return Object.is(current, next) || JSON.stringify(current) === JSON.stringify(next);
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -14,6 +14,7 @@ import {
   validateMapExpression,
 } from "@geolibre/core";
 import { addProtocol, config } from "maplibre-gl";
+import type { GeoJSON } from "geojson";
 import type maplibregl from "maplibre-gl";
 import type { PropertyValueSpecification } from "maplibre-gl";
 import { FileSource, PMTiles, Protocol } from "pmtiles";
@@ -328,6 +329,18 @@ function applyExternalNativeFeatureFilters(
 // range we keep applying the style range on every sync, including a later reset
 // back to the full [0, 24] window.
 const managedZoomRangeLayerIds = new Set<string>();
+const geoJsonSourceData = new WeakMap<maplibregl.GeoJSONSource, GeoJSON>();
+
+function rememberGeoJsonData(map: maplibregl.Map, sourceId: string, data: GeoJSON): void {
+  const source = map.getSource(sourceId);
+  if (source?.type === "geojson") geoJsonSourceData.set(source as maplibregl.GeoJSONSource, data);
+}
+
+function setGeoJsonData(source: maplibregl.GeoJSONSource, data: GeoJSON): void {
+  if (geoJsonSourceData.get(source) === data) return;
+  source.setData(data);
+  geoJsonSourceData.set(source, data);
+}
 
 function clampLayerZoom(value: number, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
@@ -598,8 +611,9 @@ function ensureExternalGeoJsonNativeLayer(
       type: "geojson",
       data: layer.geojson,
     });
+    rememberGeoJsonData(map, nativeSourceId, layer.geojson);
   } else {
-    (map.getSource(nativeSourceId) as maplibregl.GeoJSONSource).setData(layer.geojson);
+    setGeoJsonData(map.getSource(nativeSourceId) as maplibregl.GeoJSONSource, layer.geojson);
   }
 
   if (nativeLayerIds.every((id) => map.getLayer(id))) return;
@@ -1438,6 +1452,10 @@ function setNativeLayerVisibility(
   visibility: "visible" | "none",
 ): void {
   try {
+    const canRead = typeof map.getLayoutProperty === "function";
+    const current = canRead ? map.getLayoutProperty(nativeLayerId, "visibility") : undefined;
+    if (current === visibility || (canRead && current === undefined && visibility === "visible"))
+      return;
     map.setLayoutProperty(nativeLayerId, "visibility", visibility);
   } catch {
     // Custom layers from external controls may not accept layout updates.
@@ -1666,7 +1684,9 @@ function syncVectorControlPointSymbology(
   // of the other rule-based paint overrides apply to control-owned layers.
   const radius = proportionalRadiusExpression(layer.style);
   if (radius) {
-    map.setPaintProperty(circleNativeId, "circle-radius", radius);
+    if (!styleValuesEqual(map.getPaintProperty?.(circleNativeId, "circle-radius"), radius)) {
+      map.setPaintProperty(circleNativeId, "circle-radius", radius);
+    }
     overriddenRadiusIdsFor(map).add(circleNativeId);
   } else {
     restoreOverriddenCircleRadius(map, circleNativeId, layer);
@@ -1721,7 +1741,9 @@ function setExternalNativeLayerPaint(
 
   for (const [property, value] of Object.entries(paint)) {
     try {
-      map.setPaintProperty(nativeLayerId, property, value);
+      if (!styleValuesEqual(map.getPaintProperty?.(nativeLayerId, property), value)) {
+        map.setPaintProperty(nativeLayerId, property, value);
+      }
     } catch {
       // External controls can create heterogeneous style layers. Ignore paint
       // properties that do not apply to a specific native layer type.
@@ -1807,8 +1829,9 @@ function syncGeoJsonLayer(map: maplibregl.Map, layer: GeoLibreLayer, beforeId?: 
             ...(attribution ? { attribution } : {}),
           },
     );
+    rememberGeoJsonData(map, src, layer.geojson!);
   } else {
-    (map.getSource(src) as maplibregl.GeoJSONSource).setData(layer.geojson!);
+    setGeoJsonData(map.getSource(src) as maplibregl.GeoJSONSource, layer.geojson!);
   }
 
   applyVectorDataRenderLayers(map, layer, src, profile, renderer, beforeId);
@@ -3403,12 +3426,16 @@ function ensureLayer(
   if (map.getLayer(id)) {
     if (spec.paint) {
       for (const [key, value] of Object.entries(spec.paint)) {
-        map.setPaintProperty(id, key, value);
+        if (!styleValuesEqual(map.getPaintProperty?.(id, key), value)) {
+          map.setPaintProperty(id, key, value);
+        }
       }
     }
     if (spec.layout) {
       for (const [key, value] of Object.entries(spec.layout)) {
-        map.setLayoutProperty(id, key, value);
+        if (!styleValuesEqual(map.getLayoutProperty?.(id, key), value)) {
+          map.setLayoutProperty(id, key, value);
+        }
       }
     }
     if ("filter" in spec) {
@@ -3460,6 +3487,10 @@ function ensureLayer(
     return;
   }
   map.addLayer(addSpec, validBeforeId);
+}
+
+function styleValuesEqual(current: unknown, next: unknown): boolean {
+  return Object.is(current, next) || JSON.stringify(current) === JSON.stringify(next);
 }
 
 function setLayerZoomRange(

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -37,6 +37,7 @@ import {
 import {
   mbtilesStyleLayerIds,
   removeLayerFromMap,
+  styleValuesEqual,
   syncLayer,
   vectorTileStyleLayerIds,
 } from "./layer-sync";
@@ -1107,9 +1108,17 @@ export class MapController {
   }
 
   private styleLoadHandler: (() => void) | null = null;
+  private styleReloadHandler: (() => void) | null = null;
 
   waitAndSyncLayers(layers: GeoLibreLayer[]): void {
     if (!this.map) return;
+
+    if (!this.styleReloadHandler) {
+      this.styleReloadHandler = () => {
+        if (!this.styleLoadHandler) this.syncLayers(this.syncedLayers);
+      };
+      this.map.on("style.load", this.styleReloadHandler);
+    }
 
     if (this.styleLoadHandler) {
       this.map.off("style.load", this.styleLoadHandler);
@@ -1200,8 +1209,7 @@ export class MapController {
           : this.basemapOpacity;
     try {
       const current = this.map.getPaintProperty(layerId, property);
-      if (Object.is(current, opacity) || JSON.stringify(current) === JSON.stringify(opacity))
-        return;
+      if (styleValuesEqual(current, opacity)) return;
       this.map.setPaintProperty(layerId, property, opacity);
     } catch {
       // Some third-party custom style layers may not expose paint properties.

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1075,13 +1075,11 @@ export class MapController {
     const map = this.map;
 
     const nextIds = layers.map((l) => l.id);
+    const nextIdSet = new Set(nextIds);
+    const previousLayers = new Map(this.syncedLayers.map((layer) => [layer.id, layer]));
     for (const id of this.layerIds) {
-      if (!nextIds.includes(id)) {
-        removeLayerFromMap(
-          map,
-          id,
-          this.syncedLayers.find((layer) => layer.id === id),
-        );
+      if (!nextIdSet.has(id)) {
+        removeLayerFromMap(map, id, previousLayers.get(id));
       }
     }
 
@@ -1120,6 +1118,9 @@ export class MapController {
 
     const run = () => {
       if (this.styleLoadHandler !== run) return;
+      this.map?.off("load", run);
+      this.map?.off("style.load", run);
+      this.styleLoadHandler = null;
       this.syncLayers(layers);
     };
     this.styleLoadHandler = run;
@@ -1128,17 +1129,21 @@ export class MapController {
       run();
     } else {
       this.map.once("load", run);
+      this.map.once("style.load", run);
     }
-    this.map.on("style.load", run);
   }
 
   private applyBasemapVisibility(): void {
     if (!this.isStyleReady() || !this.map) return;
     const map = this.map;
+    const visibility = this.basemapVisible ? "visible" : "none";
 
     for (const layer of this.getBasemapStyleLayers()) {
       try {
-        map.setLayoutProperty(layer.id, "visibility", this.basemapVisible ? "visible" : "none");
+        const current = map.getLayoutProperty(layer.id, "visibility");
+        if (current !== visibility && !(current === undefined && visibility === "visible")) {
+          map.setLayoutProperty(layer.id, "visibility", visibility);
+        }
       } catch {
         // Some third-party custom style layers may not expose layout properties.
       }
@@ -1194,6 +1199,9 @@ export class MapController {
           ? original * this.basemapOpacity
           : this.basemapOpacity;
     try {
+      const current = this.map.getPaintProperty(layerId, property);
+      if (Object.is(current, opacity) || JSON.stringify(current) === JSON.stringify(opacity))
+        return;
       this.map.setPaintProperty(layerId, property, opacity);
     } catch {
       // Some third-party custom style layers may not expose paint properties.

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -91,6 +91,10 @@ const HALO_SAMPLE_COUNT = 16;
 // Keep decorative canvas work from competing with MapLibre on high-refresh displays.
 const EFFECTS_FRAME_MS = 1000 / 60;
 
+export function nextEffectsFrameTime(timestamp: number, lastFrameTime: number): number | null {
+  return timestamp - lastFrameTime + 0.1 < EFFECTS_FRAME_MS ? null : timestamp;
+}
+
 // Halo radial gradient as a *shape* independent of the chosen color: each stop
 // is [offset, alpha, shade] where offset is the fraction of the gradient span
 // (globe edge → haloExtent × radius), alpha is the base opacity, and shade
@@ -810,14 +814,12 @@ class EffectsEngine {
     this.rafId = null;
     if (this.destroyed) return;
 
-    const elapsed = timestamp - this.lastFrameTime;
-    // Allow for rAF timestamp rounding on a nominal 60 Hz display.
-    if (elapsed + 0.1 < EFFECTS_FRAME_MS) {
+    const nextFrameTime = nextEffectsFrameTime(timestamp, this.lastFrameTime);
+    if (nextFrameTime === null) {
       this.start();
       return;
     }
-    this.lastFrameTime =
-      elapsed >= EFFECTS_FRAME_MS * 2 ? timestamp : this.lastFrameTime + EFFECTS_FRAME_MS;
+    this.lastFrameTime = nextFrameTime;
 
     this.clear();
 

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -707,18 +707,19 @@ class EffectsEngine {
     ctx.drawImage(field, wrappedX - this.width, wrappedY - this.height, this.width, this.height);
   }
 
-  private updateAndDrawComets(): void {
-    // One comet at a time, spawned with ~0.5% probability per frame.
-    if (this.comets.length === 0 && Math.random() < 0.005) {
+  private updateAndDrawComets(frameScale: number): void {
+    // Preserve the original ~0.5% chance per 60 Hz frame when frames are skipped.
+    const spawnChance = 1 - Math.pow(1 - 0.005, frameScale);
+    if (this.comets.length === 0 && Math.random() < spawnChance) {
       this.comets.push(this.spawnComet());
     }
 
     const ctx = this.cometCtx;
     const survivors: Comet[] = [];
     for (const comet of this.comets) {
-      comet.life += 1;
-      comet.x += Math.cos(comet.angle) * comet.speed;
-      comet.y += Math.sin(comet.angle) * comet.speed;
+      comet.life += frameScale;
+      comet.x += Math.cos(comet.angle) * comet.speed * frameScale;
+      comet.y += Math.sin(comet.angle) * comet.speed * frameScale;
       comet.alpha = 1 - comet.life / comet.maxLife;
 
       const offscreen =
@@ -819,6 +820,9 @@ class EffectsEngine {
       this.start();
       return;
     }
+    const elapsed = Number.isFinite(this.lastFrameTime)
+      ? Math.min(nextFrameTime - this.lastFrameTime, EFFECTS_FRAME_MS * 2)
+      : EFFECTS_FRAME_MS;
     this.lastFrameTime = nextFrameTime;
 
     this.clear();
@@ -835,7 +839,7 @@ class EffectsEngine {
       this.drawStarfield();
       this.starsDirty = false;
     }
-    this.updateAndDrawComets();
+    this.updateAndDrawComets(elapsed / EFFECTS_FRAME_MS);
     // The atmospheric halo is Earth-only — other celestial bodies (Moon, Mars,
     // Pluto, …) are airless or don't share Earth's blue glow, so we keep the
     // space backdrop, starfield, and comets but skip the halo for them.

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -88,6 +88,8 @@ const STARFIELD_LNG_PERIOD_DEGREES = 360;
 const STARFIELD_LAT_PERIOD_DEGREES = 180;
 
 const HALO_SAMPLE_COUNT = 16;
+// Keep decorative canvas work from competing with MapLibre on high-refresh displays.
+const EFFECTS_FRAME_MS = 1000 / 60;
 
 // Halo radial gradient as a *shape* independent of the chosen color: each stop
 // is [offset, alpha, shade] where offset is the fraction of the gradient span
@@ -458,6 +460,7 @@ class EffectsEngine {
   private settings: EffectsSettings;
 
   private rafId: number | null = null;
+  private lastFrameTime = -Infinity;
   private destroyed = false;
 
   constructor(map: MapLibreMap, settings: EffectsSettings) {
@@ -803,9 +806,18 @@ class EffectsEngine {
     ctx.restore();
   }
 
-  private tick(): void {
+  private tick(timestamp: number): void {
     this.rafId = null;
     if (this.destroyed) return;
+
+    const elapsed = timestamp - this.lastFrameTime;
+    // Allow for rAF timestamp rounding on a nominal 60 Hz display.
+    if (elapsed + 0.1 < EFFECTS_FRAME_MS) {
+      this.start();
+      return;
+    }
+    this.lastFrameTime =
+      elapsed >= EFFECTS_FRAME_MS * 2 ? timestamp : this.lastFrameTime + EFFECTS_FRAME_MS;
 
     this.clear();
 

--- a/tests/effects-settings.test.ts
+++ b/tests/effects-settings.test.ts
@@ -6,6 +6,7 @@ import {
   HALO_EXTENT_MIN,
   HALO_OPACITY_MAX,
   HALO_OPACITY_MIN,
+  nextEffectsFrameTime,
   normalizeEffectsSettings,
 } from "../packages/plugins/src/plugins/maplibre-effects";
 
@@ -62,5 +63,25 @@ describe("normalizeEffectsSettings", () => {
     assert.equal(result.haloColor, "#111111");
     assert.equal(result.spaceColor, "#222222");
     assert.equal(result.haloOpacity, 0.5);
+  });
+});
+
+describe("nextEffectsFrameTime", () => {
+  it("keeps decorative frames one 60 FPS interval apart on high-refresh displays", () => {
+    let lastFrameTime = -Infinity;
+    const renderedAt: number[] = [];
+
+    for (let index = 0; index < 180; index += 1) {
+      const timestamp = index * (1000 / 90);
+      const nextFrameTime = nextEffectsFrameTime(timestamp, lastFrameTime);
+      if (nextFrameTime === null) continue;
+      renderedAt.push(nextFrameTime);
+      lastFrameTime = nextFrameTime;
+    }
+
+    assert.equal(renderedAt.length, 90);
+    for (let index = 1; index < renderedAt.length; index += 1) {
+      assert.ok(renderedAt[index] - renderedAt[index - 1] + 0.1 >= 1000 / 60);
+    }
   });
 });

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -36,6 +36,7 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
   fake: FakeMap;
 } {
   const sources = new Map<string, Record<string, unknown>>();
+  const sourceHandles = new Map<string, Record<string, unknown>>();
   const layers = new Map<string, Record<string, unknown>>();
   const order: string[] = [];
   const calls: { method: string; args: unknown[] }[] = [];
@@ -67,28 +68,32 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
       layers: order.map((id) => ({ id, ...layers.get(id) })),
       sources: Object.fromEntries(sources),
     }),
-    getSource: (id: string) =>
-      sources.has(id)
-        ? {
-            type: (sources.get(id)?.type as string) ?? "geojson",
-            bounds: sources.get(id)?.bounds,
-            // Mirrors RasterTileSource.serialize(): a copy of the original
-            // source spec, used by getLayerRasterSource.
-            serialize: () => ({ ...sources.get(id) }),
-            setData: (data: unknown) => {
-              const spec = sources.get(id);
-              if (spec) spec.data = data;
-              setDataCalls.push({ id, data });
-              calls.push({ method: "setData", args: [id, data] });
-            },
-          }
-        : undefined,
+    getSource: (id: string) => {
+      if (!sources.has(id)) return undefined;
+      if (!sourceHandles.has(id)) {
+        sourceHandles.set(id, {
+          type: (sources.get(id)?.type as string) ?? "geojson",
+          bounds: sources.get(id)?.bounds,
+          // Mirrors RasterTileSource.serialize(): a copy of the original
+          // source spec, used by getLayerRasterSource.
+          serialize: () => ({ ...sources.get(id) }),
+          setData: (data: unknown) => {
+            const spec = sources.get(id);
+            if (spec) spec.data = data;
+            setDataCalls.push({ id, data });
+            calls.push({ method: "setData", args: [id, data] });
+          },
+        });
+      }
+      return sourceHandles.get(id);
+    },
     addSource: (id: string, spec: Record<string, unknown>) => {
       sources.set(id, spec);
       calls.push({ method: "addSource", args: [id, spec] });
     },
     removeSource: (id: string) => {
       sources.delete(id);
+      sourceHandles.delete(id);
       calls.push({ method: "removeSource", args: [id] });
     },
     getLayer: (id: string) => (layers.has(id) ? { id, ...layers.get(id) } : undefined),
@@ -133,6 +138,8 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
       }
       calls.push({ method: "setLayoutProperty", args: [id, key, value] });
     },
+    getLayoutProperty: (id: string, key: string) =>
+      (layers.get(id)?.layout as Record<string, unknown> | undefined)?.[key],
     setLayerZoomRange: record("setLayerZoomRange"),
     // Camera + query helpers used by the controller's public methods.
     project: (lngLat: [number, number]) => ({ x: lngLat[0], y: lngLat[1] }),
@@ -269,6 +276,34 @@ const rasterId = (id: string) => `layer-${id}-raster`;
 const srcId = (id: string) => `source-${id}`;
 
 describe("MapController.syncLayers reconciliation", () => {
+  it("runs a deferred initial sync only once", () => {
+    const { map, fake } = makeFakeMap();
+    const listeners = new Map<string, Set<() => void>>();
+    Object.assign(map as object, {
+      on: (event: string, listener: () => void) => {
+        const eventListeners = listeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        listeners.set(event, eventListeners);
+      },
+      once: (event: string, listener: () => void) => {
+        const eventListeners = listeners.get(event) ?? new Set();
+        eventListeners.add(listener);
+        listeners.set(event, eventListeners);
+      },
+      off: (event: string, listener: () => void) => listeners.get(event)?.delete(listener),
+    });
+    const controller = createMapController();
+    const internal = internals(controller);
+    internal.map = map;
+
+    controller.waitAndSyncLayers([pointLayer("a")]);
+    internal.styleReady = true;
+    for (const listener of [...(listeners.get("style.load") ?? [])]) listener();
+    for (const listener of [...(listeners.get("load") ?? [])]) listener();
+
+    assert.equal(fake.calls.filter((call) => call.method === "addSource").length, 1);
+  });
+
   it("does nothing until the style is ready", () => {
     const { map, fake } = makeFakeMap();
     const controller = createMapController();
@@ -377,6 +412,27 @@ describe("MapController.syncLayers reconciliation", () => {
     assert.equal(addSourceCalls(), 1, "source is not re-added");
     assert.equal(fake.setDataCalls.length, 1, "data refreshed via setData");
     assert.equal(fake.setDataCalls[0].id, srcId("a"));
+  });
+
+  it("does not resend unchanged data or style values", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    const layer = pointLayer("a");
+
+    controller.syncLayers([layer]);
+    const writes = fake.calls.filter((call) =>
+      ["setData", "setPaintProperty", "setLayoutProperty"].includes(call.method),
+    ).length;
+
+    controller.syncLayers([layer]);
+
+    assert.equal(fake.setDataCalls.length, 0);
+    assert.equal(
+      fake.calls.filter((call) =>
+        ["setData", "setPaintProperty", "setLayoutProperty"].includes(call.method),
+      ).length,
+      writes,
+    );
   });
 
   it("recreates the source when a layer-level change demands it (clustering)", () => {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -276,7 +276,7 @@ const rasterId = (id: string) => `layer-${id}-raster`;
 const srcId = (id: string) => `source-${id}`;
 
 describe("MapController.syncLayers reconciliation", () => {
-  it("runs a deferred initial sync only once", () => {
+  it("runs the initial sync once and restores layers after a style reload", () => {
     const { map, fake } = makeFakeMap();
     const listeners = new Map<string, Set<() => void>>();
     Object.assign(map as object, {
@@ -302,6 +302,16 @@ describe("MapController.syncLayers reconciliation", () => {
     for (const listener of [...(listeners.get("load") ?? [])]) listener();
 
     assert.equal(fake.calls.filter((call) => call.method === "addSource").length, 1);
+
+    const styleMap = map as {
+      removeLayer: (id: string) => void;
+      removeSource: (id: string) => void;
+    };
+    styleMap.removeLayer(circleId("a"));
+    styleMap.removeSource(srcId("a"));
+    for (const listener of [...(listeners.get("style.load") ?? [])]) listener();
+
+    assert.equal(fake.calls.filter((call) => call.method === "addSource").length, 2);
   });
 
   it("does nothing until the style is ready", () => {


### PR DESCRIPTION
Fixes #1652

This is a small performance pass for globe navigation. Atmospheric Effects could make dragging feel laggy, even in an empty project after startup had settled. The change keeps the same atmosphere and layer behavior while leaving more consistent frame time for navigation, similar to how games budget decorative rendering work.

## What changed

- Avoid repeated MapLibre work when layer data and styles have not changed.
- Run deferred initial layer synchronization only once.
- Keep decorative atmospheric rendering from exceeding the display budget needed for 60 FPS navigation.

## Before / after

| User-visible result | Before | After |
| --- | --- | --- |
| Fast globe dragging with Atmospheric Effects | Laggy, with noticeable pauses behind the pointer | Smoother and more consistent with the pointer |
| Average FPS in the automated drag benchmark | Baseline | About 3.4% higher |
| Frame pacing while dragging | Visible stalls despite a similar average FPS | Stalls are noticeably reduced |
| Atmosphere and layer UX | Current visuals and behavior | Unchanged |

The modest average-FPS change does not fully describe the improvement: the main difference is fewer noticeable stalls while interacting with the globe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced redundant map layer, source, and style updates.
  * Optimized map effects for smoother animation with consistent 60 FPS pacing.
* **Bug Fixes**
  * Improved synchronization when layers are added, removed, or updated.
  * Ensured map styles and basemap settings remain synchronized after style changes.
* **Reliability**
  * Improved initial map synchronization and recovery after style reloads.
  * Prevented unchanged map data and styling from being resent unnecessarily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->