### PR TITLE
fix(recovery): stop the crash-recovery prompt firing on every visit

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -21,6 +21,8 @@ import {
   markProjectSession,
   readLastExplicitProjectSave,
   readProjectSessionState,
+  SESSION_HEARTBEAT_MS,
+  shouldOfferProjectRecovery,
 } from "../lib/project-history-session";
 const AUTOSAVE_DELAY_MS = 3_000;
 
@@ -50,10 +52,14 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
         const entries = await listProjectSnapshots();
         setSnapshots(entries.filter((entry) => entry.projectKey === currentProjectKey()));
         if (crashRecoveryEnabled) {
-          const previousSession = readProjectSessionState();
-          const lastSave = readLastExplicitProjectSave();
           const latest = entries[0];
-          if (previousSession === "open" && latest && (!lastSave || latest.createdAt > lastSave)) {
+          if (
+            shouldOfferProjectRecovery(
+              latest,
+              readProjectSessionState(),
+              readLastExplicitProjectSave(),
+            )
+          ) {
             setRecoverySnapshot(latest);
           }
         }
@@ -65,7 +71,13 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     })();
 
     const markClean = () => markProjectSession("closed");
-    if (crashRecoveryEnabled) window.addEventListener("pagehide", markClean);
+    // A tab open for hours has to stay distinguishable from one that died, so
+    // it restamps its own entry while it lives; see SESSION_HEARTBEAT_MS.
+    let heartbeat: number | null = null;
+    if (crashRecoveryEnabled) {
+      window.addEventListener("pagehide", markClean);
+      heartbeat = window.setInterval(() => markProjectSession("open"), SESSION_HEARTBEAT_MS);
+    }
     const unsubscribe = useAppStore.subscribe((state, previous) => {
       if (
         !state.isDirty ||
@@ -115,6 +127,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     return () => {
       unsubscribe();
       if (crashRecoveryEnabled) window.removeEventListener("pagehide", markClean);
+      if (heartbeat !== null) window.clearInterval(heartbeat);
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
     };
   }, [mapControllerRef, refresh]);

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -18,6 +18,8 @@ import {
   type ProjectHistorySnapshot,
 } from "../lib/project-history-store";
 import {
+  announceLiveProjectSession,
+  liveProjectSessionTabs,
   markProjectSession,
   readLastExplicitProjectSave,
   readProjectSessionState,
@@ -47,6 +49,9 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
 
   useEffect(() => {
     const crashRecoveryEnabled = !isTauri() && !isEmbedded();
+    // Installed before anything awaits, so a sibling tab probing at the same
+    // moment gets an answer from this one.
+    const stopAnnouncing = crashRecoveryEnabled ? announceLiveProjectSession() : null;
     void (async () => {
       try {
         const entries = await listProjectSnapshots();
@@ -56,7 +61,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
           if (
             shouldOfferProjectRecovery(
               latest,
-              readProjectSessionState(),
+              readProjectSessionState(await liveProjectSessionTabs()),
               readLastExplicitProjectSave(),
             )
           ) {
@@ -128,6 +133,7 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
       unsubscribe();
       if (crashRecoveryEnabled) window.removeEventListener("pagehide", markClean);
       if (heartbeat !== null) window.clearInterval(heartbeat);
+      stopAnnouncing?.();
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
     };
   }, [mapControllerRef, refresh]);

--- a/apps/geolibre-desktop/src/lib/project-history-session.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-session.ts
@@ -3,6 +3,8 @@ import { DEFAULT_PROJECT_NAME } from "@geolibre/core";
 const SESSION_KEY = "geolibre-project-session";
 const TAB_KEY = "geolibre-project-session-tab";
 const LAST_SAVE_KEY = "geolibre-project-last-explicit-save";
+const LIVE_TAB_CHANNEL = "geolibre-project-session-live";
+const LIVE_TAB_REPLY_MS = 250;
 
 /**
  * How often a live tab restamps its session entry, and how long an entry
@@ -70,13 +72,25 @@ export function pruneStaleProjectSessions(
   return fresh;
 }
 
-/** "open" when some tab that was alive recently never closed cleanly. */
+/**
+ * "open" when some tab that was alive recently never closed cleanly.
+ *
+ * `liveTabIds` are tabs that just answered a liveness ping. A second window on
+ * the same origin is the common case: it reads its sibling's perfectly healthy
+ * heartbeat, which is indistinguishable in the record from a tab that stopped
+ * heartbeating a moment ago, and would otherwise greet the user with a
+ * recovery prompt every time they open a second GeoLibre tab. A tab that
+ * answers is by definition not a crashed one, so its entry is discounted.
+ */
 export function projectSessionState(
   sessions: ProjectSessionRecord,
   nowMs: number,
+  liveTabIds: ReadonlySet<string> = new Set(),
 ): "open" | "closed" {
-  const live = Object.values(pruneStaleProjectSessions(sessions, nowMs));
-  return live.some((entry) => entry.state === "open") ? "open" : "closed";
+  const recent = Object.entries(pruneStaleProjectSessions(sessions, nowMs));
+  return recent.some(([id, entry]) => entry.state === "open" && !liveTabIds.has(id))
+    ? "open"
+    : "closed";
 }
 
 function currentTabId(): string {
@@ -90,13 +104,60 @@ function currentTabId(): string {
   return id;
 }
 
-export function readProjectSessionState(): string | null {
+export function readProjectSessionState(liveTabIds?: ReadonlySet<string>): string | null {
   try {
-    return projectSessionState(parseProjectSessions(localStorage.getItem(SESSION_KEY)), Date.now());
+    return projectSessionState(
+      parseProjectSessions(localStorage.getItem(SESSION_KEY)),
+      Date.now(),
+      liveTabIds,
+    );
   } catch (error) {
     console.error("Could not read the project session state.", error);
     return null;
   }
+}
+
+/**
+ * Answer liveness pings from other tabs for as long as this tab is alive.
+ *
+ * Returns the teardown. Nothing is announced where `BroadcastChannel` is
+ * missing; the caller then falls back to the record alone, which is what this
+ * code did before the probe existed.
+ */
+export function announceLiveProjectSession(): () => void {
+  if (typeof BroadcastChannel === "undefined") return () => {};
+  const channel = new BroadcastChannel(LIVE_TAB_CHANNEL);
+  channel.onmessage = (event: MessageEvent<{ type?: string } | null>) => {
+    if (event.data?.type === "ping") channel.postMessage({ type: "alive", id: currentTabId() });
+  };
+  return () => channel.close();
+}
+
+/**
+ * Ids of *other* tabs on this origin that answer a ping inside the reply window.
+ *
+ * This tab is excluded explicitly. A `BroadcastChannel` does not deliver to the
+ * object that posted, but it does deliver to a second object in the same tab,
+ * so the announcer above answers this tab's own ping. Keeping that answer would
+ * be wrong in the one case that matters most: reloading the tab a renderer
+ * crash just killed reuses its `sessionStorage` tab id, and discounting that id
+ * would suppress the very prompt the user needs.
+ */
+export async function liveProjectSessionTabs(): Promise<Set<string>> {
+  const live = new Set<string>();
+  if (typeof BroadcastChannel === "undefined") return live;
+  const channel = new BroadcastChannel(LIVE_TAB_CHANNEL);
+  channel.onmessage = (event: MessageEvent<{ type?: string; id?: string } | null>) => {
+    if (event.data?.type === "alive" && typeof event.data.id === "string") live.add(event.data.id);
+  };
+  try {
+    channel.postMessage({ type: "ping" });
+    await new Promise((resolve) => setTimeout(resolve, LIVE_TAB_REPLY_MS));
+  } finally {
+    channel.close();
+  }
+  live.delete(currentTabId());
+  return live;
 }
 
 export function readLastExplicitProjectSave(): string | null {

--- a/apps/geolibre-desktop/src/lib/project-history-session.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-session.ts
@@ -1,6 +1,83 @@
+import { DEFAULT_PROJECT_NAME } from "@geolibre/core";
+
 const SESSION_KEY = "geolibre-project-session";
 const TAB_KEY = "geolibre-project-session-tab";
 const LAST_SAVE_KEY = "geolibre-project-last-explicit-save";
+
+/**
+ * How often a live tab restamps its session entry, and how long an entry
+ * survives without being restamped.
+ *
+ * These exist because the session record is only ever written by the tab it
+ * describes: a tab killed without `pagehide` (crash, OS kill, "Force Reload",
+ * a mobile tab discarded under memory pressure) leaves its entry marked open
+ * with nobody left to close it, and `readProjectSessionState` reports "open"
+ * if *any* entry is. Without an expiry that one dead entry makes every later
+ * visit look like it followed a crash, forever. The heartbeat is what makes a
+ * long-lived tab distinguishable from a dead one: a tab open for hours keeps
+ * restamping, so only the genuinely gone go stale. The gap between the two
+ * values absorbs background-tab timer throttling, which browsers clamp to
+ * roughly one call per minute.
+ */
+export const SESSION_HEARTBEAT_MS = 60_000;
+const STALE_SESSION_MS = 5 * 60_000;
+
+export interface ProjectSessionEntry {
+  state: "open" | "closed";
+  at: string;
+}
+
+export type ProjectSessionRecord = Record<string, ProjectSessionEntry>;
+
+/**
+ * Parse the stored session record, dropping anything unrecognizable.
+ *
+ * Entries written before sessions carried a timestamp (a bare `"open"`, either
+ * as the whole value or per tab) are dropped rather than kept: their age is
+ * unknowable, so treating them as live would preserve exactly the stuck-open
+ * entries this expiry exists to clear.
+ */
+export function parseProjectSessions(stored: string | null): ProjectSessionRecord {
+  if (!stored || stored === "open" || stored === "closed") return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null) return {};
+  const sessions: ProjectSessionRecord = {};
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== "object" || value === null) continue;
+    const { state, at } = value as Partial<ProjectSessionEntry>;
+    if ((state === "open" || state === "closed") && typeof at === "string") {
+      sessions[id] = { state, at };
+    }
+  }
+  return sessions;
+}
+
+/** Drop entries no live tab has restamped inside the expiry window. */
+export function pruneStaleProjectSessions(
+  sessions: ProjectSessionRecord,
+  nowMs: number,
+): ProjectSessionRecord {
+  const fresh: ProjectSessionRecord = {};
+  for (const [id, entry] of Object.entries(sessions)) {
+    const at = Date.parse(entry.at);
+    if (Number.isFinite(at) && at <= nowMs && nowMs - at <= STALE_SESSION_MS) fresh[id] = entry;
+  }
+  return fresh;
+}
+
+/** "open" when some tab that was alive recently never closed cleanly. */
+export function projectSessionState(
+  sessions: ProjectSessionRecord,
+  nowMs: number,
+): "open" | "closed" {
+  const live = Object.values(pruneStaleProjectSessions(sessions, nowMs));
+  return live.some((entry) => entry.state === "open") ? "open" : "closed";
+}
 
 function currentTabId(): string {
   let id = sessionStorage.getItem(TAB_KEY);
@@ -13,20 +90,9 @@ function currentTabId(): string {
   return id;
 }
 
-function readSessions(): Record<string, "open" | "closed"> {
-  const stored = localStorage.getItem(SESSION_KEY);
-  if (!stored) return {};
-  if (stored === "open" || stored === "closed") return { legacy: stored };
-  try {
-    return JSON.parse(stored) as Record<string, "open" | "closed">;
-  } catch {
-    return {};
-  }
-}
-
 export function readProjectSessionState(): string | null {
   try {
-    return Object.values(readSessions()).includes("open") ? "open" : "closed";
+    return projectSessionState(parseProjectSessions(localStorage.getItem(SESSION_KEY)), Date.now());
   } catch (error) {
     console.error("Could not read the project session state.", error);
     return null;
@@ -42,15 +108,54 @@ export function readLastExplicitProjectSave(): string | null {
   }
 }
 
+/**
+ * Record this tab's session state, restamped to now.
+ *
+ * Writing also prunes: every other tab's expired entry is dropped here, so the
+ * record cannot grow without bound and a crashed tab stops being counted.
+ */
 export function markProjectSession(state: "open" | "closed"): void {
   try {
-    const sessions = readSessions();
-    delete sessions.legacy;
-    sessions[currentTabId()] = state;
+    const now = Date.now();
+    const sessions = pruneStaleProjectSessions(
+      parseProjectSessions(localStorage.getItem(SESSION_KEY)),
+      now,
+    );
+    sessions[currentTabId()] = { state, at: new Date(now).toISOString() };
     localStorage.setItem(SESSION_KEY, JSON.stringify(sessions));
   } catch (error) {
     console.error("Could not persist the project session state.", error);
   }
+}
+
+/** The snapshot fields the recovery decision looks at. */
+export interface ProjectRecoveryCandidate {
+  createdAt: string;
+  name: string;
+  projectKey?: string;
+}
+
+/**
+ * Whether the crash-recovery prompt should be offered for `candidate`.
+ *
+ * A snapshot only qualifies when the previous session never marked itself
+ * closed, when the snapshot is newer than the last explicit save, and when it
+ * belongs to a project the user has actually claimed: one with a path, or one
+ * they renamed. An autosave of a still-default-named,
+ * never-saved project is throwaway state: on the web build every visit starts
+ * as "Untitled Project", and a `pagehide` that never fires (or a tab whose
+ * session id is gone) leaves the session marked open forever, so recovery
+ * would prompt on every single visit for work nobody asked to keep.
+ */
+export function shouldOfferProjectRecovery(
+  candidate: ProjectRecoveryCandidate | undefined,
+  sessionState: string | null,
+  lastExplicitSave: string | null,
+): boolean {
+  if (!candidate || sessionState !== "open") return false;
+  if (lastExplicitSave && candidate.createdAt <= lastExplicitSave) return false;
+  if (candidate.projectKey?.startsWith("path:")) return true;
+  return candidate.name !== DEFAULT_PROJECT_NAME;
 }
 
 export function recordExplicitProjectSave(): void {

--- a/tests/project-history-session.test.ts
+++ b/tests/project-history-session.test.ts
@@ -138,3 +138,20 @@ describe("projectSessionState", () => {
     assert.equal(projectSessionState({}, NOW), "closed");
   });
 });
+
+describe("projectSessionState with live tabs", () => {
+  it("discounts a sibling tab that answered the liveness ping", () => {
+    // Opening a second window is not a crash: the sibling's heartbeat is fresh
+    // and open, and only its answer tells the two cases apart.
+    const sessions = { sibling: { state: "open" as const, at: stamp(0) } };
+    assert.equal(projectSessionState(sessions, NOW, new Set(["sibling"])), "closed");
+  });
+
+  it("still reports open when a different entry went unanswered", () => {
+    const sessions = {
+      sibling: { state: "open" as const, at: stamp(0) },
+      crashed: { state: "open" as const, at: stamp(90_000) },
+    };
+    assert.equal(projectSessionState(sessions, NOW, new Set(["sibling"])), "open");
+  });
+});

--- a/tests/project-history-session.test.ts
+++ b/tests/project-history-session.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_PROJECT_NAME } from "../packages/core/src/index";
+import {
+  parseProjectSessions,
+  projectSessionState,
+  pruneStaleProjectSessions,
+  SESSION_HEARTBEAT_MS,
+  shouldOfferProjectRecovery,
+  type ProjectRecoveryCandidate,
+} from "../apps/geolibre-desktop/src/lib/project-history-session";
+
+const NOW = Date.parse("2026-01-02T12:00:00.000Z");
+const stamp = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+function candidate(over: Partial<ProjectRecoveryCandidate> = {}): ProjectRecoveryCandidate {
+  return {
+    createdAt: "2026-01-02T00:00:00.000Z",
+    name: "Watershed study",
+    projectKey: "unsaved:Watershed study",
+    ...over,
+  };
+}
+
+describe("shouldOfferProjectRecovery", () => {
+  it("offers recovery for a renamed project after an unclean close", () => {
+    assert.equal(shouldOfferProjectRecovery(candidate(), "open", null), true);
+  });
+
+  it("skips a still-default-named, never-saved project", () => {
+    assert.equal(
+      shouldOfferProjectRecovery(
+        candidate({
+          name: DEFAULT_PROJECT_NAME,
+          projectKey: `unsaved:${DEFAULT_PROJECT_NAME}`,
+        }),
+        "open",
+        null,
+      ),
+      false,
+    );
+  });
+
+  it("still offers recovery for a saved project that kept the default name", () => {
+    assert.equal(
+      shouldOfferProjectRecovery(
+        candidate({
+          name: DEFAULT_PROJECT_NAME,
+          projectKey: "path:/tmp/site.geolibre.json",
+        }),
+        "open",
+        null,
+      ),
+      true,
+    );
+  });
+
+  it("skips when the previous session closed cleanly", () => {
+    assert.equal(shouldOfferProjectRecovery(candidate(), "closed", null), false);
+    assert.equal(shouldOfferProjectRecovery(candidate(), null, null), false);
+  });
+
+  it("skips when there is no snapshot", () => {
+    assert.equal(shouldOfferProjectRecovery(undefined, "open", null), false);
+  });
+
+  it("skips a snapshot that is not newer than the last explicit save", () => {
+    assert.equal(
+      shouldOfferProjectRecovery(candidate(), "open", "2026-01-02T00:00:00.000Z"),
+      false,
+    );
+    assert.equal(
+      shouldOfferProjectRecovery(candidate(), "open", "2026-01-03T00:00:00.000Z"),
+      false,
+    );
+    assert.equal(shouldOfferProjectRecovery(candidate(), "open", "2026-01-01T00:00:00.000Z"), true);
+  });
+});
+
+describe("parseProjectSessions", () => {
+  it("keeps well-formed timestamped entries", () => {
+    const stored = JSON.stringify({ tab: { state: "open", at: stamp(0) } });
+    assert.deepEqual(parseProjectSessions(stored), { tab: { state: "open", at: stamp(0) } });
+  });
+
+  it("drops entries from before sessions carried a timestamp", () => {
+    assert.deepEqual(parseProjectSessions("open"), {});
+    assert.deepEqual(parseProjectSessions(JSON.stringify({ tab: "open" })), {});
+    assert.deepEqual(parseProjectSessions(JSON.stringify({ tab: { state: "open" } })), {});
+  });
+
+  it("survives missing, malformed, and non-object storage", () => {
+    assert.deepEqual(parseProjectSessions(null), {});
+    assert.deepEqual(parseProjectSessions("{not json"), {});
+    assert.deepEqual(parseProjectSessions("[1,2]"), {});
+    assert.deepEqual(parseProjectSessions(JSON.stringify({ tab: { state: "gone", at: "" } })), {});
+  });
+});
+
+describe("pruneStaleProjectSessions", () => {
+  it("keeps an entry a live tab restamped within the window", () => {
+    const sessions = { tab: { state: "open" as const, at: stamp(SESSION_HEARTBEAT_MS) } };
+    assert.deepEqual(pruneStaleProjectSessions(sessions, NOW), sessions);
+  });
+
+  it("drops an entry nobody restamped, and unparseable or future stamps", () => {
+    assert.deepEqual(
+      pruneStaleProjectSessions(
+        {
+          dead: { state: "open", at: stamp(10 * 60_000) },
+          garbage: { state: "open", at: "not a date" },
+          skewed: { state: "open", at: stamp(-60_000) },
+        },
+        NOW,
+      ),
+      {},
+    );
+  });
+});
+
+describe("projectSessionState", () => {
+  it("reports open when a recent tab never closed cleanly", () => {
+    const sessions = {
+      gone: { state: "closed" as const, at: stamp(60_000) },
+      crashed: { state: "open" as const, at: stamp(60_000) },
+    };
+    assert.equal(projectSessionState(sessions, NOW), "open");
+  });
+
+  it("reports closed once the crashed tab's entry has expired", () => {
+    // The regression this expiry fixes: one tab killed without `pagehide` used
+    // to make every later visit look like it followed a crash, forever.
+    const sessions = { crashed: { state: "open" as const, at: stamp(60 * 60_000) } };
+    assert.equal(projectSessionState(sessions, NOW), "closed");
+  });
+
+  it("reports closed for an empty record", () => {
+    assert.equal(projectSessionState({}, NOW), "closed");
+  });
+});


### PR DESCRIPTION
## Summary
- The recovery prompt is now limited to projects the user has claimed: one with a project path, or one they renamed. An autosave of a still-default-named "Untitled Project" no longer interrupts on load, since on the web every visit starts under that name.
- Session entries now carry a timestamp and expire after 5 minutes. Previously a tab killed without `pagehide` (crash, OS kill, a discarded mobile tab) left an entry marked open that nothing could ever close, so every later visit looked like it followed a crash. Writing the record also prunes expired entries, so it cannot grow without bound.
- A live tab restamps its own entry every 60s, which is what keeps a tab open for hours distinguishable from a dead one. The gap between the two values absorbs the background-tab timer throttling browsers apply.
- Entries in the previous, untimestamped format have unknowable age and are discarded on read, which clears any already-stuck state instead of carrying it forward.
- Autosaving is unchanged; untitled snapshots are still written and still listed in the Project History dialog.

## Test plan
- [x] `npm run test:frontend` (5574 passing), including 14 new cases in `tests/project-history-session.test.ts` covering parsing, expiry, session state, and the recovery decision.
- [x] `tsc -b` and `npm run lint` clean; `pre-commit run --files` clean.
- [x] Drove the production web build in a browser with real autosaves in IndexedDB: untitled project with a tab that crashed 30s ago shows no dialog; the same project renamed does show it, naming the right project; the named project with a dead tab last seen an hour ago does not; a legacy untimestamped stuck entry does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved project recovery to identify eligible unsaved snapshots from recently active sessions.
  * Added automatic activity updates for open browser tabs.
* **Bug Fixes**
  * Prevented stale, malformed, or expired session data from affecting recovery.
  * Improved handling of renamed projects and default project names.
  * Prevented recovery prompts for cleanly closed or previously saved projects.
* **Tests**
  * Added coverage for recovery eligibility, session lifecycle, invalid data, expiration, and crashed-tab scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->