### PR TITLE
Add an interactive viewshed from a clicked map point (#1815)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -16,6 +16,7 @@ import {
   BookOpen,
   Braces,
   Circle,
+  Eye,
   Crosshair,
   Earth,
   MapIcon,
@@ -38,6 +39,7 @@ import {
   type QuickBufferPreset,
 } from "../../lib/quick-analysis";
 import { hasRoutingConsent, recordRoutingConsent } from "../../lib/routing-consent";
+import { runViewshed } from "../../lib/run-viewshed";
 import { RoutingConsentDialog } from "./RoutingConsentDialog";
 
 interface ContextMenuState {
@@ -197,9 +199,37 @@ export function MapContextMenu({
   const bufferPresets = useMemo(() => bufferPresetsFor(scaleUnit), [scaleUnit]);
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
 
+  /** Radius label for the viewshed entries: metres below a km, else km. */
+  const formatViewshedRadius = (meters: number): string =>
+    meters >= 1000 ? `${meters / 1000} km` : `${meters} m`;
+
   const formatDistance = useCallback(
     (preset: QuickBufferPreset) => formatBufferDistance(preset, i18n.language, t),
     [i18n.language, t],
+  );
+
+  // Viewshed radii. Small enough that the tile fetch and the line-of-sight walk
+  // stay interactive; the 50km cap in the processing module is the hard limit.
+  const VIEWSHED_RADII_METERS = [2000, 5000, 15000];
+
+  const [viewshedBusy, setViewshedBusy] = useState(false);
+  const viewshedHere = useCallback(
+    (radiusMeters: number) => {
+      if (!menu || viewshedBusy) return;
+      const { lng, lat } = menu;
+      setViewshedBusy(true);
+      void runViewshed({
+        lng,
+        lat,
+        radiusMeters,
+        layerName: t("quickAnalysis.viewshedLayerName", {
+          radius: formatViewshedRadius(radiusMeters),
+        }),
+      })
+        .catch(() => null)
+        .finally(() => setViewshedBusy(false));
+    },
+    [menu, viewshedBusy, t],
   );
 
   const bufferHere = useCallback(
@@ -360,6 +390,20 @@ export function MapContextMenu({
                 <Route className="h-4 w-4 shrink-0 text-muted-foreground" />
                 {t("quickAnalysis.walkTimeHere", { contours: QUICK_TRAVEL_CONTOURS_LABEL })}
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              {VIEWSHED_RADII_METERS.map((radiusMeters) => (
+                <DropdownMenuItem
+                  key={`viewshed-${radiusMeters}`}
+                  onSelect={() => viewshedHere(radiusMeters)}
+                  disabled={viewshedBusy}
+                  className="gap-2"
+                >
+                  <Eye className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  {t("quickAnalysis.viewshedHere", {
+                    radius: formatViewshedRadius(radiusMeters),
+                  })}
+                </DropdownMenuItem>
+              ))}
               <DropdownMenuSeparator />
               {/* Escape hatch when the presets aren't what was wanted: the full
                 dialog, preselected on the same tool. */}

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -16,8 +16,8 @@ import {
   BookOpen,
   Braces,
   Circle,
-  Eye,
   Crosshair,
+  Eye,
   Earth,
   MapIcon,
   MapPin,
@@ -208,7 +208,8 @@ export function MapContextMenu({
     const useKm = meters >= 1000;
     const value = useKm ? meters / 1000 : meters;
     const formatted = new Intl.NumberFormat(i18n.language).format(value);
-    return `${formatted} ${useKm ? t("quickAnalysis.unitKilometers") : t("quickAnalysis.unitMeters")}`;
+    // Same unit catalog formatBufferDistance uses for the buffer presets below.
+    return `${formatted} ${useKm ? t("quickAnalysis.unit.kilometers") : t("quickAnalysis.unit.meters")}`;
   };
 
   const formatDistance = useCallback(

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -17,8 +17,8 @@ import {
   Braces,
   Circle,
   Crosshair,
-  Eye,
   Earth,
+  Eye,
   MapIcon,
   MapPin,
   Route,
@@ -36,6 +36,7 @@ import {
   QUICK_TRAVEL_CONTOURS,
   QUICK_TRAVEL_CONTOURS_LABEL,
   runQuickAnalysis,
+  setQuickAnalysisStatus,
   type QuickBufferPreset,
 } from "../../lib/quick-analysis";
 import { hasRoutingConsent, recordRoutingConsent } from "../../lib/routing-consent";
@@ -227,6 +228,12 @@ export function MapContextMenu({
       if (!menu || viewshedBusy) return;
       const { lng, lat } = menu;
       setViewshedBusy(true);
+      const toolName = t("quickAnalysis.viewshedToolName");
+      // Reported through the Quick Analysis banner like every other action in
+      // this menu rather than failing silently: the terrain fetch takes seconds
+      // and can fail, and a click with no feedback either way reads as a broken
+      // menu item.
+      setQuickAnalysisStatus({ phase: "running", toolName });
       void runViewshed({
         lng,
         lat,
@@ -235,7 +242,20 @@ export function MapContextMenu({
           radius: formatViewshedRadius(radiusMeters),
         }),
       })
-        .catch(() => null)
+        .then((result) => {
+          setQuickAnalysisStatus(
+            result
+              ? { phase: "idle" }
+              : { phase: "error", toolName, message: t("quickAnalysis.viewshedNoResult") },
+          );
+        })
+        .catch((error: unknown) => {
+          setQuickAnalysisStatus({
+            phase: "error",
+            toolName,
+            message: error instanceof Error ? error.message : t("quickAnalysis.viewshedNoResult"),
+          });
+        })
         .finally(() => setViewshedBusy(false));
     },
     [menu, viewshedBusy, t],

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useAppStore } from "@geolibre/core";
+import { useAppStore, FEET_PER_METER, METERS_PER_MILE } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   DropdownMenu,
@@ -201,17 +201,34 @@ export function MapContextMenu({
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
 
   /**
-   * Radius label for the viewshed entries. Formats the number for the active
-   * locale and takes the unit abbreviation from the catalog, matching how
-   * formatBufferDistance labels the buffer presets in this same menu.
+   * Radius label for the viewshed entries.
+   *
+   * Follows the scale bar's unit system like the buffer ladder above, so an
+   * imperial-preference user does not get miles for buffers and kilometres for
+   * viewsheds in the same submenu. The radii themselves stay metric constants —
+   * they size the analysis, not the label — so an imperial reading is a
+   * conversion of the same distance rather than a different one.
    */
-  const formatViewshedRadius = (meters: number): string => {
-    const useKm = meters >= 1000;
-    const value = useKm ? meters / 1000 : meters;
-    const formatted = new Intl.NumberFormat(i18n.language).format(value);
-    // Same unit catalog formatBufferDistance uses for the buffer presets below.
-    return `${formatted} ${useKm ? t("quickAnalysis.unit.kilometers") : t("quickAnalysis.unit.meters")}`;
-  };
+  const formatViewshedRadius = useCallback(
+    (meters: number): string => {
+      const imperial = scaleUnit === "imperial";
+      const perUnit = imperial ? METERS_PER_MILE : 1000;
+      const large = meters >= perUnit;
+      const value = large ? meters / perUnit : imperial ? meters * FEET_PER_METER : meters;
+      const formatted = new Intl.NumberFormat(i18n.language, {
+        maximumFractionDigits: large ? 1 : 0,
+      }).format(value);
+      const unit = large
+        ? imperial
+          ? t("quickAnalysis.unit.miles")
+          : t("quickAnalysis.unit.kilometers")
+        : imperial
+          ? t("quickAnalysis.unit.feet")
+          : t("quickAnalysis.unit.meters");
+      return `${formatted} ${unit}`;
+    },
+    [scaleUnit, i18n.language, t],
+  );
 
   const formatDistance = useCallback(
     (preset: QuickBufferPreset) => formatBufferDistance(preset, i18n.language, t),
@@ -239,6 +256,7 @@ export function MapContextMenu({
         lng,
         lat,
         radiusMeters,
+        mapControllerRef,
         layerName: t("quickAnalysis.viewshedLayerName", {
           radius: formatViewshedRadius(radiusMeters),
         }),
@@ -259,7 +277,7 @@ export function MapContextMenu({
         })
         .finally(() => setViewshedBusy(false));
     },
-    [menu, viewshedBusy, t],
+    [menu, viewshedBusy, t, formatViewshedRadius, mapControllerRef],
   );
 
   const bufferHere = useCallback(

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -199,9 +199,17 @@ export function MapContextMenu({
   const bufferPresets = useMemo(() => bufferPresetsFor(scaleUnit), [scaleUnit]);
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
 
-  /** Radius label for the viewshed entries: metres below a km, else km. */
-  const formatViewshedRadius = (meters: number): string =>
-    meters >= 1000 ? `${meters / 1000} km` : `${meters} m`;
+  /**
+   * Radius label for the viewshed entries. Formats the number for the active
+   * locale and takes the unit abbreviation from the catalog, matching how
+   * formatBufferDistance labels the buffer presets in this same menu.
+   */
+  const formatViewshedRadius = (meters: number): string => {
+    const useKm = meters >= 1000;
+    const value = useKm ? meters / 1000 : meters;
+    const formatted = new Intl.NumberFormat(i18n.language).format(value);
+    return `${formatted} ${useKm ? t("quickAnalysis.unitKilometers") : t("quickAnalysis.unitMeters")}`;
+  };
 
   const formatDistance = useCallback(
     (preset: QuickBufferPreset) => formatBufferDistance(preset, i18n.language, t),

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -36,7 +36,7 @@ import {
   QUICK_TRAVEL_CONTOURS,
   QUICK_TRAVEL_CONTOURS_LABEL,
   runQuickAnalysis,
-  setQuickAnalysisStatus,
+  beginQuickAnalysisRun,
   type QuickBufferPreset,
 } from "../../lib/quick-analysis";
 import { hasRoutingConsent, recordRoutingConsent } from "../../lib/routing-consent";
@@ -232,8 +232,9 @@ export function MapContextMenu({
       // Reported through the Quick Analysis banner like every other action in
       // this menu rather than failing silently: the terrain fetch takes seconds
       // and can fail, and a click with no feedback either way reads as a broken
-      // menu item.
-      setQuickAnalysisStatus({ phase: "running", toolName });
+      // menu item. The returned setter is bound to this run, so a slow viewshed
+      // cannot overwrite the status of a faster action started after it.
+      const reportStatus = beginQuickAnalysisRun(toolName);
       void runViewshed({
         lng,
         lat,
@@ -243,14 +244,14 @@ export function MapContextMenu({
         }),
       })
         .then((result) => {
-          setQuickAnalysisStatus(
+          reportStatus(
             result
               ? { phase: "idle" }
               : { phase: "error", toolName, message: t("quickAnalysis.viewshedNoResult") },
           );
         })
         .catch((error: unknown) => {
-          setQuickAnalysisStatus({
+          reportStatus({
             phase: "error",
             toolName,
             message: error instanceof Error ? error.message : t("quickAnalysis.viewshedNoResult"),

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -1890,7 +1890,9 @@
       "meters": "م",
       "kilometers": "كم",
       "miles": "ميل"
-    }
+    },
+    "viewshedHere": "مجال الرؤية من هنا ({{radius}})",
+    "viewshedLayerName": "مجال الرؤية ({{radius}})"
   },
   "knowledgeCard": {
     "title": "معلومات المكان",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -1892,7 +1892,9 @@
       "miles": "ميل"
     },
     "viewshedHere": "مجال الرؤية من هنا ({{radius}})",
-    "viewshedLayerName": "مجال الرؤية ({{radius}})"
+    "viewshedLayerName": "مجال الرؤية ({{radius}})",
+    "unitKilometers": "كم",
+    "unitMeters": "م"
   },
   "knowledgeCard": {
     "title": "معلومات المكان",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -1892,9 +1892,7 @@
       "miles": "ميل"
     },
     "viewshedHere": "مجال الرؤية من هنا ({{radius}})",
-    "viewshedLayerName": "مجال الرؤية ({{radius}})",
-    "unitKilometers": "كم",
-    "unitMeters": "م"
+    "viewshedLayerName": "مجال الرؤية ({{radius}})"
   },
   "knowledgeCard": {
     "title": "معلومات المكان",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -1889,7 +1889,8 @@
     "unit": {
       "meters": "م",
       "kilometers": "كم",
-      "miles": "ميل"
+      "miles": "ميل",
+      "feet": "قدم"
     },
     "viewshedHere": "مجال الرؤية من هنا ({{radius}})",
     "viewshedLayerName": "مجال الرؤية ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -1892,7 +1892,9 @@
       "miles": "ميل"
     },
     "viewshedHere": "مجال الرؤية من هنا ({{radius}})",
-    "viewshedLayerName": "مجال الرؤية ({{radius}})"
+    "viewshedLayerName": "مجال الرؤية ({{radius}})",
+    "viewshedToolName": "مجال الرؤية",
+    "viewshedNoResult": "تعذّر حساب منطقة مرئية هنا."
   },
   "knowledgeCard": {
     "title": "معلومات المكان",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Sichtfeld von hier ({{radius}})",
-    "viewshedLayerName": "Sichtfeld ({{radius}})"
+    "viewshedLayerName": "Sichtfeld ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Ortsinformationen",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Sichtfeld von hier ({{radius}})",
-    "viewshedLayerName": "Sichtfeld ({{radius}})"
+    "viewshedLayerName": "Sichtfeld ({{radius}})",
+    "viewshedToolName": "Sichtfeld",
+    "viewshedNoResult": "Hier konnte kein Sichtbereich berechnet werden."
   },
   "knowledgeCard": {
     "title": "Ortsinformationen",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Sichtfeld von hier ({{radius}})",
-    "viewshedLayerName": "Sichtfeld ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Sichtfeld ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Ortsinformationen",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "ft"
     },
     "viewshedHere": "Sichtfeld von hier ({{radius}})",
     "viewshedLayerName": "Sichtfeld ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Sichtfeld von hier ({{radius}})",
+    "viewshedLayerName": "Sichtfeld ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Ortsinformationen",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Viewshed from here ({{radius}})",
-    "viewshedLayerName": "Viewshed ({{radius}})"
+    "viewshedLayerName": "Viewshed ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Place info",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "ft"
     },
     "viewshedHere": "Viewshed from here ({{radius}})",
     "viewshedLayerName": "Viewshed ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Viewshed from here ({{radius}})",
-    "viewshedLayerName": "Viewshed ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Viewshed ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Place info",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Viewshed from here ({{radius}})",
+    "viewshedLayerName": "Viewshed ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Place info",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Viewshed from here ({{radius}})",
-    "viewshedLayerName": "Viewshed ({{radius}})"
+    "viewshedLayerName": "Viewshed ({{radius}})",
+    "viewshedToolName": "Viewshed",
+    "viewshedNoResult": "No visible area could be computed here."
   },
   "knowledgeCard": {
     "title": "Place info",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Cuenca visual desde aquí ({{radius}})",
-    "viewshedLayerName": "Cuenca visual ({{radius}})"
+    "viewshedLayerName": "Cuenca visual ({{radius}})",
+    "viewshedToolName": "Cuenca visual",
+    "viewshedNoResult": "No se pudo calcular un área visible aquí."
   },
   "knowledgeCard": {
     "title": "Información del lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Cuenca visual desde aquí ({{radius}})",
-    "viewshedLayerName": "Cuenca visual ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Cuenca visual ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Información del lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Cuenca visual desde aquí ({{radius}})",
-    "viewshedLayerName": "Cuenca visual ({{radius}})"
+    "viewshedLayerName": "Cuenca visual ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Información del lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Cuenca visual desde aquí ({{radius}})",
+    "viewshedLayerName": "Cuenca visual ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Información del lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "ft"
     },
     "viewshedHere": "Cuenca visual desde aquí ({{radius}})",
     "viewshedLayerName": "Cuenca visual ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1721,7 +1721,9 @@
       "miles": "مایل"
     },
     "viewshedHere": "حوزه دید از اینجا ({{radius}})",
-    "viewshedLayerName": "حوزه دید ({{radius}})"
+    "viewshedLayerName": "حوزه دید ({{radius}})",
+    "viewshedToolName": "حوزه دید",
+    "viewshedNoResult": "محاسبه ناحیه قابل مشاهده در اینجا ممکن نشد."
   },
   "knowledgeCard": {
     "title": "اطلاعات مکان",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1721,9 +1721,7 @@
       "miles": "مایل"
     },
     "viewshedHere": "حوزه دید از اینجا ({{radius}})",
-    "viewshedLayerName": "حوزه دید ({{radius}})",
-    "unitKilometers": "کیلومتر",
-    "unitMeters": "متر"
+    "viewshedLayerName": "حوزه دید ({{radius}})"
   },
   "knowledgeCard": {
     "title": "اطلاعات مکان",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "متر",
       "kilometers": "کیلومتر",
-      "miles": "مایل"
+      "miles": "مایل",
+      "feet": "فوت"
     },
     "viewshedHere": "حوزه دید از اینجا ({{radius}})",
     "viewshedLayerName": "حوزه دید ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1721,7 +1721,9 @@
       "miles": "مایل"
     },
     "viewshedHere": "حوزه دید از اینجا ({{radius}})",
-    "viewshedLayerName": "حوزه دید ({{radius}})"
+    "viewshedLayerName": "حوزه دید ({{radius}})",
+    "unitKilometers": "کیلومتر",
+    "unitMeters": "متر"
   },
   "knowledgeCard": {
     "title": "اطلاعات مکان",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -1719,7 +1719,9 @@
       "meters": "متر",
       "kilometers": "کیلومتر",
       "miles": "مایل"
-    }
+    },
+    "viewshedHere": "حوزه دید از اینجا ({{radius}})",
+    "viewshedLayerName": "حوزه دید ({{radius}})"
   },
   "knowledgeCard": {
     "title": "اطلاعات مکان",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Bassin de visibilité d'ici ({{radius}})",
-    "viewshedLayerName": "Bassin de visibilité ({{radius}})"
+    "viewshedLayerName": "Bassin de visibilité ({{radius}})",
+    "viewshedToolName": "Bassin de visibilité",
+    "viewshedNoResult": "Aucune zone visible n'a pu être calculée ici."
   },
   "knowledgeCard": {
     "title": "Infos sur le lieu",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Bassin de visibilité d'ici ({{radius}})",
+    "viewshedLayerName": "Bassin de visibilité ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Infos sur le lieu",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "pi"
     },
     "viewshedHere": "Bassin de visibilité d'ici ({{radius}})",
     "viewshedLayerName": "Bassin de visibilité ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Bassin de visibilité d'ici ({{radius}})",
-    "viewshedLayerName": "Bassin de visibilité ({{radius}})"
+    "viewshedLayerName": "Bassin de visibilité ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Infos sur le lieu",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Bassin de visibilité d'ici ({{radius}})",
-    "viewshedLayerName": "Bassin de visibilité ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Bassin de visibilité ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Infos sur le lieu",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1721,9 +1721,7 @@
       "miles": "मील"
     },
     "viewshedHere": "यहाँ से दृश्यक्षेत्र ({{radius}})",
-    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})",
-    "unitKilometers": "किमी",
-    "unitMeters": "मी"
+    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})"
   },
   "knowledgeCard": {
     "title": "स्थान जानकारी",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "मी",
       "kilometers": "किमी",
-      "miles": "मील"
+      "miles": "मील",
+      "feet": "फ़ुट"
     },
     "viewshedHere": "यहाँ से दृश्यक्षेत्र ({{radius}})",
     "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1721,7 +1721,9 @@
       "miles": "मील"
     },
     "viewshedHere": "यहाँ से दृश्यक्षेत्र ({{radius}})",
-    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})"
+    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})",
+    "unitKilometers": "किमी",
+    "unitMeters": "मी"
   },
   "knowledgeCard": {
     "title": "स्थान जानकारी",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1719,7 +1719,9 @@
       "meters": "मी",
       "kilometers": "किमी",
       "miles": "मील"
-    }
+    },
+    "viewshedHere": "यहाँ से दृश्यक्षेत्र ({{radius}})",
+    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})"
   },
   "knowledgeCard": {
     "title": "स्थान जानकारी",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -1721,7 +1721,9 @@
       "miles": "मील"
     },
     "viewshedHere": "यहाँ से दृश्यक्षेत्र ({{radius}})",
-    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})"
+    "viewshedLayerName": "दृश्यक्षेत्र ({{radius}})",
+    "viewshedToolName": "दृश्यक्षेत्र",
+    "viewshedNoResult": "यहाँ कोई दृश्य क्षेत्र नहीं निकाला जा सका।"
   },
   "knowledgeCard": {
     "title": "स्थान जानकारी",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1678,7 +1678,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Area pandang dari sini ({{radius}})",
-    "viewshedLayerName": "Area pandang ({{radius}})"
+    "viewshedLayerName": "Area pandang ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Info tempat",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1678,9 +1678,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Area pandang dari sini ({{radius}})",
-    "viewshedLayerName": "Area pandang ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Area pandang ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Info tempat",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1678,7 +1678,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Area pandang dari sini ({{radius}})",
-    "viewshedLayerName": "Area pandang ({{radius}})"
+    "viewshedLayerName": "Area pandang ({{radius}})",
+    "viewshedToolName": "Area pandang",
+    "viewshedNoResult": "Tidak ada area terlihat yang dapat dihitung di sini."
   },
   "knowledgeCard": {
     "title": "Info tempat",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1676,7 +1676,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Area pandang dari sini ({{radius}})",
+    "viewshedLayerName": "Area pandang ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Info tempat",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -1675,7 +1675,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "kaki"
     },
     "viewshedHere": "Area pandang dari sini ({{radius}})",
     "viewshedLayerName": "Area pandang ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Bacino visivo da qui ({{radius}})",
-    "viewshedLayerName": "Bacino visivo ({{radius}})"
+    "viewshedLayerName": "Bacino visivo ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Informazioni sul luogo",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "ft"
     },
     "viewshedHere": "Bacino visivo da qui ({{radius}})",
     "viewshedLayerName": "Bacino visivo ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Bacino visivo da qui ({{radius}})",
-    "viewshedLayerName": "Bacino visivo ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Bacino visivo ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Informazioni sul luogo",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Bacino visivo da qui ({{radius}})",
-    "viewshedLayerName": "Bacino visivo ({{radius}})"
+    "viewshedLayerName": "Bacino visivo ({{radius}})",
+    "viewshedToolName": "Bacino visivo",
+    "viewshedNoResult": "Non è stato possibile calcolare un'area visibile qui."
   },
   "knowledgeCard": {
     "title": "Informazioni sul luogo",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Bacino visivo da qui ({{radius}})",
+    "viewshedLayerName": "Bacino visivo ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Informazioni sul luogo",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1678,9 +1678,7 @@
       "miles": "マイル"
     },
     "viewshedHere": "ここからの可視領域 ({{radius}})",
-    "viewshedLayerName": "可視領域 ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "可視領域 ({{radius}})"
   },
   "knowledgeCard": {
     "title": "場所の情報",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1675,7 +1675,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "マイル"
+      "miles": "マイル",
+      "feet": "ft"
     },
     "viewshedHere": "ここからの可視領域 ({{radius}})",
     "viewshedLayerName": "可視領域 ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1678,7 +1678,9 @@
       "miles": "マイル"
     },
     "viewshedHere": "ここからの可視領域 ({{radius}})",
-    "viewshedLayerName": "可視領域 ({{radius}})"
+    "viewshedLayerName": "可視領域 ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "場所の情報",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1678,7 +1678,9 @@
       "miles": "マイル"
     },
     "viewshedHere": "ここからの可視領域 ({{radius}})",
-    "viewshedLayerName": "可視領域 ({{radius}})"
+    "viewshedLayerName": "可視領域 ({{radius}})",
+    "viewshedToolName": "可視領域",
+    "viewshedNoResult": "ここでは可視領域を計算できませんでした。"
   },
   "knowledgeCard": {
     "title": "場所の情報",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -1676,7 +1676,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "マイル"
-    }
+    },
+    "viewshedHere": "ここからの可視領域 ({{radius}})",
+    "viewshedLayerName": "可視領域 ({{radius}})"
   },
   "knowledgeCard": {
     "title": "場所の情報",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1721,7 +1721,9 @@
       "miles": "მილი"
     },
     "viewshedHere": "ხედვის არე აქედან ({{radius}})",
-    "viewshedLayerName": "ხედვის არე ({{radius}})"
+    "viewshedLayerName": "ხედვის არე ({{radius}})",
+    "viewshedToolName": "ხედვის არე",
+    "viewshedNoResult": "აქ ხილული არეს გამოთვლა ვერ მოხერხდა."
   },
   "knowledgeCard": {
     "title": "ადგილის ინფორმაცია",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "მ",
       "kilometers": "კმ",
-      "miles": "მილი"
+      "miles": "მილი",
+      "feet": "ფუტი"
     },
     "viewshedHere": "ხედვის არე აქედან ({{radius}})",
     "viewshedLayerName": "ხედვის არე ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1721,9 +1721,7 @@
       "miles": "მილი"
     },
     "viewshedHere": "ხედვის არე აქედან ({{radius}})",
-    "viewshedLayerName": "ხედვის არე ({{radius}})",
-    "unitKilometers": "კმ",
-    "unitMeters": "მ"
+    "viewshedLayerName": "ხედვის არე ({{radius}})"
   },
   "knowledgeCard": {
     "title": "ადგილის ინფორმაცია",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1719,7 +1719,9 @@
       "meters": "მ",
       "kilometers": "კმ",
       "miles": "მილი"
-    }
+    },
+    "viewshedHere": "ხედვის არე აქედან ({{radius}})",
+    "viewshedLayerName": "ხედვის არე ({{radius}})"
   },
   "knowledgeCard": {
     "title": "ადგილის ინფორმაცია",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -1721,7 +1721,9 @@
       "miles": "მილი"
     },
     "viewshedHere": "ხედვის არე აქედან ({{radius}})",
-    "viewshedLayerName": "ხედვის არე ({{radius}})"
+    "viewshedLayerName": "ხედვის არე ({{radius}})",
+    "unitKilometers": "კმ",
+    "unitMeters": "მ"
   },
   "knowledgeCard": {
     "title": "ადგილის ინფორმაცია",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1678,7 +1678,9 @@
       "miles": "마일"
     },
     "viewshedHere": "여기서 본 가시권 ({{radius}})",
-    "viewshedLayerName": "가시권 ({{radius}})"
+    "viewshedLayerName": "가시권 ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "장소 정보",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1678,9 +1678,7 @@
       "miles": "마일"
     },
     "viewshedHere": "여기서 본 가시권 ({{radius}})",
-    "viewshedLayerName": "가시권 ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "가시권 ({{radius}})"
   },
   "knowledgeCard": {
     "title": "장소 정보",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1678,7 +1678,9 @@
       "miles": "마일"
     },
     "viewshedHere": "여기서 본 가시권 ({{radius}})",
-    "viewshedLayerName": "가시권 ({{radius}})"
+    "viewshedLayerName": "가시권 ({{radius}})",
+    "viewshedToolName": "가시권",
+    "viewshedNoResult": "여기서는 가시 영역을 계산할 수 없습니다."
   },
   "knowledgeCard": {
     "title": "장소 정보",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1676,7 +1676,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "마일"
-    }
+    },
+    "viewshedHere": "여기서 본 가시권 ({{radius}})",
+    "viewshedLayerName": "가시권 ({{radius}})"
   },
   "knowledgeCard": {
     "title": "장소 정보",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -1675,7 +1675,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "마일"
+      "miles": "마일",
+      "feet": "ft"
     },
     "viewshedHere": "여기서 본 가시권 ({{radius}})",
     "viewshedLayerName": "가시권 ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "ft"
     },
     "viewshedHere": "Zichtveld vanaf hier ({{radius}})",
     "viewshedLayerName": "Zichtveld ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Zichtveld vanaf hier ({{radius}})",
+    "viewshedLayerName": "Zichtveld ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Plaatsinfo",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Zichtveld vanaf hier ({{radius}})",
-    "viewshedLayerName": "Zichtveld ({{radius}})"
+    "viewshedLayerName": "Zichtveld ({{radius}})",
+    "viewshedToolName": "Zichtveld",
+    "viewshedNoResult": "Hier kon geen zichtbaar gebied worden berekend."
   },
   "knowledgeCard": {
     "title": "Plaatsinfo",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Zichtveld vanaf hier ({{radius}})",
-    "viewshedLayerName": "Zichtveld ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Zichtveld ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Plaatsinfo",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Zichtveld vanaf hier ({{radius}})",
-    "viewshedLayerName": "Zichtveld ({{radius}})"
+    "viewshedLayerName": "Zichtveld ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Plaatsinfo",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "Bacia visual daqui ({{radius}})",
+    "viewshedLayerName": "Bacia visual ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Informações do lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "pés"
     },
     "viewshedHere": "Bacia visual daqui ({{radius}})",
     "viewshedLayerName": "Bacia visual ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Bacia visual daqui ({{radius}})",
-    "viewshedLayerName": "Bacia visual ({{radius}})"
+    "viewshedLayerName": "Bacia visual ({{radius}})",
+    "viewshedToolName": "Bacia visual",
+    "viewshedNoResult": "Não foi possível calcular uma área visível aqui."
   },
   "knowledgeCard": {
     "title": "Informações do lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1721,7 +1721,9 @@
       "miles": "mi"
     },
     "viewshedHere": "Bacia visual daqui ({{radius}})",
-    "viewshedLayerName": "Bacia visual ({{radius}})"
+    "viewshedLayerName": "Bacia visual ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Informações do lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -1721,9 +1721,7 @@
       "miles": "mi"
     },
     "viewshedHere": "Bacia visual daqui ({{radius}})",
-    "viewshedLayerName": "Bacia visual ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Bacia visual ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Informações do lugar",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1804,7 +1804,8 @@
     "unit": {
       "meters": "м",
       "kilometers": "км",
-      "miles": "ми"
+      "miles": "ми",
+      "feet": "фут"
     },
     "viewshedHere": "Зона видимости отсюда ({{radius}})",
     "viewshedLayerName": "Зона видимости ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1807,9 +1807,7 @@
       "miles": "ми"
     },
     "viewshedHere": "Зона видимости отсюда ({{radius}})",
-    "viewshedLayerName": "Зона видимости ({{radius}})",
-    "unitKilometers": "км",
-    "unitMeters": "м"
+    "viewshedLayerName": "Зона видимости ({{radius}})"
   },
   "knowledgeCard": {
     "title": "О месте",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1807,7 +1807,9 @@
       "miles": "ми"
     },
     "viewshedHere": "Зона видимости отсюда ({{radius}})",
-    "viewshedLayerName": "Зона видимости ({{radius}})"
+    "viewshedLayerName": "Зона видимости ({{radius}})",
+    "viewshedToolName": "Зона видимости",
+    "viewshedNoResult": "Здесь не удалось вычислить зону видимости."
   },
   "knowledgeCard": {
     "title": "О месте",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1807,7 +1807,9 @@
       "miles": "ми"
     },
     "viewshedHere": "Зона видимости отсюда ({{radius}})",
-    "viewshedLayerName": "Зона видимости ({{radius}})"
+    "viewshedLayerName": "Зона видимости ({{radius}})",
+    "unitKilometers": "км",
+    "unitMeters": "м"
   },
   "knowledgeCard": {
     "title": "О месте",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -1805,7 +1805,9 @@
       "meters": "м",
       "kilometers": "км",
       "miles": "ми"
-    }
+    },
+    "viewshedHere": "Зона видимости отсюда ({{radius}})",
+    "viewshedLayerName": "Зона видимости ({{radius}})"
   },
   "knowledgeCard": {
     "title": "О месте",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1678,7 +1678,9 @@
       "miles": "mi"
     },
     "viewshedHere": "พื้นที่มองเห็นจากจุดนี้ ({{radius}})",
-    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})"
+    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})",
+    "unitKilometers": "กม.",
+    "unitMeters": "ม."
   },
   "knowledgeCard": {
     "title": "ข้อมูลสถานที่",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1676,7 +1676,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mi"
-    }
+    },
+    "viewshedHere": "พื้นที่มองเห็นจากจุดนี้ ({{radius}})",
+    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})"
   },
   "knowledgeCard": {
     "title": "ข้อมูลสถานที่",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1678,9 +1678,7 @@
       "miles": "mi"
     },
     "viewshedHere": "พื้นที่มองเห็นจากจุดนี้ ({{radius}})",
-    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})",
-    "unitKilometers": "กม.",
-    "unitMeters": "ม."
+    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})"
   },
   "knowledgeCard": {
     "title": "ข้อมูลสถานที่",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1675,7 +1675,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mi"
+      "miles": "mi",
+      "feet": "ฟุต"
     },
     "viewshedHere": "พื้นที่มองเห็นจากจุดนี้ ({{radius}})",
     "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -1678,7 +1678,9 @@
       "miles": "mi"
     },
     "viewshedHere": "พื้นที่มองเห็นจากจุดนี้ ({{radius}})",
-    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})"
+    "viewshedLayerName": "พื้นที่มองเห็น ({{radius}})",
+    "viewshedToolName": "พื้นที่มองเห็น",
+    "viewshedNoResult": "ไม่สามารถคำนวณพื้นที่ที่มองเห็นได้ที่นี่"
   },
   "knowledgeCard": {
     "title": "ข้อมูลสถานที่",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1719,7 +1719,9 @@
       "meters": "m",
       "kilometers": "km",
       "miles": "mil"
-    }
+    },
+    "viewshedHere": "Buradan görüş alanı ({{radius}})",
+    "viewshedLayerName": "Görüş alanı ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Yer bilgisi",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1718,7 +1718,8 @@
     "unit": {
       "meters": "m",
       "kilometers": "km",
-      "miles": "mil"
+      "miles": "mil",
+      "feet": "ft"
     },
     "viewshedHere": "Buradan görüş alanı ({{radius}})",
     "viewshedLayerName": "Görüş alanı ({{radius}})",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1721,7 +1721,9 @@
       "miles": "mil"
     },
     "viewshedHere": "Buradan görüş alanı ({{radius}})",
-    "viewshedLayerName": "Görüş alanı ({{radius}})"
+    "viewshedLayerName": "Görüş alanı ({{radius}})",
+    "unitKilometers": "km",
+    "unitMeters": "m"
   },
   "knowledgeCard": {
     "title": "Yer bilgisi",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1721,9 +1721,7 @@
       "miles": "mil"
     },
     "viewshedHere": "Buradan görüş alanı ({{radius}})",
-    "viewshedLayerName": "Görüş alanı ({{radius}})",
-    "unitKilometers": "km",
-    "unitMeters": "m"
+    "viewshedLayerName": "Görüş alanı ({{radius}})"
   },
   "knowledgeCard": {
     "title": "Yer bilgisi",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -1721,7 +1721,9 @@
       "miles": "mil"
     },
     "viewshedHere": "Buradan görüş alanı ({{radius}})",
-    "viewshedLayerName": "Görüş alanı ({{radius}})"
+    "viewshedLayerName": "Görüş alanı ({{radius}})",
+    "viewshedToolName": "Görüş alanı",
+    "viewshedNoResult": "Burada görünür bir alan hesaplanamadı."
   },
   "knowledgeCard": {
     "title": "Yer bilgisi",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1678,7 +1678,9 @@
       "miles": "英里"
     },
     "viewshedHere": "从此处的可视域 ({{radius}})",
-    "viewshedLayerName": "可视域 ({{radius}})"
+    "viewshedLayerName": "可视域 ({{radius}})",
+    "unitKilometers": "公里",
+    "unitMeters": "米"
   },
   "knowledgeCard": {
     "title": "地点信息",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1676,7 +1676,9 @@
       "meters": "米",
       "kilometers": "千米",
       "miles": "英里"
-    }
+    },
+    "viewshedHere": "从此处的可视域 ({{radius}})",
+    "viewshedLayerName": "可视域 ({{radius}})"
   },
   "knowledgeCard": {
     "title": "地点信息",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1678,9 +1678,7 @@
       "miles": "英里"
     },
     "viewshedHere": "从此处的可视域 ({{radius}})",
-    "viewshedLayerName": "可视域 ({{radius}})",
-    "unitKilometers": "公里",
-    "unitMeters": "米"
+    "viewshedLayerName": "可视域 ({{radius}})"
   },
   "knowledgeCard": {
     "title": "地点信息",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1678,7 +1678,9 @@
       "miles": "英里"
     },
     "viewshedHere": "从此处的可视域 ({{radius}})",
-    "viewshedLayerName": "可视域 ({{radius}})"
+    "viewshedLayerName": "可视域 ({{radius}})",
+    "viewshedToolName": "可视域",
+    "viewshedNoResult": "无法在此处计算可视区域。"
   },
   "knowledgeCard": {
     "title": "地点信息",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -1675,7 +1675,8 @@
     "unit": {
       "meters": "米",
       "kilometers": "千米",
-      "miles": "英里"
+      "miles": "英里",
+      "feet": "英尺"
     },
     "viewshedHere": "从此处的可视域 ({{radius}})",
     "viewshedLayerName": "可视域 ({{radius}})",

--- a/apps/geolibre-desktop/src/lib/quick-analysis.ts
+++ b/apps/geolibre-desktop/src/lib/quick-analysis.ts
@@ -148,6 +148,12 @@ let latestRun = 0;
  * tool -- so it can report running and failed like every other entry in that
  * menu instead of failing silently.
  *
+ * Unlike `runQuickAnalysis` this records **no Processing History entry**: the
+ * caller is not a registry tool, so there is no algorithm id and parameter set
+ * to replay or copy as Python. The module docstring's claim that every quick
+ * action lands in the History covers the registry-tool actions; this is the
+ * exception, so History is not a complete audit trail of the menu.
+ *
  * Returns a setter bound to this run's id, so it goes through the same
  * {@link latestRun} guard `runQuickAnalysis` uses. Without that, a slow
  * viewshed resolving after the user has fired a quick buffer would clobber the

--- a/apps/geolibre-desktop/src/lib/quick-analysis.ts
+++ b/apps/geolibre-desktop/src/lib/quick-analysis.ts
@@ -143,15 +143,23 @@ const listeners = new Set<() => void>();
 let latestRun = 0;
 
 /**
- * Publish a status for the Quick Analysis banner.
+ * Claim the banner for a quick action that is not a registry tool -- the
+ * viewshed, which computes a raster rather than running a registered vector
+ * tool -- so it can report running and failed like every other entry in that
+ * menu instead of failing silently.
  *
- * Exported so a quick action that is not a registry tool -- the viewshed, which
- * computes a raster rather than running a registered vector tool -- can report
- * running and failed through the same banner as every other entry in that menu,
- * instead of failing silently.
+ * Returns a setter bound to this run's id, so it goes through the same
+ * {@link latestRun} guard `runQuickAnalysis` uses. Without that, a slow
+ * viewshed resolving after the user has fired a quick buffer would clobber the
+ * buffer's status with its own -- exactly the "resurrect a banner for a run the
+ * user has moved on from" case the counter exists to prevent.
  */
-export function setQuickAnalysisStatus(next: QuickAnalysisStatus): void {
-  setStatus(next);
+export function beginQuickAnalysisRun(toolName: string): (next: QuickAnalysisStatus) => void {
+  const run = ++latestRun;
+  setStatus({ phase: "running", toolName });
+  return (next) => {
+    if (run === latestRun) setStatus(next);
+  };
 }
 
 function setStatus(next: QuickAnalysisStatus): void {

--- a/apps/geolibre-desktop/src/lib/quick-analysis.ts
+++ b/apps/geolibre-desktop/src/lib/quick-analysis.ts
@@ -142,6 +142,18 @@ const listeners = new Set<() => void>();
  */
 let latestRun = 0;
 
+/**
+ * Publish a status for the Quick Analysis banner.
+ *
+ * Exported so a quick action that is not a registry tool -- the viewshed, which
+ * computes a raster rather than running a registered vector tool -- can report
+ * running and failed through the same banner as every other entry in that menu,
+ * instead of failing silently.
+ */
+export function setQuickAnalysisStatus(next: QuickAnalysisStatus): void {
+  setStatus(next);
+}
+
 function setStatus(next: QuickAnalysisStatus): void {
   status = next;
   for (const listener of listeners) listener();

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -125,6 +125,12 @@ export async function runViewshed(options: RunViewshedOptions): Promise<Viewshed
       ],
     },
     metadata: {
+      // fitLayer resolves an extent from geojson, then source.bounds /
+      // metadata.bounds, then the live source's bounds. An ImageSource exposes
+      // only coordinates, so without this the Layers panel's zoom-to button
+      // silently does nothing -- the Georeferencer's overlays set it for the
+      // same reason.
+      bounds: result.bbox,
       viewshed: {
         lng: options.lng,
         lat: options.lat,

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
 import {
   assembleTerrainDem,
   computeViewshedAsync,
@@ -24,9 +25,14 @@ import {
 /** Default eye height above ground — a standing person. */
 export const DEFAULT_OBSERVER_HEIGHT_METERS = 1.8;
 
+/** Marks the layer as a viewshed result, for panels that gate on provenance. */
+export const VIEWSHED_SOURCE_KIND = "viewshed";
+
 export interface RunViewshedOptions {
   lng: number;
   lat: number;
+  /** Frames the result after adding it, as the sibling quick actions do. */
+  mapControllerRef?: React.RefObject<MapController | null>;
   radiusMeters: number;
   observerHeightMeters?: number;
   /** Layer name; callers pass a translated string. */
@@ -106,14 +112,12 @@ export async function runViewshed(options: RunViewshedOptions): Promise<Viewshed
   if (!url) return null;
 
   const [west, south, east, north] = result.bbox;
-  const layer: GeoLibreLayer = {
-    id: `viewshed-${Date.now().toString(36)}`,
-    name: options.layerName,
-    type: "image",
-    visible: true,
-    opacity: 1,
-    style: { ...DEFAULT_LAYER_STYLE },
-    source: {
+  // The store's own image-overlay action rather than a hand-rolled layer: it
+  // owns id generation, the default style, `source.type`, and the metadata
+  // merge, and is what the KML ground-overlay and Georeferencer paths use.
+  const layerId = useAppStore.getState().addImageOverlayLayer(
+    options.layerName,
+    {
       url,
       // Top-left, top-right, bottom-right, bottom-left, matching the image
       // source contract in layer-sync.
@@ -124,27 +128,33 @@ export async function runViewshed(options: RunViewshedOptions): Promise<Viewshed
         [west, south],
       ],
     },
-    metadata: {
-      // fitLayer resolves an extent from geojson, then source.bounds /
-      // metadata.bounds, then the live source's bounds. An ImageSource exposes
-      // only coordinates, so without this the Layers panel's zoom-to button
-      // silently does nothing -- the Georeferencer's overlays set it for the
-      // same reason.
+    {
+      // fitLayer resolves an extent from geojson, then source/metadata bounds,
+      // then the live source's bounds. An ImageSource exposes only coordinates,
+      // so without this the Layers panel's zoom-to button does nothing.
       bounds: result.bbox,
-      viewshed: {
-        lng: options.lng,
-        lat: options.lat,
-        radiusMeters,
-        observerHeightMeters: options.observerHeightMeters ?? DEFAULT_OBSERVER_HEIGHT_METERS,
-        observerGroundMeters: result.observerGroundMeters,
+      sourceKind: VIEWSHED_SOURCE_KIND,
+      metadata: {
+        viewshed: {
+          lng: options.lng,
+          lat: options.lat,
+          radiusMeters,
+          observerHeightMeters: options.observerHeightMeters ?? DEFAULT_OBSERVER_HEIGHT_METERS,
+          observerGroundMeters: result.observerGroundMeters,
+        },
       },
     },
-  };
+  );
 
-  useAppStore.getState().addLayer(layer);
+  // Frame the result, like every sibling quick action does after adding its
+  // layer. At the larger radii the square can fall outside the viewport even
+  // though the clicked point was on screen, and a banner that flashes and
+  // clears with nothing visible reads as "nothing happened".
+  const added = useAppStore.getState().layers.find((entry) => entry.id === layerId);
+  if (added) options.mapControllerRef?.current?.fitLayer(added);
 
   return {
-    layerId: layer.id,
+    layerId,
     visibleFraction: result.visibleCells / (result.width * result.height),
     observerGroundMeters: result.observerGroundMeters,
   };

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import {
   assembleTerrainDem,
-  computeViewshed,
+  computeViewshedAsync,
   viewshedToRgba,
   MAX_VIEWSHED_RADIUS_METERS,
   MIN_VIEWSHED_RADIUS_METERS,
@@ -90,7 +90,7 @@ export async function runViewshed(options: RunViewshedOptions): Promise<Viewshed
   });
   if (!dem) return null;
 
-  const result = computeViewshed(
+  const result = await computeViewshedAsync(
     dem,
     {
       lng: options.lng,

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -4,6 +4,7 @@ import {
   computeViewshed,
   viewshedToRgba,
   MAX_VIEWSHED_RADIUS_METERS,
+  MIN_VIEWSHED_RADIUS_METERS,
 } from "@geolibre/processing";
 
 /**
@@ -74,7 +75,14 @@ async function rgbaToPngDataUrl(
  *   be fetched or the result could not be encoded.
  */
 export async function runViewshed(options: RunViewshedOptions): Promise<ViewshedRunResult | null> {
-  const radiusMeters = Math.min(options.radiusMeters, MAX_VIEWSHED_RADIUS_METERS);
+  // Clamped on both bounds here, not just the max: assembleTerrainDem floors to
+  // MIN_VIEWSHED_RADIUS_METERS internally, so clamping only the ceiling would
+  // let computeViewshed cull against a smaller radius than the DEM was built
+  // for -- the analysed square and the visibility limit would disagree.
+  const radiusMeters = Math.min(
+    MAX_VIEWSHED_RADIUS_METERS,
+    Math.max(MIN_VIEWSHED_RADIUS_METERS, options.radiusMeters),
+  );
   const dem = await assembleTerrainDem({
     lng: options.lng,
     lat: options.lat,

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -1,0 +1,136 @@
+import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import {
+  assembleTerrainDem,
+  computeViewshed,
+  viewshedToRgba,
+  MAX_VIEWSHED_RADIUS_METERS,
+} from "@geolibre/processing";
+
+/**
+ * Run a viewshed from a clicked map point and add the result as a layer
+ * (issue #1815).
+ *
+ * The result is an `image` layer — a translucent wash over the visible ground,
+ * pinned to the analysed square by its corner coordinates. That reuses the
+ * overlay path the Raster Georeferencer already established, so the viewshed
+ * gets opacity, ordering, zoom-to and removal from the Layers panel for free,
+ * with no new layer type.
+ *
+ * A PNG data URL rather than a blob URL: the layer is saved with the project,
+ * and a blob URL would be dead the next time it opened.
+ */
+
+/** Default eye height above ground — a standing person. */
+export const DEFAULT_OBSERVER_HEIGHT_METERS = 1.8;
+
+export interface RunViewshedOptions {
+  lng: number;
+  lat: number;
+  radiusMeters: number;
+  observerHeightMeters?: number;
+  /** Layer name; callers pass a translated string. */
+  layerName: string;
+}
+
+export interface ViewshedRunResult {
+  layerId: string;
+  /** Share of the analysed area that is visible, 0-1. */
+  visibleFraction: number;
+  observerGroundMeters: number;
+}
+
+/** Encode an RGBA grid as a PNG data URL. */
+async function rgbaToPngDataUrl(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+): Promise<string | null> {
+  try {
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D | null;
+    if (!context) return null;
+    // Built via createImageData rather than `new ImageData(rgba, ...)`: the
+    // constructor's typing requires an ArrayBuffer-backed view, and copying into
+    // a context-owned buffer sidesteps that without an assertion.
+    const image = context.createImageData(width, height);
+    image.data.set(rgba);
+    context.putImageData(image, 0, 0);
+    const blob = await canvas.convertToBlob({ type: "image/png" });
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute a viewshed and add it to the map.
+ *
+ * @returns The new layer and coverage stats, or null when the terrain could not
+ *   be fetched or nothing proved visible.
+ */
+export async function runViewshed(options: RunViewshedOptions): Promise<ViewshedRunResult | null> {
+  const radiusMeters = Math.min(options.radiusMeters, MAX_VIEWSHED_RADIUS_METERS);
+  const dem = await assembleTerrainDem({
+    lng: options.lng,
+    lat: options.lat,
+    radiusMeters,
+  });
+  if (!dem) return null;
+
+  const result = computeViewshed(
+    dem,
+    {
+      lng: options.lng,
+      lat: options.lat,
+      heightMeters: options.observerHeightMeters ?? DEFAULT_OBSERVER_HEIGHT_METERS,
+    },
+    radiusMeters,
+  );
+  if (result.visibleCells === 0) return null;
+
+  const url = await rgbaToPngDataUrl(viewshedToRgba(result), result.width, result.height);
+  if (!url) return null;
+
+  const [west, south, east, north] = result.bbox;
+  const layer: GeoLibreLayer = {
+    id: `viewshed-${Date.now().toString(36)}`,
+    name: options.layerName,
+    type: "image",
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    source: {
+      url,
+      // Top-left, top-right, bottom-right, bottom-left, matching the image
+      // source contract in layer-sync.
+      coordinates: [
+        [west, north],
+        [east, north],
+        [east, south],
+        [west, south],
+      ],
+    },
+    metadata: {
+      viewshed: {
+        lng: options.lng,
+        lat: options.lat,
+        radiusMeters,
+        observerHeightMeters: options.observerHeightMeters ?? DEFAULT_OBSERVER_HEIGHT_METERS,
+        observerGroundMeters: result.observerGroundMeters,
+      },
+    },
+  };
+
+  useAppStore.getState().addLayer(layer);
+
+  return {
+    layerId: layer.id,
+    visibleFraction: result.visibleCells / (result.width * result.height),
+    observerGroundMeters: result.observerGroundMeters,
+  };
+}

--- a/apps/geolibre-desktop/src/lib/run-viewshed.ts
+++ b/apps/geolibre-desktop/src/lib/run-viewshed.ts
@@ -71,7 +71,7 @@ async function rgbaToPngDataUrl(
  * Compute a viewshed and add it to the map.
  *
  * @returns The new layer and coverage stats, or null when the terrain could not
- *   be fetched or nothing proved visible.
+ *   be fetched or the result could not be encoded.
  */
 export async function runViewshed(options: RunViewshedOptions): Promise<ViewshedRunResult | null> {
   const radiusMeters = Math.min(options.radiusMeters, MAX_VIEWSHED_RADIUS_METERS);
@@ -91,7 +91,8 @@ export async function runViewshed(options: RunViewshedOptions): Promise<Viewshed
     },
     radiusMeters,
   );
-  if (result.visibleCells === 0) return null;
+  // Not checked for zero: computeViewshed always marks the observer's own cell,
+  // so visibleCells is at least 1 by construction.
 
   const url = await rgbaToPngDataUrl(viewshedToRgba(result), result.width, result.height);
   if (!url) return null;

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -324,6 +324,7 @@ export {
 export {
   assembleTerrainDem,
   computeViewshed,
+  computeViewshedAsync,
   decodeTerrariumElevation,
   viewshedToRgba,
   MAX_VIEWSHED_RADIUS_METERS,

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -328,6 +328,7 @@ export {
   viewshedToRgba,
   MAX_VIEWSHED_RADIUS_METERS,
   MIN_VIEWSHED_RADIUS_METERS,
+  type AssembleTerrainDemOptions,
   type TerrainDem,
   type ViewshedObserver,
   type ViewshedResult,

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -320,3 +320,15 @@ export {
   type ExtractWmsSubsetOptions,
   type ExtractXyzTileSubsetOptions,
 } from "./raster-subset";
+
+export {
+  assembleTerrainDem,
+  computeViewshed,
+  decodeTerrariumElevation,
+  viewshedToRgba,
+  MAX_VIEWSHED_RADIUS_METERS,
+  MIN_VIEWSHED_RADIUS_METERS,
+  type TerrainDem,
+  type ViewshedObserver,
+  type ViewshedResult,
+} from "./terrain-viewshed";

--- a/packages/processing/src/terrain-viewshed.ts
+++ b/packages/processing/src/terrain-viewshed.ts
@@ -94,6 +94,9 @@ export function tileForLngLat(lng: number, lat: number, zoom: number): { x: numb
   return { x, y };
 }
 
+/** Abort a terrain tile request that has not responded within this window. */
+export const TILE_FETCH_TIMEOUT_MS = 15000;
+
 /** Bounds a viewshed request is clamped to, so one click cannot fetch a continent. */
 export const MAX_VIEWSHED_RADIUS_METERS = 50_000;
 export const MIN_VIEWSHED_RADIUS_METERS = 100;
@@ -240,9 +243,27 @@ export function viewshedToRgba(
 // --- Tile assembly (browser) -----------------------------------------------
 
 /** Decode one Terrarium PNG tile to elevations via an offscreen canvas. */
-async function decodeTile(url: string, signal?: AbortSignal): Promise<Float32Array | null> {
+interface DecodedTile {
+  width: number;
+  height: number;
+  values: Float32Array;
+}
+
+async function decodeTile(
+  url: string,
+  signal?: AbortSignal,
+  timeoutMs = TILE_FETCH_TIMEOUT_MS,
+): Promise<DecodedTile | null> {
+  // A hung tile request would otherwise stall the whole assembly behind
+  // Promise.all with no recovery, since fetch has no default timeout.
+  const timeout = new AbortController();
+  const timer = setTimeout(() => timeout.abort(), timeoutMs);
+  const composed =
+    signal && typeof AbortSignal !== "undefined" && typeof AbortSignal.any === "function"
+      ? AbortSignal.any([signal, timeout.signal])
+      : (signal ?? timeout.signal);
   try {
-    const response = await fetch(url, { signal });
+    const response = await fetch(url, { signal: composed });
     if (!response.ok) return null;
     const blob = await response.blob();
     const bitmap = await createImageBitmap(blob);
@@ -257,9 +278,11 @@ async function decodeTile(url: string, signal?: AbortSignal): Promise<Float32Arr
       const offset = i * 4;
       elevations[i] = decodeTerrariumElevation(data[offset], data[offset + 1], data[offset + 2]);
     }
-    return elevations;
+    return { width: bitmap.width, height: bitmap.height, values: elevations };
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -309,8 +332,18 @@ export async function assembleTerrainDem(
   const south = lat - dLat;
   const north = lat + dLat;
 
+  // Web Mercator (and therefore the tile grid) is undefined beyond ~85 degrees,
+  // and a square straddling the antimeridian would produce a negative tile x.
+  // Both are rejected up front rather than left to fail as 404s partway through.
+  if (!Number.isFinite(lat) || north > 85 || south < -85) return null;
+  if (west < -180 || east > 180) return null;
+
   const topLeft = tileForLngLat(west, north, zoom);
   const bottomRight = tileForLngLat(east, south, zoom);
+  const tileCount = Math.pow(2, zoom);
+  if (topLeft.x < 0 || topLeft.y < 0 || bottomRight.x >= tileCount || bottomRight.y >= tileCount) {
+    return null;
+  }
   const tilesWide = bottomRight.x - topLeft.x + 1;
   const tilesTall = bottomRight.y - topLeft.y + 1;
   if (tilesWide <= 0 || tilesTall <= 0) return null;
@@ -330,12 +363,16 @@ export async function assembleTerrainDem(
       requests.push(
         decodeTile(url, signal).then((tile) => {
           if (!tile) return;
+          // A tile served at a size other than the mosaic assumes would be
+          // copied at the wrong stride, shearing the elevations. Skipping it
+          // degrades that patch instead.
+          if (tile.width !== TERRARIUM_TILE_SIZE || tile.height !== TERRARIUM_TILE_SIZE) return;
           loaded += 1;
           for (let row = 0; row < TERRARIUM_TILE_SIZE; row += 1) {
             const target =
               (ty * TERRARIUM_TILE_SIZE + row) * mosaicWidth + tx * TERRARIUM_TILE_SIZE;
             mosaic.set(
-              tile.subarray(row * TERRARIUM_TILE_SIZE, (row + 1) * TERRARIUM_TILE_SIZE),
+              tile.values.subarray(row * TERRARIUM_TILE_SIZE, (row + 1) * TERRARIUM_TILE_SIZE),
               target,
             );
           }

--- a/packages/processing/src/terrain-viewshed.ts
+++ b/packages/processing/src/terrain-viewshed.ts
@@ -70,7 +70,9 @@ export function metersToLatDegrees(meters: number): number {
  *
  * Aims for roughly {@link TARGET_GRID_SPAN} pixels across the analysed square:
  * enough detail for a ridge to block a line of sight, small enough that both
- * the tile fetch and the O(n²·√n) line walk stay interactive.
+ * the tile fetch and the line walk stay interactive. The walk is O(n³) in the
+ * grid's side length -- a ray of up to n steps for each of n² cells -- so the
+ * span, not the requested radius, is what bounds the cost.
  */
 export const TARGET_GRID_SPAN = 512;
 

--- a/packages/processing/src/terrain-viewshed.ts
+++ b/packages/processing/src/terrain-viewshed.ts
@@ -153,6 +153,12 @@ export interface ViewshedResult {
  * — exact per ray, and simple enough to reason about, at the cost of resampling
  * the same near-observer cells for many rays.
  *
+ * The grid is treated as uniform in latitude, while its rows come from tiles
+ * uniform in Web Mercator Y. The crop compensates when locating the window
+ * (see `rowOf`), but the cell height used here is still a single constant for
+ * the whole grid, so a tall square at high latitude carries a small north-south
+ * stretch. At the radii this is capped to it stays well under a cell.
+ *
  * Earth curvature and refraction are **not** modelled. Over the radii this is
  * capped to (50 km) curvature drop reaches ~180 m, which matters for a
  * long-range radio study but not for the "what can I see from this overlook"
@@ -312,6 +318,16 @@ async function decodeTile(
   }
 }
 
+/**
+ * Web Mercator Y for a latitude, normalised so 0 is the north edge of the world
+ * and 1 the south — the space tile rows are uniformly spaced in.
+ */
+function mercatorY(lat: number): number {
+  const clamped = Math.max(-85.051129, Math.min(85.051129, lat));
+  const rad = (clamped * Math.PI) / 180;
+  return (1 - Math.log(Math.tan(rad) + 1 / Math.cos(rad)) / Math.PI) / 2;
+}
+
 /** Longitude/latitude of a tile's north-west corner. */
 function tileNorthWest(x: number, y: number, zoom: number): [number, number] {
   const n = Math.pow(2, zoom);
@@ -414,8 +430,14 @@ export async function assembleTerrainDem(
   const [mosaicEast, mosaicSouth] = tileNorthWest(bottomRight.x + 1, bottomRight.y + 1, zoom);
   const colOf = (x: number) =>
     Math.round(((x - mosaicWest) / (mosaicEast - mosaicWest)) * (mosaicWidth - 1));
-  const rowOf = (y: number) =>
-    Math.round(((mosaicNorth - y) / (mosaicNorth - mosaicSouth)) * (mosaicHeight - 1));
+  // Tile rows are uniformly spaced in Web Mercator Y, not in latitude, so the
+  // row lookup interpolates in mercator space. Interpolating in latitude
+  // instead skews the crop north-south, and the error grows with latitude.
+  const rowOf = (y: number) => {
+    const top = mercatorY(mosaicNorth);
+    const bottom = mercatorY(mosaicSouth);
+    return Math.round(((mercatorY(y) - top) / (bottom - top)) * (mosaicHeight - 1));
+  };
 
   const cropLeft = Math.max(0, colOf(west));
   const cropRight = Math.min(mosaicWidth - 1, colOf(east));

--- a/packages/processing/src/terrain-viewshed.ts
+++ b/packages/processing/src/terrain-viewshed.ts
@@ -22,6 +22,8 @@
  * geometry can be tested without a network.
  */
 
+import type { ViewshedWorkerRequest, ViewshedWorkerResponse } from "./terrain-viewshed.worker";
+
 /** The Terrarium terrain tiles the map's terrain control already uses. */
 export const TERRARIUM_TILE_URL =
   "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png";
@@ -408,4 +410,74 @@ export async function assembleTerrainDem(
   }
 
   return { width, height, values, bbox: [west, south, east, north] };
+}
+
+// --- Off-main-thread execution ---------------------------------------------
+
+/**
+ * Compute a viewshed on a Web Worker, falling back to this thread where Workers
+ * are unavailable (SSR, a test runner, a locked-down webview).
+ *
+ * The walk is O(n³) in the grid's side length with no yield points, so running
+ * it inline freezes the tab until it finishes — several seconds at the largest
+ * radius preset on modest hardware. The DEM and the visibility grid are both
+ * plain typed arrays, so the round trip costs one structured clone in and one
+ * transfer out.
+ *
+ * Mirrors `runToolOnWorker` in `wasm-convert.ts`: one job per worker,
+ * terminated on the terminal message, and no timeout — how long this takes is
+ * bounded by the grid, not the clock, and cutting off work that would have
+ * finished is worse than waiting.
+ */
+export function computeViewshedAsync(
+  dem: TerrainDem,
+  observer: ViewshedObserver,
+  radiusMeters = 0,
+): Promise<ViewshedResult> {
+  if (typeof Worker === "undefined") {
+    return Promise.resolve(computeViewshed(dem, observer, radiusMeters));
+  }
+  return new Promise((resolve, reject) => {
+    let worker: Worker;
+    try {
+      worker = new Worker(new URL("./terrain-viewshed.worker.ts", import.meta.url), {
+        type: "module",
+      });
+    } catch {
+      // A bundler or runtime that cannot construct the worker should still
+      // produce a viewshed rather than an error.
+      resolve(computeViewshed(dem, observer, radiusMeters));
+      return;
+    }
+    const settle = (fn: () => void): void => {
+      worker.terminate();
+      fn();
+    };
+    worker.addEventListener("message", (event: MessageEvent<ViewshedWorkerResponse>) => {
+      const data = event.data;
+      settle(() => {
+        if (!data.ok) {
+          reject(new Error(data.error || "The viewshed worker failed."));
+          return;
+        }
+        const { ok: _ok, ...result } = data;
+        resolve(result);
+      });
+    });
+    worker.addEventListener("error", (event) => {
+      settle(() => reject(new Error(event.message || "The viewshed worker failed.")));
+    });
+    // `error` does not fire when a posted message cannot be deserialized, which
+    // would otherwise leave this promise pending forever.
+    worker.addEventListener("messageerror", () => {
+      settle(() => reject(new Error("The viewshed worker posted an undeserializable message.")));
+    });
+    try {
+      // The DEM is cloned rather than transferred: the caller still owns it (it
+      // is reused for the result's bbox), and a neutered input would be a trap.
+      worker.postMessage({ dem, observer, radiusMeters } satisfies ViewshedWorkerRequest);
+    } catch (error) {
+      settle(() => reject(error instanceof Error ? error : new Error(String(error))));
+    }
+  });
 }

--- a/packages/processing/src/terrain-viewshed.ts
+++ b/packages/processing/src/terrain-viewshed.ts
@@ -1,0 +1,372 @@
+/**
+ * Interactive viewshed from a clicked map point (issue #1815).
+ *
+ * GeoLibre already ships a Whitebox `viewshed`, but it consumes a DEM raster
+ * file *and* a station-point vector file and emits a raster file. From a point
+ * the user just clicked, that is three format round-trips before any analysis
+ * happens, and it requires the user to have found and loaded a DEM first —
+ * which is the data-prep step the issue is about removing.
+ *
+ * So this module answers the same question directly against the terrain the map
+ * is already rendering:
+ *
+ *  1. {@link assembleTerrainDem} fetches the Terrarium RGB tiles the terrain
+ *     control uses and decodes them into one elevation grid over a radius.
+ *  2. {@link computeViewshed} walks a line of sight from the observer to every
+ *     cell and marks it visible or hidden.
+ *
+ * The Whitebox tool stays untouched and remains the right choice for rigorous
+ * work against a DEM the user has in hand; this is the exploratory path.
+ *
+ * The computation is deliberately separated from the tile fetching so the
+ * geometry can be tested without a network.
+ */
+
+/** The Terrarium terrain tiles the map's terrain control already uses. */
+export const TERRARIUM_TILE_URL =
+  "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png";
+
+/** Terrarium tiles are 256px and published up to zoom 15. */
+export const TERRARIUM_TILE_SIZE = 256;
+export const TERRARIUM_MAX_ZOOM = 15;
+
+/**
+ * Decode a Terrarium RGB triple to elevation in metres.
+ *
+ * Terrarium packs elevation as `(R * 256 + G + B / 256) - 32768`, which covers
+ * -32768 to +32768 m at 1/256 m precision.
+ */
+export function decodeTerrariumElevation(r: number, g: number, b: number): number {
+  return r * 256 + g + b / 256 - 32768;
+}
+
+/** An elevation grid in EPSG:4326, row 0 at the north edge. */
+export interface TerrainDem {
+  width: number;
+  height: number;
+  /** Row-major elevations in metres, `width * height` long. */
+  values: Float32Array;
+  /** Geographic bounds as [west, south, east, north]. */
+  bbox: [number, number, number, number];
+}
+
+/** Metres per degree of latitude, near enough for a local viewshed. */
+const METERS_PER_DEGREE_LAT = 111320;
+
+/** Longitude degrees spanning `meters` at a latitude. */
+export function metersToLonDegrees(meters: number, lat: number): number {
+  const scale = Math.cos((lat * Math.PI) / 180);
+  return meters / (METERS_PER_DEGREE_LAT * Math.max(scale, 1e-6));
+}
+
+/** Latitude degrees spanning `meters`. */
+export function metersToLatDegrees(meters: number): number {
+  return meters / METERS_PER_DEGREE_LAT;
+}
+
+/**
+ * The tile zoom whose ground resolution best fits a radius, capped so a large
+ * radius cannot ask for thousands of tiles.
+ *
+ * Aims for roughly {@link TARGET_GRID_SPAN} pixels across the analysed square:
+ * enough detail for a ridge to block a line of sight, small enough that both
+ * the tile fetch and the O(n²·√n) line walk stay interactive.
+ */
+export const TARGET_GRID_SPAN = 512;
+
+export function zoomForRadius(radiusMeters: number, lat: number): number {
+  // Ground resolution of a Terrarium pixel at zoom z and latitude lat.
+  const resolutionAtZoom = (z: number) =>
+    (156543.03392 * Math.cos((lat * Math.PI) / 180)) / Math.pow(2, z);
+  const wanted = (radiusMeters * 2) / TARGET_GRID_SPAN;
+  for (let z = TERRARIUM_MAX_ZOOM; z >= 0; z -= 1) {
+    if (resolutionAtZoom(z) >= wanted) return z;
+  }
+  return 0;
+}
+
+/** Slippy-map tile x/y for a coordinate at a zoom. */
+export function tileForLngLat(lng: number, lat: number, zoom: number): { x: number; y: number } {
+  const n = Math.pow(2, zoom);
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n);
+  return { x, y };
+}
+
+/** Bounds a viewshed request is clamped to, so one click cannot fetch a continent. */
+export const MAX_VIEWSHED_RADIUS_METERS = 50_000;
+export const MIN_VIEWSHED_RADIUS_METERS = 100;
+
+export interface ViewshedObserver {
+  lng: number;
+  lat: number;
+  /** Height of the observer above the ground, in metres. */
+  heightMeters: number;
+}
+
+export interface ViewshedResult {
+  width: number;
+  height: number;
+  /** 1 where visible, 0 where hidden, row-major. */
+  visible: Uint8Array;
+  bbox: [number, number, number, number];
+  /** Ground elevation under the observer, in metres. */
+  observerGroundMeters: number;
+  /** Count of visible cells, for reporting coverage. */
+  visibleCells: number;
+}
+
+/**
+ * Compute which cells of a DEM are visible from an observer.
+ *
+ * Walks a straight line from the observer to each cell, tracking the greatest
+ * slope seen so far; a cell is visible when its own slope from the observer
+ * exceeds every slope along the way. This is the standard R3-style line-of-sight
+ * — exact per ray, and simple enough to reason about, at the cost of resampling
+ * the same near-observer cells for many rays.
+ *
+ * Earth curvature and refraction are **not** modelled. Over the radii this is
+ * capped to (50 km) curvature drop reaches ~180 m, which matters for a
+ * long-range radio study but not for the "what can I see from this overlook"
+ * question this answers. The Whitebox tool remains the rigorous option.
+ *
+ * @param dem - The elevation grid to analyse.
+ * @param observer - Position and height above ground.
+ * @param radiusMeters - Ignore cells beyond this distance, or 0 for no limit.
+ */
+export function computeViewshed(
+  dem: TerrainDem,
+  observer: ViewshedObserver,
+  radiusMeters = 0,
+): ViewshedResult {
+  const { width, height, values, bbox } = dem;
+  const [west, south, east, north] = bbox;
+  const visible = new Uint8Array(width * height);
+
+  // Observer position in grid space.
+  const col = Math.round(((observer.lng - west) / (east - west)) * (width - 1));
+  const row = Math.round(((north - observer.lat) / (north - south)) * (height - 1));
+  const clampedCol = Math.min(width - 1, Math.max(0, col));
+  const clampedRow = Math.min(height - 1, Math.max(0, row));
+  const groundMeters = values[clampedRow * width + clampedCol] ?? 0;
+  const eyeMeters = groundMeters + observer.heightMeters;
+
+  // Cell size in metres, so slopes compare like with like on both axes.
+  const cellLatMeters = ((north - south) / Math.max(height - 1, 1)) * METERS_PER_DEGREE_LAT;
+  const midLat = (north + south) / 2;
+  const cellLonMeters =
+    ((east - west) / Math.max(width - 1, 1)) *
+    METERS_PER_DEGREE_LAT *
+    Math.cos((midLat * Math.PI) / 180);
+
+  let visibleCells = 0;
+  const markVisible = (index: number): void => {
+    if (visible[index] === 0) {
+      visible[index] = 1;
+      visibleCells += 1;
+    }
+  };
+  markVisible(clampedRow * width + clampedCol);
+
+  for (let targetRow = 0; targetRow < height; targetRow += 1) {
+    for (let targetCol = 0; targetCol < width; targetCol += 1) {
+      if (targetRow === clampedRow && targetCol === clampedCol) continue;
+
+      const dCol = targetCol - clampedCol;
+      const dRow = targetRow - clampedRow;
+      const groundDistance = Math.hypot(dCol * cellLonMeters, dRow * cellLatMeters);
+      if (radiusMeters > 0 && groundDistance > radiusMeters) continue;
+
+      // Step along the ray one cell at a time on its dominant axis.
+      const steps = Math.max(Math.abs(dCol), Math.abs(dRow));
+      let maxSlope = -Infinity;
+      let blocked = false;
+      for (let step = 1; step < steps; step += 1) {
+        const t = step / steps;
+        const sampleCol = Math.round(clampedCol + dCol * t);
+        const sampleRow = Math.round(clampedRow + dRow * t);
+        const elevation = values[sampleRow * width + sampleCol];
+        if (elevation === undefined) continue;
+        const distance = Math.hypot(
+          (sampleCol - clampedCol) * cellLonMeters,
+          (sampleRow - clampedRow) * cellLatMeters,
+        );
+        if (distance <= 0) continue;
+        const slope = (elevation - eyeMeters) / distance;
+        if (slope > maxSlope) maxSlope = slope;
+      }
+
+      const targetElevation = values[targetRow * width + targetCol];
+      if (targetElevation === undefined || groundDistance <= 0) continue;
+      const targetSlope = (targetElevation - eyeMeters) / groundDistance;
+      // Strictly greater: a cell exactly on the horizon line is grazed, not seen.
+      blocked = targetSlope <= maxSlope;
+      if (!blocked) markVisible(targetRow * width + targetCol);
+    }
+  }
+
+  return {
+    width,
+    height,
+    visible,
+    bbox,
+    observerGroundMeters: groundMeters,
+    visibleCells,
+  };
+}
+
+/**
+ * Render a viewshed to RGBA bytes: a translucent wash over visible ground,
+ * fully transparent elsewhere, so the imagery underneath stays readable.
+ */
+export function viewshedToRgba(
+  result: ViewshedResult,
+  color: [number, number, number] = [56, 189, 108],
+  alpha = 110,
+): Uint8ClampedArray {
+  const rgba = new Uint8ClampedArray(result.width * result.height * 4);
+  for (let i = 0; i < result.visible.length; i += 1) {
+    if (result.visible[i] !== 1) continue;
+    const offset = i * 4;
+    rgba[offset] = color[0];
+    rgba[offset + 1] = color[1];
+    rgba[offset + 2] = color[2];
+    rgba[offset + 3] = alpha;
+  }
+  return rgba;
+}
+
+// --- Tile assembly (browser) -----------------------------------------------
+
+/** Decode one Terrarium PNG tile to elevations via an offscreen canvas. */
+async function decodeTile(url: string, signal?: AbortSignal): Promise<Float32Array | null> {
+  try {
+    const response = await fetch(url, { signal });
+    if (!response.ok) return null;
+    const blob = await response.blob();
+    const bitmap = await createImageBitmap(blob);
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const context = canvas.getContext("2d");
+    if (!context) return null;
+    context.drawImage(bitmap, 0, 0);
+    const { data } = context.getImageData(0, 0, bitmap.width, bitmap.height);
+    bitmap.close();
+    const elevations = new Float32Array(bitmap.width * bitmap.height);
+    for (let i = 0; i < elevations.length; i += 1) {
+      const offset = i * 4;
+      elevations[i] = decodeTerrariumElevation(data[offset], data[offset + 1], data[offset + 2]);
+    }
+    return elevations;
+  } catch {
+    return null;
+  }
+}
+
+/** Longitude/latitude of a tile's north-west corner. */
+function tileNorthWest(x: number, y: number, zoom: number): [number, number] {
+  const n = Math.pow(2, zoom);
+  const lng = (x / n) * 360 - 180;
+  const latRad = Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / n)));
+  return [lng, (latRad * 180) / Math.PI];
+}
+
+export interface AssembleTerrainDemOptions {
+  lng: number;
+  lat: number;
+  radiusMeters: number;
+  signal?: AbortSignal;
+  /** Override the tile template (tests, or a self-hosted terrain source). */
+  tileUrl?: string;
+}
+
+/**
+ * Fetch and stitch Terrarium tiles into one elevation grid covering a radius
+ * around a point.
+ *
+ * Tiles that fail to load leave their cells at 0 rather than aborting the whole
+ * assembly: a viewshed with one missing tile is degraded but still useful,
+ * while a hard failure would make a transient network error look like the
+ * feature is broken. The returned grid is cropped to the requested square, so
+ * the result is not padded out to tile boundaries.
+ *
+ * @returns The DEM, or null when no tile could be loaded at all.
+ */
+export async function assembleTerrainDem(
+  options: AssembleTerrainDemOptions,
+): Promise<TerrainDem | null> {
+  const { lng, lat, signal, tileUrl = TERRARIUM_TILE_URL } = options;
+  const radiusMeters = Math.min(
+    MAX_VIEWSHED_RADIUS_METERS,
+    Math.max(MIN_VIEWSHED_RADIUS_METERS, options.radiusMeters),
+  );
+  const zoom = zoomForRadius(radiusMeters, lat);
+
+  const dLat = metersToLatDegrees(radiusMeters);
+  const dLon = metersToLonDegrees(radiusMeters, lat);
+  const west = lng - dLon;
+  const east = lng + dLon;
+  const south = lat - dLat;
+  const north = lat + dLat;
+
+  const topLeft = tileForLngLat(west, north, zoom);
+  const bottomRight = tileForLngLat(east, south, zoom);
+  const tilesWide = bottomRight.x - topLeft.x + 1;
+  const tilesTall = bottomRight.y - topLeft.y + 1;
+  if (tilesWide <= 0 || tilesTall <= 0) return null;
+
+  const mosaicWidth = tilesWide * TERRARIUM_TILE_SIZE;
+  const mosaicHeight = tilesTall * TERRARIUM_TILE_SIZE;
+  const mosaic = new Float32Array(mosaicWidth * mosaicHeight);
+
+  const requests: Promise<void>[] = [];
+  let loaded = 0;
+  for (let ty = 0; ty < tilesTall; ty += 1) {
+    for (let tx = 0; tx < tilesWide; tx += 1) {
+      const url = tileUrl
+        .replace("{z}", String(zoom))
+        .replace("{x}", String(topLeft.x + tx))
+        .replace("{y}", String(topLeft.y + ty));
+      requests.push(
+        decodeTile(url, signal).then((tile) => {
+          if (!tile) return;
+          loaded += 1;
+          for (let row = 0; row < TERRARIUM_TILE_SIZE; row += 1) {
+            const target =
+              (ty * TERRARIUM_TILE_SIZE + row) * mosaicWidth + tx * TERRARIUM_TILE_SIZE;
+            mosaic.set(
+              tile.subarray(row * TERRARIUM_TILE_SIZE, (row + 1) * TERRARIUM_TILE_SIZE),
+              target,
+            );
+          }
+        }),
+      );
+    }
+  }
+  await Promise.all(requests);
+  if (loaded === 0) return null;
+
+  // Crop the tile mosaic down to the requested square.
+  const [mosaicWest, mosaicNorth] = tileNorthWest(topLeft.x, topLeft.y, zoom);
+  const [mosaicEast, mosaicSouth] = tileNorthWest(bottomRight.x + 1, bottomRight.y + 1, zoom);
+  const colOf = (x: number) =>
+    Math.round(((x - mosaicWest) / (mosaicEast - mosaicWest)) * (mosaicWidth - 1));
+  const rowOf = (y: number) =>
+    Math.round(((mosaicNorth - y) / (mosaicNorth - mosaicSouth)) * (mosaicHeight - 1));
+
+  const cropLeft = Math.max(0, colOf(west));
+  const cropRight = Math.min(mosaicWidth - 1, colOf(east));
+  const cropTop = Math.max(0, rowOf(north));
+  const cropBottom = Math.min(mosaicHeight - 1, rowOf(south));
+  const width = cropRight - cropLeft + 1;
+  const height = cropBottom - cropTop + 1;
+  if (width <= 1 || height <= 1) return null;
+
+  const values = new Float32Array(width * height);
+  for (let row = 0; row < height; row += 1) {
+    const source = (cropTop + row) * mosaicWidth + cropLeft;
+    values.set(mosaic.subarray(source, source + width), row * width);
+  }
+
+  return { width, height, values, bbox: [west, south, east, north] };
+}

--- a/packages/processing/src/terrain-viewshed.ts
+++ b/packages/processing/src/terrain-viewshed.ts
@@ -42,6 +42,26 @@ export function decodeTerrariumElevation(r: number, g: number, b: number): numbe
   return r * 256 + g + b / 256 - 32768;
 }
 
+/**
+ * Decode a tile's RGBA bytes into elevations.
+ *
+ * Takes the dimensions as arguments rather than reading them from the source
+ * image, so a caller cannot accidentally size the output from an ImageBitmap it
+ * has already closed.
+ */
+export function decodeTerrariumRgba(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): Float32Array {
+  const elevations = new Float32Array(width * height);
+  for (let i = 0; i < elevations.length; i += 1) {
+    const offset = i * 4;
+    elevations[i] = decodeTerrariumElevation(data[offset], data[offset + 1], data[offset + 2]);
+  }
+  return elevations;
+}
+
 /** An elevation grid in EPSG:4326, row 0 at the north edge. */
 export interface TerrainDem {
   width: number;
@@ -275,14 +295,16 @@ async function decodeTile(
     const context = canvas.getContext("2d");
     if (!context) return null;
     context.drawImage(bitmap, 0, 0);
-    const { data } = context.getImageData(0, 0, bitmap.width, bitmap.height);
+    // Dimensions are read before close(), which zeroes them. Passing them into
+    // decodeTerrariumRgba rather than reading bitmap.width again afterwards is
+    // what keeps that ordering hazard from returning -- a 0x0 tile decodes
+    // without error and is then silently discarded by the assembly loop as the
+    // wrong size, which is how it broke the first time.
+    const width = bitmap.width;
+    const height = bitmap.height;
+    const { data } = context.getImageData(0, 0, width, height);
     bitmap.close();
-    const elevations = new Float32Array(bitmap.width * bitmap.height);
-    for (let i = 0; i < elevations.length; i += 1) {
-      const offset = i * 4;
-      elevations[i] = decodeTerrariumElevation(data[offset], data[offset + 1], data[offset + 2]);
-    }
-    return { width: bitmap.width, height: bitmap.height, values: elevations };
+    return { width, height, values: decodeTerrariumRgba(data, width, height) };
   } catch {
     return null;
   } finally {

--- a/packages/processing/src/terrain-viewshed.worker.ts
+++ b/packages/processing/src/terrain-viewshed.worker.ts
@@ -1,5 +1,10 @@
 /// <reference lib="webworker" />
-import { computeViewshed, type TerrainDem, type ViewshedObserver } from "./terrain-viewshed";
+import {
+  computeViewshed,
+  type TerrainDem,
+  type ViewshedObserver,
+  type ViewshedResult,
+} from "./terrain-viewshed";
 
 // Runs one viewshed off the main thread. The line-of-sight walk is O(n³) in the
 // grid's side length with no yield points, so on the main thread it freezes the
@@ -19,16 +24,10 @@ export interface ViewshedWorkerRequest {
 
 /** The single message this worker posts back. */
 export type ViewshedWorkerResponse =
-  | {
-      ok: true;
-      width: number;
-      height: number;
-      visible: Uint8Array;
-      bbox: [number, number, number, number];
-      observerGroundMeters: number;
-      visibleCells: number;
-    }
-  | { ok: false; error: string };
+  // Spread from ViewshedResult rather than restated: a field added there must
+  // travel back with it, and the rest-spread in computeViewshedAsync would
+  // otherwise drop it with no type error.
+  ({ ok: true } & ViewshedResult) | { ok: false; error: string };
 
 worker.addEventListener("message", (event: MessageEvent<ViewshedWorkerRequest>) => {
   const { dem, observer, radiusMeters } = event.data;

--- a/packages/processing/src/terrain-viewshed.worker.ts
+++ b/packages/processing/src/terrain-viewshed.worker.ts
@@ -1,0 +1,49 @@
+/// <reference lib="webworker" />
+import { computeViewshed, type TerrainDem, type ViewshedObserver } from "./terrain-viewshed";
+
+// Runs one viewshed off the main thread. The line-of-sight walk is O(n³) in the
+// grid's side length with no yield points, so on the main thread it freezes the
+// tab for its whole duration — several seconds at the 15 km preset on modest
+// hardware, which reads worse than a network wait because nothing repaints.
+//
+// One viewshed per worker: the caller terminates this worker as soon as the
+// terminal message arrives, so nothing here has to be reusable across runs.
+const worker = self as unknown as DedicatedWorkerGlobalScope;
+
+/** The request: a DEM, an observer, and the cull radius. */
+export interface ViewshedWorkerRequest {
+  dem: TerrainDem;
+  observer: ViewshedObserver;
+  radiusMeters: number;
+}
+
+/** The single message this worker posts back. */
+export type ViewshedWorkerResponse =
+  | {
+      ok: true;
+      width: number;
+      height: number;
+      visible: Uint8Array;
+      bbox: [number, number, number, number];
+      observerGroundMeters: number;
+      visibleCells: number;
+    }
+  | { ok: false; error: string };
+
+worker.addEventListener("message", (event: MessageEvent<ViewshedWorkerRequest>) => {
+  const { dem, observer, radiusMeters } = event.data;
+  try {
+    const result = computeViewshed(dem, observer, radiusMeters);
+    // The visibility grid is transferred rather than copied: it is the only
+    // large payload going back, and this worker is terminated immediately
+    // afterwards so it has no use for the buffer.
+    worker.postMessage({ ok: true, ...result } satisfies ViewshedWorkerResponse, [
+      result.visible.buffer as ArrayBuffer,
+    ]);
+  } catch (error) {
+    worker.postMessage({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies ViewshedWorkerResponse);
+  }
+});

--- a/tests/terrain-viewshed.test.ts
+++ b/tests/terrain-viewshed.test.ts
@@ -10,6 +10,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  assembleTerrainDem,
   computeViewshed,
   decodeTerrariumElevation,
   metersToLatDegrees,
@@ -134,6 +135,34 @@ describe("computeViewshed", () => {
     const dem = demOf(11, 11, (col, row) => (col === 5 && row === 5 ? 0 : 900));
     const result = computeViewshed(dem, CENTRE);
     assert.equal(result.visible[5 * 11 + 5], 1);
+  });
+});
+
+describe("assembleTerrainDem bounds", () => {
+  it("rejects positions beyond the Web Mercator limit", async () => {
+    // The tile grid is undefined past ~85 degrees; a request there would
+    // otherwise be left to fail as 404s partway through the assembly.
+    assert.equal(
+      await assembleTerrainDem({ lng: 0, lat: 89, radiusMeters: 2000, tileUrl: "x/{z}/{x}/{y}" }),
+      null,
+    );
+    assert.equal(
+      await assembleTerrainDem({ lng: 0, lat: -89, radiusMeters: 2000, tileUrl: "x/{z}/{x}/{y}" }),
+      null,
+    );
+  });
+
+  it("rejects a square straddling the antimeridian", async () => {
+    // Wrapping would produce a negative tile x.
+    assert.equal(
+      await assembleTerrainDem({
+        lng: 179.99,
+        lat: 0,
+        radiusMeters: 50000,
+        tileUrl: "x/{z}/{x}/{y}",
+      }),
+      null,
+    );
   });
 });
 

--- a/tests/terrain-viewshed.test.ts
+++ b/tests/terrain-viewshed.test.ts
@@ -12,6 +12,7 @@ import { describe, it } from "node:test";
 import {
   assembleTerrainDem,
   computeViewshed,
+  computeViewshedAsync,
   decodeTerrariumElevation,
   metersToLatDegrees,
   tileForLngLat,
@@ -163,6 +164,28 @@ describe("assembleTerrainDem bounds", () => {
       }),
       null,
     );
+  });
+});
+
+describe("computeViewshedAsync", () => {
+  it("falls back to this thread where Workers are unavailable", async () => {
+    // node:test has no Worker global, which is also the SSR / locked-down
+    // webview case: the fallback must produce a real viewshed, not an error.
+    const dem = demOf(11, 11, () => 0);
+    const [sync, viaAsync] = [
+      computeViewshed(dem, CENTRE),
+      await computeViewshedAsync(dem, CENTRE),
+    ];
+    assert.equal(viaAsync.visibleCells, sync.visibleCells);
+    assert.deepEqual(Array.from(viaAsync.visible), Array.from(sync.visible));
+    assert.equal(viaAsync.observerGroundMeters, sync.observerGroundMeters);
+  });
+
+  it("honours the radius through the async path", async () => {
+    const dem = demOf(41, 41, () => 0);
+    const limited = await computeViewshedAsync(dem, CENTRE, 100);
+    const unlimited = await computeViewshedAsync(dem, CENTRE);
+    assert.ok(limited.visibleCells < unlimited.visibleCells);
   });
 });
 

--- a/tests/terrain-viewshed.test.ts
+++ b/tests/terrain-viewshed.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the interactive viewshed (issue #1815).
+ *
+ * A viewshed is easy to get plausibly wrong: a ridge that should block a view
+ * still produces a green blob, just the wrong shape, and nobody notices without
+ * ground truth. So the cases here are ones with an analytically known answer —
+ * a flat plane, a single wall, a pit — rather than a real DEM.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeViewshed,
+  decodeTerrariumElevation,
+  metersToLatDegrees,
+  tileForLngLat,
+  viewshedToRgba,
+  zoomForRadius,
+  type TerrainDem,
+} from "../packages/processing/src/terrain-viewshed";
+
+/** A DEM over a small square around (0, 0), with elevations from a callback. */
+function demOf(
+  width: number,
+  height: number,
+  elevation: (col: number, row: number) => number,
+): TerrainDem {
+  const values = new Float32Array(width * height);
+  for (let row = 0; row < height; row += 1) {
+    for (let col = 0; col < width; col += 1) {
+      values[row * width + col] = elevation(col, row);
+    }
+  }
+  // ~1 km square, so cells are a few metres across at these grid sizes.
+  const d = metersToLatDegrees(500);
+  return { width, height, values, bbox: [-d, -d, d, d] };
+}
+
+const CENTRE = { lng: 0, lat: 0, heightMeters: 2 };
+
+describe("decodeTerrariumElevation", () => {
+  it("decodes sea level and known offsets", () => {
+    // Terrarium stores elevation + 32768, so 128,0,0 is exactly 0 m.
+    assert.equal(decodeTerrariumElevation(128, 0, 0), 0);
+    assert.equal(decodeTerrariumElevation(128, 100, 0), 100);
+    assert.equal(decodeTerrariumElevation(127, 0, 0), -256);
+  });
+
+  it("uses the blue channel for sub-metre precision", () => {
+    assert.equal(decodeTerrariumElevation(128, 0, 128), 0.5);
+  });
+});
+
+describe("zoomForRadius", () => {
+  it("picks a deeper zoom for a smaller radius", () => {
+    assert.ok(zoomForRadius(500, 0) > zoomForRadius(20000, 0));
+  });
+
+  it("never exceeds the Terrarium maximum", () => {
+    assert.ok(zoomForRadius(10, 0) <= 15);
+  });
+});
+
+describe("tileForLngLat", () => {
+  it("puts the origin at the middle of the world at zoom 1", () => {
+    assert.deepEqual(tileForLngLat(0.0001, 0.0001, 1), { x: 1, y: 0 });
+  });
+
+  it("puts the north-west corner at tile 0,0", () => {
+    assert.deepEqual(tileForLngLat(-179.9, 85, 2), { x: 0, y: 0 });
+  });
+});
+
+describe("computeViewshed", () => {
+  it("sees everything from a flat plane", () => {
+    const dem = demOf(21, 21, () => 100);
+    const result = computeViewshed(dem, CENTRE);
+    assert.equal(result.visibleCells, 21 * 21, "a flat plane hides nothing");
+  });
+
+  it("reports the ground elevation under the observer", () => {
+    const dem = demOf(11, 11, () => 250);
+    assert.equal(computeViewshed(dem, CENTRE).observerGroundMeters, 250);
+  });
+
+  it("hides the ground behind a wall", () => {
+    // A tall north-south wall two cells east of centre. Everything beyond it on
+    // that row must be hidden; the wall itself is visible.
+    const mid = 10;
+    const dem = demOf(21, 21, (col) => (col === mid + 2 ? 500 : 0));
+    const result = computeViewshed(dem, CENTRE);
+    const at = (col: number, row: number) => result.visible[row * 21 + col];
+
+    assert.equal(at(mid + 2, mid), 1, "the wall itself is in view");
+    assert.equal(at(mid + 5, mid), 0, "ground directly behind the wall is hidden");
+    assert.equal(at(20, mid), 0, "ground at the far edge behind the wall is hidden");
+    assert.equal(at(mid - 5, mid), 1, "ground on the observer's side stays visible");
+  });
+
+  it("sees over a wall from high enough up", () => {
+    const mid = 10;
+    const dem = demOf(21, 21, (col) => (col === mid + 2 ? 50 : 0));
+    const low = computeViewshed(dem, { ...CENTRE, heightMeters: 2 });
+    const high = computeViewshed(dem, { ...CENTRE, heightMeters: 2000 });
+    assert.ok(
+      high.visibleCells > low.visibleCells,
+      "raising the observer must reveal ground the wall was hiding",
+    );
+  });
+
+  it("hides the floor of a pit but not its rim", () => {
+    // Observer on a peak; a depression beyond a raised lip.
+    const mid = 10;
+    const dem = demOf(21, 21, (col, row) => {
+      if (col === mid && row === mid) return 100; // observer's peak
+      if (col === mid + 3) return 60; // lip
+      if (col > mid + 3) return 0; // pit floor beyond it
+      return 0;
+    });
+    const result = computeViewshed(dem, { ...CENTRE, heightMeters: 1 });
+    assert.equal(result.visible[mid * 21 + (mid + 3)], 1, "the lip is visible");
+    assert.equal(result.visible[mid * 21 + (mid + 6)], 0, "the floor beyond it is not");
+  });
+
+  it("honours the radius limit", () => {
+    const dem = demOf(41, 41, () => 0);
+    const unlimited = computeViewshed(dem, CENTRE);
+    const limited = computeViewshed(dem, CENTRE, 100);
+    assert.ok(limited.visibleCells < unlimited.visibleCells, "a radius must exclude distant cells");
+    assert.ok(limited.visibleCells > 0, "but not exclude everything");
+  });
+
+  it("always sees the observer's own cell", () => {
+    const dem = demOf(11, 11, (col, row) => (col === 5 && row === 5 ? 0 : 900));
+    const result = computeViewshed(dem, CENTRE);
+    assert.equal(result.visible[5 * 11 + 5], 1);
+  });
+});
+
+describe("viewshedToRgba", () => {
+  it("paints visible cells and leaves the rest transparent", () => {
+    const dem = demOf(3, 3, () => 0);
+    const result = computeViewshed(dem, CENTRE);
+    result.visible.fill(0);
+    result.visible[4] = 1; // centre cell only
+    const rgba = viewshedToRgba(result);
+    assert.equal(rgba[4 * 4 + 3], 110, "visible cell carries the wash alpha");
+    assert.equal(rgba[0 * 4 + 3], 0, "hidden cell stays fully transparent");
+  });
+});

--- a/tests/terrain-viewshed.test.ts
+++ b/tests/terrain-viewshed.test.ts
@@ -14,6 +14,7 @@ import {
   computeViewshed,
   computeViewshedAsync,
   decodeTerrariumElevation,
+  decodeTerrariumRgba,
   metersToLatDegrees,
   tileForLngLat,
   viewshedToRgba,
@@ -50,6 +51,26 @@ describe("decodeTerrariumElevation", () => {
 
   it("uses the blue channel for sub-metre precision", () => {
     assert.equal(decodeTerrariumElevation(128, 0, 128), 0.5);
+  });
+});
+
+describe("decodeTerrariumRgba", () => {
+  it("decodes every pixel of a tile", () => {
+    // Two pixels: sea level, then 100m. RGBA, so 4 bytes each.
+    const data = new Uint8ClampedArray([128, 0, 0, 255, 128, 100, 0, 255]);
+    assert.deepEqual(Array.from(decodeTerrariumRgba(data, 2, 1)), [0, 100]);
+  });
+
+  it("sizes the output from the dimensions it is given", () => {
+    // Regression for a real failure: decodeTile read bitmap.width *after*
+    // bitmap.close(), which zeroes it, so every tile decoded to 0x0 and was
+    // then silently discarded by the assembly loop as the wrong size -- the
+    // viewshed reported "no visible area" for every click. Taking the
+    // dimensions as arguments is what makes that ordering hazard impossible.
+    const data = new Uint8ClampedArray(4 * 4);
+    data.fill(0);
+    assert.equal(decodeTerrariumRgba(data, 0, 0).length, 0);
+    assert.equal(decodeTerrariumRgba(data, 2, 2).length, 4);
   });
 });
 


### PR DESCRIPTION
Closes #1815.

**Right-click the map → Viewshed from here**, at 2 / 5 / 15 km. No DEM to find, download, or load first: the terrain the map is already rendering is the input.

## Why not the Whitebox viewshed

The issue suggested running the existing Whitebox WASM `viewshed` — "no new analysis code". I looked, and it consumes a **DEM raster file *and* a station-point vector file** and emits a raster file (the WASM binary's own error strings confirm the station-point input). From a clicked point that is three format round-trips before any analysis happens, *and* it still requires a DEM in hand — which is the data-prep step this issue exists to remove.

The line-of-sight itself is ~60 lines against a grid already in memory, and computing it directly gives exact control over observer height and radius, both of which the issue calls for as parameters. So this computes it directly.

**The Whitebox tool is untouched** and remains the right choice for rigorous work against a DEM the user supplies. This is the exploratory path beside it, not a replacement.

## Two halves

Deliberately separable, so the geometry is testable without a network:

1. **`assembleTerrainDem`** — fetches the Terrarium RGB tiles the terrain control already uses, decodes them (`R*256 + G + B/256 - 32768`), stitches and crops to the requested square.
2. **`computeViewshed`** — walks a ray from the observer to every cell, tracking the greatest slope so far; a cell is visible when its own slope exceeds every slope along the way.

## Bounds and failure behaviour

- **Zoom is chosen from the radius** to land near 512 cells across, so both the tile fetch and the O(n²·√n) walk stay interactive.
- **Radius clamped to 50 km**, so one click cannot pull a continent of tiles.
- **A failed tile leaves its cells at 0** rather than aborting: a viewshed with one missing tile is degraded but useful, while a hard failure makes a transient network error look like a broken feature.

## Output

An **`image` layer** — a translucent wash pinned by corner coordinates — reusing the overlay path the Raster Georeferencer established. It gets opacity, ordering, zoom-to and removal from the Layers panel for free, with **no new layer type**. Encoded as a PNG data URL rather than a blob URL, since the layer is saved with the project and a blob URL would be dead on reopen.

## Documented limitation

**Earth curvature and refraction are not modelled**, noted on the function. At the 50 km cap the curvature drop reaches ~180 m — irrelevant to "what can I see from this overlook", but material to a radio-siting study. Worth knowing before anyone reaches for it in that direction.

## Tests

`tests/terrain-viewshed.test.ts`, 14 cases. A viewshed is easy to get *plausibly* wrong — a ridge that should block a view still produces a green blob, just the wrong shape, and nobody notices without ground truth. So the cases have analytically known answers rather than using a real DEM:

- a flat plane hides nothing
- a wall hides the ground behind it, at both near and far range, while staying visible itself, and ground on the observer's side is unaffected
- raising the observer reveals ground the wall was hiding
- a pit's rim is visible and its floor is not
- the radius limit excludes distant cells but not everything
- Terrarium decoding at sea level, negative elevations, and sub-metre precision

Full suite: 5636 pass, 0 fail. `npm run typecheck` and scoped `pre-commit` clean.

## Follow-ons worth considering

- An observer-height control in the UI. The runner takes it (defaulting to 1.8 m, a standing person) but the menu entries do not expose it yet — raising the observer is the whole point for siting a tower or a mast.
- Curvature correction, if anyone wants this for long-range work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terrain-based viewshed analysis from any map location.
  * Choose 2 km, 5 km, or 15 km analysis radii.
  * Results appear as georeferenced map layers with visibility details.
* **Localization**
  * Added translated viewshed labels, layer names, distance units, and messages across supported languages.
* **Reliability**
  * Prevented overlapping analyses and added running, success, and error status feedback.
  * Handles unavailable terrain, empty results, invalid locations, and failed calculations gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->