### PR TITLE
Show camera altitude ("Eye alt") in the status bar (#1816)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import { FEET_PER_METER, useAppStore, type MapScaleUnit } from "@geolibre/core";
+import {
+  FEET_PER_METER,
+  formatCameraAltitude,
+  useAppStore,
+  type MapScaleUnit,
+} from "@geolibre/core";
 import { cn } from "@geolibre/ui";
 import { Bug } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -34,6 +39,7 @@ export function StatusBar({
   const { t } = useTranslation();
   const pointerCoords = useAppStore((s) => s.pointerCoords);
   const pointerElevation = useAppStore((s) => s.pointerElevation);
+  const cameraAltitude = useAppStore((s) => s.cameraAltitude);
   const scaleUnit = useAppStore((s) => s.preferences.map.scaleUnit);
   const gpsStatus = useAppStore((s) => s.gpsStatus);
   const mapView = useAppStore((s) => s.mapView);
@@ -75,6 +81,12 @@ export function StatusBar({
   const elevationText =
     pointerElevation !== null ? formatPointerElevation(pointerElevation, scaleUnit) : null;
 
+  // Google Earth Pro's "Eye alt": how high the camera is, as opposed to how
+  // high the ground under the cursor is. Sits beside Zoom because it answers
+  // the same question in a unit a person can actually reason about.
+  const altitudeText =
+    cameraAltitude !== null ? formatCameraAltitude(cameraAltitude, scaleUnit) : null;
+
   const bboxText = mapView.bbox ? mapView.bbox.map((n) => n.toFixed(4)).join(", ") : "—";
 
   return (
@@ -94,6 +106,11 @@ export function StatusBar({
       )}
       {gpsText && <span className="shrink-0">GPS: {gpsText}</span>}
       <span className="shrink-0">Zoom: {mapView.zoom.toFixed(2)}</span>
+      {altitudeText && (
+        <span className="shrink-0" title={t("statusBar.cameraAltitudeLong")}>
+          {t("statusBar.cameraAltitude")}: {altitudeText}
+        </span>
+      )}
       <span className="shrink-0">Bearing: {mapView.bearing.toFixed(1)}°</span>
       <span className="shrink-0">Pitch: {mapView.pitch.toFixed(1)}°</span>
       {compact ? null : <span className="min-w-0 flex-1 truncate">BBox: {bboxText}</span>}

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -196,7 +196,9 @@
   },
   "statusBar": {
     "elevation": "ارتفاع",
-    "elevationLong": "الارتفاع"
+    "elevationLong": "الارتفاع",
+    "cameraAltitude": "ارتفاع الرؤية",
+    "cameraAltitudeLong": "ارتفاع الكاميرا فوق مستوى سطح البحر"
   },
   "fileNamePrompt": {
     "title": "حفظ الملف باسم",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Höhe",
-    "elevationLong": "Höhe"
+    "elevationLong": "Höhe",
+    "cameraAltitude": "Kamerahöhe",
+    "cameraAltitudeLong": "Kamerahöhe über dem Meeresspiegel"
   },
   "fileNamePrompt": {
     "title": "Datei speichern unter",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Elev",
-    "elevationLong": "Elevation"
+    "elevationLong": "Elevation",
+    "cameraAltitude": "Eye alt",
+    "cameraAltitudeLong": "Camera altitude above sea level"
   },
   "fileNamePrompt": {
     "title": "Save file as",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Elev",
-    "elevationLong": "Elevación"
+    "elevationLong": "Elevación",
+    "cameraAltitude": "Alt. cámara",
+    "cameraAltitudeLong": "Altitud de la cámara sobre el nivel del mar"
   },
   "fileNamePrompt": {
     "title": "Guardar archivo como",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "ارتفاع",
-    "elevationLong": "ارتفاع"
+    "elevationLong": "ارتفاع",
+    "cameraAltitude": "ارتفاع دید",
+    "cameraAltitudeLong": "ارتفاع دوربین از سطح دریا"
   },
   "fileNamePrompt": {
     "title": "ذخیرهٔ فایل با نام",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Alt",
-    "elevationLong": "Altitude"
+    "elevationLong": "Altitude",
+    "cameraAltitude": "Alt. caméra",
+    "cameraAltitudeLong": "Altitude de la caméra au-dessus du niveau de la mer"
   },
   "fileNamePrompt": {
     "title": "Enregistrer le fichier sous",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "ऊँचाई",
-    "elevationLong": "ऊँचाई"
+    "elevationLong": "ऊँचाई",
+    "cameraAltitude": "दृष्टि ऊँचाई",
+    "cameraAltitudeLong": "समुद्र तल से कैमरे की ऊँचाई"
   },
   "fileNamePrompt": {
     "title": "फ़ाइल को इस रूप में सहेजें",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -186,7 +186,9 @@
   },
   "statusBar": {
     "elevation": "Elev",
-    "elevationLong": "Elevasi"
+    "elevationLong": "Elevasi",
+    "cameraAltitude": "Alt. kamera",
+    "cameraAltitudeLong": "Ketinggian kamera di atas permukaan laut"
   },
   "fileNamePrompt": {
     "title": "Simpan file sebagai",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Quota",
-    "elevationLong": "Quota"
+    "elevationLong": "Quota",
+    "cameraAltitude": "Quota vista",
+    "cameraAltitudeLong": "Quota della camera sul livello del mare"
   },
   "fileNamePrompt": {
     "title": "Salva file con nome",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -186,7 +186,9 @@
   },
   "statusBar": {
     "elevation": "標高",
-    "elevationLong": "標高"
+    "elevationLong": "標高",
+    "cameraAltitude": "視点高度",
+    "cameraAltitudeLong": "海面からのカメラ高度"
   },
   "fileNamePrompt": {
     "title": "名前を付けて保存",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "სიმაღლე",
-    "elevationLong": "სიმაღლე"
+    "elevationLong": "სიმაღლე",
+    "cameraAltitude": "კამერის სიმაღლე",
+    "cameraAltitudeLong": "კამერის სიმაღლე ზღვის დონიდან"
   },
   "fileNamePrompt": {
     "title": "ფაილის შენახვა როგორც",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -186,7 +186,9 @@
   },
   "statusBar": {
     "elevation": "고도",
-    "elevationLong": "고도"
+    "elevationLong": "고도",
+    "cameraAltitude": "시점 고도",
+    "cameraAltitudeLong": "해수면 기준 카메라 고도"
   },
   "fileNamePrompt": {
     "title": "다른 이름으로 저장",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Hoogte",
-    "elevationLong": "Hoogte"
+    "elevationLong": "Hoogte",
+    "cameraAltitude": "Camerahoogte",
+    "cameraAltitudeLong": "Camerahoogte boven zeeniveau"
   },
   "fileNamePrompt": {
     "title": "Bestand opslaan als",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Elev",
-    "elevationLong": "Elevação"
+    "elevationLong": "Elevação",
+    "cameraAltitude": "Alt. câmara",
+    "cameraAltitudeLong": "Altitude da câmara acima do nível do mar"
   },
   "fileNamePrompt": {
     "title": "Salvar arquivo como",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -192,7 +192,9 @@
   },
   "statusBar": {
     "elevation": "Выс",
-    "elevationLong": "Высота"
+    "elevationLong": "Высота",
+    "cameraAltitude": "Выс. камеры",
+    "cameraAltitudeLong": "Высота камеры над уровнем моря"
   },
   "fileNamePrompt": {
     "title": "Сохранить файл как",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -186,7 +186,9 @@
   },
   "statusBar": {
     "elevation": "ระดับ",
-    "elevationLong": "ระดับความสูง"
+    "elevationLong": "ระดับความสูง",
+    "cameraAltitude": "ระดับมุมมอง",
+    "cameraAltitudeLong": "ระดับความสูงของกล้องเหนือระดับน้ำทะเล"
   },
   "fileNamePrompt": {
     "title": "บันทึกไฟล์เป็น",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -188,7 +188,9 @@
   },
   "statusBar": {
     "elevation": "Rakım",
-    "elevationLong": "Yükseklik"
+    "elevationLong": "Yükseklik",
+    "cameraAltitude": "Kamera rakımı",
+    "cameraAltitudeLong": "Deniz seviyesinden kamera yüksekliği"
   },
   "fileNamePrompt": {
     "title": "Dosyayı farklı kaydet",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -186,7 +186,9 @@
   },
   "statusBar": {
     "elevation": "高程",
-    "elevationLong": "高程"
+    "elevationLong": "高程",
+    "cameraAltitude": "视点高度",
+    "cameraAltitudeLong": "相机海拔高度"
   },
   "fileNamePrompt": {
     "title": "文件另存为",

--- a/packages/core/src/camera-altitude.ts
+++ b/packages/core/src/camera-altitude.ts
@@ -1,0 +1,57 @@
+/**
+ * Camera altitude ("Eye alt") for the status bar — issue #1816.
+ *
+ * MapLibre's `transform.getCameraAltitude()` returns the camera height above
+ * sea level in metres, which is exactly what Google Earth Pro's `Eye alt`
+ * reports. But it derives that height from the Web-Mercator scale, which is
+ * built on Earth's radius — so on a Moon / Mars / Mercury basemap it is wrong by
+ * the ratio of that body's circumference to Earth's, the same way MapLibre's
+ * built-in ScaleControl is (see `PlanetaryScaleControl`, which fixes the
+ * horizontal case).
+ *
+ * {@link scaleAltitudeToActiveBody} applies the matching correction so the
+ * readout is right on every body, using the same active-ellipsoid singleton the
+ * scale bar and the measurement tools read.
+ */
+
+import { getActiveMeanRadiusMeters, getEllipsoid, meanRadiusMeters } from "./ellipsoids";
+import { scaleDenomination } from "./scale-units";
+import type { MapScaleUnit } from "./types";
+
+/** Earth's mean radius — the radius MapLibre's Mercator maths assumes. */
+const EARTH_MEAN_RADIUS_METERS = meanRadiusMeters(getEllipsoid("earth"));
+
+/**
+ * Convert a MapLibre camera altitude (computed against Earth's radius) into the
+ * active body's true altitude. A no-op on Earth.
+ *
+ * @param earthAltitudeMeters Altitude in metres as MapLibre reports it
+ * @returns Altitude in metres above the active body's datum, or null when the
+ *   input is not a usable number (no map, degenerate transform, globe edge case)
+ */
+export function scaleAltitudeToActiveBody(earthAltitudeMeters: number | null): number | null {
+  if (earthAltitudeMeters === null || !Number.isFinite(earthAltitudeMeters)) return null;
+  return earthAltitudeMeters * (getActiveMeanRadiusMeters() / EARTH_MEAN_RADIUS_METERS);
+}
+
+/**
+ * Format a camera altitude for the status bar.
+ *
+ * Altitude spans metres (standing on a ridge) to tens of thousands of
+ * kilometres (whole-globe view), so it borrows the scale bar's denomination
+ * switching rather than printing "12,742,000 m". Metric crosses to km past
+ * 1 km, imperial to miles past a mile, and nautical stays in nautical miles —
+ * the same thresholds {@link scaleDenomination} gives the scale bar, so the two
+ * always agree about which unit this view is being described in.
+ */
+export function formatCameraAltitude(meters: number, unit: MapScaleUnit): string {
+  const { metersPerUnit, label } = scaleDenomination(Math.abs(meters), unit);
+  const value = meters / metersPerUnit;
+  // Sub-unit and single-digit values need a decimal to say anything; past that
+  // the extra digit is noise on a number that moves with every zoom step.
+  const digits = Math.abs(value) < 10 ? 1 : 0;
+  return `${value.toLocaleString(undefined, {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })} ${label}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from "./virtual-fields";
 export * from "./selection";
 export * from "./scale-units";
 export * from "./elevation";
+export * from "./camera-altitude";
 export * from "./project";
 export * from "./style-library";
 export * from "./layer-library";

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -2225,11 +2225,13 @@ export const useAppStore = create<AppState>()(
           // The copied style names a layer from the previous project, so a
           // paste in the loaded one would apply an orphaned entry.
           copiedLayerStyle: null,
-          // Ephemeral pointer readouts describe the previous project's map. The
-          // elevation especially: a project that switches to a planetary body
-          // would otherwise keep showing an Earth height until the next hover.
+          // Ephemeral readouts describe the previous project's map. The
+          // elevation and altitude especially: a project that switches to a
+          // planetary body would otherwise keep showing Earth-scaled values
+          // until the next hover or camera move.
           pointerCoords: null,
           pointerElevation: null,
+          cameraAltitude: null,
           // Present a bundled story on load; otherwise drop any presentation
           // carried over from the previous project.
           ui: {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -270,6 +270,14 @@ export interface AppState {
    * which owns the map instance the terrain sample comes from.
    */
   pointerElevation: number | null;
+  /**
+   * Camera height above sea level in metres — Google Earth Pro's "Eye alt"
+   * (issue #1816). Derived from the camera, so deliberately *not* part of
+   * `mapView`: that shape is persisted into the project file, and a stored
+   * altitude could only drift from the center/zoom/pitch it is computed from.
+   * Null before the map loads, or when MapLibre cannot report it.
+   */
+  cameraAltitude: number | null;
   /** Live GPS fix for the status bar, or null while GPS tracking is off. */
   gpsStatus: GpsStatusFix | null;
   /** Anchored review comments on map points or features (issue #1518). */
@@ -351,6 +359,7 @@ export interface AppState {
 
   setPointerCoords: (coords: [number, number] | null) => void;
   setPointerElevation: (elevation: number | null) => void;
+  setCameraAltitude: (altitude: number | null) => void;
   setGpsStatus: (fix: GpsStatusFix | null) => void;
   setCollaboration: (patch: Partial<CollaborationState>) => void;
   updateCollaborationPresence: (clientId: string, presence: CollaborationPresence | null) => void;
@@ -990,6 +999,7 @@ export const useAppStore = create<AppState>()(
       identifyLayerId: null,
       pointerCoords: null,
       pointerElevation: null,
+      cameraAltitude: null,
       gpsStatus: null,
       comments: [],
       metadata: {},
@@ -1036,6 +1046,7 @@ export const useAppStore = create<AppState>()(
       setPointerCoords: (coords) =>
         set(coords ? { pointerCoords: coords } : { pointerCoords: null, pointerElevation: null }),
       setPointerElevation: (elevation) => set({ pointerElevation: elevation }),
+      setCameraAltitude: (altitude) => set({ cameraAltitude: altitude }),
       setGpsStatus: (fix) => set({ gpsStatus: fix }),
 
       addComment: (comment) =>
@@ -2162,6 +2173,7 @@ export const useAppStore = create<AppState>()(
           copiedLayerStyle: null,
           pointerCoords: null,
           pointerElevation: null,
+          cameraAltitude: null,
           attributeFilter: "",
           // Don't carry an active story presentation into a different project.
           ui: {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1271,6 +1271,15 @@ export const MapCanvas = memo(function MapCanvas({
       onControllerReadyRef.current?.();
     });
     controller.current?.setStyle(basemapStyleUrl);
+    // Switching the active body without moving the camera -- the planet switcher
+    // or a different planetary basemap -- changes the radius the altitude is
+    // scaled by, but fires no moveend, so the readout would keep the previous
+    // body's number until the next pan. Mirrors how setStyle refreshes the
+    // scale bar for the same reason.
+    setCameraAltitude(controller.current?.readCameraAltitude() ?? null);
+    // setCameraAltitude is a stable store action; the effect is keyed on the
+    // basemap alone so it does not re-run on unrelated store changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [basemapStyleUrl]);
 
   useEffect(() => {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1065,6 +1065,7 @@ export const MapCanvas = memo(function MapCanvas({
   const setMapView = useAppStore((s) => s.setMapView);
   const setPointerCoords = useAppStore((s) => s.setPointerCoords);
   const setPointerElevation = useAppStore((s) => s.setPointerElevation);
+  const setCameraAltitude = useAppStore((s) => s.setCameraAltitude);
   const showPointerElevation = useAppStore((s) => s.preferences.map.showPointerElevation);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const pointerElevationRef = useRef<PointerElevationResolver | null>(null);
@@ -1161,6 +1162,9 @@ export const MapCanvas = memo(function MapCanvas({
       // overwrite the project's saved view ~60 times a second.
       if (event?.flightCameraToken !== undefined) return;
       setMapView(mc.readView(), Boolean(event?.originalEvent));
+      // Same moveend cadence as zoom/bearing/pitch: a bar where one number is
+      // live and the rest lag during a drag reads as broken.
+      setCameraAltitude(mc.readCameraAltitude());
     };
     map.on("moveend", updateView);
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_PROJECT_PREFERENCES,
   getPlanetaryBasemapByStyleUrl,
   PLANETARY_BASEMAP_SENTINEL_PREFIX,
+  scaleAltitudeToActiveBody,
   useAppStore,
 } from "@geolibre/core";
 import type {
@@ -1069,6 +1070,25 @@ export class MapController {
       pitch: this.map.getPitch(),
       bbox: [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()],
     };
+  }
+
+  /**
+   * The camera's height above sea level in metres — Google Earth Pro's
+   * "Eye alt" (issue #1816). Corrected for the active body, since MapLibre
+   * computes it from the Earth-based Mercator scale.
+   *
+   * `transform` is public on the Map but `getCameraAltitude` is a newer
+   * addition, so it is probed defensively: a MapLibre bump that drops or
+   * renames it should blank the readout, not throw inside a `moveend` handler.
+   */
+  readCameraAltitude(): number | null {
+    const transform = this.map?.transform as { getCameraAltitude?: () => number } | undefined;
+    if (typeof transform?.getCameraAltitude !== "function") return null;
+    try {
+      return scaleAltitudeToActiveBody(transform.getCameraAltitude());
+    } catch {
+      return null;
+    }
   }
 
   syncLayers(layers: GeoLibreLayer[]): void {

--- a/tests/camera-altitude.test.ts
+++ b/tests/camera-altitude.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the status bar's camera altitude readout (issue #1816).
+ *
+ * Two things are easy to get wrong and both are covered here: MapLibre reports
+ * altitude against Earth's radius even on a planetary basemap, and the readout
+ * has to switch denomination across the ~7 orders of magnitude between standing
+ * on a ridge and viewing the whole globe.
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  formatCameraAltitude,
+  scaleAltitudeToActiveBody,
+} from "../packages/core/src/camera-altitude";
+import { setActiveEllipsoidId } from "../packages/core/src/ellipsoids";
+
+afterEach(() => setActiveEllipsoidId("earth"));
+
+describe("scaleAltitudeToActiveBody", () => {
+  it("passes altitude through unchanged on Earth", () => {
+    setActiveEllipsoidId("earth");
+    assert.equal(scaleAltitudeToActiveBody(4200), 4200);
+  });
+
+  it("scales down on the Moon, whose radius is ~3.7x smaller", () => {
+    setActiveEllipsoidId("moon");
+    const scaled = scaleAltitudeToActiveBody(10000);
+    assert.ok(scaled !== null);
+    // Moon mean radius 1_737_400 m / Earth mean radius ~6_371_009 m ≈ 0.2727.
+    assert.ok(
+      Math.abs(scaled - 10000 * 0.2727) < 20,
+      `expected ~2727 m on the Moon, got ${scaled}`,
+    );
+  });
+
+  it("scales on Mars", () => {
+    setActiveEllipsoidId("mars");
+    const scaled = scaleAltitudeToActiveBody(10000);
+    assert.ok(scaled !== null && scaled > 5200 && scaled < 5400, `got ${scaled}`);
+  });
+
+  it("returns null for a value MapLibre could not produce", () => {
+    assert.equal(scaleAltitudeToActiveBody(null), null);
+    assert.equal(scaleAltitudeToActiveBody(Number.NaN), null);
+    assert.equal(scaleAltitudeToActiveBody(Number.POSITIVE_INFINITY), null);
+  });
+});
+
+describe("formatCameraAltitude", () => {
+  it("stays in metres below a kilometre", () => {
+    assert.match(formatCameraAltitude(420, "metric"), /^420 m$/);
+  });
+
+  it("crosses to kilometres past a kilometre", () => {
+    assert.match(formatCameraAltitude(12_742_000, "metric"), /km$/);
+  });
+
+  it("uses feet then miles for imperial", () => {
+    assert.match(formatCameraAltitude(300, "imperial"), /ft$/);
+    assert.match(formatCameraAltitude(50_000, "imperial"), /mi$/);
+  });
+
+  it("uses nautical miles for nautical", () => {
+    assert.match(formatCameraAltitude(50_000, "nautical"), /nmi$/);
+  });
+
+  it("keeps a decimal only while the number is small enough to need one", () => {
+    // 1500 m -> 1.5 km reads usefully; 12742 km -> a decimal would be noise.
+    assert.match(formatCameraAltitude(1500, "metric"), /1\.5 km/);
+    assert.ok(!/\./.test(formatCameraAltitude(12_742_000, "metric")));
+  });
+
+  it("agrees with the scale bar about which unit describes this view", () => {
+    // Both read from scaleDenomination, so a span that labels the scale bar in
+    // km must not label the altitude in m.
+    assert.match(formatCameraAltitude(999, "metric"), / m$/);
+    assert.match(formatCameraAltitude(1001, "metric"), / km$/);
+  });
+});

--- a/tests/camera-altitude.test.ts
+++ b/tests/camera-altitude.test.ts
@@ -12,8 +12,8 @@ import { afterEach, describe, it } from "node:test";
 import {
   formatCameraAltitude,
   scaleAltitudeToActiveBody,
-} from "../packages/core/src/camera-altitude";
-import { setActiveEllipsoidId } from "../packages/core/src/ellipsoids";
+  setActiveEllipsoidId,
+} from "@geolibre/core";
 
 afterEach(() => setActiveEllipsoidId("earth"));
 

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import maplibregl from "maplibre-gl";
 import {
   DEFAULT_LAYER_STYLE,
@@ -734,6 +734,11 @@ describe("MapController basemap controls", () => {
 });
 
 describe("MapController camera and query helpers", () => {
+  // setActiveEllipsoidId writes a module-level singleton, so reset it here
+  // rather than inline: an inline reset after an assertion never runs when that
+  // assertion fails, silently leaving a non-Earth body active for later tests.
+  afterEach(() => setActiveEllipsoidId("earth"));
+
   // The defensive probe in readCameraAltitude exists precisely because a
   // MapLibre bump could drop or rename transform.getCameraAltitude; without
   // these cases that fallback was never exercised (the fake map has no
@@ -755,7 +760,6 @@ describe("MapController camera and query helpers", () => {
     setActiveEllipsoidId("moon");
     const onMoon = controller.readCameraAltitude();
     assert.ok(onMoon !== null && onMoon < 3000, `expected a scaled altitude, got ${onMoon}`);
-    setActiveEllipsoidId("earth");
   });
 
   it("returns no camera altitude when MapLibre throws", () => {
@@ -779,7 +783,6 @@ describe("MapController camera and query helpers", () => {
     const onEarth = controller.readCameraAltitude();
     setActiveEllipsoidId("mars");
     const onMars = controller.readCameraAltitude();
-    setActiveEllipsoidId("earth");
     assert.ok(onEarth !== null && onMars !== null);
     assert.ok(onMars < onEarth, `Mars altitude should be smaller: ${onMars} vs ${onEarth}`);
   });

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -769,6 +769,21 @@ describe("MapController camera and query helpers", () => {
     assert.equal(controller.readCameraAltitude(), null);
   });
 
+  it("rescales a held altitude when only the body changes", () => {
+    // The planet switcher changes the active body without moving the camera, so
+    // the same MapLibre altitude must read differently for the new radius.
+    const { map } = makeFakeMap();
+    (map as { transform?: unknown }).transform = { getCameraAltitude: () => 10000 };
+    const controller = controllerWith(map);
+    setActiveEllipsoidId("earth");
+    const onEarth = controller.readCameraAltitude();
+    setActiveEllipsoidId("mars");
+    const onMars = controller.readCameraAltitude();
+    setActiveEllipsoidId("earth");
+    assert.ok(onEarth !== null && onMars !== null);
+    assert.ok(onMars < onEarth, `Mars altitude should be smaller: ${onMars} vs ${onEarth}`);
+  });
+
   it("reads the current view from the map", () => {
     const { map } = makeFakeMap();
     const controller = controllerWith(map);

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import maplibregl from "maplibre-gl";
-import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, type LayerStyle } from "@geolibre/core";
+import {
+  DEFAULT_LAYER_STYLE,
+  setActiveEllipsoidId,
+  type GeoLibreLayer,
+  type LayerStyle,
+} from "@geolibre/core";
 import { createMapController, MapController } from "../packages/map/src/map-controller";
 
 // Internal shape of MapController we reach into to inject a fake map. The
@@ -729,6 +734,41 @@ describe("MapController basemap controls", () => {
 });
 
 describe("MapController camera and query helpers", () => {
+  // The defensive probe in readCameraAltitude exists precisely because a
+  // MapLibre bump could drop or rename transform.getCameraAltitude; without
+  // these cases that fallback was never exercised (the fake map has no
+  // transform at all, so every other test hit the null path by accident).
+  it("returns no camera altitude when MapLibre does not expose one", () => {
+    const { map } = makeFakeMap();
+    const controller = controllerWith(map);
+    assert.equal(controller.readCameraAltitude(), null);
+  });
+
+  it("reads and body-scales the camera altitude when MapLibre exposes it", () => {
+    const { map } = makeFakeMap();
+    (map as { transform?: unknown }).transform = { getCameraAltitude: () => 8000 };
+    const controller = controllerWith(map);
+    setActiveEllipsoidId("earth");
+    assert.equal(controller.readCameraAltitude(), 8000);
+
+    // On a smaller body the Mercator-derived altitude must scale down.
+    setActiveEllipsoidId("moon");
+    const onMoon = controller.readCameraAltitude();
+    assert.ok(onMoon !== null && onMoon < 3000, `expected a scaled altitude, got ${onMoon}`);
+    setActiveEllipsoidId("earth");
+  });
+
+  it("returns no camera altitude when MapLibre throws", () => {
+    const { map } = makeFakeMap();
+    (map as { transform?: unknown }).transform = {
+      getCameraAltitude: () => {
+        throw new Error("degenerate transform");
+      },
+    };
+    const controller = controllerWith(map);
+    assert.equal(controller.readCameraAltitude(), null);
+  });
+
   it("reads the current view from the map", () => {
     const { map } = makeFakeMap();
     const controller = controllerWith(map);


### PR DESCRIPTION
Closes #1816.

> **Stacked on #1820** (G1). Review that first; this branch is based on it, so the diff here is only the altitude work.

The status bar reported `Zoom: 14.32` — a tile-pyramid level, not a physical quantity. An instruction like "position the view about 4,100 feet above the terrain" had nothing to aim at.

## Getting the altitude

The issue suggested `getFreeCameraOptions().position.toAltitude()`, but that is a **Mapbox** API added after the fork — MapLibre has no such method (`flight-simulator.ts` already documents this). MapLibre's equivalent is `transform.getCameraAltitude()`, documented as *"the altitude of the camera above the sea level in meters"*, which is exactly what Google Earth Pro's Eye alt reports.

`map.transform` is public and typed, but `getCameraAltitude` is a newer addition, so it is probed defensively — a MapLibre bump that renames it should blank the readout, not throw inside a `moveend` handler.

## The planetary correction

This is the part that would have been a silent bug. `getCameraAltitude()` derives the height from the Web-Mercator scale, which is built on **Earth's** radius — so on a Moon, Mars, or Mercury basemap it is wrong by the ratio of that body's circumference to Earth's.

That is the same bug class `PlanetaryScaleControl` exists to fix for the horizontal case ("MapLibre's built-in ScaleControl … on a Moon / Mars / Mercury basemap it is wrong by the ratio … the Moon reads ~3.7× too far"). `scaleAltitudeToActiveBody` applies the matching correction from the same active-ellipsoid singleton the scale bar and measurement tools read, so the readout is right on every body.

## Formatting

Altitude spans metres (standing on a ridge) to tens of thousands of kilometres (whole-globe view), so it borrows the scale bar's `scaleDenomination` rather than printing `12,742,000 m`. Both read from the same function, so the scale bar and the altitude readout can never disagree about which unit describes the current view. A decimal is kept only while the number is small enough to need one.

## Two deliberate design calls

**Not in `MapViewState`.** That shape is persisted into the project file, and altitude is fully derivable from center + zoom + pitch + viewport — storing it could only create state that drifts from what it is computed from. It lives beside `pointerCoords` as ephemeral store state instead.

**`moveend` cadence, not live.** Zoom, bearing, and pitch all update on `moveend` today. Making altitude alone live would leave one number moving while three lag during a drag, which reads as broken. The value settles the instant the interaction ends. Easy to revisit if live feedback proves more valuable than consistency.

## Tests

`tests/camera-altitude.test.ts`, 10 cases — the Moon/Mars scaling (the part that would otherwise ship wrong and unnoticed), the null guards, denomination crossings for all three unit systems, and an explicit check that the altitude and scale bar agree on units either side of the 1 km boundary.

Full suite: 5617 pass, 0 fail. `npm run typecheck` and scoped `pre-commit` clean.

## Correction to the issue

The issue speculated that showing height **above terrain** would need #1813's elevation resolver. It turns out not to: MapLibre exposes `getCameraTargetElevation()` directly, so a terrain-relative variant would need no network lookup either. This PR ships the above-sea-level reading regardless, since that is what GEP's Eye alt actually is and what instructional material references.

## i18n

`statusBar.cameraAltitude` / `cameraAltitudeLong` in all 18 catalogs, translated as the concept (camera/viewpoint height) rather than transliterating "eye" — `Alt. caméra` (fr), `视点高度` (zh), `Выс. камеры` (ru), `Kamerahöhe` (de).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera altitude to the map status bar alongside zoom.
  * Camera altitude is automatically adjusted for Earth, Moon, and Mars and displayed using the selected map units.
  * Added localized camera-altitude labels across supported languages.
* **Bug Fixes**
  * Camera altitude now refreshes after map movement and basemap changes.
  * Stale altitude readings are cleared when loading or starting a project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->