### PR TITLE
chore(deps): clear the four transitive advisories failing the audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4001,12 +4001,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -13757,9 +13757,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -15120,9 +15120,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.28",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -15466,9 +15466,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.8",
-    "fast-uri": "3.1.4",
+    "fast-uri": "^3.1.5",
     "filelist": "^2.0.2",
     "sweepline-intersections": "^1.5.0",
     "uuid": "^14.0.0"


### PR DESCRIPTION
## Why

The CI `audit` job (`npm audit --omit=dev --audit-level=high`) is currently **red on `main`**, not just on one PR. Four new advisories landed against transitive dependencies of `@modelcontextprotocol/sdk`. Every open PR inherits the failure, so this unblocks the branch generally.

## The part that was not just a lockfile refresh

`npm audit fix` cleared three of the four. `fast-uri` needed a `package.json` change: the `overrides` entry pinned it to exactly `3.1.4`, which #1378 added as the fixed version for the *previous* fast-uri advisory. GHSA-7p8r-x3mc-p8w7 covers `3.0.0 - 3.1.4`, so that pin was actively holding the vulnerable version in place against the resolver.

Moved it to `^3.1.5` rather than re-pinning an exact version, so the next patch flows in on its own instead of needing this same manual fix a third time. That also matches the caret style of the other four overrides.

## Versions moved

| Package | From | To | Advisory |
| --- | --- | --- | --- |
| `fast-uri` | 3.1.4 | 3.1.5 | GHSA-7p8r-x3mc-p8w7 (high) |
| `ip-address` | 10.2.0 | 10.4.0 | GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg (high) |
| `@hono/node-server` | 1.19.14 | 2.0.12 | GHSA-frvp-7c67-39w9 (moderate) |
| `hono` | 4.12.28 | 4.12.34 | GHSA-8j4g-w8fx-2239 (moderate) |

### On the `@hono/node-server` major

This is the only bump worth a second look. It is not a forced incompatibility: the SDK declares `"@hono/node-server": "^1.19.9 || ^2.0.5"`, so 2.x is a range it explicitly supports, and `>=2.0.5` is the floor the advisory fixes at, so the 1.x line has no patched release to move to. `npm ls --omit=dev --all` reports no invalid tree entries.

## Verification

- `npm audit --omit=dev --audit-level=high` (the exact CI command): **0 vulnerabilities**, exit 0. Previously exit 1.
- `npm audit --omit=dev` at all severities: 0 vulnerabilities.
- `npm run build`, `npm run test:frontend` (4943 passing, 1 skipped), `npm run test:worker`: all pass.
- `pre-commit` on the changed files: passes.

No source changes, only `package.json` and `package-lock.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `fast-uri` package override to use a compatible 3.1.5-or-later version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->