### PR TITLE
fix(layers): give empty groups a real position so groups can be reordered

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -30,6 +30,8 @@ import {
   supportsBridgedOpacity,
   useAppStore,
   excludeHiddenFieldsFromGeojson,
+  layerGroupMoveability,
+  placeUnpositionedGroups,
 } from "@geolibre/core";
 import type { EllipsoidId, GeoLibreLayer, LayerGroup } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
@@ -973,15 +975,17 @@ export function LayerPanel({
     }
     return result;
   }, [descendantLayerAnchorByGroup, groupDepth, layerGroups]);
-  // Empty folders have no member to anchor them, so they render pinned at the
-  // top of the panel where they are easy to drop layers into.
-  const emptyGroups = useMemo(
-    () =>
-      layerGroups.filter(
-        (group) =>
-          !firstMemberIdByGroup.has(group.id) && !descendantLayerAnchorByGroup.has(group.id),
-      ),
-    [descendantLayerAnchorByGroup, firstMemberIdByGroup, layerGroups],
+  // Empty folders have no member to anchor them, so the core places them
+  // against their neighbours in the group order instead: a folder keeps its
+  // spot relative to the other folders when one of them gains a layer, and it
+  // can still be reordered (GeoLibre#1739).
+  const unpositionedGroups = useMemo(
+    () => placeUnpositionedGroups(layers, layerGroups),
+    [layers, layerGroups],
+  );
+  const groupMoveability = useMemo(
+    () => layerGroupMoveability(layers, layerGroups),
+    [layers, layerGroups],
   );
   // Resize the metadata dialog from its bottom-end grip. The dialog is centred
   // via a -50% transform, so each edge moves by half the size change; growing
@@ -2583,8 +2587,7 @@ export function LayerPanel({
   const renderGroupHeader = (group: LayerGroup) => {
     if (hasCollapsedAncestor(group)) return null;
     const isDropTarget = dropTargetGroupId === group.id;
-    const canReorderGroup =
-      firstMemberIdByGroup.has(group.id) || descendantLayerAnchorByGroup.has(group.id);
+    const moveability = groupMoveability.get(group.id);
     const moveTargets = groupMoveTargets(group);
     return (
       <div
@@ -2746,7 +2749,7 @@ export function LayerPanel({
                   menu on select; only the rename item above keeps it, so the
                   menu's close does not race its input autofocus. */}
               <DropdownMenuItem
-                disabled={!canReorderGroup}
+                disabled={!moveability?.up}
                 onSelect={() => {
                   reorderLayerGroup(group.id, "up");
                 }}
@@ -2755,7 +2758,7 @@ export function LayerPanel({
                 {t("layers.moveGroupUp")}
               </DropdownMenuItem>
               <DropdownMenuItem
-                disabled={!canReorderGroup}
+                disabled={!moveability?.down}
                 onSelect={() => {
                   reorderLayerGroup(group.id, "down");
                 }}
@@ -2945,9 +2948,6 @@ export function LayerPanel({
               {isBeginnerProfile ? t("layers.emptyBeginner") : t("layers.empty")}
             </p>
           )}
-          {emptyGroups.map((group) => (
-            <Fragment key={group.id}>{renderGroupHeader(group)}</Fragment>
-          ))}
           {visibleLayers.map((layer, displayIndex) => {
             const group = layer.groupId ? groupById.get(layer.groupId) : undefined;
             const isFirstOfGroup = group ? firstMemberIdByGroup.get(group.id) === layer.id : false;
@@ -3113,6 +3113,9 @@ export function LayerPanel({
             const moveIds = selectedMoveIds(layer.id);
             return (
               <Fragment key={layer.id}>
+                {unpositionedGroups.aboveLayer.get(layer.id)?.map((empty) => (
+                  <Fragment key={empty.id}>{renderGroupHeader(empty)}</Fragment>
+                ))}
                 {isFirstOfGroup &&
                   group &&
                   organizerHeadersByAnchor
@@ -4024,6 +4027,11 @@ export function LayerPanel({
               </Fragment>
             );
           })}
+          {/* Folders placed below the last layer row: the panel has no layer
+              left to anchor them above. */}
+          {unpositionedGroups.bottom.map((group) => (
+            <Fragment key={group.id}>{renderGroupHeader(group)}</Fragment>
+          ))}
           <div
             data-layer-card=""
             className={`rounded-md border p-2 transition-colors ${

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -30,6 +30,7 @@ import {
   supportsBridgedOpacity,
   useAppStore,
   excludeHiddenFieldsFromGeojson,
+  layerGroupDepth,
   layerGroupMoveability,
   placeUnpositionedGroups,
 } from "@geolibre/core";
@@ -886,19 +887,7 @@ export function LayerPanel({
     [layerGroups],
   );
   const groupDepth = useCallback(
-    (group: LayerGroup) => {
-      let depth = 0;
-      let parentId = group.parentId;
-      const visited = new Set([group.id]);
-      while (parentId && !visited.has(parentId)) {
-        visited.add(parentId);
-        const parent = groupById.get(parentId);
-        if (!parent) break;
-        depth += 1;
-        parentId = parent.parentId;
-      }
-      return depth;
-    },
+    (group: LayerGroup) => layerGroupDepth(group, groupById),
     [groupById],
   );
   const hasCollapsedAncestor = useCallback(

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -391,9 +391,23 @@ export function reorderLayerGroupInPanel(
   id: string,
   direction: "up" | "down",
 ): { layers: GeoLibreLayer[]; groups: LayerGroup[] } | null {
+  return moveGroupThroughUnits(buildLayerPanelUnits(layers, groups), layers, groups, id, direction);
+}
+
+/**
+ * The body of {@link reorderLayerGroupInPanel}, against panel blocks the caller
+ * already has, so asking about every group in turn splits the panel once rather
+ * than once per question.
+ */
+function moveGroupThroughUnits(
+  units: LayerPanelUnit[],
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+  id: string,
+  direction: "up" | "down",
+): { layers: GeoLibreLayer[]; groups: LayerGroup[] } | null {
   if (!groups.some((group) => group.id === id)) return null;
   const groupById = new Map(groups.map((g) => [g.id, g]));
-  const units = buildLayerPanelUnits(layers, groups);
   const moving = groupSubtreeIds(groups, id);
   const matching = new Set<number>();
   units.forEach((unit, index) => {
@@ -440,11 +454,12 @@ export function layerGroupMoveability(
   layers: GeoLibreLayer[],
   groups: LayerGroup[],
 ): Map<string, { up: boolean; down: boolean }> {
+  const units = buildLayerPanelUnits(layers, groups);
   const result = new Map<string, { up: boolean; down: boolean }>();
   for (const group of groups) {
     result.set(group.id, {
-      up: reorderLayerGroupInPanel(layers, groups, group.id, "up") !== null,
-      down: reorderLayerGroupInPanel(layers, groups, group.id, "down") !== null,
+      up: moveGroupThroughUnits(units, layers, groups, group.id, "up") !== null,
+      down: moveGroupThroughUnits(units, layers, groups, group.id, "down") !== null,
     });
   }
   return result;

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -435,6 +435,14 @@ export function layerGroupDepth(
  * group past an empty one moves nothing but the group order, so a caller must
  * apply both.
  *
+ * `normalizeGroupContiguity` keeps each *group's* own members together, but not
+ * a whole *subtree*: nesting only rewrites `parentId`, so an unrelated block can
+ * sit between two sibling child groups. The subtree still travels as one block —
+ * "with everything nested inside it" — which means such an in-between block is
+ * left behind on the other side of it, and the move can shift more than one row.
+ * Compacting the subtree is the intended reading of the operation; the in-between
+ * block landing on the far side is the accepted cost.
+ *
  * @param layers Flat layer list in store (render) order.
  * @param groups Group definitions.
  * @param id Group to move.
@@ -477,6 +485,9 @@ function moveGroupThroughUnits(
   const neighbor = direction === "up" ? indices[0] - 1 : indices[indices.length - 1] + 1;
   if (neighbor < 0 || neighbor >= units.length) return null;
   const neighborUnit = units[neighbor];
+  // These indices need not be contiguous — sibling child groups can straddle an
+  // unrelated block. Gathering them compacts the subtree, which is the point of
+  // moving it as a whole; see the note on `reorderLayerGroupInPanel`.
   const block = units.filter((_, index) => matching.has(index));
   const remaining = units.filter((_, index) => !matching.has(index));
   const neighborIndex = remaining.indexOf(neighborUnit);

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -351,8 +351,21 @@ function groupSubtreeIds(groups: LayerGroup[], id: string): Set<string> {
   return ids;
 }
 
-/** Nesting depth of a group, so a re-sort can keep parents ahead of children. */
-function groupDepth(group: LayerGroup, groupById: ReadonlyMap<string, LayerGroup>): number {
+/**
+ * How deeply a group is nested: 0 for a top-level folder, 1 for a child of one,
+ * and so on. Drives the layer panel's indentation and keeps a parent ahead of
+ * its children when a reorder re-sorts the group array. A corrupted `parentId`
+ * cycle stops the walk instead of hanging.
+ *
+ * @param group Group to measure.
+ * @param groupById Group lookup, so a caller folding many groups against the
+ *   same set can pass a memoized map rather than rebuild one per call.
+ * @returns The nesting depth.
+ */
+export function layerGroupDepth(
+  group: LayerGroup,
+  groupById: ReadonlyMap<string, LayerGroup>,
+): number {
   let depth = 0;
   let parentId = group.parentId;
   const visited = new Set([group.id]);
@@ -434,7 +447,9 @@ function moveGroupThroughUnits(
   const ranges = groupUnitRanges(reordered, groupById);
   const nextGroups = [...groups].sort((a, b) => {
     const byPosition = (ranges.get(a.id)?.[0] ?? 0) - (ranges.get(b.id)?.[0] ?? 0);
-    return byPosition !== 0 ? byPosition : groupDepth(a, groupById) - groupDepth(b, groupById);
+    return byPosition !== 0
+      ? byPosition
+      : layerGroupDepth(a, groupById) - layerGroupDepth(b, groupById);
   });
   const layersMoved = nextLayers.some((layer, index) => layer.id !== layers[index]?.id);
   const groupsMoved = nextGroups.some((group, index) => group.id !== groups[index]?.id);

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -12,6 +12,155 @@ export type LayerTreeItem =
   | { kind: "group"; group: LayerGroup; children: GeoLibreLayer[] };
 
 /**
+ * One top-level block of the layer panel, in top-of-panel-first order: either a
+ * single ungrouped layer or the contiguous run of layers a group owns.
+ *
+ * A group that owns no layer anywhere beneath it still gets a unit, with an
+ * empty `layers` array, so that empty folders have a position in the panel and
+ * can be reordered like any other row.
+ */
+export type LayerPanelUnit = {
+  /** Group the block belongs to, or `null` for a lone ungrouped layer. */
+  groupId: string | null;
+  /** Member layers, top-first. Empty for a group with no layers under it. */
+  layers: GeoLibreLayer[];
+};
+
+/**
+ * Panel index range `[first, last]` each group spans, keyed by group id. A
+ * group with no unit of its own (an organizer whose layers all live in child
+ * groups) spans the union of its descendants' units, so it is absent only when
+ * nothing under it has a position yet.
+ */
+function groupUnitRanges(
+  units: LayerPanelUnit[],
+  groupById: ReadonlyMap<string, LayerGroup>,
+): Map<string, [number, number]> {
+  const ranges = new Map<string, [number, number]>();
+  units.forEach((unit, index) => {
+    let id: string | null = unit.groupId;
+    const visited = new Set<string>();
+    while (id && !visited.has(id)) {
+      visited.add(id);
+      const range = ranges.get(id);
+      if (range) ranges.set(id, [Math.min(range[0], index), Math.max(range[1], index)]);
+      else ranges.set(id, [index, index]);
+      // A dangling `parentId` ends the walk rather than recording a range for a
+      // group that does not exist.
+      const parentId = groupById.get(id)?.parentId;
+      id = parentId && groupById.has(parentId) ? parentId : null;
+    }
+  });
+  return ranges;
+}
+
+/**
+ * Split the panel into its top-level blocks, **top-of-panel first** (the
+ * reverse of the store's render order, where the last array element draws on
+ * top).
+ *
+ * Layers give every populated group a position of its own. A group with no
+ * layers under it has none to derive, so it is slotted in next to its
+ * neighbours in `groups` order: directly below the nearest group above it in
+ * that array, else directly above the nearest one below it, else at the top of
+ * the panel. Because the neighbours are read from `groups` rather than from the
+ * layer array, a folder keeps its place relative to the other folders when one
+ * of them gains its first layer (GeoLibre#1739). A group nested in a positioned
+ * parent lands directly below that parent's block regardless of array order.
+ *
+ * A `groupId` that does not match any group is treated as ungrouped, so a
+ * dangling reference degrades gracefully instead of dropping the layer.
+ *
+ * @param layers Flat layer list in store (render) order.
+ * @param groups Group definitions.
+ * @returns Panel blocks in top-to-bottom display order.
+ */
+export function buildLayerPanelUnits(
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+): LayerPanelUnit[] {
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+  const units: LayerPanelUnit[] = [];
+  for (let i = layers.length - 1; i >= 0; i--) {
+    const layer = layers[i];
+    const groupId = layer.groupId && groupById.has(layer.groupId) ? layer.groupId : null;
+    const last = units[units.length - 1];
+    if (groupId && last && last.groupId === groupId) last.layers.push(layer);
+    else units.push({ groupId, layers: [layer] });
+  }
+
+  let ranges = groupUnitRanges(units, groupById);
+  if (ranges.size === groups.length) return units;
+  for (let at = 0; at < groups.length; at++) {
+    const group = groups[at];
+    if (ranges.has(group.id)) continue;
+    const parentRange = group.parentId ? ranges.get(group.parentId) : undefined;
+    let insertAt = parentRange ? parentRange[1] + 1 : undefined;
+    for (let i = at - 1; insertAt === undefined && i >= 0; i--) {
+      const range = ranges.get(groups[i].id);
+      if (range) insertAt = range[1] + 1;
+    }
+    for (let i = at + 1; insertAt === undefined && i < groups.length; i++) {
+      const range = ranges.get(groups[i].id);
+      if (range) insertAt = range[0];
+    }
+    units.splice(insertAt ?? 0, 0, { groupId: group.id, layers: [] });
+    // Placing this folder shifts the units below it, and makes the folder
+    // itself an anchor for the ones still to be placed.
+    ranges = groupUnitRanges(units, groupById);
+  }
+  return units;
+}
+
+/**
+ * Where the layer panel should draw the header of each group that owns no
+ * layers, expressed against the layer rows the panel already renders.
+ */
+export type UnpositionedGroupPlacement = {
+  /** Groups drawn immediately above the keyed layer's row, in panel order. */
+  aboveLayer: Map<string, LayerGroup[]>;
+  /** Groups drawn below every layer row, in panel order. */
+  bottom: LayerGroup[];
+};
+
+/**
+ * Resolve {@link buildLayerPanelUnits} into draw positions for the folders that
+ * have no layer of their own, so a panel that renders row-by-row from the flat
+ * layer list can place them without rebuilding its whole render as a tree.
+ *
+ * @param layers Flat layer list in store (render) order.
+ * @param groups Group definitions.
+ * @returns The anchor layer (or the panel bottom) each empty folder sits above.
+ */
+export function placeUnpositionedGroups(
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+): UnpositionedGroupPlacement {
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+  const units = buildLayerPanelUnits(layers, groups);
+  const aboveLayer = new Map<string, LayerGroup[]>();
+  const bottom: LayerGroup[] = [];
+  for (let i = 0; i < units.length; i++) {
+    const unit = units[i];
+    if (unit.layers.length > 0 || !unit.groupId) continue;
+    const group = groupById.get(unit.groupId);
+    if (!group) continue;
+    let anchorId: string | undefined;
+    for (let j = i + 1; anchorId === undefined && j < units.length; j++) {
+      anchorId = units[j].layers[0]?.id;
+    }
+    if (anchorId === undefined) {
+      bottom.push(group);
+      continue;
+    }
+    const at = aboveLayer.get(anchorId);
+    if (at) at.push(group);
+    else aboveLayer.set(anchorId, [group]);
+  }
+  return { aboveLayer, bottom };
+}
+
+/**
  * Derive the layer-panel tree from the flat `layers` array and the group
  * definitions.
  *
@@ -20,8 +169,8 @@ export type LayerTreeItem =
  * children are likewise ordered top-first. Each group is emitted once, at the
  * panel position of its top-most member; a group's members are normally
  * contiguous in the array, but if they are not, every member is still gathered
- * under a single header. Groups with no members (empty folders) are emitted at
- * the very top of the panel, in `groups` order, ready to receive drops.
+ * under a single header. Groups with no members (empty folders) sit where
+ * {@link buildLayerPanelUnits} places them.
  *
  * A `groupId` that does not match any group is treated as ungrouped, so a
  * dangling reference degrades gracefully instead of dropping the layer.
@@ -32,46 +181,27 @@ export type LayerTreeItem =
  */
 export function buildLayerTree(layers: GeoLibreLayer[], groups: LayerGroup[]): LayerTreeItem[] {
   const groupById = new Map(groups.map((g) => [g.id, g]));
-  const display = [...layers].reverse();
-
-  // Bucket every layer's children by group id in a single pass so emitting a
-  // group is an O(1) lookup rather than a per-group filter over `display`.
-  const childrenByGroupId = new Map<string, GeoLibreLayer[]>();
-  for (const layer of display) {
-    if (!layer.groupId || !groupById.has(layer.groupId)) continue;
-    const bucket = childrenByGroupId.get(layer.groupId);
-    if (bucket) bucket.push(layer);
-    else childrenByGroupId.set(layer.groupId, [layer]);
-  }
-
   const items: LayerTreeItem[] = [];
-  const emitted = new Set<string>();
+  const emittedAt = new Map<string, LayerTreeItem & { kind: "group" }>();
 
-  for (const layer of display) {
-    const group = layer.groupId ? groupById.get(layer.groupId) : undefined;
+  for (const unit of buildLayerPanelUnits(layers, groups)) {
+    const group = unit.groupId ? groupById.get(unit.groupId) : undefined;
     if (!group) {
-      items.push({ kind: "layer", layer });
+      for (const layer of unit.layers) items.push({ kind: "layer", layer });
       continue;
     }
-    if (emitted.has(group.id)) continue;
-    emitted.add(group.id);
-    items.push({
-      kind: "group",
-      group,
-      children: childrenByGroupId.get(group.id) ?? [],
-    });
+    // A group's members are normally one contiguous run, but a scattered group
+    // still gets a single header, at its top-most member.
+    const existing = emittedAt.get(group.id);
+    if (existing) {
+      existing.children.push(...unit.layers);
+      continue;
+    }
+    const item = { kind: "group" as const, group, children: [...unit.layers] };
+    emittedAt.set(group.id, item);
+    items.push(item);
   }
-
-  const emptyGroups = groups.filter((g) => !childrenByGroupId.has(g.id));
-  if (emptyGroups.length === 0) return items;
-  return [
-    ...emptyGroups.map((group) => ({
-      kind: "group" as const,
-      group,
-      children: [] as GeoLibreLayer[],
-    })),
-    ...items,
-  ];
+  return items;
 }
 
 /**
@@ -201,6 +331,121 @@ export function normalizeGroupContiguity(layers: GeoLibreLayer[]): GeoLibreLayer
         placed.add(candidate.id);
       }
     }
+  }
+  return result;
+}
+
+/** `id` plus every group nested beneath it, however deep. */
+function groupSubtreeIds(groups: LayerGroup[], id: string): Set<string> {
+  const ids = new Set([id]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const group of groups) {
+      if (group.parentId && ids.has(group.parentId) && !ids.has(group.id)) {
+        ids.add(group.id);
+        grew = true;
+      }
+    }
+  }
+  return ids;
+}
+
+/** Nesting depth of a group, so a re-sort can keep parents ahead of children. */
+function groupDepth(group: LayerGroup, groupById: ReadonlyMap<string, LayerGroup>): number {
+  let depth = 0;
+  let parentId = group.parentId;
+  const visited = new Set([group.id]);
+  while (parentId && !visited.has(parentId)) {
+    visited.add(parentId);
+    const parent = groupById.get(parentId);
+    if (!parent) break;
+    depth += 1;
+    parentId = parent.parentId;
+  }
+  return depth;
+}
+
+/**
+ * Move a group — with everything nested inside it — one row up or down among
+ * the layer panel's top-level blocks.
+ *
+ * Both arrays carry part of the panel order, so both come back: `layers` holds
+ * the order of every populated block, and `groups` holds the order the empty
+ * folders are placed against (see {@link buildLayerPanelUnits}). Swapping two
+ * folders that own no layers moves nothing in `layers`, and moving a populated
+ * group past an empty one moves nothing but the group order, so a caller must
+ * apply both.
+ *
+ * @param layers Flat layer list in store (render) order.
+ * @param groups Group definitions.
+ * @param id Group to move.
+ * @param direction `"up"` toward the top of the panel, `"down"` toward the
+ *   bottom.
+ * @returns The new arrays, or `null` when the group is already at that end of
+ *   the panel and nothing would change.
+ */
+export function reorderLayerGroupInPanel(
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+  id: string,
+  direction: "up" | "down",
+): { layers: GeoLibreLayer[]; groups: LayerGroup[] } | null {
+  if (!groups.some((group) => group.id === id)) return null;
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+  const units = buildLayerPanelUnits(layers, groups);
+  const moving = groupSubtreeIds(groups, id);
+  const matching = new Set<number>();
+  units.forEach((unit, index) => {
+    if (unit.groupId && moving.has(unit.groupId)) matching.add(index);
+  });
+  if (matching.size === 0) return null;
+  const indices = [...matching].sort((a, b) => a - b);
+  // Units run top-first, so "up" swaps with the block above the group's first.
+  const neighbor = direction === "up" ? indices[0] - 1 : indices[indices.length - 1] + 1;
+  if (neighbor < 0 || neighbor >= units.length) return null;
+  const neighborUnit = units[neighbor];
+  const block = units.filter((_, index) => matching.has(index));
+  const remaining = units.filter((_, index) => !matching.has(index));
+  const neighborIndex = remaining.indexOf(neighborUnit);
+  const reordered = [...remaining];
+  reordered.splice(direction === "up" ? neighborIndex : neighborIndex + 1, 0, ...block);
+
+  // Units are top-first and so are the layers inside them; the store keeps the
+  // reverse, with the last element drawing on top.
+  const nextLayers = reordered.flatMap((unit) => unit.layers).reverse();
+  // Re-derive the group order from the new panel so the empty folders, which
+  // are placed against it, follow the move. Ties (an organizer and the child
+  // block it spans) keep parents first.
+  const ranges = groupUnitRanges(reordered, groupById);
+  const nextGroups = [...groups].sort((a, b) => {
+    const byPosition = (ranges.get(a.id)?.[0] ?? 0) - (ranges.get(b.id)?.[0] ?? 0);
+    return byPosition !== 0 ? byPosition : groupDepth(a, groupById) - groupDepth(b, groupById);
+  });
+  const layersMoved = nextLayers.some((layer, index) => layer.id !== layers[index]?.id);
+  const groupsMoved = nextGroups.some((group, index) => group.id !== groups[index]?.id);
+  if (!layersMoved && !groupsMoved) return null;
+  return { layers: nextLayers, groups: nextGroups };
+}
+
+/**
+ * Which directions {@link reorderLayerGroupInPanel} can actually move each
+ * group, so the layer panel can disable a menu item that would do nothing.
+ *
+ * @param layers Flat layer list in store (render) order.
+ * @param groups Group definitions.
+ * @returns Per-group flags, keyed by group id.
+ */
+export function layerGroupMoveability(
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+): Map<string, { up: boolean; down: boolean }> {
+  const result = new Map<string, { up: boolean; down: boolean }>();
+  for (const group of groups) {
+    result.set(group.id, {
+      up: reorderLayerGroupInPanel(layers, groups, group.id, "up") !== null,
+      down: reorderLayerGroupInPanel(layers, groups, group.id, "down") !== null,
+    });
   }
   return result;
 }

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -55,6 +55,40 @@ function groupUnitRanges(
 }
 
 /**
+ * Group indices ordered so that a group's parent always comes first, keeping
+ * the `groups` order otherwise. `moveLayerGroupToGroup` reparents in place
+ * without touching the array, so a child can sit ahead of its own parent; a
+ * parent has to be placed first for the child to have a block to sit under.
+ * A `parentId` cycle never resolves, so what is left is emitted in array order
+ * rather than dropped.
+ */
+function parentsFirstOrder(
+  groups: LayerGroup[],
+  groupById: ReadonlyMap<string, LayerGroup>,
+): number[] {
+  const order: number[] = [];
+  const placed = new Set<string>();
+  let pending = groups.map((_, index) => index);
+  while (pending.length > 0) {
+    const deferred: number[] = [];
+    for (const index of pending) {
+      const parentId = groups[index].parentId;
+      if (parentId && groupById.has(parentId) && !placed.has(parentId)) deferred.push(index);
+      else {
+        order.push(index);
+        placed.add(groups[index].id);
+      }
+    }
+    if (deferred.length === pending.length) {
+      order.push(...deferred);
+      break;
+    }
+    pending = deferred;
+  }
+  return order;
+}
+
+/**
  * Split the panel into its top-level blocks, **top-of-panel first** (the
  * reverse of the store's render order, where the last array element draws on
  * top).
@@ -67,6 +101,10 @@ function groupUnitRanges(
  * layer array, a folder keeps its place relative to the other folders when one
  * of them gains its first layer (GeoLibre#1739). A group nested in a positioned
  * parent lands directly below that parent's block regardless of array order.
+ *
+ * An *organizer* — a group with no layers of its own but with some beneath it —
+ * gets no block here: the panel draws its header against its top-most
+ * descendant layer instead. Only a group whose whole subtree is empty needs one.
  *
  * A `groupId` that does not match any group is treated as ungrouped, so a
  * dangling reference degrades gracefully instead of dropping the layer.
@@ -90,10 +128,16 @@ export function buildLayerPanelUnits(
   }
 
   let ranges = groupUnitRanges(units, groupById);
-  if (ranges.size === groups.length) return units;
-  for (let at = 0; at < groups.length; at++) {
+  // Every group a layer reaches — the ones that own a block and the organizers
+  // spanning them — already has a position. `ranges` alone cannot stand in for
+  // that set once the loop starts: splicing a folder in gives its ancestors an
+  // inherited range too, and an ancestor whose subtree holds no layer still
+  // needs a block of its own or it renders nowhere at all.
+  const positioned = new Set(ranges.keys());
+  if (positioned.size === groups.length) return units;
+  for (const at of parentsFirstOrder(groups, groupById)) {
     const group = groups[at];
-    if (ranges.has(group.id)) continue;
+    if (positioned.has(group.id)) continue;
     const parentRange = group.parentId ? ranges.get(group.parentId) : undefined;
     let insertAt = parentRange ? parentRange[1] + 1 : undefined;
     for (let i = at - 1; insertAt === undefined && i >= 0; i--) {
@@ -105,6 +149,7 @@ export function buildLayerPanelUnits(
       if (range) insertAt = range[0];
     }
     units.splice(insertAt ?? 0, 0, { groupId: group.id, layers: [] });
+    positioned.add(group.id);
     // Placing this folder shifts the units below it, and makes the folder
     // itself an anchor for the ones still to be placed.
     ranges = groupUnitRanges(units, groupById);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -17,7 +17,11 @@ import {
   DEFAULT_PROJECT_NAME,
 } from "./project";
 import { initialLayerStyle } from "./layer-defaults";
-import { DEFAULT_LAYER_GROUP_OPACITY, normalizeGroupContiguity } from "./layer-groups";
+import {
+  DEFAULT_LAYER_GROUP_OPACITY,
+  normalizeGroupContiguity,
+  reorderLayerGroupInPanel,
+} from "./layer-groups";
 import {
   DEFAULT_BASEMAP,
   DEFAULT_DASHBOARD_COLUMNS,
@@ -2119,45 +2123,14 @@ export const useAppStore = create<AppState>()(
           };
         }),
 
+      // A folder that owns no layers has no position in `layers` to move, so
+      // the panel order it takes part in lives across both arrays and the move
+      // writes both (GeoLibre#1739).
       reorderLayerGroup: (id, direction) =>
         set((s) => {
-          const groupIds = new Set([id]);
-          let foundDescendant = true;
-          while (foundDescendant) {
-            foundDescendant = false;
-            for (const group of s.layerGroups) {
-              if (group.parentId && groupIds.has(group.parentId) && !groupIds.has(group.id)) {
-                groupIds.add(group.id);
-                foundDescendant = true;
-              }
-            }
-          }
-          // Build the top-level units in store (render) order: each ungrouped
-          // layer is its own unit, and a group's contiguous members form one
-          // unit. A nested organizer group may have no direct layers, so its
-          // block includes every unit belonging to a descendant group.
-          const units: { key: string; layers: GeoLibreLayer[] }[] = [];
-          for (const layer of s.layers) {
-            const key = layer.groupId ?? `layer:${layer.id}`;
-            const last = units[units.length - 1];
-            if (last && last.key === key) last.layers.push(layer);
-            else units.push({ key, layers: [layer] });
-          }
-          const matching = units
-            .map((unit, index) => (groupIds.has(unit.key) ? index : -1))
-            .filter((index) => index >= 0);
-          if (matching.length === 0) return s;
-          const first = matching[0];
-          const last = matching[matching.length - 1];
-          const neighbor = direction === "up" ? last + 1 : first - 1;
-          if (neighbor < 0 || neighbor >= units.length) return s;
-          const block = units.filter((unit) => groupIds.has(unit.key));
-          const remaining = units.filter((unit) => !groupIds.has(unit.key));
-          const neighborKey = units[neighbor].key;
-          const neighborIndex = remaining.findIndex((unit) => unit.key === neighborKey);
-          const insertAt = direction === "up" ? neighborIndex + 1 : neighborIndex;
-          remaining.splice(insertAt, 0, ...block);
-          return { layers: remaining.flatMap((u) => u.layers), isDirty: true };
+          const moved = reorderLayerGroupInPanel(s.layers, s.layerGroups, id, direction);
+          if (!moved) return s;
+          return { layers: moved.layers, layerGroups: moved.groups, isDirty: true };
         }),
 
       newProject: (options = {}) => {

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -130,6 +130,28 @@ describe("buildLayerPanelUnits", () => {
     );
   });
 
+  it("keeps a fully empty parent visible when its child precedes it", () => {
+    // "Move to group" only rewrites parentId, so a child can sit ahead of its
+    // own parent in the array. Both folders are empty, so neither can be drawn
+    // against a descendant layer and both need a block of their own.
+    assert.deepEqual(panelOrder([], [group("child", { parentId: "parent" }), group("parent")]), [
+      "group:parent",
+      "group:child",
+    ]);
+  });
+
+  it("gives an empty organizer's own empty child a block, not the organizer", () => {
+    // "outer" has a layer beneath it via "inner", so the panel draws its header
+    // against that layer; only "spare", whose subtree is empty, needs a block.
+    const layers = [layer("a", { groupId: "inner" })];
+    const groups = [
+      group("outer"),
+      group("inner", { parentId: "outer" }),
+      group("spare", { parentId: "outer" }),
+    ];
+    assert.deepEqual(panelOrder(layers, groups), ["group:inner", "group:spare"]);
+  });
+
   it("anchors empty groups against the layer rows the panel draws", () => {
     const layers = [layer("bottom"), layer("a", { groupId: "g1" }), layer("top")];
     const placement = placeUnpositionedGroups(layers, [group("g1"), group("g2")]);

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -151,6 +151,18 @@ describe("buildLayerPanelUnits", () => {
     );
     assert.equal(placement.aboveLayer.size, 0);
   });
+
+  it("terminates on a parentId cycle instead of hanging", () => {
+    // Each group is the other's parent, so the ancestor walk gives both a
+    // position from the one layer and neither is emitted as an empty folder.
+    const groups = [group("g1", { parentId: "g2" }), group("g2", { parentId: "g1" })];
+    assert.deepEqual(panelOrder([layer("a", { groupId: "g1" })], groups), ["group:g1"]);
+  });
+
+  it("ends the ancestor walk at a parentId that names no group", () => {
+    const groups = [group("g1", { parentId: "missing" })];
+    assert.deepEqual(panelOrder([layer("a", { groupId: "g1" })], groups), ["group:g1"]);
+  });
 });
 
 describe("reorderLayerGroupInPanel", () => {
@@ -176,6 +188,31 @@ describe("reorderLayerGroupInPanel", () => {
     const moved = reorderLayerGroupInPanel(layers, groups, "g1", "down");
     assert.ok(moved);
     assert.deepEqual(panelOrder(moved.layers, moved.groups), ["group:g2", "group:g1"]);
+  });
+
+  it("carries a whole subtree past a sibling group as one block", () => {
+    const layers = [layer("c1", { groupId: "childA" }), layer("s1", { groupId: "sib" })];
+    const groups = [
+      group("parent"),
+      group("childA", { parentId: "parent" }),
+      group("childB", { parentId: "parent" }),
+      group("sib"),
+    ];
+    // Panel before: sib, [childA: c1], childB (empty, under its parent).
+    assert.deepEqual(panelOrder(layers, groups), ["group:sib", "group:childA", "group:childB"]);
+
+    const moved = reorderLayerGroupInPanel(layers, groups, "parent", "up");
+    assert.ok(moved);
+    // Both children travel with the parent and stay in its block.
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), [
+      "group:childA",
+      "group:childB",
+      "group:sib",
+    ]);
+    assert.deepEqual(
+      moved.layers.map((l) => l.id),
+      ["s1", "c1"],
+    );
   });
 
   it("returns null at the ends of the panel", () => {

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -514,6 +514,25 @@ describe("layer group store actions", () => {
     assert.deepEqual(order(), [g2, g1]);
   });
 
+  it("undoes a reorder that only moved empty groups", () => {
+    // Swapping two empty folders leaves `layers` untouched, so the history
+    // entry rests entirely on the group order having changed.
+    const g1 = useAppStore.getState().addLayerGroup("Group 1");
+    const g2 = useAppStore.getState().addLayerGroup("Group 2");
+    useAppStore.temporal.getState().clear();
+
+    useAppStore.getState().reorderLayerGroup(g2, "up");
+    assert.deepEqual(
+      useAppStore.getState().layerGroups.map((group) => group.id),
+      [g2, g1],
+    );
+    undo();
+    assert.deepEqual(
+      useAppStore.getState().layerGroups.map((group) => group.id),
+      [g1, g2],
+    );
+  });
+
   it("ungroups children by default but can delete them", () => {
     const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
     const gid = useAppStore.getState().addLayerGroup("G", [a]);

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -4,10 +4,14 @@ import {
   DEFAULT_LAYER_STYLE,
   applyGroupEffects,
   applyProjectToStore,
+  buildLayerPanelUnits,
   buildLayerTree,
   createEmptyProject,
   effectiveLayerRenderState,
+  layerGroupMoveability,
   normalizeGroupContiguity,
+  placeUnpositionedGroups,
+  reorderLayerGroupInPanel,
   parseProject,
   projectFromStore,
   serializeProject,
@@ -77,7 +81,7 @@ describe("buildLayerTree", () => {
     assert.equal(tree[2].kind, "layer");
   });
 
-  it("emits empty groups pinned at the top", () => {
+  it("emits an empty group at the top when no other group is positioned", () => {
     const tree = buildLayerTree([layer("a")], [group("empty")]);
     assert.equal(tree[0].kind, "group");
     if (tree[0].kind === "group") {
@@ -90,6 +94,105 @@ describe("buildLayerTree", () => {
     const tree = buildLayerTree([layer("a", { groupId: "missing" })], []);
     assert.equal(tree.length, 1);
     assert.equal(tree[0].kind, "layer");
+  });
+});
+
+/** Panel rows top-first as `layer:<id>` / `group:<id>`, for readable asserts. */
+function panelOrder(layers: GeoLibreLayer[], groups: LayerGroup[]): string[] {
+  return buildLayerPanelUnits(layers, groups).map((unit) =>
+    unit.groupId ? `group:${unit.groupId}` : `layer:${unit.layers[0].id}`,
+  );
+}
+
+describe("buildLayerPanelUnits", () => {
+  it("stacks empty groups in group order at the top of an empty panel", () => {
+    assert.deepEqual(panelOrder([], [group("g1"), group("g2")]), ["group:g1", "group:g2"]);
+  });
+
+  it("keeps an empty group below the populated group it follows (GeoLibre#1739)", () => {
+    // Group 1 gains a layer; Group 2 is still empty and must stay under it.
+    const layers = [layer("a", { groupId: "g1" })];
+    assert.deepEqual(panelOrder(layers, [group("g1"), group("g2")]), ["group:g1", "group:g2"]);
+  });
+
+  it("puts an empty group above the populated group that follows it", () => {
+    const layers = [layer("a", { groupId: "g2" })];
+    assert.deepEqual(panelOrder(layers, [group("g1"), group("g2")]), ["group:g1", "group:g2"]);
+  });
+
+  it("places an empty child group directly below its parent's block", () => {
+    const layers = [layer("a", { groupId: "parent" })];
+    // "child" precedes "parent" in the array, so only the parent link can put
+    // it under the parent rather than above it.
+    assert.deepEqual(
+      panelOrder(layers, [group("child", { parentId: "parent" }), group("parent")]),
+      ["group:parent", "group:child"],
+    );
+  });
+
+  it("anchors empty groups against the layer rows the panel draws", () => {
+    const layers = [layer("bottom"), layer("a", { groupId: "g1" }), layer("top")];
+    const placement = placeUnpositionedGroups(layers, [group("g1"), group("g2")]);
+    // Display order is top-first: top, [g1: a], bottom. g2 follows g1's block,
+    // so it draws immediately above "bottom".
+    assert.deepEqual(
+      placement.aboveLayer.get("bottom")?.map((g) => g.id),
+      ["g2"],
+    );
+    assert.equal(placement.bottom.length, 0);
+  });
+
+  it("drops an empty group to the panel bottom when nothing follows it", () => {
+    const layers = [layer("a", { groupId: "g1" })];
+    const placement = placeUnpositionedGroups(layers, [group("g1"), group("g2")]);
+    assert.deepEqual(
+      placement.bottom.map((g) => g.id),
+      ["g2"],
+    );
+    assert.equal(placement.aboveLayer.size, 0);
+  });
+});
+
+describe("reorderLayerGroupInPanel", () => {
+  it("swaps two empty groups without touching the layers", () => {
+    const layers = [layer("a")];
+    const groups = [group("g1"), group("g2")];
+    const moved = reorderLayerGroupInPanel(layers, groups, "g2", "up");
+    assert.ok(moved);
+    assert.deepEqual(
+      moved.groups.map((g) => g.id),
+      ["g2", "g1"],
+    );
+    assert.deepEqual(
+      moved.layers.map((l) => l.id),
+      ["a"],
+    );
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), ["group:g2", "group:g1", "layer:a"]);
+  });
+
+  it("moves a populated group past an empty one (GeoLibre#1739)", () => {
+    const layers = [layer("a", { groupId: "g1" })];
+    const groups = [group("g1"), group("g2")];
+    const moved = reorderLayerGroupInPanel(layers, groups, "g1", "down");
+    assert.ok(moved);
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), ["group:g2", "group:g1"]);
+  });
+
+  it("returns null at the ends of the panel", () => {
+    const layers = [layer("a", { groupId: "g1" })];
+    const groups = [group("g1"), group("g2")];
+    assert.equal(reorderLayerGroupInPanel(layers, groups, "g1", "up"), null);
+    assert.equal(reorderLayerGroupInPanel(layers, groups, "g2", "down"), null);
+    assert.equal(reorderLayerGroupInPanel(layers, groups, "missing", "up"), null);
+  });
+
+  it("reports the directions each group can move", () => {
+    const moveability = layerGroupMoveability(
+      [layer("a", { groupId: "g1" })],
+      [group("g1"), group("g2")],
+    );
+    assert.deepEqual(moveability.get("g1"), { up: false, down: true });
+    assert.deepEqual(moveability.get("g2"), { up: true, down: false });
   });
 });
 
@@ -384,6 +487,31 @@ describe("layer group store actions", () => {
       useAppStore.getState().layers.map((candidate) => candidate.id),
       [neighbor, childLayer],
     );
+  });
+
+  it("keeps the group order when a group gains its first layer, and reorders empty groups (GeoLibre#1739)", () => {
+    const g1 = useAppStore.getState().addLayerGroup("Group 1");
+    const g2 = useAppStore.getState().addLayerGroup("Group 2");
+    const order = () =>
+      buildLayerPanelUnits(useAppStore.getState().layers, useAppStore.getState().layerGroups)
+        .map((unit) => unit.groupId)
+        .filter(Boolean);
+    assert.deepEqual(order(), [g1, g2]);
+
+    // Both folders are empty, and both must still be movable.
+    useAppStore.getState().reorderLayerGroup(g2, "up");
+    assert.deepEqual(order(), [g2, g1]);
+    useAppStore.getState().reorderLayerGroup(g2, "down");
+    assert.deepEqual(order(), [g1, g2]);
+
+    // Adding a layer to Group 1 must not push it below the still-empty Group 2.
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    useAppStore.getState().moveLayerToGroup(a, g1);
+    assert.deepEqual(order(), [g1, g2]);
+
+    // And the now-populated group can still be moved past the empty one.
+    useAppStore.getState().reorderLayerGroup(g1, "down");
+    assert.deepEqual(order(), [g2, g1]);
   });
 
   it("ungroups children by default but can delete them", () => {

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -212,6 +212,37 @@ describe("reorderLayerGroupInPanel", () => {
     assert.deepEqual(panelOrder(moved.layers, moved.groups), ["group:g2", "group:g1"]);
   });
 
+  it("compacts a subtree that straddles an unrelated block when moving it", () => {
+    // Nesting only rewrites parentId, so "loose" can sit between two sibling
+    // child groups. Moving the parent gathers the subtree into one block and
+    // leaves "loose" on the far side of it — more than one row shifts.
+    const layers = [
+      layer("bottom"),
+      layer("c1layer", { groupId: "c1" }),
+      layer("loose"),
+      layer("c2layer", { groupId: "c2" }),
+      layer("top"),
+    ];
+    const groups = [group("p"), group("c1", { parentId: "p" }), group("c2", { parentId: "p" })];
+    assert.deepEqual(panelOrder(layers, groups), [
+      "layer:top",
+      "group:c2",
+      "layer:loose",
+      "group:c1",
+      "layer:bottom",
+    ]);
+
+    const moved = reorderLayerGroupInPanel(layers, groups, "p", "down");
+    assert.ok(moved);
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), [
+      "layer:top",
+      "layer:loose",
+      "layer:bottom",
+      "group:c2",
+      "group:c1",
+    ]);
+  });
+
   it("carries a whole subtree past a sibling group as one block", () => {
     const layers = [layer("c1", { groupId: "childA" }), layer("s1", { groupId: "sib" })];
     const groups = [


### PR DESCRIPTION
Fixes #1739

## The bug

A group's place in the layer panel was derived only from its member layers, so a folder with no layers had no position at all. Three symptoms followed, all reproduced in the app before the fix:

1. **Empty groups could not be moved.** They were pinned to the top of the panel in group order, and "Move group up" / "Move group down" were greyed out for them.
2. **Adding a layer to a group changed its order.** The moment Group 1 gained its first layer it left the pinned block and dropped below the still-empty Group 2.
3. **A populated group could not be moved past an empty one.** The menu items were enabled but did nothing, because the empty group was not part of the layer-derived order they moved through.

## The fix

Panel order now comes from a new `buildLayerPanelUnits` in `@geolibre/core`, which gives every group a block:

- a populated group sits at its layers, as before;
- a folder with none is slotted in next to its neighbours in the group array: below the nearest group above it, else above the nearest one below it, else at the top of the panel.

Because the neighbours are read from the group array rather than from the layer array, a folder keeps its place relative to the other folders when one of them gains its first layer. An empty folder nested in a positioned parent lands directly under that parent instead of at the panel top, which is also new.

Reordering follows from the same units. `reorderLayerGroupInPanel` moves a group together with everything nested inside it one block up or down and returns **both** arrays, since swapping two empty folders changes only the group order while moving a populated group moves layers. `LayerPanel` disables the two menu items per direction from `layerGroupMoveability`, so the topmost group offers only "down" and an item is greyed out only when the move genuinely cannot happen.

Known limit, unchanged in spirit from before: a folder with no layers has no way to record a position *between* two ungrouped layers, so its move is offered only against other groups. Once it holds a layer it moves freely.

## Verification

Driven in the real app (dev server, Firefox-equivalent Chromium via Playwright) with `us_cities.geojson` and `cm_regions.geojson`, replaying the issue's exact sequence, in **both light and dark themes**:

| step | before | after |
| --- | --- | --- |
| two empty groups | move up/down both greyed out | Group 1 offers "down", Group 2 offers "up"; the swap works both ways |
| move a layer into Group 1 | order flips to `Group 2, Group 1` | stays `Group 1 → us_cities → Group 2` |
| move populated Group 1 down/up past empty Group 2 | no effect | `Group 2, Group 1 → us_cities` and back |

Also checked: reordering a group past an ungrouped layer, nesting an empty group inside a populated one (renders indented under its parent), and collapsing the parent (hides the nested folder).

Tests: `tests/layer-groups.test.ts` gains a `buildLayerPanelUnits` suite, a `reorderLayerGroupInPanel` suite, and a store-level regression test replaying the reported sequence. Full frontend suite passes (5392 tests), `npm run build` and `pre-commit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved layer panel ordering for populated, empty, nested, and ungrouped layers.
  * Empty groups now appear in the correct position alongside layer rows.
  * Added support for moving complete group hierarchies up or down within the panel.
  * Move controls now accurately reflect each group’s available direction.

* **Bug Fixes**
  * Preserved group order when layers are added or removed.
  * Correctly handled missing or dangling layer references.
  * Reordering now supports undo without losing panel order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->