### PR TITLE
fix(map): correct basemap symbol occlusion under draped rasters in 3D…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "geolibre",
       "version": "2.4.1",
+      "hasInstallScript": true,
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -19,6 +20,7 @@
         "eslint": "^10.8.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "linkedom": "^0.18.13",
+        "patch-package": "^8.0.0",
         "tsx": "^4.23.1",
         "typescript-eslint": "^8.65.0"
       },
@@ -4211,9 +4213,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4231,9 +4230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4251,9 +4247,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4271,9 +4264,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4291,9 +4281,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4311,9 +4298,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4331,9 +4315,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4351,9 +4332,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4371,9 +4349,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4397,9 +4372,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4423,9 +4395,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4449,9 +4418,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4475,9 +4441,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4501,9 +4464,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4527,9 +4487,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4553,9 +4510,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6955,9 +6909,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6975,9 +6926,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6995,9 +6943,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7015,9 +6960,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7035,9 +6977,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7055,9 +6994,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11357,6 +11293,13 @@
         }
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@zarrita/storage": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
@@ -12289,6 +12232,22 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/class-variance-authority": {
@@ -13994,6 +13953,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -15589,6 +15558,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -15964,6 +15949,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -16130,10 +16128,37 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16169,6 +16194,16 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonpointer": {
@@ -16254,6 +16289,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -18060,6 +18105,23 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open-location-code-typescript": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/open-location-code-typescript/-/open-location-code-typescript-1.5.0.tgz",
@@ -18276,6 +18338,97 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -20329,6 +20482,16 @@
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -21216,9 +21379,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -21240,9 +21400,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -21264,9 +21421,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -21288,9 +21442,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "tauri:build:native-duckdb": "node scripts/tauri-build.mjs --native-duckdb",
     "tauri:build:mas": "node scripts/tauri-build.mjs --mas",
     "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/msix/build-msix.ps1",
-    "portable:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/portable/build-portable.ps1"
+    "portable:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/portable/build-portable.ps1",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
@@ -40,7 +41,8 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "linkedom": "^0.18.13",
     "tsx": "^4.23.1",
-    "typescript-eslint": "^8.65.0"
+    "typescript-eslint": "^8.65.0",
+    "patch-package": "^8.0.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "eslint": "^10.8.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "linkedom": "^0.18.13",
+    "patch-package": "^8.0.0",
     "tsx": "^4.23.1",
-    "typescript-eslint": "^8.65.0",
-    "patch-package": "^8.0.0"
+    "typescript-eslint": "^8.65.0"
   },
   "overrides": {
     "brace-expansion": "^5.0.8",

--- a/patches/maplibre-gl+5.24.0.patch
+++ b/patches/maplibre-gl+5.24.0.patch
@@ -16,7 +16,7 @@ index 648b277942..9fa86fd412 100644
 @@ -216,6 +219,28 @@ describe('render to texture', () => {
          expect(layersDrawn).toBe(3);
      });
- 
+
 +    test('skips symbols below a later opaque draped raster', () => {
 +        const symbolLayerAboveRaster = {
 +            ...symbolLayer,
@@ -63,7 +63,7 @@ index 018125552b..71dcf4f77b 100644
 +            const layer = style._layers[this._renderableLayerIds[i]];
 +            if (layer.type === 'raster' && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
 +        }
- 
+
          this._coordsAscending = {};
          for (const id in style.tileManagers) {
 @@ -138,6 +144,7 @@ export class RenderToTexture {
@@ -71,13 +71,13 @@ index 018125552b..71dcf4f77b 100644
      renderLayer(layer: StyleLayer, renderOptions: RenderOptions): boolean {
          if (layer.isHidden(this.painter.transform.zoom)) return false;
 +        if (this._isSymbolBelowOpaqueDrapedRaster(layer)) return true;
- 
+
          const options: RenderOptions = {...renderOptions, isRenderingToTexture: true};
          const type = layer.type;
 @@ -185,4 +192,9 @@ export class RenderToTexture {
          return false;
      }
- 
+
 +    _isSymbolBelowOpaqueDrapedRaster(layer: StyleLayer): boolean {
 +        if (layer.type !== 'symbol' || this._topOpaqueDrapedRasterIndex < 0) return false;
 +        const layerIndex = this._renderableLayerIds.indexOf(layer.id);
@@ -103,7 +103,7 @@ index 71dcf4f77b..dd1045a19a 100644
  import type {StyleLayer} from '../style/style_layer.ts';
  import {ImageSource} from '../source/image_source.ts';
 +import {isRasterStyleLayer} from '../style/style_layer/raster_style_layer.ts';
- 
+
  /**
   * lookup table which layers should rendered to texture
 @@ -87,7 +88,7 @@ export class RenderToTexture {
@@ -113,5 +113,5 @@ index 71dcf4f77b..dd1045a19a 100644
 -            if (layer.type === 'raster' && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
 +            if (isRasterStyleLayer(layer) && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
          }
- 
+
          this._coordsAscending = {};

--- a/patches/maplibre-gl+5.24.0.patch
+++ b/patches/maplibre-gl+5.24.0.patch
@@ -1,0 +1,117 @@
+patch-package
+diff --git a/node_modules/maplibre-gl/src/webgl/render_to_texture.test.ts b/node_modules/maplibre-gl/src/webgl/render_to_texture.test.ts
+index 648b277942..9fa86fd412 100644
+--- a/node_modules/maplibre-gl/src/webgl/render_to_texture.test.ts
++++ b/node_modules/maplibre-gl/src/webgl/render_to_texture.test.ts
+@@ -37,6 +37,9 @@ describe('render to texture', () => {
+         id: 'maine-raster',
+         type: 'raster',
+         source: 'maine',
++        paint: {
++            get: (property: string) => property === 'raster-opacity' ? 1 : undefined
++        },
+         isHidden: () => false
+     } as any as RasterStyleLayer;
+     const hillshadeLayer = {
+@@ -216,6 +219,28 @@ describe('render to texture', () => {
+         expect(layersDrawn).toBe(3);
+     });
+ 
++    test('skips symbols below a later opaque draped raster', () => {
++        const symbolLayerAboveRaster = {
++            ...symbolLayer,
++            id: 'maine-symbol-above-raster',
++        } as SymbolStyleLayer;
++        const fillExtrusionLayer = {
++            id: 'maine-building',
++            type: 'fill-extrusion',
++            source: 'maine',
++            isHidden: () => false
++        } as any;
++        style._layers['maine-symbol-above-raster'] = symbolLayerAboveRaster;
++        style._layers['maine-building'] = fillExtrusionLayer;
++        style._order = ['maine-background', 'maine-symbol', 'maine-building', 'maine-raster', 'maine-symbol-above-raster'];
++        rtt.prepareForRender(style, 0);
++
++        const renderOptions = {isRenderingToTexture: false, isRenderingGlobe: false};
++        expect(rtt.renderLayer(symbolLayer, renderOptions)).toBeTruthy();
++        expect(rtt.renderLayer(symbolLayerAboveRaster, renderOptions)).toBeFalsy();
++        expect(rtt.renderLayer(fillExtrusionLayer, renderOptions)).toBeFalsy();
++    });
++
+     test('should clear tile cache on source state update', () => {
+         const state = {revision: 0};
+         (style.tileManagers['maine'].getState as Mock).mockReturnValue(state);
+diff --git a/node_modules/maplibre-gl/src/webgl/render_to_texture.ts b/node_modules/maplibre-gl/src/webgl/render_to_texture.ts
+index 018125552b..71dcf4f77b 100644
+--- a/node_modules/maplibre-gl/src/webgl/render_to_texture.ts
++++ b/node_modules/maplibre-gl/src/webgl/render_to_texture.ts
+@@ -67,6 +67,7 @@ export class RenderToTexture {
+      * a list of all layer-ids which should be rendered
+      */
+     _renderableLayerIds: string[];
++    _topOpaqueDrapedRasterIndex: number;
+     constructor(painter: Painter, terrain: Terrain) {
+         this.painter = painter;
+         this.terrain = terrain;
+@@ -83,6 +84,11 @@ export class RenderToTexture {
+         this._rttTiles = [];
+         this._renderableTiles = this.terrain.tileManager.getRenderableTiles();
+         this._renderableLayerIds = style._order.filter(id => !style._layers[id].isHidden(zoom));
++        this._topOpaqueDrapedRasterIndex = -1;
++        for (let i = 0; i < this._renderableLayerIds.length; i++) {
++            const layer = style._layers[this._renderableLayerIds[i]];
++            if (layer.type === 'raster' && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
++        }
+ 
+         this._coordsAscending = {};
+         for (const id in style.tileManagers) {
+@@ -138,6 +144,7 @@ export class RenderToTexture {
+      */
+     renderLayer(layer: StyleLayer, renderOptions: RenderOptions): boolean {
+         if (layer.isHidden(this.painter.transform.zoom)) return false;
++        if (this._isSymbolBelowOpaqueDrapedRaster(layer)) return true;
+ 
+         const options: RenderOptions = {...renderOptions, isRenderingToTexture: true};
+         const type = layer.type;
+@@ -185,4 +192,9 @@ export class RenderToTexture {
+         return false;
+     }
+ 
++    _isSymbolBelowOpaqueDrapedRaster(layer: StyleLayer): boolean {
++        if (layer.type !== 'symbol' || this._topOpaqueDrapedRasterIndex < 0) return false;
++        const layerIndex = this._renderableLayerIds.indexOf(layer.id);
++        return layerIndex >= 0 && layerIndex < this._topOpaqueDrapedRasterIndex;
++    }
+ }
+
+From fe557a86b8f5ca753973c5db44621ce0cd0d5ff8 Mon Sep 17 00:00:00 2001
+From: Fabien Del Olmo <fabien.delolmo@gmail.com>
+Date: Mon, 29 Jun 2026 23:45:59 +0200
+Subject: [PATCH 2/2] Use raster style layer guard for opacity check
+
+---
+ src/webgl/render_to_texture.ts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/node_modules/maplibre-gl/src/webgl/render_to_texture.ts b/node_modules/maplibre-gl/src/webgl/render_to_texture.ts
+index 71dcf4f77b..dd1045a19a 100644
+--- a/node_modules/maplibre-gl/src/webgl/render_to_texture.ts
++++ b/node_modules/maplibre-gl/src/webgl/render_to_texture.ts
+@@ -8,6 +8,7 @@ import {type Terrain} from '../render/terrain.ts';
+ import {type Texture} from './texture.ts';
+ import type {StyleLayer} from '../style/style_layer.ts';
+ import {ImageSource} from '../source/image_source.ts';
++import {isRasterStyleLayer} from '../style/style_layer/raster_style_layer.ts';
+ 
+ /**
+  * lookup table which layers should rendered to texture
+@@ -87,7 +88,7 @@ export class RenderToTexture {
+         this._topOpaqueDrapedRasterIndex = -1;
+         for (let i = 0; i < this._renderableLayerIds.length; i++) {
+             const layer = style._layers[this._renderableLayerIds[i]];
+-            if (layer.type === 'raster' && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
++            if (isRasterStyleLayer(layer) && layer.paint.get('raster-opacity') === 1) this._topOpaqueDrapedRasterIndex = i;
+         }
+ 
+         this._coordsAscending = {};


### PR DESCRIPTION
## Summary
This PR fixes a visual bug where vector basemap labels and symbols were incorrectly rendering on top of overlying opaque raster layers when the 3D Terrain plugin was active.

## Problem
In Issue #781, users observed that the layer stack hierarchy was broken when using 3D terrain. A designated "Background" basemap layer would incorrectly draw its labels, buildings, and vector footprints directly over top-level, fully opaque user rasters (e.g., Esri Wayback, USGS Topo).

## Root Cause
This was caused by a known rendering limitation in our underlying engine, `maplibre-gl-js`. In 3D terrain mode, MapLibre uses a two-pass rendering system: draped layers (rasters, fills) are drawn to a texture and draped on the terrain mesh, while non-draped symbols and extrusions are drawn "live" in a separate pass afterwards to avoid clipping. This decoupled rendering meant that all basemap symbols floated above the previously drawn rasters, effectively ignoring the 2D layer list hierarchy.

## Solution
Instead of attempting a fragile workaround within GeoLibre's UI layer-sync logic, this PR applies a surgical patch directly to our `maplibre-gl` dependency using `patch-package`. The patch backports an open upstream fix (MapLibre PR #7852) which modifies `RenderToTexture.ts` to identify the highest opaque draped raster layer and explicitly skips rendering for symbol layers placed below it.

*Testing Note:* Verified locally on Windows. The frontend UI test suite passes successfully. The 8 subtest failures observed locally were confirmed to be WSL/bash path resolution issues in `metainfo-generated.test.ts` (Linux AppImage packaging) running on a Windows host, and are unrelated to this UI fix.

## References
Closes #781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map rendering by preventing symbols and 3D fill features from appearing beneath fully opaque raster layers.
  * Added coverage for raster opacity scenarios to improve visual consistency.

* **Chores**
  * Installation now automatically applies the required map rendering compatibility patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->