### PR TITLE
Document the GeoLibre R package

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Full documentation, including the User Guide and Tutorials, is published at
   - [UI Profiles](docs/ui-profiles.md)
   - [Internationalization](docs/i18n.md)
   - [Python package (Jupyter)](docs/python.md)
+  - [R package (RStudio, Quarto, and Shiny)](docs/r.md)
   - [Notebook Panel](docs/notebook.md)
   - [Roadmap](docs/roadmap.md)
   - [Contributing](docs/contributing.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -158,6 +158,7 @@ kepler.gl, see the [Comparison](comparison.md).
     - Notebook cells drive the map through an auto-loaded `geolibre` client, and external Jupyter frontends attached to that server (VS Code's Jupyter extension, `jupyter console`, nbclient) drive the map too
 - Python package (`geolibre`) that embeds the full app in Jupyter notebooks as an [anywidget](https://anywidget.dev), with two-way project sync. See the [Python package guide](python.md)
     - An expanded leafmap-style API: local raster, marker/cluster, and choropleth layers; `split_map`, `add_legend`, and `add_colorbar` helpers; typed read-back of selected and drawn features; and `to_html` export
+- R package (`geolibre`) for interactive GeoLibre maps in RStudio, Quarto, R Markdown, and Shiny, with GeoJSON, `sf`, remote raster, camera, and project-file support. See the [R package guide](r.md)
 - Optional Python FastAPI sidecar for heavier processing workflows
 
 ## Processing and analysis

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,20 @@ conda install -c conda-forge geolibre
 
 See the [Python Package](python.md) reference to get started.
 
+### In R
+
+The [`geolibre`](r.md) R package embeds GeoLibre as an interactive HTML widget
+in RStudio, Quarto, R Markdown, and Shiny. Install the development release from
+GitHub:
+
+```r
+install.packages("pak")
+pak::pak("opengeos/geolibre-r")
+```
+
+[Read the R package guide](r.md){ .md-button .md-button--primary }
+[Try the interactive example](https://r.geolibre.app/articles/interactive-map.html){ .md-button }
+
 ### On Android
 
 GeoLibre ships as a native Android app built from the same codebase, with a responsive touch layout for phones. Install it from Google Play and it updates automatically:

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,12 @@ Embed the full GeoLibre app in a Jupyter notebook with the [`geolibre`](python.m
 </div>
 
 <div class="feature-card" markdown>
+### R, Quarto, and Shiny
+
+Build interactive maps in RStudio, Quarto, R Markdown, and Shiny with the [`geolibre`](r.md) R package. Add GeoJSON, `sf` objects, and remote rasters, control the camera, and exchange portable `.geolibre.json` projects with the web and desktop applications.
+</div>
+
+<div class="feature-card" markdown>
 ### AI Assistant
 
 Chat with your data: a natural-language [assistant](user-guide/ai-assistant.md) that turns plain-English requests into GeoLibre operations — Spatial SQL, symbology, add or remove data, and map control — applied through the app so they stay auditable and undoable. Provider-pluggable (Google Gemini, Anthropic, OpenAI) with your own API key, disabled until configured.

--- a/docs/r.md
+++ b/docs/r.md
@@ -1,0 +1,148 @@
+# R package
+
+[![R-CMD-check](https://github.com/opengeos/geolibre-r/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/opengeos/geolibre-r/actions/workflows/R-CMD-check.yaml)
+
+The **`geolibre`** R package embeds the full GeoLibre map in RStudio, Quarto,
+R Markdown, and Shiny through [`htmlwidgets`](https://www.htmlwidgets.org/).
+It creates standard `.geolibre.json` projects, so maps can move between R and
+the GeoLibre web or desktop application.
+
+[View the R package website](https://r.geolibre.app/){ .md-button .md-button--primary }
+[Open the interactive example](https://r.geolibre.app/articles/interactive-map.html){ .md-button }
+[Browse the source](https://github.com/opengeos/geolibre-r){ .md-button }
+
+## Installation
+
+The package is currently available from GitHub while its first CRAN submission
+is prepared:
+
+```r
+install.packages("pak")
+pak::pak("opengeos/geolibre-r")
+```
+
+After it is published on CRAN, install the released version with:
+
+```r
+install.packages("geolibre")
+```
+
+## Quick start
+
+Create an interactive map from GeoJSON and set its initial camera:
+
+```r
+library(geolibre)
+
+places <- list(
+  type = "FeatureCollection",
+  features = list(list(
+    type = "Feature",
+    properties = list(name = "Washington, DC"),
+    geometry = list(
+      type = "Point",
+      coordinates = c(-77.0369, 38.9072)
+    )
+  ))
+)
+
+geolibre(map_only = TRUE) |>
+  add_geojson(
+    places,
+    name = "Places",
+    style = list(fillColor = "#dc2626", circleRadius = 8)
+  ) |>
+  set_view(center = c(-77.0369, 38.9072), zoom = 10)
+```
+
+The widget is responsive in the RStudio Viewer and rendered HTML documents.
+Its map loads the hosted GeoLibre application, so viewing it requires an
+internet connection unless `app_url` points to a self-hosted deployment.
+
+## Spatial data with `sf`
+
+`add_sf()` accepts an `sf` object and transforms it to WGS 84 before passing
+GeoJSON to the browser:
+
+```r
+library(sf)
+
+nc <- st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
+
+geolibre() |>
+  add_sf(nc, name = "North Carolina counties")
+```
+
+The `sf` package is optional. On Linux, installing it may require system
+libraries such as GDAL, GEOS, PROJ, and UDUNITS.
+
+## Remote rasters
+
+GeoLibre reads remote Cloud Optimized GeoTIFFs directly in the browser. The
+server hosting the raster must support CORS and HTTP range requests.
+
+```r
+geolibre() |>
+  add_raster(
+    "https://example.org/visual.tif",
+    name = "Satellite image",
+    bands = c(1, 2, 3)
+  )
+```
+
+## Project files
+
+Save the widget state as a portable GeoLibre project and restore it later:
+
+```r
+map <- geolibre() |> add_geojson(places)
+save_project(map, "example.geolibre.json")
+
+restored <- geolibre(load_project("example.geolibre.json"))
+```
+
+The saved project can also be opened in GeoLibre Web or GeoLibre Desktop. In a
+Shiny application, browser-side changes are available through
+`input$<outputId>_project`.
+
+## Shiny
+
+Use `geolibreOutput()` and `renderGeolibre()` to render a map. A proxy updates
+the live widget without rebuilding the output:
+
+```r
+library(shiny)
+library(geolibre)
+
+ui <- fluidPage(
+  geolibreOutput("map", height = "80vh"),
+  actionButton("reset", "Reset view")
+)
+
+server <- function(input, output, session) {
+  map <- reactiveVal(geolibre(map_only = TRUE))
+  output$map <- renderGeolibre(map())
+
+  observeEvent(input$reset, {
+    next_map <- set_view(map(), center = c(0, 20), zoom = 2)
+    map(next_map)
+    update_geolibre(geolibre_proxy("map"), next_map)
+  })
+}
+
+shinyApp(ui, server)
+```
+
+## Self-hosting
+
+Set a custom GeoLibre application URL for one widget or for the R session:
+
+```r
+geolibre(app_url = "https://gis.example.org/")
+
+options(geolibre.app_url = "https://gis.example.org/")
+```
+
+The deployment must expose the GeoLibre web app and its `?embed=1` project
+bridge. See the [package reference](https://r.geolibre.app/reference/) for the
+complete API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - UI Profiles: ui-profiles.md
       - Internationalization: i18n.md
       - Python Package: python.md
+      - R Package: r.md
       - MCP Server: mcp.md
       - Notebook Panel: notebook.md
       - Roadmap: roadmap.md


### PR DESCRIPTION
## Summary

- add a complete R package guide covering installation, maps, `sf`, rasters, project files, Shiny, and self-hosting
- add the R integration to Getting Started, the homepage, the feature catalog, and README
- add the guide to the MkDocs Reference navigation
- link the package website, live interactive example, API reference, and source repository

## Validation

- MkDocs site build succeeds
- all newly added external destinations return HTTP 200
- `git diff --check` passes

## Existing warnings

MkDocs strict mode remains blocked by two unrelated existing warnings: `server-api.md` is absent from the navigation and the generated `demo/` navigation target is not present in the source docs tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for using the GeoLibre R package with RStudio, Quarto, R Markdown, and Shiny.
  * Added guidance for interactive maps, `sf` and GeoJSON data, remote rasters, camera controls, project persistence, and self-hosting.
  * Added installation instructions, quick-start examples, and an interactive example link.
  * Added the R Package guide to the documentation navigation and feature overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->