### PR TITLE
fix(studio): build the JupyterLite site into studio.geolibre.app

### DIFF
--- a/.github/workflows/studio-deploy.yml
+++ b/.github/workflows/studio-deploy.yml
@@ -62,6 +62,19 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Set up Python for the JupyterLite build
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install the JupyterLite build dependencies
+        # Without these the Vite build prints "`jupyter lite` is not available --
+        # skipping the JupyterLite build" and carries on, so the site publishes
+        # with its Notebook panel unable to load and nothing failing. That is what
+        # studio.geolibre.app shipped until this step existed: /jupyterlite/
+        # returned 404 while the rest of the site served normally.
+        run: pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt
+
       - name: Install frontend dependencies
         run: npm ci
 
@@ -118,6 +131,13 @@ jobs:
           fi
           if ! grep -rqsF -- "$CLERK_KEY" apps/geolibre-desktop/dist/assets; then
             echo "::error::The configured Clerk key is not in the build — refusing to publish an ungated studio.geolibre.app."
+            exit 1
+          fi
+          # The JupyterLite build only warns when its Python deps are missing, so
+          # a break in the install step above would publish a site whose Notebook
+          # panel cannot load, with no failing step to show for it.
+          if [ ! -f apps/geolibre-desktop/dist/jupyterlite/index.html ]; then
+            echo "::error::The JupyterLite site is not in the build — the Notebook panel would not load. Check the 'Install the JupyterLite build dependencies' step."
             exit 1
           fi
 


### PR DESCRIPTION
## The bug

`studio.geolibre.app` is live but has **no JupyterLite site**, so its Notebook panel cannot load. Verified two ways:

```
https://studio.geolibre.app/jupyterlite/index.html   404
https://studio.geolibre.app/index.html               200
```

and the `gh-pages` tree of `opengeos/studio.geolibre.app` contains no `jupyterlite` directory:

```
.nojekyll, CNAME, apple-touch-icon.png, assets, basemaps-assets, cesium,
favicon.ico, favicon.png, geolibre-runtime-config.js, index.html,
manifest.webmanifest, ..., plugins, pyodide, sw.js, ...
```

## Why it happened silently

`studio-deploy.yml` installs no Python dependencies, and the Vite build treats their absence as a **warning**, not an error:

```
[build-jupyterlite] `jupyter lite` is not available — skipping the JupyterLite build.
Any build that embeds the site (web, embed) will have a Notebook panel that cannot load.
To enable it, install the build deps:
  pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt
```

So every deploy has succeeded while dropping ~787 files. There was no failing step and no size check that would notice.

## The fix

- Install the documented requirements (`actions/setup-python@v7` + `pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt`) before the build.
- Guard the **class** of failure, not just this instance: the existing verify step now also fails if `dist/jupyterlite/index.html` is absent, so a future break in the install step fails the run instead of quietly republishing a site with a dead Notebook panel.

## How it was found

While building the equivalent workflow for `opera.geolibre.app`, its first CI build produced 803 files / 121 MB against 1,590 / 172 MB locally. The difference was exactly the 787-file JupyterLite tree. Checking studio showed the same gap, already shipped.

Verified: YAML parses (10 steps, the two new ones ordered before `npm ci`), and `pre-commit run --files .github/workflows/studio-deploy.yml` passes. The real proof is the next deploy — `/jupyterlite/index.html` should return 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved studio deployment reliability by preparing required build dependencies.
  * Added validation to ensure the generated site includes the required entry page before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->