### PR TITLE
docs: point contributors at geolibre-assets for images and demos

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -204,8 +204,10 @@ repository.** Binaries are never really deleted from Git history, so every one
 of them permanently enlarges the clone for everyone, including CI.
 
 Put them in [opengeos/geolibre-assets](https://github.com/opengeos/geolibre-assets)
-instead. Anything on that repository's `main` branch is published at the
-matching path under <https://assets.geolibre.app> within about a minute:
+instead. It is a plain static host, so any file type works. Anything pushed to
+that repository's `main` branch is published by GitHub Pages at the matching
+path under its one hostname, <https://assets.geolibre.app>, usually within a
+minute:
 
 | Repository path       | Published URL                                        |
 | --------------------- | ---------------------------------------------------- |
@@ -213,11 +215,15 @@ matching path under <https://assets.geolibre.app> within about a minute:
 | `demos/my-demo.gif`    | `https://assets.geolibre.app/demos/my-demo.gif`      |
 | `data/sample.parquet`  | `https://assets.geolibre.app/data/sample.parquet`    |
 
-Then reference the absolute URL from your Markdown:
+Then reference the published URL from your Markdown:
 
 ```markdown
 ![Raster style panel](https://assets.geolibre.app/images/raster-style-panel.webp)
 ```
+
+This is the one exception to the "link to files outside `docs/` with a full
+GitHub URL" rule above: an asset in `geolibre-assets` is referenced by its
+published `assets.geolibre.app` URL, never by a GitHub blob or raw URL.
 
 A few things worth knowing:
 
@@ -225,10 +231,16 @@ A few things worth knowing:
   `data/` for sample datasets, and `styles/` or `fonts/` for map resources.
 - Prefer **WebP** or AVIF for stills, and PMTiles or GeoParquet for data. The
   screenshots on this site are WebP.
+- Keep individual files under 100 MB, GitHub's hard limit.
 - Published paths are effectively permanent. Renaming or deleting a file breaks
   every page already pointing at it, so pick the name once.
 - Assets are served with permissive CORS, so the app can fetch them
   cross-origin.
+
+Some existing pages point at other GeoLibre-operated hosts, mainly
+`data.geolibre.app` and `files.opengeos.org`. Those URLs keep working and do not
+need rewriting; `geolibre-assets` is simply the one you can open a pull request
+against, so send new assets there.
 
 The only images that belong in this repository are the handful of site chrome
 files under `docs/assets/` (the logo and favicon referenced from `mkdocs.yml`).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -209,11 +209,11 @@ that repository's `main` branch is published by GitHub Pages at the matching
 path under its one hostname, <https://assets.geolibre.app>, usually within a
 minute:
 
-| Repository path       | Published URL                                        |
-| --------------------- | ---------------------------------------------------- |
-| `images/my-panel.webp` | `https://assets.geolibre.app/images/my-panel.webp`   |
-| `demos/my-demo.gif`    | `https://assets.geolibre.app/demos/my-demo.gif`      |
-| `data/sample.parquet`  | `https://assets.geolibre.app/data/sample.parquet`    |
+| Repository path        | Published URL                                      |
+| ---------------------- | -------------------------------------------------- |
+| `images/my-panel.webp` | `https://assets.geolibre.app/images/my-panel.webp` |
+| `demos/my-demo.gif`    | `https://assets.geolibre.app/demos/my-demo.gif`    |
+| `data/sample.parquet`  | `https://assets.geolibre.app/data/sample.parquet`  |
 
 Then reference the published URL from your Markdown:
 
@@ -242,8 +242,10 @@ Some existing pages point at other GeoLibre-operated hosts, mainly
 need rewriting; `geolibre-assets` is simply the one you can open a pull request
 against, so send new assets there.
 
-The only images that belong in this repository are the handful of site chrome
-files under `docs/assets/` (the logo and favicon referenced from `mkdocs.yml`).
+The only images that belong in this repository are the site chrome under
+`docs/assets/` — currently just the icon `mkdocs.yml` uses for the logo and
+favicon. Do not add to that directory; if you find something there that nothing
+references, it is a leftover, not a precedent.
 
 ## Plugins and extensions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -197,6 +197,42 @@ links and pages left out of the navigation fail the build. Link to other docs
 pages with a relative path (for example `architecture.md`), and link to files
 outside `docs/` with a full GitHub URL.
 
+### Images, demos, and sample data
+
+**Do not commit screenshots, GIFs, videos, or sample datasets to this
+repository.** Binaries are never really deleted from Git history, so every one
+of them permanently enlarges the clone for everyone, including CI.
+
+Put them in [opengeos/geolibre-assets](https://github.com/opengeos/geolibre-assets)
+instead. Anything on that repository's `main` branch is published at the
+matching path under <https://assets.geolibre.app> within about a minute:
+
+| Repository path       | Published URL                                        |
+| --------------------- | ---------------------------------------------------- |
+| `images/my-panel.webp` | `https://assets.geolibre.app/images/my-panel.webp`   |
+| `demos/my-demo.gif`    | `https://assets.geolibre.app/demos/my-demo.gif`      |
+| `data/sample.parquet`  | `https://assets.geolibre.app/data/sample.parquet`    |
+
+Then reference the absolute URL from your Markdown:
+
+```markdown
+![Raster style panel](https://assets.geolibre.app/images/raster-style-panel.webp)
+```
+
+A few things worth knowing:
+
+- Use `images/` for stills, `demos/` for animations and screen recordings,
+  `data/` for sample datasets, and `styles/` or `fonts/` for map resources.
+- Prefer **WebP** or AVIF for stills, and PMTiles or GeoParquet for data. The
+  screenshots on this site are WebP.
+- Published paths are effectively permanent. Renaming or deleting a file breaks
+  every page already pointing at it, so pick the name once.
+- Assets are served with permissive CORS, so the app can fetch them
+  cross-origin.
+
+The only images that belong in this repository are the handful of site chrome
+files under `docs/assets/` (the logo and favicon referenced from `mkdocs.yml`).
+
 ## Plugins and extensions
 
 GeoLibre supports external plugins loaded from a zip, a local directory, or a


### PR DESCRIPTION
## What

Adds an **Images, demos, and sample data** subsection to `docs/contributing.md`, under Documentation.

## Why

PR #1763 arrived carrying ~10 MB of PNG screenshots committed into `docs/assets`. Git history keeps binaries forever, so each one permanently enlarges the clone for every contributor and every CI run. Nothing in the contributing guide said where they should go instead.

Every image reference in `docs/` is already an absolute URL to <https://assets.geolibre.app>; this just writes down the convention that was already being followed.

## What it says

- Do not commit screenshots, GIFs, videos, or sample datasets here.
- Put them in [opengeos/geolibre-assets](https://github.com/opengeos/geolibre-assets), which publishes anything on `main` to the matching path under `https://assets.geolibre.app` within about a minute.
- The repo-path to URL mapping, and which directory to use (`images/`, `demos/`, `data/`, `styles/`, `fonts/`).
- Prefer WebP/AVIF for stills and PMTiles/GeoParquet for data.
- Published paths are effectively permanent, so renaming breaks anything already pointing at them.
- The only images that belong in this repo are the logo and favicon under `docs/assets/`.

## Verification

`pre-commit run --files docs/contributing.md` passes. Zensical is not installed locally, so the `--strict` docs build was not run here; the change is a prose section with one table, one fenced block, and external links only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for handling screenshots, videos, GIFs, and sample datasets.
  * Documented approved asset hosting and URL usage.
  * Clarified requirements for file paths, formats, size limits, permanence, CORS, and permitted repository images.
  * Prohibited adding these assets directly to the repository and directed contributors to use approved hosted asset links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->