### PR TITLE
fix(netcdf): let an RGB composite be sampled like a single band

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -475,7 +475,7 @@ export function AddNetcdfDialog({ open, appApi, onOpenChange }: AddNetcdfDialogP
             scaleFactor: channels[0].scaleFactor,
             addOffset: channels[0].addOffset,
           });
-          addImageOverlayLayer(
+          const layerId = addImageOverlayLayer(
             `${baseName} - ${variable} (RGB)`,
             {
               url: encodeImageOverlay(image),
@@ -486,9 +486,25 @@ export function AddNetcdfDialog({ open, appApi, onOpenChange }: AddNetcdfDialogP
               // Without this the store defaults it to "kml-ground-overlay",
               // which every consumer of that marker would then act on.
               sourceKind: NETCDF_IMAGE_SOURCE_KIND,
-              metadata: { variable },
+              // Identify reads cell values, not features, exactly as the
+              // single-band path does; a composite reports all three channels.
+              metadata: { variable, pixelIdentify: true },
             },
           );
+          // A composite is by definition built on a band axis, so the file
+          // always stays open: it is what a click's spectral signature and the
+          // 3-D cube view are read from.
+          retainedFileRef.current = dataset.file;
+          registerNetcdfLayer(layerId, {
+            grid: channels[0],
+            variable,
+            ...(selectedVar?.units ? { units: selectedVar.units } : {}),
+            cube: cubeReader(dataset, variable, rgbAxis, selector),
+            rgb: {
+              bands: rgbBands,
+              channels: channels as [LocalNetcdfGrid, LocalNetcdfGrid, LocalNetcdfGrid],
+            },
+          });
           appApi.fitBounds?.(image.bounds);
         } else if (useImagePath) {
           // The grid itself, not just its pixels, so the Style panel can

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -221,7 +221,7 @@ import {
 } from "../../lib/postgis-connections";
 import { IS_MAS_BUILD } from "../../lib/build-flags";
 import { isTauri } from "../../lib/is-tauri";
-import { getNetcdfImageSource } from "../../lib/netcdf-image-symbology";
+import { getNetcdfLayerState } from "../../lib/netcdf-image-symbology";
 import { BasemapPickerDialog } from "./BasemapPickerDialog";
 import { LayerPanelPlaceSearch } from "./LayerPanelPlaceSearch";
 import { LayerSwatchIcon } from "./LayerSwatchIcon";
@@ -584,11 +584,13 @@ function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
   // registered by a plugin, but its values are held in memory and read directly
   // by useNetcdfIdentify. Named here rather than given a synthetic
   // `nativeLayerIds`, which would make layer-sync treat it as plugin-owned and
-  // stop drawing it. Gated on the grid actually being retained: an RGB
-  // composite shares the source kind but registers none, and a reload drops it,
-  // and offering Identify that answers nothing is worse than not offering it.
+  // stop drawing it. Gated on the grids actually being retained — a project
+  // reload drops them — since offering Identify that answers nothing is worse
+  // than not offering it. Deliberately the layer state rather than
+  // `getNetcdfImageSource`, which is null for an RGB composite: that has no
+  // colormap to re-apply but does have three channels a click can read.
   if (layer.metadata.sourceKind === NETCDF_IMAGE_SOURCE_KIND) {
-    return getNetcdfImageSource(layer.id) !== null;
+    return getNetcdfLayerState(layer.id) !== null;
   }
 
   return Array.isArray(layer.metadata.nativeLayerIds) && layer.metadata.nativeLayerIds.length > 0;

--- a/apps/geolibre-desktop/src/components/panels/NetcdfSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NetcdfSymbologySection.tsx
@@ -4,6 +4,7 @@ import { Boxes } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useColormapRamps } from "../../hooks/useColormapRamps";
+import { bandMeasure } from "../../lib/netcdf-band-axis";
 import { openNetcdfCubeSetup } from "../../lib/netcdf-cube-store";
 import {
   bakeNetcdfImage,
@@ -13,7 +14,64 @@ import {
   netcdfImageSymbology,
   warmNetcdfColormap,
   type NetcdfImageSymbology,
+  type NetcdfLayerState,
 } from "../../lib/netcdf-image-symbology";
+
+/** The three band pickers' names, red first, reused for the RGB summary rows. */
+const CHANNEL_LABEL_KEYS = [
+  "addData.netcdf.channel.red",
+  "addData.netcdf.channel.green",
+  "addData.netcdf.channel.blue",
+] as const;
+
+/**
+ * What an RGB composite gets in place of the colormap controls: the three bands
+ * it was composed from, and the way into the 3-D cube.
+ *
+ * There is nothing to re-apply here — the pixels came from three channels, each
+ * stretched to its own range, and re-baking any one of them with a colormap
+ * would replace the composite with a single-band image. So the bands are shown
+ * rather than edited; changing them means adding the layer again.
+ *
+ * @param props.layerId - The composite's layer id, for the cube setup.
+ * @param props.state - Its retained grids, which must carry `rgb`.
+ * @returns The summary section.
+ */
+function NetcdfRgbSection({ layerId, state }: { layerId: string; state: NetcdfLayerState }) {
+  const { t } = useTranslation();
+  const axis = state.cube?.axis;
+  return (
+    <>
+      <Separator />
+      <div className="space-y-3">
+        <p className="text-xs font-semibold">{t("addData.netcdf.bandCombinationLabel")}</p>
+        <dl className="space-y-1 text-xs">
+          {(state.rgb?.bands ?? []).map((band, channel) => (
+            <div key={CHANNEL_LABEL_KEYS[channel]} className="flex items-baseline gap-2">
+              <dt className="text-muted-foreground">{t(CHANNEL_LABEL_KEYS[channel])}</dt>
+              <dd className="truncate font-medium">
+                {axis ? bandMeasure(axis, band) : String(band)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+        {/* Same condition as the single-band section's button: only a layer
+            whose source file is still open on a band axis has a cube to read. */}
+        {state.cube ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => openNetcdfCubeSetup(layerId)}
+          >
+            <Boxes className="me-1.5 h-4 w-4" aria-hidden="true" />
+            {t("netcdfSymbology.openCube")}
+          </Button>
+        ) : null}
+      </div>
+    </>
+  );
+}
 
 /**
  * Symbology for a NetCDF grid baked into an `image` overlay: the same colormap
@@ -28,8 +86,12 @@ import {
  * case after a project reload: the baked pixels are in the project file but the
  * values behind them are not, so there is nothing to re-colormap.
  *
+ * An RGB composite retains its grids but has no single ramp to edit, so it gets
+ * {@link NetcdfRgbSection} — its bands, and the cube — instead.
+ *
  * @param props.layer - The image layer to style.
- * @returns The symbology controls, or null when the grid is unavailable.
+ * @returns The symbology controls, the RGB summary, or null when nothing about
+ *   the layer is retained.
  */
 export function NetcdfSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const { t } = useTranslation();
@@ -59,6 +121,11 @@ export function NetcdfSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     // the previous layer's colormap in this layer's controls until it resolves.
     setPendingSymbology(null);
   }
+
+  // After the hooks above, not before: an early return that skipped them would
+  // change the hook order between a single-band layer and a composite.
+  const rgbState = getNetcdfLayerState(layer.id);
+  if (rgbState?.rgb) return <NetcdfRgbSection layerId={layer.id} state={rgbState} />;
 
   if (!source) return null;
 

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -56,7 +56,7 @@ import { useTranslation } from "react-i18next";
 import { AttributeFormSection } from "./AttributeFormSection";
 import { LayerJoinsSection } from "./LayerJoinsSection";
 import { VirtualFieldsSection } from "./VirtualFieldsSection";
-import { getNetcdfImageSource, NETCDF_IMAGE_SOURCE_KIND } from "../../lib/netcdf-image-symbology";
+import { getNetcdfLayerState, NETCDF_IMAGE_SOURCE_KIND } from "../../lib/netcdf-image-symbology";
 import { NetcdfProfilePanel } from "./NetcdfProfilePanel";
 import { NetcdfSymbologySection } from "./NetcdfSymbologySection";
 import { RasterSymbologySection } from "./RasterSymbologySection";
@@ -4631,11 +4631,14 @@ export function StylePanel({
   }
 
   if (!hasVectorPaintControls) {
-    // The section renders nothing without a retained grid, so ask here too, or
+    // The section renders nothing without retained grids, so ask here too, or
     // the panel would suppress the fallback message and show an empty body.
+    // The layer state rather than `getNetcdfImageSource`, which is null for an
+    // RGB composite: that one has no colormap to re-apply, but it does have a
+    // band summary to show and pixels to sample.
     const hasNetcdfSymbology =
       layer.metadata.sourceKind === NETCDF_IMAGE_SOURCE_KIND &&
-      getNetcdfImageSource(layer.id) !== null;
+      getNetcdfLayerState(layer.id) !== null;
     return (
       <aside aria-label={t("style.panelLabel")} className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
@@ -4660,8 +4663,8 @@ export function StylePanel({
             {/* A NetCDF grid baked to pixels has no MapLibre paint properties,
                 so it lands in this branch; its colormap/limits are re-applied
                 by re-baking the image rather than by a style property. The
-                grid is dropped on a project reload, and an RGB composite never
-                had one, so the generic message still has to appear for those. */}
+                grids are dropped on a project reload, so the generic message
+                still has to appear for a layer restored from one. */}
             {hasNetcdfSymbology ? (
               <NetcdfSymbologySection layer={layer} />
             ) : (

--- a/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useNetcdfIdentify.ts
@@ -1,14 +1,19 @@
 import { useAppStore } from "@geolibre/core";
+import type { TFunction } from "i18next";
 import maplibregl from "maplibre-gl";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import type { MapController } from "@geolibre/map";
+import { bandMeasure } from "../lib/netcdf-band-axis";
 import {
   displayUnits,
   getNetcdfLayerState,
   gridPixelAt,
+  gridValueAt,
   NETCDF_IMAGE_SOURCE_KIND,
   readNetcdfProfile,
+  type GridPixel,
+  type NetcdfLayerState,
 } from "../lib/netcdf-image-symbology";
 import {
   addNetcdfProfileSample,
@@ -33,6 +38,55 @@ function formatValue(value: number): string {
 function formatReading(value: number, units: string | undefined): string {
   const unit = displayUnits(units);
   return unit ? `${formatValue(value)} ${unit}` : formatValue(value);
+}
+
+/**
+ * The channel names an RGB composite's rows are labelled with, red first — the
+ * same three the Add dialog's band pickers carry, so a reading is named exactly
+ * as the field that chose it.
+ */
+const CHANNEL_LABEL_KEYS = [
+  "addData.netcdf.channel.red",
+  "addData.netcdf.channel.green",
+  "addData.netcdf.channel.blue",
+] as const;
+
+/**
+ * The value rows for one clicked cell.
+ *
+ * A single-band layer reports the variable it was built from. A composite
+ * reports all three channels instead: they are the same variable at three
+ * bands, so naming it three times would say nothing, where the channel and the
+ * band it was drawn from say everything. The three share a geometry, so the
+ * cell `gridPixelAt` found on the red channel addresses the other two directly.
+ *
+ * @param state - The layer's retained grids.
+ * @param pixel - The cell under the click.
+ * @param t - The translator, for the channel names and the no-data marker.
+ * @returns Label/value pairs, in display order.
+ */
+function valueRows(
+  state: NetcdfLayerState,
+  pixel: GridPixel,
+  t: TFunction,
+): Array<[string, string]> {
+  const reading = (value: number | null): string =>
+    value === null ? t("netcdfIdentify.noData") : formatReading(value, state.units);
+
+  const rgb = state.rgb;
+  if (!rgb) return [[state.variable, reading(pixel.value)]];
+
+  const axis = state.cube?.axis;
+  return rgb.bands.map((band, channel) => {
+    const name = t(CHANNEL_LABEL_KEYS[channel]);
+    return [
+      // The axis is gone once the file behind a second cube closed it, and with
+      // it any way to say which wavelength this was; the channel name alone
+      // still reads correctly.
+      axis ? `${name} (${bandMeasure(axis, band)})` : name,
+      reading(gridValueAt(rgb.channels[channel], pixel.row, pixel.column)),
+    ] as [string, string];
+  });
 }
 
 /**
@@ -107,12 +161,7 @@ export function useNetcdfIdentify(
       const container = document.createElement("div");
       container.className = "space-y-0.5 text-xs";
       const rows: Array<[string, string]> = [
-        [
-          state.variable,
-          pixel.value === null
-            ? t("netcdfIdentify.noData")
-            : formatReading(pixel.value, state.units),
-        ],
+        ...valueRows(state, pixel, t),
         [t("netcdfIdentify.coordinates"), `${pixel.lng.toFixed(5)}, ${pixel.lat.toFixed(5)}`],
         [t("netcdfIdentify.cell"), `${pixel.row}, ${pixel.column}`],
       ];

--- a/apps/geolibre-desktop/src/lib/netcdf-band-axis.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-band-axis.ts
@@ -47,6 +47,28 @@ export function axisOptionLabel(axis: LocalNetcdfAxis, coordinate: number, index
   return `${measure} (${axis.name} ${index})`;
 }
 
+/**
+ * `"650.41 nm"` — just the band's measure, for places where the axis and the
+ * channel it feeds are already named around it (the identify popup's red/green/
+ * blue rows, the Style panel's band summary). Shorter than {@link bandLabel} on
+ * purpose: those sit inside a row that is already a label.
+ *
+ * An axis with no coordinate values, or none at this index, has no measure to
+ * show, so it falls back to naming the position — the only thing known about it.
+ *
+ * @param axis - The band axis.
+ * @param index - The band's position along it.
+ * @returns The coordinate with its units, or `"bands 47"`.
+ */
+export function bandMeasure(axis: LocalNetcdfAxis, index: number): string {
+  const coordinate = axis.values?.[index];
+  if (coordinate === undefined) return `${axis.name} ${index}`;
+  const rounded = Number.isInteger(coordinate) ? String(coordinate) : coordinate.toFixed(2);
+  // Without units the bare number reads as nothing in particular, so keep the
+  // axis name in front of it rather than showing a naked "47".
+  return axis.units ? `${rounded} ${axis.units}` : `${axis.name} ${rounded}`;
+}
+
 /** How one band index should read in a picker, whatever the axis carries. */
 export function bandLabel(axis: LocalNetcdfAxis, index: number): string {
   const coordinate = axis.values?.[index];

--- a/apps/geolibre-desktop/src/lib/netcdf-image-symbology.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-image-symbology.ts
@@ -1,168 +1,30 @@
-import { interpolateColors, parseHexColor, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import { interpolateColors, parseHexColor, type GeoLibreLayer } from "@geolibre/core";
 import {
   colormapColors,
   composeColormappedImage,
   warmColormapColors,
-  type LocalNetcdfAxis,
-  type LocalNetcdfGrid,
   type LocalNetcdfImage,
-  type LocalNetcdfProfile,
-  type LocalNetcdfWindow,
 } from "@geolibre/plugins";
-
-import { closeNetcdfCubeForLayer } from "./netcdf-cube-store";
+import type { NetcdfImageSource } from "./netcdf-layer-registry";
 
 export { NETCDF_IMAGE_SOURCE_KIND } from "@geolibre/core";
 // Re-exported so callers reach one module for everything about these layers.
-export { gridPixelAt, type GridPixel } from "@geolibre/plugins";
+export { gridPixelAt, gridValueAt, type GridPixel } from "@geolibre/plugins";
+// The retained grids live in their own module, which stays clear of the plugin
+// barrel this one needs for the colormapper; re-exported here so a caller that
+// wants both still reaches for one import.
+export {
+  getNetcdfImageSource,
+  getNetcdfLayerState,
+  readNetcdfProfile,
+  registerNetcdfLayer,
+  releaseNetcdfLayer,
+  type NetcdfLayerState,
+} from "./netcdf-layer-registry";
+export type { NetcdfImageSource };
 
 /** Ramp stops resampled for the CPU colormapper (8-bit lookup depth). */
 export const COLORMAP_STOPS = 256;
-
-/**
- * The decoded slice behind one baked NetCDF image, kept so the Style panel can
- * re-colormap it without re-reading the file.
- *
- * Held in memory rather than in the project, because the values are large (tens
- * of MB for a satellite scene) and a browser cannot silently re-open the source
- * file after a reload. A reloaded project therefore keeps its baked pixels and
- * simply loses the live controls, which the section handles by hiding itself.
- */
-export type NetcdfImageSource = LocalNetcdfGrid;
-
-/** Everything retained in memory for one baked NetCDF layer. */
-export interface NetcdfLayerState {
-  /** The displayed slice: backs both re-colormapping and pixel identify. */
-  grid: LocalNetcdfGrid;
-  /** The variable the layer was built from, for labelling readouts. */
-  variable: string;
-  /** The variable's CF `units`, when it declares any. */
-  units?: string;
-  /**
-   * Present only for a layer built from a cube. Reading a spectral signature
-   * needs the whole band axis at one pixel, and the 3-D cube view needs many
-   * band planes; only the source file has either, so it stays open for as long
-   * as the layer does.
-   *
-   * Functions rather than the file itself, because the two sources answer
-   * differently: a local file reads synchronously in place, a remote one round
-   * trips to the worker that owns its range-request mount.
-   */
-  cube?: {
-    /** The leading axis the bands run along, with its coordinate values. */
-    axis: LocalNetcdfAxis;
-    /** Read one pixel's values along {@link axis}. */
-    readProfile: (row: number, column: number) => Promise<LocalNetcdfProfile>;
-    /** Read one band's plane, optionally windowed and decimated. */
-    readBand: (bandIndex: number, window?: LocalNetcdfWindow) => Promise<LocalNetcdfGrid>;
-    /** Release the underlying file or worker. */
-    close: () => void;
-  };
-}
-
-const states = new Map<string, NetcdfLayerState>();
-let unsubscribe: (() => void) | null = null;
-/** The layer array the pruner last saw, so unrelated store writes cost nothing. */
-let lastLayers: unknown = null;
-
-/**
- * Remember what a baked NetCDF layer was made from, so its symbology stays
- * editable and its pixels stay readable, and start releasing entries whose
- * layer is gone.
- *
- * An open file is large (a hyperspectral cube runs to ~1 GB in the WebAssembly
- * heap), and the address space is 4 GB, so **only one** file is retained: adding
- * a second cube closes the first, which loses only its spectral profiles. Every
- * layer keeps its own grid, which is far smaller.
- *
- * @param layerId - The image layer's id.
- * @param state - The decoded slice, and the open file when it came from a cube.
- */
-export function registerNetcdfLayer(layerId: string, state: NetcdfLayerState): void {
-  if (state.cube) {
-    for (const [id, existing] of states) {
-      if (id !== layerId && existing.cube) {
-        existing.cube.close();
-        states.set(id, { ...existing, cube: undefined });
-        // The window renders from that file; leaving it open would strand a
-        // frame whose "reload" can no longer read anything.
-        closeNetcdfCubeForLayer(id);
-      }
-    }
-  }
-  states.set(layerId, state);
-  // A removed layer would otherwise strand its grid, and its file, for the rest
-  // of the session. One subscription serves every registration.
-  unsubscribe ??= useAppStore.subscribe((current) => {
-    // Every store write lands here, including the pointer coordinates the map
-    // writes on each mouse move, so do nothing until the layer array itself is
-    // replaced. Without this guard a registered grid costs a Set of every layer
-    // id per mouse move.
-    if (current.layers === lastLayers) return;
-    lastLayers = current.layers;
-    if (states.size === 0) return;
-    const live = new Set(current.layers.map((layer) => layer.id));
-    for (const id of states.keys()) {
-      if (!live.has(id)) releaseNetcdfLayer(id);
-    }
-    // Nothing left to prune: stop listening entirely rather than waking on
-    // every layer edit for the rest of the session. The next register
-    // re-subscribes, because `unsubscribe` is cleared here.
-    if (states.size === 0) {
-      unsubscribe?.();
-      unsubscribe = null;
-    }
-  });
-}
-
-/**
- * What a baked NetCDF layer was made from, or null when this layer is not one
- * (or its state was lost with a project reload).
- *
- * @param layerId - The layer's id.
- * @returns The retained state, or null.
- */
-export function getNetcdfLayerState(layerId: string): NetcdfLayerState | null {
-  return states.get(layerId) ?? null;
-}
-
-/** The displayed slice for a layer, or null. */
-export function getNetcdfImageSource(layerId: string): NetcdfImageSource | null {
-  return states.get(layerId)?.grid ?? null;
-}
-
-/** Drop a layer's retained grid and close its file, if it had one. */
-export function releaseNetcdfLayer(layerId: string): void {
-  states.get(layerId)?.cube?.close();
-  states.delete(layerId);
-  closeNetcdfCubeForLayer(layerId);
-}
-
-/**
- * Read one pixel's values along the layer's profile axis.
- *
- * @param layerId - The layer's id.
- * @param row - Row into the grid's y extent.
- * @param column - Column into the grid's x extent.
- * @returns The profile, or null when this layer has no retained file or the
- *   read failed.
- */
-export async function readNetcdfProfile(
-  layerId: string,
-  row: number,
-  column: number,
-): Promise<LocalNetcdfProfile | null> {
-  const state = states.get(layerId);
-  if (!state?.cube) return null;
-  try {
-    return await state.cube.readProfile(row, column);
-  } catch {
-    // A profile is an extra on top of the pixel readout, and the caller reads it
-    // outside the click handler; a failed read must degrade to "no chart", not
-    // surface as an unhandled rejection on every click.
-    return null;
-  }
-}
 
 /** The symbology a baked NetCDF image is currently drawn with. */
 export interface NetcdfImageSymbology {

--- a/apps/geolibre-desktop/src/lib/netcdf-layer-registry.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-layer-registry.ts
@@ -1,0 +1,197 @@
+import { useAppStore } from "@geolibre/core";
+import type {
+  LocalNetcdfAxis,
+  LocalNetcdfGrid,
+  LocalNetcdfProfile,
+  LocalNetcdfWindow,
+} from "@geolibre/plugins/local-netcdf";
+
+import { closeNetcdfCubeForLayer } from "./netcdf-cube-store";
+
+/**
+ * What every baked NetCDF layer keeps in memory: its decoded slices, and the
+ * open file behind a cube.
+ *
+ * Its own module, reachable without `netcdf-image-symbology` — that one pulls in
+ * the plugin barrel for the colormapper, which drags a browser-only dependency
+ * graph behind it. Everything here is plain state, so keeping it separate is
+ * what lets it be exercised outside a browser.
+ */
+
+/**
+ * The decoded slice behind one baked NetCDF image, kept so the Style panel can
+ * re-colormap it without re-reading the file.
+ *
+ * Held in memory rather than in the project, because the values are large (tens
+ * of MB for a satellite scene) and a browser cannot silently re-open the source
+ * file after a reload. A reloaded project therefore keeps its baked pixels and
+ * simply loses the live controls, which the section handles by hiding itself.
+ */
+export type NetcdfImageSource = LocalNetcdfGrid;
+
+/** Everything retained in memory for one baked NetCDF layer. */
+export interface NetcdfLayerState {
+  /**
+   * The displayed slice: backs both re-colormapping and pixel identify.
+   *
+   * For an RGB composite this is the red channel — the three share one geometry,
+   * and every consumer that reads this field (identify's cell lookup, the cube
+   * view's window) wants the geometry rather than the values.
+   */
+  grid: LocalNetcdfGrid;
+  /** The variable the layer was built from, for labelling readouts. */
+  variable: string;
+  /** The variable's CF `units`, when it declares any. */
+  units?: string;
+  /**
+   * Present only for a layer built from a cube. Reading a spectral signature
+   * needs the whole band axis at one pixel, and the 3-D cube view needs many
+   * band planes; only the source file has either, so it stays open for as long
+   * as the layer does.
+   *
+   * Functions rather than the file itself, because the two sources answer
+   * differently: a local file reads synchronously in place, a remote one round
+   * trips to the worker that owns its range-request mount.
+   */
+  cube?: {
+    /** The leading axis the bands run along, with its coordinate values. */
+    axis: LocalNetcdfAxis;
+    /** Read one pixel's values along {@link axis}. */
+    readProfile: (row: number, column: number) => Promise<LocalNetcdfProfile>;
+    /** Read one band's plane, optionally windowed and decimated. */
+    readBand: (bandIndex: number, window?: LocalNetcdfWindow) => Promise<LocalNetcdfGrid>;
+    /** Release the underlying file or worker. */
+    close: () => void;
+  };
+  /**
+   * Present only for a layer drawn as an RGB composite: the three slices its
+   * pixels were composed from, so a click can report all three readings at once
+   * instead of the one channel {@link grid} happens to be.
+   *
+   * Its presence is also what tells the Style panel there is no colormap to
+   * edit — re-baking a composite with one would replace it with a single-band
+   * image. See {@link getNetcdfImageSource}.
+   */
+  rgb?: {
+    /** Indices into {@link cube}'s axis, red first. */
+    bands: [number, number, number];
+    /** The channel slices, in the same order as {@link bands}. */
+    channels: [LocalNetcdfGrid, LocalNetcdfGrid, LocalNetcdfGrid];
+  };
+}
+
+const states = new Map<string, NetcdfLayerState>();
+let unsubscribe: (() => void) | null = null;
+/** The layer array the pruner last saw, so unrelated store writes cost nothing. */
+let lastLayers: unknown = null;
+
+/**
+ * Remember what a baked NetCDF layer was made from, so its symbology stays
+ * editable and its pixels stay readable, and start releasing entries whose
+ * layer is gone.
+ *
+ * An open file is large (a hyperspectral cube runs to ~1 GB in the WebAssembly
+ * heap), and the address space is 4 GB, so **only one** file is retained: adding
+ * a second cube closes the first, which loses only its spectral profiles. Every
+ * layer keeps its own grids, which are far smaller.
+ *
+ * @param layerId - The image layer's id.
+ * @param state - The decoded slices, and the open file when it came from a cube.
+ */
+export function registerNetcdfLayer(layerId: string, state: NetcdfLayerState): void {
+  if (state.cube) {
+    for (const [id, existing] of states) {
+      if (id !== layerId && existing.cube) {
+        existing.cube.close();
+        states.set(id, { ...existing, cube: undefined });
+        // The window renders from that file; leaving it open would strand a
+        // frame whose "reload" can no longer read anything.
+        closeNetcdfCubeForLayer(id);
+      }
+    }
+  }
+  states.set(layerId, state);
+  // A removed layer would otherwise strand its grids, and its file, for the rest
+  // of the session. One subscription serves every registration.
+  unsubscribe ??= useAppStore.subscribe((current) => {
+    // Every store write lands here, including the pointer coordinates the map
+    // writes on each mouse move, so do nothing until the layer array itself is
+    // replaced. Without this guard a registered grid costs a Set of every layer
+    // id per mouse move.
+    if (current.layers === lastLayers) return;
+    lastLayers = current.layers;
+    if (states.size === 0) return;
+    const live = new Set(current.layers.map((layer) => layer.id));
+    for (const id of states.keys()) {
+      if (!live.has(id)) releaseNetcdfLayer(id);
+    }
+    // Nothing left to prune: stop listening entirely rather than waking on
+    // every layer edit for the rest of the session. The next register
+    // re-subscribes, because `unsubscribe` is cleared here.
+    if (states.size === 0) {
+      unsubscribe?.();
+      unsubscribe = null;
+    }
+  });
+}
+
+/**
+ * What a baked NetCDF layer was made from, or null when this layer is not one
+ * (or its state was lost with a project reload).
+ *
+ * @param layerId - The layer's id.
+ * @returns The retained state, or null.
+ */
+export function getNetcdfLayerState(layerId: string): NetcdfLayerState | null {
+  return states.get(layerId) ?? null;
+}
+
+/**
+ * The slice a layer's symbology can be re-applied to, or null.
+ *
+ * Null for an RGB composite even though it retains its grids: its pixels come
+ * from three channels, and re-baking any one of them with a colormap would
+ * silently replace the composite with a single-band image. Callers asking
+ * "is anything retained for this layer?" — identify, the spectral profile —
+ * want {@link getNetcdfLayerState} instead.
+ *
+ * @param layerId - The layer's id.
+ * @returns The slice, or null.
+ */
+export function getNetcdfImageSource(layerId: string): NetcdfImageSource | null {
+  const state = states.get(layerId);
+  return state && !state.rgb ? state.grid : null;
+}
+
+/** Drop a layer's retained grids and close its file, if it had one. */
+export function releaseNetcdfLayer(layerId: string): void {
+  states.get(layerId)?.cube?.close();
+  states.delete(layerId);
+  closeNetcdfCubeForLayer(layerId);
+}
+
+/**
+ * Read one pixel's values along the layer's profile axis.
+ *
+ * @param layerId - The layer's id.
+ * @param row - Row into the grid's y extent.
+ * @param column - Column into the grid's x extent.
+ * @returns The profile, or null when this layer has no retained file or the
+ *   read failed.
+ */
+export async function readNetcdfProfile(
+  layerId: string,
+  row: number,
+  column: number,
+): Promise<LocalNetcdfProfile | null> {
+  const state = states.get(layerId);
+  if (!state?.cube) return null;
+  try {
+    return await state.cube.readProfile(row, column);
+  } catch {
+    // A profile is an extra on top of the pixel readout, and the caller reads it
+    // outside the click handler; a failed read must degrade to "no chart", not
+    // surface as an unhandled rejection on every click.
+    return null;
+  }
+}

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -154,6 +154,7 @@ export {
   composeRgbImage,
   gridBounds,
   gridPixelAt,
+  gridValueAt,
   percentileClim,
   type ColormapComposition,
   type RgbComposition,

--- a/packages/plugins/src/plugins/local-netcdf.ts
+++ b/packages/plugins/src/plugins/local-netcdf.ts
@@ -2105,6 +2105,20 @@ export function gridPixelAt(grid: LocalNetcdfGrid, lng: number, lat: number): Gr
  * @returns The value, or null when the cell is fill/nodata or out of range.
  */
 export function gridValueAt(grid: LocalNetcdfGrid, row: number, column: number): number | null {
+  // A cell located on one grid is only addressable on another that shares its
+  // shape. Without this a column past the row's width would silently fold into
+  // the next row and report a real value from the wrong place — worse than the
+  // documented miss, because nothing about the reading looks wrong.
+  if (
+    !Number.isInteger(row) ||
+    !Number.isInteger(column) ||
+    row < 0 ||
+    row >= grid.ny ||
+    column < 0 ||
+    column >= grid.nx
+  ) {
+    return null;
+  }
   const raw = Number(grid.values[row * grid.nx + column]);
   const fill = typeof grid.fillValue === "number" ? grid.fillValue : null;
   if (!Number.isFinite(raw) || (fill !== null && raw === fill)) return null;

--- a/packages/plugins/src/plugins/local-netcdf.ts
+++ b/packages/plugins/src/plugins/local-netcdf.ts
@@ -2082,17 +2082,34 @@ export function gridPixelAt(grid: LocalNetcdfGrid, lng: number, lat: number): Gr
     (lng < 0 ? nearestIndex(grid.lon, lng + 360) : nearestIndex(grid.lon, lng - 360));
   if (row === null || column === null) return null;
 
-  const raw = Number(grid.values[row * grid.nx + column]);
-  const fill = typeof grid.fillValue === "number" ? grid.fillValue : null;
-  const missing = !Number.isFinite(raw) || (fill !== null && raw === fill);
-  const value = missing ? null : raw * (grid.scaleFactor ?? 1) + (grid.addOffset ?? 0);
   return {
     row,
     column,
     lng: Number(grid.lon[column]),
     lat: Number(grid.lat[row]),
-    value: value !== null && Number.isFinite(value) ? value : null,
+    value: gridValueAt(grid, row, column),
   };
+}
+
+/**
+ * One cell's value in physical units, with the grid's packing applied.
+ *
+ * Split out of {@link gridPixelAt} for the caller that has already located the
+ * cell and wants the same reading from a *second* grid: the channels of an RGB
+ * composite share one geometry, so the coordinate search runs once and this
+ * reads the other two channels straight off the index.
+ *
+ * @param grid - The retained slice.
+ * @param row - Row into its y extent.
+ * @param column - Column into its x extent.
+ * @returns The value, or null when the cell is fill/nodata or out of range.
+ */
+export function gridValueAt(grid: LocalNetcdfGrid, row: number, column: number): number | null {
+  const raw = Number(grid.values[row * grid.nx + column]);
+  const fill = typeof grid.fillValue === "number" ? grid.fillValue : null;
+  if (!Number.isFinite(raw) || (fill !== null && raw === fill)) return null;
+  const value = raw * (grid.scaleFactor ?? 1) + (grid.addOffset ?? 0);
+  return Number.isFinite(value) ? value : null;
 }
 
 /**

--- a/tests/local-netcdf.test.ts
+++ b/tests/local-netcdf.test.ts
@@ -924,6 +924,16 @@ describe("gridPixelAt", () => {
     const values = new Float32Array([-9999, 2, 3, 4, 5, 6]);
     assert.equal(gridValueAt({ ...grid(), values }, 0, 0), null);
   });
+
+  it("reports a miss rather than folding an out-of-range column into the next row", () => {
+    // `column === nx` would index the first cell of the following row, which
+    // reads as a perfectly ordinary value from the wrong place.
+    assert.equal(gridValueAt(grid(), 0, 3), null);
+    assert.equal(gridValueAt(grid(), 0, -1), null);
+    assert.equal(gridValueAt(grid(), 2, 0), null);
+    assert.equal(gridValueAt(grid(), -1, 0), null);
+    assert.equal(gridValueAt(grid(), 0.5, 1), null);
+  });
 });
 
 describe("readProfile (NetCDF-3)", () => {

--- a/tests/local-netcdf.test.ts
+++ b/tests/local-netcdf.test.ts
@@ -10,6 +10,7 @@ import {
   composeRgbImage,
   gridBounds,
   gridPixelAt,
+  gridValueAt,
   openLocalNetcdf,
   percentileClim,
   type InlineZarrGrid,
@@ -907,6 +908,21 @@ describe("gridPixelAt", () => {
     // The extent runs half a cell past the last centre, so the very edge of the
     // drawn image must still resolve rather than reporting a miss.
     assert.equal(gridPixelAt(grid(), 2.4, 20)?.column, 2);
+  });
+
+  it("reads the same cell from a second grid without searching again", () => {
+    // What an RGB composite's identify does: the click locates the cell on one
+    // channel, and the other two are read straight off those indices.
+    const pixel = gridPixelAt(grid(), 1.1, 19.6);
+    assert.ok(pixel);
+    const green = { ...grid(), values: new Float32Array([10, 20, 30, 40, 50, 60]) };
+    assert.equal(gridValueAt(green, pixel.row, pixel.column), 20);
+  });
+
+  it("unpacks and masks the same way gridPixelAt does", () => {
+    assert.equal(gridValueAt({ ...grid(), scaleFactor: 2, addOffset: 1 }, 0, 0), 3);
+    const values = new Float32Array([-9999, 2, 3, 4, 5, 6]);
+    assert.equal(gridValueAt({ ...grid(), values }, 0, 0), null);
   });
 });
 

--- a/tests/netcdf-band-axis.test.ts
+++ b/tests/netcdf-band-axis.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   axisOptionLabel,
   bandLabel,
+  bandMeasure,
   defaultRgbBands,
   isTimeAxisName,
   pickBandAxis,
@@ -94,6 +95,21 @@ describe("axis labelling", () => {
 
   it("falls back to the bare index when the axis has no coordinates", () => {
     assert.equal(bandLabel(axis("bands", 3), 2), "bands 2");
+  });
+
+  it("gives the measure alone where the axis is already implied", () => {
+    // The identify popup's channel rows: "Red band (500.50 nm)" reads, "Red
+    // band (500.50 nm (bands 1))" does not.
+    assert.equal(bandMeasure(axis("bands", 3, 400, 600, "nm"), 1), "500 nm");
+    assert.equal(bandMeasure(axis("bands", 5, 400, 600, "nm"), 1), "450 nm");
+  });
+
+  it("keeps the axis name in the measure when there are no units to give it meaning", () => {
+    assert.equal(bandMeasure(axis("level", 3, 0, 2), 1), "level 1");
+    assert.equal(bandMeasure(axis("bands", 3), 2), "bands 2");
+    // Past the end of the coordinates, which is what a composite carried over
+    // from a wider axis would ask for.
+    assert.equal(bandMeasure(axis("bands", 3, 400, 600, "nm"), 9), "bands 9");
   });
 });
 

--- a/tests/netcdf-layer-registry.test.ts
+++ b/tests/netcdf-layer-registry.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  getNetcdfImageSource,
+  getNetcdfLayerState,
+  registerNetcdfLayer,
+  releaseNetcdfLayer,
+} from "../apps/geolibre-desktop/src/lib/netcdf-layer-registry";
+import type { LocalNetcdfGrid } from "../packages/plugins/src/plugins/local-netcdf";
+
+/** A 2x2 slice whose values tag their cell, so a mix-up between two is visible. */
+function grid(first: number): LocalNetcdfGrid {
+  return {
+    ny: 2,
+    nx: 2,
+    values: new Float32Array([first, first + 1, first + 2, first + 3]),
+    lat: new Float64Array([20, 10]),
+    lon: new Float64Array([0, 1]),
+    fillValue: null,
+    dataClim: [first, first + 3],
+  };
+}
+
+const registered: string[] = [];
+
+/** Register a layer and remember it, so a failing assertion cannot leak state. */
+function register(id: string, state: Parameters<typeof registerNetcdfLayer>[1]): void {
+  registered.push(id);
+  registerNetcdfLayer(id, state);
+}
+
+afterEach(() => {
+  for (const id of registered.splice(0)) releaseNetcdfLayer(id);
+});
+
+describe("netcdf layer registry", () => {
+  it("offers a single-band layer's slice for re-colormapping", () => {
+    register("single", { grid: grid(1), variable: "reflectance" });
+    assert.equal(getNetcdfImageSource("single")?.dataClim[0], 1);
+    assert.equal(getNetcdfLayerState("single")?.variable, "reflectance");
+  });
+
+  it("retains an RGB composite but offers it no colormap to re-apply", () => {
+    // The pixels came from three channels, each stretched to its own range;
+    // re-baking any one of them with a colormap would replace the composite
+    // with a single-band image, so the symbology controls must stay away.
+    const channels: [LocalNetcdfGrid, LocalNetcdfGrid, LocalNetcdfGrid] = [
+      grid(1),
+      grid(10),
+      grid(100),
+    ];
+    register("rgb", {
+      grid: channels[0],
+      variable: "reflectance",
+      rgb: { bands: [40, 25, 10], channels },
+    });
+
+    // Null here is what keeps the Style panel's colormap section closed...
+    assert.equal(getNetcdfImageSource("rgb"), null);
+    // ...while the state itself is what Identify and the spectral profile ask
+    // for, so a composite is still clickable.
+    const state = getNetcdfLayerState("rgb");
+    assert.equal(state?.rgb?.bands[0], 40);
+    assert.equal(state?.rgb?.channels[1].values[0], 10);
+    // The red channel doubles as the grid, so the cell lookup and the cube
+    // window read the geometry all three share.
+    assert.equal(state?.grid, channels[0]);
+  });
+
+  it("forgets everything about a released layer", () => {
+    register("gone", { grid: grid(1), variable: "reflectance" });
+    releaseNetcdfLayer("gone");
+    assert.equal(getNetcdfLayerState("gone"), null);
+    assert.equal(getNetcdfImageSource("gone"), null);
+  });
+
+  it("closes the previous cube when a second one registers, keeping its channels", () => {
+    let closed = 0;
+    const cube = {
+      axis: { name: "bands", size: 3 },
+      readProfile: async () => ({ axis: "bands", values: [] }) as never,
+      readBand: async () => grid(1),
+      close: () => {
+        closed += 1;
+      },
+    };
+    const channels: [LocalNetcdfGrid, LocalNetcdfGrid, LocalNetcdfGrid] = [
+      grid(1),
+      grid(10),
+      grid(100),
+    ];
+    register("first", {
+      grid: channels[0],
+      variable: "reflectance",
+      cube,
+      rgb: { bands: [0, 1, 2], channels },
+    });
+    register("second", { grid: grid(1), variable: "other", cube: { ...cube, close: () => {} } });
+
+    assert.equal(closed, 1);
+    // Only the file goes: the retained channels are what the popup reads, and
+    // dropping them would leave the older composite silently unclickable.
+    const first = getNetcdfLayerState("first");
+    assert.equal(first?.cube, undefined);
+    assert.equal(first?.rgb?.channels.length, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adding a NetCDF/HDF cube as an **RGB composite** left the layer with nothing retained in memory, so the pixel inspector (Identify) stayed disabled and the spectral profile never appeared. The composite now registers its three channel grids and its cube reader, exactly as the single-band path does.
- The identify popup reports all three channels with the band each was drawn from (`Red band (641.13 nm): 0.030785`) rather than one variable row. The cell is located once and the other two channels are read straight off those indices via a `gridValueAt` helper split out of `gridPixelAt`.
- The Style panel gives a composite a read-only band summary plus the 3D cube button, in place of the colormap controls. Re-baking any one channel with a colormap would replace the composite with a single-band image, so `getNetcdfImageSource` returns null for it while `getNetcdfLayerState` is what Identify and the profile gate on.
- The retained-grid registry moves to its own module (`netcdf-layer-registry.ts`) so it can be exercised outside a browser; `netcdf-image-symbology.ts` pulls the plugin barrel for the colormapper and cannot be imported in a plain test run.
- No new translation keys: the channel names reuse the Add dialog's own `addData.netcdf.channel.*`, so every shipped locale is already covered.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings)
- [x] `npm run test:frontend:coverage` (5364 pass, 0 fail); new coverage for the layer registry, `bandMeasure`, and `gridValueAt`
- [x] `pre-commit run --files <changed>`
- [x] Real browser, production build, against an EMIT L3 reflectance cube subset, in both light and dark themes:
  - RGB composite added, Identify offered and active, popup reports Red/Green/Blue values with wavelengths plus lon/lat and row/col
  - three sampled pixels chart as spectral signatures; dock and pop-out both work
  - the 3D cube setup opens from the composite
  - a single-band layer still gets its full NetCDF symbology section (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for RGB NetCDF composite layers in styling and layer controls.
  - RGB layers now display their red, green, and blue bands, with an option to reopen cube setup.
  - Identify popups now show separate channel values with units where available.
  - NetCDF pixel values correctly apply scale, offset, and missing-data handling.

- **Bug Fixes**
  - Improved identification and symbology for retained NetCDF and RGB layers.
  - Improved cleanup when NetCDF layers or datasets are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->