### PR TITLE
fix: keep KMZ icons above lower layers

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2141,7 +2141,8 @@ export class MapController {
   private getBeforeStyleLayerId(layers: GeoLibreLayer[], layerIndex: number): string | undefined {
     if (!this.map) return undefined;
 
-    const styleLayers = this.map.getStyle().layers ?? [];
+    const styleLayerIds =
+      this.map.getLayersOrder?.() ?? (this.map.getStyle().layers ?? []).map(({ id }) => id);
     for (const layer of layers.slice(layerIndex + 1)) {
       const candidateIds = new Set(this.getCandidateStyleLayers(layer).map(({ id }) => id));
       // A logical layer can render through several MapLibre style layers. KML
@@ -2149,7 +2150,7 @@ export class MapController {
       // circle for features without icons. Anchor beneath whichever companion
       // is currently lowest in the real style order so the inserted layer
       // cannot split that logical layer in two.
-      const bottommostId = styleLayers.find(({ id }) => candidateIds.has(id))?.id;
+      const bottommostId = styleLayerIds.find((id) => candidateIds.has(id));
       if (bottommostId) return bottommostId;
     }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2141,6 +2141,7 @@ export class MapController {
   private getBeforeStyleLayerId(layers: GeoLibreLayer[], layerIndex: number): string | undefined {
     if (!this.map) return undefined;
 
+    const styleLayers = this.map.getStyle().layers ?? [];
     for (const layer of layers.slice(layerIndex + 1)) {
       const candidateIds = new Set(this.getCandidateStyleLayers(layer).map(({ id }) => id));
       // A logical layer can render through several MapLibre style layers. KML
@@ -2148,9 +2149,7 @@ export class MapController {
       // circle for features without icons. Anchor beneath whichever companion
       // is currently lowest in the real style order so the inserted layer
       // cannot split that logical layer in two.
-      const bottommostId = (this.map.getStyle().layers ?? []).find(({ id }) =>
-        candidateIds.has(id),
-      )?.id;
+      const bottommostId = styleLayers.find(({ id }) => candidateIds.has(id))?.id;
       if (bottommostId) return bottommostId;
     }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2142,10 +2142,16 @@ export class MapController {
     if (!this.map) return undefined;
 
     for (const layer of layers.slice(layerIndex + 1)) {
-      const beforeLayer = this.getCandidateStyleLayers(layer).find(({ id }) =>
-        this.map?.getLayer(id),
-      );
-      if (beforeLayer) return beforeLayer.id;
+      const candidateIds = new Set(this.getCandidateStyleLayers(layer).map(({ id }) => id));
+      // A logical layer can render through several MapLibre style layers. KML
+      // icon points, for example, use a symbol companion plus a fallback
+      // circle for features without icons. Anchor beneath whichever companion
+      // is currently lowest in the real style order so the inserted layer
+      // cannot split that logical layer in two.
+      const bottommostId = (this.map.getStyle().layers ?? []).find(({ id }) =>
+        candidateIds.has(id),
+      )?.id;
+      if (bottommostId) return bottommostId;
     }
 
     if (layerIndex >= 0) {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -41,6 +41,7 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
   const order: string[] = [];
   const calls: { method: string; args: unknown[] }[] = [];
   const setDataCalls: { id: string; data: unknown }[] = [];
+  const images = new Set<string>();
   let pendingRenderedFeatures: unknown[] = [];
 
   for (const id of initialBasemapLayers) {
@@ -97,6 +98,9 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
       calls.push({ method: "removeSource", args: [id] });
     },
     getLayer: (id: string) => (layers.has(id) ? { id, ...layers.get(id) } : undefined),
+    hasImage: (id: string) => images.has(id),
+    addImage: (id: string) => images.add(id),
+    removeImage: (id: string) => images.delete(id),
     addLayer: (spec: Record<string, unknown>, beforeId?: string) => {
       layers.set(spec.id as string, spec);
       insertBefore(spec.id as string, beforeId);
@@ -276,6 +280,38 @@ const rasterId = (id: string) => `layer-${id}-raster`;
 const srcId = (id: string) => `source-${id}`;
 
 describe("MapController.syncLayers reconciliation", () => {
+  it("keeps a lower raster beneath every companion of a mixed KML point layer", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    const kml = pointLayer("kml", {
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {
+              __geolibre_kml_icon_url:
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            },
+            geometry: { type: "Point", coordinates: [0, 0] },
+          },
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [1, 1] },
+          },
+        ],
+      },
+    });
+
+    controller.syncLayers([rasterLayer("imagery"), kml]);
+
+    const imageryIndex = fake.order.indexOf(rasterId("imagery"));
+    assert.ok(imageryIndex >= 0);
+    assert.ok(imageryIndex < fake.order.indexOf(markerId("kml")));
+    assert.ok(imageryIndex < fake.order.indexOf(circleId("kml")));
+  });
+
   it("runs the initial sync once and restores layers after a style reload", () => {
     const { map, fake } = makeFakeMap();
     const listeners = new Map<string, Set<() => void>>();

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -69,6 +69,7 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
       layers: order.map((id) => ({ id, ...layers.get(id) })),
       sources: Object.fromEntries(sources),
     }),
+    getLayersOrder: () => [...order],
     getSource: (id: string) => {
       if (!sources.has(id)) return undefined;
       if (!sourceHandles.has(id)) {


### PR DESCRIPTION
## Summary
- anchor reordered layers beneath the lowest live MapLibre companion of the layer above
- keep mixed KMZ icon symbols and fallback circles together around raster basemaps
- add a regression test for the split KMZ rendering order

## Test plan
- [x] Run the MapController frontend test suite
- [x] Run the production web build
- [x] Run pre-commit on the changed files
- [x] Verify the reported GhostMaps KMZ above World Imagery in light and dark themes

Fixes #1700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map layer ordering to keep multi-layer representations together when layers are inserted or reordered.
  * Ensured raster layers remain below all related native layers for mixed KML point data.

* **Tests**
  * Added coverage for layer ordering and image handling during map reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->