### PR TITLE
docs: add Europa, Callisto, and Charon basemap screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ GeoLibre is not limited to Earth. Planetary basemaps from OpenPlanetaryMap and U
     <td align="center"><b>Pluto</b></td>
     <td align="center"><b>Venus</b></td>
   </tr>
+  <tr>
+    <td width="33%"><a href="https://files.opengeos.org/europa.webp"><img src="https://files.opengeos.org/europa.webp" alt="GeoLibre globe view of Europa over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://files.opengeos.org/callisto.webp"><img src="https://files.opengeos.org/callisto.webp" alt="GeoLibre globe view of Callisto over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://files.opengeos.org/charon.webp"><img src="https://files.opengeos.org/charon.webp" alt="GeoLibre globe view of Charon over a starfield backdrop"></a></td>
+  </tr>
+  <tr>
+    <td align="center"><b>Europa</b></td>
+    <td align="center"><b>Callisto</b></td>
+    <td align="center"><b>Charon</b></td>
+  </tr>
 </table>
 
 Switch bodies from the planet switcher in the Layers panel. See [Demos](https://geolibre.app/demos/) for more.

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -67,6 +67,16 @@ The deep-space starfield behind each globe comes from the
     <td align="center"><b>Pluto</b><br>New Horizons Mosaic (NASA / JHU APL / SwRI)</td>
     <td align="center"><b>Venus</b><br>Magellan C3-MDIR Colour (NASA / JPL)</td>
   </tr>
+  <tr>
+    <td width="33%"><a href="https://files.opengeos.org/europa.webp"><img src="https://files.opengeos.org/europa.webp" alt="GeoLibre globe view of Europa over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://files.opengeos.org/callisto.webp"><img src="https://files.opengeos.org/callisto.webp" alt="GeoLibre globe view of Callisto over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://files.opengeos.org/charon.webp"><img src="https://files.opengeos.org/charon.webp" alt="GeoLibre globe view of Charon over a starfield backdrop"></a></td>
+  </tr>
+  <tr>
+    <td align="center"><b>Europa</b><br>Galileo / Voyager (NASA / JPL)</td>
+    <td align="center"><b>Callisto</b><br>Galileo / Voyager (NASA / JPL)</td>
+    <td align="center"><b>Charon</b><br>New Horizons Mosaic (NASA / JHU APL / SwRI)</td>
+  </tr>
 </table>
 
 ## SQL Workspace


### PR DESCRIPTION
## Summary
- Adds a third row of planetary basemap screenshots (Europa, Callisto, Charon) to the tables in `README.md` and `docs/demos.md`.
- The surrounding prose in both files already listed the Galilean moons and Charon among the covered bodies, so only the image tables needed updating. The demos captions carry the basemap name and attribution taken from `packages/core/src/ellipsoids.ts`.

## Test plan
- [x] All three image URLs return HTTP 200.
- [x] Each screenshot was opened and verified to show the body it is labelled with.
- [x] Captions match the basemap `name` and `attribution` fields in `packages/core/src/ellipsoids.ts`.
- [ ] Rendered tables look correct on the GitHub README and the published docs site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the planetary basemaps demo gallery with new entries for Europa, Callisto, and Charon.
  * Added labeled image links and source credits for each newly displayed planetary basemap.
  * Updated the README and demo documentation to reflect the expanded gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->