### PR TITLE
fix: redact credentials from a layer's connection record

### DIFF
--- a/packages/core/src/credentials.ts
+++ b/packages/core/src/credentials.ts
@@ -1,4 +1,4 @@
-import type { GeoLibreProject } from "./types";
+import type { GeoLibreProject, LayerConnection } from "./types";
 
 /**
  * Project fields whose values are credentials. Keep this registry as the
@@ -277,6 +277,20 @@ export function redactProjectCredentials(project: GeoLibreProject): CredentialRe
             redactedPaths,
             redactedCount,
           ) as string,
+        }
+      : {}),
+    // `connection.lastError` is free-form text taken from a caught error, and a
+    // refresh path that words it as `Failed to fetch ${url}` would carry the
+    // request's credential parameters. Sweeping it costs nothing and keeps the
+    // no-secret guarantee from depending on how an error message is phrased.
+    ...(layer.connection
+      ? {
+          connection: redactConfigurationValue(
+            layer.connection,
+            `layers[${index}].connection`,
+            redactedPaths,
+            redactedCount,
+          ) as LayerConnection,
         }
       : {}),
   }));

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -148,7 +148,11 @@ def redact_credentials(project: dict[str, Any]) -> dict[str, Any]:
         for layer in layers:
             if not isinstance(layer, dict):
                 continue
-            for field in ("source", "metadata", "sourcePath"):
+            # `connection.lastError` is free-form text taken from a caught
+            # error, which a future refresh path could easily build from the
+            # request URL. Sweeping it costs nothing and keeps the no-secret
+            # guarantee from depending on how an error message is worded.
+            for field in ("source", "metadata", "sourcePath", "connection"):
                 if field in layer:
                     layer[field] = _redact_config(layer[field])
     plugins = safe.get("plugins")

--- a/python/tests/test_scripting.py
+++ b/python/tests/test_scripting.py
@@ -397,6 +397,30 @@ def test_python_credential_field_registry_matches_js():
     assert safe["layers"][0]["source"] == {"sr": 4326, "key": "layer-identifier"}
 
 
+def test_python_redaction_sweeps_layer_connection():
+    """`connection.lastError` is free-form error text and must be swept too."""
+    safe = redact_credentials(
+        {
+            "layers": [
+                {
+                    "source": {"url": "https://example.com/tiles"},
+                    "connection": {
+                        "layerId": "auth",
+                        "interval": 300,
+                        "lastSyncedAt": "2026-01-01T00:00:00.000Z",
+                        "lastError": "Failed to fetch https://example.com/tiles?token=py-connection-secret",
+                        "onFailure": "keep-last",
+                    },
+                }
+            ]
+        }
+    )
+    connection = safe["layers"][0]["connection"]
+    assert "py-connection-secret" not in str(safe)
+    assert connection["lastError"] == "Failed to fetch https://example.com/tiles"
+    assert connection["interval"] == 300
+
+
 def test_python_redaction_fails_closed_at_depth_limit():
     nested = {"password": "too-deep-secret"}
     for _ in range(12):

--- a/tests/project-credentials.test.ts
+++ b/tests/project-credentials.test.ts
@@ -139,6 +139,25 @@ describe("project credential redaction", () => {
     assert.deepEqual(safe.layers[0].source, { sr: 4326, key: "layer-identifier" });
   });
 
+  it("sweeps a layer's connection record, not only its source", () => {
+    // `lastError` is free-form text from a caught error, so a refresh path that
+    // words it with the request URL must not carry the credential out.
+    const project = credentialProject();
+    project.layers[0].connection = {
+      layerId: "auth",
+      interval: 300,
+      lastSyncedAt: "2026-01-01T00:00:00.000Z",
+      lastError: "Failed to fetch https://example.com/tiles?token=connection-secret",
+      onFailure: "keep-last",
+    };
+
+    const { project: safe, redactedPaths } = redactProjectCredentials(project);
+    assert.ok(!serializeProject(safe).includes("connection-secret"));
+    assert.equal(safe.layers[0].connection?.lastError, "Failed to fetch https://example.com/tiles");
+    assert.equal(safe.layers[0].connection?.interval, 300);
+    assert.ok(redactedPaths.includes("layers[0].connection.lastError"));
+  });
+
   it("fails closed when configuration exceeds the traversal depth", () => {
     let nested: Record<string, unknown> = { arbitrary: "too-deep-secret" };
     for (let index = 0; index < 12; index += 1) nested = { child: nested };


### PR DESCRIPTION
Follow-up to #1702, closing the last gap the review raised there (that comment landed after the PR was merged).

## The gap

`redactProjectCredentials` sweeps each layer's `source`, `metadata`, and `sourcePath`, but `layer.connection` passes through untouched. `connection.lastError` is free-form text taken from a caught error, and a refresh path that words it as `` `Failed to fetch ${url}` `` — a common pattern — would carry the request's `?token=…` straight through Share, HTML export, embed, and collaboration.

Today's built-in refresh paths (`layer-refresh.ts`) only ever store generic strings like `"Request failed with status 403"`, so nothing leaks in practice. This closes the blind spot so the module's no-secret guarantee does not depend on how a future error message happens to be phrased.

## Changes

- `packages/core/src/credentials.ts` — sweep `layer.connection` through `redactConfigurationValue` alongside the other three fields.
- `python/src/geolibre/project.py` — the same field in the Python mirror, which had the identical gap.
- Tests on both sides assert the token is stripped while the rest of the connection record (interval, timestamps, `onFailure`) survives.

## Verification

- `npm run test:frontend` — 5056 passing (2 new)
- `python -m pytest` in `python/` — 175 passing (1 new)
- `pre-commit run --files <changed>` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded credential redaction to sanitize sensitive information in layer connection details, including nested data and URLs.
  * Removed credentials from connection error messages while preserving non-sensitive connection information.
  * Improved redaction tracking for sanitized connection fields.

* **Tests**
  * Added coverage confirming tokens are removed from serialized project data and connection errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->