### PR TITLE
feat: expose read-only layer queries to external plugins

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -26,6 +26,7 @@ import {
   setEffectsSettings,
   type EffectsSettings,
   maplibreEarthdataGisPlugin,
+  SKETCHES_SOURCE_KIND,
   setEarthdataCogSaver,
   maplibreEnviroAtlasPlugin,
   maplibreEsriWaybackPlugin,
@@ -93,6 +94,7 @@ import type {
   GeoLibreExternalNativeLayerRegistration,
   GeoLibreFileDialogOptions,
   GeoLibreMapControlPosition,
+  GeoLibreSelection,
   GeoLibreTileLayerOptions,
   GeoLibreWmsLayerOptions,
   GeoLibreZarrLayerOptions,
@@ -829,6 +831,19 @@ export function useTimeSliderAutoClose(mapControllerRef: RefObject<MapController
   }, [mapControllerRef]);
 }
 
+function readPluginSelection(): GeoLibreSelection {
+  const state = useAppStore.getState();
+  const layer = state.layers.find((item) => item.id === state.selectedLayerId);
+  if (!layer || state.selectedFeatureIds.length === 0) {
+    return { layerId: state.selectedLayerId, features: [] };
+  }
+  const selected = new Set(state.selectedFeatureIds);
+  const features = (layer.geojson?.features ?? []).filter((feature, index) =>
+    selected.has(String(feature.id ?? index)),
+  );
+  return { layerId: state.selectedLayerId, features };
+}
+
 export function createAppAPI(mapControllerRef?: RefObject<MapController | null>) {
   const store = useAppStore.getState();
   // Captured so methods that delegate to plugin helpers taking the AppAPI
@@ -840,6 +855,34 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       const id = store.addGeoJsonLayer(name, data, sourcePath);
       return id;
     },
+    listLayers: () =>
+      useAppStore.getState().layers.map(({ id, name, type, visible, opacity }) => ({
+        id,
+        name,
+        type,
+        visible,
+        opacity,
+      })),
+    getLayerFeatures: (layerId: string) => {
+      const layer = useAppStore.getState().layers.find((item) => item.id === layerId);
+      if (!layer) throw new Error(`No layer with id "${layerId}"`);
+      return layer.geojson?.features ?? [];
+    },
+    getSelectedFeatures: () => readPluginSelection().features,
+    getSelectedLayerId: () => useAppStore.getState().selectedLayerId,
+    getDrawnFeatures: () =>
+      useAppStore.getState().layers.flatMap((layer) =>
+        layer.metadata.sourceKind === SKETCHES_SOURCE_KIND ? (layer.geojson?.features ?? []) : [],
+      ),
+    onSelectionChange: (callback: (selection: GeoLibreSelection) => void) =>
+      useAppStore.subscribe((state, previous) => {
+        if (
+          state.selectedLayerId !== previous.selectedLayerId ||
+          state.selectedFeatureIds !== previous.selectedFeatureIds
+        ) {
+          callback(readPluginSelection());
+        }
+      }),
     addTileLayer: (name: string, url: string, options?: GeoLibreTileLayerOptions) =>
       store.addTileLayer(
         name,

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -838,8 +838,10 @@ function readPluginSelection(): GeoLibreSelection {
     return { layerId: state.selectedLayerId, features: [] };
   }
   const selected = new Set(state.selectedFeatureIds);
-  const features = (layer.geojson?.features ?? []).filter((feature, index) =>
-    selected.has(String(feature.id ?? index)),
+  const features = structuredClone(
+    (layer.geojson?.features ?? []).filter((feature, index) =>
+      selected.has(String(feature.id ?? index)),
+    ),
   );
   return { layerId: state.selectedLayerId, features };
 }
@@ -866,16 +868,20 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     getLayerFeatures: (layerId: string) => {
       const layer = useAppStore.getState().layers.find((item) => item.id === layerId);
       if (!layer) throw new Error(`No layer with id "${layerId}"`);
-      return layer.geojson?.features ?? [];
+      return structuredClone(layer.geojson?.features ?? []);
     },
     getSelectedFeatures: () => readPluginSelection().features,
     getSelectedLayerId: () => useAppStore.getState().selectedLayerId,
     getDrawnFeatures: () =>
-      useAppStore
-        .getState()
-        .layers.flatMap((layer) =>
-          layer.metadata.sourceKind === SKETCHES_SOURCE_KIND ? (layer.geojson?.features ?? []) : [],
-        ),
+      structuredClone(
+        useAppStore
+          .getState()
+          .layers.flatMap((layer) =>
+            layer.metadata.sourceKind === SKETCHES_SOURCE_KIND
+              ? (layer.geojson?.features ?? [])
+              : [],
+          ),
+      ),
     onSelectionChange: (callback: (selection: GeoLibreSelection) => void) =>
       useAppStore.subscribe((state, previous) => {
         if (

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -871,9 +871,11 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     getSelectedFeatures: () => readPluginSelection().features,
     getSelectedLayerId: () => useAppStore.getState().selectedLayerId,
     getDrawnFeatures: () =>
-      useAppStore.getState().layers.flatMap((layer) =>
-        layer.metadata.sourceKind === SKETCHES_SOURCE_KIND ? (layer.geojson?.features ?? []) : [],
-      ),
+      useAppStore
+        .getState()
+        .layers.flatMap((layer) =>
+          layer.metadata.sourceKind === SKETCHES_SOURCE_KIND ? (layer.geojson?.features ?? []) : [],
+        ),
     onSelectionChange: (callback: (selection: GeoLibreSelection) => void) =>
       useAppStore.subscribe((state, previous) => {
         if (

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -3,7 +3,7 @@
 ## Interface
 
 ```typescript
-import type { FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection } from "geojson";
 import type { IControl } from "maplibre-gl";
 
 export type GeoLibreMapControlPosition =
@@ -55,6 +55,19 @@ export interface GeoLibreDeckGL {
   mapbox: typeof import("@deck.gl/mapbox");
 }
 
+export interface GeoLibreLayerSummary {
+  id: string;
+  name: string;
+  type: string;
+  visible: boolean;
+  opacity: number;
+}
+
+export interface GeoLibreSelection {
+  layerId: string | null;
+  features: Feature[];
+}
+
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (
@@ -62,6 +75,14 @@ export interface GeoLibreAppAPI {
     data: FeatureCollection,
     sourcePath?: string,
   ) => string;
+  listLayers?: () => GeoLibreLayerSummary[];
+  getLayerFeatures?: (layerId: string) => Feature[];
+  getSelectedFeatures?: () => Feature[];
+  getSelectedLayerId?: () => string | null;
+  getDrawnFeatures?: () => Feature[];
+  onSelectionChange?: (
+    callback: (selection: GeoLibreSelection) => void,
+  ) => () => void;
   // Native raster/tile layers (see "Raster and tile layers" below). Each
   // returns the new layer's id and the layer appears in the Layers panel and
   // persists with the project, like addGeoJsonLayer does for vector data.
@@ -415,6 +436,48 @@ https://web.geolibre.app/?url=https://example.com/project.geolibre.json&exampleG
 ```
 
 A URL parameter activates only an already-registered (installed) plugin that owns it; it never loads a plugin from the URL. For external plugins, include the plugin manifest URL in the project `plugins` state (so the plugin is registered) before relying on its URL handler — the matching parameter then activates and dispatches it even if it is not in the active set.
+
+## Read-only layer and feature queries
+
+External plugins can inspect the current layer list, a layer's GeoJSON features,
+the current feature selection, and features in GeoEditor's Sketches layers. The
+methods are optional so the same plugin remains compatible with older hosts.
+
+```typescript
+const layers = app.listLayers?.() ?? [];
+const selectedLayerId = app.getSelectedLayerId?.() ?? null;
+const selectedFeatures = app.getSelectedFeatures?.() ?? [];
+
+if (selectedLayerId && app.getLayerFeatures) {
+  const layerFeatures = app.getLayerFeatures(selectedLayerId);
+  console.log(layers, layerFeatures, selectedFeatures);
+}
+
+const drawnFeatures = app.getDrawnFeatures?.() ?? [];
+```
+
+`getSelectedFeatures` returns every selected feature in the selected layer, not
+only the most recently selected feature. Features without a GeoJSON `id` are
+matched using their zero-based array index converted to a string. An empty
+selection returns an empty array. `getLayerFeatures` throws when the layer id is
+unknown and returns an empty array for a layer that has no GeoJSON features.
+
+Selection subscriptions fire after the selected layer or selected feature-id
+array changes. Keep and call the returned unsubscribe function during plugin
+deactivation:
+
+```typescript
+const unsubscribe = app.onSelectionChange?.(({ layerId, features }) => {
+  console.log(layerId, features);
+});
+
+// In deactivate or another cleanup path:
+unsubscribe?.();
+```
+
+These methods are a read-only query surface: calling them does not change the
+GeoLibre store. Plugins must also treat returned GeoJSON features as read-only
+and use host APIs such as `addGeoJsonLayer` when they need to add data.
 
 ## Raster and tile layers
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -3,7 +3,7 @@
 ## Interface
 
 ```typescript
-import type { Feature, FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { IControl } from "maplibre-gl";
 
 export type GeoLibreMapControlPosition =
@@ -65,7 +65,7 @@ export interface GeoLibreLayerSummary {
 
 export interface GeoLibreSelection {
   layerId: string | null;
-  features: Feature[];
+  features: Feature<Geometry | null>[];
 }
 
 export interface GeoLibreAppAPI {
@@ -76,10 +76,10 @@ export interface GeoLibreAppAPI {
     sourcePath?: string,
   ) => string;
   listLayers?: () => GeoLibreLayerSummary[];
-  getLayerFeatures?: (layerId: string) => Feature[];
-  getSelectedFeatures?: () => Feature[];
+  getLayerFeatures?: (layerId: string) => Feature<Geometry | null>[];
+  getSelectedFeatures?: () => Feature<Geometry | null>[];
   getSelectedLayerId?: () => string | null;
-  getDrawnFeatures?: () => Feature[];
+  getDrawnFeatures?: () => Feature<Geometry | null>[];
   onSelectionChange?: (
     callback: (selection: GeoLibreSelection) => void,
   ) => () => void;

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -10,7 +10,7 @@ import type {
   QueryResult as ZarrQueryResult,
   Selector as ZarrSelector,
 } from "@carbonplan/zarr-layer";
-import type { FeatureCollection, Geometry } from "geojson";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 import type { OvertureTheme } from "maplibre-gl-overture-maps";
 import type { TemporalLayerAdapter } from "./plugins/temporal-layers";
@@ -331,9 +331,28 @@ export interface GeoLibrePickedVectorFile {
   nativeData?: FeatureCollection;
 }
 
+export interface GeoLibreLayerSummary {
+  id: string;
+  name: string;
+  type: string;
+  visible: boolean;
+  opacity: number;
+}
+
+export interface GeoLibreSelection {
+  layerId: string | null;
+  features: Feature[];
+}
+
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (name: string, data: FeatureCollection, sourcePath?: string) => string;
+  listLayers?: () => GeoLibreLayerSummary[];
+  getLayerFeatures?: (layerId: string) => Feature[];
+  getSelectedFeatures?: () => Feature[];
+  getSelectedLayerId?: () => string | null;
+  getDrawnFeatures?: () => Feature[];
+  onSelectionChange?: (callback: (selection: GeoLibreSelection) => void) => () => void;
   /**
    * Add a native XYZ raster tile layer from a tile URL template (with
    * `{x}`/`{y}`/`{z}` placeholders) and return its layer id. Unlike calling

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -341,17 +341,17 @@ export interface GeoLibreLayerSummary {
 
 export interface GeoLibreSelection {
   layerId: string | null;
-  features: Feature[];
+  features: Feature<Geometry | null>[];
 }
 
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (name: string, data: FeatureCollection, sourcePath?: string) => string;
   listLayers?: () => GeoLibreLayerSummary[];
-  getLayerFeatures?: (layerId: string) => Feature[];
-  getSelectedFeatures?: () => Feature[];
+  getLayerFeatures?: (layerId: string) => Feature<Geometry | null>[];
+  getSelectedFeatures?: () => Feature<Geometry | null>[];
   getSelectedLayerId?: () => string | null;
-  getDrawnFeatures?: () => Feature[];
+  getDrawnFeatures?: () => Feature<Geometry | null>[];
   onSelectionChange?: (callback: (selection: GeoLibreSelection) => void) => () => void;
   /**
    * Add a native XYZ raster tile layer from a tile URL template (with

--- a/tests/plugin-query-api.test.ts
+++ b/tests/plugin-query-api.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { createRequire, registerHooks } from "node:module";
+import { before, beforeEach, describe, it } from "node:test";
+
+(globalThis as typeof globalThis & { window: typeof globalThis }).window = globalThis;
+(globalThis as typeof globalThis & { location: { search: string } }).location = { search: "" };
+const emptyStorage = { getItem: () => null };
+(globalThis as typeof globalThis & { sessionStorage: typeof emptyStorage }).sessionStorage =
+  emptyStorage;
+(globalThis as typeof globalThis & { localStorage: typeof emptyStorage }).localStorage = emptyStorage;
+const maplibreGl = createRequire(`${process.cwd()}/package.json`)("maplibre-gl") as Record<
+  string,
+  unknown
+>;
+(globalThis as typeof globalThis & { __maplibreGl: Record<string, unknown> }).__maplibreGl =
+  maplibreGl;
+const maplibreGlModuleSource = [
+  "export default globalThis.__maplibreGl;",
+  ...Object.keys(maplibreGl)
+    .filter((name) => name !== "default" && /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name))
+    .map((name) => `export const ${name} = globalThis.__maplibreGl[${JSON.stringify(name)}];`),
+].join("\n");
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "maplibre-gl") {
+      return { url: "test:maplibre-gl", shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (url === "test:maplibre-gl") {
+      return { format: "module", source: maplibreGlModuleSource, shortCircuit: true };
+    }
+    if (url.endsWith(".css")) {
+      return { format: "module", source: "", shortCircuit: true };
+    }
+    if (url === "virtual:bundled-plugins") {
+      return {
+        format: "module",
+        source: "export const bundledPluginManifestPaths = [];",
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
+let useAppStore: typeof import("@geolibre/core").useAppStore;
+let createAppAPI: typeof import("../apps/geolibre-desktop/src/hooks/usePlugins").createAppAPI;
+
+before(async () => {
+  [{ useAppStore }, { createAppAPI }] = await Promise.all([
+    import("@geolibre/core"),
+    import("../apps/geolibre-desktop/src/hooks/usePlugins"),
+  ]);
+});
+
+describe("external plugin query API", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Plugin query API" });
+  });
+
+  it("returns every selected feature and its layer id", () => {
+    const store = useAppStore.getState();
+    const layerId = store.addGeoJsonLayer("Catchments", {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", id: "A", properties: { NAME: "A" }, geometry: null },
+        { type: "Feature", id: "B", properties: { NAME: "B" }, geometry: null },
+      ],
+    });
+    store.selectLayer(layerId);
+    store.selectFeatures(["A", "B"]);
+
+    const app = createAppAPI();
+    assert.equal(app.getSelectedLayerId?.(), layerId);
+    assert.deepEqual(
+      app.getSelectedFeatures?.().map((feature) => feature.id),
+      ["A", "B"],
+    );
+  });
+
+  it("notifies and unsubscribes selection listeners", () => {
+    const app = createAppAPI();
+    const events: unknown[] = [];
+    const unsubscribe = app.onSelectionChange?.((selection) => events.push(selection));
+    assert.ok(unsubscribe);
+    useAppStore.getState().selectFeatures(["A"]);
+    assert.equal(events.length, 1);
+    unsubscribe();
+    useAppStore.getState().selectFeatures([]);
+    assert.equal(events.length, 1);
+  });
+
+  it("lists layers and returns feature properties and geometry without mutating state", () => {
+    const store = useAppStore.getState();
+    const layerId = store.addGeoJsonLayer("Catchments", {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "A",
+          properties: { NAME: "Upper Basin", AREA_KM2: 12.5 },
+          geometry: { type: "Point", coordinates: [101.7, 3.1] },
+        },
+      ],
+    });
+    const before = JSON.stringify(useAppStore.getState());
+
+    const app = createAppAPI();
+    assert.deepEqual(app.listLayers?.(), [
+      {
+        id: layerId,
+        name: "Catchments",
+        type: "geojson",
+        visible: true,
+        opacity: 1,
+      },
+    ]);
+    assert.deepEqual(app.getLayerFeatures?.(layerId), [
+      {
+        type: "Feature",
+        id: "A",
+        properties: { NAME: "Upper Basin", AREA_KM2: 12.5 },
+        geometry: { type: "Point", coordinates: [101.7, 3.1] },
+      },
+    ]);
+    app.getSelectedFeatures?.();
+    app.getSelectedLayerId?.();
+    app.getDrawnFeatures?.();
+
+    assert.equal(JSON.stringify(useAppStore.getState()), before);
+  });
+
+  it("throws when a requested layer does not exist", () => {
+    const app = createAppAPI();
+    assert.throws(() => app.getLayerFeatures?.("missing-layer"), {
+      message: 'No layer with id "missing-layer"',
+    });
+  });
+
+  it("resolves selected features by their array index when ids are absent", () => {
+    const store = useAppStore.getState();
+    const layerId = store.addGeoJsonLayer("Unkeyed", {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", properties: { NAME: "First" }, geometry: null },
+        { type: "Feature", properties: { NAME: "Second" }, geometry: null },
+      ],
+    });
+    store.selectLayer(layerId);
+    store.selectFeatures(["1"]);
+
+    assert.deepEqual(
+      createAppAPI()
+        .getSelectedFeatures?.()
+        .map((feature) => feature.properties?.NAME),
+      ["Second"],
+    );
+  });
+
+  it("returns an empty feature list for an empty selection", () => {
+    const store = useAppStore.getState();
+    const layerId = store.addGeoJsonLayer("Catchments", {
+      type: "FeatureCollection",
+      features: [{ type: "Feature", id: "A", properties: {}, geometry: null }],
+    });
+    store.selectLayer(layerId);
+
+    const app = createAppAPI();
+    assert.equal(app.getSelectedLayerId?.(), layerId);
+    assert.deepEqual(app.getSelectedFeatures?.(), []);
+  });
+
+  it("returns features from every sketch layer and excludes ordinary layers", () => {
+    const store = useAppStore.getState();
+    store.addGeoJsonLayer("Catchments", {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", id: "ordinary", properties: {}, geometry: null },
+      ],
+    });
+    const sketchLayerId = store.addGeoJsonLayer("Sketches", {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "drawn-1",
+          properties: { label: "Outlet" },
+          geometry: { type: "Point", coordinates: [101.6, 3.2] },
+        },
+      ],
+    });
+    store.updateLayer(sketchLayerId, {
+      metadata: { sourceKind: SKETCHES_SOURCE_KIND },
+    });
+
+    assert.deepEqual(createAppAPI().getDrawnFeatures?.(), [
+      {
+        type: "Feature",
+        id: "drawn-1",
+        properties: { label: "Outlet" },
+        geometry: { type: "Point", coordinates: [101.6, 3.2] },
+      },
+    ]);
+  });
+});

--- a/tests/plugin-query-api.test.ts
+++ b/tests/plugin-query-api.test.ts
@@ -7,7 +7,8 @@ import { before, beforeEach, describe, it } from "node:test";
 const emptyStorage = { getItem: () => null };
 (globalThis as typeof globalThis & { sessionStorage: typeof emptyStorage }).sessionStorage =
   emptyStorage;
-(globalThis as typeof globalThis & { localStorage: typeof emptyStorage }).localStorage = emptyStorage;
+(globalThis as typeof globalThis & { localStorage: typeof emptyStorage }).localStorage =
+  emptyStorage;
 const maplibreGl = createRequire(`${process.cwd()}/package.json`)("maplibre-gl") as Record<
   string,
   unknown
@@ -176,9 +177,7 @@ describe("external plugin query API", () => {
     const store = useAppStore.getState();
     store.addGeoJsonLayer("Catchments", {
       type: "FeatureCollection",
-      features: [
-        { type: "Feature", id: "ordinary", properties: {}, geometry: null },
-      ],
+      features: [{ type: "Feature", id: "ordinary", properties: {}, geometry: null }],
     });
     const sketchLayerId = store.addGeoJsonLayer("Sketches", {
       type: "FeatureCollection",

--- a/tests/plugin-query-api.test.ts
+++ b/tests/plugin-query-api.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createRequire, registerHooks } from "node:module";
 import { before, beforeEach, describe, it } from "node:test";
+import type { GeoLibreSelection } from "@geolibre/plugins";
 
 (globalThis as typeof globalThis & { window: typeof globalThis }).window = globalThis;
 (globalThis as typeof globalThis & { location: { search: string } }).location = { search: "" };
@@ -131,6 +132,55 @@ describe("external plugin query API", () => {
     app.getDrawnFeatures?.();
 
     assert.equal(JSON.stringify(useAppStore.getState()), before);
+  });
+
+  it("returns detached features from every plugin query boundary", () => {
+    const store = useAppStore.getState();
+    const layerId = store.addGeoJsonLayer("Sketches", {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "A",
+          properties: { metadata: { label: "Original" } },
+          geometry: { type: "Point", coordinates: [101.7, 3.1] },
+        },
+      ],
+    });
+    store.updateLayer(layerId, {
+      metadata: { sourceKind: SKETCHES_SOURCE_KIND },
+    });
+    store.selectLayer(layerId);
+
+    const app = createAppAPI();
+    let callbackSelection: GeoLibreSelection | undefined;
+    const unsubscribe = app.onSelectionChange?.((selection) => {
+      callbackSelection = selection;
+    });
+    assert.ok(unsubscribe);
+    store.selectFeatures(["A"]);
+    assert.ok(callbackSelection);
+
+    const returnedFeatures = [
+      app.getLayerFeatures?.(layerId)[0],
+      app.getSelectedFeatures?.()[0],
+      app.getDrawnFeatures?.()[0],
+      callbackSelection.features[0],
+    ];
+    for (const feature of returnedFeatures) {
+      assert.ok(feature);
+      const properties = feature.properties as { metadata: { label: string } };
+      properties.metadata.label = "Mutated by plugin";
+      assert.equal(feature.geometry?.type, "Point");
+      feature.geometry.coordinates[0] = 0;
+    }
+    unsubscribe();
+
+    const storedFeature = useAppStore.getState().layers.find((layer) => layer.id === layerId)
+      ?.geojson?.features[0];
+    assert.ok(storedFeature);
+    assert.deepEqual(storedFeature.properties, { metadata: { label: "Original" } });
+    assert.deepEqual(storedFeature.geometry, { type: "Point", coordinates: [101.7, 3.1] });
   });
 
   it("throws when a requested layer does not exist", () => {


### PR DESCRIPTION
## Summary

- expose optional read-only layer and feature query methods to external plugins
- expose the selected layer, all selected features, sketch features, and selection-change subscriptions
- document compatibility and cleanup behavior for plugin authors
- add focused tests for selection, layer lookup, sketch filtering, missing IDs, and unsubscribe behavior

## Why

External plugins can add layers, but they currently cannot inspect GeoLibre's current layer list or feature selection through the public plugin API. Plugins that need to run an analysis for a user-selected feature therefore have no supported read-only path to obtain that context.

The new methods remain optional so existing plugins can continue to run against older GeoLibre hosts. The query surface does not mutate the application store, and subscription callers receive an unsubscribe function for plugin cleanup.

## API

- `listLayers()`
- `getLayerFeatures(layerId)`
- `getSelectedFeatures()`
- `getSelectedLayerId()`
- `getDrawnFeatures()`
- `onSelectionChange(callback)`

## Validation

- `node --import tsx --test tests/plugin-query-api.test.ts` — 7 passed
- `npm run lint` — 0 errors (40 existing warnings)
- `npm run build` — passed

The API was also exercised from an external hydrology plugin in the Tauri desktop during a synthetic end-to-end workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only plugin APIs for listing layers and retrieving layer, selected, and drawn features.
  * Plugins can now identify the selected layer and subscribe to selection changes.
  * Added layer visibility, opacity, type, and name details to layer information.
  * Documented selection behavior, empty results, error handling, and subscription cleanup.

* **Tests**
  * Added coverage for layer and feature queries, selection updates, drawn features, errors, and immutable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->