### PR TITLE
fix(print-layout): preserve graticule label visibility

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1236,8 +1236,13 @@ export function PrintLayoutDialog({
         : mapBodyAspectRatio(pageOptions);
       const viewportFrame = atlasViewportFrame(viewportWidth, viewportHeight, targetAspect);
       const coverageFeature = atlasLayer?.geojson?.features[page.sourceIndex];
-      if (atlasMaskEnabled) showAtlasFeatureMask(map, coverageFeature);
-      else clearAtlasFeatureMask(map);
+      if (atlasMaskEnabled) {
+        showAtlasFeatureMask(
+          map,
+          coverageFeature,
+          containMap ? GRATICULE_LABEL_LAYER_ID : undefined,
+        );
+      } else clearAtlasFeatureMask(map);
       const [w, s, e, n] = expandBounds(page.bounds, atlasFitMarginPct);
       map.fitBounds(
         [

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1242,7 +1242,9 @@ export function PrintLayoutDialog({
           coverageFeature,
           containMap ? GRATICULE_LABEL_LAYER_ID : undefined,
         );
-      } else clearAtlasFeatureMask(map);
+      } else {
+        clearAtlasFeatureMask(map);
+      }
       const [w, s, e, n] = expandBounds(page.bounds, atlasFitMarginPct);
       map.fitBounds(
         [

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1316,8 +1316,8 @@
       "position": "Position",
       "filterToPage": "Seulement les entités dans l'emprise de la page",
       "filterToPageHint": "S'applique aux pages d'atlas et à une emprise d'impression dessinée ; sinon, la couche entière est utilisée.",
-      "filterToAtlasFeature": "Seulement l’entité courante de l’atlas",
-      "filterToAtlasFeatureHint": "Disponible lorsque la table utilise la couche de couverture de l’atlas. Ce filtre est prioritaire sur l’emprise de la page."
+      "filterToAtlasFeature": "Seulement l'entité courante de l'atlas",
+      "filterToAtlasFeatureHint": "Disponible lorsque la table utilise la couche de couverture de l'atlas. Ce filtre est prioritaire sur l'emprise de la page."
     },
     "dataTable": {
       "columns": "Colonnes",
@@ -1447,8 +1447,8 @@
       "extentMargin": "Marge autour de l'entité",
       "extentScale": "Échelle fixe",
       "marginLabel": "Marge (%)",
-      "maskOutside": "Masquer la zone hors de l’entité courante",
-      "maskOutsideHint": "Applique un remplissage inversé translucide pour mettre en évidence l’entité courante de l’atlas.",
+      "maskOutside": "Masquer la zone hors de l'entité courante",
+      "maskOutsideHint": "Applique un remplissage inversé translucide pour mettre en évidence l'entité courante de l'atlas.",
       "scaleLabel": "Échelle",
       "scaleRequired": "Entrez une échelle supérieure à zéro.",
       "sortField": "Trier par",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1316,8 +1316,8 @@
       "position": "Position",
       "filterToPage": "Seulement les entités dans l'emprise de la page",
       "filterToPageHint": "S'applique aux pages d'atlas et à une emprise d'impression dessinée ; sinon, la couche entière est utilisée.",
-      "filterToAtlasFeature": "Seulement l'entité courante de l'atlas",
-      "filterToAtlasFeatureHint": "Disponible lorsque la table utilise la couche de couverture de l'atlas. Ce filtre est prioritaire sur l'emprise de la page."
+      "filterToAtlasFeature": "Seulement l’entité courante de l’atlas",
+      "filterToAtlasFeatureHint": "Disponible lorsque la table utilise la couche de couverture de l’atlas. Ce filtre est prioritaire sur l’emprise de la page."
     },
     "dataTable": {
       "columns": "Colonnes",
@@ -1447,8 +1447,8 @@
       "extentMargin": "Marge autour de l'entité",
       "extentScale": "Échelle fixe",
       "marginLabel": "Marge (%)",
-      "maskOutside": "Masquer la zone hors de l'entité courante",
-      "maskOutsideHint": "Applique un remplissage inversé translucide pour mettre en évidence l'entité courante de l'atlas.",
+      "maskOutside": "Masquer la zone hors de l’entité courante",
+      "maskOutsideHint": "Applique un remplissage inversé translucide pour mettre en évidence l’entité courante de l’atlas.",
       "scaleLabel": "Échelle",
       "scaleRequired": "Entrez une échelle supérieure à zéro.",
       "sortField": "Trier par",

--- a/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
+++ b/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
@@ -21,9 +21,14 @@ export function clearAtlasFeatureMask(map: MapLibreMap): void {
  *
  * @param map - MapLibre map used by the Print Layout capture.
  * @param feature - Current coverage feature.
+ * @param beforeLayerId - Optional label layer that should remain above the mask.
  * @returns Whether a polygon mask could be rendered.
  */
-export function showAtlasFeatureMask(map: MapLibreMap, feature: Feature | undefined): boolean {
+export function showAtlasFeatureMask(
+  map: MapLibreMap,
+  feature: Feature | undefined,
+  beforeLayerId?: string,
+): boolean {
   if (feature?.geometry?.type !== "Polygon" && feature?.geometry?.type !== "MultiPolygon") {
     clearAtlasFeatureMask(map);
     return false;
@@ -46,17 +51,20 @@ export function showAtlasFeatureMask(map: MapLibreMap, feature: Feature | undefi
   if (source) source.setData(mask);
   else map.addSource(SOURCE_ID, { type: "geojson", data: mask });
   if (!map.getLayer(FILL_LAYER_ID)) {
-    map.addLayer({
-      id: FILL_LAYER_ID,
-      type: "fill",
-      source: SOURCE_ID,
-      metadata: { "geolibre:internal": true },
-      paint: {
-        "fill-color": "#ffffff",
-        "fill-opacity": 0.7,
-        "fill-outline-color": "rgba(0, 0, 0, 0)",
+    map.addLayer(
+      {
+        id: FILL_LAYER_ID,
+        type: "fill",
+        source: SOURCE_ID,
+        metadata: { "geolibre:internal": true },
+        paint: {
+          "fill-color": "#ffffff",
+          "fill-opacity": 0.7,
+          "fill-outline-color": "rgba(0, 0, 0, 0)",
+        },
       },
-    });
+      beforeLayerId && map.getLayer(beforeLayerId) ? beforeLayerId : undefined,
+    );
   }
   return true;
 }

--- a/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
+++ b/apps/geolibre-desktop/src/lib/print-atlas-mask.ts
@@ -50,7 +50,12 @@ export function showAtlasFeatureMask(
   const source = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
   if (source) source.setData(mask);
   else map.addSource(SOURCE_ID, { type: "geojson", data: mask });
-  if (!map.getLayer(FILL_LAYER_ID)) {
+  const fillLayer = map.getLayer(FILL_LAYER_ID);
+  const targetLayerId =
+    beforeLayerId && beforeLayerId !== FILL_LAYER_ID && map.getLayer(beforeLayerId)
+      ? beforeLayerId
+      : undefined;
+  if (!fillLayer) {
     map.addLayer(
       {
         id: FILL_LAYER_ID,
@@ -63,8 +68,10 @@ export function showAtlasFeatureMask(
           "fill-outline-color": "rgba(0, 0, 0, 0)",
         },
       },
-      beforeLayerId && map.getLayer(beforeLayerId) ? beforeLayerId : undefined,
+      targetLayerId,
     );
+  } else if (targetLayerId) {
+    map.moveLayer(FILL_LAYER_ID, targetLayerId);
   }
   return true;
 }

--- a/tests/print-atlas-mask.test.ts
+++ b/tests/print-atlas-mask.test.ts
@@ -17,6 +17,7 @@ class FakeMap {
   sources = new Map<string, FakeSource>();
   addedBeforeLayerId: string | undefined;
   movedBeforeLayerId: string | undefined;
+  moveLayerCallCount = 0;
 
   getLayer(id: string) {
     return this.layers.get(id);
@@ -28,6 +29,7 @@ class FakeMap {
   }
 
   moveLayer(_id: string, beforeLayerId?: string) {
+    this.moveLayerCallCount += 1;
     this.movedBeforeLayerId = beforeLayerId;
   }
 
@@ -116,6 +118,7 @@ describe("atlas feature mask", () => {
     map.layers.set("graticule-labels", {});
 
     showAtlasFeatureMask(map as never, polygon, "graticule-labels");
+    assert.equal(map.moveLayerCallCount, 1);
     assert.equal(map.movedBeforeLayerId, "graticule-labels");
   });
 
@@ -124,7 +127,7 @@ describe("atlas feature mask", () => {
     showAtlasFeatureMask(map as never, polygon);
 
     showAtlasFeatureMask(map as never, polygon, "geolibre-print-atlas-mask-fill");
-    assert.equal(map.movedBeforeLayerId, undefined);
+    assert.equal(map.moveLayerCallCount, 0);
   });
 
   it("rejects a non-polygon feature and removes any previous mask", () => {

--- a/tests/print-atlas-mask.test.ts
+++ b/tests/print-atlas-mask.test.ts
@@ -15,13 +15,15 @@ interface FakeSource {
 class FakeMap {
   layers = new Map<string, unknown>();
   sources = new Map<string, FakeSource>();
+  addedBeforeLayerId: string | undefined;
 
   getLayer(id: string) {
     return this.layers.get(id);
   }
 
-  addLayer(layer: { id: string }) {
+  addLayer(layer: { id: string }, beforeLayerId?: string) {
     this.layers.set(layer.id, layer);
+    this.addedBeforeLayerId = beforeLayerId;
   }
 
   removeLayer(id: string) {
@@ -86,6 +88,14 @@ describe("atlas feature mask", () => {
     assert.strictEqual(source?.data, firstMask);
     assert.equal(map.layers.size, 1);
     assert.equal(map.sources.size, 1);
+  });
+
+  it("places the mask below a requested label layer", () => {
+    const map = new FakeMap();
+    map.layers.set("graticule-labels", {});
+
+    showAtlasFeatureMask(map as never, polygon, "graticule-labels");
+    assert.equal(map.addedBeforeLayerId, "graticule-labels");
   });
 
   it("rejects a non-polygon feature and removes any previous mask", () => {

--- a/tests/print-atlas-mask.test.ts
+++ b/tests/print-atlas-mask.test.ts
@@ -16,6 +16,7 @@ class FakeMap {
   layers = new Map<string, unknown>();
   sources = new Map<string, FakeSource>();
   addedBeforeLayerId: string | undefined;
+  movedBeforeLayerId: string | undefined;
 
   getLayer(id: string) {
     return this.layers.get(id);
@@ -24,6 +25,10 @@ class FakeMap {
   addLayer(layer: { id: string }, beforeLayerId?: string) {
     this.layers.set(layer.id, layer);
     this.addedBeforeLayerId = beforeLayerId;
+  }
+
+  moveLayer(_id: string, beforeLayerId?: string) {
+    this.movedBeforeLayerId = beforeLayerId;
   }
 
   removeLayer(id: string) {
@@ -96,6 +101,30 @@ describe("atlas feature mask", () => {
 
     showAtlasFeatureMask(map as never, polygon, "graticule-labels");
     assert.equal(map.addedBeforeLayerId, "graticule-labels");
+  });
+
+  it("falls back to the top when the requested label layer is missing", () => {
+    const map = new FakeMap();
+
+    showAtlasFeatureMask(map as never, polygon, "missing-labels");
+    assert.equal(map.addedBeforeLayerId, undefined);
+  });
+
+  it("moves an existing mask below a requested label layer", () => {
+    const map = new FakeMap();
+    showAtlasFeatureMask(map as never, polygon);
+    map.layers.set("graticule-labels", {});
+
+    showAtlasFeatureMask(map as never, polygon, "graticule-labels");
+    assert.equal(map.movedBeforeLayerId, "graticule-labels");
+  });
+
+  it("does not move the mask before itself", () => {
+    const map = new FakeMap();
+    showAtlasFeatureMask(map as never, polygon);
+
+    showAtlasFeatureMask(map as never, polygon, "geolibre-print-atlas-mask-fill");
+    assert.equal(map.movedBeforeLayerId, undefined);
   });
 
   it("rejects a non-polygon feature and removes any previous mask", () => {


### PR DESCRIPTION
## Summary

- keep print graticule labels above the inverted atlas feature mask
- preserve optional layer ordering for new and existing mask layers
- cover label ordering, missing-label fallback, and self-order guards

Follow-up to #1783.

## Testing

- `npm run test:frontend -- --run tests/print-atlas-mask.test.ts tests/print-atlas.test.ts tests/print-data-blocks.test.ts tests/print-layout.test.ts`
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Atlas print masks now appear beneath graticule labels, keeping those labels visible and correctly positioned.
  * Improved handling when label layers are unavailable or when masks already exist.

* **Tests**
  * Added coverage for mask placement, repositioning, fallback behavior, and self-referential layer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->