### PR TITLE
docs: use raw URLs in the embedding data/style examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,7 @@ https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibr
 You can also open hosted data directly. `data` accepts GeoJSON, GeoParquet, PMTiles, REST endpoints returning GeoJSON or ZIP, ZIP archives containing multiple GeoJSON files, and COGs. Add `style` to apply hosted vector or raster symbology:
 
 ```text
-https://web.geolibre.app/?data=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fplaces.geojson&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fsample.style.json
+https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson&style=https://assets.geolibre.app/data/sample.style.json
 ```
 
 Vector layers can produce a compatible file from **Layer actions → Styles → Export GeoLibre URL style**, and apply it again with **Import style (GeoLibre URL / Mapbox GL / SLD / QML)…**.

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -164,6 +164,51 @@ You do not need to author that JSON by hand. Open the vector layer's **Layer act
 
 The same file can be applied interactively to an existing vector layer through **Layer actions → Styles → Import style (GeoLibre URL / Mapbox GL / SLD / QML)…**. Interactive import ignores the file's query-param `source` binding and applies its supported symbology to the layer you selected, so the data filename does not need to match.
 
+### An "Open in GeoLibre" badge
+
+If you publish a dataset — in a repository README, a data catalog, a paper's
+supplementary material — an **Open in GeoLibre** badge turns it into a one-click
+interactive map. Copy one of these and swap in your own URL:
+
+[![Open in GeoLibre](https://img.shields.io/badge/Open%20in-GeoLibre-green.svg)](https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson)
+
+```markdown
+[![Open in GeoLibre](https://img.shields.io/badge/Open%20in-GeoLibre-green.svg)](https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson)
+```
+
+The same badge can open a shared project instead of a single file, using `url`:
+
+```markdown
+[![Open in GeoLibre](https://img.shields.io/badge/Open%20in-GeoLibre-green.svg)](https://web.geolibre.app/?url=https://share.geolibre.app/you/project.geolibre.json)
+```
+
+In reStructuredText:
+
+```rst
+.. image:: https://img.shields.io/badge/Open%20in-GeoLibre-green.svg
+   :target: https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson
+   :alt: Open in GeoLibre
+```
+
+In HTML:
+
+```html
+<a href="https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson">
+  <img src="https://img.shields.io/badge/Open%20in-GeoLibre-green.svg" alt="Open in GeoLibre" />
+</a>
+```
+
+Add any of the [URL parameters](#url-parameters) to the link to control how the
+map opens — `&style=` for symbology, `&theme=dark`, or `&maponly` for a
+chrome-free view.
+
+One caveat specific to badges: a badge lives in a `README.md` that GitHub, PyPI,
+and docs sites all render, and each of those rewrites links differently. Keep
+the target URL **absolute**, and remember that if your data URL carries its own
+query string it needs the percent-encoding described above — inside a Markdown
+link an unencoded `&` will also end the link at that character in some
+renderers.
+
 ## Talking to the map at runtime
 
 URL parameters configure the app once, at load. To keep talking to a **live**

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -134,7 +134,7 @@ A public DEM COG can be tested directly:
 https://web.geolibre.app/?data=https://data.source.coop/giswqs/opengeos/dem.tif
 ```
 
-A plain `https://…` URL can be passed as-is, as above: `:` and `/` are legal in a query value and need no escaping. Encode the nested data and style URLs with `encodeURIComponent` only when they contain a character that would be read as GeoLibre's own query syntax — `&`, `=`, `+`, `%`, or `#`. Remote servers must permit browser cross-origin requests (CORS). COG, GeoParquet, and PMTiles servers should also support HTTP byte-range requests.
+A plain `https://…` URL can be passed as-is, as above: `:` and `/` are legal in a query value and need no escaping. Encode the nested data and style URLs with `encodeURIComponent` only when they contain a character that would be read as GeoLibre's own query syntax — `&`, `+`, `%`, or `#`. A bare `=` inside the value is fine, since only the first `=` in each `&`-delimited pair separates the name from the value. Remote servers must permit browser cross-origin requests (CORS). COG, GeoParquet, and PMTiles servers should also support HTTP byte-range requests.
 
 For a COG, `style` may point to a raster style JSON object. Supported fields are `mode` (`single`, `rgb`, or `index`), 1-based `bands`, `rescale` ranges, `colormap`, `reversed`, `nodata`, `opacity`, `gamma`, `stretch` (`linear`, `log`, or `sqrt`), and the normalized-difference `index` preset. For example:
 

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -2,76 +2,6 @@
 
 GeoLibre's browser build can be embedded in any web page and configured through URL query parameters. This is how you turn a shared project into a live, focused map for a website, a report, or a dashboard.
 
-## Open remote data
-
-Use `data` to open public GeoJSON, GeoParquet, PMTiles, Cloud-Optimized GeoTIFF (COG), or a ZIP archive containing one or more `.geojson`/`.json` FeatureCollections. Each GeoJSON file in a ZIP becomes a separate layer. An optional `style` URL applies Mapbox/MapLibre style JSON to vector data:
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fplaces.geojson&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fsample.style.json
-```
-
-`data` may also point to a REST API endpoint that returns either a GeoJSON `FeatureCollection` or a ZIP containing multiple GeoJSON files. ZIP API responses are recognized from their `Content-Type`/`Content-Disposition` headers or their ZIP file signature, so the endpoint does not need a `.zip` suffix. For example:
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fapi.example.com%2Ffeatures%3Fcategory%3Dparks%26limit%3D100
-```
-
-The example API URL is illustrative. Use the hosted `places.geojson` example above for a directly runnable test.
-
-A hosted ZIP with per-file styles can be tested directly:
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fmultiple-layers.zip&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fmultiple-layers.style.json
-```
-
-GeoParquet is loaded through GeoLibre's DuckDB-backed vector reader. PMTiles is streamed with HTTP range requests and may contain either vector or raster tiles. These real vector examples also apply the hosted sample style:
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fbuilding_count_h3.parquet&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fsample.style.json
-```
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fbuilding_count_h3.pmtiles&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fsample.style.json
-```
-
-For a vector PMTiles archive, the style is applied to the layer after the archive's source layers are discovered. A raster PMTiles archive can be loaded with `data`, but it does not accept a MapLibre vector style through `style`.
-
-A public DEM COG can be tested directly:
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fdem.tif
-```
-
-Encode the nested data and style URLs with `encodeURIComponent`, especially when they contain their own query parameters. Remote servers must permit browser cross-origin requests (CORS). COG, GeoParquet, and PMTiles servers should also support HTTP byte-range requests.
-
-For a COG, `style` may point to a raster style JSON object. Supported fields are `mode` (`single`, `rgb`, or `index`), 1-based `bands`, `rescale` ranges, `colormap`, `reversed`, `nodata`, `opacity`, `gamma`, `stretch` (`linear`, `log`, or `sqrt`), and the normalized-difference `index` preset. For example:
-
-```json
-{
-  "mode": "single",
-  "bands": [1],
-  "rescale": [[0, 1000]],
-  "colormap": "viridis",
-  "reversed": false,
-  "nodata": "auto",
-  "opacity": 0.85,
-  "gamma": 1,
-  "stretch": "linear"
-}
-```
-
-After hosting that JSON as `dem.style.json`, pass both encoded URLs:
-
-```text
-https://web.geolibre.app/?data=https%3A%2F%2Fdata.source.coop%2Fgiswqs%2Fopengeos%2Fdem.tif&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fdem.style.json
-```
-
-For a ZIP containing files of the same geometry type, assign different styles by setting each Mapbox style layer's `source` to the corresponding filename stem. For example, `source: "parks"` targets `parks.geojson`, while `source: "counties"` targets `counties.geojson`. Style layers without a `source` are shared by every imported file. GeoLibre validates all filename/style matches before adding any ZIP layers.
-
-You do not need to author that JSON by hand. Open the vector layer's **Layer actions → Styles → Export GeoLibre URL style** menu. The downloaded `.geolibre.style.json` contains only symbology—not feature data—and its render-layer `source` is already set to the original GeoJSON filename stem. Host the file on a CORS-enabled server and pass its URL as `style` alongside the corresponding `data` URL. For a multi-file ZIP, export each layer's GeoLibre URL style and combine their `layers` and `sources` into one style document; layers without `source` can be used for rules shared by every ZIP member.
-
-The same file can be applied interactively to an existing vector layer through **Layer actions → Styles → Import style (GeoLibre URL / Mapbox GL / SLD / QML)…**. Interactive import ignores the file's query-param `source` binding and applies its supported symbology to the layer you selected, so the data filename does not need to match.
-
 ## The live viewer
 
 The browser build is hosted at `https://web.geolibre.app/`. It is a static site deployed on GitHub Pages that runs entirely in your browser: it has no analytics and no server account, and the data you load is processed client-side. Data leaves your browser only when you add a remote URL or explicitly share a project.
@@ -163,6 +93,76 @@ So an embed cannot be steered into authoring by a key press, a drag, or a
 project file. Display plugins (layer control, basemaps, time slider, legend and
 colorbar components) keep working, so the project still looks as it was saved. Use `layout=compact` for the complete authoring
 toolbar in a smaller space, or `maponly` for a pure map.
+
+## Open remote data
+
+Use `data` to open public GeoJSON, GeoParquet, PMTiles, Cloud-Optimized GeoTIFF (COG), or a ZIP archive containing one or more `.geojson`/`.json` FeatureCollections. Each GeoJSON file in a ZIP becomes a separate layer. An optional `style` URL applies Mapbox/MapLibre style JSON to vector data:
+
+```text
+https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson&style=https://assets.geolibre.app/data/sample.style.json
+```
+
+`data` may also point to a REST API endpoint that returns either a GeoJSON `FeatureCollection` or a ZIP containing multiple GeoJSON files. ZIP API responses are recognized from their `Content-Type`/`Content-Disposition` headers or their ZIP file signature, so the endpoint does not need a `.zip` suffix. An endpoint that takes its own query parameters is the case that does need percent-encoding, so its `&` separators are not read as GeoLibre's own:
+
+```text
+https://web.geolibre.app/?data=https%3A%2F%2Fapi.example.com%2Ffeatures%3Fcategory%3Dparks%26limit%3D100
+```
+
+The example API URL is illustrative. Use the hosted `places.geojson` example above for a directly runnable test.
+
+A hosted ZIP with per-file styles can be tested directly:
+
+```text
+https://web.geolibre.app/?data=https://assets.geolibre.app/data/multiple-layers.zip&style=https://assets.geolibre.app/data/multiple-layers.style.json
+```
+
+GeoParquet is loaded through GeoLibre's DuckDB-backed vector reader. PMTiles is streamed with HTTP range requests and may contain either vector or raster tiles. These real vector examples also apply the hosted sample style:
+
+```text
+https://web.geolibre.app/?data=https://data.source.coop/giswqs/opengeos/building_count_h3.parquet&style=https://assets.geolibre.app/data/sample.style.json
+```
+
+```text
+https://web.geolibre.app/?data=https://data.source.coop/giswqs/opengeos/building_count_h3.pmtiles&style=https://assets.geolibre.app/data/sample.style.json
+```
+
+For a vector PMTiles archive, the style is applied to the layer after the archive's source layers are discovered. A raster PMTiles archive can be loaded with `data`, but it does not accept a MapLibre vector style through `style`.
+
+A public DEM COG can be tested directly:
+
+```text
+https://web.geolibre.app/?data=https://data.source.coop/giswqs/opengeos/dem.tif
+```
+
+A plain `https://…` URL can be passed as-is, as above: `:` and `/` are legal in a query value and need no escaping. Encode the nested data and style URLs with `encodeURIComponent` only when they contain a character that would be read as GeoLibre's own query syntax — `&`, `=`, `+`, `%`, or `#`. Remote servers must permit browser cross-origin requests (CORS). COG, GeoParquet, and PMTiles servers should also support HTTP byte-range requests.
+
+For a COG, `style` may point to a raster style JSON object. Supported fields are `mode` (`single`, `rgb`, or `index`), 1-based `bands`, `rescale` ranges, `colormap`, `reversed`, `nodata`, `opacity`, `gamma`, `stretch` (`linear`, `log`, or `sqrt`), and the normalized-difference `index` preset. For example:
+
+```json
+{
+  "mode": "single",
+  "bands": [1],
+  "rescale": [[0, 1000]],
+  "colormap": "viridis",
+  "reversed": false,
+  "nodata": "auto",
+  "opacity": 0.85,
+  "gamma": 1,
+  "stretch": "linear"
+}
+```
+
+After hosting that JSON as `dem.style.json`, pass both URLs:
+
+```text
+https://web.geolibre.app/?data=https://data.source.coop/giswqs/opengeos/dem.tif&style=https://assets.geolibre.app/data/dem.style.json
+```
+
+For a ZIP containing files of the same geometry type, assign different styles by setting each Mapbox style layer's `source` to the corresponding filename stem. For example, `source: "parks"` targets `parks.geojson`, while `source: "counties"` targets `counties.geojson`. Style layers without a `source` are shared by every imported file. GeoLibre validates all filename/style matches before adding any ZIP layers.
+
+You do not need to author that JSON by hand. Open the vector layer's **Layer actions → Styles → Export GeoLibre URL style** menu. The downloaded `.geolibre.style.json` contains only symbology—not feature data—and its render-layer `source` is already set to the original GeoJSON filename stem. Host the file on a CORS-enabled server and pass its URL as `style` alongside the corresponding `data` URL. For a multi-file ZIP, export each layer's GeoLibre URL style and combine their `layers` and `sources` into one style document; layers without `source` can be used for rules shared by every ZIP member.
+
+The same file can be applied interactively to an existing vector layer through **Layer actions → Styles → Import style (GeoLibre URL / Mapbox GL / SLD / QML)…**. Interactive import ignores the file's query-param `source` binding and applies its supported symbology to the layer you selected, so the data filename does not need to match.
 
 ## Talking to the map at runtime
 

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -203,11 +203,11 @@ map opens — `&style=` for symbology, `&theme=dark`, or `&maponly` for a
 chrome-free view.
 
 One caveat specific to badges: a badge lives in a `README.md` that GitHub, PyPI,
-and docs sites all render, and each of those rewrites links differently. Keep
-the target URL **absolute**, and remember that if your data URL carries its own
-query string it needs the percent-encoding described above — inside a Markdown
-link an unencoded `&` will also end the link at that character in some
-renderers.
+and docs sites all render, and each of those rewrites relative links
+differently, so keep the target URL **absolute**. The encoding rule above
+applies unchanged — a data URL carrying its own query string still needs
+`encodeURIComponent`, because the `&` is read as GeoLibre's own separator well
+before the browser ever sees it.
 
 ## Talking to the map at runtime
 

--- a/docs/user-guide/layers.md
+++ b/docs/user-guide/layers.md
@@ -33,7 +33,7 @@ Vector layers have a **Layer actions → Styles** submenu for symbology intercha
 To use a GeoLibre URL style, upload it to a CORS-enabled web host and open GeoLibre with both URLs:
 
 ```text
-https://web.geolibre.app/?data=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fplaces.geojson&style=https%3A%2F%2Fassets.geolibre.app%2Fdata%2Fsample.style.json
+https://web.geolibre.app/?data=https://assets.geolibre.app/data/places.geojson&style=https://assets.geolibre.app/data/sample.style.json
 ```
 
 See [Embedding & Sharing](embedding.md#open-remote-data) for GeoParquet and PMTiles deep links, ZIP source matching, REST API responses, raster-style JSON, and encoding nested URLs.

--- a/tests/data-url.test.ts
+++ b/tests/data-url.test.ts
@@ -122,6 +122,11 @@ describe("data URL deep links", () => {
     );
     assert.equal(parsed?.dataUrl, "https://assets.geolibre.app/data/places.geojson");
     assert.equal(parsed?.styleUrl, "https://assets.geolibre.app/data/sample.style.json");
+
+    // Only the first `=` of each `&`-delimited pair separates name from value,
+    // so a nested `=` survives unencoded — the docs tell readers not to escape it.
+    const nested = dataUrlParameters("?data=https://api.example.com/features?category=parks");
+    assert.equal(nested?.dataUrl, "https://api.example.com/features?category=parks");
   });
 
   it("rejects non-http data URLs", () => {

--- a/tests/data-url.test.ts
+++ b/tests/data-url.test.ts
@@ -113,6 +113,17 @@ describe("data URL deep links", () => {
     assert.equal(parsed?.styleUrl, style);
   });
 
+  it("parses raw, unencoded data and style URLs as documented", () => {
+    // The spelling docs/user-guide/embedding.md leads with: `:` and `/` are legal
+    // in a query value, so a plain https URL needs no encodeURIComponent.
+    const parsed = dataUrlParameters(
+      "?data=https://assets.geolibre.app/data/places.geojson" +
+        "&style=https://assets.geolibre.app/data/sample.style.json",
+    );
+    assert.equal(parsed?.dataUrl, "https://assets.geolibre.app/data/places.geojson");
+    assert.equal(parsed?.styleUrl, "https://assets.geolibre.app/data/sample.style.json");
+  });
+
   it("rejects non-http data URLs", () => {
     assert.equal(dataUrlParameters("?data=file:///tmp/private.geojson"), null);
   });


### PR DESCRIPTION
## Summary

- Rewrites the `data` and `style` deep-link examples in the embedding guide to use plain, unencoded URLs. `:` and `/` are legal in a query value, so the percent-encoded spelling was noise that made the examples hard to read and copy. Encoding is now shown only on the REST endpoint example, which carries its own query string and genuinely needs it, and the trailing guidance names the characters that actually break (`&`, `+`, `%`, `#`) instead of advising encoding everywhere.
- Moves the "Open remote data" section below "Embedding in a page" so the page introduces the iframe before the parameters it takes. The `#open-remote-data` anchor is unchanged, so the inbound links from the layers and styling guides still resolve.
- Applies the same raw spelling to the two duplicate copies of the example in `docs/index.md` and `docs/user-guide/layers.md`, which otherwise disagreed with the embedding guide.
- Adds an "Open in GeoLibre" badge subsection with copy-paste Markdown, reStructuredText, and HTML snippets, for both the `data=` and `url=` deep links. It reuses the shields.io green already used by the badges in `docs/getting-started.md`. This was added after the PR was opened, so it is a deliberate inclusion rather than a rebase artifact.
- Adds tests pinning the raw spelling and the nested-`=` behavior. The suite previously covered only the `encodeURIComponent`-wrapped form, so nothing guarded the form the docs lead with.

## Test plan

- [x] `node --import tsx --test tests/data-url.test.ts` passes (19/19), covering the raw form and a nested `=` that survives unencoded
- [x] Pre-commit hooks pass on the changed files, including the build
- [x] Verified against `dataUrlParameters` that extraction is a plain `URLSearchParams.get()` with no additional decode step, so raw values round-trip unchanged
- [x] Verified with a CommonMark renderer that `&` does not terminate a Markdown link destination, and corrected the badge caveat that claimed otherwise
- [ ] Rendered docs spot-check: section order reads correctly, the badge renders, and the three cross-links to `#open-remote-data` still land

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated web app, embedding, and layer examples to use clearer unencoded HTTPS URL formats.
  * Clarified when nested URLs require encoding in query parameters.
  * Added guidance for “Open in GeoLibre” badges in Markdown, reStructuredText, and HTML.
  * Refined instructions for loading remote data, styles, COGs, GeoParquet, and PMTiles.

* **Tests**
  * Added coverage confirming raw HTTPS data and style URLs are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->