### PR TITLE
ci: keep studio.geolibre.app out of search results

### DIFF
--- a/.github/workflows/studio-deploy.yml
+++ b/.github/workflows/studio-deploy.yml
@@ -129,6 +129,24 @@ jobs:
           touch .nojekyll
           # Keeps the custom domain if the Pages settings are ever reset.
           echo "studio.geolibre.app" > CNAME
+          # Keep the gated instance out of search results. Nothing here is
+          # useful to a crawler — every route renders the sign-in card until a
+          # session exists — and the deployment is meant to be reached by
+          # invitation, not found.
+          printf 'User-agent: *\nDisallow: /\n' > robots.txt
+          # A second signal for crawlers that ignore robots.txt. Note the two
+          # do not compose: a crawler that honours the Disallow above never
+          # fetches this page and so never reads the noindex, which is why a
+          # URL linked from elsewhere can still be listed (bare, no title). If
+          # studio is ever linked publicly and that matters, relax robots.txt
+          # to "Allow: /" so the noindex is the rule that applies.
+          # Appended to the end of <head> rather than the start, so the charset
+          # declaration keeps its place as the first thing in the document.
+          sed -i '0,/<\/head>/s//    <meta name="robots" content="noindex, nofollow" \/>\n  <\/head>/' index.html
+          # The tag is injected into generated markup, so fail loudly if a
+          # future index.html no longer matches rather than publishing an
+          # indexable page.
+          grep -q 'name="robots"' index.html
           # Published Pages sites may be no larger than 1 GB. The build is
           # ~200 MB today, most of it the two DuckDB-WASM binaries; fail early
           # rather than publish a site Pages will reject.


### PR DESCRIPTION
## Summary

The gated instance is meant to be reached by invitation, and nothing on it is useful to a crawler — every route renders the sign-in card until a session exists.

The deploy step now writes a `robots.txt` disallowing everything, and appends `<meta name="robots" content="noindex, nofollow">` to `<head>`.

## Why both, and the caveat

They deliberately do not compose. A crawler that honours the `Disallow` never fetches the page, so it never reads the `noindex` — which is why a URL linked from elsewhere can still be listed (bare, no title). The `Disallow` stops crawling; the meta covers crawlers that ignore robots.txt.

For this deployment that is the right trade: nothing links to `studio.geolibre.app`, so nothing should discover it in the first place. The inline comment records the switch to make if that ever changes — relax `robots.txt` to `Allow: /` so the `noindex` becomes the rule that applies.

## Notes

- The meta is appended to the *end* of `<head>` so the charset declaration keeps its place as the first thing in the document.
- It is injected into generated markup, so the step greps for it afterwards and fails the run rather than publishing an indexable page if a future `index.html` stops matching the pattern.

## Validation

Ran the exact `sed` against the real built `apps/geolibre-desktop/dist/index.html`: injected once, `</head>` count unchanged, charset still first, and the document still parses as `<html> <head> </head> <body> </body> </html>`. `check-yaml` and the full `npm build` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search-engine blocking for deployed sites through `robots.txt` and `noindex, nofollow` metadata.
  * Deployments now verify that the search-engine exclusion settings are present before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->