### PR TITLE
fix(layers): apply group opacity to vector controls

### DIFF
--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -1,11 +1,12 @@
 import {
   DUCKDB_VECTOR_FEATURE_WARN_COUNT,
   DUCKDB_VECTOR_ROUTE_BYTES,
+  effectiveLayerRenderState,
   getSpatialExtensionPath,
   hasPathTraversal,
   useAppStore,
 } from "@geolibre/core";
-import type { GeoLibreLayer } from "@geolibre/core";
+import type { GeoLibreLayer, LayerGroup } from "@geolibre/core";
 // Imported from the `/errors` subpath, a standalone entry point holding just
 // these helpers. The package root re-exports VectorControl, so importing from
 // there would statically pull the control's module graph in and undo the
@@ -26,6 +27,7 @@ import type {
 import {
   isEmbeddableLocalVectorLayer,
   isVectorControlStoreLayer,
+  rememberControlVectorRenderState,
   resetVectorStoreSyncSuspension,
   resumeVectorStoreSync,
   savedVectorState,
@@ -271,6 +273,9 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         if (!storeLayerIds.has(info.id)) control.removeLayer(info.id);
       }
 
+      const restoredGroups = new Map(
+        useAppStore.getState().layerGroups.map((group) => [group.id, group] as const),
+      );
       for (const layer of useAppStore.getState().layers) {
         if (!isVectorControlStoreLayer(layer)) continue;
         if (control.getLayer(layer.id)) continue;
@@ -278,7 +283,7 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         const url =
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;
         if (url) {
-          pending.push(replayVectorLayer(control, layer, url));
+          pending.push(replayVectorLayer(control, layer, url, restoredGroups));
           continue;
         }
 
@@ -315,7 +320,7 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
                 const source = file.nativeData
                   ? nativeGeoJsonFile(file.file, file.nativeData)
                   : file.file;
-                return replayVectorLayer(control, layer, source, {
+                return replayVectorLayer(control, layer, source, restoredGroups, {
                   companionFiles: file.nativeData ? undefined : file.companionFiles,
                   localPath,
                 });
@@ -336,7 +341,7 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         // next save.
         const embedded = readEmbeddedVectorGeoJSON(layer.metadata.embeddedGeoJSON);
         if (embedded) {
-          pending.push(replayVectorLayer(control, layer, embedded));
+          pending.push(replayVectorLayer(control, layer, embedded, restoredGroups));
           continue;
         }
 
@@ -388,6 +393,7 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
  * @param control - The vector control to add the layer to.
  * @param layer - The saved store layer being restored.
  * @param source - The URL, File, or FeatureCollection to load the data from.
+ * @param groups - Restored groups used to compute the layer's effective state.
  * @param options - The shapefile sidecars and/or absolute path of a File source.
  * @returns A promise that settles when the layer has loaded or failed.
  */
@@ -395,8 +401,13 @@ function replayVectorLayer(
   control: VectorControl,
   layer: GeoLibreLayer,
   source: string | File | FeatureCollection,
+  groups: ReadonlyMap<string, LayerGroup>,
   options: { companionFiles?: File[]; localPath?: string } = {},
 ): Promise<unknown> {
+  const effective = effectiveLayerRenderState(layer, groups);
+  // Record the folded values before addData so its first layer event is treated
+  // as a restore echo rather than as an edit to the child's own state.
+  rememberControlVectorRenderState(layer.id, effective);
   return control
     .addData(source, {
       ...savedVectorState(layer),
@@ -405,8 +416,8 @@ function replayVectorLayer(
       fitBounds: false,
       id: layer.id,
       name: layer.name,
-      opacity: layer.opacity,
-      visible: layer.visible,
+      opacity: effective.opacity,
+      visible: effective.visible,
     })
     .catch((error) => {
       console.error(`[GeoLibre] Failed to restore vector layer "${layer.name}"`, error);

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -397,7 +397,7 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
  * @param options - The shapefile sidecars and/or absolute path of a File source.
  * @returns A promise that settles when the layer has loaded or failed.
  */
-function replayVectorLayer(
+export function replayVectorLayer(
   control: VectorControl,
   layer: GeoLibreLayer,
   source: string | File | FeatureCollection,

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -1,4 +1,5 @@
 import {
+  applyGroupEffects,
   DEFAULT_LAYER_STYLE,
   extrusionColorValue,
   extrusionHeightValue,
@@ -48,6 +49,24 @@ let syncingLayersToStore = false;
 // control emits layer* events from those calls, and syncing mid-mutation
 // would observe a partially restored layer list.
 let storeSyncSuspended = 0;
+// The last visibility/opacity this module knows each vector to hold in the
+// control. Group-folded values exist only at render time, so this record lets
+// the control-to-store mirror distinguish an echoed fold from a genuine edit.
+const controlRenderState = new Map<string, { visible?: boolean; opacity?: number }>();
+
+/**
+ * Record the effective render state most recently pushed to the vector control.
+ *
+ * @param id - The vector/store layer id.
+ * @param patch - The fields the control now holds.
+ */
+export function rememberControlVectorRenderState(
+  id: string,
+  patch: { visible?: boolean; opacity?: number },
+): void {
+  const existing = controlRenderState.get(id);
+  controlRenderState.set(id, existing ? { ...existing, ...patch } : { ...patch });
+}
 
 /**
  * Detects a layer panel entry owned by the maplibre-gl-vector control.
@@ -173,6 +192,12 @@ export function syncVectorLayersToStore(control: VectorSyncableControl): void {
   const infoIds = new Set(infos.map((info) => info.id));
   const panelCollapsed = vectorPanelCollapsedFromControl(control);
 
+  // A removed vector can no longer echo a pushed render state. Clearing it also
+  // prevents a future layer that reuses the id from inheriting stale state.
+  for (const id of controlRenderState.keys()) {
+    if (!infoIds.has(id)) controlRenderState.delete(id);
+  }
+
   syncingLayersToStore = true;
   try {
     for (const storeLayer of useAppStore.getState().layers) {
@@ -191,10 +216,27 @@ export function syncVectorLayersToStore(control: VectorSyncableControl): void {
         continue;
       }
 
+      // A group fold pushed through the control API is reported back in the
+      // next full control snapshot. Keep the child's own values for such echoes
+      // so showing or unfading the group restores them. A different value came
+      // from the control's UI and remains a real layer edit.
+      const known = controlRenderState.get(layer.id);
+      const visibleIsEcho = known?.visible !== undefined && layer.visible === known.visible;
+      const opacityIsEcho =
+        known?.opacity !== undefined && numbersEqual(layer.opacity, known.opacity);
+      const visible = visibleIsEcho ? existing.visible : layer.visible;
+      const opacity = opacityIsEcho ? existing.opacity : layer.opacity;
+      if (!visibleIsEcho || !opacityIsEcho) {
+        rememberControlVectorRenderState(layer.id, {
+          ...(visibleIsEcho ? {} : { visible: layer.visible }),
+          ...(opacityIsEcho ? {} : { opacity: layer.opacity }),
+        });
+      }
+
       if (
         existing.type !== layer.type ||
-        existing.visible !== layer.visible ||
-        existing.opacity !== layer.opacity ||
+        existing.visible !== visible ||
+        existing.opacity !== opacity ||
         existing.sourcePath !== layer.sourcePath ||
         !recordsEqual(existing.source, layer.source) ||
         !recordsEqual(existing.metadata, layer.metadata)
@@ -207,12 +249,12 @@ export function syncVectorLayersToStore(control: VectorSyncableControl): void {
           // control (getLayerGeoJSON), so a reopened layer drops its loaded
           // blob here and re-embeds current data on the next save.
           metadata: layer.metadata,
-          opacity: layer.opacity,
+          opacity,
           source: layer.source,
           sourcePath: layer.sourcePath,
           // A render-mode switch in the panel flips geojson <-> vector-tiles.
           type: layer.type,
-          visible: layer.visible,
+          visible,
         });
       }
     }
@@ -241,7 +283,7 @@ export function wireVectorStoreSync(control: VectorSyncableControl): void {
       !activeControl ||
       syncingLayersToStore ||
       isVectorStoreSyncSuspended() ||
-      state.layers === previous.layers
+      (state.layers === previous.layers && state.layerGroups === previous.layerGroups)
     ) {
       return;
     }
@@ -250,22 +292,30 @@ export function wireVectorStoreSync(control: VectorSyncableControl): void {
     // when the previous snapshot held no control-managed layers at all.
     if (!previous.layers.some(isVectorControlStoreLayer)) return;
 
-    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+    // Diff effective render values so edits to a parent or nested group reach
+    // vector layers whose paint is owned by the external control.
+    const currentById = new Map(
+      applyGroupEffects(state.layers, state.layerGroups).map((layer) => [layer.id, layer]),
+    );
+    const previousLayers = applyGroupEffects(previous.layers, previous.layerGroups);
     runWithVectorStoreSyncSuspended(() => {
-      for (const layer of previous.layers) {
+      for (const layer of previousLayers) {
         if (!isVectorControlStoreLayer(layer)) continue;
 
         const current = currentById.get(layer.id);
         if (!current) {
           activeControl.removeLayer(layer.id);
+          controlRenderState.delete(layer.id);
           continue;
         }
 
         if (current.visible !== layer.visible) {
           activeControl.setLayerVisibility(layer.id, current.visible);
+          rememberControlVectorRenderState(layer.id, { visible: current.visible });
         }
         if (current.opacity !== layer.opacity) {
           activeControl.setLayerOpacity(layer.id, current.opacity);
+          rememberControlVectorRenderState(layer.id, { opacity: current.opacity });
         }
         const nextStyle = layerStyleToVectorStyle(current.style);
         if (!vectorStylesEqual(layerStyleToVectorStyle(layer.style), nextStyle)) {
@@ -311,6 +361,7 @@ export function unwireVectorStoreSync(): void {
   storeUnsubscribe?.();
   storeUnsubscribe = null;
   syncedControl = null;
+  controlRenderState.clear();
 }
 
 /**
@@ -836,6 +887,10 @@ function valuesEqual(left: unknown, right: unknown): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function numbersEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) < 1e-9;
 }
 
 function serializableVectorState(info: VectorLayerInfo): Record<string, unknown> {

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -68,6 +68,22 @@ export function rememberControlVectorRenderState(
   controlRenderState.set(id, existing ? { ...existing, ...patch } : { ...patch });
 }
 
+function forgetControlVectorRenderState(
+  id: string,
+  fields: { visible?: boolean; opacity?: boolean },
+): void {
+  const existing = controlRenderState.get(id);
+  if (!existing) return;
+  const next = { ...existing };
+  if (fields.visible) delete next.visible;
+  if (fields.opacity) delete next.opacity;
+  if (next.visible === undefined && next.opacity === undefined) {
+    controlRenderState.delete(id);
+  } else {
+    controlRenderState.set(id, next);
+  }
+}
+
 /**
  * Detects a layer panel entry owned by the maplibre-gl-vector control.
  *
@@ -226,12 +242,6 @@ export function syncVectorLayersToStore(control: VectorSyncableControl): void {
         known?.opacity !== undefined && numbersEqual(layer.opacity, known.opacity);
       const visible = visibleIsEcho ? existing.visible : layer.visible;
       const opacity = opacityIsEcho ? existing.opacity : layer.opacity;
-      if (!visibleIsEcho || !opacityIsEcho) {
-        rememberControlVectorRenderState(layer.id, {
-          ...(visibleIsEcho ? {} : { visible: layer.visible }),
-          ...(opacityIsEcho ? {} : { opacity: layer.opacity }),
-        });
-      }
 
       if (
         existing.type !== layer.type ||
@@ -256,6 +266,37 @@ export function syncVectorLayersToStore(control: VectorSyncableControl): void {
           type: layer.type,
           visible,
         });
+      }
+
+      // The control uses one value for both its layer UI and map paint. After a
+      // genuine control-side edit updates the child's own value, immediately
+      // fold the current group chain back over it so a faded or hidden parent
+      // continues to affect the rendered layer.
+      if (!visibleIsEcho || !opacityIsEcho) {
+        const state = useAppStore.getState();
+        const effective = applyGroupEffects(state.layers, state.layerGroups).find(
+          (current) => current.id === layer.id,
+        );
+        if (effective) {
+          runWithVectorStoreSyncSuspended(() => {
+            if (!visibleIsEcho) {
+              if (effective.visible !== layer.visible) {
+                control.setLayerVisibility(layer.id, effective.visible);
+                rememberControlVectorRenderState(layer.id, { visible: effective.visible });
+              } else {
+                forgetControlVectorRenderState(layer.id, { visible: true });
+              }
+            }
+            if (!opacityIsEcho) {
+              if (!numbersEqual(effective.opacity, layer.opacity)) {
+                control.setLayerOpacity(layer.id, effective.opacity);
+                rememberControlVectorRenderState(layer.id, { opacity: effective.opacity });
+              } else {
+                forgetControlVectorRenderState(layer.id, { opacity: true });
+              }
+            }
+          });
+        }
       }
     }
   } finally {

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -68,6 +68,12 @@ export function rememberControlVectorRenderState(
   controlRenderState.set(id, existing ? { ...existing, ...patch } : { ...patch });
 }
 
+/**
+ * Stop treating selected render fields as echoes of a prior control push.
+ *
+ * @param id - The vector/store layer id.
+ * @param fields - The tracked fields to clear.
+ */
 function forgetControlVectorRenderState(
   id: string,
   fields: { visible?: boolean; opacity?: boolean },
@@ -930,6 +936,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Compare render opacities while tolerating floating-point group multiplication.
+ *
+ * @param left - The first opacity.
+ * @param right - The second opacity.
+ * @returns True when the values differ only by floating-point noise.
+ */
 function numbersEqual(left: number, right: number): boolean {
   return Math.abs(left - right) < 1e-9;
 }

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -744,6 +744,125 @@ describe("wireVectorStoreSync", () => {
   });
 });
 
+describe("wireVectorStoreSync with layer groups", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [], layerGroups: [] });
+  });
+
+  afterEach(() => {
+    unwireVectorStoreSync();
+    resetVectorStoreSyncSuspension();
+    useAppStore.setState({ layerGroups: [] });
+  });
+
+  it("multiplies the layer and parent group opacities", () => {
+    const { control, calls } = fakeControl([vectorInfo({ opacity: 0.5 })]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
+    calls.length = 0;
+    useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
+
+    assert.deepEqual(calls, [{ method: "setLayerOpacity", args: ["vector-1", 0.2] }]);
+  });
+
+  it("updates the control from both opacity sliders in a nested group chain", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const childId = useAppStore.getState().addLayerGroup("Child", ["vector-1"]);
+    const parentId = useAppStore.getState().addLayerGroup("Parent");
+    useAppStore.getState().moveLayerGroupToGroup(childId, parentId);
+    calls.length = 0;
+
+    useAppStore.getState().setLayerGroupOpacity(childId, 0.5);
+    assert.deepEqual(calls, [{ method: "setLayerOpacity", args: ["vector-1", 0.5] }]);
+
+    calls.length = 0;
+    useAppStore.getState().setLayerGroupOpacity(parentId, 0.4);
+    assert.deepEqual(calls, [{ method: "setLayerOpacity", args: ["vector-1", 0.2] }]);
+
+    calls.length = 0;
+    useAppStore.getState().setLayerGroupOpacity(childId, 0.25);
+    assert.deepEqual(calls, [{ method: "setLayerOpacity", args: ["vector-1", 0.1] }]);
+  });
+
+  it("keeps the layer opacity when the control echoes a group fold", () => {
+    const { control } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
+    useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
+
+    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.4 })]).control);
+
+    assert.equal(useAppStore.getState().layers[0].opacity, 1);
+  });
+
+  it("keeps the layer visibility when the control echoes a group fold", () => {
+    const { control } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
+    useAppStore.getState().setLayerGroupVisibility(groupId, false);
+
+    syncVectorLayersToStore(fakeControl([vectorInfo({ visible: false })]).control);
+
+    assert.equal(useAppStore.getState().layers[0].visible, true);
+  });
+
+  it("records a control-side opacity edit made under a faded group", () => {
+    const { control } = fakeControl([vectorInfo({ opacity: 0.5 })]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
+    useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
+
+    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.9 })]).control);
+
+    assert.equal(useAppStore.getState().layers[0].opacity, 0.9);
+  });
+
+  it("records a control-side toggle away from the pushed value and back", () => {
+    const { control } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
+    useAppStore.getState().setLayerGroupVisibility(groupId, false);
+
+    syncVectorLayersToStore(control);
+    assert.equal(useAppStore.getState().layers[0].visible, true);
+
+    syncVectorLayersToStore(fakeControl([vectorInfo({ visible: false })]).control);
+    assert.equal(useAppStore.getState().layers[0].visible, false);
+  });
+
+  it("hides and shows a vector through a nested parent group", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    const childId = useAppStore.getState().addLayerGroup("Child", ["vector-1"]);
+    const parentId = useAppStore.getState().addLayerGroup("Parent");
+    useAppStore.getState().moveLayerGroupToGroup(childId, parentId);
+    calls.length = 0;
+
+    useAppStore.getState().setLayerGroupVisibility(parentId, false);
+    useAppStore.getState().setLayerGroupVisibility(parentId, true);
+
+    assert.deepEqual(calls, [
+      { method: "setLayerVisibility", args: ["vector-1", false] },
+      { method: "setLayerVisibility", args: ["vector-1", true] },
+    ]);
+  });
+});
+
 describe("removeVectorStoreLayers", () => {
   beforeEach(() => {
     useAppStore.setState({ layers: [] });

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -987,6 +987,32 @@ describe("replayVectorLayer with layer groups", () => {
       assert.equal(useAppStore.getState().layers[0].visible, true);
     });
   }
+
+  it("clears restored render tracking after group overrides are removed", async () => {
+    const info = vectorInfo();
+    const layer = {
+      ...createVectorStoreLayer(info),
+      groupId: "child-group",
+      opacity: 0.8,
+      visible: true,
+    };
+    useAppStore.setState({ layers: [layer], layerGroups: [...groups.values()] });
+    const control = {
+      addData: async () => info,
+    } as unknown as VectorControl;
+    await replayVectorLayer(control, layer, "https://example.com/countries.geojson", groups);
+
+    // With the groups gone, this genuine edit needs no render override. It
+    // clears the old folded value (0.1) from the echo tracker.
+    useAppStore.setState({ layerGroups: [] });
+    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.6 })]).control);
+    assert.equal(useAppStore.getState().layers[0].opacity, 0.6);
+
+    // Returning to the former folded value is still a genuine edit and must
+    // reach the child's store state instead of being swallowed as an echo.
+    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.1 })]).control);
+    assert.equal(useAppStore.getState().layers[0].opacity, 0.1);
+  });
 });
 
 describe("removeVectorStoreLayers", () => {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, useAppStore } from "@geolibre/core";
-import type { VectorLayerInfo, VectorLayerStyle } from "maplibre-gl-vector";
+import type {
+  VectorControl,
+  VectorLayerInfo,
+  VectorLayerOptions,
+  VectorLayerStyle,
+} from "maplibre-gl-vector";
+import { replayVectorLayer } from "../packages/plugins/src/plugins/maplibre-vector";
 import {
   createVectorStoreLayer,
   isEmbeddableLocalVectorLayer,
@@ -823,12 +829,17 @@ describe("wireVectorStoreSync with layer groups", () => {
     const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
     useAppStore.getState().setLayerGroupOpacity(groupId, 0.4);
 
-    syncVectorLayersToStore(fakeControl([vectorInfo({ opacity: 0.9 })]).control);
+    const edited = fakeControl([vectorInfo({ opacity: 0.9 })]);
+    syncVectorLayersToStore(edited.control);
 
     assert.equal(useAppStore.getState().layers[0].opacity, 0.9);
+    assert.equal(edited.calls.length, 1);
+    assert.equal(edited.calls[0].method, "setLayerOpacity");
+    assert.equal(edited.calls[0].args[0], "vector-1");
+    assert.ok(Math.abs((edited.calls[0].args[1] as number) - 0.36) < 1e-9);
   });
 
-  it("records a control-side toggle away from the pushed value and back", () => {
+  it("reapplies a hidden parent after a control-side visibility edit", () => {
     const { control } = fakeControl([vectorInfo()]);
     syncVectorLayersToStore(control);
     wireVectorStoreSync(control);
@@ -836,11 +847,11 @@ describe("wireVectorStoreSync with layer groups", () => {
     const groupId = useAppStore.getState().addLayerGroup("Group 1", ["vector-1"]);
     useAppStore.getState().setLayerGroupVisibility(groupId, false);
 
-    syncVectorLayersToStore(control);
-    assert.equal(useAppStore.getState().layers[0].visible, true);
+    const edited = fakeControl([vectorInfo({ visible: true })]);
+    syncVectorLayersToStore(edited.control);
 
-    syncVectorLayersToStore(fakeControl([vectorInfo({ visible: false })]).control);
-    assert.equal(useAppStore.getState().layers[0].visible, false);
+    assert.equal(useAppStore.getState().layers[0].visible, true);
+    assert.deepEqual(edited.calls, [{ method: "setLayerVisibility", args: ["vector-1", false] }]);
   });
 
   it("hides and shows a vector through a nested parent group", () => {
@@ -861,6 +872,121 @@ describe("wireVectorStoreSync with layer groups", () => {
       { method: "setLayerVisibility", args: ["vector-1", true] },
     ]);
   });
+});
+
+describe("replayVectorLayer with layer groups", () => {
+  const groups = new Map([
+    [
+      "child-group",
+      {
+        id: "child-group",
+        name: "Child",
+        parentId: "parent-group",
+        collapsed: false,
+        visible: true,
+        opacity: 0.5,
+      },
+    ],
+    [
+      "parent-group",
+      {
+        id: "parent-group",
+        name: "Parent",
+        collapsed: false,
+        visible: false,
+        opacity: 0.25,
+      },
+    ],
+  ]);
+  const embedded = {
+    type: "FeatureCollection" as const,
+    features: [],
+  };
+  const cases = [
+    {
+      name: "URL",
+      info: vectorInfo(),
+      source: "https://example.com/countries.geojson",
+      options: {},
+    },
+    {
+      name: "local file",
+      info: vectorInfo({
+        source: {
+          kind: "file",
+          fileName: "countries.geojson",
+          path: "/data/countries.geojson",
+        },
+      }),
+      source: new File([""], "countries.geojson", { type: "application/geo+json" }),
+      options: { localPath: "/data/countries.geojson" },
+    },
+    {
+      name: "embedded GeoJSON",
+      info: vectorInfo({
+        source: { kind: "file", fileName: "countries.geojson" },
+      }),
+      source: embedded,
+      options: {},
+    },
+  ] as const;
+
+  beforeEach(() => {
+    unwireVectorStoreSync();
+    useAppStore.setState({ layers: [], layerGroups: [] });
+  });
+
+  afterEach(() => {
+    unwireVectorStoreSync();
+    resetVectorStoreSyncSuspension();
+    useAppStore.setState({ layers: [], layerGroups: [] });
+  });
+
+  for (const restoreCase of cases) {
+    it(`restores folded opacity and visibility for a ${restoreCase.name} source`, async () => {
+      const layer = {
+        ...createVectorStoreLayer(restoreCase.info),
+        groupId: "child-group",
+        opacity: 0.8,
+        visible: true,
+      };
+      useAppStore.setState({ layers: [layer], layerGroups: [...groups.values()] });
+      let addDataCall:
+        | {
+            source: unknown;
+            options: VectorLayerOptions | undefined;
+          }
+        | undefined;
+      const control = {
+        addData: async (source: unknown, options?: VectorLayerOptions) => {
+          addDataCall = { source, options };
+          return restoreCase.info;
+        },
+      } as unknown as VectorControl;
+
+      await replayVectorLayer(control, layer, restoreCase.source, groups, restoreCase.options);
+
+      assert.ok(addDataCall);
+      assert.equal(addDataCall.source, restoreCase.source);
+      assert.equal(addDataCall.options?.opacity, 0.1);
+      assert.equal(addDataCall.options?.visible, false);
+
+      // The control's first post-restore snapshot echoes the folded render
+      // values. The child's own settings must remain ready for its groups to
+      // be shown or unfaded later.
+      syncVectorLayersToStore(
+        fakeControl([
+          {
+            ...restoreCase.info,
+            opacity: 0.1,
+            visible: false,
+          },
+        ]).control,
+      );
+      assert.equal(useAppStore.getState().layers[0].opacity, 0.8);
+      assert.equal(useAppStore.getState().layers[0].visible, true);
+    });
+  }
 });
 
 describe("removeVectorStoreLayers", () => {


### PR DESCRIPTION
## Summary
- apply cumulative parent and nested group opacity and visibility to control-managed vector layers
- preserve each child layer own opacity and visibility when the control echoes effective render values
- restore saved vector layers with group effects already applied

## Testing
- node --import tsx --test tests/vector-layer-sync.test.ts
- npm run lint
- npm run build
- pre-commit run --all-files
- verified nested opacity sliders in a real browser in light and dark themes

Fixes #1749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored vector layers now correctly honor visibility and opacity settings from their layer groups.
  * Layer groups, including nested groups, now synchronize reliably with rendered vector layers.
  * Direct layer adjustments are preserved when group-level settings are applied.
  * Fixed restoration and synchronization for local files, embedded layers, and URL-based layers.
  * Removed stale rendering overrides when layers are moved out of folded or overridden groups.
  * Improved consistency when group settings change after a layer has been rendered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->