### PR TITLE
docs: add a Become a Sponsor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,19 @@ Full documentation, including the User Guide and Tutorials, is published at
   - [Roadmap](docs/roadmap.md)
   - [Contributing](docs/contributing.md)
   - [How to Cite](docs/citation.md)
+  - [Become a Sponsor](docs/sponsor.md)
 
 Contributions are welcome. See the [Contributing](docs/contributing.md) guide
 for the development setup, repository layout, and quality gate.
+
+## Sponsor
+
+GeoLibre is free and open source, and stays that way. If it is useful to you or your team, sponsorship is the most direct way to keep development, hosting, and cross-platform distribution going.
+
+- [**GitHub Sponsors**](https://github.com/sponsors/giswqs) - monthly or one-time, billed through your GitHub account.
+- [**Buy Me a Coffee**](https://buymeacoffee.com/giswqs) - a quick one-off contribution, no account required.
+
+See the [Become a Sponsor](https://geolibre.app/sponsor/) page for what sponsorship supports and for other, free ways to help.
 
 ## Acknowledgements
 

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -78,3 +78,6 @@ a discussion, or shared GeoLibre with their community.
 Want to see your name here? Contributions of every size are welcome — from
 filing a well-described bug report to writing a plugin. See the
 [Contributing guide](contributing.md) to get started.
+
+If you would rather support the project financially, see
+[Become a Sponsor](sponsor.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -225,6 +225,14 @@ launch), see the [sidecar README](https://github.com/opengeos/GeoLibre/blob/main
 Run its tests with `npm run test:backend` from the repository root, or
 `python -m pytest` from the backend directory.
 
+## Sponsoring
+
+Code is not the only way to contribute. If you or your organization depend on
+GeoLibre, financial support keeps development, hosting, and app-store
+distribution going — see [Become a Sponsor](sponsor.md) for
+[GitHub Sponsors](https://github.com/sponsors/giswqs) and
+[Buy Me a Coffee](https://buymeacoffee.com/giswqs).
+
 ## License
 
 GeoLibre is released under the [MIT License](https://github.com/opengeos/GeoLibre/blob/main/LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -203,3 +203,11 @@ widget that cross-filters the other widgets, and
 [NMEA receiver support](user-guide/map-controls.md#gps-tracking) in GPS Tracking.
 
 The [roadmap](roadmap.md) tracks every release, version by version.
+
+## Support GeoLibre
+
+GeoLibre is free and open source, and stays that way. If it is useful to you or
+your team, [becoming a sponsor](sponsor.md) — through
+[GitHub Sponsors](https://github.com/sponsors/giswqs) or
+[Buy Me a Coffee](https://buymeacoffee.com/giswqs) — is the most direct way to
+keep development, hosting, and app-store distribution going.

--- a/docs/sponsor.md
+++ b/docs/sponsor.md
@@ -1,0 +1,77 @@
+# Become a Sponsor
+
+GeoLibre is free and open-source software, released under the
+[MIT License](https://github.com/opengeos/GeoLibre/blob/main/LICENSE) and
+developed in the open. There is no paid tier, no seat licence, and no telemetry —
+everything on this site is available to everyone, forever.
+
+That model only works if the work behind it is sustainable. If GeoLibre saves you
+or your team time, sponsorship is the most direct way to keep it moving.
+
+[Sponsor on GitHub](https://github.com/sponsors/giswqs){ .md-button .md-button--primary }
+[Buy me a coffee](https://buymeacoffee.com/giswqs){ .md-button }
+
+## Ways to sponsor
+
+| | What it is | Best for |
+| --- | --- | --- |
+| **[GitHub Sponsors](https://github.com/sponsors/giswqs)** | Monthly or one-time sponsorship, billed through your existing GitHub account. | Individuals and organizations that want recurring support, and companies that can expense it alongside other GitHub spend. |
+| **[Buy Me a Coffee](https://buymeacoffee.com/giswqs)** | A quick one-off contribution, no account required. | A small thank-you for a feature or bug fix that helped you. |
+
+Both go to [Qiusheng Wu](https://github.com/giswqs), the maintainer of GeoLibre
+and the wider [opengeos](https://github.com/opengeos) ecosystem.
+
+## What your sponsorship supports
+
+- **Development time** — new features from the [Roadmap](roadmap.md), bug fixes,
+  and keeping up with fast-moving upstream dependencies such as MapLibre GL JS,
+  DuckDB-WASM, deck.gl, and Tauri.
+- **Shipping to every platform** — the paid developer accounts, code signing, and
+  notarization behind the [Mac App Store](mac-app-store.md), Microsoft Store, and
+  [Google Play](android.md) listings, which the project pays for whether or not
+  anyone sponsors it.
+- **Hosting** — [geolibre.app](https://geolibre.app), the
+  [web app](https://web.geolibre.app/), and the demo data behind the
+  [tutorials](tutorials/index.md).
+- **Documentation and teaching** — the [User Guide](user-guide/interface.md),
+  tutorials, and example projects that make the tool usable without training.
+- **Support** — triaging issues, answering questions, and reviewing community
+  pull requests.
+
+## Sponsoring as an organization
+
+If your team depends on GeoLibre and you would like to discuss a larger or
+invoiced sponsorship, please
+[open an issue](https://github.com/opengeos/GeoLibre/issues/new/choose) or start a
+[discussion](https://github.com/opengeos/GeoLibre/discussions) to get in touch.
+
+Grant-funded and institutional support is welcome too. If GeoLibre is part of a
+proposal, please also see [How to Cite](citation.md).
+
+## Other ways to support GeoLibre
+
+Sponsorship is not the only currency, and none of these cost anything:
+
+- **Star and share** — [star the repository](https://github.com/opengeos/GeoLibre)
+  and tell colleagues who are looking for a lightweight GIS.
+- **Report bugs well** — a reproducible
+  [issue](https://github.com/opengeos/GeoLibre/issues) is worth a great deal.
+- **Contribute code or plugins** — see the [Contributing guide](contributing.md)
+  and the [Plugin API](plugin-api.md).
+- **Translate the interface** — GeoLibre ships in many languages; see
+  [Internationalization](i18n.md) to add or improve one.
+- **Cite it** — if GeoLibre supports your research, [cite it](citation.md). A
+  citation record helps justify the time spent on open-source tools.
+
+## Thank you
+
+Every sponsor, contributor, bug reporter, and beta tester listed on the
+[Acknowledgements](acknowledgements.md) page has helped make GeoLibre what it is.
+Thank you.
+
+## See also
+
+- [Features](features.md) — what GeoLibre can do today.
+- [Roadmap](roadmap.md) — release history and what comes next.
+- [Contributing](contributing.md) — the development setup and quality gate.
+- [Acknowledgements](acknowledgements.md) — the projects and people behind GeoLibre.

--- a/docs/sponsor.md
+++ b/docs/sponsor.md
@@ -2,7 +2,7 @@
 
 GeoLibre is free and open-source software, released under the
 [MIT License](https://github.com/opengeos/GeoLibre/blob/main/LICENSE) and
-developed in the open. There is no paid tier, no seat licence, and no telemetry —
+developed in the open. There is no paid tier, no seat license, and no telemetry —
 everything on this site is available to everyone, forever.
 
 That model only works if the work behind it is sustainable. If GeoLibre saves you
@@ -13,7 +13,7 @@ or your team time, sponsorship is the most direct way to keep it moving.
 
 ## Ways to sponsor
 
-| | What it is | Best for |
+| Option | What it is | Best for |
 | --- | --- | --- |
 | **[GitHub Sponsors](https://github.com/sponsors/giswqs)** | Monthly or one-time sponsorship, billed through your existing GitHub account. | Individuals and organizations that want recurring support, and companies that can expense it alongside other GitHub spend. |
 | **[Buy Me a Coffee](https://buymeacoffee.com/giswqs)** | A quick one-off contribution, no account required. | A small thank-you for a feature or bug fix that helped you. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - Comparison: comparison.md
   - Demos: demos.md
   - Downloads: downloads.md
+  - Sponsor: sponsor.md
   - Launch GeoLibre Web: /demo/
   - User Guide:
       - Interface Overview: user-guide/interface.md
@@ -118,3 +119,9 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/opengeos/GeoLibre
       name: GeoLibre on GitHub
+    - icon: fontawesome/solid/heart
+      link: https://github.com/sponsors/giswqs
+      name: Sponsor GeoLibre on GitHub
+    - icon: fontawesome/solid/mug-hot
+      link: https://buymeacoffee.com/giswqs
+      name: Buy the maintainer a coffee


### PR DESCRIPTION
## Summary
- Adds `docs/sponsor.md`, a Become a Sponsor page with buttons for GitHub Sponsors and Buy Me a Coffee, a table comparing the two, what sponsorship supports (development time, app-store developer accounts and signing, hosting, docs, support), an organization/grant section, and free ways to help such as starring, bug reports, plugins, translations, and citation.
- Surfaces it everywhere a reader would look: a top-level `Sponsor` nav entry and two new footer social icons in `mkdocs.yml`, a Support GeoLibre section on the home page, cross-links from the contributing guide and acknowledgements, and a Sponsor section plus reference-list entry in the README.
- The two handles already exist in `.github/FUNDING.yml`, so the GitHub sponsor button was live but nothing on geolibre.app pointed at it. No tiers, prices, or perks are invented, since none are defined.

## Test plan
- [x] `zensical build` completes with "No issues found"
- [x] All relative links in `docs/sponsor.md` resolve to existing pages
- [x] Served the build and confirmed in a browser that the two buttons, the nav entry, and the three footer icons render on the sponsor page
- [x] `pre-commit run --files <changed paths>` passes, including the npm build hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated sponsorship page with GitHub Sponsors and Buy Me a Coffee options.
  * Added sponsorship links and support information throughout the website.
  * Added details on financial contributions, organizational and grant-funded sponsorships, and non-monetary ways to help.

* **Documentation**
  * Updated acknowledgements, contributing guidance, homepage content, and reference links with sponsorship information.
  * Added the sponsorship page to site navigation and social metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->