### PR TITLE
fix(arcgis): load feature services by viewport

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -27,6 +27,7 @@ import {
   reattachSun,
   reattachRouteAnimation,
   reattachFlightSimulator,
+  restoreArcGISViewportLayers,
   restoreRasterLayers,
   restoreThreeDTilesLayers,
   restoreVectorLayers,
@@ -1150,6 +1151,9 @@ export function DesktopShell({
     restoreRasterLayers(appAPI);
     restorePlanetaryComputerLayers(appAPI);
     restoreVectorLayers(appAPI);
+    // Re-bind saved ArcGIS feature layers to the viewport. Without this a
+    // reopened project's layer stays frozen on the extent it was saved with.
+    restoreArcGISViewportLayers(appAPI);
     // Re-stream saved LiDAR (COPC) point clouds. A `lidar-url` layer restores
     // into the store as inert metadata; the point cloud is loaded by the LiDAR
     // control, not the store, so without this the layer shows in the panel but

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -577,9 +577,15 @@ async function refreshArcGISLayer(layer: GeoLibreLayer): Promise<GeoJsonRefreshR
   // the callers that only read refresh metadata.
   const { refreshArcGISFeatureLayer, reloadArcGISViewportLayer } =
     await import("@geolibre/plugins");
-  const viewport =
-    layer.metadata.viewportLoading === true ? reloadArcGISViewportLayer(layer.id) : null;
-  if (viewport) {
+  if (layer.metadata.viewportLoading === true) {
+    const viewport = reloadArcGISViewportLayer(layer.id);
+    // No live loader yet: a just-reopened project is still resolving the
+    // service metadata its loader needs, or that resolve failed. Falling
+    // through to the unbounded replay below would download the entire service
+    // — the cost this layer is loaded by viewport to avoid — so say so instead.
+    if (!viewport) {
+      throw new Error("This layer is still binding to the map viewport. Try again in a moment.");
+    }
     const bounded = await viewport;
     return { geojson: bounded, featureCount: bounded.features.length };
   }

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -579,12 +579,12 @@ async function refreshArcGISLayer(layer: GeoLibreLayer): Promise<GeoJsonRefreshR
     await import("@geolibre/plugins");
   if (layer.metadata.viewportLoading === true) {
     const viewport = reloadArcGISViewportLayer(layer.id);
-    // No live loader yet: a just-reopened project is still resolving the
-    // service metadata its loader needs, or that resolve failed. Falling
-    // through to the unbounded replay below would download the entire service
-    // — the cost this layer is loaded by viewport to avoid — so say so instead.
+    // No loader at all: the layer is in a host with no map (`restoreArcGISViewportLayers`
+    // registers one synchronously wherever there is one). Falling through to
+    // the unbounded replay below would download the entire service — the cost
+    // this layer is loaded by viewport to avoid — so say so instead.
     if (!viewport) {
-      throw new Error("This layer is still binding to the map viewport. Try again in a moment.");
+      throw new Error("This layer is not bound to a map viewport, so it cannot be refreshed.");
     }
     const bounded = await viewport;
     return { geojson: bounded, featureCount: bounded.features.length };

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -559,6 +559,11 @@ function isWfsLayer(layer: GeoLibreLayer): boolean {
  * that case derives the endpoint from the stored URL, which is the same
  * `/query` path with the unbounded parameters that get replaced anyway.
  *
+ * A layer that is loading by viewport is the exception: it only ever holds the
+ * current extent, so replaying the unbounded download here would swap the whole
+ * service in behind the user's back until the next `moveend` — the very cost
+ * viewport loading avoids. Those refresh by re-running the bounded query.
+ *
  * @param layer - The ArcGIS feature layer to reload.
  * @returns The reloaded features and their count.
  */
@@ -568,15 +573,23 @@ async function refreshArcGISLayer(layer: GeoLibreLayer): Promise<GeoJsonRefreshR
     maxFeatures?: unknown;
     pageSize?: unknown;
   };
+  // Imported here rather than at module scope so this module stays light for
+  // the callers that only read refresh metadata.
+  const { refreshArcGISFeatureLayer, reloadArcGISViewportLayer } =
+    await import("@geolibre/plugins");
+  const viewport =
+    layer.metadata.viewportLoading === true ? reloadArcGISViewportLayer(layer.id) : null;
+  if (viewport) {
+    const bounded = await viewport;
+    return { geojson: bounded, featureCount: bounded.features.length };
+  }
+
   const stored = typeof source.arcgisQueryUrl === "string" ? source.arcgisQueryUrl.trim() : "";
   // Fall back to the layer's own URL, stripped of its query string: it is the
   // `/query` endpoint the paged fetch wants, just with the parameters attached.
   const queryUrl = stored || (layerHttpUrl(layer) ?? "").split("?")[0];
   if (!queryUrl) throw new Error("This layer does not have a refreshable GeoJSON URL.");
 
-  // Imported here rather than at module scope so this module stays light for
-  // the callers that only read refresh metadata.
-  const { refreshArcGISFeatureLayer } = await import("@geolibre/plugins");
   const data = await refreshArcGISFeatureLayer({
     maxFeatures: typeof source.maxFeatures === "number" ? source.maxFeatures : undefined,
     pageSize: typeof source.pageSize === "number" ? source.pageSize : undefined,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -64,6 +64,7 @@ export {
   ARCGIS_MAP_SERVICE_SOURCE_KIND,
   parseArcGISLayerType,
   refreshArcGISFeatureLayer,
+  reloadArcGISViewportLayer,
   type ArcGISLayerOptions,
   type ArcGISLayerType,
   type ArcGISSourceType,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -65,6 +65,7 @@ export {
   parseArcGISLayerType,
   refreshArcGISFeatureLayer,
   reloadArcGISViewportLayer,
+  restoreArcGISViewportLayers,
   type ArcGISLayerOptions,
   type ArcGISLayerType,
   type ArcGISSourceType,

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -459,6 +459,10 @@ function startArcGISViewportLoader(
 ): void {
   let abort: AbortController | null = null;
   let requestSequence = 0;
+  // The Add Data dialog's progress callback belongs to the initial download. It
+  // is unmounted well before the first viewport query lands, so carrying it for
+  // the layer's lifetime would keep that closure alive to no purpose.
+  const queryOptions: ArcGISLayerOptions = { ...options, onProgress: undefined };
   const loader: ArcGISViewportLoader = {
     abort: null,
     load: () => Promise.resolve({ type: "FeatureCollection", features: [] }),
@@ -466,6 +470,15 @@ function startArcGISViewportLoader(
     move: () => undefined,
   };
 
+  /**
+   * Query the map's current extent, publishing each page as it lands.
+   *
+   * Resolves with whatever the layer holds — never rejects — when a newer
+   * viewport supersedes the call: that abort is bookkeeping, not a failure, and
+   * the replacement is already publishing. A refresh running concurrently with
+   * a pan must not be reported as a failed refresh (and, under an `onFailure`
+   * of `"clear"`, wipe a layer that is perfectly healthy).
+   */
   const load = async (): Promise<FeatureCollection> => {
     abort?.abort();
     const controller = new AbortController();
@@ -489,26 +502,34 @@ function startArcGISViewportLoader(
       }
       useAppStore.getState().updateLayer(layerId, { geojson: collect() });
     };
-    await Promise.all(
-      envelopes.map(async (envelope, index) => {
-        const data = await fetchArcGISFeaturePages(queryUrl, options, layerInfo, {
-          params: {
-            geometry: envelope.join(","),
-            geometryType: "esriGeometryEnvelope",
-            inSR: "4326",
-            spatialRel: "esriSpatialRelIntersects",
-          },
-          signal: controller.signal,
-          onPage: (features) => {
-            pages[index] = features;
-            publish();
-          },
-        });
-        pages[index] = data.features;
-        publish();
-      }),
-    );
-    if (sequence === requestSequence) reportArcGISViewportError(layerId, null);
+    try {
+      await Promise.all(
+        envelopes.map(async (envelope, index) => {
+          const data = await fetchArcGISFeaturePages(queryUrl, queryOptions, layerInfo, {
+            params: {
+              geometry: envelope.join(","),
+              geometryType: "esriGeometryEnvelope",
+              inSR: "4326",
+              spatialRel: "esriSpatialRelIntersects",
+            },
+            signal: controller.signal,
+            onPage: (features) => {
+              pages[index] = features;
+              publish();
+            },
+          });
+          pages[index] = data.features;
+          publish();
+        }),
+      );
+    } catch (error) {
+      if (sequence !== requestSequence && isArcGISAbortError(error)) {
+        return currentArcGISLayerGeojson(layerId);
+      }
+      throw error;
+    }
+    if (sequence !== requestSequence) return currentArcGISLayerGeojson(layerId);
+    reportArcGISViewportError(layerId, null);
     return collect();
   };
 
@@ -541,6 +562,59 @@ export function reloadArcGISViewportLayer(layerId: string): Promise<FeatureColle
 }
 
 /**
+ * Re-attach viewport loaders after a project is loaded.
+ *
+ * {@link startArcGISViewportLoader} only runs in the Add Data flow, but
+ * `metadata.viewportLoading` round-trips through the saved project. Without
+ * this, a reopened project's feature layer is frozen on whichever extent was in
+ * view when it was saved: panning fetches nothing, and a refresh falls back to
+ * the unbounded download the viewport path exists to avoid.
+ *
+ * @param app - The host app API, for the map the loaders bind to.
+ */
+export function restoreArcGISViewportLayers(app: GeoLibreAppAPI): void {
+  const map = app.getMap?.();
+  if (!map) return;
+  for (const layer of useAppStore.getState().layers) {
+    if (
+      layer.metadata.viewportLoading !== true ||
+      layer.metadata.sourceKind !== ARCGIS_FEATURE_SOURCE_KIND ||
+      arcgisFeatureLoaders.has(layer.id)
+    ) {
+      continue;
+    }
+    const source = layer.source as {
+      arcgisQueryUrl?: unknown;
+      maxFeatures?: unknown;
+      pageSize?: unknown;
+    };
+    const queryUrl = typeof source.arcgisQueryUrl === "string" ? source.arcgisQueryUrl.trim() : "";
+    if (!queryUrl) continue;
+    const options: ArcGISLayerOptions = {
+      layerType: "feature",
+      maxFeatures: typeof source.maxFeatures === "number" ? source.maxFeatures : undefined,
+      pageSize: typeof source.pageSize === "number" ? source.pageSize : undefined,
+      sourceType: "url",
+    };
+    const layerId = layer.id;
+    // Re-read the service metadata rather than trusting a stored copy, the same
+    // reason refreshArcGISFeatureLayer does: paging capabilities and
+    // `maxRecordCount` are the service's to change between sessions.
+    void fetchArcGISJson<ArcGISFeatureLayerInfo>(
+      trimTrailingSlash(queryUrl).replace(/\/query$/i, ""),
+      options,
+      undefined,
+    )
+      .then((layerInfo) => {
+        // The layer may have been removed while the metadata was in flight.
+        if (!useAppStore.getState().layers.some((entry) => entry.id === layerId)) return;
+        startArcGISViewportLoader(layerId, map, queryUrl, options, layerInfo);
+      })
+      .catch((error: unknown) => handleArcGISViewportError(layerId, error));
+  }
+}
+
+/**
  * Tear down viewport loaders for layers that have left the store.
  *
  * One shared subscription for every loader, matching
@@ -569,9 +643,19 @@ function stopArcGISViewportLoader(layerId: string): void {
 }
 
 function handleArcGISViewportError(layerId: string, error: unknown): void {
-  if (error instanceof DOMException && error.name === "AbortError") return;
+  if (isArcGISAbortError(error)) return;
   console.error("[GeoLibre] ArcGIS viewport query failed", error);
   reportArcGISViewportError(layerId, error instanceof Error ? error.message : String(error));
+}
+
+function isArcGISAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+/** The features a layer currently holds, for a query that has nothing newer. */
+function currentArcGISLayerGeojson(layerId: string): FeatureCollection {
+  const layer = useAppStore.getState().layers.find((entry) => entry.id === layerId);
+  return layer?.geojson ?? { type: "FeatureCollection", features: [] };
 }
 
 /**

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -445,17 +445,23 @@ async function addArcGISFeatureLayerAsGeoJson(
 
   const bounds = arcgisExtentToBounds(layerInfo.extent);
   if (bounds && options.zoomTo !== false) app.fitBounds?.(bounds);
-  if (map) startArcGISViewportLoader(id, map, queryUrl, options, layerInfo);
+  if (map) startArcGISViewportLoader(id, map, queryUrl, options, () => Promise.resolve(layerInfo));
   return id;
 }
 
-/** Keep one FeatureServer layer synchronized with the settled map viewport. */
+/**
+ * Keep one FeatureServer layer synchronized with the settled map viewport.
+ *
+ * `resolveLayerInfo` is a thunk rather than a value so the restore path can
+ * register a loader before it has the service metadata: the fetch then happens
+ * on the first query, and a failed one is retried by the next.
+ */
 function startArcGISViewportLoader(
   layerId: string,
   map: maplibregl.Map,
   queryUrl: string,
   options: ArcGISLayerOptions,
-  layerInfo: ArcGISFeatureLayerInfo,
+  resolveLayerInfo: () => Promise<ArcGISFeatureLayerInfo>,
 ): void {
   let abort: AbortController | null = null;
   let requestSequence = 0;
@@ -488,6 +494,13 @@ function startArcGISViewportLoader(
     abort = controller;
     loader.abort = controller;
     const sequence = ++requestSequence;
+    let layerInfo: ArcGISFeatureLayerInfo;
+    try {
+      layerInfo = await resolveLayerInfo();
+    } catch (error) {
+      if (sequence !== requestSequence) return currentArcGISLayerGeojson(layerId);
+      throw error;
+    }
     const envelopes = arcgisViewportEnvelopes(map.getBounds());
     // One bucket per envelope, so a viewport split across the antimeridian
     // publishes both halves together instead of each replacing the other.
@@ -579,6 +592,10 @@ export function reloadArcGISViewportLayer(layerId: string): Promise<FeatureColle
  * view when it was saved: panning fetches nothing, and a refresh falls back to
  * the unbounded download the viewport path exists to avoid.
  *
+ * Loaders are registered synchronously, before the service metadata they need
+ * is fetched, so there is no window in which a refresh finds the layer
+ * unbound.
+ *
  * @param app - The host app API, for the map the loaders bind to.
  */
 export function restoreArcGISViewportLayers(app: GeoLibreAppAPI): void {
@@ -608,21 +625,23 @@ export function restoreArcGISViewportLayers(app: GeoLibreAppAPI): void {
       pageSize: typeof source.pageSize === "number" ? source.pageSize : undefined,
       sourceType: "url",
     };
-    const layerId = layer.id;
     // Re-read the service metadata rather than trusting a stored copy, the same
     // reason refreshArcGISFeatureLayer does: paging capabilities and
-    // `maxRecordCount` are the service's to change between sessions.
-    void fetchArcGISJson<ArcGISFeatureLayerInfo>(
-      trimTrailingSlash(queryUrl).replace(/\/query$/i, ""),
-      options,
-      undefined,
-    )
-      .then((layerInfo) => {
-        // The layer may have been removed while the metadata was in flight.
-        if (!useAppStore.getState().layers.some((entry) => entry.id === layerId)) return;
-        startArcGISViewportLoader(layerId, map, queryUrl, options, layerInfo);
-      })
-      .catch((error: unknown) => handleArcGISViewportError(layerId, error));
+    // `maxRecordCount` are the service's to change between sessions. Fetched
+    // lazily on the first query and memoized, with a failure clearing the
+    // memo — so a blocked or flaky reopen retries on the next pan or refresh
+    // instead of leaving the layer permanently unbound.
+    let pending: Promise<ArcGISFeatureLayerInfo> | null = null;
+    const resolveLayerInfo = (): Promise<ArcGISFeatureLayerInfo> =>
+      (pending ??= fetchArcGISJson<ArcGISFeatureLayerInfo>(
+        trimTrailingSlash(queryUrl).replace(/\/query$/i, ""),
+        options,
+        undefined,
+      ).catch((error: unknown) => {
+        pending = null;
+        throw error;
+      }));
+    startArcGISViewportLoader(layer.id, map, queryUrl, options, resolveLayerInfo);
   }
 }
 
@@ -1241,7 +1260,7 @@ async function planArcGISPaging(
     supportsOrderBy: layerInfo.advancedQueryCapabilities?.supportsOrderBy !== false,
     // Spatial counts can be as expensive as fetching the first page on large
     // polygon services. Start rendering immediately for viewport queries.
-    total: request.params ? null : await fetchArcGISFeatureCount(queryUrl, params, request.signal),
+    total: request.params ? null : await fetchArcGISFeatureCount(queryUrl, params),
   };
 }
 
@@ -1275,13 +1294,16 @@ function positiveInteger(value: number | undefined): number | null {
  * condition. Best-effort: a service that will not answer `returnCountOnly`
  * still pages fine, so any failure resolves to `null` rather than throwing.
  *
+ * Takes no abort signal, and needs none: {@link planArcGISPaging} skips the
+ * count entirely for a viewport query (the only cancellable caller), because a
+ * spatial count can cost as much as the first page.
+ *
  * @param queryUrl - The layer's `/query` endpoint.
- * @param token - The access token to send, if any.
+ * @param params - The query params every request in the plan shares.
  */
 async function fetchArcGISFeatureCount(
   queryUrl: string,
   params: Record<string, string | undefined>,
-  signal?: AbortSignal,
 ): Promise<number | null> {
   try {
     const response = await fetch(
@@ -1291,15 +1313,13 @@ async function fetchArcGISFeatureCount(
         returnCountOnly: "true",
         where: "1=1",
       }),
-      { signal },
     );
     if (!response.ok) return null;
     const json = (await response.json()) as { count?: unknown };
     return typeof json.count === "number" && Number.isFinite(json.count) && json.count >= 0
       ? json.count
       : null;
-  } catch (error) {
-    if (signal?.aborted) throw error;
+  } catch {
     return null;
   }
 }

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -231,6 +231,10 @@ interface ArcGISRuntimeLayer {
 let arcgisLayerSequence = 0;
 const arcgisLayerInstances = new Map<string, ArcGISRuntimeLayer>();
 let arcgisStoreUnsubscribe: (() => void) | null = null;
+const arcgisFeatureLoaders = new Map<
+  string,
+  { abort: AbortController | null; map: maplibregl.Map; move: () => void }
+>();
 
 export async function addArcGISLayer(
   app: GeoLibreAppAPI,
@@ -393,14 +397,18 @@ async function addArcGISFeatureLayerAsGeoJson(
     returnGeometry: "true",
     where: "1=1",
   });
-  const geojson = await fetchArcGISFeaturePages(queryUrl, options, layerInfo);
-
   const name =
     options.name?.trim() || layerInfo.name || layerNameFromArcGISInput(layerUrl, "ArcGIS Layer");
   const store = useAppStore.getState();
-  // Persist the GeoJSON query endpoint (not the service-description base URL) as
-  // the source path so the layer's GeoJSON refresh re-fetches valid features.
-  const id = store.addGeoJsonLayer(name, geojson, refreshUrl, options.beforeLayerId ?? null);
+  const map = app.getMap?.();
+  // Headless/API consumers have no viewport to query, so retain the complete
+  // paged download for them. The interactive app takes the bounded path below.
+  const initialData: FeatureCollection = map
+    ? { type: "FeatureCollection", features: [] }
+    : await fetchArcGISFeaturePages(queryUrl, options, layerInfo);
+  // Add the layer before downloading features. Large services must not hold the
+  // Add Data dialog open while hundreds of thousands of records are fetched.
+  const id = store.addGeoJsonLayer(name, initialData, refreshUrl, options.beforeLayerId ?? null);
 
   store.updateLayer(id, {
     source: {
@@ -417,12 +425,90 @@ async function addArcGISFeatureLayerAsGeoJson(
       maxFeatures: options.maxFeatures,
       pageSize: options.pageSize,
     },
-    metadata: { sourceKind: ARCGIS_FEATURE_SOURCE_KIND },
+    metadata: { sourceKind: ARCGIS_FEATURE_SOURCE_KIND, viewportLoading: Boolean(map) },
   });
 
   const bounds = arcgisExtentToBounds(layerInfo.extent);
   if (bounds && options.zoomTo !== false) app.fitBounds?.(bounds);
+  if (map) startArcGISViewportLoader(id, map, queryUrl, options, layerInfo);
   return id;
+}
+
+/** Keep one FeatureServer layer synchronized with the settled map viewport. */
+function startArcGISViewportLoader(
+  layerId: string,
+  map: maplibregl.Map,
+  queryUrl: string,
+  options: ArcGISLayerOptions,
+  layerInfo: ArcGISFeatureLayerInfo,
+): void {
+  let abort: AbortController | null = null;
+  let requestSequence = 0;
+  const loader: { abort: AbortController | null; map: maplibregl.Map; move: () => void } = {
+    abort: null,
+    map,
+    move: () => undefined,
+  };
+
+  const load = (): void => {
+    abort?.abort();
+    abort = new AbortController();
+    loader.abort = abort;
+    const sequence = ++requestSequence;
+    const bounds = map.getBounds();
+    const bbox: [number, number, number, number] = [
+      Math.max(-180, bounds.getWest()),
+      Math.max(-90, bounds.getSouth()),
+      Math.min(180, bounds.getEast()),
+      Math.min(90, bounds.getNorth()),
+    ];
+    const query = {
+      geometry: bbox.join(","),
+      geometryType: "esriGeometryEnvelope",
+      inSR: "4326",
+      spatialRel: "esriSpatialRelIntersects",
+    };
+    const publish = (features: Feature[]): void => {
+      if (
+        sequence !== requestSequence ||
+        !useAppStore.getState().layers.some((l) => l.id === layerId)
+      ) {
+        return;
+      }
+      useAppStore.getState().updateLayer(layerId, {
+        geojson: { type: "FeatureCollection", features: [...features] },
+      });
+    };
+    void fetchArcGISFeaturePages(queryUrl, options, layerInfo, {
+      params: query,
+      signal: abort.signal,
+      onPage: publish,
+    })
+      .then((data) => publish(data.features))
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        console.error("[GeoLibre] ArcGIS viewport query failed", error);
+      });
+  };
+
+  const move = (): void => load();
+  loader.move = move;
+  map.on("moveend", move);
+  const existing = arcgisFeatureLoaders.get(layerId);
+  existing?.abort?.abort();
+  if (existing) existing.map.off("moveend", existing.move);
+  arcgisFeatureLoaders.set(layerId, loader);
+  // fitBounds may still be animating. Its moveend will replace this first query.
+  if (!map.isMoving()) load();
+
+  const unsubscribe = useAppStore.subscribe((state) => {
+    if (state.layers.some((layer) => layer.id === layerId)) return;
+    const loader = arcgisFeatureLoaders.get(layerId);
+    loader?.abort?.abort();
+    loader?.map.off("moveend", loader.move);
+    arcgisFeatureLoaders.delete(layerId);
+    unsubscribe();
+  });
 }
 
 /**
@@ -786,12 +872,14 @@ interface ArcGISPagingPlan {
   /** The layer's ObjectID field, when the service names one. */
   objectIdField: string | undefined;
   onProgress: ArcGISLayerOptions["onProgress"];
+  onPage?: (features: Feature[]) => void;
   /** Features to request per `/query` call. */
   pageSize: number;
   /** Query params every page shares (including the token, if any). */
   params: Record<string, string | undefined>;
   /** The `/query` endpoint, without paging params. */
   queryUrl: string;
+  signal?: AbortSignal;
   /** Whether the service claims to honor `resultOffset`. */
   supportsPagination: boolean;
   /** Whether the service accepts `orderByFields` (needed for stable paging). */
@@ -833,8 +921,13 @@ async function fetchArcGISFeaturePages(
   queryUrl: string,
   options: ArcGISLayerOptions,
   layerInfo: ArcGISFeatureLayerInfo,
+  request: {
+    params?: Record<string, string>;
+    signal?: AbortSignal;
+    onPage?: (features: Feature[]) => void;
+  } = {},
 ): Promise<FeatureCollection> {
-  const plan = await planArcGISPaging(queryUrl, options, layerInfo);
+  const plan = await planArcGISPaging(queryUrl, options, layerInfo, request);
 
   if (plan.supportsPagination) {
     const paged = await fetchArcGISPagesByOffset(plan);
@@ -858,6 +951,11 @@ async function planArcGISPaging(
   queryUrl: string,
   options: ArcGISLayerOptions,
   layerInfo: ArcGISFeatureLayerInfo,
+  request: {
+    params?: Record<string, string>;
+    signal?: AbortSignal;
+    onPage?: (features: Feature[]) => void;
+  },
 ): Promise<ArcGISPagingPlan> {
   const params = {
     f: "geojson",
@@ -865,17 +963,22 @@ async function planArcGISPaging(
     returnGeometry: "true",
     where: "1=1",
     token: options.token?.trim() || undefined,
+    ...request.params,
   };
   return {
     maxFeatures: positiveInteger(options.maxFeatures),
     objectIdField: layerInfo.objectIdField?.trim() || undefined,
     onProgress: options.onProgress,
+    onPage: request.onPage,
     pageSize: resolveArcGISPageSize(options.pageSize, layerInfo.maxRecordCount),
     params,
     queryUrl,
+    signal: request.signal,
     supportsPagination: layerInfo.advancedQueryCapabilities?.supportsPagination === true,
     supportsOrderBy: layerInfo.advancedQueryCapabilities?.supportsOrderBy !== false,
-    total: await fetchArcGISFeatureCount(queryUrl, params.token),
+    // Spatial counts can be as expensive as fetching the first page on large
+    // polygon services. Start rendering immediately for viewport queries.
+    total: request.params ? null : await fetchArcGISFeatureCount(queryUrl, params, request.signal),
   };
 }
 
@@ -914,23 +1017,26 @@ function positiveInteger(value: number | undefined): number | null {
  */
 async function fetchArcGISFeatureCount(
   queryUrl: string,
-  token: string | undefined,
+  params: Record<string, string | undefined>,
+  signal?: AbortSignal,
 ): Promise<number | null> {
   try {
     const response = await fetch(
       appendArcGISParams(queryUrl, {
+        ...params,
         f: "json",
         returnCountOnly: "true",
         where: "1=1",
-        token,
       }),
+      { signal },
     );
     if (!response.ok) return null;
     const json = (await response.json()) as { count?: unknown };
     return typeof json.count === "number" && Number.isFinite(json.count) && json.count >= 0
       ? json.count
       : null;
-  } catch {
+  } catch (error) {
+    if (signal?.aborted) throw error;
     return null;
   }
 }
@@ -968,6 +1074,7 @@ async function fetchArcGISPagesByOffset(
         resultOffset: String(features.length),
         resultRecordCount: String(wanted),
       }),
+      plan.signal,
     );
     if (chunk.features.length === 0) break;
 
@@ -980,6 +1087,7 @@ async function fetchArcGISPagesByOffset(
     previousSignature = signature;
 
     features.push(...chunk.features);
+    plan.onPage?.(features);
     plan.onProgress?.(features.length, plan.total);
 
     if (plan.total !== null && features.length >= plan.total) break;
@@ -1032,6 +1140,7 @@ async function fetchArcGISPagesByObjectId(
         ...plan.params,
         where: `${field} >= ${objectIds[start]} AND ${field} <= ${objectIds[end - 1]}`,
       }),
+      plan.signal,
     );
 
     // The range spans `end - start` ObjectIDs, so a shorter capped page would
@@ -1048,6 +1157,7 @@ async function fetchArcGISPagesByObjectId(
     }
 
     features.push(...chunk.features);
+    plan.onPage?.(features);
     start = end;
     plan.onProgress?.(features.length, plan.total ?? objectIds.length);
   }
@@ -1062,11 +1172,12 @@ async function fetchArcGISObjectIds(
   try {
     const response = await fetch(
       appendArcGISParams(plan.queryUrl, {
+        ...plan.params,
         f: "json",
         returnIdsOnly: "true",
         where: "1=1",
-        token: plan.params.token,
       }),
+      { signal: plan.signal },
     );
     if (!response.ok) return null;
     const json = (await response.json()) as {
@@ -1081,7 +1192,8 @@ async function fetchArcGISObjectIds(
       (typeof json.objectIdFieldName === "string" ? json.objectIdFieldName.trim() : "") ||
       plan.objectIdField;
     return field && objectIds.length > 0 ? { field, objectIds } : null;
-  } catch {
+  } catch (error) {
+    if (plan.signal?.aborted) throw error;
     return null;
   }
 }
@@ -1178,8 +1290,9 @@ function arcgisErrorMessage(error: ArcGISErrorEnvelope | undefined, fallback: st
  */
 async function fetchArcGISGeoJson(
   url: string,
+  signal?: AbortSignal,
 ): Promise<FeatureCollection & { exceededTransferLimit: boolean }> {
-  const response = await fetch(url);
+  const response = await fetch(url, { signal });
   if (!response.ok) {
     throw new Error(`ArcGIS feature query failed with ${response.status}.`);
   }

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -94,6 +94,11 @@ export interface ArcGISLayerOptions {
    * Only meaningful for `layerType: "feature"`, whose features are pulled into
    * an in-memory GeoJSON source; a cap is the escape hatch for a layer too big
    * to hold in the browser at all.
+   *
+   * In the interactive app a feature layer loads by viewport, so the cap
+   * applies to each viewport query rather than to the layer as a whole: every
+   * pan issues a fresh bounded download of up to this many features. Headless
+   * callers, which download the layer whole, get the total cap.
    */
   maxFeatures?: number;
   name?: string;
@@ -231,10 +236,20 @@ interface ArcGISRuntimeLayer {
 let arcgisLayerSequence = 0;
 const arcgisLayerInstances = new Map<string, ArcGISRuntimeLayer>();
 let arcgisStoreUnsubscribe: (() => void) | null = null;
-const arcgisFeatureLoaders = new Map<
-  string,
-  { abort: AbortController | null; map: maplibregl.Map; move: () => void }
->();
+
+/** A live viewport-bound FeatureServer download for one GeoJSON layer. */
+interface ArcGISViewportLoader {
+  /** The in-flight request, aborted when a newer viewport supersedes it. */
+  abort: AbortController | null;
+  /** Re-run the query for the map's current extent. */
+  load: () => Promise<FeatureCollection>;
+  map: maplibregl.Map;
+  /** The `moveend` handler, kept so it can be detached on removal. */
+  move: () => void;
+}
+
+const arcgisFeatureLoaders = new Map<string, ArcGISViewportLoader>();
+let arcgisFeatureLoaderUnsubscribe: (() => void) | null = null;
 
 export async function addArcGISLayer(
   app: GeoLibreAppAPI,
@@ -444,71 +459,223 @@ function startArcGISViewportLoader(
 ): void {
   let abort: AbortController | null = null;
   let requestSequence = 0;
-  const loader: { abort: AbortController | null; map: maplibregl.Map; move: () => void } = {
+  const loader: ArcGISViewportLoader = {
     abort: null,
+    load: () => Promise.resolve({ type: "FeatureCollection", features: [] }),
     map,
     move: () => undefined,
   };
 
-  const load = (): void => {
+  const load = async (): Promise<FeatureCollection> => {
     abort?.abort();
-    abort = new AbortController();
-    loader.abort = abort;
+    const controller = new AbortController();
+    abort = controller;
+    loader.abort = controller;
     const sequence = ++requestSequence;
-    const bounds = map.getBounds();
-    const bbox: [number, number, number, number] = [
-      Math.max(-180, bounds.getWest()),
-      Math.max(-90, bounds.getSouth()),
-      Math.min(180, bounds.getEast()),
-      Math.min(90, bounds.getNorth()),
-    ];
-    const query = {
-      geometry: bbox.join(","),
-      geometryType: "esriGeometryEnvelope",
-      inSR: "4326",
-      spatialRel: "esriSpatialRelIntersects",
-    };
-    const publish = (features: Feature[]): void => {
+    const envelopes = arcgisViewportEnvelopes(map.getBounds());
+    // One bucket per envelope, so a viewport split across the antimeridian
+    // publishes both halves together instead of each replacing the other.
+    const pages: Feature[][] = envelopes.map(() => []);
+    const collect = (): FeatureCollection => ({
+      type: "FeatureCollection",
+      features: mergeArcGISViewportFeatures(pages, layerInfo.objectIdField),
+    });
+    const publish = (): void => {
       if (
         sequence !== requestSequence ||
         !useAppStore.getState().layers.some((l) => l.id === layerId)
       ) {
         return;
       }
-      useAppStore.getState().updateLayer(layerId, {
-        geojson: { type: "FeatureCollection", features: [...features] },
-      });
+      useAppStore.getState().updateLayer(layerId, { geojson: collect() });
     };
-    void fetchArcGISFeaturePages(queryUrl, options, layerInfo, {
-      params: query,
-      signal: abort.signal,
-      onPage: publish,
-    })
-      .then((data) => publish(data.features))
-      .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === "AbortError") return;
-        console.error("[GeoLibre] ArcGIS viewport query failed", error);
-      });
+    await Promise.all(
+      envelopes.map(async (envelope, index) => {
+        const data = await fetchArcGISFeaturePages(queryUrl, options, layerInfo, {
+          params: {
+            geometry: envelope.join(","),
+            geometryType: "esriGeometryEnvelope",
+            inSR: "4326",
+            spatialRel: "esriSpatialRelIntersects",
+          },
+          signal: controller.signal,
+          onPage: (features) => {
+            pages[index] = features;
+            publish();
+          },
+        });
+        pages[index] = data.features;
+        publish();
+      }),
+    );
+    if (sequence === requestSequence) reportArcGISViewportError(layerId, null);
+    return collect();
   };
 
-  const move = (): void => load();
+  const move = (): void => {
+    void load().catch((error: unknown) => handleArcGISViewportError(layerId, error));
+  };
+  loader.load = load;
   loader.move = move;
+  stopArcGISViewportLoader(layerId);
   map.on("moveend", move);
-  const existing = arcgisFeatureLoaders.get(layerId);
-  existing?.abort?.abort();
-  if (existing) existing.map.off("moveend", existing.move);
   arcgisFeatureLoaders.set(layerId, loader);
+  ensureArcGISFeatureLoaderCleanup();
   // fitBounds may still be animating. Its moveend will replace this first query.
-  if (!map.isMoving()) load();
+  if (!map.isMoving()) move();
+}
 
-  const unsubscribe = useAppStore.subscribe((state) => {
-    if (state.layers.some((layer) => layer.id === layerId)) return;
-    const loader = arcgisFeatureLoaders.get(layerId);
-    loader?.abort?.abort();
-    loader?.map.off("moveend", loader.move);
-    arcgisFeatureLoaders.delete(layerId);
-    unsubscribe();
+/**
+ * Re-run the viewport query for a layer that loads by extent.
+ *
+ * A refresh must not fall back to the unbounded paged download for these
+ * layers: that would pull the whole service into memory behind the user's
+ * back, which is the very thing viewport loading exists to avoid.
+ *
+ * @param layerId - The layer to reload.
+ * @returns The features for the map's current extent, or `null` when the layer
+ *   has no live loader (a project restored from disk, or a headless host).
+ */
+export function reloadArcGISViewportLayer(layerId: string): Promise<FeatureCollection> | null {
+  return arcgisFeatureLoaders.get(layerId)?.load() ?? null;
+}
+
+/**
+ * Tear down viewport loaders for layers that have left the store.
+ *
+ * One shared subscription for every loader, matching
+ * {@link ensureArcGISStoreCleanup}: a subscription per layer would run a linear
+ * scan of `state.layers` on every unrelated store update for the life of the
+ * app, multiplied by however many such layers are open.
+ */
+function ensureArcGISFeatureLoaderCleanup(): void {
+  arcgisFeatureLoaderUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (arcgisFeatureLoaders.size === 0) return;
+    for (const layer of previous.layers) {
+      if (!state.layers.some((current) => current.id === layer.id)) {
+        stopArcGISViewportLoader(layer.id);
+      }
+    }
   });
+}
+
+/** Cancel a layer's viewport loader and detach its `moveend` handler. */
+function stopArcGISViewportLoader(layerId: string): void {
+  const loader = arcgisFeatureLoaders.get(layerId);
+  if (!loader) return;
+  loader.abort?.abort();
+  loader.map.off("moveend", loader.move);
+  arcgisFeatureLoaders.delete(layerId);
+}
+
+function handleArcGISViewportError(layerId: string, error: unknown): void {
+  if (error instanceof DOMException && error.name === "AbortError") return;
+  console.error("[GeoLibre] ArcGIS viewport query failed", error);
+  reportArcGISViewportError(layerId, error instanceof Error ? error.message : String(error));
+}
+
+/**
+ * Record a viewport query's outcome on the layer's connection record, which is
+ * what the Layers panel already reads to show a synchronization error. Without
+ * it a failed pan leaves the previous extent's features on screen with nothing
+ * to say the query for the current one never landed.
+ */
+function reportArcGISViewportError(layerId: string, message: string | null): void {
+  const layer = useAppStore.getState().layers.find((l) => l.id === layerId);
+  // Only written when the state actually changes, so a successful pan over a
+  // healthy layer does not dirty the project on every `moveend`.
+  if (!layer || (layer.connection?.lastError ?? null) === message) return;
+  useAppStore.getState().updateLayer(layerId, {
+    connection: {
+      interval: null,
+      lastSyncedAt: null,
+      onFailure: "keep-last",
+      ...layer.connection,
+      layerId,
+      lastError: message,
+    },
+  });
+}
+
+/** A `[west, south, east, north]` query envelope, in WGS84 degrees. */
+type ArcGISEnvelope = [number, number, number, number];
+
+/**
+ * The ArcGIS query envelopes covering a map viewport.
+ *
+ * MapLibre reports the viewport's raw longitudes, which run outside ±180 as
+ * soon as the view crosses the antimeridian or the user keeps panning around
+ * the globe. Clamping each edge on its own would either invert the envelope
+ * (west 170, east -170) or collapse it to zero width (west 200, east 210), and
+ * ArcGIS answers both with nothing for that part of the screen. So the span is
+ * normalized onto ±180 and, when it straddles the antimeridian, split into the
+ * two envelopes that cover it — the same treatment `splitAntimeridian` gives
+ * the offline tile download.
+ *
+ * @param bounds - The map's current bounds.
+ * @returns One envelope, or two when the viewport crosses the antimeridian.
+ */
+function arcgisViewportEnvelopes(bounds: {
+  getEast(): number;
+  getNorth(): number;
+  getSouth(): number;
+  getWest(): number;
+}): ArcGISEnvelope[] {
+  const south = Math.max(-90, Math.min(90, bounds.getSouth()));
+  const north = Math.min(90, Math.max(-90, bounds.getNorth()));
+  const rawWest = bounds.getWest();
+  const rawEast = bounds.getEast();
+  if (!Number.isFinite(rawWest) || !Number.isFinite(rawEast)) {
+    return [[-180, south, 180, north]];
+  }
+  // A wrapped viewport reports east < west; unwrap it before measuring the span.
+  const span = rawEast >= rawWest ? rawEast - rawWest : rawEast + 360 - rawWest;
+  if (span >= 360) return [[-180, south, 180, north]];
+  const west = wrapLongitude(rawWest);
+  const east = west + span;
+  return east > 180
+    ? [
+        [west, south, 180, north],
+        [-180, south, wrapLongitude(east), north],
+      ]
+    : [[west, south, east, north]];
+}
+
+/** Fold a longitude onto ±180, which the map's raw bounds may run past. */
+function wrapLongitude(longitude: number): number {
+  return ((((longitude + 180) % 360) + 360) % 360) - 180;
+}
+
+/**
+ * Concatenate the per-envelope results of one viewport query, dropping the
+ * duplicate a feature straddling the antimeridian produces by matching both
+ * halves. A feature the service gives no identifier for is kept as-is: showing
+ * it twice is better than guessing at identity by geometry.
+ */
+function mergeArcGISViewportFeatures(
+  pages: Feature[][],
+  objectIdField: string | undefined,
+): Feature[] {
+  if (pages.length === 1) return [...pages[0]];
+  const seen = new Set<string>();
+  const merged: Feature[] = [];
+  for (const page of pages) {
+    for (const feature of page) {
+      const key = arcgisFeatureKey(feature, objectIdField);
+      if (key !== null) {
+        if (seen.has(key)) continue;
+        seen.add(key);
+      }
+      merged.push(feature);
+    }
+  }
+  return merged;
+}
+
+function arcgisFeatureKey(feature: Feature, objectIdField: string | undefined): string | null {
+  if (typeof feature.id === "string" || typeof feature.id === "number") return String(feature.id);
+  const value = objectIdField ? feature.properties?.[objectIdField] : undefined;
+  return typeof value === "string" || typeof value === "number" ? String(value) : null;
 }
 
 /**

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -463,6 +463,7 @@ function startArcGISViewportLoader(
   // is unmounted well before the first viewport query lands, so carrying it for
   // the layer's lifetime would keep that closure alive to no purpose.
   const queryOptions: ArcGISLayerOptions = { ...options, onProgress: undefined };
+  const maxFeatures = positiveInteger(options.maxFeatures);
   const loader: ArcGISViewportLoader = {
     abort: null,
     load: () => Promise.resolve({ type: "FeatureCollection", features: [] }),
@@ -473,11 +474,13 @@ function startArcGISViewportLoader(
   /**
    * Query the map's current extent, publishing each page as it lands.
    *
-   * Resolves with whatever the layer holds — never rejects — when a newer
-   * viewport supersedes the call: that abort is bookkeeping, not a failure, and
-   * the replacement is already publishing. A refresh running concurrently with
-   * a pan must not be reported as a failed refresh (and, under an `onFailure`
-   * of `"clear"`, wipe a layer that is perfectly healthy).
+   * Resolves with whatever the layer holds — never rejects, whatever the
+   * error — when a newer viewport supersedes the call: the replacement is
+   * already publishing, so a failure the superseded request happened to hit
+   * (an abort, or a request that failed just before its abort landed) is not
+   * this layer's problem. A refresh running concurrently with a pan must not be
+   * reported as a failed refresh (and, under an `onFailure` of `"clear"`, wipe
+   * a layer that is perfectly healthy).
    */
   const load = async (): Promise<FeatureCollection> => {
     abort?.abort();
@@ -489,10 +492,16 @@ function startArcGISViewportLoader(
     // One bucket per envelope, so a viewport split across the antimeridian
     // publishes both halves together instead of each replacing the other.
     const pages: Feature[][] = envelopes.map(() => []);
-    const collect = (): FeatureCollection => ({
-      type: "FeatureCollection",
-      features: mergeArcGISViewportFeatures(pages, layerInfo.objectIdField),
-    });
+    const collect = (): FeatureCollection => {
+      const features = mergeArcGISViewportFeatures(pages, layerInfo.objectIdField);
+      // A split viewport issues one request per envelope, each honoring
+      // `maxFeatures` on its own, so the merge is trimmed to keep the option a
+      // bound on what the layer holds for one viewport rather than per half.
+      return {
+        type: "FeatureCollection",
+        features: maxFeatures === null ? features : features.slice(0, maxFeatures),
+      };
+    };
     const publish = (): void => {
       if (
         sequence !== requestSequence ||
@@ -502,33 +511,33 @@ function startArcGISViewportLoader(
       }
       useAppStore.getState().updateLayer(layerId, { geojson: collect() });
     };
-    try {
-      await Promise.all(
-        envelopes.map(async (envelope, index) => {
-          const data = await fetchArcGISFeaturePages(queryUrl, queryOptions, layerInfo, {
-            params: {
-              geometry: envelope.join(","),
-              geometryType: "esriGeometryEnvelope",
-              inSR: "4326",
-              spatialRel: "esriSpatialRelIntersects",
-            },
-            signal: controller.signal,
-            onPage: (features) => {
-              pages[index] = features;
-              publish();
-            },
-          });
-          pages[index] = data.features;
-          publish();
-        }),
-      );
-    } catch (error) {
-      if (sequence !== requestSequence && isArcGISAbortError(error)) {
-        return currentArcGISLayerGeojson(layerId);
-      }
-      throw error;
-    }
+    // `allSettled`, not `all`: a split viewport must not report a failure while
+    // its surviving half is still running, or that half's later pages would
+    // publish over an already-reported error with nothing to clear it.
+    const results = await Promise.allSettled(
+      envelopes.map(async (envelope, index) => {
+        const data = await fetchArcGISFeaturePages(queryUrl, queryOptions, layerInfo, {
+          params: {
+            geometry: envelope.join(","),
+            geometryType: "esriGeometryEnvelope",
+            inSR: "4326",
+            spatialRel: "esriSpatialRelIntersects",
+          },
+          signal: controller.signal,
+          onPage: (features) => {
+            pages[index] = features;
+            publish();
+          },
+        });
+        pages[index] = data.features;
+        publish();
+      }),
+    );
     if (sequence !== requestSequence) return currentArcGISLayerGeojson(layerId);
+    // One half failing still leaves the other's features on the map; the error
+    // says the view is incomplete rather than pretending it is whole.
+    const failed = results.find((result) => result.status === "rejected");
+    if (failed) throw failed.reason;
     reportArcGISViewportError(layerId, null);
     return collect();
   };
@@ -576,10 +585,13 @@ export function restoreArcGISViewportLayers(app: GeoLibreAppAPI): void {
   const map = app.getMap?.();
   if (!map) return;
   for (const layer of useAppStore.getState().layers) {
+    // Skip only a loader already bound to *this* map: the restore effect also
+    // runs when the map is reinitialized, and a loader left on the old instance
+    // would listen to a dead map and query its stale bounds.
     if (
       layer.metadata.viewportLoading !== true ||
       layer.metadata.sourceKind !== ARCGIS_FEATURE_SOURCE_KIND ||
-      arcgisFeatureLoaders.has(layer.id)
+      arcgisFeatureLoaders.get(layer.id)?.map === map
     ) {
       continue;
     }

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -523,12 +523,16 @@ function startArcGISViewportLoader(
         return;
       }
       useAppStore.getState().updateLayer(layerId, { geojson: collect() });
+      // Clear as soon as the service answers at all, not when the whole walk
+      // finishes: a dense extent pages for tens of seconds, and leaving a stale
+      // "zoom in" on screen while its features stream in reads as a live error.
+      reportArcGISViewportError(layerId, null);
     };
     // `allSettled`, not `all`: a split viewport must not report a failure while
     // its surviving half is still running, or that half's later pages would
     // publish over an already-reported error with nothing to clear it.
-    const results = await Promise.allSettled(
-      envelopes.map(async (envelope, index) => {
+    const walk = async (envelope: ArcGISEnvelope, index: number, attempt = 0): Promise<void> => {
+      try {
         const data = await fetchArcGISFeaturePages(queryUrl, queryOptions, layerInfo, {
           params: {
             geometry: envelope.join(","),
@@ -544,8 +548,17 @@ function startArcGISViewportLoader(
         });
         pages[index] = data.features;
         publish();
-      }),
-    );
+      } catch (error) {
+        // The service timing out under load is the common failure on a wide
+        // extent, and it clears on a retry far more often than not, so one is
+        // worth the wait rather than leaving the user an empty layer.
+        if (attempt === 0 && !controller.signal.aborted && isArcGISTransientQueryError(error)) {
+          return walk(envelope, index, attempt + 1);
+        }
+        throw error;
+      }
+    };
+    const results = await Promise.allSettled(envelopes.map((e, index) => walk(e, index)));
     if (sequence !== requestSequence) return currentArcGISLayerGeojson(layerId);
     // One half failing still leaves the other's features on the map; the error
     // says the view is incomplete rather than pretending it is whole.
@@ -556,7 +569,16 @@ function startArcGISViewportLoader(
   };
 
   const move = (): void => {
-    void load().catch((error: unknown) => handleArcGISViewportError(layerId, error));
+    void load().catch((error: unknown) => {
+      // A timeout that survived its retry gets guidance the user can act on;
+      // ArcGIS's own wording for it blames the query parameters, which are fine.
+      if (isArcGISTransientQueryError(error)) {
+        console.error("[GeoLibre] ArcGIS viewport query timed out", error);
+        reportArcGISViewportError(layerId, ARCGIS_VIEWPORT_TIMEOUT);
+        return;
+      }
+      handleArcGISViewportError(layerId, error);
+    });
   };
   loader.load = load;
   loader.move = move;
@@ -681,6 +703,33 @@ function handleArcGISViewportError(layerId: string, error: unknown): void {
 
 function isArcGISAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
+}
+
+/**
+ * Shown when the service gave up on a viewport query. Deliberately not the
+ * service's own wording: ArcGIS reports its timeout as a 400 blaming the query
+ * parameters, which are correct — the identical request succeeds on a retry.
+ */
+const ARCGIS_VIEWPORT_TIMEOUT =
+  "The ArcGIS service did not return features for this extent in time. Pan or zoom to try again, or zoom in to request fewer features.";
+
+/**
+ * Whether a failed query is worth retrying rather than reporting verbatim.
+ *
+ * A dense feature service can take tens of seconds to answer a geometry-bearing
+ * query over a wide envelope, and exceeds its own timeout when it is busy. It
+ * reports that either as a gateway/timeout status or — confusingly — as an
+ * error envelope with `code` 400 whose detail reads "Unable to perform query.
+ * Please check your parameters."
+ *
+ * Measured against Vicmap_Parcel (GeoLibre#1756): the same 0.25° envelope that
+ * failed six times running at ~56s later succeeded three times running in
+ * 19-34s. The failure is load, not the request.
+ */
+function isArcGISTransientQueryError(error: unknown): boolean {
+  if (!(error instanceof ArcGISQueryError)) return false;
+  if (error.status !== null) return [408, 429, 500, 502, 503, 504].includes(error.status);
+  return error.code === 400 && /unable to perform query/i.test(error.message);
 }
 
 /** The features a layer currently holds, for a query that has nothing newer. */
@@ -1534,8 +1583,30 @@ function finishArcGISPaging(
 
 /** The JSON error envelope ArcGIS returns, usually with an HTTP 200 status. */
 interface ArcGISErrorEnvelope {
+  code?: unknown;
   message?: string;
   details?: unknown;
+}
+
+/**
+ * A `/query` the service answered with a failure, carrying enough of that
+ * failure to tell "this extent is too much for me" apart from a fault the user
+ * could act on differently. ArcGIS reports the former either as a gateway
+ * timeout or — confusingly — as an error envelope whose `code` is 400 and whose
+ * detail blames the parameters, which are in fact fine: the identical query
+ * over a smaller extent succeeds.
+ */
+class ArcGISQueryError extends Error {
+  /** HTTP status, when the transport itself failed. */
+  readonly status: number | null;
+  /** `error.code` from an ArcGIS error envelope returned with HTTP 200. */
+  readonly code: number | null;
+  constructor(message: string, source: { status?: number | null; code?: number | null } = {}) {
+    super(message);
+    this.name = "ArcGISQueryError";
+    this.status = source.status ?? null;
+    this.code = source.code ?? null;
+  }
 }
 
 /**
@@ -1577,7 +1648,9 @@ async function fetchArcGISGeoJson(
 ): Promise<FeatureCollection & { exceededTransferLimit: boolean }> {
   const response = await fetch(url, { signal });
   if (!response.ok) {
-    throw new Error(`ArcGIS feature query failed with ${response.status}.`);
+    throw new ArcGISQueryError(`ArcGIS feature query failed with ${response.status}.`, {
+      status: response.status,
+    });
   }
   // ArcGIS Enterprise (and services behind a WAF) can answer 200 with an HTML
   // login/redirect page when a token is missing or expired. Read the body as
@@ -1600,7 +1673,9 @@ async function fetchArcGISGeoJson(
     throw new Error("The ArcGIS feature layer did not return GeoJSON features.");
   }
   if (json.error) {
-    throw new Error(arcgisErrorMessage(json.error, "ArcGIS feature query failed."));
+    throw new ArcGISQueryError(arcgisErrorMessage(json.error, "ArcGIS feature query failed."), {
+      code: typeof json.error.code === "number" ? json.error.code : null,
+    });
   }
   if (json.type !== "FeatureCollection" || !Array.isArray(json.features)) {
     throw new Error("The ArcGIS feature layer did not return GeoJSON features.");

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -344,6 +344,51 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual(view.offCalls, [["moveend", move]]);
   });
 
+  it("ignores a superseded viewport query that fails for its own reasons", async () => {
+    const rejections: Array<(error: Error) => void> = [];
+    let pan = false;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) return jsonResponse(VIEWPORT_LAYER_INFO);
+      const offset = Number(url.searchParams.get("resultOffset") ?? "0");
+      if (offset > 0) return jsonResponse({ type: "FeatureCollection", features: [] });
+      // The first query never resolves until the test rejects it by hand; the
+      // replacement answers normally.
+      if (pan) return jsonResponse({ type: "FeatureCollection", features: [viewportFeature(7)] });
+      return new Promise<Response>((_resolve, reject) => rejections.push(reject));
+    }) as typeof fetch;
+
+    const view = fakeViewportMap([144, -39, 146, -37]);
+    app = {
+      getMap: () => view.map,
+      fitBounds: (bounds) => fitBoundsCalls.push(bounds),
+    } as unknown as GeoLibreAppAPI;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+    await settle();
+
+    pan = true;
+    view.setBounds([150, -35, 152, -33]);
+    view.listeners.get("moveend")?.();
+    await settle();
+
+    // A plain network failure, not an AbortError, landing after the pan.
+    rejections[0](new Error("Connection reset"));
+    await settle();
+
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
+    assert.equal(
+      layer?.connection?.lastError ?? null,
+      null,
+      "a stale failure must not be reported",
+    );
+    assert.equal(layer?.geojson?.features.length, 1);
+  });
+
   it("records a failed viewport query on the layer connection and clears it", async () => {
     let fail = true;
     globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -414,6 +459,41 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual([...geometries].sort(), ["-180,-20,-170,20", "170,-20,180,20"]);
     const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
     assert.equal(layer?.geojson?.features.length, 1, "the shared feature is published once");
+  });
+
+  it("holds a split viewport to maxFeatures across both envelopes", async () => {
+    // Each half answers with the cap's worth of distinct features, so an
+    // uncoordinated limit would leave the layer holding twice the maximum.
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) return jsonResponse(VIEWPORT_LAYER_INFO);
+      const offset = Number(url.searchParams.get("resultOffset") ?? "0");
+      if (offset > 0) return jsonResponse({ type: "FeatureCollection", features: [] });
+      const west = url.searchParams.get("geometry")?.startsWith("170") === true;
+      return jsonResponse({
+        type: "FeatureCollection",
+        features: west
+          ? [viewportFeature(1), viewportFeature(2)]
+          : [viewportFeature(3), viewportFeature(4)],
+      });
+    }) as typeof fetch;
+
+    const view = fakeViewportMap([170, -20, -170, 20]);
+    app = {
+      getMap: () => view.map,
+      fitBounds: (bounds) => fitBoundsCalls.push(bounds),
+    } as unknown as GeoLibreAppAPI;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+      maxFeatures: 2,
+    });
+    await settle();
+
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
+    assert.equal(layer?.geojson?.features.length, 2);
   });
 
   it("never persists the access token in the refresh URL", async () => {

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -221,6 +221,57 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual(fitBoundsCalls, [[-160, 18, -154, 23]]);
   });
 
+  it("adds an interactive layer immediately and queries the current viewport", async () => {
+    let resolveQuery!: (response: Response) => void;
+    const queryResponse = new Promise<Response>((resolve) => {
+      resolveQuery = resolve;
+    });
+    const requests: URL[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) return jsonResponse(LAYER_INFO);
+      requests.push(url);
+      return queryResponse;
+    }) as typeof fetch;
+
+    const listeners = new Map<string, () => void>();
+    const map = {
+      getBounds: () => ({
+        getWest: () => 144,
+        getSouth: () => -39,
+        getEast: () => 146,
+        getNorth: () => -37,
+      }),
+      isMoving: () => false,
+      on: (event: string, listener: () => void) => listeners.set(event, listener),
+      off: (event: string) => listeners.delete(event),
+    };
+    app = {
+      getMap: () => map,
+      fitBounds: (bounds) => fitBoundsCalls.push(bounds),
+    } as unknown as GeoLibreAppAPI;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+
+    const initial = useAppStore.getState().layers.find((layer) => layer.id === id);
+    assert.equal(initial?.geojson?.features.length, 0);
+    assert.equal(initial?.metadata.viewportLoading, true);
+    assert.ok(listeners.has("moveend"));
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].searchParams.get("geometry"), "144,-39,146,-37");
+    assert.equal(requests[0].searchParams.get("geometryType"), "esriGeometryEnvelope");
+    assert.equal(requests[0].searchParams.get("spatialRel"), "esriSpatialRelIntersects");
+
+    resolveQuery(jsonResponse(QUERY_GEOJSON));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const loaded = useAppStore.getState().layers.find((layer) => layer.id === id);
+    assert.equal(loaded?.geojson?.features.length, 1);
+  });
+
   it("never persists the access token in the refresh URL", async () => {
     const fetchUrls: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL) => {

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -5,6 +5,8 @@ import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 import {
   addArcGISLayer,
   refreshArcGISFeatureLayer,
+  reloadArcGISViewportLayer,
+  restoreArcGISViewportLayers,
 } from "../packages/plugins/src/plugins/arcgis-layer";
 
 // Minimal ArcGIS FeatureServer layer metadata (the `?f=json` response) with a
@@ -459,6 +461,76 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual([...geometries].sort(), ["-180,-20,-170,20", "170,-20,180,20"]);
     const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
     assert.equal(layer?.geojson?.features.length, 1, "the shared feature is published once");
+  });
+
+  it("re-binds a reopened project's layer to the viewport", async () => {
+    const geometries: string[] = [];
+    let metadataFailures = 1;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) {
+        // The first metadata read fails, as a flaky reopen would.
+        if (metadataFailures > 0) {
+          metadataFailures -= 1;
+          throw new Error("Service unavailable");
+        }
+        return jsonResponse(VIEWPORT_LAYER_INFO);
+      }
+      const offset = Number(url.searchParams.get("resultOffset") ?? "0");
+      if (offset > 0) return jsonResponse({ type: "FeatureCollection", features: [] });
+      geometries.push(url.searchParams.get("geometry") ?? "");
+      return jsonResponse({ type: "FeatureCollection", features: [viewportFeature(1)] });
+    }) as typeof fetch;
+
+    // A layer as a saved project restores it: viewport metadata and the stored
+    // query URL, but no live loader.
+    const id = useAppStore
+      .getState()
+      .addGeoJsonLayer("Restored", { type: "FeatureCollection", features: [] }, undefined, null);
+    useAppStore.getState().updateLayer(id, {
+      source: { type: "geojson", arcgisQueryUrl: `${SERVICE_URL}/query` },
+      metadata: { sourceKind: "arcgis-feature-query", viewportLoading: true },
+    });
+    assert.equal(reloadArcGISViewportLayer(id), null, "no loader before the project is restored");
+
+    const view = fakeViewportMap([144, -39, 146, -37]);
+    restoreArcGISViewportLayers({ getMap: () => view.map } as unknown as GeoLibreAppAPI);
+    // Registered before the metadata fetch is even started, so a refresh in
+    // this window never finds the layer unbound.
+    assert.ok(view.listeners.has("moveend"), "the loader binds synchronously");
+    await settle();
+
+    // The first query failed on metadata, which is reported, not swallowed.
+    assert.match(
+      useAppStore.getState().layers.find((layer) => layer.id === id)?.connection?.lastError ?? "",
+      /Service unavailable/,
+    );
+
+    // The next pan retries the metadata rather than staying stuck.
+    view.setBounds([150, -35, 152, -33]);
+    view.listeners.get("moveend")?.();
+    await settle();
+    assert.deepEqual(geometries, ["150,-35,152,-33"]);
+    const restored = useAppStore.getState().layers.find((layer) => layer.id === id);
+    assert.equal(restored?.connection?.lastError, null);
+    assert.equal(restored?.geojson?.features.length, 1);
+
+    // Re-running the restore against a new map rebinds rather than skipping.
+    const remounted = fakeViewportMap([10, 10, 12, 12]);
+    restoreArcGISViewportLayers({ getMap: () => remounted.map } as unknown as GeoLibreAppAPI);
+    await settle();
+    assert.deepEqual(
+      view.offCalls.map(([event]) => event),
+      ["moveend"],
+      "the loader detaches from the old map",
+    );
+    assert.ok(remounted.listeners.has("moveend"));
+    assert.deepEqual(geometries, ["150,-35,152,-33", "10,10,12,12"]);
+
+    // A refresh takes this same bounded path rather than the unbounded replay.
+    const reloaded = await reloadArcGISViewportLayer(id);
+    assert.equal(reloaded?.features.length, 1);
+    assert.deepEqual(geometries, ["150,-35,152,-33", "10,10,12,12", "10,10,12,12"]);
   });
 
   it("holds a split viewport to maxFeatures across both envelopes", async () => {

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -463,6 +463,72 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.equal(layer?.geojson?.features.length, 1, "the shared feature is published once");
   });
 
+  // The exact body Vicmap_Parcel returns (with HTTP 200) when it exceeds its
+  // own query timeout on a wide extent — it blames the parameters, which are
+  // correct: the identical request succeeds on a retry (GeoLibre#1756).
+  const TIMEOUT_ENVELOPE = {
+    error: {
+      code: 400,
+      message: "",
+      details: ["Unable to perform query. Please check your parameters."],
+    },
+  };
+
+  /** Answers the first `failures` viewport queries with a service timeout. */
+  function timingOutService(failures: number) {
+    const state = { attempts: 0 };
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) return jsonResponse(VIEWPORT_LAYER_INFO);
+      if (Number(url.searchParams.get("resultOffset") ?? "0") > 0) {
+        return jsonResponse({ type: "FeatureCollection", features: [] });
+      }
+      state.attempts += 1;
+      return state.attempts <= failures
+        ? jsonResponse(TIMEOUT_ENVELOPE)
+        : jsonResponse({ type: "FeatureCollection", features: [viewportFeature(1)] });
+    }) as typeof fetch;
+    return state;
+  }
+
+  async function addViewportLayer(): Promise<string> {
+    const view = fakeViewportMap([144, -39, 146, -37]);
+    app = {
+      getMap: () => view.map,
+      fitBounds: (bounds) => fitBoundsCalls.push(bounds),
+    } as unknown as GeoLibreAppAPI;
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+    await settle();
+    return id;
+  }
+
+  it("retries a viewport query the service timed out on", async () => {
+    const state = timingOutService(1);
+    const id = await addViewportLayer();
+
+    assert.equal(state.attempts, 2, "the timed-out query is retried once");
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
+    assert.equal(layer?.geojson?.features.length, 1, "the retry's features are published");
+    assert.equal(layer?.connection?.lastError ?? null, null, "a recovered query reports no error");
+  });
+
+  it("reports actionable guidance when the retry times out too", async () => {
+    const state = timingOutService(Number.POSITIVE_INFINITY);
+    const id = await addViewportLayer();
+
+    assert.equal(state.attempts, 2, "retried once, not indefinitely");
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
+    // Not ArcGIS's own "check your parameters", which sends the user nowhere.
+    assert.match(
+      layer?.connection?.lastError ?? "",
+      /did not return features for this extent in time/,
+    );
+  });
+
   it("re-binds a reopened project's layer to the viewport", async () => {
     const geometries: string[] = [];
     let metadataFailures = 1;

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -344,6 +344,46 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual(view.offCalls, [["moveend", move]]);
   });
 
+  it("records a failed viewport query on the layer connection and clears it", async () => {
+    let fail = true;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) return jsonResponse(VIEWPORT_LAYER_INFO);
+      if (fail) throw new Error("Network unreachable");
+      const offset = Number(url.searchParams.get("resultOffset") ?? "0");
+      return jsonResponse({
+        type: "FeatureCollection",
+        features: offset > 0 ? [] : [viewportFeature(1)],
+      });
+    }) as typeof fetch;
+
+    const view = fakeViewportMap([144, -39, 146, -37]);
+    app = {
+      getMap: () => view.map,
+      fitBounds: (bounds) => fitBoundsCalls.push(bounds),
+    } as unknown as GeoLibreAppAPI;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+    await settle();
+
+    // The Layers panel renders this as its sync-error status line.
+    assert.match(
+      useAppStore.getState().layers.find((layer) => layer.id === id)?.connection?.lastError ?? "",
+      /Network unreachable/,
+    );
+
+    fail = false;
+    view.listeners.get("moveend")?.();
+    await settle();
+    const recovered = useAppStore.getState().layers.find((layer) => layer.id === id);
+    assert.equal(recovered?.connection?.lastError, null);
+    assert.equal(recovered?.geojson?.features.length, 1);
+  });
+
   it("splits an antimeridian-crossing viewport into two envelopes", async () => {
     const geometries: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL) => {

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -58,6 +58,62 @@ function makeArcGISFetch(): typeof fetch {
 
 const SERVICE_URL = "https://example.com/arcgis/rest/services/Cities/FeatureServer/0";
 
+// The same layer, advertising offset paging and an ObjectID field, so a viewport
+// query is one page of features followed by an empty one.
+const VIEWPORT_LAYER_INFO = {
+  ...LAYER_INFO,
+  objectIdField: "OBJECTID",
+  advancedQueryCapabilities: { supportsPagination: true, supportsOrderBy: true },
+};
+
+function viewportFeature(objectId: number) {
+  return {
+    type: "Feature",
+    id: objectId,
+    geometry: { type: "Point", coordinates: [-157.8, 21.3] },
+    properties: { OBJECTID: objectId, NAME: `City ${objectId}` },
+  };
+}
+
+/**
+ * A fake interactive map whose bounds the test can move, recording the
+ * listeners the viewport loader attaches and detaches.
+ */
+function fakeViewportMap(initial: [number, number, number, number]) {
+  let [west, south, east, north] = initial;
+  const listeners = new Map<string, () => void>();
+  const offCalls: Array<[string, () => void]> = [];
+  const map = {
+    getBounds: () => ({
+      getWest: () => west,
+      getSouth: () => south,
+      getEast: () => east,
+      getNorth: () => north,
+    }),
+    isMoving: () => false,
+    on: (event: string, listener: () => void) => listeners.set(event, listener),
+    off: (event: string, listener: () => void) => {
+      offCalls.push([event, listener]);
+      listeners.delete(event);
+    },
+  };
+  return {
+    listeners,
+    map,
+    offCalls,
+    setBounds: (next: [number, number, number, number]) => {
+      [west, south, east, north] = next;
+    },
+  };
+}
+
+/** Let the loader's queued fetches and store writes settle. */
+async function settle(): Promise<void> {
+  for (let tick = 0; tick < 4; tick += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 interface FakeArcGISServiceOptions {
   /** The per-query ceiling the service actually enforces. */
   maxRecordCount: number;
@@ -222,32 +278,23 @@ describe("addArcGISLayer (feature layer)", () => {
   });
 
   it("adds an interactive layer immediately and queries the current viewport", async () => {
-    let resolveQuery!: (response: Response) => void;
-    const queryResponse = new Promise<Response>((resolve) => {
-      resolveQuery = resolve;
-    });
     const requests: URL[] = [];
+    // Only the first page of each viewport query is deferred, so the test can
+    // settle them out of order; the follow-up page is empty and ends the walk.
+    const pages: Array<(response: Response) => void> = [];
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = new URL(typeof input === "string" ? input : input.toString());
-      if (!url.pathname.endsWith("/query")) return jsonResponse(LAYER_INFO);
+      if (!url.pathname.endsWith("/query")) return jsonResponse(VIEWPORT_LAYER_INFO);
+      if (Number(url.searchParams.get("resultOffset") ?? "0") > 0) {
+        return jsonResponse({ type: "FeatureCollection", features: [] });
+      }
       requests.push(url);
-      return queryResponse;
+      return new Promise<Response>((resolve) => pages.push(resolve));
     }) as typeof fetch;
 
-    const listeners = new Map<string, () => void>();
-    const map = {
-      getBounds: () => ({
-        getWest: () => 144,
-        getSouth: () => -39,
-        getEast: () => 146,
-        getNorth: () => -37,
-      }),
-      isMoving: () => false,
-      on: (event: string, listener: () => void) => listeners.set(event, listener),
-      off: (event: string) => listeners.delete(event),
-    };
+    const view = fakeViewportMap([144, -39, 146, -37]);
     app = {
-      getMap: () => map,
+      getMap: () => view.map,
       fitBounds: (bounds) => fitBoundsCalls.push(bounds),
     } as unknown as GeoLibreAppAPI;
 
@@ -256,20 +303,77 @@ describe("addArcGISLayer (feature layer)", () => {
       sourceType: "url",
       url: SERVICE_URL,
     });
+    await settle();
 
     const initial = useAppStore.getState().layers.find((layer) => layer.id === id);
     assert.equal(initial?.geojson?.features.length, 0);
     assert.equal(initial?.metadata.viewportLoading, true);
-    assert.ok(listeners.has("moveend"));
+    const move = view.listeners.get("moveend");
+    assert.ok(move, "expected a moveend listener");
     assert.equal(requests.length, 1);
     assert.equal(requests[0].searchParams.get("geometry"), "144,-39,146,-37");
     assert.equal(requests[0].searchParams.get("geometryType"), "esriGeometryEnvelope");
     assert.equal(requests[0].searchParams.get("spatialRel"), "esriSpatialRelIntersects");
 
-    resolveQuery(jsonResponse(QUERY_GEOJSON));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Pan before the first query lands: the replacement must query the new
+    // extent, and the superseded response must not overwrite it.
+    view.setBounds([150, -35, 152, -33]);
+    move();
+    await settle();
+    assert.equal(requests.length, 2);
+    assert.equal(requests[1].searchParams.get("geometry"), "150,-35,152,-33");
+
+    pages[0](jsonResponse({ type: "FeatureCollection", features: [viewportFeature(1)] }));
+    await settle();
+    assert.equal(
+      useAppStore.getState().layers.find((layer) => layer.id === id)?.geojson?.features.length,
+      0,
+      "the superseded viewport response must be discarded",
+    );
+
+    pages[1](jsonResponse({ type: "FeatureCollection", features: [viewportFeature(2)] }));
+    await settle();
     const loaded = useAppStore.getState().layers.find((layer) => layer.id === id);
-    assert.equal(loaded?.geojson?.features.length, 1);
+    assert.deepEqual(
+      loaded?.geojson?.features.map((feature) => feature.properties?.OBJECTID),
+      [2],
+    );
+
+    // Removing the layer detaches the listener it registered.
+    useAppStore.getState().removeLayer(id);
+    assert.deepEqual(view.offCalls, [["moveend", move]]);
+  });
+
+  it("splits an antimeridian-crossing viewport into two envelopes", async () => {
+    const geometries: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = new URL(typeof input === "string" ? input : input.toString());
+      if (!url.pathname.endsWith("/query")) return jsonResponse(VIEWPORT_LAYER_INFO);
+      const offset = Number(url.searchParams.get("resultOffset") ?? "0");
+      if (offset > 0) return jsonResponse({ type: "FeatureCollection", features: [] });
+      geometries.push(url.searchParams.get("geometry") ?? "");
+      // Both halves return the feature straddling the dateline.
+      return jsonResponse({ type: "FeatureCollection", features: [viewportFeature(1)] });
+    }) as typeof fetch;
+
+    const view = fakeViewportMap([170, -20, -170, 20]);
+    app = {
+      getMap: () => view.map,
+      fitBounds: (bounds) => fitBoundsCalls.push(bounds),
+    } as unknown as GeoLibreAppAPI;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+    await settle();
+
+    // Clamping each edge on its own would have inverted this envelope into
+    // `170,-20,-170,20`, which ArcGIS answers with nothing.
+    assert.deepEqual([...geometries].sort(), ["-180,-20,-170,20", "170,-20,180,20"]);
+    const layer = useAppStore.getState().layers.find((entry) => entry.id === id);
+    assert.equal(layer?.geojson?.features.length, 1, "the shared feature is published once");
   });
 
   it("never persists the access token in the refresh URL", async () => {


### PR DESCRIPTION
## Summary

- add ArcGIS feature layers immediately without waiting for the full service download
- query and progressively render features intersecting the current map viewport
- cancel stale requests and reload when the map extent changes
- retain complete paged downloads for headless API consumers

## Verification

- `node --import tsx --test tests/arcgis-feature-layer.test.ts`
- `npm run build`
- real browser using the Vicmap Parcel FeatureServer from the issue
- verified viewport request cancellation and reload while zooming and panning
- verified rendering in light and dark themes

Fixes #1756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ArcGIS feature layers appear immediately while visible features load dynamically for the current viewport.
  * Map movements refresh displayed features incrementally, including across the international date line.
  * Saved projects restore viewport-based ArcGIS layers automatically.
  * Layers can be reloaded for the current viewport.
  * Complete paginated downloads remain available for non-map use.

* **Bug Fixes**
  * Canceled or outdated requests no longer overwrite newer map results.
  * Layer removal stops pending loading activity.
  * Refreshing layers preserves the current visible map area.
  * Query failures are reported and recover on subsequent reloads.
  * Feature limits remain accurate across split map regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->