### PR TITLE
Allow the opera.geolibre.app origin on the AI proxy

### DIFF
--- a/workers/ai-proxy/wrangler.jsonc
+++ b/workers/ai-proxy/wrangler.jsonc
@@ -19,7 +19,7 @@
     ]
   },
   "vars": {
-    "ALLOWED_ORIGINS": "https://geolibre.app,https://web.geolibre.app,https://viewer.geolibre.app,https://studio.geolibre.app,http://localhost:5173,http://localhost:1420,tauri://localhost,http://tauri.localhost",
+    "ALLOWED_ORIGINS": "https://geolibre.app,https://web.geolibre.app,https://viewer.geolibre.app,https://studio.geolibre.app,https://opera.geolibre.app,http://localhost:5173,http://localhost:1420,tauri://localhost,http://tauri.localhost",
     "ALLOWED_MODELS": "openai/gpt-5.5,anthropic/claude-opus-5,anthropic/claude-sonnet-5,google/gemini-3.6-flash,google/gemini-3.5-flash,google/gemini-3.5-flash-lite",
     "DEFAULT_MODEL": "openai/gpt-5.5",
     "AI_GATEWAY_ID": "default",


### PR DESCRIPTION
Adds `https://opera.geolibre.app` to `ALLOWED_ORIGINS`, alongside studio, for the NASA OPERA deployment.

```diff
-...,https://studio.geolibre.app,http://localhost:5173,...
+...,https://studio.geolibre.app,https://opera.geolibre.app,http://localhost:5173,...
```

## What this actually does

Worth being precise, because an origin allowlist is easy to mistake for access control. In `workers/ai-proxy/src/index.ts` the resolved origin is used **only** to build CORS response headers:

```ts
const origin = allowedOrigin(request, env);
if (!(await hasValidInstanceToken(request, env))) {
  return jsonError("Unauthorized", 401, responseHeaders(origin));
}
```

`hasValidInstanceToken()` is what decides whether a request is served, and it runs regardless. So a request carrying a valid instance token succeeds whether or not its `Origin` is listed; an unlisted origin merely gets a response without CORS headers.

`opera.geolibre.app` reaches this Worker through a same-origin `/ai` path served by a Cloudflare Pages worker, which forwards server-to-server. CORS is not involved on either hop, so **this entry is not load-bearing for that deployment**. It is here so the allowlist stays an accurate statement of which deployments legitimately use the proxy, and so a direct browser call from that origin behaves like the other first-party sites.

## Verification

- `npm run test:worker` (typechecks the ai-proxy Worker) passes.
- `pre-commit run --files workers/ai-proxy/wrangler.jsonc` passes.
- Parsed the edited file and split the list the same way `parseList()` does: 9 entries, no duplicates, every `https://` entry a canonical origin, `https://opera.geolibre.app` present.

## Deploying

This Worker has **no CI deploy workflow** — no workflow in `.github/workflows/` references it, and `workers/ai-proxy/README.md` documents `npx wrangler deploy` as the deploy path. So merging this changes nothing in production until someone runs, from `workers/ai-proxy/`:

```sh
npm run deploy:dry-run
npx wrangler deploy
```

I have no Cloudflare credentials here and did not attempt it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Enabled access from `https://opera.geolibre.app`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->