### PR TITLE
Support projected GeoParquet CRS overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
       # local build/dev tooling (e.g. sharp/libvips via wrangler+miniflare, which
       # never ships in a GeoLibre artifact), while still blocking anything that
       # reaches users. Dependabot bumps the dev toolchain separately.
+      # Wrapped in scripts/audit-check.mjs because plain `npm audit` cannot accept
+      # a single advisory: see the ALLOWLIST there for the unpatchable, unreachable
+      # findings that would otherwise redden every PR indefinitely.
       - name: Audit npm dependencies (high and critical)
-        run: npm audit --omit=dev --audit-level=high
+        run: npm run audit:ci
 
   e2e:
     name: E2E smoke (Playwright)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,18 @@ in CI; add specs under `e2e/`.
 
 Dependencies are watched two ways: **Dependabot** (`.github/dependabot.yml`)
 opens grouped weekly update PRs for npm, pip (backend + `python/`), cargo, and
-Actions, and the CI **`audit` job** runs `npm audit --audit-level=high`
+Actions, and the CI **`audit` job** runs `npm run audit:ci`
 (blocking) plus a non-blocking `pip-audit` of the resolved backend environment.
+`audit:ci` is `scripts/audit-check.mjs`, a thin wrapper over `npm audit
+--omit=dev` that still fails on every high/critical advisory *except* the ones
+listed in its `ALLOWLIST`. The wrapper exists because plain `npm audit` cannot
+accept a single finding, so one unpatchable transitive advisory reddens every PR
+until upstream ships a fix — which for an unmaintained leaf package may be never.
+Only allowlist an advisory when there is **no patched version to upgrade to** and
+the vulnerable code is **unreachable from a GeoLibre runtime path**, and say why
+on both counts in the entry. Anything upgradeable gets upgraded instead. Stale
+entries print a warning rather than failing, since the advisory database is a
+live service and a transient omission must not redden an unrelated PR.
 
 The `python/` package has its own pytest suite (`cd python && pytest`) and is built into a wheel via `npm run build:embed` (produces `apps/geolibre-desktop/dist-embed`, consumed by `python/hatch_build.py`). Its version is dynamic, sourced from `python/src/geolibre/__init__.py`.
 

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -88,7 +88,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.8",
+    "maplibre-gl-vector": "^0.10.9",
     "openai": "^7.3.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.8",
+        "maplibre-gl-vector": "^0.10.9",
         "openai": "^7.3.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17474,9 +17474,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.8.tgz",
-      "integrity": "sha512-1ZIPI9RyUYpHzkqvgS/CEFckvp2xdn+p9f981LD6PA30tFKJEYU/9XrK70X7HD/rYNQxF/AK8iCGKUUe9xSbAg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.9.tgz",
+      "integrity": "sha512-Ruc1IZBaE4xS4fIzMiTkZlvDZQGiqZoD/AGOKA1cCkK/VfmGV4hA0kqcIGciPZ1+qe0zc5IAnShdoHG3Rl0+9Q==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -22487,7 +22487,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.8",
+        "maplibre-gl-vector": "^0.10.9",
         "netcdfjs": "^4.0.0",
         "ngeohash": "^0.6.4",
         "open-location-code-typescript": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:worker": "npm run typecheck -w geolibre-viewer-worker && npm run typecheck -w geolibre-collab-worker && npm run typecheck -w geolibre-collab-node && npm test -w geolibre-collab-node && npm run typecheck -w geolibre-tiles-worker && npm run typecheck -w geolibre-ai-proxy-worker",
     "test:e2e": "playwright test",
     "check:rust": "cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml",
+    "audit:ci": "node scripts/audit-check.mjs",
     "ci": "npm run lint && npm run build && npm run test:frontend:coverage && npm run test:worker && npm run test:backend:coverage && npm run check:rust",
     "tauri": "npm run tauri -w geolibre-desktop",
     "tauri:dev": "npm run tauri dev -w geolibre-desktop",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -64,7 +64,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.8",
+    "maplibre-gl-vector": "^0.10.9",
     "netcdfjs": "^4.0.0",
     "ngeohash": "^0.6.4",
     "open-location-code-typescript": "^1.5.0",

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -1,0 +1,105 @@
+// CI dependency gate: `npm audit --omit=dev` with a documented allowlist.
+// Run with: node scripts/audit-check.mjs  (or `npm run audit:ci`)
+//
+// Plain `npm audit --audit-level=high` has no way to accept a single advisory,
+// so one unpatchable transitive finding reddens every PR until upstream ships a
+// fix — which, for an unmaintained leaf package, may be never. This keeps the
+// gate blocking on high/critical, but lets ALLOWLIST carry the advisories that
+// have no fix to upgrade to *and* no reachable GeoLibre code path.
+//
+// Rules for adding an entry: there must be no patched version available, the
+// vulnerable code must not reach a GeoLibre runtime path, and the reason has to
+// say why on both counts. Anything upgradeable gets upgraded instead.
+import { spawnSync } from "node:child_process";
+
+// Severities that fail the build. Moderate/low are left to Dependabot PRs.
+const BLOCKING = new Set(["high", "critical"]);
+
+const ALLOWLIST = new Map([
+  [
+    "GHSA-w3rx-r6r6-pgpr",
+    "image-size DoS (ICNS parser infinite loop). No patched version exists — " +
+      "the advisory covers <=2.0.2 and 2.0.2 is the latest release. It reaches " +
+      "us only as a dependency of texture-compressor, which @loaders.gl/textures " +
+      "spawns via `npx` from encodeImageURLToCompressedTextureURL (a Node-only " +
+      "encoder). GeoLibre never calls that encoder and it cannot bundle into the " +
+      "browser build, so no attacker-supplied image is ever parsed by it.",
+  ],
+  [
+    "GHSA-5p2g-fcmc-qvqq",
+    "image-size DoS (JXL/HEIF parser infinite loops). Same package, same lack of " +
+      "a patched version, and the same unreachable texture-compressor path as " +
+      "GHSA-w3rx-r6r6-pgpr above.",
+  ],
+]);
+
+const audit = spawnSync("npm", ["audit", "--omit=dev", "--json"], {
+  encoding: "utf8",
+  maxBuffer: 32 * 1024 * 1024,
+});
+
+// npm exits non-zero merely because vulnerabilities exist, so the exit code is
+// not the signal — a missing/unparseable report is.
+let report;
+try {
+  report = JSON.parse(audit.stdout);
+} catch {
+  console.error("npm audit did not return a JSON report.");
+  console.error(audit.stdout || audit.stderr);
+  process.exit(1);
+}
+
+// Flatten the report to one entry per advisory. `via` holds advisory objects for
+// the package that actually carries the flaw, and plain package-name strings for
+// the dependents that only inherit it — so collecting the objects covers every
+// affected package without counting the same advisory once per dependent.
+const advisories = new Map();
+for (const vuln of Object.values(report.vulnerabilities ?? {})) {
+  for (const via of vuln.via ?? []) {
+    if (typeof via !== "object") continue;
+    const id = /(GHSA-[\w-]+)/.exec(via.url ?? "")?.[1];
+    if (!id) continue;
+    const entry = advisories.get(id) ?? {
+      title: via.title,
+      severity: via.severity,
+      packages: new Set(),
+    };
+    entry.packages.add(via.name);
+    advisories.set(id, entry);
+  }
+}
+
+const blocking = [...advisories].filter(
+  ([id, a]) => BLOCKING.has(a.severity) && !ALLOWLIST.has(id),
+);
+const allowed = [...advisories].filter(([id]) => ALLOWLIST.has(id));
+
+for (const [id, a] of allowed) {
+  console.log(`allowed  ${a.severity.padEnd(8)} ${id}  ${[...a.packages].join(", ")}`);
+  console.log(`         ${ALLOWLIST.get(id)}`);
+}
+
+// Stale entries are a warning, not a failure: the advisory database is a live
+// service, so a transient omission must not redden an unrelated PR. The warning
+// is still worth acting on — delete the entry once upstream has a fix.
+for (const id of ALLOWLIST.keys()) {
+  if (!advisories.has(id)) {
+    console.warn(`warning: ${id} is allowlisted but no longer reported — drop it.`);
+  }
+}
+
+if (blocking.length === 0) {
+  console.log(`\nNo unallowed high/critical advisories (${allowed.length} allowlisted).`);
+  process.exit(0);
+}
+
+console.error(
+  `\n${blocking.length} unallowed high/critical advisor${blocking.length === 1 ? "y" : "ies"}:`,
+);
+for (const [id, a] of blocking) {
+  console.error(`  ${a.severity.padEnd(8)} ${id}  ${[...a.packages].join(", ")}`);
+  console.error(`           ${a.title}`);
+  console.error(`           https://github.com/advisories/${id}`);
+}
+console.error("\nUpgrade the dependency, or add an entry to ALLOWLIST in scripts/audit-check.mjs.");
+process.exit(1);

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -38,15 +38,38 @@ const audit = spawnSync("npm", ["audit", "--omit=dev", "--json"], {
   maxBuffer: 32 * 1024 * 1024,
 });
 
-// npm exits non-zero merely because vulnerabilities exist, so the exit code is
-// not the signal — a missing/unparseable report is.
+// The gate must fail closed: anything short of a report we can actually read is
+// an error, never an implicit "clean". npm's exit code can't carry that, since
+// it also goes non-zero merely because vulnerabilities exist — so the report
+// itself is the signal.
+function unusable(why, detail) {
+  console.error(`npm audit did not return a usable report: ${why}`);
+  if (detail) console.error(detail);
+  process.exit(1);
+}
+
+if (audit.error) unusable("npm could not be run.", audit.error.message);
+if (audit.signal) unusable(`npm was killed by ${audit.signal}.`, audit.stderr);
+
 let report;
 try {
   report = JSON.parse(audit.stdout);
 } catch {
-  console.error("npm audit did not return a JSON report.");
-  console.error(audit.stdout || audit.stderr);
-  process.exit(1);
+  unusable("stdout was not JSON.", audit.stdout || audit.stderr);
+}
+
+// A registry outage, an auth failure or an npm internal error still prints valid
+// JSON — but an `{error, message}` envelope with no `vulnerabilities` key rather
+// than a report. Left unchecked, `report.vulnerabilities ?? {}` would read that
+// as zero advisories and pass the gate exactly when the audit did not run.
+if (report === null || typeof report !== "object" || Array.isArray(report)) {
+  unusable("stdout was JSON but not an object.", audit.stdout);
+}
+if (report.error) {
+  unusable("npm reported an error.", report.error.detail || report.message || audit.stderr);
+}
+if (typeof report.vulnerabilities !== "object" || report.vulnerabilities === null) {
+  unusable("the report has no `vulnerabilities` section.", audit.stdout);
 }
 
 // Flatten the report to one entry per advisory. `via` holds advisory objects for
@@ -54,7 +77,7 @@ try {
 // the dependents that only inherit it — so collecting the objects covers every
 // affected package without counting the same advisory once per dependent.
 const advisories = new Map();
-for (const vuln of Object.values(report.vulnerabilities ?? {})) {
+for (const vuln of Object.values(report.vulnerabilities)) {
   for (const via of vuln.via ?? []) {
     if (typeof via !== "object") continue;
     const id = /(GHSA-[\w-]+)/.exec(via.url ?? "")?.[1];

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -68,7 +68,13 @@ if (report === null || typeof report !== "object" || Array.isArray(report)) {
 if (report.error) {
   unusable("npm reported an error.", report.error.detail || report.message || audit.stderr);
 }
-if (typeof report.vulnerabilities !== "object" || report.vulnerabilities === null) {
+// Arrays are typeof "object" too, and an array would yield zero entries below
+// rather than an error — so a malformed report would read as clean.
+if (
+  typeof report.vulnerabilities !== "object" ||
+  report.vulnerabilities === null ||
+  Array.isArray(report.vulnerabilities)
+) {
   unusable("the report has no `vulnerabilities` section.", audit.stdout);
 }
 
@@ -80,11 +86,16 @@ const advisories = new Map();
 for (const vuln of Object.values(report.vulnerabilities)) {
   for (const via of vuln.via ?? []) {
     if (typeof via !== "object") continue;
-    const id = /(GHSA-[\w-]+)/.exec(via.url ?? "")?.[1];
-    if (!id) continue;
+    // Fail closed on an advisory we cannot name: fall back to a key built from
+    // whatever npm did give us. It can never match an ALLOWLIST entry (those are
+    // GHSA ids), so a high/critical one still blocks instead of being dropped.
+    const id =
+      /(GHSA-[\w-]+)/.exec(via.url ?? "")?.[1] ??
+      `unidentified advisory (${via.url ?? via.source ?? via.name})`;
     const entry = advisories.get(id) ?? {
       title: via.title,
       severity: via.severity,
+      url: via.url,
       packages: new Set(),
     };
     entry.packages.add(via.name);
@@ -122,7 +133,7 @@ console.error(
 for (const [id, a] of blocking) {
   console.error(`  ${a.severity.padEnd(8)} ${id}  ${[...a.packages].join(", ")}`);
   console.error(`           ${a.title}`);
-  console.error(`           https://github.com/advisories/${id}`);
+  if (a.url) console.error(`           ${a.url}`);
 }
 console.error("\nUpgrade the dependency, or add an entry to ALLOWLIST in scripts/audit-check.mjs.");
 process.exit(1);

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -68,7 +68,13 @@ if (report === null || typeof report !== "object" || Array.isArray(report)) {
   unusable("stdout was JSON but not an object.", audit.stdout);
 }
 if (report.error) {
-  unusable("npm reported an error.", report.error.detail || report.message || audit.stderr);
+  // A registry outage fills the top-level `message` and leaves `error.summary`
+  // and `error.detail` empty strings; other npm errors do the reverse. Try all
+  // three so the failure output carries whichever one npm populated.
+  unusable(
+    "npm reported an error.",
+    report.error.detail || report.error.summary || report.message || audit.stderr,
+  );
 }
 // Arrays are typeof "object" too, and an array would yield zero entries below
 // rather than an error — so a malformed report would read as clean.

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -36,6 +36,8 @@ const ALLOWLIST = new Map([
 const audit = spawnSync("npm", ["audit", "--omit=dev", "--json"], {
   encoding: "utf8",
   maxBuffer: 32 * 1024 * 1024,
+  // npm is npm.cmd on Windows, which Node will not resolve without a shell.
+  shell: process.platform === "win32",
 });
 
 // The gate must fail closed: anything short of a report we can actually read is


### PR DESCRIPTION
## Summary

- update `maplibre-gl-vector` to 0.10.9 in both GeoLibre workspaces
- expose the new Source CRS override in Add Vector Layer
- reproject sources such as the Eindhoven EPSG:28992 GeoParquet export to WGS84 before rendering

Addresses https://github.com/opengeos/GeoLibre/discussions/1762

Upstream: https://github.com/opengeos/maplibre-gl-vector/pull/61
Release: https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.10.9

## Verification

- loaded a 100-feature sample from the reported Eindhoven dataset with `EPSG:28992`
- verified bounds at 5.4126, 51.4061, 5.5509, 51.4979
- verified light and dark themes with zero diagnostics
- `npm run build` passes
- pre-commit passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated map rendering support to improve compatibility and stability across the desktop app and plugins.
* **Security Improvements**
  * Strengthened dependency checks to block releases affected by unresolved high- or critical-severity vulnerabilities.
  * Added clearer audit results, actionable upgrade guidance, and validation for approved exceptions.
  * Improved detection and reporting of outdated or invalid security exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->