### PR TITLE
fix(layers): hide control-rendered rasters with their group

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2962,6 +2962,11 @@ export function LayerPanel({
             // row does not rebuild that map once per layer.
             const groupHidden =
               layer.visible && !effectiveLayerRenderState(layer, groupById).visible;
+            const visibilityToggleLabel = groupHidden
+              ? `${t("layers.hiddenByGroup")} — ${t("layers.hideLayer")}`
+              : layer.visible
+                ? t("layers.hideLayer")
+                : t("layers.showLayer");
             const canIdentify =
               layer.type === "geojson" ||
               isDuckDBQueryLayer(layer) ||
@@ -3183,14 +3188,11 @@ export function LayerPanel({
                         // "Show layer" that turns the layer's own toggle off,
                         // so revealing it later would take two clicks. The
                         // muted icon plus the tooltip say why it is not drawn.
-                        title={
-                          groupHidden
-                            ? `${t("layers.hiddenByGroup")} — ${t("layers.hideLayer")}`
-                            : layer.visible
-                              ? t("layers.hideLayer")
-                              : t("layers.showLayer")
-                        }
-                        aria-label={layer.visible ? t("layers.hideLayer") : t("layers.showLayer")}
+                        // Same string for the tooltip and the accessible name,
+                        // so the group-hidden context reaches a screen reader
+                        // and not only a sighted hover.
+                        title={visibilityToggleLabel}
+                        aria-label={visibilityToggleLabel}
                         onClick={(e) => {
                           e.stopPropagation();
                           setLayerVisibility(layer.id, !layer.visible);

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2957,9 +2957,11 @@ export function LayerPanel({
             // hiding it (issue #430). If the layer's own toggle is also off,
             // the EyeOff icon already explains it, so skip the group cue then.
             // Folded through effectiveLayerRenderState rather than read off the
-            // immediate parent, so a hidden grandparent gets the cue too.
+            // immediate parent, so a hidden grandparent gets the cue too. Given
+            // the memoized `groupById` rather than the array, so folding every
+            // row does not rebuild that map once per layer.
             const groupHidden =
-              layer.visible && !effectiveLayerRenderState(layer, layerGroups).visible;
+              layer.visible && !effectiveLayerRenderState(layer, groupById).visible;
             const canIdentify =
               layer.type === "geojson" ||
               isDuckDBQueryLayer(layer) ||

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -16,6 +16,7 @@ import type { ParseKeys, TFunction } from "i18next";
 import {
   NETCDF_IMAGE_SOURCE_KIND,
   DEFAULT_BASEMAP,
+  effectiveLayerRenderState,
   getPlanetaryBasemapById,
   getPlanetaryBasemapByStyleUrl,
   isDuckDBQueryLayer,
@@ -2950,12 +2951,15 @@ export function LayerPanel({
             const isFirstOfGroup = group ? firstMemberIdByGroup.get(group.id) === layer.id : false;
             const groupCollapsed = group?.collapsed ?? false;
             const groupAncestorCollapsed = group ? hasCollapsedAncestor(group) : false;
-            // When the parent group is hidden, a layer whose own visibility
+            // When an ancestor group is hidden, a layer whose own visibility
             // toggle is still on is not rendered — a surprising state. Grey its
-            // name out as a cue that the group-level setting is what's hiding
-            // it (issue #430). If the layer's own toggle is also off, the
-            // EyeOff icon already explains it, so skip the group cue then.
-            const groupHidden = group ? !group.visible && layer.visible : false;
+            // name and eye out as a cue that the group-level setting is what's
+            // hiding it (issue #430). If the layer's own toggle is also off,
+            // the EyeOff icon already explains it, so skip the group cue then.
+            // Folded through effectiveLayerRenderState rather than read off the
+            // immediate parent, so a hidden grandparent gets the cue too.
+            const groupHidden =
+              layer.visible && !effectiveLayerRenderState(layer, layerGroups).visible;
             const canIdentify =
               layer.type === "geojson" ||
               isDuckDBQueryLayer(layer) ||
@@ -3172,7 +3176,18 @@ export function LayerPanel({
                       <button
                         type="button"
                         className="rounded p-0.5 hover:bg-muted"
-                        title={layer.visible ? t("layers.hideLayer") : t("layers.showLayer")}
+                        // The eye stays the layer's *own* switch even while a
+                        // group hides it — showing EyeOff here would offer a
+                        // "Show layer" that turns the layer's own toggle off,
+                        // so revealing it later would take two clicks. The
+                        // muted icon plus the tooltip say why it is not drawn.
+                        title={
+                          groupHidden
+                            ? `${t("layers.hiddenByGroup")} — ${t("layers.hideLayer")}`
+                            : layer.visible
+                              ? t("layers.hideLayer")
+                              : t("layers.showLayer")
+                        }
                         aria-label={layer.visible ? t("layers.hideLayer") : t("layers.showLayer")}
                         onClick={(e) => {
                           e.stopPropagation();
@@ -3180,7 +3195,9 @@ export function LayerPanel({
                         }}
                       >
                         {layer.visible ? (
-                          <Eye className="h-3.5 w-3.5" />
+                          <Eye
+                            className={`h-3.5 w-3.5 ${groupHidden ? "text-muted-foreground" : ""}`}
+                          />
                         ) : (
                           <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
                         )}

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -92,21 +92,58 @@ export function applyGroupEffects(layers: GeoLibreLayer[], groups: LayerGroup[])
   if (groups.length === 0) return layers;
   const groupById = new Map(groups.map((g) => [g.id, g]));
   return layers.map((layer) => {
-    if (!layer.groupId) return layer;
-    let group = groupById.get(layer.groupId);
-    if (!group) return layer;
-    let visible = layer.visible;
-    let opacity = layer.opacity;
-    const visited = new Set<string>();
-    while (group && !visited.has(group.id)) {
-      visited.add(group.id);
-      visible = visible && group.visible;
-      opacity *= group.opacity;
-      group = group.parentId ? groupById.get(group.parentId) : undefined;
-    }
+    if (!layer.groupId || !groupById.has(layer.groupId)) return layer;
+    const { visible, opacity } = foldGroupChain(layer, groupById);
     if (visible === layer.visible && opacity === layer.opacity) return layer;
     return { ...layer, visible, opacity };
   });
+}
+
+/**
+ * Walk a layer's group chain upward, ANDing each group's visibility into the
+ * layer's own and multiplying each group's opacity into it. The `visited` set
+ * makes a corrupted `parentId` cycle terminate instead of hanging.
+ */
+function foldGroupChain(
+  layer: GeoLibreLayer,
+  groupById: Map<string, LayerGroup>,
+): { visible: boolean; opacity: number } {
+  let visible = layer.visible;
+  let opacity = layer.opacity;
+  let group = layer.groupId ? groupById.get(layer.groupId) : undefined;
+  const visited = new Set<string>();
+  while (group && !visited.has(group.id)) {
+    visited.add(group.id);
+    visible = visible && group.visible;
+    opacity *= group.opacity;
+    group = group.parentId ? groupById.get(group.parentId) : undefined;
+  }
+  return { visible, opacity };
+}
+
+/**
+ * The single layer form of {@link applyGroupEffects}: the visibility and
+ * opacity a layer should actually render at once its (possibly nested) parent
+ * groups are folded in.
+ *
+ * Group state never mutates a child's own `visible`/`opacity` fields, so any
+ * renderer that cannot read the folded array — a plugin control that owns its
+ * own paint and is driven layer by layer — asks for a single layer here
+ * instead.
+ *
+ * @param layer The layer to fold.
+ * @param groups Group definitions.
+ * @returns The effective render state (the layer's own values when it is
+ *   ungrouped or its `groupId` is dangling).
+ */
+export function effectiveLayerRenderState(
+  layer: GeoLibreLayer,
+  groups: LayerGroup[],
+): { visible: boolean; opacity: number } {
+  if (groups.length === 0 || !layer.groupId) {
+    return { visible: layer.visible, opacity: layer.opacity };
+  }
+  return foldGroupChain(layer, new Map(groups.map((g) => [g.id, g])));
 }
 
 /**

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -106,7 +106,7 @@ export function applyGroupEffects(layers: GeoLibreLayer[], groups: LayerGroup[])
  */
 function foldGroupChain(
   layer: GeoLibreLayer,
-  groupById: Map<string, LayerGroup>,
+  groupById: ReadonlyMap<string, LayerGroup>,
 ): { visible: boolean; opacity: number } {
   let visible = layer.visible;
   let opacity = layer.opacity;
@@ -132,18 +132,25 @@ function foldGroupChain(
  * instead.
  *
  * @param layer The layer to fold.
- * @param groups Group definitions.
+ * @param groups Group definitions, or an already-built id → group map. Callers
+ *   in a render path that fold many layers against the same groups (the layer
+ *   panel) should pass a memoized map, since the array form rebuilds one per
+ *   call.
  * @returns The effective render state (the layer's own values when it is
  *   ungrouped or its `groupId` is dangling).
  */
 export function effectiveLayerRenderState(
   layer: GeoLibreLayer,
-  groups: LayerGroup[],
+  groups: LayerGroup[] | ReadonlyMap<string, LayerGroup>,
 ): { visible: boolean; opacity: number } {
-  if (groups.length === 0 || !layer.groupId) {
+  const size = Array.isArray(groups) ? groups.length : groups.size;
+  if (size === 0 || !layer.groupId) {
     return { visible: layer.visible, opacity: layer.opacity };
   }
-  return foldGroupChain(layer, new Map(groups.map((g) => [g.id, g])));
+  return foldGroupChain(
+    layer,
+    Array.isArray(groups) ? new Map(groups.map((g) => [g.id, g])) : groups,
+  );
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -17,6 +17,7 @@ import {
 import {
   isRasterControlStoreLayer,
   rememberLocalRasterPath,
+  rememberPushedRasterRenderState,
   rendersNativeMapLibreLayer,
   resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
@@ -591,7 +592,10 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
         // A parent group's visibility/opacity never touch the child layer's
         // own fields, so replay the folded values — otherwise a project saved
         // with a hidden group reopens with its rasters painted on the map.
+        // Recorded so the first control event after the restore reads them as
+        // this replay's echo rather than as a control-side edit.
         const effective = effectiveLayerRenderState(layer, restoredGroups);
+        rememberPushedRasterRenderState(layer.id, effective);
 
         pending.push(
           control

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -566,7 +566,11 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
         if (!storeLayerIds.has(info.id)) control.removeRaster(info.id);
       }
 
-      const restoredGroups = useAppStore.getState().layerGroups;
+      // Built once here rather than handed to effectiveLayerRenderState as an
+      // array, which would rebuild it for every grouped raster in the loop.
+      const restoredGroups = new Map(
+        useAppStore.getState().layerGroups.map((group) => [group.id, group] as const),
+      );
       for (const layer of useAppStore.getState().layers) {
         if (!isRasterControlStoreLayer(layer)) continue;
         if (control.getRaster(layer.id)) continue;

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -17,7 +17,7 @@ import {
 import {
   isRasterControlStoreLayer,
   rememberLocalRasterPath,
-  rememberPushedRasterRenderState,
+  rememberControlRasterRenderState,
   rendersNativeMapLibreLayer,
   resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
@@ -595,7 +595,7 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
         // Recorded so the first control event after the restore reads them as
         // this replay's echo rather than as a control-side edit.
         const effective = effectiveLayerRenderState(layer, restoredGroups);
-        rememberPushedRasterRenderState(layer.id, effective);
+        rememberControlRasterRenderState(layer.id, effective);
 
         pending.push(
           control

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -1,4 +1,4 @@
-import { styleValue, useAppStore } from "@geolibre/core";
+import { effectiveLayerRenderState, styleValue, useAppStore } from "@geolibre/core";
 import type { Layer } from "@deck.gl/core";
 import type {
   RasterControl,
@@ -565,6 +565,7 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
         if (!storeLayerIds.has(info.id)) control.removeRaster(info.id);
       }
 
+      const restoredGroups = useAppStore.getState().layerGroups;
       for (const layer of useAppStore.getState().layers) {
         if (!isRasterControlStoreLayer(layer)) continue;
         if (control.getRaster(layer.id)) continue;
@@ -587,6 +588,11 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
           continue;
         }
 
+        // A parent group's visibility/opacity never touch the child layer's
+        // own fields, so replay the folded values — otherwise a project saved
+        // with a hidden group reopens with its rasters painted on the map.
+        const effective = effectiveLayerRenderState(layer, restoredGroups);
+
         pending.push(
           control
             .addRaster(source, {
@@ -594,8 +600,8 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
               name: layer.name,
               state: {
                 ...savedRasterState(layer),
-                opacity: layer.opacity,
-                visible: layer.visible,
+                opacity: effective.opacity,
+                visible: effective.visible,
                 // The zoom range lives on layer.style (the shared Style-panel
                 // control), not in metadata.rasterState, so it is replayed here
                 // to survive a project reload / map reinitialisation.

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -1,4 +1,11 @@
-import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, styleValue, useAppStore } from "@geolibre/core";
+import {
+  applyGroupEffects,
+  DEFAULT_LAYER_STYLE,
+  effectiveLayerRenderState,
+  type GeoLibreLayer,
+  styleValue,
+  useAppStore,
+} from "@geolibre/core";
 import type { RasterLayerInfo, RasterLayerState, RenderEngine } from "maplibre-gl-raster";
 
 export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
@@ -240,6 +247,8 @@ export function syncRasterLayersToStoreWithOptions(
   const infos = control.getRasters();
   const infoIds = new Set(infos.map((info) => info.id));
   const panelCollapsed = rasterPanelCollapsedFromControl(control);
+  // Nothing below adds or edits a group, so one read covers the whole pass.
+  const groups = useAppStore.getState().layerGroups;
 
   syncingLayersToStore = true;
   try {
@@ -272,9 +281,21 @@ export function syncRasterLayersToStoreWithOptions(
       const metadata =
         Object.keys(preserved).length > 0 ? { ...layer.metadata, ...preserved } : layer.metadata;
 
+      // wireRasterStoreSync pushes the *group-folded* visibility/opacity at the
+      // control, so a control that reports those values back is echoing the
+      // group, not recording a user edit. Mirroring the echo would burn a
+      // hidden group's `false` into the layer's own `visible`, leaving it
+      // hidden after the group is shown again. Only a value that differs from
+      // the fold is a genuine control-side change.
+      const effective = effectiveLayerRenderState(existing, groups);
+      const visible = layer.visible === effective.visible ? existing.visible : layer.visible;
+      const opacity = numbersEqual(layer.opacity, effective.opacity)
+        ? existing.opacity
+        : layer.opacity;
+
       if (
-        existing.visible !== layer.visible ||
-        existing.opacity !== layer.opacity ||
+        existing.visible !== visible ||
+        existing.opacity !== opacity ||
         existing.sourcePath !== layer.sourcePath ||
         !recordsEqual(existing.source, layer.source) ||
         !recordsEqual(existing.metadata, metadata)
@@ -283,10 +304,10 @@ export function syncRasterLayersToStoreWithOptions(
           // Replace metadata wholesale so stale keys (error, bounds) cannot
           // survive a raster being swapped out under the same id.
           metadata,
-          opacity: layer.opacity,
+          opacity,
           source: layer.source,
           sourcePath: layer.sourcePath,
-          visible: layer.visible,
+          visible,
         });
       }
     }
@@ -314,7 +335,7 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
       !activeControl ||
       syncingLayersToStore ||
       isRasterStoreSyncSuspended() ||
-      state.layers === previous.layers
+      (state.layers === previous.layers && state.layerGroups === previous.layerGroups)
     ) {
       return;
     }
@@ -323,9 +344,17 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
     // when the previous snapshot held no control-managed rasters at all.
     if (!previous.layers.some(isRasterControlStoreLayer)) return;
 
-    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+    // Diff the *group-folded* visibility and opacity, not the layers' own
+    // fields: hiding or fading a parent group never touches a child layer, so
+    // watching `layer.visible` alone leaves a grouped raster on the map
+    // (GeoLibre#1717). A deck.gl-rendered raster has no MapLibre style layer
+    // for layer-sync to toggle, so this control push is its only channel.
+    const currentById = new Map(
+      applyGroupEffects(state.layers, state.layerGroups).map((layer) => [layer.id, layer]),
+    );
+    const previousLayers = applyGroupEffects(previous.layers, previous.layerGroups);
     runWithRasterStoreSyncSuspended(() => {
-      for (const layer of previous.layers) {
+      for (const layer of previousLayers) {
         if (!isRasterControlStoreLayer(layer)) continue;
 
         const current = currentById.get(layer.id);
@@ -614,6 +643,14 @@ function valuesEqual(left: unknown, right: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Opacity round-trips through the control as a float that a group fold has
+// multiplied, so compare the echo with a tolerance rather than by identity —
+// a last-bit difference would read as a user edit and overwrite the layer's
+// own opacity with the folded one.
+function numbersEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) < 1e-9;
 }
 
 function serializableRasterState(state: RasterLayerState): Record<string, unknown> {

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -88,32 +88,34 @@ let syncingLayersToStore = false;
 // control emits raster* events synchronously from those calls, and syncing
 // mid-mutation would observe a partially updated layer list.
 let storeSyncSuspended = 0;
-// The group-folded visibility/opacity this module last forced on each raster,
-// by layer id. A parent group's state never lives on the child layer, so it
-// only reaches a deck.gl raster by being pushed at the control -- which then
-// reports it back on every later event. Recording what was pushed is what lets
-// the control->store mirror tell that echo from a real control-side edit; see
-// syncRasterLayersToStoreWithOptions. Keyed on the *pushed* value rather than
-// on re-deriving the fold so a user edit that numerically coincides with the
-// fold is still recorded: the only value this misses is the one the control
-// already holds, which is a no-op edit.
-const pushedRenderState = new Map<string, { visible?: boolean; opacity?: number }>();
+// The last visibility/opacity this module knows each raster to hold in the
+// control, by layer id -- whether it got there by being pushed (a group fold,
+// which never lives on the child layer and so reaches a deck.gl raster only
+// through the control) or by a control-side edit this module accepted. The
+// control reports its state back on every later event, and comparing against
+// this is what lets syncRasterLayersToStoreWithOptions tell that echo from a
+// real edit. It must track *accepted* values too, not just pushed ones: with
+// only the pushed value recorded, a user toggling a control's checkbox away
+// and back would land on the pushed value again and have that second edit
+// misread as an echo and dropped.
+const controlRenderState = new Map<string, { visible?: boolean; opacity?: number }>();
 
 /**
- * Record a group-folded value handed to the control, so the next
- * control->store mirror can recognize it as an echo rather than a user edit.
- * Called by this module's store subscriber and by the project-restore replay
- * in maplibre-raster, the two places that force folded values on the control.
+ * Record what the control now holds for a raster, so the next control->store
+ * mirror can recognize it as an echo rather than a user edit. Called wherever
+ * this module forces a group-folded value on the control -- its own store
+ * subscriber and the project-restore replay in maplibre-raster -- and again
+ * whenever the mirror accepts a control-side edit.
  *
  * @param id - The raster/store layer id.
- * @param patch - The folded fields just pushed.
+ * @param patch - The fields the control now holds.
  */
-export function rememberPushedRasterRenderState(
+export function rememberControlRasterRenderState(
   id: string,
   patch: { visible?: boolean; opacity?: number },
 ): void {
-  const existing = pushedRenderState.get(id);
-  pushedRenderState.set(id, existing ? { ...existing, ...patch } : { ...patch });
+  const existing = controlRenderState.get(id);
+  controlRenderState.set(id, existing ? { ...existing, ...patch } : { ...patch });
 }
 
 /**
@@ -276,8 +278,8 @@ export function syncRasterLayersToStoreWithOptions(
 
   // A raster the control no longer holds can never echo again, and its id
   // could otherwise mis-suppress a future raster added under the same id.
-  for (const id of pushedRenderState.keys()) {
-    if (!infoIds.has(id)) pushedRenderState.delete(id);
+  for (const id of controlRenderState.keys()) {
+    if (!infoIds.has(id)) controlRenderState.delete(id);
   }
 
   syncingLayersToStore = true;
@@ -311,20 +313,24 @@ export function syncRasterLayersToStoreWithOptions(
       const metadata =
         Object.keys(preserved).length > 0 ? { ...layer.metadata, ...preserved } : layer.metadata;
 
-      // A control still reporting the group-folded value this module forced on
-      // it is echoing the group, not recording a user edit. Mirroring the echo
+      // A control still reporting the value this module last knows it to hold
+      // is echoing that value, not recording a user edit. Mirroring the echo
       // would burn a hidden group's `false` into the layer's own `visible`,
-      // leaving it hidden after the group is shown again. Any other value is a
-      // genuine control-side change and is recorded as before.
-      const pushed = pushedRenderState.get(layer.id);
-      const visible =
-        pushed?.visible !== undefined && layer.visible === pushed.visible
-          ? existing.visible
-          : layer.visible;
-      const opacity =
-        pushed?.opacity !== undefined && numbersEqual(layer.opacity, pushed.opacity)
-          ? existing.opacity
-          : layer.opacity;
+      // leaving it hidden after the group is shown again. Anything else is a
+      // genuine control-side change: take it, and remember it so the control's
+      // next report is compared against the value it actually holds now.
+      const known = controlRenderState.get(layer.id);
+      const visibleIsEcho = known?.visible !== undefined && layer.visible === known.visible;
+      const opacityIsEcho =
+        known?.opacity !== undefined && numbersEqual(layer.opacity, known.opacity);
+      const visible = visibleIsEcho ? existing.visible : layer.visible;
+      const opacity = opacityIsEcho ? existing.opacity : layer.opacity;
+      if (!visibleIsEcho || !opacityIsEcho) {
+        rememberControlRasterRenderState(layer.id, {
+          ...(visibleIsEcho ? {} : { visible: layer.visible }),
+          ...(opacityIsEcho ? {} : { opacity: layer.opacity }),
+        });
+      }
 
       if (
         existing.visible !== visible ||
@@ -393,17 +399,17 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
         const current = currentById.get(layer.id);
         if (!current) {
           activeControl.removeRaster(layer.id);
-          pushedRenderState.delete(layer.id);
+          controlRenderState.delete(layer.id);
           continue;
         }
 
         if (current.visible !== layer.visible) {
           activeControl.setVisible(layer.id, current.visible);
-          rememberPushedRasterRenderState(layer.id, { visible: current.visible });
+          rememberControlRasterRenderState(layer.id, { visible: current.visible });
         }
         if (current.opacity !== layer.opacity) {
           activeControl.setRasterState(layer.id, { opacity: current.opacity });
-          rememberPushedRasterRenderState(layer.id, { opacity: current.opacity });
+          rememberControlRasterRenderState(layer.id, { opacity: current.opacity });
         }
         const patch = rasterStatePatch(layer, current);
         if (patch) activeControl.setRasterState(layer.id, patch);
@@ -502,7 +508,7 @@ export function unwireRasterStoreSync(): void {
   syncedControl = null;
   // The successor control has been told nothing, so no echo of this one's
   // pushes can arrive; a stale record would only mis-suppress its first sync.
-  pushedRenderState.clear();
+  controlRenderState.clear();
 }
 
 /**

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -1,7 +1,6 @@
 import {
   applyGroupEffects,
   DEFAULT_LAYER_STYLE,
-  effectiveLayerRenderState,
   type GeoLibreLayer,
   styleValue,
   useAppStore,
@@ -89,6 +88,33 @@ let syncingLayersToStore = false;
 // control emits raster* events synchronously from those calls, and syncing
 // mid-mutation would observe a partially updated layer list.
 let storeSyncSuspended = 0;
+// The group-folded visibility/opacity this module last forced on each raster,
+// by layer id. A parent group's state never lives on the child layer, so it
+// only reaches a deck.gl raster by being pushed at the control -- which then
+// reports it back on every later event. Recording what was pushed is what lets
+// the control->store mirror tell that echo from a real control-side edit; see
+// syncRasterLayersToStoreWithOptions. Keyed on the *pushed* value rather than
+// on re-deriving the fold so a user edit that numerically coincides with the
+// fold is still recorded: the only value this misses is the one the control
+// already holds, which is a no-op edit.
+const pushedRenderState = new Map<string, { visible?: boolean; opacity?: number }>();
+
+/**
+ * Record a group-folded value handed to the control, so the next
+ * control->store mirror can recognize it as an echo rather than a user edit.
+ * Called by this module's store subscriber and by the project-restore replay
+ * in maplibre-raster, the two places that force folded values on the control.
+ *
+ * @param id - The raster/store layer id.
+ * @param patch - The folded fields just pushed.
+ */
+export function rememberPushedRasterRenderState(
+  id: string,
+  patch: { visible?: boolean; opacity?: number },
+): void {
+  const existing = pushedRenderState.get(id);
+  pushedRenderState.set(id, existing ? { ...existing, ...patch } : { ...patch });
+}
 
 /**
  * Detects a layer panel entry owned by the maplibre-gl-raster control.
@@ -247,8 +273,12 @@ export function syncRasterLayersToStoreWithOptions(
   const infos = control.getRasters();
   const infoIds = new Set(infos.map((info) => info.id));
   const panelCollapsed = rasterPanelCollapsedFromControl(control);
-  // Nothing below adds or edits a group, so one read covers the whole pass.
-  const groups = useAppStore.getState().layerGroups;
+
+  // A raster the control no longer holds can never echo again, and its id
+  // could otherwise mis-suppress a future raster added under the same id.
+  for (const id of pushedRenderState.keys()) {
+    if (!infoIds.has(id)) pushedRenderState.delete(id);
+  }
 
   syncingLayersToStore = true;
   try {
@@ -281,17 +311,20 @@ export function syncRasterLayersToStoreWithOptions(
       const metadata =
         Object.keys(preserved).length > 0 ? { ...layer.metadata, ...preserved } : layer.metadata;
 
-      // wireRasterStoreSync pushes the *group-folded* visibility/opacity at the
-      // control, so a control that reports those values back is echoing the
-      // group, not recording a user edit. Mirroring the echo would burn a
-      // hidden group's `false` into the layer's own `visible`, leaving it
-      // hidden after the group is shown again. Only a value that differs from
-      // the fold is a genuine control-side change.
-      const effective = effectiveLayerRenderState(existing, groups);
-      const visible = layer.visible === effective.visible ? existing.visible : layer.visible;
-      const opacity = numbersEqual(layer.opacity, effective.opacity)
-        ? existing.opacity
-        : layer.opacity;
+      // A control still reporting the group-folded value this module forced on
+      // it is echoing the group, not recording a user edit. Mirroring the echo
+      // would burn a hidden group's `false` into the layer's own `visible`,
+      // leaving it hidden after the group is shown again. Any other value is a
+      // genuine control-side change and is recorded as before.
+      const pushed = pushedRenderState.get(layer.id);
+      const visible =
+        pushed?.visible !== undefined && layer.visible === pushed.visible
+          ? existing.visible
+          : layer.visible;
+      const opacity =
+        pushed?.opacity !== undefined && numbersEqual(layer.opacity, pushed.opacity)
+          ? existing.opacity
+          : layer.opacity;
 
       if (
         existing.visible !== visible ||
@@ -360,14 +393,17 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
         const current = currentById.get(layer.id);
         if (!current) {
           activeControl.removeRaster(layer.id);
+          pushedRenderState.delete(layer.id);
           continue;
         }
 
         if (current.visible !== layer.visible) {
           activeControl.setVisible(layer.id, current.visible);
+          rememberPushedRasterRenderState(layer.id, { visible: current.visible });
         }
         if (current.opacity !== layer.opacity) {
           activeControl.setRasterState(layer.id, { opacity: current.opacity });
+          rememberPushedRasterRenderState(layer.id, { opacity: current.opacity });
         }
         const patch = rasterStatePatch(layer, current);
         if (patch) activeControl.setRasterState(layer.id, patch);
@@ -464,6 +500,9 @@ export function unwireRasterStoreSync(): void {
   storeUnsubscribe?.();
   storeUnsubscribe = null;
   syncedControl = null;
+  // The successor control has been told nothing, so no echo of this one's
+  // pushes can arrive; a stale record would only mis-suppress its first sync.
+  pushedRenderState.clear();
 }
 
 /**

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -6,6 +6,7 @@ import {
   applyProjectToStore,
   buildLayerTree,
   createEmptyProject,
+  effectiveLayerRenderState,
   normalizeGroupContiguity,
   parseProject,
   projectFromStore,
@@ -126,6 +127,36 @@ describe("applyGroupEffects", () => {
     const result = applyGroupEffects(layers, groups);
     assert.equal(result[0].visible, false);
     assert.equal(result[0].opacity, 0.1);
+  });
+});
+
+describe("effectiveLayerRenderState", () => {
+  it("folds the whole group chain, matching applyGroupEffects", () => {
+    const child = layer("a", { groupId: "child", opacity: 0.8 });
+    const groups = [
+      group("parent", { opacity: 0.5, visible: false }),
+      group("child", { parentId: "parent", opacity: 0.25 }),
+    ];
+    assert.deepEqual(effectiveLayerRenderState(child, groups), {
+      visible: false,
+      opacity: 0.1,
+    });
+  });
+
+  it("returns the layer's own values when it is ungrouped", () => {
+    const orphan = layer("a", { opacity: 0.3, visible: false });
+    assert.deepEqual(effectiveLayerRenderState(orphan, [group("g", { visible: false })]), {
+      visible: false,
+      opacity: 0.3,
+    });
+  });
+
+  it("ignores a dangling groupId rather than dropping the layer", () => {
+    const dangling = layer("a", { groupId: "gone", opacity: 0.6 });
+    assert.deepEqual(effectiveLayerRenderState(dangling, [group("g", { opacity: 0.5 })]), {
+      visible: true,
+      opacity: 0.6,
+    });
   });
 });
 

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -620,6 +620,109 @@ describe("wireRasterStoreSync", () => {
   });
 });
 
+// A group's visibility/opacity never touch the child layer's own fields, and a
+// deck.gl-rendered raster has no MapLibre style layer for layer-sync to toggle,
+// so the control push below is the only thing that can hide it (GeoLibre#1717).
+describe("wireRasterStoreSync with layer groups", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [], layerGroups: [] });
+  });
+
+  afterEach(() => {
+    unwireRasterStoreSync();
+    useAppStore.setState({ layerGroups: [] });
+  });
+
+  it("hides a raster through the control when its parent group is hidden", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    // Joining a visible group changes nothing about how the raster renders.
+    assert.deepEqual(calls, []);
+
+    useAppStore.getState().setLayerGroupVisibility(groupId, false);
+    assert.deepEqual(calls, [{ method: "setVisible", args: ["raster-1", false] }]);
+
+    calls.length = 0;
+    useAppStore.getState().setLayerGroupVisibility(groupId, true);
+    assert.deepEqual(calls, [{ method: "setVisible", args: ["raster-1", true] }]);
+  });
+
+  it("multiplies a parent group's opacity into the pushed raster opacity", () => {
+    const { control, calls } = fakeControl([rasterInfo({ state: rasterState({ opacity: 0.5 }) })]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    calls.length = 0;
+    useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
+
+    assert.deepEqual(calls, [{ method: "setRasterState", args: ["raster-1", { opacity: 0.2 }] }]);
+  });
+
+  it("hides a raster dragged into an already hidden group", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1");
+    useAppStore.getState().setLayerGroupVisibility(groupId, false);
+    calls.length = 0;
+    useAppStore.getState().moveLayerToGroup("raster-1", groupId);
+
+    assert.deepEqual(calls, [{ method: "setVisible", args: ["raster-1", false] }]);
+  });
+
+  it("keeps the layer's own visibility when the control echoes the group fold", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    useAppStore.getState().setLayerGroupVisibility(groupId, false);
+
+    // Any later control event (a colormap edit, a header load) mirrors the
+    // control's whole raster list back. It now reports the folded `false`, and
+    // burning that into the layer would leave it hidden after the group is
+    // shown again.
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ visible: false }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].visible, true);
+  });
+
+  it("keeps the layer's own opacity when the control echoes the group fold", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
+
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ opacity: 0.4 }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].opacity, 1);
+  });
+
+  it("still records a genuine control-side hide made under a visible group", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ visible: false }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].visible, false);
+  });
+});
+
 describe("removeRasterStoreLayers", () => {
   beforeEach(() => {
     useAppStore.setState({ layers: [] });

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -709,6 +709,24 @@ describe("wireRasterStoreSync with layer groups", () => {
     assert.equal(useAppStore.getState().layers[0].opacity, 1);
   });
 
+  it("still records a control-side opacity edit made under a faded group", () => {
+    const { control } = fakeControl([rasterInfo({ state: rasterState({ opacity: 0.5 }) })]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
+
+    // The guard suppresses only the 0.2 this module pushed (0.5 * 0.4). The
+    // user dragging the control's own opacity slider reports something else,
+    // which must still reach the layer's own opacity.
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ opacity: 0.9 }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].opacity, 0.9);
+  });
+
   it("still records a genuine control-side hide made under a visible group", () => {
     const { control } = fakeControl([rasterInfo()]);
     syncRasterLayersToStore(control);

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -727,6 +727,28 @@ describe("wireRasterStoreSync with layer groups", () => {
     assert.equal(useAppStore.getState().layers[0].opacity, 0.9);
   });
 
+  it("records a control-side toggle away from the pushed value and back again", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["raster-1"]);
+    useAppStore.getState().setLayerGroupVisibility(groupId, false);
+
+    // The user checks the control's own box, then unchecks it. The second edit
+    // lands back on the value the group fold pushed, so a guard that only ever
+    // remembered the *pushed* value would read it as an echo and drop it --
+    // leaving the raster to reappear when the group is shown again.
+    syncRasterLayersToStore(control);
+    assert.equal(useAppStore.getState().layers[0].visible, true);
+
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ visible: false }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].visible, false);
+  });
+
   it("still records a genuine control-side hide made under a visible group", () => {
     const { control } = fakeControl([rasterInfo()]);
     syncRasterLayersToStore(control);


### PR DESCRIPTION
Fixes #1717

## The bug

Turning a group off left its COG layers painted on the map. Reported against both the desktop 2.4 build and https://web.geolibre.app.

## Root cause

`wireRasterStoreSync` (`packages/plugins/src/plugins/raster-layer-sync.ts`) watched `state.layers` and diffed each layer's own `visible`/`opacity`. Group visibility and opacity live in `state.layerGroups` and deliberately never mutate a child layer, so the subscriber returned at its `state.layers === previous.layers` guard and the control was never told.

For an ordinary control-painted vector this was already masked: `layer-sync` applies the folded visibility straight to the native MapLibre layers (#1590). A deck.gl-rendered raster has no MapLibre style layer to toggle (it draws inside a `deck-layer-group-*`), so the control push is its only channel, and the raster stayed on the map.

Reproduced with the `maplibre-gl-raster` (GPU) engine. The `cog-tiler-wasm` and `titiler` engines add a real MapLibre raster layer and so were already hidden correctly, which is why this looked engine-specific.

## The fix

- The subscriber wakes on `layerGroups` changes and diffs the **group-folded** values, so hiding or fading a group reaches the control.
- `restoreRasterLayers` replays the folded values, so a project saved with a hidden group no longer reopens with its rasters on the map.
- Because the control now holds folded values, the control -> store mirror would burn a hidden group's `false` into the layer's own `visible` on the next control event, leaving it hidden after the group was shown again. It now ignores a reported value matching the fold and records only one that differs, which is a genuine control-side edit.
- Adds `effectiveLayerRenderState` to `@geolibre/core`, the single-layer form of `applyGroupEffects`, so the fold (nested-group walk plus its cycle guard) has one definition.

## Verification

Driven in the real app (`npm run dev`) with Playwright, using the DEM sample COG (`https://data.source.coop/giswqs/opengeos/dem.tif`) on the GPU engine, in **both light and dark themes**:

- Hide the group -> raster leaves the map; show it -> the raster returns, and the layer's own eye stays on throughout.
- Group opacity 0.40 -> the raster fades while the layer's own opacity stays 1.00.
- Reload with the autosave restore -> the raster stays off the map under the hidden group.
- Unchecking the raster control's own checkbox under a **visible** group still flips the layer's own visibility, so the echo guard does not swallow real edits.

`npm run test:frontend` (5230 pass), `npm run build`, and `pre-commit run --files <changed>` are green. Adds nine regression tests across `tests/raster-layer-sync.test.ts` and `tests/layer-groups.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Raster layers now correctly inherit visibility and opacity from nested layer groups.
  * Restored raster layers retain their groups’ effective appearance.
  * Moving rasters between groups immediately applies the correct settings.
  * Group-derived settings no longer overwrite raster-specific properties.
  * Genuine visibility and opacity changes synchronize correctly.
  * The layer panel indicates when an ancestor group hides a layer.
  * Ungrouped layers and layers with missing group references retain their individual settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->