### PR TITLE
fix(layers): keep nested groups in order and movable inside their parent

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -32,7 +32,7 @@ import {
   excludeHiddenFieldsFromGeojson,
   layerGroupDepth,
   layerGroupMoveability,
-  placeUnpositionedGroups,
+  layerPanelGroupHeaders,
 } from "@geolibre/core";
 import type { EllipsoidId, GeoLibreLayer, LayerGroup } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
@@ -920,56 +920,14 @@ export function LayerPanel({
       }),
     [groupById, layerGroups],
   );
-  const firstMemberIdByGroup = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const layer of visibleLayers) {
-      if (layer.groupId && !map.has(layer.groupId)) {
-        map.set(layer.groupId, layer.id);
-      }
-    }
-    return map;
-  }, [visibleLayers]);
-  const descendantLayerAnchorByGroup = useMemo(() => {
-    const result = new Map<string, string>();
-    const displayGroupIds = visibleLayers
-      .map((layer) => layer.groupId)
-      .filter((id): id is string => Boolean(id && groupById.has(id)));
-    for (const group of layerGroups) {
-      if (firstMemberIdByGroup.has(group.id)) continue;
-      const anchor = displayGroupIds.find((candidateId) => {
-        let parentId = groupById.get(candidateId)?.parentId;
-        const visited = new Set<string>();
-        while (parentId && !visited.has(parentId)) {
-          if (parentId === group.id) return true;
-          visited.add(parentId);
-          parentId = groupById.get(parentId)?.parentId;
-        }
-        return false;
-      });
-      if (anchor) result.set(group.id, anchor);
-    }
-    return result;
-  }, [firstMemberIdByGroup, groupById, layerGroups, visibleLayers]);
-  const organizerHeadersByAnchor = useMemo(() => {
-    const result = new Map<string, LayerGroup[]>();
-    for (const group of layerGroups) {
-      const anchor = descendantLayerAnchorByGroup.get(group.id);
-      if (!anchor) continue;
-      const headers = result.get(anchor) ?? [];
-      headers.push(group);
-      result.set(anchor, headers);
-    }
-    for (const headers of result.values()) {
-      headers.sort((a, b) => groupDepth(a) - groupDepth(b));
-    }
-    return result;
-  }, [descendantLayerAnchorByGroup, groupDepth, layerGroups]);
-  // Empty folders have no member to anchor them, so the core places them
-  // against their neighbours in the group order instead: a folder keeps its
-  // spot relative to the other folders when one of them gains a layer, and it
-  // can still be reordered (GeoLibre#1739).
-  const unpositionedGroups = useMemo(
-    () => placeUnpositionedGroups(layers, layerGroups),
+  // Every group header — the group a row belongs to, the organizers above it
+  // whose layers all live in child groups, and the folders holding no layer at
+  // all — comes from one core walk, anchored to the layer row it is drawn
+  // above. Deriving them together is what keeps a nested folder below the
+  // parent it sits in, and lets an empty folder keep its spot relative to its
+  // siblings when one of them gains a layer (GeoLibre#1739).
+  const groupHeaders = useMemo(
+    () => layerPanelGroupHeaders(layers, layerGroups),
     [layers, layerGroups],
   );
   const groupMoveability = useMemo(
@@ -2939,7 +2897,6 @@ export function LayerPanel({
           )}
           {visibleLayers.map((layer, displayIndex) => {
             const group = layer.groupId ? groupById.get(layer.groupId) : undefined;
-            const isFirstOfGroup = group ? firstMemberIdByGroup.get(group.id) === layer.id : false;
             const groupCollapsed = group?.collapsed ?? false;
             const groupAncestorCollapsed = group ? hasCollapsedAncestor(group) : false;
             // When an ancestor group is hidden, a layer whose own visibility
@@ -3102,17 +3059,9 @@ export function LayerPanel({
             const moveIds = selectedMoveIds(layer.id);
             return (
               <Fragment key={layer.id}>
-                {unpositionedGroups.aboveLayer.get(layer.id)?.map((empty) => (
-                  <Fragment key={empty.id}>{renderGroupHeader(empty)}</Fragment>
+                {groupHeaders.aboveLayer.get(layer.id)?.map((header) => (
+                  <Fragment key={header.id}>{renderGroupHeader(header)}</Fragment>
                 ))}
-                {isFirstOfGroup &&
-                  group &&
-                  organizerHeadersByAnchor
-                    .get(group.id)
-                    ?.map((organizer) => (
-                      <Fragment key={organizer.id}>{renderGroupHeader(organizer)}</Fragment>
-                    ))}
-                {isFirstOfGroup && group && renderGroupHeader(group)}
                 {!groupCollapsed && !groupAncestorCollapsed && (
                   <div
                     data-layer-card=""
@@ -4016,9 +3965,9 @@ export function LayerPanel({
               </Fragment>
             );
           })}
-          {/* Folders placed below the last layer row: the panel has no layer
+          {/* Headers placed below the last layer row: the panel has no layer
               left to anchor them above. */}
-          {unpositionedGroups.bottom.map((group) => (
+          {groupHeaders.bottom.map((group) => (
             <Fragment key={group.id}>{renderGroupHeader(group)}</Fragment>
           ))}
           <div

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -27,6 +27,21 @@ export type LayerPanelUnit = {
 };
 
 /**
+ * The group a group is really nested under: its `parentId`, or `null` when it
+ * is top-level or its `parentId` points at a group that no longer exists. Every
+ * placement rule reads the parent through here so a dangling reference behaves
+ * like a top-level folder rather than falling into a branch of the tree that is
+ * not there.
+ */
+function effectiveParentId(
+  group: LayerGroup | undefined,
+  groupById: ReadonlyMap<string, LayerGroup>,
+): string | null {
+  const parentId = group?.parentId;
+  return parentId && groupById.has(parentId) ? parentId : null;
+}
+
+/**
  * Panel index range `[first, last]` each group spans, keyed by group id. A
  * group with no unit of its own (an organizer whose layers all live in child
  * groups) spans the union of its descendants' units, so it is absent only when
@@ -47,8 +62,7 @@ function groupUnitRanges(
       else ranges.set(id, [index, index]);
       // A dangling `parentId` ends the walk rather than recording a range for a
       // group that does not exist.
-      const parentId = groupById.get(id)?.parentId;
-      id = parentId && groupById.has(parentId) ? parentId : null;
+      id = effectiveParentId(groupById.get(id), groupById);
     }
   });
   return ranges;
@@ -95,12 +109,19 @@ function parentsFirstOrder(
  *
  * Layers give every populated group a position of its own. A group with no
  * layers under it has none to derive, so it is slotted in next to its
- * neighbours in `groups` order: directly below the nearest group above it in
- * that array, else directly above the nearest one below it, else at the top of
- * the panel. Because the neighbours are read from `groups` rather than from the
- * layer array, a folder keeps its place relative to the other folders when one
- * of them gains its first layer (GeoLibre#1739). A group nested in a positioned
- * parent lands directly below that parent's block regardless of array order.
+ * **siblings** — the groups sharing its parent — in `groups` order: directly
+ * below the nearest sibling above it in that array, else directly above the
+ * nearest one below it. Because the neighbours are read from `groups` rather
+ * than from the layer array, a folder keeps its place relative to its siblings
+ * when one of them gains its first layer (GeoLibre#1739).
+ *
+ * Only a sibling can place it. An ancestor's range already contains the slot
+ * being chosen, and an unrelated group's range covers a different branch of the
+ * tree, so anchoring on either drops the folder into someone else's block —
+ * which is how a nested folder used to land outside its own parent once a
+ * cousin gained a layer (GeoLibre#1739 follow-up). With no sibling positioned
+ * yet, a nested folder falls to the end of its parent's block and a top-level
+ * one to the top of the panel.
  *
  * An *organizer* — a group with no layers of its own but with some beneath it —
  * gets no block here: the panel draws its header against its top-most
@@ -138,16 +159,22 @@ export function buildLayerPanelUnits(
   for (const at of parentsFirstOrder(groups, groupById)) {
     const group = groups[at];
     if (positioned.has(group.id)) continue;
-    const parentRange = group.parentId ? ranges.get(group.parentId) : undefined;
-    let insertAt = parentRange ? parentRange[1] + 1 : undefined;
+    const parentId = effectiveParentId(group, groupById);
+    const isSibling = (other: LayerGroup) => effectiveParentId(other, groupById) === parentId;
+    let insertAt: number | undefined;
     for (let i = at - 1; insertAt === undefined && i >= 0; i--) {
+      if (!isSibling(groups[i])) continue;
       const range = ranges.get(groups[i].id);
       if (range) insertAt = range[1] + 1;
     }
     for (let i = at + 1; insertAt === undefined && i < groups.length; i++) {
+      if (!isSibling(groups[i])) continue;
       const range = ranges.get(groups[i].id);
       if (range) insertAt = range[0];
     }
+    // No sibling to sit beside: stay inside the parent's block rather than
+    // drifting to the top of the panel past groups this one is nested in.
+    if (insertAt === undefined && parentId) insertAt = (ranges.get(parentId)?.[1] ?? -1) + 1;
     units.splice(insertAt ?? 0, 0, { groupId: group.id, layers: [] });
     positioned.add(group.id);
     // Placing this folder shifts the units below it, and makes the folder
@@ -158,49 +185,75 @@ export function buildLayerPanelUnits(
 }
 
 /**
- * Where the layer panel should draw the header of each group that owns no
- * layers, expressed against the layer rows the panel already renders.
+ * Where the layer panel should draw every group header, expressed against the
+ * layer rows the panel already renders.
  */
-export type UnpositionedGroupPlacement = {
-  /** Groups drawn immediately above the keyed layer's row, in panel order. */
+export type LayerPanelGroupHeaders = {
+  /** Headers drawn immediately above the keyed layer's row, in panel order. */
   aboveLayer: Map<string, LayerGroup[]>;
-  /** Groups drawn below every layer row, in panel order. */
+  /** Headers drawn below every layer row, in panel order. */
   bottom: LayerGroup[];
 };
 
 /**
- * Resolve {@link buildLayerPanelUnits} into draw positions for the folders that
- * have no layer of their own, so a panel that renders row-by-row from the flat
- * layer list can place them without rebuilding its whole render as a tree.
+ * Resolve {@link buildLayerPanelUnits} into a draw position for each group
+ * header, so a panel that renders row by row from the flat layer list can place
+ * them without rebuilding its whole render as a tree.
+ *
+ * Every header comes from the one walk: the group a layer belongs to, the
+ * *organizers* above it whose own layers all live in child groups, and the
+ * folders holding no layer at all. Deriving them together is what keeps them in
+ * order — each is emitted the first time the walk reaches its subtree, parents
+ * ahead of children, so a nested folder can never be drawn above the parent it
+ * sits inside (GeoLibre#1739 follow-up).
+ *
+ * A group is emitted once, at its top-most block, so a group whose members are
+ * scattered still gets a single header.
  *
  * @param layers Flat layer list in store (render) order.
  * @param groups Group definitions.
- * @returns The anchor layer (or the panel bottom) each empty folder sits above.
+ * @returns The anchor layer (or the panel bottom) each header sits above.
  */
-export function placeUnpositionedGroups(
+export function layerPanelGroupHeaders(
   layers: GeoLibreLayer[],
   groups: LayerGroup[],
-): UnpositionedGroupPlacement {
+): LayerPanelGroupHeaders {
   const groupById = new Map(groups.map((g) => [g.id, g]));
   const units = buildLayerPanelUnits(layers, groups);
   const aboveLayer = new Map<string, LayerGroup[]>();
   const bottom: LayerGroup[] = [];
+  const drawn = new Set<string>();
   for (let i = 0; i < units.length; i++) {
     const unit = units[i];
-    if (unit.layers.length > 0 || !unit.groupId) continue;
-    const group = groupById.get(unit.groupId);
-    if (!group) continue;
-    let anchorId: string | undefined;
+    if (!unit.groupId) continue;
+    // Walk up to the root and reverse, so an ancestor's header precedes the
+    // headers of everything nested in it. A `parentId` cycle stops the walk
+    // instead of hanging.
+    const chain: LayerGroup[] = [];
+    let id: string | null = unit.groupId;
+    const visited = new Set<string>();
+    while (id && !visited.has(id) && !drawn.has(id)) {
+      visited.add(id);
+      const group = groupById.get(id);
+      if (!group) break;
+      chain.unshift(group);
+      id = effectiveParentId(group, groupById);
+    }
+    if (chain.length === 0) continue;
+    // The block's own first layer anchors it; a folder with none borrows the
+    // first layer below it, and falls to the panel bottom when there is none.
+    let anchorId = unit.layers[0]?.id;
     for (let j = i + 1; anchorId === undefined && j < units.length; j++) {
       anchorId = units[j].layers[0]?.id;
     }
+    for (const group of chain) drawn.add(group.id);
     if (anchorId === undefined) {
-      bottom.push(group);
+      bottom.push(...chain);
       continue;
     }
     const at = aboveLayer.get(anchorId);
-    if (at) at.push(group);
-    else aboveLayer.set(anchorId, [group]);
+    if (at) at.push(...chain);
+    else aboveLayer.set(anchorId, chain);
   }
   return { aboveLayer, bottom };
 }
@@ -380,20 +433,36 @@ export function normalizeGroupContiguity(layers: GeoLibreLayer[]): GeoLibreLayer
   return result;
 }
 
-/** `id` plus every group nested beneath it, however deep. */
-function groupSubtreeIds(groups: LayerGroup[], id: string): Set<string> {
-  const ids = new Set([id]);
-  let grew = true;
-  while (grew) {
-    grew = false;
-    for (const group of groups) {
-      if (group.parentId && ids.has(group.parentId) && !ids.has(group.id)) {
-        ids.add(group.id);
-        grew = true;
-      }
-    }
+/**
+ * Which of `parentId`'s own blocks a panel unit belongs to, used to move a group
+ * only among the blocks it shares a parent with:
+ *
+ * - the id of the child of `parentId` the unit is nested in, however deep — the
+ *   sibling block a move steps over, or the moving group's own block;
+ * - `parentId` itself when the unit holds that group's own layers, the block a
+ *   first child cannot move above;
+ * - `null` for an ungrouped layer at the root of the panel (`parentId` `null`);
+ * - `undefined` when the unit sits outside `parentId` altogether — a wall,
+ *   since a nested group has no position outside the parent holding it.
+ *
+ * A `parentId` cycle reads as outside rather than looping.
+ */
+function branchUnder(
+  parentId: string | null,
+  groupId: string | null,
+  groupById: ReadonlyMap<string, LayerGroup>,
+): string | null | undefined {
+  if (groupId === null) return parentId === null ? null : undefined;
+  if (groupId === parentId) return groupId;
+  let id = groupId;
+  const visited = new Set([id]);
+  for (;;) {
+    const next = effectiveParentId(groupById.get(id), groupById);
+    if (next === parentId) return id;
+    if (next === null || visited.has(next)) return undefined;
+    visited.add(next);
+    id = next;
   }
-  return ids;
 }
 
 /**
@@ -425,8 +494,13 @@ export function layerGroupDepth(
 }
 
 /**
- * Move a group — with everything nested inside it — one row up or down among
- * the layer panel's top-level blocks.
+ * Move a group — with everything nested inside it — one block up or down among
+ * its siblings, the groups sharing its parent.
+ *
+ * A nested group moves inside its parent only: it steps over a whole sibling
+ * block rather than into it, and the parent's own rows are the end of its
+ * travel, so `null` comes back once it is the first or last child. A top-level
+ * group moves among the other top-level groups and the ungrouped layers.
  *
  * Both arrays carry part of the panel order, so both come back: `layers` holds
  * the order of every populated block, and `groups` holds the order the empty
@@ -472,27 +546,43 @@ function moveGroupThroughUnits(
   id: string,
   direction: "up" | "down",
 ): { layers: GeoLibreLayer[]; groups: LayerGroup[] } | null {
-  if (!groups.some((group) => group.id === id)) return null;
   const groupById = new Map(groups.map((g) => [g.id, g]));
-  const moving = groupSubtreeIds(groups, id);
+  const group = groupById.get(id);
+  if (!group) return null;
+  // Label every unit with the block it occupies among the moving group's own
+  // siblings, so the move steps over a whole neighbouring block and stops at the
+  // edge of the parent instead of stepping one unit at a time into it.
+  const parentId = effectiveParentId(group, groupById);
+  const branches = units.map((unit) => branchUnder(parentId, unit.groupId, groupById));
   const matching = new Set<number>();
-  units.forEach((unit, index) => {
-    if (unit.groupId && moving.has(unit.groupId)) matching.add(index);
+  branches.forEach((branch, index) => {
+    if (branch === id) matching.add(index);
   });
   if (matching.size === 0) return null;
   const indices = [...matching].sort((a, b) => a - b);
-  // Units run top-first, so "up" swaps with the block above the group's first.
+  // Units run top-first, so "up" steps over the block above the group's first.
   const neighbor = direction === "up" ? indices[0] - 1 : indices[indices.length - 1] + 1;
   if (neighbor < 0 || neighbor >= units.length) return null;
-  const neighborUnit = units[neighbor];
-  // These indices need not be contiguous — sibling child groups can straddle an
-  // unrelated block. Gathering them compacts the subtree, which is the point of
-  // moving it as a whole; see the note on `reorderLayerGroupInPanel`.
+  const neighborBranch = branches[neighbor];
+  // Outside the parent: the group is already at that end of its own block.
+  if (neighborBranch === undefined) return null;
+  // A neighbouring group travels whole, so the move clears everything nested in
+  // it; an ungrouped layer is a block of one.
+  const neighborUnits =
+    neighborBranch === null
+      ? [units[neighbor]]
+      : units.filter((_, index) => branches[index] === neighborBranch);
+  // The moving group's own indices need not be contiguous — sibling child groups
+  // can straddle an unrelated block. Gathering them compacts the subtree, which
+  // is the point of moving it as a whole; see `reorderLayerGroupInPanel`.
   const block = units.filter((_, index) => matching.has(index));
   const remaining = units.filter((_, index) => !matching.has(index));
-  const neighborIndex = remaining.indexOf(neighborUnit);
+  const edge =
+    direction === "up"
+      ? remaining.indexOf(neighborUnits[0])
+      : remaining.indexOf(neighborUnits[neighborUnits.length - 1]) + 1;
   const reordered = [...remaining];
-  reordered.splice(direction === "up" ? neighborIndex : neighborIndex + 1, 0, ...block);
+  reordered.splice(edge, 0, ...block);
 
   // Units are top-first and so are the layers inside them; the store keeps the
   // reverse, with the last element drawing on top.

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -439,8 +439,9 @@ export function normalizeGroupContiguity(layers: GeoLibreLayer[]): GeoLibreLayer
  *
  * - the id of the child of `parentId` the unit is nested in, however deep — the
  *   sibling block a move steps over, or the moving group's own block;
- * - `parentId` itself when the unit holds that group's own layers, the block a
- *   first child cannot move above;
+ * - `parentId` itself when the unit holds that group's own layers: one more
+ *   block inside the parent, which a child steps over like any other rather
+ *   than a wall;
  * - `null` for an ungrouped layer at the root of the panel (`parentId` `null`);
  * - `undefined` when the unit sits outside `parentId` altogether — a wall,
  *   since a nested group has no position outside the parent holding it.
@@ -498,9 +499,16 @@ export function layerGroupDepth(
  * its siblings, the groups sharing its parent.
  *
  * A nested group moves inside its parent only: it steps over a whole sibling
- * block rather than into it, and the parent's own rows are the end of its
- * travel, so `null` comes back once it is the first or last child. A top-level
- * group moves among the other top-level groups and the ungrouped layers.
+ * block rather than into it, and the parent's boundary is the end of its
+ * travel, so `null` comes back rather than a move that would take it out of the
+ * folder holding it. Inside that boundary it steps over its parent's *own*
+ * layers as readily as over a sibling folder, since those rows are one more
+ * block of the parent and ordering a child against them is a real reorder. A
+ * folder holding no layer is the exception: it has no way to record a position
+ * between two layer rows, so a move that would only cross them changes nothing
+ * and reports `null` — the same limit empty folders already have at the top
+ * level. A top-level group moves among the other top-level groups and the
+ * ungrouped layers.
  *
  * Both arrays carry part of the panel order, so both come back: `layers` holds
  * the order of every populated block, and `groups` holds the order the empty

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -195,6 +195,31 @@ describe("buildLayerPanelUnits", () => {
     assert.equal(headers.bottom.length, 0);
   });
 
+  it("orders and draws grandchild folders at two levels of nesting", () => {
+    // Depth 2: only "leafB" holds a layer, so "leafA" is placed by its own
+    // sibling rather than by "mid" or "p", both of which are ancestors whose
+    // ranges already contain the slot. "other" clears the whole subtree.
+    const layers = [layer("a", { groupId: "leafB" })];
+    const groups = [
+      group("p"),
+      group("mid", { parentId: "p" }),
+      group("leafA", { parentId: "mid" }),
+      group("leafB", { parentId: "mid" }),
+      group("other"),
+    ];
+    assert.deepEqual(panelOrder(layers, groups), ["group:leafA", "group:leafB", "group:other"]);
+    // Every ancestor header precedes the folders nested in it.
+    const headers = layerPanelGroupHeaders(layers, groups);
+    assert.deepEqual(
+      headers.aboveLayer.get("a")?.map((g) => g.id),
+      ["p", "mid", "leafA", "leafB"],
+    );
+    assert.deepEqual(
+      headers.bottom.map((g) => g.id),
+      ["other"],
+    );
+  });
+
   it("anchors headers against the layer rows the panel draws", () => {
     const layers = [layer("bottom"), layer("a", { groupId: "g1" }), layer("top")];
     const headers = layerPanelGroupHeaders(layers, [group("g1"), group("g2")]);
@@ -394,6 +419,29 @@ describe("reorderLayerGroupInPanel", () => {
     assert.deepEqual(panelOrder(layers, groups), ["group:p", "group:c1"]);
     assert.equal(reorderLayerGroupInPanel(layers, groups, "c1", "up"), null);
     assert.equal(reorderLayerGroupInPanel(layers, groups, "c1", "down"), null);
+  });
+
+  it("moves a grandchild among its siblings and stops at its own parent", () => {
+    const layers = [layer("a", { groupId: "leafB" })];
+    const groups = [
+      group("p"),
+      group("mid", { parentId: "p" }),
+      group("leafA", { parentId: "mid" }),
+      group("leafB", { parentId: "mid" }),
+      group("other"),
+    ];
+    // "mid" is the wall for its children, not the outer "p" or "other".
+    const moveability = layerGroupMoveability(layers, groups);
+    assert.deepEqual(moveability.get("leafA"), { up: false, down: true });
+    assert.deepEqual(moveability.get("leafB"), { up: true, down: false });
+
+    const moved = reorderLayerGroupInPanel(layers, groups, "leafA", "down");
+    assert.ok(moved);
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), [
+      "group:leafB",
+      "group:leafA",
+      "group:other",
+    ]);
   });
 
   it("steps a top-level group over a whole subtree in one move", () => {

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -362,6 +362,40 @@ describe("reorderLayerGroupInPanel", () => {
     assert.equal(reorderLayerGroupInPanel(layers, groups, "c2", "down"), null);
   });
 
+  it("steps a nested group over its parent's own layers without leaving it", () => {
+    // "p" owns "L" directly and holds the populated child "c1". Those rows are
+    // one more block inside "p", so ordering the child against them is a real
+    // reorder — but "other" is outside "p" and stays a wall.
+    const layers = [
+      layer("Z", { groupId: "other" }),
+      layer("L", { groupId: "p" }),
+      layer("M", { groupId: "c1" }),
+    ];
+    const groups = [group("p"), group("c1", { parentId: "p" }), group("other")];
+    assert.deepEqual(panelOrder(layers, groups), ["group:c1", "group:p", "group:other"]);
+
+    const moved = reorderLayerGroupInPanel(layers, groups, "c1", "down");
+    assert.ok(moved);
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), [
+      "group:p",
+      "group:c1",
+      "group:other",
+    ]);
+    // Still the last block inside "p": it cannot go on to cross "other".
+    assert.equal(reorderLayerGroupInPanel(moved.layers, moved.groups, "c1", "down"), null);
+  });
+
+  it("leaves an empty child where it is when only layer rows are adjacent", () => {
+    // An empty folder cannot record a position between two layer rows, so a
+    // move that would only cross its parent's own layers changes nothing — the
+    // same limit empty folders have at the top level.
+    const layers = [layer("L", { groupId: "p" })];
+    const groups = [group("p"), group("c1", { parentId: "p" })];
+    assert.deepEqual(panelOrder(layers, groups), ["group:p", "group:c1"]);
+    assert.equal(reorderLayerGroupInPanel(layers, groups, "c1", "up"), null);
+    assert.equal(reorderLayerGroupInPanel(layers, groups, "c1", "down"), null);
+  });
+
   it("steps a top-level group over a whole subtree in one move", () => {
     const layers = [layer("a", { groupId: "c1" }), layer("b", { groupId: "c2" })];
     const groups = [

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -9,8 +9,8 @@ import {
   createEmptyProject,
   effectiveLayerRenderState,
   layerGroupMoveability,
+  layerPanelGroupHeaders,
   normalizeGroupContiguity,
-  placeUnpositionedGroups,
   reorderLayerGroupInPanel,
   parseProject,
   projectFromStore,
@@ -152,26 +152,86 @@ describe("buildLayerPanelUnits", () => {
     assert.deepEqual(panelOrder(layers, groups), ["group:inner", "group:spare"]);
   });
 
-  it("anchors empty groups against the layer rows the panel draws", () => {
+  it("keeps a nested empty folder beside its sibling, not outside its parent", () => {
+    // The reported follow-up to GeoLibre#1739: "c2" gains the first layer, and
+    // "c1" has to stay next to it under "p" rather than being pushed past the
+    // unrelated top-level "other".
+    const layers = [layer("a", { groupId: "c2" })];
+    const groups = [
+      group("p"),
+      group("c1", { parentId: "p" }),
+      group("c2", { parentId: "p" }),
+      group("other"),
+    ];
+    assert.deepEqual(panelOrder(layers, groups), ["group:c1", "group:c2", "group:other"]);
+  });
+
+  it("anchors a top-level folder past a whole subtree, not inside it", () => {
+    // "other" follows "p" in the array, so it belongs below everything nested
+    // in it. The nested "c2" sits at the top of p's block, so anchoring on the
+    // nearest group in array order rather than on the nearest *sibling* would
+    // wedge "other" between p's two children.
+    const layers = [layer("a1", { groupId: "c1" }), layer("a2", { groupId: "c2" })];
+    const groups = [
+      group("p"),
+      group("c1", { parentId: "p" }),
+      group("c2", { parentId: "p" }),
+      group("other"),
+    ];
+    assert.deepEqual(panelOrder(layers, groups), ["group:c2", "group:c1", "group:other"]);
+  });
+
+  it("draws a parent header above the nested folder it holds", () => {
+    // "p" has a layer only through "c2", so its header is drawn against that
+    // layer's row; the empty "c1" is drawn against the same row and must follow
+    // the parent it sits inside.
+    const layers = [layer("a", { groupId: "c2" })];
+    const groups = [group("p"), group("c1", { parentId: "p" }), group("c2", { parentId: "p" })];
+    const headers = layerPanelGroupHeaders(layers, groups);
+    assert.deepEqual(
+      headers.aboveLayer.get("a")?.map((g) => g.id),
+      ["p", "c1", "c2"],
+    );
+    assert.equal(headers.bottom.length, 0);
+  });
+
+  it("anchors headers against the layer rows the panel draws", () => {
     const layers = [layer("bottom"), layer("a", { groupId: "g1" }), layer("top")];
-    const placement = placeUnpositionedGroups(layers, [group("g1"), group("g2")]);
+    const headers = layerPanelGroupHeaders(layers, [group("g1"), group("g2")]);
     // Display order is top-first: top, [g1: a], bottom. g2 follows g1's block,
     // so it draws immediately above "bottom".
     assert.deepEqual(
-      placement.aboveLayer.get("bottom")?.map((g) => g.id),
+      headers.aboveLayer.get("a")?.map((g) => g.id),
+      ["g1"],
+    );
+    assert.deepEqual(
+      headers.aboveLayer.get("bottom")?.map((g) => g.id),
       ["g2"],
     );
-    assert.equal(placement.bottom.length, 0);
+    assert.equal(headers.bottom.length, 0);
   });
 
   it("drops an empty group to the panel bottom when nothing follows it", () => {
     const layers = [layer("a", { groupId: "g1" })];
-    const placement = placeUnpositionedGroups(layers, [group("g1"), group("g2")]);
+    const headers = layerPanelGroupHeaders(layers, [group("g1"), group("g2")]);
     assert.deepEqual(
-      placement.bottom.map((g) => g.id),
+      headers.bottom.map((g) => g.id),
       ["g2"],
     );
-    assert.equal(placement.aboveLayer.size, 0);
+    assert.deepEqual(
+      headers.aboveLayer.get("a")?.map((g) => g.id),
+      ["g1"],
+    );
+  });
+
+  it("emits a scattered group's header once, at its top-most block", () => {
+    const layers = [layer("g1", { groupId: "g" }), layer("x"), layer("g2", { groupId: "g" })];
+    const headers = layerPanelGroupHeaders(layers, [group("g")]);
+    assert.deepEqual(
+      headers.aboveLayer.get("g2")?.map((h) => h.id),
+      ["g"],
+    );
+    assert.equal(headers.aboveLayer.has("g1"), false);
   });
 
   it("terminates on a parentId cycle instead of hanging", () => {
@@ -274,6 +334,52 @@ describe("reorderLayerGroupInPanel", () => {
     assert.equal(reorderLayerGroupInPanel(layers, groups, "g1", "up"), null);
     assert.equal(reorderLayerGroupInPanel(layers, groups, "g2", "down"), null);
     assert.equal(reorderLayerGroupInPanel(layers, groups, "missing", "up"), null);
+  });
+
+  it("swaps two nested folders inside their parent", () => {
+    const layers = [layer("a", { groupId: "c2" })];
+    const groups = [group("p"), group("c1", { parentId: "p" }), group("c2", { parentId: "p" })];
+    assert.deepEqual(panelOrder(layers, groups), ["group:c1", "group:c2"]);
+
+    const moved = reorderLayerGroupInPanel(layers, groups, "c1", "down");
+    assert.ok(moved);
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), ["group:c2", "group:c1"]);
+  });
+
+  it("keeps a nested group inside its parent at either end", () => {
+    // "other" is not a sibling, so it is a wall rather than the next block:
+    // "c1" cannot move up past its parent's header, nor "c2" down out of it.
+    const layers = [layer("a", { groupId: "c1" })];
+    const groups = [
+      group("p"),
+      group("c1", { parentId: "p" }),
+      group("c2", { parentId: "p" }),
+      group("other"),
+    ];
+    const moveability = layerGroupMoveability(layers, groups);
+    assert.deepEqual(moveability.get("c1"), { up: false, down: true });
+    assert.deepEqual(moveability.get("c2"), { up: true, down: false });
+    assert.equal(reorderLayerGroupInPanel(layers, groups, "c2", "down"), null);
+  });
+
+  it("steps a top-level group over a whole subtree in one move", () => {
+    const layers = [layer("a", { groupId: "c1" }), layer("b", { groupId: "c2" })];
+    const groups = [
+      group("p"),
+      group("c1", { parentId: "p" }),
+      group("c2", { parentId: "p" }),
+      group("other"),
+    ];
+    assert.deepEqual(panelOrder(layers, groups), ["group:c2", "group:c1", "group:other"]);
+
+    const moved = reorderLayerGroupInPanel(layers, groups, "other", "up");
+    assert.ok(moved);
+    // "other" clears both of p's children rather than landing between them.
+    assert.deepEqual(panelOrder(moved.layers, moved.groups), [
+      "group:other",
+      "group:c2",
+      "group:c1",
+    ]);
   });
 
   it("reports the directions each group can move", () => {


### PR DESCRIPTION
Follow-up to #1741, reported by @foosint in https://github.com/opengeos/GeoLibre/pull/1741#issuecomment-5206335610: the fix works for top-level groups, but "the same bug appears again inside these nested groups."

## The bug

#1741 gave every empty folder a position, but derived it from the nearest group in **array order**, and for a nested folder from the end of its **parent's** range. Neither of those reads as a sibling, so as soon as one child of a group gained a layer, its sibling folders were placed against the wrong block.

Reproduced in the app before the fix, with `Group 1 > [Group 2, Group 3]` and a top-level `Group 4`:

| step | before | after |
| --- | --- | --- |
| move `us_cities` into the nested Group 3 | panel becomes `Group 1 > Group 3 > us_cities`, `Group 4`, `Group 2` — the empty sibling is pushed past an unrelated top-level group and out of the parent it belongs to, while still drawn at child indentation | `Group 1 > [Group 2, Group 3 > us_cities]`, `Group 4` |
| move a nested group up/down past its sibling | menu enabled, panel unchanged (the folder snapped straight back to where it was) | the two siblings swap, and swap back |
| move a top-level group past a populated parent | lands *between* that parent's two children | clears the whole subtree in one move |

## The fix

**Placement anchors on siblings.** An unpositioned group is now slotted in next to the groups sharing its parent, whose ranges span their whole subtrees. An ancestor's range already contains the slot being chosen, and an unrelated group's covers a different branch of the tree, so neither can position it. With no sibling positioned yet, a nested folder falls to the end of its parent's block and a top-level one to the top of the panel, as before.

**Reordering uses the same shape.** `moveGroupThroughUnits` labels each panel block with the branch it occupies under the moving group's parent, so a move steps over a whole neighbouring sibling block rather than one unit at a time into it, and the edge of the parent is a wall. A nested group therefore moves among its siblings only, and the menu greys out at the first and last child instead of offering a move that does nothing.

**One source for header order.** `placeUnpositionedGroups` is replaced by `layerPanelGroupHeaders`, which emits *every* header from one walk — the group a row belongs to, the organizers above it whose layers all live in child groups, and the folders holding no layer at all — parents first, against the same anchors. Deriving them together is what keeps a nested folder below the parent it sits inside; `LayerPanel` had three independent anchor mechanisms that could disagree, and now renders one ordered list per layer row.

## Verification

Driven in the real app (dev server, Playwright) with `us_cities.geojson`, replaying the reporter's nested scenario, in **both light and dark themes**:

- two levels: `Group 1 > [Group 2, Group 3 > us_cities]`, `Group 4` renders in order; Group 2 and Group 3 swap and swap back; Group 4 clears Group 1's whole subtree in one move.
- three levels: `Group 2 > [Group 5, Group 6, Group 7]` renders in order and the middle grandchild moves both ways.
- move menus: greyed out exactly at each parent's first and last child (`Group 5` up-only-off, `Group 6` down-only-off, same at the outer level), enabled everywhere a move has a visible effect.

Tests: `tests/layer-groups.test.ts` gains nested-sibling placement cases, a top-level-anchor case that would wedge a folder inside a subtree, header-ordering cases for `layerPanelGroupHeaders`, and reorder cases for swapping nested folders and for the parent boundary. Full frontend suite passes, `npm run build` and `pre-commit` clean.

Fixes #1739.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layer panel group header placement and ordering, including nested and empty folders.
  * Prevented nested folders from moving outside their parent group during reordering.
  * Improved handling of missing or invalid parent relationships.
  * Ensured top-level groups can move across complete nested group subtrees as a single block.

* **Tests**
  * Expanded coverage for nested folder movement, header anchoring, ordering, and empty-group scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->