### PR TITLE
Chart a spectral profile for multiband GeoTIFF, not just NetCDF (#1818)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -117,6 +117,7 @@ import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { useEmbedBridge } from "../../hooks/useEmbedBridge";
 import { useRasterIdentify } from "../../hooks/useRasterIdentify";
 import { useNetcdfIdentify } from "../../hooks/useNetcdfIdentify";
+import { useCogSpectralIdentify } from "../../hooks/useCogSpectralIdentify";
 import {
   useAutoCollapsedPanel,
   useReplaceLayersPanelId,
@@ -894,6 +895,7 @@ export function DesktopShell({
   // COG layers (read band values on click). Inert until a COG is identified.
   useRasterIdentify();
   useNetcdfIdentify(mapControllerRef, mapReadyGeneration);
+  useCogSpectralIdentify(mapControllerRef, mapReadyGeneration);
   const [layerPanelWidth, setLayerPanelWidth] = useState(initialSidePanelWidth);
   const [stylePanelWidth, setStylePanelWidth] = useState(initialSidePanelWidth);
   const [stylePanelOpenRequest, setStylePanelOpenRequest] = useState(0);

--- a/apps/geolibre-desktop/src/components/panels/NetcdfProfileChart.tsx
+++ b/apps/geolibre-desktop/src/components/panels/NetcdfProfileChart.tsx
@@ -126,6 +126,12 @@ export function NetcdfProfileChart({
     const xMin = Math.min(...positions);
     const xMax = Math.max(...positions);
     const xSpan = xMax - xMin || 1;
+    // A band axis counts bands, so "1.5" labels a band that does not exist —
+    // most visible on a 4-band scene, where the default steps halve. Read off
+    // the positions rather than the axis name, because the axis is band numbers
+    // for some files and wavelengths for others, and a wavelength list that
+    // happens to be whole numbers is just as well served by whole ticks.
+    const integerAxis = positions.every(Number.isInteger);
     const scaleX = (position: number) => MARGIN.left + ((position - xMin) / xSpan) * INNER_W;
     const scaleY = (value: number) =>
       MARGIN.top + INNER_H - ((value - min) / (max - min || 1)) * INNER_H;
@@ -188,7 +194,7 @@ export function NetcdfProfileChart({
           {formatValue(min)}
         </text>
 
-        {niceTickValues(xMin, xMax, X_TICK_TARGET).map((position) => (
+        {niceTickValues(xMin, xMax, X_TICK_TARGET, { integerOnly: integerAxis }).map((position) => (
           <g key={position}>
             <line
               x1={scaleX(position)}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -4599,6 +4599,13 @@ export function StylePanel({
             {layer.metadata.sourceKind === TIME_SLIDER_SOURCE_KIND && (
               <TimeSliderSymbologySection layer={layer} />
             )}
+            {/* The same section the NetCDF branch renders below: a multiband COG
+                identified with the pixel inspector samples into the same store
+                (see useCogSpectralIdentify), so its spectra need a home on the
+                branch a raster layer actually lands on. The section renders null
+                until this layer has a sampled pixel, so it costs nothing for the
+                single-band and tile rasters that also come through here. */}
+            <NetcdfProfilePanel layerId={layer.id} />
             <Separator />
             <Button
               type="button"

--- a/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
@@ -2,13 +2,15 @@ import { useEffect } from "react";
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import type maplibregl from "maplibre-gl";
-import { readCogSpectralProfile } from "@geolibre/plugins/cog-spectral-profile";
+import { knownCogBandCount, readCogSpectralProfile } from "@geolibre/plugins/cog-spectral-profile";
 import { useTranslation } from "react-i18next";
+import { useShallow } from "zustand/react/shallow";
 import {
   addNetcdfProfileSample,
   removeNetcdfProfileSample,
   setNetcdfProfileSampleProfile,
 } from "../lib/netcdf-profile-store";
+import { fetchRemoteArrayBuffer } from "./usePlugins";
 
 /**
  * Charts a clicked pixel's values across every band of a multiband COG
@@ -32,26 +34,26 @@ export function useCogSpectralIdentify(
   mapReadyGeneration: number,
 ): void {
   const { t } = useTranslation();
-  // One selector returning a primitive, matching useRasterIdentify: Zustand
-  // re-renders only when the resolved id changes.
-  const activeCogId = useAppStore((s): string | null => {
-    if (!s.identifyLayerId) return null;
-    const layer = s.layers.find((item) => item.id === s.identifyLayerId);
-    return layer?.type === "cog" ? layer.id : null;
-  });
-  const cogUrl = useAppStore((s): string | null => {
-    if (!s.identifyLayerId) return null;
-    const layer = s.layers.find((item) => item.id === s.identifyLayerId);
-    if (layer?.type !== "cog") return null;
-    // `source` is a union across layer kinds, so narrow to the string form
-    // rather than trusting a `url` that is not on every member.
-    const url = (layer.source as { url?: unknown } | undefined)?.url;
-    return typeof url === "string" && url ? url : null;
-  });
-  const cogName = useAppStore((s): string | null => {
-    if (!s.identifyLayerId) return null;
-    return s.layers.find((item) => item.id === s.identifyLayerId)?.name ?? null;
-  });
+  // One selector, one scan of the layer list, like useNetcdfIdentify: the three
+  // fields are read from the same layer, so finding it three times was three
+  // subscriptions and three scans to answer one question. `useShallow` is what
+  // keeps returning an object from being a new reference on every store change.
+  const { activeCogId, cogUrl, cogName } = useAppStore(
+    useShallow((s): { activeCogId: string | null; cogUrl: string | null; cogName: string } => {
+      const layer = s.identifyLayerId
+        ? s.layers.find((item) => item.id === s.identifyLayerId)
+        : undefined;
+      if (layer?.type !== "cog") return { activeCogId: null, cogUrl: null, cogName: "" };
+      // `source` is a union across layer kinds, so narrow to the string form
+      // rather than trusting a `url` that is not on every member.
+      const url = (layer.source as { url?: unknown } | undefined)?.url;
+      return {
+        activeCogId: layer.id,
+        cogUrl: typeof url === "string" && url ? url : null,
+        cogName: layer.name ?? "",
+      };
+    }),
+  );
 
   useEffect(() => {
     const map = mapControllerRef.current?.getMap();
@@ -59,11 +61,22 @@ export function useCogSpectralIdentify(
 
     const handleClick = (event: maplibregl.MapMouseEvent) => {
       const { lng, lat } = event.lngLat;
+      // A single-band raster -- a DEM, a grayscale scene -- has no spectrum, so
+      // every click on one would add a marker and take it away again a moment
+      // later. Once the first read has told us the band count, skip the marker
+      // entirely rather than flashing one per click. The first click on such a
+      // layer still flashes, because the count is not known until something has
+      // read the file.
+      const bandCount = knownCogBandCount(cogUrl);
+      if (bandCount !== null && bandCount < 2) return;
+
       // The marker and list entry go in immediately so the click registers on
       // the map; the profile is attached when the range requests resolve.
       const sampleId = addNetcdfProfileSample({
         layerId: activeCogId,
-        variable: cogName ?? t("netcdfProfile.rasterFallbackName"),
+        // `||`, not `??`: a project authored by hand or by another tool can
+        // carry an empty name, which would leave the chart's title blank.
+        variable: cogName || t("netcdfProfile.rasterFallbackName"),
         lng,
         lat,
       });
@@ -75,7 +88,13 @@ export function useCogSpectralIdentify(
       // is exactly the stuck-load appearance this is trying to avoid. The
       // store's own guards make it safe: both calls below no-op for a sample
       // that has since been cleared or aged off the cap.
-      void readCogSpectralProfile(cogUrl, lng, lat).then((profile) => {
+      void readCogSpectralProfile(cogUrl, lng, lat, {
+        // Only used if geotiff.js's range requests are refused: the desktop app
+        // renders COGs from hosts with no CORS headers at all by going through
+        // the native HTTP path, and without this the layer would display while
+        // every click on it silently produced no profile.
+        fetchBytes: fetchRemoteArrayBuffer,
+      }).then((profile) => {
         if (profile) {
           setNetcdfProfileSampleProfile(sampleId, profile);
           return;

--- a/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
@@ -1,0 +1,95 @@
+import { useEffect } from "react";
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import type maplibregl from "maplibre-gl";
+import { readCogSpectralProfile } from "@geolibre/plugins/cog-spectral-profile";
+import {
+  addNetcdfProfileSample,
+  clearNetcdfProfileSamplesForLayer,
+  setNetcdfProfileSampleProfile,
+} from "../lib/netcdf-profile-store";
+
+/**
+ * Charts a clicked pixel's values across every band of a multiband COG
+ * (issue #1818).
+ *
+ * The COG Identify path already reports the clicked pixel's band values in a
+ * popup (see `useRasterIdentify`, which drives the raster control's inspector).
+ * What it could not do is show the *shape* of that response across bands, which
+ * is the operation introductory remote sensing turns on: click water, click
+ * vegetation, click asphalt, compare the three curves.
+ *
+ * Everything downstream is reused rather than rebuilt — the profile store, the
+ * chart, the numbered map markers, the floating window, the PNG/CSV export are
+ * all shared with the NetCDF cube path, because the reader returns the same
+ * shape. This hook is only the bridge from a map click to that store.
+ *
+ * Mounted once at the app shell, alongside the other identify hooks.
+ */
+export function useCogSpectralIdentify(
+  mapControllerRef: React.RefObject<MapController | null>,
+  mapReadyGeneration: number,
+): void {
+  // One selector returning a primitive, matching useRasterIdentify: Zustand
+  // re-renders only when the resolved id changes.
+  const activeCogId = useAppStore((s): string | null => {
+    if (!s.identifyLayerId) return null;
+    const layer = s.layers.find((item) => item.id === s.identifyLayerId);
+    return layer?.type === "cog" ? layer.id : null;
+  });
+  const cogUrl = useAppStore((s): string | null => {
+    if (!s.identifyLayerId) return null;
+    const layer = s.layers.find((item) => item.id === s.identifyLayerId);
+    if (layer?.type !== "cog") return null;
+    // `source` is a union across layer kinds, so narrow to the string form
+    // rather than trusting a `url` that is not on every member.
+    const url = (layer.source as { url?: unknown } | undefined)?.url;
+    return typeof url === "string" && url ? url : null;
+  });
+  const cogName = useAppStore((s): string | null => {
+    if (!s.identifyLayerId) return null;
+    return s.layers.find((item) => item.id === s.identifyLayerId)?.name ?? null;
+  });
+
+  useEffect(() => {
+    const map = mapControllerRef.current?.getMap();
+    if (!map || !activeCogId || !cogUrl) return;
+
+    // Reads in flight when the hook tears down (identify switched off, layer
+    // removed) must not attach to whatever the store holds by then.
+    let disposed = false;
+
+    const handleClick = (event: maplibregl.MapMouseEvent) => {
+      const { lng, lat } = event.lngLat;
+      // The marker and list entry go in immediately so the click registers on
+      // the map; the profile is attached when the range requests resolve.
+      const sampleId = addNetcdfProfileSample({
+        layerId: activeCogId,
+        variable: cogName ?? "Raster",
+        lng,
+        lat,
+      });
+
+      void readCogSpectralProfile(cogUrl, lng, lat).then((profile) => {
+        if (disposed) return;
+        if (profile) {
+          setNetcdfProfileSampleProfile(sampleId, profile);
+          return;
+        }
+        // Single-band rasters and clicks outside the raster have nothing to
+        // chart. Leaving a permanently profile-less marker in the list would
+        // read as a stuck load, so drop the layer's samples instead.
+        clearNetcdfProfileSamplesForLayer(activeCogId);
+      });
+    };
+
+    map.on("click", handleClick);
+    return () => {
+      disposed = true;
+      map.off("click", handleClick);
+    };
+    // mapReadyGeneration re-runs this once the map exists, matching the other
+    // identify hooks — the ref is empty on the first render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapControllerRef, mapReadyGeneration, activeCogId, cogUrl, cogName]);
+}

--- a/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useCogSpectralIdentify.ts
@@ -3,9 +3,10 @@ import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import type maplibregl from "maplibre-gl";
 import { readCogSpectralProfile } from "@geolibre/plugins/cog-spectral-profile";
+import { useTranslation } from "react-i18next";
 import {
   addNetcdfProfileSample,
-  clearNetcdfProfileSamplesForLayer,
+  removeNetcdfProfileSample,
   setNetcdfProfileSampleProfile,
 } from "../lib/netcdf-profile-store";
 
@@ -30,6 +31,7 @@ export function useCogSpectralIdentify(
   mapControllerRef: React.RefObject<MapController | null>,
   mapReadyGeneration: number,
 ): void {
+  const { t } = useTranslation();
   // One selector returning a primitive, matching useRasterIdentify: Zustand
   // re-renders only when the resolved id changes.
   const activeCogId = useAppStore((s): string | null => {
@@ -55,41 +57,44 @@ export function useCogSpectralIdentify(
     const map = mapControllerRef.current?.getMap();
     if (!map || !activeCogId || !cogUrl) return;
 
-    // Reads in flight when the hook tears down (identify switched off, layer
-    // removed) must not attach to whatever the store holds by then.
-    let disposed = false;
-
     const handleClick = (event: maplibregl.MapMouseEvent) => {
       const { lng, lat } = event.lngLat;
       // The marker and list entry go in immediately so the click registers on
       // the map; the profile is attached when the range requests resolve.
       const sampleId = addNetcdfProfileSample({
         layerId: activeCogId,
-        variable: cogName ?? "Raster",
+        variable: cogName ?? t("netcdfProfile.rasterFallbackName"),
         lng,
         lat,
       });
 
+      // Deliberately not discarded on teardown, matching useNetcdfIdentify: the
+      // effect tears down whenever the identify target *or the layer's name*
+      // changes, and short-circuiting here would leave the marker already in the
+      // store permanently profile-less -- a numbered point with no line, which
+      // is exactly the stuck-load appearance this is trying to avoid. The
+      // store's own guards make it safe: both calls below no-op for a sample
+      // that has since been cleared or aged off the cap.
       void readCogSpectralProfile(cogUrl, lng, lat).then((profile) => {
-        if (disposed) return;
         if (profile) {
           setNetcdfProfileSampleProfile(sampleId, profile);
           return;
         }
-        // Single-band rasters and clicks outside the raster have nothing to
-        // chart. Leaving a permanently profile-less marker in the list would
-        // read as a stuck load, so drop the layer's samples instead.
-        clearNetcdfProfileSamplesForLayer(activeCogId);
+        // Nothing to chart here: a single-band raster, a click outside the
+        // raster, an all-nodata pixel, or a failed read. Drop only this sample,
+        // not the layer's whole session -- an all-nodata pixel sits right beside
+        // valid data on any cloud-masked or rotated scene, and wiping the
+        // comparison the user just built would be a poor answer to one stray click.
+        removeNetcdfProfileSample(sampleId);
       });
     };
 
     map.on("click", handleClick);
     return () => {
-      disposed = true;
       map.off("click", handleClick);
     };
     // mapReadyGeneration re-runs this once the map exists, matching the other
     // identify hooks — the ref is empty on the first render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapControllerRef, mapReadyGeneration, activeCogId, cogUrl, cogName]);
+  }, [mapControllerRef, mapReadyGeneration, activeCogId, cogUrl, cogName, t]);
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1254,7 +1254,16 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
   return api;
 }
 
-async function fetchRemoteArrayBuffer(url: string): Promise<ArrayBuffer> {
+/**
+ * The app's CORS/Tauri-aware whole-file fetch: native HTTP on the desktop
+ * (bypassing webview CORS), the dev raster proxy in local development, plain
+ * `fetch` otherwise.
+ *
+ * Exported for readers outside the plugin API that need the same path — the COG
+ * spectral profile falls back to it when geotiff.js's own range requests are
+ * refused (`useCogSpectralIdentify`).
+ */
+export async function fetchRemoteArrayBuffer(url: string): Promise<ArrayBuffer> {
   if (isTauriRuntime() && isLocalFileReference(url)) {
     return normalizeBytes(await readFile(localPathFromReference(url)));
   }

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -5482,7 +5482,8 @@
     "noValues": "لا توجد قيم لرسمها لهذه البكسلات.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "تعذّر تصدير المخطط."
+    "exportError": "تعذّر تصدير المخطط.",
+    "rasterFallbackName": "طبقة نقطية"
   },
   "netcdfIdentify": {
     "noData": "لا توجد بيانات",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -5187,7 +5187,8 @@
     "noValues": "Für diese Pixel gibt es keine darstellbaren Werte.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Das Diagramm konnte nicht exportiert werden."
+    "exportError": "Das Diagramm konnte nicht exportiert werden.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "keine Daten",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -5187,7 +5187,8 @@
     "noValues": "No values to chart for these pixels.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Could not export the chart."
+    "exportError": "Could not export the chart.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "no data",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -5187,7 +5187,8 @@
     "noValues": "No hay valores que representar para estos píxeles.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "No se pudo exportar el gráfico."
+    "exportError": "No se pudo exportar el gráfico.",
+    "rasterFallbackName": "Ráster"
   },
   "netcdfIdentify": {
     "noData": "sin datos",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -5187,7 +5187,8 @@
     "noValues": "برای این پیکسل‌ها مقداری برای نمودار نیست.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "خروجی نمودار ممکن نشد."
+    "exportError": "خروجی نمودار ممکن نشد.",
+    "rasterFallbackName": "رستر"
   },
   "netcdfIdentify": {
     "noData": "بدون‌داده",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -5187,7 +5187,8 @@
     "noValues": "Aucune valeur à représenter pour ces pixels.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Impossible d'exporter le graphique."
+    "exportError": "Impossible d'exporter le graphique.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "sans données",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -5187,7 +5187,8 @@
     "noValues": "इन पिक्सेल के लिए चार्ट बनाने योग्य कोई मान नहीं है।",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "चार्ट निर्यात नहीं किया जा सका।"
+    "exportError": "चार्ट निर्यात नहीं किया जा सका।",
+    "rasterFallbackName": "रास्टर"
   },
   "netcdfIdentify": {
     "noData": "कोई डेटा नहीं",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -5113,7 +5113,8 @@
     "noValues": "Tidak ada nilai yang bisa dibagankan untuk piksel ini.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Tidak dapat mengekspor bagan."
+    "exportError": "Tidak dapat mengekspor bagan.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "tanpa data",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -5187,7 +5187,8 @@
     "noValues": "Nessun valore da rappresentare per questi pixel.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Impossibile esportare il grafico."
+    "exportError": "Impossibile esportare il grafico.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "nessun dato",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -5113,7 +5113,8 @@
     "noValues": "これらのピクセルにはグラフ化できる値がありません。",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "グラフをエクスポートできませんでした。"
+    "exportError": "グラフをエクスポートできませんでした。",
+    "rasterFallbackName": "ラスター"
   },
   "netcdfIdentify": {
     "noData": "データなし",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -5187,7 +5187,8 @@
     "noValues": "ამ პიქსელებისთვის დიაგრამაზე გამოსატანი მნიშვნელობები არ არის.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "დიაგრამის ექსპორტი ვერ მოხერხდა."
+    "exportError": "დიაგრამის ექსპორტი ვერ მოხერხდა.",
+    "rasterFallbackName": "რასტრი"
   },
   "netcdfIdentify": {
     "noData": "მონაცემები არ არის",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -5113,7 +5113,8 @@
     "noValues": "이 픽셀들에는 차트로 그릴 값이 없습니다.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "차트를 내보낼 수 없습니다."
+    "exportError": "차트를 내보낼 수 없습니다.",
+    "rasterFallbackName": "래스터"
   },
   "netcdfIdentify": {
     "noData": "데이터 없음",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -5187,7 +5187,8 @@
     "noValues": "Geen waarden om weer te geven voor deze pixels.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Kon het diagram niet exporteren."
+    "exportError": "Kon het diagram niet exporteren.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "geen gegevens",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -5187,7 +5187,8 @@
     "noValues": "Nenhum valor para representar nestes pixels.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Não foi possível exportar o gráfico."
+    "exportError": "Não foi possível exportar o gráfico.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "sem dados",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -5335,7 +5335,8 @@
     "noValues": "Для этих пикселей нет значений для графика.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Не удалось экспортировать график."
+    "exportError": "Не удалось экспортировать график.",
+    "rasterFallbackName": "Растр"
   },
   "netcdfIdentify": {
     "noData": "нет данных",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -5113,7 +5113,8 @@
     "noValues": "ไม่มีค่าที่จะพล็อตสำหรับพิกเซลเหล่านี้",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "ไม่สามารถส่งออกแผนภูมิได้"
+    "exportError": "ไม่สามารถส่งออกแผนภูมิได้",
+    "rasterFallbackName": "แรสเตอร์"
   },
   "netcdfIdentify": {
     "noData": "ไม่มีข้อมูล",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -5187,7 +5187,8 @@
     "noValues": "Bu pikseller için grafiğe dökülecek değer yok.",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "Grafik dışa aktarılamadı."
+    "exportError": "Grafik dışa aktarılamadı.",
+    "rasterFallbackName": "Raster"
   },
   "netcdfIdentify": {
     "noData": "veri yok",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -5113,7 +5113,8 @@
     "noValues": "这些像素没有可绘制的数值。",
     "exportPng": "PNG",
     "exportCsv": "CSV",
-    "exportError": "无法导出该图表。"
+    "exportError": "无法导出该图表。",
+    "rasterFallbackName": "栅格"
   },
   "netcdfIdentify": {
     "noData": "无数据",

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-series.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-series.ts
@@ -72,14 +72,25 @@ function tickCount(min: number, max: number, step: number): number {
  * @param max - Domain end.
  * @param target - Roughly how many ticks to aim for; round numbers win over
  *   hitting it exactly, so the result lands near it rather than on it.
+ * @param options.integerOnly - Restrict the step to whole numbers, for an axis
+ *   whose positions are counts rather than measurements. A band axis runs 1, 2,
+ *   3 …, so a tick at "1.5" labels a band that does not exist; a wavelength axis
+ *   has no such constraint and leaves this off. Falls back to the unrestricted
+ *   steps when no whole-numbered one fits, so a narrow domain still gets ticks.
  * @returns The ticks, ascending. A degenerate domain yields its single value.
  */
-export function niceTickValues(min: number, max: number, target: number): number[] {
+export function niceTickValues(
+  min: number,
+  max: number,
+  target: number,
+  options?: { integerOnly?: boolean },
+): number[] {
   const span = max - min;
   if (!Number.isFinite(span) || span <= 0 || target < 2) return [min];
 
   const middle = Math.floor(Math.log10(span / target));
   let best: { step: number; score: number } | null = null;
+  let bestAny: { step: number; score: number } | null = null;
   // Two powers either side of the estimate covers every step that could plausibly
   // land near `target`, without depending on where the rounding fell.
   for (let exponent = middle - 1; exponent <= middle + 2; exponent++) {
@@ -90,11 +101,16 @@ export function niceTickValues(min: number, max: number, target: number): number
       if (count < 2) continue;
       // Ties, and near-ties against 2.5, go to the rounder and sparser step.
       const score = Math.abs(count - target) + (multiplier === 2.5 ? 1 : 0);
-      if (!best || score < best.score || (score === best.score && step > best.step)) {
-        best = { step, score };
-      }
+      const better = (current: { step: number; score: number } | null) =>
+        !current || score < current.score || (score === current.score && step > current.step);
+      if (better(bestAny)) bestAny = { step, score };
+      // Ticks are multiples of the step, so a whole-numbered step is exactly the
+      // condition for whole-numbered labels, whatever the domain starts at.
+      if (options?.integerOnly && !Number.isInteger(step)) continue;
+      if (better(best)) best = { step, score };
     }
   }
+  best ??= bestAny;
   if (!best) return [min, max];
 
   const { step } = best;

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
@@ -139,12 +139,24 @@ export function clearNetcdfProfileSamplesForLayer(layerId: string): void {
  * sample that has since been cleared or aged off the cap lands nowhere.
  */
 export function removeNetcdfProfileSample(id: number): void {
-  const kept = samples.filter((item) => item.id !== id);
-  if (kept.length === samples.length) return;
-  samples = kept;
-  if (kept.length === 0) {
+  const removed = samples.find((item) => item.id === id);
+  if (!removed) return;
+  samples = samples.filter((item) => item.id !== id);
+  if (samples.length === 0) {
     orderCounter = 0;
     poppedOut = false;
+  } else if (removed.order === orderCounter) {
+    // Give the number back when the sample being dropped is the newest one,
+    // which is the usual case: the caller adds a marker on click and removes it
+    // when the read comes back with nothing to chart. Without this the next
+    // click is labelled "3" beside a "1", and since the series color is keyed
+    // off the number the chart's colors skip too.
+    //
+    // Only the newest, because `order` is assigned once and never renumbered —
+    // a point keeps its label and color when an older one falls off the cap. So
+    // a failed read that resolves *after* a later click still leaves a gap;
+    // renumbering to close it would move the labels under the user's cursor.
+    orderCounter -= 1;
   }
   emit();
 }

--- a/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
+++ b/apps/geolibre-desktop/src/lib/netcdf-profile-store.ts
@@ -126,6 +126,29 @@ export function clearNetcdfProfileSamplesForLayer(layerId: string): void {
   emit();
 }
 
+/**
+ * Drop one sample by id.
+ *
+ * Used when a click turns out to have nothing to chart (a single-band raster, a
+ * point outside the raster, an all-nodata pixel, a failed read). Clearing the
+ * whole layer for those would discard the comparison the user has been
+ * building — and an all-nodata pixel sits right beside valid data on any
+ * cloud-masked or rotated scene, so it is a click they will make often.
+ *
+ * A no-op for an id that is no longer in the list, so a late result for a
+ * sample that has since been cleared or aged off the cap lands nowhere.
+ */
+export function removeNetcdfProfileSample(id: number): void {
+  const kept = samples.filter((item) => item.id !== id);
+  if (kept.length === samples.length) return;
+  samples = kept;
+  if (kept.length === 0) {
+    orderCounter = 0;
+    poppedOut = false;
+  }
+  emit();
+}
+
 /** The current samples, for `useSyncExternalStore`. */
 export function getNetcdfProfileSamples(): NetcdfProfileSample[] {
   return samples;

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./cog-spectral-profile": "./src/plugins/cog-spectral-profile.ts",
     "./local-netcdf": "./src/plugins/local-netcdf.ts",
     "./raster-symbology": "./src/plugins/raster-symbology.ts",
     "./zarr-time-axis": "./src/plugins/zarr-time-axis.ts"

--- a/packages/plugins/src/plugins/cog-spectral-profile.ts
+++ b/packages/plugins/src/plugins/cog-spectral-profile.ts
@@ -88,11 +88,12 @@ function wavelengthsFor(image: ImageLike, bandCount: number): number[] | null {
   const directory = image.getFileDirectory();
   const raw = directory?.["wavelength"] ?? directory?.["Wavelength"];
   const list = Array.isArray(raw) ? raw : typeof raw === "string" ? raw.split(/[,\s]+/) : null;
-  if (!list) return null;
-  const values = list
-    .map((entry) => Number.parseFloat(String(entry)))
-    .filter((value) => Number.isFinite(value));
-  return values.length === bandCount ? values : null;
+  if (!list || list.length !== bandCount) return null;
+  const values = list.map((entry) => Number.parseFloat(String(entry)));
+  // Every entry must parse. Filtering the bad ones out instead would let a list
+  // with one junk extra entry still match the band count, silently shifting
+  // every following wavelength onto the wrong band.
+  return values.every((value) => Number.isFinite(value)) ? values : null;
 }
 
 /**
@@ -104,19 +105,56 @@ function wavelengthsFor(image: ImageLike, bandCount: number): number[] | null {
  * @returns The profile, or null when the file has a single band, the point
  *   falls outside the raster, or the file cannot be read.
  */
+/**
+ * Opened images, keyed by URL.
+ *
+ * The workflow this exists for is repeated clicks on one scene ("click water,
+ * click vegetation, click asphalt"), and `fromUrl` + `getImage` re-fetches the
+ * header and IFD every time. Caching the promise means only the first click
+ * pays for it. Bounded because a session realistically touches a handful of
+ * rasters; the entries hold headers, not pixels.
+ */
+const openedImages = new Map<string, Promise<ImageLike | null>>();
+const MAX_OPEN_IMAGES = 8;
+
+async function openImage(url: string): Promise<ImageLike | null> {
+  const cached = openedImages.get(url);
+  if (cached) return cached;
+  const opened = (async () => {
+    try {
+      const tiff = await fromUrl(url);
+      return (await tiff.getImage()) as unknown as ImageLike;
+    } catch {
+      return null;
+    }
+  })();
+  if (openedImages.size >= MAX_OPEN_IMAGES) {
+    const oldest = openedImages.keys().next();
+    if (!oldest.done) openedImages.delete(oldest.value);
+  }
+  openedImages.set(url, opened);
+  const image = await opened;
+  // A failed open is not worth remembering: the next click should retry rather
+  // than inherit a transient network error for the rest of the session.
+  if (!image) openedImages.delete(url);
+  return image;
+}
+
 export async function readCogSpectralProfile(
   url: string,
   lng: number,
   lat: number,
 ): Promise<CogSpectralProfile | null> {
-  let image: ImageLike;
+  const image = await openImage(url);
+  if (!image) return null;
   try {
-    const tiff = await fromUrl(url);
-    image = (await tiff.getImage()) as unknown as ImageLike;
+    return await readProfileFromImage(image, lng, lat);
   } catch {
+    // Metadata accessors throw on a malformed file -- getBoundingBox does so
+    // when the image carries no affine transform -- and the caller treats a
+    // rejection as an unresolved sample rather than a missing one.
     return null;
   }
-  return readProfileFromImage(image, lng, lat);
 }
 
 /**
@@ -140,13 +178,26 @@ export async function readProfileFromImage(
   // Project the click into the raster's own CRS before indexing into it.
   let x = lng;
   let y = lat;
-  const definition = await projectionFor(image.getGeoKeys());
+  const geoKeys = image.getGeoKeys();
+  const hasGeoKeys = Boolean(geoKeys && Object.keys(geoKeys).length > 0);
+  const definition = await projectionFor(geoKeys);
   if (definition) {
     try {
       [x, y] = proj4("EPSG:4326", definition, [lng, lat]) as [number, number];
     } catch {
       return null;
     }
+  } else if (hasGeoKeys) {
+    // The file declares a CRS but no proj4 definition came back. Falling
+    // through would index the raster with degrees as if they were its own
+    // units, producing a confident reading of the wrong pixel.
+    //
+    // Unreachable through geotiff-geokeys-to-proj4's own output today -- it
+    // returns a definition (falling back to longlat) even for user-defined and
+    // unsupported keys, reporting the problem in a separate errors object. The
+    // reachable case is the dynamic import itself failing, where treating the
+    // file as geographic would be a guess.
+    return null;
   }
 
   const [minX, minY, maxX, maxY] = bbox as [number, number, number, number];

--- a/packages/plugins/src/plugins/cog-spectral-profile.ts
+++ b/packages/plugins/src/plugins/cog-spectral-profile.ts
@@ -1,0 +1,193 @@
+/**
+ * Per-pixel spectral profile for a multiband GeoTIFF / COG (issue #1818).
+ *
+ * GeoLibre could already chart a pixel's values across a band axis, but only for
+ * NetCDF/HDF cubes. A stacked Landsat or Sentinel scene — the most common
+ * multispectral data there is — got RGB band combination and single-value
+ * Identify, and no way to see one pixel's response across every band.
+ *
+ * This module supplies the missing reader. The chart, the multi-point sampling
+ * UI, the numbered map markers and the PNG/CSV export are all reused unchanged:
+ * the returned shape deliberately matches `LocalNetcdfProfile` so the existing
+ * profile store and chart accept it without knowing where it came from.
+ *
+ * Reads are range requests via geotiff.js, so only the tile containing the
+ * clicked pixel is fetched rather than the whole scene.
+ */
+
+import { fromUrl } from "geotiff";
+import proj4 from "proj4";
+
+/** One pixel's values across a raster's bands, shaped for the profile chart. */
+export interface CogSpectralProfile {
+  axis: {
+    /** Axis name shown on the chart's x-axis. */
+    name: string;
+    /** Number of entries along the axis — the band count. */
+    size: number;
+    /** Band numbers, or wavelengths when the file declares them. */
+    values?: number[];
+    /** Axis units, e.g. "nm" when wavelengths were found. */
+    units?: string;
+  };
+  /** One value per band, null where the pixel is nodata or unreadable. */
+  values: (number | null)[];
+}
+
+/** The subset of a geotiff.js image this module needs (kept narrow for tests). */
+export interface ImageLike {
+  getBoundingBox: () => number[];
+  getWidth: () => number;
+  getHeight: () => number;
+  getSamplesPerPixel: () => number;
+  getGeoKeys: () => Record<string, unknown> | undefined;
+  getGDALNoData?: () => number | null;
+  getFileDirectory: () => Record<string, unknown>;
+  readRasters: (options: {
+    window: number[];
+    samples?: number[];
+  }) => Promise<ArrayLike<ArrayLike<number>>>;
+}
+
+let geokeysParser: Promise<((keys: Record<string, unknown>) => string | null) | null> | null = null;
+
+/**
+ * Resolve a GeoTIFF's geokeys to a proj4 definition, reusing the same
+ * `geotiff-geokeys-to-proj4` dependency the COG raster layer uses so a file that
+ * renders correctly also profiles correctly. Returns null for a file whose
+ * projection cannot be resolved; the caller then assumes the coordinates are
+ * already geographic.
+ */
+async function projectionFor(geoKeys: Record<string, unknown> | undefined): Promise<string | null> {
+  if (!geoKeys) return null;
+  geokeysParser ??= import("geotiff-geokeys-to-proj4")
+    .then((mod) => (keys: Record<string, unknown>) => {
+      try {
+        const projection = mod.toProj4(keys as never);
+        // The `+axis=` directive makes proj4 swap easting/northing on some
+        // CRSs, which would transpose the pixel lookup.
+        return projection?.proj4 ? projection.proj4.replace(/\+axis=\w+\s*/g, "") : null;
+      } catch {
+        return null;
+      }
+    })
+    .catch(() => null);
+  const parse = await geokeysParser;
+  return parse ? parse(geoKeys) : null;
+}
+
+/**
+ * Wavelengths for each band, when the file declares them.
+ *
+ * Landsat/Sentinel products written by common tooling put a per-band
+ * `wavelength` in the GDAL metadata; ENVI-style headers use `wavelength` on the
+ * file directory. Neither is guaranteed, so a file without them charts against
+ * band number instead — which is still the useful axis, just less physical.
+ */
+function wavelengthsFor(image: ImageLike, bandCount: number): number[] | null {
+  const directory = image.getFileDirectory();
+  const raw = directory?.["wavelength"] ?? directory?.["Wavelength"];
+  const list = Array.isArray(raw) ? raw : typeof raw === "string" ? raw.split(/[,\s]+/) : null;
+  if (!list) return null;
+  const values = list
+    .map((entry) => Number.parseFloat(String(entry)))
+    .filter((value) => Number.isFinite(value));
+  return values.length === bandCount ? values : null;
+}
+
+/**
+ * Read one pixel's value in every band of a multiband GeoTIFF.
+ *
+ * @param url - The COG/GeoTIFF URL. Range requests fetch only what is needed.
+ * @param lng - Longitude of the clicked point, in WGS84 degrees.
+ * @param lat - Latitude of the clicked point, in WGS84 degrees.
+ * @returns The profile, or null when the file has a single band, the point
+ *   falls outside the raster, or the file cannot be read.
+ */
+export async function readCogSpectralProfile(
+  url: string,
+  lng: number,
+  lat: number,
+): Promise<CogSpectralProfile | null> {
+  let image: ImageLike;
+  try {
+    const tiff = await fromUrl(url);
+    image = (await tiff.getImage()) as unknown as ImageLike;
+  } catch {
+    return null;
+  }
+  return readProfileFromImage(image, lng, lat);
+}
+
+/**
+ * The reader's logic, separated from opening the file so the pixel indexing,
+ * nodata handling and axis selection can be tested against a stub image rather
+ * than a real GeoTIFF served over HTTP.
+ */
+export async function readProfileFromImage(
+  image: ImageLike,
+  lng: number,
+  lat: number,
+): Promise<CogSpectralProfile | null> {
+  const bandCount = image.getSamplesPerPixel();
+  // A single-band raster has no spectrum to chart; Identify's existing value
+  // readout already covers it.
+  if (!Number.isFinite(bandCount) || bandCount < 2) return null;
+
+  const bbox = image.getBoundingBox();
+  if (bbox.length !== 4) return null;
+
+  // Project the click into the raster's own CRS before indexing into it.
+  let x = lng;
+  let y = lat;
+  const definition = await projectionFor(image.getGeoKeys());
+  if (definition) {
+    try {
+      [x, y] = proj4("EPSG:4326", definition, [lng, lat]) as [number, number];
+    } catch {
+      return null;
+    }
+  }
+
+  const [minX, minY, maxX, maxY] = bbox as [number, number, number, number];
+  const width = image.getWidth();
+  const height = image.getHeight();
+  const column = Math.floor(((x - minX) / (maxX - minX)) * width);
+  // Raster rows run north to south, so the y axis is inverted against the bbox.
+  const row = Math.floor(((maxY - y) / (maxY - minY)) * height);
+  if (!Number.isFinite(column) || !Number.isFinite(row)) return null;
+  if (column < 0 || column >= width || row < 0 || row >= height) return null;
+
+  let rasters: ArrayLike<ArrayLike<number>>;
+  try {
+    rasters = await image.readRasters({ window: [column, row, column + 1, row + 1] });
+  } catch {
+    return null;
+  }
+
+  const nodata = image.getGDALNoData?.() ?? null;
+  const values: (number | null)[] = [];
+  for (let band = 0; band < bandCount; band += 1) {
+    const value = rasters[band]?.[0];
+    values.push(
+      typeof value === "number" && Number.isFinite(value) && (nodata === null || value !== nodata)
+        ? value
+        : null,
+    );
+  }
+  // Every band nodata means the click landed on a masked pixel; charting a flat
+  // line of nulls says nothing, so report it as no profile.
+  if (values.every((value) => value === null)) return null;
+
+  const wavelengths = wavelengthsFor(image, bandCount);
+  return {
+    axis: wavelengths
+      ? { name: "wavelength", size: bandCount, values: wavelengths, units: "nm" }
+      : {
+          name: "band",
+          size: bandCount,
+          values: Array.from({ length: bandCount }, (_, i) => i + 1),
+        },
+    values,
+  };
+}

--- a/packages/plugins/src/plugins/cog-spectral-profile.ts
+++ b/packages/plugins/src/plugins/cog-spectral-profile.ts
@@ -15,7 +15,7 @@
  * clicked pixel is fetched rather than the whole scene.
  */
 
-import { fromUrl } from "geotiff";
+import { fromArrayBuffer, fromUrl } from "geotiff";
 import proj4 from "proj4";
 
 /** One pixel's values across a raster's bands, shaped for the profile chart. */
@@ -77,17 +77,80 @@ async function projectionFor(geoKeys: Record<string, unknown> | undefined): Prom
 }
 
 /**
+ * Per-band wavelengths out of the `GDAL_METADATA` tag.
+ *
+ * This is where GDAL and rasterio actually put them: one `<Item name="…"
+ * sample="N">` per band inside an XML blob, rather than a flat array on the file
+ * directory. A stacked Landsat or Sentinel scene written by either tool is the
+ * target of this feature, so reading only the flat form would have meant the
+ * wavelength axis never appearing for the files it was built for.
+ *
+ * Matched on the item names those tools write (`wavelength`, and the
+ * `central_wavelength` STAC-derived exports use), case-insensitively. Parsed
+ * with a regular expression rather than a DOM parser: this is one well-known
+ * tag shape, `DOMParser` is not available in every runtime this package builds
+ * for, and an XML parser on file-supplied content is a larger surface than the
+ * data warrants.
+ *
+ * @param directory - The image's file directory.
+ * @param bandCount - How many bands the image has.
+ * @returns One wavelength per band in band order, or null when the tag is
+ *   absent, unparseable, or does not cover exactly every band.
+ */
+function gdalMetadataWavelengths(
+  directory: Record<string, unknown> | undefined,
+  bandCount: number,
+): number[] | null {
+  const xml = directory?.["GDAL_METADATA"];
+  if (typeof xml !== "string" || !xml) return null;
+  const bySample = new Map<number, number>();
+  const item = /<Item\b([^>]*)>([^<]*)<\/Item>/gi;
+  for (const match of xml.matchAll(item)) {
+    const [, attributes, text] = match;
+    const name = /\bname\s*=\s*"([^"]*)"/i.exec(attributes)?.[1]?.toLowerCase();
+    if (name !== "wavelength" && name !== "central_wavelength") continue;
+    // A wavelength with no `sample` is a dataset-level item, not a per-band one,
+    // so it says nothing about which band it belongs to.
+    const sample = Number.parseInt(/\bsample\s*=\s*"(\d+)"/i.exec(attributes)?.[1] ?? "", 10);
+    const value = Number.parseFloat(text.trim());
+    if (!Number.isInteger(sample) || !Number.isFinite(value)) continue;
+    // First writer wins, so a file carrying both names does not have one
+    // silently override the other halfway down the list.
+    if (!bySample.has(sample)) bySample.set(sample, value);
+  }
+  // `sample` is 0-based, and every band has to be covered: a partial list would
+  // put the bands it does cover at the wrong place on the axis.
+  if (bySample.size !== bandCount) return null;
+  const values: number[] = [];
+  for (let band = 0; band < bandCount; band += 1) {
+    const value = bySample.get(band);
+    if (value === undefined) return null;
+    values.push(value);
+  }
+  return values;
+}
+
+/**
  * Wavelengths for each band, when the file declares them.
  *
- * Landsat/Sentinel products written by common tooling put a per-band
- * `wavelength` in the GDAL metadata; ENVI-style headers use `wavelength` on the
- * file directory. Neither is guaranteed, so a file without them charts against
+ * Two shapes, because two toolchains: GDAL/rasterio write per-band items into
+ * `GDAL_METADATA`, while ENVI-style headers put a flat `wavelength` list on the
+ * file directory. Neither is guaranteed, so a file with neither charts against
  * band number instead — which is still the useful axis, just less physical.
  */
 function wavelengthsFor(image: ImageLike, bandCount: number): number[] | null {
   const directory = image.getFileDirectory();
+  const fromGdal = gdalMetadataWavelengths(directory, bandCount);
+  if (fromGdal) return fromGdal;
   const raw = directory?.["wavelength"] ?? directory?.["Wavelength"];
-  const list = Array.isArray(raw) ? raw : typeof raw === "string" ? raw.split(/[,\s]+/) : null;
+  // Trimmed before splitting: a leading space on " 443, 560, 665" would
+  // otherwise produce an empty first element, fail the band-count match, and
+  // drop a perfectly good wavelength list for being loosely formatted.
+  const list = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+      ? raw.trim().split(/[,\s]+/)
+      : null;
   if (!list || list.length !== bandCount) return null;
   const values = list.map((entry) => Number.parseFloat(String(entry)));
   // Every entry must parse. Filtering the bad ones out instead would let a list
@@ -97,14 +160,14 @@ function wavelengthsFor(image: ImageLike, bandCount: number): number[] | null {
 }
 
 /**
- * Read one pixel's value in every band of a multiband GeoTIFF.
+ * Fetches a whole file's bytes, for the fallback path below.
  *
- * @param url - The COG/GeoTIFF URL. Range requests fetch only what is needed.
- * @param lng - Longitude of the clicked point, in WGS84 degrees.
- * @param lat - Latitude of the clicked point, in WGS84 degrees.
- * @returns The profile, or null when the file has a single band, the point
- *   falls outside the raster, or the file cannot be read.
+ * The app's CORS/Tauri-aware fetch has this shape (`app.fetchArrayBuffer`); the
+ * reader takes it as an argument rather than importing it, since this package
+ * cannot depend on the desktop app.
  */
+export type CogByteLoader = (url: string) => Promise<ArrayBuffer>;
+
 /**
  * Opened images, keyed by URL.
  *
@@ -117,15 +180,56 @@ function wavelengthsFor(image: ImageLike, bandCount: number): number[] | null {
 const openedImages = new Map<string, Promise<ImageLike | null>>();
 const MAX_OPEN_IMAGES = 8;
 
-async function openImage(url: string): Promise<ImageLike | null> {
+/**
+ * Band counts of images opened this session, keyed by URL.
+ *
+ * Outlives `openedImages` deliberately: it is two numbers, and its only reader
+ * wants to know "can this layer ever chart?" without holding the image open.
+ */
+const bandCounts = new Map<string, number>();
+
+/**
+ * The band count for a URL already read this session, if any.
+ *
+ * Lets a caller skip the work — and the map marker — for a raster it has already
+ * learned has a single band, which can never produce a profile. Null when this
+ * URL has not been read yet, which is not the same as "unknown band count": the
+ * first read is what fills it in.
+ */
+export function knownCogBandCount(url: string): number | null {
+  return bandCounts.get(url) ?? null;
+}
+
+async function openImage(url: string, fetchBytes?: CogByteLoader): Promise<ImageLike | null> {
   const cached = openedImages.get(url);
-  if (cached) return cached;
+  // Re-inserted on a hit so eviction is least-recently-used: without this the
+  // map evicts whatever was opened first, which on a long session is as likely
+  // to be the scene being clicked as a stale one.
+  if (cached) {
+    openedImages.delete(url);
+    openedImages.set(url, cached);
+    return cached;
+  }
   const opened = (async () => {
     try {
       const tiff = await fromUrl(url);
       return (await tiff.getImage()) as unknown as ImageLike;
     } catch {
-      return null;
+      // Range requests through the raw fetch geotiff.js uses are the fast path,
+      // not the only one: a host without permissive CORS headers refuses them
+      // outright, and in the desktop app that is exactly the file the map is
+      // *displaying*, because rendering went through the native HTTP bypass (or
+      // the dev raster proxy) instead. Falling back to the caller's fetch costs
+      // the whole file rather than one tile, which is the same download the
+      // layer already made to render, and the cache above means one click pays
+      // it rather than every click.
+      if (!fetchBytes) return null;
+      try {
+        const tiff = await fromArrayBuffer(await fetchBytes(url));
+        return (await tiff.getImage()) as unknown as ImageLike;
+      } catch {
+        return null;
+      }
     }
   })();
   if (openedImages.size >= MAX_OPEN_IMAGES) {
@@ -140,14 +244,28 @@ async function openImage(url: string): Promise<ImageLike | null> {
   return image;
 }
 
+/**
+ * Read one pixel's value in every band of a multiband GeoTIFF.
+ *
+ * @param url - The COG/GeoTIFF URL. Range requests fetch only what is needed.
+ * @param lng - Longitude of the clicked point, in WGS84 degrees.
+ * @param lat - Latitude of the clicked point, in WGS84 degrees.
+ * @param options.fetchBytes - Whole-file fetch used only when the range
+ *   requests fail, for hosts the browser will not let this read directly.
+ * @returns The profile, or null when the file has a single band, the point
+ *   falls outside the raster, or the file cannot be read.
+ */
 export async function readCogSpectralProfile(
   url: string,
   lng: number,
   lat: number,
+  options?: { fetchBytes?: CogByteLoader },
 ): Promise<CogSpectralProfile | null> {
-  const image = await openImage(url);
+  const image = await openImage(url, options?.fetchBytes);
   if (!image) return null;
   try {
+    const bandCount = image.getSamplesPerPixel();
+    if (Number.isFinite(bandCount)) bandCounts.set(url, bandCount);
     return await readProfileFromImage(image, lng, lat);
   } catch {
     // Metadata accessors throw on a malformed file -- getBoundingBox does so

--- a/tests/cog-spectral-profile.test.ts
+++ b/tests/cog-spectral-profile.test.ts
@@ -21,6 +21,7 @@ interface StubOptions {
   height?: number;
   nodata?: number | null;
   directory?: Record<string, unknown>;
+  geoKeys?: Record<string, unknown>;
   /** Values returned per band; defaults to band index + 1. */
   valueFor?: (band: number, column: number, row: number) => number;
   onRead?: (window: number[]) => void;
@@ -35,6 +36,7 @@ function stubImage(options: StubOptions = {}): ImageLike {
     height = 100,
     nodata = null,
     directory = {},
+    geoKeys,
     valueFor = (band) => band + 1,
     onRead,
   } = options;
@@ -43,7 +45,7 @@ function stubImage(options: StubOptions = {}): ImageLike {
     getWidth: () => width,
     getHeight: () => height,
     getSamplesPerPixel: () => bands,
-    getGeoKeys: () => undefined,
+    getGeoKeys: () => geoKeys,
     getGDALNoData: () => nodata,
     getFileDirectory: () => directory,
     readRasters: async ({ window }) => {
@@ -148,6 +150,36 @@ describe("readProfileFromImage", () => {
       0,
     );
     assert.equal(profile, null);
+  });
+
+  it("rejects a wavelength list containing a junk entry", async () => {
+    // Filtering the bad entry out would leave a list that still matches the band
+    // count, shifting every following wavelength onto the wrong band.
+    const profile = await readProfileFromImage(
+      stubImage({ bands: 3, directory: { wavelength: [443, "n/a", 560, 665] } }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "band", "a junk entry must invalidate the whole list");
+  });
+
+  it("still reads a file with no CRS metadata as geographic", async () => {
+    const profile = await readProfileFromImage(stubImage({ geoKeys: undefined }), 0, 0);
+    assert.ok(profile, "a file without geokeys keeps the geographic fallback");
+  });
+
+  it("survives a metadata accessor that throws", async () => {
+    // getBoundingBox throws when the image carries no affine transform.
+    const image: ImageLike = {
+      ...stubImage(),
+      getBoundingBox: () => {
+        throw new Error("no affine transformation");
+      },
+    };
+    await assert.rejects(async () => {
+      await readProfileFromImage(image, 0, 0);
+    }, /affine/);
   });
 
   it("survives a read failure without throwing", async () => {

--- a/tests/cog-spectral-profile.test.ts
+++ b/tests/cog-spectral-profile.test.ts
@@ -84,6 +84,91 @@ describe("readProfileFromImage", () => {
     assert.equal(profile.axis.units, "nm");
   });
 
+  it("charts against wavelengths written into GDAL_METADATA", async () => {
+    // Where GDAL and rasterio actually put them, and so where a real Landsat or
+    // Sentinel stack carries them — the flat directory field is the ENVI shape.
+    const profile = await readProfileFromImage(
+      stubImage({
+        bands: 3,
+        directory: {
+          GDAL_METADATA:
+            "<GDALMetadata>" +
+            '<Item name="wavelength" sample="0" role="wavelength">443</Item>' +
+            '<Item name="wavelength" sample="1" role="wavelength">560</Item>' +
+            '<Item name="wavelength" sample="2" role="wavelength">665</Item>' +
+            "</GDALMetadata>",
+        },
+      }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "wavelength");
+    assert.deepEqual(profile.axis.values, [443, 560, 665]);
+  });
+
+  it("orders GDAL_METADATA wavelengths by sample, not by document order", async () => {
+    const profile = await readProfileFromImage(
+      stubImage({
+        bands: 3,
+        directory: {
+          GDAL_METADATA:
+            '<Item name="wavelength" sample="2">665</Item>' +
+            '<Item name="wavelength" sample="0">443</Item>' +
+            '<Item name="wavelength" sample="1">560</Item>',
+        },
+      }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.deepEqual(profile.axis.values, [443, 560, 665]);
+  });
+
+  it("ignores a GDAL_METADATA list that does not cover every band", async () => {
+    // A partial list would put the bands it does cover at the wrong place on
+    // the axis, which is worse than plotting against band number.
+    const profile = await readProfileFromImage(
+      stubImage({
+        bands: 4,
+        directory: {
+          GDAL_METADATA:
+            '<Item name="wavelength" sample="0">443</Item>' +
+            '<Item name="wavelength" sample="1">560</Item>',
+        },
+      }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "band");
+  });
+
+  it("ignores a dataset-level wavelength that names no band", async () => {
+    const profile = await readProfileFromImage(
+      stubImage({
+        bands: 2,
+        directory: { GDAL_METADATA: '<Item name="wavelength">443</Item>' },
+      }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "band");
+  });
+
+  it("reads a loosely formatted ENVI wavelength list", async () => {
+    // Leading whitespace would otherwise split into an empty first element,
+    // fail the band-count match, and drop a perfectly good list.
+    const profile = await readProfileFromImage(
+      stubImage({ bands: 3, directory: { wavelength: " 443, 560, 665 " } }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.deepEqual(profile.axis.values, [443, 560, 665]);
+  });
+
   it("ignores a wavelength list that does not match the band count", async () => {
     // A mismatched list is more likely stale metadata than a shorter spectrum;
     // plotting against it would mislabel every point.

--- a/tests/cog-spectral-profile.test.ts
+++ b/tests/cog-spectral-profile.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the multiband GeoTIFF spectral profile reader (issue #1818).
+ *
+ * Exercised against a stub image rather than a real COG: what needs pinning is
+ * the pixel indexing (rows run north-to-south, so the y axis inverts against
+ * the bounding box), the nodata handling, and the choices about when there is
+ * no profile worth charting.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  readProfileFromImage,
+  type ImageLike,
+} from "../packages/plugins/src/plugins/cog-spectral-profile";
+
+interface StubOptions {
+  bands?: number;
+  bbox?: [number, number, number, number];
+  width?: number;
+  height?: number;
+  nodata?: number | null;
+  directory?: Record<string, unknown>;
+  /** Values returned per band; defaults to band index + 1. */
+  valueFor?: (band: number, column: number, row: number) => number;
+  onRead?: (window: number[]) => void;
+}
+
+/** A geotiff.js image stub in EPSG:4326 (no geokeys, so no reprojection). */
+function stubImage(options: StubOptions = {}): ImageLike {
+  const {
+    bands = 7,
+    bbox = [-10, -10, 10, 10],
+    width = 100,
+    height = 100,
+    nodata = null,
+    directory = {},
+    valueFor = (band) => band + 1,
+    onRead,
+  } = options;
+  return {
+    getBoundingBox: () => bbox,
+    getWidth: () => width,
+    getHeight: () => height,
+    getSamplesPerPixel: () => bands,
+    getGeoKeys: () => undefined,
+    getGDALNoData: () => nodata,
+    getFileDirectory: () => directory,
+    readRasters: async ({ window }) => {
+      onRead?.(window);
+      const [column, row] = window;
+      return Array.from({ length: bands }, (_, band) => [valueFor(band, column, row)]);
+    },
+  };
+}
+
+describe("readProfileFromImage", () => {
+  it("returns one value per band", async () => {
+    const profile = await readProfileFromImage(stubImage({ bands: 7 }), 0, 0);
+    assert.ok(profile);
+    assert.equal(profile.values.length, 7);
+    assert.deepEqual(profile.values, [1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("charts against band number when the file declares no wavelengths", async () => {
+    const profile = await readProfileFromImage(stubImage({ bands: 4 }), 0, 0);
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "band");
+    assert.deepEqual(profile.axis.values, [1, 2, 3, 4]);
+    assert.equal(profile.axis.size, 4);
+  });
+
+  it("charts against wavelength when the file declares them", async () => {
+    const profile = await readProfileFromImage(
+      stubImage({ bands: 3, directory: { wavelength: [443, 560, 665] } }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "wavelength");
+    assert.deepEqual(profile.axis.values, [443, 560, 665]);
+    assert.equal(profile.axis.units, "nm");
+  });
+
+  it("ignores a wavelength list that does not match the band count", async () => {
+    // A mismatched list is more likely stale metadata than a shorter spectrum;
+    // plotting against it would mislabel every point.
+    const profile = await readProfileFromImage(
+      stubImage({ bands: 5, directory: { wavelength: [443, 560] } }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.equal(profile.axis.name, "band");
+  });
+
+  it("inverts the y axis, because raster rows run north to south", async () => {
+    let seen: number[] = [];
+    // A point near the *north* edge must read a row near 0, not near height.
+    await readProfileFromImage(
+      stubImage({ bbox: [-10, -10, 10, 10], width: 100, height: 100, onRead: (w) => (seen = w) }),
+      0,
+      9.9,
+    );
+    assert.ok(seen[1] < 5, `expected a top row for a northern point, got ${seen[1]}`);
+
+    await readProfileFromImage(
+      stubImage({ bbox: [-10, -10, 10, 10], width: 100, height: 100, onRead: (w) => (seen = w) }),
+      0,
+      -9.9,
+    );
+    assert.ok(seen[1] > 95, `expected a bottom row for a southern point, got ${seen[1]}`);
+  });
+
+  it("reads a single-pixel window rather than the whole scene", async () => {
+    let seen: number[] = [];
+    await readProfileFromImage(stubImage({ onRead: (w) => (seen = w) }), 0, 0);
+    assert.equal(seen[2] - seen[0], 1, "window should be one column wide");
+    assert.equal(seen[3] - seen[1], 1, "window should be one row tall");
+  });
+
+  it("has no profile for a single-band raster", async () => {
+    // Identify's existing value readout already covers this case.
+    assert.equal(await readProfileFromImage(stubImage({ bands: 1 }), 0, 0), null);
+  });
+
+  it("has no profile for a click outside the raster", async () => {
+    const image = stubImage({ bbox: [-10, -10, 10, 10] });
+    assert.equal(await readProfileFromImage(image, 40, 0), null);
+    assert.equal(await readProfileFromImage(image, 0, 40), null);
+  });
+
+  it("nulls nodata bands but keeps the rest of the spectrum", async () => {
+    const profile = await readProfileFromImage(
+      stubImage({ bands: 4, nodata: 3, valueFor: (band) => band + 1 }),
+      0,
+      0,
+    );
+    assert.ok(profile);
+    assert.deepEqual(profile.values, [1, 2, null, 4]);
+  });
+
+  it("has no profile when every band is nodata", async () => {
+    // A flat line of nulls says nothing; better to report nothing to chart.
+    const profile = await readProfileFromImage(
+      stubImage({ bands: 4, nodata: 0, valueFor: () => 0 }),
+      0,
+      0,
+    );
+    assert.equal(profile, null);
+  });
+
+  it("survives a read failure without throwing", async () => {
+    const image: ImageLike = {
+      ...stubImage(),
+      readRasters: async () => {
+        throw new Error("range request failed");
+      },
+    };
+    assert.equal(await readProfileFromImage(image, 0, 0), null);
+  });
+});

--- a/tests/netcdf-profile-series.test.ts
+++ b/tests/netcdf-profile-series.test.ts
@@ -79,6 +79,44 @@ describe("netcdf profile series", () => {
     assert.deepEqual(niceTickValues(0, 23, 8), [0, 5, 10, 15, 20]);
   });
 
+  it("labels a short band axis on whole bands, not half bands", () => {
+    // A 4-band scene (RGB+NIR, the common Sentinel-2 subset) is narrow enough
+    // that the step targeting ~6 labels halves, and "1.5" names no band.
+    assert.deepEqual(niceTickValues(1, 4, 8, { integerOnly: true }), [1, 2, 3, 4]);
+    assert.deepEqual(niceTickValues(1, 3, 8, { integerOnly: true }), [1, 2, 3]);
+    // Left off, the same domain is free to halve — the wavelength behavior.
+    assert.ok(
+      niceTickValues(1, 4, 8).some((tick) => !Number.isInteger(tick)),
+      "a wavelength axis should keep its fractional steps",
+    );
+  });
+
+  it("never labels a whole-numbered axis with a fraction", () => {
+    // Includes the 2.5 multiplier's domains, where a step above 1 is still
+    // fractional, and hyperspectral band counts.
+    for (const [min, max] of [
+      [1, 2],
+      [1, 4],
+      [1, 12],
+      [1, 25],
+      [1, 224],
+      [0, 2],
+    ]) {
+      for (const tick of niceTickValues(min, max, 8, { integerOnly: true })) {
+        assert.ok(Number.isInteger(tick), `${tick} is not a whole band on ${min}..${max}`);
+      }
+    }
+  });
+
+  it("falls back to a fractional step when no whole one fits", () => {
+    // No whole-numbered step yields two ticks inside this domain, and an
+    // unlabelled axis would be worse than a fractionally labelled one.
+    assert.deepEqual(
+      niceTickValues(0.1, 0.5, 8, { integerOnly: true }),
+      niceTickValues(0.1, 0.5, 8),
+    );
+  });
+
   it("does not drift on a fractional step", () => {
     // Repeated addition would surface as "0.6000000000000001" in a label.
     assert.deepEqual(niceTickValues(0, 1, 8), [0, 0.2, 0.4, 0.6, 0.8, 1]);

--- a/tests/netcdf-profile-store.test.ts
+++ b/tests/netcdf-profile-store.test.ts
@@ -7,6 +7,7 @@ import {
   getNetcdfProfileSamples,
   isNetcdfProfilePoppedOut,
   MAX_PROFILE_SAMPLES,
+  removeNetcdfProfileSample,
   setNetcdfProfilePoppedOut,
   setNetcdfProfileSampleProfile,
   subscribeNetcdfProfile,
@@ -160,6 +161,53 @@ describe("netcdf profile store", () => {
     addNetcdfProfileSample(sample("a", 2));
     assert.equal(calls, 2);
     setNetcdfProfilePoppedOut(false);
+  });
+
+  it("gives the number back when the newest sample is dropped", () => {
+    // The COG path adds a marker on click and removes it if the read comes back
+    // with nothing to chart. Without the rollback the next click is labelled
+    // "3" beside a "1", and the series color, keyed off the number, skips too.
+    addNetcdfProfileSample(sample("a", 1));
+    const pending = addNetcdfProfileSample(sample("a", 2));
+    removeNetcdfProfileSample(pending);
+    addNetcdfProfileSample(sample("a", 3));
+    assert.deepEqual(
+      getNetcdfProfileSamples().map((item) => item.order),
+      [1, 2],
+    );
+  });
+
+  it("keeps the numbers of the samples it did not drop", () => {
+    // Only the newest gives its number back: `order` is assigned once, so a
+    // read that resolves after a later click leaves a gap rather than
+    // renumbering points the user is already looking at.
+    const first = addNetcdfProfileSample(sample("a", 1));
+    addNetcdfProfileSample(sample("a", 2));
+    removeNetcdfProfileSample(first);
+    assert.deepEqual(
+      getNetcdfProfileSamples().map((item) => item.order),
+      [2],
+    );
+  });
+
+  it("restarts numbering when the last sample is dropped", () => {
+    const only = addNetcdfProfileSample(sample("a", 1));
+    setNetcdfProfilePoppedOut(true);
+    removeNetcdfProfileSample(only);
+    addNetcdfProfileSample(sample("a", 2));
+    assert.equal(getNetcdfProfileSamples()[0].order, 1);
+    // Emptying the list docks the chart, as a full clear does — an empty window
+    // stranded over the map is the thing being avoided.
+    assert.equal(isNetcdfProfilePoppedOut(), false);
+  });
+
+  it("does not notify when removing an id that is not in the list", () => {
+    addNetcdfProfileSample(sample("a", 1));
+    let calls = 0;
+    const unsubscribe = subscribeNetcdfProfile(() => calls++);
+    removeNetcdfProfileSample(9999);
+    assert.equal(calls, 0);
+    unsubscribe();
   });
 
   it("does not notify when clearing an already-empty list", () => {


### PR DESCRIPTION
Closes #1818.

GeoLibre could already chart a pixel's values across a band axis — but only for **NetCDF/HDF cubes**. A stacked Landsat or Sentinel scene, the most common multispectral data there is, got RGB band combination and single-value Identify, and no way to see one pixel's response across every band.

That is the operation introductory remote sensing turns on: click water, click vegetation, click asphalt, compare the three curves. It is also what makes NDVI stop being a formula to memorise and start being an obvious consequence of the vegetation curve's red edge.

## Almost entirely a reader

As the issue predicted, the chart, the multi-point sampling UI, the numbered map markers, the floating window and the PNG/CSV export are all already written. The returned shape deliberately matches `LocalNetcdfProfile`, so the existing profile store and chart accept it **without knowing where it came from**.

New UI in this PR: none. The bridge is a ~50-line hook alongside the existing `useRasterIdentify` / `useNetcdfIdentify`.

## Reading

- **Range requests** via geotiff.js, so a click fetches the tile containing the pixel rather than the scene, and reads a 1×1 window.
- **Reprojected** into the raster's own CRS through the same `geotiff-geokeys-to-proj4` path the COG raster layer already uses, so a file that renders correctly also profiles correctly. The `+axis=` directive is stripped, since it would transpose the pixel lookup on some CRSs.
- **Wavelength axis** when the file declares one per band, else band number. A wavelength list whose length does not match the band count is *ignored* rather than trusted — more likely stale metadata than a shorter spectrum, and plotting against it would mislabel every point.

## Three cases that yield no profile

Each is a deliberate choice rather than an oversight:

| Case | Why not chart it |
| --- | --- |
| Single-band raster | No spectrum exists; Identify's value readout already covers it |
| Click outside the raster | Reporting the nearest edge pixel would be misleading |
| Every band nodata | A flat line of nulls says nothing |

Individual nodata bands *are* nulled while the rest of the spectrum is kept, so a masked band breaks the line instead of plotting a spike at the fill value.

## Import path

Uses the `@geolibre/plugins/cog-spectral-profile` subpath rather than the barrel, matching `local-netcdf` / `raster-symbology`. The barrel pulls in every plugin (Earth Engine included), which also makes it unimportable from a Node test.

## Tests

`tests/cog-spectral-profile.test.ts`, 11 cases against a stub image. The reader is split into `readProfileFromImage` so the logic is testable without standing up a real COG over HTTP. Covered: per-band values, both axis modes, the mismatched-wavelength guard, **the y-axis inversion** (raster rows run north-to-south, so a northern click must read a *low* row — easy to get backwards and invisible until someone checks a real scene), the 1×1 window, all three no-profile cases, nodata handling, and a read failure.

Full suite: 5633 pass, 0 fail. `npm run typecheck` and scoped `pre-commit` clean.

## Not covered

The reader assumes the layer's `source.url` points at a readable GeoTIFF; layers backed by bytes rather than a URL fall through to no profile. Worth revisiting if local multiband files become a common case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spectral profile identification for COG/GeoTIFF layers by clicking the map.
  * Displays sampled multiband profiles using wavelength or band-number axes.
  * Makes profiles available across raster layers while handling unsupported imagery gracefully.
  * Improves chart axis labels for integer-based band values.

* **Bug Fixes**
  * Removes invalid samples without affecting other profiles.
  * Prevents stale results after map or layer changes.

* **Localization**
  * Added translated raster fallback names and profile export error messages.

* **Tests**
  * Expanded coverage for metadata, coordinate mapping, nodata values, bounds, and read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->