### PR TITLE
Fix mobile style panel scrolling

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -711,9 +711,11 @@ function validateExpressionJson(value: string, label: string, t: TFunction): str
 }
 
 // Shared shell classes for every expanded StylePanel return branch. On phones
-// (max-md) it overlays the map as a bottom sheet instead of squeezing it.
+// (max-md) it overlays the map as a bottom sheet instead of squeezing it. The
+// sheet needs a definite height so the Radix ScrollArea viewport can resolve
+// its percentage height and scroll instead of growing to the content height.
 const STYLE_PANEL_ASIDE_CLASS =
-  "relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card max-md:absolute max-md:inset-x-0 max-md:bottom-0 max-md:z-30 max-md:shadow-xl md:max-h-none md:w-[var(--style-panel-width)] md:border-s md:border-t-0";
+  "relative flex h-[min(24rem,42vh)] supports-[height:1dvh]:h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card max-md:absolute max-md:inset-x-0 max-md:bottom-0 max-md:z-30 max-md:shadow-xl md:h-auto md:w-[var(--style-panel-width)] md:border-s md:border-t-0";
 
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;


### PR DESCRIPTION
## Summary

- give the mobile Style bottom sheet a definite viewport-relative height so its scroll viewport remains constrained
- preserve the existing desktop panel sizing
- make lower vector style controls reachable with touch scrolling

Fixes #1800

## Testing

- `npm run build`
- `pre-commit run --all-files`
- Playwright at 412 x 915 with `us_regions.geojson` in light and dark themes
- touch swipe moved the Style viewport and exposed the fill and outline color controls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in the mobile style panel.
  * Ensured the bottom-sheet layout uses the available viewport height correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->