### PR TITLE
fix: save a project opened from Android document storage (#1833)

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -936,7 +936,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     try {
       path =
         !options?.saveAs && existingLocalPath
-          ? await saveProjectFileToPath(contentToSave, existingLocalPath)
+          ? await saveProjectFileToPath(contentToSave, existingLocalPath, saveName)
           : await saveProjectFile(
               contentToSave,
               promptForName ? saveName : (existingLocalPath ?? saveName),

--- a/apps/geolibre-desktop/src/lib/android-content-uri.ts
+++ b/apps/geolibre-desktop/src/lib/android-content-uri.ts
@@ -85,3 +85,49 @@ export function isUriWritePermissionError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return URI_WRITE_PERMISSION_PATTERN.test(message);
 }
+
+/** The two I/O calls {@link writeInPlaceWithAndroidFallback} needs. */
+export interface InPlaceWriteHandlers {
+  /** Write the content to an already-known path. Rejects if it cannot. */
+  write: (path: string, content: string) => Promise<void>;
+  /** Open the native save dialog and write there. Null if cancelled. */
+  saveAs: (content: string, defaultName?: string) => Promise<string | null>;
+}
+
+/**
+ * Write to an already-known path, falling back to the save dialog when Android
+ * refuses a read-only `content://` grant (GeoLibre#1833).
+ *
+ * The handlers are injected so the fallback rule can be tested without mocking
+ * the Tauri modules: this is the behaviour that keeps Save working on Android,
+ * so a dependency bump that changes how a refusal is reported should fail a
+ * test rather than silently drop the user back to a broken Save.
+ *
+ * Falling back is safe because Android rejects the request when the output
+ * stream is opened, before the document is truncated, so a refused write leaves
+ * the original file untouched.
+ *
+ * @param content - The text to write.
+ * @param path - The path or content URI the file was opened from.
+ * @param fallbackName - Save-dialog file name, used only when the path carries
+ *   no usable name of its own.
+ * @param handlers - The write and save-as implementations.
+ * @returns The path actually written, or null if a fallback dialog was
+ *   cancelled.
+ */
+export async function writeInPlaceWithAndroidFallback(
+  content: string,
+  path: string,
+  fallbackName: string | undefined,
+  handlers: InPlaceWriteHandlers,
+): Promise<string | null> {
+  try {
+    await handlers.write(path, content);
+  } catch (error) {
+    if (isAndroidContentUri(path) && isUriWritePermissionError(error)) {
+      return handlers.saveAs(content, androidContentUriFileName(path) ?? fallbackName);
+    }
+    throw error;
+  }
+  return path;
+}

--- a/apps/geolibre-desktop/src/lib/android-content-uri.ts
+++ b/apps/geolibre-desktop/src/lib/android-content-uri.ts
@@ -125,6 +125,13 @@ export async function writeInPlaceWithAndroidFallback(
     await handlers.write(path, content);
   } catch (error) {
     if (isAndroidContentUri(path) && isUriWritePermissionError(error)) {
+      // The refusal is matched by wording, and OEM storage providers phrase
+      // their failures differently, so a provider could in principle report an
+      // unrelated error that reads like a permission denial and land here. That
+      // shows up as an unexplained "why is it asking me to save again?", so
+      // record the original error: `console.warn` is captured by the
+      // Diagnostics panel, which is where a user reporting this would look.
+      console.warn(`Falling back to the save dialog; cannot write ${path} in place`, error);
       return handlers.saveAs(content, androidContentUriFileName(path) ?? fallbackName);
     }
     throw error;

--- a/apps/geolibre-desktop/src/lib/android-content-uri.ts
+++ b/apps/geolibre-desktop/src/lib/android-content-uri.ts
@@ -1,0 +1,87 @@
+// Helpers for the Android Storage Access Framework `content://` URIs that the
+// native document picker returns in place of a filesystem path. Kept in their
+// own module (free of Tauri/React imports) so they can be unit-tested in Node.
+//
+// Android hands back two kinds of URI and only one of them is writable.
+// `tauri-plugin-dialog`'s `open()` launches `ACTION_GET_CONTENT`, whose grant is
+// read-only and cannot be upgraded from inside the app; writing to it is refused
+// with "Permission Denial: ... requires android.permission.MANAGE_DOCUMENTS, or
+// grantUriPermission()" (GeoLibre#1833). Its `save()` launches
+// `ACTION_CREATE_DOCUMENT`, whose grant does include write. So a project opened
+// from device storage reads and edits fine but cannot be saved back in place,
+// while one created through the save dialog can.
+//
+// Nothing in the URI itself says which grant it carries, so callers attempt the
+// write and use `isUriWritePermissionError` to tell "this URI is read-only"
+// apart from a genuine I/O failure.
+
+/**
+ * Whether a path is an Android SAF content URI rather than a filesystem path.
+ *
+ * @param path - The stored project path (a filesystem path, an HTTP URL, or a
+ *   `content://` URI on Android).
+ * @returns True for a `content://` URI.
+ */
+export function isAndroidContentUri(path: string): boolean {
+  return /^content:\/\//i.test(path);
+}
+
+/**
+ * Recover the original file name from an Android SAF content URI, so a save
+ * dialog opened as a fallback can be pre-filled with the name the user already
+ * knows instead of a generic default.
+ *
+ * The document id is provider-defined and percent-encoded in the last URI
+ * segment: `ExternalStorageProvider` uses a path-like
+ * `primary:Documents/json/Project.geolibre.json`, while the Downloads provider
+ * uses opaque ids such as `msf:1000000123`. Only a segment that still looks like
+ * a file name (it carries an extension) is usable, so an opaque id yields null
+ * and the caller falls back to a project-derived name.
+ *
+ * @param uri - The content URI to inspect.
+ * @returns The file name, or null when the URI carries no usable one.
+ */
+export function androidContentUriFileName(uri: string): string | null {
+  if (!isAndroidContentUri(uri)) return null;
+  const withoutQuery = uri.split(/[?#]/)[0];
+  const lastSegment = withoutQuery.split("/").pop() ?? "";
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(lastSegment);
+  } catch {
+    // A malformed escape sequence makes the whole segment undecodable; fall
+    // back to the raw text rather than losing the name entirely.
+    decoded = lastSegment;
+  }
+  const name = (decoded.split(/[/:]/).pop() ?? "").trim();
+  return /\.[A-Za-z0-9]+$/.test(name) ? name : null;
+}
+
+/**
+ * Android permission refusals reaching the webview as message text.
+ *
+ * Matched by text because there is no typed signal: the failure originates in
+ * Android's `ContentResolver` and crosses the Tauri bridge as a plain string
+ * ("failed to open file: Permission Denial: writing ... uri content://... from
+ * pid=7564, uid=10393 requires android.permission.MANAGE_DOCUMENTS, or
+ * grantUriPermission()"). The POSIX codes cover the same refusal surfacing from
+ * the Rust side rather than the Java one.
+ *
+ * Deliberately narrow: a real write failure (no space left, a provider that has
+ * gone away) must keep propagating as an error rather than quietly reopening a
+ * save dialog.
+ */
+const URI_WRITE_PERMISSION_PATTERN =
+  /permission denial|permission denied|granturipermission|manage_documents|no permission|\beacces\b|\beperm\b|read-only file system/i;
+
+/**
+ * Whether a write failure was Android refusing the URI's grant, rather than an
+ * ordinary I/O error.
+ *
+ * @param error - The value thrown by the write attempt.
+ * @returns True when the message reads as a permission refusal.
+ */
+export function isUriWritePermissionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return URI_WRITE_PERMISSION_PATTERN.test(message);
+}

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -27,11 +27,7 @@ import {
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "./delimited-text";
-import {
-  androidContentUriFileName,
-  isAndroidContentUri,
-  isUriWritePermissionError,
-} from "./android-content-uri";
+import { writeInPlaceWithAndroidFallback } from "./android-content-uri";
 import { IS_MAS_BUILD } from "./build-flags";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 import {
@@ -2746,23 +2742,15 @@ export async function saveProjectFileToPath(
   if (!isTauri() || isHttpUrl(path)) {
     return saveProjectFile(content, path);
   }
-  try {
-    await writeTextFile(path, content);
-  } catch (error) {
-    // On Android a project opened through the document picker carries a
-    // read-only `content://` grant, so writing back to it is refused and Save
-    // fails outright (GeoLibre#1833). Android rejects the request when the
-    // output stream is opened, before the document is touched, so nothing has
-    // been written yet and falling back to the save dialog loses nothing: that
-    // dialog asks Android to *create* the document, which does grant write. The
-    // returned URI is writable, so later saves in the same session go through
-    // in place with no further prompt.
-    if (isAndroidContentUri(path) && isUriWritePermissionError(error)) {
-      return saveProjectFile(content, androidContentUriFileName(path) ?? fallbackName);
-    }
-    throw error;
-  }
-  return path;
+  // On Android a project opened through the document picker carries a read-only
+  // `content://` grant, so writing back to it is refused and Save fails outright
+  // (GeoLibre#1833). The save dialog asks Android to *create* the document,
+  // which does grant write, so the fallback below recovers; see
+  // `writeInPlaceWithAndroidFallback` for why it cannot lose data.
+  return writeInPlaceWithAndroidFallback(content, path, fallbackName, {
+    write: writeTextFile,
+    saveAs: saveProjectFile,
+  });
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -2729,8 +2729,10 @@ export async function saveProjectFile(
  *
  * @param content - The serialized project to write.
  * @param path - The path the project was opened from or last saved to.
- * @param fallbackName - File name for the save dialog when the in-place write
- *   cannot be done; used only when the path carries no usable name of its own.
+ * @param fallbackName - File name for the save dialog when an attempted
+ *   in-place write is refused, and only when the path carries no usable name of
+ *   its own. The two branches below never attempt one, so they pass the path
+ *   itself as the dialog's name and ignore this.
  * @returns The path actually written, or null if a fallback dialog was
  *   cancelled.
  */

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -27,6 +27,11 @@ import {
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "./delimited-text";
+import {
+  androidContentUriFileName,
+  isAndroidContentUri,
+  isUriWritePermissionError,
+} from "./android-content-uri";
 import { IS_MAS_BUILD } from "./build-flags";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 import {
@@ -2725,12 +2730,38 @@ export async function saveProjectFile(
  * Save a project directly to an already-known local path without prompting.
  * Falls back to the save dialog when not running in Tauri (the browser never
  * has a writable filesystem path) or when the path is an HTTP(S) URL.
+ *
+ * @param content - The serialized project to write.
+ * @param path - The path the project was opened from or last saved to.
+ * @param fallbackName - File name for the save dialog when the in-place write
+ *   cannot be done; used only when the path carries no usable name of its own.
+ * @returns The path actually written, or null if a fallback dialog was
+ *   cancelled.
  */
-export async function saveProjectFileToPath(content: string, path: string): Promise<string | null> {
+export async function saveProjectFileToPath(
+  content: string,
+  path: string,
+  fallbackName?: string,
+): Promise<string | null> {
   if (!isTauri() || isHttpUrl(path)) {
     return saveProjectFile(content, path);
   }
-  await writeTextFile(path, content);
+  try {
+    await writeTextFile(path, content);
+  } catch (error) {
+    // On Android a project opened through the document picker carries a
+    // read-only `content://` grant, so writing back to it is refused and Save
+    // fails outright (GeoLibre#1833). Android rejects the request when the
+    // output stream is opened, before the document is touched, so nothing has
+    // been written yet and falling back to the save dialog loses nothing: that
+    // dialog asks Android to *create* the document, which does grant write. The
+    // returned URI is writable, so later saves in the same session go through
+    // in place with no further prompt.
+    if (isAndroidContentUri(path) && isUriWritePermissionError(error)) {
+      return saveProjectFile(content, androidContentUriFileName(path) ?? fallbackName);
+    }
+    throw error;
+  }
   return path;
 }
 

--- a/tests/android-content-uri.test.ts
+++ b/tests/android-content-uri.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  androidContentUriFileName,
+  isAndroidContentUri,
+  isUriWritePermissionError,
+} from "../apps/geolibre-desktop/src/lib/android-content-uri";
+
+// The URI from GeoLibre#1833: a project opened from Documents/json through the
+// Android document picker.
+const EXTERNAL_STORAGE_URI =
+  "content://com.android.externalstorage.documents/document/primary%3ADocuments%2Fjson%2FGeneral_Project.geolibre.json";
+
+describe("isAndroidContentUri", () => {
+  it("accepts a SAF content URI", () => {
+    assert.equal(isAndroidContentUri(EXTERNAL_STORAGE_URI), true);
+  });
+
+  it("rejects filesystem paths and URLs", () => {
+    assert.equal(isAndroidContentUri("/home/user/project.geolibre.json"), false);
+    assert.equal(isAndroidContentUri("C:\\Users\\user\\project.geolibre.json"), false);
+    assert.equal(isAndroidContentUri("https://example.com/project.geolibre.json"), false);
+    assert.equal(isAndroidContentUri("file:///tmp/project.geolibre.json"), false);
+  });
+});
+
+describe("androidContentUriFileName", () => {
+  it("recovers the file name from an ExternalStorageProvider document id", () => {
+    assert.equal(androidContentUriFileName(EXTERNAL_STORAGE_URI), "General_Project.geolibre.json");
+  });
+
+  it("recovers the file name from a tree-scoped document URI", () => {
+    const uri =
+      "content://com.android.externalstorage.documents/tree/primary%3ADocuments/document/primary%3ADocuments%2FMy%20Map.geolibre.json";
+    assert.equal(androidContentUriFileName(uri), "My Map.geolibre.json");
+  });
+
+  it("returns null for an opaque provider id with no file name", () => {
+    // The Downloads provider hands back ids like "msf:1000000123", which carry
+    // no name for the save dialog to reuse.
+    assert.equal(
+      androidContentUriFileName(
+        "content://com.android.providers.downloads.documents/document/msf%3A1000000123",
+      ),
+      null,
+    );
+    assert.equal(androidContentUriFileName("content://media/external/file/12345"), null);
+  });
+
+  it("ignores a query string or fragment", () => {
+    assert.equal(
+      androidContentUriFileName(`${EXTERNAL_STORAGE_URI}?mode=r#frag`),
+      "General_Project.geolibre.json",
+    );
+  });
+
+  it("falls back to the raw segment when the escape sequence is malformed", () => {
+    assert.equal(
+      androidContentUriFileName("content://provider/document/broken%2Eproject.json"),
+      "broken.project.json",
+    );
+    assert.equal(
+      androidContentUriFileName("content://provider/document/bad%project.json"),
+      "bad%project.json",
+    );
+  });
+
+  it("returns null for anything that is not a content URI", () => {
+    assert.equal(androidContentUriFileName("/home/user/project.geolibre.json"), null);
+  });
+});
+
+describe("isUriWritePermissionError", () => {
+  it("matches the Android permission denial reported in #1833", () => {
+    const error = new Error(
+      "failed to open file: Permission Denial: writing com.android.externalstorage.ExternalStorageProvider uri " +
+        `${EXTERNAL_STORAGE_URI} from pid=7564, uid=10393 requires android.permission.MANAGE_DOCUMENTS, ` +
+        "or grantUriPermission()",
+    );
+    assert.equal(isUriWritePermissionError(error), true);
+  });
+
+  it("matches a refusal that crossed the bridge as a bare string", () => {
+    assert.equal(isUriWritePermissionError("java.io.FileNotFoundException: No permission"), true);
+    assert.equal(isUriWritePermissionError("EACCES: permission denied, open"), true);
+  });
+
+  it("does not match ordinary write failures", () => {
+    assert.equal(isUriWritePermissionError(new Error("No space left on device")), false);
+    assert.equal(
+      isUriWritePermissionError(new Error("os error 2: no such file or directory")),
+      false,
+    );
+    assert.equal(isUriWritePermissionError(new Error("Failed to serialize project")), false);
+  });
+});

--- a/tests/android-content-uri.test.ts
+++ b/tests/android-content-uri.test.ts
@@ -5,6 +5,7 @@ import {
   androidContentUriFileName,
   isAndroidContentUri,
   isUriWritePermissionError,
+  writeInPlaceWithAndroidFallback,
 } from "../apps/geolibre-desktop/src/lib/android-content-uri";
 
 // The URI from GeoLibre#1833: a project opened from Documents/json through the
@@ -93,5 +94,125 @@ describe("isUriWritePermissionError", () => {
       false,
     );
     assert.equal(isUriWritePermissionError(new Error("Failed to serialize project")), false);
+  });
+});
+
+// The message Android returns for a read-only `content://` grant, verbatim from
+// the issue's diagnostic log.
+const DENIAL = new Error(
+  "failed to open file: Permission Denial: writing com.android.externalstorage.ExternalStorageProvider uri " +
+    `${EXTERNAL_STORAGE_URI} from pid=7564, uid=10393 requires android.permission.MANAGE_DOCUMENTS, ` +
+    "or grantUriPermission()",
+);
+
+// A save-dialog URI is writable, so the fallback's own write succeeds; only the
+// in-place write to the read-only URI is refused, as on a device.
+const CREATED_URI =
+  "content://com.android.externalstorage.documents/document/primary%3ADocuments%2Fjson%2FGeneral_Project(1).geolibre.json";
+
+function makeHandlers(options: { writeError?: unknown; saveAsResult?: string | null } = {}) {
+  const writes: Array<{ path: string; content: string }> = [];
+  const saveAsCalls: Array<{ content: string; defaultName?: string }> = [];
+  return {
+    writes,
+    saveAsCalls,
+    handlers: {
+      write: async (path: string, content: string) => {
+        if (options.writeError && path !== CREATED_URI) throw options.writeError;
+        writes.push({ path, content });
+      },
+      saveAs: async (content: string, defaultName?: string) => {
+        saveAsCalls.push({ content, defaultName });
+        const created = options.saveAsResult === undefined ? CREATED_URI : options.saveAsResult;
+        if (created !== null) writes.push({ path: created, content });
+        return created;
+      },
+    },
+  };
+}
+
+describe("writeInPlaceWithAndroidFallback", () => {
+  it("writes in place and never opens a dialog when the write succeeds", async () => {
+    const { handlers, writes, saveAsCalls } = makeHandlers();
+    const path = await writeInPlaceWithAndroidFallback(
+      "{}",
+      "/home/user/a.geolibre.json",
+      "a.geolibre.json",
+      handlers,
+    );
+    assert.equal(path, "/home/user/a.geolibre.json");
+    assert.deepEqual(writes, [{ path: "/home/user/a.geolibre.json", content: "{}" }]);
+    assert.equal(saveAsCalls.length, 0);
+  });
+
+  it("falls back to the save dialog when Android refuses a content URI", async () => {
+    const { handlers, writes, saveAsCalls } = makeHandlers({ writeError: DENIAL });
+    const path = await writeInPlaceWithAndroidFallback(
+      "{}",
+      EXTERNAL_STORAGE_URI,
+      "Untitled Project.geolibre.json",
+      handlers,
+    );
+    // The dialog is pre-filled with the name recovered from the URI, not the
+    // generic project name, so the user can save over the file they opened.
+    assert.deepEqual(saveAsCalls, [
+      { content: "{}", defaultName: "General_Project.geolibre.json" },
+    ]);
+    // The refused write touched nothing; only the created document was written.
+    assert.deepEqual(writes, [{ path: CREATED_URI, content: "{}" }]);
+    // The writable URI becomes the project path, so later saves go in place.
+    assert.equal(path, CREATED_URI);
+  });
+
+  it("falls back to the caller's name when the URI has no usable one", async () => {
+    const { handlers, saveAsCalls } = makeHandlers({ writeError: DENIAL });
+    await writeInPlaceWithAndroidFallback(
+      "{}",
+      "content://com.android.providers.downloads.documents/document/msf%3A1000000123",
+      "Untitled Project.geolibre.json",
+      handlers,
+    );
+    assert.equal(saveAsCalls[0]?.defaultName, "Untitled Project.geolibre.json");
+  });
+
+  it("reports a cancelled fallback dialog as no save", async () => {
+    const { handlers, writes } = makeHandlers({ writeError: DENIAL, saveAsResult: null });
+    const path = await writeInPlaceWithAndroidFallback(
+      "{}",
+      EXTERNAL_STORAGE_URI,
+      "Untitled Project.geolibre.json",
+      handlers,
+    );
+    assert.equal(path, null);
+    assert.deepEqual(writes, []);
+  });
+
+  it("rethrows an ordinary write failure instead of reopening a dialog", async () => {
+    const { handlers, saveAsCalls } = makeHandlers({
+      writeError: new Error("No space left on device"),
+    });
+    await assert.rejects(
+      () =>
+        writeInPlaceWithAndroidFallback(
+          "{}",
+          EXTERNAL_STORAGE_URI,
+          "Untitled Project.geolibre.json",
+          handlers,
+        ),
+      /No space left/,
+    );
+    assert.equal(saveAsCalls.length, 0);
+  });
+
+  it("rethrows a permission error on a plain filesystem path", async () => {
+    const { handlers, saveAsCalls } = makeHandlers({
+      writeError: new Error("EACCES: permission denied, open '/etc/a.geolibre.json'"),
+    });
+    await assert.rejects(
+      () =>
+        writeInPlaceWithAndroidFallback("{}", "/etc/a.geolibre.json", "a.geolibre.json", handlers),
+      /EACCES/,
+    );
+    assert.equal(saveAsCalls.length, 0);
   });
 });

--- a/tests/android-content-uri.test.ts
+++ b/tests/android-content-uri.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 
 import {
   androidContentUriFileName,
@@ -132,6 +132,22 @@ function makeHandlers(options: { writeError?: unknown; saveAsResult?: string | n
 }
 
 describe("writeInPlaceWithAndroidFallback", () => {
+  // The fallback logs the original refusal to the Diagnostics panel, so collect
+  // `console.warn` rather than letting it scribble over the test output.
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+
+  beforeEach(() => {
+    warnings.length = 0;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
   it("writes in place and never opens a dialog when the write succeeds", async () => {
     const { handlers, writes, saveAsCalls } = makeHandlers();
     const path = await writeInPlaceWithAndroidFallback(
@@ -162,6 +178,11 @@ describe("writeInPlaceWithAndroidFallback", () => {
     assert.deepEqual(writes, [{ path: CREATED_URI, content: "{}" }]);
     // The writable URI becomes the project path, so later saves go in place.
     assert.equal(path, CREATED_URI);
+    // The original refusal reaches the Diagnostics panel, so an unexpected
+    // fallback on some other provider can be diagnosed from a user's report.
+    assert.equal(warnings.length, 1);
+    assert.match(String(warnings[0]?.[0]), /cannot write .* in place/);
+    assert.equal(warnings[0]?.[1], DENIAL);
   });
 
   it("falls back to the caller's name when the URI has no usable one", async () => {


### PR DESCRIPTION
Fixes #1833.

## Root cause

`tauri-plugin-dialog` uses two different Android intents, and only one of them grants write:

| API | Intent | Grant |
| --- | --- | --- |
| `open()` | `ACTION_GET_CONTENT` | read only, not upgradeable from inside the app |
| `save()` | `ACTION_CREATE_DOCUMENT` | read + write |

So a project opened through the Android document picker gets a read-only `content://` URI. It reads and edits fine, then Save calls `writeTextFile` on that URI and Android refuses:

```
failed to open file: Permission Denial: writing com.android.externalstorage.ExternalStorageProvider
uri content://com.android.externalstorage.documents/document/primary%3ADocuments%2Fjson%2FGeneral_Project.geolibre.json
from pid=7564, uid=10393 requires android.permission.MANAGE_DOCUMENTS, or grantUriPermission()
```

The picker plugin is upstream (`tauri-plugin-dialog`, which still carries a `// TODO: ACTION_OPEN_DOCUMENT ??` at that line), and its `fileAccessMode` option is iOS-only, so there is no way to ask for a writable grant at open time from GeoLibre.

## The fix

A project opened via Save As also carries a `content://` path, and that one *is* writable. Nothing in the URI distinguishes the two, so `saveProjectFileToPath` now attempts the in-place write and falls back to the save dialog only when Android refuses a `content://` URI:

- Android rejects the request when the output stream is opened, before the document is touched, so nothing has been written and the fallback loses nothing.
- The dialog is pre-filled with the file name recovered from the URI's percent-encoded document id (`primary:Documents/json/General_Project.geolibre.json` -> `General_Project.geolibre.json`), falling back to the project-derived name for providers that use opaque ids.
- The URI the dialog returns is writable and becomes the new project path, so later saves in the same session go through in place with no further prompt.
- An ordinary write failure (no space left, a provider that has gone away) and a permission error on a plain filesystem path both keep propagating, so no unexpected dialog appears in place of a real error.

The URI/error predicates live in a new `apps/geolibre-desktop/src/lib/android-content-uri.ts`, free of Tauri imports so they are unit-testable.

## Verification

- New `tests/android-content-uri.test.ts` (11 cases) covers URI detection, file-name recovery (ExternalStorageProvider, tree-scoped URIs, opaque Downloads ids, query strings, malformed escapes) and the permission-error match, including the exact message from the issue.
- The fallback wiring in `saveProjectFileToPath` was exercised with a throwaway harness stubbing `@tauri-apps/plugin-fs`/`plugin-dialog`, confirming all four branches: in-place write on success, dialog fallback on the reported denial (pre-filled `General_Project.geolibre.json`), rethrow on "No space left on device", rethrow on `EACCES` for a filesystem path. It is not committed because it needs Node's experimental module mocking, which this suite does not enable.
- Full frontend suite: 5755 passing, 0 failing. `npm run typecheck` (build) clean, pre-commit clean.
- Drove the real app at `localhost:5173` with Playwright in both light and dark themes: loaded `us_cities.geojson`, switched the basemap (the reporter's edit), and ran Project -> Save; no new console errors in either theme.

**Not verified on a device.** This machine has no Android SDK/NDK or emulator, so the original repro could not be reproduced or the fix confirmed on hardware. The root cause is established from the plugin's Kotlin source and the reporter's log, and every branch of the new logic is covered above, but a check on a real Android build before release would be worthwhile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Android file handling when saving projects to storage-provider locations.
  * Prompts for a new writable location when an existing Android file cannot be overwritten.
  * Preserves the selected filename when saving to an existing local path.
  * Retains the original filename when opening the fallback save dialog.

* **Bug Fixes**
  * Improved filename detection for Android storage-provider links, including unusual or malformed URI formats.
  * Prevents save operations from silently failing when Android permissions prevent overwriting a file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->