### PR TITLE
Fix browser OSM vector downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14373,9 +14373,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.4.2.tgz",
-      "integrity": "sha512-HR4WXCfSsbtWsfBjPi4Z6f+vuqcNhUSpEwonWswuCgGOiPtwe7nlrrEMtop5EnSX+fl+ZbewvO6uhfM0TINZoA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.4.3.tgz",
+      "integrity": "sha512-G+XuGmvcmfuNdzlHn9OLhUiNxyK0atJ/YfY3R0r5tXJgrESgpyajHNUsmXbBfQuJYqbN41XxeiKl4IhmcJfhQQ==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -22635,7 +22635,7 @@
         "@turf/voronoi": "^7.3.5",
         "dggal": "^0.0.6",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^1.4.2",
+        "geolibre-wasm": "^1.4.3",
         "geotiff": "^3.0.5",
         "onnxruntime-web": "1.27.0",
         "s2js": "^1.44.0"

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -34,7 +34,7 @@
     "@turf/voronoi": "^7.3.5",
     "dggal": "^0.0.6",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^1.4.2",
+    "geolibre-wasm": "^1.4.3",
     "geotiff": "^3.0.5",
     "onnxruntime-web": "1.27.0",
     "s2js": "^1.44.0"


### PR DESCRIPTION
## Summary

- update `geolibre-wasm` to 1.4.3
- fetch Overpass responses in the browser host and pass them into the WASI tool
- preserve the Rust parsing, filtering, clipping, reprojection, and output pipeline

## Root cause

The WASI implementation attempted to open a network socket through Rust `std::net`. Browser WASI shims do not provide sockets, so the reported DNS error was a browser runtime limitation rather than a Windows-specific resolver failure.

## Upstream

- opengeos/whitebox-wasm#17
- opengeos/geolibre-rust#552
- geolibre-wasm v1.4.3

## Verification

- `npm run build`
- pre-commit checks for the changed manifest and lockfile
- real Overpass download of Warsaw roads in light and dark themes: 40 features each
- confirmed no `operation not supported on this platform` failure

Fixes #1793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the geospatial processing component to a newer version, providing the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->