### PR TITLE
Populate the elevation readout when the toggle is switched on

### DIFF
--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1085,13 +1085,20 @@ export const MapCanvas = memo(function MapCanvas({
   // map (a keyboard-only toggle) would otherwise leave the last resolved value
   // on screen until the next mousemove.
   useEffect(() => {
-    if (showPointerElevation) return;
-    // invalidate() before clearing: a lookup scheduled inside the 500ms debounce
-    // window would otherwise still fire the request, and only be suppressed
-    // afterwards by the isEnabled() re-check. Cancelling the timer means the
-    // request is never made at all.
-    pointerElevationRef.current?.invalidate();
-    setPointerElevation(null);
+    if (!showPointerElevation) {
+      // invalidate() before clearing: a lookup scheduled inside the 500ms
+      // debounce window would otherwise still fire the request, and only be
+      // suppressed afterwards by the isEnabled() re-check. Cancelling the timer
+      // means the request is never made at all.
+      pointerElevationRef.current?.invalidate();
+      setPointerElevation(null);
+      return;
+    }
+    // Symmetrically, switching it *on* while the cursor sits still would show
+    // nothing until the next mousemove. Resolve once for wherever the pointer
+    // already is, so the readout appears with the toggle.
+    const coords = useAppStore.getState().pointerCoords;
+    if (coords) pointerElevationRef.current?.update(coords);
   }, [showPointerElevation, setPointerElevation]);
   const previousSelectedFeatureKey = useRef<string | null>(null);
   const previousDuckDBSelectionLayerId = useRef<string | null>(null);


### PR DESCRIPTION
Follow-up to #1820, which merged before this landed.

The effect added there clears the readout when **Controls → Elevation** is switched off while the pointer is stationary, but the symmetric case was unhandled: switching it **on** with the cursor still showed nothing until the next `mousemove`.

It now resolves once for wherever the pointer already is, so the readout appears with the toggle.

Raised by the review bot on #1820 after that PR had already been merged, so it could not go in there.