### PR TITLE
refactor(netcdf): share the band label's coordinate rounding

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/NetcdfSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NetcdfSymbologySection.tsx
@@ -122,10 +122,12 @@ export function NetcdfSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     setPendingSymbology(null);
   }
 
-  // After the hooks above, not before: an early return that skipped them would
-  // change the hook order between a single-band layer and a composite.
-  const rgbState = getNetcdfLayerState(layer.id);
-  if (rgbState?.rgb) return <NetcdfRgbSection layerId={layer.id} state={rgbState} />;
+  // Read once and reused by the cube button below, so the two checks cannot
+  // drift apart. After the hooks above, not before: an early return that
+  // skipped them would change the hook order between a single-band layer and a
+  // composite.
+  const layerState = getNetcdfLayerState(layer.id);
+  if (layerState?.rgb) return <NetcdfRgbSection layerId={layer.id} state={layerState} />;
 
   if (!source) return null;
 
@@ -232,7 +234,7 @@ export function NetcdfSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           {/* Only for a layer whose source file is still open on a band axis:
               the cube is read plane by plane from that file, so a plain 2-D
               grid (or a reloaded project) has nothing to build one from. */}
-          {getNetcdfLayerState(layer.id)?.cube ? (
+          {layerState?.cube ? (
             <Button
               type="button"
               variant="outline"

--- a/apps/geolibre-desktop/src/lib/netcdf-band-axis.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-band-axis.ts
@@ -40,9 +40,18 @@ const MICROMETRE_UNITS = new Set([
   "micrometres",
 ]);
 
+/**
+ * A coordinate as it reads in a label: two decimals, or as it stands when it is
+ * whole. Shared by every label below so a wavelength cannot come out to one
+ * precision in the band picker and another in the identify popup.
+ */
+function roundedCoordinate(coordinate: number): string {
+  return Number.isInteger(coordinate) ? String(coordinate) : coordinate.toFixed(2);
+}
+
 /** `"650.41 nm (bands 47)"` — the coordinate value first, then where it sits. */
 export function axisOptionLabel(axis: LocalNetcdfAxis, coordinate: number, index: number): string {
-  const rounded = Number.isInteger(coordinate) ? String(coordinate) : coordinate.toFixed(2);
+  const rounded = roundedCoordinate(coordinate);
   const measure = axis.units ? `${rounded} ${axis.units}` : rounded;
   return `${measure} (${axis.name} ${index})`;
 }
@@ -63,7 +72,7 @@ export function axisOptionLabel(axis: LocalNetcdfAxis, coordinate: number, index
 export function bandMeasure(axis: LocalNetcdfAxis, index: number): string {
   const coordinate = axis.values?.[index];
   if (coordinate === undefined) return `${axis.name} ${index}`;
-  const rounded = Number.isInteger(coordinate) ? String(coordinate) : coordinate.toFixed(2);
+  const rounded = roundedCoordinate(coordinate);
   // Without units the bare number reads as nothing in particular, so keep the
   // axis name in front of it rather than showing a naked "47".
   return axis.units ? `${rounded} ${axis.units}` : `${axis.name} ${rounded}`;


### PR DESCRIPTION
## Summary
Follow-up to #1723, addressing the two quality observations the review bot left on that PR after it was merged.

- `axisOptionLabel` and `bandMeasure` each rounded a band coordinate with their own copy of `Number.isInteger(c) ? String(c) : c.toFixed(2)`. Both now go through one `roundedCoordinate` helper, so a wavelength cannot end up at one precision in the Add dialog's band picker and another in the identify popup.
- `NetcdfSymbologySection` looked the layer's retained state up twice in the same render, once to decide the RGB branch and once to decide whether to show the 3D cube button. Hoisted to a single `layerState` so the two checks stay visibly in sync.

No behavior change; both are readability and drift-prevention fixes.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test:frontend` (5376 pass, 0 fail), including the existing `bandMeasure` and `axisOptionLabel` label assertions
- [x] `pre-commit run --files <changed>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when displaying fractional NetCDF coordinate and band values by rounding them to two decimal places.
  * Preserved existing formatting for whole-number values.
  * Improved NetCDF layer handling for RGB detection and cube controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->