### PR TITLE
fix: replace jupyter relay dispatch with broadcast to fix broken active notebooks

### DIFF
--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -98,10 +98,6 @@ _pending_results: dict[str, Future[dict[str, Any]]] = {}
 # Caller request ids currently in flight, used only to reject concurrent reuse.
 _pending_request_ids: set[str] = set()
 
-# Which window each correlated request was dispatched to. A stable authoritative
-# window keeps layer ids returned by addGeoJsonLayer valid for later read-backs.
-_pending_owners: dict[str, GeoLibreRelaySocket] = {}
-
 #: How long a correlated POST waits for the app's result before answering 504.
 #: The kernel client's own socket timeout (``_RELAY_TIMEOUT_SECONDS + 1`` in
 #: ``notebook_client.py``) must stay longer than this, so the precise 504 message
@@ -219,15 +215,6 @@ def _broadcast(message: dict[str, Any]) -> int:
     return sum(_try_write(socket, encoded) for socket in list(_listeners))
 
 
-def _dispatch_one(message: dict[str, Any]) -> GeoLibreRelaySocket | None:
-    """Send ``message`` to the oldest open app window that accepts it."""
-    encoded = json.dumps(message)
-    for socket in list(_listeners):
-        if _try_write(socket, encoded):
-            return socket
-    return None
-
-
 class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHandler):
     """The app side: subscribes to every command posted to the relay."""
 
@@ -258,27 +245,13 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
         except (ValueError, json.JSONDecodeError):
             return
         dispatch_id = result["requestId"]
-        if _pending_owners.get(dispatch_id) is not self:
-            return
         future = _pending_results.get(dispatch_id)
         if future is not None and not future.done():
             future.set_result(result)
 
     def on_close(self) -> None:
-        """Unregister this app window and fail its correlated requests."""
+        """Unregister this app window."""
         _drop_listener(self)
-        for dispatch_id, owner in list(_pending_owners.items()):
-            if owner is not self:
-                continue
-            future = _pending_results.get(dispatch_id)
-            if future is not None and not future.done():
-                future.set_result(
-                    {
-                        "requestId": dispatch_id,
-                        "ok": False,
-                        "error": "The GeoLibre window running this command closed.",
-                    }
-                )
 
 
 class GeoLibreRelayCommandHandler(APIHandler):
@@ -304,20 +277,18 @@ class GeoLibreRelayCommandHandler(APIHandler):
         _pending_request_ids.add(request_id)
         _pending_results[dispatch_id] = future
         try:
-            owner = _dispatch_one(message)
-            if owner is None:
+            delivered = _broadcast(message)
+            if delivered == 0:
                 self.finish(json.dumps({"delivered": 0}))
                 return
-            _pending_owners[dispatch_id] = owner
             try:
                 result = await wait_for(future, RESULT_TIMEOUT_SECONDS)
             except (TimeoutError, AsyncTimeoutError) as error:
                 raise web.HTTPError(504, "GeoLibre did not return a result in time.") from error
             result["requestId"] = request_id
-            self.finish(json.dumps({"delivered": 1, **result}))
+            self.finish(json.dumps({"delivered": delivered, **result}))
         finally:
             _pending_results.pop(dispatch_id, None)
-            _pending_owners.pop(dispatch_id, None)
             _pending_request_ids.discard(request_id)
 
 

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -87,20 +87,13 @@ _ALLOWED_ORIGIN_SCHEMES = frozenset({"http", "https", "tauri"})
 # Open app-side sockets, oldest connection first. Module level (not per-handler)
 # because every handler instance is created per request: the POST handler needs
 # the list the WebSocket handlers registered themselves in. Ordered (a list, not
-# a set) because single-window dispatch below takes the first entry: with a set
-# that would be whatever the hash table happens to yield, so a correlated
-# read-back could land in a different window than the mutation it follows up on
-# once a second window connects.
+# the list the WebSocket handlers registered themselves in.
 _listeners: list[GeoLibreRelaySocket] = []
 
 # Correlated read-back requests waiting for the app-side socket to execute a
 # scripting handler. Fire-and-forget commands keep an empty requestId and never
 # enter this mapping.
 _pending_results: dict[str, Future[dict[str, Any]]] = {}
-
-# Which window each in-flight correlated request was dispatched to, so closing
-# that window can fail its requests at once instead of waiting out the timeout.
-_pending_owners: dict[str, GeoLibreRelaySocket] = {}
 
 #: How long a correlated POST waits for the app's result before answering 504.
 #: The kernel client's own socket timeout (``_RELAY_TIMEOUT_SECONDS + 1`` in
@@ -219,20 +212,6 @@ def _broadcast(message: dict[str, Any]) -> int:
     return sum(_try_write(socket, encoded) for socket in list(_listeners))
 
 
-def _dispatch_one(message: dict[str, Any]) -> GeoLibreRelaySocket | None:
-    """Send ``message`` to exactly one app window; return the one that took it.
-
-    That is the oldest still-open window, a choice that is stable for as long as
-    it stays open, so a mutation and the read-back that follows it reach the same
-    map. Returns None when no window could be written to.
-    """
-    encoded = json.dumps(message)
-    for socket in list(_listeners):
-        if _try_write(socket, encoded):
-            return socket
-    return None
-
-
 class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHandler):
     """The app side: subscribes to every command posted to the relay."""
 
@@ -262,33 +241,13 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
             result = normalize_result(json.loads(message))
         except (ValueError, json.JSONDecodeError):
             return
-        # Only the window a request was dispatched to may answer it. Nothing else
-        # can learn the id today, but the single-authoritative-window guarantee
-        # this file builds up is worth enforcing where it is actually consumed.
-        if _pending_owners.get(result["requestId"]) is not self:
-            return
         future = _pending_results.get(result["requestId"])
         if future is not None and not future.done():
             future.set_result(result)
 
     def on_close(self) -> None:
-        """Unregister this app window and fail anything it still owed."""
+        """Unregister this app window."""
         _drop_listener(self)
-        # A correlated command runs in exactly one window. When that window is
-        # this one, nothing can answer it any more, so say so now rather than
-        # making the kernel sit out RESULT_TIMEOUT_SECONDS for a certain 504.
-        for request_id, owner in list(_pending_owners.items()):
-            if owner is not self:
-                continue
-            future = _pending_results.get(request_id)
-            if future is not None and not future.done():
-                future.set_result(
-                    {
-                        "requestId": request_id,
-                        "ok": False,
-                        "error": "The GeoLibre window running this command closed.",
-                    }
-                )
 
 
 class GeoLibreRelayCommandHandler(APIHandler):
@@ -311,24 +270,18 @@ class GeoLibreRelayCommandHandler(APIHandler):
         future: Future[dict[str, Any]] = Future()
         _pending_results[request_id] = future
         try:
-            # A correlated mutation must execute in only one app window; its
-            # returned layer id then always belongs to the window that handled
-            # it. Fire-and-forget commands retain the historical broadcast.
-            owner = _dispatch_one(message)
-            if owner is None:
+            # We broadcast to all windows. The first one to return a result wins.
+            delivered = _broadcast(message)
+            if delivered == 0:
                 self.finish(json.dumps({"delivered": 0}))
                 return
-            # No await between the dispatch and this record, so the window's
-            # on_close can never miss the request it is now responsible for.
-            _pending_owners[request_id] = owner
             try:
                 result = await wait_for(future, RESULT_TIMEOUT_SECONDS)
             except (TimeoutError, AsyncTimeoutError) as error:
                 raise web.HTTPError(504, "GeoLibre did not return a result in time.") from error
-            self.finish(json.dumps({"delivered": 1, **result}))
+            self.finish(json.dumps({"delivered": delivered, **result}))
         finally:
             _pending_results.pop(request_id, None)
-            _pending_owners.pop(request_id, None)
 
 
 class GeoLibreRelayStatusHandler(APIHandler):

--- a/backend/geolibre_server/geolibre_server/jupyter_relay.py
+++ b/backend/geolibre_server/geolibre_server/jupyter_relay.py
@@ -48,6 +48,7 @@ from asyncio import Future, wait_for
 from asyncio import TimeoutError as AsyncTimeoutError
 from typing import Any
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from jupyter_server.base.websocket import WebSocketMixin
@@ -84,16 +85,22 @@ COMMAND_TYPE = "geolibre:command"
 _ALLOWED_ORIGIN_HOSTS = frozenset({"localhost", "127.0.0.1", "tauri.localhost"})
 _ALLOWED_ORIGIN_SCHEMES = frozenset({"http", "https", "tauri"})
 
-# Open app-side sockets, oldest connection first. Module level (not per-handler)
-# because every handler instance is created per request: the POST handler needs
-# the list the WebSocket handlers registered themselves in. Ordered (a list, not
-# the list the WebSocket handlers registered themselves in.
+# Open app-side sockets. Module level (not per-handler) because every handler
+# instance is created per request: the POST handler needs the list the
+# WebSocket handlers registered themselves in.
 _listeners: list[GeoLibreRelaySocket] = []
 
 # Correlated read-back requests waiting for the app-side socket to execute a
-# scripting handler. Fire-and-forget commands keep an empty requestId and never
-# enter this mapping.
+# scripting handler. These are keyed by a server-generated dispatch id so a
+# delayed socket result cannot satisfy a later request that reused its caller id.
 _pending_results: dict[str, Future[dict[str, Any]]] = {}
+
+# Caller request ids currently in flight, used only to reject concurrent reuse.
+_pending_request_ids: set[str] = set()
+
+# Which window each correlated request was dispatched to. A stable authoritative
+# window keeps layer ids returned by addGeoJsonLayer valid for later read-backs.
+_pending_owners: dict[str, GeoLibreRelaySocket] = {}
 
 #: How long a correlated POST waits for the app's result before answering 504.
 #: The kernel client's own socket timeout (``_RELAY_TIMEOUT_SECONDS + 1`` in
@@ -212,6 +219,15 @@ def _broadcast(message: dict[str, Any]) -> int:
     return sum(_try_write(socket, encoded) for socket in list(_listeners))
 
 
+def _dispatch_one(message: dict[str, Any]) -> GeoLibreRelaySocket | None:
+    """Send ``message`` to the oldest open app window that accepts it."""
+    encoded = json.dumps(message)
+    for socket in list(_listeners):
+        if _try_write(socket, encoded):
+            return socket
+    return None
+
+
 class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHandler):
     """The app side: subscribes to every command posted to the relay."""
 
@@ -241,13 +257,28 @@ class GeoLibreRelaySocket(WebSocketMixin, websocket.WebSocketHandler, JupyterHan
             result = normalize_result(json.loads(message))
         except (ValueError, json.JSONDecodeError):
             return
-        future = _pending_results.get(result["requestId"])
+        dispatch_id = result["requestId"]
+        if _pending_owners.get(dispatch_id) is not self:
+            return
+        future = _pending_results.get(dispatch_id)
         if future is not None and not future.done():
             future.set_result(result)
 
     def on_close(self) -> None:
-        """Unregister this app window."""
+        """Unregister this app window and fail its correlated requests."""
         _drop_listener(self)
+        for dispatch_id, owner in list(_pending_owners.items()):
+            if owner is not self:
+                continue
+            future = _pending_results.get(dispatch_id)
+            if future is not None and not future.done():
+                future.set_result(
+                    {
+                        "requestId": dispatch_id,
+                        "ok": False,
+                        "error": "The GeoLibre window running this command closed.",
+                    }
+                )
 
 
 class GeoLibreRelayCommandHandler(APIHandler):
@@ -265,23 +296,29 @@ class GeoLibreRelayCommandHandler(APIHandler):
             self.finish(json.dumps({"delivered": _broadcast(message)}))
             return
 
-        if request_id in _pending_results:
+        if request_id in _pending_request_ids:
             raise web.HTTPError(409, "Duplicate requestId.")
+        dispatch_id = uuid4().hex
+        message["requestId"] = dispatch_id
         future: Future[dict[str, Any]] = Future()
-        _pending_results[request_id] = future
+        _pending_request_ids.add(request_id)
+        _pending_results[dispatch_id] = future
         try:
-            # We broadcast to all windows. The first one to return a result wins.
-            delivered = _broadcast(message)
-            if delivered == 0:
+            owner = _dispatch_one(message)
+            if owner is None:
                 self.finish(json.dumps({"delivered": 0}))
                 return
+            _pending_owners[dispatch_id] = owner
             try:
                 result = await wait_for(future, RESULT_TIMEOUT_SECONDS)
             except (TimeoutError, AsyncTimeoutError) as error:
                 raise web.HTTPError(504, "GeoLibre did not return a result in time.") from error
-            self.finish(json.dumps({"delivered": delivered, **result}))
+            result["requestId"] = request_id
+            self.finish(json.dumps({"delivered": 1, **result}))
         finally:
-            _pending_results.pop(request_id, None)
+            _pending_results.pop(dispatch_id, None)
+            _pending_owners.pop(dispatch_id, None)
+            _pending_request_ids.discard(request_id)
 
 
 class GeoLibreRelayStatusHandler(APIHandler):

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -31,6 +32,17 @@ class FakeSocket:
         if self.fails:
             raise RuntimeError("socket is closed")
         self.received.append(message)
+
+
+class FakeCommandHandler:
+    """Minimal command handler surface for exercising ``post`` directly."""
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.request = SimpleNamespace(body=json.dumps(payload).encode())
+        self.response: str | None = None
+
+    def finish(self, response: str) -> None:
+        self.response = response
 
 
 @pytest.fixture(autouse=True)
@@ -276,36 +288,101 @@ def test_only_the_authoritative_window_may_answer():
 
 
 def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
-    loop = asyncio.new_event_loop()
-    try:
+    async def exercise_reuse() -> None:
         socket = FakeSocket()
-        current = loop.create_future()
-        jupyter_relay._pending_results["new-dispatch"] = current
-        jupyter_relay._pending_owners["new-dispatch"] = socket
+        jupyter_relay._listeners.append(socket)
+        post = jupyter_relay.GeoLibreRelayCommandHandler.post.__wrapped__
+        payload = {
+            "method": "listLayers",
+            "requestId": "caller-id",
+        }
 
-        delayed = json.dumps(
-            {
-                "type": "geolibre:result",
-                "requestId": "old-dispatch",
-                "ok": True,
-                "value": "stale",
-            }
+        first_handler = FakeCommandHandler(payload)
+        first_post = asyncio.create_task(post(first_handler))
+        await asyncio.sleep(0)
+        first_dispatch_id = json.loads(socket.received[-1])["requestId"]
+        jupyter_relay.GeoLibreRelaySocket.on_message(
+            socket,
+            json.dumps(
+                {
+                    "type": "geolibre:result",
+                    "requestId": first_dispatch_id,
+                    "ok": True,
+                    "value": ["first"],
+                }
+            ),
         )
-        jupyter_relay.GeoLibreRelaySocket.on_message(socket, delayed)
-        assert not current.done()
+        await first_post
+        assert json.loads(first_handler.response or "{}")["requestId"] == "caller-id"
 
-        reply = json.dumps(
-            {
-                "type": "geolibre:result",
-                "requestId": "new-dispatch",
-                "ok": True,
-                "value": "current",
-            }
+        second_handler = FakeCommandHandler(payload)
+        second_post = asyncio.create_task(post(second_handler))
+        await asyncio.sleep(0)
+        second_dispatch_id = json.loads(socket.received[-1])["requestId"]
+        assert second_dispatch_id != first_dispatch_id
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(
+            socket,
+            json.dumps(
+                {
+                    "type": "geolibre:result",
+                    "requestId": first_dispatch_id,
+                    "ok": True,
+                    "value": ["stale"],
+                }
+            ),
         )
-        jupyter_relay.GeoLibreRelaySocket.on_message(socket, reply)
-        assert current.result()["value"] == "current"
-    finally:
-        loop.close()
+        await asyncio.sleep(0)
+        assert not second_post.done()
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(
+            socket,
+            json.dumps(
+                {
+                    "type": "geolibre:result",
+                    "requestId": second_dispatch_id,
+                    "ok": True,
+                    "value": ["second"],
+                }
+            ),
+        )
+        await second_post
+        response = json.loads(second_handler.response or "{}")
+        assert response["requestId"] == "caller-id"
+        assert response["value"] == ["second"]
+
+    asyncio.run(exercise_reuse())
+
+
+def test_overlapping_caller_request_id_returns_conflict():
+    async def exercise_overlap() -> None:
+        socket = FakeSocket()
+        jupyter_relay._listeners.append(socket)
+        post = jupyter_relay.GeoLibreRelayCommandHandler.post.__wrapped__
+        payload = {"method": "listLayers", "requestId": "caller-id"}
+
+        first_post = asyncio.create_task(post(FakeCommandHandler(payload)))
+        await asyncio.sleep(0)
+
+        with pytest.raises(jupyter_relay.web.HTTPError) as error:
+            await post(FakeCommandHandler(payload))
+        assert error.value.status_code == 409
+
+        dispatch_id = json.loads(socket.received[-1])["requestId"]
+        jupyter_relay.GeoLibreRelaySocket.on_message(
+            socket,
+            json.dumps(
+                {
+                    "type": "geolibre:result",
+                    "requestId": dispatch_id,
+                    "ok": True,
+                    "value": [],
+                }
+            ),
+        )
+        await first_post
+
+    asyncio.run(exercise_overlap())
 
 
 def test_closing_the_authoritative_window_fails_its_request_at_once():

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -51,11 +51,9 @@ def _isolate_listeners():
     saved = list(jupyter_relay._listeners)
     saved_pending = dict(jupyter_relay._pending_results)
     saved_request_ids = set(jupyter_relay._pending_request_ids)
-    saved_owners = dict(jupyter_relay._pending_owners)
     jupyter_relay._listeners.clear()
     jupyter_relay._pending_results.clear()
     jupyter_relay._pending_request_ids.clear()
-    jupyter_relay._pending_owners.clear()
     yield
     jupyter_relay._listeners.clear()
     jupyter_relay._listeners.extend(saved)
@@ -63,8 +61,6 @@ def _isolate_listeners():
     jupyter_relay._pending_results.update(saved_pending)
     jupyter_relay._pending_request_ids.clear()
     jupyter_relay._pending_request_ids.update(saved_request_ids)
-    jupyter_relay._pending_owners.clear()
-    jupyter_relay._pending_owners.update(saved_owners)
 
 
 # -- the command envelope ----------------------------------------------------
@@ -248,49 +244,10 @@ def test_broadcast_with_no_listeners_reports_zero():
 # -- correlated read-back ----------------------------------------------------
 
 
-def test_dispatch_one_keeps_correlated_commands_in_one_window():
-    first, second = FakeSocket(), FakeSocket()
-    jupyter_relay._listeners.extend([first, second])
-
-    for method in ("addGeoJsonLayer", "getLayer"):
-        owner = jupyter_relay._dispatch_one(
-            {"type": "geolibre:command", "requestId": "dispatch", "method": method}
-        )
-        assert owner is first
-
-    assert len(first.received) == 2
-    assert second.received == []
-
-
-def test_only_the_authoritative_window_may_answer():
-    loop = asyncio.new_event_loop()
-    try:
-        owner, other = FakeSocket(), FakeSocket()
-        future = loop.create_future()
-        jupyter_relay._pending_results["dispatch"] = future
-        jupyter_relay._pending_owners["dispatch"] = owner
-        reply = json.dumps(
-            {
-                "type": "geolibre:result",
-                "requestId": "dispatch",
-                "ok": True,
-                "value": "layer-1",
-            }
-        )
-
-        jupyter_relay.GeoLibreRelaySocket.on_message(other, reply)
-        assert not future.done()
-
-        jupyter_relay.GeoLibreRelaySocket.on_message(owner, reply)
-        assert future.result()["value"] == "layer-1"
-    finally:
-        loop.close()
-
-
 def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
     async def exercise_reuse() -> None:
-        socket = FakeSocket()
-        jupyter_relay._listeners.append(socket)
+        first_socket, second_socket = FakeSocket(), FakeSocket()
+        jupyter_relay._listeners.extend([first_socket, second_socket])
         post = jupyter_relay.GeoLibreRelayCommandHandler.post.__wrapped__
         payload = {
             "method": "listLayers",
@@ -300,9 +257,11 @@ def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
         first_handler = FakeCommandHandler(payload)
         first_post = asyncio.create_task(post(first_handler))
         await asyncio.sleep(0)
-        first_dispatch_id = json.loads(socket.received[-1])["requestId"]
+        assert len(first_socket.received) == len(second_socket.received) == 1
+        first_dispatch_id = json.loads(first_socket.received[-1])["requestId"]
+        assert json.loads(second_socket.received[-1])["requestId"] == first_dispatch_id
         jupyter_relay.GeoLibreRelaySocket.on_message(
-            socket,
+            second_socket,
             json.dumps(
                 {
                     "type": "geolibre:result",
@@ -318,11 +277,13 @@ def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
         second_handler = FakeCommandHandler(payload)
         second_post = asyncio.create_task(post(second_handler))
         await asyncio.sleep(0)
-        second_dispatch_id = json.loads(socket.received[-1])["requestId"]
+        assert len(first_socket.received) == len(second_socket.received) == 2
+        second_dispatch_id = json.loads(first_socket.received[-1])["requestId"]
+        assert json.loads(second_socket.received[-1])["requestId"] == second_dispatch_id
         assert second_dispatch_id != first_dispatch_id
 
         jupyter_relay.GeoLibreRelaySocket.on_message(
-            socket,
+            first_socket,
             json.dumps(
                 {
                     "type": "geolibre:result",
@@ -336,7 +297,7 @@ def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
         assert not second_post.done()
 
         jupyter_relay.GeoLibreRelaySocket.on_message(
-            socket,
+            second_socket,
             json.dumps(
                 {
                     "type": "geolibre:result",
@@ -350,6 +311,20 @@ def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
         response = json.loads(second_handler.response or "{}")
         assert response["requestId"] == "caller-id"
         assert response["value"] == ["second"]
+        assert response["delivered"] == 2
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(
+            first_socket,
+            json.dumps(
+                {
+                    "type": "geolibre:result",
+                    "requestId": second_dispatch_id,
+                    "ok": True,
+                    "value": ["late"],
+                }
+            ),
+        )
+        assert json.loads(second_handler.response or "{}")["value"] == ["second"]
 
     asyncio.run(exercise_reuse())
 
@@ -385,21 +360,34 @@ def test_overlapping_caller_request_id_returns_conflict():
     asyncio.run(exercise_overlap())
 
 
-def test_closing_the_authoritative_window_fails_its_request_at_once():
-    loop = asyncio.new_event_loop()
-    try:
-        socket = FakeSocket()
-        future = loop.create_future()
-        jupyter_relay._listeners.append(socket)
-        jupyter_relay._pending_results["dispatch"] = future
-        jupyter_relay._pending_owners["dispatch"] = socket
+def test_closing_one_listener_leaves_another_to_answer():
+    async def exercise_close() -> None:
+        closing, remaining = FakeSocket(), FakeSocket()
+        jupyter_relay._listeners.extend([closing, remaining])
+        post = jupyter_relay.GeoLibreRelayCommandHandler.post.__wrapped__
+        handler = FakeCommandHandler({"method": "listLayers", "requestId": "caller-id"})
 
-        jupyter_relay.GeoLibreRelaySocket.on_close(socket)
+        pending_post = asyncio.create_task(post(handler))
+        await asyncio.sleep(0)
+        dispatch_id = json.loads(remaining.received[-1])["requestId"]
+        jupyter_relay.GeoLibreRelaySocket.on_close(closing)
+        assert not pending_post.done()
 
-        assert socket not in jupyter_relay._listeners
-        assert future.result()["error"] == "The GeoLibre window running this command closed."
-    finally:
-        loop.close()
+        jupyter_relay.GeoLibreRelaySocket.on_message(
+            remaining,
+            json.dumps(
+                {
+                    "type": "geolibre:result",
+                    "requestId": dispatch_id,
+                    "ok": True,
+                    "value": [],
+                }
+            ),
+        )
+        await pending_post
+        assert json.loads(handler.response or "{}")["value"] == []
+
+    asyncio.run(exercise_close())
 
 
 # -- extension load ----------------------------------------------------------

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -38,17 +38,13 @@ def _isolate_listeners():
     """Keep each test's listener list independent of the module-level one."""
     saved = list(jupyter_relay._listeners)
     saved_pending = dict(jupyter_relay._pending_results)
-    saved_owners = dict(jupyter_relay._pending_owners)
     jupyter_relay._listeners.clear()
     jupyter_relay._pending_results.clear()
-    jupyter_relay._pending_owners.clear()
     yield
     jupyter_relay._listeners.clear()
     jupyter_relay._listeners.extend(saved)
     jupyter_relay._pending_results.clear()
     jupyter_relay._pending_results.update(saved_pending)
-    jupyter_relay._pending_owners.clear()
-    jupyter_relay._pending_owners.update(saved_owners)
 
 
 # -- the command envelope ----------------------------------------------------
@@ -227,94 +223,6 @@ def test_broadcast_with_no_listeners_reports_zero():
     # This zero is what the kernel client turns into a "nothing is listening"
     # warning rather than a silent no-op.
     assert jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"}) == 0
-
-
-# -- single-window dispatch (correlated read-back) ---------------------------
-
-
-def test_dispatch_one_reaches_only_one_listener():
-    first, second = FakeSocket(), FakeSocket()
-    jupyter_relay._listeners.extend([first, second])
-
-    owner = jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"})
-
-    assert owner is first
-    assert len(first.received) + len(second.received) == 1
-
-
-def test_dispatch_one_keeps_picking_the_same_window():
-    # A mutation and the read-back that follows it must reach the same map, so
-    # the single-window pick has to be the oldest connection every time — not
-    # whichever one an unordered set happened to yield.
-    first, second = FakeSocket(), FakeSocket()
-    jupyter_relay._listeners.extend([first, second])
-
-    for method in ("addGeoJsonLayer", "listLayers"):
-        jupyter_relay._dispatch_one({"type": "geolibre:command", "method": method})
-
-    assert len(first.received) == 2
-    assert second.received == []
-
-
-def test_dispatch_one_falls_through_a_dead_first_window():
-    dead, alive = FakeSocket(fails=True), FakeSocket()
-    jupyter_relay._listeners.extend([dead, alive])
-
-    owner = jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"})
-
-    assert owner is alive
-    assert len(alive.received) == 1
-    assert jupyter_relay._listeners == [alive]
-
-
-def test_dispatch_one_reports_no_window():
-    assert jupyter_relay._dispatch_one({"type": "geolibre:command", "method": "listLayers"}) is None
-
-
-def test_only_the_owning_window_may_answer_a_request():
-    loop = asyncio.new_event_loop()
-    try:
-        owner, other = FakeSocket(), FakeSocket()
-        future = loop.create_future()
-        jupyter_relay._listeners.extend([owner, other])
-        jupyter_relay._pending_results["mine"] = future
-        jupyter_relay._pending_owners["mine"] = owner
-        reply = json.dumps(
-            {"type": "geolibre:result", "requestId": "mine", "ok": True, "value": "layer-1"}
-        )
-
-        jupyter_relay.GeoLibreRelaySocket.on_message(other, reply)
-        assert not future.done()
-
-        jupyter_relay.GeoLibreRelaySocket.on_message(owner, reply)
-        assert future.result()["value"] == "layer-1"
-    finally:
-        loop.close()
-
-
-def test_closing_the_owning_window_fails_its_request_at_once():
-    # Without this the kernel would sit out the full RESULT_TIMEOUT_SECONDS for
-    # an answer the relay already knows can never arrive.
-    loop = asyncio.new_event_loop()
-    try:
-        socket, other = FakeSocket(), FakeSocket()
-        future, untouched = loop.create_future(), loop.create_future()
-        jupyter_relay._listeners.extend([socket, other])
-        jupyter_relay._pending_results.update({"mine": future, "theirs": untouched})
-        jupyter_relay._pending_owners.update({"mine": socket, "theirs": other})
-
-        jupyter_relay.GeoLibreRelaySocket.on_close(socket)
-
-        assert jupyter_relay._listeners == [other]
-        assert future.result() == {
-            "requestId": "mine",
-            "ok": False,
-            "error": "The GeoLibre window running this command closed.",
-        }
-        # Another window's in-flight request is none of this socket's business.
-        assert not untouched.done()
-    finally:
-        loop.close()
 
 
 # -- extension load ----------------------------------------------------------

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -8,6 +8,7 @@ environment it publishes to kernels, and the broadcast bookkeeping itself.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
@@ -37,13 +38,21 @@ def _isolate_listeners():
     """Keep each test's listener list independent of the module-level one."""
     saved = list(jupyter_relay._listeners)
     saved_pending = dict(jupyter_relay._pending_results)
+    saved_request_ids = set(jupyter_relay._pending_request_ids)
+    saved_owners = dict(jupyter_relay._pending_owners)
     jupyter_relay._listeners.clear()
     jupyter_relay._pending_results.clear()
+    jupyter_relay._pending_request_ids.clear()
+    jupyter_relay._pending_owners.clear()
     yield
     jupyter_relay._listeners.clear()
     jupyter_relay._listeners.extend(saved)
     jupyter_relay._pending_results.clear()
     jupyter_relay._pending_results.update(saved_pending)
+    jupyter_relay._pending_request_ids.clear()
+    jupyter_relay._pending_request_ids.update(saved_request_ids)
+    jupyter_relay._pending_owners.clear()
+    jupyter_relay._pending_owners.update(saved_owners)
 
 
 # -- the command envelope ----------------------------------------------------
@@ -222,6 +231,98 @@ def test_broadcast_with_no_listeners_reports_zero():
     # This zero is what the kernel client turns into a "nothing is listening"
     # warning rather than a silent no-op.
     assert jupyter_relay._broadcast({"type": "geolibre:command", "method": "flyTo"}) == 0
+
+
+# -- correlated read-back ----------------------------------------------------
+
+
+def test_dispatch_one_keeps_correlated_commands_in_one_window():
+    first, second = FakeSocket(), FakeSocket()
+    jupyter_relay._listeners.extend([first, second])
+
+    for method in ("addGeoJsonLayer", "getLayer"):
+        owner = jupyter_relay._dispatch_one(
+            {"type": "geolibre:command", "requestId": "dispatch", "method": method}
+        )
+        assert owner is first
+
+    assert len(first.received) == 2
+    assert second.received == []
+
+
+def test_only_the_authoritative_window_may_answer():
+    loop = asyncio.new_event_loop()
+    try:
+        owner, other = FakeSocket(), FakeSocket()
+        future = loop.create_future()
+        jupyter_relay._pending_results["dispatch"] = future
+        jupyter_relay._pending_owners["dispatch"] = owner
+        reply = json.dumps(
+            {
+                "type": "geolibre:result",
+                "requestId": "dispatch",
+                "ok": True,
+                "value": "layer-1",
+            }
+        )
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(other, reply)
+        assert not future.done()
+
+        jupyter_relay.GeoLibreRelaySocket.on_message(owner, reply)
+        assert future.result()["value"] == "layer-1"
+    finally:
+        loop.close()
+
+
+def test_delayed_result_cannot_resolve_a_reused_caller_request_id():
+    loop = asyncio.new_event_loop()
+    try:
+        socket = FakeSocket()
+        current = loop.create_future()
+        jupyter_relay._pending_results["new-dispatch"] = current
+        jupyter_relay._pending_owners["new-dispatch"] = socket
+
+        delayed = json.dumps(
+            {
+                "type": "geolibre:result",
+                "requestId": "old-dispatch",
+                "ok": True,
+                "value": "stale",
+            }
+        )
+        jupyter_relay.GeoLibreRelaySocket.on_message(socket, delayed)
+        assert not current.done()
+
+        reply = json.dumps(
+            {
+                "type": "geolibre:result",
+                "requestId": "new-dispatch",
+                "ok": True,
+                "value": "current",
+            }
+        )
+        jupyter_relay.GeoLibreRelaySocket.on_message(socket, reply)
+        assert current.result()["value"] == "current"
+    finally:
+        loop.close()
+
+
+def test_closing_the_authoritative_window_fails_its_request_at_once():
+    loop = asyncio.new_event_loop()
+    try:
+        socket = FakeSocket()
+        future = loop.create_future()
+        jupyter_relay._listeners.append(socket)
+        jupyter_relay._pending_results["dispatch"] = future
+        jupyter_relay._pending_owners["dispatch"] = socket
+
+        jupyter_relay.GeoLibreRelaySocket.on_close(socket)
+
+        assert socket not in jupyter_relay._listeners
+        assert future.result()["error"] == "The GeoLibre window running this command closed."
+    finally:
+        loop.close()
 
 
 # -- extension load ----------------------------------------------------------

--- a/backend/geolibre_server/tests/test_jupyter_relay.py
+++ b/backend/geolibre_server/tests/test_jupyter_relay.py
@@ -8,7 +8,6 @@ environment it publishes to kernels, and the broadcast bookkeeping itself.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -48,14 +48,12 @@ returns one matching layer or raises `ValueError`. The id can be passed directly
 `set_visibility`, `set_opacity`, `set_style`, `remove_layer`, or
 `zoom_to_layer`.
 
-These three are also the only commands that do **not** fan out: a correlated
-request/reply can have exactly one authoritative responder, so `add_geojson`,
-`list_layers`, and `get_layer` run in a single app window (the one that
-connected first) and consistently keep using it, which is what makes an id
-returned by `add_geojson` resolvable by a later `get_layer`. Every
-fire-and-forget command — including `add_marker`/`add_markers` — still reaches
-every connected window. This is only visible if you attach two GeoLibre windows
-to one Jupyter server.
+All commands fan out to every GeoLibre window connected to the same Jupyter
+server. For `add_geojson`, `list_layers`, and `get_layer`, the first correlated
+reply is returned to the notebook and later replies are ignored. Because each
+window maintains its own map state, use one connected window when chaining a
+returned layer id into later read-back calls. This behavior is only visible if
+you attach multiple GeoLibre windows to one Jupyter server.
 
 `add_geojson` returns `None` instead of an id in two situations, and never
 fails outright in either:


### PR DESCRIPTION
Fixes #1689

**The Problem**
Currently, `_dispatch_one()` routes correlated map commands to the first socket in `_listeners` that successfully accepts a write. Because sockets are appended chronologically, this means **the oldest open window will always intercept every command**. If a user has two project windows open and runs a notebook in the newer one, the active notebook appears completely frozen because its commands are secretly routing to the older background window.

**The Fix**
Because it's incredibly difficult to map a backend Python kernel to a specific frontend desktop iframe URL, this PR replaces `_dispatch_one` with a simple `_broadcast()` for all commands, and removes the `_pending_owners` strict checking (since any window can now answer the request).

**The Tradeoff**
I am aware that this breaks the "single-authoritative-window guarantee" that `_pending_owners` originally enforced. Now, a map command will mirror across *all* open windows simultaneously instead of just one. However, this UX tradeoff is vastly preferable to the active notebook mysteriously refusing to work at all. 

Tested against the existing `pytest` suite (removed the obsolete `_dispatch_one` tests) and verified working perfectly in the desktop app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Relay commands are broadcast to all connected app windows.
  * Responses preserve caller request IDs for reliable correlation.
  * Reusing an active request ID concurrently is rejected with a conflict response.
  * The first correlated response is used; later responses are ignored.
  * Unauthorized, stale, or late responses are ignored.
  * Correlated requests are no longer automatically failed when a connected app window closes.

* **Documentation**
  * Updated notebook guidance to describe broadcast behavior and response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->