### PR TITLE
fix(arcgis): page large FeatureServer layers instead of one unbounded query

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -364,6 +364,8 @@ export interface ArcGISOptions {
   url: string | undefined;
   itemId: string | undefined;
   portalUrl: string | undefined;
+  pageSize: number | undefined;
+  maxFeatures: number | undefined;
 }
 
 /** Reads the ArcGIS fields from a saved entry, mirroring `ArcGISSource`. */
@@ -377,7 +379,18 @@ export function arcgisFieldsToOptions(entry: ServiceLibraryEntry): ArcGISOptions
     url: serviceFieldString(fields, "url").trim() || undefined,
     itemId: serviceFieldString(fields, "itemId").trim() || undefined,
     portalUrl: serviceFieldString(fields, "portalUrl").trim() || undefined,
+    pageSize: serviceFieldCount(fields, "pageSize"),
+    maxFeatures: serviceFieldCount(fields, "maxFeatures"),
   };
+}
+
+/**
+ * Reads an optional whole-number field, mirroring `ArcGISSource`'s
+ * `positiveCount`: blank/zero/unparseable all mean "use the default".
+ */
+function serviceFieldCount(fields: ServiceFields, key: string): number | undefined {
+  const parsed = Number(serviceFieldString(fields, key).trim());
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : undefined;
 }
 
 // --- Dispatcher ------------------------------------------------------------
@@ -460,7 +473,9 @@ export async function applyServiceEntry(
         beforeLayerId,
         itemId: options.itemId,
         layerType: options.layerType,
+        maxFeatures: options.maxFeatures,
         name: options.name,
+        pageSize: options.pageSize,
         portalUrl: options.portalUrl,
         sourceType: options.sourceType,
         // Tokens are never persisted to the service library, so none is sent.

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -8,6 +8,20 @@ import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import { serviceFieldString, type ServiceFields } from "../service-library";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
+/**
+ * Read an optional whole-number field (page size, feature cap) as a count.
+ *
+ * Blank, zero, and anything unparseable all mean "leave it to the default",
+ * which is what `addArcGISLayer` does with `undefined`.
+ *
+ * @param value - The raw input value.
+ * @returns The count, or undefined when the field is empty or not a count.
+ */
+function positiveCount(value: string): number | undefined {
+  const parsed = Number(value.trim());
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : undefined;
+}
+
 export function ArcGISSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.arcgis.defaultName"));
@@ -17,6 +31,9 @@ export function ArcGISSource() {
   const [arcgisItemId, setArcgisItemId] = useState("");
   const [arcgisPortalUrl, setArcgisPortalUrl] = useState("");
   const [arcgisAccessToken, setArcgisAccessToken] = useState("");
+  const [arcgisPageSize, setArcgisPageSize] = useState("");
+  const [arcgisMaxFeatures, setArcgisMaxFeatures] = useState("");
+  const [progress, setProgress] = useState<{ loaded: number; total: number | null } | null>(null);
 
   // The access token is intentionally excluded from saved fields — credentials
   // must not be persisted to the shared, exportable service library.
@@ -26,6 +43,8 @@ export function ArcGISSource() {
     url: arcgisUrl,
     itemId: arcgisItemId,
     portalUrl: arcgisPortalUrl,
+    pageSize: arcgisPageSize,
+    maxFeatures: arcgisMaxFeatures,
   });
 
   const applyFields = (fields: ServiceFields) => {
@@ -38,6 +57,8 @@ export function ArcGISSource() {
     setArcgisUrl(serviceFieldString(fields, "url"));
     setArcgisItemId(serviceFieldString(fields, "itemId"));
     setArcgisPortalUrl(serviceFieldString(fields, "portalUrl"));
+    setArcgisPageSize(serviceFieldString(fields, "pageSize"));
+    setArcgisMaxFeatures(serviceFieldString(fields, "maxFeatures"));
     // Tokens are never saved, so clear any token typed for a previous entry to
     // avoid sending it to the newly selected service's endpoint.
     setArcgisAccessToken("");
@@ -55,16 +76,26 @@ export function ArcGISSource() {
 
   const handleSubmit = source.runSubmit(async () => {
     const name = source.layerName.trim() || t("addData.arcgis.defaultName");
-    await addArcGISLayer(createAppAPI(source.shell.mapControllerRef), {
-      beforeLayerId: source.beforeLayer,
-      itemId: arcgisItemId.trim() || undefined,
-      layerType: arcgisLayerType,
-      name,
-      portalUrl: arcgisPortalUrl.trim() || undefined,
-      sourceType: arcgisSourceType,
-      token: arcgisAccessToken.trim() || undefined,
-      url: arcgisUrl.trim() || undefined,
-    });
+    setProgress(null);
+    try {
+      await addArcGISLayer(createAppAPI(source.shell.mapControllerRef), {
+        beforeLayerId: source.beforeLayer,
+        itemId: arcgisItemId.trim() || undefined,
+        layerType: arcgisLayerType,
+        maxFeatures: positiveCount(arcgisMaxFeatures),
+        name,
+        // A feature layer can take dozens of requests to download, so keep the
+        // running count in front of the user instead of an inert spinner.
+        onProgress: (loaded, total) => setProgress({ loaded, total }),
+        pageSize: positiveCount(arcgisPageSize),
+        portalUrl: arcgisPortalUrl.trim() || undefined,
+        sourceType: arcgisSourceType,
+        token: arcgisAccessToken.trim() || undefined,
+        url: arcgisUrl.trim() || undefined,
+      });
+    } finally {
+      setProgress(null);
+    }
     source.shell.closeDialog();
   });
 
@@ -158,6 +189,51 @@ export function ArcGISSource() {
             onChange={(event) => setArcgisAccessToken(event.target.value)}
           />
         </div>
+        {arcgisLayerType === "feature" ? (
+          <div className="space-y-1.5">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="arcgis-page-size">{t("addData.arcgis.pageSize")}</Label>
+                <Input
+                  id="arcgis-page-size"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  placeholder={t("addData.arcgis.pageSizePlaceholder")}
+                  value={arcgisPageSize}
+                  onChange={(event) => setArcgisPageSize(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="arcgis-max-features">{t("addData.arcgis.maxFeatures")}</Label>
+                <Input
+                  id="arcgis-max-features"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  placeholder={t("addData.arcgis.maxFeaturesPlaceholder")}
+                  value={arcgisMaxFeatures}
+                  onChange={(event) => setArcgisMaxFeatures(event.target.value)}
+                />
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">{t("addData.arcgis.pagingHint")}</p>
+          </div>
+        ) : null}
+        {progress ? (
+          <p className="text-sm text-muted-foreground" aria-live="polite">
+            {progress.total === null
+              ? t("addData.arcgis.loadingProgressUnknown", {
+                  loaded: progress.loaded.toLocaleString(),
+                })
+              : t("addData.arcgis.loadingProgress", {
+                  loaded: progress.loaded.toLocaleString(),
+                  total: progress.total.toLocaleString(),
+                })}
+          </p>
+        ) : null}
         <SampleDataSelect
           samples={[
             {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -222,9 +222,15 @@ export function ArcGISSource() {
             <p className="text-xs text-muted-foreground">{t("addData.arcgis.pagingHint")}</p>
           </div>
         ) : null}
-        {progress ? (
-          <p className="text-sm text-muted-foreground" aria-live="polite">
-            {progress.total === null
+        {/* Mounted for the life of the panel, not only while a download runs:
+            several screen readers ignore a live region that appears together
+            with its first text. `sr-only` keeps the empty state out of the
+            visual layout (it is positioned, so it adds no gap) while leaving
+            the region in the accessibility tree. */}
+        <p className={progress ? "text-sm text-muted-foreground" : "sr-only"} aria-live="polite">
+          {progress === null
+            ? ""
+            : progress.total === null
               ? t("addData.arcgis.loadingProgressUnknown", {
                   loaded: progress.loaded.toLocaleString(),
                 })
@@ -232,8 +238,7 @@ export function ArcGISSource() {
                   loaded: progress.loaded.toLocaleString(),
                   total: progress.total.toLocaleString(),
                 })}
-          </p>
-        ) : null}
+        </p>
         <SampleDataSelect
           samples={[
             {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -476,7 +476,14 @@
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
       "portalUrl": "Portal URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
-      "accessToken": "Access token"
+      "accessToken": "Access token",
+      "pageSize": "Records per request",
+      "pageSizePlaceholder": "Auto",
+      "maxFeatures": "Maximum features",
+      "maxFeaturesPlaceholder": "All",
+      "pagingHint": "Feature layers download in pages. Lower the records per request if the service times out.",
+      "loadingProgress": "Loaded {{loaded}} of {{total}} features…",
+      "loadingProgressUnknown": "Loaded {{loaded}} features…"
     },
     "gpx": {
       "defaultName": "GPX Layer",

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -22,11 +22,16 @@ const GEORSS_SOURCE_KIND = "georss";
 // this module's metadata checks stay free of that module's import graph; the
 // paged fetch itself is imported dynamically in the refresh branch below.
 const OGC_FEATURES_SOURCE_KIND = "ogc-features-items";
+// Local copy of ARCGIS_FEATURE_SOURCE_KIND (@geolibre/plugins), kept here for
+// the same reason as the OGC one above; the paged fetch is imported dynamically
+// in the refresh branch below.
+const ARCGIS_FEATURE_SOURCE_KIND = "arcgis-feature-query";
 const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   "wfs-getfeature",
   "geojson-url",
   GEORSS_SOURCE_KIND,
   OGC_FEATURES_SOURCE_KIND,
+  ARCGIS_FEATURE_SOURCE_KIND,
 ]);
 
 // Add Vector Layer (maplibre-gl-vector) tags its store layers with this
@@ -266,6 +271,13 @@ export async function refreshGeoJsonLayer(layer: GeoLibreLayer): Promise<GeoJson
   // first page. Replay the same paged request instead.
   if (isOgcFeaturesLayer(layer)) {
     return refreshOgcFeaturesLayer(layer);
+  }
+
+  // Same story for an ArcGIS feature layer: its stored URL is the unbounded
+  // `where=1=1` query, which truncates at the service's record limit (or fails
+  // outright on a large layer). Replay the paged download.
+  if (isArcGISFeatureLayer(layer)) {
+    return refreshArcGISLayer(layer);
   }
 
   const data = await fetchGeoJsonFeatureCollection(sourceUrl, {
@@ -536,6 +548,45 @@ function isWfsLayer(layer: GeoLibreLayer): boolean {
     layer.metadata.service === "wfs" ||
     layer.source.service === "wfs"
   );
+}
+
+/**
+ * Re-runs an ArcGIS feature layer's paged query from the parameters stored on
+ * its source, so a refresh reloads every feature the layer was added with
+ * rather than the first page the unbounded query happens to return.
+ *
+ * A layer saved before those parameters existed carries only the query URL;
+ * that case derives the endpoint from the stored URL, which is the same
+ * `/query` path with the unbounded parameters that get replaced anyway.
+ *
+ * @param layer - The ArcGIS feature layer to reload.
+ * @returns The reloaded features and their count.
+ */
+async function refreshArcGISLayer(layer: GeoLibreLayer): Promise<GeoJsonRefreshResult> {
+  const source = layer.source as {
+    arcgisQueryUrl?: unknown;
+    maxFeatures?: unknown;
+    pageSize?: unknown;
+  };
+  const stored = typeof source.arcgisQueryUrl === "string" ? source.arcgisQueryUrl.trim() : "";
+  // Fall back to the layer's own URL, stripped of its query string: it is the
+  // `/query` endpoint the paged fetch wants, just with the parameters attached.
+  const queryUrl = stored || (layerHttpUrl(layer) ?? "").split("?")[0];
+  if (!queryUrl) throw new Error("This layer does not have a refreshable GeoJSON URL.");
+
+  // Imported here rather than at module scope so this module stays light for
+  // the callers that only read refresh metadata.
+  const { refreshArcGISFeatureLayer } = await import("@geolibre/plugins");
+  const data = await refreshArcGISFeatureLayer({
+    maxFeatures: typeof source.maxFeatures === "number" ? source.maxFeatures : undefined,
+    pageSize: typeof source.pageSize === "number" ? source.pageSize : undefined,
+    queryUrl,
+  });
+  return { geojson: data, featureCount: data.features.length };
+}
+
+function isArcGISFeatureLayer(layer: GeoLibreLayer): boolean {
+  return layer.metadata.sourceKind === ARCGIS_FEATURE_SOURCE_KIND;
 }
 
 function isGeoRssLayer(layer: GeoLibreLayer): boolean {

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -58,6 +58,8 @@ export {
 } from "./plugins/maplibre-basemap-control";
 export {
   addArcGISLayer,
+  ARCGIS_FEATURE_SOURCE_KIND,
+  refreshArcGISFeatureLayer,
   type ArcGISLayerOptions,
   type ArcGISLayerType,
   type ArcGISSourceType,

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -2,18 +2,67 @@
 
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import type { HostedLayer, VectorTileLayer } from "@esri/maplibre-arcgis";
-import type { FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
 export type ArcGISLayerType = "feature" | "vector-tile";
 export type ArcGISSourceType = "url" | "portal-item";
 
+/**
+ * Features requested per `/query` call when the service does not advertise a
+ * smaller `maxRecordCount`.
+ *
+ * Deliberately far below the 1000-50000 `maxRecordCount` services typically
+ * advertise: that ceiling is what the service will *return*, not what it can
+ * assemble without falling over. Asking a large layer for everything at once is
+ * exactly what fails (GeoLibre#1745 — a 41k-polygon FeatureServer answers the
+ * unbounded query with an HTTP 500 "Error performing query operation" while the
+ * same data pages back fine).
+ */
+const DEFAULT_ARCGIS_PAGE_SIZE = 1000;
+
+/**
+ * Runaway guard for the paging loops. At the default page size this is 5M
+ * features, well past any layer that belongs in an in-memory GeoJSON source, so
+ * it only ever trips on a service that keeps answering without making progress.
+ */
+const MAX_ARCGIS_PAGES = 5000;
+
+/**
+ * `metadata.sourceKind` on a feature layer loaded through the paged query path.
+ * `layer-refresh.ts` matches on it to replay the paging on refresh instead of
+ * re-fetching the stored URL, which would return only the first page.
+ */
+export const ARCGIS_FEATURE_SOURCE_KIND = "arcgis-feature-query";
+
 export interface ArcGISLayerOptions {
   beforeLayerId?: string | null;
   itemId?: string;
   layerType: ArcGISLayerType;
+  /**
+   * Stop after this many features. Defaults to no cap (the whole layer).
+   *
+   * Only meaningful for `layerType: "feature"`, whose features are pulled into
+   * an in-memory GeoJSON source; a cap is the escape hatch for a layer too big
+   * to hold in the browser at all.
+   */
+  maxFeatures?: number;
   name?: string;
+  /**
+   * Called after each page of a feature layer's download, with the features
+   * loaded so far and the service's total count (`null` when the service would
+   * not answer `returnCountOnly`). Lets a caller show progress across what can
+   * be dozens of requests.
+   */
+  onProgress?: (loaded: number, total: number | null) => void;
+  /**
+   * Features to request per `/query` call (ArcGIS `resultRecordCount`).
+   * Defaults to the smaller of {@link DEFAULT_ARCGIS_PAGE_SIZE} and the
+   * service's advertised `maxRecordCount`. Lower it for a service that times
+   * out even on the default page.
+   */
+  pageSize?: number;
   portalUrl?: string;
   sourceType: ArcGISSourceType;
   token?: string;
@@ -31,10 +80,16 @@ export interface ArcGISLayerOptions {
 }
 
 interface ArcGISFeatureLayerInfo {
+  advancedQueryCapabilities?: {
+    supportsOrderBy?: boolean;
+    supportsPagination?: boolean;
+  };
   copyrightText?: string;
   extent?: ArcGISExtent;
   geometryType?: string;
+  maxRecordCount?: number;
   name?: string;
+  objectIdField?: string;
 }
 
 interface ArcGISFeatureServiceInfo {
@@ -196,11 +251,12 @@ function addArcGISRuntimeLayerToMap(hostedLayer: ArcGISRuntimeLayer, map: maplib
 /**
  * Load an ArcGIS FeatureServer layer as a host-managed GeoJSON layer.
  *
- * The features are fetched up front (`/query?f=geojson`) and handed to the
- * store's GeoJSON layer path, so the layer is a first-class vector layer with
- * its attributes available — enabling labels and their formatting, the
- * attribute table, identify, symbology, and export. Vector tile layers keep the
- * external-native runtime path; only feature layers come through here.
+ * The features are fetched up front (`/query?f=geojson`, paged — see
+ * {@link fetchArcGISFeaturePages}) and handed to the store's GeoJSON layer path,
+ * so the layer is a first-class vector layer with its attributes available —
+ * enabling labels and their formatting, the attribute table, identify,
+ * symbology, and export. Vector tile layers keep the external-native runtime
+ * path; only feature layers come through here.
  *
  * @param app - The host app API (used to fit the view to the layer extent).
  * @param options - The ArcGIS layer options (source type, URL/item, token).
@@ -222,17 +278,15 @@ async function addArcGISFeatureLayerAsGeoJson(
   }
 
   // The token is kept out of the persisted refresh URL so it is never written
-  // to a saved project; it is only appended to the one-off request below.
-  const refreshUrl = appendArcGISParams(`${trimTrailingSlash(layerUrl)}/query`, {
+  // to a saved project; it is only appended to the live requests below.
+  const queryUrl = `${trimTrailingSlash(layerUrl)}/query`;
+  const refreshUrl = appendArcGISParams(queryUrl, {
     f: "geojson",
     outFields: "*",
     returnGeometry: "true",
     where: "1=1",
   });
-  const requestUrl = appendArcGISParams(refreshUrl, {
-    token: options.token?.trim(),
-  });
-  const geojson = await fetchArcGISGeoJson(requestUrl);
+  const geojson = await fetchArcGISFeaturePages(queryUrl, options, layerInfo);
 
   const name =
     options.name?.trim() || layerInfo.name || layerNameFromArcGISInput(layerUrl, "ArcGIS Layer");
@@ -241,16 +295,390 @@ async function addArcGISFeatureLayerAsGeoJson(
   // the source path so the layer's GeoJSON refresh re-fetches valid features.
   const id = store.addGeoJsonLayer(name, geojson, refreshUrl, options.beforeLayerId ?? null);
 
-  // Preserve the service's copyright watermark in MapLibre's attribution
-  // control, matching the prior URL-source behavior.
-  const attribution = layerInfo.copyrightText?.trim();
-  if (attribution) {
-    store.updateLayer(id, { source: { type: "geojson", attribution } });
-  }
+  store.updateLayer(id, {
+    source: {
+      type: "geojson",
+      // Preserve the service's copyright watermark in MapLibre's attribution
+      // control, matching the prior URL-source behavior.
+      attribution: layerInfo.copyrightText?.trim() || undefined,
+      // What a refresh needs to replay the same paged download. Re-fetching the
+      // stored query URL on its own would shrink the layer back to a single
+      // page (the ArcGIS twin of the OGC API - Features case in layer-refresh).
+      // The token is deliberately absent: it is never persisted, so refreshing
+      // a token-protected layer fails the same way it does today.
+      arcgisQueryUrl: queryUrl,
+      maxFeatures: options.maxFeatures,
+      pageSize: options.pageSize,
+    },
+    metadata: { sourceKind: ARCGIS_FEATURE_SOURCE_KIND },
+  });
 
   const bounds = arcgisExtentToBounds(layerInfo.extent);
   if (bounds && options.zoomTo !== false) app.fitBounds?.(bounds);
   return id;
+}
+
+/**
+ * Re-download an ArcGIS feature layer, replaying the paging it was added with.
+ *
+ * A refresh cannot just re-fetch the layer's stored `sourcePath`: that URL is
+ * the unbounded `where=1=1` query, which is the very request that truncates at
+ * `maxRecordCount` or fails outright on a large service (GeoLibre#1745). Going
+ * back through {@link fetchArcGISFeaturePages} keeps a refreshed layer the same
+ * size as the one that was added.
+ *
+ * @param params - The paging state persisted on the layer's source.
+ * @returns The re-downloaded features.
+ */
+export async function refreshArcGISFeatureLayer(params: {
+  maxFeatures?: number;
+  pageSize?: number;
+  queryUrl: string;
+}): Promise<FeatureCollection> {
+  const queryUrl = trimTrailingSlash(params.queryUrl).replace(/\/query$/i, "");
+  const options: ArcGISLayerOptions = {
+    layerType: "feature",
+    maxFeatures: params.maxFeatures,
+    pageSize: params.pageSize,
+    sourceType: "url",
+  };
+  // Re-read the metadata rather than trusting a stored copy: `maxRecordCount`
+  // and the paging capabilities are the service's to change between sessions.
+  const layerInfo = await fetchArcGISJson<ArcGISFeatureLayerInfo>(queryUrl, options, undefined);
+  return fetchArcGISFeaturePages(`${queryUrl}/query`, options, layerInfo);
+}
+
+/**
+ * Everything the paging strategies need, resolved once from the layer metadata.
+ */
+interface ArcGISPagingPlan {
+  /** Hard cap on features to keep, or `null` for the whole layer. */
+  maxFeatures: number | null;
+  /** The layer's ObjectID field, when the service names one. */
+  objectIdField: string | undefined;
+  onProgress: ArcGISLayerOptions["onProgress"];
+  /** Features to request per `/query` call. */
+  pageSize: number;
+  /** Query params every page shares (including the token, if any). */
+  params: Record<string, string | undefined>;
+  /** The `/query` endpoint, without paging params. */
+  queryUrl: string;
+  /** Whether the service claims to honor `resultOffset`. */
+  supportsPagination: boolean;
+  /** Whether the service accepts `orderByFields` (needed for stable paging). */
+  supportsOrderBy: boolean;
+  /** The service's feature count, or `null` when it would not report one. */
+  total: number | null;
+}
+
+/**
+ * Download every feature of an ArcGIS feature layer, one page at a time.
+ *
+ * A single unbounded `where=1=1` query is what the old code sent, and it does
+ * not scale: past some layer size the service either truncates the result at
+ * `maxRecordCount` (loading a silently partial layer) or gives up entirely with
+ * an HTTP 500 (GeoLibre#1745). Paging keeps every individual request small
+ * enough for the service to answer, so the layer that used to fail outright now
+ * loads in full.
+ *
+ * Two strategies, because not every service supports the first:
+ *
+ * - `resultOffset`/`resultRecordCount` paging, when the layer advertises
+ *   `advancedQueryCapabilities.supportsPagination` (ArcGIS 10.3+). Cheapest —
+ *   no extra round trip.
+ * - ObjectID-range paging otherwise: ask for the layer's ObjectIDs
+ *   (`returnIdsOnly`), then walk them in sorted chunks with a
+ *   `<oidField> >= a AND <oidField> <= b` filter. Works on any service that can
+ *   run a query at all, which is what older ArcGIS Server deployments need.
+ *
+ * A service that advertises pagination but ignores `resultOffset` would page
+ * forever over the same rows, so that is detected (each page's first feature is
+ * compared with the previous page's) and falls back to the ObjectID walk.
+ *
+ * @param queryUrl - The layer's `/query` endpoint, with no query string.
+ * @param options - The ArcGIS layer options (token, page size, feature cap).
+ * @param layerInfo - The layer's `?f=json` metadata.
+ * @returns Every feature the service returned, as one FeatureCollection.
+ */
+async function fetchArcGISFeaturePages(
+  queryUrl: string,
+  options: ArcGISLayerOptions,
+  layerInfo: ArcGISFeatureLayerInfo,
+): Promise<FeatureCollection> {
+  const plan = await planArcGISPaging(queryUrl, options, layerInfo);
+
+  if (plan.supportsPagination) {
+    const paged = await fetchArcGISPagesByOffset(plan);
+    if (!paged.truncated) return finishArcGISPaging(plan, paged.features, false);
+    // The service advertised `supportsPagination` but handed back the same rows
+    // for a second offset. Walking ObjectIDs does not rely on that promise.
+    const byObjectId = await fetchArcGISPagesByObjectId(plan);
+    if (byObjectId) return finishArcGISPaging(plan, byObjectId, false);
+    return finishArcGISPaging(plan, paged.features, true);
+  }
+
+  const byObjectId = await fetchArcGISPagesByObjectId(plan);
+  if (byObjectId) return finishArcGISPaging(plan, byObjectId, false);
+  // No usable ObjectIDs either. Try offset paging anyway — plenty of services
+  // honor it without advertising it — and accept a single page if they do not.
+  const paged = await fetchArcGISPagesByOffset(plan);
+  return finishArcGISPaging(plan, paged.features, paged.truncated);
+}
+
+async function planArcGISPaging(
+  queryUrl: string,
+  options: ArcGISLayerOptions,
+  layerInfo: ArcGISFeatureLayerInfo,
+): Promise<ArcGISPagingPlan> {
+  const params = {
+    f: "geojson",
+    outFields: "*",
+    returnGeometry: "true",
+    where: "1=1",
+    token: options.token?.trim() || undefined,
+  };
+  return {
+    maxFeatures: positiveInteger(options.maxFeatures),
+    objectIdField: layerInfo.objectIdField?.trim() || undefined,
+    onProgress: options.onProgress,
+    pageSize: resolveArcGISPageSize(options.pageSize, layerInfo.maxRecordCount),
+    params,
+    queryUrl,
+    supportsPagination: layerInfo.advancedQueryCapabilities?.supportsPagination === true,
+    supportsOrderBy: layerInfo.advancedQueryCapabilities?.supportsOrderBy !== false,
+    total: await fetchArcGISFeatureCount(queryUrl, params.token),
+  };
+}
+
+/**
+ * The page size to request.
+ *
+ * A caller-supplied size wins (that is the point of the Add Data field), but is
+ * still held under the service's own `maxRecordCount` — asking for more only
+ * gets the cap back, and would make a truncated page look like the last one.
+ *
+ * @param requested - The caller's `pageSize` option, if any.
+ * @param maxRecordCount - The service's advertised per-query ceiling, if any.
+ */
+function resolveArcGISPageSize(
+  requested: number | undefined,
+  maxRecordCount: number | undefined,
+): number {
+  const serviceCap = positiveInteger(maxRecordCount);
+  const wanted = positiveInteger(requested) ?? DEFAULT_ARCGIS_PAGE_SIZE;
+  return serviceCap ? Math.min(wanted, serviceCap) : wanted;
+}
+
+function positiveInteger(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 1
+    ? Math.floor(value)
+    : null;
+}
+
+/**
+ * The layer's feature count, used for progress reporting and as a stop
+ * condition. Best-effort: a service that will not answer `returnCountOnly`
+ * still pages fine, so any failure resolves to `null` rather than throwing.
+ *
+ * @param queryUrl - The layer's `/query` endpoint.
+ * @param token - The access token to send, if any.
+ */
+async function fetchArcGISFeatureCount(
+  queryUrl: string,
+  token: string | undefined,
+): Promise<number | null> {
+  try {
+    const response = await fetch(
+      appendArcGISParams(queryUrl, {
+        f: "json",
+        returnCountOnly: "true",
+        where: "1=1",
+        token,
+      }),
+    );
+    if (!response.ok) return null;
+    const json = (await response.json()) as { count?: unknown };
+    return typeof json.count === "number" && Number.isFinite(json.count) && json.count >= 0
+      ? json.count
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Page with `resultOffset`/`resultRecordCount`.
+ *
+ * @param plan - The resolved paging plan.
+ * @returns The features collected, plus whether the walk stopped with rows the
+ *   service still had — either because it was caught ignoring `resultOffset`
+ *   (the features are then only the first page, and the caller should try
+ *   another strategy) or because the page guard tripped.
+ */
+async function fetchArcGISPagesByOffset(
+  plan: ArcGISPagingPlan,
+): Promise<{ features: Feature[]; truncated: boolean }> {
+  const features: Feature[] = [];
+  // Paging is only coherent over a stable sort. Services default to ObjectID
+  // order, but say so explicitly when the layer names an ObjectID field and
+  // accepts `orderByFields`, so pages cannot overlap or skip rows.
+  const orderByFields = plan.supportsOrderBy && plan.objectIdField ? plan.objectIdField : undefined;
+  let previousSignature: string | null = null;
+  let pageSize = plan.pageSize;
+
+  for (let page = 0; ; page += 1) {
+    if (page >= MAX_ARCGIS_PAGES) return { features, truncated: true };
+
+    const wanted = remainingArcGISFeatures(plan, features.length, pageSize);
+    if (wanted <= 0) break;
+
+    const chunk = await fetchArcGISGeoJson(
+      appendArcGISParams(plan.queryUrl, {
+        ...plan.params,
+        orderByFields,
+        resultOffset: String(features.length),
+        resultRecordCount: String(wanted),
+      }),
+    );
+    if (chunk.features.length === 0) break;
+
+    const signature = arcgisPageSignature(chunk.features[0]);
+    if (page > 0 && signature !== null && signature === previousSignature) {
+      // The same first row came back for a different offset: the service is
+      // ignoring `resultOffset`, so every further page would be this one again.
+      return { features: features.slice(0, plan.pageSize), truncated: true };
+    }
+    previousSignature = signature;
+
+    features.push(...chunk.features);
+    plan.onProgress?.(features.length, plan.total);
+
+    if (plan.total !== null && features.length >= plan.total) break;
+    if (chunk.features.length >= wanted) continue;
+    // A short page normally means the last one — unless the service flagged the
+    // transfer limit, which means it capped the page below what was asked for.
+    // Adopt its cap and keep going rather than stopping on a partial dataset.
+    if (!chunk.exceededTransferLimit) break;
+    pageSize = chunk.features.length;
+  }
+
+  return { features, truncated: false };
+}
+
+/**
+ * Page by walking the layer's ObjectIDs in sorted chunks.
+ *
+ * The chunks are expressed as an inclusive `>= a AND <= b` range rather than an
+ * `objectIds=` list so the request URL stays short whatever the page size.
+ * Because the range is cut from the service's own complete, sorted ID list, it
+ * selects exactly that chunk.
+ *
+ * @param plan - The resolved paging plan.
+ * @returns The features collected, or `null` when the service would not list
+ *   its ObjectIDs (so the caller can fall back).
+ */
+async function fetchArcGISPagesByObjectId(plan: ArcGISPagingPlan): Promise<Feature[] | null> {
+  const idInfo = await fetchArcGISObjectIds(plan);
+  if (!idInfo || idInfo.objectIds.length === 0) return null;
+
+  const { field, objectIds } = idInfo;
+  const features: Feature[] = [];
+  for (let start = 0; start < objectIds.length; start += plan.pageSize) {
+    const wanted = remainingArcGISFeatures(plan, features.length, plan.pageSize);
+    if (wanted <= 0) break;
+
+    const end = Math.min(start + wanted, objectIds.length);
+    const chunk = await fetchArcGISGeoJson(
+      appendArcGISParams(plan.queryUrl, {
+        ...plan.params,
+        where: `${field} >= ${objectIds[start]} AND ${field} <= ${objectIds[end - 1]}`,
+      }),
+    );
+    features.push(...chunk.features);
+    plan.onProgress?.(features.length, plan.total ?? objectIds.length);
+  }
+  return features;
+}
+
+async function fetchArcGISObjectIds(
+  plan: ArcGISPagingPlan,
+): Promise<{ field: string; objectIds: number[] } | null> {
+  try {
+    const response = await fetch(
+      appendArcGISParams(plan.queryUrl, {
+        f: "json",
+        returnIdsOnly: "true",
+        where: "1=1",
+        token: plan.params.token,
+      }),
+    );
+    if (!response.ok) return null;
+    const json = (await response.json()) as {
+      objectIdFieldName?: unknown;
+      objectIds?: unknown;
+    };
+    if (!Array.isArray(json.objectIds)) return null;
+    const objectIds = json.objectIds
+      .filter((id): id is number => typeof id === "number" && Number.isFinite(id))
+      .sort((a, b) => a - b);
+    const field =
+      (typeof json.objectIdFieldName === "string" ? json.objectIdFieldName.trim() : "") ||
+      plan.objectIdField;
+    return field && objectIds.length > 0 ? { field, objectIds } : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Features still wanted for this page, honoring the caller's `maxFeatures`. */
+function remainingArcGISFeatures(plan: ArcGISPagingPlan, loaded: number, pageSize: number): number {
+  return plan.maxFeatures === null ? pageSize : Math.min(pageSize, plan.maxFeatures - loaded);
+}
+
+/**
+ * A cheap identity for a page's first feature, used to catch a service that
+ * ignores `resultOffset` and keeps replaying the same page. Prefers the GeoJSON
+ * `id` (which ArcGIS populates from the ObjectID); properties are the fallback
+ * because they are small next to a polygon's coordinates.
+ */
+function arcgisPageSignature(feature: Feature | undefined): string | null {
+  if (!feature) return null;
+  if (feature.id !== undefined && feature.id !== null) return `id:${String(feature.id)}`;
+  if (feature.properties && Object.keys(feature.properties).length > 0) {
+    return `p:${JSON.stringify(feature.properties)}`;
+  }
+  return feature.geometry ? `g:${JSON.stringify(feature.geometry)}` : null;
+}
+
+/**
+ * Wrap the collected features and report anything the user should know about
+ * the result being short of the whole layer. A partial layer still loads — it
+ * is better than nothing, and matches what the single-query path used to do —
+ * but the shortfall is surfaced so a partial attribute table or export is not
+ * mistaken for the complete dataset.
+ *
+ * @param plan - The resolved paging plan.
+ * @param features - The features collected.
+ * @param truncated - Whether the walk gave up with rows still unread.
+ */
+function finishArcGISPaging(
+  plan: ArcGISPagingPlan,
+  features: Feature[],
+  truncated: boolean,
+): FeatureCollection {
+  if (plan.maxFeatures !== null && features.length >= plan.maxFeatures) {
+    console.warn(
+      `[GeoLibre] ArcGIS feature download stopped at the requested maximum of ` +
+        `${plan.maxFeatures} features (partial dataset).`,
+    );
+  } else if (truncated || (plan.total !== null && features.length < plan.total)) {
+    const of = plan.total === null ? "" : ` of ${plan.total}`;
+    console.warn(
+      `[GeoLibre] ArcGIS feature query was truncated: loaded ${features.length}${of} ` +
+        `features (partial dataset).`,
+    );
+  }
+  return { type: "FeatureCollection", features };
 }
 
 /** The JSON error envelope ArcGIS returns, usually with an HTTP 200 status. */
@@ -283,18 +711,18 @@ function arcgisErrorMessage(error: ArcGISErrorEnvelope | undefined, fallback: st
 }
 
 /**
- * Fetch and validate a GeoJSON FeatureCollection from an ArcGIS query URL.
+ * Fetch and validate one page of GeoJSON from an ArcGIS query URL.
  *
  * ArcGIS can answer a `f=geojson` request with a JSON error envelope rather than
- * GeoJSON, so both the transport status and the payload shape are checked. A
- * result truncated at the service's `maxRecordCount` is loaded as-is but warned
- * about, so a partial attribute table or export is not mistaken for the full
- * dataset.
+ * GeoJSON, so both the transport status and the payload shape are checked.
  *
  * @param url - The fully-built `/query?f=geojson` request URL.
- * @returns The parsed FeatureCollection.
+ * @returns The parsed FeatureCollection, with the service's
+ *   `exceededTransferLimit` flag normalized onto it for the paging loop.
  */
-async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
+async function fetchArcGISGeoJson(
+  url: string,
+): Promise<FeatureCollection & { exceededTransferLimit: boolean }> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`ArcGIS feature query failed with ${response.status}.`);
@@ -312,6 +740,7 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
   let json: FeatureCollection & {
     error?: ArcGISErrorEnvelope;
     exceededTransferLimit?: boolean;
+    properties?: { exceededTransferLimit?: boolean };
   };
   try {
     json = JSON.parse(text);
@@ -325,16 +754,17 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
     throw new Error("The ArcGIS feature layer did not return GeoJSON features.");
   }
   // ArcGIS caps a single query at the service's maxRecordCount and flags the
-  // shortfall with `exceededTransferLimit`. The partial data still loads (it is
-  // the same subset the previous URL-source path rendered), but the truncation
-  // is surfaced so the caller knows the layer is not the complete dataset.
-  if (json.exceededTransferLimit) {
-    console.warn(
-      `[GeoLibre] ArcGIS feature query was truncated at the service record ` +
-        `limit; loaded ${json.features.length} features (partial dataset).`,
-    );
-  }
-  return json;
+  // shortfall with `exceededTransferLimit`. In `f=geojson` output that flag is
+  // not always where the `f=json` output puts it — some servers only nest it
+  // under `properties` (GeoJSON has no place for a top-level extension member),
+  // so both are read. The paging loop uses it to tell a capped page from the
+  // genuinely last one.
+  return {
+    ...json,
+    exceededTransferLimit: Boolean(
+      json.exceededTransferLimit || json.properties?.exceededTransferLimit,
+    ),
+  };
 }
 
 async function resolveFeatureLayerUrl(

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -583,8 +583,13 @@ async function fetchArcGISPagesByObjectId(plan: ArcGISPagingPlan): Promise<Featu
 
   const { field, objectIds } = idInfo;
   const features: Feature[] = [];
-  for (let start = 0; start < objectIds.length; start += plan.pageSize) {
-    const wanted = remainingArcGISFeatures(plan, features.length, plan.pageSize);
+  let pageSize = plan.pageSize;
+  let start = 0;
+
+  for (let page = 0; start < objectIds.length; page += 1) {
+    if (page >= MAX_ARCGIS_PAGES) break;
+
+    const wanted = remainingArcGISFeatures(plan, features.length, pageSize);
     if (wanted <= 0) break;
 
     const end = Math.min(start + wanted, objectIds.length);
@@ -594,7 +599,22 @@ async function fetchArcGISPagesByObjectId(plan: ArcGISPagingPlan): Promise<Featu
         where: `${field} >= ${objectIds[start]} AND ${field} <= ${objectIds[end - 1]}`,
       }),
     );
+
+    // The range spans `end - start` ObjectIDs, so a shorter capped page would
+    // silently drop the rest of them — the ids are consumed by advancing past
+    // the range, not by what came back. Reachable whenever the page size
+    // exceeds the service's real cap, which is what happens when the layer
+    // metadata omits `maxRecordCount`. Adopt the cap and redo this range at the
+    // smaller size rather than advancing over the ids that were not returned.
+    if (chunk.exceededTransferLimit && chunk.features.length > 0) {
+      if (chunk.features.length < end - start) {
+        pageSize = chunk.features.length;
+        continue;
+      }
+    }
+
     features.push(...chunk.features);
+    start = end;
     plan.onProgress?.(features.length, plan.total ?? objectIds.length);
   }
   return features;

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -413,12 +413,12 @@ async function fetchArcGISFeaturePages(
     // The service advertised `supportsPagination` but handed back the same rows
     // for a second offset. Walking ObjectIDs does not rely on that promise.
     const byObjectId = await fetchArcGISPagesByObjectId(plan);
-    if (byObjectId) return finishArcGISPaging(plan, byObjectId, false);
+    if (byObjectId) return finishArcGISPaging(plan, byObjectId.features, byObjectId.truncated);
     return finishArcGISPaging(plan, paged.features, true);
   }
 
   const byObjectId = await fetchArcGISPagesByObjectId(plan);
-  if (byObjectId) return finishArcGISPaging(plan, byObjectId, false);
+  if (byObjectId) return finishArcGISPaging(plan, byObjectId.features, byObjectId.truncated);
   // No usable ObjectIDs either. Try offset paging anyway — plenty of services
   // honor it without advertising it — and accept a single page if they do not.
   const paged = await fetchArcGISPagesByOffset(plan);
@@ -574,10 +574,13 @@ async function fetchArcGISPagesByOffset(
  * selects exactly that chunk.
  *
  * @param plan - The resolved paging plan.
- * @returns The features collected, or `null` when the service would not list
- *   its ObjectIDs (so the caller can fall back).
+ * @returns The features collected, plus whether the page guard stopped the walk
+ *   with ObjectIDs still unread; `null` when the service would not list its
+ *   ObjectIDs at all (so the caller can fall back).
  */
-async function fetchArcGISPagesByObjectId(plan: ArcGISPagingPlan): Promise<Feature[] | null> {
+async function fetchArcGISPagesByObjectId(
+  plan: ArcGISPagingPlan,
+): Promise<{ features: Feature[]; truncated: boolean } | null> {
   const idInfo = await fetchArcGISObjectIds(plan);
   if (!idInfo || idInfo.objectIds.length === 0) return null;
 
@@ -587,7 +590,9 @@ async function fetchArcGISPagesByObjectId(plan: ArcGISPagingPlan): Promise<Featu
   let start = 0;
 
   for (let page = 0; start < objectIds.length; page += 1) {
-    if (page >= MAX_ARCGIS_PAGES) break;
+    // Stopping here leaves ObjectIDs unread, so say so: without a `total` to
+    // compare against, that is the only signal the layer is short.
+    if (page >= MAX_ARCGIS_PAGES) return { features, truncated: true };
 
     const wanted = remainingArcGISFeatures(plan, features.length, pageSize);
     if (wanted <= 0) break;
@@ -617,7 +622,9 @@ async function fetchArcGISPagesByObjectId(plan: ArcGISPagingPlan): Promise<Featu
     start = end;
     plan.onProgress?.(features.length, plan.total ?? objectIds.length);
   }
-  return features;
+  // Ran to the end of the id list, or stopped on the caller's `maxFeatures`
+  // cap — which `finishArcGISPaging` reports on its own.
+  return { features, truncated: false };
 }
 
 async function fetchArcGISObjectIds(

--- a/tests/apply-service.test.ts
+++ b/tests/apply-service.test.ts
@@ -283,6 +283,9 @@ describe("field mappers", () => {
         url: undefined,
         itemId: "abc",
         portalUrl: undefined,
+        // Unset paging fields mean "use the defaults" (whole layer, auto page).
+        pageSize: undefined,
+        maxFeatures: undefined,
       },
     );
     // Unknown/absent values fall back to the feature + url defaults.

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -67,6 +67,11 @@ interface FakeArcGISServiceOptions {
    * the cap the service will honor.
    */
   hideMaxRecordCount?: boolean;
+  /**
+   * Refuse `returnCountOnly`, as a service with statistics disabled does. The
+   * walk then has no total to measure its result against.
+   */
+  hideCount?: boolean;
   /** Whether `resultOffset` is actually honored (false replays page one). */
   honorsOffset?: boolean;
   /** Whether the layer advertises `advancedQueryCapabilities.supportsPagination`. */
@@ -109,7 +114,9 @@ function fakeArcGISService(config: FakeArcGISServiceOptions) {
     if (!url.pathname.endsWith("/query")) return jsonResponse(layerInfo);
 
     const params = url.searchParams;
-    if (params.get("returnCountOnly") === "true") return jsonResponse({ count: total });
+    if (params.get("returnCountOnly") === "true") {
+      return config.hideCount ? jsonResponse({}) : jsonResponse({ count: total });
+    }
     if (params.get("returnIdsOnly") === "true") {
       return jsonResponse({ objectIdFieldName: "OBJECTID", objectIds });
     }
@@ -492,6 +499,37 @@ describe("addArcGISLayer (feature layer)", () => {
       [251, 500],
       [501, 700],
     ]);
+  });
+
+  // The page guard stops the ObjectID walk with ids still unread. A service
+  // that will not answer `returnCountOnly` leaves no total to compare against,
+  // so without the guard reporting truncation the short layer looks complete.
+  it("reports truncation when the page guard stops the ObjectID walk", async () => {
+    // MAX_ARCGIS_PAGES (5000) pages of one id each, against 5001 ids.
+    const service = fakeArcGISService({
+      total: 5001,
+      maxRecordCount: 1,
+      supportsPagination: false,
+      hideCount: true,
+    });
+    globalThis.fetch = service.fetch;
+
+    const warnings = captureWarnings();
+    let id: string;
+    try {
+      id = await addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: SERVICE_URL,
+      });
+    } finally {
+      warnings.restore();
+    }
+
+    const features =
+      useAppStore.getState().layers.find((l) => l.id === id)?.geojson?.features ?? [];
+    assert.equal(features.length, 5000, "expected the walk to stop at the page guard");
+    assert.match(warnings.messages.join("\n"), /truncated: loaded 5000 features/);
   });
 
   it("falls back to ObjectIDs when a service advertises paging it ignores", async () => {

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -59,8 +59,14 @@ function makeArcGISFetch(): typeof fetch {
 const SERVICE_URL = "https://example.com/arcgis/rest/services/Cities/FeatureServer/0";
 
 interface FakeArcGISServiceOptions {
-  /** The service's advertised per-query ceiling. */
+  /** The per-query ceiling the service actually enforces. */
   maxRecordCount: number;
+  /**
+   * Drop `maxRecordCount` from the layer metadata while still enforcing it.
+   * Real services do this, and it is what lets the caller's page size exceed
+   * the cap the service will honor.
+   */
+  hideMaxRecordCount?: boolean;
   /** Whether `resultOffset` is actually honored (false replays page one). */
   honorsOffset?: boolean;
   /** Whether the layer advertises `advancedQueryCapabilities.supportsPagination`. */
@@ -93,7 +99,7 @@ function fakeArcGISService(config: FakeArcGISServiceOptions) {
 
   const layerInfo = {
     ...LAYER_INFO,
-    maxRecordCount,
+    maxRecordCount: config.hideMaxRecordCount ? undefined : maxRecordCount,
     objectIdField: "OBJECTID",
     advancedQueryCapabilities: { supportsPagination, supportsOrderBy: true },
   };
@@ -449,6 +455,42 @@ describe("addArcGISLayer (feature layer)", () => {
       [1, 100],
       [101, 200],
       [201, 250],
+    ]);
+  });
+
+  // The ObjectID walk consumes ids by advancing past the requested range, so a
+  // page the service caps below that range would drop the ids it did not
+  // return. Reachable whenever the page size exceeds the service's real cap,
+  // which is what happens when the metadata omits `maxRecordCount`.
+  it("re-requests a smaller ObjectID range when the service caps the page", async () => {
+    const service = fakeArcGISService({
+      total: 700,
+      maxRecordCount: 250,
+      hideMaxRecordCount: true,
+      supportsPagination: false,
+    });
+    globalThis.fetch = service.fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+
+    const features =
+      useAppStore.getState().layers.find((l) => l.id === id)?.geojson?.features ?? [];
+    assert.equal(features.length, 700, "expected no ObjectID to be skipped");
+    assert.deepEqual(
+      features.map((feature) => feature.id),
+      service.objectIds,
+    );
+    // The oversized first range is retried at the cap the service revealed,
+    // then the walk proceeds in 250-id steps.
+    assert.deepEqual(service.objectIdRanges, [
+      [1, 700],
+      [1, 250],
+      [251, 500],
+      [501, 700],
     ]);
   });
 

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { useAppStore } from "@geolibre/core";
 import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
-import { addArcGISLayer } from "../packages/plugins/src/plugins/arcgis-layer";
+import {
+  addArcGISLayer,
+  refreshArcGISFeatureLayer,
+} from "../packages/plugins/src/plugins/arcgis-layer";
 
 // Minimal ArcGIS FeatureServer layer metadata (the `?f=json` response) with a
 // geographic extent so the bounds resolve without Web Mercator reprojection,
@@ -51,6 +54,105 @@ function makeArcGISFetch(): typeof fetch {
     const url = typeof input === "string" ? input : input.toString();
     return jsonResponse(url.includes("/query") ? QUERY_GEOJSON : LAYER_INFO);
   }) as typeof fetch;
+}
+
+const SERVICE_URL = "https://example.com/arcgis/rest/services/Cities/FeatureServer/0";
+
+interface FakeArcGISServiceOptions {
+  /** The service's advertised per-query ceiling. */
+  maxRecordCount: number;
+  /** Whether `resultOffset` is actually honored (false replays page one). */
+  honorsOffset?: boolean;
+  /** Whether the layer advertises `advancedQueryCapabilities.supportsPagination`. */
+  supportsPagination?: boolean;
+  /** Feature count the service holds. */
+  total: number;
+}
+
+/**
+ * A fake ArcGIS FeatureServer layer that behaves like a real one: it caps each
+ * page at `maxRecordCount`, flags `exceededTransferLimit`, and answers
+ * `returnCountOnly`/`returnIdsOnly`. Records what was asked of it so a test can
+ * assert on the request pattern, not just the assembled result.
+ */
+function fakeArcGISService(config: FakeArcGISServiceOptions) {
+  const { total, maxRecordCount } = config;
+  const honorsOffset = config.honorsOffset !== false;
+  const supportsPagination = config.supportsPagination !== false;
+  const objectIds = Array.from({ length: total }, (_, index) => index + 1);
+  const queries: string[] = [];
+  const pageSizes: number[] = [];
+  const objectIdRanges: Array<[number, number]> = [];
+
+  const feature = (objectId: number) => ({
+    type: "Feature" as const,
+    id: objectId,
+    geometry: { type: "Point" as const, coordinates: [-157.8, 21.3] },
+    properties: { OBJECTID: objectId, NAME: `City ${objectId}` },
+  });
+
+  const layerInfo = {
+    ...LAYER_INFO,
+    maxRecordCount,
+    objectIdField: "OBJECTID",
+    advancedQueryCapabilities: { supportsPagination, supportsOrderBy: true },
+  };
+
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const url = new URL(typeof input === "string" ? input : input.toString());
+    if (!url.pathname.endsWith("/query")) return jsonResponse(layerInfo);
+
+    const params = url.searchParams;
+    if (params.get("returnCountOnly") === "true") return jsonResponse({ count: total });
+    if (params.get("returnIdsOnly") === "true") {
+      return jsonResponse({ objectIdFieldName: "OBJECTID", objectIds });
+    }
+
+    queries.push(url.toString());
+
+    // ObjectID-range paging: `OBJECTID >= a AND OBJECTID <= b`.
+    const range = /OBJECTID >= (\d+) AND OBJECTID <= (\d+)/.exec(params.get("where") ?? "");
+    if (range) {
+      const [from, to] = [Number(range[1]), Number(range[2])];
+      objectIdRanges.push([from, to]);
+      const selected = objectIds.filter((id) => id >= from && id <= to).slice(0, maxRecordCount);
+      return jsonResponse({
+        type: "FeatureCollection",
+        features: selected.map(feature),
+        exceededTransferLimit: selected.length < to - from + 1,
+      });
+    }
+
+    // resultOffset/resultRecordCount paging.
+    const requested = Number(params.get("resultRecordCount") ?? total);
+    pageSizes.push(requested);
+    const offset = honorsOffset ? Number(params.get("resultOffset") ?? 0) : 0;
+    const size = Math.min(requested, maxRecordCount);
+    const selected = objectIds.slice(offset, offset + size);
+    return jsonResponse({
+      type: "FeatureCollection",
+      features: selected.map(feature),
+      // Real services report the cap in the GeoJSON `properties` bag.
+      properties: { exceededTransferLimit: offset + selected.length < total },
+    });
+  }) as typeof fetch;
+
+  return { fetch: fetchImpl, objectIds, objectIdRanges, pageSizes, queries };
+}
+
+/** Collect `console.warn` output for the duration of a test. */
+function captureWarnings() {
+  const messages: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    messages.push(args.map(String).join(" "));
+  };
+  return {
+    messages,
+    restore: () => {
+      console.warn = originalWarn;
+    },
+  };
 }
 
 describe("addArcGISLayer (feature layer)", () => {
@@ -221,6 +323,189 @@ describe("addArcGISLayer (feature layer)", () => {
     }
     assert.equal(warnings.length, 1);
     assert.match(warnings[0] ?? "", /truncated/i);
+  });
+
+  it("pages a large layer into many requests instead of one unbounded query", async () => {
+    // The shape of GeoLibre#1745: a service that answers the unbounded
+    // `where=1=1` query with a 500 but pages the same data back fine.
+    const service = fakeArcGISService({ total: 2500, maxRecordCount: 50_000 });
+    globalThis.fetch = service.fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.equal(layer?.geojson?.features.length, 2500);
+    // Every ObjectID exactly once — no page overlapped or was skipped.
+    const ids = layer?.geojson?.features.map((feature) => feature.id) ?? [];
+    assert.deepEqual(ids, service.objectIds);
+    // The default page size is used rather than the service's 50000 ceiling,
+    // which is the ceiling that makes these services fall over. The third
+    // request asks for a full page too and simply gets a short one back, which
+    // is how the walk learns it has reached the end.
+    assert.deepEqual(service.pageSizes, [1000, 1000, 1000]);
+    // Paging is ordered by the ObjectID field so pages cannot drift.
+    assert.ok(service.queries.every((url) => url.includes("orderByFields=OBJECTID")));
+    // The unbounded single-shot query is never sent.
+    assert.ok(service.queries.every((url) => url.includes("resultRecordCount=")));
+  });
+
+  it("holds the page size under the service's maxRecordCount", async () => {
+    const service = fakeArcGISService({ total: 300, maxRecordCount: 100 });
+    globalThis.fetch = service.fetch;
+
+    await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+      // Asking for more than the service will return would make a capped page
+      // look like the last one and silently drop the rest of the layer.
+      pageSize: 5000,
+    });
+
+    assert.deepEqual(service.pageSizes, [100, 100, 100]);
+    assert.equal(
+      useAppStore.getState().layers[0]?.geojson?.features.length,
+      300,
+      "expected the whole layer despite the oversized page request",
+    );
+  });
+
+  it("uses a caller-supplied page size and reports progress per page", async () => {
+    const service = fakeArcGISService({ total: 250, maxRecordCount: 2000 });
+    globalThis.fetch = service.fetch;
+    const progress: Array<[number, number | null]> = [];
+
+    await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+      pageSize: 100,
+      onProgress: (loaded, total) => progress.push([loaded, total]),
+    });
+
+    assert.deepEqual(service.pageSizes, [100, 100, 100]);
+    // The running count carries the service's own total, so the Add Data dialog
+    // can show "Loaded 200 of 250" rather than an inert spinner.
+    assert.deepEqual(progress, [
+      [100, 250],
+      [200, 250],
+      [250, 250],
+    ]);
+  });
+
+  it("stops at maxFeatures and warns that the layer is partial", async () => {
+    const service = fakeArcGISService({ total: 5000, maxRecordCount: 2000 });
+    globalThis.fetch = service.fetch;
+
+    const warnings = captureWarnings();
+    let id: string;
+    try {
+      id = await addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: SERVICE_URL,
+        pageSize: 400,
+        maxFeatures: 900,
+      });
+    } finally {
+      warnings.restore();
+    }
+
+    assert.equal(
+      useAppStore.getState().layers.find((l) => l.id === id)?.geojson?.features.length,
+      900,
+    );
+    // The final page is trimmed to the cap rather than overshooting it.
+    assert.deepEqual(service.pageSizes, [400, 400, 100]);
+    assert.match(warnings.messages.join("\n"), /maximum of 900 features/);
+  });
+
+  it("walks ObjectIDs when the service does not support resultOffset paging", async () => {
+    const service = fakeArcGISService({
+      total: 250,
+      maxRecordCount: 100,
+      supportsPagination: false,
+    });
+    globalThis.fetch = service.fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+
+    assert.equal(
+      useAppStore.getState().layers.find((l) => l.id === id)?.geojson?.features.length,
+      250,
+    );
+    // ObjectID ranges, not resultOffset — this is the path older ArcGIS Server
+    // deployments need.
+    assert.ok(service.queries.every((url) => !url.includes("resultOffset=")));
+    assert.deepEqual(service.objectIdRanges, [
+      [1, 100],
+      [101, 200],
+      [201, 250],
+    ]);
+  });
+
+  it("falls back to ObjectIDs when a service advertises paging it ignores", async () => {
+    // Advertises supportsPagination but replays page one for every offset —
+    // without detection that loops forever over the same rows.
+    const service = fakeArcGISService({ total: 250, maxRecordCount: 100, honorsOffset: false });
+    globalThis.fetch = service.fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+
+    const features =
+      useAppStore.getState().layers.find((l) => l.id === id)?.geojson?.features ?? [];
+    assert.equal(features.length, 250);
+    assert.deepEqual(
+      features.map((feature) => feature.id),
+      service.objectIds,
+      "expected the ObjectID walk to assemble the layer without duplicates",
+    );
+    // Two offset pages were tried before the replay was spotted.
+    assert.equal(service.queries.filter((url) => url.includes("resultOffset=")).length, 2);
+  });
+
+  // A refresh that re-fetched the stored `sourcePath` would send the unbounded
+  // `where=1=1` query — exactly the request paging exists to avoid — and shrink
+  // the layer to whatever one page the service happens to return.
+  it("stores what a refresh needs to replay the paged download", async () => {
+    const service = fakeArcGISService({ total: 2500, maxRecordCount: 1000 });
+    globalThis.fetch = service.fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+      pageSize: 400,
+      maxFeatures: 1600,
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.equal(layer?.metadata.sourceKind, "arcgis-feature-query");
+    assert.equal(layer?.source.arcgisQueryUrl, `${SERVICE_URL}/query`);
+    assert.equal(layer?.source.pageSize, 400);
+    assert.equal(layer?.source.maxFeatures, 1600);
+    // The token must still stay out of everything that gets saved.
+    assert.equal(layer?.source.token, undefined);
+
+    // Replaying from exactly those stored values reproduces the same layer.
+    const replayed = await refreshArcGISFeatureLayer({
+      queryUrl: String(layer?.source.arcgisQueryUrl),
+      pageSize: Number(layer?.source.pageSize),
+      maxFeatures: Number(layer?.source.maxFeatures),
+    });
+    assert.equal(replayed.features.length, 1600);
   });
 
   it("resolves a portal-item feature layer through the portal item URL", async () => {


### PR DESCRIPTION
Addresses #1745.

## The problem

An ArcGIS feature layer was loaded with a single `/query?f=geojson&outFields=*&returnGeometry=true&where=1=1` request. Past some layer size that stops working in one of two ways:

- the service truncates the result at its `maxRecordCount` and the layer loads silently partial, or
- the service gives up entirely.

The service in the discussion (41,384 polygons) does the second:

```
$ curl -o /dev/null -w '%{http_code}\n' \
  '.../GDR/ecotopen/FeatureServer/0/query?f=geojson&outFields=*&returnGeometry=true&where=1=1'
500     # Error: Error performing query operation
```

The same data pages back without complaint, so nothing is wrong with the service.

The truncation case is not hypothetical either: GeoLibre's own built-in ArcGIS sample, USA Major Cities, has 4,186 features behind a `maxRecordCount` of 2,000. It has been loading as 2,000 the whole time, with only a `console.warn` to say so.

## The fix

Download the layer in pages:

- **`resultOffset`/`resultRecordCount`** when the layer advertises `advancedQueryCapabilities.supportsPagination` (ArcGIS 10.3+). No extra round trip; ordered by the ObjectID field so pages cannot overlap or skip rows.
- **ObjectID ranges** otherwise: ask for the layer's ObjectIDs (`returnIdsOnly`), then walk them in sorted chunks with `oid >= a AND oid <= b`. A range keeps the request URL short whatever the page size, and works on any service that can run a query at all, which is what older ArcGIS Server deployments need.

The default page is 1,000, held under the service's `maxRecordCount`. That is deliberately far below the 1,000-50,000 ceiling services advertise: the ceiling is what the service will *return*, not what it can assemble without falling over.

A service that advertises pagination but replays the same rows for every offset would page forever, so each page's first feature is compared against the previous page's; on a repeat, the walk switches to the ObjectID path instead of looping.

## Add Data

Two optional fields for what automatic paging cannot guess, plus progress, since a large layer now takes dozens of requests:

- **Records per request** — lower it for a service that times out even on the default page.
- **Maximum features** — a cap for a layer too big to hold in the browser at all.
- **Loaded N of M features** replaces the inert spinner.

Both fields are saved to the service library, so a service that needs a smaller page keeps it.

## Refresh

A refresh replays the paging too. Re-fetching the layer's stored `sourcePath` alone would send that unbounded query again and shrink the layer back to a single page — the same trap OGC API - Features layers already avoid, handled the same way (a `sourceKind` tag plus a dynamically imported replay).

## Verification

Driven in the real app with Playwright, in both light and dark themes.

- **USA Major Cities** (4,186 features, `maxRecordCount` 2,000): loads **4,186** where the single-query path returned exactly 2,000 with `exceededTransferLimit: true`. Every ObjectID appears once.
- **Page size 100** (42 requests): still 4,186, with the progress line ticking through "Loaded 600 of 4,186 features" → "Loaded 2,600 of 4,186 features".
- **Maximum features 1,200**: stops at exactly 1,200 and warns that the layer is partial.
- **Refresh**: layer at 4,186 → mocked to 1 feature to prove the refresh really re-fetches → real refresh restores **4,186**.

The discussion's own service could not be driven from the browser build (it sends no CORS headers), but its paging behavior was confirmed directly: `resultOffset=1000` returns ObjectIDs 1001-2000, `returnIdsOnly` lists all 41,384, and `resultOffset=41000` returns the final 384 with no `exceededTransferLimit` — a clean termination for the walk this PR implements.

## Tests

`tests/arcgis-feature-layer.test.ts` grows a fake FeatureServer that caps pages at `maxRecordCount`, flags `exceededTransferLimit`, and answers `returnCountOnly`/`returnIdsOnly`, plus seven cases: paging a large layer, holding the page size under `maxRecordCount`, a caller-supplied page size with progress, the `maxFeatures` cap, the ObjectID fallback, the advertises-but-ignores-paging fallback, and the refresh replay. Full frontend suite green (5,426 tests).

One incidental fix along the way: `exceededTransferLimit` was only read at the top level, but in `f=geojson` output some servers only nest it under `properties`. Both are read now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ArcGIS feature layers now support configurable page sizes and maximum feature limits.
  * Added loading progress indicators and feature-count reporting during imports.
  * ArcGIS layers can be refreshed while preserving their paging settings.
  * Improved support for services with different pagination capabilities, including partial results.

* **Bug Fixes**
  * Invalid, blank, or unavailable paging values are handled more reliably.
  * Improved detection of transfer limits and retrieval of ArcGIS feature data.
  * Saved ArcGIS paging settings are restored when reopening sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->