### PR TITLE
feat(ui): add app typeface and a real dark-mode elevation ladder

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -31,6 +31,8 @@
     "@dvt3d/maplibre-three-plugin": "^1.7.1",
     "@electric-sql/pglite": "^0.5.4",
     "@electric-sql/pglite-postgis": "^0.2.4",
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@geolibre/core": "*",
     "@geolibre/embed": "*",
     "@geolibre/map": "*",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1,8 +1,31 @@
 @import "@geolibre/ui/globals.css";
+
 /* Supplies the custom-color/border-radius theme that @geolibre/ui's globals.css
    relies on via @apply (background, border, etc.). globals.css is intentionally
    config-agnostic; the consuming app provides the Tailwind config here. */
 @config "../tailwind.config.js";
+
+/* App typeface: IBM Plex Sans for UI, IBM Plex Mono for the numeric/coordinate
+   readouts (StatusBar, code, feature IDs). One matched superfamily, so the mono
+   readouts and the surrounding UI share a voice. The @font-face rules are
+   loaded from main.tsx — see the note there for why they cannot be @imported
+   here. Self-hosted rather than CDN-loaded: the desktop build must render
+   offline, and the Tauri CSP is `default-src 'self'`.
+
+   This block drives both the `font-sans`/`font-mono` utilities and Tailwind's
+   preflight default, so no `font-family` on <body> is needed.
+
+   Plex covers latin, latin-ext, cyrillic, greek and vietnamese only. The
+   locales it does NOT cover (ar, fa, hi, ja, ka, ko, th, zh) rely on per-glyph
+   fallback to the system stack below — which is why that stack must stay a
+   full, ordered list rather than a bare `sans-serif`. */
+@theme {
+  --font-sans:
+    "IBM Plex Sans Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Noto Sans", "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --font-mono:
+    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+}
 
 html,
 body,

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -1,6 +1,16 @@
 import "./lib/symbol-dispose-polyfill";
 import React from "react";
 import ReactDOM from "react-dom/client";
+/* App typeface — see the --font-sans/--font-mono note in index.css.
+   These must be imported from JS, not via `@import` in index.css: Tailwind v4
+   resolves CSS @imports itself and inlines them before Vite sees them, so the
+   relative `url(./files/*.woff2)` in fontsource's CSS is never rewritten into
+   an asset reference and no font file is emitted into dist/. The result builds
+   clean and 404s at runtime, silently falling back to system fonts. Importing
+   from JS routes the CSS through Vite's asset pipeline instead. */
+import "@fontsource-variable/ibm-plex-sans/wght.css";
+import "@fontsource/ibm-plex-mono/400.css";
+import "@fontsource/ibm-plex-mono/700.css";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import "@maplibre/maplibre-gl-directions/dist/style.css";
 import "maplibre-gl-3d-tiles/style.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,8 @@
         "@dvt3d/maplibre-three-plugin": "^1.7.1",
         "@electric-sql/pglite": "^0.5.4",
         "@electric-sql/pglite-postgis": "^0.2.4",
+        "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@geolibre/core": "*",
         "@geolibre/embed": "*",
         "@geolibre/map": "*",
@@ -3875,6 +3877,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource-variable/ibm-plex-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+      "integrity": "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@geoarrow/deck.gl-geoarrow": {
       "version": "0.4.1",

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -45,7 +45,10 @@ export const DialogContent = React.forwardRef<
       <div className={cn("grid min-h-0 flex-1 gap-4 overflow-auto", bodyClassName ?? "p-4 sm:p-6")}>
         {children}
       </div>
-      <DialogPrimitive.Close className="absolute end-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+      {/* ring-offset matches the popover surface this sits on, not --background.
+          Inert today (no ring-offset width utility is applied, so the offset
+          colour never paints) but wrong the moment one is added. */}
+      <DialogPrimitive.Close className="absolute end-4 top-4 rounded-sm opacity-70 ring-offset-popover transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -37,7 +37,7 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden border bg-background shadow-lg duration-200 supports-[not_(max-height:1dvh)]:max-h-[calc(100vh-1rem)] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden border bg-popover text-popover-foreground shadow-lg duration-200 supports-[not_(max-height:1dvh)]:max-h-[calc(100vh-1rem)] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -69,8 +69,11 @@
     --destructive-foreground: 210 40% 98%;
     --border: 220 14% 26%;
     --input: 220 12% 38%;
-    /* Matches --primary, as every non-default accent scheme below already does,
-       so the focus ring stays visible against the lifted surfaces. */
+    /* Matches --primary, so the focus ring stays visible against the lifted
+       surfaces (4.98:1 on --background, 4.64:1 on --card). The violet, rose and
+       amber schemes below already pair ring with primary this way; emerald was
+       the one exception and is brought into line there, since the lifted
+       surfaces left its darker ring almost no headroom. */
     --ring: 217.2 91.2% 59.8%;
   }
 
@@ -95,10 +98,17 @@
     --primary-foreground: 355.7 100% 97.3%;
     --ring: 142.1 76.2% 36.3%;
   }
+  /* Unlike violet/rose/amber, emerald's dark ring used to sit well below its
+     primary (142.4 71.8% 29.2%). Against the old near-black canvas that still
+     cleared the 3:1 focus-indicator floor at 3.98:1, but the lifted surfaces in
+     .dark drop it to 3.65:1 on --background and 3.13:1 on --popover — passing
+     by ~4%, so any later surface tweak would break it. Pairing ring with
+     primary restores the headroom (8.04:1 on --background) and makes the
+     ring == primary invariant hold across every scheme. */
   [data-theme="emerald"].dark {
     --primary: 142.1 70.6% 45.3%;
     --primary-foreground: 144.9 80.4% 10%;
-    --ring: 142.4 71.8% 29.2%;
+    --ring: 142.1 70.6% 45.3%;
   }
 
   [data-theme="rose"] {

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -11,42 +11,67 @@
     --popover-foreground: 222.2 84% 4.9%;
     --primary: 221.2 83.2% 53.3%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
+    /* Neutrals sit at ~16% saturation rather than the stock 40%, so the chrome
+       reads as grey next to the map instead of tinting blue. --accent is one
+       step darker than --muted so hover fills register on white surfaces. */
+    --secondary: 220 16% 96%;
     --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
+    --muted: 220 16% 96%;
     /* Darkened from 46.9% L so secondary text meets WCAG AA (4.5:1) even on the
        muted/secondary backgrounds it is paired with (e.g. kbd badges). */
     --muted-foreground: 215.4 16.3% 40%;
-    --accent: 210 40% 96.1%;
+    --accent: 220 16% 94%;
     --accent-foreground: 222.2 47.4% 11.2%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
+    /* --border is decorative (dividers, panel edges); --input is a control
+       boundary, so it is deliberately darker. See the note in .dark below. */
+    --border: 220 15% 88%;
+    --input: 220 13% 76%;
     --ring: 221.2 83.2% 53.3%;
     --radius: 0.5rem;
   }
 
+  /* Dark mode is built as an explicit elevation ladder. Previously --background,
+     --card and --popover were all 222.2 84% 4.9%, and --border, --input,
+     --muted, --secondary and --accent were all 217.2 32.6% 17.5% — five tokens,
+     one colour — so panels, dialogs and menus were indistinguishable from the
+     app canvas and only a 1px border separated them. Each step below is a
+     distinct surface:
+
+       background  9%   app canvas / base chrome
+       card       12%   toolbar, docked panels
+       popover    15%   menus, tooltips, dialogs
+       muted      20%   inset fills (status bar, wells)
+       accent     22%   hover fill — must read above popover, since menu items
+                        sit on it
+
+     Saturation also drops from 84% to ~22%: the old value was a strongly
+     blue-tinted near-black that clashed with satellite imagery in the map view.
+     Every foreground/surface pair here clears WCAG AA 4.5:1 (lowest is
+     muted-foreground on accent at 4.82:1). */
   .dark {
-    --background: 222.2 84% 4.9%;
+    --background: 222 24% 9%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+    --card: 222 22% 12%;
     --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
+    --popover: 222 21% 15%;
     --popover-foreground: 210 40% 98%;
     --primary: 217.2 91.2% 59.8%;
     --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
+    --secondary: 220 18% 20%;
     --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
+    --muted: 220 18% 20%;
     --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
+    --accent: 220 18% 22%;
     --accent-foreground: 210 40% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --border: 220 14% 26%;
+    --input: 220 12% 38%;
+    /* Matches --primary, as every non-default accent scheme below already does,
+       so the focus ring stays visible against the lifted surfaces. */
+    --ring: 217.2 91.2% 59.8%;
   }
 
   /* Accent color schemes. Each scheme overrides only the accent-bearing tokens


### PR DESCRIPTION
## What

The theme was **unmodified shadcn/ui**: the stock slate + blue palette, and no font declared anywhere — so the app rendered in Segoe UI on Windows, Roboto on Linux and SF on macOS. This is the first of a planned set of UI modernization changes (typography + elevation); shadow/motion/radius systematization is deliberately left for follow-up.

## Typography

- Self-host **IBM Plex Sans** (UI) + **IBM Plex Mono** (coordinate/numeric readouts) via `@fontsource`, driven from a Tailwind v4 `@theme` block so both the `font-sans`/`font-mono` utilities and preflight pick them up. One matched superfamily, so the `StatusBar` readout and the surrounding UI share a voice.
- No CDN: the desktop build must render offline under the Tauri CSP (`default-src 'self'`). No CSP change was needed — fonts are emitted as same-origin files, and none are inlined as `data:` URIs.

### One trap worth flagging for review

The `@font-face` rules are imported from `main.tsx`, **not** `index.css`. Tailwind v4 resolves CSS `@import`s itself and inlines them before Vite sees them, so fontsource's relative `url(./files/*.woff2)` was never rewritten into an asset reference and **zero font files were emitted into `dist/`**. That build succeeds and 404s at runtime, silently falling back to system fonts — i.e. the change would have looked done and been a no-op. Importing from JS routes the CSS through Vite's asset pipeline.

### Size

Roman weight axis only, and subsets are `unicode-range`-scoped:

| | download |
|---|---|
| Plex Sans variable, latin | 44.6 KB |
| Plex Mono 400, latin | 14.4 KB |
| **What a Latin user actually fetches** | **~59 KB** |
| Current `dist/` | 192 MB |

The `ar`/`fa`/`hi`/`ja`/`ka`/`ko`/`th`/`zh` locales fetch **zero** Plex bytes — Plex has no coverage there, so they fall through to the system stack per glyph (which is why that fallback list is kept full and ordered). `font-display: swap`, so nothing blocks first paint.

## Elevation

Dark mode had `--background`, `--card` and `--popover` all at `222.2 84% 4.9%`, and `--border`, `--input`, `--muted`, `--secondary` and `--accent` all at `217.2 32.6% 17.5%` — **five tokens, one colour**. Panels, dialogs and menus were indistinguishable from the canvas, separated only by a 1px border.

- Explicit ladder: `background 9%` / `card 12%` / `popover 15%` / `muted 20%` / `accent 22%` (accent must read above popover, since menu items sit on it).
- Dark saturation drops 84% → ~22%; the old value was a strongly blue-tinted near-black that clashed with satellite imagery in the map view. Light neutrals drop 40% → ~16% for the same reason.
- `--input` (a control boundary) is split from `--border` (decorative); they were identical.
- `Dialog` moves to `bg-popover` — it used `bg-background`, which under the new ladder would put the highest-elevation surface on the lowest step. Map-floating panels intentionally **stay** on `bg-background/90..95`: they are translucent scrims over imagery, where the base step is correct.
- Dark `--ring` now matches `--primary`, as every non-default accent scheme already does.

## Accessibility

Every foreground/surface pair clears **WCAG AA 4.5:1**; the tightest is `muted-foreground` on `accent` at **4.82:1**.

Input-border contrast improves from **1.23:1 → 1.84:1** (light) and **1.37:1 → 2.58:1** (dark). That is still short of the **3:1** WCAG 1.4.11 asks of control boundaries — both the old and new values fail it. Closing it fully needs a visibly heavier field outline (roughly `L 58%` in light), which is a design decision rather than a token tweak, so it is **left for follow-up** rather than smuggled into this PR.

## Verification

- `npm run build` — clean; font files confirmed emitted into `dist/assets/`.
- `npm run test:frontend` — **5473 pass, 0 fail**.
- `pre-commit run --files <changed>` — all hooks pass.
- Driven in the **built** app with Playwright in **both themes**: `document.fonts.check()` reports Plex Sans and Plex Mono as genuinely *loaded* (not fallback), and the three dark surfaces measure as distinct sampled pixels — canvas `(17,21,28)`, toolbar `(24,28,37)`, menu and dialog `(30,35,46)`. Light mode verified white by pixel sample.

Light mode is deliberately the smaller change here: it gets the typeface, desaturated neutrals and crisper borders, but no elevation ladder, because white-on-white surfaces there are load-bearing for the 42 map-floating panels. Light-mode depth is a shadow-scale problem, which is the follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Added IBM Plex Sans and IBM Plex Mono typography with offline and multilingual fallbacks.
  - Refined light and dark theme colors, borders, surfaces, and focus states for improved contrast and visual hierarchy.
  - Updated dialog surfaces to use popover background styling for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->