### PR TITLE
fix(recovery): harden session parsing and cover cross-tab liveness

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -54,20 +54,21 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     const stopAnnouncing = crashRecoveryEnabled ? announceLiveProjectSession() : null;
     void (async () => {
       try {
-        // Independent work: the liveness probe waits a fixed window for other
-        // tabs to answer, so run it alongside the IndexedDB read rather than
-        // adding its wait to every load.
-        const [entries, liveTabs] = await Promise.all([
-          listProjectSnapshots(),
-          crashRecoveryEnabled ? liveProjectSessionTabs() : Promise.resolve(new Set<string>()),
-        ]);
+        // The liveness probe waits a fixed window for other tabs to answer, so
+        // it is started first and awaited last: its wait overlaps the IndexedDB
+        // read instead of being added to it, and the history list still renders
+        // the moment the snapshots arrive rather than trailing the probe.
+        const liveTabs = crashRecoveryEnabled
+          ? liveProjectSessionTabs().catch(() => new Set<string>())
+          : Promise.resolve(new Set<string>());
+        const entries = await listProjectSnapshots();
         setSnapshots(entries.filter((entry) => entry.projectKey === currentProjectKey()));
         if (crashRecoveryEnabled) {
           const latest = entries[0];
           if (
             shouldOfferProjectRecovery(
               latest,
-              readProjectSessionState(liveTabs),
+              readProjectSessionState(await liveTabs),
               readLastExplicitProjectSave(),
             )
           ) {

--- a/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectHistory.ts
@@ -54,14 +54,20 @@ export function useProjectHistory(mapControllerRef: RefObject<MapController | nu
     const stopAnnouncing = crashRecoveryEnabled ? announceLiveProjectSession() : null;
     void (async () => {
       try {
-        const entries = await listProjectSnapshots();
+        // Independent work: the liveness probe waits a fixed window for other
+        // tabs to answer, so run it alongside the IndexedDB read rather than
+        // adding its wait to every load.
+        const [entries, liveTabs] = await Promise.all([
+          listProjectSnapshots(),
+          crashRecoveryEnabled ? liveProjectSessionTabs() : Promise.resolve(new Set<string>()),
+        ]);
         setSnapshots(entries.filter((entry) => entry.projectKey === currentProjectKey()));
         if (crashRecoveryEnabled) {
           const latest = entries[0];
           if (
             shouldOfferProjectRecovery(
               latest,
-              readProjectSessionState(await liveProjectSessionTabs()),
+              readProjectSessionState(liveTabs),
               readLastExplicitProjectSave(),
             )
           ) {

--- a/apps/geolibre-desktop/src/lib/project-history-session.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-session.ts
@@ -47,7 +47,9 @@ export function parseProjectSessions(stored: string | null): ProjectSessionRecor
   } catch {
     return {};
   }
-  if (typeof parsed !== "object" || parsed === null) return {};
+  // Arrays are objects, and `Object.entries` would index one into "0", "1", …
+  // tab ids, so a tampered array of session-shaped values would survive.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
   const sessions: ProjectSessionRecord = {};
   for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
     if (typeof value !== "object" || value === null) continue;
@@ -127,8 +129,11 @@ export function readProjectSessionState(liveTabIds?: ReadonlySet<string>): strin
 export function announceLiveProjectSession(): () => void {
   if (typeof BroadcastChannel === "undefined") return () => {};
   const channel = new BroadcastChannel(LIVE_TAB_CHANNEL);
+  // Resolved once: this tab's id is fixed for its lifetime, and answering with
+  // whatever `sessionStorage` holds at reply time would be a needless read.
+  const id = currentTabId();
   channel.onmessage = (event: MessageEvent<{ type?: string } | null>) => {
-    if (event.data?.type === "ping") channel.postMessage({ type: "alive", id: currentTabId() });
+    if (event.data?.type === "ping") channel.postMessage({ type: "alive", id });
   };
   return () => channel.close();
 }

--- a/apps/geolibre-desktop/src/lib/project-history-session.ts
+++ b/apps/geolibre-desktop/src/lib/project-history-session.ts
@@ -131,7 +131,18 @@ export function announceLiveProjectSession(): () => void {
   const channel = new BroadcastChannel(LIVE_TAB_CHANNEL);
   // Resolved once: this tab's id is fixed for its lifetime, and answering with
   // whatever `sessionStorage` holds at reply time would be a needless read.
-  const id = currentTabId();
+  // Guarded like every other storage access here, because this one runs during
+  // effect setup: where storage access throws (a privacy mode that blocks it),
+  // an escaping exception would abort the effect before the heartbeat and
+  // `pagehide` listeners are wired up. A tab that cannot identify itself simply
+  // does not answer.
+  let id: string;
+  try {
+    id = currentTabId();
+  } catch (error) {
+    console.error("Could not identify this tab for project recovery.", error);
+    return () => channel.close();
+  }
   channel.onmessage = (event: MessageEvent<{ type?: string } | null>) => {
     if (event.data?.type === "ping") channel.postMessage({ type: "alive", id });
   };

--- a/tests/project-history-session.test.ts
+++ b/tests/project-history-session.test.ts
@@ -223,3 +223,26 @@ describe("cross-tab liveness", () => {
     }
   });
 });
+
+describe("announceLiveProjectSession where storage is blocked", () => {
+  it("returns a teardown instead of throwing out of effect setup", () => {
+    // A privacy mode that blocks storage must not take the caller down with
+    // it: this runs during effect setup, before the heartbeat and `pagehide`
+    // listeners are wired up.
+    const original = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw new Error("access denied");
+      },
+    });
+    try {
+      const stopAnnouncing = announceLiveProjectSession();
+      assert.equal(typeof stopAnnouncing, "function");
+      stopAnnouncing();
+    } finally {
+      if (original) Object.defineProperty(globalThis, "sessionStorage", original);
+      else Reflect.deleteProperty(globalThis, "sessionStorage");
+    }
+  });
+});

--- a/tests/project-history-session.test.ts
+++ b/tests/project-history-session.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { DEFAULT_PROJECT_NAME } from "../packages/core/src/index";
+import { DEFAULT_PROJECT_NAME } from "@geolibre/core";
 import {
+  announceLiveProjectSession,
+  liveProjectSessionTabs,
   parseProjectSessions,
   projectSessionState,
   pruneStaleProjectSessions,
@@ -153,5 +155,67 @@ describe("projectSessionState with live tabs", () => {
       crashed: { state: "open" as const, at: stamp(90_000) },
     };
     assert.equal(projectSessionState(sessions, NOW, new Set(["sibling"])), "open");
+  });
+});
+
+describe("cross-tab liveness", () => {
+  // `currentTabId` reads sessionStorage, which node lacks. Swapping the id the
+  // stub returns between the announce and the probe is what makes one process
+  // stand in for two tabs.
+  function withTabIdentity(): { setTabId: (id: string) => void; restore: () => void } {
+    let tabId = "tab";
+    const original = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: { getItem: () => tabId, setItem: () => {} },
+    });
+    return {
+      setTabId: (id) => {
+        tabId = id;
+      },
+      restore: () => {
+        if (original) Object.defineProperty(globalThis, "sessionStorage", original);
+        else Reflect.deleteProperty(globalThis, "sessionStorage");
+      },
+    };
+  }
+
+  it("collects the id of a tab that answers the ping", async () => {
+    const identity = withTabIdentity();
+    identity.setTabId("sibling");
+    const stopAnnouncing = announceLiveProjectSession();
+    identity.setTabId("self");
+    try {
+      assert.deepEqual([...(await liveProjectSessionTabs())], ["sibling"]);
+    } finally {
+      stopAnnouncing();
+      identity.restore();
+    }
+  });
+
+  it("excludes its own answer, so a reload after a crash still recovers", async () => {
+    // Reloading the tab a renderer crash killed reuses its sessionStorage tab
+    // id, and its own announcer answers its own ping. Counting that answer
+    // would discount the crashed entry and swallow the prompt.
+    const identity = withTabIdentity();
+    identity.setTabId("same-tab");
+    const stopAnnouncing = announceLiveProjectSession();
+    try {
+      assert.deepEqual([...(await liveProjectSessionTabs())], []);
+    } finally {
+      stopAnnouncing();
+      identity.restore();
+    }
+  });
+
+  it("reports no live tabs where BroadcastChannel is missing", async () => {
+    const original = Object.getOwnPropertyDescriptor(globalThis, "BroadcastChannel");
+    Reflect.deleteProperty(globalThis, "BroadcastChannel");
+    try {
+      assert.equal(announceLiveProjectSession()(), undefined);
+      assert.equal((await liveProjectSessionTabs()).size, 0);
+    } finally {
+      if (original) Object.defineProperty(globalThis, "BroadcastChannel", original);
+    }
   });
 });

--- a/tests/project-history-session.test.ts
+++ b/tests/project-history-session.test.ts
@@ -95,6 +95,10 @@ describe("parseProjectSessions", () => {
     assert.deepEqual(parseProjectSessions(null), {});
     assert.deepEqual(parseProjectSessions("{not json"), {});
     assert.deepEqual(parseProjectSessions("[1,2]"), {});
+    // A session-shaped array is the case the plain "[1,2]" above cannot catch:
+    // its elements pass entry validation, so only rejecting arrays outright
+    // stops `Object.entries` turning the indexes into "0", "1", ... tab ids.
+    assert.deepEqual(parseProjectSessions(JSON.stringify([{ state: "open", at: stamp(0) }])), {});
     assert.deepEqual(parseProjectSessions(JSON.stringify({ tab: { state: "gone", at: "" } })), {});
   });
 });


### PR DESCRIPTION
## Summary
Follow-ups from the review on #1798, which merged before these landed.

- `parseProjectSessions` now rejects arrays. `Object.entries` indexes an array into "0", "1", ... tab ids, so a tampered or corrupted record of session-shaped values slipped through a check meant to reject malformed storage.
- The liveness probe runs alongside `listProjectSnapshots` instead of after it, so its fixed reply window overlaps the IndexedDB read rather than adding to every load.
- The announcing tab resolves its own id once at announce time rather than on each reply.
- Tests now cover the cross-tab liveness mechanism itself, which had none: a sibling's answer is collected, a tab's own answer is not, and a missing `BroadcastChannel` degrades to no live tabs. The self-exclusion case matters because reloading the tab a renderer crash killed reuses its `sessionStorage` tab id, and counting that self-answer would swallow the prompt.

## Test plan
- [x] `npm run test:frontend` (5579 passing), including 3 new liveness cases.
- [x] `pre-commit run --files` clean on the changed files.
- [x] Re-ran the browser check on the production build with real autosaves: a tab that crashed 30s ago prompts, a second tab beside a live heartbeating sibling does not, and a third tab with both a live sibling and a genuinely dead entry still prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project-history recovery by loading saved snapshots and active session data concurrently.
  * Enhanced detection of active project sessions across browser tabs.
  * Prevented invalid session data from being treated as project sessions.
  * Improved behavior when cross-tab communication is unavailable.

* **Tests**
  * Added coverage for cross-tab session detection, current-tab exclusion, and unavailable communication channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->