### PR TITLE
feat(arcgis): add MapServer and ImageServer support to Add Data

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/apply-service.ts
@@ -357,6 +357,27 @@ export function buildOgcFeaturesLayer(params: OgcFeaturesLayerParams): GeoLibreL
 
 // --- ArcGIS ----------------------------------------------------------------
 
+/**
+ * The known ArcGIS layer types, as a runtime lookup.
+ *
+ * `@geolibre/plugins` exports the same list, but importing it here would be a
+ * *runtime* import of that package (which loads maplibre-gl), and this module's
+ * pure exports are deliberately importable under Node for the unit tests. The
+ * `satisfies` clause is what keeps the two from drifting: adding a layer type to
+ * the union without adding it here fails the type-check.
+ */
+const ARCGIS_LAYER_TYPE_KEYS = {
+  feature: true,
+  "vector-tile": true,
+  "map-service": true,
+  "image-service": true,
+} satisfies Record<ArcGISLayerType, true>;
+
+/** Narrows a stored `layerType` field, defaulting to the feature layer. */
+function arcgisLayerTypeFromField(value: string): ArcGISLayerType {
+  return value in ARCGIS_LAYER_TYPE_KEYS ? (value as ArcGISLayerType) : "feature";
+}
+
 export interface ArcGISOptions {
   name: string;
   layerType: ArcGISLayerType;
@@ -366,6 +387,10 @@ export interface ArcGISOptions {
   portalUrl: string | undefined;
   pageSize: number | undefined;
   maxFeatures: number | undefined;
+  /** MapServer sublayer ids (`0,2,5`), for a `map-service` entry. */
+  sublayers: string | undefined;
+  /** ImageServer rendering rule JSON, for an `image-service` entry. */
+  renderingRule: string | undefined;
 }
 
 /** Reads the ArcGIS fields from a saved entry, mirroring `ArcGISSource`. */
@@ -373,14 +398,15 @@ export function arcgisFieldsToOptions(entry: ServiceLibraryEntry): ArcGISOptions
   const { fields } = entry;
   return {
     name: entry.name,
-    layerType:
-      serviceFieldString(fields, "layerType") === "vector-tile" ? "vector-tile" : "feature",
+    layerType: arcgisLayerTypeFromField(serviceFieldString(fields, "layerType")),
     sourceType: serviceFieldString(fields, "sourceType") === "portal-item" ? "portal-item" : "url",
     url: serviceFieldString(fields, "url").trim() || undefined,
     itemId: serviceFieldString(fields, "itemId").trim() || undefined,
     portalUrl: serviceFieldString(fields, "portalUrl").trim() || undefined,
     pageSize: serviceFieldCount(fields, "pageSize"),
     maxFeatures: serviceFieldCount(fields, "maxFeatures"),
+    sublayers: serviceFieldString(fields, "sublayers").trim() || undefined,
+    renderingRule: serviceFieldString(fields, "renderingRule").trim() || undefined,
   };
 }
 
@@ -477,7 +503,9 @@ export async function applyServiceEntry(
         name: options.name,
         pageSize: options.pageSize,
         portalUrl: options.portalUrl,
+        renderingRule: options.renderingRule,
         sourceType: options.sourceType,
+        sublayers: options.sublayers,
         // Tokens are never persisted to the service library, so none is sent.
         token: undefined,
         url: options.url,

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -120,9 +120,20 @@ export const DEFAULT_ARCGIS_FEATURE_URL =
   "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/USA_Major_Cities/FeatureServer/0";
 export const DEFAULT_ARCGIS_VECTOR_TILE_URL =
   "https://vectortileservices3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Santa_Monica_parcels_VTL/VectorTileServer";
+// USGS National Boundaries Dataset (states, counties, tribal and federal areas).
+// A keyless *dynamic* (uncached) MapServer, so it exercises the `/export` path
+// rather than a tile cache.
+export const DEFAULT_ARCGIS_MAP_SERVICE_URL =
+  "https://carto.nationalmap.gov/arcgis/rest/services/govunits/MapServer";
+// USGS 3DEP bare-earth elevation, a keyless ImageServer that renders through
+// `/exportImage` (it has no tile cache) and accepts rendering rules.
+export const DEFAULT_ARCGIS_IMAGE_SERVICE_URL =
+  "https://elevation.nationalmap.gov/arcgis/rest/services/3DEPElevation/ImageServer";
 export const DEFAULT_ARCGIS_URLS: Record<ArcGISLayerType, string> = {
   feature: DEFAULT_ARCGIS_FEATURE_URL,
   "vector-tile": DEFAULT_ARCGIS_VECTOR_TILE_URL,
+  "map-service": DEFAULT_ARCGIS_MAP_SERVICE_URL,
+  "image-service": DEFAULT_ARCGIS_IMAGE_SERVICE_URL,
 };
 // Keep in sync with GPX_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
 export const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -1,4 +1,9 @@
-import { addArcGISLayer, type ArcGISLayerType, type ArcGISSourceType } from "@geolibre/plugins";
+import {
+  addArcGISLayer,
+  parseArcGISLayerType,
+  type ArcGISLayerType,
+  type ArcGISSourceType,
+} from "@geolibre/plugins";
 import { Input, Label, Select } from "@geolibre/ui";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -22,6 +27,14 @@ function positiveCount(value: string): number | undefined {
   return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : undefined;
 }
 
+/** The example URL shown for each layer type, so the expected endpoint is clear. */
+const URL_PLACEHOLDER_KEYS = {
+  feature: "addData.arcgis.featureUrlPlaceholder",
+  "vector-tile": "addData.arcgis.vectorTileUrlPlaceholder",
+  "map-service": "addData.arcgis.mapServiceUrlPlaceholder",
+  "image-service": "addData.arcgis.imageServiceUrlPlaceholder",
+} as const satisfies Record<ArcGISLayerType, string>;
+
 export function ArcGISSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.arcgis.defaultName"));
@@ -33,6 +46,8 @@ export function ArcGISSource() {
   const [arcgisAccessToken, setArcgisAccessToken] = useState("");
   const [arcgisPageSize, setArcgisPageSize] = useState("");
   const [arcgisMaxFeatures, setArcgisMaxFeatures] = useState("");
+  const [arcgisSublayers, setArcgisSublayers] = useState("");
+  const [arcgisRenderingRule, setArcgisRenderingRule] = useState("");
   const [progress, setProgress] = useState<{ loaded: number; total: number | null } | null>(null);
 
   // The access token is intentionally excluded from saved fields — credentials
@@ -45,12 +60,12 @@ export function ArcGISSource() {
     portalUrl: arcgisPortalUrl,
     pageSize: arcgisPageSize,
     maxFeatures: arcgisMaxFeatures,
+    sublayers: arcgisSublayers,
+    renderingRule: arcgisRenderingRule,
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setArcgisLayerType(
-      serviceFieldString(fields, "layerType") === "vector-tile" ? "vector-tile" : "feature",
-    );
+    setArcgisLayerType(parseArcGISLayerType(serviceFieldString(fields, "layerType")));
     setArcgisSourceType(
       serviceFieldString(fields, "sourceType") === "portal-item" ? "portal-item" : "url",
     );
@@ -59,6 +74,8 @@ export function ArcGISSource() {
     setArcgisPortalUrl(serviceFieldString(fields, "portalUrl"));
     setArcgisPageSize(serviceFieldString(fields, "pageSize"));
     setArcgisMaxFeatures(serviceFieldString(fields, "maxFeatures"));
+    setArcgisSublayers(serviceFieldString(fields, "sublayers"));
+    setArcgisRenderingRule(serviceFieldString(fields, "renderingRule"));
     // Tokens are never saved, so clear any token typed for a previous entry to
     // avoid sending it to the newly selected service's endpoint.
     setArcgisAccessToken("");
@@ -89,7 +106,9 @@ export function ArcGISSource() {
         onProgress: (loaded, total) => setProgress({ loaded, total }),
         pageSize: positiveCount(arcgisPageSize),
         portalUrl: arcgisPortalUrl.trim() || undefined,
+        renderingRule: arcgisRenderingRule.trim() || undefined,
         sourceType: arcgisSourceType,
+        sublayers: arcgisSublayers.trim() || undefined,
         token: arcgisAccessToken.trim() || undefined,
         url: arcgisUrl.trim() || undefined,
       });
@@ -131,6 +150,8 @@ export function ArcGISSource() {
             >
               <option value="feature">{t("addData.arcgis.featureLayer")}</option>
               <option value="vector-tile">{t("addData.arcgis.vectorTileLayer")}</option>
+              <option value="map-service">{t("addData.arcgis.mapServiceLayer")}</option>
+              <option value="image-service">{t("addData.arcgis.imageServiceLayer")}</option>
             </Select>
           </div>
           <div className="space-y-1.5">
@@ -150,11 +171,7 @@ export function ArcGISSource() {
             <Label htmlFor="arcgis-url">{t("addData.common.serviceUrl")}</Label>
             <Input
               id="arcgis-url"
-              placeholder={
-                arcgisLayerType === "feature"
-                  ? t("addData.arcgis.featureUrlPlaceholder")
-                  : t("addData.arcgis.vectorTileUrlPlaceholder")
-              }
+              placeholder={t(URL_PLACEHOLDER_KEYS[arcgisLayerType])}
               value={arcgisUrl}
               onChange={(event) => setArcgisUrl(event.target.value)}
             />
@@ -222,6 +239,30 @@ export function ArcGISSource() {
             <p className="text-xs text-muted-foreground">{t("addData.arcgis.pagingHint")}</p>
           </div>
         ) : null}
+        {arcgisLayerType === "map-service" ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="arcgis-sublayers">{t("addData.arcgis.sublayers")}</Label>
+            <Input
+              id="arcgis-sublayers"
+              placeholder={t("addData.arcgis.sublayersPlaceholder")}
+              value={arcgisSublayers}
+              onChange={(event) => setArcgisSublayers(event.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">{t("addData.arcgis.sublayersHint")}</p>
+          </div>
+        ) : null}
+        {arcgisLayerType === "image-service" ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="arcgis-rendering-rule">{t("addData.arcgis.renderingRule")}</Label>
+            <Input
+              id="arcgis-rendering-rule"
+              placeholder={t("addData.arcgis.renderingRulePlaceholder")}
+              value={arcgisRenderingRule}
+              onChange={(event) => setArcgisRenderingRule(event.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">{t("addData.arcgis.renderingRuleHint")}</p>
+          </div>
+        ) : null}
         {/* Mounted for the life of the panel, not only while a download runs:
             several screen readers ignore a live region that appears together
             with its first text. `sr-only` keeps the empty state out of the
@@ -255,6 +296,26 @@ export function ArcGISSource() {
                 layerType: "vector-tile",
                 sourceType: "url",
                 url: DEFAULT_ARCGIS_URLS["vector-tile"],
+              },
+            },
+            {
+              label: t("addData.arcgis.sampleMapServiceLabel"),
+              value: {
+                layerType: "map-service",
+                sourceType: "url",
+                url: DEFAULT_ARCGIS_URLS["map-service"],
+              },
+            },
+            {
+              label: t("addData.arcgis.sampleImageServiceLabel"),
+              value: {
+                layerType: "image-service",
+                sourceType: "url",
+                url: DEFAULT_ARCGIS_URLS["image-service"],
+                // 3DEP is a single-band elevation service, so the default
+                // grayscale stretch reads as a flat gray sheet. The hillshade
+                // rule is what makes the sample look like terrain.
+                renderingRule: '{"rasterFunction":"Hillshade"}',
               },
             },
           ]}

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -307,7 +307,7 @@
       },
       "arcgis": {
         "label": "إضافة طبقة ArcGIS",
-        "description": "إضافة طبقة من ArcGIS FeatureServer، أو طبقة VectorTileServer، أو عنصر بوابة."
+        "description": "أضف طبقة ArcGIS من نوع FeatureServer أو VectorTileServer أو MapServer أو ImageServer، أو عنصر بوابة."
       },
       "postgres": {
         "label": "إضافة طبقة PostgreSQL",
@@ -471,11 +471,23 @@
       "defaultName": "طبقة ArcGIS",
       "sampleFeatureLabel": "المدن الأمريكية الكبرى (معالم)",
       "sampleVectorTileLabel": "قطع أراضي سانتا مونيكا (بلاطات متجهة)",
+      "sampleMapServiceLabel": "حدود الولايات المتحدة (خدمة خرائط)",
+      "sampleImageServiceLabel": "تظليل تضاريس USGS 3DEP (خدمة صور)",
       "featureLayer": "طبقة معالم",
       "vectorTileLayer": "طبقة بلاطات متجهة",
+      "mapServiceLayer": "خدمة خرائط",
+      "imageServiceLayer": "خدمة صور",
       "portalItemId": "معرّف عنصر البوابة",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "الطبقات الفرعية",
+      "sublayersPlaceholder": "كل الطبقات الفرعية الظاهرة",
+      "sublayersHint": "معرفات طبقات فرعية اختيارية مفصولة بفواصل، مثل 0,2,5. اختيار طبقات فرعية يرسم الخدمة ديناميكيًا بدلًا من استخدام بلاطاتها المخزنة.",
+      "renderingRule": "قاعدة العرض",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON اختياري لدالة راستر تطبقها الخدمة. قاعدة العرض ترسم الخدمة ديناميكيًا بدلًا من استخدام بلاطاتها المخزنة.",
       "portalUrl": "عنوان URL للبوابة",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "رمز الوصول"

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -307,7 +307,7 @@
       },
       "arcgis": {
         "label": "إضافة طبقة ArcGIS",
-        "description": "أضف طبقة ArcGIS من نوع FeatureServer أو VectorTileServer أو MapServer أو ImageServer، أو عنصر بوابة."
+        "description": "إضافة طبقة ArcGIS من نوع FeatureServer أو VectorTileServer أو MapServer أو ImageServer، أو عنصر بوابة."
       },
       "postgres": {
         "label": "إضافة طبقة PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "ArcGIS-Ebene hinzufügen",
-        "description": "ArcGIS-Ebene von einem FeatureServer, VectorTileServer, MapServer oder ImageServer oder ein Portalelement hinzufügen."
+        "description": "Fügt eine ArcGIS-Ebene von einem FeatureServer, VectorTileServer, MapServer oder ImageServer oder ein Portalelement hinzu."
       },
       "postgres": {
         "label": "PostgreSQL-Ebene hinzufügen",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "ArcGIS-Ebene hinzufügen",
-        "description": "Fügt eine ArcGIS-FeatureServer-Ebene, VectorTileServer-Ebene oder ein Portalelement hinzu."
+        "description": "ArcGIS-Ebene von einem FeatureServer, VectorTileServer, MapServer oder ImageServer oder ein Portalelement hinzufügen."
       },
       "postgres": {
         "label": "PostgreSQL-Ebene hinzufügen",
@@ -447,11 +447,23 @@
       "defaultName": "ArcGIS-Ebene",
       "sampleFeatureLabel": "Große US-Städte (Feature)",
       "sampleVectorTileLabel": "Flurstücke Santa Monica (Vektorkacheln)",
+      "sampleMapServiceLabel": "US-Grenzen (Kartendienst)",
+      "sampleImageServiceLabel": "USGS-3DEP-Schummerung (Bilddienst)",
       "featureLayer": "Feature-Ebene",
       "vectorTileLayer": "Vektorkachelebene",
+      "mapServiceLayer": "Kartendienst",
+      "imageServiceLayer": "Bilddienst",
       "portalItemId": "Portalelement-ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Unterebenen",
+      "sublayersPlaceholder": "Alle sichtbaren Unterebenen",
+      "sublayersHint": "Optionale kommagetrennte IDs der Unterebenen, zum Beispiel 0,2,5. Eine Auswahl zeichnet den Dienst dynamisch statt über seine zwischengespeicherten Kacheln.",
+      "renderingRule": "Rendering-Regel",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "Optionales JSON einer Rasterfunktion, die der Dienst anwendet. Eine Rendering-Regel zeichnet den Dienst dynamisch statt über seine zwischengespeicherten Kacheln.",
       "portalUrl": "Portal-URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Zugriffstoken"

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -303,7 +303,7 @@
       },
       "arcgis": {
         "label": "Add ArcGIS Layer",
-        "description": "Add an ArcGIS FeatureServer layer, VectorTileServer layer, or portal item."
+        "description": "Add an ArcGIS FeatureServer, VectorTileServer, MapServer, or ImageServer layer, or a portal item."
       },
       "postgres": {
         "label": "Add PostgreSQL Layer",
@@ -469,11 +469,23 @@
       "defaultName": "ArcGIS Layer",
       "sampleFeatureLabel": "US major cities (feature)",
       "sampleVectorTileLabel": "Santa Monica parcels (vector tiles)",
+      "sampleMapServiceLabel": "US boundaries (map service)",
+      "sampleImageServiceLabel": "USGS 3DEP hillshade (image service)",
       "featureLayer": "Feature layer",
       "vectorTileLayer": "Vector tile layer",
+      "mapServiceLayer": "Map service",
+      "imageServiceLayer": "Image service",
       "portalItemId": "Portal item ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Sublayers",
+      "sublayersPlaceholder": "All visible sublayers",
+      "sublayersHint": "Optional comma-separated sublayer ids, for example 0,2,5. Selecting sublayers draws the service dynamically instead of using its cached tiles.",
+      "renderingRule": "Rendering rule",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "Optional raster function JSON applied by the service. A rendering rule draws the service dynamically instead of using its cached tiles.",
       "portalUrl": "Portal URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Access token",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "Añadir capa de ArcGIS",
-        "description": "Añade una capa FeatureServer de ArcGIS, una capa VectorTileServer o un elemento del portal."
+        "description": "Añade una capa de ArcGIS FeatureServer, VectorTileServer, MapServer o ImageServer, o un elemento de portal."
       },
       "postgres": {
         "label": "Añadir capa de PostgreSQL",
@@ -447,11 +447,23 @@
       "defaultName": "Capa de ArcGIS",
       "sampleFeatureLabel": "Principales ciudades de EE. UU. (entidades)",
       "sampleVectorTileLabel": "Parcelas de Santa Monica (teselas vectoriales)",
+      "sampleMapServiceLabel": "Límites de EE. UU. (servicio de mapas)",
+      "sampleImageServiceLabel": "Relieve sombreado USGS 3DEP (servicio de imágenes)",
       "featureLayer": "Capa de entidades",
       "vectorTileLayer": "Capa de teselas vectoriales",
+      "mapServiceLayer": "Servicio de mapas",
+      "imageServiceLayer": "Servicio de imágenes",
       "portalItemId": "ID del elemento del portal",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Subcapas",
+      "sublayersPlaceholder": "Todas las subcapas visibles",
+      "sublayersHint": "Ids de subcapas opcionales separados por comas, por ejemplo 0,2,5. Seleccionar subcapas dibuja el servicio de forma dinámica en lugar de usar sus teselas en caché.",
+      "renderingRule": "Regla de representación",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON opcional de una función ráster que aplica el servicio. Una regla de representación dibuja el servicio de forma dinámica en lugar de usar sus teselas en caché.",
       "portalUrl": "URL del portal",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Token de acceso"

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "Ajouter une couche ArcGIS",
-        "description": "Ajouter une couche ArcGIS FeatureServer, une couche VectorTileServer, ou un élément de portail."
+        "description": "Ajouter une couche ArcGIS FeatureServer, VectorTileServer, MapServer ou ImageServer, ou un élément de portail."
       },
       "postgres": {
         "label": "Ajouter une couche PostgreSQL",
@@ -447,11 +447,23 @@
       "defaultName": "Couche ArcGIS",
       "sampleFeatureLabel": "Grandes villes américaines (entités)",
       "sampleVectorTileLabel": "Parcelles de Santa Monica (tuiles vectorielles)",
+      "sampleMapServiceLabel": "Limites administratives des États-Unis (service de carte)",
+      "sampleImageServiceLabel": "Ombrage USGS 3DEP (service d'imagerie)",
       "featureLayer": "Couche d'entités",
       "vectorTileLayer": "Couche de tuiles vectorielles",
+      "mapServiceLayer": "Service de carte",
+      "imageServiceLayer": "Service d'imagerie",
       "portalItemId": "ID de l'élément du portail",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Sous-couches",
+      "sublayersPlaceholder": "Toutes les sous-couches visibles",
+      "sublayersHint": "Identifiants de sous-couches facultatifs séparés par des virgules, par exemple 0,2,5. Sélectionner des sous-couches dessine le service dynamiquement au lieu d'utiliser ses tuiles en cache.",
+      "renderingRule": "Règle de rendu",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON facultatif d'une fonction raster appliquée par le service. Une règle de rendu dessine le service dynamiquement au lieu d'utiliser ses tuiles en cache.",
       "portalUrl": "URL du portail",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Jeton d'accès"

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "ArcGIS लेयर जोड़ें",
-        "description": "एक ArcGIS FeatureServer लेयर, VectorTileServer लेयर, या पोर्टल आइटम जोड़ें।"
+        "description": "ArcGIS FeatureServer, VectorTileServer, MapServer या ImageServer लेयर, या पोर्टल आइटम जोड़ें।"
       },
       "postgres": {
         "label": "PostgreSQL लेयर जोड़ें",
@@ -447,11 +447,23 @@
       "defaultName": "ArcGIS लेयर",
       "sampleFeatureLabel": "US प्रमुख शहर (फ़ीचर)",
       "sampleVectorTileLabel": "Santa Monica पार्सल (वेक्टर टाइल्स)",
+      "sampleMapServiceLabel": "US सीमाएँ (मैप सेवा)",
+      "sampleImageServiceLabel": "USGS 3DEP हिलशेड (इमेज सेवा)",
       "featureLayer": "फ़ीचर लेयर",
       "vectorTileLayer": "वेक्टर टाइल लेयर",
+      "mapServiceLayer": "मैप सेवा",
+      "imageServiceLayer": "इमेज सेवा",
       "portalItemId": "पोर्टल आइटम ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "उप-लेयर",
+      "sublayersPlaceholder": "सभी दृश्य उप-लेयर",
+      "sublayersHint": "वैकल्पिक अल्पविराम से अलग किए गए उप-लेयर आईडी, जैसे 0,2,5. उप-लेयर चुनने पर सेवा कैश की गई टाइल्स के बजाय गतिशील रूप से बनाई जाती है।",
+      "renderingRule": "रेंडरिंग नियम",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "सेवा द्वारा लागू किया जाने वाला वैकल्पिक रास्टर फ़ंक्शन JSON. रेंडरिंग नियम देने पर सेवा कैश की गई टाइल्स के बजाय गतिशील रूप से बनाई जाती है।",
       "portalUrl": "पोर्टल URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "एक्सेस टोकन"

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -297,7 +297,7 @@
       },
       "arcgis": {
         "label": "Tambahkan Layer ArcGIS",
-        "description": "Tambahkan layer ArcGIS FeatureServer, layer VectorTileServer, atau item portal."
+        "description": "Tambahkan layer ArcGIS FeatureServer, VectorTileServer, MapServer, atau ImageServer, atau item portal."
       },
       "postgres": {
         "label": "Tambahkan Layer PostgreSQL",
@@ -441,11 +441,23 @@
       "defaultName": "Layer ArcGIS",
       "sampleFeatureLabel": "Kota-kota besar AS (fitur)",
       "sampleVectorTileLabel": "Bidang tanah Santa Monica (ubin vektor)",
+      "sampleMapServiceLabel": "Batas wilayah AS (layanan peta)",
+      "sampleImageServiceLabel": "Hillshade USGS 3DEP (layanan citra)",
       "featureLayer": "Layer fitur",
       "vectorTileLayer": "Layer ubin vektor",
+      "mapServiceLayer": "Layanan peta",
+      "imageServiceLayer": "Layanan citra",
       "portalItemId": "ID item portal",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Sublayer",
+      "sublayersPlaceholder": "Semua sublayer yang terlihat",
+      "sublayersHint": "Id sublayer opsional dipisahkan koma, misalnya 0,2,5. Memilih sublayer menggambar layanan secara dinamis alih-alih memakai ubin cache-nya.",
+      "renderingRule": "Aturan render",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON fungsi raster opsional yang diterapkan layanan. Aturan render menggambar layanan secara dinamis alih-alih memakai ubin cache-nya.",
       "portalUrl": "URL portal",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Token akses"

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "Aggiungi livello ArcGIS",
-        "description": "Aggiungi un livello ArcGIS FeatureServer, un livello VectorTileServer o un elemento del portale."
+        "description": "Aggiungi un livello ArcGIS FeatureServer, VectorTileServer, MapServer o ImageServer, oppure un elemento del portale."
       },
       "postgres": {
         "label": "Aggiungi livello PostgreSQL",
@@ -447,11 +447,23 @@
       "defaultName": "Livello ArcGIS",
       "sampleFeatureLabel": "Principali città USA (elementi)",
       "sampleVectorTileLabel": "Particelle di Santa Monica (tile vettoriali)",
+      "sampleMapServiceLabel": "Confini degli USA (servizio mappa)",
+      "sampleImageServiceLabel": "Ombreggiatura USGS 3DEP (servizio immagini)",
       "featureLayer": "Livello di elementi",
       "vectorTileLayer": "Livello di tile vettoriali",
+      "mapServiceLayer": "Servizio mappa",
+      "imageServiceLayer": "Servizio immagini",
       "portalItemId": "ID elemento del portale",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Sottolivelli",
+      "sublayersPlaceholder": "Tutti i sottolivelli visibili",
+      "sublayersHint": "Id dei sottolivelli facoltativi separati da virgole, ad esempio 0,2,5. Selezionare i sottolivelli disegna il servizio in modo dinamico anziché usare le sue tile in cache.",
+      "renderingRule": "Regola di rendering",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON facoltativo di una funzione raster applicata dal servizio. Una regola di rendering disegna il servizio in modo dinamico anziché usare le sue tile in cache.",
       "portalUrl": "URL del portale",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Token di accesso"

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -297,7 +297,7 @@
       },
       "arcgis": {
         "label": "ArcGISレイヤーを追加",
-        "description": "ArcGISのFeatureServerレイヤー、VectorTileServerレイヤー、またはポータルアイテムを追加します。"
+        "description": "ArcGIS の FeatureServer、VectorTileServer、MapServer、ImageServer レイヤー、またはポータル アイテムを追加します。"
       },
       "postgres": {
         "label": "PostgreSQLレイヤーを追加",
@@ -441,11 +441,23 @@
       "defaultName": "ArcGISレイヤー",
       "sampleFeatureLabel": "米国の主要都市(フィーチャ)",
       "sampleVectorTileLabel": "サンタモニカの地籍(ベクタータイル)",
+      "sampleMapServiceLabel": "米国の行政界(マップサービス)",
+      "sampleImageServiceLabel": "USGS 3DEP 陰影起伏(イメージサービス)",
       "featureLayer": "フィーチャレイヤー",
       "vectorTileLayer": "ベクタータイルレイヤー",
+      "mapServiceLayer": "マップサービス",
+      "imageServiceLayer": "イメージサービス",
       "portalItemId": "ポータルアイテムID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "サブレイヤー",
+      "sublayersPlaceholder": "表示中のすべてのサブレイヤー",
+      "sublayersHint": "任意のサブレイヤー ID をカンマ区切りで指定します(例: 0,2,5)。サブレイヤーを選ぶと、キャッシュされたタイルではなく動的な描画になります。",
+      "renderingRule": "レンダリング ルール",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "サービスが適用するラスター関数の JSON(任意)。レンダリング ルールを指定すると、キャッシュされたタイルではなく動的な描画になります。",
       "portalUrl": "ポータルURL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "アクセストークン"

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -303,7 +303,7 @@
       },
       "arcgis": {
         "label": "ArcGIS შრის დამატება",
-        "description": "დაამატეთ ArcGIS FeatureServer შრე, VectorTileServer შრე ან პორტალის ელემენტი."
+        "description": "დაამატეთ ArcGIS-ის FeatureServer, VectorTileServer, MapServer ან ImageServer შრე, ან პორტალის ელემენტი."
       },
       "postgres": {
         "label": "PostgreSQL შრის დამატება",
@@ -469,11 +469,23 @@
       "defaultName": "ArcGIS შრე",
       "sampleFeatureLabel": "აშშ-ის მსხვილი ქალაქები (ობიექტები)",
       "sampleVectorTileLabel": "Santa Monica-ის ნაკვეთები (ვექტორული ფილები)",
+      "sampleMapServiceLabel": "აშშ-ის საზღვრები (რუკის სერვისი)",
+      "sampleImageServiceLabel": "USGS 3DEP დაჩრდილვა (გამოსახულების სერვისი)",
       "featureLayer": "ობიექტების შრე",
       "vectorTileLayer": "ვექტორული ფილების შრე",
+      "mapServiceLayer": "რუკის სერვისი",
+      "imageServiceLayer": "გამოსახულების სერვისი",
       "portalItemId": "პორტალის ელემენტის ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "ქვეშრეები",
+      "sublayersPlaceholder": "ყველა ხილული ქვეშრე",
+      "sublayersHint": "არასავალდებულო ქვეშრეების id-ები მძიმით გამოყოფილი, მაგალითად 0,2,5. ქვეშრეების არჩევისას სერვისი დინამიკურად დაიხატება ქეშირებული ფილების ნაცვლად.",
+      "renderingRule": "რენდერის წესი",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "არასავალდებულო რასტრული ფუნქციის JSON, რომელსაც სერვისი იყენებს. რენდერის წესის მითითებისას სერვისი დინამიკურად დაიხატება ქეშირებული ფილების ნაცვლად.",
       "portalUrl": "პორტალის URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "წვდომის ტოკენი"

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -297,7 +297,7 @@
       },
       "arcgis": {
         "label": "ArcGIS 레이어 추가",
-        "description": "ArcGIS FeatureServer 레이어, VectorTileServer 레이어, 또는 포털 항목을 추가합니다."
+        "description": "ArcGIS FeatureServer, VectorTileServer, MapServer, ImageServer 레이어 또는 포털 항목을 추가합니다."
       },
       "postgres": {
         "label": "PostgreSQL 레이어 추가",
@@ -441,11 +441,23 @@
       "defaultName": "ArcGIS 레이어",
       "sampleFeatureLabel": "미국 주요 도시(피처)",
       "sampleVectorTileLabel": "산타모니카 필지(벡터 타일)",
+      "sampleMapServiceLabel": "미국 행정 경계(맵 서비스)",
+      "sampleImageServiceLabel": "USGS 3DEP 음영기복(이미지 서비스)",
       "featureLayer": "피처 레이어",
       "vectorTileLayer": "벡터 타일 레이어",
+      "mapServiceLayer": "맵 서비스",
+      "imageServiceLayer": "이미지 서비스",
       "portalItemId": "포털 항목 ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "하위 레이어",
+      "sublayersPlaceholder": "표시된 모든 하위 레이어",
+      "sublayersHint": "선택 사항인 하위 레이어 ID를 쉼표로 구분해 입력합니다(예: 0,2,5). 하위 레이어를 선택하면 캐시된 타일 대신 서비스를 동적으로 그립니다.",
+      "renderingRule": "렌더링 규칙",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "서비스가 적용하는 래스터 함수 JSON(선택 사항)입니다. 렌더링 규칙을 지정하면 캐시된 타일 대신 서비스를 동적으로 그립니다.",
       "portalUrl": "포털 URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "액세스 토큰"

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "ArcGIS-laag toevoegen",
-        "description": "Voeg een ArcGIS FeatureServer-laag, VectorTileServer-laag of portalitem toe."
+        "description": "Voeg een ArcGIS FeatureServer-, VectorTileServer-, MapServer- of ImageServer-laag toe, of een portalitem."
       },
       "postgres": {
         "label": "PostgreSQL-laag toevoegen",
@@ -447,11 +447,23 @@
       "defaultName": "ArcGIS-laag",
       "sampleFeatureLabel": "Grote Amerikaanse steden (feature)",
       "sampleVectorTileLabel": "Kadastrale percelen Santa Monica (vectortegels)",
+      "sampleMapServiceLabel": "Amerikaanse grenzen (kaartservice)",
+      "sampleImageServiceLabel": "USGS 3DEP-heuvelarcering (beeldservice)",
       "featureLayer": "Featurelaag",
       "vectorTileLayer": "Vectortegellaag",
+      "mapServiceLayer": "Kaartservice",
+      "imageServiceLayer": "Beeldservice",
       "portalItemId": "Portalitem-ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Sublagen",
+      "sublayersPlaceholder": "Alle zichtbare sublagen",
+      "sublayersHint": "Optionele sublaag-id's, gescheiden door komma's, bijvoorbeeld 0,2,5. Sublagen kiezen tekent de service dynamisch in plaats van via de tegels in de cache.",
+      "renderingRule": "Renderregel",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "Optionele JSON van een rasterfunctie die de service toepast. Een renderregel tekent de service dynamisch in plaats van via de tegels in de cache.",
       "portalUrl": "Portal-URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Toegangstoken"

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "Adicionar camada ArcGIS",
-        "description": "Adicione uma camada ArcGIS FeatureServer, camada VectorTileServer ou item de portal."
+        "description": "Adicione uma camada ArcGIS FeatureServer, VectorTileServer, MapServer ou ImageServer, ou um item de portal."
       },
       "postgres": {
         "label": "Adicionar camada PostgreSQL",
@@ -447,11 +447,23 @@
       "defaultName": "Camada ArcGIS",
       "sampleFeatureLabel": "Principais cidades dos EUA (feição)",
       "sampleVectorTileLabel": "Lotes de Santa Monica (tiles vetoriais)",
+      "sampleMapServiceLabel": "Limites dos EUA (serviço de mapa)",
+      "sampleImageServiceLabel": "Sombreamento USGS 3DEP (serviço de imagem)",
       "featureLayer": "Camada de feições",
       "vectorTileLayer": "Camada de tiles vetoriais",
+      "mapServiceLayer": "Serviço de mapa",
+      "imageServiceLayer": "Serviço de imagem",
       "portalItemId": "ID do item do portal",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Subcamadas",
+      "sublayersPlaceholder": "Todas as subcamadas visíveis",
+      "sublayersHint": "Ids de subcamadas opcionais separados por vírgulas, por exemplo 0,2,5. Selecionar subcamadas desenha o serviço dinamicamente em vez de usar seus tiles em cache.",
+      "renderingRule": "Regra de renderização",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON opcional de uma função raster aplicada pelo serviço. Uma regra de renderização desenha o serviço dinamicamente em vez de usar seus tiles em cache.",
       "portalUrl": "URL do portal",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Token de acesso"

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -303,7 +303,7 @@
       },
       "arcgis": {
         "label": "Добавить слой ArcGIS",
-        "description": "Добавьте слой ArcGIS FeatureServer, VectorTileServer, MapServer или ImageServer либо элемент портала."
+        "description": "Добавить слой ArcGIS FeatureServer, VectorTileServer, MapServer или ImageServer либо элемент портала."
       },
       "postgres": {
         "label": "Добавить слой PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -303,7 +303,7 @@
       },
       "arcgis": {
         "label": "Добавить слой ArcGIS",
-        "description": "Добавить слой ArcGIS FeatureServer, VectorTileServer или элемент портала."
+        "description": "Добавьте слой ArcGIS FeatureServer, VectorTileServer, MapServer или ImageServer либо элемент портала."
       },
       "postgres": {
         "label": "Добавить слой PostgreSQL",
@@ -459,11 +459,23 @@
       "defaultName": "Слой ArcGIS",
       "sampleFeatureLabel": "Крупные города США (объектный)",
       "sampleVectorTileLabel": "Участки Санта-Моники (векторные тайлы)",
+      "sampleMapServiceLabel": "Границы США (сервис карт)",
+      "sampleImageServiceLabel": "Отмывка рельефа USGS 3DEP (сервис изображений)",
       "featureLayer": "Объектный слой",
       "vectorTileLayer": "Слой векторных тайлов",
+      "mapServiceLayer": "Сервис карт",
+      "imageServiceLayer": "Сервис изображений",
       "portalItemId": "ID элемента портала",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Подслои",
+      "sublayersPlaceholder": "Все видимые подслои",
+      "sublayersHint": "Необязательные идентификаторы подслоёв через запятую, например 0,2,5. Выбор подслоёв отрисовывает сервис динамически вместо использования его кэшированных тайлов.",
+      "renderingRule": "Правило отрисовки",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "Необязательный JSON растровой функции, применяемой сервисом. Правило отрисовки отрисовывает сервис динамически вместо использования его кэшированных тайлов.",
       "portalUrl": "URL портала",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Токен доступа"

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -301,7 +301,7 @@
       },
       "arcgis": {
         "label": "เพิ่มเลเยอร์ ArcGIS",
-        "description": "เพิ่มเลเยอร์ ArcGIS FeatureServer, เลเยอร์ VectorTileServer หรือรายการจากพอร์ทัล"
+        "description": "เพิ่มเลเยอร์ ArcGIS แบบ FeatureServer, VectorTileServer, MapServer หรือ ImageServer หรือรายการพอร์ทัล"
       },
       "postgres": {
         "label": "เพิ่มเลเยอร์ PostgreSQL",
@@ -462,11 +462,23 @@
       "defaultName": "เลเยอร์ ArcGIS",
       "sampleFeatureLabel": "เมืองสำคัญของสหรัฐฯ (ฟีเจอร์)",
       "sampleVectorTileLabel": "แปลงที่ดินซานตาโมนิกา (ไทล์เวกเตอร์)",
+      "sampleMapServiceLabel": "ขอบเขตการปกครองสหรัฐฯ (บริการแผนที่)",
+      "sampleImageServiceLabel": "ภาพเงาภูมิประเทศ USGS 3DEP (บริการภาพ)",
       "featureLayer": "เลเยอร์ฟีเจอร์",
       "vectorTileLayer": "เลเยอร์ไทล์เวกเตอร์",
+      "mapServiceLayer": "บริการแผนที่",
+      "imageServiceLayer": "บริการภาพ",
       "portalItemId": "รหัสรายการในพอร์ทัล",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "เลเยอร์ย่อย",
+      "sublayersPlaceholder": "เลเยอร์ย่อยที่แสดงทั้งหมด",
+      "sublayersHint": "ระบุรหัสเลเยอร์ย่อยคั่นด้วยจุลภาคได้ตามต้องการ เช่น 0,2,5 การเลือกเลเยอร์ย่อยจะวาดบริการแบบไดนามิกแทนการใช้ไทล์ที่แคชไว้",
+      "renderingRule": "กฎการเรนเดอร์",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "JSON ของฟังก์ชันแรสเตอร์ที่บริการนำไปใช้ (ไม่บังคับ) การกำหนดกฎการเรนเดอร์จะวาดบริการแบบไดนามิกแทนการใช้ไทล์ที่แคชไว้",
       "portalUrl": "URL ของพอร์ทัล",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "โทเค็นการเข้าถึง"

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -299,7 +299,7 @@
       },
       "arcgis": {
         "label": "ArcGIS Katmanı Ekle",
-        "description": "Bir ArcGIS FeatureServer katmanı, VectorTileServer katmanı veya portal öğesi ekleyin."
+        "description": "ArcGIS FeatureServer, VectorTileServer, MapServer veya ImageServer katmanı ya da bir portal öğesi ekleyin."
       },
       "postgres": {
         "label": "PostgreSQL Katmanı Ekle",
@@ -447,11 +447,23 @@
       "defaultName": "ArcGIS Katmanı",
       "sampleFeatureLabel": "ABD büyük şehirleri (öğe)",
       "sampleVectorTileLabel": "Santa Monica parselleri (vektör döşemeler)",
+      "sampleMapServiceLabel": "ABD idari sınırları (harita servisi)",
+      "sampleImageServiceLabel": "USGS 3DEP kabartma gölgesi (görüntü servisi)",
       "featureLayer": "Öğe katmanı",
       "vectorTileLayer": "Vektör döşeme katmanı",
+      "mapServiceLayer": "Harita servisi",
+      "imageServiceLayer": "Görüntü servisi",
       "portalItemId": "Portal öğe kimliği",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "Alt katmanlar",
+      "sublayersPlaceholder": "Görünen tüm alt katmanlar",
+      "sublayersHint": "İsteğe bağlı, virgülle ayrılmış alt katman kimlikleri, örneğin 0,2,5. Alt katman seçmek servisi önbelleğe alınmış döşemeler yerine dinamik olarak çizer.",
+      "renderingRule": "Görselleştirme kuralı",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "Servisin uyguladığı isteğe bağlı raster işlevi JSON'u. Görselleştirme kuralı, servisi önbelleğe alınmış döşemeler yerine dinamik olarak çizer.",
       "portalUrl": "Portal URL'si",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "Erişim belirteci"

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -297,7 +297,7 @@
       },
       "arcgis": {
         "label": "添加 ArcGIS 图层",
-        "description": "添加 ArcGIS FeatureServer 图层、VectorTileServer 图层或门户项目。"
+        "description": "添加 ArcGIS FeatureServer、VectorTileServer、MapServer 或 ImageServer 图层，或门户项目。"
       },
       "postgres": {
         "label": "添加 PostgreSQL 图层",
@@ -441,11 +441,23 @@
       "defaultName": "ArcGIS 图层",
       "sampleFeatureLabel": "美国主要城市（要素）",
       "sampleVectorTileLabel": "圣莫尼卡地块（矢量瓦片）",
+      "sampleMapServiceLabel": "美国行政边界（地图服务）",
+      "sampleImageServiceLabel": "USGS 3DEP 山体阴影（影像服务）",
       "featureLayer": "要素图层",
       "vectorTileLayer": "矢量瓦片图层",
+      "mapServiceLayer": "地图服务",
+      "imageServiceLayer": "影像服务",
       "portalItemId": "门户项目 ID",
       "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
       "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "mapServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../MapServer",
+      "imageServiceUrlPlaceholder": "https://.../arcgis/rest/services/.../ImageServer",
+      "sublayers": "子图层",
+      "sublayersPlaceholder": "所有可见子图层",
+      "sublayersHint": "可选的子图层 ID，以逗号分隔，例如 0,2,5。选择子图层后将动态绘制该服务，而不使用其缓存切片。",
+      "renderingRule": "渲染规则",
+      "renderingRulePlaceholder": "{\"rasterFunction\":\"Hillshade\"}",
+      "renderingRuleHint": "可选的栅格函数 JSON，由服务端应用。设置渲染规则后将动态绘制该服务，而不使用其缓存切片。",
       "portalUrl": "门户 URL",
       "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
       "accessToken": "访问令牌"

--- a/docs/features.md
+++ b/docs/features.md
@@ -42,7 +42,7 @@ kepler.gl, see the [Comparison](comparison.md).
 - Reproject vector layers to EPSG:4326 on load, render vector layers that carry Z coordinates in true 3D rather than flattening them onto the ground plane, and split dragged GPX files into named waypoint, track, and route layers
 - Large local vector layers render through client-side vector tiling, with a warning before loading very large files
 - Add Data menu covering every remote and cloud-native source:
-    - **Tile and map services**: XYZ tiles; WMS and WFS, with layers and feature types discovered from the service's GetCapabilities so you pick from a populated dropdown; vector tiles, including OGC API - Tiles services; and ArcGIS FeatureServer and VectorTileServer layers
+    - **Tile and map services**: XYZ tiles; WMS and WFS, with layers and feature types discovered from the service's GetCapabilities so you pick from a populated dropdown; vector tiles, including OGC API - Tiles services; and ArcGIS FeatureServer, VectorTileServer, MapServer, and ImageServer layers, the last two with optional sublayer selection and server-side raster functions
     - **Feature services and feeds**: GeoJSON URLs; GeoRSS feeds from a URL or file; and OGC API - Features collections added as vector layers from whatever URL you have in hand — a landing page, `/collections`, a collection, or a full items URL
     - **Raster**: COG and GeoTIFF; Cloud-Optimized NetCDF/HDF via kerchunk references, plus local HDF5 and NetCDF-4 files; and MBTiles
     - **Cloud-native archives**: PMTiles, and Zarr from a remote store or a folder on disk, with variable and dimension pickers that offer the store's real coordinate values rather than raw indices

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -277,7 +277,7 @@ layer), falling back to `style.textColor` when a feature does not set it.
 | `raster`         | Supported for raster tile templates                                                                |
 | `vector-tiles`   | Supported for MapLibre vector tile sources                                                         |
 | `mbtiles`        | Supported in the desktop app through a local MapLibre protocol                                     |
-| `arcgis`         | Supported for ArcGIS FeatureServer and VectorTileServer layers                                     |
+| `arcgis`         | Supported for ArcGIS VectorTileServer layers (FeatureServer layers are saved as `geojson`, and MapServer/ImageServer layers as `raster`) |
 | `pmtiles`        | Supported through the Components plugin                                                            |
 | `cog`            | Supported for COG and GeoTIFF raster layers                                                        |
 | `flatgeobuf`     | Supported through the Components plugin and imported as GeoJSON when loaded as a local vector file |

--- a/docs/user-guide/adding-data.md
+++ b/docs/user-guide/adding-data.md
@@ -51,8 +51,36 @@ Vector files are reprojected to EPSG:4326 on load. In the browser, vector import
 | **WMS Layer** | A Web Map Service layer, with click-to-identify through GetFeatureInfo where supported. |
 | **WFS Layer** | A Web Feature Service layer, with optional automatic refresh. |
 | **WMTS Layer** | A Web Map Tile Service layer. |
-| **ArcGIS Layer** | An ArcGIS FeatureServer or VectorTileServer layer. |
+| **ArcGIS Layer** | An ArcGIS FeatureServer, VectorTileServer, MapServer, or ImageServer layer. See [ArcGIS services](#arcgis-services). |
 | **STAC Layer** | Searches a STAC catalog and adds the matching raster items. |
+
+### ArcGIS services
+
+Pick the **Layer type** that matches the service, then give it a service URL or a
+portal item ID (with an access token for a secured service).
+
+| Layer type | Service | How it loads |
+| --- | --- | --- |
+| **Feature layer** | FeatureServer | Downloaded page by page as a GeoJSON layer, so labels, the attribute table, identify, symbology, and export all work on it. |
+| **Vector tile layer** | VectorTileServer | Rendered from the service's own style. |
+| **Map service** | MapServer | A raster layer. Cached services are read as tiles; dynamic ones are drawn per tile through `/export`. |
+| **Image service** | ImageServer | A raster layer drawn through `/exportImage` (or the service's tile cache). |
+
+Map and image services become ordinary raster layers, so opacity, the Style
+panel's brightness/contrast/saturation controls, reordering, and saving to a
+project all work on them.
+
+Two optional fields shape what the service draws:
+
+- **Sublayers** (map service) takes the sublayer ids to draw, such as `0,2,5`.
+  Leave it blank for the service's own default set. Pasting a URL that ends in a
+  sublayer id (`.../MapServer/3`) selects that sublayer for you.
+- **Rendering rule** (image service) takes an Esri raster function as JSON, such
+  as `{"rasterFunction":"Hillshade"}`, applied by the server before the image is
+  sent.
+
+Either choice draws the service dynamically, because a cached service's tiles
+were rendered before the choice existed and cannot honor it.
 
 ## Cloud formats
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -59,6 +59,10 @@ export {
 export {
   addArcGISLayer,
   ARCGIS_FEATURE_SOURCE_KIND,
+  ARCGIS_IMAGE_SERVICE_SOURCE_KIND,
+  ARCGIS_LAYER_TYPES,
+  ARCGIS_MAP_SERVICE_SOURCE_KIND,
+  parseArcGISLayerType,
   refreshArcGISFeatureLayer,
   type ArcGISLayerOptions,
   type ArcGISLayerType,

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -54,6 +54,7 @@ const ARCGIS_EXPORT_TILE_SIZE = 256;
  * tile spanning the whole world).
  */
 const WEB_MERCATOR_ORIGIN_X = -20037508.342787;
+const WEB_MERCATOR_ORIGIN_Y = 20037508.342787;
 const WEB_MERCATOR_LEVEL0_RESOLUTION = 156543.03392800014;
 
 /**
@@ -465,10 +466,21 @@ async function addArcGISImageServiceLayer(
     undefined,
   );
 
-  // A sublayer id read off the pasted URL is a default: the explicit field wins
-  // when the user filled both in.
-  const sublayers = normalizeArcGISSublayers(options.sublayers) ?? resolved.sublayers;
-  const renderingRule = validArcGISRenderingRule(options.renderingRule);
+  // Each option belongs to exactly one of the two service types, and the Add
+  // Data form keeps both field values when the layer type is switched (so the
+  // user's typing survives a change of mind). Reading only the applicable one
+  // keeps a leftover rendering rule from blocking a MapServer submission — or,
+  // when it happens to be valid JSON, from silently costing it its tile cache.
+  const sublayers =
+    options.layerType === "map-service"
+      ? // A sublayer id read off the pasted URL is a default: the explicit field
+        // wins when the user filled both in.
+        (normalizeArcGISSublayers(options.sublayers) ?? resolved.sublayers)
+      : undefined;
+  const renderingRule =
+    options.layerType === "image-service"
+      ? validArcGISRenderingRule(options.renderingRule)
+      : undefined;
   const token = options.token?.trim() || undefined;
 
   // Sublayers and rendering rules are dynamic-only, so the cache is only an
@@ -701,9 +713,14 @@ function arcgisTileScheme(info: ArcGISImageProducingServiceInfo): ArcGISTileSche
   if (typeof tileSize !== "number" || tileSize !== tileInfo.rows) return null;
   if (tileSize !== 256 && tileSize !== 512) return null;
 
+  // Both axes: a cache anchored at the correct left edge but a different top
+  // edge would line up horizontally and be off vertically, which reads as
+  // imagery that is subtly in the wrong place rather than as an obvious break.
+  // One metre of slack, since services round the origin to varying precision.
   const originX = tileInfo.origin?.x;
-  // One metre of slack: services round the origin to a varying number of places.
+  const originY = tileInfo.origin?.y;
   if (typeof originX !== "number" || Math.abs(originX - WEB_MERCATOR_ORIGIN_X) > 1) return null;
+  if (typeof originY !== "number" || Math.abs(originY - WEB_MERCATOR_ORIGIN_Y) > 1) return null;
 
   const levels = (tileInfo.lods ?? []).filter(
     (lod): lod is { level: number; resolution: number } =>

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -6,8 +6,55 @@ import type { Feature, FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
-export type ArcGISLayerType = "feature" | "vector-tile";
+export type ArcGISLayerType = "feature" | "vector-tile" | "map-service" | "image-service";
 export type ArcGISSourceType = "url" | "portal-item";
+
+/**
+ * Every {@link ArcGISLayerType}, as a runtime list so a stored value (a saved
+ * service-library entry, a hand-edited project) can be validated against it
+ * instead of being coerced to a default that silently loads the wrong service.
+ */
+export const ARCGIS_LAYER_TYPES: readonly ArcGISLayerType[] = [
+  "feature",
+  "vector-tile",
+  "map-service",
+  "image-service",
+];
+
+/**
+ * Narrow an untrusted string to an {@link ArcGISLayerType}.
+ *
+ * @param value - The stored or user-supplied layer type.
+ * @param fallback - The type to use when `value` is not a known layer type.
+ * @returns The matching layer type, or `fallback`.
+ */
+export function parseArcGISLayerType(
+  value: unknown,
+  fallback: ArcGISLayerType = "feature",
+): ArcGISLayerType {
+  return ARCGIS_LAYER_TYPES.find((layerType) => layerType === value) ?? fallback;
+}
+
+/**
+ * `metadata.sourceKind` for the two image-producing service types. A MapServer
+ * or ImageServer renders as ordinary raster tiles, so the layer these produce is
+ * a plain `raster` layer rather than an `arcgis` one; the source kind is what
+ * marks where it came from.
+ */
+export const ARCGIS_MAP_SERVICE_SOURCE_KIND = "arcgis-map-service";
+export const ARCGIS_IMAGE_SERVICE_SOURCE_KIND = "arcgis-image-service";
+
+/** Tile size requested from `/export` and `/exportImage`, in pixels. */
+const ARCGIS_EXPORT_TILE_SIZE = 256;
+
+/**
+ * The Web Mercator tiling scheme a cached ArcGIS service must use for its
+ * `/tile/{z}/{y}/{x}` endpoint to be an XYZ source MapLibre can consume: the
+ * top-left origin and the level-0 resolution of the standard scheme (a 256 px
+ * tile spanning the whole world).
+ */
+const WEB_MERCATOR_ORIGIN_X = -20037508.342787;
+const WEB_MERCATOR_LEVEL0_RESOLUTION = 156543.03392800014;
 
 /**
  * Features requested per `/query` call when the service does not advertise a
@@ -64,7 +111,26 @@ export interface ArcGISLayerOptions {
    */
   pageSize?: number;
   portalUrl?: string;
+  /**
+   * ImageServer rendering rule, as the JSON ArcGIS expects for the
+   * `renderingRule` parameter (e.g. `{"rasterFunction":"Hillshade"}`).
+   *
+   * Only meaningful for `layerType: "image-service"`. Supplying one forces the
+   * dynamic `/exportImage` path: a cached service's tiles were rendered when
+   * the cache was built, so they cannot honor a rule chosen here.
+   */
+  renderingRule?: string;
   sourceType: ArcGISSourceType;
+  /**
+   * MapServer sublayers to draw, as the comma-separated id list ArcGIS takes in
+   * `layers=show:<ids>` (e.g. `0,2,5`). Blank draws the service's own default
+   * set of visible sublayers.
+   *
+   * Only meaningful for `layerType: "map-service"`. Supplying a list forces the
+   * dynamic `/export` path, because a cached service serves one fused image per
+   * tile that no longer has separable sublayers.
+   */
+  sublayers?: string;
   token?: string;
   url?: string;
   /**
@@ -103,6 +169,37 @@ interface ArcGISServiceInfo {
   extent?: ArcGISExtent;
   fullExtent?: ArcGISExtent;
   initialExtent?: ArcGISExtent;
+}
+
+/**
+ * The `?f=json` description of a MapServer or ImageServer, narrowed to what the
+ * raster path reads: the extent to fit, the credit line, and whether the service
+ * has a Web Mercator tile cache that can be consumed as XYZ tiles.
+ */
+interface ArcGISImageProducingServiceInfo extends ArcGISServiceInfo {
+  copyrightText?: string;
+  mapName?: string;
+  name?: string;
+  singleFusedMapCache?: boolean;
+  tileInfo?: ArcGISTileInfo;
+}
+
+interface ArcGISTileInfo {
+  cols?: number;
+  lods?: Array<{ level?: number; resolution?: number }>;
+  origin?: { x?: number; y?: number };
+  rows?: number;
+  spatialReference?: {
+    latestWkid?: number;
+    wkid?: number;
+  };
+}
+
+/** A cached service's tile endpoint, resolved to what a raster source needs. */
+interface ArcGISTileScheme {
+  maxzoom: number;
+  minzoom: number;
+  tileSize: number;
 }
 
 interface ArcGISPortalItemInfo {
@@ -147,6 +244,15 @@ export async function addArcGISLayer(
   // instead of only the fill/stroke paint an external-native layer exposes.
   if (options.layerType === "feature") {
     return addArcGISFeatureLayerAsGeoJson(app, options, input);
+  }
+
+  // A MapServer or ImageServer hands back rendered images, not data, so it is
+  // loaded as an ordinary raster layer (cached tiles when the service has a Web
+  // Mercator cache, otherwise an `/export` request per tile). That keeps the
+  // whole raster surface — opacity, brightness/contrast, reordering, and project
+  // save/reload — working without a bespoke handler.
+  if (options.layerType === "map-service" || options.layerType === "image-service") {
+    return addArcGISImageServiceLayer(app, options, input);
   }
 
   const map = app.getMap?.();
@@ -316,6 +422,312 @@ async function addArcGISFeatureLayerAsGeoJson(
   const bounds = arcgisExtentToBounds(layerInfo.extent);
   if (bounds && options.zoomTo !== false) app.fitBounds?.(bounds);
   return id;
+}
+
+/**
+ * Load an ArcGIS MapServer or ImageServer as a raster tile layer.
+ *
+ * Both services answer with rendered images rather than data, so neither has a
+ * useful GeoJSON or vector-tile form. They become an ordinary `raster` layer,
+ * which is what makes the whole raster surface (opacity, the Style panel's
+ * raster adjustments, reordering, project save and reload) work on them with no
+ * dedicated handler anywhere else in the app.
+ *
+ * Two tile strategies, chosen from the service's own metadata:
+ *
+ * - **Cached tiles** (`/tile/{z}/{y}/{x}`) when the service advertises a fused
+ *   cache built on the standard Web Mercator scheme. These are pre-rendered and
+ *   CDN-friendly, so they are used whenever they are available and applicable.
+ * - **Dynamic export** (`/export` for MapServer, `/exportImage` for ImageServer)
+ *   otherwise, as a `{bbox-epsg-3857}` request template — the same mechanism
+ *   GeoLibre's WMS layers use. This is also forced when the caller picked
+ *   sublayers or a rendering rule, because a cache was rendered before either
+ *   choice existed and cannot honor it.
+ *
+ * @param app - The host app API (used to fit the view to the service extent).
+ * @param options - The ArcGIS layer options (source type, URL/item, token).
+ * @param input - The resolved service URL or portal item id from the options.
+ * @returns The new GeoLibre layer's id.
+ */
+async function addArcGISImageServiceLayer(
+  app: GeoLibreAppAPI,
+  options: ArcGISLayerOptions,
+  input: string,
+): Promise<string> {
+  const resolved =
+    options.sourceType === "url"
+      ? resolveArcGISImageServiceUrl(input, options.layerType)
+      : await resolvePortalArcGISImageServiceUrl(input, options);
+  const { serviceUrl } = resolved;
+  const info = await fetchArcGISJson<ArcGISImageProducingServiceInfo>(
+    serviceUrl,
+    options,
+    undefined,
+  );
+
+  // A sublayer id read off the pasted URL is a default: the explicit field wins
+  // when the user filled both in.
+  const sublayers = normalizeArcGISSublayers(options.sublayers) ?? resolved.sublayers;
+  const renderingRule = validArcGISRenderingRule(options.renderingRule);
+  const token = options.token?.trim() || undefined;
+
+  // Sublayers and rendering rules are dynamic-only, so the cache is only an
+  // option when neither was asked for.
+  const tileScheme = sublayers || renderingRule ? null : arcgisTileScheme(info);
+  const tiles = tileScheme
+    ? arcgisCachedTileUrl(serviceUrl, token)
+    : arcgisExportTileUrl(serviceUrl, {
+        layerType: options.layerType,
+        renderingRule,
+        sublayers,
+        token,
+      });
+
+  const bounds = arcgisExtentToBounds(info.fullExtent ?? info.initialExtent ?? info.extent);
+  const attribution = info.copyrightText?.trim() || undefined;
+  const id = createArcGISLayerId();
+  const layer: GeoLibreLayer = {
+    id,
+    name: options.name?.trim() || layerNameFromArcGISInput(serviceUrl, "ArcGIS Layer"),
+    type: "raster",
+    source: {
+      type: "raster",
+      tiles: [tiles],
+      tileSize: tileScheme?.tileSize ?? ARCGIS_EXPORT_TILE_SIZE,
+      ...(bounds ? { bounds } : {}),
+      ...(attribution ? { attribution } : {}),
+      ...(tileScheme ? { minzoom: tileScheme.minzoom, maxzoom: tileScheme.maxzoom } : {}),
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      arcgisLayerType: options.layerType,
+      arcgisSourceType: options.sourceType,
+      arcgisTiled: tileScheme !== null,
+      ...(bounds ? { bounds } : {}),
+      // The token has to travel in the tile URL for the tiles to render at all,
+      // unlike the feature path where it is only on the live requests. It is
+      // flagged here for the same reason the vector-tile path flags it, and
+      // `redactCredentials` (core) strips the `token` parameter from any project
+      // that leaves the app through sharing, embedding, or collaboration.
+      hasAccessToken: Boolean(token),
+      ...(options.sourceType === "portal-item" ? { itemId: input } : {}),
+      ...(options.portalUrl?.trim() ? { portalUrl: options.portalUrl.trim() } : {}),
+      ...(renderingRule ? { arcgisRenderingRule: renderingRule } : {}),
+      ...(sublayers ? { arcgisSublayers: sublayers } : {}),
+      sourceKind:
+        options.layerType === "image-service"
+          ? ARCGIS_IMAGE_SERVICE_SOURCE_KIND
+          : ARCGIS_MAP_SERVICE_SOURCE_KIND,
+    },
+    sourcePath: serviceUrl,
+  };
+
+  useAppStore.getState().addLayer(layer, options.beforeLayerId ?? null);
+  if (bounds && options.zoomTo !== false) app.fitBounds?.(bounds);
+  return id;
+}
+
+/**
+ * Validate a MapServer/ImageServer URL and split off a trailing sublayer id.
+ *
+ * `/export` and `/exportImage` live on the service root, so a URL that points at
+ * one MapServer sublayer (`.../MapServer/3`, which is what the REST directory
+ * links to) is rewritten to the root plus a `show:3` sublayer selection rather
+ * than rejected.
+ *
+ * @param input - The URL the caller supplied.
+ * @param layerType - Which of the two service types is expected.
+ * @returns The service root URL and any sublayer id read from the input.
+ */
+function resolveArcGISImageServiceUrl(
+  input: string,
+  layerType: ArcGISLayerType,
+): { serviceUrl: string; sublayers?: string } {
+  // A URL copied from the REST directory often carries `?f=html` (or a token);
+  // the query is rebuilt from scratch below, so drop whatever came in.
+  const url = trimTrailingSlash(stripArcGISUrlQuery(input));
+  if (layerType === "image-service") {
+    if (!/\/ImageServer$/i.test(url)) {
+      throw new Error("Enter an ArcGIS ImageServer URL.");
+    }
+    return { serviceUrl: url };
+  }
+
+  const match = /^(.*\/MapServer)(?:\/(\d+))?$/i.exec(url);
+  if (!match) {
+    throw new Error("Enter an ArcGIS MapServer URL.");
+  }
+  return { serviceUrl: match[1], ...(match[2] ? { sublayers: match[2] } : {}) };
+}
+
+/** Resolves a portal item to the MapServer/ImageServer URL it points at. */
+async function resolvePortalArcGISImageServiceUrl(
+  itemId: string,
+  options: ArcGISLayerOptions,
+): Promise<{ serviceUrl: string; sublayers?: string }> {
+  const itemInfo = await fetchArcGISPortalItemInfo(itemId, options, undefined);
+  if (!itemInfo.url) {
+    throw new Error("The ArcGIS portal item does not include a service URL.");
+  }
+  return resolveArcGISImageServiceUrl(itemInfo.url, options.layerType);
+}
+
+function stripArcGISUrlQuery(input: string): string {
+  const trimmed = input.trim();
+  const cut = trimmed.search(/[?#]/);
+  return cut === -1 ? trimmed : trimmed.slice(0, cut);
+}
+
+/**
+ * Normalize a sublayer selection to the comma-separated id list ArcGIS takes.
+ *
+ * A non-numeric entry throws rather than being dropped: silently ignoring it
+ * would draw the service's default sublayers, which looks like the selection
+ * was honored.
+ *
+ * @param value - The caller's raw `sublayers` input.
+ * @returns The normalized id list, or undefined when nothing was selected.
+ * @throws If the input contains anything that is not a sublayer id.
+ */
+function normalizeArcGISSublayers(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const ids = trimmed.split(/[\s,]+/).filter(Boolean);
+  if (!ids.every((id) => /^\d+$/.test(id))) {
+    throw new Error("Enter the MapServer sublayers as numeric ids, for example 0,2,5.");
+  }
+  return ids.join(",");
+}
+
+/**
+ * Validate an ImageServer rendering rule. ArcGIS answers an unparseable rule
+ * with an error image on every tile, so a bad rule is rejected up front where
+ * the message can still reach the dialog.
+ *
+ * @param value - The caller's raw `renderingRule` input.
+ * @returns The trimmed rule JSON, or undefined when none was supplied.
+ * @throws If the rule is not valid JSON.
+ */
+function validArcGISRenderingRule(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  try {
+    JSON.parse(trimmed);
+  } catch {
+    throw new Error('The rendering rule must be JSON, for example {"rasterFunction":"Hillshade"}.');
+  }
+  return trimmed;
+}
+
+/**
+ * The `/tile/{z}/{y}/{x}` template for a cached service.
+ *
+ * Built by hand rather than through `appendArcGISParams`: the WHATWG URL parser
+ * percent-encodes the braces, and MapLibre only substitutes literal `{z}`/`{x}`/
+ * `{y}` placeholders.
+ */
+function arcgisCachedTileUrl(serviceUrl: string, token: string | undefined): string {
+  const template = `${trimTrailingSlash(serviceUrl)}/tile/{z}/{y}/{x}`;
+  return token ? `${template}?token=${encodeURIComponent(token)}` : template;
+}
+
+/**
+ * The `/export` (MapServer) or `/exportImage` (ImageServer) request template for
+ * a service with no usable cache, as a MapLibre `{bbox-epsg-3857}` raster tile
+ * URL. `png32` with `transparent=true` keeps the service drawable as an overlay
+ * over the basemap rather than an opaque sheet.
+ */
+function arcgisExportTileUrl(
+  serviceUrl: string,
+  options: {
+    layerType: ArcGISLayerType;
+    renderingRule: string | undefined;
+    sublayers: string | undefined;
+    token: string | undefined;
+  },
+): string {
+  const isImageService = options.layerType === "image-service";
+  const size = `${ARCGIS_EXPORT_TILE_SIZE},${ARCGIS_EXPORT_TILE_SIZE}`;
+  const params: Array<[string, string]> = [
+    ["bbox", "{bbox-epsg-3857}"],
+    ["bboxSR", "3857"],
+    ["imageSR", "3857"],
+    ["size", size],
+    ["format", "png32"],
+    ["transparent", "true"],
+  ];
+  if (!isImageService) params.push(["dpi", "96"]);
+  if (!isImageService && options.sublayers) params.push(["layers", `show:${options.sublayers}`]);
+  if (isImageService && options.renderingRule) {
+    params.push(["renderingRule", options.renderingRule]);
+  }
+  if (options.token) params.push(["token", options.token]);
+  params.push(["f", "image"]);
+
+  const query = params
+    // The bbox placeholder is the one value MapLibre substitutes, so it has to
+    // survive as literal braces; everything else is encoded normally.
+    .map(
+      ([key, value]) =>
+        `${key}=${value === "{bbox-epsg-3857}" ? value : encodeURIComponent(value)}`,
+    )
+    .join("&");
+  return `${trimTrailingSlash(serviceUrl)}/${isImageService ? "exportImage" : "export"}?${query}`;
+}
+
+/**
+ * Read a service's tile cache as an XYZ scheme, when it is one.
+ *
+ * A fused cache is only usable as a MapLibre raster source if it was built on
+ * the standard Web Mercator scheme: the same projection, the same top-left
+ * origin, and resolutions that halve per level from the world-in-one-tile
+ * level 0. Caches in other projections or with custom LOD tables exist and would
+ * render misaligned, so anything that does not match falls back to `/export`,
+ * which is correct for every service.
+ *
+ * @param info - The service's `?f=json` description.
+ * @returns The tile size and zoom range, or null when the cache is not usable.
+ */
+function arcgisTileScheme(info: ArcGISImageProducingServiceInfo): ArcGISTileScheme | null {
+  const tileInfo = info.tileInfo;
+  if (info.singleFusedMapCache !== true || !tileInfo) return null;
+
+  const wkid = tileInfo.spatialReference?.latestWkid ?? tileInfo.spatialReference?.wkid;
+  if (wkid !== 3857 && wkid !== 102100 && wkid !== 102113) return null;
+
+  const tileSize = tileInfo.cols;
+  if (typeof tileSize !== "number" || tileSize !== tileInfo.rows) return null;
+  if (tileSize !== 256 && tileSize !== 512) return null;
+
+  const originX = tileInfo.origin?.x;
+  // One metre of slack: services round the origin to a varying number of places.
+  if (typeof originX !== "number" || Math.abs(originX - WEB_MERCATOR_ORIGIN_X) > 1) return null;
+
+  const levels = (tileInfo.lods ?? []).filter(
+    (lod): lod is { level: number; resolution: number } =>
+      typeof lod.level === "number" &&
+      Number.isFinite(lod.level) &&
+      typeof lod.resolution === "number" &&
+      lod.resolution > 0,
+  );
+  if (levels.length === 0) return null;
+
+  // Compare against the standard resolution for each level rather than assuming
+  // the cache starts at level 0 — plenty of caches begin partway down.
+  const level0Resolution = WEB_MERCATOR_LEVEL0_RESOLUTION * (256 / tileSize);
+  const matchesScheme = levels.every((lod) => {
+    const expected = level0Resolution / 2 ** lod.level;
+    return Math.abs(lod.resolution - expected) / expected < 0.01;
+  });
+  if (!matchesScheme) return null;
+
+  return {
+    maxzoom: Math.max(...levels.map((lod) => lod.level)),
+    minzoom: Math.min(...levels.map((lod) => lod.level)),
+    tileSize,
+  };
 }
 
 /**
@@ -1041,7 +1453,9 @@ function layerNameFromArcGISInput(input: string, fallback: string): string {
   try {
     const url = new URL(input);
     const parts = url.pathname.split("/").filter(Boolean);
-    const serverIndex = parts.findIndex((part) => /^(FeatureServer|VectorTileServer)$/i.test(part));
+    const serverIndex = parts.findIndex((part) =>
+      /^(FeatureServer|VectorTileServer|MapServer|ImageServer)$/i.test(part),
+    );
     const namePart = serverIndex > 0 ? parts[serverIndex - 1] : parts[parts.length - 1];
     return decodeURIComponent(namePart ?? "").replaceAll("_", " ") || fallback;
   } catch {

--- a/tests/apply-service.test.ts
+++ b/tests/apply-service.test.ts
@@ -286,6 +286,8 @@ describe("field mappers", () => {
         // Unset paging fields mean "use the defaults" (whole layer, auto page).
         pageSize: undefined,
         maxFeatures: undefined,
+        sublayers: undefined,
+        renderingRule: undefined,
       },
     );
     // Unknown/absent values fall back to the feature + url defaults.
@@ -293,6 +295,34 @@ describe("field mappers", () => {
     assert.equal(defaults.layerType, "feature");
     assert.equal(defaults.sourceType, "url");
     assert.equal(defaults.url, "https://s");
+  });
+
+  it("round-trips a saved map service, keeping its sublayer selection", () => {
+    const options = arcgisFieldsToOptions(
+      entry("arcgis", {
+        layerType: "map-service",
+        sourceType: "url",
+        url: "https://e/arcgis/rest/services/Boundaries/MapServer",
+        sublayers: " 2,5 ",
+      }),
+    );
+    // A saved map service must come back as one: coercing an unknown layer type
+    // to "feature" would silently load the wrong thing from the Browser panel.
+    assert.equal(options.layerType, "map-service");
+    assert.equal(options.sublayers, "2,5");
+  });
+
+  it("round-trips a saved image service, keeping its rendering rule", () => {
+    const options = arcgisFieldsToOptions(
+      entry("arcgis", {
+        layerType: "image-service",
+        sourceType: "url",
+        url: "https://e/arcgis/rest/services/Elevation/ImageServer",
+        renderingRule: '{"rasterFunction":"Hillshade"}',
+      }),
+    );
+    assert.equal(options.layerType, "image-service");
+    assert.equal(options.renderingRule, '{"rasterFunction":"Hillshade"}');
   });
 });
 

--- a/tests/arcgis-image-service.test.ts
+++ b/tests/arcgis-image-service.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import { useAppStore } from "@geolibre/core";
+import {
+  createEmptyProject,
+  redactCredentials,
+  serializeProject,
+  useAppStore,
+} from "@geolibre/core";
 import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 import { addArcGISLayer } from "../packages/plugins/src/plugins/arcgis-layer";
 
@@ -197,6 +202,25 @@ describe("addArcGISLayer (map and image services)", () => {
     assert.match(tileTemplate(id), /\/export\?/);
   });
 
+  it("falls back to /export when the cache origin is off the Web Mercator corner", async () => {
+    respondWith({
+      ...CACHED_MAP_SERVICE,
+      tileInfo: {
+        ...CACHED_MAP_SERVICE.tileInfo,
+        // The left edge is right but the top edge is not: read as XYZ tiles this
+        // renders horizontally aligned and vertically shifted, which looks like
+        // real imagery in the wrong place rather than an obvious break.
+        origin: { x: -20037508.342787, y: 19999999 },
+      },
+    });
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+    });
+    assert.match(tileTemplate(id), /\/export\?/);
+  });
+
   it("falls back to /export when the cache LODs are not the standard resolutions", async () => {
     respondWith({
       ...CACHED_MAP_SERVICE,
@@ -278,6 +302,30 @@ describe("addArcGISLayer (map and image services)", () => {
     assert.ok(template.includes(encodeURIComponent('{"rasterFunction":"Hillshade"}')), template);
   });
 
+  it("ignores the option that does not belong to the selected service type", async () => {
+    respondWith(CACHED_MAP_SERVICE);
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+      // The Add Data form keeps both fields when the layer type is switched, so
+      // a map service can arrive carrying whatever was typed for an image
+      // service. An unparseable leftover must not block the submission, and a
+      // parseable one must not cost the layer its tile cache.
+      renderingRule: "not json at all",
+    });
+    assert.equal(tileTemplate(id), `${MAP_SERVICE_URL}/tile/{z}/{y}/{x}`);
+
+    respondWith({ ...IMAGE_SERVICE, ...CACHED_MAP_SERVICE });
+    const imageId = await addArcGISLayer(app, {
+      layerType: "image-service",
+      sourceType: "url",
+      url: IMAGE_SERVICE_URL,
+      sublayers: "not an id",
+    });
+    assert.equal(tileTemplate(imageId), `${IMAGE_SERVICE_URL}/tile/{z}/{y}/{x}`);
+  });
+
   it("rejects a rendering rule that is not JSON", async () => {
     respondWith(IMAGE_SERVICE);
     await assert.rejects(
@@ -343,6 +391,26 @@ describe("addArcGISLayer (map and image services)", () => {
       fetchUrls.some((url) => url.includes("token=secret-token-123")),
       "expected the metadata request to carry the token",
     );
+  });
+
+  it("redacts the token from the tile URL when the project leaves the app", async () => {
+    await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+      token: "secret-token-123",
+    });
+
+    // The token has to sit in the tile template for the tiles to load, so what
+    // keeps it out of a shared, embedded, or collaborated project is the egress
+    // redaction pass. Assert that here rather than trusting the flag alone.
+    const project = createEmptyProject("ArcGIS");
+    project.layers = useAppStore.getState().layers;
+    const serialized = serializeProject(redactCredentials(project));
+    assert.doesNotMatch(serialized, /secret-token-123/);
+    // The layer is still recognizable as token-protected on the other side, so
+    // a viewer can be told why it will not draw.
+    assert.match(serialized, /"hasAccessToken": true/);
   });
 
   it("resolves a portal item to the service it points at", async () => {

--- a/tests/arcgis-image-service.test.ts
+++ b/tests/arcgis-image-service.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { useAppStore } from "@geolibre/core";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
+import { addArcGISLayer } from "../packages/plugins/src/plugins/arcgis-layer";
+
+const MAP_SERVICE_URL = "https://example.com/arcgis/rest/services/Boundaries/MapServer";
+const IMAGE_SERVICE_URL = "https://example.com/arcgis/rest/services/Elevation/ImageServer";
+
+/** A dynamic (uncached) MapServer: no fused cache, so `/export` is the only way in. */
+const DYNAMIC_MAP_SERVICE = {
+  mapName: "Layers",
+  singleFusedMapCache: false,
+  copyrightText: "© Example Boundaries",
+  fullExtent: {
+    xmin: -125,
+    ymin: 24,
+    xmax: -66,
+    ymax: 50,
+    spatialReference: { wkid: 4326 },
+  },
+};
+
+/** A MapServer cached on the standard Web Mercator scheme, levels 0-3. */
+const CACHED_MAP_SERVICE = {
+  ...DYNAMIC_MAP_SERVICE,
+  singleFusedMapCache: true,
+  tileInfo: {
+    rows: 256,
+    cols: 256,
+    origin: { x: -20037508.342787, y: 20037508.342787 },
+    spatialReference: { wkid: 102100, latestWkid: 3857 },
+    lods: [
+      { level: 0, resolution: 156543.03392800014 },
+      { level: 1, resolution: 78271.51696399994 },
+      { level: 2, resolution: 39135.75848200009 },
+      { level: 3, resolution: 19567.87924099992 },
+    ],
+  },
+};
+
+const IMAGE_SERVICE = {
+  name: "Elevation",
+  copyrightText: "© Example Elevation",
+  fullExtent: {
+    // Web Mercator, so the bounds conversion is exercised too.
+    xmin: -13914936,
+    ymin: 2870341,
+    xmax: -7451501,
+    ymax: 6446275,
+    spatialReference: { wkid: 102100, latestWkid: 3857 },
+  },
+};
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+describe("addArcGISLayer (map and image services)", () => {
+  let fitBoundsCalls: Array<[number, number, number, number]>;
+  let fetchUrls: string[];
+  let app: GeoLibreAppAPI;
+  let originalFetch: typeof fetch;
+  let serviceInfo: unknown;
+
+  /** Answers every `?f=json` request with the service description under test. */
+  function respondWith(info: unknown): void {
+    serviceInfo = info;
+  }
+
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "ArcGIS" });
+    useAppStore.temporal.getState().clear();
+    fitBoundsCalls = [];
+    fetchUrls = [];
+    serviceInfo = DYNAMIC_MAP_SERVICE;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchUrls.push(typeof input === "string" ? input : input.toString());
+      return jsonResponse(serviceInfo);
+    }) as typeof fetch;
+    app = {
+      // Neither service touches the map: both become plain raster layers.
+      getMap: () => null,
+      fitBounds: (bounds) => {
+        fitBoundsCalls.push(bounds);
+      },
+    } as unknown as GeoLibreAppAPI;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  /** The single tile template of the layer that was just added. */
+  function tileTemplate(id: string): string {
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer, "expected the service layer to be added to the store");
+    const tiles = layer.source.tiles as string[] | undefined;
+    assert.equal(tiles?.length, 1);
+    return tiles?.[0] ?? "";
+  }
+
+  it("loads a dynamic map service as a raster layer of /export requests", async () => {
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+      name: "Boundaries",
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer);
+    // A plain raster layer, so opacity, the raster style controls, reordering,
+    // and project save/reload work with no dedicated handler.
+    assert.equal(layer.type, "raster");
+    assert.notEqual(layer.metadata.externalNativeLayer, true);
+    assert.equal(layer.metadata.sourceKind, "arcgis-map-service");
+    assert.equal(layer.metadata.arcgisTiled, false);
+
+    const template = tileTemplate(id);
+    assert.match(template, /\/MapServer\/export\?/);
+    // MapLibre only substitutes literal braces, so the bbox token must survive
+    // unencoded while everything else is escaped.
+    assert.ok(template.includes("bbox={bbox-epsg-3857}"), template);
+    assert.ok(template.includes("bboxSR=3857"), template);
+    assert.ok(template.includes("imageSR=3857"), template);
+    assert.ok(template.includes("size=256%2C256"), template);
+    // Transparent png32 is what lets the service draw over the basemap.
+    assert.ok(template.includes("format=png32"), template);
+    assert.ok(template.includes("transparent=true"), template);
+    assert.ok(template.endsWith("f=image"), template);
+
+    assert.equal(layer.source.attribution, "© Example Boundaries");
+    assert.deepEqual(fitBoundsCalls, [[-125, 24, -66, 50]]);
+  });
+
+  it("loads an image service through /exportImage", async () => {
+    respondWith(IMAGE_SERVICE);
+    const id = await addArcGISLayer(app, {
+      layerType: "image-service",
+      sourceType: "url",
+      url: IMAGE_SERVICE_URL,
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.equal(layer?.metadata.sourceKind, "arcgis-image-service");
+    // The service name is read off the URL when the caller supplies none.
+    assert.equal(layer?.name, "Elevation");
+    assert.match(tileTemplate(id), /\/ImageServer\/exportImage\?/);
+    // The Web Mercator extent is converted to the geographic bounds MapLibre wants.
+    const [west, south, east, north] = fitBoundsCalls[0] ?? [];
+    assert.ok(west > -126 && west < -124, `west ${west}`);
+    assert.ok(east > -67 && east < -66, `east ${east}`);
+    assert.ok(south > 24 && south < 25, `south ${south}`);
+    assert.ok(north > 49 && north < 51, `north ${north}`);
+  });
+
+  it("uses the tile cache when the service has a standard Web Mercator one", async () => {
+    respondWith(CACHED_MAP_SERVICE);
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+    });
+
+    // Pre-rendered tiles are cheaper than an export per tile, so they win.
+    assert.equal(tileTemplate(id), `${MAP_SERVICE_URL}/tile/{z}/{y}/{x}`);
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.equal(layer?.metadata.arcgisTiled, true);
+    assert.equal(layer?.source.tileSize, 256);
+    // The cache's own level range, so MapLibre neither requests levels the
+    // service does not hold nor stops short of the ones it does.
+    assert.equal(layer?.source.minzoom, 0);
+    assert.equal(layer?.source.maxzoom, 3);
+  });
+
+  it("falls back to /export when the cache uses a non-standard scheme", async () => {
+    respondWith({
+      ...CACHED_MAP_SERVICE,
+      tileInfo: {
+        ...CACHED_MAP_SERVICE.tileInfo,
+        // A cache in a state plane projection cannot be read as XYZ tiles.
+        spatialReference: { wkid: 2229 },
+      },
+    });
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+    });
+    assert.match(tileTemplate(id), /\/export\?/);
+  });
+
+  it("falls back to /export when the cache LODs are not the standard resolutions", async () => {
+    respondWith({
+      ...CACHED_MAP_SERVICE,
+      tileInfo: {
+        ...CACHED_MAP_SERVICE.tileInfo,
+        // A custom LOD table would render at the wrong scale per zoom level.
+        lods: [
+          { level: 0, resolution: 100000 },
+          { level: 1, resolution: 50000 },
+        ],
+      },
+    });
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+    });
+    assert.match(tileTemplate(id), /\/export\?/);
+  });
+
+  it("draws selected sublayers dynamically even when the service is cached", async () => {
+    respondWith(CACHED_MAP_SERVICE);
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+      sublayers: " 2, 5 ",
+    });
+
+    const template = tileTemplate(id);
+    // A fused cache holds one image per tile, so honoring a sublayer choice
+    // means giving the cache up for the dynamic endpoint.
+    assert.match(template, /\/export\?/);
+    assert.ok(template.includes("layers=show%3A2%2C5"), template);
+    assert.equal(
+      useAppStore.getState().layers.find((l) => l.id === id)?.metadata.arcgisSublayers,
+      "2,5",
+    );
+  });
+
+  it("reads a sublayer id off a /MapServer/<id> URL", async () => {
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: `${MAP_SERVICE_URL}/3`,
+    });
+
+    const template = tileTemplate(id);
+    // `/export` lives on the service root, so the id becomes a selection.
+    assert.ok(template.startsWith(`${MAP_SERVICE_URL}/export?`), template);
+    assert.ok(template.includes("layers=show%3A3"), template);
+  });
+
+  it("rejects a sublayer list that is not made of ids", async () => {
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "map-service",
+        sourceType: "url",
+        url: MAP_SERVICE_URL,
+        sublayers: "roads",
+      }),
+      /numeric ids/,
+    );
+    // Nothing must be added: a silently ignored selection would look honored.
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
+  it("applies an image service rendering rule and skips the cache for it", async () => {
+    respondWith({ ...IMAGE_SERVICE, ...CACHED_MAP_SERVICE, name: "Elevation" });
+    const id = await addArcGISLayer(app, {
+      layerType: "image-service",
+      sourceType: "url",
+      url: IMAGE_SERVICE_URL,
+      renderingRule: '{"rasterFunction":"Hillshade"}',
+    });
+
+    const template = tileTemplate(id);
+    assert.match(template, /\/exportImage\?/);
+    assert.ok(template.includes(encodeURIComponent('{"rasterFunction":"Hillshade"}')), template);
+  });
+
+  it("rejects a rendering rule that is not JSON", async () => {
+    respondWith(IMAGE_SERVICE);
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "image-service",
+        sourceType: "url",
+        url: IMAGE_SERVICE_URL,
+        renderingRule: "Hillshade",
+      }),
+      /must be JSON/,
+    );
+  });
+
+  it("rejects a URL that is not the expected service type", async () => {
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "map-service",
+        sourceType: "url",
+        url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      }),
+      /MapServer URL/,
+    );
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "image-service",
+        sourceType: "url",
+        url: MAP_SERVICE_URL,
+      }),
+      /ImageServer URL/,
+    );
+  });
+
+  it("drops a query string left on a pasted service URL", async () => {
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      // What the REST directory's address bar hands you.
+      url: `${MAP_SERVICE_URL}?f=html`,
+    });
+    // The request template is rebuilt from scratch, so `f=html` must not
+    // survive to fight with `f=image`.
+    assert.ok(tileTemplate(id).startsWith(`${MAP_SERVICE_URL}/export?`), tileTemplate(id));
+    assert.doesNotMatch(tileTemplate(id), /f=html/);
+  });
+
+  it("carries the token into the tile requests and flags the layer", async () => {
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+      token: "secret-token-123",
+    });
+
+    // Unlike the feature path, a raster tile cannot be fetched without the
+    // token in its URL, so it travels there and the layer is flagged for the
+    // credential redaction that runs on any project leaving the app.
+    assert.ok(tileTemplate(id).includes("token=secret-token-123"), tileTemplate(id));
+    assert.equal(
+      useAppStore.getState().layers.find((l) => l.id === id)?.metadata.hasAccessToken,
+      true,
+    );
+    assert.ok(
+      fetchUrls.some((url) => url.includes("token=secret-token-123")),
+      "expected the metadata request to carry the token",
+    );
+  });
+
+  it("resolves a portal item to the service it points at", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchUrls.push(url);
+      return jsonResponse(
+        url.includes("/content/items/") ? { url: MAP_SERVICE_URL } : DYNAMIC_MAP_SERVICE,
+      );
+    }) as typeof fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "portal-item",
+      itemId: "abc123",
+    });
+
+    assert.ok(tileTemplate(id).startsWith(`${MAP_SERVICE_URL}/export?`), tileTemplate(id));
+    assert.equal(useAppStore.getState().layers.find((l) => l.id === id)?.metadata.itemId, "abc123");
+  });
+
+  it("leaves the camera alone when the caller opts out of zooming", async () => {
+    await addArcGISLayer(app, {
+      layerType: "map-service",
+      sourceType: "url",
+      url: MAP_SERVICE_URL,
+      // Project import restores its own camera, so fitting each service in turn
+      // would pan away from the saved extent.
+      zoomTo: false,
+    });
+    assert.deepEqual(fitBoundsCalls, []);
+  });
+});


### PR DESCRIPTION
Fixes #1746

Add Data → **ArcGIS Layer** only offered FeatureServer and VectorTileServer, so the two ArcGIS service types that serve *rendered images* had no way into the map. This adds **Map service** (MapServer) and **Image service** (ImageServer) to the layer-type picker.

## How they load

Both become ordinary `raster` layers rather than a bespoke layer type. That is what makes the whole raster surface work on them for free: opacity, the Style panel's brightness / contrast / saturation / greyscale controls, reordering, and project save and reload.

Tiles come from one of two places, chosen from the service's own `?f=json` metadata:

- **The service's tile cache** (`/tile/{z}/{y}/{x}`) when it advertises a fused cache built on the standard Web Mercator scheme (same projection, same top-left origin, resolutions that halve per level). Pre-rendered and CDN-friendly, so it wins whenever it applies. The cache's own LOD range becomes the source's `minzoom`/`maxzoom`.
- **The dynamic endpoint** otherwise: `/export` for MapServer, `/exportImage` for ImageServer, as a `{bbox-epsg-3857}` request template — the same mechanism GeoLibre's WMS layers already use. A cache in another projection or with a custom LOD table would render misaligned, so anything that does not match the standard scheme falls back here rather than drawing something subtly wrong.

`format=png32&transparent=true` keeps a service drawable as an overlay instead of an opaque sheet, and the service's `copyrightText` and `fullExtent` become the layer's attribution and fitted bounds.

## Two optional fields

- **Sublayers** (map service) takes ArcGIS sublayer ids, e.g. `0,2,5` → `layers=show:0,2,5`. Pasting a URL that ends in a sublayer id (`.../MapServer/3`) selects that sublayer, since `/export` itself lives on the service root. A non-numeric entry is rejected rather than dropped, because a silently ignored selection looks honored.
- **Rendering rule** (image service) takes an Esri raster function as JSON, e.g. `{"rasterFunction":"Hillshade"}`, validated up front so a bad rule surfaces in the dialog instead of as an error image on every tile.

Either choice forces the dynamic path: a fused cache was rendered before the choice existed and cannot honor it.

## Token handling

Unlike the feature path, a raster tile cannot be fetched without its token in the URL, so the token travels in the tile template and the layer carries `metadata.hasAccessToken`. `redactCredentials` (core) already strips the `token` parameter from any project that leaves the app through sharing, embedding, or collaboration.

## Verified in the app

Driven in the running app with Playwright against real, keyless public services, in **both light and dark themes**:

| Path | Service | Result |
| --- | --- | --- |
| Dynamic `/export` | USGS National Boundaries (`carto.nationalmap.gov/.../govunits/MapServer`) | State/county boundaries and labels drawn over the basemap |
| Dynamic `/exportImage` + rendering rule | USGS 3DEP (`elevation.nationalmap.gov/.../3DEPElevation/ImageServer`) | Hillshade terrain |
| Cached `/tile/{z}/{y}/{x}` | USGS Imagery (`basemap.nationalmap.gov/.../USGSImageryOnly/MapServer`) | `/tile/...` requests, imagery rendered |
| Sublayer selection | govunits with `27, 28` | `layers=show:27,28`, only Native American Areas drawn |

A page reload plus session restore brought all four layers back rendering, confirming the project round trip.

## Also in this PR

- 15 new unit tests (`tests/arcgis-image-service.test.ts`) covering both endpoints, cache detection and both fallback cases, sublayer and rendering-rule handling, URL validation, portal-item resolution, and token propagation; plus service-library round-trip tests in `tests/apply-service.test.ts`.
- Saved services keep the new layer types: `arcgisFieldsToOptions` now narrows the stored `layerType` against the full union instead of coercing anything unknown to `feature`, so a saved map service loaded from the Browser panel no longer comes back as the wrong service.
- Two sample entries (US boundaries, USGS 3DEP hillshade) in the Add Data sample picker.
- All 17 locale catalogs translated, not just `en.json`.
- Docs: a new **ArcGIS services** section in `docs/user-guide/adding-data.md`, plus `features.md` and `project-format.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ArcGIS MapServer and ImageServer layers.
  * Configure sublayers and raster rendering rules when adding services.
  * Supports service URLs and portal items, with cached or dynamic rendering where available.
  * Preserves ArcGIS service options when saving and reopening layers.

* **Documentation**
  * Updated user guides and supported-service documentation.

* **Localization**
  * Added translated labels, hints, and placeholders for the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->