### PR TITLE
fix(vector): stop a failed restore from deleting multi-layer URL layers

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -825,6 +825,16 @@ fn ensure_fetchable_url(url: &str) -> Result<(), String> {
 
 /// A redirect policy that re-applies [`url_is_fetchable`] to every hop, so a
 /// public URL that 3xx-redirects to an internal address is not followed.
+///
+/// A blocked hop fails the request via `attempt.error` rather than
+/// `attempt.stop`: stopping makes reqwest hand the 30x response back as `Ok`,
+/// which reaches the frontend as a bland "Request failed with status 302" that
+/// [`is_ssrf_guard_error`] cannot recognise — and an unrecognised failure is
+/// retried by the webview's unguarded `fetch`, which would follow the very
+/// redirect this policy refused. Failing with [`SSRF_BLOCKED_MESSAGE`] in the
+/// error's source chain keeps that fallback closed. The hop cap still uses
+/// `stop`: an over-long but otherwise allowed chain is not an SSRF rejection
+/// and must not be reported as one.
 fn guarded_redirect_policy() -> reqwest::redirect::Policy {
     reqwest::redirect::Policy::custom(|attempt| {
         if attempt.previous().len() >= 10 {
@@ -832,9 +842,40 @@ fn guarded_redirect_policy() -> reqwest::redirect::Policy {
         }
         match url_is_fetchable(attempt.url()) {
             Ok(()) => attempt.follow(),
-            Err(_) => attempt.stop(),
+            Err(_) => attempt.error(SSRF_BLOCKED_MESSAGE),
         }
     })
+}
+
+/// True when a reqwest failure was caused by the SSRF guard rather than by the
+/// network.
+///
+/// Neither guard's rejection is visible in the top-level `Display`: the redirect
+/// policy's error is wrapped in reqwest's "error following redirect", and
+/// [`GuardedDnsResolver`]'s is wrapped by the connector. Both keep
+/// [`SSRF_BLOCKED_MESSAGE`] in the source chain, so walk it.
+fn is_ssrf_guard_error(error: &dyn std::error::Error) -> bool {
+    let mut current = Some(error);
+    while let Some(error) = current {
+        if error.to_string().contains(SSRF_BLOCKED_MESSAGE) {
+            return true;
+        }
+        current = error.source();
+    }
+    false
+}
+
+/// Renders a request failure for the frontend, preserving
+/// [`SSRF_BLOCKED_MESSAGE`] verbatim when the guard was what refused it.
+///
+/// `isBlockedUrlError` in `src/lib/vector-url-fetch.ts` matches on that wording
+/// to decide whether retrying in the webview is safe, so a guard rejection that
+/// reaches it as a generic transport error fails *open* into an unguarded fetch.
+fn request_error_message(error: &reqwest::Error) -> String {
+    if is_ssrf_guard_error(error) {
+        return SSRF_BLOCKED_MESSAGE.to_string();
+    }
+    format!("Request failed: {error}")
 }
 
 /// A DNS resolver that drops any address in a blocked range, so reqwest connects
@@ -1073,7 +1114,7 @@ fn fetch_url_bytes_blocking(url: String, timeout_secs: Option<u64>) -> Result<Ve
         .get(&url)
         .timeout(Duration::from_secs(timeout))
         .send()
-        .map_err(|error| format!("Request failed: {error}"))?;
+        .map_err(|error| request_error_message(&error))?;
     let status = response.status();
     if !status.is_success() {
         return Err(format!("Request failed with status {status}"));
@@ -1574,7 +1615,7 @@ fn resolve_url_redirect_blocking(url: String) -> Result<String, String> {
         .header("accept", "application/json, text/plain;q=0.9, */*;q=0.8")
         .timeout(timeout)
         .send()
-        .map_err(|error| format!("Request failed: {error}"))?;
+        .map_err(|error| request_error_message(&error))?;
     if has_xyz_placeholders(response.url().as_str()) {
         return Ok(response.url().to_string());
     }
@@ -4024,8 +4065,8 @@ mod tests {
     use super::{
         client_cert_is_pkcs12, client_cert_password_without_path, ensure_fetchable_url,
         is_allowed_local_vector_path, is_allowed_project_path, is_disallowed_ip,
-        is_safe_absolute_path, path_is_under, resolve_fetch_timeout_secs, tcp_table_port,
-        MAX_FETCH_TIMEOUT_SECS, REMOTE_TILE_TIMEOUT_SECS,
+        is_safe_absolute_path, is_ssrf_guard_error, path_is_under, resolve_fetch_timeout_secs,
+        tcp_table_port, MAX_FETCH_TIMEOUT_SECS, REMOTE_TILE_TIMEOUT_SECS, SSRF_BLOCKED_MESSAGE,
     };
     #[cfg(target_os = "linux")]
     use super::{linux_uses_nvidia_renderer, nvidia_is_primary_gpu};
@@ -4279,6 +4320,35 @@ mod tests {
         assert!(ensure_fetchable_url("https://1.1.1.1/").is_ok());
         assert!(ensure_fetchable_url("http://127.0.0.1:8081/tiles/0/0/0.png").is_ok());
         assert!(ensure_fetchable_url("http://[::1]:8081/data.pmtiles").is_ok());
+    }
+
+    #[test]
+    fn ssrf_guard_error_is_detected_through_the_source_chain() {
+        use std::error::Error;
+        use std::fmt;
+
+        #[derive(Debug)]
+        struct Wrapper(Box<dyn Error + Send + Sync>);
+        impl fmt::Display for Wrapper {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // Deliberately hides the cause, the way reqwest's "error
+                // following redirect" / connector errors hide theirs.
+                write!(f, "error following redirect for url (https://example.com/)")
+            }
+        }
+        impl Error for Wrapper {
+            fn source(&self) -> Option<&(dyn Error + 'static)> {
+                Some(self.0.as_ref())
+            }
+        }
+
+        let blocked = Wrapper(SSRF_BLOCKED_MESSAGE.into());
+        assert!(!blocked.to_string().contains(SSRF_BLOCKED_MESSAGE));
+        assert!(is_ssrf_guard_error(&blocked));
+
+        // A genuine transport failure must stay fallback-eligible.
+        let transport = Wrapper("connection reset by peer".into());
+        assert!(!is_ssrf_guard_error(&transport));
     }
 
     #[test]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -136,6 +136,10 @@ const UV_INSTALL_BASE_URL: &str = "https://astral.sh/uv";
 const REMOTE_TILE_TIMEOUT_SECS: u64 = 8;
 const REMOTE_TILE_CONNECT_TIMEOUT_SECS: u64 = 4;
 const URL_RESOLVE_TIMEOUT_SECS: u64 = 15;
+/// Ceiling for a caller-supplied `fetch_url_bytes` budget. The default suits a
+/// tile; callers that download a whole dataset (Add Vector Layer) ask for more,
+/// but not without bound, so a bad value cannot wedge a request indefinitely.
+const MAX_FETCH_TIMEOUT_SECS: u64 = 600;
 
 #[cfg(all(unix, not(feature = "mas")))]
 const SIGTERM: i32 = 15;
@@ -1035,21 +1039,39 @@ fn build_guarded_http_client() -> Result<reqwest::blocking::Client, String> {
         .map_err(|error| format!("Could not create HTTP client: {error}"))
 }
 
+/// Fetches a URL's bytes, bypassing browser CORS.
+///
+/// `timeout_secs` overrides the tile-sized default for callers that download a
+/// whole dataset rather than a tile; it is clamped to
+/// `[REMOTE_TILE_TIMEOUT_SECS, MAX_FETCH_TIMEOUT_SECS]`, so the budget can only
+/// ever be raised and never removed.
 #[tauri::command]
-async fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
-    tauri::async_runtime::spawn_blocking(move || fetch_url_bytes_blocking(url))
+async fn fetch_url_bytes(url: String, timeout_secs: Option<u64>) -> Result<Vec<u8>, String> {
+    tauri::async_runtime::spawn_blocking(move || fetch_url_bytes_blocking(url, timeout_secs))
         .await
         .map_err(|error| format!("Tile fetch task failed: {error}"))?
 }
 
-fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
+/// Resolves the request budget for a fetch, defaulting to the tile timeout and
+/// clamping a caller-supplied value into `[REMOTE_TILE_TIMEOUT_SECS,
+/// MAX_FETCH_TIMEOUT_SECS]`. A caller can therefore only ever raise the budget,
+/// and never past the ceiling or down to zero (which reqwest reads as "no
+/// timeout" and would let a stalled request hang forever).
+fn resolve_fetch_timeout_secs(timeout_secs: Option<u64>) -> u64 {
+    timeout_secs
+        .unwrap_or(REMOTE_TILE_TIMEOUT_SECS)
+        .clamp(REMOTE_TILE_TIMEOUT_SECS, MAX_FETCH_TIMEOUT_SECS)
+}
+
+fn fetch_url_bytes_blocking(url: String, timeout_secs: Option<u64>) -> Result<Vec<u8>, String> {
     ensure_fetchable_url(&url)?;
 
     let client = guarded_http_client()?;
+    let timeout = resolve_fetch_timeout_secs(timeout_secs);
 
     let response = client
         .get(&url)
-        .timeout(Duration::from_secs(REMOTE_TILE_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(timeout))
         .send()
         .map_err(|error| format!("Request failed: {error}"))?;
     let status = response.status();
@@ -4002,7 +4024,8 @@ mod tests {
     use super::{
         client_cert_is_pkcs12, client_cert_password_without_path, ensure_fetchable_url,
         is_allowed_local_vector_path, is_allowed_project_path, is_disallowed_ip,
-        is_safe_absolute_path, path_is_under, tcp_table_port,
+        is_safe_absolute_path, path_is_under, resolve_fetch_timeout_secs, tcp_table_port,
+        MAX_FETCH_TIMEOUT_SECS, REMOTE_TILE_TIMEOUT_SECS,
     };
     #[cfg(target_os = "linux")]
     use super::{linux_uses_nvidia_renderer, nvidia_is_primary_gpu};
@@ -4659,6 +4682,26 @@ mod tests {
         assert_eq!(tcp_table_port(0x0000_3E22), 8766);
         assert_eq!(tcp_table_port(0xDEAD_3E22), 8766);
         assert_eq!(tcp_table_port(0x0000_223E), 0x3E22);
+    }
+
+    // Add Vector Layer downloads a whole dataset through the same command that
+    // fetches tiles, so it asks for a longer budget. The clamp is what keeps
+    // that override from becoming a way to disable the timeout entirely.
+    #[test]
+    fn clamps_the_fetch_timeout_into_the_allowed_range() {
+        // No override: the tile-sized default.
+        assert_eq!(resolve_fetch_timeout_secs(None), REMOTE_TILE_TIMEOUT_SECS);
+        // A dataset-sized budget is honored as asked.
+        assert_eq!(resolve_fetch_timeout_secs(Some(180)), 180);
+        // Zero would mean "no timeout" to reqwest, so it is raised to the floor
+        // rather than letting a stalled request hang forever.
+        assert_eq!(resolve_fetch_timeout_secs(Some(0)), REMOTE_TILE_TIMEOUT_SECS);
+        // Below the floor is raised; above the ceiling is capped.
+        assert_eq!(resolve_fetch_timeout_secs(Some(1)), REMOTE_TILE_TIMEOUT_SECS);
+        assert_eq!(
+            resolve_fetch_timeout_secs(Some(u64::MAX)),
+            MAX_FETCH_TIMEOUT_SECS
+        );
     }
 
     // The image-path guard is what keeps the reaper from killing a Jupyter the

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -55,6 +55,7 @@ import {
   materializeEmbeddableVectorLayers,
   RASTER_SOURCE_KIND,
   reloadVectorControlLayer,
+  replayVectorControlLayerById,
   SKETCHES_SOURCE_KIND,
   TIME_SLIDER_PLUGIN_ID,
   type TimePropertyCandidate,
@@ -1376,10 +1377,16 @@ export function LayerPanel({
           return;
         }
         if (isVectorControlRefreshLayer(layer)) {
-          const info = await reloadVectorControlLayer(layer.id);
+          // A layer whose restore failed stays in the project but never made it
+          // into the control, so reloadLayer cannot find it. Replaying it is
+          // what brings such a layer back once the source is reachable again,
+          // which is why refresh (manual and automatic) tries that second.
+          const info =
+            (await reloadVectorControlLayer(layer.id)) ??
+            (await replayVectorControlLayerById(layer.id));
           if (!info) {
             // The control is unavailable (panel never opened, or torn down
-            // and not yet replayed) or no longer knows this layer id.
+            // and not yet replayed) or the replay above did not succeed.
             // Automatic ticks fire on a timer the user didn't initiate, so
             // skip silently and clear the transient note instead of surfacing
             // an error every interval until the control comes back.

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1044,11 +1044,13 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     fetchVectorUrl: (url: string) =>
       dedupeVectorUrlFetch(url, async () => {
         const name = vectorDownloadFileName(url);
-        // Every request here shares one budget. Sibling layers now await a
-        // single download, so a stalled fetch would hold all of them pending
-        // rather than just itself; the browser paths need the same ceiling the
-        // native command is given below.
-        const signal = AbortSignal.timeout(VECTOR_DOWNLOAD_TIMEOUT_SECS * 1000);
+        // Each attempt gets its own budget rather than sharing one across all
+        // three. A shared deadline would be spent by the native call in exactly
+        // the case the fallbacks exist for (a slow origin), leaving them to
+        // reject instantly on an already-aborted signal. Sibling layers now
+        // await a single download, so an unbounded fetch would hold all of them
+        // pending, which is why each attempt is bounded at all.
+        const budget = () => AbortSignal.timeout(VECTOR_DOWNLOAD_TIMEOUT_SECS * 1000);
         if (isTauriRuntime()) {
           try {
             const bytes = await fetchUrlBytes(url, {
@@ -1068,7 +1070,7 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
             // Keep the browser path as a fallback for CORS-enabled origins the
             // native command could not reach.
             try {
-              const response = await fetch(url, { signal });
+              const response = await fetch(url, { signal: budget() });
               if (!response.ok) {
                 throw new Error(`HTTP ${response.status} ${response.statusText}`);
               }
@@ -1081,7 +1083,7 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
         }
         const proxyUrl = githubRawVectorProxyUrl(url);
         if (!proxyUrl) return null;
-        const response = await fetch(proxyUrl, { signal });
+        const response = await fetch(proxyUrl, { signal: budget() });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status} ${response.statusText}`);
         }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -121,6 +121,7 @@ import { appendDiagnostic } from "../lib/diagnostics";
 import { pickZarrDirectory, zarrDirectoryPickerSupported } from "../lib/zarr-directory-picker";
 import { openExternalLink } from "../lib/open-external";
 import { fetchUrlBytes } from "../lib/native-http";
+import { dedupeVectorUrlFetch, vectorDownloadFileName } from "../lib/vector-url-fetch";
 import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
 import { setTimeSliderOpenedByBinding, shouldCloseTimeSliderDock } from "../lib/time-slider-dock";
 import { createWmsTileUrl, normalizeWmsVersion } from "../components/layout/add-data/helpers";
@@ -1033,35 +1034,47 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     // presence to auto-discover shapefile sidecars instead of forcing the user
     // to select every component, and to capture the file's path for restore.
     pickVectorFilesWithSidecars: isTauriRuntime() ? pickVectorFilesWithSidecars : undefined,
-    fetchVectorUrl: async (url: string) => {
-      if (isTauriRuntime()) {
-        try {
-          const bytes = await fetchUrlBytes(url, { context: "Add Vector Layer" });
-          const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
-          return new Blob([array as Uint8Array<ArrayBuffer>]);
-        } catch {
-          // The shared native command has a short, tile-oriented timeout.
-          // Preserve the former browser path for large CORS-enabled datasets.
+    // Shared across the sibling layers of one multi-layer container, which all
+    // carry the container's URL: without this a six-layer KMZ downloaded itself
+    // six times over on every project open and every refresh tick.
+    fetchVectorUrl: (url: string) =>
+      dedupeVectorUrlFetch(url, async () => {
+        const name = vectorDownloadFileName(url);
+        if (isTauriRuntime()) {
           try {
-            const response = await fetch(url);
-            if (!response.ok) {
-              throw new Error(`HTTP ${response.status} ${response.statusText}`);
-            }
-            return response.blob();
+            const bytes = await fetchUrlBytes(url, {
+              context: "Add Vector Layer",
+              // The default budget on this command is tile-sized (8s). A vector
+              // dataset is not a tile. A few megabytes from a slow origin
+              // routinely needs longer, and timing out here used to drop the
+              // layer entirely, so ask for a download-sized budget instead.
+              timeoutSecs: VECTOR_DOWNLOAD_TIMEOUT_SECS,
+            });
+            const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+            return new File([array as Uint8Array<ArrayBuffer>], name);
           } catch {
-            // GitHub's /raw route rejects browser CORS, so fall through to the
-            // same guarded proxy used by the web build.
+            // Keep the browser path as a fallback for CORS-enabled origins the
+            // native command could not reach.
+            try {
+              const response = await fetch(url);
+              if (!response.ok) {
+                throw new Error(`HTTP ${response.status} ${response.statusText}`);
+              }
+              return new File([await response.blob()], name);
+            } catch {
+              // GitHub's /raw route rejects browser CORS, so fall through to the
+              // same guarded proxy used by the web build.
+            }
           }
         }
-      }
-      const proxyUrl = githubRawVectorProxyUrl(url);
-      if (!proxyUrl) return null;
-      const response = await fetch(proxyUrl);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status} ${response.statusText}`);
-      }
-      return response.blob();
-    },
+        const proxyUrl = githubRawVectorProxyUrl(url);
+        if (!proxyUrl) return null;
+        const response = await fetch(proxyUrl);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status} ${response.statusText}`);
+        }
+        return new File([await response.blob()], name);
+      }),
     readLocalVectorFile: readVectorFileWithSidecars,
     exportTextFile: (filename: string, content: string, options?: GeoLibreFileDialogOptions) => {
       const description = options?.description ?? "GeoJSON";
@@ -1332,6 +1345,14 @@ function isTauriRuntime(): boolean {
 }
 
 const GITHUB_RAW_VECTOR_PROXY = "https://tiles.geolibre.app/github-raw";
+
+/**
+ * Budget for a native Add Vector Layer download, in seconds. Deliberately far
+ * above `fetch_url_bytes`'s tile-sized default: this command carries whole
+ * datasets, not 256px tiles, and a timeout here is not a slow tile that resolves
+ * next frame but a layer that fails to restore.
+ */
+const VECTOR_DOWNLOAD_TIMEOUT_SECS = 180;
 
 function githubRawVectorProxyUrl(value: string): string | null {
   let url: URL;

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -121,7 +121,11 @@ import { appendDiagnostic } from "../lib/diagnostics";
 import { pickZarrDirectory, zarrDirectoryPickerSupported } from "../lib/zarr-directory-picker";
 import { openExternalLink } from "../lib/open-external";
 import { fetchUrlBytes } from "../lib/native-http";
-import { dedupeVectorUrlFetch, vectorDownloadFileName } from "../lib/vector-url-fetch";
+import {
+  dedupeVectorUrlFetch,
+  isBlockedUrlError,
+  vectorDownloadFileName,
+} from "../lib/vector-url-fetch";
 import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
 import { setTimeSliderOpenedByBinding, shouldCloseTimeSliderDock } from "../lib/time-slider-dock";
 import { createWmsTileUrl, normalizeWmsVersion } from "../components/layout/add-data/helpers";
@@ -1040,6 +1044,11 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     fetchVectorUrl: (url: string) =>
       dedupeVectorUrlFetch(url, async () => {
         const name = vectorDownloadFileName(url);
+        // Every request here shares one budget. Sibling layers now await a
+        // single download, so a stalled fetch would hold all of them pending
+        // rather than just itself; the browser paths need the same ceiling the
+        // native command is given below.
+        const signal = AbortSignal.timeout(VECTOR_DOWNLOAD_TIMEOUT_SECS * 1000);
         if (isTauriRuntime()) {
           try {
             const bytes = await fetchUrlBytes(url, {
@@ -1052,11 +1061,14 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
             });
             const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
             return new File([array as Uint8Array<ArrayBuffer>], name);
-          } catch {
+          } catch (error) {
+            // The webview is not subject to the backend's SSRF guard, so a URL
+            // the native command refused by policy must not be retried here.
+            if (isBlockedUrlError(error)) throw error;
             // Keep the browser path as a fallback for CORS-enabled origins the
             // native command could not reach.
             try {
-              const response = await fetch(url);
+              const response = await fetch(url, { signal });
               if (!response.ok) {
                 throw new Error(`HTTP ${response.status} ${response.statusText}`);
               }
@@ -1069,7 +1081,7 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
         }
         const proxyUrl = githubRawVectorProxyUrl(url);
         if (!proxyUrl) return null;
-        const response = await fetch(proxyUrl);
+        const response = await fetch(proxyUrl, { signal });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status} ${response.statusText}`);
         }

--- a/apps/geolibre-desktop/src/lib/native-http.ts
+++ b/apps/geolibre-desktop/src/lib/native-http.ts
@@ -20,11 +20,20 @@ export type NativeHttpCommand = "fetch_url_bytes" | "resolve_url_redirect";
 interface NativeHttpOptions {
   /** Short feature label (e.g. "WFS GetCapabilities") added to the record. */
   context?: string;
+}
+
+/**
+ * Options for {@link fetchUrlBytes}. `timeoutSecs` lives here rather than on
+ * {@link NativeHttpOptions} because only the `fetch_url_bytes` command accepts
+ * a timeout argument; `resolve_url_redirect` hardcodes its own, so offering the
+ * field there would invite a caller to set it and silently have no effect.
+ */
+interface FetchUrlBytesOptions extends NativeHttpOptions {
   /**
    * Request budget in seconds, overriding the command's tile-sized default.
-   * Set it for calls that carry a whole dataset rather than a tile; the backend
-   * clamps the value, so an out-of-range number degrades to the default rather
-   * than removing the timeout.
+   * Set it for calls that carry a whole dataset rather than a tile. The backend
+   * clamps it into `[8, 600]`, so a smaller value is raised to 8 and a larger
+   * one is capped at 600; the timeout can be raised but never removed.
    */
   timeoutSecs?: number;
 }
@@ -86,7 +95,7 @@ export function nativeHttpFailureRecord(
 async function invokeNativeHttp<T>(
   command: NativeHttpCommand,
   url: string,
-  options?: NativeHttpOptions,
+  options?: FetchUrlBytesOptions,
 ): Promise<T> {
   const startedAt = performance.now();
   try {
@@ -130,7 +139,7 @@ async function invokeNativeHttp<T>(
  */
 export function fetchUrlBytes(
   url: string,
-  options?: NativeHttpOptions,
+  options?: FetchUrlBytesOptions,
 ): Promise<number[] | Uint8Array> {
   return invokeNativeHttp<number[] | Uint8Array>("fetch_url_bytes", url, options);
 }

--- a/apps/geolibre-desktop/src/lib/native-http.ts
+++ b/apps/geolibre-desktop/src/lib/native-http.ts
@@ -20,6 +20,13 @@ export type NativeHttpCommand = "fetch_url_bytes" | "resolve_url_redirect";
 interface NativeHttpOptions {
   /** Short feature label (e.g. "WFS GetCapabilities") added to the record. */
   context?: string;
+  /**
+   * Request budget in seconds, overriding the command's tile-sized default.
+   * Set it for calls that carry a whole dataset rather than a tile; the backend
+   * clamps the value, so an out-of-range number degrades to the default rather
+   * than removing the timeout.
+   */
+  timeoutSecs?: number;
 }
 
 function recordSource(command: NativeHttpCommand, context?: string): string {
@@ -83,7 +90,12 @@ async function invokeNativeHttp<T>(
 ): Promise<T> {
   const startedAt = performance.now();
   try {
-    const result = await invoke<T>(command, { url });
+    // `timeoutSecs` is omitted rather than sent as undefined so the Rust side
+    // sees an absent argument and applies its own default.
+    const result = await invoke<T>(command, {
+      url,
+      ...(options?.timeoutSecs === undefined ? {} : { timeoutSecs: options.timeoutSecs }),
+    });
     appendDiagnostic(
       nativeHttpSuccessRecord(
         command,
@@ -112,7 +124,8 @@ async function invokeNativeHttp<T>(
  * subject to browser CORS), recording the request in the diagnostics log.
  *
  * @param url - The absolute HTTP(S) URL to fetch.
- * @param options - Optional context label for the diagnostics record.
+ * @param options - Optional context label for the diagnostics record, and an
+ *   optional request budget for callers downloading more than a tile.
  * @returns The response body bytes (Tauri may hand back a plain number array).
  */
 export function fetchUrlBytes(

--- a/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
@@ -1,0 +1,109 @@
+/**
+ * De-duplication for Add Vector Layer's remote downloads.
+ *
+ * A multi-layer container (a KMZ of KML folders, a GeoPackage of tables, a DXF)
+ * becomes one store layer per source layer, but every one of them keeps the
+ * *container's* URL. Restoring such a project replays each layer independently,
+ * and auto-refresh ticks them independently too, so a six-layer KMZ issued six
+ * concurrent downloads of the same archive on every project open and on every
+ * refresh interval (opengeos/GeoLibre discussion #1757). On a slow origin that
+ * is enough to blow the fetch budget and fail layers that would have loaded had
+ * they asked once.
+ *
+ * `dedupeVectorUrlFetch` collapses those into a single in-flight request per
+ * URL. Two properties matter:
+ *
+ * - **In-flight only.** The entry is dropped as soon as the download settles, so
+ *   this is a request collapser and never a cache: a later auto-refresh always
+ *   re-downloads and genuinely refreshes the layer. Sibling layers of one
+ *   container share a download only because they ask within the same window.
+ * - **One identity.** Every caller gets the *same* `File` object, not a copy.
+ *   maplibre-gl-vector keys its per-source caches (the unzipped KML it
+ *   registers with DuckDB, a GeoPackage's bytes) on the source object, so
+ *   handing all six layers one identical `File` collapses the unzip and the
+ *   DuckDB registration too: a 91 MB KML is registered once instead of six
+ *   times. Returning a `Blob` would not: the control wraps a plain `Blob` in a
+ *   fresh `File` per call, and the caches would miss again.
+ */
+
+/**
+ * In-flight downloads keyed by URL. Entries live only until they settle.
+ *
+ * The value is a wrapper rather than the bare promise so the download's own
+ * `finally` can identify (and clear) exactly its own entry while still running
+ * *inside* the promise. A `.finally()` chained onto the outside would resolve a
+ * tick after awaiting callers, leaving a settled entry briefly visible and
+ * letting an immediate retry share an already-finished download.
+ */
+interface InFlightEntry {
+  promise: Promise<File | null>;
+}
+
+const inFlight = new Map<string, InFlightEntry>();
+
+/**
+ * Runs `download` for `url`, sharing the request with any call for the same URL
+ * that is still in flight.
+ *
+ * @param url - The absolute URL being downloaded.
+ * @param download - Performs the actual download. Called at most once per
+ *   in-flight window; returns null when no loader could serve the URL.
+ * @returns The downloaded file (the identical object for every sharer), or null.
+ */
+export function dedupeVectorUrlFetch(
+  url: string,
+  download: () => Promise<File | null>,
+): Promise<File | null> {
+  const existing = inFlight.get(url);
+  if (existing) return existing.promise;
+
+  const entry = {} as InFlightEntry;
+  entry.promise = (async () => {
+    try {
+      return await download();
+    } finally {
+      // Cleared either way: a failure must not be replayed to a later refresh,
+      // and a success must not be served as a stale cache hit. Only our own
+      // entry is cleared, since a retry that started later owns the key.
+      if (inFlight.get(url) === entry) inFlight.delete(url);
+    }
+  })();
+  inFlight.set(url, entry);
+  return entry.promise;
+}
+
+/**
+ * Names a downloaded blob so the vector control's format detection still works.
+ *
+ * The control derives the format from the file name, so the URL's last path
+ * segment is used when it has an extension; otherwise the blob is handed over
+ * under a generic name and the control falls back to sniffing the content type.
+ *
+ * @param url - The URL the bytes came from.
+ * @param fallback - Name to use when the URL carries no usable file name.
+ * @returns A file name for the downloaded bytes.
+ */
+export function vectorDownloadFileName(url: string, fallback = "data"): string {
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return fallback;
+  }
+  const last = pathname.slice(pathname.lastIndexOf("/") + 1);
+  const decoded = safeDecode(last);
+  return /\.[A-Za-z0-9]+$/.test(decoded) ? decoded : fallback;
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Clears every in-flight entry. Exported for tests. */
+export function resetVectorUrlFetchDedupe(): void {
+  inFlight.clear();
+}

--- a/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
@@ -109,12 +109,20 @@ export function resetVectorUrlFetchDedupe(): void {
 }
 
 /**
- * Phrases the native fetch command rejects a URL with *before* issuing any
- * request, mirroring `url_is_fetchable` / `ensure_fetchable_url` in
- * `src-tauri/src/lib.rs` (`SSRF_BLOCKED_MESSAGE` and its siblings). The Rust
- * strings cannot be imported across the process boundary, so re-check this list
- * when that guard's messages change; a phrase that drifts fails open into the
- * browser fallback rather than breaking the build.
+ * Phrases the native fetch command rejects a URL with, mirroring
+ * `url_is_fetchable` / `ensure_fetchable_url` in `src-tauri/src/lib.rs`
+ * (`SSRF_BLOCKED_MESSAGE` and its siblings). The Rust strings cannot be imported
+ * across the process boundary, so re-check this list when that guard's messages
+ * change; a phrase that drifts fails open into the browser fallback rather than
+ * breaking the build.
+ *
+ * "Refusing to fetch" covers more than the pre-request check: the guarded
+ * redirect policy and `GuardedDnsResolver` reject mid-request, and both are
+ * normalised back to `SSRF_BLOCKED_MESSAGE` by `request_error_message` on the
+ * Rust side precisely so they land on this list. Without that normalisation a
+ * URL that passes the initial check and *then* redirects to (or re-resolves to)
+ * a blocked address surfaces as a generic transport failure, and the fallback
+ * below follows it with none of the guard's protections.
  */
 const URL_POLICY_REJECTIONS = [
   "Refusing to fetch",

--- a/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
+++ b/apps/geolibre-desktop/src/lib/vector-url-fetch.ts
@@ -107,3 +107,37 @@ function safeDecode(value: string): string {
 export function resetVectorUrlFetchDedupe(): void {
   inFlight.clear();
 }
+
+/**
+ * Phrases the native fetch command rejects a URL with *before* issuing any
+ * request, mirroring `url_is_fetchable` / `ensure_fetchable_url` in
+ * `src-tauri/src/lib.rs` (`SSRF_BLOCKED_MESSAGE` and its siblings). The Rust
+ * strings cannot be imported across the process boundary, so re-check this list
+ * when that guard's messages change; a phrase that drifts fails open into the
+ * browser fallback rather than breaking the build.
+ */
+const URL_POLICY_REJECTIONS = [
+  "Refusing to fetch",
+  "Unsupported URL scheme",
+  "Invalid URL",
+  "URL has no host",
+];
+
+/**
+ * True when the native fetch failed because the URL is one the backend refuses
+ * to reach (a link-local, unspecified, or multicast address, or a non-HTTP
+ * scheme) rather than because the request itself went wrong.
+ *
+ * The browser fallback exists for transport failures the native client cannot
+ * handle, but the webview is not subject to the Rust SSRF guard, so falling back
+ * on a policy rejection would let a crafted project reach exactly the addresses
+ * the guard blocked. Those failures are re-thrown instead.
+ *
+ * @param error - The rejection from the native command.
+ * @returns Whether the URL was refused by policy.
+ */
+export function isBlockedUrlError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+  return URL_POLICY_REJECTIONS.some((phrase) => message.includes(phrase));
+}

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -479,6 +479,15 @@ function syncExternalNativeLayer(
     clearExternalNativeExtrusion(map, layer, nativeLayerIds);
 
     for (const nativeLayerId of nativeLayerIds) {
+      // A store layer can legitimately outlive its map layers: a layer whose
+      // restore failed keeps the `nativeLayerIds` it was saved with, and the
+      // owning control has not (yet) recreated them. Styling a layer that is
+      // not on the map raises "Cannot get style of non-existing layer" on the
+      // map's error channel, which fills the Diagnostics panel with noise the
+      // user can do nothing about, so skip those ids until the control brings
+      // them back.
+      const nativeLayer = map.getLayer(nativeLayerId);
+      if (!nativeLayer) continue;
       moveLayer(map, nativeLayerId, beforeId);
       // The owning control mirrors direct per-layer visibility changes from
       // the store, but effective state such as a hidden parent group never
@@ -492,8 +501,7 @@ function syncExternalNativeLayer(
       // hide-unmatched filter: filtering is independent of the paint the
       // control owns. Native layers without a filter (deck.gl / 3D Tiles
       // custom layers) are skipped by the type guard.
-      const nativeLayer = map.getLayer(nativeLayerId);
-      if (nativeLayer && nativeLayerSupportsFilter(nativeLayer.type)) {
+      if (nativeLayerSupportsFilter(nativeLayer.type)) {
         applyExternalNativeFeatureFilters(map, nativeLayerId, layer);
       }
     }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -265,6 +265,7 @@ export {
   materializeEmbeddableVectorLayers,
   openVectorLayerPanel,
   reloadVectorControlLayer,
+  replayVectorControlLayerById,
   restoreVectorLayers,
   setKmlFileImportHandler,
   isKmlFileSelection,

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -360,12 +360,18 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
                   return replayVectorLayer(control, layer, source, restoredGroups, {
                     companionFiles: file.nativeData ? undefined : file.companionFiles,
                     localPath,
+                    // The file was read, so the layer's source still exists and
+                    // the failure was in the load. Preserve it like the URL and
+                    // embedded branches; reopening the project re-reads the same
+                    // path and can succeed.
+                    onError: () => failedLayerIds.add(layer.id),
                   });
                 })
+                // Only a failed read reaches here: replayVectorLayer settles its
+                // own rejection. A file that cannot be read is genuinely gone,
+                // which is the one case that still drops the layer.
                 .catch((error) => {
-                  console.error(`[GeoLibre] Failed to restore vector layer "${layer.name}"`, error);
-                  // Consistent with the missing-file case above: drop the layer
-                  // rather than leave a zombie panel entry with no map output.
+                  console.error(`[GeoLibre] Failed to read vector layer "${layer.name}"`, error);
                   useAppStore.getState().removeLayer(layer.id);
                 }),
             ),

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -113,6 +113,22 @@ let restorePanelExpandTimeout: number | null = null;
 const replayingLayerIds = new Set<string>();
 
 /**
+ * Layers whose replay failed (a download error, an unreadable source). They are
+ * kept in the project rather than pruned by the closing sync: a feed that was
+ * briefly unreachable must not cost the user their layers.
+ *
+ * Module-scoped for the same reason `replayingLayerIds` is. Overlapping restore
+ * passes divide the layers between them — the claim above makes each id the
+ * property of exactly one pass — but every pass ends with its own
+ * `syncVectorLayersToStore`, and the *last* one to run has the final say, since
+ * the suspension counter only clears once all of them have resumed. A call-local
+ * set would leave that final sync knowing only its own pass's failures and
+ * pruning its sibling's, which is precisely the loss this restore path exists to
+ * prevent.
+ */
+const failedLayerIds = new Set<string>();
+
+/**
  * Claims `id` for the duration of a replay so nothing else re-adds the same
  * layer while it loads.
  *
@@ -122,6 +138,10 @@ const replayingLayerIds = new Set<string>();
  */
 function trackReplay(id: string, replay: Promise<unknown>): Promise<unknown> {
   replayingLayerIds.add(id);
+  // A fresh attempt supersedes any earlier verdict for this id, so a refresh
+  // that succeeds clears the mark a previous failure left behind. Only this
+  // replay's own onError can put it back.
+  failedLayerIds.delete(id);
   return replay.finally(() => replayingLayerIds.delete(id));
 }
 /** One KML/KMZ file handed to the host importer. */
@@ -268,10 +288,6 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
     );
 
     const pending: Promise<unknown>[] = [];
-    // Layers whose replay failed (a download error, an unreadable source). They
-    // are kept in the project rather than pruned by the closing sync: a feed
-    // that was briefly unreachable must not cost the user their layers.
-    const failedLayerIds = new Set<string>();
     const panelCollapsed = vectorPanelCollapsedFromLayers(useAppStore.getState().layers);
     // Unlike maplibre-gl-raster (whose addRaster registers the raster
     // synchronously before loading), VectorControl.addData only adds a
@@ -430,6 +446,13 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         // let this stale callback rewrite layers owned by its successor.
         if (control !== vectorControl) return;
         syncVectorLayersToStore(control, { preserveLayerIds: failedLayerIds });
+        // The set outlives this call now, so drop ids the store no longer knows
+        // about (a project closed, a layer the user deleted). Preserving a
+        // stale id is harmless to the sync, but keeping it forever is a leak.
+        const liveIds = new Set(useAppStore.getState().layers.map((layer) => layer.id));
+        for (const id of failedLayerIds) {
+          if (!liveIds.has(id)) failedLayerIds.delete(id);
+        }
       }, 0);
     });
   })().catch((error) => {

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -244,6 +244,10 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
     );
 
     const pending: Promise<unknown>[] = [];
+    // Layers whose replay failed (a download error, an unreadable source). They
+    // are kept in the project rather than pruned by the closing sync: a feed
+    // that was briefly unreachable must not cost the user their layers.
+    const failedLayerIds = new Set<string>();
     const panelCollapsed = vectorPanelCollapsedFromLayers(useAppStore.getState().layers);
     // Unlike maplibre-gl-raster (whose addRaster registers the raster
     // synchronously before loading), VectorControl.addData only adds a
@@ -283,7 +287,11 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         const url =
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;
         if (url) {
-          pending.push(replayVectorLayer(control, layer, url, restoredGroups));
+          pending.push(
+            replayVectorLayer(control, layer, url, restoredGroups, {
+              onError: () => failedLayerIds.add(layer.id),
+            }),
+          );
           continue;
         }
 
@@ -341,7 +349,11 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         // next save.
         const embedded = readEmbeddedVectorGeoJSON(layer.metadata.embeddedGeoJSON);
         if (embedded) {
-          pending.push(replayVectorLayer(control, layer, embedded, restoredGroups));
+          pending.push(
+            replayVectorLayer(control, layer, embedded, restoredGroups, {
+              onError: () => failedLayerIds.add(layer.id),
+            }),
+          );
           continue;
         }
 
@@ -372,7 +384,7 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         // A control torn down mid-restore (map reinitialisation) must not
         // let this stale callback rewrite layers owned by its successor.
         if (control !== vectorControl) return;
-        syncVectorLayersToStore(control);
+        syncVectorLayersToStore(control, { preserveLayerIds: failedLayerIds });
       }, 0);
     });
   })().catch((error) => {
@@ -394,7 +406,9 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
  * @param layer - The saved store layer being restored.
  * @param source - The URL, File, or FeatureCollection to load the data from.
  * @param groups - Restored groups used to compute the layer's effective state.
- * @param options - The shapefile sidecars and/or absolute path of a File source.
+ * @param options - The shapefile sidecars and/or absolute path of a File source,
+ *   plus an optional `onError` hook so a caller can record which layers failed
+ *   without losing the "never rejects" contract this function's callers rely on.
  * @returns A promise that settles when the layer has loaded or failed.
  */
 export function replayVectorLayer(
@@ -402,7 +416,11 @@ export function replayVectorLayer(
   layer: GeoLibreLayer,
   source: string | File | FeatureCollection,
   groups: ReadonlyMap<string, LayerGroup>,
-  options: { companionFiles?: File[]; localPath?: string } = {},
+  options: {
+    companionFiles?: File[];
+    localPath?: string;
+    onError?: (error: unknown) => void;
+  } = {},
 ): Promise<unknown> {
   const effective = effectiveLayerRenderState(layer, groups);
   // Record the folded values before addData so its first layer event is treated
@@ -421,7 +439,74 @@ export function replayVectorLayer(
     })
     .catch((error) => {
       console.error(`[GeoLibre] Failed to restore vector layer "${layer.name}"`, error);
+      options.onError?.(error);
     });
+}
+
+/**
+ * Re-adds a saved vector layer the control does not currently hold, so a layer
+ * whose restore failed can be recovered without the user rebuilding it.
+ *
+ * Restore keeps such a layer in the project (see
+ * {@link syncVectorLayersToStore}'s `preserveLayerIds`) but the control has no
+ * record of it, which is why {@link reloadVectorControlLayer} returns undefined
+ * for it. The layer panel's refresh (the button and the auto-refresh tick)
+ * falls through to this, so the next successful fetch brings the layer back.
+ *
+ * Only URL-backed and embedded layers can be replayed here: a desktop
+ * local-file layer needs the host's filesystem reader, which lives with the
+ * restore path rather than in this module.
+ *
+ * @param id - The store layer id to replay.
+ * @returns The replayed layer info, or undefined when the control is
+ *   unavailable, the layer is unknown, already present, or has no replayable
+ *   source.
+ */
+export async function replayVectorControlLayerById(
+  id: string,
+): Promise<VectorLayerInfo | undefined> {
+  const control = vectorControl;
+  if (!control) return undefined;
+  // Already held by the control: reloadLayer is the right call, not a re-add
+  // (which would throw on the duplicate id).
+  if (control.getLayer(id)) return undefined;
+
+  const state = useAppStore.getState();
+  const layer = state.layers.find((candidate) => candidate.id === id);
+  if (!layer || !isVectorControlStoreLayer(layer)) return undefined;
+
+  const url = typeof layer.source.url === "string" && layer.source.url ? layer.source.url : null;
+  const source: string | FeatureCollection | null =
+    url ?? readEmbeddedVectorGeoJSON(layer.metadata.embeddedGeoJSON);
+  if (!source) return undefined;
+
+  const groups = new Map(state.layerGroups.map((group) => [group.id, group] as const));
+  // Held across the replay for the same reason restore holds it: addData only
+  // registers the layer once loaded, so an intermediate sync would diff a
+  // control that does not yet have it and prune it right back out.
+  suspendVectorStoreSync();
+  try {
+    await replayVectorLayer(control, layer, source, groups);
+  } finally {
+    resumeVectorStoreSync();
+  }
+  // A control torn down mid-replay must not have its successor's layers
+  // rewritten from this stale callback.
+  if (control !== vectorControl) return undefined;
+  // Additive only. Recovering one layer says nothing about the others: the rest
+  // of a multi-layer container may still be waiting for their own replay, and
+  // the plain diff would read their absence from the control as a removal and
+  // delete them, which is the very loss this recovery path exists to undo.
+  const controlIds = new Set(control.getLayers().map((info) => info.id));
+  const stillMissing = new Set(
+    useAppStore
+      .getState()
+      .layers.filter((candidate) => isVectorControlStoreLayer(candidate))
+      .map((candidate) => candidate.id)
+      .filter((candidateId) => !controlIds.has(candidateId)),
+  );
+  syncVectorLayersToStore(control, { preserveLayerIds: stillMissing });
+  return control.getLayer(id);
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -306,7 +306,13 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
       );
       for (const layer of useAppStore.getState().layers) {
         if (!isVectorControlStoreLayer(layer)) continue;
-        if (control.getLayer(layer.id)) continue;
+        // Project loading can invoke this restore pass more than once before
+        // the first pass finishes. addData does not expose the layer through
+        // getLayer until its async ingest completes, so getLayer alone lets the
+        // second pass replay the same id and race the first when adding its
+        // MapLibre source ("Source ... already exists"). The shared claim also
+        // blocks refresh replays for the same in-flight id.
+        if (control.getLayer(layer.id) || replayingLayerIds.has(layer.id)) continue;
 
         const url =
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -100,8 +100,30 @@ let vectorControl: VectorControl | null = null;
 let vectorControlMounted = false;
 let openPanelTimeout: number | null = null;
 let restorePanelExpandTimeout: number | null = null;
-/** Layer ids currently being re-added by replayVectorControlLayerById. */
+/**
+ * Layer ids with an `addData` replay in flight, from project restore or from
+ * replayVectorControlLayerById.
+ *
+ * `control.getLayer(id)` cannot serve as the guard on its own: the control only
+ * registers a layer once its data has loaded, so during that window an id looks
+ * absent to everyone. A refresh tick landing mid-restore would then re-add a
+ * layer restore is already loading, costing a redundant download and a
+ * duplicate-id throw. Claiming the id for the whole replay closes that window.
+ */
 const replayingLayerIds = new Set<string>();
+
+/**
+ * Claims `id` for the duration of a replay so nothing else re-adds the same
+ * layer while it loads.
+ *
+ * @param id - The layer id being replayed.
+ * @param replay - The in-flight replay promise.
+ * @returns The same promise, with the claim released once it settles.
+ */
+function trackReplay(id: string, replay: Promise<unknown>): Promise<unknown> {
+  replayingLayerIds.add(id);
+  return replay.finally(() => replayingLayerIds.delete(id));
+}
 /** One KML/KMZ file handed to the host importer. */
 export interface KmlFileImport {
   file: File;
@@ -290,9 +312,12 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
           typeof layer.source.url === "string" && layer.source.url ? layer.source.url : undefined;
         if (url) {
           pending.push(
-            replayVectorLayer(control, layer, url, restoredGroups, {
-              onError: () => failedLayerIds.add(layer.id),
-            }),
+            trackReplay(
+              layer.id,
+              replayVectorLayer(control, layer, url, restoredGroups, {
+                onError: () => failedLayerIds.add(layer.id),
+              }),
+            ),
           );
           continue;
         }
@@ -316,31 +341,34 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
             : undefined;
         if (localPath && app.readLocalVectorFile) {
           pending.push(
-            app
-              .readLocalVectorFile(localPath)
-              .then((file) => {
-                if (!file) {
-                  // The file moved or was deleted since the project was saved.
-                  console.info(
-                    `[GeoLibre] Vector layer "${layer.name}" could not be re-read from "${localPath}"; removing it.`,
-                  );
+            trackReplay(
+              layer.id,
+              app
+                .readLocalVectorFile(localPath)
+                .then((file) => {
+                  if (!file) {
+                    // The file moved or was deleted since the project was saved.
+                    console.info(
+                      `[GeoLibre] Vector layer "${layer.name}" could not be re-read from "${localPath}"; removing it.`,
+                    );
+                    useAppStore.getState().removeLayer(layer.id);
+                    return undefined;
+                  }
+                  const source = file.nativeData
+                    ? nativeGeoJsonFile(file.file, file.nativeData)
+                    : file.file;
+                  return replayVectorLayer(control, layer, source, restoredGroups, {
+                    companionFiles: file.nativeData ? undefined : file.companionFiles,
+                    localPath,
+                  });
+                })
+                .catch((error) => {
+                  console.error(`[GeoLibre] Failed to restore vector layer "${layer.name}"`, error);
+                  // Consistent with the missing-file case above: drop the layer
+                  // rather than leave a zombie panel entry with no map output.
                   useAppStore.getState().removeLayer(layer.id);
-                  return undefined;
-                }
-                const source = file.nativeData
-                  ? nativeGeoJsonFile(file.file, file.nativeData)
-                  : file.file;
-                return replayVectorLayer(control, layer, source, restoredGroups, {
-                  companionFiles: file.nativeData ? undefined : file.companionFiles,
-                  localPath,
-                });
-              })
-              .catch((error) => {
-                console.error(`[GeoLibre] Failed to restore vector layer "${layer.name}"`, error);
-                // Consistent with the missing-file case above: drop the layer
-                // rather than leave a zombie panel entry with no map output.
-                useAppStore.getState().removeLayer(layer.id);
-              }),
+                }),
+            ),
           );
           continue;
         }
@@ -352,9 +380,12 @@ export function restoreVectorLayers(app: GeoLibreAppAPI): void {
         const embedded = readEmbeddedVectorGeoJSON(layer.metadata.embeddedGeoJSON);
         if (embedded) {
           pending.push(
-            replayVectorLayer(control, layer, embedded, restoredGroups, {
-              onError: () => failedLayerIds.add(layer.id),
-            }),
+            trackReplay(
+              layer.id,
+              replayVectorLayer(control, layer, embedded, restoredGroups, {
+                onError: () => failedLayerIds.add(layer.id),
+              }),
+            ),
           );
           continue;
         }

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -100,6 +100,8 @@ let vectorControl: VectorControl | null = null;
 let vectorControlMounted = false;
 let openPanelTimeout: number | null = null;
 let restorePanelExpandTimeout: number | null = null;
+/** Layer ids currently being re-added by replayVectorControlLayerById. */
+const replayingLayerIds = new Set<string>();
 /** One KML/KMZ file handed to the host importer. */
 export interface KmlFileImport {
   file: File;
@@ -453,14 +455,16 @@ export function replayVectorLayer(
  * for it. The layer panel's refresh (the button and the auto-refresh tick)
  * falls through to this, so the next successful fetch brings the layer back.
  *
- * Only URL-backed and embedded layers can be replayed here: a desktop
- * local-file layer needs the host's filesystem reader, which lives with the
- * restore path rather than in this module.
+ * URL-backed only. A local-file layer needs the host's filesystem reader, which
+ * lives with the restore path rather than in this module, and an embedded-source
+ * layer never reaches here: refresh is gated on `isVectorControlRefreshLayer`,
+ * which requires an HTTP URL. Such a layer is still preserved by restore, it
+ * just has nothing to re-fetch.
  *
  * @param id - The store layer id to replay.
  * @returns The replayed layer info, or undefined when the control is
- *   unavailable, the layer is unknown, already present, or has no replayable
- *   source.
+ *   unavailable, the layer is unknown, already present, already being replayed,
+ *   or has no URL.
  */
 export async function replayVectorControlLayerById(
   id: string,
@@ -470,25 +474,30 @@ export async function replayVectorControlLayerById(
   // Already held by the control: reloadLayer is the right call, not a re-add
   // (which would throw on the duplicate id).
   if (control.getLayer(id)) return undefined;
+  // The getLayer check above cannot hold across the await below, because addData
+  // only registers the layer once its data has loaded. Two concurrent calls for
+  // one id would both pass it and the second would throw on the duplicate id, so
+  // the id is claimed for the whole replay.
+  if (replayingLayerIds.has(id)) return undefined;
 
   const state = useAppStore.getState();
   const layer = state.layers.find((candidate) => candidate.id === id);
   if (!layer || !isVectorControlStoreLayer(layer)) return undefined;
 
   const url = typeof layer.source.url === "string" && layer.source.url ? layer.source.url : null;
-  const source: string | FeatureCollection | null =
-    url ?? readEmbeddedVectorGeoJSON(layer.metadata.embeddedGeoJSON);
-  if (!source) return undefined;
+  if (!url) return undefined;
 
   const groups = new Map(state.layerGroups.map((group) => [group.id, group] as const));
   // Held across the replay for the same reason restore holds it: addData only
   // registers the layer once loaded, so an intermediate sync would diff a
   // control that does not yet have it and prune it right back out.
+  replayingLayerIds.add(id);
   suspendVectorStoreSync();
   try {
-    await replayVectorLayer(control, layer, source, groups);
+    await replayVectorLayer(control, layer, url, groups);
   } finally {
     resumeVectorStoreSync();
+    replayingLayerIds.delete(id);
   }
   // A control torn down mid-replay must not have its successor's layers
   // rewritten from this stale callback.

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -206,10 +206,21 @@ export function createVectorStoreLayer(
  * layer panel survive later syncs.
  *
  * @param control - The vector control to mirror.
+ * @param options - `preserveLayerIds` names store layers that must survive this
+ *   diff even though the control does not have them. Restore passes the layers
+ *   whose replay *failed*: their absence means a download or read error, not a
+ *   removal, and pruning them would delete the user's layers from the project
+ *   over a transient network fault (opengeos/GeoLibre discussion #1757). They
+ *   stay in the project, and a refresh replays them (see
+ *   replayVectorControlLayerById).
  */
-export function syncVectorLayersToStore(control: VectorSyncableControl): void {
+export function syncVectorLayersToStore(
+  control: VectorSyncableControl,
+  options: { preserveLayerIds?: ReadonlySet<string> } = {},
+): void {
   if (isVectorStoreSyncSuspended()) return;
 
+  const preserveLayerIds = options.preserveLayerIds;
   const infos = control.getLayers();
   const infoIds = new Set(infos.map((info) => info.id));
   const panelCollapsed = vectorPanelCollapsedFromControl(control);
@@ -224,7 +235,7 @@ export function syncVectorLayersToStore(control: VectorSyncableControl): void {
   try {
     for (const storeLayer of useAppStore.getState().layers) {
       if (!isVectorControlStoreLayer(storeLayer)) continue;
-      if (!infoIds.has(storeLayer.id)) {
+      if (!infoIds.has(storeLayer.id) && !preserveLayerIds?.has(storeLayer.id)) {
         useAppStore.getState().removeLayer(storeLayer.id);
       }
     }

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -534,8 +534,16 @@ export interface GeoLibreAppAPI {
   /**
    * Desktop-native downloader for Add Vector Layer URL sources. The web app
    * leaves this unset so the control uses ordinary browser networking.
+   *
+   * Must resolve to a `File` rather than a bare `Blob`, and to the *same* object
+   * for concurrent callers asking for one URL. The vector control keys its
+   * per-source caches (a KMZ's unzipped KML, a GeoPackage's bytes) on the source
+   * object and wraps a plain `Blob` in a fresh `File` per call, so returning a
+   * `Blob` would make every sibling layer of a multi-layer container re-unzip
+   * and re-register the same archive. The type says `File` so that contract is
+   * enforced rather than only documented.
    */
-  fetchVectorUrl?: (url: string) => Promise<Blob | null>;
+  fetchVectorUrl?: (url: string) => Promise<File | null>;
   /**
    * Read a local vector file back into a File (with any shapefile sidecars) from
    * the absolute path persisted on a layer's `sourcePath`, so the Add Vector

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -122,3 +122,47 @@ describe("controlOwnsPaint external native layers", () => {
     );
   });
 });
+
+// A store layer can outlive its map layers: restore now keeps a layer whose
+// replay failed (opengeos/GeoLibre discussion #1757), and its saved
+// `nativeLayerIds` still name layers the control never recreated. Styling those
+// raises "Cannot get style of non-existing layer" on the map's error channel,
+// which floods the Diagnostics panel with entries the user cannot act on.
+describe("external native layers whose map layers are missing", () => {
+  it("touches nothing when the native layer is not on the map", () => {
+    // The stub only knows "mub-deliveries", so the layer's id resolves to
+    // undefined from getLayer, standing in for a failed restore.
+    const { map, calls } = makeMapStub("some-other-layer", "circle");
+
+    assert.doesNotThrow(() => syncLayer(map as never, externalNativeLayer()));
+
+    assert.deepEqual(
+      calls.map((call) => call.method),
+      [],
+      "expected no style, visibility, or ordering calls against a layer that is not on the map",
+    );
+  });
+
+  it("still syncs the layers that are present alongside a missing one", () => {
+    const { map, calls } = makeMapStub("mub-deliveries", "circle");
+    const layer = externalNativeLayer({
+      metadata: {
+        externalNativeLayer: true,
+        // The first id is stale; only the second exists on the map.
+        nativeLayerIds: ["mub-deliveries-gone", "mub-deliveries"],
+        sourceIds: ["mub-deliveries"],
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    const touched = calls.flatMap((call) =>
+      typeof call.args[0] === "string" ? [call.args[0]] : [],
+    );
+    assert.ok(touched.includes("mub-deliveries"), "expected the present layer to still be synced");
+    assert.ok(
+      !touched.includes("mub-deliveries-gone"),
+      "expected the missing layer to be skipped rather than dropping the whole sync",
+    );
+  });
+});

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -130,8 +130,8 @@ describe("controlOwnsPaint external native layers", () => {
 // which floods the Diagnostics panel with entries the user cannot act on.
 describe("external native layers whose map layers are missing", () => {
   it("touches nothing when the native layer is not on the map", () => {
-    // The stub only knows "mub-deliveries", so the layer's id resolves to
-    // undefined from getLayer, standing in for a failed restore.
+    // The stub only knows "some-other-layer", so getLayer("mub-deliveries")
+    // returns undefined, standing in for a failed restore.
     const { map, calls } = makeMapStub("some-other-layer", "circle");
 
     assert.doesNotThrow(() => syncLayer(map as never, externalNativeLayer()));

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -377,6 +377,40 @@ describe("syncVectorLayersToStore", () => {
     assert.equal(useAppStore.getState().layers.length, 0);
   });
 
+  // Restore replays each layer of a multi-layer container independently, so one
+  // unreachable feed used to delete those layers from the project outright
+  // (opengeos/GeoLibre discussion #1757). A failed replay is not a removal.
+  it("keeps preserved layers the control does not have", () => {
+    const { control } = fakeControl([vectorInfo(), vectorInfo({ id: "vector-2", name: "cities" })]);
+    syncVectorLayersToStore(control);
+    assert.equal(useAppStore.getState().layers.length, 2);
+
+    // vector-2 failed to replay: absent from the control, but still the user's.
+    syncVectorLayersToStore(fakeControl([vectorInfo()]).control, {
+      preserveLayerIds: new Set(["vector-2"]),
+    });
+
+    assert.deepEqual(
+      useAppStore.getState().layers.map((layer) => layer.id),
+      ["vector-1", "vector-2"],
+    );
+  });
+
+  it("still prunes layers outside the preserved set", () => {
+    const { control } = fakeControl([vectorInfo(), vectorInfo({ id: "vector-2", name: "cities" })]);
+    syncVectorLayersToStore(control);
+
+    // Only vector-2 failed; vector-1 was genuinely removed at the control.
+    syncVectorLayersToStore(fakeControl([]).control, {
+      preserveLayerIds: new Set(["vector-2"]),
+    });
+
+    assert.deepEqual(
+      useAppStore.getState().layers.map((layer) => layer.id),
+      ["vector-2"],
+    );
+  });
+
   it("refreshes changed fields but preserves panel renames", () => {
     const { control } = fakeControl([vectorInfo()]);
     syncVectorLayersToStore(control);

--- a/tests/vector-url-fetch.test.ts
+++ b/tests/vector-url-fetch.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  dedupeVectorUrlFetch,
+  resetVectorUrlFetchDedupe,
+  vectorDownloadFileName,
+} from "../apps/geolibre-desktop/src/lib/vector-url-fetch";
+
+const KMZ_URL =
+  "https://firms.modaps.eosdis.nasa.gov/api/kml_fire_footprints/russia_asia/24h/" +
+  "suomi-npp-viirs-c2/FirespotArea_russia_asia_suomi-npp-viirs-c2_24h.kmz";
+
+/** A deferred promise, so a test can hold a download open across assertions. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("dedupeVectorUrlFetch", () => {
+  afterEach(() => {
+    resetVectorUrlFetchDedupe();
+  });
+
+  // The whole point: the six layers of one KMZ must not pull the archive six
+  // times over on every project open (opengeos/GeoLibre discussion #1757).
+  it("shares one in-flight download across concurrent callers", async () => {
+    const gate = deferred<File | null>();
+    let downloads = 0;
+    const download = () => {
+      downloads += 1;
+      return gate.promise;
+    };
+
+    const callers = Array.from({ length: 6 }, () => dedupeVectorUrlFetch(KMZ_URL, download));
+    assert.equal(downloads, 1);
+
+    const file = new File([new Uint8Array([1, 2, 3])], "fires.kmz");
+    gate.resolve(file);
+    const results = await Promise.all(callers);
+
+    assert.equal(downloads, 1);
+    // Identity, not just equality: the vector control keys its unzip and DuckDB
+    // registration caches on the source object, so one object means one unzip.
+    for (const result of results) assert.equal(result, file);
+  });
+
+  it("keeps distinct URLs on their own downloads", async () => {
+    const seen: string[] = [];
+    const download = (url: string) => async () => {
+      seen.push(url);
+      return new File([], "data.geojson");
+    };
+
+    await Promise.all([
+      dedupeVectorUrlFetch("https://example.com/a.geojson", download("a")),
+      dedupeVectorUrlFetch("https://example.com/b.geojson", download("b")),
+    ]);
+
+    assert.deepEqual(seen.sort(), ["a", "b"]);
+  });
+
+  // A collapser, never a cache: auto-refresh exists to pick up new data, so a
+  // later tick has to hit the network again.
+  it("re-downloads once the previous request has settled", async () => {
+    let downloads = 0;
+    const download = async () => {
+      downloads += 1;
+      return new File([], "fires.kmz");
+    };
+
+    await dedupeVectorUrlFetch(KMZ_URL, download);
+    await dedupeVectorUrlFetch(KMZ_URL, download);
+
+    assert.equal(downloads, 2);
+  });
+
+  it("shares a rejection with every caller and does not cache it", async () => {
+    const gate = deferred<File | null>();
+    let downloads = 0;
+    const failing = () => {
+      downloads += 1;
+      return gate.promise;
+    };
+
+    const first = dedupeVectorUrlFetch(KMZ_URL, failing);
+    const second = dedupeVectorUrlFetch(KMZ_URL, failing);
+    gate.reject(new Error("Failed to fetch KMZ (503 Service Unavailable)."));
+
+    await assert.rejects(first, /503/);
+    await assert.rejects(second, /503/);
+    assert.equal(downloads, 1);
+
+    // The failure must not stick: the next attempt gets a fresh download.
+    const recovered = await dedupeVectorUrlFetch(KMZ_URL, async () => new File([], "fires.kmz"));
+    assert.ok(recovered);
+    assert.equal(downloads, 1);
+  });
+
+  it("passes a null loader result through unchanged", async () => {
+    const result = await dedupeVectorUrlFetch(KMZ_URL, async () => null);
+    assert.equal(result, null);
+  });
+});
+
+describe("vectorDownloadFileName", () => {
+  it("uses the URL's file name so format detection still works", () => {
+    assert.equal(
+      vectorDownloadFileName(KMZ_URL),
+      "FirespotArea_russia_asia_suomi-npp-viirs-c2_24h.kmz",
+    );
+  });
+
+  it("ignores the query string", () => {
+    assert.equal(
+      vectorDownloadFileName("https://example.com/data/roads.gpkg?token=abc"),
+      "roads.gpkg",
+    );
+  });
+
+  it("decodes a percent-encoded name", () => {
+    assert.equal(
+      vectorDownloadFileName("https://example.com/my%20data.geojson"),
+      "my data.geojson",
+    );
+  });
+
+  it("falls back when the URL carries no extension", () => {
+    // An OGC API / ArcGIS endpoint: the control sniffs the content type instead.
+    assert.equal(vectorDownloadFileName("https://example.com/collections/items"), "data");
+  });
+
+  it("falls back on an unparseable URL", () => {
+    assert.equal(vectorDownloadFileName("not a url"), "data");
+  });
+});

--- a/tests/vector-url-fetch.test.ts
+++ b/tests/vector-url-fetch.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import {
   dedupeVectorUrlFetch,
+  isBlockedUrlError,
   resetVectorUrlFetchDedupe,
   vectorDownloadFileName,
 } from "../apps/geolibre-desktop/src/lib/vector-url-fetch";
@@ -136,5 +137,39 @@ describe("vectorDownloadFileName", () => {
 
   it("falls back on an unparseable URL", () => {
     assert.equal(vectorDownloadFileName("not a url"), "data");
+  });
+});
+
+describe("isBlockedUrlError", () => {
+  // The webview is not subject to the backend SSRF guard, so these must never
+  // fall through to a plain browser fetch of the same URL.
+  it("recognizes the backend's URL-policy rejections", () => {
+    for (const message of [
+      "Refusing to fetch a link-local, unspecified, or multicast address",
+      "Unsupported URL scheme: file",
+      "Invalid URL: relative URL without a base",
+      "URL has no host",
+    ]) {
+      assert.equal(isBlockedUrlError(new Error(message)), true, message);
+    }
+  });
+
+  it("reads a bare string rejection too (Tauri rejects with the raw message)", () => {
+    assert.equal(
+      isBlockedUrlError("Refusing to fetch a link-local, unspecified, or multicast address"),
+      true,
+    );
+  });
+
+  // Transport failures are exactly what the browser fallback is for.
+  it("lets ordinary request failures fall back", () => {
+    for (const message of [
+      "Request failed: error sending request",
+      "Could not read response body: error decoding response body",
+      "Request failed with status 503 Service Unavailable",
+      "Could not resolve host example.com",
+    ]) {
+      assert.equal(isBlockedUrlError(new Error(message)), false, message);
+    }
   });
 });


### PR DESCRIPTION
Fixes the layer loss, duplicate downloads, and fetch timeouts reported for NASA FIRMS fire-footprint KMZ feeds in discussion #1757.

## What was happening

A multi-layer container (a KMZ of KML folders, a GeoPackage of tables) expands into one store layer per source layer, and every one of them keeps the **container's** URL. Three defects compounded from there.

**1. A failed restore deleted the layers.** Restore replays each layer independently and then diffs the control's layer list into the store, where a store layer the control does not have is treated as removed. So a layer whose replay failed for any transient reason was pruned from the project, and the next save wrote that loss to disk. This is the reporter's "layers disappear and I'm unable to get them back".

**2. One URL, N downloads.** Each sibling layer downloaded the container separately. On desktop a six-layer KMZ pulled the same 3 MB archive six times on every project open and on every auto-refresh tick, then unzipped and registered a 91 MB KML into DuckDB six times over. This is the reporter's own question: *"Is Auto Refresh trying to load the url 6 times when 1 time should be enough?"* It was.

**3. Those parallel downloads hit a tile-sized timeout.** `fetch_url_bytes` is shared with tile fetching and carries an 8s budget. Six concurrent downloads of a slow feed blow straight through it, which is exactly the reporter's `Could not read response body: error decoding response body` failures logged at 8424 ms and 8390 ms.

## What changed

- **Restore keeps layers whose replay failed.** `syncVectorLayersToStore` takes a `preserveLayerIds` set; restore passes the layers that failed, so an unreachable feed no longer costs the user their layers.
- **Refresh recovers them.** New `replayVectorControlLayerById` re-adds a saved layer the control does not hold. The layer panel's refresh (button and auto-refresh tick) falls through to it, so the next successful fetch brings the layer back rather than leaving a dead entry. That recovery sync is additive on purpose: recovering one layer says nothing about siblings still waiting on their own replay.
- **One download per URL.** `fetchVectorUrl` collapses concurrent calls for the same URL into a single in-flight request. It is a request collapser, never a cache: the entry is cleared as the download settles, so auto-refresh still genuinely refreshes. It also returns a `File` rather than a `Blob`, so every sibling gets the identical object and the control's per-source unzip and DuckDB-registration caches collapse with it.
- **Dataset-sized fetch budget.** `fetch_url_bytes` accepts an optional `timeout_secs`, clamped to `[8, 600]` so a caller can only raise the budget and never remove it (0 would mean "no timeout" to reqwest). Add Vector Layer asks for 180s.
- **Quieter diagnostics.** A store layer that outlives its map layers no longer gets its style synced, which was filling the Diagnostics panel with `Cannot get style of non-existing layer` (the reporter's second screenshot).

## Verification

Reproduced and verified in the real app against the reporter's actual feed, `FirespotArea_russia_asia_suomi-npp-viirs-c2_24h.kmz` (7 layers, 3.2 MB compressed, 91 MB of KML), driven with Playwright.

Loaded the feed, styled the 6 layers, saved a project, then reopened it with the origin forced to 503:

| | before | after |
|---|---|---|
| layers surviving a failed restore | **0 of 6** | **6 of 6** |
| console | 6x `Failed to restore vector layer` and the layers gone | same errors, layers intact |

Then cleared the failure and hit Refresh on one layer: it replayed with **exactly one** network request, showed `Last synced 4 seconds ago`, and the other five layers were untouched (this last part caught a real bug in my first attempt, where the recovery sync pruned the siblings).

Measured downloads across a successful 6-layer restore by intercepting the origin: **6 HEAD size probes and 1 GET**. Worth noting the browser build was already collapsing the body download (the control caches by URL string there); the 6x full download is specific to the desktop loader, which materializes a distinct `File` per layer, and is what the reporter hit.

Also confirmed no `Cannot get style of non-existing layer` entries in the preserved-layer state.

Desktop-specific pieces are covered by tests rather than a driven run, since the Tauri webview cannot be driven by Playwright: the JS collapser and the Rust clamp both have unit tests, and the camelCase-to-snake_case invoke argument convention matches the existing `install_external_plugin_archive` / `sourcePath` command in this repo.

- `npm run test:frontend` 5486 tests pass (12 new)
- `cargo test --lib` 35 pass (1 new)
- `npm run build`, `npm run check:rust`, `pre-commit run --files <changed>` all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector downloads now receive meaningful filenames and avoid duplicate simultaneous downloads.
  * Missing vector layers can be restored automatically while preserving existing layers during synchronization.
  * Remote requests support configurable time limits, up to 10 minutes.

* **Bug Fixes**
  * Improved recovery when vector layers fail to reload or temporarily disappear.
  * Prevented synchronization issues caused by missing map layers.
  * Added safer fallback handling for vector downloads through alternative request methods.
  * Improved handling of unavailable or unreadable local vector files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->