### PR TITLE
Show every category in the print layout legend

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -733,6 +733,7 @@ export function PrintLayoutDialog({
       legend,
       legendTitle: legendConfig.title,
       legendGroupByLayer: legendConfig.groupByLayer,
+      legendFormatNote: (count: number) => t("printLayout.legend.moreItems", { count }),
       markerIcons,
       metersPerPixel: captured?.metersPerPixel ?? 0,
       bearingDeg: captured?.bearingDeg ?? 0,

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -1546,7 +1546,13 @@
       "moveUp": "نقل المدخل لأعلى",
       "moveDown": "نقل المدخل لأسفل",
       "showEntry": "إظهار المدخل",
-      "hideEntry": "إخفاء المدخل"
+      "hideEntry": "إخفاء المدخل",
+      "moreItems_zero": "+{{count}} عنصر إضافي",
+      "moreItems_one": "+{{count}} عنصر إضافي",
+      "moreItems_two": "+{{count}} عنصران إضافيان",
+      "moreItems_few": "+{{count}} عناصر إضافية",
+      "moreItems_many": "+{{count}} عنصرًا إضافيًا",
+      "moreItems_other": "+{{count}} عنصر إضافي"
     },
     "atlas": {
       "section": "أطلس (سلسلة خرائط)",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Eintrag nach oben verschieben",
       "moveDown": "Eintrag nach unten verschieben",
       "showEntry": "Eintrag anzeigen",
-      "hideEntry": "Eintrag ausblenden"
+      "hideEntry": "Eintrag ausblenden",
+      "moreItems_one": "+{{count}} weitere",
+      "moreItems_other": "+{{count}} weitere"
     },
     "atlas": {
       "section": "Atlas (Kartenserie)",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Move entry up",
       "moveDown": "Move entry down",
       "showEntry": "Show entry",
-      "hideEntry": "Hide entry"
+      "hideEntry": "Hide entry",
+      "moreItems_one": "+{{count}} more",
+      "moreItems_other": "+{{count}} more"
     },
     "atlas": {
       "section": "Atlas (map series)",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Mover entrada hacia arriba",
       "moveDown": "Mover entrada hacia abajo",
       "showEntry": "Mostrar entrada",
-      "hideEntry": "Ocultar entrada"
+      "hideEntry": "Ocultar entrada",
+      "moreItems_one": "+{{count}} más",
+      "moreItems_other": "+{{count}} más"
     },
     "atlas": {
       "section": "Atlas (serie de mapas)",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Déplacer l'entrée vers le haut",
       "moveDown": "Déplacer l'entrée vers le bas",
       "showEntry": "Afficher l'entrée",
-      "hideEntry": "Masquer l'entrée"
+      "hideEntry": "Masquer l'entrée",
+      "moreItems_one": "+{{count}} de plus",
+      "moreItems_other": "+{{count}} de plus"
     },
     "atlas": {
       "section": "Atlas (série de cartes)",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1398,7 +1398,9 @@
       "moveUp": "प्रविष्टि ऊपर ले जाएं",
       "moveDown": "प्रविष्टि नीचे ले जाएं",
       "showEntry": "प्रविष्टि दिखाएं",
-      "hideEntry": "प्रविष्टि छिपाएं"
+      "hideEntry": "प्रविष्टि छिपाएं",
+      "moreItems_one": "+{{count}} और",
+      "moreItems_other": "+{{count}} और"
     },
     "atlas": {
       "section": "एटलस (मानचित्र शृंखला)",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1361,7 +1361,8 @@
       "moveUp": "Pindahkan entri ke atas",
       "moveDown": "Pindahkan entri ke bawah",
       "showEntry": "Tampilkan entri",
-      "hideEntry": "Sembunyikan entri"
+      "hideEntry": "Sembunyikan entri",
+      "moreItems_other": "+{{count}} lagi"
     },
     "atlas": {
       "section": "Atlas (seri peta)",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Sposta voce in alto",
       "moveDown": "Sposta voce in basso",
       "showEntry": "Mostra voce",
-      "hideEntry": "Nascondi voce"
+      "hideEntry": "Nascondi voce",
+      "moreItems_one": "+{{count}} altra",
+      "moreItems_other": "+{{count}} altre"
     },
     "atlas": {
       "section": "Atlante (serie di mappe)",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1361,7 +1361,8 @@
       "moveUp": "項目を上に移動",
       "moveDown": "項目を下に移動",
       "showEntry": "項目を表示",
-      "hideEntry": "項目を非表示"
+      "hideEntry": "項目を非表示",
+      "moreItems_other": "ほか{{count}}件"
     },
     "atlas": {
       "section": "アトラス（地図シリーズ）",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1398,7 +1398,9 @@
       "moveUp": "ჩანაწერის აწევა",
       "moveDown": "ჩანაწერის ჩამოწევა",
       "showEntry": "ჩანაწერის ჩვენება",
-      "hideEntry": "ჩანაწერის დამალვა"
+      "hideEntry": "ჩანაწერის დამალვა",
+      "moreItems_one": "+{{count}} მეტი",
+      "moreItems_other": "+{{count}} მეტი"
     },
     "atlas": {
       "section": "ატლასი (რუკების სერია)",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1361,7 +1361,8 @@
       "moveUp": "항목 위로 이동",
       "moveDown": "항목 아래로 이동",
       "showEntry": "항목 표시",
-      "hideEntry": "항목 숨기기"
+      "hideEntry": "항목 숨기기",
+      "moreItems_other": "+{{count}}개 더"
     },
     "atlas": {
       "section": "아틀라스 (지도 시리즈)",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Item omhoog verplaatsen",
       "moveDown": "Item omlaag verplaatsen",
       "showEntry": "Item weergeven",
-      "hideEntry": "Item verbergen"
+      "hideEntry": "Item verbergen",
+      "moreItems_one": "+{{count}} meer",
+      "moreItems_other": "+{{count}} meer"
     },
     "atlas": {
       "section": "Atlas (kaartenreeks)",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Mover entrada para cima",
       "moveDown": "Mover entrada para baixo",
       "showEntry": "Mostrar entrada",
-      "hideEntry": "Ocultar entrada"
+      "hideEntry": "Ocultar entrada",
+      "moreItems_one": "+{{count}} mais",
+      "moreItems_other": "+{{count}} mais"
     },
     "atlas": {
       "section": "Atlas (série de mapas)",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1472,7 +1472,11 @@
       "moveUp": "Переместить запись вверх",
       "moveDown": "Переместить запись вниз",
       "showEntry": "Показать запись",
-      "hideEntry": "Скрыть запись"
+      "hideEntry": "Скрыть запись",
+      "moreItems_one": "+ ещё {{count}}",
+      "moreItems_few": "+ ещё {{count}}",
+      "moreItems_many": "+ ещё {{count}}",
+      "moreItems_other": "+ ещё {{count}}"
     },
     "atlas": {
       "section": "Атлас (серия карт)",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1361,7 +1361,8 @@
       "moveUp": "เลื่อนรายการขึ้น",
       "moveDown": "เลื่อนรายการลง",
       "showEntry": "แสดงรายการ",
-      "hideEntry": "ซ่อนรายการ"
+      "hideEntry": "ซ่อนรายการ",
+      "moreItems_other": "+อีก {{count}} รายการ"
     },
     "atlas": {
       "section": "แอตลาส (ชุดแผนที่)",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1398,7 +1398,9 @@
       "moveUp": "Girişi yukarı taşı",
       "moveDown": "Girişi aşağı taşı",
       "showEntry": "Girişi göster",
-      "hideEntry": "Girişi gizle"
+      "hideEntry": "Girişi gizle",
+      "moreItems_one": "+{{count}} daha",
+      "moreItems_other": "+{{count}} daha"
     },
     "atlas": {
       "section": "Atlas (harita serisi)",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1361,7 +1361,8 @@
       "moveUp": "上移条目",
       "moveDown": "下移条目",
       "showEntry": "显示条目",
-      "hideEntry": "隐藏条目"
+      "hideEntry": "隐藏条目",
+      "moreItems_other": "还有 {{count}} 项"
     },
     "atlas": {
       "section": "地图集（地图系列）",

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -426,6 +426,12 @@ export interface LayoutOptions {
    */
   legendGroupByLayer: boolean;
   /**
+   * Translated formatter for the legend's "+N more" note, drawn when the class
+   * rows do not fit the map body; falls back to English when omitted (like the
+   * table's and chart's formatters).
+   */
+  legendFormatNote?: (count: number) => string;
+  /**
    * Preloaded custom-SVG marker icons for legend swatches, keyed by the
    * swatch marker's `svg` string ({@link LegendMarker.svg}). Loading SVGs is
    * async, but {@link drawLayout} is synchronous, so the caller resolves them
@@ -882,6 +888,8 @@ export function drawLayout(canvas: HTMLCanvasElement, opts: LayoutOptions): void
       title: opts.legendTitle,
       groupByLayer: opts.legendGroupByLayer,
       markerIcons: opts.markerIcons,
+      maxHeight: bodyH - inset * 2,
+      formatNote: opts.legendFormatNote,
     });
     ctx.restore();
   }
@@ -1982,6 +1990,9 @@ function drawLegend(
     title: string;
     groupByLayer: boolean;
     markerIcons?: ReadonlyMap<string, CanvasImageSource>;
+    /** Vertical space the box may occupy before rows are elided. */
+    maxHeight?: number;
+    formatNote?: (count: number) => string;
   },
 ): number {
   const pad = unit * 1.4;
@@ -2040,6 +2051,26 @@ function drawLegend(
   const rowHasSwatch = (r: { color: string; marker?: LegendMarker }): boolean =>
     Boolean(r.color) || Boolean(r.marker);
 
+  // Fit the rows to the space the caller allows. A categorized layer can carry
+  // dozens of classes, and the legend is clipped to the map body, so without
+  // this the tail would vanish at the body edge with nothing to say it had
+  // (GH #1608). Reserve one row for the note the truncation produces, the same
+  // budget rule the attribute-table panel uses.
+  let hiddenRows = 0;
+  const maxHeight = opts.maxHeight;
+  if (maxHeight !== undefined) {
+    const chromeH = pad * 2 + (hasTitle ? titleSize + unit : 0);
+    if (chromeH + rows.length * rowH > maxHeight) {
+      const fitRows = Math.max(0, Math.floor((maxHeight - chromeH - rowH) / rowH));
+      if (fitRows < rows.length) {
+        hiddenRows = rows.length - fitRows;
+        rows.length = fitRows;
+      }
+    }
+  }
+  const note = hiddenRows > 0 ? (opts.formatNote?.(hiddenRows) ?? `+${hiddenRows} more`) : "";
+  const hasNote = note.length > 0;
+
   // Cap proportional circles so a huge max radius still fits the legend box,
   // while keeping ratios within each entry (same idea as the on-map LegendSwatch).
   const MAX_CIRCLE_R = swatch * 0.55;
@@ -2065,10 +2096,11 @@ function drawLegend(
     const w = ctx.measureText(r.text).width + (rowHasSwatch(r) ? swatch + unit : 0);
     if (w > maxText) maxText = w;
   }
+  if (hasNote) maxText = Math.max(maxText, ctx.measureText(note).width);
 
   const boxW = maxText + pad * 2;
   const titleBlock = hasTitle ? titleSize + unit : 0;
-  const boxH = pad * 2 + titleBlock + rows.length * rowH;
+  const boxH = pad * 2 + titleBlock + (rows.length + (hasNote ? 1 : 0)) * rowH;
 
   ctx.fillStyle = "rgba(255,255,255,0.85)";
   ctx.strokeStyle = BORDER;
@@ -2122,6 +2154,12 @@ function drawLegend(
     ctx.fillStyle = hasSwatch ? INK : MUTED;
     ctx.font = `${hasSwatch ? 400 : 600} ${labelSize}px system-ui, sans-serif`;
     ctx.fillText(r.text, textX, cy);
+  }
+  if (hasNote) {
+    cy += rowH;
+    ctx.fillStyle = MUTED;
+    ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+    ctx.fillText(note, x + pad, cy);
   }
   ctx.restore();
   return boxH;

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -2015,6 +2015,8 @@ function drawLegend(
     text: string;
     marker?: LegendMarker;
     size?: number;
+    /** True for a groupByLayer layer heading: scaffolding, not a legend item. */
+    heading?: boolean;
   }[] = [];
   for (const entry of entries) {
     if (entry.swatches.length <= 1) {
@@ -2032,7 +2034,7 @@ function drawLegend(
       });
     } else {
       if (opts.groupByLayer) {
-        rows.push({ entryId: entry.id, color: "", text: entry.name });
+        rows.push({ entryId: entry.id, color: "", text: entry.name, heading: true });
       }
       for (const sw of entry.swatches) {
         // Carry the marker so a marker + diagram layer (a multi-swatch entry
@@ -2063,8 +2065,15 @@ function drawLegend(
     if (chromeH + rows.length * rowH > maxHeight) {
       const fitRows = Math.max(0, Math.floor((maxHeight - chromeH - rowH) / rowH));
       if (fitRows < rows.length) {
-        hiddenRows = rows.length - fitRows;
-        rows.length = fitRows;
+        // A layer heading only means something with class rows under it, so a
+        // cut that lands right after one drops it too rather than printing a
+        // section title that describes nothing.
+        let kept = fitRows;
+        while (kept > 0 && rows[kept - 1]!.heading) kept -= 1;
+        // Headings are scaffolding, so the note counts elided class rows only;
+        // counting the headings too would overstate what the reader is missing.
+        hiddenRows = rows.slice(kept).filter((r) => !r.heading).length;
+        rows.length = kept;
       }
     }
   }

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -2064,6 +2064,12 @@ function drawLegend(
     const chromeH = pad * 2 + (hasTitle ? titleSize + unit : 0);
     if (chromeH + rows.length * rowH > maxHeight) {
       const fitRows = Math.max(0, Math.floor((maxHeight - chromeH - rowH) / rowH));
+      // Not even one row plus its note fits. Drawing anyway would produce a box
+      // taller than the caller allotted whose only content is "+N more", so
+      // draw nothing and report no height. Defensive: every unit here scales
+      // with the page, so drawLayout's own maxHeight always clears ~24 rows
+      // whatever the paper size. Safe to return early — ctx.save() is below.
+      if (fitRows === 0) return 0;
       if (fitRows < rows.length) {
         // A layer heading only means something with class rows under it, so a
         // cut that lands right after one drops it too rather than printing a

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -49,9 +49,10 @@ const MAX_RAMP_SWATCHES = 6;
  * every class is listed and only a runaway class count is elided from the tail.
  * Mirrors the on-map auto legend's `MAX_LEGEND_ROWS` so both legends elide at
  * the same point; kept as a local copy because `auto-legend.ts` imports from
- * this module and the reverse import would be circular.
+ * this module and the reverse import would be circular. Exported so
+ * `tests/print-legend.test.ts` can fail if the two drift apart.
  */
-const MAX_CATEGORY_SWATCHES = 100;
+export const MAX_CATEGORY_SWATCHES = 100;
 
 /**
  * Build legend entries from the visible layers. Vector layers contribute a

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -42,6 +42,16 @@ export const NON_LEGEND_TYPES: ReadonlySet<LayerType> = new Set<LayerType>([
 
 const NEUTRAL_SWATCH = "#94a3b8";
 const MAX_RAMP_SWATCHES = 6;
+/**
+ * Upper bound on categorized class rows. Categories are nominal values, so
+ * dropping one loses information no neighbouring row implies (unlike a
+ * graduated ramp, where sampling still reads as the same continuous range) —
+ * every class is listed and only a runaway class count is elided from the tail.
+ * Mirrors the on-map auto legend's `MAX_LEGEND_ROWS` so both legends elide at
+ * the same point; kept as a local copy because `auto-legend.ts` imports from
+ * this module and the reverse import would be circular.
+ */
+const MAX_CATEGORY_SWATCHES = 100;
 
 /**
  * Build legend entries from the visible layers. Vector layers contribute a
@@ -89,10 +99,16 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
       Array.isArray(stops) &&
       stops.length > 0
     ) {
-      // Sample once so color/label rows and proportional sizes stay paired when
-      // the class list exceeds MAX_RAMP_SWATCHES.
+      // Reduce once so color/label rows and proportional sizes stay paired when
+      // the class list is long. A graduated ramp is a continuous range, so
+      // sampling evenly still describes it; categories are discrete, so every
+      // one is listed (GH #1608).
       const displayedStops =
-        stops.length > MAX_RAMP_SWATCHES ? sampleEvenly(stops, MAX_RAMP_SWATCHES) : stops;
+        mode === "categorized"
+          ? stops.slice(0, MAX_CATEGORY_SWATCHES)
+          : stops.length > MAX_RAMP_SWATCHES
+            ? sampleEvenly(stops, MAX_RAMP_SWATCHES)
+            : stops;
       const ramp = rampSwatches(displayedStops, mode);
       const classProperty = styleValue(layer.style, "vectorStyleProperty");
       // Same field classified and sized: merge sizes into the class rows so the

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -164,6 +164,57 @@ describe("drawLayout legend rendering", () => {
     );
   });
 
+  it("elides class rows that do not fit the map body and says how many (GH #1608)", () => {
+    // A categorized layer can carry more classes than the body is tall; the
+    // legend is clipped to the body, so the overflow must be reported rather
+    // than disappearing at the edge.
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "otex",
+            name: "Farms",
+            swatches: Array.from({ length: 60 }, (_, i) => ({
+              color: "#00aa00",
+              label: `class-${i.toString()}`,
+            })),
+          },
+        ],
+        legendFormatNote: (count) => `+${count.toString()} more`,
+      }),
+    );
+    const drawn = fills.filter((f) => f.text.startsWith("class-"));
+    assert.ok(drawn.length > 0, "expected some class rows to be drawn");
+    assert.ok(drawn.length < 60, "expected the overflowing rows to be elided");
+    const note = fills.find((f) => f.text.startsWith("+") && f.text.endsWith("more"));
+    assert.ok(note, "expected a truncation note");
+    assert.equal(note.text, `+${(60 - drawn.length).toString()} more`);
+  });
+
+  it("draws no truncation note when every class row fits", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "otex",
+            name: "Farms",
+            swatches: Array.from({ length: 4 }, (_, i) => ({
+              color: "#00aa00",
+              label: `class-${i.toString()}`,
+            })),
+          },
+        ],
+        legendFormatNote: (count) => `+${count.toString()} more`,
+      }),
+    );
+    assert.equal(fills.filter((f) => f.text.startsWith("class-")).length, 4);
+    assert.ok(!fills.some((f) => f.text.endsWith("more")));
+  });
+
   it("renders the layer name for a genuine single-symbol entry", () => {
     const { canvas, fills } = recordingCanvas();
     drawLayout(

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -193,6 +193,43 @@ describe("drawLayout legend rendering", () => {
     assert.equal(note.text, `+${(60 - drawn.length).toString()} more`);
   });
 
+  it("counts only class rows in the note and drops a dangling group heading", () => {
+    // With groupByLayer on, the flattened rows interleave layer headings. A
+    // heading is scaffolding: it must not inflate the "+N more" count, and one
+    // left with no classes under it describes nothing.
+    const { canvas, fills } = recordingCanvas();
+    const entry = (id: string, name: string, n: number): LegendEntry => ({
+      id,
+      name,
+      swatches: Array.from({ length: n }, (_, i) => ({
+        color: "#00aa00",
+        label: `${id}-${i.toString()}`,
+      })),
+    });
+    // Sized so the cut falls on Layer B's heading: at this page size the body
+    // fits 25 legend rows, and Layer A occupies exactly the first 24.
+    drawLayout(
+      canvas,
+      baseOptions({
+        legendGroupByLayer: true,
+        legend: [entry("a", "Layer A", 23), entry("b", "Layer B", 30)],
+        legendFormatNote: (count) => `+${count.toString()} more`,
+      }),
+    );
+    const texts = fills.map((f) => f.text);
+    const classRows = texts.filter((t) => /^[ab]-\d+$/.test(t));
+    const note = texts.find((t) => t.startsWith("+") && t.endsWith("more"));
+    assert.ok(note, "expected a truncation note");
+    // 53 class rows across the two layers; the headings must not be counted.
+    assert.equal(note, `+${(53 - classRows.length).toString()} more`);
+    // A heading is only drawn when at least one of its classes survives the cut.
+    assert.ok(
+      !texts.includes("Layer B") || classRows.some((t) => t.startsWith("b-")),
+      "expected no orphan layer heading",
+    );
+    assert.ok(texts.includes("Layer A"), "expected the surviving layer's heading");
+  });
+
   it("draws no truncation note when every class row fits", () => {
     const { canvas, fills } = recordingCanvas();
     drawLayout(

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -10,10 +10,12 @@ import {
   applyLegendConfig,
   buildLegend,
   legendEditorRows,
+  MAX_CATEGORY_SWATCHES,
   reorderLegendEntry,
   setLegendItemLabel,
   toggleLegendItemHidden,
 } from "../apps/geolibre-desktop/src/lib/print-legend";
+import { MAX_LEGEND_ROWS } from "../apps/geolibre-desktop/src/lib/auto-legend";
 
 function config(overrides: Partial<LegendConfig> = {}): LegendConfig {
   return { ...DEFAULT_LEGEND_CONFIG, order: [], overrides: {}, ...overrides };
@@ -463,6 +465,13 @@ describe("buildLegend", () => {
       legend[0].swatches.map((s) => s.label),
       stops.map((s) => s.value),
     );
+  });
+
+  it("elides categorized classes at the same point as the on-map auto legend", () => {
+    // print-legend cannot import auto-legend (auto-legend imports print-legend),
+    // so the cap is a hand-kept copy. If the two drift, the printed legend and
+    // the on-map legend silently disagree about where a long class list stops.
+    assert.equal(MAX_CATEGORY_SWATCHES, MAX_LEGEND_ROWS);
   });
 
   it("elides the tail of a runaway categorized class list", () => {

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -425,9 +425,28 @@ describe("buildLegend", () => {
     });
   });
 
-  it("caps ramp swatches at six samples", () => {
+  it("caps graduated ramp swatches at six samples", () => {
     const stops = Array.from({ length: 12 }, (_, i) => ({
       value: i,
+      color: `#0000${(i % 10).toString()}0`,
+    }));
+    const legend = buildLegend([
+      makeLayer({
+        name: "Many",
+        style: {
+          vectorStyleMode: "graduated",
+          vectorStyleStops: stops,
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 6);
+  });
+
+  it("lists every categorized class rather than sampling six (GH #1608)", () => {
+    // Categories are nominal, so a sampled subset silently drops values the
+    // reader has no way to infer from the rows that survive.
+    const stops = Array.from({ length: 14 }, (_, i) => ({
+      value: `class-${i.toString()}`,
       color: `#0000${(i % 10).toString()}0`,
     }));
     const legend = buildLegend([
@@ -439,7 +458,30 @@ describe("buildLegend", () => {
         } as LayerStyle,
       }),
     ]);
-    assert.equal(legend[0].swatches.length, 6);
+    assert.equal(legend[0].swatches.length, 14);
+    assert.deepEqual(
+      legend[0].swatches.map((s) => s.label),
+      stops.map((s) => s.value),
+    );
+  });
+
+  it("elides the tail of a runaway categorized class list", () => {
+    const stops = Array.from({ length: 140 }, (_, i) => ({
+      value: `class-${i.toString()}`,
+      color: "#000000",
+    }));
+    const legend = buildLegend([
+      makeLayer({
+        name: "Runaway",
+        style: {
+          vectorStyleMode: "categorized",
+          vectorStyleStops: stops,
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 100);
+    assert.equal(legend[0].swatches[0].label, "class-0");
+    assert.equal(legend[0].swatches[99].label, "class-99");
   });
 
   it("gives raster and service layers a single neutral swatch", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1609, reported in https://github.com/opengeos/GeoLibre/discussions/1608#discussioncomment-17893682: after `All (N)` classes became available, the categorized style itself was correct but the **Print Layout** legend still showed only 6 of the 14 classes, in both the legend editor and the exported map.

Root cause is `MAX_RAMP_SWATCHES = 6` in `print-legend.ts`, which evenly sampled any class list longer than six. Sampling is reasonable for a graduated ramp (the rows still describe the same continuous range) but not for categorized symbology, where every class is a distinct nominal value and a dropped one is simply gone.

- categorized symbology now contributes one legend row per class, elided past 100 to match the on-map auto legend's `MAX_LEGEND_ROWS`
- graduated ramps and rule-based renderers keep the existing six-sample behavior
- `drawLegend` now fits its rows to the map body and draws a translated `+N more` note when they overflow, rather than letting the tail get clipped at the body edge with no indication; `printLayout.legend.moreItems` added to all 17 catalogs

## Verification

- reproduced with the reporter's `OTEX` dataset from discussion 1608 (14 distinct values): before, the Print Layout legend editor and preview listed 6 classes; after, all 14
- exercised the overflow path with two 14-class layers on A4 landscape: the legend stops at the body edge and prints `+5 more`
- checked in both light and dark themes
- `npm run test:frontend` (the one failure, `tests/collab-comment-validate.test.ts`, is a module-resolution error that also fails on `main` and is unrelated)
- `npm run build`

Fixes the follow-up in #1608.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Print legends now respect height limits and show localized counts of hidden entries when content overflows.
  * Categorized legends display up to 100 classes while preserving their order and labels.
  * Legend overflow and hide-entry messages are now translated across supported languages.

* **Bug Fixes**
  * Improved handling of oversized legends, orphaned headings, and graduated color ramps in print layouts.

* **Tests**
  * Added coverage for legend overflow, truncation, class limits, and localized notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->