### PR TITLE
fix(docker): publish the OPERA news endpoint where the plugin reads it

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -136,6 +136,12 @@ import base64
 from urllib.parse import urlsplit
 
 deployment = {}
+# Values published as bare globals rather than inside __GEOLIBRE_DEPLOYMENT_ENV__.
+# That object is a GeoLibre convention (see deployment-env.ts); a plugin from
+# outside this repo answers to its own contract, and some of them read a plain
+# global. Keys here are literals from this file, never operator input, so they
+# cannot inject anything into the generated script.
+browser_globals = {}
 if os.environ.get("GEOLIBRE_AI_URL"):
     deployment["VITE_GEOLIBRE_AI_URL"] = os.environ["GEOLIBRE_AI_URL"]
     deployment["VITE_GEOLIBRE_AI_MODEL"] = os.environ["GEOLIBRE_AI_MODEL"]
@@ -292,19 +298,20 @@ elif os.environ.get("GEOLIBRE_AI_URL"):
 else:
     news_endpoint = ""
 if news_endpoint:
-    # Three spellings of one value, because the reader is a plugin loaded from
-    # outside this repo and the app itself never reads any of them. No apostrophes
-    # below: this whole program is one single-quoted `python -c` argument, and a
-    # literal apostrophe in a comment ends it just as surely as one in code (see
-    # the allowed_hosts note in service_url above).
-    #   - the bare key is the contract name owned by the plugin;
-    #   - VITE_NASA_OPERA_… is the plugin-owned build-env spelling, which drops the
-    #     GEOLIBRE_ segment because the variable belongs to the plugin, not here;
-    #   - VITE_GEOLIBRE_NASA_OPERA_… is the VITE_GEOLIBRE_<NAME> alias every other
-    #     entry in this dict uses, readable through readDeploymentEnvValue().
-    deployment["GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
-    deployment["VITE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
-    deployment["VITE_GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
+    # A TOP-LEVEL global, not a key in the deployment env object, because the
+    # reader is a plugin loaded from outside this repo and its contract is its
+    # own. geolibre-nasa-opera resolves this in src/lib/opera/news.ts as
+    # globalThis[GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT], falling back to its own
+    # build-time VITE_NEWS_PROXY_ENDPOINT; across the whole history of that repo it has
+    # never read window.__GEOLIBRE_DEPLOYMENT_ENV__ for this value. Publishing it
+    # only inside that object, as this block did before, therefore configured
+    # nothing: the plugin looked for a global that was not there, found nothing,
+    # and reported the news proxy as unconfigured.
+    #
+    # No apostrophes below: this whole program is one single-quoted `python -c`
+    # argument, and a literal apostrophe in a comment ends it just as surely as one
+    # in code (see the allowed_hosts note in service_url above).
+    browser_globals["GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
 
 
 # Project sharing server. Unset means the public hosted service; "off" removes
@@ -329,6 +336,10 @@ with open("/usr/share/nginx/html/geolibre-runtime-config.js", "w") as output:
     output.write("window.__GEOLIBRE_DEPLOYMENT_ENV__ = ")
     json.dump(deployment, output, separators=(",", ":"))
     output.write(";\n")
+    for global_name, global_value in browser_globals.items():
+        output.write("window." + global_name + " = ")
+        json.dump(global_value, output)
+        output.write(";\n")
 '
 
 # Strip surrounding whitespace exactly as the Python block above does, so the boot


### PR DESCRIPTION
## The bug

`GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT` was written into `window.__GEOLIBRE_DEPLOYMENT_ENV__`, which the plugin never reads for this value. Setting it configured nothing: the plugin looked for a global that was not there and reported the news proxy as unconfigured.

`geolibre-nasa-opera` resolves it in `src/lib/opera/news.ts`:

```ts
const NEWS_PROXY_GLOBAL = "GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT";
function readGlobal()   { return globalThis[NEWS_PROXY_GLOBAL]; }
function readBuildEnv() { return import.meta.env?.VITE_NEWS_PROXY_ENDPOINT; }
resolveNewsProxyEndpoint = clean(override) || clean(readGlobal()) || clean(readBuildEnv()) || ""
```

Across the **whole history** of that repository (36 commits) `news.ts` has never read `window.__GEOLIBRE_DEPLOYMENT_ENV__`, nor any `VITE_*NASA*` spelling. So all three keys this block published were dead — including the two aliases I added in #1838 on the assumption that one of them might be the contract. This replaces them with the one global the plugin actually looks up.

This is the gap the review bot suspected on #1838 ("this key will just silently never be found"), which I could not confirm at the time because the plugin was not available. It now is.

## The change

```diff
-    deployment["GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
-    deployment["VITE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
-    deployment["VITE_GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
+    browser_globals["GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT"] = news_endpoint
```

`__GEOLIBRE_DEPLOYMENT_ENV__` stays the home for GeoLibre's own `VITE_*` settings. A second dict carries values published as bare globals, for readers outside this repo that answer to their own contract. Its keys are literals from this file, never operator input, so nothing can be injected into the generated script.

Output now:

```js
window.__GEOLIBRE_DEPLOYMENT_ENV__ = {"VITE_GEOLIBRE_AI_URL":"/ai","VITE_GEOLIBRE_AI_MODEL":"openai/gpt-5.5"};
window.GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT = "/ai";
```

which is the same shape the `opera.geolibre.app` deploy workflow writes for its static build.

## Verification

Ran the real embedded `python -c` command through `sh` (not the block extracted as a `.py` file — that bypasses the shell quoting this file is sensitive to):

| Input | Result |
| --- | --- |
| `GEOLIBRE_AI_URL=/ai` | `window.GEOLIBRE_NASA_OPERA_NEWS_PROXY_ENDPOINT = "/ai";` |
| explicit `https://news.example.org/` | same global, trailing slash stripped |
| neither set | no global emitted |
| `https://u:p@news.example.org` | still exits 1 |

plus `sh -n` and `bash -n` clean, and `pre-commit run --files docker/entrypoint.sh` passing.

## Note on a related gap

The plugin reads a second top-level global, `GEOLIBRE_NASA_OPERA_TITILER_CMR_ENDPOINT`, which this entrypoint does not publish at all. Left alone deliberately — out of scope here, and the plugin has a working default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime configuration generation for plugin-owned browser globals.
  * Published the NASA OPERA news proxy endpoint through a dedicated top-level browser setting.
  * Ensured generated configuration consistently separates deployment settings from browser globals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->