### PR TITLE
fix(ios): raise the deployment target to iOS 15.0

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -164,7 +164,14 @@ jobs:
           conf="apps/geolibre-desktop/src-tauri/tauri.ios.conf.json"
           project="apps/geolibre-desktop/src-tauri/gen/apple/project.yml"
 
-          want="$(jq -er '.bundle.iOS.minimumSystemVersion' "$conf")"
+          # `// empty` rather than `jq -e` so a removed or renamed key lands on
+          # the message below instead of jq's bare "Error: null (null)". Invalid
+          # JSON still fails the step through `set -e`, as it should.
+          want="$(jq -r '.bundle.iOS.minimumSystemVersion // empty' "$conf")"
+          if [ -z "$want" ]; then
+            echo "::error::$conf does not set bundle.iOS.minimumSystemVersion, so the Tauri CLI's 14.0 default would apply (ITMS-90068)"
+            exit 1
+          fi
 
           # Component-wise dotted-version compare, exiting 0 when the configured
           # target is at or above the floor. Deliberately not `sort -V`: this

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -187,9 +187,17 @@ jobs:
             echo "::error::No generated project.yml at $project"
             exit 1
           fi
-          # tr strips YAML quoting if the template ever emits any, leaving the
-          # bare dotted version.
-          got="$(awk '/^[[:space:]]*deploymentTarget:/ {f=1; next} f && /^[[:space:]]*iOS:/ {print $2; exit}' "$project" | tr -cd '0-9.')"
+          # Scoped to the `deploymentTarget:` block, resetting at the first line
+          # that dedents back out of it, so an `iOS:` key elsewhere in the file
+          # can never be read as this one. Parsed as text rather than YAML on
+          # purpose: a YAML loader turns `15.0` into a float, and `15.10` would
+          # come back out as `15.1`. tr strips quoting if the template emits any.
+          got="$(awk '
+            /^[[:space:]]*deploymentTarget:/ { depth = match($0, /[^[:space:]]/); inblock = 1; next }
+            !inblock || /^[[:space:]]*$/ { next }
+            match($0, /[^[:space:]]/) <= depth { inblock = 0; next }
+            $1 == "iOS:" { print $2; exit }
+          ' "$project" | tr -cd '0-9.')"
           if [ "$got" != "$want" ]; then
             echo "::error::Generated project.yml has deploymentTarget.iOS '$got', expected the configured '$want'. Did the Tauri CLI stop honoring bundle.iOS.minimumSystemVersion?"
             exit 1

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -166,10 +166,20 @@ jobs:
 
           want="$(jq -er '.bundle.iOS.minimumSystemVersion' "$conf")"
 
-          # Dotted-version compare: if 15.0 is not the lower of the two, the
-          # configured target is below Apple's floor.
-          if [ "$(printf '%s\n%s\n' "15.0" "$want" | sort -V | head -1)" != "15.0" ]; then
-            echo "::error::$conf sets bundle.iOS.minimumSystemVersion to '$want', below Apple's 15.0 floor (ITMS-90068)"
+          # Component-wise dotted-version compare, exiting 0 when the configured
+          # target is at or above the floor. Deliberately not `sort -V`: this
+          # runs on macOS, whose sort is BSD rather than GNU, and a `-V` that
+          # errored out would fail the step with the message below no matter what
+          # the config actually says. awk behaves the same on both.
+          floor="15.0"
+          if ! awk -v want="$want" -v floor="$floor" 'BEGIN {
+                n = split(want, a, "."); m = split(floor, b, ".")
+                for (i = 1; i <= (n > m ? n : m); i++) {
+                  if (a[i] + 0 != b[i] + 0) exit (a[i] + 0 < b[i] + 0)
+                }
+                exit 0
+              }'; then
+            echo "::error::$conf sets bundle.iOS.minimumSystemVersion to '$want', below Apple's $floor floor (ITMS-90068)"
             exit 1
           fi
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -143,6 +143,53 @@ jobs:
         # upload rather than at build time.
         run: ./scripts/sync-ios-app-icon.sh
 
+      - name: Verify the iOS deployment target
+        # Apple's floor, not ours: from Spring 2027 App Store Connect refuses any
+        # upload whose MinimumOSVersion is below 15.0, and today it accepts the
+        # build and answers with a warning email instead (ITMS-90068, which is how
+        # 2.5.0 build 7 was found to still carry 14.0). A warning that arrives
+        # after the upload is exactly the kind of failure this job asserts away.
+        #
+        # The value is NOT written by anything in this repo: it comes from
+        # `bundle.iOS.minimumSystemVersion` in tauri.ios.conf.json, which the Tauri
+        # CLI templates into the generated project.yml as XcodeGen's
+        # `deploymentTarget.iOS` (-> IPHONEOS_DEPLOYMENT_TARGET -> the .app's
+        # MinimumOSVersion). Omit the key and the CLI's own default (14.0) applies
+        # silently. So the config is read as the source of truth, checked against
+        # Apple's floor, and then compared with what `ios init` actually
+        # generated: a CLI that stopped honoring the key would otherwise look
+        # identical here and only surface as another warning email.
+        run: |
+          set -euo pipefail
+          conf="apps/geolibre-desktop/src-tauri/tauri.ios.conf.json"
+          project="apps/geolibre-desktop/src-tauri/gen/apple/project.yml"
+
+          want="$(jq -er '.bundle.iOS.minimumSystemVersion' "$conf")"
+
+          # Dotted-version compare: if 15.0 is not the lower of the two, the
+          # configured target is below Apple's floor.
+          if [ "$(printf '%s\n%s\n' "15.0" "$want" | sort -V | head -1)" != "15.0" ]; then
+            echo "::error::$conf sets bundle.iOS.minimumSystemVersion to '$want', below Apple's 15.0 floor (ITMS-90068)"
+            exit 1
+          fi
+
+          if [ ! -f "$project" ]; then
+            echo "::error::No generated project.yml at $project"
+            exit 1
+          fi
+          # tr strips YAML quoting if the template ever emits any, leaving the
+          # bare dotted version.
+          got="$(awk '/^[[:space:]]*deploymentTarget:/ {f=1; next} f && /^[[:space:]]*iOS:/ {print $2; exit}' "$project" | tr -cd '0-9.')"
+          if [ "$got" != "$want" ]; then
+            echo "::error::Generated project.yml has deploymentTarget.iOS '$got', expected the configured '$want'. Did the Tauri CLI stop honoring bundle.iOS.minimumSystemVersion?"
+            exit 1
+          fi
+
+          echo "::notice::iOS deployment target $want"
+          # Handed to the IPA verify step so it asserts against the configured
+          # value rather than a second hardcoded copy of it.
+          echo "IOS_MIN_OS=$want" >> "$GITHUB_ENV"
+
       - name: Check for Apple signing secrets
         id: signing
         # `secrets` can't be used in a step-level `if:`, so presence is turned
@@ -481,7 +528,16 @@ jobs:
             exit 1
           fi
 
-          echo "IPA $ipa: bundle id $EXPECTED_BUNDLE_ID, version $short ($build), signed by $authority."
+          # The deployment target was checked against the generated project.yml
+          # before the archive; this asserts it survived into the shipped bytes,
+          # which is the copy App Store Connect reads for ITMS-90068.
+          minos="$(/usr/libexec/PlistBuddy -c 'Print :MinimumOSVersion' "$plist")"
+          if [ "$minos" != "$IOS_MIN_OS" ]; then
+            echo "::error::$ipa has MinimumOSVersion '$minos', expected the configured '$IOS_MIN_OS'"
+            exit 1
+          fi
+
+          echo "IPA $ipa: bundle id $EXPECTED_BUNDLE_ID, version $short ($build), min iOS $minos, signed by $authority."
           echo "IPA_PATH=$ipa" >> "$GITHUB_ENV"
 
       - name: Clean up the signing keychain

--- a/apps/geolibre-desktop/src-tauri/tauri.ios.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.ios.conf.json
@@ -3,6 +3,9 @@
   "productName": "GeoLibre",
   "identifier": "org.geolibre.app",
   "bundle": {
-    "resources": []
+    "resources": [],
+    "iOS": {
+      "minimumSystemVersion": "15.0"
+    }
   }
 }

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -64,6 +64,45 @@ It covers all three location consumers: Field Collection, GPS Tracking, and the
 Controls → GeoLocate map control. After a build, confirm the key survived the
 merge (see *Build* below).
 
+## Minimum iOS version
+
+GeoLibre targets **iOS 15.0**, set once in `src-tauri/tauri.ios.conf.json`:
+
+```json
+"bundle": { "iOS": { "minimumSystemVersion": "15.0" } }
+```
+
+Tauri templates that value into the generated `gen/apple/project.yml` as
+XcodeGen's `deploymentTarget.iOS`, which Xcode turns into
+`IPHONEOS_DEPLOYMENT_TARGET` and finally the app's `MinimumOSVersion`. There is
+nothing to hand-edit in the generated project, and nothing in `Info.ios.plist`:
+Xcode writes the plist key from the build setting.
+
+Leave the key out and the **Tauri CLI's own default applies**, which is `14.0`.
+That is below Apple's floor: starting Spring 2027, App Store Connect refuses any
+upload with a `MinimumOSVersion` under 15.0. Until then it accepts the build and
+sends a warning email afterwards (`ITMS-90068`), which is how version 2.5.0
+build 7 was found to have shipped at 14.0.
+
+Because `gen/apple` is generated, a change here only takes effect once the
+project is regenerated. CI regenerates on every run, so it picks the value up
+automatically; locally, delete `src-tauri/gen/apple` and re-run
+`npx tauri ios init`. Confirm what an existing build actually carries with:
+
+```bash
+/usr/libexec/PlistBuddy -c 'Print :MinimumOSVersion' \
+  src-tauri/gen/apple/geolibre-desktop_iOS/Info.plist
+```
+
+The CI job asserts this in two places (see *Continuous integration*): the
+configured value against Apple's floor and against the generated `project.yml`
+right after `ios init`, and then the exported `.ipa`'s `MinimumOSVersion`, which
+is the copy App Store Connect actually reads.
+
+Raising the floor further is a product decision, not a technical one. iOS 15 is
+the last release for the iPhone 6s/7 and iPad Air 2 generation, so 16.0 would
+drop those devices in exchange for a newer WebKit baseline.
+
 ## Toolchain setup (one time)
 
 You need a **Mac** with **Xcode** (from the App Store; open it once to accept the
@@ -144,8 +183,8 @@ npx tauri ios build --no-sign          # unsigned .ipa + .xcarchive (no Apple ac
 > list is not evidence the signing failed — check the `.ipa` itself.
 
 - `gen/apple` is generated (git-ignored) and regenerated on demand. `init` also
-  merges `tauri.ios.conf.json` (bundle id, drops the Python backend) and
-  `Info.ios.plist` (the location string).
+  merges `tauri.ios.conf.json` (bundle id, deployment target, drops the Python
+  backend) and `Info.ios.plist` (the location string).
 - The app is named **GeoLibre** on iOS (the desktop build is "GeoLibre Desktop")
   and uses the bundle id **`org.geolibre.app`**, both set via
   `src-tauri/tauri.ios.conf.json` — the same override pattern and reasoning as
@@ -204,8 +243,8 @@ not free to choose — see the Xcode floor below.
 
 - **With Apple signing secrets set**, it imports the identity into a throwaway
   keychain, archives **unsigned**, exports a signed `.ipa` under manual signing,
-  verifies the bundle id and the signature, and uploads it as the
-  `geolibre-ios-ipa` artifact:
+  verifies the bundle id, the signature, the build number shape and the
+  `MinimumOSVersion`, and uploads it as the `geolibre-ios-ipa` artifact:
   - `APPLE_IOS_CERTIFICATE_BASE64` — `base64 -i dist.p12`
   - `APPLE_IOS_CERTIFICATE_PASSWORD`
   - `APPLE_IOS_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -66,7 +66,8 @@ merge (see *Build* below).
 
 ## Minimum iOS version
 
-GeoLibre targets **iOS 15.0**, set once in `src-tauri/tauri.ios.conf.json`:
+GeoLibre targets **iOS 15.0**, set once in
+`apps/geolibre-desktop/src-tauri/tauri.ios.conf.json`:
 
 ```json
 "bundle": { "iOS": { "minimumSystemVersion": "15.0" } }
@@ -81,17 +82,27 @@ Xcode writes the plist key from the build setting.
 Leave the key out and the **Tauri CLI's own default applies**, which is `14.0`.
 That is below Apple's floor: starting Spring 2027, App Store Connect refuses any
 upload with a `MinimumOSVersion` under 15.0. Until then it accepts the build and
-sends a warning email afterwards (`ITMS-90068`), which is how version 2.5.0
+sends a warning email afterward (`ITMS-90068`), which is how version 2.5.0
 build 7 was found to have shipped at 14.0.
 
 Because `gen/apple` is generated, a change here only takes effect once the
 project is regenerated. CI regenerates on every run, so it picks the value up
-automatically; locally, delete `src-tauri/gen/apple` and re-run
-`npx tauri ios init`. Confirm what an existing build actually carries with:
+automatically; locally, regenerate it yourself (paths relative to
+`apps/geolibre-desktop`, as everywhere else in this document):
 
 ```bash
+cd apps/geolibre-desktop
+rm -rf src-tauri/gen/apple
+npx tauri ios init
+
+# What init generated:
+grep -A2 'deploymentTarget:' src-tauri/gen/apple/project.yml
+
+# What a build actually shipped. `MinimumOSVersion` exists only in the *built*
+# app, since Xcode writes it from the build setting; it is not in the generated
+# source Info.plist.
 /usr/libexec/PlistBuddy -c 'Print :MinimumOSVersion' \
-  src-tauri/gen/apple/geolibre-desktop_iOS/Info.plist
+  src-tauri/gen/apple/build/geolibre-desktop_iOS.xcarchive/Products/Applications/GeoLibre.app/Info.plist
 ```
 
 The CI job asserts this in two places (see *Continuous integration*): the
@@ -182,9 +193,10 @@ npx tauri ios build --no-sign          # unsigned .ipa + .xcarchive (no Apple ac
 > *not* appear in `security find-identity -v -p codesigning`. An empty identity
 > list is not evidence the signing failed — check the `.ipa` itself.
 
-- `gen/apple` is generated (git-ignored) and regenerated on demand. `init` also
-  merges `tauri.ios.conf.json` (bundle id, deployment target, drops the Python
-  backend) and `Info.ios.plist` (the location string).
+- `gen/apple` is generated (git-ignored) and regenerated on demand. `init`
+  applies `tauri.ios.conf.json` (bundle id, deployment target, drops the Python
+  backend); `Info.ios.plist` (the location string) is merged later, by
+  `tauri ios build`/`dev`, as noted below.
 - The app is named **GeoLibre** on iOS (the desktop build is "GeoLibre Desktop")
   and uses the bundle id **`org.geolibre.app`**, both set via
   `src-tauri/tauri.ios.conf.json` — the same override pattern and reasoning as

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -100,7 +100,9 @@ grep -A2 'deploymentTarget:' src-tauri/gen/apple/project.yml
 
 # What a build actually shipped. `MinimumOSVersion` exists only in the *built*
 # app, since Xcode writes it from the build setting; it is not in the generated
-# source Info.plist.
+# source Info.plist. So this needs an archive, which `init` alone does not
+# produce.
+npx tauri ios build --no-sign
 /usr/libexec/PlistBuddy -c 'Print :MinimumOSVersion' \
   src-tauri/gen/apple/build/geolibre-desktop_iOS.xcarchive/Products/Applications/GeoLibre.app/Info.plist
 ```


### PR DESCRIPTION
## Summary

- Set `bundle.iOS.minimumSystemVersion` to `15.0` in `src-tauri/tauri.ios.conf.json`. Nothing set a deployment target before, so the Tauri CLI's own default of 14.0 applied silently and App Store Connect answered the 2.5.0 build 7 upload with `ITMS-90068`. Apple refuses anything below 15.0 starting Spring 2027.
- Added two assertions to `.github/workflows/ios.yml`: a new step after `tauri ios init` that checks the configured value against Apple's floor and against the `deploymentTarget.iOS` the CLI actually generated, plus a `MinimumOSVersion` check on the exported IPA in the existing verify step. The warning only arrives after a successful upload, which is the most expensive place to find it, and the value is produced by the CLI rather than by anything in this repo.
- Documented the default-is-14.0 trap, the `gen/apple` regeneration requirement, and how to check an existing build in `docs/ios.md`.

## Test plan

- [x] Confirmed against the vendored `@tauri-apps/cli` 2.11.4 config schema that `bundle.iOS.minimumSystemVersion` maps to `IPHONEOS_DEPLOYMENT_TARGET` and defaults to `14.0`, and against Tauri's `templates/mobile/ios/project.yml` that it lands as `deploymentTarget.iOS`.
- [x] Exercised the new shell logic against a sample generated `project.yml` in quoted and unquoted forms, and ran 14.0 / 9.0 / 15.0 / 16.1 through the floor comparison.
- [x] `pre-commit run --files` on the three changed files.
- [ ] iOS workflow run on a macOS runner: the new step reports `iOS deployment target 15.0` and the IPA verify step reports `min iOS 15.0`. This cannot be checked from Linux, since iOS is not cross-compilable.
- [ ] Next App Store Connect upload comes back without `ITMS-90068`.

## Notes

15.0 is the minimum Apple demands. iOS 15 is the last release for the iPhone 6s/7 and iPad Air 2, so 16.0 would buy a newer WebKit baseline at the cost of those devices. Build 7 itself stays valid; this affects the next upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoLibre for iOS now supports iOS 15.0 and later.
  * iOS builds verify that packaged apps declare the correct minimum system version.

* **Documentation**
  * Added guidance on iOS deployment targets, project regeneration, validation, build numbers, bundle identifiers, and signing.
  * Documented App Store requirements for the minimum supported iOS version.

* **Chores**
  * Improved automated checks to ensure generated projects and packaged apps use the configured iOS version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->