### PR TITLE
chore(deps): bump dompurify to 3.4.13; re-verify the image-size allowlist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12968,9 +12968,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/scripts/audit-check.mjs
+++ b/scripts/audit-check.mjs
@@ -19,17 +19,27 @@ const ALLOWLIST = new Map([
   [
     "GHSA-w3rx-r6r6-pgpr",
     "image-size DoS (ICNS parser infinite loop). No patched version exists — " +
-      "the advisory covers <=2.0.2 and 2.0.2 is the latest release. It reaches " +
+      "the advisory covers <=2.0.2, 2.0.2 is the latest release, and the GitHub " +
+      "advisory API reports first_patched_version: null. Nor can we upgrade past " +
+      "it: the latest @loaders.gl/textures (4.4.4) still depends on " +
+      "texture-compressor@^1.0.2, which pins image-size@^0.7.4. It reaches " +
       "us only as a dependency of texture-compressor, which @loaders.gl/textures " +
       "spawns via `npx` from encodeImageURLToCompressedTextureURL (a Node-only " +
       "encoder). GeoLibre never calls that encoder and it cannot bundle into the " +
-      "browser build, so no attacker-supplied image is ever parsed by it.",
+      "browser build, so no attacker-supplied image is ever parsed by it — " +
+      "confirmed by grepping the production build, which contains no reference " +
+      "to image-size or texture-compressor. Re-verified 2026-08-07.",
   ],
   [
     "GHSA-5p2g-fcmc-qvqq",
     "image-size DoS (JXL/HEIF parser infinite loops). Same package, same lack of " +
       "a patched version, and the same unreachable texture-compressor path as " +
-      "GHSA-w3rx-r6r6-pgpr above.",
+      "GHSA-w3rx-r6r6-pgpr above. Note that plain `npm audit` inflates these two " +
+      "advisories into ~16 high findings by counting them once per package in the " +
+      "chain (texture-compressor → @loaders.gl/textures → gltf/3d-tiles/i3s → " +
+      "deck.gl → the maplibre-gl-* wrappers). There is only ever one copy of " +
+      "image-size in the tree; `npm ls image-size` is the honest count. " +
+      "Re-verified 2026-08-07.",
   ],
 ]);
 


### PR DESCRIPTION
## What

Two commits:

1. **Bumps `dompurify` 3.4.12 → 3.4.13** to clear [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) — DOMPurify `<=3.4.12` leaves a detached subtree executable after `IN_PLACE` hook removal, allowing XSS. This was the **only actionable advisory** in `npm audit`.
2. **Refreshes the `image-size` allowlist rationale** in `scripts/audit-check.mjs` (comments only, no behavior change) with re-verification evidence, so the next person doesn't have to redo the investigation.

## 1. The dompurify bump

Lockfile-only. `dompurify` is a direct dependency of `geolibre-desktop` at `^3.4.12`, and all three transitive consumers declare ranges that accept 3.4.13:

| Consumer | Declared range |
| --- | --- |
| `@cesium/engine` | `^3.3.0` |
| `@geoman-io/maplibre-geoman-free` | `^3.4.11` |
| `maplibre-gl-geoagent` | `^3.4.2` |

So a plain in-range `npm update dompurify` moves the single deduped copy — no `package.json` edit, no `--force`, no breaking upgrade.

## 2. Why the 16 remaining "high" findings are not fixed here

They are **not 16 distinct problems**. They are the same two `image-size` DoS advisories (`GHSA-w3rx-r6r6-pgpr`, `GHSA-5p2g-fcmc-qvqq`) counted once per package in the chain: `texture-compressor` → `@loaders.gl/textures` → `gltf`/`3d-tiles`/`i3s` → `deck.gl` → the `maplibre-gl-*` wrappers. `npm ls image-size` shows the honest count — **one** copy, `image-size@0.7.5`.

They cannot be fixed by any dependency change available today:

- **No patched version exists.** The GitHub advisory API reports `first_patched_version: null` for both. Affected range is `<= 2.0.2`, and 2.0.2 is the newest release ever published — no version escapes the range.
- **No upgrade higher in the chain helps.** The latest `@loaders.gl/textures` (4.4.4) still hard-depends on `texture-compressor@^1.0.2`, which pins `image-size@^0.7.4`.
- **It is not in the shipped code.** `@loaders.gl/textures` reaches the encoder by *spawning a child process* (`command: 'npx'` in `encode-texture.js`), so it cannot bundle. Grepping the production build confirms it: zero references to `image-size` or `texture-compressor` in `apps/geolibre-desktop/dist`. The vulnerable ICNS/JXL/HEIF header parsing lives in `texture-compressor`'s CLI, which GeoLibre never invokes.

`npm audit fix --force` would instead downgrade `maplibre-gl-time-slider` to 1.1.0 — a breaking change that still would not fix the advisory, since there is no patched `image-size` to land on.

The only way to make the raw count read zero would be an npm `override` swapping `image-size` for a stub. That is cosmetic, masks any *future* real advisory in that subtree, and would silently break `encodeImageURLToCompressedTextureURL` with no build error. Deliberately not done — this is exactly the case `scripts/audit-check.mjs` exists to handle, and Dependabot will pick up a genuine fix automatically if upstream ever ships one.

## Verification

- `npm run audit:ci` — passes, 2 allowlisted, no unallowed high/critical
- `npm run build` — clean
- `npm run test:frontend` — 5498 pass, 0 fail, 1 skipped