### PR TITLE
fix(deps): patch the two high-severity audit findings without downgrading wrangler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11980,9 +11980,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20662,9 +20662,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,12 @@
     "typescript-eslint": "^8.65.0"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.5",
     "filelist": "^2.0.2",
+    "miniflare": {
+      "undici": "^7.29.0"
+    },
     "sweepline-intersections": "^1.5.0",
     "uuid": "^14.0.0"
   },


### PR DESCRIPTION
`npm i` reported 4 vulnerabilities (2 high, 2 moderate). They are two unrelated problems, and neither is fixed by what npm suggested.

### `brace-expansion` (high)

A stale lockfile, not a missing fix. The override was already `^5.0.8`, and the caret already permitted the patched 5.0.9 that [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) requires — the lock had just never been refreshed. Raised the floor to `^5.0.9` so it is explicit and cannot silently regress.

### `undici` (high, via miniflare ← wrangler)

npm's suggested fix was wrong. `npm audit fix --force` wanted to install **wrangler 4.35.0**, a downgrade from 4.118.0 across ~80 releases — npm walking backwards to a version predating the vulnerable miniflare rather than fixing anything.

Upstream has no fix yet either: the newest wrangler (4.119.0) and miniflare (`5.20260801.0-alpha`) still exact-pin `undici: 7.28.0`. So this overrides it to `^7.29.0`, where all five advisories are fixed.

The override is **scoped to miniflare's subtree** deliberately:

```json
"miniflare": { "undici": "^7.29.0" }
```

A top-level `"undici": "^7.29.0"` would have downgraded `geolibre-desktop`'s direct **undici 8.10.0** by a full major version. 8.x sits outside the advisory range (`>=7.0.0 <7.29.0`) and was never affected.

One npm quirk for whoever hits this next: npm registers the nested override but does **not** re-resolve an existing lock entry — the tree stays at 7.28.0, flagged `invalid: "^7.29.0"`. `npm update undici` forces it through.

### Scope

CI was **already green** before this — all four findings were dev-only (wrangler is a devDependency in all four `workers/*`), and the audit step runs `npm audit --omit=dev`. This clears the local `npm i` warning rather than unblocking anything.

### Verification

- `npm audit` → **0 vulnerabilities** (was 4); same for `npm audit --omit=dev --audit-level=high`, exactly as CI runs it
- `wrangler --version` → 4.118.0, and `wrangler deploy --dry-run` still bundles the ai-proxy worker with all bindings intact — worth checking given miniflare exact-pinned undici, which can signal reliance on internals
- `npm run test:worker` → all 6 workspaces typecheck, 7/7 collab-node tests pass
- `pre-commit run --files package.json package-lock.json` → clean (oxfmt re-sorted the `overrides` keys alphabetically; semantics unchanged)

Diff is 3 lines of `package.json` and 12 of `package-lock.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package compatibility requirements.
  * Applied maintenance updates to improve dependency stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->