### PR TITLE
fix(assistant): stop OpenAI SDK telemetry headers from failing the CORS preflight

### DIFF
--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -508,16 +508,23 @@ export function availableProviders(env: RuntimeEnv = readRuntimeEnv()): Assistan
  * Dropping them leaves the preflight asking only for headers such a gateway
  * already allows. `User-Agent` is included because the browser supplies its own
  * once the SDK's override is gone.
+ *
+ * This is exactly the set the client attaches to *every* request. The SDK's
+ * remaining `X-Stainless-*` names (`Helper-Method`, `Poll-Helper`,
+ * `Custom-Poll-Interval`) are deliberately absent: they are set per request by
+ * the assistants/vector-store polling helpers, whose per-request headers are
+ * merged *after* `defaultHeaders` and so cannot be stripped here anyway. The
+ * assistant reaches the API through plain `chat.completions.create`, which never
+ * uses those helpers. The `openAiCompatibleHeaders` test asserts the header
+ * names actually put on the wire, so an SDK bump that adds one to every request
+ * fails there rather than in a user's gateway.
  */
 export const OPENAI_COMPATIBLE_STRIPPED_HEADERS: readonly string[] = [
   "User-Agent",
   "X-Stainless-Arch",
-  "X-Stainless-Custom-Poll-Interval",
-  "X-Stainless-Helper-Method",
   "X-Stainless-Lang",
   "X-Stainless-OS",
   "X-Stainless-Package-Version",
-  "X-Stainless-Poll-Helper",
   "X-Stainless-Retry-Count",
   "X-Stainless-Runtime",
   "X-Stainless-Runtime-Version",
@@ -529,10 +536,11 @@ export const OPENAI_COMPATIBLE_STRIPPED_HEADERS: readonly string[] = [
  * (`ollama` / `custom`).
  *
  * A `null` value tells the SDK to *remove* that header rather than send an empty
- * one, and `defaultHeaders` is merged after the SDK's own block, so every name in
- * {@link OPENAI_COMPATIBLE_STRIPPED_HEADERS} is dropped before the request is
- * built. `Authorization` joins them when the endpoint is the managed same-origin
- * proxy, which is authenticated by the browser session instead of a Bearer token.
+ * one, and `defaultHeaders` is merged after the block where the client sets its
+ * own, so every name in {@link OPENAI_COMPATIBLE_STRIPPED_HEADERS} is dropped
+ * before the request is built. `Authorization` joins them when the endpoint is
+ * the managed same-origin proxy, which is authenticated by the browser session
+ * instead of a Bearer token.
  *
  * @param suppressAuthorizationHeader Also drop `Authorization` (managed proxy).
  * @returns A header map whose every value is `null`.

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -491,6 +491,62 @@ export function availableProviders(env: RuntimeEnv = readRuntimeEnv()): Assistan
 }
 
 /**
+ * Headers the OpenAI SDK attaches to every request that carry no meaning for a
+ * third-party OpenAI-compatible endpoint: its own telemetry (`X-Stainless-*`)
+ * and a `User-Agent` override.
+ *
+ * They are harmless against `api.openai.com`, but they break OpenAI-compatible
+ * gateways in the browser (issue #1834). Any of them makes the request
+ * non-simple, so the browser sends a CORS preflight listing every one of them in
+ * `Access-Control-Request-Headers`. A gateway that allows only the standard
+ * `Authorization`/`Content-Type`/`Accept` trio answers that preflight without an
+ * `Access-Control-Allow-Origin` header, the browser rejects it, and the SDK sees
+ * the opaque `TypeError: Failed to fetch`, reported as "Connection error" with
+ * three identical network diagnostics (one per SDK retry) even though the
+ * endpoint's CORS policy is otherwise fine and the credentials are valid.
+ *
+ * Dropping them leaves the preflight asking only for headers such a gateway
+ * already allows. `User-Agent` is included because the browser supplies its own
+ * once the SDK's override is gone.
+ */
+export const OPENAI_COMPATIBLE_STRIPPED_HEADERS: readonly string[] = [
+  "User-Agent",
+  "X-Stainless-Arch",
+  "X-Stainless-Custom-Poll-Interval",
+  "X-Stainless-Helper-Method",
+  "X-Stainless-Lang",
+  "X-Stainless-OS",
+  "X-Stainless-Package-Version",
+  "X-Stainless-Poll-Helper",
+  "X-Stainless-Retry-Count",
+  "X-Stainless-Runtime",
+  "X-Stainless-Runtime-Version",
+  "X-Stainless-Timeout",
+];
+
+/**
+ * The `defaultHeaders` to hand the OpenAI SDK for an OpenAI-compatible endpoint
+ * (`ollama` / `custom`).
+ *
+ * A `null` value tells the SDK to *remove* that header rather than send an empty
+ * one, and `defaultHeaders` is merged after the SDK's own block, so every name in
+ * {@link OPENAI_COMPATIBLE_STRIPPED_HEADERS} is dropped before the request is
+ * built. `Authorization` joins them when the endpoint is the managed same-origin
+ * proxy, which is authenticated by the browser session instead of a Bearer token.
+ *
+ * @param suppressAuthorizationHeader Also drop `Authorization` (managed proxy).
+ * @returns A header map whose every value is `null`.
+ */
+export function openAiCompatibleHeaders(
+  suppressAuthorizationHeader: boolean,
+): Record<string, null> {
+  const headers: Record<string, null> = {};
+  for (const name of OPENAI_COMPATIBLE_STRIPPED_HEADERS) headers[name] = null;
+  if (suppressAuthorizationHeader) headers.Authorization = null;
+  return headers;
+}
+
+/**
  * Build a Strands {@link Model} for the resolved provider. The provider SDK is
  * dynamically imported so unused providers never enter the initial bundle.
  *
@@ -537,7 +593,7 @@ export async function createModel(config: AssistantProviderConfig): Promise<Mode
         modelId: config.modelId,
         clientConfig: {
           baseURL: config.baseURL,
-          defaultHeaders: config.suppressAuthorizationHeader ? { Authorization: null } : undefined,
+          defaultHeaders: openAiCompatibleHeaders(Boolean(config.suppressAuthorizationHeader)),
           dangerouslyAllowBrowser: true,
         },
       }) as unknown as Model;

--- a/apps/geolibre-desktop/src/lib/fetch-error.ts
+++ b/apps/geolibre-desktop/src/lib/fetch-error.ts
@@ -11,6 +11,8 @@
  * carry a descriptive message, so its errors can be narrowed further by keyword.
  */
 
+import { isTauri } from "./is-tauri";
+
 export type FetchFailureKind = "abort" | "timeout" | "network" | "unknown";
 
 export interface FetchFailure {
@@ -46,11 +48,30 @@ const NATIVE_NETWORK_KEYWORDS = [
   "os error",
 ];
 
-// Shown for a browser fetch failure: the browser cannot say which of these
-// happened, and the desktop app bypasses browser CORS, so "try the desktop app"
-// is genuinely useful advice here.
-const BROWSER_NETWORK_HINT =
-  "The request could not be completed. In the browser this is usually a CORS rejection (the server sent no Access-Control-Allow-Origin header for this origin), a TLS/certificate error, blocked mixed content, or an unreachable host. Try the desktop app, which is not subject to browser CORS, or check the host's certificate, firewall, and proxy rules.";
+// Shown for a `fetch()` failure, which the browser cannot narrow further. The
+// desktop app runs this same code in a WebView, so its plain `fetch()` is
+// subject to CORS too and the causes listed here all still apply (issue #1834).
+// Only the closing advice differs, see `browserNetworkHint`.
+const BROWSER_NETWORK_CAUSES =
+  "The request could not be completed. This is usually a CORS rejection (the server sent no Access-Control-Allow-Origin header for this origin, or rejected the preflight because of a request header), a TLS/certificate error, blocked mixed content, or an unreachable host.";
+
+// Appended on the web, where switching to the desktop app is a real option: its
+// native HTTP paths (geocoding, share, GeoLens) are not subject to browser CORS.
+const BROWSER_NETWORK_ADVICE =
+  "Try the desktop app, whose native requests are not subject to browser CORS, or check the host's certificate, firewall, and proxy rules.";
+
+// Appended in the desktop app instead: the user is already there, so telling
+// them to "try the desktop app" is a dead end.
+const DESKTOP_BROWSER_NETWORK_ADVICE =
+  "Check the server's CORS policy (including which request headers it allows), its certificate, and any firewall or proxy rules.";
+
+/**
+ * The hint for a browser `fetch()` failure, tailored to where the app is running
+ * so the desktop app never advises the user to switch to the desktop app.
+ */
+function browserNetworkHint(): string {
+  return `${BROWSER_NETWORK_CAUSES} ${isTauri() ? DESKTOP_BROWSER_NETWORK_ADVICE : BROWSER_NETWORK_ADVICE}`;
+}
 
 // Shown for a native (Tauri/reqwest) failure: this path already runs in the
 // desktop app and is not subject to browser CORS, so the CORS / "try the desktop
@@ -106,7 +127,7 @@ export function classifyFetchFailure(error: unknown): FetchFailure {
     return {
       kind: "network",
       label: "network/TLS/CORS",
-      hint: BROWSER_NETWORK_HINT,
+      hint: browserNetworkHint(),
     };
   }
   // A native reqwest error embeds the full request URL (usually in parens);

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -4,6 +4,8 @@ import {
   availableProviders,
   configForProvider,
   hasManagedAssistantProxy,
+  openAiCompatibleHeaders,
+  OPENAI_COMPATIBLE_STRIPPED_HEADERS,
   readBuildTimeAssistantEnv,
   readDeploymentAssistantEnv,
   readRuntimeEnv,
@@ -304,6 +306,66 @@ describe("resolveProviderConfig", () => {
       })?.suppressAuthorizationHeader,
       false,
     );
+  });
+});
+
+describe("openAiCompatibleHeaders", () => {
+  /**
+   * Drive a real OpenAI client through a stub `fetch` and return the header
+   * names it actually put on the wire. Using the installed SDK rather than a
+   * hand-written expectation is the point: it is the SDK's own header set that
+   * has to end up small enough for a third-party gateway's CORS preflight.
+   */
+  async function sentHeaderNames(defaultHeaders?: Record<string, null>): Promise<string[]> {
+    const { default: OpenAI } = await import("openai");
+    let names: string[] = [];
+    const client = new OpenAI({
+      apiKey: "test-key",
+      baseURL: "https://gateway.example.com/v1",
+      defaultHeaders,
+      fetch: async (_url, init) => {
+        names = [...new Headers(init?.headers).keys()].sort();
+        return new Response('{"id":"x","object":"chat.completion","choices":[]}', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    await client.chat.completions.create({
+      model: "test-model",
+      messages: [{ role: "user", content: "show countries with pop over 50 million" }],
+    });
+    return names;
+  }
+
+  it("leaves only headers a third-party gateway's CORS preflight allows", async () => {
+    // Baseline: the SDK's own telemetry headers are what break the preflight
+    // against an OpenAI-compatible gateway that allows just the standard trio.
+    const baseline = await sentHeaderNames();
+    assert.ok(baseline.some((name) => name.startsWith("x-stainless-")));
+    assert.ok(baseline.includes("user-agent"));
+
+    // With the suppression map, nothing outside the trio is requested, so the
+    // preflight asks only for headers such a gateway already allows (#1834).
+    assert.deepEqual(await sentHeaderNames(openAiCompatibleHeaders(false)), [
+      "accept",
+      "authorization",
+      "content-type",
+    ]);
+  });
+
+  it("keeps Authorization unless the managed same-origin proxy asked to drop it", async () => {
+    assert.ok((await sentHeaderNames(openAiCompatibleHeaders(false))).includes("authorization"));
+    assert.deepEqual(await sentHeaderNames(openAiCompatibleHeaders(true)), [
+      "accept",
+      "content-type",
+    ]);
+  });
+
+  it("maps every stripped header to null so the SDK removes rather than blanks it", () => {
+    const headers = openAiCompatibleHeaders(false);
+    assert.deepEqual(Object.keys(headers).sort(), [...OPENAI_COMPATIBLE_STRIPPED_HEADERS].sort());
+    assert.ok(Object.values(headers).every((value) => value === null));
   });
 });
 

--- a/tests/fetch-error.test.ts
+++ b/tests/fetch-error.test.ts
@@ -27,9 +27,30 @@ describe("classifyFetchFailure", () => {
     const result = classifyFetchFailure(new TypeError("Failed to fetch"));
     assert.equal(result.kind, "network");
     assert.equal(result.label, "network/TLS/CORS");
-    // The browser hint keeps the CORS / "try the desktop app" advice.
+    // On the web the hint keeps the CORS / "try the desktop app" advice.
     assert.ok(result.hint?.includes("CORS"));
     assert.ok(result.hint?.includes("desktop app"));
+  });
+
+  it("drops the 'try the desktop app' advice when already in the desktop app", () => {
+    // The desktop WebView's plain `fetch()` is subject to CORS just like the
+    // browser's, so it hits this same branch, but telling a desktop user to
+    // try the desktop app is a dead end (issue #1834).
+    const globals = globalThis as { window?: unknown };
+    const hadWindow = "window" in globals;
+    const previousWindow = globals.window;
+    globals.window = { __TAURI_INTERNALS__: {} };
+    try {
+      const result = classifyFetchFailure(new TypeError("Failed to fetch"));
+      assert.equal(result.kind, "network");
+      assert.equal(result.label, "network/TLS/CORS");
+      // The CORS explanation stays; only the "switch apps" advice goes.
+      assert.ok(result.hint?.includes("CORS"));
+      assert.ok(!result.hint?.includes("desktop app"));
+    } finally {
+      if (hadWindow) globals.window = previousWindow;
+      else delete globals.window;
+    }
   });
 
   it("classifies the WebKit 'Load failed' TypeError as network", () => {


### PR DESCRIPTION
Fixes #1834

## The bug

The AI Assistant reported `Connection error` against an OpenAI-compatible endpoint, with three identical `POST request failed (network/TLS/CORS)` diagnostics, even though the endpoint's CORS policy and the user's credentials were both fine.

## Root cause

Not the endpoint's `Access-Control-Allow-Origin`. It was the **request headers**.

The OpenAI SDK attaches its own telemetry headers to every request (`X-Stainless-Lang`, `X-Stainless-Arch`, `X-Stainless-Retry-Count`, ...) plus a `User-Agent` override. Any of those makes the request non-simple, so the browser sends a CORS preflight naming all of them in `Access-Control-Request-Headers`. A gateway that allows only the standard `Authorization` / `Content-Type` / `Accept` trio answers that preflight without an `Access-Control-Allow-Origin` header, the browser rejects it, and the SDK sees the opaque `TypeError: Failed to fetch`. One per SDK retry, which is why the report shows three identical entries.

Probing the reporter's endpoint makes it exact:

| `Access-Control-Request-Headers` | Preflight result |
| --- | --- |
| `authorization, content-type` | allowed |
| `authorization, content-type, accept` | allowed |
| `authorization, content-type, accept, user-agent` | **no CORS headers returned, rejected** |
| `authorization, content-type, accept, x-stainless-lang` | **no CORS headers returned, rejected** |

The desktop app is affected too. It runs this code in a WebView, so its plain `fetch()` is subject to CORS exactly like the browser's. That is why the reporter hit this on Desktop v2.5.0.

## The fix

Pass the SDK a `defaultHeaders` map that nulls those headers out for the `ollama` and `custom` providers (`null` tells the SDK to remove a header rather than blank it), so the preflight asks only for headers such a gateway already allows. They carry no meaning for a third-party endpoint, and the browser supplies its own `User-Agent` once the SDK's override is gone. `api.openai.com` keeps them.

Verified against the installed SDK, header names actually put on the wire:

- before: `accept, authorization, content-type, user-agent, x-stainless-arch, x-stainless-lang, x-stainless-os, x-stainless-package-version, x-stainless-retry-count, x-stainless-runtime, x-stainless-runtime-version`
- after: `accept, authorization, content-type`

Second, smaller fix: the network-failure hint told the reporter to "Try the desktop app, which is not subject to browser CORS" while they were already in the desktop app. That advice is now dropped inside Tauri, and the hint mentions that a preflight can be rejected over a request header rather than only over the origin.

## Verification

Driven in the real app with Playwright, both themes.

1. **Reproduced** against the reporter's own endpoint (`https://aicredits.in/v1`, dummy key): assistant showed `Connection error`, and the browser console confirmed three preflight rejections.
2. **After the fix**, same endpoint: the request reaches the server and the assistant shows the real, actionable `401 Invalid API Key` from the dummy key. The CORS wall is gone.
3. **End to end** against a local gateway that mimics the restrictive policy (allows only `Authorization` / `Content-Type` / `Accept`): the preflight passed requesting only `authorization, content-type`, and the streamed completion rendered in the assistant panel. Confirmed in dark and light themes.

## Tests

- `openAiCompatibleHeaders` is covered by driving a real `openai` client through a stub `fetch` and asserting the header names it puts on the wire. Testing against the installed SDK rather than a hand-written list is the point: if a future SDK bump adds a new header, the test fails instead of the user's gateway.
- Coverage that `Authorization` survives unless the managed same-origin proxy asked to drop it, so the existing proxy path is unchanged.
- A `classifyFetchFailure` case for the desktop branch of the hint.

`npm run typecheck`, `npm run lint`, and the full frontend suite (5733 tests) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Ollama and custom AI providers by filtering unsupported request headers.
  - Enhanced network error guidance based on whether the app is running in a desktop or browser environment.
  - Desktop users now receive more relevant advice for CORS, certificates, firewalls, and proxy-related connection issues.
  - Improved compatibility with managed AI proxies by handling authorization headers appropriately.

- **Tests**
  - Added coverage for provider request headers and environment-specific network error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->