### PR TITLE
docs(python): document marimo workaround

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -279,7 +279,7 @@ from geolibre import Map
 m = Map(center=(-100, 40), zoom=4)
 m._app_url = "https://web.geolibre.app/"
 m.add_basemap("dark")
-m.add_geojson(
+m.add_vector(
     "https://data.source.coop/giswqs/opengeos/world_cities.geojson",
     name="World cities",
 )
@@ -289,6 +289,10 @@ m
 This uses the same project-sync bridge as the regular widget; only the app's
 location changes. Set `_app_url` before returning `m` from the cell so the
 iframe uses the hosted URL on its first render.
+
+The example uses `add_vector()` so the hosted browser app fetches the remote
+GeoJSON directly. `add_geojson(url)` instead downloads and inlines the file in
+Python, which can fail when a data host rejects Python's HTTP client.
 
 Because the hosted app cannot access files exposed by the kernel's temporary
 localhost server, use hosted URLs for rasters and other sources the browser

--- a/docs/python.md
+++ b/docs/python.md
@@ -265,6 +265,38 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 Style keyword arguments (for example `fillColor`, `strokeColor`, `strokeWidth`,
 `circleRadius`) map to the GeoLibre [layer style fields](project-format.md).
 
+## Use in marimo
+
+[marimo](https://marimo.io/) can render GeoLibre's anywidget, but its browser
+may not be able to reach the random `127.0.0.1` port where GeoLibre normally
+serves the bundled app. The symptom is an iframe displaying
+`127.0.0.1 refused to connect`. Point the widget at GeoLibre's hosted app before
+displaying it:
+
+```python
+from geolibre import Map
+
+m = Map(center=(-100, 40), zoom=4)
+m._app_url = "https://web.geolibre.app/"
+m.add_basemap("dark")
+m.add_geojson(
+    "https://data.source.coop/giswqs/opengeos/world_cities.geojson",
+    name="World cities",
+)
+m
+```
+
+This uses the same project-sync bridge as the regular widget; only the app's
+location changes. Set `_app_url` before returning `m` from the cell so the
+iframe uses the hosted URL on its first render.
+
+Because the hosted app cannot access files exposed by the kernel's temporary
+localhost server, use hosted URLs for rasters and other sources the browser
+loads directly. Local GeoJSON, CSV, and vector files that GeoLibre reads in
+Python and inlines into the project continue to work. The `_app_url` attribute
+is currently an internal compatibility workaround rather than a public
+constructor option.
+
 ## How it works
 
 The wheel bundles the GeoLibre web build. At import time the package starts a
@@ -275,8 +307,8 @@ UI edits flow back the same way.
 
 !!! note "Environment support"
 
-    The interactive widget works in **local Jupyter, VS Code, Google Colab, and
-    JupyterHub / remote servers**:
+    The interactive widget works in **local Jupyter, VS Code, Google Colab,
+    JupyterHub / remote servers, and marimo**:
 
     - **Local Jupyter / VS Code** - the app is served directly from localhost.
     - **Google Colab** - routes through Colab's built-in port proxy
@@ -295,6 +327,9 @@ UI edits flow back the same way.
           wherever `jupyter-server-proxy` is installed.
     - **Other remote servers** (Binder, remote JupyterLab over SSH/network) -
       pass `Map(server_proxy=True)` to use that same dual-route remote path.
+    - **marimo** - use the hosted app URL shown in [Use in
+      marimo](#use-in-marimo); Jupyter's proxy and server-extension routes are
+      not available in marimo.
 
     Set `Map(server_proxy=False)` to force the direct localhost path. If the app
     fails to load on a hub, either install `jupyter-server-proxy`, or confirm the

--- a/docs/python.md
+++ b/docs/python.md
@@ -301,6 +301,11 @@ Python and inlines into the project continue to work. The `_app_url` attribute
 is currently an internal compatibility workaround rather than a public
 constructor option.
 
+**Privacy:** The widget sends its synchronized project, including any inlined
+local data, to the origin in `_app_url` through `window.postMessage`. Use only a
+trusted app URL, or host the GeoLibre app yourself, when working with sensitive
+data.
+
 ## How it works
 
 The wheel bundles the GeoLibre web build. At import time the package starts a
@@ -308,6 +313,8 @@ small localhost static server that serves the bundled app; the widget renders
 that app in an iframe and exchanges the project over `window.postMessage`.
 Adding data from Python rewrites the synced project and pushes it into the app;
 UI edits flow back the same way.
+
+<!-- markdownlint-disable MD046 -->
 
 !!! note "Environment support"
 
@@ -340,6 +347,8 @@ UI edits flow back the same way.
     extension is enabled with `jupyter server extension list` (look for
     `geolibre`; run `jupyter server extension enable geolibre` if absent) and
     **restart** the Jupyter server so the extension loads.
+
+<!-- markdownlint-enable MD046 -->
 
 !!! warning "URL fetching"
 

--- a/python/README.md
+++ b/python/README.md
@@ -167,6 +167,11 @@ anywhere untrusted, or use `Map.save_project`, which redacts by default.
   CSV, and vector files that are read in Python and inlined still work. The
   example uses `add_vector()` so the browser, rather than Python, fetches the
   remote GeoJSON URL.
+
+  **Privacy:** The widget sends its synchronized project, including any inlined
+  local data, to the origin in `_app_url` through `window.postMessage`. Use only
+  a trusted app URL, or host the GeoLibre app yourself, when working with
+  sensitive data.
 - The bundled app is served from a localhost HTTP server, so the interactive
   widget works in local Jupyter and VS Code directly. **Google Colab** routes
   through its built-in port proxy automatically. On **JupyterHub** (including

--- a/python/README.md
+++ b/python/README.md
@@ -154,13 +154,19 @@ anywhere untrusted, or use `Map.save_project`, which redacts by default.
   m = Map(center=(-100, 40), zoom=4)
   m._app_url = "https://web.geolibre.app/"
   m.add_basemap("dark")
+  m.add_vector(
+      "https://data.source.coop/giswqs/opengeos/world_cities.geojson",
+      name="World cities",
+  )
   m
   ```
 
   Set `_app_url` before returning `m` from the cell. With the hosted app, use
   hosted URLs for rasters and other browser-loaded sources; it cannot access
   files served from the kernel's temporary localhost server. Local GeoJSON,
-  CSV, and vector files that are read in Python and inlined still work.
+  CSV, and vector files that are read in Python and inlined still work. The
+  example uses `add_vector()` so the browser, rather than Python, fetches the
+  remote GeoJSON URL.
 - The bundled app is served from a localhost HTTP server, so the interactive
   widget works in local Jupyter and VS Code directly. **Google Colab** routes
   through its built-in port proxy automatically. On **JupyterHub** (including

--- a/python/README.md
+++ b/python/README.md
@@ -143,6 +143,24 @@ anywhere untrusted, or use `Map.save_project`, which redacts by default.
 
 ## Notes
 
+- **marimo** can render the anywidget, but its browser may not be able to reach
+  GeoLibre's random localhost port. If the iframe reports
+  `127.0.0.1 refused to connect`, select the hosted app before displaying the
+  map:
+
+  ```python
+  from geolibre import Map
+
+  m = Map(center=(-100, 40), zoom=4)
+  m._app_url = "https://web.geolibre.app/"
+  m.add_basemap("dark")
+  m
+  ```
+
+  Set `_app_url` before returning `m` from the cell. With the hosted app, use
+  hosted URLs for rasters and other browser-loaded sources; it cannot access
+  files served from the kernel's temporary localhost server. Local GeoJSON,
+  CSV, and vector files that are read in Python and inlined still work.
 - The bundled app is served from a localhost HTTP server, so the interactive
   widget works in local Jupyter and VS Code directly. **Google Colab** routes
   through its built-in port proxy automatically. On **JupyterHub** (including


### PR DESCRIPTION
## Summary

- document how to render the GeoLibre anywidget in marimo using the hosted app
- add a marimo example using the World Cities sample dataset
- explain why localhost-backed browser sources remain unavailable

## Checks

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using the application with marimo, including hosted-app configuration and project synchronization behavior.
  * Documented limitations involving localhost access, browser-loaded sources, and Jupyter proxy routes.
  * Added a workaround for displaying widgets when localhost access fails.
  * Clarified that Python-inlined local GeoJSON, CSV, and vector files remain supported in hosted apps.
  * Added privacy guidance for data synchronized with the configured application origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->