### PR TITLE
fix(backend): validate aspatial geopackage layer writes & add test co…

### DIFF
--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -229,6 +229,11 @@ def _write_geopackage(target: Path, geojson: dict, layer: Optional[str]) -> tupl
                 status_code=404,
                 detail=f"Layer '{layer}' not found in {target.name}",
             )
+        if layer not in spatial:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Layer '{layer}' is an aspatial table and cannot be written",
+            )
         target_layer = layer
     elif spatial:
         # Match the reader's "first feature layer" default (gpkg-reader.ts

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -214,8 +214,8 @@ def _write_geopackage(target: Path, geojson: dict, layer: Optional[str]) -> tupl
         A ``(feature_count, layer_name)`` tuple.
 
     Raises:
-        HTTPException: The named layer is absent, or the file has several feature
-            layers and none was specified.
+        HTTPException: The named layer is absent, the named layer is an aspatial
+            attribute table, or the file holds no feature layer at all.
     """
     gpd = vector_ops._import_geopandas()
     layers = gpd.list_layers(str(target))
@@ -241,9 +241,10 @@ def _write_geopackage(target: Path, geojson: dict, layer: Optional[str]) -> tupl
         # it too. Explicit per-layer targeting for a multi-layer GeoPackage is a
         # follow-up (issue #1070).
         target_layer = spatial[0]
-    elif len(names) == 1:
-        target_layer = names[0]
     else:
+        # Only aspatial tables (or nothing) left: there is no writable target, and
+        # falling back to names[0] here would hand OGR the very aspatial table the
+        # explicit-layer branch above rejects.
         raise HTTPException(
             status_code=400,
             detail=f"No feature layer to write in {target.name}",

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -222,7 +222,7 @@ def _write_geopackage(target: Path, geojson: dict, layer: Optional[str]) -> tupl
     names = list(layers["name"])
     # Layers with a geometry type are the writable feature tables; aspatial
     # attribute tables (geometry_type is None) are never a write target.
-    spatial = [name for name, geom in zip(names, layers["geometry_type"]) if geom is not None]
+    spatial = layers[layers["geometry_type"].notna()]["name"].tolist()
     if layer:
         if layer not in names:
             raise HTTPException(

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -316,6 +316,29 @@ def test_write_geopackage_rejects_unknown_layer(tmp_path) -> None:
 
 
 @requires_geopandas
+def test_write_geopackage_rejects_aspatial_layer(tmp_path, monkeypatch) -> None:
+    import geopandas as gpd
+    import pandas as pd
+
+    src = tmp_path / "layer.gpkg"
+    gpd.GeoDataFrame.from_features(_edited("a")["features"], crs="EPSG:4326").to_file(
+        src, layer="places", driver="GPKG"
+    )
+
+    def mock_list_layers(path):
+        return pd.DataFrame({
+            "name": ["places", "aspatial_data"],
+            "geometry_type": ["Polygon", None]
+        })
+    monkeypatch.setattr(gpd, "list_layers", mock_list_layers)
+
+    with pytest.raises(HTTPException) as exc:
+        vector_write(WriteVectorRequest(path=str(src), geojson=_edited("b"), layer="aspatial_data"))
+    assert exc.value.status_code == 400
+    assert "aspatial table" in exc.value.detail
+
+
+@requires_geopandas
 def test_write_geopackage_defaults_to_first_feature_layer(tmp_path) -> None:
     # With no layer specified, write-back targets the first feature layer, the
     # same layer the reader loads — leaving later layers untouched.

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -325,7 +325,7 @@ def test_write_geopackage_rejects_aspatial_layer(tmp_path, monkeypatch) -> None:
         src, layer="places", driver="GPKG"
     )
 
-    def mock_list_layers(path):
+    def mock_list_layers(_path: str) -> pd.DataFrame:
         return pd.DataFrame(
             {"name": ["places", "aspatial_data"], "geometry_type": ["Polygon", None]}
         )
@@ -335,7 +335,31 @@ def test_write_geopackage_rejects_aspatial_layer(tmp_path, monkeypatch) -> None:
     with pytest.raises(HTTPException) as exc:
         vector_write(WriteVectorRequest(path=str(src), geojson=_edited("b"), layer="aspatial_data"))
     assert exc.value.status_code == 400
-    assert "aspatial table" in exc.value.detail
+    assert exc.value.detail == "Layer 'aspatial_data' is an aspatial table and cannot be written"
+
+
+@requires_geopandas
+def test_write_geopackage_rejects_aspatial_only_file(tmp_path, monkeypatch) -> None:
+    # With no layer specified there is nothing to auto-select: every table is
+    # aspatial, so the write is refused rather than silently handing OGR the
+    # first (aspatial) table.
+    import geopandas as gpd
+    import pandas as pd
+
+    src = tmp_path / "attrs.gpkg"
+    gpd.GeoDataFrame.from_features(_edited("a")["features"], crs="EPSG:4326").to_file(
+        src, layer="places", driver="GPKG"
+    )
+
+    def mock_list_layers(_path: str) -> pd.DataFrame:
+        return pd.DataFrame({"name": ["aspatial_data"], "geometry_type": [None]})
+
+    monkeypatch.setattr(gpd, "list_layers", mock_list_layers)
+
+    with pytest.raises(HTTPException) as exc:
+        vector_write(WriteVectorRequest(path=str(src), geojson=_edited("b")))
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "No feature layer to write in attrs.gpkg"
 
 
 @requires_geopandas

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -326,10 +326,10 @@ def test_write_geopackage_rejects_aspatial_layer(tmp_path, monkeypatch) -> None:
     )
 
     def mock_list_layers(path):
-        return pd.DataFrame({
-            "name": ["places", "aspatial_data"],
-            "geometry_type": ["Polygon", None]
-        })
+        return pd.DataFrame(
+            {"name": ["places", "aspatial_data"], "geometry_type": ["Polygon", None]}
+        )
+
     monkeypatch.setattr(gpd, "list_layers", mock_list_layers)
 
     with pytest.raises(HTTPException) as exc:

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -1197,6 +1197,39 @@ def test_fix_geometries_no_op_on_valid_layer() -> None:
 
 
 @requires_geopandas
+def test_fix_geometries_leaves_unfixable_unchanged(monkeypatch) -> None:
+    # A degenerate polygon (e.g., <3 distinct points) that make_valid cannot repair
+    # into a valid polygonal area will either raise or return empty. The tool should
+    # leave the original unchanged and increment the unfixable count.
+    import shapely.validation
+    
+    def mock_make_valid(geom):
+        raise ValueError("Simulated unfixable geometry")
+        
+    monkeypatch.setattr(shapely.validation, "make_valid", mock_make_valid)
+
+    degenerate = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "degenerate"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [1, 1], [0, 0]]],
+                },
+            }
+        ],
+    }
+    geojson, messages = run_vector_tool("fix-geometries", degenerate)
+    assert len(geojson["features"]) == 1
+    # GeoPandas pads the LinearRing to 4 coordinates when loading/dumping
+    coords = geojson["features"][0]["geometry"]["coordinates"]
+    assert coords == [[[0.0, 0.0], [1.0, 1.0], [0.0, 0.0], [0.0, 0.0]]]
+    assert any("1 could not be repaired" in m for m in messages)
+
+
+@requires_geopandas
 def test_validity_anchor_parses_scientific_notation() -> None:
     anchor = vector_ops._validity_anchor("Self-intersection[1.5e-10 -2.3e-05]", None)
     assert anchor == (1.5e-10, -2.3e-05)

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -7,6 +7,7 @@ bad input, and :func:`run_vector_tool_json` round-trips through JSON strings.
 """
 
 import json
+from typing import NoReturn
 
 import pytest
 
@@ -1197,16 +1198,26 @@ def test_fix_geometries_no_op_on_valid_layer() -> None:
 
 
 @requires_geopandas
-def test_fix_geometries_leaves_unfixable_unchanged(monkeypatch) -> None:
+@pytest.mark.parametrize("failure", ["raises", "returns_empty"])
+def test_fix_geometries_leaves_unfixable_unchanged(monkeypatch, failure: str) -> None:
     # A degenerate polygon (e.g., <3 distinct points) that make_valid cannot repair
-    # into a valid polygonal area will either raise or return empty. The tool should
-    # leave the original unchanged and increment the unfixable count.
+    # into a valid polygonal area will either raise or return empty. Both are
+    # separate branches of _repair; each leaves the original unchanged and
+    # increments the unfixable count.
     import shapely.validation
+    from shapely.geometry import Polygon
 
-    def mock_make_valid(geom):
-        raise ValueError("Simulated unfixable geometry")
+    def raising_make_valid(_geom: object) -> NoReturn:
+        raise ValueError
 
-    monkeypatch.setattr(shapely.validation, "make_valid", mock_make_valid)
+    def emptying_make_valid(_geom: object) -> Polygon:
+        return Polygon()
+
+    monkeypatch.setattr(
+        shapely.validation,
+        "make_valid",
+        raising_make_valid if failure == "raises" else emptying_make_valid,
+    )
 
     degenerate = {
         "type": "FeatureCollection",

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -1202,10 +1202,10 @@ def test_fix_geometries_leaves_unfixable_unchanged(monkeypatch) -> None:
     # into a valid polygonal area will either raise or return empty. The tool should
     # leave the original unchanged and increment the unfixable count.
     import shapely.validation
-    
+
     def mock_make_valid(geom):
         raise ValueError("Simulated unfixable geometry")
-        
+
     monkeypatch.setattr(shapely.validation, "make_valid", mock_make_valid)
 
     degenerate = {


### PR DESCRIPTION
### What
`_write_geopackage` accepted any layer name that existed in the GeoPackage, including aspatial tables (those with `geometry_type = None`). Passing an aspatial table name caused an OGR crash at write time instead of a clean HTTP error

### Why
The existing guard only checked `if layer not in names` (404 for missing), but didnt check whether the matched layer was actually a spatial table.

### Fix
Add a second check `if layer not in spatial` after  404 guard, returning 400 with clear message: `"Layer 'X' is an aspatial table and cannot be written"`.

### Tests
- `test_write_geopackage_rejects_aspatial_layer` - verifies the new 400 path
- `test_fix_geometries_leaves_unfixable_unchanged` -  covers the previously untested `unfixable` branch in `_fix_geometries` (geometry that `make_valid` cant repair is left unchanged and counted)

All 119 existing + new vector tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GeoPackage write-back now rejects explicitly selected non-spatial tables with a clear HTTP 400 error.
  * GeoPackages containing no spatial layers now return a clear HTTP 400 error.
  * Missing layers continue to return HTTP 404 errors.
  * Geometry repair now preserves unrepairable degenerate polygons and reports them accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->