### PR TITLE
fix(conversion): stop discarding the reason a browser conversion failed

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -47,6 +47,7 @@ import {
 import type { LargeVectorDataset } from "../../lib/duckdb-vector-guard";
 import { IS_MAS_BUILD } from "../../lib/build-flags";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
+import { isRasterTooLargeForWasm, messageFromThrown } from "../../lib/wasm-error";
 import { beginProcessingRun, type ProcessingRunTracker } from "../../lib/processing-history";
 import i18n from "../../i18n";
 
@@ -867,8 +868,9 @@ export function ConversionDialog() {
         ]),
       );
     } catch (err) {
-      const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
+      // The wasm engines reject with a bare string, so read the message off any
+      // thrown shape; `instanceof Error` alone would drop it (GeoLibre#1743).
+      const detail = messageFromThrown(err, i18n.t("toolbar.conversion.convertFailed"));
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -922,8 +924,9 @@ export function ConversionDialog() {
         ]),
       );
     } catch (err) {
-      const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
+      // The wasm engines reject with a bare string, so read the message off any
+      // thrown shape; `instanceof Error` alone would drop it (GeoLibre#1743).
+      const detail = messageFromThrown(err, i18n.t("toolbar.conversion.convertFailed"));
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -964,6 +967,10 @@ export function ConversionDialog() {
         i18n.t("toolbar.conversion.convertingWithWasm", { name: mainFile.name }),
       ]),
     );
+    // Kept outside the try so a failure can still report the shape. The reason
+    // the browser engine refuses a raster is almost always how big it is, and
+    // the size is the one thing the message needs to be actionable.
+    let shape = "";
     try {
       const { convertGeoTiffToCog, readGeoTiffInfo } = await import("@geolibre/processing");
       const bytes = new Uint8Array(await mainFile.arrayBuffer());
@@ -973,6 +980,11 @@ export function ConversionDialog() {
       if (!info.ok) {
         throw new Error(i18n.t("toolbar.conversion.notAGeoTiff"));
       }
+      shape = i18n.t("toolbar.conversion.rasterShape", {
+        width: info.width,
+        height: info.height,
+        bands: info.bands,
+      });
       const data = await convertGeoTiffToCog(bytes, {
         compression: compression as CogWasmCompression,
       });
@@ -989,11 +1001,7 @@ export function ConversionDialog() {
       });
       setJob(
         browserConversionJob(toolId, "succeeded", [
-          i18n.t("toolbar.conversion.rasterShape", {
-            width: info.width,
-            height: info.height,
-            bands: info.bands,
-          }),
+          shape,
           i18n.t("toolbar.conversion.wroteCog", { compression }),
           savedName
             ? i18n.t("toolbar.conversion.savedFile", { name: savedName })
@@ -1001,9 +1009,16 @@ export function ConversionDialog() {
         ]),
       );
     } catch (err) {
-      const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
-      setJob(browserConversionJob(toolId, "failed", [detail], detail));
+      // The wasm engines reject with a bare string, so read the message off any
+      // thrown shape; `instanceof Error` alone would drop it (GeoLibre#1743).
+      const detail = messageFromThrown(err, i18n.t("toolbar.conversion.convertFailed"));
+      // The engine explains the size limit in its own terms (it names internal
+      // APIs); say what to do about it instead.
+      const lines = [shape, detail].filter(Boolean);
+      if (isRasterTooLargeForWasm(detail)) {
+        lines.push(i18n.t("toolbar.conversion.rasterTooLargeForBrowser"));
+      }
+      setJob(browserConversionJob(toolId, "failed", lines, detail));
     }
   };
 
@@ -1079,8 +1094,9 @@ export function ConversionDialog() {
         ]),
       );
     } catch (err) {
-      const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
+      // The wasm engines reject with a bare string, so read the message off any
+      // thrown shape; `instanceof Error` alone would drop it (GeoLibre#1743).
+      const detail = messageFromThrown(err, i18n.t("toolbar.conversion.convertFailed"));
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -1155,8 +1171,9 @@ export function ConversionDialog() {
         ]),
       );
     } catch (err) {
-      const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
+      // The wasm engines reject with a bare string, so read the message off any
+      // thrown shape; `instanceof Error` alone would drop it (GeoLibre#1743).
+      const detail = messageFromThrown(err, i18n.t("toolbar.conversion.convertFailed"));
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };
@@ -1274,8 +1291,9 @@ export function ConversionDialog() {
         ]),
       );
     } catch (err) {
-      const detail =
-        err instanceof Error ? err.message : i18n.t("toolbar.conversion.convertFailed");
+      // The wasm engines reject with a bare string, so read the message off any
+      // thrown shape; `instanceof Error` alone would drop it (GeoLibre#1743).
+      const detail = messageFromThrown(err, i18n.t("toolbar.conversion.convertFailed"));
       setJob(browserConversionJob(toolId, "failed", [detail], detail));
     }
   };

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2172,6 +2172,7 @@
       "rasterShape": "Read {{width}}×{{height}} raster with {{bands}} band(s)",
       "wroteCog": "Wrote a tiled COG with overviews ({{compression}})",
       "notAGeoTiff": "This file is not a readable GeoTIFF. In the browser, Raster to COG reads GeoTIFF only; other formats need the desktop app.",
+      "rasterTooLargeForBrowser": "In the browser this decodes the whole raster in WebAssembly, which is limited to about 4 GB, so this one does not fit. Convert it with the GeoLibre desktop app, or build the COG beforehand with gdal_translate or rio-cogeo.",
       "zoomRangeError": "Zoom levels must satisfy 0 ≤ min ≤ max ≤ {{max}}.",
       "colormap": "Colormap",
       "resampling": "Resampling",

--- a/apps/geolibre-desktop/src/lib/wasm-error.ts
+++ b/apps/geolibre-desktop/src/lib/wasm-error.ts
@@ -45,9 +45,15 @@ export function messageFromThrown(thrown: unknown, fallback: string): string {
  * that mean nothing to someone converting a file, so recognizing this case lets
  * the UI add what to actually do instead.
  *
+ * Matched on the whole documented phrase rather than a fragment of it,
+ * deliberately: the two ways this can be wrong are not symmetric. Missing a
+ * reworded refusal only drops a hint the engine's own text partly covers, while
+ * matching some other failure would tell someone to go and install GDAL over a
+ * problem that has nothing to do with size.
+ *
  * @param message - The message extracted by {@link messageFromThrown}.
  * @returns True when the raster exceeds what the browser engine can decode.
  */
 export function isRasterTooLargeForWasm(message: string): boolean {
-  return /too large to fully decode/i.test(message);
+  return /raster too large to fully decode in 32-bit wasm/i.test(message);
 }

--- a/apps/geolibre-desktop/src/lib/wasm-error.ts
+++ b/apps/geolibre-desktop/src/lib/wasm-error.ts
@@ -1,0 +1,53 @@
+/**
+ * Message extraction for values thrown by the WebAssembly conversion engines.
+ *
+ * `geolibre-wasm` is a wasm-bindgen module, and a Rust `Err(JsValue)` crosses
+ * the boundary as a bare **string**, not an `Error`. Code that only reads
+ * `err instanceof Error ? err.message : fallback` therefore throws away the one
+ * useful thing the engine said. That is how GeoLibre#1743's Raster to COG
+ * failure surfaced as "Could not convert this file." when the engine had in
+ * fact reported "raster too large to fully decode in 32-bit WASM:
+ * 110162x51992 x 1 band(s) = 5727542704 cells".
+ */
+
+/**
+ * The human-readable message carried by a thrown value, whatever its shape.
+ *
+ * Handles the three forms these code paths actually see: an `Error` (thrown by
+ * our own code and by `fetch`), a bare string (wasm-bindgen's `JsValue`
+ * rejection), and an object carrying a string `message` (some DOM exceptions
+ * and structured-cloned errors from workers).
+ *
+ * @param thrown - The caught value.
+ * @param fallback - Message to use when `thrown` carries nothing readable.
+ * @returns The extracted message, or `fallback`.
+ */
+export function messageFromThrown(thrown: unknown, fallback: string): string {
+  if (thrown instanceof Error) return thrown.message || fallback;
+  if (typeof thrown === "string") return thrown.trim() || fallback;
+  if (typeof thrown === "object" && thrown !== null) {
+    const { message } = thrown as { message?: unknown };
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  return fallback;
+}
+
+/**
+ * Whether a conversion failure is the engine refusing a raster for its size.
+ *
+ * `geolibre-wasm` (re-verified against the bundled build) reports this as
+ * "raster too large to fully decode in 32-bit WASM: WxH x N band(s) = C cells",
+ * and that phrase is the only signal it exposes, so the match is coupled to the
+ * wording. Re-verify it when bumping `geolibre-wasm`; a reworded message
+ * degrades to showing the engine's text alone, not to a crash.
+ *
+ * The engine's own message names internal APIs (`geotiff_info`, `CogStream`)
+ * that mean nothing to someone converting a file, so recognizing this case lets
+ * the UI add what to actually do instead.
+ *
+ * @param message - The message extracted by {@link messageFromThrown}.
+ * @returns True when the raster exceeds what the browser engine can decode.
+ */
+export function isRasterTooLargeForWasm(message: string): boolean {
+  return /too large to fully decode/i.test(message);
+}

--- a/tests/wasm-error.test.ts
+++ b/tests/wasm-error.test.ts
@@ -57,4 +57,12 @@ describe("isRasterTooLargeForWasm", () => {
     assert.equal(isRasterTooLargeForWasm(FALLBACK), false);
     assert.equal(isRasterTooLargeForWasm(""), false);
   });
+
+  it("needs the whole documented phrase, not a fragment of it", () => {
+    // A fragment could show up in a message about something else entirely, and
+    // sending someone to install GDAL over an unrelated failure is worse than
+    // staying quiet. Missing a reworded refusal only drops the extra hint.
+    assert.equal(isRasterTooLargeForWasm("too large to fully decode"), false);
+    assert.equal(isRasterTooLargeForWasm("raster too large"), false);
+  });
 });

--- a/tests/wasm-error.test.ts
+++ b/tests/wasm-error.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isRasterTooLargeForWasm,
+  messageFromThrown,
+} from "../apps/geolibre-desktop/src/lib/wasm-error";
+
+const FALLBACK = "Could not convert this file.";
+
+/** The exact refusal geolibre-wasm returns for the raster in GeoLibre#1743. */
+const TOO_LARGE =
+  "raster too large to fully decode in 32-bit WASM: 110162x51992 x 1 band(s) = " +
+  "5727542704 cells. Use geotiff_info for metadata, or stream tiles with CogStream.";
+
+describe("messageFromThrown", () => {
+  it("keeps a bare string, which is how wasm-bindgen rejects", () => {
+    // Reading the message off `err instanceof Error` alone dropped the whole
+    // thing and left the user with the fallback, so the size limit looked like
+    // an unexplained bug.
+    assert.equal(messageFromThrown(TOO_LARGE, FALLBACK), TOO_LARGE);
+  });
+
+  it("reads an Error's message", () => {
+    assert.equal(
+      messageFromThrown(new Error("Not a readable GeoTIFF."), FALLBACK),
+      "Not a readable GeoTIFF.",
+    );
+  });
+
+  it("reads a message off a plain object", () => {
+    // Workers structured-clone a rejection into a bare object, losing the
+    // prototype but keeping the message.
+    assert.equal(messageFromThrown({ message: "decode failed" }, FALLBACK), "decode failed");
+  });
+
+  it("falls back for values carrying nothing readable", () => {
+    for (const empty of [null, undefined, 0, "", "   ", {}, { message: "" }, { message: 7 }, []]) {
+      assert.equal(messageFromThrown(empty, FALLBACK), FALLBACK, `for ${JSON.stringify(empty)}`);
+    }
+  });
+
+  it("falls back for an Error with an empty message", () => {
+    assert.equal(messageFromThrown(new Error(""), FALLBACK), FALLBACK);
+  });
+});
+
+describe("isRasterTooLargeForWasm", () => {
+  it("recognizes the engine's size refusal", () => {
+    assert.equal(isRasterTooLargeForWasm(TOO_LARGE), true);
+  });
+
+  it("does not claim unrelated conversion failures are about size", () => {
+    // These must keep the engine's own wording, with no "use the desktop app"
+    // advice bolted on: the desktop app would fail on them too.
+    assert.equal(isRasterTooLargeForWasm("Unsupported sample format"), false);
+    assert.equal(isRasterTooLargeForWasm("Not a readable GeoTIFF."), false);
+    assert.equal(isRasterTooLargeForWasm(FALLBACK), false);
+    assert.equal(isRasterTooLargeForWasm(""), false);
+  });
+});


### PR DESCRIPTION
Raster to COG on the 74 MB raster in #1743 reported "Could not convert this
file." The engine had actually said something useful:

  raster too large to fully decode in 32-bit WASM: 110162x51992 x 1 band(s)
  = 5727542704 cells

but all six browser-conversion paths read the message with
`err instanceof Error ? err.message : t("convertFailed")`, and `geolibre-wasm`
is a wasm-bindgen module: a Rust `Err(JsValue)` arrives as a bare **string**,
not an `Error`. So every one of them fell through to the generic fallback, and
a clean, explained refusal looked like an unexplained bug.

Read the message off whatever was thrown instead (`messageFromThrown`: Error,
string, or `{message}` from a structured-cloned worker rejection), and use it at
all six sites.

Raster to COG gains two more things, because the engine's own wording is aimed
at API callers:

- The raster's shape is now reported on failure, not only on success. It is
  already read from the header before any pixels are decoded, and the size is
  what makes the message actionable.
- When the failure is the size limit, append what to do about it: the engine
  suggests `geotiff_info` and `CogStream`, which mean nothing to someone
  converting a file. `isRasterTooLargeForWasm` matches the engine's phrase, the
  way `isNonTiledRasterError` already matches maplibre-gl-raster's; a reworded
  message degrades to showing the engine's text alone.

Verified in the browser against the reporter's file (the failure now explains
itself, in both themes) and against dem.tif, which still converts and saves.

Refs #1743.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during browser-based conversions, including clearer handling of unexpected failures.
  * Added a specific message when raster files exceed browser WebAssembly size limits.
  * Conversion logs now include raster dimensions to make successes and failures easier to understand.
  * Clarified that oversized rasters can be converted with the desktop app or preprocessed with external tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->