### PR TITLE
Fix categorized styling for marker icons

### DIFF
--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -60,6 +60,7 @@ import { prepareFillPattern } from "./fill-patterns";
 import { prepareLineDecoration } from "./line-decorations";
 import {
   KML_ICON_URL_PROPERTY,
+  markerImageValue,
   markerIconSizeValue,
   prepareKmlFeatureIcons,
   prepareMarker,
@@ -1636,9 +1637,9 @@ function syncVectorControlPointSymbology(
 
   const circleSpec = getStyleLayerSpec(map, circleNativeId);
   ensureGeneratedImageHandler(map);
-  const markerImageId = prepareMarker(layer.style);
+  const markerImage = markerImageValue(layer.style);
 
-  if (markerImageId && circleSpec) {
+  if (markerImage && circleSpec) {
     // Reuse the control's own base filter (the tracked base when Time-Slider /
     // rule extras are active, so they never nest) combined with the current
     // extras, mirroring applyExternalNativeFeatureFilters.
@@ -1662,7 +1663,7 @@ function syncVectorControlPointSymbology(
         // on the update path (ensureLayer only diffs keys that exist).
         filter: filter ?? undefined,
         layout: {
-          "icon-image": markerImageId,
+          "icon-image": markerImage as PropertyValueSpecification<string>,
           "icon-size": markerIconSizeValue(layer.style) as PropertyValueSpecification<number>,
           "icon-allow-overlap": true,
           "icon-ignore-placement": true,
@@ -1921,6 +1922,7 @@ function applyVectorDataRenderLayers(
   ensureGeneratedImageHandler(map);
   const fillPatternId = prepareFillPattern(layer.style);
   const markerImageId = prepareMarker(layer.style);
+  const markerImage = markerImageValue(layer.style);
   const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!, markerImageId ?? "");
   // Derived companion symbology (inverted mask, geometry generator, dedup
   // labels) is built from the raw features, so no MapLibre filter applies to
@@ -2213,7 +2215,7 @@ function applyVectorDataRenderLayers(
       layer,
       hasTextMarkers ? nonTextMarkerPointFilter : pointGeometryFilter,
     );
-    if (markerImageId || kmlIconImage) {
+    if (markerImage || kmlIconImage) {
       removeIfExists(map, circleLayerId(layer.id));
       ensureLayer(
         map,
@@ -2225,7 +2227,7 @@ function applyVectorDataRenderLayers(
           ...styleLayerZoomRange(layer.style),
           filter: pointFilter,
           layout: {
-            "icon-image": (kmlIconImage ?? markerImageId) as string,
+            "icon-image": (kmlIconImage ?? markerImage) as PropertyValueSpecification<string>,
             // The sprite is baked at its display size, so icon-size stays 1
             // unless proportional sizing scales it per feature.
             "icon-size": (kmlIconImage

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1923,7 +1923,7 @@ function applyVectorDataRenderLayers(
   const fillPatternId = prepareFillPattern(layer.style);
   const markerImageId = prepareMarker(layer.style);
   const markerImage = markerImageValue(layer.style);
-  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!, markerImageId ?? "");
+  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!, markerImage ?? markerImageId ?? "");
   // Derived companion symbology (inverted mask, geometry generator, dedup
   // labels) is built from the raw features, so no MapLibre filter applies to
   // it. While a Time Slider window or a rule-based visibility filter is

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -63,7 +63,6 @@ import {
   markerImageValue,
   markerIconSizeValue,
   prepareKmlFeatureIcons,
-  prepareMarker,
 } from "./markers";
 import { isPlaceholderLayer } from "./placeholders";
 import {
@@ -1921,9 +1920,10 @@ function applyVectorDataRenderLayers(
   // a generated image id.
   ensureGeneratedImageHandler(map);
   const fillPatternId = prepareFillPattern(layer.style);
-  const markerImageId = prepareMarker(layer.style);
+  // markerImageValue resolves the same base marker internally, so it is null
+  // exactly when no marker applies — no separate prepareMarker call is needed.
   const markerImage = markerImageValue(layer.style);
-  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!, markerImage ?? markerImageId ?? "");
+  const kmlIconImage = prepareKmlFeatureIcons(layer.geojson!, markerImage ?? "");
   // Derived companion symbology (inverted mask, geometry generator, dedup
   // labels) is built from the raw features, so no MapLibre filter applies to
   // it. While a Time Slider window or a rule-based visibility filter is
@@ -2241,7 +2241,7 @@ function applyVectorDataRenderLayers(
         },
         beforeId,
       );
-      if (kmlIconImage && !markerImageId) {
+      if (kmlIconImage && !markerImage) {
         // Features without a KML icon still use the ordinary circle renderer.
         ensureLayer(
           map,

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -22,6 +22,8 @@ const MAX_MARKER_SIZE = 96;
 const MAX_SVG_SOURCE_CACHE = 64;
 export const KML_ICON_URL_PROPERTY = "__geolibre_kml_icon_url";
 const svgSourceCache = new Map<string, Promise<string | null>>();
+// The expression heads whose outputs markerImageValue rewrites into sprite ids.
+const COLOR_BRANCH_HEADS: ReadonlySet<string> = new Set(["match", "step", "case"]);
 
 const BUILTIN_SHAPES: ReadonlySet<MarkerShape> = new Set([
   "circle",
@@ -118,6 +120,12 @@ async function colorizedSvgSource(markup: string, color: string): Promise<string
     if (fetched !== null) {
       sourceMarkup = fetched;
     } else {
+      // Do not keep a failed fetch cached: a transient network error would
+      // otherwise block every later color variant of the same source (and any
+      // styleimagemissing retry) until the entry is evicted. Dropping it only
+      // after the await still lets concurrent callers share the in-flight
+      // promise.
+      if (svgSourceCache.get(markup) === pending) svgSourceCache.delete(markup);
       // Preserve the original source when a remote host blocks CORS. The
       // marker still renders, although its QGIS color parameters cannot be
       // resolved without access to the SVG text.
@@ -268,9 +276,6 @@ export function markerImageValue(style: LayerStyle): string | unknown[] | null {
   const baseId = prepareMarker(style, fallback);
   if (!baseId) return null;
 
-  const colorValue = vectorColorExpression(style, fallback);
-  if (!Array.isArray(colorValue)) return baseId;
-
   const imageFor = (value: unknown): unknown => {
     if (typeof value === "string") {
       return normalizeHexColor(value) ? (prepareMarker(style, value) ?? baseId) : baseId;
@@ -279,7 +284,7 @@ export function markerImageValue(style: LayerStyle): string | unknown[] | null {
 
     const expression = [...value];
     const firstOutput = expression[0] === "match" ? 3 : 2;
-    if (!new Set(["match", "step", "case"]).has(String(expression[0]))) return baseId;
+    if (!COLOR_BRANCH_HEADS.has(String(expression[0]))) return baseId;
     for (let index = firstOutput; index < expression.length; index += 2) {
       expression[index] = imageFor(expression[index]);
     }
@@ -288,7 +293,10 @@ export function markerImageValue(style: LayerStyle): string | unknown[] | null {
     }
     return expression;
   };
-  return imageFor(colorValue) as unknown[];
+  // A flat resolved color still goes through imageFor: rule-based mode with no
+  // drawable rules returns the else rule's color, which need not equal the
+  // layer's markerColor that baseId was baked from.
+  return imageFor(vectorColorExpression(style, fallback)) as string | unknown[];
 }
 
 function loadRasterMarker(url: string): Promise<GeneratedImageResult | null> {

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -278,7 +278,12 @@ export function markerImageValue(style: LayerStyle): string | unknown[] | null {
 
   const imageFor = (value: unknown): unknown => {
     if (typeof value === "string") {
-      return normalizeHexColor(value) ? (prepareMarker(style, value) ?? baseId) : baseId;
+      // Bake the canonical form: prepareMarker uses the color verbatim for both
+      // the sprite id and the fill, so a bare or shorthand hex ("fff") from a
+      // hand-authored expression would otherwise draw black, and "#FDE725"
+      // would bake a second sprite for a color already registered lowercase.
+      const normalized = normalizeHexColor(value);
+      return normalized ? (prepareMarker(style, normalized) ?? baseId) : baseId;
     }
     if (!Array.isArray(value)) return baseId;
 

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -19,7 +19,9 @@ const MARKER_PIXEL_RATIO = 2;
 // enormous canvas; the rendered size is set via the marker image's own pixels.
 const MIN_MARKER_SIZE = 6;
 const MAX_MARKER_SIZE = 96;
+const MAX_SVG_SOURCE_CACHE = 64;
 export const KML_ICON_URL_PROPERTY = "__geolibre_kml_icon_url";
+const svgSourceCache = new Map<string, Promise<string | null>>();
 
 const BUILTIN_SHAPES: ReadonlySet<MarkerShape> = new Set([
   "circle",
@@ -101,10 +103,21 @@ function replaceSvgColorParameters(markup: string, color: string): string {
 async function colorizedSvgSource(markup: string, color: string): Promise<string | null> {
   let sourceMarkup = markup;
   if (/^(?:https?:|data:image\/svg\+xml)/i.test(markup)) {
-    try {
-      const response = await fetch(markup);
-      if (response.ok) sourceMarkup = await response.text();
-    } catch {
+    let pending = svgSourceCache.get(markup);
+    if (!pending) {
+      pending = fetch(markup)
+        .then((response) => (response.ok ? response.text() : null))
+        .catch(() => null);
+      if (svgSourceCache.size >= MAX_SVG_SOURCE_CACHE) {
+        const oldest = svgSourceCache.keys().next().value;
+        if (oldest !== undefined) svgSourceCache.delete(oldest);
+      }
+      svgSourceCache.set(markup, pending);
+    }
+    const fetched = await pending;
+    if (fetched !== null) {
+      sourceMarkup = fetched;
+    } else {
       // Preserve the original source when a remote host blocks CORS. The
       // marker still renders, although its QGIS color parameters cannot be
       // resolved without access to the SVG text.

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -3,6 +3,7 @@ import {
   normalizeHexColor,
   proportionalSizeRange,
   styleValue,
+  vectorColorExpression,
   type LayerStyle,
   type MarkerShape,
 } from "@geolibre/core";
@@ -88,8 +89,36 @@ export function loadMarkerSvgImage(markup: string): Promise<HTMLImageElement | n
   });
 }
 
-function loadSvgMarker(markup: string, size: number): Promise<GeneratedImageResult | null> {
-  const src = resolveSvgSource(markup);
+function replaceSvgColorParameters(markup: string, color: string): string {
+  return markup
+    .replace(/param\(fill\)/gi, color)
+    .replace(/param\(fill-opacity\)/gi, "1")
+    .replace(/param\(outline\)/gi, color)
+    .replace(/param\(outline-opacity\)/gi, "1")
+    .replace(/param\(outline-width\)/gi, "0");
+}
+
+async function colorizedSvgSource(markup: string, color: string): Promise<string | null> {
+  let sourceMarkup = markup;
+  if (/^(?:https?:|data:image\/svg\+xml)/i.test(markup)) {
+    try {
+      const response = await fetch(markup);
+      if (response.ok) sourceMarkup = await response.text();
+    } catch {
+      // Preserve the original source when a remote host blocks CORS. The
+      // marker still renders, although its QGIS color parameters cannot be
+      // resolved without access to the SVG text.
+    }
+  }
+  return resolveSvgSource(replaceSvgColorParameters(sourceMarkup, color));
+}
+
+async function loadSvgMarker(
+  markup: string,
+  color: string,
+  size: number,
+): Promise<GeneratedImageResult | null> {
+  const src = await colorizedSvgSource(markup, color);
   if (!src) return Promise.resolve(null);
   const ratio = MARKER_PIXEL_RATIO;
   const px = size * ratio;
@@ -193,7 +222,7 @@ export function markerIconSizeValue(style: LayerStyle): number | unknown[] {
  * @param style - The layer style.
  * @returns The image id, or `null` when no marker applies.
  */
-export function prepareMarker(style: LayerStyle): string | null {
+export function prepareMarker(style: LayerStyle, colorOverride?: string): string | null {
   if (!styleValue(style, "markerEnabled")) return null;
   const shape = styleValue(style, "markerShape");
   const size = markerBakedSize(style);
@@ -201,18 +230,60 @@ export function prepareMarker(style: LayerStyle): string | null {
   if (shape === "custom") {
     const markup = styleValue(style, "markerSvg").trim();
     if (!markup) return null;
-    const id = `geolibre-marker-svg-${hashText(markup)}-${size}`;
+    const color = colorOverride ?? markerColor(style);
+    const id = `geolibre-marker-svg-${hashText(`${markup}\0${color}`)}-${size}`;
     // Capture the markup in the factory closure so the lazy generator never
     // depends on a separate, evictable cache (which could blank the marker).
-    registerGeneratedImage(id, () => loadSvgMarker(markup, size));
+    registerGeneratedImage(id, () => loadSvgMarker(markup, color, size));
     return id;
   }
 
   if (!BUILTIN_SHAPES.has(shape)) return null;
-  const color = markerColor(style);
+  const color = colorOverride ?? markerColor(style);
   const id = `geolibre-marker-${shape}-${color.replace("#", "")}-${size}`;
   registerGeneratedImage(id, () => drawBuiltinMarker(shape, color, size));
   return id;
+}
+
+/**
+ * Resolve a marker's `icon-image` layout value. Categorized, graduated, and
+ * rule-based color expressions select a separately baked sprite per class,
+ * because ordinary bitmap sprites cannot be tinted per feature by MapLibre.
+ */
+export function markerImageValue(style: LayerStyle): string | unknown[] | null {
+  const fallback = markerColor(style);
+  const baseId = prepareMarker(style, fallback);
+  if (!baseId) return null;
+
+  const colorValue = vectorColorExpression(style, fallback);
+  if (!Array.isArray(colorValue)) return baseId;
+
+  const imageFor = (value: unknown): unknown => {
+    if (typeof value !== "string" || !normalizeHexColor(value)) return value;
+    return prepareMarker(style, value) ?? baseId;
+  };
+  const expression = [...colorValue];
+  switch (expression[0]) {
+    case "match":
+      for (let index = 3; index < expression.length; index += 2) {
+        expression[index] = imageFor(expression[index]);
+      }
+      expression[expression.length - 1] = imageFor(expression[expression.length - 1]);
+      return expression;
+    case "step":
+      for (let index = 2; index < expression.length; index += 2) {
+        expression[index] = imageFor(expression[index]);
+      }
+      return expression;
+    case "case":
+      for (let index = 2; index < expression.length; index += 2) {
+        expression[index] = imageFor(expression[index]);
+      }
+      expression[expression.length - 1] = imageFor(expression[expression.length - 1]);
+      return expression;
+    default:
+      return baseId;
+  }
 }
 
 function loadRasterMarker(url: string): Promise<GeneratedImageResult | null> {

--- a/packages/map/src/markers.ts
+++ b/packages/map/src/markers.ts
@@ -259,31 +259,23 @@ export function markerImageValue(style: LayerStyle): string | unknown[] | null {
   if (!Array.isArray(colorValue)) return baseId;
 
   const imageFor = (value: unknown): unknown => {
-    if (typeof value !== "string" || !normalizeHexColor(value)) return value;
-    return prepareMarker(style, value) ?? baseId;
+    if (typeof value === "string") {
+      return normalizeHexColor(value) ? (prepareMarker(style, value) ?? baseId) : baseId;
+    }
+    if (!Array.isArray(value)) return baseId;
+
+    const expression = [...value];
+    const firstOutput = expression[0] === "match" ? 3 : 2;
+    if (!new Set(["match", "step", "case"]).has(String(expression[0]))) return baseId;
+    for (let index = firstOutput; index < expression.length; index += 2) {
+      expression[index] = imageFor(expression[index]);
+    }
+    if (expression[0] !== "step") {
+      expression[expression.length - 1] = imageFor(expression[expression.length - 1]);
+    }
+    return expression;
   };
-  const expression = [...colorValue];
-  switch (expression[0]) {
-    case "match":
-      for (let index = 3; index < expression.length; index += 2) {
-        expression[index] = imageFor(expression[index]);
-      }
-      expression[expression.length - 1] = imageFor(expression[expression.length - 1]);
-      return expression;
-    case "step":
-      for (let index = 2; index < expression.length; index += 2) {
-        expression[index] = imageFor(expression[index]);
-      }
-      return expression;
-    case "case":
-      for (let index = 2; index < expression.length; index += 2) {
-        expression[index] = imageFor(expression[index]);
-      }
-      expression[expression.length - 1] = imageFor(expression[expression.length - 1]);
-      return expression;
-    default:
-      return baseId;
-  }
+  return imageFor(colorValue) as unknown[];
 }
 
 function loadRasterMarker(url: string): Promise<GeneratedImageResult | null> {
@@ -303,7 +295,7 @@ function loadRasterMarker(url: string): Promise<GeneratedImageResult | null> {
  */
 export function prepareKmlFeatureIcons(
   collection: GeoJSON.FeatureCollection,
-  fallbackImage = "",
+  fallbackImage: unknown = "",
 ): unknown[] | null {
   const matches: unknown[] = [];
   const seen = new Set<string>();

--- a/tests/marker-categories.test.ts
+++ b/tests/marker-categories.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
-import { markerImageValue } from "../packages/map/src/markers";
+import {
+  KML_ICON_URL_PROPERTY,
+  markerImageValue,
+  prepareKmlFeatureIcons,
+} from "../packages/map/src/markers";
 
 function categorizedMarker(patch: Partial<LayerStyle> = {}): LayerStyle {
   return {
@@ -60,5 +64,71 @@ describe("markerImageValue", () => {
 
     assert.ok(Array.isArray(value));
     assert.equal(new Set([value[3], value[5], value[6]]).size, 3);
+  });
+
+  it("uses the base marker for invalid expression color outputs", () => {
+    const value = markerImageValue(
+      categorizedMarker({
+        vectorStyleMode: "expression",
+        vectorStyleExpression: '["match",["get","status"],"good","red","#fde725"]',
+      }),
+    );
+
+    assert.ok(Array.isArray(value));
+    assert.equal(value[3], "geolibre-marker-circle-3b82f6-18");
+    assert.equal(value[4], "geolibre-marker-circle-fde725-18");
+  });
+
+  it("recursively converts colors in zoom-scoped rule expressions", () => {
+    const value = markerImageValue(
+      categorizedMarker({
+        vectorStyleMode: "expression",
+        vectorStyleExpression:
+          '["step",["zoom"],["case",["get","selected"],"#339084","#fde725"],10,["case",["get","selected"],"#fde725","#339084"]]',
+      }),
+    );
+
+    assert.deepEqual(value, [
+      "step",
+      ["zoom"],
+      [
+        "case",
+        ["get", "selected"],
+        "geolibre-marker-circle-339084-18",
+        "geolibre-marker-circle-fde725-18",
+      ],
+      10,
+      [
+        "case",
+        ["get", "selected"],
+        "geolibre-marker-circle-fde725-18",
+        "geolibre-marker-circle-339084-18",
+      ],
+    ]);
+  });
+
+  it("keeps categorized marker fallback inside a mixed KML icon expression", () => {
+    const markerImage = markerImageValue(categorizedMarker());
+    const value = prepareKmlFeatureIcons(
+      {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [0, 0] },
+            properties: { [KML_ICON_URL_PROPERTY]: "data:image/png;base64,AA==" },
+          },
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [1, 1] },
+            properties: { status: "good" },
+          },
+        ],
+      },
+      markerImage,
+    );
+
+    assert.ok(Array.isArray(value));
+    assert.deepEqual(value[value.length - 1], markerImage);
   });
 });

--- a/tests/marker-categories.test.ts
+++ b/tests/marker-categories.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
+import { ensureGeneratedImageHandler } from "../packages/map/src/generated-images";
 import {
   KML_ICON_URL_PROPERTY,
   markerImageValue,
   prepareKmlFeatureIcons,
+  prepareMarker,
 } from "../packages/map/src/markers";
 
 function categorizedMarker(patch: Partial<LayerStyle> = {}): LayerStyle {
@@ -107,6 +109,26 @@ describe("markerImageValue", () => {
     ]);
   });
 
+  it("bakes the else-rule color when no rule is drawable", () => {
+    const value = markerImageValue(
+      categorizedMarker({
+        vectorStyleMode: "rule-based",
+        vectorRules: [
+          {
+            id: "else",
+            label: "Other",
+            filter: "",
+            color: "#fde725",
+            enabled: true,
+            isElse: true,
+          },
+        ],
+      }),
+    );
+
+    assert.equal(value, "geolibre-marker-circle-fde725-18");
+  });
+
   it("keeps categorized marker fallback inside a mixed KML icon expression", () => {
     const markerImage = markerImageValue(categorizedMarker());
     const value = prepareKmlFeatureIcons(
@@ -130,5 +152,64 @@ describe("markerImageValue", () => {
 
     assert.ok(Array.isArray(value));
     assert.deepEqual(value[value.length - 1], markerImage);
+  });
+});
+
+describe("custom SVG marker fetches", () => {
+  it("retries a remote SVG whose first fetch failed", async () => {
+    // Run the registered sprite factory the way styleimagemissing does.
+    let missing: ((event: { id: string }) => void) | undefined;
+    const map = {
+      on: (_event: string, handler: (event: { id: string }) => void) => {
+        missing = handler;
+      },
+      hasImage: () => false,
+      addImage: () => {},
+    };
+    ensureGeneratedImageHandler(map as never);
+
+    // The sprite is rasterized through an Image; erroring out keeps the test
+    // off the canvas APIs while still exercising the fetch path.
+    class StubImage {
+      decoding = "";
+      crossOrigin = "";
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_value: string) {
+        queueMicrotask(() => this.onerror?.());
+      }
+    }
+    const previousImage = globalThis.Image;
+    const previousFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.Image = StubImage as never;
+    globalThis.fetch = (() => {
+      calls += 1;
+      return calls === 1
+        ? Promise.reject(new Error("offline"))
+        : Promise.resolve({ ok: true, text: () => Promise.resolve("<svg/>") });
+    }) as never;
+
+    try {
+      const id = prepareMarker(
+        categorizedMarker({
+          markerShape: "custom",
+          markerSvg: "https://example.com/retry.svg",
+          vectorStyleMode: "single",
+        }),
+      );
+      assert.ok(id);
+      missing?.({ id });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      missing?.({ id });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      globalThis.Image = previousImage;
+      globalThis.fetch = previousFetch;
+    }
+
+    // A failed fetch must not be cached, or the marker stays uncolorized for
+    // the rest of the session.
+    assert.equal(calls, 2);
   });
 });

--- a/tests/marker-categories.test.ts
+++ b/tests/marker-categories.test.ts
@@ -109,6 +109,42 @@ describe("markerImageValue", () => {
     ]);
   });
 
+  it("selects a marker per class for graduated stops", () => {
+    assert.deepEqual(
+      markerImageValue(
+        categorizedMarker({
+          vectorStyleMode: "graduated",
+          vectorStyleProperty: "pop",
+          vectorStyleStops: [
+            { value: 0, color: "#339084" },
+            { value: 100, color: "#fde725" },
+          ],
+        }),
+      ),
+      [
+        "step",
+        ["to-number", ["get", "pop"], 0],
+        "geolibre-marker-circle-339084-18",
+        100,
+        "geolibre-marker-circle-fde725-18",
+      ],
+    );
+  });
+
+  it("bakes the canonical color for shorthand and upper-case hex outputs", () => {
+    const value = markerImageValue(
+      categorizedMarker({
+        vectorStyleMode: "expression",
+        vectorStyleExpression: '["match",["get","status"],"good","fff","#FDE725"]',
+      }),
+    );
+
+    assert.ok(Array.isArray(value));
+    // "fff" would be handed to fillStyle verbatim and draw black.
+    assert.equal(value[3], "geolibre-marker-circle-ffffff-18");
+    assert.equal(value[4], "geolibre-marker-circle-fde725-18");
+  });
+
   it("bakes the else-rule color when no rule is drawable", () => {
     const value = markerImageValue(
       categorizedMarker({

--- a/tests/marker-categories.test.ts
+++ b/tests/marker-categories.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
+import { markerImageValue } from "../packages/map/src/markers";
+
+function categorizedMarker(patch: Partial<LayerStyle> = {}): LayerStyle {
+  return {
+    ...DEFAULT_LAYER_STYLE,
+    markerEnabled: true,
+    markerShape: "circle",
+    markerColor: "#3b82f6",
+    markerSize: 18,
+    vectorStyleMode: "categorized",
+    vectorStyleProperty: "status",
+    vectorStyleStops: [
+      { value: "good", color: "#339084" },
+      { value: "bad", color: "#fde725" },
+    ],
+    ...patch,
+  };
+}
+
+describe("markerImageValue", () => {
+  it("selects a separately colored built-in marker for each category", () => {
+    assert.deepEqual(markerImageValue(categorizedMarker()), [
+      "match",
+      ["to-string", ["get", "status"]],
+      "good",
+      "geolibre-marker-circle-339084-18",
+      "bad",
+      "geolibre-marker-circle-fde725-18",
+      "geolibre-marker-circle-3b82f6-18",
+    ]);
+  });
+
+  it("creates distinct parameterized SVG sprites for category colors", () => {
+    const value = markerImageValue(
+      categorizedMarker({
+        markerShape: "custom",
+        markerSvg:
+          '<svg xmlns="http://www.w3.org/2000/svg"><path fill="param(fill)" d="M0 0h10v10z"/></svg>',
+      }),
+    );
+
+    assert.ok(Array.isArray(value));
+    const imageIds = [value[3], value[5], value[6]];
+    assert.ok(
+      imageIds.every((id) => typeof id === "string" && id.startsWith("geolibre-marker-svg-")),
+    );
+    assert.equal(new Set(imageIds).size, 3);
+  });
+
+  it("creates distinct category sprites when the SVG is supplied by URL", () => {
+    const value = markerImageValue(
+      categorizedMarker({
+        markerShape: "custom",
+        markerSvg: "https://example.com/tree.svg",
+      }),
+    );
+
+    assert.ok(Array.isArray(value));
+    assert.equal(new Set([value[3], value[5], value[6]]).size, 3);
+  });
+});


### PR DESCRIPTION
## Summary

- apply categorized, graduated, and rule-based color expressions to built-in marker sprites
- resolve QGIS SVG color parameters for inline, data URL, and remote SVG markers
- add regression coverage for built-in and custom categorized markers

## Verification

- reproduced with the PS1 point shapefile from discussion 1780
- verified built-in circle markers and the supplied tree SVG in light and dark themes
- npm run test:frontend
- npm run build
- pre-commit checks for changed files

Related to https://github.com/opengeos/GeoLibre/discussions/1780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marker icons can now change color based on feature data and style expressions.
  * Custom SVG markers support color overrides, including remotely hosted and data-based SVG sources.
  * External overlays and GeoJSON symbol layers now use configured marker image values.

* **Bug Fixes**
  * Improved categorized marker rendering with distinct colors, custom SVG imagery, and fallback handling for unavailable sources.
  * Failed remote SVG requests are retried rather than incorrectly treated as permanently unavailable.

* **Tests**
  * Added coverage for categorized markers, colored SVG sprites, recursive styling expressions, and remotely loaded SVGs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->