### PR TITLE
fix(ci): opt in to fork PR checkout so Claude review stops failing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -128,6 +128,28 @@ jobs:
           ref: ${{ steps.pr.outputs.sha }}
           persist-credentials: false
           fetch-depth: 1
+          # actions/checkout hard-refuses a fork PR head under
+          # pull_request_target unless this opt-in is set — it is guarding
+          # against "pwn request", where a workflow checks out fork code and
+          # then *executes* it (npm ci, build, test, a lifecycle script) with the
+          # base repo's write-scoped token and secrets. That guard landed in a
+          # v7 patch release, so every fork PR — including known contributors,
+          # who are the ones the `if:` above lets through — started failing this
+          # step with no change on our side.
+          #
+          # This job does none of the things the guard protects against: it never
+          # installs dependencies, never runs a build or test, and never executes
+          # anything from the checkout. The head is only ever *read* — by Claude's
+          # Read/Grep/Glob, which is the entire point of checking it out. The
+          # token is kept out of .git/config by persist-credentials above, out of
+          # the agent's subprocesses by the action's env scrub (see the header),
+          # and the agent has no Bash tool with which to run checked-out code
+          # even if it wanted to. So we opt in deliberately.
+          #
+          # This stays true only as long as no step in this job executes the
+          # checkout. Do not add a build, install, or test step here — put it in
+          # ci.yml, which runs under `pull_request` and gets no secrets.
+          allow-unsafe-pr-checkout: true
 
       # Claude cannot fetch the diff itself (no token in its subprocesses — see
       # the header). Stage it on disk instead. This runs AFTER the checkout and


### PR DESCRIPTION
## Problem

Every Claude Code Review run on an external PR fails within seconds at the checkout step:

> Refusing to check out fork pull request code from a `pull_request_target` workflow. […] To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set `allow-unsafe-pr-checkout: true` on the actions/checkout step.

Example: [run 31022945517](https://github.com/opengeos/GeoLibre/actions/runs/31022945517/job/92364055370?pr=1714) on #1714.

Nothing changed in this repo. A recent `actions/checkout` **v7 patch release** added this guard, and `@v7` is a mutable tag, so it moved under us. Because every external PR is cross-repository, this hits *all* of them — including known `CONTRIBUTOR` authors, who are precisely the ones the job's `if:` gate is meant to review automatically.

## Fix

Set `allow-unsafe-pr-checkout: true` on that one checkout step.

## Why that is safe here

The guard exists to stop "pwn request": a workflow that checks out fork code and then **executes** it — `npm ci`, a build, a test, an npm lifecycle script — with the base repository's write-scoped `GITHUB_TOKEN` and secrets.

This job does none of that. It never installs dependencies, never builds, never tests, and never runs anything from the checkout. The head is only ever *read*, by Claude's `Read`/`Grep`/`Glob` — which is the entire reason it is checked out (the base ref alone would hide added files and show pre-change context). Layered on top of that, already in place before this PR:

- `persist-credentials: false` keeps the token out of `.git/config`.
- The action's subprocess env scrub (auto-enabled by `allowed_non_write_users`) strips `GITHUB_TOKEN`/`GH_TOKEN` from every subprocess the agent spawns.
- `--allowedTools` grants **no Bash tool**, so the agent has no way to execute the checked-out code even if a prompt injection told it to.

The step comment records the invariant this rests on: it holds only while no step in this job executes the checkout. Build/install/test steps belong in `ci.yml`, which runs under `pull_request` and gets no secrets.

## Verification

The workflow parses and the input name matches `actions/checkout`'s `action.yml`:

```
Checkout PR head for review context (read-only; never executed)
{ "ref": "...", "persist-credentials": false, "fetch-depth": 1, "allow-unsafe-pr-checkout": true }
```

`pre-commit run --files .github/workflows/claude-code-review.yml` passes. End-to-end confirmation is the next fork PR's review run going green — this PR is same-repo, so it does not exercise the fork path itself.

Note: `pr-preview.yml` is the repo's only other `pull_request_target` workflow, and it is unaffected — it checks out the default branch with no `ref:`, so it never touches fork code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request review workflow handling to support contributions from forked repositories.
  * Added safeguards and documentation clarifying that checked-out code is read-only and must not be executed, installed, built, or tested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->