### PR TITLE
feat(collaboration): portable snapshots and navigable map comments

### DIFF
--- a/apps/geolibre-desktop/src/components/comments/AddCommentDialog.tsx
+++ b/apps/geolibre-desktop/src/components/comments/AddCommentDialog.tsx
@@ -12,6 +12,9 @@ import {
 } from "@geolibre/ui";
 import { MapPin, Layers, MessageSquare, Send, User } from "lucide-react";
 import type { PendingCommentState } from "./useCommentTool";
+import { formatShortcut, isMacPlatform, matchesShortcut, type Shortcut } from "../../lib/commands";
+
+export const POST_COMMENT_SHORTCUT: Shortcut = { key: "Enter", mod: true };
 
 interface AddCommentDialogProps {
   pendingComment: PendingCommentState;
@@ -34,6 +37,8 @@ export function AddCommentDialog({ pendingComment, onSubmit, onCancel }: AddComm
 
   const [text, setText] = useState("");
   const [authorName, setAuthorName] = useState(savedName ?? "");
+  const canSubmit = !!text.trim() && (hasSavedName || !!authorName.trim());
+  const shortcutLabel = formatShortcut(POST_COMMENT_SHORTCUT, isMacPlatform());
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -74,7 +79,19 @@ export function AddCommentDialog({ pendingComment, onSubmit, onCancel }: AddComm
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-3.5">
+        <form
+          onSubmit={handleSubmit}
+          onKeyDown={(event) => {
+            if (
+              canSubmit &&
+              matchesShortcut(event.nativeEvent, POST_COMMENT_SHORTCUT, isMacPlatform())
+            ) {
+              event.preventDefault();
+              event.currentTarget.requestSubmit();
+            }
+          }}
+          className="space-y-3.5"
+        >
           <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 p-2.5 rounded-md border border-border/60">
             {anchor.type === "feature" ? (
               <>
@@ -163,10 +180,13 @@ export function AddCommentDialog({ pendingComment, onSubmit, onCancel }: AddComm
               variant="default"
               size="sm"
               className="gap-1.5"
-              disabled={!text.trim() || (!hasSavedName && !authorName.trim())}
+              disabled={!canSubmit}
+              title={t("comments.postShortcutTooltip", { shortcut: shortcutLabel })}
+              aria-keyshortcuts="Control+Enter Meta+Enter"
             >
               <Send className="h-3.5 w-3.5" />
-              <span>Post Comment</span>
+              <span>{t("comments.post")}</span>
+              <kbd className="ms-1 text-[10px] font-normal opacity-70">{shortcutLabel}</kbd>
             </Button>
           </div>
         </form>

--- a/apps/geolibre-desktop/src/components/comments/AddCommentDialog.tsx
+++ b/apps/geolibre-desktop/src/components/comments/AddCommentDialog.tsx
@@ -14,7 +14,9 @@ import { MapPin, Layers, MessageSquare, Send, User } from "lucide-react";
 import type { PendingCommentState } from "./useCommentTool";
 import { formatShortcut, isMacPlatform, matchesShortcut, type Shortcut } from "../../lib/commands";
 
-export const POST_COMMENT_SHORTCUT: Shortcut = { key: "Enter", mod: true };
+// `shift` is explicit: omitting it means "ignored", which would post on
+// Ctrl/⌘+Shift+Enter too, a chord the button never advertises.
+export const POST_COMMENT_SHORTCUT: Shortcut = { key: "Enter", mod: true, shift: false };
 
 interface AddCommentDialogProps {
   pendingComment: PendingCommentState;

--- a/apps/geolibre-desktop/src/components/comments/CommentMapOverlay.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentMapOverlay.tsx
@@ -131,10 +131,17 @@ export function CommentMapOverlay({
 
         const pinColor = comment.author?.color || "#3b82f6";
 
+        // MapLibre writes its geographic translate transform onto the marker
+        // element itself. Keep that outer element transform-free and animate a
+        // child instead; a hover transform on `container` would replace
+        // MapLibre's translate and make the marker jump across the viewport.
         const container = document.createElement("div");
-        container.className =
-          "group relative cursor-pointer select-none transition-transform duration-150 ease-out hover:scale-[1.15]";
+        container.className = "relative cursor-pointer select-none";
         container.style.zIndex = comment.resolved ? "9" : "10";
+
+        const hoverTarget = document.createElement("div");
+        hoverTarget.className =
+          "origin-bottom transition-transform duration-150 ease-out hover:scale-[1.15]";
 
         // Build the pin with DOM APIs so the author color is set as a style
         // property, never interpolated into markup — defense-in-depth against
@@ -159,7 +166,8 @@ export function CommentMapOverlay({
           "transform:rotate(45deg);color:#ffffff;font-size:11px;font-weight:700;font-family:system-ui,sans-serif;line-height:1";
         label.textContent = `#${idx + 1}`;
         pin.appendChild(label);
-        container.appendChild(pin);
+        hoverTarget.appendChild(pin);
+        container.appendChild(hoverTarget);
 
         container.addEventListener("click", (e) => {
           e.stopPropagation();

--- a/apps/geolibre-desktop/src/components/comments/CommentThread.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentThread.tsx
@@ -21,6 +21,7 @@ interface CommentThreadProps {
   onDelete: (commentId: string) => void;
   onZoomTo: (comment: ProjectComment) => void;
   readOnly?: boolean;
+  selected?: boolean;
 }
 
 export function CommentThread({
@@ -31,6 +32,7 @@ export function CommentThread({
   onDelete,
   onZoomTo,
   readOnly = false,
+  selected = false,
 }: CommentThreadProps) {
   const { t } = useTranslation();
   const [replyText, setReplyText] = useState("");
@@ -51,6 +53,7 @@ export function CommentThread({
         comment.resolved
           ? "bg-muted/30 border-border/40 opacity-70"
           : "bg-card border-border shadow-xs hover:border-border/80",
+        selected && "border-primary ring-1 ring-inset ring-primary",
       )}
     >
       {/* Thread Header */}

--- a/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
@@ -15,6 +15,7 @@ import {
   Check,
 } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
+import { useTranslation } from "react-i18next";
 import { CommentThread } from "./CommentThread";
 import { resolveCommentCoordinates } from "./CommentMapOverlay";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
@@ -66,6 +67,7 @@ export function CommentsPanel({
   selectedCommentId,
   onClearSelectedComment,
 }: CommentsPanelProps) {
+  const { t } = useTranslation();
   const comments = useAppStore((s) => s.comments);
   const replyToComment = useAppStore((s) => s.replyToComment);
   const toggleResolveComment = useAppStore((s) => s.toggleResolveComment);
@@ -342,7 +344,7 @@ export function CommentsPanel({
                 size="sm"
                 onClick={handleCopySessionUrl}
                 className="h-7 px-2 text-[11px] shrink-0"
-                title="Copy session URL"
+                title={t("collaborate.copyLink")}
               >
                 <Copy className="h-3 w-3 me-1" />
                 {copied ? "Copied" : "Copy"}

--- a/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
+++ b/apps/geolibre-desktop/src/components/comments/CommentsPanel.tsx
@@ -51,6 +51,10 @@ interface CommentsPanelProps {
   /** Called when the resolved-pins visibility should change. Receives `true`
    *  when the "Resolved" or "All" filter is active, `false` for "Open". */
   onShowResolvedChange?: (showResolved: boolean) => void;
+  /** Comment selected from its map marker. The matching card is revealed,
+   * highlighted, and scrolled into view. */
+  selectedCommentId?: string | null;
+  onClearSelectedComment?: () => void;
 }
 
 export function CommentsPanel({
@@ -59,6 +63,8 @@ export function CommentsPanel({
   onActivateCommentTool,
   isCommentToolActive,
   onShowResolvedChange,
+  selectedCommentId,
+  onClearSelectedComment,
 }: CommentsPanelProps) {
   const comments = useAppStore((s) => s.comments);
   const replyToComment = useAppStore((s) => s.replyToComment);
@@ -67,6 +73,36 @@ export function CommentsPanel({
   const collab = useAppStore((s) => s.collaboration);
 
   const [filter, setFilter] = useState<"all" | "open" | "resolved">("open");
+  const commentCardRefs = useRef(new Map<string, HTMLDivElement>());
+  const revealedSelectionRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedCommentId) {
+      revealedSelectionRef.current = null;
+      return;
+    }
+    if (revealedSelectionRef.current === selectedCommentId) return;
+    const selected = comments.find((comment) => comment.id === selectedCommentId);
+    if (!selected) return;
+    revealedSelectionRef.current = selectedCommentId;
+
+    // A resolved marker can remain visible after the panel was displaced and
+    // remounted with its default Open filter. Reveal whichever filter contains
+    // the selected card before trying to scroll to it.
+    if ((selected.resolved && filter === "open") || (!selected.resolved && filter === "resolved")) {
+      setFilter(selected.resolved ? "resolved" : "open");
+    }
+  }, [comments, filter, selectedCommentId]);
+
+  useEffect(() => {
+    if (!selectedCommentId) return;
+    const frame = requestAnimationFrame(() => {
+      commentCardRefs.current
+        .get(selectedCommentId)
+        ?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [filter, selectedCommentId]);
 
   // Notify parent whenever resolved pins should show/hide so the map overlay
   // stays in sync with the sidebar filter.
@@ -112,10 +148,12 @@ export function CommentsPanel({
   // The real session code comes from the store once start() has resolved.
   const activeCode = collab.sessionId ?? "";
 
-  const handleCopyCode = async () => {
+  const handleCopySessionUrl = async () => {
     if (!activeCode) return;
     try {
-      await navigator.clipboard.writeText(activeCode);
+      const sessionUrl = new URL(window.location.href);
+      sessionUrl.searchParams.set("collab", activeCode);
+      await navigator.clipboard.writeText(sessionUrl.toString());
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
@@ -225,6 +263,9 @@ export function CommentsPanel({
           >
             <Plus className="h-3.5 w-3.5" />
             <span>Add Comment</span>
+            <kbd className="ms-1 rounded border border-current/25 px-1 font-mono text-[9px] leading-4 opacity-70">
+              C
+            </kbd>
           </Button>
         )}
       </div>
@@ -299,9 +340,9 @@ export function CommentsPanel({
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={handleCopyCode}
+                onClick={handleCopySessionUrl}
                 className="h-7 px-2 text-[11px] shrink-0"
-                title="Copy session code"
+                title="Copy session URL"
               >
                 <Copy className="h-3 w-3 me-1" />
                 {copied ? "Copied" : "Copy"}
@@ -392,7 +433,10 @@ export function CommentsPanel({
           <button
             key={f}
             type="button"
-            onClick={() => setFilter(f)}
+            onClick={() => {
+              onClearSelectedComment?.();
+              setFilter(f);
+            }}
             className={cn(
               "flex-1 py-1 px-2 text-[11px] font-medium rounded transition-colors text-center",
               filter === f
@@ -426,17 +470,29 @@ export function CommentsPanel({
           <div className="space-y-3">
             {filteredComments.map((comment) => {
               const originalIndex = comments.findIndex((c) => c.id === comment.id);
+              const selected = comment.id === selectedCommentId;
               return (
-                <CommentThread
+                <div
                   key={comment.id}
-                  comment={comment}
-                  index={originalIndex >= 0 ? originalIndex : 0}
-                  onReply={handleReply}
-                  onToggleResolve={handleToggleResolve}
-                  onDelete={handleDelete}
-                  onZoomTo={handleZoomTo}
-                  readOnly={!canModifyComments}
-                />
+                  ref={(element) => {
+                    if (element) commentCardRefs.current.set(comment.id, element);
+                    else commentCardRefs.current.delete(comment.id);
+                  }}
+                  data-comment-id={comment.id}
+                  data-selected={selected || undefined}
+                  className="rounded-lg"
+                >
+                  <CommentThread
+                    comment={comment}
+                    index={originalIndex >= 0 ? originalIndex : 0}
+                    onReply={handleReply}
+                    onToggleResolve={handleToggleResolve}
+                    onDelete={handleDelete}
+                    onZoomTo={handleZoomTo}
+                    readOnly={!canModifyComments}
+                    selected={selected}
+                  />
+                </div>
               );
             })}
           </div>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -833,6 +833,7 @@ export function DesktopShell({
   const collaboration = useCollaboration(mapControllerRef);
   const commentTool = useCommentTool({ mapControllerRef, collaboration });
   const [showResolvedComments, setShowResolvedComments] = useState(false);
+  const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null);
   const collaborateDialogOpen = useAppStore((s) => s.ui.collaborateDialogOpen);
   const setCollaborateDialogOpen = useAppStore((s) => s.setCollaborateDialogOpen);
   // When opened via a `?collab=<code>` share link, auto-open the Collaborate
@@ -2142,6 +2143,7 @@ export function DesktopShell({
             }}
             onToggleThemeMode={onToggleThemeMode}
             onOpenBasemapExtract={() => setBasemapExtractOpen(true)}
+            onAddComment={commentTool.toggleTool}
             viewer={layoutOptions.viewer}
           />
         </SectionErrorBoundary>
@@ -2168,6 +2170,8 @@ export function DesktopShell({
                 onActivateCommentTool={commentTool.toggleTool}
                 isCommentToolActive={commentTool.isActive}
                 onShowResolvedChange={setShowResolvedComments}
+                selectedCommentId={selectedCommentId}
+                onClearSelectedComment={() => setSelectedCommentId(null)}
               />,
               commentsContentEl,
             )
@@ -2305,7 +2309,10 @@ export function DesktopShell({
               <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
               <CommentMapOverlay
                 mapControllerRef={mapControllerRef}
-                onSelectComment={() => openRightPanel(COMMENTS_PANEL_ID)}
+                onSelectComment={(commentId) => {
+                  setSelectedCommentId(commentId);
+                  openRightPanel(COMMENTS_PANEL_ID);
+                }}
                 showResolved={showResolvedComments}
               />
               <MapContextMenu

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -426,9 +426,12 @@ export function SettingsDialog({
       closeRightPanel(BROWSER_PANEL_ID);
     }
   };
+  // Collapsed for the same reason as Browser above, and to match the state
+  // Comments registers itself in on mount.
   const toggleCommentsPanel = (show: boolean) => {
     if (show) {
       openRightPanel(COMMENTS_PANEL_ID);
+      collapseRightPanel(COMMENTS_PANEL_ID);
     } else {
       closeRightPanel(COMMENTS_PANEL_ID);
     }

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -429,7 +429,6 @@ export function SettingsDialog({
   const toggleCommentsPanel = (show: boolean) => {
     if (show) {
       openRightPanel(COMMENTS_PANEL_ID);
-      collapseRightPanel(COMMENTS_PANEL_ID);
     } else {
       closeRightPanel(COMMENTS_PANEL_ID);
     }

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1748,8 +1748,9 @@ export function TopToolbar({
   // The shortcut layer is narrowed rather than switched off, because the View
   // menu *does* stay visible in this mode: `view.*` is camera and theme work
   // only, so dropping its keys would leave those items clickable but silently
-  // keyless. Every command carrying a `shortcut` is either `view.*` or
-  // `project.*`, so this is the whole authoring keyboard surface.
+  // keyless. Everything else carrying a `shortcut` authors the project
+  // (`project.*`, `add.comment`), so filtering to `view.*` drops exactly the
+  // authoring keyboard surface.
   const shortcutCommands = useMemo(
     () => (viewer ? commands.filter((command) => command.id.startsWith("view.")) : commands),
     [commands, viewer],

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -187,6 +187,8 @@ interface TopToolbarProps {
   // Opens the Offline Basemap Extract panel, mounted in DesktopShell over the
   // map so it can stay non-modal (the map is interactive for drawing a bbox).
   onOpenBasemapExtract: () => void;
+  /** Activates the map tool for placing an anchored review comment. */
+  onAddComment: () => void;
   viewer?: boolean;
 }
 
@@ -204,6 +206,7 @@ export function TopToolbar({
   onOpenProjectHistory,
   onToggleThemeMode,
   onOpenBasemapExtract,
+  onAddComment,
   viewer = false,
 }: TopToolbarProps) {
   const { t, i18n } = useTranslation();
@@ -1330,6 +1333,15 @@ export function TopToolbar({
       title: t("toolbar.command.addDuckdbLayer"),
       group: t("toolbar.commandGroup.addData"),
       run: addLayer.duckdb,
+    },
+    {
+      id: "add.comment",
+      title: t("comments.addDialogTitle"),
+      group: t("toolbar.commandGroup.addData"),
+      keywords: "review note feedback",
+      icon: MessageSquare,
+      shortcut: { key: "c", shift: false },
+      run: onAddComment,
     },
     // Processing
     {

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -13,7 +13,10 @@ import type { RefObject } from "react";
 import type { MapController } from "@geolibre/map";
 import type { Map as MapLibreMap } from "maplibre-gl";
 import i18n from "../i18n";
-import { buildProjectEgressSnapshot } from "../lib/build-project-snapshot";
+import {
+  buildCollaborationSnapshot,
+  buildProjectEgressSnapshot,
+} from "../lib/build-project-snapshot";
 import { projectChanged } from "../lib/project-broadcast-changed";
 import {
   CollabConnection,
@@ -49,6 +52,7 @@ export function useCollaboration(
   const teardownRef = useRef<(() => void) | null>(null);
   const lastContentRef = useRef<string | null>(null);
   const revRef = useRef(0);
+  const snapshotRequestRef = useRef(0);
   const selfIdRef = useRef<string | null>(null);
   const syncPausedRef = useRef(false);
   const restoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -74,9 +78,13 @@ export function useCollaboration(
     return self?.editOverride ?? c.mode === "co-edit";
   };
 
-  const sendSnapshot = (): void => {
+  const sendSnapshot = async (): Promise<void> => {
     if (!canEdit() || syncPausedRef.current) return;
-    const project = buildProjectEgressSnapshot(mapControllerRef);
+    const request = ++snapshotRequestRef.current;
+    const project = await buildCollaborationSnapshot(mapControllerRef);
+    // Materializing control-managed vector data is asynchronous. Discard an
+    // older result if a newer broadcast started while it was being read.
+    if (request !== snapshotRequestRef.current || !canEdit() || syncPausedRef.current) return;
     const content = serializeProject(project);
     if (content === lastContentRef.current) return;
     lastContentRef.current = content;
@@ -134,6 +142,13 @@ export function useCollaboration(
           });
         }
         if (message.snapshot) applyRemoteSnapshot(message.snapshot, true);
+        // Guests follow the host by default. Apply the host's latest presence
+        // immediately instead of waiting for their next moveend event.
+        if (message.role === "guest" && useAppStore.getState().collaboration.followHost) {
+          const host = message.participants.find((participant) => participant.role === "host");
+          const hostView = host ? message.presence[host.clientId]?.view : null;
+          if (hostView) mapControllerRef.current?.applyView(hostView);
+        }
         const pending = pendingConnectRef.current;
         pendingConnectRef.current = null;
         pending?.resolve();
@@ -211,7 +226,7 @@ export function useCollaboration(
       if (debounce) clearTimeout(debounce);
       debounce = setTimeout(() => {
         debounce = null;
-        sendSnapshot();
+        void sendSnapshot();
       }, SNAPSHOT_DEBOUNCE_MS);
     };
 
@@ -293,6 +308,9 @@ export function useCollaboration(
       mode: "co-edit",
       clientId: selfIdRef.current,
       participants: [selfParticipant],
+      // A participant joining an existing session normally wants to arrive at
+      // and stay with the host's viewport. They can turn this off at any time.
+      followHost: !hostToken,
       error: null,
     });
 
@@ -329,6 +347,7 @@ export function useCollaboration(
   };
 
   const disconnect = (): void => {
+    snapshotRequestRef.current += 1;
     teardownRef.current?.();
     teardownRef.current = null;
     if (pendingConnectRef.current) {

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -88,9 +88,11 @@ export function useCollaboration(
     } catch {
       // Materializing control-managed vector data can fail (the plugin chunk
       // or a DuckDB query). Surface it so the participant knows their edits
-      // stopped propagating, but only for the newest request: a stale failure
-      // must not overwrite the state of the broadcast that superseded it.
-      if (request === snapshotRequestRef.current) {
+      // stopped propagating, but only for the newest request that is still
+      // allowed to broadcast: a stale failure, or one racing a relay error
+      // that already paused sync, must not overwrite the message the user
+      // needs to see.
+      if (request === snapshotRequestRef.current && canEdit() && !syncPausedRef.current) {
         useAppStore.getState().setCollaboration({ error: i18n.t("collaborate.shareFailed") });
       }
       return;

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -82,7 +82,19 @@ export function useCollaboration(
   const sendSnapshot = async (): Promise<void> => {
     if (!canEdit() || syncPausedRef.current) return;
     const request = ++snapshotRequestRef.current;
-    const project = await buildCollaborationSnapshot(mapControllerRef);
+    let project: GeoLibreProject;
+    try {
+      project = await buildCollaborationSnapshot(mapControllerRef);
+    } catch {
+      // Materializing control-managed vector data can fail (the plugin chunk
+      // or a DuckDB query). Surface it so the participant knows their edits
+      // stopped propagating, but only for the newest request: a stale failure
+      // must not overwrite the state of the broadcast that superseded it.
+      if (request === snapshotRequestRef.current) {
+        useAppStore.getState().setCollaboration({ error: i18n.t("collaborate.shareFailed") });
+      }
+      return;
+    }
     // Materializing control-managed vector data is asynchronous. Discard an
     // older result if a newer broadcast started while it was being read.
     if (request !== snapshotRequestRef.current || !canEdit() || syncPausedRef.current) return;

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -25,6 +25,7 @@ import {
   sessionWsUrl,
 } from "../lib/collab-client";
 import type { CommentMutationAction, ServerMessage } from "../lib/collab-protocol";
+import { mergeInboundCollaborationProject } from "../lib/collaboration-project";
 
 const SNAPSHOT_DEBOUNCE_MS = 250;
 const CURSOR_THROTTLE_MS = 40;
@@ -101,8 +102,9 @@ export function useCollaboration(
   };
 
   const applyRemoteSnapshot = (project: GeoLibreProject, initial: boolean): void => {
-    const localView = mapControllerRef.current?.readView() ?? useAppStore.getState().mapView;
-    const merged: GeoLibreProject = { ...project, mapView: localView };
+    const state = useAppStore.getState();
+    const localView = mapControllerRef.current?.readView() ?? state.mapView;
+    const merged = mergeInboundCollaborationProject(project, localView, state.projectPlugins);
     if (initial) {
       useAppStore
         .getState()
@@ -141,7 +143,16 @@ export function useCollaboration(
             view: entry.view,
           });
         }
-        if (message.snapshot) applyRemoteSnapshot(message.snapshot, true);
+        if (message.snapshot) {
+          applyRemoteSnapshot(message.snapshot, true);
+        } else if (message.role === "host") {
+          // A newly created session has no relay snapshot yet. The store
+          // subscription only observes changes made after attach(), so without
+          // this seed a project (especially external-plugin layers loaded
+          // before starting collaboration) stays invisible to the first guest
+          // until the host happens to edit something.
+          void sendSnapshot();
+        }
         // Guests follow the host by default. Apply the host's latest presence
         // immediately instead of waiting for their next moveend event.
         if (message.role === "guest" && useAppStore.getState().collaboration.followHost) {

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -651,6 +651,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       secondaryMapViews: state.secondaryMapViews,
       primaryMapLabel: state.primaryMapLabel,
       styleLibrary: state.projectStyleLibrary,
+      comments: state.comments,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/hooks/useRegisterCommentsPanel.ts
+++ b/apps/geolibre-desktop/src/hooks/useRegisterCommentsPanel.ts
@@ -1,4 +1,4 @@
-import { registerRightPanel } from "@geolibre/plugins";
+import { collapseRightPanel, openRightPanel, registerRightPanel } from "@geolibre/plugins";
 import { useEffect } from "react";
 import i18n from "../i18n";
 
@@ -9,8 +9,8 @@ export const COMMENTS_PANEL_ID = "comments";
  * Registers the Comments panel as a dockable right panel sharing the Style (right)
  * sidebar's rail (`replace-style`).
  *
- * Unlike the Browser panel, Comments is opt-in: opening it on mount would
- * displace Browser because dockable panels share one active registry slot.
+ * Comments is enabled by default but collapsed onto the Style rail, so it is
+ * discoverable without taking map space.
  */
 export function useRegisterCommentsPanel(): void {
   useEffect(() => {
@@ -22,6 +22,8 @@ export function useRegisterCommentsPanel(): void {
       dock: "replace-style",
       render: () => {},
     });
+    openRightPanel(COMMENTS_PANEL_ID);
+    collapseRightPanel(COMMENTS_PANEL_ID);
     return dispose;
   }, []);
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -5379,6 +5379,8 @@
     "authorNamePlaceholder": "e.g. Alex or Sarah",
     "commentLabel": "Comment / Feedback",
     "commentPlaceholder": "Type your review note or feedback here...",
+    "post": "Post Comment",
+    "postShortcutTooltip": "Post Comment ({{shortcut}})",
     "confirmDelete": "Are you sure you want to delete this comment thread?",
     "sessionDisconnected": "Session disconnected.",
     "defaultAuthorName": "Author"

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1146,6 +1146,7 @@
     "guest": "Guest",
     "connectFailed": "Could not connect to the collaboration server.",
     "copyFailed": "Could not copy to clipboard.",
+    "shareFailed": "Could not share the latest project changes.",
     "connecting": "Connecting…",
     "reconnecting": "Reconnecting…",
     "connected": "Live session active",

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -7,6 +7,7 @@ import {
 import type { RefObject } from "react";
 import type { MapController } from "@geolibre/map";
 import { getPluginManager } from "../hooks/usePlugins";
+import { prepareCollaborationLayers } from "./collaboration-layers";
 
 /**
  * Build a `GeoLibreProject` snapshot from the live store and map controller.
@@ -63,4 +64,48 @@ export function buildProjectEgressSnapshot(
   mapControllerRef: RefObject<MapController | null>,
 ): GeoLibreProject {
   return redactCredentials(buildProjectSnapshot(mapControllerRef));
+}
+
+/** Build a self-contained public snapshot for a remote collaborator. */
+export async function buildCollaborationSnapshot(
+  mapControllerRef: RefObject<MapController | null>,
+): Promise<GeoLibreProject> {
+  const state = useAppStore.getState();
+  // Keep the plugins barrel out of this module's eager dependency graph: some
+  // optional controls load browser-only SDKs at module evaluation time.
+  const { materializeEmbeddableVectorLayers } = await import("@geolibre/plugins");
+  const materialized = await materializeEmbeddableVectorLayers(state.layers);
+  const layers = prepareCollaborationLayers(useAppStore.getState().layers, materialized);
+  const snapshot = buildProjectSnapshot(mapControllerRef);
+  // Rebuild only when portability changed a layer. This keeps the ordinary
+  // snapshot path synchronous for embed consumers.
+  if (layers.every((layer, index) => layer === useAppStore.getState().layers[index])) {
+    return redactCredentials(snapshot);
+  }
+  const current = useAppStore.getState();
+  const portable = projectFromStore({
+    projectName: current.projectName,
+    mapView: mapControllerRef.current?.readView() ?? current.mapView,
+    basemapStyleUrl: current.basemapStyleUrl,
+    basemapVisible: current.basemapVisible,
+    basemapOpacity: current.basemapOpacity,
+    layers,
+    selectedLayerId: current.selectedLayerId,
+    layerGroups: current.layerGroups,
+    preferences: current.preferences,
+    plugins: snapshot.plugins,
+    legend: current.legend,
+    storymap: current.storymap,
+    models: current.models,
+    processingHistory: current.processingHistory,
+    widgets: current.widgets,
+    dashboardColumns: current.dashboardColumns,
+    mapLayout: current.mapLayout,
+    secondaryMapViews: current.secondaryMapViews,
+    primaryMapLabel: current.primaryMapLabel,
+    styleLibrary: current.projectStyleLibrary,
+    comments: current.comments,
+    metadata: current.metadata,
+  });
+  return redactCredentials(portable);
 }

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -78,17 +78,25 @@ export async function buildCollaborationSnapshot(
   // Keep the plugins barrel out of this module's eager dependency graph: some
   // optional controls load browser-only SDKs at module evaluation time.
   const { materializeEmbeddableVectorLayers } = await import("@geolibre/plugins");
-  // Read the layer array once, after the import, and feed that same array to
-  // both steps. Materializing against one revision and applying the result to
-  // a later one would strip `localFileReloadable` from a layer added during
-  // the await while leaving it without embedded features — a layer that looks
-  // portable and arrives empty. A layer added after this read is simply absent
-  // from this snapshot; the store change that added it schedules the next one.
-  const source = useAppStore.getState().layers;
-  const materialized = await materializeEmbeddableVectorLayers(source);
+  // Materialize against one layer revision and build the snapshot from that
+  // same revision. Mixing two would strip `localFileReloadable` from a layer
+  // added during the await while leaving it without embedded features (a layer
+  // that looks portable and arrives empty), and would let `layerGroups` or
+  // `selectedLayerId` name a layer the broadcast does not carry.
+  let source = useAppStore.getState().layers;
+  let materialized = await materializeEmbeddableVectorLayers(source);
+  // An edit that lands mid-read invalidates the result, so read again rather
+  // than combine revisions. Bounded: a participant editing continuously still
+  // gets a broadcast, at worst one revision behind on group membership.
+  for (let attempt = 0; attempt < 3 && useAppStore.getState().layers !== source; attempt += 1) {
+    source = useAppStore.getState().layers;
+    materialized = await materializeEmbeddableVectorLayers(source);
+  }
   const layers = prepareCollaborationLayers(source, materialized);
   // Pass the prepared layers only when portability actually rewrote one, so an
-  // unaffected project still snapshots straight from the live store.
+  // unaffected project still snapshots straight from the live store. Nothing
+  // below awaits, so the override and every field `buildProjectSnapshot` reads
+  // from the store come from the same instant.
   const changed = layers.some((layer, index) => layer !== source[index]);
   return redactCredentials(buildProjectSnapshot(mapControllerRef, changed ? { layers } : {}));
 }

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -2,6 +2,7 @@ import {
   projectFromStore,
   redactCredentials,
   useAppStore,
+  type GeoLibreLayer,
   type GeoLibreProject,
 } from "@geolibre/core";
 import type { RefObject } from "react";
@@ -20,10 +21,14 @@ import { prepareCollaborationLayers } from "./collaboration-layers";
  *
  * @param mapControllerRef - Ref to the live map controller; its `readView()`
  *   supplies the current camera.
+ * @param overrides - Replacements for store fields the caller has already
+ *   transformed. Routing every caller through this one field list keeps a new
+ *   project field from reaching one snapshot path but not another.
  * @returns The serializable project snapshot.
  */
 export function buildProjectSnapshot(
   mapControllerRef: RefObject<MapController | null>,
+  overrides: { layers?: GeoLibreLayer[] } = {},
 ): GeoLibreProject {
   const state = useAppStore.getState();
   return projectFromStore({
@@ -32,7 +37,7 @@ export function buildProjectSnapshot(
     basemapStyleUrl: state.basemapStyleUrl,
     basemapVisible: state.basemapVisible,
     basemapOpacity: state.basemapOpacity,
-    layers: state.layers,
+    layers: overrides.layers ?? state.layers,
     selectedLayerId: state.selectedLayerId,
     layerGroups: state.layerGroups,
     preferences: state.preferences,
@@ -70,42 +75,20 @@ export function buildProjectEgressSnapshot(
 export async function buildCollaborationSnapshot(
   mapControllerRef: RefObject<MapController | null>,
 ): Promise<GeoLibreProject> {
-  const state = useAppStore.getState();
   // Keep the plugins barrel out of this module's eager dependency graph: some
   // optional controls load browser-only SDKs at module evaluation time.
   const { materializeEmbeddableVectorLayers } = await import("@geolibre/plugins");
-  const materialized = await materializeEmbeddableVectorLayers(state.layers);
-  const layers = prepareCollaborationLayers(useAppStore.getState().layers, materialized);
-  const snapshot = buildProjectSnapshot(mapControllerRef);
-  // Rebuild only when portability changed a layer. This keeps the ordinary
-  // snapshot path synchronous for embed consumers.
-  if (layers.every((layer, index) => layer === useAppStore.getState().layers[index])) {
-    return redactCredentials(snapshot);
-  }
-  const current = useAppStore.getState();
-  const portable = projectFromStore({
-    projectName: current.projectName,
-    mapView: mapControllerRef.current?.readView() ?? current.mapView,
-    basemapStyleUrl: current.basemapStyleUrl,
-    basemapVisible: current.basemapVisible,
-    basemapOpacity: current.basemapOpacity,
-    layers,
-    selectedLayerId: current.selectedLayerId,
-    layerGroups: current.layerGroups,
-    preferences: current.preferences,
-    plugins: snapshot.plugins,
-    legend: current.legend,
-    storymap: current.storymap,
-    models: current.models,
-    processingHistory: current.processingHistory,
-    widgets: current.widgets,
-    dashboardColumns: current.dashboardColumns,
-    mapLayout: current.mapLayout,
-    secondaryMapViews: current.secondaryMapViews,
-    primaryMapLabel: current.primaryMapLabel,
-    styleLibrary: current.projectStyleLibrary,
-    comments: current.comments,
-    metadata: current.metadata,
-  });
-  return redactCredentials(portable);
+  // Read the layer array once, after the import, and feed that same array to
+  // both steps. Materializing against one revision and applying the result to
+  // a later one would strip `localFileReloadable` from a layer added during
+  // the await while leaving it without embedded features — a layer that looks
+  // portable and arrives empty. A layer added after this read is simply absent
+  // from this snapshot; the store change that added it schedules the next one.
+  const source = useAppStore.getState().layers;
+  const materialized = await materializeEmbeddableVectorLayers(source);
+  const layers = prepareCollaborationLayers(source, materialized);
+  // Pass the prepared layers only when portability actually rewrote one, so an
+  // unaffected project still snapshots straight from the live store.
+  const changed = layers.some((layer, index) => layer !== source[index]);
+  return redactCredentials(buildProjectSnapshot(mapControllerRef, changed ? { layers } : {}));
 }

--- a/apps/geolibre-desktop/src/lib/collaboration-layers.ts
+++ b/apps/geolibre-desktop/src/lib/collaboration-layers.ts
@@ -1,0 +1,27 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+
+/**
+ * Make local vector layers portable across a collaboration connection.
+ *
+ * Normal project saves may intentionally retain a desktop file reference and
+ * omit its features. A collaborator cannot read that path, so collaboration
+ * snapshots clear the reloadable flag and embed control-managed vector data.
+ * Plain GeoJSON layers already carry their features and only need the flag
+ * removed so the core save preparation does not strip them.
+ */
+export function prepareCollaborationLayers(
+  layers: GeoLibreLayer[],
+  materialized: ReadonlyMap<string, FeatureCollection>,
+): GeoLibreLayer[] {
+  return layers.map((layer) => {
+    let metadata = layer.metadata;
+    const collection = materialized.get(layer.id);
+    if (collection) metadata = { ...metadata, embeddedGeoJSON: collection };
+    if (metadata.localFileReloadable === true) {
+      const { localFileReloadable: _localFileReloadable, ...portableMetadata } = metadata;
+      metadata = portableMetadata;
+    }
+    return metadata === layer.metadata ? layer : { ...layer, metadata };
+  });
+}

--- a/apps/geolibre-desktop/src/lib/collaboration-project.ts
+++ b/apps/geolibre-desktop/src/lib/collaboration-project.ts
@@ -1,0 +1,25 @@
+import type { GeoLibreProject, MapViewState, ProjectPluginState } from "@geolibre/core";
+
+/**
+ * Keep participant-local runtime state out of an inbound collaboration
+ * snapshot. External plugin code is installed and activated independently on
+ * each client; applying a peer's activePluginIds would deactivate local
+ * controls and let their teardown remove every native layer they own.
+ *
+ * Plugin-created layers themselves remain in `project.layers` and are portable
+ * GeoJSON, so they still synchronize and render without synchronizing plugin
+ * lifecycle state.
+ */
+export function mergeInboundCollaborationProject(
+  project: GeoLibreProject,
+  localView: MapViewState,
+  localPlugins: ProjectPluginState | null,
+): GeoLibreProject {
+  const merged: GeoLibreProject = { ...project, mapView: localView };
+  if (localPlugins) {
+    merged.plugins = localPlugins;
+  } else {
+    delete merged.plugins;
+  }
+  return merged;
+}

--- a/apps/geolibre-desktop/src/lib/project-broadcast-changed.ts
+++ b/apps/geolibre-desktop/src/lib/project-broadcast-changed.ts
@@ -18,7 +18,14 @@ type AppState = ReturnType<typeof useAppStore.getState>;
  * The compared fields must stay aligned with `buildProjectSnapshot` (minus
  * camera): models, processing history, dashboard widgets, map grid, and the
  * project style library are part of the snapshot payload and must trigger a
- * broadcast when they change on their own.
+ * broadcast when they change on their own. Plugin activation/settings are
+ * participant-local: plugin-created layer records trigger their own broadcast,
+ * while sharing `activePluginIds` would deactivate controls on other clients.
+ * Comments are deliberately excluded:
+ * active collaboration sessions synchronize them through `comment-mutation`.
+ * Treating an inbound comment as a project change would make every peer answer
+ * it with a whole-project snapshot, allowing a comment to overwrite unrelated
+ * plugin-managed layer state.
  */
 export function projectChanged(a: AppState, b: AppState): boolean {
   return (
@@ -29,7 +36,6 @@ export function projectChanged(a: AppState, b: AppState): boolean {
     a.layers !== b.layers ||
     a.layerGroups !== b.layerGroups ||
     a.preferences !== b.preferences ||
-    a.projectPlugins !== b.projectPlugins ||
     a.legend !== b.legend ||
     a.storymap !== b.storymap ||
     a.models !== b.models ||
@@ -40,9 +46,6 @@ export function projectChanged(a: AppState, b: AppState): boolean {
     a.secondaryMapViews !== b.secondaryMapViews ||
     a.primaryMapLabel !== b.primaryMapLabel ||
     a.projectStyleLibrary !== b.projectStyleLibrary ||
-    a.metadata !== b.metadata ||
-    // Comments are part of the project snapshot (buildProjectSnapshot includes
-    // state.comments) so a change must trigger a broadcast to peers.
-    a.comments !== b.comments
+    a.metadata !== b.metadata
   );
 }

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -115,9 +115,12 @@ via `ws.serializeAttachment()` (survives hibernation). Durable storage holds the
 in-memory / per-socket attachment. Server-side enforcement: a `snapshot` from a
 guest who cannot edit (session `view-only`, or a host-set per-participant
 view-only override) is dropped with an `error: forbidden`; `set-mode` and
-`set-participant-mode` require the host token. Oversized snapshots (> ~1 MiB, the
-Cloudflare frame cap) are rejected with `error: too-large`. An empty session is
-reclaimed after a TTL via a storage alarm.
+`set-participant-mode` require the host token. Oversized snapshots (> 10 MB by
+default) are rejected with
+`error: too-large`. Hosted snapshots live in the Durable Object's SQLite table
+rather than a single key/value entry, allowing portable GeoJSON from local files
+and external plugins to exceed the storage API's per-entry limit. An empty
+session is reclaimed after a TTL via a storage alarm.
 
 ## Frontend
 
@@ -230,7 +233,19 @@ core:
 - `workers/collab-node` is the self-hostable Node/SQLite relay. It is included
   as `geolibre-collab` in the root `docker-compose.yml`; its persistent database
   is mounted at `/data/collab.sqlite`. Configure `COLLAB_MAX_SNAPSHOT_BYTES`
-  (default 1,000,000) and `COLLAB_IDLE_TTL_MS` (default two hours) when needed.
+  (default 10,000,000) and `COLLAB_IDLE_TTL_MS` (default two hours) when needed.
+
+Both relay implementations accept `COLLAB_MAX_SNAPSHOT_BYTES` as a positive
+integer number of bytes. For the Cloudflare relay, set it as a Worker variable,
+for example:
+
+```toml
+[vars]
+COLLAB_MAX_SNAPSHOT_BYTES = "10000000"
+```
+
+The configured value must remain below the deployment platform's WebSocket
+message-size limit.
 
 The hosted relay deploys to Cloudflare Workers the same way as `workers/viewer`:
 

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -116,11 +116,13 @@ in-memory / per-socket attachment. Server-side enforcement: a `snapshot` from a
 guest who cannot edit (session `view-only`, or a host-set per-participant
 view-only override) is dropped with an `error: forbidden`; `set-mode` and
 `set-participant-mode` require the host token. Oversized snapshots (> 10 MB by
-default) are rejected with
-`error: too-large`. Hosted snapshots live in the Durable Object's SQLite table
-rather than a single key/value entry, allowing portable GeoJSON from local files
-and external plugins to exceed the storage API's per-entry limit. An empty
-session is reclaimed after a TTL via a storage alarm.
+default) are rejected with `error: too-large`; the cap sits under Cloudflare's
+32 MiB ceiling on a received WebSocket message. Hosted snapshots are stored in
+chunks across rows of a SQLite table, because a Durable Object caps both a
+key/value entry and a single SQLite string at 2 MB — well under what portable
+GeoJSON from local files and external plugins needs. An empty session is
+reclaimed after a TTL via a storage alarm, which drops the chunks with the rest
+of the database.
 
 ## Frontend
 

--- a/packages/collab-core/src/session.ts
+++ b/packages/collab-core/src/session.ts
@@ -8,7 +8,11 @@ import type {
 } from "./protocol";
 import { finite, HEX_COLOR_RE } from "./internal/validate";
 
-export const MAX_SNAPSHOT_BYTES = 1_000_000;
+// Large in-memory/plugin datasets are embedded as GeoJSON in collaboration
+// snapshots so peers can render them without the originating plugin or local
+// file. Keep this comfortably below Cloudflare's 32 MiB inbound WebSocket
+// frame ceiling while allowing representative multi-layer datasets.
+export const MAX_SNAPSHOT_BYTES = 10_000_000;
 export const EMPTY_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 export const MAX_CHAT_TEXT_LENGTH = 2000;
 export const CHAT_HISTORY_LIMIT = 50;

--- a/packages/collab-core/src/session.ts
+++ b/packages/collab-core/src/session.ts
@@ -10,8 +10,10 @@ import { finite, HEX_COLOR_RE } from "./internal/validate";
 
 // Large in-memory/plugin datasets are embedded as GeoJSON in collaboration
 // snapshots so peers can render them without the originating plugin or local
-// file. Keep this comfortably below Cloudflare's 32 MiB inbound WebSocket
-// frame ceiling while allowing representative multi-layer datasets.
+// file. Keep this comfortably below Cloudflare's 32 MiB ceiling on a received
+// WebSocket message while allowing representative multi-layer datasets. Note
+// this is only the transport bound: a Durable Object caps a stored SQLite
+// string at 2 MB, so `workers/collab` splits a snapshot across rows.
 export const MAX_SNAPSHOT_BYTES = 10_000_000;
 export const EMPTY_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 export const MAX_CHAT_TEXT_LENGTH = 2000;

--- a/tests/collaboration-project-changed.test.ts
+++ b/tests/collaboration-project-changed.test.ts
@@ -83,13 +83,27 @@ describe("collaboration projectChanged", () => {
     assert.equal(projectChanged(before, useAppStore.getState()), true);
   });
 
-  it("detects project-plugin edits", () => {
+  it("keeps plugin activation and settings local to each participant", () => {
     const before = useAppStore.getState();
     useAppStore.setState({
       projectPlugins: { manifestUrls: ["https://example.com/plugin.json"] },
       isDirty: true,
     });
-    assert.equal(projectChanged(before, useAppStore.getState()), true);
+    assert.equal(projectChanged(before, useAppStore.getState()), false);
+  });
+
+  it("leaves comment synchronization to the dedicated mutation protocol", () => {
+    const before = useAppStore.getState();
+    useAppStore.getState().addComment({
+      id: "comment-1",
+      anchor: { type: "point", lngLat: [12, 34] },
+      author: { name: "Ada", color: "#123456" },
+      body: "Check this location",
+      createdAt: "2026-08-06T00:00:00.000Z",
+      resolved: false,
+      replies: [],
+    });
+    assert.equal(projectChanged(before, useAppStore.getState()), false);
   });
 
   it("ignores camera-only and UI-only churn", () => {

--- a/tests/collaboration-project-changed.test.ts
+++ b/tests/collaboration-project-changed.test.ts
@@ -86,7 +86,12 @@ describe("collaboration projectChanged", () => {
   it("keeps plugin activation and settings local to each participant", () => {
     const before = useAppStore.getState();
     useAppStore.setState({
-      projectPlugins: { manifestUrls: ["https://example.com/plugin.json"] },
+      projectPlugins: {
+        manifestUrls: ["https://example.com/plugin.json"],
+        activePluginIds: [],
+        mapControlPositions: {},
+        settings: {},
+      },
       isDirty: true,
     });
     assert.equal(projectChanged(before, useAppStore.getState()), false);

--- a/tests/collaboration-project.test.ts
+++ b/tests/collaboration-project.test.ts
@@ -10,6 +10,7 @@ describe("inbound collaboration project", () => {
     const localPlugins: ProjectPluginState = {
       activePluginIds: ["maplibre-gl-annotate-geocodes"],
       settings: { "maplibre-gl-annotate-geocodes": { collapsed: false } },
+      mapControlPositions: {},
       manifestUrls: [],
     };
     const incoming = {
@@ -20,6 +21,7 @@ describe("inbound collaboration project", () => {
       plugins: {
         activePluginIds: [],
         settings: {},
+        mapControlPositions: {},
         manifestUrls: [],
       },
     } as GeoLibreProject;
@@ -38,6 +40,7 @@ describe("inbound collaboration project", () => {
       plugins: {
         activePluginIds: ["maplibre-gl-annotate-geocodes"],
         settings: {},
+        mapControlPositions: {},
         manifestUrls: [],
       },
     } as GeoLibreProject;

--- a/tests/collaboration-project.test.ts
+++ b/tests/collaboration-project.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { GeoLibreProject, ProjectPluginState } from "@geolibre/core";
+import { mergeInboundCollaborationProject } from "../apps/geolibre-desktop/src/lib/collaboration-project";
+
+const view = { center: [1, 2] as [number, number], zoom: 3, bearing: 0, pitch: 0 };
+
+describe("inbound collaboration project", () => {
+  it("keeps local plugin activation instead of applying a peer's stale state", () => {
+    const localPlugins: ProjectPluginState = {
+      activePluginIds: ["maplibre-gl-annotate-geocodes"],
+      settings: { "maplibre-gl-annotate-geocodes": { collapsed: false } },
+      manifestUrls: [],
+    };
+    const incoming = {
+      version: 1,
+      name: "Peer",
+      mapView: view,
+      layers: [],
+      plugins: {
+        activePluginIds: [],
+        settings: {},
+        manifestUrls: [],
+      },
+    } as GeoLibreProject;
+
+    const merged = mergeInboundCollaborationProject(incoming, view, localPlugins);
+    assert.equal(merged.plugins, localPlugins);
+    assert.deepEqual(merged.plugins?.activePluginIds, ["maplibre-gl-annotate-geocodes"]);
+  });
+
+  it("does not install or activate a plugin merely because a peer has it", () => {
+    const incoming = {
+      version: 1,
+      name: "Peer",
+      mapView: view,
+      layers: [],
+      plugins: {
+        activePluginIds: ["maplibre-gl-annotate-geocodes"],
+        settings: {},
+        manifestUrls: [],
+      },
+    } as GeoLibreProject;
+
+    const merged = mergeInboundCollaborationProject(incoming, view, null);
+    assert.equal(merged.plugins, undefined);
+  });
+});

--- a/tests/collaboration-snapshot.test.ts
+++ b/tests/collaboration-snapshot.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { FeatureCollection } from "geojson";
+import { prepareCollaborationLayers } from "../apps/geolibre-desktop/src/lib/collaboration-layers";
+import { geojsonLayer } from "./helpers/layer-fixtures";
+
+const FEATURES: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: { name: "shared" },
+      geometry: { type: "Point", coordinates: [1, 2] },
+    },
+  ],
+};
+
+describe("collaboration vector snapshots", () => {
+  it("makes path-backed plain GeoJSON portable", () => {
+    const layer = geojsonLayer({
+      id: "plain-local",
+      geojson: FEATURES,
+      metadata: { localFileReloadable: true },
+    });
+
+    const [portable] = prepareCollaborationLayers([layer], new Map());
+
+    assert.equal(portable.metadata.localFileReloadable, undefined);
+    assert.equal(portable.geojson, FEATURES);
+  });
+
+  it("embeds control-managed local vectors for collaborators", () => {
+    const layer = geojsonLayer({
+      id: "control-local",
+      geojson: undefined,
+      metadata: {
+        externalNativeLayer: true,
+        sourceKind: "maplibre-gl-vector",
+        localFileReloadable: true,
+      },
+    });
+
+    const [portable] = prepareCollaborationLayers([layer], new Map([["control-local", FEATURES]]));
+
+    assert.equal(portable.metadata.localFileReloadable, undefined);
+    assert.equal(portable.metadata.embeddedGeoJSON, FEATURES);
+  });
+});

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -52,6 +52,8 @@ function parseStoredSnapshot(snapshot: string | undefined): unknown {
 
 export interface Env {
   COLLAB_SESSION: DurableObjectNamespace<CollabSession>;
+  /** Optional deployment-specific snapshot ceiling, expressed in bytes. */
+  COLLAB_MAX_SNAPSHOT_BYTES?: string;
 }
 
 // The snapshot cap, empty-session TTL, and chat limits now live in
@@ -89,6 +91,46 @@ type PresenceState = PresenceEntry;
 export class CollabSession extends DurableObject<Env> {
   // Re-established lazily after a hibernation wake; never persisted.
   private presence = new Map<string, PresenceState>();
+
+  private maxSnapshotBytes(): number {
+    const configured = Number(this.env.COLLAB_MAX_SNAPSHOT_BYTES);
+    return Number.isSafeInteger(configured) && configured > 0 ? configured : MAX_SNAPSHOT_BYTES;
+  }
+
+  /**
+   * Snapshots can exceed Durable Objects' 2 MiB key/value entry limit once
+   * portable GeoJSON from local files or external plugins is embedded. The
+   * SQLite-backed class has no such per-value KV ceiling, so keep the project
+   * in a one-row SQL table. Read the legacy KV key as a migration fallback for
+   * sessions created before this table existed.
+   */
+  private readSqlSnapshot(): string | undefined {
+    this.ctx.storage.sql.exec(
+      "CREATE TABLE IF NOT EXISTS collab_snapshot (id INTEGER PRIMARY KEY CHECK (id = 1), value TEXT NOT NULL)",
+    );
+    // Not `.one()`: that throws unless the result set holds exactly one row,
+    // so a session that has not stored a snapshot yet would fail instead of
+    // falling through to the legacy KV read below.
+    const row = this.ctx.storage.sql
+      .exec<{ value: string }>("SELECT value FROM collab_snapshot WHERE id = 1")
+      .toArray()[0];
+    return row?.value;
+  }
+
+  private async readSnapshot(): Promise<string | undefined> {
+    const sqlSnapshot = this.readSqlSnapshot();
+    if (sqlSnapshot !== undefined) return sqlSnapshot;
+    return this.ctx.storage.get<string>("snapshot");
+  }
+
+  private async writeSnapshot(snapshot: string): Promise<void> {
+    this.ctx.storage.sql.exec(
+      "INSERT INTO collab_snapshot (id, value) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET value = excluded.value",
+      snapshot,
+    );
+    // A migrated session must not retain a second, stale copy.
+    await this.ctx.storage.delete("snapshot");
+  }
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -251,7 +293,7 @@ export class CollabSession extends DurableObject<Env> {
       this.ctx.storage.get<string>("hostToken"),
       this.ctx.storage.get<CollaborationMode>("mode"),
       this.ctx.storage.get<number>("rev"),
-      this.ctx.storage.get<string>("snapshot"),
+      this.readSnapshot(),
       this.ctx.storage.get<string>("chat"),
     ]);
 
@@ -307,7 +349,7 @@ export class CollabSession extends DurableObject<Env> {
     // A host-set per-participant override takes precedence over the session
     // default, so a single guest can be pinned to view-only (or granted edit) in
     // an otherwise co-edit (or view-only) session (#754, Part 3).
-    const decision = authorizeSnapshot(attachment, mode, byteLength);
+    const decision = authorizeSnapshot(attachment, mode, byteLength, this.maxSnapshotBytes());
     if (!decision.ok) {
       this.send(ws, {
         type: "error",
@@ -325,16 +367,14 @@ export class CollabSession extends DurableObject<Env> {
     // project below, which heals a sender that had drifted.
     const project = preserveStoredComments(
       message.project ?? null,
-      parseStoredSnapshot(await this.ctx.storage.get<string>("snapshot")),
+      parseStoredSnapshot(await this.readSnapshot()),
     );
     // `rev` is written during /init before any socket can join, so the stored
     // value is always present; the `?? 0` is a defensive floor, never the
     // client's counter (a server-owned monotonic value must not trust input).
     const rev = ((await this.ctx.storage.get<number>("rev")) ?? 0) + 1;
-    await this.ctx.storage.put({
-      snapshot: JSON.stringify(project),
-      rev,
-    });
+    await this.writeSnapshot(JSON.stringify(project));
+    await this.ctx.storage.put("rev", rev);
 
     this.broadcast(
       {
@@ -678,7 +718,7 @@ export class CollabSession extends DurableObject<Env> {
     // Persist even when no full project snapshot has been written yet, so early
     // comments survive late joiners / reconnects. Seed an empty object when
     // storage is empty or corrupt — the relay never inspects other project fields.
-    const rawSnapshot = await this.ctx.storage.get<string>("snapshot");
+    const rawSnapshot = await this.readSnapshot();
     let parsed: Record<string, unknown> = { comments: [] };
     if (rawSnapshot) {
       try {
@@ -763,7 +803,7 @@ export class CollabSession extends DurableObject<Env> {
       // `handleSnapshot` bounds a full project the same way. Check before the
       // put so an oversized value surfaces as an error the sender can see
       // rather than a throw the catch below would have to guess at.
-      if (ENCODER.encode(serialized).length > MAX_SNAPSHOT_BYTES) {
+      if (ENCODER.encode(serialized).length > this.maxSnapshotBytes()) {
         this.send(ws, {
           type: "error",
           code: "bad-message",
@@ -771,7 +811,7 @@ export class CollabSession extends DurableObject<Env> {
         });
         return;
       }
-      await this.ctx.storage.put("snapshot", serialized);
+      await this.writeSnapshot(serialized);
     } catch {
       // The mutation never reached storage, so a late joiner or a reconnect
       // (both of which read from storage) would not see it. Tell the sender and

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -64,6 +64,11 @@ export interface Env {
 // second), so we don't allocate a new encoder per message.
 const ENCODER = new TextEncoder();
 
+// Characters per stored snapshot chunk. A Durable Object caps a SQLite string
+// at 2 MB of UTF-8, and a JS string character can encode to 4 bytes, so this
+// leaves a chunk at half the ceiling even for text that is entirely non-ASCII.
+const SNAPSHOT_CHUNK_CHARS = 256 * 1024;
+
 /**
  * The shared `SessionParticipant` state, serialized onto a hibernatable socket.
  * `editOverride`, `lastChatTs`, and `lastCommentTs` ride on the attachment so
@@ -97,24 +102,27 @@ export class CollabSession extends DurableObject<Env> {
     return Number.isSafeInteger(configured) && configured > 0 ? configured : MAX_SNAPSHOT_BYTES;
   }
 
+  private ensureSnapshotTable(): void {
+    this.ctx.storage.sql.exec(
+      "CREATE TABLE IF NOT EXISTS collab_snapshot_chunks (seq INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+    );
+  }
+
   /**
-   * Snapshots can exceed Durable Objects' 2 MiB key/value entry limit once
-   * portable GeoJSON from local files or external plugins is embedded. The
-   * SQLite-backed class has no such per-value KV ceiling, so keep the project
-   * in a one-row SQL table. Read the legacy KV key as a migration fallback for
-   * sessions created before this table existed.
+   * Read the stored project, reassembled from its chunks.
+   *
+   * Falls back to the legacy `snapshot` key/value entry so a session created
+   * before this table existed still serves late joiners.
    */
   private readSqlSnapshot(): string | undefined {
-    this.ctx.storage.sql.exec(
-      "CREATE TABLE IF NOT EXISTS collab_snapshot (id INTEGER PRIMARY KEY CHECK (id = 1), value TEXT NOT NULL)",
-    );
+    this.ensureSnapshotTable();
     // Not `.one()`: that throws unless the result set holds exactly one row,
     // so a session that has not stored a snapshot yet would fail instead of
     // falling through to the legacy KV read below.
-    const row = this.ctx.storage.sql
-      .exec<{ value: string }>("SELECT value FROM collab_snapshot WHERE id = 1")
-      .toArray()[0];
-    return row?.value;
+    const rows = this.ctx.storage.sql
+      .exec<{ value: string }>("SELECT value FROM collab_snapshot_chunks ORDER BY seq")
+      .toArray();
+    return rows.length > 0 ? rows.map((row) => row.value).join("") : undefined;
   }
 
   private async readSnapshot(): Promise<string | undefined> {
@@ -123,11 +131,29 @@ export class CollabSession extends DurableObject<Env> {
     return this.ctx.storage.get<string>("snapshot");
   }
 
+  /**
+   * Store the project across as many rows as it needs.
+   *
+   * A snapshot outgrew single-value storage once portable GeoJSON from local
+   * files and external plugins started being embedded: a Durable Object caps a
+   * key/value entry *and* a SQLite string at 2 MB, while `MAX_SNAPSHOT_BYTES`
+   * now admits several times that. Only the per-object total (10 GB) bounds a
+   * run of rows, so the project is split and rejoined on read.
+   */
   private async writeSnapshot(snapshot: string): Promise<void> {
-    this.ctx.storage.sql.exec(
-      "INSERT INTO collab_snapshot (id, value) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET value = excluded.value",
-      snapshot,
-    );
+    this.ensureSnapshotTable();
+    this.ctx.storage.sql.exec("DELETE FROM collab_snapshot_chunks");
+    for (
+      let offset = 0, seq = 0;
+      offset < snapshot.length;
+      offset += SNAPSHOT_CHUNK_CHARS, seq += 1
+    ) {
+      this.ctx.storage.sql.exec(
+        "INSERT INTO collab_snapshot_chunks (seq, value) VALUES (?, ?)",
+        seq,
+        snapshot.slice(offset, offset + SNAPSHOT_CHUNK_CHARS),
+      );
+    }
     // A migrated session must not retain a second, stale copy.
     await this.ctx.storage.delete("snapshot");
   }


### PR DESCRIPTION
## Summary
- Collaboration snapshots are now self-contained: control-managed vector data is materialized and the local-file reloadable flag is cleared, so a guest no longer joins to an empty map. A stale async snapshot is discarded if a newer broadcast starts, and the host seeds a snapshot when the relay has none (previously a project loaded before starting collaboration stayed invisible until the host edited something).
- Plugin activation and settings stay participant-local. Applying a peer's `activePluginIds` deactivated local controls and let their teardown remove the native layers they own; plugin-created layers still travel as portable GeoJSON. Comments are likewise excluded from `projectChanged` because the `comment-mutation` protocol already syncs them.
- Embedded GeoJSON outgrew the old limits, so the snapshot cap moves from 1 MB to 10 MB (configurable per deployment via `COLLAB_MAX_SNAPSHOT_BYTES`) and the Cloudflare relay stores the project in a SQLite row instead of a Durable Object key/value entry, with a fallback read for sessions created before that table existed.
- Guests apply the host's current view on join, follow-host defaults on for joiners, and the session Copy button copies a joinable `?collab=` URL rather than a bare code.
- Comments are reachable from the map: clicking a pin reveals, highlights and scrolls to its card, the panel ships collapsed on the Style rail for discoverability, comments are persisted with the project, and `C` places a new comment from the command palette. Marker hover scaling moved to a child element so it no longer fights MapLibre's translate transform.

## Test plan
- [x] `npm run build`
- [x] `npm run test:frontend` (5473 pass, 0 fail)
- [x] `npm run test:worker`
- [x] `pre-commit run --files <changed paths>`
- [ ] Host a session in one browser, join from another with the copied URL, and confirm local GeoJSON and external-plugin layers render for the guest without the host editing first
- [ ] Confirm activating a plugin control on one client does not deactivate it on the other, and that adding a comment does not revert peer layer state
- [ ] Join a session created before this change and confirm the legacy stored snapshot still loads
- [ ] Share a project large enough to exceed 1 MB and confirm it is accepted
- [ ] Confirm the guest lands on the host's viewport immediately after joining
- [ ] Click a map comment pin and confirm the matching card is revealed, highlighted and scrolled into view, including for a resolved comment
- [ ] Press `C` and confirm the comment placement tool activates
- [ ] Save and reopen a project and confirm comments survive the round trip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added synchronized comment selection between the map and Comments panel, including filtering, scrolling, and visual highlighting.
  - Added toolbar and keyboard shortcuts for creating and posting comments.
  - Comments are enabled by default and collapsed in the side rail.
  - Collaboration now shares portable local vector data and supports host viewport following.
  - Session sharing copies a complete collaboration URL.
  - Increased supported collaboration snapshot size to 10 MB.

- **Bug Fixes**
  - Improved marker hover behavior without affecting map positioning.
  - Project exports now retain comments.
  - Collaboration preserves local map and plugin settings during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->