### PR TITLE
Enable topological polygon digitizing

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.10.2",
+    "maplibre-gl-geo-editor": "^0.10.3",
     "maplibre-gl-geoagent": "^0.5.6",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.10.2",
+        "maplibre-gl-geo-editor": "^0.10.3",
         "maplibre-gl-geoagent": "^0.5.6",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
@@ -17044,9 +17044,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.2.tgz",
-      "integrity": "sha512-DdXsxSWcqBC22SJh4EgzZOuTLNdTD/2JQI6e+7OGsMv0rgQ50YKhRioZe6tL6DTfozqyh6wq1E8gRevcZiEM+w==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.3.tgz",
+      "integrity": "sha512-Ab5USKUbau3CKnKf/daAahKgxXm/+EpwqKRaRtD7+0ikHvRFHggPCIQAOz2NDjpFTNqD8pSUTipLMVAHbfCvWQ==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -22454,7 +22454,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.10.2",
+        "maplibre-gl-geo-editor": "^0.10.3",
         "maplibre-gl-geoagent": "^0.5.6",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.10.2",
+    "maplibre-gl-geo-editor": "^0.10.3",
     "maplibre-gl-geoagent": "^0.5.6",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",


### PR DESCRIPTION
## Summary

- upgrade `maplibre-gl-geo-editor` to 0.10.3
- add topology-safe polygon digitizing with exact shared boundaries
- propagate shared-node edits across adjacent polygons
- keep topology edits together as one undoable operation

Addresses https://github.com/opengeos/GeoLibre/discussions/1735

Upstream implementation: https://github.com/opengeos/maplibre-gl-geo-editor/pull/40
Release: https://github.com/opengeos/maplibre-gl-geo-editor/releases/tag/v0.10.3

## Testing

- `npm run build`
- pre-commit checks for all changed files
- verified overlapping polygon clipping produces byte-identical shared boundary coordinates
- verified moving a shared node updates both adjacent polygons
- verified Undo restores both polygons together
- verified light and dark themes with no browser console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the map editing component to version 0.10.3.
  * Applied the update consistently across the desktop app and plugin integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->