### PR TITLE
Add native startup project preferences

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -15,6 +15,7 @@ import { useStyleLibraryPersistence } from "./hooks/useStyleLibraryPersistence";
 import { useTemplateLibraryPersistence } from "./hooks/useTemplateLibraryPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
 import { useStartupUpdateCheck } from "./hooks/useStartupUpdateCheck";
+import { useStartupProject } from "./hooks/useStartupProject";
 import { useThemeMode } from "./hooks/useThemeMode";
 import { useThemeScheme } from "./hooks/useThemeScheme";
 import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
@@ -42,10 +43,10 @@ export default function App() {
   const dataUrlLoadState = useDataUrlLoader(mapAppAPI);
   const { showOnboarding, dismissOnboarding } = useUiProfileBootstrap();
   const { pending: pendingUpdate, remindLater, skipVersion } = useStartupUpdateCheck();
-
   useDesktopSettingsPersistence();
   useThemeScheme();
   useRecentProjectsPersistence();
+  const startupProjectWarning = useStartupProject();
   useStyleLibraryPersistence();
   useLayerLibraryPersistence();
   useTemplateLibraryPersistence();
@@ -69,6 +70,14 @@ export default function App() {
         onRemindLater={remindLater}
         onSkipVersion={skipVersion}
       />
+      {startupProjectWarning ? (
+        <div
+          role="alert"
+          className="fixed bottom-10 left-1/2 z-50 -translate-x-1/2 rounded-md border bg-background px-4 py-3 text-sm shadow-lg"
+        >
+          {startupProjectWarning}
+        </div>
+      ) : null}
     </DirectionProvider>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1044,10 +1044,7 @@ export function SettingsDialog({
   const updateCesiumIonToken = (value: string) => {
     // Draft-only until Save, like the share token above (a secret field should
     // not persist on every keystroke).
-    setDraftDesktopSettings((current) => ({
-      ...current,
-      cesiumIonToken: value,
-    }));
+    setDraftDesktopSettings((current) => ({ ...current, cesiumIonToken: value }));
   };
 
   const updateUiProfile = (patch: Partial<UiProfileSettings>) => {
@@ -1397,9 +1394,7 @@ export function SettingsDialog({
                   <span
                     aria-hidden
                     className="me-2 h-3.5 w-3.5 shrink-0 rounded-full border"
-                    style={{
-                      backgroundColor: desktopSettings.theme.customColor,
-                    }}
+                    style={{ backgroundColor: desktopSettings.theme.customColor }}
                   />
                   {t("settings.appearance.custom")}
                 </DropdownMenuRadioItem>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -43,6 +43,7 @@ import {
   Check,
   Crosshair,
   DownloadCloud,
+  FolderOpen,
   ExternalLink,
   Eye,
   EyeOff,
@@ -82,6 +83,7 @@ import {
   type ExperienceLevel,
   type UiProfileSettings,
   type UpdateSettings,
+  type StartupSettings,
 } from "../../hooks/useDesktopSettings";
 import { useLanguage } from "../../hooks/useLanguage";
 import { BROWSER_PANEL_ID } from "../../hooks/useRegisterBrowserPanel";
@@ -93,6 +95,7 @@ import { THEME_SCHEMES, normalizeHexColor, type ThemeScheme } from "../../lib/th
 import { IS_MAS_BUILD } from "../../lib/build-flags";
 import { resolveShareHost, shareHostLabel } from "../../lib/share-geolibre";
 import { IS_STORE_BUILD, type UpdateNotificationLevel } from "../../lib/updates";
+import { openProjectFile } from "../../lib/tauri-io";
 import {
   DATA_SOURCE_CATALOG,
   DATA_SOURCE_SECTION_LABEL_KEYS,
@@ -130,7 +133,8 @@ export type SettingsSection =
   | "geocoding"
   | "ai"
   | "environment"
-  | "updates";
+  | "updates"
+  | "startup";
 
 /** A field a deep-link can ask Settings to focus once the section renders. */
 export type SettingsFocusTarget = "shareToken" | "accentColor";
@@ -205,6 +209,7 @@ const SECTION_ITEMS: Array<{
     labelKey: "settings.section.updates",
     icon: DownloadCloud,
   },
+  { id: "startup", labelKey: "settings.section.startup", icon: FolderOpen },
 ];
 
 // The menu-item id that gates each Settings section, mirroring the dropdown.
@@ -239,6 +244,7 @@ interface DraftDesktopSettings {
   defaultAiProfileId: string | null;
   uiProfile: UiProfileSettings;
   updates: UpdateSettings;
+  startup: StartupSettings;
 }
 
 function createDraftId(): string {
@@ -279,6 +285,7 @@ function cloneDesktopSettings(settings: DesktopSettings): DraftDesktopSettings {
       hiddenMenuItems: [...settings.uiProfile.hiddenMenuItems],
     },
     updates: { ...settings.updates },
+    startup: { ...settings.startup },
   };
 }
 
@@ -464,6 +471,7 @@ export function SettingsDialog({
     // The Microsoft Store build has no in-app update flow to configure (policy
     // 10.2.5), so its settings section is dropped entirely.
     if (id === "updates" && IS_STORE_BUILD) return false;
+    if (id === "startup" && !isTauri()) return false;
     const gate = SECTION_GATE[id];
     return gate ? showSettingsItem(gate) : true;
   };
@@ -978,6 +986,29 @@ export function SettingsDialog({
     updateDraftUpdateSettings(DEFAULT_UPDATE_SETTINGS);
   };
 
+  const updateDraftStartupSettings = (patch: Partial<StartupSettings>) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      startup: { ...current.startup, ...patch },
+    }));
+    setError(null);
+  };
+
+  const chooseStartupProject = async () => {
+    try {
+      const result = await openProjectFile();
+      if (!result) return;
+      updateDraftStartupSettings({
+        mode: "specific",
+        projectPath: result.path,
+        projectName: result.project.name,
+      });
+    } catch (error) {
+      console.error("Could not select a startup project.", error);
+      setError(t("settings.startup.selectError"));
+    }
+  };
+
   // Live updates from the Settings dropdown's Interface submenu (not the draft,
   // which only the dialog commits on Save). Reads the latest state so rapid
   // toggles do not clobber each other.
@@ -1013,7 +1044,10 @@ export function SettingsDialog({
   const updateCesiumIonToken = (value: string) => {
     // Draft-only until Save, like the share token above (a secret field should
     // not persist on every keystroke).
-    setDraftDesktopSettings((current) => ({ ...current, cesiumIonToken: value }));
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      cesiumIonToken: value,
+    }));
   };
 
   const updateUiProfile = (patch: Partial<UiProfileSettings>) => {
@@ -1171,6 +1205,7 @@ export function SettingsDialog({
       defaultAiProfileId: draftDesktopSettings.defaultAiProfileId,
       uiProfile: committedUiProfile,
       updates: draftDesktopSettings.updates,
+      startup: draftDesktopSettings.startup,
     });
     setOpen(false);
   };
@@ -1362,7 +1397,9 @@ export function SettingsDialog({
                   <span
                     aria-hidden
                     className="me-2 h-3.5 w-3.5 shrink-0 rounded-full border"
-                    style={{ backgroundColor: desktopSettings.theme.customColor }}
+                    style={{
+                      backgroundColor: desktopSettings.theme.customColor,
+                    }}
                   />
                   {t("settings.appearance.custom")}
                 </DropdownMenuRadioItem>
@@ -2473,6 +2510,64 @@ export function SettingsDialog({
                       })}
                     </div>
                   )}
+                </div>
+              ) : null}
+              {effectiveSection === "startup" ? (
+                <div className="space-y-5">
+                  <div>
+                    <h3 className="text-sm font-semibold">{t("settings.startup.title")}</h3>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.startup.description")}
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    {(["default", "last"] as const).map((mode) => (
+                      <label
+                        key={mode}
+                        className="flex items-start gap-3 rounded-md border p-3 text-sm"
+                      >
+                        <input
+                          className="mt-0.5 h-4 w-4"
+                          type="radio"
+                          name="startup-project-mode"
+                          checked={draftDesktopSettings.startup.mode === mode}
+                          onChange={() => updateDraftStartupSettings({ mode })}
+                        />
+                        <span className="space-y-1">
+                          <span className="block">{t(`settings.startup.mode.${mode}`)}</span>
+                          <span className="block text-xs text-muted-foreground">
+                            {t(`settings.startup.modeHint.${mode}`)}
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                    <label className="flex items-start gap-3 rounded-md border p-3 text-sm">
+                      <input
+                        className="mt-0.5 h-4 w-4"
+                        type="radio"
+                        name="startup-project-mode"
+                        checked={draftDesktopSettings.startup.mode === "specific"}
+                        disabled={!draftDesktopSettings.startup.projectPath}
+                        onChange={() => updateDraftStartupSettings({ mode: "specific" })}
+                      />
+                      <span className="min-w-0 flex-1 space-y-1">
+                        <span className="block">{t("settings.startup.mode.specific")}</span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {draftDesktopSettings.startup.projectName ??
+                            t("settings.startup.noProjectSelected")}
+                        </span>
+                      </span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void chooseStartupProject()}
+                      >
+                        <FolderOpen className="h-3.5 w-3.5" />
+                        {t("settings.startup.chooseProject")}
+                      </Button>
+                    </label>
+                  </div>
                 </div>
               ) : null}
               {effectiveSection === "updates" ? (

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -83,6 +83,16 @@ export interface DesktopSettings {
    * desktop (Tauri) build; on the web these settings are inert.
    */
   updates: UpdateSettings;
+  /** Native-app project restoration policy. Browser builds ignore this setting. */
+  startup: StartupSettings;
+}
+
+export type StartupProjectMode = "default" | "last" | "specific";
+
+export interface StartupSettings {
+  mode: StartupProjectMode;
+  projectPath: string | null;
+  projectName: string | null;
 }
 
 export interface ThemeSettings {
@@ -173,6 +183,12 @@ export const DEFAULT_UPDATE_SETTINGS: UpdateSettings = {
   notificationLevel: "all",
 };
 
+export const DEFAULT_STARTUP_SETTINGS: StartupSettings = {
+  mode: "default",
+  projectPath: null,
+  projectName: null,
+};
+
 export const DEFAULT_THEME_SETTINGS: ThemeSettings = {
   scheme: DEFAULT_THEME_SCHEME,
   customColor: DEFAULT_CUSTOM_COLOR,
@@ -190,6 +206,7 @@ const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   theme: DEFAULT_THEME_SETTINGS,
   uiProfile: DEFAULT_UI_PROFILE_SETTINGS,
   updates: DEFAULT_UPDATE_SETTINGS,
+  startup: DEFAULT_STARTUP_SETTINGS,
 };
 
 /** The experience-level presets, in order. Single source of truth. */
@@ -228,6 +245,27 @@ export function normalizeDesktopSettings(settings: unknown): DesktopSettings {
     theme: normalizeThemeSettings(candidate.theme),
     uiProfile: normalizeUiProfileSettings(candidate.uiProfile),
     updates: normalizeUpdateSettings(candidate.updates),
+    startup: normalizeStartupSettings(candidate.startup),
+  };
+}
+
+function normalizeStartupSettings(startup: unknown): StartupSettings {
+  if (!startup || typeof startup !== "object") return DEFAULT_STARTUP_SETTINGS;
+  const candidate = startup as Partial<StartupSettings>;
+  const mode: StartupProjectMode =
+    candidate.mode === "last" || candidate.mode === "specific" ? candidate.mode : "default";
+  const projectPath =
+    typeof candidate.projectPath === "string" && candidate.projectPath.trim()
+      ? candidate.projectPath.trim()
+      : null;
+  const projectName =
+    typeof candidate.projectName === "string" && candidate.projectName.trim()
+      ? candidate.projectName.trim()
+      : null;
+  return {
+    mode: mode === "specific" && !projectPath ? "default" : mode,
+    projectPath,
+    projectName,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
+++ b/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
@@ -13,7 +13,16 @@ function isRecentProjectEntry(value: unknown): value is RecentProjectEntry {
   );
 }
 
-function loadRecentProjects(): RecentProjectEntry[] {
+/**
+ * Read the persisted recent-projects list straight from storage.
+ *
+ * Exported so a consumer that runs before this hook's hydration effect (see
+ * `useStartupProject`) can read the same list without depending on its own
+ * position in `App.tsx`'s hook order. Entries come back in stored order; the
+ * store's `setRecentProjects` dedups and trims but does not reorder, so "most
+ * recent first" holds either way.
+ */
+export function loadRecentProjects(): RecentProjectEntry[] {
   if (typeof window === "undefined") return [];
 
   try {

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -4,9 +4,11 @@ import { useTranslation } from "react-i18next";
 import { dataUrlParameters } from "../lib/data-url";
 import { isTauri } from "../lib/is-tauri";
 import { projectUrlFromLocation } from "../lib/project-url";
+import { startupProjectPath } from "../lib/startup-project";
 import { openRecentProjectFile, RecentProjectGoneError } from "../lib/tauri-io";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 import { DEFAULT_STARTUP_SETTINGS, useDesktopSettingsStore } from "./useDesktopSettings";
+import { loadRecentProjects } from "./useRecentProjectsPersistence";
 
 export function useStartupProject(): string | null {
   const { t } = useTranslation();
@@ -26,14 +28,19 @@ export function useStartupProject(): string | null {
     if (projectUrlFromLocation() !== null) return;
     if (dataUrlParameters(window.location.search) !== null) return;
     const settings = useDesktopSettingsStore.getState().desktopSettings.startup;
-    if (settings.mode === "default") return;
-    // Reads what `useRecentProjectsPersistence` hydrated from localStorage, so
-    // it must stay above this hook in `App.tsx` -- run first, "last project"
-    // mode would see an empty list and silently fall through to no-op.
-    const recentProjects = useAppStore.getState().recentProjects;
-    const path =
-      settings.mode === "specific" ? settings.projectPath : (recentProjects[0]?.path ?? null);
+    // `useRecentProjectsPersistence` hydrates the store from localStorage in its
+    // own mount effect. Fall back to reading storage directly when that has not
+    // happened yet, so "last project" mode does not silently no-op if this hook
+    // is ever ordered above it in `App.tsx`.
+    const stored = useAppStore.getState().recentProjects;
+    const path = startupProjectPath(settings, stored.length > 0 ? stored : loadRecentProjects());
     if (!path) return;
+
+    // The workspace this restore is allowed to replace. The XYZ probes below
+    // reach the network and the shell is interactive throughout, so the user can
+    // open their own project first; `loadProject` swaps the whole store with no
+    // unsaved-work prompt, so a restore that lost that race must stand down.
+    const restoringOver = useAppStore.getState().projectPath;
 
     let cancelled = false;
     let warningTimer: number | undefined;
@@ -44,7 +51,10 @@ export function useStartupProject(): string | null {
       try {
         const result = await openRecentProjectFile(path, abortController.signal);
         const project = await resolveProjectXyzLayers(result.project, abortController.signal);
-        if (!cancelled) useAppStore.getState().loadProject(project, result.path);
+        if (cancelled) return;
+        const { projectPath, isDirty } = useAppStore.getState();
+        if (projectPath !== restoringOver || isDirty) return;
+        useAppStore.getState().loadProject(project, result.path);
       } catch (error) {
         if (cancelled) return;
         if (error instanceof RecentProjectGoneError) {

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -2,9 +2,10 @@ import { useAppStore } from "@geolibre/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { isTauri } from "../lib/is-tauri";
+import { projectUrlFromLocation } from "../lib/project-url";
 import { openRecentProjectFile, RecentProjectGoneError } from "../lib/tauri-io";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
-import { useDesktopSettingsStore } from "./useDesktopSettings";
+import { DEFAULT_STARTUP_SETTINGS, useDesktopSettingsStore } from "./useDesktopSettings";
 
 export function useStartupProject(): string | null {
   const { t } = useTranslation();
@@ -13,10 +14,14 @@ export function useStartupProject(): string | null {
   useEffect(() => {
     if (!isTauri()) return;
     // Explicit launch payloads take precedence over the device default. Without
-    // this guard, the startup read and a shared ?url= project could race, with
-    // whichever request happened to finish last replacing the other.
+    // this guard, the startup read and a shared project deep link could race,
+    // with whichever request happened to finish last replacing the other. Defer
+    // to `projectUrlFromLocation` rather than naming query keys here, so this
+    // guard and `useProjectUrlLoader` can never disagree about what counts as an
+    // explicit project (it covers every key in `PROJECT_URL_PARAMS` plus a bare
+    // `?https://...` query).
     const params = new URLSearchParams(window.location.search);
-    if (params.has("url") || params.has("data")) return;
+    if (params.has("data") || projectUrlFromLocation() !== null) return;
     const settings = useDesktopSettingsStore.getState().desktopSettings.startup;
     if (settings.mode === "default") return;
     const recentProjects = useAppStore.getState().recentProjects;
@@ -35,11 +40,15 @@ export function useStartupProject(): string | null {
         if (cancelled) return;
         if (error instanceof RecentProjectGoneError) {
           useAppStore.getState().forgetRecentProject(path);
-          if (settings.mode === "specific") {
-            const current = useDesktopSettingsStore.getState().desktopSettings;
+          // Re-read the preference rather than trusting the snapshot taken
+          // before the await: the user may have picked a different startup
+          // project while this load was in flight, and clearing that newer
+          // choice because an older path turned out to be gone would be wrong.
+          const current = useDesktopSettingsStore.getState().desktopSettings;
+          if (current.startup.mode === "specific" && current.startup.projectPath === path) {
             useDesktopSettingsStore.getState().setDesktopSettings({
               ...current,
-              startup: { mode: "default", projectPath: null, projectName: null },
+              startup: DEFAULT_STARTUP_SETTINGS,
             });
           }
         }

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from "@geolibre/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { dataUrlParameters } from "../lib/data-url";
 import { isTauri } from "../lib/is-tauri";
 import { projectUrlFromLocation } from "../lib/project-url";
 import { openRecentProjectFile, RecentProjectGoneError } from "../lib/tauri-io";
@@ -15,15 +16,20 @@ export function useStartupProject(): string | null {
     if (!isTauri()) return;
     // Explicit launch payloads take precedence over the device default. Without
     // this guard, the startup read and a shared project deep link could race,
-    // with whichever request happened to finish last replacing the other. Defer
-    // to `projectUrlFromLocation` rather than naming query keys here, so this
-    // guard and `useProjectUrlLoader` can never disagree about what counts as an
-    // explicit project (it covers every key in `PROJECT_URL_PARAMS` plus a bare
-    // `?https://...` query).
-    const params = new URLSearchParams(window.location.search);
-    if (params.has("data") || projectUrlFromLocation() !== null) return;
+    // with whichever request happened to finish last replacing the other. Ask
+    // the loaders' own parsers rather than naming query keys here, so this guard
+    // can never disagree with them about what counts as an explicit payload:
+    // `projectUrlFromLocation` covers every key in `PROJECT_URL_PARAMS` plus a
+    // bare `?https://...` query, and `dataUrlParameters` only claims a `?data=`
+    // that is an absolute http(s) URL -- a malformed one leaves `useDataUrlLoader`
+    // a no-op, so yielding to it would strand the user on an empty workspace.
+    if (projectUrlFromLocation() !== null) return;
+    if (dataUrlParameters(window.location.search) !== null) return;
     const settings = useDesktopSettingsStore.getState().desktopSettings.startup;
     if (settings.mode === "default") return;
+    // Reads what `useRecentProjectsPersistence` hydrated from localStorage, so
+    // it must stay above this hook in `App.tsx` -- run first, "last project"
+    // mode would see an empty list and silently fall through to no-op.
     const recentProjects = useAppStore.getState().recentProjects;
     const path =
       settings.mode === "specific" ? settings.projectPath : (recentProjects[0]?.path ?? null);
@@ -31,10 +37,13 @@ export function useStartupProject(): string | null {
 
     let cancelled = false;
     let warningTimer: number | undefined;
+    // `cancelled` alone would leave a discarded run's read and XYZ probes in
+    // flight; the signal ends them, matching `useProjectUrlLoader`.
+    const abortController = new AbortController();
     void (async () => {
       try {
-        const result = await openRecentProjectFile(path);
-        const project = await resolveProjectXyzLayers(result.project);
+        const result = await openRecentProjectFile(path, abortController.signal);
+        const project = await resolveProjectXyzLayers(result.project, abortController.signal);
         if (!cancelled) useAppStore.getState().loadProject(project, result.path);
       } catch (error) {
         if (cancelled) return;
@@ -59,6 +68,7 @@ export function useStartupProject(): string | null {
     })();
     return () => {
       cancelled = true;
+      abortController.abort();
       if (warningTimer !== undefined) window.clearTimeout(warningTimer);
     };
     // Startup restoration is intentionally one-shot. In particular, changing

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -40,7 +40,11 @@ export function useStartupProject(): string | null {
     // reach the network and the shell is interactive throughout, so the user can
     // open their own project first; `loadProject` swaps the whole store with no
     // unsaved-work prompt, so a restore that lost that race must stand down.
-    const restoringOver = useAppStore.getState().projectPath;
+    // `projectGeneration` is the discriminator rather than `projectPath`, which
+    // File > New resets to the same `null` the app started on -- a restore
+    // landing after that would clobber the new project and look identical to
+    // landing on the untouched startup state.
+    const restoringOver = useAppStore.getState().projectGeneration;
 
     let cancelled = false;
     let warningTimer: number | undefined;
@@ -52,8 +56,10 @@ export function useStartupProject(): string | null {
         const result = await openRecentProjectFile(path, abortController.signal);
         const project = await resolveProjectXyzLayers(result.project, abortController.signal);
         if (cancelled) return;
-        const { projectPath, isDirty } = useAppStore.getState();
-        if (projectPath !== restoringOver || isDirty) return;
+        // `isDirty` too: editing the startup workspace in place (dropping a file
+        // on the map) leaves the generation untouched but is still work to keep.
+        const { projectGeneration, isDirty } = useAppStore.getState();
+        if (projectGeneration !== restoringOver || isDirty) return;
         useAppStore.getState().loadProject(project, result.path);
       } catch (error) {
         if (cancelled) return;

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -8,7 +8,7 @@ import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 export function useStartupProject(): string | null {
   const { t } = useTranslation();
-  const [warning, setWarning] = useState<string | null>(null);
+  const [hasWarning, setHasWarning] = useState(false);
 
   useEffect(() => {
     if (!isTauri()) return;
@@ -35,17 +35,27 @@ export function useStartupProject(): string | null {
         if (cancelled) return;
         if (error instanceof RecentProjectGoneError) {
           useAppStore.getState().forgetRecentProject(path);
+          if (settings.mode === "specific") {
+            const current = useDesktopSettingsStore.getState().desktopSettings;
+            useDesktopSettingsStore.getState().setDesktopSettings({
+              ...current,
+              startup: { mode: "default", projectPath: null, projectName: null },
+            });
+          }
         }
         console.warn("Could not restore the startup project.", error);
-        setWarning(t("settings.startup.loadWarning"));
-        warningTimer = window.setTimeout(() => setWarning(null), 8000);
+        setHasWarning(true);
+        warningTimer = window.setTimeout(() => setHasWarning(false), 8000);
       }
     })();
     return () => {
       cancelled = true;
       if (warningTimer !== undefined) window.clearTimeout(warningTimer);
     };
-  }, [t]);
+    // Startup restoration is intentionally one-shot. In particular, changing
+    // language must not reopen this project over the user's current workspace.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  return warning;
+  return hasWarning ? t("settings.startup.loadWarning") : null;
 }

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -1,0 +1,51 @@
+import { useAppStore } from "@geolibre/core";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { isTauri } from "../lib/is-tauri";
+import { openRecentProjectFile, RecentProjectGoneError } from "../lib/tauri-io";
+import { resolveProjectXyzLayers } from "../lib/xyz-url";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
+
+export function useStartupProject(): string | null {
+  const { t } = useTranslation();
+  const [warning, setWarning] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    // Explicit launch payloads take precedence over the device default. Without
+    // this guard, the startup read and a shared ?url= project could race, with
+    // whichever request happened to finish last replacing the other.
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("url") || params.has("data")) return;
+    const settings = useDesktopSettingsStore.getState().desktopSettings.startup;
+    if (settings.mode === "default") return;
+    const recentProjects = useAppStore.getState().recentProjects;
+    const path =
+      settings.mode === "specific" ? settings.projectPath : (recentProjects[0]?.path ?? null);
+    if (!path) return;
+
+    let cancelled = false;
+    let warningTimer: number | undefined;
+    void (async () => {
+      try {
+        const result = await openRecentProjectFile(path);
+        const project = await resolveProjectXyzLayers(result.project);
+        if (!cancelled) useAppStore.getState().loadProject(project, result.path);
+      } catch (error) {
+        if (cancelled) return;
+        if (error instanceof RecentProjectGoneError) {
+          useAppStore.getState().forgetRecentProject(path);
+        }
+        console.warn("Could not restore the startup project.", error);
+        setWarning(t("settings.startup.loadWarning"));
+        warningTimer = window.setTimeout(() => setWarning(null), 8000);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (warningTimer !== undefined) window.clearTimeout(warningTimer);
+    };
+  }, [t]);
+
+  return warning;
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1737,7 +1737,8 @@
       "geocoding": "Geocoding",
       "ai": "AI Providers",
       "environment": "Environment",
-      "updates": "Updates"
+      "updates": "Updates",
+      "startup": "Startup"
     },
     "menu": {
       "mapPreferences": "Map Preferences",
@@ -1764,6 +1765,23 @@
         "minor": "Major and minor releases only",
         "major": "Major releases only"
       }
+    },
+    "startup": {
+      "title": "Startup project",
+      "description": "Choose the workspace GeoLibre opens when the native app starts.",
+      "mode": {
+        "default": "Open the default workspace",
+        "last": "Reopen the last project",
+        "specific": "Open a specific project"
+      },
+      "modeHint": {
+        "default": "Start with a new, untitled project.",
+        "last": "Open the most recently used local project."
+      },
+      "chooseProject": "Choose Project",
+      "noProjectSelected": "No project selected",
+      "selectError": "The selected project could not be read.",
+      "loadWarning": "The startup project is unavailable. GeoLibre opened the default workspace instead."
     },
     "map": {
       "constraintsTitle": "Map constraints",

--- a/apps/geolibre-desktop/src/lib/startup-project.ts
+++ b/apps/geolibre-desktop/src/lib/startup-project.ts
@@ -1,0 +1,40 @@
+import type { StartupSettings } from "../hooks/useDesktopSettings";
+
+/**
+ * The subset of a recent-projects entry this module needs. Structural so the
+ * helper stays importable from a plain Node test without pulling in the store.
+ */
+interface RecentPath {
+  path: string;
+}
+
+function isRemotePath(path: string): boolean {
+  try {
+    const url = new URL(path);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    // Not a URL at all, so a local filesystem path.
+    return false;
+  }
+}
+
+/**
+ * The project a startup restore should open, or `null` when nothing applies.
+ *
+ * Lives here rather than in `useStartupProject` so it is reachable from a test
+ * without loading that hook's Tauri I/O dependencies.
+ */
+export function startupProjectPath(
+  settings: StartupSettings,
+  recentProjects: readonly RecentPath[],
+): string | null {
+  if (settings.mode === "default") return null;
+  if (settings.mode === "specific") return settings.projectPath;
+  // "Reopen the last project" is documented as the most recently used *local*
+  // project, so skip remote entries. Opening a share link also records it in
+  // `recentProjects` (by its `https://` URL, since `loadProject` remembers
+  // whatever path it was given), and replaying that on every launch would turn
+  // a startup preference into a background request to a third-party host --
+  // plus the failure banner on any launch where that host is unreachable.
+  return recentProjects.find((entry) => !isRemotePath(entry.path))?.path ?? null;
+}

--- a/tests/startup-project-settings.test.ts
+++ b/tests/startup-project-settings.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { normalizeDesktopSettings } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+import {
+  DEFAULT_STARTUP_SETTINGS,
+  normalizeDesktopSettings,
+} from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+import { startupProjectPath } from "../apps/geolibre-desktop/src/lib/startup-project";
 
 describe("startup project settings", () => {
   it("defaults to the normal untitled workspace", () => {
@@ -36,6 +40,68 @@ describe("startup project settings", () => {
     assert.equal(
       normalizeDesktopSettings({ startup: { mode: "tampered" } }).startup.mode,
       "default",
+    );
+  });
+});
+
+describe("startupProjectPath", () => {
+  const recent = (...paths: string[]) =>
+    paths.map((path) => ({ path, name: path, openedAt: "2026-01-01T00:00:00.000Z" }));
+
+  it("restores nothing in default mode", () => {
+    assert.equal(
+      startupProjectPath(DEFAULT_STARTUP_SETTINGS, recent("/tmp/a.geolibre.json")),
+      null,
+    );
+  });
+
+  it("uses the configured path in specific mode, ignoring recent projects", () => {
+    assert.equal(
+      startupProjectPath(
+        { mode: "specific", projectPath: "/tmp/pinned.geolibre.json", projectName: "Pinned" },
+        recent("/tmp/other.geolibre.json"),
+      ),
+      "/tmp/pinned.geolibre.json",
+    );
+  });
+
+  it("reopens the most recent project in last mode", () => {
+    assert.equal(
+      startupProjectPath(
+        { mode: "last", projectPath: null, projectName: null },
+        recent("/tmp/newest.geolibre.json", "/tmp/older.geolibre.json"),
+      ),
+      "/tmp/newest.geolibre.json",
+    );
+  });
+
+  it("skips remote share links so last mode stays a local, offline reopen", () => {
+    // Opening a share link records it in `recentProjects` by its URL. Replaying
+    // that on every launch would hit a third-party host at startup, which the
+    // setting's own copy ("most recently used local project") does not promise.
+    assert.equal(
+      startupProjectPath(
+        { mode: "last", projectPath: null, projectName: null },
+        recent("https://share.geolibre.app/p/abc", "/tmp/local.geolibre.json"),
+      ),
+      "/tmp/local.geolibre.json",
+    );
+  });
+
+  it("restores nothing when every recent project is remote", () => {
+    assert.equal(
+      startupProjectPath(
+        { mode: "last", projectPath: null, projectName: null },
+        recent("https://share.geolibre.app/p/abc"),
+      ),
+      null,
+    );
+  });
+
+  it("restores nothing in last mode with no history", () => {
+    assert.equal(
+      startupProjectPath({ mode: "last", projectPath: null, projectName: null }, []),
+      null,
     );
   });
 });

--- a/tests/startup-project-settings.test.ts
+++ b/tests/startup-project-settings.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { normalizeDesktopSettings } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+
+describe("startup project settings", () => {
+  it("defaults to the normal untitled workspace", () => {
+    assert.deepEqual(normalizeDesktopSettings({}).startup, {
+      mode: "default",
+      projectPath: null,
+      projectName: null,
+    });
+  });
+
+  it("normalizes a selected startup project", () => {
+    assert.deepEqual(
+      normalizeDesktopSettings({
+        startup: {
+          mode: "specific",
+          projectPath: " /tmp/field.geolibre.json ",
+          projectName: " Field ",
+        },
+      }).startup,
+      {
+        mode: "specific",
+        projectPath: "/tmp/field.geolibre.json",
+        projectName: "Field",
+      },
+    );
+  });
+
+  it("rejects a specific mode without a path and unknown modes", () => {
+    assert.equal(
+      normalizeDesktopSettings({ startup: { mode: "specific" } }).startup.mode,
+      "default",
+    );
+    assert.equal(
+      normalizeDesktopSettings({ startup: { mode: "tampered" } }).startup.mode,
+      "default",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a native-only Startup settings section
- support the default workspace, reopening the latest project, or selecting a fixed startup project
- fall back safely with a brief warning when the configured project is unavailable
- keep explicit URL/data launch payloads ahead of the saved startup preference

## Verification

- production build
- frontend test suite (5,593 passed, 1 skipped)
- focused startup settings tests
- pre-commit hooks
- Playwright verification in light and dark themes

Fixes #1809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop startup options to open the default project, the most recently used project, or a selected project.
  * Added project selection through the file picker with localized error messages.
  * Startup preferences are saved and restored across launches.
  * Displays a notification when the configured startup project cannot be loaded.
* **Bug Fixes**
  * Invalid or incomplete startup settings now safely fall back to the default project.
  * Missing recent projects are automatically removed from the startup history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->