### PR TITLE
Fix oval Whitebox vector buffers

### DIFF
--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -264,6 +264,7 @@ export {
   outputBaseName,
   fileOutputTargetExtension,
   outputTextFormatHint,
+  prepareGeographicBufferInput,
   isTiff,
 } from "./wasm-client";
 export {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -500,16 +500,20 @@ export function prepareGeographicBufferInput(
   const projected = structuredClone(geojson) as FeatureCollection & {
     crs?: { type: "name"; properties: { name: string } };
   };
-  for (const feature of projected.features) {
-    if (feature.geometry && "coordinates" in feature.geometry) {
-      feature.geometry.coordinates = projectCoordinates(feature.geometry.coordinates) as never;
-    } else if (feature.geometry?.type === "GeometryCollection") {
-      for (const geometry of feature.geometry.geometries) {
-        if ("coordinates" in geometry) {
-          geometry.coordinates = projectCoordinates(geometry.coordinates) as never;
-        }
+  const projectGeometry = (geometry: (typeof projected.features)[number]["geometry"]): void => {
+    if (!geometry) return;
+    if (geometry.type === "GeometryCollection") {
+      for (const member of geometry.geometries) {
+        projectGeometry(member);
       }
+      return;
     }
+    if ("coordinates" in geometry) {
+      geometry.coordinates = projectCoordinates(geometry.coordinates) as never;
+    }
+  };
+  for (const feature of projected.features) {
+    projectGeometry(feature.geometry);
   }
   projected.crs = { type: "name", properties: { name: "EPSG:3857" } };
 
@@ -638,6 +642,17 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
   const input: Record<string, Uint8Array> = {};
   const args: string[] = [];
   const parameterOverrides: Record<string, unknown> = {};
+  let geographicBufferInput: FeatureCollection | null = null;
+  if (request.tool_id === "buffer_vector") {
+    const geojson = request.layer_inputs?.input?.geojson;
+    const prepared = geojson
+      ? prepareGeographicBufferInput(geojson, request.parameters.distance)
+      : null;
+    if (prepared) {
+      geographicBufferInput = prepared.geojson;
+      parameterOverrides.distance = prepared.distance;
+    }
+  }
   // How each output file is turned into a job output: "geojson" is parsed into a
   // FeatureCollection (a map layer); "raster" is normalized to a COG before it
   // reaches the map; "bytes" is returned raw (a file_out blob or a
@@ -667,13 +682,7 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
       // A map layer is RFC 7946 WGS84, while Whitebox's buffer is Cartesian.
       // Run this one operation in Web Mercator so its round buffers stay round
       // on the map; the EPSG tag makes the tool's GeoJSON writer return WGS84.
-      if (request.tool_id === "buffer_vector" && name === "input") {
-        const prepared = prepareGeographicBufferInput(geojson, request.parameters.distance);
-        if (prepared) {
-          geojson = prepared.geojson;
-          parameterOverrides.distance = prepared.distance;
-        }
-      }
+      if (name === "input" && geographicBufferInput) geojson = geographicBufferInput;
       const file = `${name}.geojson`;
       input[file] = encoder.encode(JSON.stringify(geojson));
       args.push(`--${name}=/work/${file}`);

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -449,6 +449,76 @@ function isFeatureCollection(value: unknown): value is FeatureCollection {
   );
 }
 
+const WEB_MERCATOR_RADIUS = 6378137;
+const MAX_WEB_MERCATOR_LATITUDE = 85.0511287798066;
+
+/**
+ * Prepare a WGS84 map layer for Whitebox's planar buffer operation.
+ *
+ * `buffer_vector` treats both axes as Cartesian map units. Buffering RFC 7946
+ * longitude/latitude directly therefore creates a circle in degrees which is
+ * stretched into an oval when MapLibre displays it in Web Mercator. Projecting
+ * the input to EPSG:3857 makes the tool operate in the same conformal plane as
+ * the map. The GeoJSON writer sees the attached CRS and reprojects the result
+ * back to WGS84 before GeoLibre imports it.
+ *
+ * The dialog stores the buffer distance in degrees, including values converted
+ * from metres by its explicitly approximate geographic-distance control. Using
+ * the equatorial metres-per-degree scale preserves the old buffer's horizontal
+ * radius while making its vertical radius match.
+ */
+export function prepareGeographicBufferInput(
+  geojson: FeatureCollection,
+  distance: unknown,
+): { geojson: FeatureCollection; distance: number } | null {
+  const degrees = typeof distance === "number" ? distance : Number(distance);
+  if (!Number.isFinite(degrees) || degrees <= 0) return null;
+
+  const projectPosition = (position: number[]): number[] => {
+    const longitude = position[0];
+    const latitude = Math.max(
+      -MAX_WEB_MERCATOR_LATITUDE,
+      Math.min(MAX_WEB_MERCATOR_LATITUDE, position[1]),
+    );
+    const x = WEB_MERCATOR_RADIUS * ((longitude * Math.PI) / 180);
+    const y = WEB_MERCATOR_RADIUS * Math.log(Math.tan(Math.PI / 4 + (latitude * Math.PI) / 360));
+    return [x, y, ...position.slice(2)];
+  };
+
+  const projectCoordinates = (coordinates: unknown): unknown => {
+    if (!Array.isArray(coordinates)) return coordinates;
+    if (
+      coordinates.length >= 2 &&
+      typeof coordinates[0] === "number" &&
+      typeof coordinates[1] === "number"
+    ) {
+      return projectPosition(coordinates as number[]);
+    }
+    return coordinates.map(projectCoordinates);
+  };
+
+  const projected = structuredClone(geojson) as FeatureCollection & {
+    crs?: { type: "name"; properties: { name: string } };
+  };
+  for (const feature of projected.features) {
+    if (feature.geometry && "coordinates" in feature.geometry) {
+      feature.geometry.coordinates = projectCoordinates(feature.geometry.coordinates) as never;
+    } else if (feature.geometry?.type === "GeometryCollection") {
+      for (const geometry of feature.geometry.geometries) {
+        if ("coordinates" in geometry) {
+          geometry.coordinates = projectCoordinates(geometry.coordinates) as never;
+        }
+      }
+    }
+  }
+  projected.crs = { type: "name", properties: { name: "EPSG:3857" } };
+
+  return {
+    geojson: projected,
+    distance: WEB_MERCATOR_RADIUS * ((degrees * Math.PI) / 180),
+  };
+}
+
 /**
  * Whether bytes start with the TIFF signature: "II" (little-endian) or "MM"
  * (big-endian) followed by the version number in the byte order's own
@@ -567,6 +637,7 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
   const encoder = new TextEncoder();
   const input: Record<string, Uint8Array> = {};
   const args: string[] = [];
+  const parameterOverrides: Record<string, unknown> = {};
   // How each output file is turned into a job output: "geojson" is parsed into a
   // FeatureCollection (a map layer); "raster" is normalized to a COG before it
   // reaches the map; "bytes" is returned raw (a file_out blob or a
@@ -591,8 +662,18 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
     const name = param.name;
 
     if (kind === "vector_in") {
-      const geojson = request.layer_inputs?.[name]?.geojson;
+      let geojson = request.layer_inputs?.[name]?.geojson;
       if (!geojson) throw new Error(`Missing vector input for "${name}"`);
+      // A map layer is RFC 7946 WGS84, while Whitebox's buffer is Cartesian.
+      // Run this one operation in Web Mercator so its round buffers stay round
+      // on the map; the EPSG tag makes the tool's GeoJSON writer return WGS84.
+      if (request.tool_id === "buffer_vector" && name === "input") {
+        const prepared = prepareGeographicBufferInput(geojson, request.parameters.distance);
+        if (prepared) {
+          geojson = prepared.geojson;
+          parameterOverrides.distance = prepared.distance;
+        }
+      }
       const file = `${name}.geojson`;
       input[file] = encoder.encode(JSON.stringify(geojson));
       args.push(`--${name}=/work/${file}`);
@@ -659,7 +740,7 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
       outputs.push({ name, file, kind: kind === "raster_out" ? "raster" : "bytes" });
       args.push(`--${name}=/work/${file}`);
     } else {
-      const value = request.parameters[name];
+      const value = parameterOverrides[name] ?? request.parameters[name];
       if (value !== undefined && value !== null && value !== "") {
         args.push(`--${name}=${value}`);
       }

--- a/tests/wasm-geographic-buffer.test.ts
+++ b/tests/wasm-geographic-buffer.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { FeatureCollection, Point } from "geojson";
+import { prepareGeographicBufferInput } from "@geolibre/processing";
+
+const warsaw: FeatureCollection<Point> = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      properties: { name: "Warsaw" },
+      geometry: { type: "Point", coordinates: [21.0122, 52.2297] },
+    },
+  ],
+};
+
+describe("prepareGeographicBufferInput", () => {
+  it("projects WGS84 coordinates and degree distances into Web Mercator", () => {
+    const prepared = prepareGeographicBufferInput(warsaw, "0.1");
+    assert.ok(prepared);
+    assert.deepEqual((prepared.geojson as FeatureCollection & { crs?: unknown }).crs, {
+      type: "name",
+      properties: { name: "EPSG:3857" },
+    });
+
+    const point = prepared.geojson.features[0].geometry as Point;
+    assert.ok(Math.abs(point.coordinates[0] - 2_339_067.4) < 1);
+    assert.ok(Math.abs(point.coordinates[1] - 6_841_765.2) < 1);
+    assert.ok(Math.abs(prepared.distance - 11_131.949) < 0.01);
+  });
+
+  it("does not mutate the map layer supplied by the caller", () => {
+    const before = structuredClone(warsaw);
+    prepareGeographicBufferInput(warsaw, 0.1);
+    assert.deepEqual(warsaw, before);
+  });
+
+  it("rejects missing, non-numeric, and non-positive distances", () => {
+    for (const distance of [undefined, "", "not a number", 0, -1]) {
+      assert.equal(prepareGeographicBufferInput(warsaw, distance), null);
+    }
+  });
+});

--- a/tests/wasm-geographic-buffer.test.ts
+++ b/tests/wasm-geographic-buffer.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { FeatureCollection, Point } from "geojson";
+import type { FeatureCollection, GeometryCollection, Point } from "geojson";
 import { prepareGeographicBufferInput } from "@geolibre/processing";
 
 const warsaw: FeatureCollection<Point> = {
@@ -33,6 +33,35 @@ describe("prepareGeographicBufferInput", () => {
     const before = structuredClone(warsaw);
     prepareGeographicBufferInput(warsaw, 0.1);
     assert.deepEqual(warsaw, before);
+  });
+
+  it("projects coordinate geometries nested inside geometry collections", () => {
+    const nested: FeatureCollection<GeometryCollection> = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "GeometryCollection",
+            geometries: [
+              {
+                type: "GeometryCollection",
+                geometries: [{ type: "Point", coordinates: [21.0122, 52.2297] }],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const prepared = prepareGeographicBufferInput(nested, 0.1);
+    assert.ok(prepared);
+    const outer = prepared.geojson.features[0].geometry as GeometryCollection;
+    const inner = outer.geometries[0] as GeometryCollection;
+    const point = inner.geometries[0] as Point;
+    assert.ok(Math.abs(point.coordinates[0] - 2_339_067.4) < 1);
+    assert.ok(Math.abs(point.coordinates[1] - 6_841_765.2) < 1);
   });
 
   it("rejects missing, non-numeric, and non-positive distances", () => {


### PR DESCRIPTION
## Summary

- project in-memory WGS84 layers to Web Mercator before running Whitebox Buffer Vector
- convert the submitted degree distance to matching projected map units
- preserve the source layer and return the Whitebox result to GeoLibre as WGS84 GeoJSON
- add regression tests for projection, distance conversion, and input immutability

## Verification

- `node --import tsx --test tests/wasm-geographic-buffer.test.ts`
- `npm run build`
- `pre-commit run --files packages/processing/src/wasm-client.ts packages/processing/src/index.ts tests/wasm-geographic-buffer.test.ts`
- real browser run with `los_observer.geojson` and a 1 km Whitebox Buffer Vector output in light and dark themes

Fixes #1796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geographic buffer operations now support WGS84 inputs by projecting them to Web Mercator and converting distances to metres.
  * Added public access to geographic buffer input preparation.
* **Bug Fixes**
  * Invalid, missing, non-numeric, or non-positive buffer distances are rejected.
  * Original input layers remain unchanged during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->