### PR TITLE
fix(print-layout): improve atlas feature framing

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -42,6 +42,7 @@ import {
 import {
   computeScaleRatio,
   drawLayout,
+  mapBodyAspectRatio,
   PAPER_SIZES,
   resolvePageSize,
   type BodyCorner,
@@ -58,6 +59,7 @@ import {
   DEFAULT_TABLE_ROWS,
   layerRows,
   MAX_TABLE_ROWS,
+  rowForAtlasFeature,
   rowsWithinBounds,
   type ChartBlockType,
 } from "../../lib/print-data-blocks";
@@ -91,9 +93,11 @@ import {
 } from "../../lib/print-layout-export";
 import {
   atlasEntryName,
+  atlasViewportFrame,
   buildAtlasPages,
   buildLineAtlasPages,
   collectAtlasFeatures,
+  geometryBounds,
   hasLineGeometry,
   MAX_LINE_ATLAS_PAGES,
   expandBounds,
@@ -106,6 +110,7 @@ import {
   type AtlasPage,
   type AtlasTokenContext,
 } from "../../lib/print-atlas";
+import { clearAtlasFeatureMask, showAtlasFeatureMask } from "../../lib/print-atlas-mask";
 
 interface PrintLayoutDialogProps {
   open: boolean;
@@ -287,6 +292,7 @@ export function PrintLayoutDialog({
   const [tableMaxRows, setTableMaxRows] = useState(DEFAULT_TABLE_ROWS);
   const [tablePosition, setTablePosition] = useState<BodyCorner>("bottom-left");
   const [tableFilterToPage, setTableFilterToPage] = useState(true);
+  const [tableFilterToAtlasFeature, setTableFilterToAtlasFeature] = useState(false);
   const [showDataChart, setShowDataChart] = useState(false);
   const [chartLayerId, setChartLayerId] = useState("");
   const [chartTitle, setChartTitle] = useState("");
@@ -318,6 +324,7 @@ export function PrintLayoutDialog({
   const [atlasNameField, setAtlasNameField] = useState("");
   const [atlasExtentMode, setAtlasExtentMode] = useState<"margin" | "scale">("margin");
   const [atlasMarginPct, setAtlasMarginPct] = useState(10);
+  const [atlasMaskEnabled, setAtlasMaskEnabled] = useState(false);
   const [atlasScale, setAtlasScale] = useState("50000");
   const [atlasSortField, setAtlasSortField] = useState("");
   const [atlasSortDescending, setAtlasSortDescending] = useState(false);
@@ -629,7 +636,10 @@ export function PrintLayoutDialog({
       if (!atlasActiveRef.current) recapture();
     } else if (!open && wasOpenRef.current && !drawingRef.current) {
       // Closing for good (not to draw): take the extent box off the map.
-      if (map) clearPrintExtent(map);
+      if (map) {
+        clearPrintExtent(map);
+        clearAtlasFeatureMask(map);
+      }
     }
     wasOpenRef.current = open;
   }, [open, projectName, recapture, mapControllerRef, extentBbox]);
@@ -657,6 +667,7 @@ export function PrintLayoutDialog({
           idleRecaptureRef.current = null;
         }
         clearPrintExtent(map);
+        clearAtlasFeatureMask(map);
       }
     },
     [mapControllerRef],
@@ -812,6 +823,17 @@ export function PrintLayoutDialog({
     () => atlasLayers.find((l) => l.id === atlasLayerId) ?? null,
     [atlasLayers, atlasLayerId],
   );
+  const atlasMaskAvailable = useMemo(
+    () =>
+      atlasCoverage === "features" &&
+      Boolean(
+        atlasLayer?.geojson?.features.some(
+          (feature) =>
+            feature.geometry?.type === "Polygon" || feature.geometry?.type === "MultiPolygon",
+        ),
+      ),
+    [atlasCoverage, atlasLayer],
+  );
   // The per-vertex geometry walk runs once per coverage layer; sort/filter
   // edits below only re-iterate these lightweight per-feature records.
   const atlasFeatureInfos = useMemo(
@@ -881,6 +903,14 @@ export function PrintLayoutDialog({
   const currentAtlasPage = atlasEnabled ? (atlasPages[clampedAtlasIndex] ?? null) : null;
   const atlasActive = atlasEnabled && atlasPageCount > 0;
   atlasActiveRef.current = atlasActive;
+  // The mask is a temporary live-map layer. Remove it immediately when the
+  // option, atlas, or dialog is turned off instead of waiting for another
+  // camera drive that may never happen.
+  useEffect(() => {
+    if (open && atlasEnabled && atlasMaskEnabled) return;
+    const map = mapControllerRef.current?.getMap();
+    if (map) clearAtlasFeatureMask(map);
+  }, [open, atlasEnabled, atlasMaskEnabled, mapControllerRef]);
   const atlasFilterValid = atlasFilterPredicate !== null;
   const atlasScaleValid = atlasExtentMode !== "scale" || Number(atlasScale) > 0;
   // A floor (not just > 0) keeps a mistyped tiny length from cutting a long
@@ -920,6 +950,9 @@ export function PrintLayoutDialog({
   const chartLayer = useMemo(
     () => atlasLayers.find((l) => l.id === chartLayerId) ?? null,
     [atlasLayers, chartLayerId],
+  );
+  const tableUsesAtlasLayer = Boolean(
+    atlasEnabled && atlasLayer && tableLayer?.id === atlasLayer.id,
   );
   const tableFields = useMemo(
     () => (tableLayer?.geojson ? listAtlasFields(tableLayer.geojson.features) : []),
@@ -1093,7 +1126,9 @@ export function PrintLayoutDialog({
   const displayTableRows = useMemo(
     () =>
       showDataTable
-        ? rowsForBlock(tableFeatureInfos, tableAllRows, tableFilterToPage, displayFilterBounds)
+        ? tableFilterToAtlasFeature && tableUsesAtlasLayer && currentAtlasPage
+          ? rowForAtlasFeature(tableAllRows, currentAtlasPage.sourceIndex)
+          : rowsForBlock(tableFeatureInfos, tableAllRows, tableFilterToPage, displayFilterBounds)
         : [],
     [
       showDataTable,
@@ -1101,6 +1136,9 @@ export function PrintLayoutDialog({
       tableFeatureInfos,
       tableAllRows,
       tableFilterToPage,
+      tableFilterToAtlasFeature,
+      tableUsesAtlasLayer,
+      currentAtlasPage,
       displayFilterBounds,
     ],
   );
@@ -1163,25 +1201,49 @@ export function PrintLayoutDialog({
   // Drive the live map to one atlas page's extent and capture it. Margin mode
   // grows the feature's box before fitting; fixed-scale mode fits first, then
   // corrects the zoom by the log2 ratio difference (like applyScale) and
-  // recaptures. Returns the capture plus the map's final visible bounds, so
-  // the data blocks can filter to what the page actually shows.
+  // recaptures. Returns the capture plus the print frame's final visible
+  // bounds, so data blocks exclude the part of the live map that cover-crop
+  // removes from the page.
   const captureAtlasPage = useCallback(
     async (page: AtlasPage): Promise<{ cap: CapturedMap; viewBounds: AtlasBounds }> => {
       const map = mapControllerRef.current?.getMap();
       if (!map) throw new Error("Map is not ready");
+      const ctx: AtlasTokenContext = {
+        name: page.name,
+        pageNumber: page.index + 1,
+        total: atlasPageCount,
+        properties: page.properties,
+      };
+      const pageOptions: LayoutOptions = {
+        ...options,
+        title: substituteAtlasTokens(options.title, ctx),
+        subtitle: substituteAtlasTokens(options.subtitle, ctx),
+        footerText: substituteAtlasTokens(options.footerText, ctx),
+      };
+      const containMap = Boolean(map.getLayer(GRATICULE_LABEL_LAYER_ID));
+      const canvas = map.getCanvas();
+      const viewportWidth = canvas.clientWidth || canvas.width;
+      const viewportHeight = canvas.clientHeight || canvas.height;
+      const targetAspect = containMap
+        ? viewportWidth / Math.max(1, viewportHeight)
+        : mapBodyAspectRatio(pageOptions);
+      const viewportFrame = atlasViewportFrame(viewportWidth, viewportHeight, targetAspect);
+      const coverageFeature = atlasLayer?.geojson?.features[page.sourceIndex];
+      if (atlasMaskEnabled) showAtlasFeatureMask(map, coverageFeature);
+      else clearAtlasFeatureMask(map);
       const [w, s, e, n] = expandBounds(page.bounds, atlasFitMarginPct);
       map.fitBounds(
         [
           [w, s],
           [e, n],
         ],
-        { animate: false, padding: 0 },
+        { animate: false, padding: viewportFrame.padding },
       );
       await waitForAtlasSettle(map);
       // Mirror recapture: an active graticule draws coordinate labels at the
       // map edges, so fit with "contain" to keep them un-cropped on every
       // atlas page (mapFit is persistent state, so it must be set here too).
-      setMapFit(map.getLayer(GRATICULE_LABEL_LAYER_ID) ? "contain" : "cover");
+      setMapFit(containMap ? "contain" : "cover");
       // Hide the drawn print-extent box while reading the buffer, as recapture
       // does, so its outline is never baked into a page.
       const capture = () => {
@@ -1199,17 +1261,8 @@ export function PrintLayoutDialog({
         // a title/footer made purely of tokens can resolve to empty for a
         // given feature, which collapses that row and changes the body height
         // the scale is computed from.
-        const ctx: AtlasTokenContext = {
-          name: page.name,
-          pageNumber: page.index + 1,
-          total: atlasPageCount,
-          properties: page.properties,
-        };
         const ratio = computeScaleRatio({
-          ...options,
-          title: substituteAtlasTokens(options.title, ctx),
-          subtitle: substituteAtlasTokens(options.subtitle, ctx),
-          footerText: substituteAtlasTokens(options.footerText, ctx),
+          ...pageOptions,
           metersPerPixel: cap.metersPerPixel,
           mapPixelRatio: cap.pixelRatio,
           bearingDeg: cap.bearingDeg,
@@ -1235,10 +1288,24 @@ export function PrintLayoutDialog({
       } else {
         setAtlasScaleNotice(null);
       }
+      const frameBounds = containMap
+        ? null
+        : geometryBounds({
+            type: "MultiPoint",
+            coordinates: [
+              [viewportFrame.crop.left, viewportFrame.crop.top],
+              [viewportFrame.crop.right, viewportFrame.crop.top],
+              [viewportFrame.crop.right, viewportFrame.crop.bottom],
+              [viewportFrame.crop.left, viewportFrame.crop.bottom],
+            ].map(([x, y]) => {
+              const point = map.unproject([x, y]);
+              return [point.lng, point.lat];
+            }),
+          });
       const b = map.getBounds();
       return {
         cap,
-        viewBounds: [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()],
+        viewBounds: frameBounds ?? [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()],
       };
     },
     [
@@ -1247,6 +1314,8 @@ export function PrintLayoutDialog({
       atlasFitMarginPct,
       atlasScale,
       atlasPageCount,
+      atlasLayer,
+      atlasMaskEnabled,
       waitForAtlasSettle,
       options,
       t,
@@ -1340,6 +1409,7 @@ export function PrintLayoutDialog({
     atlasExtentMode,
     atlasMarginPct,
     atlasScale,
+    atlasMaskEnabled,
     // Along-a-line coverage: a new segment length can keep the same page
     // count (sourceIndex signature unchanged) while every extent moved.
     atlasCoverage,
@@ -1635,7 +1705,9 @@ export function PrintLayoutDialog({
             // Each page's table/chart re-filters to the extent the page's
             // capture actually shows (not just the nominal feature bounds).
             ...buildBlocksFromRows(
-              rowsForBlock(tableFeatureInfos, tableAllRows, tableFilterToPage, viewBounds),
+              tableFilterToAtlasFeature && tableUsesAtlasLayer
+                ? rowForAtlasFeature(tableAllRows, pages[i].sourceIndex)
+                : rowsForBlock(tableFeatureInfos, tableAllRows, tableFilterToPage, viewBounds),
               rowsForBlock(chartFeatureInfos, chartAllRows, chartFilterToPage, viewBounds),
             ),
             title: substituteAtlasTokens(options.title, ctx),
@@ -2191,6 +2263,20 @@ export function PrintLayoutDialog({
                           )}
                         </div>
                       )}
+                      {atlasMaskAvailable && (
+                        <div className="space-y-1.5">
+                          <ToggleField
+                            id="atlas-mask-outside"
+                            label={t("printLayout.atlas.maskOutside")}
+                            checked={atlasMaskEnabled}
+                            disabled={atlasBusy}
+                            onChange={setAtlasMaskEnabled}
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            {t("printLayout.atlas.maskOutsideHint")}
+                          </p>
+                        </div>
+                      )}
                       {/* Along-a-line pages follow the line's own chainage,
                           so ordering controls only apply per-feature mode. */}
                       {atlasCoverage === "features" && (
@@ -2705,11 +2791,26 @@ export function PrintLayoutDialog({
                       id="dt-filter-page"
                       label={t("printLayout.dataBlocks.filterToPage")}
                       checked={tableFilterToPage}
+                      disabled={tableFilterToAtlasFeature && tableUsesAtlasLayer}
                       onChange={setTableFilterToPage}
                     />
                     <p className="text-xs text-muted-foreground">
                       {t("printLayout.dataBlocks.filterToPageHint")}
                     </p>
+                    {atlasEnabled && (
+                      <>
+                        <ToggleField
+                          id="dt-filter-atlas-feature"
+                          label={t("printLayout.dataBlocks.filterToAtlasFeature")}
+                          checked={tableFilterToAtlasFeature}
+                          disabled={!tableUsesAtlasLayer}
+                          onChange={setTableFilterToAtlasFeature}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          {t("printLayout.dataBlocks.filterToAtlasFeatureHint")}
+                        </p>
+                      </>
+                    )}
                     {!displayDataBlocks.dataTable && (
                       <p className="text-xs text-muted-foreground">
                         {t("printLayout.dataTable.noRows")}
@@ -3028,7 +3129,9 @@ export function PrintLayoutDialog({
                                     // encodeURIComponent, which leaves ( ) unescaped, and an
                                     // unquoted ) (common in SVG: translate(), rgba(), url(#id))
                                     // would prematurely close the CSS url() token.
-                                    style={{ backgroundImage: `url("${svgSrc}")` }}
+                                    style={{
+                                      backgroundImage: `url("${svgSrc}")`,
+                                    }}
                                   />
                                 );
                               }

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1123,8 +1123,10 @@ export function PrintLayoutDialog({
   const displayTableRows = useMemo(
     () =>
       showDataTable
-        ? tableFilterToAtlasFeature && tableUsesAtlasLayer && currentAtlasPage
-          ? rowForAtlasFeature(tableAllRows, currentAtlasPage.sourceIndex)
+        ? tableFilterToAtlasFeature && tableUsesAtlasLayer
+          ? currentAtlasPage
+            ? rowForAtlasFeature(tableAllRows, currentAtlasPage.sourceIndex)
+            : []
           : rowsForBlock(tableFeatureInfos, tableAllRows, tableFilterToPage, displayFilterBounds)
         : [],
     [

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1227,8 +1227,10 @@ export function PrintLayoutDialog({
       };
       const containMap = Boolean(map.getLayer(GRATICULE_LABEL_LAYER_ID));
       const canvas = map.getCanvas();
-      const viewportWidth = canvas.clientWidth || canvas.width;
-      const viewportHeight = canvas.clientHeight || canvas.height;
+      const mapPixelRatio = map.getPixelRatio();
+      const cssPixelRatio = Number.isFinite(mapPixelRatio) && mapPixelRatio > 0 ? mapPixelRatio : 1;
+      const viewportWidth = canvas.clientWidth || canvas.width / cssPixelRatio;
+      const viewportHeight = canvas.clientHeight || canvas.height / cssPixelRatio;
       const targetAspect = containMap
         ? viewportWidth / Math.max(1, viewportHeight)
         : mapBodyAspectRatio(pageOptions);

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -823,17 +823,6 @@ export function PrintLayoutDialog({
     () => atlasLayers.find((l) => l.id === atlasLayerId) ?? null,
     [atlasLayers, atlasLayerId],
   );
-  const atlasMaskAvailable = useMemo(
-    () =>
-      atlasCoverage === "features" &&
-      Boolean(
-        atlasLayer?.geojson?.features.some(
-          (feature) =>
-            feature.geometry?.type === "Polygon" || feature.geometry?.type === "MultiPolygon",
-        ),
-      ),
-    [atlasCoverage, atlasLayer],
-  );
   // The per-vertex geometry walk runs once per coverage layer; sort/filter
   // edits below only re-iterate these lightweight per-feature records.
   const atlasFeatureInfos = useMemo(
@@ -903,6 +892,14 @@ export function PrintLayoutDialog({
   const currentAtlasPage = atlasEnabled ? (atlasPages[clampedAtlasIndex] ?? null) : null;
   const atlasActive = atlasEnabled && atlasPageCount > 0;
   atlasActiveRef.current = atlasActive;
+  const currentAtlasFeature = currentAtlasPage
+    ? atlasLayer?.geojson?.features[currentAtlasPage.sourceIndex]
+    : undefined;
+  const atlasMaskAvailable = Boolean(
+    atlasCoverage === "features" &&
+    (currentAtlasFeature?.geometry?.type === "Polygon" ||
+      currentAtlasFeature?.geometry?.type === "MultiPolygon"),
+  );
   // The mask is a temporary live-map layer. Remove it immediately when the
   // option, atlas, or dialog is turned off instead of waiting for another
   // camera drive that may never happen.
@@ -1205,7 +1202,13 @@ export function PrintLayoutDialog({
   // bounds, so data blocks exclude the part of the live map that cover-crop
   // removes from the page.
   const captureAtlasPage = useCallback(
-    async (page: AtlasPage): Promise<{ cap: CapturedMap; viewBounds: AtlasBounds }> => {
+    async (
+      page: AtlasPage,
+    ): Promise<{
+      cap: CapturedMap;
+      viewBounds: AtlasBounds;
+      mapFit: "cover" | "contain";
+    }> => {
       const map = mapControllerRef.current?.getMap();
       if (!map) throw new Error("Map is not ready");
       const ctx: AtlasTokenContext = {
@@ -1243,7 +1246,8 @@ export function PrintLayoutDialog({
       // Mirror recapture: an active graticule draws coordinate labels at the
       // map edges, so fit with "contain" to keep them un-cropped on every
       // atlas page (mapFit is persistent state, so it must be set here too).
-      setMapFit(containMap ? "contain" : "cover");
+      const atlasMapFit = containMap ? "contain" : "cover";
+      setMapFit(atlasMapFit);
       // Hide the drawn print-extent box while reading the buffer, as recapture
       // does, so its outline is never baked into a page.
       const capture = () => {
@@ -1306,6 +1310,7 @@ export function PrintLayoutDialog({
       return {
         cap,
         viewBounds: frameBounds ?? [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()],
+        mapFit: atlasMapFit,
       };
     },
     [
@@ -1694,7 +1699,7 @@ export function PrintLayoutDialog({
         onProgress: (current: number, totalPages: number) =>
           setAtlasProgress({ current, total: totalPages }),
         optionsForPage: async (i: number): Promise<LayoutOptions> => {
-          const { cap, viewBounds } = await captureAtlasPage(pages[i]);
+          const { cap, viewBounds, mapFit: atlasMapFit } = await captureAtlasPage(pages[i]);
           // Mirror progress into the dialog preview as pages are produced.
           setCaptured(cap);
           setAtlasViewBounds({ index: i, bounds: viewBounds });
@@ -1719,6 +1724,7 @@ export function PrintLayoutDialog({
             mapImage: cap.image,
             mapImageWidth: cap.width,
             mapImageHeight: cap.height,
+            mapFit: atlasMapFit,
           };
         },
       };
@@ -1746,8 +1752,16 @@ export function PrintLayoutDialog({
     }
   };
 
+  const handleDialogOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen && (atlasBusy || exporting)) return;
+      onOpenChange(nextOpen);
+    },
+    [atlasBusy, exporting, onOpenChange],
+  );
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent
         ref={dialogRef}
         className="max-w-5xl"
@@ -3303,7 +3317,11 @@ export function PrintLayoutDialog({
               })}
             </span>
           )}
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="ghost"
+            disabled={atlasBusy || exporting}
+            onClick={() => handleDialogOpenChange(false)}
+          >
             {t("common.close")}
           </Button>
           {/* Copy the composed layout straight to the clipboard (GH #773). */}

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -907,10 +907,10 @@ export function PrintLayoutDialog({
   // option, atlas, or dialog is turned off instead of waiting for another
   // camera drive that may never happen.
   useEffect(() => {
-    if (open && atlasEnabled && atlasMaskEnabled) return;
+    if (open && atlasActive && atlasMaskEnabled && atlasMaskAvailable) return;
     const map = mapControllerRef.current?.getMap();
     if (map) clearAtlasFeatureMask(map);
-  }, [open, atlasEnabled, atlasMaskEnabled, mapControllerRef]);
+  }, [open, atlasActive, atlasMaskEnabled, atlasMaskAvailable, mapControllerRef]);
   const atlasFilterValid = atlasFilterPredicate !== null;
   const atlasScaleValid = atlasExtentMode !== "scale" || Number(atlasScale) > 0;
   // A floor (not just > 0) keeps a mistyped tiny length from cutting a long

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1323,7 +1323,9 @@
       "titleLabel": "Heading",
       "position": "Position",
       "filterToPage": "Only features in the page extent",
-      "filterToPageHint": "Applies to atlas pages and a drawn print extent; otherwise the whole layer is used."
+      "filterToPageHint": "Applies to atlas pages and a drawn print extent; otherwise the whole layer is used.",
+      "filterToAtlasFeature": "Only the current atlas feature",
+      "filterToAtlasFeatureHint": "Available when the table uses the atlas coverage layer. This takes priority over the page extent filter."
     },
     "dataTable": {
       "columns": "Columns",
@@ -1453,6 +1455,8 @@
       "extentMargin": "Margin around feature",
       "extentScale": "Fixed scale",
       "marginLabel": "Margin (%)",
+      "maskOutside": "Mask area outside current feature",
+      "maskOutsideHint": "Applies a translucent inverted fill to emphasize the current atlas feature.",
       "scaleLabel": "Scale",
       "scaleRequired": "Enter a scale greater than zero.",
       "sortField": "Sort by",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1315,7 +1315,9 @@
       "titleLabel": "En-tête",
       "position": "Position",
       "filterToPage": "Seulement les entités dans l'emprise de la page",
-      "filterToPageHint": "S'applique aux pages d'atlas et à une emprise d'impression dessinée ; sinon, la couche entière est utilisée."
+      "filterToPageHint": "S'applique aux pages d'atlas et à une emprise d'impression dessinée ; sinon, la couche entière est utilisée.",
+      "filterToAtlasFeature": "Seulement l’entité courante de l’atlas",
+      "filterToAtlasFeatureHint": "Disponible lorsque la table utilise la couche de couverture de l’atlas. Ce filtre est prioritaire sur l’emprise de la page."
     },
     "dataTable": {
       "columns": "Colonnes",
@@ -1445,6 +1447,8 @@
       "extentMargin": "Marge autour de l'entité",
       "extentScale": "Échelle fixe",
       "marginLabel": "Marge (%)",
+      "maskOutside": "Masquer la zone hors de l’entité courante",
+      "maskOutsideHint": "Applique un remplissage inversé translucide pour mettre en évidence l’entité courante de l’atlas.",
       "scaleLabel": "Échelle",
       "scaleRequired": "Entrez une échelle supérieure à zéro.",
       "sortField": "Trier par",

--- a/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
+++ b/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
@@ -1,10 +1,14 @@
 /** Temporary inverted-fill mask for the active Print Layout atlas feature. */
-import { buildInvertedMask } from "@geolibre/map";
+import { buildInvertedMask } from "@geolibre/map/derived-geometry";
 import type { Feature, FeatureCollection, MultiPolygon, Polygon } from "geojson";
 import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
 
 const SOURCE_ID = "geolibre-print-atlas-mask";
 const FILL_LAYER_ID = "geolibre-print-atlas-mask-fill";
+const featureCollections = new WeakMap<
+  Feature<Polygon | MultiPolygon>,
+  FeatureCollection<Polygon | MultiPolygon>
+>();
 
 /** Remove the atlas mask source and layer, if present. */
 export function clearAtlasFeatureMask(map: MapLibreMap): void {
@@ -24,10 +28,15 @@ export function showAtlasFeatureMask(map: MapLibreMap, feature: Feature | undefi
     clearAtlasFeatureMask(map);
     return false;
   }
-  const collection: FeatureCollection<Polygon | MultiPolygon> = {
-    type: "FeatureCollection",
-    features: [feature as Feature<Polygon | MultiPolygon>],
-  };
+  const polygonFeature = feature as Feature<Polygon | MultiPolygon>;
+  let collection = featureCollections.get(polygonFeature);
+  if (!collection) {
+    collection = {
+      type: "FeatureCollection",
+      features: [polygonFeature],
+    };
+    featureCollections.set(polygonFeature, collection);
+  }
   const mask = buildInvertedMask(collection);
   if (!mask) {
     clearAtlasFeatureMask(map);

--- a/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
+++ b/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
@@ -1,0 +1,53 @@
+/** Temporary inverted-fill mask for the active Print Layout atlas feature. */
+import { buildInvertedMask } from "@geolibre/map";
+import type { Feature, FeatureCollection, MultiPolygon, Polygon } from "geojson";
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+
+const SOURCE_ID = "geolibre-print-atlas-mask";
+const FILL_LAYER_ID = "geolibre-print-atlas-mask-fill";
+
+/** Remove the atlas mask source and layer, if present. */
+export function clearAtlasFeatureMask(map: MapLibreMap): void {
+  if (map.getLayer(FILL_LAYER_ID)) map.removeLayer(FILL_LAYER_ID);
+  if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID);
+}
+
+/**
+ * Show a translucent inverted fill around one polygon atlas feature.
+ *
+ * @param map - MapLibre map used by the Print Layout capture.
+ * @param feature - Current coverage feature.
+ * @returns Whether a polygon mask could be rendered.
+ */
+export function showAtlasFeatureMask(map: MapLibreMap, feature: Feature | undefined): boolean {
+  if (feature?.geometry?.type !== "Polygon" && feature?.geometry?.type !== "MultiPolygon") {
+    clearAtlasFeatureMask(map);
+    return false;
+  }
+  const collection: FeatureCollection<Polygon | MultiPolygon> = {
+    type: "FeatureCollection",
+    features: [feature as Feature<Polygon | MultiPolygon>],
+  };
+  const mask = buildInvertedMask(collection);
+  if (!mask) {
+    clearAtlasFeatureMask(map);
+    return false;
+  }
+  const source = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+  if (source) source.setData(mask);
+  else map.addSource(SOURCE_ID, { type: "geojson", data: mask });
+  if (!map.getLayer(FILL_LAYER_ID)) {
+    map.addLayer({
+      id: FILL_LAYER_ID,
+      type: "fill",
+      source: SOURCE_ID,
+      metadata: { "geolibre:internal": true },
+      paint: {
+        "fill-color": "#ffffff",
+        "fill-opacity": 0.7,
+        "fill-outline-color": "rgba(0, 0, 0, 0)",
+      },
+    });
+  }
+  return true;
+}

--- a/apps/geolibre-desktop/src/lib/print-atlas.ts
+++ b/apps/geolibre-desktop/src/lib/print-atlas.ts
@@ -11,6 +11,54 @@ import type { FeatureCollection, Geometry, Position } from "geojson";
 /** Geographic bounds as `[west, south, east, north]` in WGS84 degrees. */
 export type AtlasBounds = [number, number, number, number];
 
+/** Symmetric fit padding and matching cover-crop rectangle for an atlas page. */
+export interface AtlasViewportFrame {
+  padding: { top: number; bottom: number; left: number; right: number };
+  crop: { top: number; bottom: number; left: number; right: number };
+}
+
+/**
+ * Fit a target print-frame aspect ratio inside the live map viewport. The
+ * returned padding constrains `fitBounds` to the exact centered rectangle that
+ * the print renderer later keeps when it cover-crops the captured map.
+ *
+ * @param viewportWidth - Live map width in CSS pixels.
+ * @param viewportHeight - Live map height in CSS pixels.
+ * @param frameAspect - Printed map-frame width divided by height.
+ */
+export function atlasViewportFrame(
+  viewportWidth: number,
+  viewportHeight: number,
+  frameAspect: number,
+): AtlasViewportFrame {
+  const width = Math.max(0, viewportWidth);
+  const height = Math.max(0, viewportHeight);
+  let horizontal = 0;
+  let vertical = 0;
+  if (width > 0 && height > 0 && Number.isFinite(frameAspect) && frameAspect > 0) {
+    const viewportAspect = width / height;
+    if (viewportAspect > frameAspect) {
+      horizontal = Math.max(0, (width - height * frameAspect) / 2);
+    } else if (viewportAspect < frameAspect) {
+      vertical = Math.max(0, (height - width / frameAspect) / 2);
+    }
+  }
+  return {
+    padding: {
+      top: vertical,
+      bottom: vertical,
+      left: horizontal,
+      right: horizontal,
+    },
+    crop: {
+      top: vertical,
+      bottom: height - vertical,
+      left: horizontal,
+      right: width - horizontal,
+    },
+  };
+}
+
 /** One page of an atlas: a coverage feature plus its resolved identity. */
 export interface AtlasPage {
   /** 0-based position in the final (filtered + sorted) page order. */

--- a/apps/geolibre-desktop/src/lib/print-data-blocks.ts
+++ b/apps/geolibre-desktop/src/lib/print-data-blocks.ts
@@ -71,6 +71,16 @@ export function rowsWithinBounds(
   return rows;
 }
 
+/**
+ * Select the attribute row belonging to the current atlas coverage feature.
+ * `AtlasPage.sourceIndex` is stable across filtering and sorting, and the row
+ * array preserves the source collection's order, so the two align directly.
+ */
+export function rowForAtlasFeature(rows: readonly ChartRow[], sourceIndex: number): ChartRow[] {
+  const row = rows[sourceIndex];
+  return row ? [row] : [];
+}
+
 /** Format one attribute value for a table cell (blank for null/undefined). */
 function cellText(value: unknown): string {
   if (value === null || value === undefined) return "";

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -52,8 +52,22 @@ export interface PaperSize {
  * {@link LayoutOptions.customSize}.
  */
 export const PAPER_SIZES: PaperSize[] = [
-  { id: "a4", label: "A4 (210 × 297 mm)", width: 210, height: 297, unit: "mm", group: "paper" },
-  { id: "a3", label: "A3 (297 × 420 mm)", width: 297, height: 420, unit: "mm", group: "paper" },
+  {
+    id: "a4",
+    label: "A4 (210 × 297 mm)",
+    width: 210,
+    height: 297,
+    unit: "mm",
+    group: "paper",
+  },
+  {
+    id: "a3",
+    label: "A3 (297 × 420 mm)",
+    width: 297,
+    height: 420,
+    unit: "mm",
+    group: "paper",
+  },
   {
     id: "letter",
     label: "Letter (8.5 × 11 in)",
@@ -86,7 +100,14 @@ export const PAPER_SIZES: PaperSize[] = [
     unit: "px",
     group: "screen",
   },
-  { id: "hd", label: "HD (1280 × 720 px)", width: 720, height: 1280, unit: "px", group: "screen" },
+  {
+    id: "hd",
+    label: "HD (1280 × 720 px)",
+    width: 720,
+    height: 1280,
+    unit: "px",
+    group: "screen",
+  },
   {
     id: "uhd4k",
     label: "4K UHD (3840 × 2160 px)",
@@ -103,7 +124,14 @@ export const PAPER_SIZES: PaperSize[] = [
     unit: "px",
     group: "screen",
   },
-  { id: "custom", label: "Custom…", width: 1280, height: 720, unit: "px", group: "screen" },
+  {
+    id: "custom",
+    label: "Custom…",
+    width: 1280,
+    height: 720,
+    unit: "px",
+    group: "screen",
+  },
 ];
 
 export function getPaperSize(id: PaperSizeId): PaperSize {
@@ -156,7 +184,10 @@ export function pageMm(size: ResolvedPageSize): {
   heightMm: number;
 } {
   if (size.unit === "mm") return { widthMm: size.width, heightMm: size.height };
-  return { widthMm: size.width / PX_PER_MM_96, heightMm: size.height / PX_PER_MM_96 };
+  return {
+    widthMm: size.width / PX_PER_MM_96,
+    heightMm: size.height / PX_PER_MM_96,
+  };
 }
 
 /**
@@ -550,6 +581,19 @@ function computeBodyRect(opts: LayoutOptions, W: number, H: number): BodyRect {
     bodyW: W - margin * 2,
     bodyH: Math.max(unit * 10, bodyBottom - bodyTop),
   };
+}
+
+/**
+ * Aspect ratio of the map frame after page margins, outside titles, and the
+ * footer row reserve their space. Atlas camera fitting uses this ratio so the
+ * feature remains visible after the captured live map is cover-cropped into
+ * the print frame.
+ */
+export function mapBodyAspectRatio(opts: LayoutOptions): number {
+  const page = resolvePageSize(opts);
+  const rect = computeBodyRect(opts, page.width, page.height);
+  const ratio = rect.bodyW / rect.bodyH;
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : page.width / page.height;
 }
 
 /**
@@ -2104,7 +2148,12 @@ function drawLegend(
       });
     } else {
       if (opts.groupByLayer) {
-        rows.push({ entryId: entry.id, color: "", text: entry.name, heading: true });
+        rows.push({
+          entryId: entry.id,
+          color: "",
+          text: entry.name,
+          heading: true,
+        });
       }
       for (const sw of entry.swatches) {
         // Carry the marker so a marker + diagram layer (a multi-swatch entry

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -6,7 +6,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./derived-geometry": "./src/derived-geometry.ts"
   },
   "dependencies": {
     "@geolibre/core": "*",

--- a/tests/print-atlas-mask.test.ts
+++ b/tests/print-atlas-mask.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Feature, Point, Polygon } from "geojson";
+
+import {
+  clearAtlasFeatureMask,
+  showAtlasFeatureMask,
+} from "../apps/geolibre-desktop/src/lib/print-atlas-mask";
+
+interface FakeSource {
+  data: unknown;
+  setData: (data: unknown) => void;
+}
+
+class FakeMap {
+  layers = new Map<string, unknown>();
+  sources = new Map<string, FakeSource>();
+
+  getLayer(id: string) {
+    return this.layers.get(id);
+  }
+
+  addLayer(layer: { id: string }) {
+    this.layers.set(layer.id, layer);
+  }
+
+  removeLayer(id: string) {
+    this.layers.delete(id);
+  }
+
+  getSource(id: string) {
+    return this.sources.get(id);
+  }
+
+  addSource(id: string, source: { data: unknown }) {
+    const fakeSource: FakeSource = {
+      data: source.data,
+      setData: (data) => {
+        fakeSource.data = data;
+      },
+    };
+    this.sources.set(id, fakeSource);
+  }
+
+  removeSource(id: string) {
+    this.sources.delete(id);
+  }
+}
+
+const polygon: Feature<Polygon> = {
+  type: "Feature",
+  properties: { name: "coverage" },
+  geometry: {
+    type: "Polygon",
+    coordinates: [
+      [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+        [0, 2],
+        [0, 0],
+      ],
+    ],
+  },
+};
+
+describe("atlas feature mask", () => {
+  it("adds and clears the temporary mask source and layer", () => {
+    const map = new FakeMap();
+    assert.equal(showAtlasFeatureMask(map as never, polygon), true);
+    assert.equal(map.layers.size, 1);
+    assert.equal(map.sources.size, 1);
+
+    clearAtlasFeatureMask(map as never);
+    assert.equal(map.layers.size, 0);
+    assert.equal(map.sources.size, 0);
+  });
+
+  it("reuses the derived mask when the same feature is shown again", () => {
+    const map = new FakeMap();
+    showAtlasFeatureMask(map as never, polygon);
+    const source = map.sources.get("geolibre-print-atlas-mask");
+    const firstMask = source?.data;
+
+    showAtlasFeatureMask(map as never, polygon);
+    assert.strictEqual(source?.data, firstMask);
+    assert.equal(map.layers.size, 1);
+    assert.equal(map.sources.size, 1);
+  });
+
+  it("rejects a non-polygon feature and removes any previous mask", () => {
+    const map = new FakeMap();
+    showAtlasFeatureMask(map as never, polygon);
+    const point: Feature<Point> = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Point", coordinates: [1, 1] },
+    };
+
+    assert.equal(showAtlasFeatureMask(map as never, point), false);
+    assert.equal(map.layers.size, 0);
+    assert.equal(map.sources.size, 0);
+  });
+});

--- a/tests/print-atlas.test.ts
+++ b/tests/print-atlas.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import type { Feature, FeatureCollection } from "geojson";
 import {
   atlasEntryName,
+  atlasViewportFrame,
   buildAtlasPages,
   buildLineAtlasPages,
   hasLineGeometry,
@@ -180,6 +181,55 @@ describe("expandBounds", () => {
     assert.ok(e > w);
     assert.ok(s >= -85 && n <= 85);
     assert.ok(n - s >= 0.005 - 1e-12);
+  });
+});
+
+describe("atlasViewportFrame", () => {
+  it("adds vertical padding when the print frame is wider than the live map", () => {
+    const frame = atlasViewportFrame(1200, 900, 2);
+    assert.deepEqual(frame.padding, {
+      top: 150,
+      bottom: 150,
+      left: 0,
+      right: 0,
+    });
+    assert.deepEqual(frame.crop, {
+      top: 150,
+      bottom: 750,
+      left: 0,
+      right: 1200,
+    });
+  });
+
+  it("adds horizontal padding when the print frame is narrower than the live map", () => {
+    const frame = atlasViewportFrame(1200, 600, 1);
+    assert.deepEqual(frame.padding, {
+      top: 0,
+      bottom: 0,
+      left: 300,
+      right: 300,
+    });
+    assert.deepEqual(frame.crop, {
+      top: 0,
+      bottom: 600,
+      left: 300,
+      right: 900,
+    });
+  });
+
+  it("keeps the full viewport for matching or invalid aspect ratios", () => {
+    assert.deepEqual(atlasViewportFrame(1200, 600, 2).padding, {
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    });
+    assert.deepEqual(atlasViewportFrame(1200, 600, 0).crop, {
+      top: 0,
+      bottom: 600,
+      left: 0,
+      right: 1200,
+    });
   });
 });
 

--- a/tests/print-data-blocks.test.ts
+++ b/tests/print-data-blocks.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_TABLE_ROWS,
   layerRows,
   MAX_TABLE_ROWS,
+  rowForAtlasFeature,
   rowsWithinBounds,
 } from "../apps/geolibre-desktop/src/lib/print-data-blocks";
 import { collectAtlasFeatures } from "../apps/geolibre-desktop/src/lib/print-atlas";
@@ -78,6 +79,14 @@ describe("rowsWithinBounds", () => {
 
   it("returns no rows for a fully disjoint extent", () => {
     assert.equal(rowsWithinBounds(infos, [-30, -30, -20, -20]).length, 0);
+  });
+});
+
+describe("rowForAtlasFeature", () => {
+  it("uses the stable source index and handles an out-of-range page", () => {
+    const source = rows({ name: "a" }, { name: "b" }, { name: "c" });
+    assert.deepEqual(rowForAtlasFeature(source, 1), [source[1]]);
+    assert.deepEqual(rowForAtlasFeature(source, 99), []);
   });
 });
 

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   computeScaleRatio,
   drawLayout,
+  mapBodyAspectRatio,
   pageMm,
   pagePx,
   resolvePageSize,
@@ -156,7 +157,11 @@ describe("drawLayout legend rendering", () => {
       canvas,
       baseOptions({
         legend: [
-          { id: "pop", name: "Population", swatches: [{ color: "#00aa00", label: "High" }] },
+          {
+            id: "pop",
+            name: "Population",
+            swatches: [{ color: "#00aa00", label: "High" }],
+          },
         ],
       }),
     );
@@ -278,7 +283,12 @@ describe("drawLayout legend rendering", () => {
           {
             id: "pts",
             name: "Sites",
-            swatches: [{ color: "#00aa55", marker: { shape: "triangle", color: "#00aa55" } }],
+            swatches: [
+              {
+                color: "#00aa55",
+                marker: { shape: "triangle", color: "#00aa55" },
+              },
+            ],
           },
         ],
       }),
@@ -305,7 +315,12 @@ describe("drawLayout legend rendering", () => {
           {
             id: "bees",
             name: "Bees",
-            swatches: [{ color: "#3b82f6", marker: { shape: "custom", color: "#3b82f6", svg } }],
+            swatches: [
+              {
+                color: "#3b82f6",
+                marker: { shape: "custom", color: "#3b82f6", svg },
+              },
+            ],
           },
         ],
         markerIcons: new Map([[svg, image]]),
@@ -433,7 +448,11 @@ describe("drawLayout legend rendering", () => {
         name: "Hives",
         swatches: [{ color: "#3b82f6", label: "9000", size: 900, marker }],
       },
-      { id: "wells", name: "Wells", swatches: [{ color: "#3b82f6", label: "3", size: 8, marker }] },
+      {
+        id: "wells",
+        name: "Wells",
+        swatches: [{ color: "#3b82f6", label: "3", size: 8, marker }],
+      },
     ];
     const rec = recordingCanvas();
     drawLayout(
@@ -462,7 +481,12 @@ describe("drawLayout legend rendering", () => {
           {
             id: "bees",
             name: "Bees",
-            swatches: [{ color: "#3b82f6", marker: { shape: "custom", color: "#3b82f6", svg } }],
+            swatches: [
+              {
+                color: "#3b82f6",
+                marker: { shape: "custom", color: "#3b82f6", svg },
+              },
+            ],
           },
         ],
         // No markerIcons: the icon is unavailable.
@@ -516,7 +540,10 @@ describe("drawLayout legend rendering", () => {
             id: "md",
             name: "Marker+Diagram",
             swatches: [
-              { color: "#00aa55", marker: { shape: "triangle", color: "#00aa55" } },
+              {
+                color: "#00aa55",
+                marker: { shape: "triangle", color: "#00aa55" },
+              },
               { color: "#111111", label: "votes" },
             ],
           },
@@ -548,14 +575,23 @@ describe("drawLayout legend rendering", () => {
 
 describe("resolvePageSize", () => {
   it("swaps width/height for landscape preset paper", () => {
-    const portrait = resolvePageSize({ paperSize: "a4", orientation: "portrait" });
+    const portrait = resolvePageSize({
+      paperSize: "a4",
+      orientation: "portrait",
+    });
     assert.deepEqual(portrait, { width: 210, height: 297, unit: "mm" });
-    const landscape = resolvePageSize({ paperSize: "a4", orientation: "landscape" });
+    const landscape = resolvePageSize({
+      paperSize: "a4",
+      orientation: "landscape",
+    });
     assert.deepEqual(landscape, { width: 297, height: 210, unit: "mm" });
   });
 
   it("resolves a pixel screen preset to its oriented pixel dimensions", () => {
-    const landscape = resolvePageSize({ paperSize: "fullhd", orientation: "landscape" });
+    const landscape = resolvePageSize({
+      paperSize: "fullhd",
+      orientation: "landscape",
+    });
     assert.deepEqual(landscape, { width: 1920, height: 1080, unit: "px" });
   });
 
@@ -575,6 +611,26 @@ describe("resolvePageSize", () => {
       customSize: { width: 0, height: 0, unit: "px" },
     });
     assert.deepEqual(size, { width: 1280, height: 720, unit: "px" });
+  });
+});
+
+describe("mapBodyAspectRatio", () => {
+  it("accounts for an outside title when fitting the atlas camera", () => {
+    const inside = mapBodyAspectRatio(
+      baseOptions({
+        titlePlacement: "inside",
+        showAttribution: false,
+        showDate: false,
+      }),
+    );
+    const outside = mapBodyAspectRatio(
+      baseOptions({
+        titlePlacement: "outside",
+        showAttribution: false,
+        showDate: false,
+      }),
+    );
+    assert.ok(outside > inside);
   });
 });
 
@@ -747,7 +803,12 @@ describe("drawLayout cartographic furniture", () => {
         projectNumber: "PRJ-42",
         crs: "EPSG:28992",
         revision: "Rev 01",
-        infoLabels: { author: "Author", project: "Project", crs: "CRS", revision: "Rev" },
+        infoLabels: {
+          author: "Author",
+          project: "Project",
+          crs: "CRS",
+          revision: "Rev",
+        },
       }),
     );
     for (const v of ["Jane Cartographer", "PRJ-42", "EPSG:28992", "Rev 01"]) {


### PR DESCRIPTION
## Summary

- fit atlas bounds to the actual print map frame so margin-based pages do not crop coverage features
- add an optional inverted-fill mask for the current polygon feature
- add a current atlas feature filter for attribute tables and use the true print crop bounds for page-extent filtering

## Testing

- `npm run test:frontend`
- `npm run build`
- `pre-commit run --all-files`
- verified the reporter's GeoJSON in light and dark themes

Addresses https://github.com/opengeos/GeoLibre/discussions/1778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atlas-page controls to filter content to the current atlas feature.
  * Added an option to mask areas outside the selected atlas feature on printed maps.
  * Improved atlas previews and exports with accurate print-frame geographic bounds.
  * Added automatic cleanup of atlas overlays when closing or disabling print layout.
  * Updated English and French guidance for the new filtering and masking options.

* **Bug Fixes**
  * Improved handling of invalid or unavailable atlas feature geometry.
  * Ensured legends render correctly when using background images.
  * Prevented print-layout dialogs from closing during capture or export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->