### PR TITLE
feat(netcdf): mark sampled pixels and float the spectral profile

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -2284,7 +2284,10 @@ export function DesktopShell({
               <MapModeBanner mapControllerRef={mapControllerRef} />
               <QuickAnalysisBanner />
               <PixelTimeSeriesControl mapControllerRef={mapControllerRef} />
-              <NetcdfSampleMarkers mapControllerRef={mapControllerRef} />
+              <NetcdfSampleMarkers
+                mapControllerRef={mapControllerRef}
+                mapReadyGeneration={mapReadyGeneration}
+              />
               <NetcdfProfileWindow />
               <MapLegendPanel
                 mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -126,6 +126,8 @@ import { useCollaboration } from "../../hooks/useCollaboration";
 import { MapModeBanner } from "./MapModeBanner";
 import { QuickAnalysisBanner } from "./QuickAnalysisBanner";
 import { PixelTimeSeriesControl } from "./PixelTimeSeriesControl";
+import { NetcdfSampleMarkers } from "./NetcdfSampleMarkers";
+import { NetcdfProfileWindow } from "./NetcdfProfileWindow";
 import { MapLegendPanel } from "../legend/MapLegendPanel";
 import { RasterSubsetPanel } from "./RasterSubsetPanel";
 import { BasemapExtractPanel } from "./BasemapExtractPanel";
@@ -2282,6 +2284,8 @@ export function DesktopShell({
               <MapModeBanner mapControllerRef={mapControllerRef} />
               <QuickAnalysisBanner />
               <PixelTimeSeriesControl mapControllerRef={mapControllerRef} />
+              <NetcdfSampleMarkers mapControllerRef={mapControllerRef} />
+              <NetcdfProfileWindow />
               <MapLegendPanel
                 mapControllerRef={mapControllerRef}
                 mapReadyGeneration={mapReadyGeneration}

--- a/apps/geolibre-desktop/src/components/layout/NetcdfProfileWindow.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfProfileWindow.tsx
@@ -1,0 +1,118 @@
+import { Button } from "@geolibre/ui";
+import { GripVertical, LineChart, X } from "lucide-react";
+import { useSyncExternalStore } from "react";
+import { useTranslation } from "react-i18next";
+import { useFloatingPanelRect } from "../../hooks/useFloatingPanelRect";
+import {
+  clearNetcdfProfileSamples,
+  getNetcdfProfileSamples,
+  isNetcdfProfilePoppedOut,
+  setNetcdfProfilePoppedOut,
+  subscribeNetcdfProfile,
+} from "../../lib/netcdf-profile-store";
+import { NetcdfProfileChart } from "../panels/NetcdfProfileChart";
+
+/** Panel geometry (px). The window opens in the top-left corner, inset by
+ * {@link PANEL_MARGIN}, and can then be dragged and resized anywhere on the map.
+ * Top-left because the only resize grip is the bottom-right one: opening on the
+ * right would put that grip against the Style panel with nowhere to grow. The
+ * CSS default below and {@link FALLBACK_RECT} describe the same corner, so a
+ * drag that starts from the untouched default does not jump. */
+const PANEL_MIN_W = 360;
+const PANEL_MIN_H = 260;
+const PANEL_MARGIN = 12;
+const FALLBACK_RECT = { x: PANEL_MARGIN, y: PANEL_MARGIN, w: 520, h: 420 };
+
+/**
+ * The spectral profile detached from the Style panel into a movable, resizable
+ * window over the map.
+ *
+ * The Style panel is narrow and scrolls, which is a poor home for a chart the
+ * user wants to read closely; floating it gives the chart room and lets it sit
+ * beside the pixels it was sampled from. The store holds one layer's samples at
+ * a time, so the window charts "the current samples" without tracking a layer.
+ *
+ * Mounted in the map area so it is positioned against the map, not the shell.
+ *
+ * @returns The window, or null while the chart is docked or has nothing to show.
+ */
+export function NetcdfProfileWindow() {
+  const { t } = useTranslation();
+  const samples = useSyncExternalStore(
+    subscribeNetcdfProfile,
+    getNetcdfProfileSamples,
+    getNetcdfProfileSamples,
+  );
+  const poppedOut = useSyncExternalStore(
+    subscribeNetcdfProfile,
+    isNetcdfProfilePoppedOut,
+    isNetcdfProfilePoppedOut,
+  );
+  const { panelRef, rect, handleDragStart, handleResizeStart } = useFloatingPanelRect({
+    minWidth: PANEL_MIN_W,
+    minHeight: PANEL_MIN_H,
+    margin: PANEL_MARGIN,
+    fallback: FALLBACK_RECT,
+  });
+
+  if (!poppedOut || samples.length === 0) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      className={
+        rect
+          ? "pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+          : "pointer-events-auto absolute start-3 top-3 z-20 flex h-[26rem] max-h-[calc(100%-6rem)] w-[min(32rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+      }
+      style={rect ? { left: rect.x, top: rect.y, width: rect.w, height: rect.h } : undefined}
+      role="region"
+      aria-label={t("netcdfProfile.heading")}
+      data-testid="netcdf-profile-window"
+    >
+      <div
+        className="flex cursor-move touch-none select-none items-center justify-between gap-2 border-b px-3 py-2"
+        onPointerDown={handleDragStart}
+      >
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <LineChart className="h-4 w-4 text-primary" aria-hidden="true" />
+          {t("netcdfProfile.heading")}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button type="button" variant="ghost" size="sm" onClick={clearNetcdfProfileSamples}>
+            {t("netcdfProfile.clear")}
+          </Button>
+          <button
+            type="button"
+            className="rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring"
+            onClick={() => setNetcdfProfilePoppedOut(false)}
+            aria-label={t("netcdfProfile.dock")}
+            title={t("netcdfProfile.dock")}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto p-3">
+        {/* `flex-1` rather than a fixed height: the chart scales with the
+            window, which is the point of resizing it. */}
+        <NetcdfProfileChart samples={samples} chartClassName="flex-1" />
+      </div>
+
+      {/* Resize grip (bottom-right). The diagonal lines hint the affordance.
+          Mouse/touch-only, so it is presentational — there is no keyboard
+          resize to expose to assistive tech. */}
+      <div
+        className="absolute bottom-0 right-0 h-4 w-4 cursor-se-resize touch-none"
+        onPointerDown={handleResizeStart}
+        role="presentation"
+      >
+        <svg viewBox="0 0 10 10" className="h-full w-full text-muted-foreground" aria-hidden="true">
+          <path d="M9 1 L1 9 M9 5 L5 9" stroke="currentColor" strokeWidth={1} fill="none" />
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/NetcdfProfileWindow.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfProfileWindow.tsx
@@ -12,18 +12,26 @@ import {
 } from "../../lib/netcdf-profile-store";
 import { NetcdfProfileChart } from "../panels/NetcdfProfileChart";
 
-/** Panel geometry (px). The window opens in the top-left corner, inset by
- * {@link PANEL_MARGIN}, and can then be dragged and resized anywhere on the map.
- * Top-left because the only resize grip is the bottom-right one: opening on the
- * right would put that grip against the Style panel with nowhere to grow. The
- * CSS default below and {@link FALLBACK_RECT} describe the same corner, so a
- * drag that starts from the untouched default does not jump. */
+/** Panel geometry (px). The window opens near the top-left corner and can then
+ * be dragged and resized anywhere on the map. Top-left because the only resize
+ * grip is the bottom-right one: opening on the right would put that grip against
+ * the Style panel with nowhere to grow. The CSS default below and
+ * {@link FALLBACK_RECT} describe the same spot, so a drag that starts from the
+ * untouched default does not jump. */
 const PANEL_MIN_W = 360;
 const PANEL_MIN_H = 260;
 const PANEL_MARGIN = 12;
+/**
+ * Vertical offset from the top inset. The Time Slider's pixel chart opens at the
+ * same corner and z-index, and the two are gated independently, so a user with a
+ * time-slider stack *and* a popped-out NetCDF profile would otherwise get two
+ * windows stacked exactly on top of each other. Cascading this one down leaves
+ * that panel's drag header exposed and grabbable underneath.
+ */
+const PANEL_TOP = 64;
 // 512x416 is the CSS default below (32rem x 26rem at a 16px root) in px, so the
 // fallback matches the size as well as the corner.
-const FALLBACK_RECT = { x: PANEL_MARGIN, y: PANEL_MARGIN, w: 512, h: 416 };
+const FALLBACK_RECT = { x: PANEL_MARGIN, y: PANEL_TOP, w: 512, h: 416 };
 
 /**
  * The spectral profile detached from the Style panel into a movable, resizable
@@ -65,7 +73,7 @@ export function NetcdfProfileWindow() {
       className={
         rect
           ? "pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
-          : "pointer-events-auto absolute start-3 top-3 z-20 flex h-[26rem] max-h-[calc(100%-6rem)] w-[min(32rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
+          : "pointer-events-auto absolute start-3 top-16 z-20 flex h-[26rem] max-h-[calc(100%-9rem)] w-[min(32rem,calc(100vw-1.5rem))] flex-col overflow-hidden rounded-lg border bg-background shadow-xl"
       }
       style={rect ? { left: rect.x, top: rect.y, width: rect.w, height: rect.h } : undefined}
       role="region"

--- a/apps/geolibre-desktop/src/components/layout/NetcdfProfileWindow.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfProfileWindow.tsx
@@ -21,7 +21,9 @@ import { NetcdfProfileChart } from "../panels/NetcdfProfileChart";
 const PANEL_MIN_W = 360;
 const PANEL_MIN_H = 260;
 const PANEL_MARGIN = 12;
-const FALLBACK_RECT = { x: PANEL_MARGIN, y: PANEL_MARGIN, w: 520, h: 420 };
+// 512x416 is the CSS default below (32rem x 26rem at a 16px root) in px, so the
+// fallback matches the size as well as the corner.
+const FALLBACK_RECT = { x: PANEL_MARGIN, y: PANEL_MARGIN, w: 512, h: 416 };
 
 /**
  * The spectral profile detached from the Style panel into a movable, resizable

--- a/apps/geolibre-desktop/src/components/layout/NetcdfSampleMarkers.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfSampleMarkers.tsx
@@ -1,0 +1,80 @@
+import maplibregl from "maplibre-gl";
+import { type RefObject, useEffect, useSyncExternalStore } from "react";
+import type { MapController } from "@geolibre/map";
+import { netcdfSeriesColor } from "../../lib/netcdf-profile-series";
+import {
+  getNetcdfProfileSamples,
+  type NetcdfProfileSample,
+  subscribeNetcdfProfile,
+} from "../../lib/netcdf-profile-store";
+
+/**
+ * Builds a sampled point's marker element: a numbered dot in the point's series
+ * color, so a line in the spectral profile and the pixel it was read from are
+ * matched by both color and number.
+ *
+ * A custom element rather than MapLibre's default pin because the series colors
+ * include `hsl(var(--primary))`, and a CSS variable does not resolve in the
+ * `fill` *attribute* the built-in pin sets — only in a CSS property, which is
+ * what `style.backgroundColor` writes here.
+ *
+ * @param sample - The sampled pixel the marker represents.
+ * @returns The marker element.
+ */
+function buildMarkerElement(sample: NetcdfProfileSample): HTMLElement {
+  const element = document.createElement("div");
+  element.className =
+    "flex h-5 w-5 items-center justify-center rounded-full border-2 border-white text-[10px] font-semibold leading-none text-white shadow-md";
+  element.style.backgroundColor = netcdfSeriesColor(sample);
+  element.textContent = String(sample.order);
+  // The profile panel already lists every point as text, and a marker that
+  // swallowed clicks would block sampling the pixel underneath it.
+  element.style.pointerEvents = "none";
+  element.setAttribute("aria-hidden", "true");
+  return element;
+}
+
+/**
+ * Shows where each NetCDF pixel sampled with Identify was read from.
+ *
+ * Renders no React output: the markers are imperative map objects reconciled
+ * against the sample store, so "Clear", the oldest point aging off the cap, and
+ * a switch to another layer all clear the map without bookkeeping of their own.
+ *
+ * Mounted in the map area so its re-renders (one per click) stay off the shell.
+ *
+ * @param props.mapControllerRef - The live map controller.
+ * @returns Nothing.
+ */
+export function NetcdfSampleMarkers({
+  mapControllerRef,
+}: {
+  mapControllerRef: RefObject<MapController | null>;
+}) {
+  const samples = useSyncExternalStore(
+    subscribeNetcdfProfile,
+    getNetcdfProfileSamples,
+    getNetcdfProfileSamples,
+  );
+
+  useEffect(() => {
+    const map = mapControllerRef.current?.getMap();
+    if (!map) return;
+    const live = new Map<number, maplibregl.Marker>();
+    for (const sample of samples) {
+      live.set(
+        sample.id,
+        new maplibregl.Marker({ element: buildMarkerElement(sample), anchor: "center" })
+          .setLngLat([sample.lng, sample.lat])
+          .addTo(map),
+      );
+    }
+    // Rebuilding the whole set each time keeps this to one short effect: there
+    // are at most MAX_PROFILE_SAMPLES markers, and they only change on a click.
+    return () => {
+      for (const marker of live.values()) marker.remove();
+    };
+  }, [samples, mapControllerRef]);
+
+  return null;
+}

--- a/apps/geolibre-desktop/src/components/layout/NetcdfSampleMarkers.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NetcdfSampleMarkers.tsx
@@ -41,15 +41,23 @@ function buildMarkerElement(sample: NetcdfProfileSample): HTMLElement {
  * against the sample store, so "Clear", the oldest point aging off the cap, and
  * a switch to another layer all clear the map without bookkeeping of their own.
  *
- * Mounted in the map area so its re-renders (one per click) stay off the shell.
+ * Mounted in the map area so its re-renders (one per sample change) stay off
+ * the shell.
  *
  * @param props.mapControllerRef - The live map controller.
+ * @param props.mapReadyGeneration - Bumped by the shell each time the map
+ *   (re)initialises. A ref's `.current` pointing at a new map does not re-run an
+ *   effect, so without this the markers would stay on the discarded map and not
+ *   reappear on the new one until the next click changed `samples`. The same
+ *   signal `useNetcdfIdentify` takes, for the same reason.
  * @returns Nothing.
  */
 export function NetcdfSampleMarkers({
   mapControllerRef,
+  mapReadyGeneration,
 }: {
   mapControllerRef: RefObject<MapController | null>;
+  mapReadyGeneration: number;
 }) {
   const samples = useSyncExternalStore(
     subscribeNetcdfProfile,
@@ -69,12 +77,15 @@ export function NetcdfSampleMarkers({
           .addTo(map),
       );
     }
-    // Rebuilding the whole set each time keeps this to one short effect: there
-    // are at most MAX_PROFILE_SAMPLES markers, and they only change on a click.
+    // Rebuilding the whole set each time keeps this to one short effect. It runs
+    // more often than the markers actually change — every resolved band-axis
+    // read replaces the `samples` array too, without moving or recoloring
+    // anything — but at MAX_PROFILE_SAMPLES markers that is cheaper than the
+    // bookkeeping to reconcile them.
     return () => {
       for (const marker of live.values()) marker.remove();
     };
-  }, [samples, mapControllerRef]);
+  }, [samples, mapControllerRef, mapReadyGeneration]);
 
   return null;
 }

--- a/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
@@ -11,16 +11,7 @@ import {
 } from "@geolibre/plugins";
 import { Button, Input, Select } from "@geolibre/ui";
 import { Crosshair, Download, GripVertical, LineChart, Loader2, Trash2, X } from "lucide-react";
-import {
-  type PointerEvent as ReactPointerEvent,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type RefObject, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
 import type { MapController } from "@geolibre/map";

--- a/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
@@ -24,8 +24,8 @@ import {
 import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
 import type { MapController } from "@geolibre/map";
-import { clamp } from "../../lib/clamp";
 import { type ChartDomain, resolveChartDomain } from "../../lib/chart-domain";
+import { useFloatingPanelRect } from "../../hooks/useFloatingPanelRect";
 import { usePluginRegistry } from "../../hooks/usePlugins";
 import { exportVectorLayer } from "../../lib/vector-export";
 
@@ -41,13 +41,8 @@ const PANEL_MIN_H = 240;
 const PANEL_MARGIN = 12;
 const PANEL_TOP = PANEL_MARGIN;
 
-/** A movable/resizable panel rect, in px relative to the map area. */
-interface PanelRect {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-}
+/** Assumed geometry before the panel has been measured (no DOM node yet). */
+const PANEL_FALLBACK_RECT = { x: PANEL_MARGIN, y: PANEL_TOP, w: PANEL_DEFAULT_W, h: 400 };
 
 // Theme primary first, then a small fixed palette for additional points. Kept
 // above the component so its use inside the component does not rely on hoisting.
@@ -193,98 +188,15 @@ export function PixelTimeSeriesControl({ mapControllerRef }: PixelTimeSeriesCont
   // point, and the Time Slider teardown all empty).
   const markers = useRef<Map<number, maplibregl.Marker>>(new Map());
 
-  // Panel geometry. Null means "use the default top-left placement (CSS)"; once
-  // the user drags or resizes, we switch to absolute px so the panel is fully
-  // movable and resizable within the map area.
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  const [rect, setRect] = useState<PanelRect | null>(null);
-
-  // The current panel rect relative to its positioned ancestor (the map area),
-  // measured from the DOM so a drag/resize can begin from the CSS default.
-  const measureRect = useCallback((): PanelRect => {
-    const el = panelRef.current;
-    if (!el) return { x: PANEL_MARGIN, y: PANEL_TOP, w: PANEL_DEFAULT_W, h: 400 };
-    const parent = (el.offsetParent as HTMLElement | null) ?? el.parentElement;
-    const pb = parent?.getBoundingClientRect();
-    const eb = el.getBoundingClientRect();
-    return {
-      x: eb.left - (pb?.left ?? 0),
-      y: eb.top - (pb?.top ?? 0),
-      w: eb.width,
-      h: eb.height,
-    };
-  }, []);
-
-  // Shared pointer-capture drag loop: `onMove` receives the px delta from the
-  // gesture start and the rect captured when it began.
-  const startPointerGesture = useCallback(
-    (
-      event: ReactPointerEvent<HTMLElement>,
-      onMove: (dx: number, dy: number, start: PanelRect, bounds?: DOMRect) => void,
-    ) => {
-      event.preventDefault();
-      const start = rect ?? measureRect();
-      if (!rect) setRect(start);
-      const handle = event.currentTarget;
-      handle.setPointerCapture(event.pointerId);
-      const startX = event.clientX;
-      const startY = event.clientY;
-      const parent =
-        (panelRef.current?.offsetParent as HTMLElement | null) ??
-        panelRef.current?.parentElement ??
-        null;
-      const move = (m: PointerEvent) => {
-        // Bail if the panel unmounted mid-gesture (e.g. reset() on Time Slider
-        // deactivation) so we don't setState for a panel that is gone.
-        if (!panelRef.current) return;
-        onMove(m.clientX - startX, m.clientY - startY, start, parent?.getBoundingClientRect());
-      };
-      const end = () => {
-        if (handle.hasPointerCapture(event.pointerId))
-          handle.releasePointerCapture(event.pointerId);
-        handle.removeEventListener("pointermove", move);
-        handle.removeEventListener("pointerup", end);
-        handle.removeEventListener("pointercancel", end);
-      };
-      handle.addEventListener("pointermove", move);
-      handle.addEventListener("pointerup", end);
-      handle.addEventListener("pointercancel", end);
-    },
-    [rect, measureRect],
-  );
-
-  const handleDragStart = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      // Let header buttons (close) work without starting a drag.
-      if ((event.target as HTMLElement).closest("button")) return;
-      startPointerGesture(event, (dx, dy, start, b) => {
-        const maxX = b ? b.width - start.w - PANEL_MARGIN : Number.POSITIVE_INFINITY;
-        const maxY = b ? b.height - start.h - PANEL_MARGIN : Number.POSITIVE_INFINITY;
-        setRect({
-          ...start,
-          x: clamp(start.x + dx, 0, Math.max(0, maxX)),
-          y: clamp(start.y + dy, 0, Math.max(0, maxY)),
-        });
-      });
-    },
-    [startPointerGesture],
-  );
-
-  const handleResizeStart = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      event.stopPropagation();
-      startPointerGesture(event, (dx, dy, start, b) => {
-        const maxW = b ? b.width - start.x - PANEL_MARGIN : Number.POSITIVE_INFINITY;
-        const maxH = b ? b.height - start.y - PANEL_MARGIN : Number.POSITIVE_INFINITY;
-        setRect({
-          ...start,
-          w: clamp(start.w + dx, PANEL_MIN_W, Math.max(PANEL_MIN_W, maxW)),
-          h: clamp(start.h + dy, PANEL_MIN_H, Math.max(PANEL_MIN_H, maxH)),
-        });
-      });
-    },
-    [startPointerGesture],
-  );
+  // Panel geometry. A null rect means "use the default top-left placement
+  // (CSS)"; the first drag or resize switches to absolute px so the panel is
+  // fully movable and resizable within the map area.
+  const { panelRef, rect, handleDragStart, handleResizeStart, resetRect } = useFloatingPanelRect({
+    minWidth: PANEL_MIN_W,
+    minHeight: PANEL_MIN_H,
+    margin: PANEL_MARGIN,
+    fallback: PANEL_FALLBACK_RECT,
+  });
 
   const abortAll = useCallback(() => {
     for (const ac of abortControllers.current.values()) ac.abort();
@@ -432,9 +344,9 @@ export function PixelTimeSeriesControl({ mapControllerRef }: PixelTimeSeriesCont
     setExportError(null);
     setPicking(false);
     setOpen(false);
-    setRect(null);
+    resetRect();
     idCounter.current = 0;
-  }, [abortAll]);
+  }, [abortAll, resetRect]);
 
   useEffect(() => {
     if (!timeSliderActive || !hasRasterStack) reset();

--- a/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PixelTimeSeriesControl.tsx
@@ -32,9 +32,9 @@ import { exportVectorLayer } from "../../lib/vector-export";
 /** Default panel geometry (px). The panel opens flush in the top-left corner,
  * inset by {@link PANEL_MARGIN} on both sides, and its max height keeps it clear
  * of the Time Slider timeline at the bottom; the user can then drag/resize it.
- * The CSS default below and {@link PixelTimeSeriesControl.measureRect}'s
- * fallback describe the same corner, so a drag that starts from the untouched
- * default does not jump. */
+ * The CSS default below and {@link PANEL_FALLBACK_RECT}, which {@link
+ * useFloatingPanelRect} measures against, describe the same corner, so a drag
+ * that starts from the untouched default does not jump. */
 const PANEL_DEFAULT_W = 448;
 const PANEL_MIN_W = 320;
 const PANEL_MIN_H = 240;

--- a/apps/geolibre-desktop/src/components/panels/NetcdfProfileChart.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NetcdfProfileChart.tsx
@@ -3,7 +3,7 @@ import { Download, Image as ImageIcon } from "lucide-react";
 import { useId, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { resolveChartDomain } from "../../lib/chart-domain";
-import { downloadChartPng } from "../../lib/chart-export";
+import { downloadChartPng, triggerDownload } from "../../lib/chart-export";
 import { displayUnits } from "../../lib/netcdf-image-symbology";
 import {
   buildNetcdfProfileCsv,
@@ -41,17 +41,6 @@ function formatValue(value: number): string {
   const abs = Math.abs(value);
   if (abs !== 0 && (abs >= 1e6 || abs <= 1e-3)) return value.toExponential(1);
   return Number(value.toFixed(abs >= 100 ? 0 : 3)).toString();
-}
-
-function triggerTextDownload(text: string, filename: string, type: string): void {
-  const url = URL.createObjectURL(new Blob([text], { type }));
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
 }
 
 /**
@@ -120,7 +109,7 @@ export function NetcdfProfileChart({
     if (!csv) return;
     setExportError(null);
     try {
-      triggerTextDownload(csv, `${exportBase}.csv`, "text/csv;charset=utf-8");
+      triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), `${exportBase}.csv`);
     } catch (error) {
       setExportError(error instanceof Error ? error.message : t("netcdfProfile.exportError"));
     }
@@ -292,7 +281,14 @@ export function NetcdfProfileChart({
           {t("netcdfProfile.exportCsv")}
         </Button>
       </div>
-      {exportError ? <p className="text-[10px] text-destructive">{exportError}</p> : null}
+      {/* `role="alert"` like the Time Slider chart's export error: the message
+          arrives after the click that triggered it, so without a live region a
+          screen-reader user gets no word that the export failed. */}
+      {exportError ? (
+        <p className="text-[10px] text-destructive" role="alert">
+          {exportError}
+        </p>
+      ) : null}
 
       <ul className="space-y-0.5">
         {samples.map((sample) => (
@@ -300,8 +296,11 @@ export function NetcdfProfileChart({
             key={sample.id}
             className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
           >
+            {/* Not aria-hidden: the color is decorative, but the digit inside
+                is what ties this row to its marker on the map, and the marker
+                itself is hidden from assistive tech. This list is where that
+                number has to be readable. */}
             <span
-              aria-hidden
               className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full text-[8px] font-semibold text-white"
               style={{ backgroundColor: netcdfSeriesColor(sample) }}
             >

--- a/apps/geolibre-desktop/src/components/panels/NetcdfProfileChart.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NetcdfProfileChart.tsx
@@ -1,0 +1,316 @@
+import { Button } from "@geolibre/ui";
+import { Download, Image as ImageIcon } from "lucide-react";
+import { useId, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { resolveChartDomain } from "../../lib/chart-domain";
+import { downloadChartPng } from "../../lib/chart-export";
+import { displayUnits } from "../../lib/netcdf-image-symbology";
+import {
+  buildNetcdfProfileCsv,
+  netcdfAxisPositions,
+  netcdfSeriesColor,
+  niceTickValues,
+} from "../../lib/netcdf-profile-series";
+import type { NetcdfProfileSample } from "../../lib/netcdf-profile-store";
+import { sanitizeExportFileName } from "../../lib/vector-export";
+
+/** Chart geometry. Fixed, and scaled to the container by the SVG viewBox, so a
+ * resized window magnifies the whole chart rather than reflowing it — and the
+ * PNG export has a resolution to render at without measuring the DOM. */
+const CHART_W = 560;
+const CHART_H = 260;
+const MARGIN = { top: 12, right: 12, bottom: 40, left: 56 };
+const INNER_W = CHART_W - MARGIN.left - MARGIN.right;
+const INNER_H = CHART_H - MARGIN.top - MARGIN.bottom;
+const AXIS = "hsl(var(--border))";
+const TICK = "hsl(var(--muted-foreground))";
+/** Roughly how many x-axis labels to aim for. Eight fits without crowding at
+ * this width, and is enough to locate a feature on a wavelength axis. */
+const X_TICK_TARGET = 8;
+
+/**
+ * Format an axis value compactly, dropping noise digits on large magnitudes.
+ *
+ * Deliberately coarser than `formatReading` in `useNetcdfIdentify`, which is the
+ * readout for one pixel the user asked about and so keeps full precision. These
+ * are tick labels on a 560px-wide chart, where a 6-decimal number would collide
+ * with its neighbour.
+ */
+function formatValue(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  const abs = Math.abs(value);
+  if (abs !== 0 && (abs >= 1e6 || abs <= 1e-3)) return value.toExponential(1);
+  return Number(value.toFixed(abs >= 100 ? 0 : 3)).toString();
+}
+
+function triggerTextDownload(text: string, filename: string, type: string): void {
+  const url = URL.createObjectURL(new Blob([text], { type }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * The spectral profile itself: the plotted lines, the export buttons, and the
+ * list of sampled points.
+ *
+ * Shared by the docked section in the Style panel and the floating window, which
+ * differ only in their header and in how much room they give the chart.
+ *
+ * Plots against the axis' coordinate values where the file provides them, so a
+ * hyperspectral cube reads as reflectance against wavelength in nm rather than
+ * against a band number. Fill readings break the line instead of dropping it to
+ * the nodata value.
+ *
+ * @param props.samples - The sampled pixels, charted in list order. Points whose
+ *   profile has not resolved (or that came from a 2-D grid) still appear in the
+ *   list, matching their marker on the map; they just draw no line.
+ * @param props.chartClassName - Sizing for the chart's box, so the window can
+ *   let it fill the remaining height while the docked panel fixes it.
+ * @returns The chart body.
+ */
+export function NetcdfProfileChart({
+  samples,
+  chartClassName = "h-44",
+}: {
+  samples: NetcdfProfileSample[];
+  chartClassName?: string;
+}) {
+  const { t } = useTranslation();
+  const clipId = `${useId()}-plot`;
+  const chartRef = useRef<HTMLDivElement | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const charted = samples.filter(
+    (sample): sample is NetcdfProfileSample & { profile: NonNullable<typeof sample.profile> } =>
+      sample.profile !== undefined,
+  );
+  const values = charted.flatMap((sample) =>
+    sample.profile.values.filter((value): value is number => value !== null),
+  );
+  const hasChart = values.length > 0;
+
+  const first = charted[0];
+  const valueUnits = first ? displayUnits(first.units) : undefined;
+  const valueLabel = first
+    ? valueUnits
+      ? `${first.variable} (${valueUnits})`
+      : first.variable
+    : "";
+
+  const exportBase = sanitizeExportFileName(`${first?.variable ?? "netcdf"}-spectral-profile`);
+
+  const downloadPng = () => {
+    const svg = chartRef.current?.querySelector("svg");
+    if (!svg) return;
+    setExportError(null);
+    // Rasterization is async (image load + canvas), so surface a rejection
+    // rather than letting it become an unhandled promise.
+    downloadChartPng(svg, CHART_W, CHART_H, `${exportBase}.png`).catch((error: unknown) =>
+      setExportError(error instanceof Error ? error.message : t("netcdfProfile.exportError")),
+    );
+  };
+
+  const downloadCsv = () => {
+    const csv = buildNetcdfProfileCsv(samples);
+    if (!csv) return;
+    setExportError(null);
+    try {
+      triggerTextDownload(csv, `${exportBase}.csv`, "text/csv;charset=utf-8");
+    } catch (error) {
+      setExportError(error instanceof Error ? error.message : t("netcdfProfile.exportError"));
+    }
+  };
+
+  // Only computed when there is something to plot; the guards above keep the
+  // domain and scales away from an empty value set.
+  let body: React.ReactNode = (
+    <p className="text-[10px] text-muted-foreground">{t("netcdfProfile.noValues")}</p>
+  );
+  if (hasChart) {
+    const { min, max } = resolveChartDomain(values, { min: null, max: null });
+    const positions = charted.flatMap(netcdfAxisPositions);
+    const xMin = Math.min(...positions);
+    const xMax = Math.max(...positions);
+    const xSpan = xMax - xMin || 1;
+    const scaleX = (position: number) => MARGIN.left + ((position - xMin) / xSpan) * INNER_W;
+    const scaleY = (value: number) =>
+      MARGIN.top + INNER_H - ((value - min) / (max - min || 1)) * INNER_H;
+
+    // Through `displayUnits` like the value label above: a coordinate variable
+    // can declare `unitless`/`1`/`n/a`, and "wavelength (1)" is noise on an axis.
+    const axisUnits = displayUnits(first.profile.axis.units);
+    const axisLabel = axisUnits
+      ? `${first.profile.axis.name} (${axisUnits})`
+      : first.profile.axis.name;
+
+    body = (
+      <svg
+        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+        className="h-full w-full"
+        role="img"
+        aria-label={t("netcdfProfile.chartAria")}
+      >
+        <defs>
+          {/* Scopes the clip to this chart, so a second instance cannot clip
+              against the first's rect. */}
+          <clipPath id={clipId}>
+            <rect x={MARGIN.left} y={MARGIN.top} width={INNER_W} height={INNER_H} />
+          </clipPath>
+        </defs>
+
+        <line
+          x1={MARGIN.left}
+          y1={MARGIN.top}
+          x2={MARGIN.left}
+          y2={MARGIN.top + INNER_H}
+          stroke={AXIS}
+        />
+        <line
+          x1={MARGIN.left}
+          y1={MARGIN.top + INNER_H}
+          x2={MARGIN.left + INNER_W}
+          y2={MARGIN.top + INNER_H}
+          stroke={AXIS}
+        />
+
+        <text
+          x={MARGIN.left - 6}
+          y={MARGIN.top}
+          textAnchor="end"
+          dominantBaseline="middle"
+          fontSize={10}
+          fill={TICK}
+        >
+          {formatValue(max)}
+        </text>
+        <text
+          x={MARGIN.left - 6}
+          y={MARGIN.top + INNER_H}
+          textAnchor="end"
+          dominantBaseline="middle"
+          fontSize={10}
+          fill={TICK}
+        >
+          {formatValue(min)}
+        </text>
+
+        {niceTickValues(xMin, xMax, X_TICK_TARGET).map((position) => (
+          <g key={position}>
+            <line
+              x1={scaleX(position)}
+              y1={MARGIN.top + INNER_H}
+              x2={scaleX(position)}
+              y2={MARGIN.top + INNER_H + 4}
+              stroke={AXIS}
+            />
+            <text
+              x={scaleX(position)}
+              y={MARGIN.top + INNER_H + 16}
+              textAnchor="middle"
+              fontSize={10}
+              fill={TICK}
+            >
+              {formatValue(position)}
+            </text>
+          </g>
+        ))}
+        <text
+          x={MARGIN.left + INNER_W / 2}
+          y={CHART_H - 6}
+          textAnchor="middle"
+          fontSize={10}
+          fill={TICK}
+        >
+          {axisLabel}
+        </text>
+
+        <g clipPath={`url(#${clipId})`}>
+          {charted.map((sample) => {
+            const xs = netcdfAxisPositions(sample);
+            // Break the path at every fill reading, so a gap shows as a gap
+            // rather than a line drawn through the nodata value.
+            const segments: string[] = [];
+            let current: string[] = [];
+            sample.profile.values.forEach((value, i) => {
+              if (value === null) {
+                if (current.length > 1) segments.push(current.join(" "));
+                current = [];
+                return;
+              }
+              current.push(`${current.length === 0 ? "M" : "L"}${scaleX(xs[i])} ${scaleY(value)}`);
+            });
+            if (current.length > 1) segments.push(current.join(" "));
+            return (
+              <path
+                key={sample.id}
+                d={segments.join(" ")}
+                fill="none"
+                stroke={netcdfSeriesColor(sample)}
+                strokeWidth={1.25}
+              />
+            );
+          })}
+        </g>
+      </svg>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
+      {valueLabel ? <p className="text-[10px] text-muted-foreground">{valueLabel}</p> : null}
+
+      <div ref={chartRef} className={`min-h-0 ${hasChart ? chartClassName : ""}`}>
+        {body}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5 text-[11px]"
+          disabled={!hasChart}
+          onClick={downloadPng}
+        >
+          <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          {t("netcdfProfile.exportPng")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5 text-[11px]"
+          disabled={!hasChart}
+          onClick={downloadCsv}
+        >
+          <Download className="h-3.5 w-3.5" aria-hidden="true" />
+          {t("netcdfProfile.exportCsv")}
+        </Button>
+      </div>
+      {exportError ? <p className="text-[10px] text-destructive">{exportError}</p> : null}
+
+      <ul className="space-y-0.5">
+        {samples.map((sample) => (
+          <li
+            key={sample.id}
+            className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
+          >
+            <span
+              aria-hidden
+              className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full text-[8px] font-semibold text-white"
+              style={{ backgroundColor: netcdfSeriesColor(sample) }}
+            >
+              {sample.order}
+            </span>
+            {sample.lng.toFixed(4)}, {sample.lat.toFixed(4)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/NetcdfProfilePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NetcdfProfilePanel.tsx
@@ -1,237 +1,74 @@
 import { Button } from "@geolibre/ui";
-import { useId, useSyncExternalStore } from "react";
+import { ExternalLink } from "lucide-react";
+import { useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
-import { resolveChartDomain } from "../../lib/chart-domain";
-import { displayUnits } from "../../lib/netcdf-image-symbology";
 import {
-  clearNetcdfProfileReadings,
-  getNetcdfProfileReadings,
-  subscribeNetcdfProfileReadings,
-  type NetcdfProfileReading,
+  clearNetcdfProfileSamples,
+  getNetcdfProfileSamples,
+  isNetcdfProfilePoppedOut,
+  setNetcdfProfilePoppedOut,
+  subscribeNetcdfProfile,
 } from "../../lib/netcdf-profile-store";
-
-// Matches the Time Slider's pixel chart so the two read as one family.
-const SERIES_COLORS = [
-  "hsl(var(--primary))",
-  "hsl(12 76% 61%)",
-  "hsl(173 58% 39%)",
-  "hsl(262 52% 56%)",
-  "hsl(43 74% 49%)",
-  "hsl(199 89% 48%)",
-];
-
-const CHART_W = 560;
-const CHART_H = 260;
-const MARGIN = { top: 12, right: 12, bottom: 40, left: 56 };
-const INNER_W = CHART_W - MARGIN.left - MARGIN.right;
-const INNER_H = CHART_H - MARGIN.top - MARGIN.bottom;
-const AXIS = "hsl(var(--border))";
-const TICK = "hsl(var(--muted-foreground))";
+import { NetcdfProfileChart } from "./NetcdfProfileChart";
 
 /**
- * Format an axis value compactly, dropping noise digits on large magnitudes.
+ * The Style panel's section for the pixels sampled with Identify on a NetCDF
+ * layer: their spectral signatures, and the Clear that removes them from the map.
  *
- * Deliberately coarser than `formatReading` in `useNetcdfIdentify`, which is the
- * readout for one pixel the user asked about and so keeps full precision. These
- * are tick labels on a 560px-wide chart, where a 6-decimal number would collide
- * with its neighbour.
- */
-function formatValue(value: number): string {
-  if (!Number.isFinite(value)) return "";
-  const abs = Math.abs(value);
-  if (abs !== 0 && (abs >= 1e6 || abs <= 1e-3)) return value.toExponential(1);
-  return Number(value.toFixed(abs >= 100 ? 0 : 3)).toString();
-}
-
-/**
- * The x-axis positions for a reading: the axis' own coordinate values when the
- * file has them (wavelengths in nm), else the bare index.
- */
-function axisPositions(reading: NetcdfProfileReading): number[] {
-  const { axis, values } = reading.profile;
-  if (axis.values && axis.values.length === values.length) return axis.values;
-  return values.map((_, index) => index);
-}
-
-/**
- * Spectral signature of the pixels sampled with Identify on a NetCDF cube: one
- * line per clicked point, value against the cube's own band axis.
+ * Renders nothing until a pixel has been sampled, so it costs nothing for a
+ * layer nobody has clicked. When the chart is popped out into the floating
+ * window the section keeps its header — Clear and the dock control have to stay
+ * reachable — but hands the chart itself to the window rather than drawing two.
  *
- * Plots against the axis' coordinate values where the file provides them, so a
- * hyperspectral cube reads as reflectance against wavelength in nm rather than
- * against a band number. Fill readings break the line instead of dropping it to
- * the nodata value.
- *
- * Renders nothing until a pixel has been sampled, so it costs nothing for the
- * (common) 2-D grid that has no band axis to profile.
- *
- * @param props.layerId - The layer whose readings to chart; readings sampled
- *   from any other layer are ignored, so selecting a second NetCDF layer does
- *   not show the first one's spectra under the second one's heading.
- * @returns The chart, or null when this layer has no sampled pixel.
+ * @param props.layerId - The layer whose samples to show; samples taken from any
+ *   other layer are ignored, so selecting a second NetCDF layer does not show
+ *   the first one's spectra under the second one's heading.
+ * @returns The section, or null when this layer has no sampled pixel.
  */
 export function NetcdfProfilePanel({ layerId }: { layerId: string }) {
   const { t } = useTranslation();
-  const clipId = `${useId()}-plot`;
-  const allReadings = useSyncExternalStore(
-    subscribeNetcdfProfileReadings,
-    getNetcdfProfileReadings,
-    getNetcdfProfileReadings,
+  const allSamples = useSyncExternalStore(
+    subscribeNetcdfProfile,
+    getNetcdfProfileSamples,
+    getNetcdfProfileSamples,
   );
-  const readings = allReadings.filter((reading) => reading.layerId === layerId);
-
-  if (readings.length === 0) return null;
-
-  const values = readings.flatMap((reading) =>
-    reading.profile.values.filter((value): value is number => value !== null),
+  const poppedOut = useSyncExternalStore(
+    subscribeNetcdfProfile,
+    isNetcdfProfilePoppedOut,
+    isNetcdfProfilePoppedOut,
   );
-  if (values.length === 0) return null;
+  const samples = allSamples.filter((sample) => sample.layerId === layerId);
 
-  const { min, max } = resolveChartDomain(values, { min: null, max: null });
-  const positions = readings.flatMap(axisPositions);
-  const xMin = Math.min(...positions);
-  const xMax = Math.max(...positions);
-  const xSpan = xMax - xMin || 1;
-
-  const scaleX = (position: number) => MARGIN.left + ((position - xMin) / xSpan) * INNER_W;
-  const scaleY = (value: number) => MARGIN.top + INNER_H - ((value - min) / (max - min)) * INNER_H;
-
-  const first = readings[0];
-  // Through `displayUnits` like the value label below: a coordinate variable can
-  // declare `unitless`/`1`/`n/a`, and "wavelength (1)" is noise on an axis.
-  const axisUnits = displayUnits(first.profile.axis.units);
-  const axisLabel = axisUnits
-    ? `${first.profile.axis.name} (${axisUnits})`
-    : first.profile.axis.name;
-  const valueUnits = displayUnits(first.units);
-  const valueLabel = valueUnits ? `${first.variable} (${valueUnits})` : first.variable;
+  if (samples.length === 0) return null;
 
   return (
     <div className="space-y-2 border-t p-3">
       <div className="flex items-center justify-between gap-2">
         <p className="text-xs font-semibold">{t("netcdfProfile.heading")}</p>
-        <Button type="button" variant="ghost" size="sm" onClick={clearNetcdfProfileReadings}>
-          {t("netcdfProfile.clear")}
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="gap-1.5"
+            aria-pressed={poppedOut}
+            title={poppedOut ? t("netcdfProfile.dock") : t("netcdfProfile.popOut")}
+            onClick={() => setNetcdfProfilePoppedOut(!poppedOut)}
+          >
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            {poppedOut ? t("netcdfProfile.dock") : t("netcdfProfile.popOut")}
+          </Button>
+          <Button type="button" variant="ghost" size="sm" onClick={clearNetcdfProfileSamples}>
+            {t("netcdfProfile.clear")}
+          </Button>
+        </div>
       </div>
-      <p className="text-[10px] text-muted-foreground">{valueLabel}</p>
 
-      <svg
-        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-        width="100%"
-        role="img"
-        aria-label={t("netcdfProfile.chartAria")}
-      >
-        <defs>
-          {/* Scopes the clip to this chart, so a second instance cannot clip
-              against the first's rect. */}
-          <clipPath id={clipId}>
-            <rect x={MARGIN.left} y={MARGIN.top} width={INNER_W} height={INNER_H} />
-          </clipPath>
-        </defs>
-
-        <line
-          x1={MARGIN.left}
-          y1={MARGIN.top}
-          x2={MARGIN.left}
-          y2={MARGIN.top + INNER_H}
-          stroke={AXIS}
-        />
-        <line
-          x1={MARGIN.left}
-          y1={MARGIN.top + INNER_H}
-          x2={MARGIN.left + INNER_W}
-          y2={MARGIN.top + INNER_H}
-          stroke={AXIS}
-        />
-
-        <text
-          x={MARGIN.left - 6}
-          y={MARGIN.top}
-          textAnchor="end"
-          dominantBaseline="middle"
-          fontSize={10}
-          fill={TICK}
-        >
-          {formatValue(max)}
-        </text>
-        <text
-          x={MARGIN.left - 6}
-          y={MARGIN.top + INNER_H}
-          textAnchor="end"
-          dominantBaseline="middle"
-          fontSize={10}
-          fill={TICK}
-        >
-          {formatValue(min)}
-        </text>
-
-        {[xMin, (xMin + xMax) / 2, xMax].map((position, index) => (
-          <text
-            key={index}
-            x={scaleX(position)}
-            y={MARGIN.top + INNER_H + 14}
-            textAnchor={index === 0 ? "start" : index === 2 ? "end" : "middle"}
-            fontSize={10}
-            fill={TICK}
-          >
-            {formatValue(position)}
-          </text>
-        ))}
-        <text
-          x={MARGIN.left + INNER_W / 2}
-          y={CHART_H - 6}
-          textAnchor="middle"
-          fontSize={10}
-          fill={TICK}
-        >
-          {axisLabel}
-        </text>
-
-        <g clipPath={`url(#${clipId})`}>
-          {readings.map((reading, index) => {
-            const xs = axisPositions(reading);
-            // Break the path at every fill reading, so a gap shows as a gap
-            // rather than a line drawn through the nodata value.
-            const segments: string[] = [];
-            let current: string[] = [];
-            reading.profile.values.forEach((value, i) => {
-              if (value === null) {
-                if (current.length > 1) segments.push(current.join(" "));
-                current = [];
-                return;
-              }
-              current.push(`${current.length === 0 ? "M" : "L"}${scaleX(xs[i])} ${scaleY(value)}`);
-            });
-            if (current.length > 1) segments.push(current.join(" "));
-            return (
-              <path
-                key={`${reading.lng},${reading.lat},${index}`}
-                d={segments.join(" ")}
-                fill="none"
-                stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
-                strokeWidth={1.25}
-              />
-            );
-          })}
-        </g>
-      </svg>
-
-      <ul className="space-y-0.5">
-        {readings.map((reading, index) => (
-          <li
-            key={`${reading.lng},${reading.lat},${index}`}
-            className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
-          >
-            <span
-              aria-hidden
-              className="h-2 w-2 shrink-0 rounded-full"
-              style={{ backgroundColor: SERIES_COLORS[index % SERIES_COLORS.length] }}
-            />
-            {reading.lng.toFixed(4)}, {reading.lat.toFixed(4)}
-          </li>
-        ))}
-      </ul>
+      {poppedOut ? (
+        <p className="text-[10px] text-muted-foreground">{t("netcdfProfile.poppedOutHint")}</p>
+      ) : (
+        <NetcdfProfileChart samples={samples} />
+      )}
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/hooks/useFloatingPanelRect.ts
+++ b/apps/geolibre-desktop/src/hooks/useFloatingPanelRect.ts
@@ -1,0 +1,153 @@
+import { type PointerEvent as ReactPointerEvent, useCallback, useRef, useState } from "react";
+import { clamp } from "../lib/clamp";
+
+/** A movable/resizable panel rect, in px relative to its positioned ancestor. */
+export interface PanelRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface FloatingPanelRectOptions {
+  /** Smallest width the panel can be dragged down to. */
+  minWidth: number;
+  /** Smallest height the panel can be dragged down to. */
+  minHeight: number;
+  /** Inset kept between the panel and its container's far edges. */
+  margin: number;
+  /** Rect assumed when the panel has not been measured yet (no DOM node). */
+  fallback: PanelRect;
+}
+
+export interface FloatingPanelRect {
+  /** Attach to the panel element; the gestures measure and clamp against it. */
+  panelRef: React.RefObject<HTMLDivElement | null>;
+  /**
+   * The panel's px geometry, or null while it still sits at its CSS default.
+   * Apply as `style` only when non-null, so an untouched panel keeps whatever
+   * responsive placement its classes describe.
+   */
+  rect: PanelRect | null;
+  /** Attach to the panel's header to move it. */
+  handleDragStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  /** Attach to the panel's corner grip to resize it. */
+  handleResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  /** Drop back to the CSS default placement, for a full teardown of the panel. */
+  resetRect: () => void;
+}
+
+/**
+ * Pointer-driven move and resize for a panel floating over the map.
+ *
+ * The panel starts at its CSS placement (`rect` is null) and switches to
+ * absolute px on the first gesture, measured from the DOM so it does not jump.
+ * Both gestures clamp to the positioned ancestor, so a panel cannot be pushed
+ * off the map area.
+ *
+ * Shared by the Time Slider's pixel chart and the NetCDF spectral profile, which
+ * are the same kind of window over the same kind of container.
+ *
+ * @param options - Size floors, edge inset, and the pre-measurement fallback.
+ * @returns The ref to attach, the current rect, and the two gesture handlers.
+ */
+export function useFloatingPanelRect({
+  minWidth,
+  minHeight,
+  margin,
+  fallback,
+}: FloatingPanelRectOptions): FloatingPanelRect {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [rect, setRect] = useState<PanelRect | null>(null);
+
+  // The current panel rect relative to its positioned ancestor (the map area),
+  // measured from the DOM so a drag/resize can begin from the CSS default.
+  const measureRect = useCallback((): PanelRect => {
+    const el = panelRef.current;
+    if (!el) return fallback;
+    const parent = (el.offsetParent as HTMLElement | null) ?? el.parentElement;
+    const pb = parent?.getBoundingClientRect();
+    const eb = el.getBoundingClientRect();
+    return {
+      x: eb.left - (pb?.left ?? 0),
+      y: eb.top - (pb?.top ?? 0),
+      w: eb.width,
+      h: eb.height,
+    };
+  }, [fallback]);
+
+  // Shared pointer-capture drag loop: `onMove` receives the px delta from the
+  // gesture start and the rect captured when it began.
+  const startPointerGesture = useCallback(
+    (
+      event: ReactPointerEvent<HTMLElement>,
+      onMove: (dx: number, dy: number, start: PanelRect, bounds?: DOMRect) => void,
+    ) => {
+      event.preventDefault();
+      const start = rect ?? measureRect();
+      if (!rect) setRect(start);
+      const handle = event.currentTarget;
+      handle.setPointerCapture(event.pointerId);
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const parent =
+        (panelRef.current?.offsetParent as HTMLElement | null) ??
+        panelRef.current?.parentElement ??
+        null;
+      const move = (m: PointerEvent) => {
+        // Bail if the panel unmounted mid-gesture so we don't setState for a
+        // panel that is gone.
+        if (!panelRef.current) return;
+        onMove(m.clientX - startX, m.clientY - startY, start, parent?.getBoundingClientRect());
+      };
+      const end = () => {
+        if (handle.hasPointerCapture(event.pointerId))
+          handle.releasePointerCapture(event.pointerId);
+        handle.removeEventListener("pointermove", move);
+        handle.removeEventListener("pointerup", end);
+        handle.removeEventListener("pointercancel", end);
+      };
+      handle.addEventListener("pointermove", move);
+      handle.addEventListener("pointerup", end);
+      handle.addEventListener("pointercancel", end);
+    },
+    [rect, measureRect],
+  );
+
+  const handleDragStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      // Let header buttons (close, pop-in) work without starting a drag.
+      if ((event.target as HTMLElement).closest("button")) return;
+      startPointerGesture(event, (dx, dy, start, b) => {
+        const maxX = b ? b.width - start.w - margin : Number.POSITIVE_INFINITY;
+        const maxY = b ? b.height - start.h - margin : Number.POSITIVE_INFINITY;
+        setRect({
+          ...start,
+          x: clamp(start.x + dx, 0, Math.max(0, maxX)),
+          y: clamp(start.y + dy, 0, Math.max(0, maxY)),
+        });
+      });
+    },
+    [startPointerGesture, margin],
+  );
+
+  const handleResizeStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      startPointerGesture(event, (dx, dy, start, b) => {
+        const maxW = b ? b.width - start.x - margin : Number.POSITIVE_INFINITY;
+        const maxH = b ? b.height - start.y - margin : Number.POSITIVE_INFINITY;
+        setRect({
+          ...start,
+          w: clamp(start.w + dx, minWidth, Math.max(minWidth, maxW)),
+          h: clamp(start.h + dy, minHeight, Math.max(minHeight, maxH)),
+        });
+      });
+    },
+    [startPointerGesture, margin, minWidth, minHeight],
+  );
+
+  const resetRect = useCallback(() => setRect(null), []);
+
+  return { panelRef, rect, handleDragStart, handleResizeStart, resetRect };
+}

--- a/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
@@ -80,10 +80,16 @@ export function useNetcdfIdentify(
     canvas.style.cursor = "crosshair";
     let popup: maplibregl.Popup | null = null;
     // Each deferred read below is addressed to the point it was started for, so
-    // several can be in flight at once; they are tracked only so the timeouts
-    // can be dropped on teardown.
+    // several can be in flight at once; they are tracked only so a read that has
+    // not started yet is not started after teardown.
+    //
+    // A read already in flight is deliberately *not* discarded on teardown: the
+    // effect tears down whenever the identify target changes, and switching away
+    // and back during a read that takes tens of seconds would otherwise leave
+    // that point permanently profile-less even though the fetch completed. The
+    // store's own guard is what makes this safe — a result for a point that has
+    // since been cleared or aged off the cap lands nowhere.
     const profileTimeouts = new Set<number>();
-    let disposed = false;
 
     const handleClick = (event: maplibregl.MapMouseEvent) => {
       const state = getNetcdfLayerState(activeLayerId);
@@ -154,7 +160,7 @@ export function useNetcdfIdentify(
         // this point, and attaching to a point that has since been cleared or
         // aged off the cap is a no-op, so a stale read lands nowhere.
         void readNetcdfProfile(activeLayerId, pixel.row, pixel.column).then((profile) => {
-          if (profile && !disposed) setNetcdfProfileSampleProfile(sampleId, profile);
+          if (profile) setNetcdfProfileSampleProfile(sampleId, profile);
         });
       }, 0);
       profileTimeouts.add(timeout);
@@ -162,7 +168,6 @@ export function useNetcdfIdentify(
 
     map.on("click", handleClick);
     return () => {
-      disposed = true;
       map.off("click", handleClick);
       for (const timeout of profileTimeouts) window.clearTimeout(timeout);
       profileTimeouts.clear();

--- a/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
@@ -11,8 +11,9 @@ import {
   readNetcdfProfile,
 } from "../lib/netcdf-image-symbology";
 import {
-  clearNetcdfProfileReadingsForLayer,
-  setNetcdfProfileReading,
+  addNetcdfProfileSample,
+  clearNetcdfProfileSamplesForLayer,
+  setNetcdfProfileSampleProfile,
 } from "../lib/netcdf-profile-store";
 
 /**
@@ -43,8 +44,10 @@ function formatReading(value: number, units: string | undefined): string {
  * is a nearest-cell lookup rather than a fetch: the readout is instant and works
  * offline.
  *
- * When the layer came from a cube, the same click also reads that pixel's values
- * along the band axis and hands them to the spectral profile panel.
+ * Every click inside the grid is also recorded as a sampled point, which puts a
+ * numbered marker on the map. When the layer came from a cube, the click reads
+ * that pixel's values along the band axis too and attaches them to the point,
+ * which is what the spectral profile charts.
  *
  * Mounted once at the app shell, alongside `useRasterIdentify`. MapCanvas bails
  * for these layers so the two never both handle a click.
@@ -76,12 +79,11 @@ export function useNetcdfIdentify(
     const previousCursor = canvas.style.cursor;
     canvas.style.cursor = "crosshair";
     let popup: maplibregl.Popup | null = null;
-    // The deferred profile read below captures this click's layer and pixel, so
-    // a pending one must be dropped when the identify target changes or another
-    // click lands — otherwise a stale read overwrites the newer reading.
-    let profileTimeout: number | null = null;
-    /** Drops the in-flight profile read's result, if one is outstanding. */
-    let cancelProfile: (() => void) | null = null;
+    // Each deferred read below is addressed to the point it was started for, so
+    // several can be in flight at once; they are tracked only so the timeouts
+    // can be dropped on teardown.
+    const profileTimeouts = new Set<number>();
+    let disposed = false;
 
     const handleClick = (event: maplibregl.MapMouseEvent) => {
       const state = getNetcdfLayerState(activeLayerId);
@@ -89,14 +91,10 @@ export function useNetcdfIdentify(
       const pixel = gridPixelAt(state.grid, event.lngLat.lng, event.lngLat.lat);
       popup?.remove();
       popup = null;
-      if (profileTimeout !== null) window.clearTimeout(profileTimeout);
-      profileTimeout = null;
-      cancelProfile?.();
-      cancelProfile = null;
       // A click outside the grid clears the readout rather than reporting the
       // nearest edge cell, which would be misleading far from the data.
       if (!pixel) {
-        clearNetcdfProfileReadingsForLayer(activeLayerId);
+        clearNetcdfProfileSamplesForLayer(activeLayerId);
         return;
       }
 
@@ -134,42 +132,40 @@ export function useNetcdfIdentify(
         .setDOMContent(container)
         .addTo(map);
 
+      // The point goes in before the (slow) profile read, so its marker lands on
+      // the map with the popup rather than a beat later.
+      const sampleId = addNetcdfProfileSample({
+        layerId: activeLayerId,
+        variable: state.variable,
+        units: state.units,
+        lng: pixel.lng,
+        lat: pixel.lat,
+      });
+
       // A cube also yields the pixel's spectrum. Reading it walks the whole band
       // axis in the source file (~200 ms for an EMIT scene), so it runs after
-      // the popup is already on screen.
-      if (!state.profile) {
-        clearNetcdfProfileReadingsForLayer(activeLayerId);
-        return;
-      }
-      profileTimeout = window.setTimeout(() => {
-        profileTimeout = null;
+      // the popup is already on screen. A 2-D grid has no band axis, so the point
+      // stays profile-less: still a marker and a list entry, just no line.
+      if (!state.profile) return;
+      const timeout = window.setTimeout(() => {
+        profileTimeouts.delete(timeout);
         // A remote read is a worker round trip over range requests, so this can
-        // take tens of seconds; `cancelled` drops a result the user has moved on
-        // from rather than charting a stale pixel.
-        let cancelled = false;
-        cancelProfile = () => {
-          cancelled = true;
-        };
+        // take tens of seconds. Nothing cancels it: the result is addressed to
+        // this point, and attaching to a point that has since been cleared or
+        // aged off the cap is a no-op, so a stale read lands nowhere.
         void readNetcdfProfile(activeLayerId, pixel.row, pixel.column).then((profile) => {
-          if (profile && !cancelled) {
-            setNetcdfProfileReading({
-              layerId: activeLayerId,
-              variable: state.variable,
-              units: state.units,
-              lng: pixel.lng,
-              lat: pixel.lat,
-              profile,
-            });
-          }
+          if (profile && !disposed) setNetcdfProfileSampleProfile(sampleId, profile);
         });
       }, 0);
+      profileTimeouts.add(timeout);
     };
 
     map.on("click", handleClick);
     return () => {
+      disposed = true;
       map.off("click", handleClick);
-      if (profileTimeout !== null) window.clearTimeout(profileTimeout);
-      cancelProfile?.();
+      for (const timeout of profileTimeouts) window.clearTimeout(timeout);
+      profileTimeouts.clear();
       popup?.remove();
       canvas.style.cursor = previousCursor;
     };

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -5048,7 +5048,14 @@
   "netcdfProfile": {
     "heading": "Spectral profile",
     "clear": "Clear",
-    "chartAria": "Sampled pixel values along the band axis"
+    "chartAria": "Sampled pixel values along the band axis",
+    "popOut": "Pop out",
+    "dock": "Dock",
+    "poppedOutHint": "The chart is open in a window on the map.",
+    "noValues": "No values to chart for these pixels.",
+    "exportPng": "PNG",
+    "exportCsv": "CSV",
+    "exportError": "Could not export the chart."
   },
   "netcdfIdentify": {
     "noData": "no data",

--- a/apps/geolibre-desktop/src/lib/cf-units.ts
+++ b/apps/geolibre-desktop/src/lib/cf-units.ts
@@ -1,0 +1,27 @@
+/**
+ * CF `units` presentation, shared by the NetCDF readout, the spectral profile
+ * chart, and that chart's CSV export.
+ *
+ * Kept dependency-free, like `./csv`, so pure modules (and their `node --test`
+ * runs) can import it without pulling in `netcdf-image-symbology` — which
+ * reaches the plugin barrel and, through it, browser-only bundles.
+ */
+
+/**
+ * CF `units` values that mean "this quantity has no unit". Writers spell that
+ * several ways, and printing any of them next to a number is noise: EMIT
+ * reflectance declares `unitless`, so a readout would say "0.0145 unitless".
+ */
+const EMPTY_UNITS = new Set(["", "unitless", "dimensionless", "none", "n/a", "na", "-", "1"]);
+
+/**
+ * A variable's units when they are worth showing, else undefined.
+ *
+ * @param units - The CF `units` attribute, if any.
+ * @returns The units to render beside a value, or undefined to render none.
+ */
+export function displayUnits(units: string | undefined): string | undefined {
+  const trimmed = units?.trim();
+  if (!trimmed || EMPTY_UNITS.has(trimmed.toLowerCase())) return undefined;
+  return trimmed;
+}

--- a/apps/geolibre-desktop/src/lib/chart-export.ts
+++ b/apps/geolibre-desktop/src/lib/chart-export.ts
@@ -33,7 +33,17 @@ export function serializeChartSvg(svg: SVGSVGElement, width: number, height: num
   return source;
 }
 
-function triggerDownload(blob: Blob, filename: string): void {
+/**
+ * Hand a blob to the browser as a download.
+ *
+ * Exported so the charts that write their *data* out (the NetCDF spectral
+ * profile's CSV) use the same anchor-and-revoke path as the image exports here,
+ * rather than each growing its own copy.
+ *
+ * @param blob - The file contents.
+ * @param filename - The name to save it under.
+ */
+export function triggerDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;

--- a/apps/geolibre-desktop/src/lib/netcdf-image-symbology.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-image-symbology.ts
@@ -272,21 +272,6 @@ export function encodeImageOverlay(image: LocalNetcdfImage): string {
   return canvas.toDataURL("image/png");
 }
 
-/**
- * CF `units` values that mean "this quantity has no unit". Writers spell that
- * several ways, and printing any of them next to a number is noise: EMIT
- * reflectance declares `unitless`, so a readout would say "0.0145 unitless".
- */
-const EMPTY_UNITS = new Set(["", "unitless", "dimensionless", "none", "n/a", "na", "-", "1"]);
-
-/**
- * A variable's units when they are worth showing, else undefined.
- *
- * @param units - The CF `units` attribute, if any.
- * @returns The units to render beside a value, or undefined to render none.
- */
-export function displayUnits(units: string | undefined): string | undefined {
-  const trimmed = units?.trim();
-  if (!trimmed || EMPTY_UNITS.has(trimmed.toLowerCase())) return undefined;
-  return trimmed;
-}
+// Lives in its own dependency-free module so the profile CSV builder can reach
+// it without importing this one, which pulls in the plugin barrel.
+export { displayUnits } from "./cf-units";

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-series.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-series.ts
@@ -1,0 +1,157 @@
+import type { NetcdfProfileSample } from "./netcdf-profile-store";
+import { csvCell } from "./csv";
+
+/**
+ * Per-sample colors, shared by the chart lines, the legend swatches, and the
+ * on-map markers so a line and the pixel it was read from are matched by color
+ * as well as by number. Matches the Time Slider's pixel chart so the two read
+ * as one family.
+ */
+export const NETCDF_SERIES_COLORS = [
+  "hsl(var(--primary))",
+  "hsl(12 76% 61%)",
+  "hsl(173 58% 39%)",
+  "hsl(262 52% 56%)",
+  "hsl(43 74% 49%)",
+  "hsl(199 89% 48%)",
+];
+
+/**
+ * The color for a sample, keyed off its stable `order` rather than its position
+ * in the list, so a point does not change color when an older one falls off the
+ * cap.
+ *
+ * @param sample - The sampled pixel.
+ * @returns A CSS color, possibly referencing a theme variable.
+ */
+export function netcdfSeriesColor(sample: Pick<NetcdfProfileSample, "order">): string {
+  return NETCDF_SERIES_COLORS[(sample.order - 1) % NETCDF_SERIES_COLORS.length];
+}
+
+/**
+ * The x-axis positions for a sample: the axis' own coordinate values when the
+ * file has them (wavelengths in nm), else the bare index.
+ *
+ * @param sample - A sample whose profile has resolved.
+ * @returns One position per profile value.
+ */
+export function netcdfAxisPositions(
+  sample: NetcdfProfileSample & { profile: NonNullable<NetcdfProfileSample["profile"]> },
+): number[] {
+  const { axis, values } = sample.profile;
+  if (axis.values && axis.values.length === values.length) return axis.values;
+  return values.map((_, index) => index);
+}
+
+/** Multipliers a tick step may take, per power of ten. 2.5 earns its place on a
+ * 400-2500 nm spectrum, where the alternatives give either 4 labels or 11; it is
+ * penalized below because on a small integer axis (band indices) it puts ticks
+ * on half-bands. */
+const TICK_MULTIPLIERS = [1, 2, 2.5, 5];
+
+/** How many ticks a step yields inside `[min, max]`. */
+function tickCount(min: number, max: number, step: number): number {
+  return Math.floor(max / step) - Math.ceil(min / step) + 1;
+}
+
+/**
+ * Tick positions across a domain, on round numbers.
+ *
+ * Labelling only the ends and the midpoint leaves a wavelength axis nearly
+ * unreadable — you cannot tell where 1000 nm falls. This walks round multiples
+ * instead, so the labels are values a reader recognizes rather than whatever the
+ * data's extremes happened to be.
+ *
+ * Picks the step whose resulting *count* lands nearest `target`, rather than
+ * rounding the interval up to the next round number: rounding up overshoots
+ * badly on the domains this chart actually sees, turning an asked-for 8 labels
+ * into 4.
+ *
+ * @param min - Domain start.
+ * @param max - Domain end.
+ * @param target - Roughly how many ticks to aim for; round numbers win over
+ *   hitting it exactly, so the result lands near it rather than on it.
+ * @returns The ticks, ascending. A degenerate domain yields its single value.
+ */
+export function niceTickValues(min: number, max: number, target: number): number[] {
+  const span = max - min;
+  if (!Number.isFinite(span) || span <= 0 || target < 2) return [min];
+
+  const middle = Math.floor(Math.log10(span / target));
+  let best: { step: number; score: number } | null = null;
+  // Two powers either side of the estimate covers every step that could plausibly
+  // land near `target`, without depending on where the rounding fell.
+  for (let exponent = middle - 1; exponent <= middle + 2; exponent++) {
+    const power = 10 ** exponent;
+    for (const multiplier of TICK_MULTIPLIERS) {
+      const step = multiplier * power;
+      const count = tickCount(min, max, step);
+      if (count < 2) continue;
+      // Ties, and near-ties against 2.5, go to the rounder and sparser step.
+      const score = Math.abs(count - target) + (multiplier === 2.5 ? 1 : 0);
+      if (!best || score < best.score || (score === best.score && step > best.step)) {
+        best = { step, score };
+      }
+    }
+  }
+  if (!best) return [min, max];
+
+  const { step } = best;
+  const ticks: number[] = [];
+  const firstIndex = Math.ceil(min / step);
+  const lastIndex = Math.floor(max / step);
+  for (let index = firstIndex; index <= lastIndex; index++) {
+    // Multiply the index rather than accumulating: repeated addition drifts, and
+    // the drift shows up as "1400.0000000000002" in a label.
+    ticks.push(Number((index * step).toPrecision(12)));
+  }
+  return ticks;
+}
+
+/**
+ * Lay the sampled profiles out as CSV: one row per axis entry, one column per
+ * sampled pixel.
+ *
+ * Samples of the same variable share a band axis, so the axis column is taken
+ * from the first sample that has one; a sample whose profile is shorter (or
+ * still unread) leaves its cells empty rather than shifting the rows out of
+ * alignment. A fill reading is empty too, which is what a spreadsheet and most
+ * plotting tools read as a gap — the same break the chart draws.
+ *
+ * @param samples - The sampled pixels, in list order.
+ * @returns The CSV text, or null when no sample has a profile to write.
+ */
+export function buildNetcdfProfileCsv(samples: NetcdfProfileSample[]): string | null {
+  const charted = samples.filter(
+    (sample): sample is NetcdfProfileSample & { profile: NonNullable<typeof sample.profile> } =>
+      sample.profile !== undefined && sample.profile.values.length > 0,
+  );
+  if (charted.length === 0) return null;
+
+  const first = charted[0];
+  const axisName = first.profile.axis.units
+    ? `${first.profile.axis.name} (${first.profile.axis.units})`
+    : first.profile.axis.name;
+  const positions = netcdfAxisPositions(first);
+  const rowCount = Math.max(...charted.map((sample) => sample.profile.values.length));
+
+  const header = [
+    csvCell(axisName),
+    ...charted.map((sample) =>
+      // The lon/lat is what identifies the pixel; the point number ties the
+      // column back to its marker on the map.
+      csvCell(`point ${sample.order} (${sample.lng.toFixed(5)}, ${sample.lat.toFixed(5)})`),
+    ),
+  ].join(",");
+
+  const rows = Array.from({ length: rowCount }, (_, index) => {
+    const position = index < positions.length ? csvCell(positions[index]) : "";
+    const cells = charted.map((sample) => {
+      const value = sample.profile.values[index];
+      return value === null || value === undefined ? "" : csvCell(value);
+    });
+    return [position, ...cells].join(",");
+  });
+
+  return [header, ...rows].join("\n");
+}

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-series.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-series.ts
@@ -1,5 +1,6 @@
 import type { NetcdfProfileSample } from "./netcdf-profile-store";
-import { csvCell } from "./csv";
+import { csvCell, spreadsheetSafeText } from "./csv";
+import { displayUnits } from "./cf-units";
 
 /**
  * Per-sample colors, shared by the chart lines, the legend swatches, and the
@@ -129,14 +130,21 @@ export function buildNetcdfProfileCsv(samples: NetcdfProfileSample[]): string | 
   if (charted.length === 0) return null;
 
   const first = charted[0];
-  const axisName = first.profile.axis.units
-    ? `${first.profile.axis.name} (${first.profile.axis.units})`
+  // Through `displayUnits` like the chart's own axis label: a coordinate
+  // variable can declare `unitless`/`1`/`n/a`, and the export should not say
+  // "wavelength (1)" where the chart it came from says "wavelength".
+  const axisUnits = displayUnits(first.profile.axis.units);
+  const axisName = axisUnits
+    ? `${first.profile.axis.name} (${axisUnits})`
     : first.profile.axis.name;
   const positions = netcdfAxisPositions(first);
   const rowCount = Math.max(...charted.map((sample) => sample.profile.values.length));
 
   const header = [
-    csvCell(axisName),
+    // The axis name and units are free text out of the file's own metadata, so
+    // guard the export against spreadsheet formula injection. The point columns
+    // below are built from numbers and stay verbatim.
+    csvCell(spreadsheetSafeText(axisName)),
     ...charted.map((sample) =>
       // The lon/lat is what identifies the pixel; the point number ties the
       // column back to its marker on the map.

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
@@ -1,28 +1,44 @@
 import type { LocalNetcdfProfile } from "@geolibre/plugins";
 
-/** One sampled pixel's profile, with where it came from. */
-export interface NetcdfProfileReading {
+/** One pixel sampled with Identify, and its profile once that read resolves. */
+export interface NetcdfProfileSample {
+  /** Stable identity, used to attach the deferred profile read and key markers. */
+  id: number;
   /** The layer the pixel was read from. */
   layerId: string;
-  /** The variable profiled, for the chart's title. */
+  /** The variable sampled, for the chart's title. */
   variable: string;
   /** The variable's CF `units`, when it declares any. */
   units?: string;
   /** The sampled cell's centre. */
   lng: number;
   lat: number;
-  /** The values along the profile axis. */
-  profile: LocalNetcdfProfile;
+  /**
+   * 1-based position in the sampling session, shown on the map marker and in
+   * the legend. Assigned once and never renumbered, so a point keeps its label
+   * and its color when an older point falls off the cap.
+   */
+  order: number;
+  /**
+   * The values along the profile axis, once read. Absent while the read is in
+   * flight, and for a 2-D grid that has no band axis to walk — those pixels
+   * still appear as markers and in the list, they just chart nothing.
+   */
+  profile?: LocalNetcdfProfile;
 }
 
 /**
- * How many sampled pixels the chart keeps. Past this the oldest is dropped, so
+ * How many sampled pixels the store keeps. Past this the oldest is dropped, so
  * a long clicking session stays readable and bounded (each reading holds a few
  * hundred numbers, so the cost is the chart's legibility, not memory).
  */
-export const MAX_PROFILE_READINGS = 6;
+export const MAX_PROFILE_SAMPLES = 6;
 
-let readings: NetcdfProfileReading[] = [];
+let samples: NetcdfProfileSample[] = [];
+/** Whether the chart is detached into the floating window over the map. */
+let poppedOut = false;
+/** Feeds both `id` and `order`; reset with the list so labels restart at 1. */
+let counter = 0;
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -30,54 +46,102 @@ function emit(): void {
 }
 
 /**
- * Append a sampled pixel's profile, or clear the panel when passed null.
+ * Record a clicked pixel, and return the id to attach its profile to.
  *
- * Readings from a *different* layer replace the list rather than joining it:
- * two variables share no y-axis, so charting them together would be misleading.
+ * Samples from a *different* layer replace the list rather than joining it: two
+ * variables share no y-axis, so charting them together would be misleading.
+ * That also keeps the list single-layer, which is what lets the floating window
+ * chart "the current samples" without tracking a layer of its own.
  *
- * @param reading - The new reading, or null to clear.
+ * @param sample - The clicked pixel, without the fields the store assigns.
+ * @returns The new sample's id.
  */
-export function setNetcdfProfileReading(reading: NetcdfProfileReading | null): void {
-  if (!reading) {
-    if (readings.length === 0) return;
-    readings = [];
-    emit();
-    return;
-  }
-  const sameLayer = readings.filter((item) => item.layerId === reading.layerId);
-  readings = [...sameLayer, reading].slice(-MAX_PROFILE_READINGS);
+export function addNetcdfProfileSample(sample: Omit<NetcdfProfileSample, "id" | "order">): number {
+  const sameLayer = samples.filter((item) => item.layerId === sample.layerId);
+  // A layer switch starts a fresh session, so numbering restarts at 1 rather
+  // than continuing from the discarded layer's count.
+  if (sameLayer.length !== samples.length) counter = 0;
+  counter += 1;
+  const added: NetcdfProfileSample = { ...sample, id: counter, order: counter };
+  samples = [...sameLayer, added].slice(-MAX_PROFILE_SAMPLES);
   emit();
-}
-
-/** Drop every sampled profile. */
-export function clearNetcdfProfileReadings(): void {
-  setNetcdfProfileReading(null);
+  return added.id;
 }
 
 /**
- * Drop only the profiles sampled from one layer.
+ * Attach a resolved profile to a sample.
  *
- * What an off-grid click should clear: the identify target's own readout, not a
- * chart another layer's panel is still showing. The list holds one layer at a
- * time, so clearing it wholesale would take that other layer's readings with it
- * whenever the user switched identify targets before landing a hit on the new one.
+ * A no-op when that sample is gone (cleared, or dropped past the cap), which is
+ * what makes a slow read safe to leave running: a result the user has moved on
+ * from lands nowhere instead of charting a stale pixel.
  *
- * @param layerId - The layer whose readings to drop.
+ * @param id - The sample the profile was read for.
+ * @param profile - The values along the profile axis.
  */
-export function clearNetcdfProfileReadingsForLayer(layerId: string): void {
-  const kept = readings.filter((item) => item.layerId !== layerId);
-  if (kept.length === readings.length) return;
-  readings = kept;
+export function setNetcdfProfileSampleProfile(id: number, profile: LocalNetcdfProfile): void {
+  if (!samples.some((item) => item.id === id)) return;
+  samples = samples.map((item) => (item.id === id ? { ...item, profile } : item));
   emit();
 }
 
-/** The current readings, for `useSyncExternalStore`. */
-export function getNetcdfProfileReadings(): NetcdfProfileReading[] {
-  return readings;
+/** Drop every sampled pixel, and with it the markers and the chart. */
+export function clearNetcdfProfileSamples(): void {
+  if (samples.length === 0 && !poppedOut) return;
+  samples = [];
+  counter = 0;
+  // The window charts the samples, so leaving it open would strand an empty
+  // frame over the map.
+  poppedOut = false;
+  emit();
 }
 
-/** Subscribe to reading changes, for `useSyncExternalStore`. */
-export function subscribeNetcdfProfileReadings(listener: () => void): () => void {
+/**
+ * Drop only the pixels sampled from one layer.
+ *
+ * What an off-grid click should clear: the identify target's own points, not a
+ * chart another layer's panel is still showing. The list holds one layer at a
+ * time, so clearing it wholesale would take that other layer's samples with it
+ * whenever the user switched identify targets before landing a hit on the new one.
+ *
+ * @param layerId - The layer whose samples to drop.
+ */
+export function clearNetcdfProfileSamplesForLayer(layerId: string): void {
+  const kept = samples.filter((item) => item.layerId !== layerId);
+  if (kept.length === samples.length) return;
+  samples = kept;
+  // Emptied by this clear, so restart numbering and dock the (now empty) window,
+  // exactly as a full clear would.
+  if (kept.length === 0) {
+    counter = 0;
+    poppedOut = false;
+  }
+  emit();
+}
+
+/** The current samples, for `useSyncExternalStore`. */
+export function getNetcdfProfileSamples(): NetcdfProfileSample[] {
+  return samples;
+}
+
+/** Whether the chart is detached into the floating window. */
+export function isNetcdfProfilePoppedOut(): boolean {
+  return poppedOut;
+}
+
+/**
+ * Detach the chart into the floating window over the map, or dock it back into
+ * the Style panel.
+ *
+ * @param value - True to float the chart, false to dock it.
+ */
+export function setNetcdfProfilePoppedOut(value: boolean): void {
+  if (poppedOut === value) return;
+  poppedOut = value;
+  emit();
+}
+
+/** Subscribe to sample or pop-out changes, for `useSyncExternalStore`. */
+export function subscribeNetcdfProfile(listener: () => void): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);
 }

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
@@ -37,8 +37,15 @@ export const MAX_PROFILE_SAMPLES = 6;
 let samples: NetcdfProfileSample[] = [];
 /** Whether the chart is detached into the floating window over the map. */
 let poppedOut = false;
-/** Feeds both `id` and `order`; reset with the list so labels restart at 1. */
-let counter = 0;
+/**
+ * Feeds `id`. Never reset, unlike `orderCounter`: a profile read in flight when
+ * the list is cleared still resolves against whatever id it was issued, so
+ * recycling ids would let that stale read attach its spectrum to an unrelated
+ * later sample that happened to reuse the number.
+ */
+let idCounter = 0;
+/** Feeds `order`; reset with the list so marker labels restart at 1. */
+let orderCounter = 0;
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -60,9 +67,10 @@ export function addNetcdfProfileSample(sample: Omit<NetcdfProfileSample, "id" | 
   const sameLayer = samples.filter((item) => item.layerId === sample.layerId);
   // A layer switch starts a fresh session, so numbering restarts at 1 rather
   // than continuing from the discarded layer's count.
-  if (sameLayer.length !== samples.length) counter = 0;
-  counter += 1;
-  const added: NetcdfProfileSample = { ...sample, id: counter, order: counter };
+  if (sameLayer.length !== samples.length) orderCounter = 0;
+  idCounter += 1;
+  orderCounter += 1;
+  const added: NetcdfProfileSample = { ...sample, id: idCounter, order: orderCounter };
   samples = [...sameLayer, added].slice(-MAX_PROFILE_SAMPLES);
   emit();
   return added.id;
@@ -88,7 +96,7 @@ export function setNetcdfProfileSampleProfile(id: number, profile: LocalNetcdfPr
 export function clearNetcdfProfileSamples(): void {
   if (samples.length === 0 && !poppedOut) return;
   samples = [];
-  counter = 0;
+  orderCounter = 0;
   // The window charts the samples, so leaving it open would strand an empty
   // frame over the map.
   poppedOut = false;
@@ -112,7 +120,7 @@ export function clearNetcdfProfileSamplesForLayer(layerId: string): void {
   // Emptied by this clear, so restart numbering and dock the (now empty) window,
   // exactly as a full clear would.
   if (kept.length === 0) {
-    counter = 0;
+    orderCounter = 0;
     poppedOut = false;
   }
   emit();

--- a/tests/netcdf-profile-series.test.ts
+++ b/tests/netcdf-profile-series.test.ts
@@ -11,6 +11,18 @@ import type { NetcdfProfileSample } from "../apps/geolibre-desktop/src/lib/netcd
 
 type ProfileAxis = { name: string; size: number; units?: string; values?: number[] };
 
+type ChartedSample = NetcdfProfileSample & { profile: NonNullable<NetcdfProfileSample["profile"]> };
+
+/**
+ * Narrows a sample built with values to the shape the axis helper requires,
+ * rather than casting the argument away with `as never` — which would let a
+ * change to that helper's parameter type through unnoticed.
+ */
+function charted(sample: NetcdfProfileSample): ChartedSample {
+  assert.ok(sample.profile);
+  return sample as ChartedSample;
+}
+
 /** A sampled pixel, optionally with a profile attached. */
 function sample(
   order: number,
@@ -47,11 +59,11 @@ describe("netcdf profile series", () => {
       units: "nm",
       values: [381.5, 388.4],
     });
-    assert.deepEqual(netcdfAxisPositions(withWavelengths as never), [381.5, 388.4]);
+    assert.deepEqual(netcdfAxisPositions(charted(withWavelengths)), [381.5, 388.4]);
   });
 
   it("falls back to the band index when the axis carries no coordinates", () => {
-    assert.deepEqual(netcdfAxisPositions(sample(1, [0.1, 0.2]) as never), [0, 1]);
+    assert.deepEqual(netcdfAxisPositions(charted(sample(1, [0.1, 0.2]))), [0, 1]);
   });
 
   it("labels an EMIT wavelength axis on round numbers", () => {

--- a/tests/netcdf-profile-series.test.ts
+++ b/tests/netcdf-profile-series.test.ts
@@ -117,6 +117,22 @@ describe("netcdf profile series", () => {
     assert.deepEqual(csv?.split("\n").slice(1), ["0,0.1,0.4", "1,0.2,", "2,0.3,"]);
   });
 
+  it("drops noise units from the header, as the chart's axis label does", () => {
+    const csv = buildNetcdfProfileCsv([
+      sample(1, [0.5], { name: "bands", size: 1, units: "unitless" }),
+    ]);
+    assert.equal(csv?.split("\n")[0].split(",")[0], "bands");
+  });
+
+  it("neutralizes a formula in an axis name out of the file's metadata", () => {
+    // A dimension name is untrusted file content; a leading `=` would execute
+    // when the export is opened in a spreadsheet.
+    const csv = buildNetcdfProfileCsv([sample(1, [0.5], { name: "=cmd|'/c calc'!A0", size: 1 })]);
+    // The leading apostrophe is what stops the spreadsheet evaluating it; the
+    // cell needs no quoting, since it carries no comma, quote, or newline.
+    assert.equal(csv?.split("\n")[0].split(",")[0], "'=cmd|'/c calc'!A0");
+  });
+
   it("skips samples with no profile, and returns null when none has one", () => {
     assert.equal(buildNetcdfProfileCsv([sample(1), sample(2)]), null);
     const csv = buildNetcdfProfileCsv([sample(1), sample(2, [0.5])]);

--- a/tests/netcdf-profile-series.test.ts
+++ b/tests/netcdf-profile-series.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildNetcdfProfileCsv,
+  netcdfAxisPositions,
+  netcdfSeriesColor,
+  NETCDF_SERIES_COLORS,
+  niceTickValues,
+} from "../apps/geolibre-desktop/src/lib/netcdf-profile-series";
+import type { NetcdfProfileSample } from "../apps/geolibre-desktop/src/lib/netcdf-profile-store";
+
+type ProfileAxis = { name: string; size: number; units?: string; values?: number[] };
+
+/** A sampled pixel, optionally with a profile attached. */
+function sample(
+  order: number,
+  values?: Array<number | null>,
+  axis?: ProfileAxis,
+): NetcdfProfileSample {
+  return {
+    id: order,
+    order,
+    layerId: "a",
+    variable: "reflectance",
+    lng: 1.5,
+    lat: -2.5,
+    profile: values ? { axis: axis ?? { name: "bands", size: values.length }, values } : undefined,
+  };
+}
+
+describe("netcdf profile series", () => {
+  it("keys a sample's color off its number, not its position", () => {
+    // A point must keep its color when an older one falls off the cap, so the
+    // marker on the map and the line in the chart never disagree.
+    assert.equal(netcdfSeriesColor({ order: 1 }), NETCDF_SERIES_COLORS[0]);
+    assert.equal(netcdfSeriesColor({ order: 3 }), NETCDF_SERIES_COLORS[2]);
+    assert.equal(
+      netcdfSeriesColor({ order: NETCDF_SERIES_COLORS.length + 1 }),
+      NETCDF_SERIES_COLORS[0],
+    );
+  });
+
+  it("plots against the axis' own coordinates when the file has them", () => {
+    const withWavelengths = sample(1, [0.1, 0.2], {
+      name: "wavelength",
+      size: 2,
+      units: "nm",
+      values: [381.5, 388.4],
+    });
+    assert.deepEqual(netcdfAxisPositions(withWavelengths as never), [381.5, 388.4]);
+  });
+
+  it("falls back to the band index when the axis carries no coordinates", () => {
+    assert.deepEqual(netcdfAxisPositions(sample(1, [0.1, 0.2]) as never), [0, 1]);
+  });
+
+  it("labels an EMIT wavelength axis on round numbers", () => {
+    // The real complaint: 381 / 1437 / 2493 told you nothing about where a
+    // feature sat. Round multiples do.
+    assert.deepEqual(
+      niceTickValues(381.0, 2493.0, 8),
+      [500, 750, 1000, 1250, 1500, 1750, 2000, 2250],
+    );
+  });
+
+  it("keeps a band-index axis on whole numbers", () => {
+    assert.deepEqual(niceTickValues(0, 23, 8), [0, 5, 10, 15, 20]);
+  });
+
+  it("does not drift on a fractional step", () => {
+    // Repeated addition would surface as "0.6000000000000001" in a label.
+    assert.deepEqual(niceTickValues(0, 1, 8), [0, 0.2, 0.4, 0.6, 0.8, 1]);
+  });
+
+  it("stays inside the domain, so no tick is drawn off the plot", () => {
+    for (const [min, max] of [
+      [381, 2493],
+      [0, 23],
+      [-0.5, 0.5],
+      [1e-4, 5e-4],
+    ]) {
+      for (const tick of niceTickValues(min, max, 8)) {
+        assert.ok(tick >= min && tick <= max, `${tick} outside ${min}..${max}`);
+      }
+    }
+  });
+
+  it("degenerates safely on a single-band or empty domain", () => {
+    assert.deepEqual(niceTickValues(5, 5, 8), [5]);
+    assert.deepEqual(niceTickValues(10, 1, 8), [10]);
+    assert.deepEqual(niceTickValues(0, Number.NaN, 8), [0]);
+  });
+
+  it("writes one column per sampled pixel, with the axis first", () => {
+    const csv = buildNetcdfProfileCsv([
+      sample(1, [0.1, 0.2], { name: "wavelength", size: 2, units: "nm", values: [400, 410] }),
+      sample(2, [0.3, 0.4], { name: "wavelength", size: 2, units: "nm", values: [400, 410] }),
+    ]);
+    assert.equal(
+      csv,
+      [
+        // The lon/lat carries a comma, so the header cells are quoted.
+        'wavelength (nm),"point 1 (1.50000, -2.50000)","point 2 (1.50000, -2.50000)"',
+        "400,0.1,0.3",
+        "410,0.2,0.4",
+      ].join("\n"),
+    );
+  });
+
+  it("leaves a fill reading empty so it reads as a gap", () => {
+    const csv = buildNetcdfProfileCsv([sample(1, [0.1, null, 0.3])]);
+    assert.deepEqual(csv?.split("\n").slice(1), ["0,0.1", "1,", "2,0.3"]);
+  });
+
+  it("pads a shorter profile rather than shifting the rows out of line", () => {
+    const csv = buildNetcdfProfileCsv([sample(1, [0.1, 0.2, 0.3]), sample(2, [0.4])]);
+    assert.deepEqual(csv?.split("\n").slice(1), ["0,0.1,0.4", "1,0.2,", "2,0.3,"]);
+  });
+
+  it("skips samples with no profile, and returns null when none has one", () => {
+    assert.equal(buildNetcdfProfileCsv([sample(1), sample(2)]), null);
+    const csv = buildNetcdfProfileCsv([sample(1), sample(2, [0.5])]);
+    assert.deepEqual(csv?.split("\n"), ['bands,"point 2 (1.50000, -2.50000)"', "0,0.5"]);
+  });
+});

--- a/tests/netcdf-profile-store.test.ts
+++ b/tests/netcdf-profile-store.test.ts
@@ -88,6 +88,29 @@ describe("netcdf profile store", () => {
     assert.equal(getNetcdfProfileSamples()[0].order, 1);
   });
 
+  it("never reissues an id, so a stale read cannot land on a later sample", () => {
+    // Marker numbering restarts at 1 after a clear, but ids must not: a read
+    // still in flight when the user cleared would otherwise resolve onto a new,
+    // unrelated point that happened to recycle its number.
+    const stale = addNetcdfProfileSample(sample("a", 1));
+    clearNetcdfProfileSamples();
+    const fresh = addNetcdfProfileSample(sample("a", 2));
+    assert.notEqual(stale, fresh);
+    assert.equal(getNetcdfProfileSamples()[0].order, 1);
+
+    setNetcdfProfileSampleProfile(stale, PROFILE);
+    assert.equal(getNetcdfProfileSamples()[0].profile, undefined);
+  });
+
+  it("never reissues an id after a per-layer clear either", () => {
+    const stale = addNetcdfProfileSample(sample("a", 1));
+    clearNetcdfProfileSamplesForLayer("a");
+    const fresh = addNetcdfProfileSample(sample("a", 2));
+    assert.notEqual(stale, fresh);
+    setNetcdfProfileSampleProfile(stale, PROFILE);
+    assert.equal(getNetcdfProfileSamples()[0].profile, undefined);
+  });
+
   it("clears one layer's samples without touching another's", () => {
     // An off-grid click on the identify target must not wipe a chart another
     // layer's Style panel is still showing.

--- a/tests/netcdf-profile-store.test.ts
+++ b/tests/netcdf-profile-store.test.ts
@@ -1,98 +1,148 @@
 import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 import {
-  clearNetcdfProfileReadings,
-  clearNetcdfProfileReadingsForLayer,
-  getNetcdfProfileReadings,
-  MAX_PROFILE_READINGS,
-  setNetcdfProfileReading,
-  subscribeNetcdfProfileReadings,
-  type NetcdfProfileReading,
+  addNetcdfProfileSample,
+  clearNetcdfProfileSamples,
+  clearNetcdfProfileSamplesForLayer,
+  getNetcdfProfileSamples,
+  isNetcdfProfilePoppedOut,
+  MAX_PROFILE_SAMPLES,
+  setNetcdfProfilePoppedOut,
+  setNetcdfProfileSampleProfile,
+  subscribeNetcdfProfile,
+  type NetcdfProfileSample,
 } from "../apps/geolibre-desktop/src/lib/netcdf-profile-store";
 
-/** A reading with just enough shape for the store's bookkeeping. */
-function reading(layerId: string, lng: number): NetcdfProfileReading {
-  return {
-    layerId,
-    variable: "reflectance",
-    lng,
-    lat: 0,
-    profile: { axis: { name: "bands", size: 2 }, values: [0.1, 0.2] },
-  };
+/** A clicked pixel with just enough shape for the store's bookkeeping. */
+function sample(layerId: string, lng: number): Omit<NetcdfProfileSample, "id" | "order"> {
+  return { layerId, variable: "reflectance", lng, lat: 0 };
 }
 
-describe("netcdf profile store", () => {
-  beforeEach(() => clearNetcdfProfileReadings());
+const PROFILE = { axis: { name: "bands", size: 2 }, values: [0.1, 0.2] };
 
-  it("accumulates readings from the same layer", () => {
-    setNetcdfProfileReading(reading("a", 1));
-    setNetcdfProfileReading(reading("a", 2));
+describe("netcdf profile store", () => {
+  beforeEach(() => clearNetcdfProfileSamples());
+
+  it("accumulates samples from the same layer", () => {
+    addNetcdfProfileSample(sample("a", 1));
+    addNetcdfProfileSample(sample("a", 2));
     assert.deepEqual(
-      getNetcdfProfileReadings().map((item) => item.lng),
+      getNetcdfProfileSamples().map((item) => item.lng),
       [1, 2],
     );
   });
 
-  it("replaces the list when the reading comes from another layer", () => {
-    // Two variables share no y-axis, so charting them together would mislead.
-    setNetcdfProfileReading(reading("a", 1));
-    setNetcdfProfileReading(reading("b", 9));
+  it("numbers samples from 1 so the marker matches the legend", () => {
+    addNetcdfProfileSample(sample("a", 1));
+    addNetcdfProfileSample(sample("a", 2));
     assert.deepEqual(
-      getNetcdfProfileReadings().map((item) => [item.layerId, item.lng]),
-      [["b", 9]],
+      getNetcdfProfileSamples().map((item) => item.order),
+      [1, 2],
     );
   });
 
-  it("drops the oldest reading past the cap", () => {
-    for (let i = 0; i <= MAX_PROFILE_READINGS; i++) setNetcdfProfileReading(reading("a", i));
-    const kept = getNetcdfProfileReadings();
-    assert.equal(kept.length, MAX_PROFILE_READINGS);
+  it("replaces the list when the sample comes from another layer", () => {
+    // Two variables share no y-axis, so charting them together would mislead.
+    addNetcdfProfileSample(sample("a", 1));
+    addNetcdfProfileSample(sample("b", 9));
+    assert.deepEqual(
+      getNetcdfProfileSamples().map((item) => [item.layerId, item.lng, item.order]),
+      [["b", 9, 1]],
+    );
+  });
+
+  it("drops the oldest sample past the cap, without renumbering the rest", () => {
+    for (let i = 0; i <= MAX_PROFILE_SAMPLES; i++) addNetcdfProfileSample(sample("a", i));
+    const kept = getNetcdfProfileSamples();
+    assert.equal(kept.length, MAX_PROFILE_SAMPLES);
     assert.equal(kept[0].lng, 1);
-    assert.equal(kept[kept.length - 1].lng, MAX_PROFILE_READINGS);
+    // The survivor keeps the number (and so the color) it was drawn with.
+    assert.equal(kept[0].order, 2);
+    assert.equal(kept[kept.length - 1].lng, MAX_PROFILE_SAMPLES);
   });
 
-  it("clears on a null reading", () => {
-    setNetcdfProfileReading(reading("a", 1));
-    setNetcdfProfileReading(null);
-    assert.deepEqual(getNetcdfProfileReadings(), []);
+  it("attaches a profile to the sample it was read for", () => {
+    const first = addNetcdfProfileSample(sample("a", 1));
+    addNetcdfProfileSample(sample("a", 2));
+    setNetcdfProfileSampleProfile(first, PROFILE);
+    assert.deepEqual(
+      getNetcdfProfileSamples().map((item) => item.profile?.values ?? null),
+      [[0.1, 0.2], null],
+    );
   });
 
-  it("clears one layer's readings without touching another's", () => {
+  it("ignores a profile for a sample that is gone", () => {
+    // A slow read whose pixel the user has since cleared must land nowhere
+    // rather than charting a stale spectrum.
+    const id = addNetcdfProfileSample(sample("a", 1));
+    clearNetcdfProfileSamples();
+    setNetcdfProfileSampleProfile(id, PROFILE);
+    assert.deepEqual(getNetcdfProfileSamples(), []);
+  });
+
+  it("clears the samples and restarts numbering", () => {
+    addNetcdfProfileSample(sample("a", 1));
+    clearNetcdfProfileSamples();
+    assert.deepEqual(getNetcdfProfileSamples(), []);
+    addNetcdfProfileSample(sample("a", 5));
+    assert.equal(getNetcdfProfileSamples()[0].order, 1);
+  });
+
+  it("clears one layer's samples without touching another's", () => {
     // An off-grid click on the identify target must not wipe a chart another
     // layer's Style panel is still showing.
-    setNetcdfProfileReading(reading("b", 9));
-    clearNetcdfProfileReadingsForLayer("a");
+    addNetcdfProfileSample(sample("b", 9));
+    clearNetcdfProfileSamplesForLayer("a");
     assert.deepEqual(
-      getNetcdfProfileReadings().map((item) => [item.layerId, item.lng]),
+      getNetcdfProfileSamples().map((item) => [item.layerId, item.lng]),
       [["b", 9]],
     );
-    clearNetcdfProfileReadingsForLayer("b");
-    assert.deepEqual(getNetcdfProfileReadings(), []);
+    clearNetcdfProfileSamplesForLayer("b");
+    assert.deepEqual(getNetcdfProfileSamples(), []);
   });
 
   it("does not notify when a per-layer clear matches nothing", () => {
-    setNetcdfProfileReading(reading("b", 9));
+    addNetcdfProfileSample(sample("b", 9));
     let calls = 0;
-    const unsubscribe = subscribeNetcdfProfileReadings(() => calls++);
-    clearNetcdfProfileReadingsForLayer("a");
+    const unsubscribe = subscribeNetcdfProfile(() => calls++);
+    clearNetcdfProfileSamplesForLayer("a");
     assert.equal(calls, 0);
     unsubscribe();
   });
 
+  it("docks the chart when the samples are cleared", () => {
+    addNetcdfProfileSample(sample("a", 1));
+    setNetcdfProfilePoppedOut(true);
+    clearNetcdfProfileSamples();
+    assert.equal(isNetcdfProfilePoppedOut(), false);
+  });
+
+  it("docks the chart when a per-layer clear empties the list", () => {
+    // Otherwise the window is left floating over the map with nothing in it.
+    addNetcdfProfileSample(sample("a", 1));
+    setNetcdfProfilePoppedOut(true);
+    clearNetcdfProfileSamplesForLayer("a");
+    assert.equal(isNetcdfProfilePoppedOut(), false);
+    assert.deepEqual(getNetcdfProfileSamples(), []);
+  });
+
   it("notifies subscribers, and stops after unsubscribe", () => {
     let calls = 0;
-    const unsubscribe = subscribeNetcdfProfileReadings(() => calls++);
-    setNetcdfProfileReading(reading("a", 1));
+    const unsubscribe = subscribeNetcdfProfile(() => calls++);
+    addNetcdfProfileSample(sample("a", 1));
     assert.equal(calls, 1);
+    setNetcdfProfilePoppedOut(true);
+    assert.equal(calls, 2);
     unsubscribe();
-    setNetcdfProfileReading(reading("a", 2));
-    assert.equal(calls, 1);
+    addNetcdfProfileSample(sample("a", 2));
+    assert.equal(calls, 2);
+    setNetcdfProfilePoppedOut(false);
   });
 
   it("does not notify when clearing an already-empty list", () => {
     let calls = 0;
-    const unsubscribe = subscribeNetcdfProfileReadings(() => calls++);
-    setNetcdfProfileReading(null);
+    const unsubscribe = subscribeNetcdfProfile(() => calls++);
+    clearNetcdfProfileSamples();
     assert.equal(calls, 0);
     unsubscribe();
   });


### PR DESCRIPTION
Follow-up to #1708. Makes the NetCDF spectral profile usable on a real hyperspectral cube.

## Markers at the sampled pixels

Clicking a pixel with Identify now records it as a sampled point and draws a numbered dot on the map in that point's chart color, so a line in the profile and the pixel it came from match by both number and color. Previously nothing showed where a spectrum had been read from, and several lines on one chart could not be told apart by location.

This turns the profile store from a list of readings into a list of points. The point goes in on the click so its marker lands with the popup, and the (slow) band-axis read attaches to it by id when it resolves. A result addressed to a point that has since been cleared, or aged off the six-point cap, lands nowhere, so a slow read no longer needs cancelling. Points keep their number and color when an older one falls off the cap.

Clear drops the markers along with the chart, since both derive from the same list.

A pixel from a 2-D grid is now kept as a point too, rather than clearing the list. It has no band axis to profile so it charts nothing, but it still gets a marker and a list entry.

## Pop-out window

The chart can be detached from the Style panel into a draggable, resizable window over the map. The panel is narrow and scrolls, which is a poor place to read a 285-band spectrum closely.

It opens top-left because its only resize grip is the bottom-right one, which on the right would sit against the Style panel with nowhere to grow. The drag/resize gesture is extracted from the Time Slider's pixel chart (`useFloatingPanelRect`) rather than duplicated, since the two are the same kind of window over the same container; `PixelTimeSeriesControl` now uses the shared hook.

## PNG and CSV export

Through the existing `lib/chart-export`, which already resolves the theme CSS variables the SVG references so the PNG is not unstyled. CSV is a pure, tested builder: axis column first, one column per sampled pixel, fill readings left empty so they read as gaps.

## Denser x-axis

The axis labelled only its two ends and the midpoint, so on a 381-2493 nm range it told you nothing about where a feature sat. It now labels round multiples with tick marks.

Worth a look in review: the step is chosen by which candidate's tick *count* lands nearest the target, not by rounding the interval up to the next round number. Rounding up overshoots badly on this domain -- 2112 nm / 8 rounds 264 up to 500, giving 4 labels where 8 were asked for. Bringing 2.5 into the ladder is what makes 250 nm reachable, and it carries a small penalty so that a band-*index* axis breaks toward 0/5/10/15/20 rather than onto half-bands.

## Verification

Driven in a real browser against a 285-band 381-2493 nm HDF5 cube (production build, GPU, dark and light):

- three clicks give three numbered markers and three spectra
- window opens 12px from the map's top-left, drags (656,56 -> 364,220) and resizes (512x416 -> 736x580)
- PNG (67 KB) and CSV (25 rows) both export with the theme resolved
- Clear drops the markers to 0 and docks the window
- x-axis reads 500 / 750 / 1000 / 1250 / 1500 / 1750 / 2000 / 2250

`npm run typecheck`, the frontend suite (5217 passing), and `pre-commit` are green. New unit tests cover the sample store's numbering, cap, per-layer clear and late-profile handling, plus the tick generator and the CSV builder.

## Note for the reviewer

New UI strings are in `en.json` only, matching what #1708 did; other locales fall back to English until the i18n pass runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added numbered, color-coded map markers and multi-sample profile comparison.
  * Introduced a movable, resizable pop-out profile window with docking support.
  * Added PNG and CSV profile exports with missing-value handling.

* **Improvements**
  * Profile reads now load independently and attach to the correct sampled point.
  * Improved chart responsiveness, accessibility, localization, and empty-state messaging.
  * Limited profile history to six samples for clearer map and chart views.
  * Added clearer unit formatting and more reliable handling of stale or cleared samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->