### PR TITLE
feat(export): Exclude hidden fields from vector data 

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PROJECT_NAME,
+  excludeHiddenFieldsFromProject,
   redactProjectCredentials,
   serializeProject,
   useAppStore,
@@ -2002,7 +2003,7 @@ export function TopToolbar({
           // Shared projects are opened on another machine where the local files
           // don't exist, so always embed the vector data (never file references).
           const { project, defaultProjectName } = await projectFiles.buildEmbeddedProject(title);
-          const redacted = redactProjectCredentials(project);
+          const redacted = redactProjectCredentials(excludeHiddenFieldsFromProject(project));
           // Strip path separators, control chars, and other characters that are
           // illegal in filenames so the server gets a predictable name.
           const safeName = defaultProjectName.replace(

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1388,7 +1388,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => handleToggleExcluded(col)}>
               <Ban className="me-2 h-3.5 w-3.5" />
-              {layer?.fieldVisibility?.[col] === "excluded" ? t("attributeTable.includeField", "Include field on export") : t("attributeTable.excludeField", "Exclude field on export")}
+              {layer?.fieldVisibility?.[col] === "excluded"
+                ? t("attributeTable.includeField", "Include field on export")
+                : t("attributeTable.excludeField", "Exclude field on export")}
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isRtl ? index === columns.length - 1 : index === 0}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -5,6 +5,7 @@ import {
   isDuckDBQueryLayer,
   useAppStore,
   validateAttributeFormValues,
+  excludeHiddenFieldsFromGeojson,
   type AttributeFormConfig,
   type AttributeFormFieldConfig,
   type AttributeFormFieldError,
@@ -70,6 +71,7 @@ import {
   Telescope,
   Trash2,
   X,
+  Ban,
 } from "lucide-react";
 import {
   type MouseEvent as ReactMouseEvent,
@@ -927,8 +929,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     try {
       setExportError(null);
       setExportWarning(null);
-      const exportGeojson = geojsonWithDrafts();
+      let exportGeojson = geojsonWithDrafts();
       if (!exportGeojson) return;
+      if (layer.fieldVisibility) {
+        exportGeojson = excludeHiddenFieldsFromGeojson(exportGeojson, layer.fieldVisibility);
+      }
 
       const baseName = sanitizeExportFileName(layer.name);
       const savedPath = await exportVectorLayer(exportGeojson, format, baseName, layer.name);
@@ -993,6 +998,19 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const handleToggleHidden = (col: string) => {
     if (!layer) return;
     updateLayer(layer.id, toggleColumnHidden(layer, col));
+  };
+
+  const handleToggleExcluded = (col: string) => {
+    if (!layer) return;
+    const current = layer.fieldVisibility || {};
+    const isExcluded = current[col] === "excluded";
+    const next = { ...current };
+    if (isExcluded) {
+      delete next[col];
+    } else {
+      next[col] = "excluded";
+    }
+    updateLayer(layer.id, { fieldVisibility: next });
   };
 
   const handleShowAllColumns = () => {
@@ -1367,6 +1385,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             <DropdownMenuItem onSelect={() => handleToggleHidden(col)}>
               <EyeOff className="me-2 h-3.5 w-3.5" />
               {t("attributeTable.hideField")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => handleToggleExcluded(col)}>
+              <Ban className="me-2 h-3.5 w-3.5" />
+              {layer?.fieldVisibility?.[col] === "excluded" ? t("attributeTable.includeField", "Include field on export") : t("attributeTable.excludeField", "Exclude field on export")}
             </DropdownMenuItem>
             <DropdownMenuItem
               disabled={isRtl ? index === columns.length - 1 : index === 0}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -27,6 +27,7 @@ import {
   pluginOwnsPaint,
   supportsBridgedOpacity,
   useAppStore,
+  excludeHiddenFieldsFromGeojson,
 } from "@geolibre/core";
 import type { EllipsoidId, GeoLibreLayer, LayerGroup } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
@@ -1542,8 +1543,11 @@ export function LayerPanel({
           scheduleStatusClear(layer.id);
           return;
         }
+        const egressGeojson = layer.fieldVisibility
+          ? excludeHiddenFieldsFromGeojson(geojson, layer.fieldVisibility)
+          : geojson;
         const savedPath = await exportVectorLayer(
-          geojson,
+          egressGeojson,
           format,
           sanitizeExportFileName(layer.name),
           layer.name,
@@ -1915,6 +1919,11 @@ export function LayerPanel({
               connection,
               schema_name: schema,
               table,
+              excluded_fields: layer.fieldVisibility
+                ? Object.keys(layer.fieldVisibility).filter(
+                    (k) => layer.fieldVisibility![k] === "excluded",
+                  )
+                : undefined,
             });
           } catch {
             // The write committed; only the refresh failed. Reporting this as

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -3,6 +3,7 @@ import {
   detachProjectCopy,
   projectFromStore,
   redactProjectCredentials,
+  excludeHiddenFieldsFromProject,
   serializeProject,
   useAppStore,
   type GeoLibreLayer,
@@ -843,13 +844,18 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     // them. Make keeping them an explicit choice and use the same central
     // redaction pass as every external egress.
     let contentToSave = content;
-    const redacted = redactProjectCredentials(project);
+    const projectToEgress = excludeHiddenFieldsFromProject(project);
+    const redacted = redactProjectCredentials(projectToEgress);
     if (redacted.redactedPaths.length > 0) {
       const choice = await askStripCredentials(redacted.redactedCount);
       if (choice === "cancel") return false;
       if (choice === "strip") {
         contentToSave = serializeProject(redacted.project);
+      } else {
+        contentToSave = serializeProject(projectToEgress);
       }
+    } else {
+      contentToSave = serializeProject(projectToEgress);
     }
     // Projects opened from a URL have no writable path, so both Save and
     // Save As fall back to the save dialog for them.

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4207,6 +4207,8 @@
     "manageFieldAria": "Manage field {{name}}",
     "renameField": "Rename field",
     "hideField": "Hide field",
+    "excludeField": "Exclude field on export",
+    "includeField": "Include field on export",
     "moveLeft": "Move left",
     "moveRight": "Move right",
     "deleteField": "Delete field",

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -256,6 +256,7 @@ class PostgisReadRequest(BaseModel):
     connection: str
     schema_name: str = "public"
     table: str
+    excluded_fields: list[str] = []
 
 
 class PostgisWriteRequest(BaseModel):
@@ -538,8 +539,11 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
                 if info["srid"] not in (0, 4326)
                 else sql.SQL("ST_AsGeoJSON({geom})").format(geom=geom)
             )
+            read_columns = [
+                col for col in info["columns"] if col not in request.excluded_fields
+            ]
             column_list = sql.SQL(", ").join(
-                [geom_expr] + [sql.Identifier(column) for column in info["columns"]]
+                [geom_expr] + [sql.Identifier(col) for col in read_columns]
             )
             query = sql.SQL("SELECT {columns} FROM {schema}.{table} LIMIT %s").format(
                 columns=column_list,
@@ -576,7 +580,7 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
     pk = info["primary_key"]
     features = []
     for row in rows:
-        properties = {column: _json_safe(value) for column, value in zip(info["columns"], row[1:])}
+        properties = {column: _json_safe(value) for column, value in zip(read_columns, row[1:])}
         feature: dict[str, Any] = {
             "type": "Feature",
             "geometry": json.loads(row[0]) if row[0] else None,

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -581,7 +581,9 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
     pk = info["primary_key"]
     features = []
     for row in rows:
-        properties_raw = {column: _json_safe(value) for column, value in zip(read_columns, row[1:], strict=True)}
+        properties_raw = {
+            column: _json_safe(value) for column, value in zip(read_columns, row[1:], strict=True)
+        }
         feature: dict[str, Any] = {
             "type": "Feature",
             "geometry": json.loads(row[0]) if row[0] else None,

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -539,9 +539,7 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
                 if info["srid"] not in (0, 4326)
                 else sql.SQL("ST_AsGeoJSON({geom})").format(geom=geom)
             )
-            read_columns = [
-                col for col in info["columns"] if col not in request.excluded_fields
-            ]
+            read_columns = [col for col in info["columns"] if col not in request.excluded_fields]
             column_list = sql.SQL(", ").join(
                 [geom_expr] + [sql.Identifier(col) for col in read_columns]
             )

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -539,7 +539,10 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
                 if info["srid"] not in (0, 4326)
                 else sql.SQL("ST_AsGeoJSON({geom})").format(geom=geom)
             )
-            read_columns = [col for col in info["columns"] if col not in request.excluded_fields]
+            pk = info["primary_key"]
+            read_columns = [
+                col for col in info["columns"] if col not in request.excluded_fields or col == pk
+            ]
             column_list = sql.SQL(", ").join(
                 [geom_expr] + [sql.Identifier(col) for col in read_columns]
             )
@@ -578,14 +581,16 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
     pk = info["primary_key"]
     features = []
     for row in rows:
-        properties = {column: _json_safe(value) for column, value in zip(read_columns, row[1:])}
+        properties_raw = {column: _json_safe(value) for column, value in zip(read_columns, row[1:], strict=True)}
         feature: dict[str, Any] = {
             "type": "Feature",
             "geometry": json.loads(row[0]) if row[0] else None,
-            "properties": properties,
+            "properties": {
+                k: v for k, v in properties_raw.items() if k not in request.excluded_fields
+            },
         }
-        if pk is not None and properties.get(pk) is not None:
-            feature["id"] = properties[pk]
+        if pk is not None and properties_raw.get(pk) is not None:
+            feature["id"] = properties_raw[pk]
         features.append(feature)
 
     return {

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -365,9 +365,7 @@ def test_read_returns_wgs84_with_primary_key(live_table) -> None:
 def test_read_drops_excluded_fields(live_table) -> None:
     result = postgis_read(
         PostgisReadRequest(
-            connection=LIVE_DSN,
-            table=TABLE,
-            excluded_fields=["population", "name", "gid"]
+            connection=LIVE_DSN, table=TABLE, excluded_fields=["population", "name", "gid"]
         )
     )
     features = result["geojson"]["features"]

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -362,6 +362,26 @@ def test_read_returns_wgs84_with_primary_key(live_table) -> None:
 
 
 @requires_live_postgis
+def test_read_drops_excluded_fields(live_table) -> None:
+    result = postgis_read(
+        PostgisReadRequest(
+            connection=LIVE_DSN,
+            table=TABLE,
+            excluded_fields=["population", "name"]
+        )
+    )
+    features = result["geojson"]["features"]
+    assert len(features) == 3
+    knox = features[0]
+    assert "gid" in knox["properties"]
+    assert "population" not in knox["properties"]
+    assert "name" not in knox["properties"]
+    # The geometry and id must still be populated correctly.
+    assert "geometry" in knox
+    assert "id" in knox
+
+
+@requires_live_postgis
 def test_read_unknown_table_404(live_table) -> None:
     with pytest.raises(HTTPException) as exc:
         postgis_read(PostgisReadRequest(connection=LIVE_DSN, table="no_such"))

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -364,14 +364,18 @@ def test_read_returns_wgs84_with_primary_key(live_table) -> None:
 @requires_live_postgis
 def test_read_drops_excluded_fields(live_table) -> None:
     result = postgis_read(
-        PostgisReadRequest(connection=LIVE_DSN, table=TABLE, excluded_fields=["population", "name"])
+        PostgisReadRequest(
+            connection=LIVE_DSN,
+            table=TABLE,
+            excluded_fields=["population", "name", "gid"]
+        )
     )
     features = result["geojson"]["features"]
     assert len(features) == 3
     knox = features[0]
-    assert "gid" in knox["properties"]
     assert "population" not in knox["properties"]
     assert "name" not in knox["properties"]
+    assert "gid" not in knox["properties"]
     # The geometry and id must still be populated correctly.
     assert "geometry" in knox
     assert "id" in knox

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -364,11 +364,7 @@ def test_read_returns_wgs84_with_primary_key(live_table) -> None:
 @requires_live_postgis
 def test_read_drops_excluded_fields(live_table) -> None:
     result = postgis_read(
-        PostgisReadRequest(
-            connection=LIVE_DSN,
-            table=TABLE,
-            excluded_fields=["population", "name"]
-        )
+        PostgisReadRequest(connection=LIVE_DSN, table=TABLE, excluded_fields=["population", "name"])
     )
     features = result["geojson"]["features"]
     assert len(features) == 3

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,7 +130,4 @@ export {
   redactUrlCredentials,
   type CredentialRedactionResult,
 } from "./credentials";
-export {
-  excludeHiddenFieldsFromGeojson,
-  excludeHiddenFieldsFromProject,
-} from "./visibility";
+export { excludeHiddenFieldsFromGeojson, excludeHiddenFieldsFromProject } from "./visibility";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,3 +130,7 @@ export {
   redactUrlCredentials,
   type CredentialRedactionResult,
 } from "./credentials";
+export {
+  excludeHiddenFieldsFromGeojson,
+  excludeHiddenFieldsFromProject,
+} from "./visibility";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -852,6 +852,13 @@ export interface LayerConnection {
   onFailure: "keep-last" | "clear";
 }
 
+/**
+ * Visibility of a layer's attribute field.
+ * - "hidden": Not shown in the attribute table, identify popup, tooltips, or field pickers, but remains in the data.
+ * - "excluded": Removed entirely from the data when the project is shared or exported.
+ */
+export type FieldVisibility = "hidden" | "excluded";
+
 export interface GeoLibreLayer {
   id: string;
   name: string;
@@ -863,6 +870,11 @@ export interface GeoLibreLayer {
   metadata: Record<string, unknown>;
   beforeId?: string;
   geojson?: FeatureCollection;
+  /**
+   * Field-level visibility overrides. Fields marked as "excluded" are physically
+   * removed from the data during export and sharing.
+   */
+  fieldVisibility?: Record<string, FieldVisibility>;
   /**
    * Per-field edit-widget, constraint, and visibility configuration authored
    * in the Attribute Form designer. Applied by the attribute editing surfaces

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -6,12 +6,12 @@ import type { GeoLibreProject, FieldVisibility } from "./types";
  */
 export function excludeHiddenFieldsFromGeojson(
   geojson: FeatureCollection,
-  fieldVisibility?: Record<string, FieldVisibility>
+  fieldVisibility?: Record<string, FieldVisibility>,
 ): FeatureCollection {
   const excludedKeys = new Set(
     Object.entries(fieldVisibility || {})
       .filter(([_, visibility]) => visibility === "excluded")
-      .map(([key]) => key)
+      .map(([key]) => key),
   );
 
   if (excludedKeys.size === 0) {

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -1,0 +1,54 @@
+import type { FeatureCollection } from "geojson";
+import type { GeoLibreProject, FieldVisibility } from "./types";
+
+/**
+ * Returns a new FeatureCollection with properties marked as "excluded" removed.
+ */
+export function excludeHiddenFieldsFromGeojson(
+  geojson: FeatureCollection,
+  fieldVisibility?: Record<string, FieldVisibility>
+): FeatureCollection {
+  const excludedKeys = new Set(
+    Object.entries(fieldVisibility || {})
+      .filter(([_, visibility]) => visibility === "excluded")
+      .map(([key]) => key)
+  );
+
+  if (excludedKeys.size === 0) {
+    return geojson;
+  }
+
+  // Deep clone to avoid mutating the live store state
+  const stripped: FeatureCollection = {
+    ...geojson,
+    features: geojson.features.map((feature) => {
+      const properties = { ...feature.properties };
+      for (const key of excludedKeys) {
+        delete properties[key];
+      }
+      return { ...feature, properties };
+    }),
+  };
+
+  return stripped;
+}
+
+/**
+ * Returns a new GeoLibreProject where all layers have their excluded fields
+ * physically removed from their inline GeoJSON.
+ */
+export function excludeHiddenFieldsFromProject(project: GeoLibreProject): GeoLibreProject {
+  let changed = false;
+  const layers = project.layers.map((layer) => {
+    if (layer.fieldVisibility && layer.geojson) {
+      const strippedGeojson = excludeHiddenFieldsFromGeojson(layer.geojson, layer.fieldVisibility);
+      if (strippedGeojson !== layer.geojson) {
+        changed = true;
+        return { ...layer, geojson: strippedGeojson };
+      }
+    }
+    return layer;
+  });
+
+  return changed ? { ...project, layers } : project;
+}

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -41,7 +41,7 @@ export function excludeHiddenFieldsFromProject(project: GeoLibreProject): GeoLib
   let changed = false;
   const layers = project.layers.map((layer) => {
     if (!layer.fieldVisibility) return layer;
-    
+
     let updatedLayer = layer;
 
     if (layer.geojson) {
@@ -53,7 +53,10 @@ export function excludeHiddenFieldsFromProject(project: GeoLibreProject): GeoLib
     }
 
     if (layer.metadata?.embeddedGeoJSON) {
-      const strippedEmbedded = excludeHiddenFieldsFromGeojson(layer.metadata.embeddedGeoJSON as FeatureCollection, layer.fieldVisibility);
+      const strippedEmbedded = excludeHiddenFieldsFromGeojson(
+        layer.metadata.embeddedGeoJSON as FeatureCollection,
+        layer.fieldVisibility,
+      );
       if (strippedEmbedded !== layer.metadata.embeddedGeoJSON) {
         changed = true;
         updatedLayer = {

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -40,14 +40,33 @@ export function excludeHiddenFieldsFromGeojson(
 export function excludeHiddenFieldsFromProject(project: GeoLibreProject): GeoLibreProject {
   let changed = false;
   const layers = project.layers.map((layer) => {
-    if (layer.fieldVisibility && layer.geojson) {
+    if (!layer.fieldVisibility) return layer;
+    
+    let updatedLayer = layer;
+
+    if (layer.geojson) {
       const strippedGeojson = excludeHiddenFieldsFromGeojson(layer.geojson, layer.fieldVisibility);
       if (strippedGeojson !== layer.geojson) {
         changed = true;
-        return { ...layer, geojson: strippedGeojson };
+        updatedLayer = { ...updatedLayer, geojson: strippedGeojson };
       }
     }
-    return layer;
+
+    if (layer.metadata?.embeddedGeoJSON) {
+      const strippedEmbedded = excludeHiddenFieldsFromGeojson(layer.metadata.embeddedGeoJSON as FeatureCollection, layer.fieldVisibility);
+      if (strippedEmbedded !== layer.metadata.embeddedGeoJSON) {
+        changed = true;
+        updatedLayer = {
+          ...updatedLayer,
+          metadata: {
+            ...updatedLayer.metadata,
+            embeddedGeoJSON: strippedEmbedded,
+          },
+        };
+      }
+    }
+
+    return updatedLayer;
   });
 
   return changed ? { ...project, layers } : project;

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -796,6 +796,7 @@ export interface ReadPostgisTableRequest {
   connection: string;
   schema_name?: string;
   table: string;
+  excluded_fields?: string[];
 }
 
 export interface ReadPostgisTableResult {

--- a/tests/visibility.test.ts
+++ b/tests/visibility.test.ts
@@ -50,7 +50,7 @@ describe("visibility", () => {
     };
 
     const stripped = excludeHiddenFieldsFromProject(project);
-    
+
     // Check main geojson
     const feature1 = stripped.layers[0].geojson!.features[0];
     assert.strictEqual(feature1.properties?.keep, 1);

--- a/tests/visibility.test.ts
+++ b/tests/visibility.test.ts
@@ -1,0 +1,64 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import type { GeoLibreProject } from "@geolibre/core";
+import { excludeHiddenFieldsFromProject } from "../packages/core/src/visibility";
+
+describe("visibility", () => {
+  test("excludeHiddenFieldsFromProject strips excluded fields from geojson and embeddedGeoJSON", () => {
+    const project: GeoLibreProject = {
+      id: "proj-1",
+      name: "Test",
+      version: 1,
+      viewState: {
+        longitude: 0,
+        latitude: 0,
+        zoom: 0,
+        pitch: 0,
+        bearing: 0,
+      },
+      layers: [
+        {
+          id: "layer-1",
+          name: "Layer",
+          type: "geojson",
+          visible: true,
+          metadata: {
+            embeddedGeoJSON: {
+              type: "FeatureCollection",
+              features: [
+                {
+                  type: "Feature",
+                  geometry: { type: "Point", coordinates: [0, 0] },
+                  properties: { keep: 1, drop: 2 },
+                },
+              ],
+            },
+          },
+          fieldVisibility: { drop: "excluded" },
+          geojson: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [0, 0] },
+                properties: { keep: 1, drop: 2 },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const stripped = excludeHiddenFieldsFromProject(project);
+    
+    // Check main geojson
+    const feature1 = stripped.layers[0].geojson!.features[0];
+    assert.strictEqual(feature1.properties?.keep, 1);
+    assert.strictEqual(feature1.properties?.drop, undefined);
+
+    // Check embedded geojson
+    const embeddedFeature = (stripped.layers[0].metadata.embeddedGeoJSON as any).features[0];
+    assert.strictEqual(embeddedFeature.properties?.keep, 1);
+    assert.strictEqual(embeddedFeature.properties?.drop, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
* Implements a new "Exclude field on export" option in the attribute table column menu.
* Intercepts layer serialization across vector data export, project saves, and project sharing to actively prune excluded fields from the embedded `layer.geojson` data.
* Applies exclusions natively at the database level when syncing tables from PostGIS via `backend/geolibre_server`.

## Problem
Currently, GeoLibre projects package all source fields inside the embedded GeoJSON vectors. Hiding a column merely removes it from the data grid UI but still writes it to the `.geolibre.json` payload, network requests (during sharing), and `.geojson` file exports, inadvertently leaking potentially sensitive metadata (names, addresses, PII, etc).

## Root Cause
The export pipeline and the PostGIS sync requests didn't differentiate between fields meant to be visible and fields meant to be completely excluded. The serialization steps simply pulled `layer.geojson` wholesale and SQL sync requests queried all available columns blindly.

## Solution
* Defined a `"excluded"` property under the layer's `fieldVisibility` dict mapping. 
* Added `excludeHiddenFieldsFromProject` and `excludeHiddenFieldsFromGeojson` to `@geolibre/core` to recursively strip excluded properties prior to serialization.
* Updated `TopToolbar`, `LayerPanel`, and `useProjectFileActions` to route through the exclusion pipeline during sharing, exports, and saves.
* Patched `/postgis/read` in the backend sidecar to construct its SQL `SELECT` geometry projection by omitting `excluded_fields`.
* Added UI triggers in the `AttributeTable` dropdown to exclude or include fields.

## Testing & Verification
- [x] Passed pre-commit hooks and frontend linting (`npm run lint`).
- [x] Passed TypeScript typecheck (`npm run typecheck`).
- [x] Passed frontend test suite (`npm run test:frontend`) without dropping coverage below thresholds.
- [x] Added `test_read_drops_excluded_fields` regression test and passed backend test suite successfully (`npm run test:backend`).
- [x] Visual validation of the Attribute Table context menu.

## References
Closes #1676


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added field-level controls to include or exclude selected columns from exports.
  * Excluded fields are omitted from GeoJSON, vector exports, shared projects, and saved projects.
  * PostGIS reads support excluding selected fields while preserving geometry and feature IDs.
  * Added clear include/exclude labels and visual indicators in the attribute table.

* **Bug Fixes**
  * Hidden or excluded fields are consistently removed before sharing, saving, and exporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->