### PR TITLE
fix(mas): build JupyterLite so the Notebook panel is not a second map

### DIFF
--- a/.github/workflows/mas-store.yml
+++ b/.github/workflows/mas-store.yml
@@ -74,6 +74,21 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: apps/geolibre-desktop/jupyterlite/requirements.txt
+
+      - name: Install JupyterLite build dependencies
+        # Unlike the other desktop builds, the sandboxed Store build cannot
+        # spawn a JupyterLab server, so its Notebook panel embeds the
+        # self-hosted JupyterLite site and the `prebuild` hook must be able to
+        # generate it. Without these the build fails at that guard rather than
+        # shipping a Notebook panel that renders a second copy of the app.
+        run: python -m pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt
+
       - name: Install Rust stable
         # Pinned to a commit SHA (not the moving `stable` branch) because this
         # job later holds the App Store signing certificates in its keychain.

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import { readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -584,8 +584,22 @@ function removeJupyterLiteFromTauriDistPlugin(): Plugin {
       if (!IS_TAURI_BUILD) return;
       // The MAS build keeps JupyterLite: the Jupyter server is compiled out
       // there and the Notebook panel falls back to the JupyterLite site
-      // (Pyodide runs inside WebKit, which App Review permits).
-      if (IS_MAS_BUILD) return;
+      // (Pyodide runs inside WebKit, which App Review permits). Assert it is
+      // actually in the bundle: Tauri's asset resolver answers a missing asset
+      // with index.html, so a MAS build without the site renders a second copy
+      // of GeoLibre inside the Notebook panel instead of a notebook.
+      if (IS_MAS_BUILD) {
+        const entry = path.resolve(__dirname, "dist/jupyterlite/lab/index.html");
+        if (!existsSync(entry)) {
+          throw new Error(
+            "The Mac App Store build embeds the JupyterLite site, but " +
+              `${path.relative(__dirname, entry)} is missing. Run ` +
+              "`npm run build:jupyterlite` (it needs the `jupyter lite` CLI from " +
+              "apps/geolibre-desktop/jupyterlite/requirements.txt).",
+          );
+        }
+        return;
+      }
       rmSync(path.resolve(__dirname, "dist/jupyterlite"), {
         recursive: true,
         force: true,

--- a/docs/mac-app-store.md
+++ b/docs/mac-app-store.md
@@ -114,6 +114,18 @@ onnxruntime-web detection/segment-everything, geocoding, and collaboration.
 
 ## Building locally
 
+Unlike the other desktop builds, this one **embeds the JupyterLite site**, so
+the `jupyter lite` CLI has to be installed before you build:
+
+```bash
+pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt
+```
+
+Without it the build fails with an explicit error rather than producing an app
+whose Notebook panel loads the wrong thing (Tauri answers a missing asset with
+`index.html`, so a MAS build with no JupyterLite renders a second copy of
+GeoLibre inside the panel).
+
 ```bash
 # One-time: render the entitlements with your team id.
 APPLE_TEAM_ID=XXXXXXXXXX scripts/render-mas-entitlements.sh

--- a/scripts/build-jupyterlite.mjs
+++ b/scripts/build-jupyterlite.mjs
@@ -96,8 +96,9 @@ if (probe.status !== 0) {
   }
   console.warn(
     "[build-jupyterlite] `jupyter lite` is not available — skipping the " +
-      "JupyterLite build. The Notebook panel will fail to load on the web " +
-      "build. To enable it, install the build deps:\n" +
+      "JupyterLite build. Any build that embeds the site (web, embed) will " +
+      "have a Notebook panel that cannot load. To enable it, install the " +
+      "build deps:\n" +
       install,
   );
   process.exit(0);

--- a/scripts/build-jupyterlite.mjs
+++ b/scripts/build-jupyterlite.mjs
@@ -36,11 +36,18 @@ const outputDir = resolve(repoRoot, "apps/geolibre-desktop/public/jupyterlite");
 
 const isWin = process.platform === "win32";
 
-// The desktop (Tauri) build launches a real JupyterLab server, so the static
-// JupyterLite site is dead weight in the installer. Tauri sets TAURI_ENV_* on
-// its beforeBuildCommand; skip the build there. The plain web build and the
-// embed build (Jupyter widget) do not set it, so they still get the site.
-if (process.env.TAURI_ENV_PLATFORM) {
+// The Mac App Store build cannot spawn the JupyterLab server (App Sandbox +
+// guideline 2.5.2), so its Notebook panel embeds the JupyterLite site exactly
+// like the web build and the site is NOT dead weight there. `tauri-build.mjs`
+// sets GEOLIBRE_MAS_BUILD=1 on the tauri CLI, which the beforeBuildCommand
+// inherits, so this is visible here.
+const IS_MAS_BUILD = process.env.GEOLIBRE_MAS_BUILD === "1";
+
+// Every other desktop (Tauri) build launches a real JupyterLab server, so the
+// static site is dead weight in the installer. Tauri sets TAURI_ENV_* on its
+// beforeBuildCommand; skip the build there. The plain web build and the embed
+// build (Jupyter widget) do not set it, so they still get the site.
+if (process.env.TAURI_ENV_PLATFORM && !IS_MAS_BUILD) {
   console.log(
     "[build-jupyterlite] Tauri build detected — skipping JupyterLite " +
       "(desktop uses a real JupyterLab server).",
@@ -70,12 +77,28 @@ const probe = spawnSync("jupyter", ["lite", "--version"], {
 });
 
 if (probe.status !== 0) {
+  const install =
+    "  pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt\n" +
+    "then re-run `npm run build:jupyterlite`.";
+  // Best-effort everywhere except the Mac App Store build, which has no
+  // JupyterLab server to fall back to: shipping it without the site leaves the
+  // Notebook panel pointing at a missing asset, and Tauri's asset resolver
+  // serves index.html for anything it cannot find, so the panel would render a
+  // second copy of GeoLibre inside its iframe. Fail the build instead.
+  if (IS_MAS_BUILD) {
+    console.error(
+      "[build-jupyterlite] `jupyter lite` is not available, but the Mac App " +
+        "Store build embeds the JupyterLite site (it cannot spawn a Jupyter " +
+        "server). Install the build deps:\n" +
+        install,
+    );
+    process.exit(1);
+  }
   console.warn(
     "[build-jupyterlite] `jupyter lite` is not available — skipping the " +
-      "JupyterLite build. The web Notebook panel will show a 'not built' " +
-      "message. To enable it, install the build deps:\n" +
-      "  pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt\n" +
-      "then re-run `npm run build:jupyterlite`.",
+      "JupyterLite build. The Notebook panel will fail to load on the web " +
+      "build. To enable it, install the build deps:\n" +
+      install,
   );
   process.exit(0);
 }

--- a/tests/build-jupyterlite.test.ts
+++ b/tests/build-jupyterlite.test.ts
@@ -24,13 +24,17 @@ interface Run {
  * Run the script with `jupyter` unreachable (empty PATH), so it always stops at
  * the CLI probe instead of spending a minute building the real site. What is
  * under test is the decision it makes before that point.
+ *
+ * Both build-flavor variables are cleared first so a caller that already has
+ * them set (running the suite from inside a Tauri build, say) cannot flip a
+ * case onto the wrong branch; each test opts back in through `env`.
  */
 function run(env: Record<string, string>): Run {
   // The script reports on both streams (console.log for the skip, console.warn
   // / console.error for the missing CLI), so read them together.
   const result = spawnSync(process.execPath, [script], {
     cwd: repoRoot,
-    env: { ...process.env, PATH: "", GEOLIBRE_MAS_BUILD: "", ...env },
+    env: { ...process.env, PATH: "", TAURI_ENV_PLATFORM: "", GEOLIBRE_MAS_BUILD: "", ...env },
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/tests/build-jupyterlite.test.ts
+++ b/tests/build-jupyterlite.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// scripts/build-jupyterlite.mjs decides, from the environment alone, whether a
+// build needs the self-hosted JupyterLite site. Getting that decision wrong is
+// invisible at build time and only shows up in the shipped app: the Notebook
+// panel points at `jupyterlite/lab/index.html`, and Tauri answers a missing
+// asset with index.html, so a desktop build that skipped the site renders a
+// second copy of GeoLibre inside the notebook iframe instead of a notebook
+// (GeoLibre#1656 follow-up). The Mac App Store build is the case that matters:
+// it has no JupyterLab server to fall back to.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(repoRoot, "scripts", "build-jupyterlite.mjs");
+
+interface Run {
+  status: number;
+  output: string;
+}
+
+/**
+ * Run the script with `jupyter` unreachable (empty PATH), so it always stops at
+ * the CLI probe instead of spending a minute building the real site. What is
+ * under test is the decision it makes before that point.
+ */
+function run(env: Record<string, string>): Run {
+  // The script reports on both streams (console.log for the skip, console.warn
+  // / console.error for the missing CLI), so read them together.
+  const result = spawnSync(process.execPath, [script], {
+    cwd: repoRoot,
+    env: { ...process.env, PATH: "", GEOLIBRE_MAS_BUILD: "", ...env },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return { status: result.status ?? 1, output: `${result.stdout}${result.stderr}` };
+}
+
+describe("build-jupyterlite.mjs", () => {
+  it("skips the site for a regular desktop build, which ships a JupyterLab server", () => {
+    const { status, output } = run({ TAURI_ENV_PLATFORM: "macos" });
+    assert.equal(status, 0);
+    assert.match(output, /skipping JupyterLite/);
+  });
+
+  it("does not skip the site for the Mac App Store build", () => {
+    // The regression: this build is also a Tauri build, but its Jupyter server
+    // is compiled out, so skipping the site leaves the Notebook panel with
+    // nothing to load.
+    const { output } = run({ TAURI_ENV_PLATFORM: "macos", GEOLIBRE_MAS_BUILD: "1" });
+    assert.doesNotMatch(output, /skipping JupyterLite/);
+  });
+
+  it("fails the Mac App Store build when the JupyterLite CLI is missing", () => {
+    // Best-effort would ship the broken Notebook panel; this build must stop.
+    const { status, output } = run({ TAURI_ENV_PLATFORM: "macos", GEOLIBRE_MAS_BUILD: "1" });
+    assert.equal(status, 1);
+    assert.match(output, /Mac App Store build embeds the JupyterLite site/);
+    assert.match(output, /jupyterlite\/requirements\.txt/);
+  });
+
+  it("stays best-effort for the web build when the CLI is missing", () => {
+    const { status, output } = run({});
+    assert.equal(status, 0);
+    assert.match(output, /is not available/);
+  });
+});


### PR DESCRIPTION
## Summary

Processing → Jupyter Notebook opened a second copy of the GeoLibre map instead of a notebook on the Mac App Store build.

Root cause, end to end:

1. The MAS build compiles out the Jupyter server, so `NotebookPanel` points its iframe at the bundled JupyterLite site (`apps/geolibre-desktop/src/components/panels/NotebookPanel.tsx:51`).
2. `scripts/build-jupyterlite.mjs` skipped whenever `TAURI_ENV_PLATFORM` is set, which includes the MAS build, so `public/jupyterlite/` was never generated.
3. The `IS_MAS_BUILD` branch in `vite.config.ts` that exists to keep `dist/jupyterlite` therefore had nothing to keep.
4. Tauri answers an unresolvable asset with `index.html` (`tauri-2.11.5/src/manager/mod.rs:423`), so the iframe loaded the whole app: a second map.
5. Even with the skip fixed, `mas-store.yml` never installed the `jupyter lite` CLI, and the script was best-effort (warn, exit 0), so CI would have shipped the same broken build silently.

Changes:

- `scripts/build-jupyterlite.mjs`: skip only for non-MAS Tauri builds, and make a missing CLI a hard failure on the MAS build instead of a warning.
- `apps/geolibre-desktop/vite.config.ts`: fail the MAS build if `dist/jupyterlite/lab/index.html` is absent, so this can never ship silently again.
- `.github/workflows/mas-store.yml`: install the JupyterLite build dependencies, matching how `pages.yml` and `pr-preview.yml` do it.
- `tests/build-jupyterlite.test.ts`: cover the skip decision for all four build flavors.
- `docs/mac-app-store.md`: document the new local build prerequisite.

## Test plan

- [x] `npm run test:frontend` passes (4879 pass, 0 fail), including the 4 new cases.
- [x] The new test fails against the pre-fix script (the two MAS cases) and passes after, so it pins the regression.
- [x] MAS-flavored build with the CLI installed produces `apps/geolibre-desktop/dist/jupyterlite/lab/index.html`.
- [x] MAS-flavored build with the site absent fails with an actionable message and exit code 1.
- [x] A regular Tauri build still strips `dist/jupyterlite` (installer size unchanged) and exits 0.
- [x] `pre-commit run --files <changed>` passes, including eslint and the full `npm build` hook.
- [ ] Verify on a Mac: build the sandboxed app, open Processing → Jupyter Notebook, and confirm JupyterLite loads with a working Pyodide kernel. This was verified on Linux by reproducing the build-side chain, not by running the signed macOS app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mac App Store builds so the Notebook panel is included and validated correctly.
  * Builds now provide clear errors when required Notebook components are unavailable.
  * Other macOS and web builds retain their existing best-effort behavior.

* **Documentation**
  * Updated Mac App Store build instructions with the required Notebook build dependency installation step.

* **Tests**
  * Added coverage for Notebook build behavior across Mac App Store, macOS, and web builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->