### PR TITLE
docs: link hero screenshots and move media to assets.geolibre.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 
 ### 3D Tiles
 
-[![GeoLibre demo showing 3D Tiles rendered on a MapLibre map](https://files.opengeos.org/GeoLibre-demo.webp)](https://files.opengeos.org/GeoLibre-demo.webp)
+[![GeoLibre demo showing 3D Tiles rendered on a MapLibre map](https://assets.geolibre.app/images/GeoLibre-demo.webp)](https://assets.geolibre.app/images/GeoLibre-demo.webp)
 
 [Open the live project](https://share.geolibre.app/giswqs/3d-tiles)
 
@@ -47,11 +47,11 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 
 Manhattan building footprints extruded in 3D and colored by construction era, with the MTA subway lines and stations on top and a legend generated automatically from the layers' symbology.
 
-[![Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend](https://files.opengeos.org/nyc-buildings.webp)](https://files.opengeos.org/nyc-buildings.webp)
+[![Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend](https://assets.geolibre.app/images/nyc-buildings.webp)](https://assets.geolibre.app/images/nyc-buildings.webp)
 
 The animation below runs the Time Slider along the buildings' construction year, from 1850 to 2025, so Manhattan fills in era by era. Click it to play the full-quality video.
 
-[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://files.opengeos.org/nyc-buildings-gif.gif)](https://files.opengeos.org/nyc-buildings.webm)
+[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://assets.geolibre.app/demos/nyc-buildings-gif.gif)](https://assets.geolibre.app/demos/nyc-buildings.webm)
 
 [Open the live project](https://share.geolibre.app/giswqs/nyc-buildings-and-subways)
 
@@ -61,9 +61,9 @@ GeoLibre is not limited to Earth. Planetary basemaps from OpenPlanetaryMap and U
 
 <table>
   <tr>
-    <td width="33%"><a href="https://files.opengeos.org/earth.webp"><img src="https://files.opengeos.org/earth.webp" alt="GeoLibre globe view of Earth over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/moon.webp"><img src="https://files.opengeos.org/moon.webp" alt="GeoLibre globe view of the Moon over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/mars.webp"><img src="https://files.opengeos.org/mars.webp" alt="GeoLibre globe view of Mars over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/earth.webp"><img src="https://assets.geolibre.app/images/earth.webp" alt="GeoLibre globe view of Earth over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/moon.webp"><img src="https://assets.geolibre.app/images/moon.webp" alt="GeoLibre globe view of the Moon over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/mars.webp"><img src="https://assets.geolibre.app/images/mars.webp" alt="GeoLibre globe view of Mars over a starfield backdrop"></a></td>
   </tr>
   <tr>
     <td align="center"><b>Earth</b></td>
@@ -71,9 +71,9 @@ GeoLibre is not limited to Earth. Planetary basemaps from OpenPlanetaryMap and U
     <td align="center"><b>Mars</b></td>
   </tr>
   <tr>
-    <td width="33%"><a href="https://files.opengeos.org/mercury.webp"><img src="https://files.opengeos.org/mercury.webp" alt="GeoLibre globe view of Mercury over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/pluto.webp"><img src="https://files.opengeos.org/pluto.webp" alt="GeoLibre globe view of Pluto over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/venus.webp"><img src="https://files.opengeos.org/venus.webp" alt="GeoLibre globe view of Venus over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/mercury.webp"><img src="https://assets.geolibre.app/images/mercury.webp" alt="GeoLibre globe view of Mercury over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/pluto.webp"><img src="https://assets.geolibre.app/images/pluto.webp" alt="GeoLibre globe view of Pluto over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/venus.webp"><img src="https://assets.geolibre.app/images/venus.webp" alt="GeoLibre globe view of Venus over a starfield backdrop"></a></td>
   </tr>
   <tr>
     <td align="center"><b>Mercury</b></td>
@@ -81,9 +81,9 @@ GeoLibre is not limited to Earth. Planetary basemaps from OpenPlanetaryMap and U
     <td align="center"><b>Venus</b></td>
   </tr>
   <tr>
-    <td width="33%"><a href="https://files.opengeos.org/europa.webp"><img src="https://files.opengeos.org/europa.webp" alt="GeoLibre globe view of Europa over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/callisto.webp"><img src="https://files.opengeos.org/callisto.webp" alt="GeoLibre globe view of Callisto over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/charon.webp"><img src="https://files.opengeos.org/charon.webp" alt="GeoLibre globe view of Charon over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/europa.webp"><img src="https://assets.geolibre.app/images/europa.webp" alt="GeoLibre globe view of Europa over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/callisto.webp"><img src="https://assets.geolibre.app/images/callisto.webp" alt="GeoLibre globe view of Callisto over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/charon.webp"><img src="https://assets.geolibre.app/images/charon.webp" alt="GeoLibre globe view of Charon over a starfield backdrop"></a></td>
   </tr>
   <tr>
     <td align="center"><b>Europa</b></td>
@@ -101,7 +101,7 @@ Switch bodies from the planet switcher in the Layers panel. See [Demos](https://
 
 ## Geoprocessing: 1,000+ tools, zero install
 
-[![The GeoLibre Whitebox toolbox running locally with WebAssembly, listing the full catalog of 1,000+ tools with the Regularize Building Footprints tool selected](https://files.opengeos.org/whitebox.webp)](https://files.opengeos.org/whitebox.webp)
+[![The GeoLibre Whitebox toolbox running locally with WebAssembly, listing the full catalog of 1,000+ tools with the Regularize Building Footprints tool selected](https://assets.geolibre.app/images/whitebox.webp)](https://assets.geolibre.app/images/whitebox.webp)
 
 **Processing → Whitebox** opens a toolbox of **1,000+ geoprocessing tools** that
 execute in the browser through a WebAssembly runtime with native raster and

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -237,10 +237,10 @@ A few things worth knowing:
 - Assets are served with permissive CORS, so the app can fetch them
   cross-origin.
 
-Some existing pages point at other GeoLibre-operated hosts, mainly
-`data.geolibre.app` and `files.opengeos.org`. Those URLs keep working and do not
-need rewriting; `geolibre-assets` is simply the one you can open a pull request
-against, so send new assets there.
+Sample datasets are still served from another GeoLibre-operated host,
+`data.geolibre.app`. Those URLs keep working and do not need rewriting;
+`geolibre-assets` is simply the one you can open a pull request against, so send
+new assets there.
 
 The only images that belong in this repository are the site chrome under
 `docs/assets/` — currently just the icon `mkdocs.yml` uses for the logo and

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -11,7 +11,7 @@ Photogrammetry and mesh datasets stream in as [3D Tiles](user-guide/adding-data.
 and render on deck.gl over the MapLibre map, including authenticated tilesets via
 custom request headers.
 
-[![GeoLibre showing 3D Tiles rendered on a MapLibre map](https://files.opengeos.org/GeoLibre-demo.webp)](https://files.opengeos.org/GeoLibre-demo.webp)
+[![GeoLibre showing 3D Tiles rendered on a MapLibre map](https://assets.geolibre.app/images/GeoLibre-demo.webp)](https://assets.geolibre.app/images/GeoLibre-demo.webp)
 
 [Open the live project](https://share.geolibre.app/giswqs/3d-tiles){ .md-button .md-button--primary }
 
@@ -21,14 +21,14 @@ Manhattan building footprints extruded in 3D and colored by construction era,
 with the MTA subway lines and stations on top. The legend is
 [generated automatically](user-guide/styling.md) from the layers' symbology.
 
-[![Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend](https://files.opengeos.org/nyc-buildings.webp)](https://files.opengeos.org/nyc-buildings.webp)
+[![Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend](https://assets.geolibre.app/images/nyc-buildings.webp)](https://assets.geolibre.app/images/nyc-buildings.webp)
 
 The animation below runs the [Time Slider](features.md#plugins) along the
 buildings' construction year, from 1850 to 2025, so Manhattan fills in era by
 era — the camera stays put and the data moves. Click it to play the
 full-quality video.
 
-[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://files.opengeos.org/nyc-buildings-gif.gif)](https://files.opengeos.org/nyc-buildings.webm)
+[![Animation of Manhattan buildings appearing by construction year as the Time Slider advances from 1850 to 2025](https://assets.geolibre.app/demos/nyc-buildings-gif.gif)](https://assets.geolibre.app/demos/nyc-buildings.webm)
 
 [Open the live project](https://share.geolibre.app/giswqs/nyc-buildings-and-subways){ .md-button .md-button--primary }
 
@@ -48,9 +48,9 @@ The deep-space starfield behind each globe comes from the
 
 <table>
   <tr>
-    <td width="33%"><a href="https://files.opengeos.org/earth.webp"><img src="https://files.opengeos.org/earth.webp" alt="GeoLibre globe view of Earth over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/moon.webp"><img src="https://files.opengeos.org/moon.webp" alt="GeoLibre globe view of the Moon over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/mars.webp"><img src="https://files.opengeos.org/mars.webp" alt="GeoLibre globe view of Mars over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/earth.webp"><img src="https://assets.geolibre.app/images/earth.webp" alt="GeoLibre globe view of Earth over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/moon.webp"><img src="https://assets.geolibre.app/images/moon.webp" alt="GeoLibre globe view of the Moon over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/mars.webp"><img src="https://assets.geolibre.app/images/mars.webp" alt="GeoLibre globe view of Mars over a starfield backdrop"></a></td>
   </tr>
   <tr>
     <td align="center"><b>Earth</b><br>Street, satellite, and cloudless imagery</td>
@@ -58,9 +58,9 @@ The deep-space starfield behind each globe comes from the
     <td align="center"><b>Mars</b><br>Colour MOLA Elevation (NASA / MOLA)</td>
   </tr>
   <tr>
-    <td width="33%"><a href="https://files.opengeos.org/mercury.webp"><img src="https://files.opengeos.org/mercury.webp" alt="GeoLibre globe view of Mercury over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/pluto.webp"><img src="https://files.opengeos.org/pluto.webp" alt="GeoLibre globe view of Pluto over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/venus.webp"><img src="https://files.opengeos.org/venus.webp" alt="GeoLibre globe view of Venus over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/mercury.webp"><img src="https://assets.geolibre.app/images/mercury.webp" alt="GeoLibre globe view of Mercury over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/pluto.webp"><img src="https://assets.geolibre.app/images/pluto.webp" alt="GeoLibre globe view of Pluto over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/venus.webp"><img src="https://assets.geolibre.app/images/venus.webp" alt="GeoLibre globe view of Venus over a starfield backdrop"></a></td>
   </tr>
   <tr>
     <td align="center"><b>Mercury</b><br>MESSENGER Colour Mosaic (NASA / JHU APL / CIW)</td>
@@ -68,9 +68,9 @@ The deep-space starfield behind each globe comes from the
     <td align="center"><b>Venus</b><br>Magellan C3-MDIR Colour (NASA / JPL)</td>
   </tr>
   <tr>
-    <td width="33%"><a href="https://files.opengeos.org/europa.webp"><img src="https://files.opengeos.org/europa.webp" alt="GeoLibre globe view of Europa over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/callisto.webp"><img src="https://files.opengeos.org/callisto.webp" alt="GeoLibre globe view of Callisto over a starfield backdrop"></a></td>
-    <td width="33%"><a href="https://files.opengeos.org/charon.webp"><img src="https://files.opengeos.org/charon.webp" alt="GeoLibre globe view of Charon over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/europa.webp"><img src="https://assets.geolibre.app/images/europa.webp" alt="GeoLibre globe view of Europa over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/callisto.webp"><img src="https://assets.geolibre.app/images/callisto.webp" alt="GeoLibre globe view of Callisto over a starfield backdrop"></a></td>
+    <td width="33%"><a href="https://assets.geolibre.app/images/charon.webp"><img src="https://assets.geolibre.app/images/charon.webp" alt="GeoLibre globe view of Charon over a starfield backdrop"></a></td>
   </tr>
   <tr>
     <td align="center"><b>Europa</b><br>Galileo / Voyager (NASA / JPL)</td>

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,9 @@ hide:
   </div>
   <div class="hero__media">
     <figure>
-      <img src="https://assets.geolibre.app/images/GeoLibre-demo.webp" alt="GeoLibre map interface showing the GIS workspace">
+      <a href="https://share.geolibre.app/giswqs/3d-tiles" title="Open the 3D Tiles map">
+        <img src="https://assets.geolibre.app/images/GeoLibre-demo.webp" alt="GeoLibre map interface showing the GIS workspace">
+      </a>
     </figure>
     <figure>
       <a href="https://share.geolibre.app/giswqs/nyc-buildings-and-subways" title="Open the New York City buildings and subways map">

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,14 @@ hide:
       <a class="md-button" href="downloads/">Download app</a>
     </div>
   </div>
-  <figure class="hero__media">
-    <img src="https://files.opengeos.org/GeoLibre-demo.webp" alt="GeoLibre map interface showing the GIS workspace">
-  </figure>
+  <div class="hero__media">
+    <figure>
+      <img src="https://assets.geolibre.app/images/GeoLibre-demo.webp" alt="GeoLibre map interface showing the GIS workspace">
+    </figure>
+    <figure>
+      <img src="https://assets.geolibre.app/images/nyc-buildings.webp" alt="Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend">
+    </figure>
+  </div>
 </section>
 
 ## What GeoLibre does today

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Add Data covers XYZ, WMS, WFS, WMTS, ArcGIS, and STAC services; GeoParquet, Flat
 <div class="feature-card" markdown>
 ### 1,000+ geoprocessing tools
 
-Run **1,000+ geoprocessing tools** — vector, raster, remote sensing, hydrology, terrain, LiDAR, conversion, network, and projection — from the Whitebox toolbox, browsable by category in the Processing menu. They execute in the browser on a WebAssembly runtime with raster and vector I/O, so there is no Python sidecar to install and the full set works on the web, desktop, and Android. 
+Run **1,000+ geoprocessing tools** — vector, raster, remote sensing, hydrology, terrain, LiDAR, conversion, network, and projection — from the Whitebox toolbox, browsable by category in the Processing menu. They execute in the browser on a WebAssembly runtime with raster and vector I/O, so there is no Python sidecar to install and the full set works on the web, desktop, and Android.
 </div>
 
 <div class="feature-card" markdown>

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Add Data covers XYZ, WMS, WFS, WMTS, ArcGIS, and STAC services; GeoParquet, Flat
 <div class="feature-card" markdown>
 ### 1,000+ geoprocessing tools
 
-Run **1,000+ geoprocessing tools** — vector, raster, remote sensing, hydrology, terrain, LiDAR, conversion, network, and projection — from the Whitebox toolbox, browsable by category in the Processing menu. They execute in the browser on a WebAssembly runtime with raster and vector I/O, so there is no Python sidecar to install and the full set works on the web, desktop, and Android. The Conversion menu writes cloud-native GeoParquet, FlatGeobuf, PMTiles, and COG, client-side in the browser build or through the Python sidecar on desktop, whose GDAL stack reads more input formats and tiles deeper.
+Run **1,000+ geoprocessing tools** — vector, raster, remote sensing, hydrology, terrain, LiDAR, conversion, network, and projection — from the Whitebox toolbox, browsable by category in the Processing menu. They execute in the browser on a WebAssembly runtime with raster and vector I/O, so there is no Python sidecar to install and the full set works on the web, desktop, and Android. 
 </div>
 
 <div class="feature-card" markdown>
@@ -110,12 +110,6 @@ Chat with your data: a natural-language [assistant](user-guide/ai-assistant.md) 
 ### Collaboration and story maps
 
 Edit the same project with others in real time ([collaboration](collaboration.md) MVP; requires `VITE_GEOLIBRE_COLLAB_URL`), and build scroll-driven [story maps](user-guide/storymaps.md) with a presenter view and a standalone HTML export you can publish anywhere.
-</div>
-
-<div class="feature-card" markdown>
-### Network analysis and geocoding
-
-Compute isochrones, service areas, and origin–destination cost matrices for network analysis, and run forward, batch, and reverse [geocoding](user-guide/data-integrations.md#geocoding) through a multi-provider abstraction with pluggable providers.
 </div>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,9 @@ hide:
       <img src="https://assets.geolibre.app/images/GeoLibre-demo.webp" alt="GeoLibre map interface showing the GIS workspace">
     </figure>
     <figure>
-      <img src="https://assets.geolibre.app/images/nyc-buildings.webp" alt="Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend">
+      <a href="https://share.geolibre.app/giswqs/nyc-buildings-and-subways" title="Open the New York City buildings and subways map">
+        <img src="https://assets.geolibre.app/images/nyc-buildings.webp" alt="Manhattan buildings extruded in 3D and colored by construction era, with MTA subway lines and stations and an auto-generated legend">
+      </a>
     </figure>
   </div>
 </section>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -85,6 +85,12 @@
 }
 
 .hero__media {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.hero__media figure {
   margin: 0;
 }
 

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -117,7 +117,7 @@ The conversion sidecar is hardened with a path allowlist.
 
 **Processing → Whitebox** opens the geoprocessing toolbox: **1,000+ tools** covering vector, raster, remote sensing, hydrology, terrain, LiDAR, conversion, network, and projection analysis.
 
-![The Whitebox toolbox running locally with WebAssembly, listing the full catalog of 1,000+ tools with the Regularize Building Footprints tool selected](https://files.opengeos.org/whitebox.webp)
+![The Whitebox toolbox running locally with WebAssembly, listing the full catalog of 1,000+ tools with the Regularize Building Footprints tool selected](https://assets.geolibre.app/images/whitebox.webp)
 
 The tools come from the [Whitebox Next Gen](https://github.com/opengeos/Whitebox-Next-Gen-ArcGIS) suite together with GeoLibre's own WASM tools, which the dialog mixes into the same catalog (use the **sources** dropdown to filter to one or the other).
 

--- a/packaging/linux/org.geolibre.desktop.metainfo.xml
+++ b/packaging/linux/org.geolibre.desktop.metainfo.xml
@@ -56,7 +56,7 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://files.opengeos.org/GeoLibre-demo.webp</image>
+      <image>https://assets.geolibre.app/images/GeoLibre-demo.webp</image>
       <caption>3D Tiles rendered on a MapLibre map in GeoLibre</caption>
     </screenshot>
   </screenshots>

--- a/scripts/render-linux-metainfo.sh
+++ b/scripts/render-linux-metainfo.sh
@@ -81,7 +81,7 @@ cat <<XML
 
   <screenshots>
     <screenshot type="default">
-      <image>https://files.opengeos.org/GeoLibre-demo.webp</image>
+      <image>https://assets.geolibre.app/images/GeoLibre-demo.webp</image>
       <caption>3D Tiles rendered on a MapLibre map in GeoLibre</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
## Summary
- Show a second screenshot in the landing-page hero (3D extruded Manhattan buildings with subway layers and a legend) next to the existing map view, and link each hero image to the live shared project it shows.
- Move every README screenshot and the Time Slider animation off `files.opengeos.org` onto the project's own asset host: images under `assets.geolibre.app/images`, the GIF and WebM under `assets.geolibre.app/demos`.
- Wrap the hero media in a grid so the two figures stack with consistent spacing.

## Test plan
- [ ] `mkdocs serve` and confirm both hero images load, are spaced evenly, and open their shared maps when clicked.
- [ ] Check the hero at narrow viewport widths (mobile) and in both light and dark theme.
- [ ] Confirm every image and the animation render on the rendered README, and that no reference to the old host remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a linked NYC buildings visualization alongside the existing GeoLibre demo in the hero section.
* **Style**
  * Updated the hero media layout to display multiple visual examples in a grid.
  * Refined figure spacing and presentation for consistent media display.
* **Documentation**
  * Updated demo, basemap, and geoprocessing image links.
  * Clarified asset-hosting guidance for sample datasets and new media.
  * Streamlined the Whitebox geoprocessing description.
  * Removed the network analysis and geocoding feature card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->