### PR TITLE
Do not flag embedded deck.gl rows as unloadable in the share-readiness check

### DIFF
--- a/apps/geolibre-desktop/src/lib/share-readiness.ts
+++ b/apps/geolibre-desktop/src/lib/share-readiness.ts
@@ -377,7 +377,12 @@ function carriesOwnData(layer: GeoLibreLayer, embeddedLayerIds?: ReadonlySet<str
   if (layer.geojson) return true;
   const metadata = layer.metadata ?? {};
   if (metadata.embeddedGeoJSON) return true;
-  return isPlainObject((layer.source ?? {}).data);
+  const data = (layer.source ?? {}).data;
+  // An object is an inline GeoJSON payload; an array is the row set a
+  // non-GeoJSON deck.gl visualization (arc, heatmap, hexagon built from a CSV)
+  // keeps in `source.data`. Both travel inside the project file. Only a *string*
+  // `data` is a URL, and that is a reference like any other.
+  return isPlainObject(data) || Array.isArray(data);
 }
 
 /**
@@ -513,8 +518,22 @@ async function probeTarget(
     if (!RETRY_WITH_RANGED_GET.has(head.status)) return outcomeForStatus(head.status);
     // Plenty of object stores and CDNs refuse HEAD while serving GET happily,
     // so a one-byte ranged GET decides it rather than a false "needs a login".
-    const ranged = await request("GET");
-    return outcomeForStatus(ranged.status);
+    try {
+      const ranged = await request("GET");
+      return outcomeForStatus(ranged.status);
+    } catch (error) {
+      const failure = classifyFetchFailure(error);
+      if (failure.kind === "abort") return { status: "unchecked", reason: "aborted" };
+      if (failure.kind === "timeout") return { status: "unchecked", reason: "timeout" };
+      // The HEAD already proved the host answers and lets this origin read the
+      // response, so a rejection here is about the ranged request rather than
+      // the host. `Range` is CORS-safelisted only for a simple byte range, and
+      // an older webview may preflight it and get no matching
+      // `Access-Control-Allow-Headers` back, even though the plain GET a
+      // renderer issues would succeed. Fall back to what HEAD said instead of
+      // reporting a working host as unreachable.
+      return outcomeForStatus(head.status);
+    }
   } catch (error) {
     const failure = classifyFetchFailure(error);
     if (failure.kind === "abort") return { status: "unchecked", reason: "aborted" };

--- a/tests/share-readiness.test.ts
+++ b/tests/share-readiness.test.ts
@@ -194,6 +194,23 @@ describe("collectShareSources", () => {
     assert.equal(refs[0].probeUrl, "https://tiles.example.com/tileset.json");
   });
 
+  it("skips a deck.gl visualization whose rows are inlined as an array", () => {
+    const refs = collectShareSources({
+      layers: [
+        layer({
+          id: "a",
+          name: "Arcs from CSV",
+          type: "deckgl-viz",
+          source: { type: "deckgl-viz", data: [{ lat: 1, lon: 2 }] },
+          // Set when the layer is built from a local file, and not a reference
+          // a recipient needs: the rows travel in `source.data`.
+          sourcePath: "/home/me/flows.csv",
+        }),
+      ],
+    });
+    assert.deepEqual(refs, []);
+  });
+
   it("reports a query-backed layer that names no reference at all", () => {
     const refs = collectShareSources({
       layers: [
@@ -330,6 +347,38 @@ describe("probeShareSources", () => {
       { method: "HEAD", range: undefined },
       { method: "GET", range: "bytes=0-0" },
     ]);
+  });
+
+  it("falls back to the HEAD verdict when only the ranged GET is rejected", async () => {
+    const refs = collectShareSources({
+      layers: [
+        layer({ id: "a", name: "A", type: "cog", source: { url: "https://s3.example.com/a.tif" } }),
+      ],
+    });
+    // HEAD answers 405, so the host is up and readable cross-origin; the ranged
+    // GET is rejected on its own (an older webview preflighting `Range`). That
+    // must not turn a working host into a "blocked" verdict.
+    const fn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "HEAD") return new Response(null, { status: 405 });
+      throw new TypeError("Failed to fetch");
+    }) as unknown as typeof fetch;
+    const { refs: probed } = await probeShareSources(refs, { fetchImpl: fn });
+    assert.equal(probed[0].status, "reachable");
+  });
+
+  it("keeps a HEAD 403 credentialed when the ranged GET is also rejected", async () => {
+    const refs = collectShareSources({
+      layers: [
+        layer({ id: "a", name: "A", type: "cog", source: { url: "https://s3.example.com/a.tif" } }),
+      ],
+    });
+    const fn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "HEAD") return new Response(null, { status: 403 });
+      throw new TypeError("Failed to fetch");
+    }) as unknown as typeof fetch;
+    const { refs: probed } = await probeShareSources(refs, { fetchImpl: fn });
+    assert.equal(probed[0].status, "credentialed");
+    assert.equal(probed[0].reason, "auth-required");
   });
 
   it("reads an opaque browser rejection as browser-blocked", async () => {

--- a/tests/share-readiness.test.ts
+++ b/tests/share-readiness.test.ts
@@ -45,6 +45,23 @@ function fakeFetch(routes: Record<string, number | Error>) {
   return { fn, calls };
 }
 
+/**
+ * Answers HEAD with `headStatus` and rejects the ranged GET, recording both
+ * attempts so a test can prove the retry actually ran.
+ */
+function rejectingRangedGet(headStatus: number) {
+  const attempts: { method?: string; range?: string }[] = [];
+  const fn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    attempts.push({
+      method: init?.method,
+      range: (init?.headers as Record<string, string> | undefined)?.Range,
+    });
+    if (init?.method === "HEAD") return new Response(null, { status: headStatus });
+    throw new TypeError("Failed to fetch");
+  }) as unknown as typeof fetch;
+  return { fn, attempts };
+}
+
 describe("isPrivateHostname", () => {
   it("recognizes loopback, private ranges, and reserved suffixes", () => {
     for (const host of [
@@ -358,12 +375,15 @@ describe("probeShareSources", () => {
     // HEAD answers 405, so the host is up and readable cross-origin; the ranged
     // GET is rejected on its own (an older webview preflighting `Range`). That
     // must not turn a working host into a "blocked" verdict.
-    const fn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 405 });
-      throw new TypeError("Failed to fetch");
-    }) as unknown as typeof fetch;
+    const { fn, attempts } = rejectingRangedGet(405);
     const { refs: probed } = await probeShareSources(refs, { fetchImpl: fn });
     assert.equal(probed[0].status, "reachable");
+    // Without this the test would still pass if the retry were dropped
+    // entirely, since a bare HEAD 405 also reads as reachable.
+    assert.deepEqual(attempts, [
+      { method: "HEAD", range: undefined },
+      { method: "GET", range: "bytes=0-0" },
+    ]);
   });
 
   it("keeps a HEAD 403 credentialed when the ranged GET is also rejected", async () => {
@@ -372,13 +392,14 @@ describe("probeShareSources", () => {
         layer({ id: "a", name: "A", type: "cog", source: { url: "https://s3.example.com/a.tif" } }),
       ],
     });
-    const fn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "HEAD") return new Response(null, { status: 403 });
-      throw new TypeError("Failed to fetch");
-    }) as unknown as typeof fetch;
+    const { fn, attempts } = rejectingRangedGet(403);
     const { refs: probed } = await probeShareSources(refs, { fetchImpl: fn });
     assert.equal(probed[0].status, "credentialed");
     assert.equal(probed[0].reason, "auth-required");
+    assert.deepEqual(attempts, [
+      { method: "HEAD", range: undefined },
+      { method: "GET", range: "bytes=0-0" },
+    ]);
   });
 
   it("reads an opaque browser rejection as browser-blocked", async () => {


### PR DESCRIPTION
Two follow-ups to the share-readiness check from #1812. Both came from review comments that landed after that PR was merged, so they could not be folded into it.

Refs #1671.

## Embedded deck.gl rows were reported as unloadable

A non-GeoJSON deck.gl visualization (arc, heatmap, hexagon built from a CSV) keeps its rows in `source.data` as an **array** (`createDeckVizStoreLayer` in `packages/plugins/src/plugins/deckgl-viz/store-layer.ts`, read back by `deckVizRows`). `carriesOwnData` tested that field with `isPlainObject`, which explicitly excludes arrays, and `layer.geojson` is unset for these layers, so neither embedded-data check caught them.

The layer then fell through to the reference walk, which finds no string reference (`source.data` is skipped by `nonEmptyString`), and it was reported as `no-source` or, when `sourcePath` still held the original CSV name, as `local-file`. A layer whose data travels entirely inside the project file was told to the author as something the recipient cannot load.

An array `data` now counts as embedded, alongside an inline `FeatureCollection`. Only a **string** `data` is a URL, and that is a reference like any other.

## A rejected ranged GET no longer condemns the host

The probe retries with `Range: bytes=0-0` when a HEAD comes back 400/403/405/501, so a HEAD-refusing object store is not misread as credential-gated (and so the check never downloads a whole COG). But `Range` is CORS-safelisted only for a simple byte range, and an older webview may preflight it and get no matching `Access-Control-Allow-Headers` back, even where the plain GET a renderer issues would succeed. That rejection was being reported as `blocked`/`cors`: "a browser cannot fetch this host", about a host that works.

The HEAD that preceded the retry already proved the host answers and lets this origin read the response, so a rejection on the retry is about the ranged request rather than the host. The probe now falls back to the HEAD's own verdict: a 405 stays reachable, a 403 stays credentialed. Aborts and timeouts are still reported as such.

## Testing

Three new cases in `tests/share-readiness.test.ts`: a row-based deck.gl layer with a `sourcePath` producing no findings, and the two ranged-GET fallbacks (HEAD 405 → reachable, HEAD 403 → credentialed). Full frontend suite green (5625 passing), build and pre-commit clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Inline map data is no longer incorrectly flagged as requiring an external source when preparing projects for sharing.
  - Share readiness checks now preserve successful availability results when follow-up requests fail, while continuing to handle authorization, cancellation, and timeout cases correctly.

- **Tests**
  - Added coverage for inline data sources and request fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->