### PR TITLE
fix(attributes): make web URLs clickable

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1837,7 +1837,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                             : "h-7 min-w-0 px-2 text-xs";
                         const config = formFields.get(col);
                         const current = draft ?? formatAttributeValue(value);
-                        const linkUrl = attributeLinkUrl(value);
+                        const isEditableCell = isEditing && !derivedColumns.has(col);
+                        const linkUrl = isEditableCell ? null : attributeLinkUrl(value);
                         const invalidTitle = invalid
                           ? formError
                             ? formErrorText(formError)
@@ -1862,7 +1863,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                                   : undefined
                             }
                           >
-                            {isEditing && !derivedColumns.has(col) ? (
+                            {isEditableCell ? (
                               config?.widget === "valueMap" && config.valueMap?.length ? (
                                 <Select
                                   className={inputClassName}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import {
+  attributeLinkUrl,
   coerceAttributeFormValue,
   isDuckDBQueryLayer,
   useAppStore,
@@ -125,6 +126,7 @@ import {
   type VectorExportFormat,
 } from "../../lib/vector-export";
 import { PANEL_RESIZE_END_EVENT, PANEL_RESIZE_START_EVENT } from "../../lib/panel-resize";
+import { openExternalLink } from "../../lib/open-external";
 
 type SortDirection = "asc" | "desc";
 type SortKey = "__featureId" | string;
@@ -1835,6 +1837,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                             : "h-7 min-w-0 px-2 text-xs";
                         const config = formFields.get(col);
                         const current = draft ?? formatAttributeValue(value);
+                        const linkUrl = attributeLinkUrl(value);
                         const invalidTitle = invalid
                           ? formError
                             ? formErrorText(formError)
@@ -1918,6 +1921,21 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                                   onChange={(event) => commitDraft(event.target.value)}
                                 />
                               )
+                            ) : linkUrl ? (
+                              <a
+                                href={linkUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                title={linkUrl}
+                                className="inline-block max-w-full truncate align-bottom text-primary underline underline-offset-2"
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  void openExternalLink(linkUrl);
+                                }}
+                              >
+                                {linkUrl}
+                              </a>
                             ) : (
                               formatAttributeValue(value)
                             )}

--- a/apps/geolibre-desktop/src/lib/open-external.ts
+++ b/apps/geolibre-desktop/src/lib/open-external.ts
@@ -20,7 +20,7 @@ export async function openExternalLink(url: string): Promise<void> {
     try {
       await openUrl(url);
     } catch (error) {
-      console.warn("[GeoLibre] failed to open external link", url, error);
+      console.warn("[GeoLibre] failed to open external link", error);
     }
     return;
   }
@@ -29,6 +29,6 @@ export async function openExternalLink(url: string): Promise<void> {
   // debuggable rather than silent.
   const opened = window.open(url, "_blank", "noopener,noreferrer");
   if (!opened) {
-    console.warn("[GeoLibre] failed to open external link (popup blocked?)", url);
+    console.warn("[GeoLibre] failed to open external link (popup blocked?)");
   }
 }

--- a/packages/core/src/hyperlink.ts
+++ b/packages/core/src/hyperlink.ts
@@ -1,0 +1,20 @@
+/**
+ * Return a whole-value HTTP(S) URL that is safe to expose as an attribute link.
+ *
+ * Attribute values may contain arbitrary user data, so only explicit web URLs
+ * are accepted. Substrings in prose and schemes such as `javascript:` and
+ * `file:` remain plain text.
+ */
+export function attributeLinkUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || /\s/.test(trimmed)) return null;
+  if (!/^https?:\/\/[^/?#]/i.test(trimmed)) return null;
+
+  try {
+    const { protocol } = new URL(trimmed);
+    return protocol === "http:" || protocol === "https:" ? trimmed : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/hyperlink.ts
+++ b/packages/core/src/hyperlink.ts
@@ -9,6 +9,9 @@ export function attributeLinkUrl(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   if (!trimmed || /\s/.test(trimmed)) return null;
+  // Bidirectional controls can make an untrusted hostname appear to read as a
+  // different domain even though the browser opens the original URL.
+  if (/[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u.test(trimmed)) return null;
   if (!/^https?:\/\/[^/?#]/i.test(trimmed)) return null;
 
   try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types";
 export * from "./diagram";
 export * from "./marker-shape";
+export * from "./hyperlink";
 export * from "./photo";
 export * from "./ellipsoids";
 export * from "./geojson-z";

--- a/tests/attribute-hyperlink.test.ts
+++ b/tests/attribute-hyperlink.test.ts
@@ -16,6 +16,7 @@ describe("attributeLinkUrl", () => {
     assert.equal(attributeLinkUrl("file:///etc/passwd"), null);
     assert.equal(attributeLinkUrl("data:text/html,hello"), null);
     assert.equal(attributeLinkUrl("mailto:someone@example.com"), null);
+    assert.equal(attributeLinkUrl("https://example.com/\u202eevil.test"), null);
     assert.equal(attributeLinkUrl("https:"), null);
     assert.equal(attributeLinkUrl("https://"), null);
     assert.equal(attributeLinkUrl("www.example.com"), null);

--- a/tests/attribute-hyperlink.test.ts
+++ b/tests/attribute-hyperlink.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { attributeLinkUrl } from "@geolibre/core";
+
+describe("attributeLinkUrl", () => {
+  it("accepts whole HTTP and HTTPS URLs", () => {
+    assert.equal(attributeLinkUrl("https://www.bbc.co.uk/"), "https://www.bbc.co.uk/");
+    assert.equal(attributeLinkUrl("http://example.com"), "http://example.com");
+    assert.equal(attributeLinkUrl("  https://example.com/a?b=1#c "), "https://example.com/a?b=1#c");
+    assert.equal(attributeLinkUrl("HTTPS://Example.com/x"), "HTTPS://Example.com/x");
+  });
+
+  it("rejects prose and unsafe or incomplete URLs", () => {
+    assert.equal(attributeLinkUrl("see https://example.com for details"), null);
+    assert.equal(attributeLinkUrl("javascript:alert(1)"), null);
+    assert.equal(attributeLinkUrl("file:///etc/passwd"), null);
+    assert.equal(attributeLinkUrl("data:text/html,hello"), null);
+    assert.equal(attributeLinkUrl("mailto:someone@example.com"), null);
+    assert.equal(attributeLinkUrl("https:"), null);
+    assert.equal(attributeLinkUrl("https://"), null);
+    assert.equal(attributeLinkUrl("www.example.com"), null);
+  });
+
+  it("rejects non-string and empty values", () => {
+    assert.equal(attributeLinkUrl(null), null);
+    assert.equal(attributeLinkUrl(42), null);
+    assert.equal(attributeLinkUrl({ href: "https://example.com" }), null);
+    assert.equal(attributeLinkUrl("   "), null);
+  });
+});


### PR DESCRIPTION
## Summary

- render whole-value HTTP and HTTPS attribute values as clickable links
- open links through the existing desktop-safe external browser helper
- reject unsafe schemes, prose containing URLs, and incomplete URLs
- add focused URL detection tests

Addresses https://github.com/opengeos/GeoLibre/discussions/1655

## Verification

- loaded `earthquake_2.5_month.geojson` and opened its attribute table
- confirmed URL cells are links in light and dark themes
- `node --import tsx --test tests/attribute-hyperlink.test.ts`
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/src/components/panels/AttributeTable.tsx packages/core/src/hyperlink.ts packages/core/src/index.ts tests/attribute-hyperlink.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute tables now automatically turn valid HTTP and HTTPS values into clickable links.
  * Links open externally without triggering row selection or navigation.
  * Links are disabled while editing a cell, preserving normal editing behavior.

* **Bug Fixes**
  * Invalid, incomplete, unsafe, or non-text values are no longer treated as links.
  * External-link errors no longer expose the link address in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->