### PR TITLE
fix(legend): draw proportional size ramps with the layer's marker

### DIFF
--- a/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
+++ b/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
@@ -6,7 +6,7 @@
  * Adapted from the GeoLens viewer legend design (Apache-2.0) to GeoLibre's
  * layer model.
  */
-import { drawMarkerPath, type MarkerShape } from "@geolibre/core";
+import { drawMarkerPath, resolveSvgSource, type MarkerShape } from "@geolibre/core";
 import { Image as RasterIcon } from "lucide-react";
 import { useEffect, useRef } from "react";
 import type { LayerSwatchShape } from "../../lib/layer-swatch";
@@ -15,8 +15,17 @@ import type { LegendMarker } from "../../lib/print-layout";
 /** Neutral outline that reads on both light and dark themes. */
 const OUTLINE = "rgba(107,114,128,0.6)";
 
-/** Largest radius / stroke width a proportional legend symbol is drawn at (px). */
-const MAX_SWATCH_RADIUS = 12;
+/**
+ * Largest radius / stroke width a proportional legend symbol is drawn at (px).
+ *
+ * A proportional row's `size` IS the radius the map paints for that value (and,
+ * for markers, half the sprite's on-screen width — see `markerIconSizeValue` in
+ * `@geolibre/map`), so below the cap the legend symbol is drawn at exactly the
+ * size the reader sees on the map. The radius cap matches the style editor's
+ * default max radius (24) so the common ramp is 1:1 rather than shrunk to
+ * roughly half scale; ramps configured past it scale down as one entry.
+ */
+const MAX_SWATCH_RADIUS = 24;
 const MAX_SWATCH_STROKE = 8;
 
 /**
@@ -111,50 +120,91 @@ export function GeometrySwatch({
   );
 }
 
+/** Chip edge length for a marker with no proportional size (px). */
+const MARKER_CHIP_SIZE = 14;
+
 /**
  * A point-marker preview: built-in shapes are traced with the same
  * {@link drawMarkerPath} the map's sprite baker uses, so the legend chip and
- * the on-map marker cannot disagree; custom SVG markers render as an image.
+ * the on-map marker cannot disagree; custom SVG markers render as an image
+ * whose source is resolved by the shared {@link resolveSvgSource} — inline
+ * markup, a `data:` URL, and an `https:` URL are all valid `markerSvg` inputs,
+ * and re-encoding the latter two as data URLs left the chip blank.
+ *
+ * `size` (a proportional row's radius) and `maxSize` (the entry's largest)
+ * scale the marker exactly like {@link GeometrySwatch} scales a circle, so a
+ * marker layer's size ramp reads at the map's true symbol widths.
  */
-export function MarkerSwatch({ marker, opacity = 1 }: { marker: LegendMarker; opacity?: number }) {
+export function MarkerSwatch({
+  marker,
+  size,
+  maxSize,
+  opacity = 1,
+}: {
+  marker: LegendMarker;
+  size?: number;
+  maxSize?: number;
+  opacity?: number;
+}) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const style = opacity < 1 ? { opacity } : undefined;
+  // The map draws a marker at the diameter its proportional radius spans, so
+  // the chip box is 2×radius after the entry's shared fit-to-legend scale.
+  const box =
+    size !== undefined
+      ? Math.max(4, Math.round(size * swatchScale(maxSize, size, MAX_SWATCH_RADIUS) * 2))
+      : MARKER_CHIP_SIZE;
+  // One column width per entry, so labels stay aligned when rows differ in size.
+  const boxWidth =
+    size !== undefined
+      ? Math.max(
+          box,
+          Math.round(
+            Math.max(maxSize ?? size, size) * swatchScale(maxSize, size, MAX_SWATCH_RADIUS) * 2,
+          ),
+        )
+      : MARKER_CHIP_SIZE;
 
   useEffect(() => {
     if (marker.shape === "custom") return;
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
     if (!canvas || !ctx) return;
-    const size = canvas.width;
-    ctx.clearRect(0, 0, size, size);
-    drawMarkerPath(ctx, marker.shape as MarkerShape, size);
+    const edge = canvas.width;
+    ctx.clearRect(0, 0, edge, edge);
+    drawMarkerPath(ctx, marker.shape as MarkerShape, edge);
     ctx.fillStyle = marker.color;
     ctx.fill();
     ctx.strokeStyle = OUTLINE;
     ctx.lineWidth = 1;
     ctx.stroke();
-  }, [marker]);
+  }, [marker, box]);
 
-  if (marker.shape === "custom" && marker.svg) {
+  const svgSource = marker.shape === "custom" ? resolveSvgSource(marker.svg ?? "") : null;
+  if (marker.shape === "custom" && svgSource) {
     return (
-      <img
+      <span
         aria-hidden="true"
-        className="h-3.5 w-3.5 shrink-0 object-contain"
-        style={style}
-        alt=""
-        src={`data:image/svg+xml;utf8,${encodeURIComponent(marker.svg)}`}
-      />
+        className="flex shrink-0 items-center justify-center"
+        style={{ width: boxWidth, ...style }}
+      >
+        <img
+          className="object-contain"
+          style={{ width: box, height: box }}
+          alt=""
+          src={svgSource}
+        />
+      </span>
     );
   }
   return (
-    <canvas
-      ref={canvasRef}
-      width={14}
-      height={14}
-      className="h-3.5 w-3.5 shrink-0"
-      style={style}
+    <span
       aria-hidden="true"
-    />
+      className="flex shrink-0 items-center justify-center"
+      style={{ width: boxWidth, ...style }}
+    >
+      <canvas ref={canvasRef} width={box} height={box} style={{ width: box, height: box }} />
+    </span>
   );
 }
 

--- a/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
+++ b/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
@@ -150,19 +150,12 @@ export function MarkerSwatch({
   const style = opacity < 1 ? { opacity } : undefined;
   // The map draws a marker at the diameter its proportional radius spans, so
   // the chip box is 2×radius after the entry's shared fit-to-legend scale.
-  const box =
-    size !== undefined
-      ? Math.max(4, Math.round(size * swatchScale(maxSize, size, MAX_SWATCH_RADIUS) * 2))
-      : MARKER_CHIP_SIZE;
+  const scale = size !== undefined ? swatchScale(maxSize, size, MAX_SWATCH_RADIUS) : 1;
+  const box = size !== undefined ? Math.max(4, Math.round(size * scale * 2)) : MARKER_CHIP_SIZE;
   // One column width per entry, so labels stay aligned when rows differ in size.
   const boxWidth =
     size !== undefined
-      ? Math.max(
-          box,
-          Math.round(
-            Math.max(maxSize ?? size, size) * swatchScale(maxSize, size, MAX_SWATCH_RADIUS) * 2,
-          ),
-        )
+      ? Math.max(box, Math.round(Math.max(maxSize ?? size, size) * scale * 2))
       : MARKER_CHIP_SIZE;
 
   const svgSource = marker.shape === "custom" ? resolveSvgSource(marker.svg ?? "") : null;

--- a/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
+++ b/apps/geolibre-desktop/src/components/legend/LegendSwatch.tsx
@@ -165,8 +165,14 @@ export function MarkerSwatch({
         )
       : MARKER_CHIP_SIZE;
 
+  const svgSource = marker.shape === "custom" ? resolveSvgSource(marker.svg ?? "") : null;
+
   useEffect(() => {
-    if (marker.shape === "custom") return;
+    // A custom marker whose source resolved renders as an <img> below; one that
+    // did not (an unsupported scheme — `pointMarkerSwatch` only rejects EMPTY
+    // markup) falls through to this canvas, where drawMarkerPath traces its
+    // documented default circle rather than leaving the chip blank.
+    if (marker.shape === "custom" && svgSource) return;
     const canvas = canvasRef.current;
     const ctx = canvas?.getContext("2d");
     if (!canvas || !ctx) return;
@@ -178,9 +184,8 @@ export function MarkerSwatch({
     ctx.strokeStyle = OUTLINE;
     ctx.lineWidth = 1;
     ctx.stroke();
-  }, [marker, box]);
+  }, [marker, box, svgSource]);
 
-  const svgSource = marker.shape === "custom" ? resolveSvgSource(marker.svg ?? "") : null;
   if (marker.shape === "custom" && svgSource) {
     return (
       <span

--- a/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
+++ b/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
@@ -931,7 +931,12 @@ function LegendClassRow({
       )}
       <div className="flex items-center gap-1.5">
         {row.marker ? (
-          <MarkerSwatch marker={row.marker} opacity={entry.opacity} />
+          <MarkerSwatch
+            marker={row.marker}
+            size={row.size}
+            maxSize={maxRowSize > 0 ? maxRowSize : undefined}
+            opacity={entry.opacity}
+          />
         ) : (
           <GeometrySwatch
             shape={row.shape}

--- a/apps/geolibre-desktop/src/lib/auto-legend.ts
+++ b/apps/geolibre-desktop/src/lib/auto-legend.ts
@@ -457,6 +457,8 @@ function proportionalSizeRows(
   locale: string | undefined,
   /** Field caption for the block, when the entry's own caption names another. */
   caption?: string,
+  /** The layer's point marker, so the ramp shows the symbol the map draws. */
+  marker?: LegendMarker,
 ): RawRow[] {
   const rowShape: LayerSwatchShape = shape === "line" ? "line" : "circle";
   return [0, 0.5, 1].map((ratio, index) => ({
@@ -464,6 +466,7 @@ function proportionalSizeRows(
     color,
     shape: rowShape,
     size: lerp(range.minRadius, range.maxRadius, ratio),
+    ...(marker ? { marker } : {}),
     ...(index === 0 && caption ? { caption } : {}),
   }));
 }
@@ -492,6 +495,8 @@ function sizeClassRows(
   rows: RawRow[],
   stops: VectorStyleStop[],
   range: ProportionalSizeRange,
+  /** The layer's point marker, so the ramp shows the symbol the map draws. */
+  marker?: LegendMarker,
 ): RawRow[] {
   return rows.map((row, index) => {
     const from = Number(stops[index]?.value);
@@ -499,7 +504,11 @@ function sizeClassRows(
     // The top class has no upper bound ("≥ x"): represent it at its lower bound.
     const representative = Number.isFinite(to) ? (from + to) / 2 : from;
     if (!Number.isFinite(representative)) return row;
-    return { ...row, size: proportionalSize(range, representative) };
+    return {
+      ...row,
+      size: proportionalSize(range, representative),
+      ...(marker ? { marker } : {}),
+    };
   });
 }
 
@@ -673,6 +682,11 @@ function vectorParts(
   // sizing on exactly the layers the map actually sizes. Only circles and line
   // strokes carry a size; polygon fills ignore it.
   const sizeRange = shape === "circle" || shape === "line" ? proportionalSizeRange(style) : null;
+  // A marker layer's proportional rows draw the marker (scaled by icon-size on
+  // the map), not a circle, so carry it onto every sized row. Lines never take a
+  // marker. Markers bake ONE sprite from markerColor, so a per-row color is not
+  // something the map renders here — the marker is the faithful symbol.
+  const sizeMarker = shape === "circle" ? pointMarkerSwatch(style)?.marker : undefined;
 
   if ((mode === "graduated" || mode === "categorized") && stops.length > 0) {
     const classProperty = styleValue(style, "vectorStyleProperty");
@@ -683,7 +697,9 @@ function vectorParts(
       sizeRange !== null && mode === "graduated" && sizeRange.property === classProperty;
     return {
       rows: [
-        ...(merged && sizeRange ? sizeClassRows(classRows, stops, sizeRange) : classRows),
+        ...(merged && sizeRange
+          ? sizeClassRows(classRows, stops, sizeRange, sizeMarker)
+          : classRows),
         ...(sizeRange && !merged
           ? proportionalSizeRows(
               sizeRange,
@@ -693,6 +709,7 @@ function vectorParts(
               // The entry caption already names the classified field; say which
               // field this second block sizes by so the two are not confused.
               sizeRange.property === classProperty ? undefined : sizeRange.property,
+              sizeMarker,
             )
           : []),
         ...diagrams,
@@ -715,6 +732,7 @@ function vectorParts(
                 shape,
                 locale,
                 sizeRange.property,
+                sizeMarker,
               )
             : []),
           ...diagrams,
@@ -737,6 +755,7 @@ function vectorParts(
                 shape,
                 locale,
                 sizeRange.property === parts.fieldLabel ? undefined : sizeRange.property,
+                sizeMarker,
               )
             : []),
           ...diagrams,
@@ -751,7 +770,14 @@ function vectorParts(
   // Single symbology: the size ramp IS the classification, so it carries the
   // field caption and replaces the single-swatch heading chip.
   const sizeRows = sizeRange
-    ? proportionalSizeRows(sizeRange, styleValue(style, "fillColor") || NEUTRAL, shape, locale)
+    ? proportionalSizeRows(
+        sizeRange,
+        styleValue(style, "fillColor") || NEUTRAL,
+        shape,
+        locale,
+        undefined,
+        sizeMarker,
+      )
     : [];
   const marker = pointMarkerSwatch(style);
   const headerSwatch = marker

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -1935,6 +1935,11 @@ function drawDataChart(
  * built-in shape recolored to the marker color. Falls back to a plain
  * `fallbackColor` square when a custom SVG has not been (or could not be)
  * preloaded, so the swatch is never blank.
+ *
+ * `boxed` frames a custom SVG so a light or transparent-edged icon still reads
+ * as a bounded swatch. A proportional size ramp passes false: there the varying
+ * icon size IS the information, and a frame around each step makes the rows read
+ * as nested squares instead of one growing symbol.
  */
 function drawLegendMarker(
   ctx: CanvasRenderingContext2D,
@@ -1944,16 +1949,18 @@ function drawLegendMarker(
   size: number,
   fallbackColor: string,
   markerIcons?: ReadonlyMap<string, CanvasImageSource>,
+  boxed = true,
 ): void {
   if (marker.shape === "custom") {
     const icon = marker.svg ? markerIcons?.get(marker.svg) : undefined;
     if (icon) {
       ctx.drawImage(icon, sx, sy, size, size);
-      // Border for parity with every other swatch (built-in shapes, the
-      // fallback square, fill/ramp squares), so a light or transparent-edged
-      // SVG still reads as a bounded swatch.
-      ctx.strokeStyle = BORDER;
-      ctx.strokeRect(sx, sy, size, size);
+      if (boxed) {
+        // Border for parity with every other swatch (built-in shapes, the
+        // fallback square, fill/ramp squares).
+        ctx.strokeStyle = BORDER;
+        ctx.strokeRect(sx, sy, size, size);
+      }
       return;
     }
     // SVG not available: fall back to a neutral color square.
@@ -1996,8 +2003,16 @@ function drawLegend(
   },
 ): number {
   const pad = unit * 1.4;
-  const rowH = unit * 2.6;
-  const swatch = unit * 2;
+  // Proportional-symbol rows are only as faithful as the box they fit in: a
+  // swatch column sized for a text-height color square crushes a 4 → 24 px ramp
+  // into near-identical dots. When any entry carries sized symbols, the whole
+  // box grows (uniformly, so rows stay evenly spaced) and the ramp reads at
+  // roughly the ratios the map draws.
+  const hasSizedSwatch = entries.some((entry) =>
+    entry.swatches.some((swatch) => swatch.size !== undefined),
+  );
+  const rowH = unit * (hasSizedSwatch ? 3.6 : 2.6);
+  const swatch = unit * (hasSizedSwatch ? 3 : 2);
   const titleSize = unit * 2;
   const labelSize = unit * 1.7;
   const title = opts.title.trim();
@@ -2148,7 +2163,23 @@ function drawLegend(
     const sx = x + pad;
     const sy = cy - swatch * 0.85;
     if (r.marker) {
-      drawLegendMarker(ctx, r.marker, sx, sy, swatch, r.color, opts.markerIcons);
+      // A sized marker row is a proportional symbol: the map scales the sprite
+      // through icon-size, so draw the marker at the same footprint the circle
+      // branch below would use (same center, edge = 2 × radius) rather than at
+      // the fixed swatch box, which would flatten the whole ramp.
+      const edge =
+        r.size !== undefined ? Math.max(unit * 0.7, r.size * rowScale[index]! * 2) : swatch;
+      const inset = (swatch - edge) / 2;
+      drawLegendMarker(
+        ctx,
+        r.marker,
+        sx + inset,
+        sy + inset,
+        edge,
+        r.color,
+        opts.markerIcons,
+        r.size === undefined,
+      );
     } else if (r.size !== undefined && r.color) {
       const radius = Math.max(unit * 0.35, r.size * rowScale[index]!);
       const cx = sx + swatch / 2;

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -2009,7 +2009,7 @@ function drawLegend(
   // box grows (uniformly, so rows stay evenly spaced) and the ramp reads at
   // roughly the ratios the map draws.
   const hasSizedSwatch = entries.some((entry) =>
-    entry.swatches.some((swatch) => swatch.size !== undefined),
+    entry.swatches.some((entrySwatch) => entrySwatch.size !== undefined),
   );
   const rowH = unit * (hasSizedSwatch ? 3.6 : 2.6);
   const swatch = unit * (hasSizedSwatch ? 3 : 2);

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -1963,10 +1963,21 @@ function drawLegendMarker(
       }
       return;
     }
-    // SVG not available: fall back to a neutral color square.
+    // SVG not available (still loading, or the load failed): fall back to a
+    // neutral shape. A proportional row falls back to the same circle the
+    // markerless ramp draws, so an entry mid-load still reads as one growing
+    // symbol; the outline stays either way, since a pale fallback color would
+    // otherwise vanish against the legend box.
     ctx.fillStyle = fallbackColor || "#999999";
-    ctx.fillRect(sx, sy, size, size);
     ctx.strokeStyle = BORDER;
+    if (!boxed) {
+      ctx.beginPath();
+      ctx.arc(sx + size / 2, sy + size / 2, size / 2, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      return;
+    }
+    ctx.fillRect(sx, sy, size, size);
     ctx.strokeRect(sx, sy, size, size);
     return;
   }

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -95,6 +95,14 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
     const sizeRange = layerSupportsProportionalLegend(layer)
       ? proportionalSizeRange(layer.style)
       : null;
+    // A marker layer's sized rows draw the marker (the map scales the sprite via
+    // icon-size), not a plain circle. Mirrors the on-map auto legend so both
+    // legends show the symbol the reader actually sees. Excluded for lines,
+    // whose sized rows are strokes and which the map never draws a marker for.
+    const sizeMarker =
+      sizeRange && legendGeometryKind(layer) !== "line"
+        ? (pointMarkerSwatch(layer.style)?.marker ?? undefined)
+        : undefined;
     if (
       (mode === "graduated" || mode === "categorized") &&
       Array.isArray(stops) &&
@@ -115,11 +123,13 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
       // Same field classified and sized: merge sizes into the class rows so the
       // print legend matches the on-map auto-legend (one block, not two).
       if (sizeRange && mode === "graduated" && sizeRange.property === classProperty) {
-        return [...sizeClassSwatches(ramp, displayedStops, sizeRange), ...diagrams];
+        return [...sizeClassSwatches(ramp, displayedStops, sizeRange, sizeMarker), ...diagrams];
       }
       return [
         ...ramp,
-        ...(sizeRange ? proportionalSizeSwatches(sizeRange, sizeRampColor(ramp, layer.style)) : []),
+        ...(sizeRange
+          ? proportionalSizeSwatches(sizeRange, sizeRampColor(ramp, layer.style), sizeMarker)
+          : []),
         ...diagrams,
       ];
     }
@@ -129,7 +139,7 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
         return [
           ...swatches,
           ...(sizeRange
-            ? proportionalSizeSwatches(sizeRange, sizeRampColor(swatches, layer.style))
+            ? proportionalSizeSwatches(sizeRange, sizeRampColor(swatches, layer.style), sizeMarker)
             : []),
           ...diagrams,
         ];
@@ -141,6 +151,7 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
         ...proportionalSizeSwatches(
           sizeRange,
           styleValue(layer.style, "fillColor") || NEUTRAL_SWATCH,
+          sizeMarker,
         ),
         ...diagrams,
       ];
@@ -481,24 +492,35 @@ function rampSwatches(
 }
 
 /**
+ * The geometry the legend should represent this layer as, from its metadata
+ * when present and otherwise sniffed from the loaded features. `null` means
+ * "unknown" — no metadata and nothing conclusive in the sample — which callers
+ * treat permissively (a tiled layer whose features have not loaded yet).
+ */
+function legendGeometryKind(layer: GeoLibreLayer): "point" | "line" | "polygon" | null {
+  const geometryType =
+    typeof layer.metadata?.geometryType === "string" ? layer.metadata.geometryType : null;
+  if (geometryType === "point" || geometryType === "line" || geometryType === "polygon") {
+    return geometryType;
+  }
+
+  const features = layer.geojson?.features;
+  if (!features || features.length === 0) return null;
+  for (const feature of features.slice(0, 200)) {
+    const type = feature.geometry?.type ?? "";
+    if (type === "Point" || type === "MultiPoint") return "point";
+    if (type === "LineString" || type === "MultiLineString") return "line";
+    if (type === "Polygon" || type === "MultiPolygon") return "polygon";
+  }
+  return null;
+}
+
+/**
  * Whether the map would size this layer's symbols (circles / line strokes).
  * Polygon fills ignore proportional sizing, matching the on-map auto-legend.
  */
 function layerSupportsProportionalLegend(layer: GeoLibreLayer): boolean {
-  const geometryType =
-    typeof layer.metadata?.geometryType === "string" ? layer.metadata.geometryType : null;
-  if (geometryType === "point" || geometryType === "line") return true;
-  if (geometryType === "polygon") return false;
-
-  const features = layer.geojson?.features;
-  if (!features || features.length === 0) return true;
-  for (const feature of features.slice(0, 200)) {
-    const type = feature.geometry?.type ?? "";
-    if (type === "Point" || type === "MultiPoint") return true;
-    if (type === "LineString" || type === "MultiLineString") return true;
-    if (type === "Polygon" || type === "MultiPolygon") return false;
-  }
-  return true;
+  return legendGeometryKind(layer) !== "polygon";
 }
 
 function lerp(from: number, to: number, ratio: number): number {
@@ -509,11 +531,17 @@ function lerp(from: number, to: number, ratio: number): number {
  * Proportional-symbol size rows: min / middle / max symbol sizes with their
  * data values, mirroring the interpolate the map renders and the on-map legend.
  */
-function proportionalSizeSwatches(range: ProportionalSizeRange, color: string): LegendSwatch[] {
+function proportionalSizeSwatches(
+  range: ProportionalSizeRange,
+  color: string,
+  /** The layer's point marker, so the ramp shows the symbol the map draws. */
+  marker?: LegendMarker,
+): LegendSwatch[] {
   return [0, 0.5, 1].map((ratio) => ({
     color,
     label: formatStopValue(lerp(range.minValue, range.maxValue, ratio)),
     size: lerp(range.minRadius, range.maxRadius, ratio),
+    ...(marker ? { marker } : {}),
   }));
 }
 
@@ -526,6 +554,8 @@ function sizeClassSwatches(
   swatches: { color: string; label: string }[],
   stops: VectorStyleStop[],
   range: ProportionalSizeRange,
+  /** The layer's point marker, so the ramp shows the symbol the map draws. */
+  marker?: LegendMarker,
 ): LegendSwatch[] {
   return swatches.map((swatch, index) => {
     const from = Number(stops[index]?.value);
@@ -536,6 +566,7 @@ function sizeClassSwatches(
     return {
       ...swatch,
       size: lerp(range.minRadius, range.maxRadius, Math.min(1, Math.max(0, ratio))),
+      ...(marker ? { marker } : {}),
     };
   });
 }

--- a/packages/core/src/marker-shape.ts
+++ b/packages/core/src/marker-shape.ts
@@ -90,3 +90,52 @@ export function drawMarkerPath(
       ctx.arc(c, c, r, 0, Math.PI * 2);
   }
 }
+
+// Remote SVG sources we have already warned about, so the console message below
+// fires once per distinct URL instead of on every image regeneration.
+const warnedRemoteSvgSources = new Set<string>();
+
+/**
+ * Resolve user-supplied SVG input to an `Image.src`: inline markup (starting
+ * with `<`) is encoded as a data URL; otherwise only `data:` and `http(s):`
+ * URLs are accepted. Returns null for empty input or an unsupported scheme
+ * (e.g. `file:`), which the caller treats as "no image" rather than letting an
+ * arbitrary URL be loaded.
+ *
+ * Remote `http(s):` URLs are supported intentionally (custom marker/pattern
+ * SVGs) but trigger a cross-origin request when rendered. Because a shared
+ * `.geolibre.json` can carry such a URL, we log a one-time warning so the
+ * outbound request is visible; prefer inline `<svg>` or `data:` in shared
+ * projects.
+ *
+ * Lives here (rather than beside the map's sprite baker) because every surface
+ * that previews a custom marker — the map, the Print Layout legend, the on-map
+ * Legend panel — must resolve the same input the same way. A second, local
+ * `data:image/svg+xml,…` wrapper is exactly what left URL and `data:` markers
+ * blank in the on-map legend while the map drew them fine.
+ *
+ * @param markup - Raw SVG markup, a `data:` URL, or an `http(s)` URL.
+ * @returns An `Image.src` value, or `null` when nothing loadable was given.
+ */
+export function resolveSvgSource(markup: string): string | null {
+  const trimmed = markup.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("<")) {
+    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(trimmed)}`;
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    if (!warnedRemoteSvgSources.has(trimmed)) {
+      warnedRemoteSvgSources.add(trimmed);
+      console.warn(
+        `[geolibre] Loading a custom SVG from a remote URL triggers a ` +
+          `cross-origin request: ${trimmed}. Prefer inline <svg> markup or a ` +
+          `data: URL in shared projects.`,
+      );
+    }
+    return trimmed;
+  }
+  if (trimmed.startsWith("data:")) {
+    return trimmed;
+  }
+  return null;
+}

--- a/packages/map/src/generated-images.ts
+++ b/packages/map/src/generated-images.ts
@@ -34,45 +34,10 @@ export function hashText(text: string): string {
   return (h2 >>> 0).toString(16).padStart(8, "0") + (h1 >>> 0).toString(16).padStart(8, "0");
 }
 
-// Remote SVG sources we have already warned about, so the console message below
-// fires once per distinct URL instead of on every image regeneration.
-const warnedRemoteSvgSources = new Set<string>();
-
-/**
- * Resolve user-supplied SVG input to an `Image.src`: inline markup (starting
- * with `<`) is encoded as a data URL; otherwise only `data:` and `http(s):`
- * URLs are accepted. Returns null for empty input or an unsupported scheme
- * (e.g. `file:`), which the caller treats as "no image" rather than letting an
- * arbitrary URL be loaded.
- *
- * Remote `http(s):` URLs are supported intentionally (custom marker/pattern
- * SVGs) but trigger a cross-origin request when rendered. Because a shared
- * `.geolibre.json` can carry such a URL, we log a one-time warning so the
- * outbound request is visible; prefer inline `<svg>` or `data:` in shared
- * projects.
- */
-export function resolveSvgSource(markup: string): string | null {
-  const trimmed = markup.trim();
-  if (!trimmed) return null;
-  if (trimmed.startsWith("<")) {
-    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(trimmed)}`;
-  }
-  if (/^https?:\/\//i.test(trimmed)) {
-    if (!warnedRemoteSvgSources.has(trimmed)) {
-      warnedRemoteSvgSources.add(trimmed);
-      console.warn(
-        `[geolibre] Loading a custom SVG from a remote URL triggers a ` +
-          `cross-origin request: ${trimmed}. Prefer inline <svg> markup or a ` +
-          `data: URL in shared projects.`,
-      );
-    }
-    return trimmed;
-  }
-  if (trimmed.startsWith("data:")) {
-    return trimmed;
-  }
-  return null;
-}
+// The custom-SVG source resolver lives in @geolibre/core so the map's sprite
+// baker and the two legend renderers cannot disagree about what a marker's
+// `markerSvg` means; re-exported here for the existing call sites.
+export { resolveSvgSource } from "@geolibre/core";
 
 /** A bitmap accepted by `map.addImage`. */
 export type GeneratedImage = Parameters<maplibregl.Map["addImage"]>[1];

--- a/tests/auto-legend.test.ts
+++ b/tests/auto-legend.test.ts
@@ -284,6 +284,116 @@ describe("buildAutoLegend — vector layers", () => {
     );
   });
 
+  it("draws the size ramp with the layer's marker, not a plain circle", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "marked",
+          metadata: { geometryType: "point" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            markerEnabled: true,
+            markerShape: "custom",
+            markerColor: "#3b82f6",
+            markerSvg: "https://example.com/bee.svg",
+            proportionalSizeEnabled: true,
+            proportionalSizeProperty: "nb_ruches",
+            proportionalSizeMinValue: 1,
+            proportionalSizeMaxValue: 86,
+            proportionalSizeMinRadius: 4,
+            proportionalSizeMaxRadius: 24,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    const [entry] = entries;
+    // The map scales the marker sprite through icon-size, so every sized row
+    // carries the marker; a plain circle would advertise a symbol the map does
+    // not draw (GH discussion #1711).
+    assert.deepEqual(
+      entry.rows.map((row) => [row.size, row.marker?.shape, row.marker?.svg]),
+      [
+        [4, "custom", "https://example.com/bee.svg"],
+        [14, "custom", "https://example.com/bee.svg"],
+        [24, "custom", "https://example.com/bee.svg"],
+      ],
+    );
+    // The heading chip stays the marker too, so the entry reads as one symbol.
+    assert.equal(entry.headerSwatch?.marker?.shape, "custom");
+  });
+
+  it("carries the marker onto merged graduated class rows", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "merged",
+          metadata: { geometryType: "point" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            vectorStyleMode: "graduated",
+            vectorStyleProperty: "pop_max",
+            vectorStyleStops: [
+              { value: 0, color: "#440154" },
+              { value: 100, color: "#31688e" },
+              { value: 200, color: "#fde725" },
+            ],
+            markerEnabled: true,
+            markerShape: "star",
+            markerColor: "#f59e0b",
+            proportionalSizeEnabled: true,
+            proportionalSizeProperty: "pop_max",
+            proportionalSizeMinValue: 0,
+            proportionalSizeMaxValue: 200,
+            proportionalSizeMinRadius: 4,
+            proportionalSizeMaxRadius: 24,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    const [entry] = entries;
+    assert.deepEqual(
+      entry.rows.map((row) => [row.size, row.marker?.shape]),
+      [
+        [9, "star"],
+        [19, "star"],
+        [24, "star"],
+      ],
+    );
+  });
+
+  it("leaves a line layer's size ramp markerless", () => {
+    const entries = buildAutoLegend(
+      [
+        layer({
+          id: "line",
+          metadata: { geometryType: "line" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            // markerEnabled on a line layer draws nothing on the map, so the
+            // stroke ramp must not pick up a marker.
+            markerEnabled: true,
+            markerShape: "star",
+            proportionalSizeEnabled: true,
+            proportionalSizeProperty: "flow",
+            proportionalSizeMinValue: 0,
+            proportionalSizeMaxValue: 100,
+            proportionalSizeMinRadius: 1,
+            proportionalSizeMaxRadius: 8,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+    const [entry] = entries;
+    assert.ok(entry.rows.length > 0);
+    assert.ok(entry.rows.every((row) => row.marker === undefined && row.shape === "line"));
+  });
+
   it("omits size rows when the proportional range is degenerate", () => {
     const entries = buildAutoLegend(
       [

--- a/tests/marker-shape.test.ts
+++ b/tests/marker-shape.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveSvgSource } from "../packages/core/src/marker-shape";
+
+describe("resolveSvgSource", () => {
+  it("encodes inline markup as a data URL", () => {
+    const source = resolveSvgSource("<svg><circle r='4'/></svg>");
+    assert.ok(source?.startsWith("data:image/svg+xml;charset=utf-8,"));
+    assert.equal(
+      decodeURIComponent(source.slice("data:image/svg+xml;charset=utf-8,".length)),
+      "<svg><circle r='4'/></svg>",
+    );
+  });
+
+  it("passes an http(s) URL through untouched", () => {
+    // Re-encoding a URL as a data URL is what left the on-map legend's marker
+    // chip blank while the map drew the same marker fine (GH discussion #1711).
+    const url = "https://example.com/bee.svg";
+    assert.equal(resolveSvgSource(url), url);
+  });
+
+  it("passes a data: URL through untouched rather than double-encoding it", () => {
+    const url = "data:image/svg+xml;base64,PHN2Zy8+";
+    assert.equal(resolveSvgSource(url), url);
+  });
+
+  it("rejects blank input and unsupported schemes", () => {
+    assert.equal(resolveSvgSource("   "), null);
+    assert.equal(resolveSvgSource("file:///etc/passwd"), null);
+    assert.equal(resolveSvgSource("javascript:alert(1)"), null);
+  });
+});

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -20,12 +20,16 @@ function recordingCanvas(): {
   canvas: HTMLCanvasElement;
   fills: { text: string; textAlign: string; textBaseline: string }[];
   fillRects: { w: number; h: number; fillStyle: string }[];
+  imageBoxes: { w: number; h: number }[];
   arcs: number;
   polylines: number[];
 } {
   const fills: { text: string; textAlign: string; textBaseline: string }[] = [];
   // Filled rectangles (swatches, chart bars), with the fill colour in effect.
   const fillRects: { w: number; h: number; fillStyle: string }[] = [];
+  // Drawn images (custom SVG marker icons), with the box each was drawn into,
+  // so a proportional marker ramp's graduated sizes can be asserted.
+  const imageBoxes: { w: number; h: number }[] = [];
   // Stroked polylines: one entry per beginPath..stroke sequence that used
   // lineTo, holding the segment count (the line chart's path).
   const polylines: number[] = [];
@@ -55,8 +59,9 @@ function recordingCanvas(): {
         };
       }
       if (prop === "drawImage") {
-        return () => {
+        return (_img: unknown, _x: number, _y: number, w: number, h: number) => {
           counters.drawImages += 1;
+          imageBoxes.push({ w, h });
         };
       }
       if (prop === "beginPath") {
@@ -93,6 +98,7 @@ function recordingCanvas(): {
     canvas,
     fills,
     fillRects,
+    imageBoxes,
     get arcs() {
       return counters.arcs;
     },
@@ -309,6 +315,45 @@ describe("drawLayout legend rendering", () => {
     assert.ok(
       !rec.fillRects.some((r) => r.fillStyle === "#3b82f6" && r.w === r.h),
       "expected no fallback color square when the icon is available",
+    );
+  });
+
+  it("scales a proportional size ramp's marker icons instead of drawing one fixed box", () => {
+    const svg = "<svg/>";
+    const image = {} as unknown as CanvasImageSource;
+    const marker = { shape: "custom", color: "#3b82f6", svg } as const;
+    const rec = recordingCanvas();
+    drawLayout(
+      rec.canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "ruchers",
+            name: "Ruchers",
+            swatches: [
+              { color: "#3b82f6", label: "1", size: 4, marker },
+              { color: "#3b82f6", label: "43.5", size: 14, marker },
+              { color: "#3b82f6", label: "86", size: 24, marker },
+            ],
+          },
+        ],
+        markerIcons: new Map([[svg, image]]),
+      }),
+    );
+    assert.equal(rec.drawImages, 3);
+    const widths = rec.imageBoxes.map((box) => box.w);
+    // Strictly growing, at the map's size ratios, so the ramp reads as one
+    // symbol growing rather than three identical icons (GH discussion #1711).
+    // The smallest row sits on the shared visible-symbol floor (like the circle
+    // branch), so the ratio is asserted between the two unclamped rows.
+    assert.ok(widths[0] < widths[1] && widths[1] < widths[2], `not growing: ${widths.join()}`);
+    assert.ok(
+      Math.abs(widths[1] / widths[2] - 14 / 24) < 0.02,
+      `middle/max ratio off: ${widths.join()}`,
+    );
+    assert.ok(
+      rec.imageBoxes.every((box) => box.w === box.h),
+      "expected square marker boxes",
     );
   });
 

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -380,6 +380,37 @@ describe("drawLayout legend rendering", () => {
     );
   });
 
+  it("falls back to sized circles, not framed squares, for an unloaded ramp icon", () => {
+    const svg = "<svg/>";
+    const marker = { shape: "custom", color: "#3b82f6", svg } as const;
+    const rec = recordingCanvas();
+    drawLayout(
+      rec.canvas,
+      baseOptions({
+        legend: [
+          {
+            id: "ruchers",
+            name: "Ruchers",
+            swatches: [
+              { color: "#3b82f6", label: "1", size: 4, marker },
+              { color: "#3b82f6", label: "43.5", size: 14, marker },
+              { color: "#3b82f6", label: "86", size: 24, marker },
+            ],
+          },
+        ],
+        // No markerIcons: a remote icon still fetching, or one that failed.
+      }),
+    );
+    assert.equal(rec.drawImages, 0);
+    // Three filled circles, so the ramp still reads as one growing symbol
+    // during the load window rather than a column of identical framed boxes.
+    assert.ok(rec.arcs >= 3, `expected fallback circles, got ${rec.arcs} arcs`);
+    assert.ok(
+      !rec.fillRects.some((r) => r.fillStyle === "#3b82f6" && r.w === r.h),
+      "expected no square fallback swatch for a proportional row",
+    );
+  });
+
   it("draws the marker of a multi-swatch entry's primary swatch as a shape", () => {
     const { canvas, polylines, fillRects } = recordingCanvas();
     drawLayout(

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -199,6 +199,64 @@ describe("buildLegend", () => {
     assert.equal(legend[0].swatches[0].marker, undefined);
   });
 
+  it("draws a marker layer's proportional size ramp with the marker", () => {
+    const svg = "https://example.com/bee.svg";
+    const legend = buildLegend([
+      makeLayer({
+        name: "Ruchers",
+        metadata: { geometryType: "point" },
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#3388ff",
+          markerEnabled: true,
+          markerShape: "custom",
+          markerColor: "#3b82f6",
+          markerSvg: svg,
+          proportionalSizeEnabled: true,
+          proportionalSizeProperty: "nb_ruches",
+          proportionalSizeMinValue: 1,
+          proportionalSizeMaxValue: 86,
+          proportionalSizeMinRadius: 4,
+          proportionalSizeMaxRadius: 24,
+        } as LayerStyle,
+      }),
+    ]);
+    // Three sized rows, each carrying the marker the map scales through
+    // icon-size, rather than a plain circle (GH discussion #1711).
+    assert.deepEqual(
+      legend[0].swatches.map((swatch) => [swatch.size, swatch.marker?.shape, swatch.marker?.svg]),
+      [
+        [4, "custom", svg],
+        [14, "custom", svg],
+        [24, "custom", svg],
+      ],
+    );
+  });
+
+  it("keeps a line layer's proportional stroke ramp markerless", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Rivers",
+        metadata: { geometryType: "line" },
+        style: {
+          vectorStyleMode: "single",
+          fillColor: "#3388ff",
+          markerEnabled: true,
+          markerShape: "star",
+          markerColor: "#ff8800",
+          proportionalSizeEnabled: true,
+          proportionalSizeProperty: "flow",
+          proportionalSizeMinValue: 0,
+          proportionalSizeMaxValue: 100,
+          proportionalSizeMinRadius: 1,
+          proportionalSizeMaxRadius: 8,
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 3);
+    assert.ok(legend[0].swatches.every((swatch) => swatch.marker === undefined));
+  });
+
   it("leaves non-marker layers with a plain fill swatch and no marker", () => {
     const legend = buildLegend([
       makeLayer({


### PR DESCRIPTION
Reported in [discussion #1711](https://github.com/opengeos/GeoLibre/discussions/1711) (follow-up to [#1311](https://github.com/opengeos/GeoLibre/discussions/1311)).

A point layer with **both a custom marker and proportional sizing** was described by two legends that each got half of it right:

- **Print Layout legend:** drew the marker, no size ramp.
- **Controls > Legend:** drew a size ramp of plain blue circles, and the heading chip was blank.

Neither matched the map, and the ramp's symbols were drawn at roughly half the size the map paints.

## What was wrong

**1. The on-map legend could not render a URL or `data:` marker.** `MarkerSwatch` built its image source as `` `data:image/svg+xml;utf8,${encodeURIComponent(marker.svg)}` `` unconditionally. `markerSvg` accepts inline markup, a `data:` URL, *or* an `https:` URL (the field's own placeholder says so), and the map resolves all three through `resolveSvgSource`. Re-encoding the latter two produced a broken source, so the chip rendered blank while the map drew the marker fine.

`resolveSvgSource` now lives in `@geolibre/core` beside `drawMarkerPath` (which the same doc comment already describes as shared between the sprite baker and the legend renderers), and `@geolibre/map` re-exports it for its existing call sites. One resolver, three surfaces.

**2. Size ramps ignored the marker.** The map sizes a marker layer by scaling the sprite through `icon-size` (`markerIconSizeValue`), so its symbols are markers at graduated widths, never circles. Proportional rows in both legends now carry the layer's marker, and both renderers draw it at the row's size. This covers the standalone ramp, a rule-based layer's ramp, and merged graduated class rows. Line layers keep their stroke ramp: the map draws no marker for them, and `legendGeometryKind` (factored out of the old `layerSupportsProportionalLegend`) is the guard.

**3. Symbols were drawn far smaller than the map's.** The reporter's second point. A proportional row's `size` **is** the radius the map paints, so the legend can draw it 1:1. The on-map cap rises from a 12 px radius to 24 (the style editor's default maximum), making the common 4-24 ramp exact rather than half scale; ramps configured past the cap still scale down as one entry so the map's ratios survive. The print legend's swatch column and row height grow when an entry carries sized symbols, and the per-step frame around a custom SVG is dropped there (three nested squares read as boxes, not as one growing symbol).

Note the "no size ramp in the Print Layout legend" half of the report was already fixed on `main` by #1548, which landed just after v2.4.0 - but that fix drew plain circles for a marker layer, which is what this PR completes.

## Verification

Driven in the real app with the reporter's own dataset (`ruchers_018.csv`, 492 points, `nb_ruches` 1-86) and a remote SVG marker URL, in **both light and dark themes**:

| | before | after |
|---|---|---|
| Controls > Legend | blank heading chip, 3 plain circles capped at r=12 | marker chip, 3 markers at 4/14/24 px matching the map |
| Print Layout | 3 plain circles crushed into a text-height swatch box | 3 markers at the map's ratios |

Also checked: a built-in shape marker (star), a marker-less circle layer (now 1:1 with the map), and a graduated layer whose size field differs from its class field (unchanged two-block layout).

Tests: `npm run test:frontend` 5347 passing, including 8 new cases across `tests/marker-shape.test.ts` (new), `tests/auto-legend.test.ts`, `tests/print-legend.test.ts`, and `tests/print-layout.test.ts`. `npm run build` and `pre-commit run --files` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Legend markers now preserve custom shapes across proportional-size ramps.
  - Marker sizes scale consistently with map symbols in on-screen and printed legends.
  - Custom inline, data URL, and HTTPS SVG markers are supported.
  - Point and polygon legends retain marker styling, while line legends remain marker-free.

- **Bug Fixes**
  - Improved fallback handling for invalid or unavailable custom marker sources.
  - Increased the maximum proportional swatch size for clearer legends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->