### PR TITLE
fix(docker): build and serve JupyterLite in the official image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,22 @@
 # arch-independent static files, so emulating arm64 with QEMU here only
 # slows down multi-arch builds without changing the result.
 # ($BUILDPLATFORM is a Docker-provided automatic ARG, set by BuildKit.)
-FROM --platform=$BUILDPLATFORM node:22-alpine AS build
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS build
+
+# Debian rather than Alpine because this stage now also runs the JupyterLite
+# build, whose Python dependency tree (jupyterlab, notebook, jupyterlite-core)
+# resolves to prebuilt manylinux wheels here instead of compiling against musl.
+# Only apps/geolibre-desktop/dist is copied into the runtime image, so the larger
+# builder costs nothing in the shipped image.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+# A venv keeps pip off the Debian-managed interpreter, which refuses installs
+# under PEP 668.
+ENV VIRTUAL_ENV=/opt/jupyterlite
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 WORKDIR /app
 
@@ -19,6 +34,11 @@ COPY packages/processing/package.json packages/processing/package.json
 COPY packages/ui/package.json packages/ui/package.json
 
 RUN npm ci
+
+# Its own layer, keyed only on the requirements file, so touching app source does
+# not reinstall the Python tree.
+COPY apps/geolibre-desktop/jupyterlite/requirements.txt apps/geolibre-desktop/jupyterlite/requirements.txt
+RUN pip install --no-cache-dir -r apps/geolibre-desktop/jupyterlite/requirements.txt
 
 COPY . .
 
@@ -48,7 +68,21 @@ ENV VITE_GEOLIBRE_EMBED_ORIGINS=${VITE_GEOLIBRE_EMBED_ORIGINS}
 ENV VITE_GEOLIBRE_SHARE_URL=${VITE_GEOLIBRE_SHARE_URL}
 ENV VITE_GEOLIBRE_COLLAB_URL=${VITE_GEOLIBRE_COLLAB_URL}
 
+# The `prebuild` hook of apps/geolibre-desktop runs scripts/build-jupyterlite.mjs,
+# which generates the site the Notebook panel embeds. That script is best-effort
+# by default: without the `jupyter lite` CLI it warns and exits 0, and the build
+# still succeeds. nginx then answers the panel's iframe URL with index.html
+# through its SPA fallback, so the panel renders a second copy of GeoLibre
+# instead of a notebook, which is how this image shipped for so long
+# (GeoLibre#1851). Make the absence fatal here rather than silent.
+ENV GEOLIBRE_JUPYTERLITE_REQUIRED=1
+
 RUN npm run build
+
+# The site is generated, not committed (public/jupyterlite/ is git-ignored), so
+# assert it reached the output rather than trusting the step above.
+RUN test -f apps/geolibre-desktop/dist/jupyterlite/lab/index.html \
+  || (echo "ERROR: dist/jupyterlite is missing; the Notebook panel would render a second copy of the app." && exit 1)
 
 # Runtime image bundles the static web app (served by nginx) and the optional
 # Python conversion/Whitebox sidecar (uvicorn), reverse-proxied at /sidecar.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -56,6 +56,35 @@ server {
         proxy_read_timeout 600s;
     }
 
+    # The self-hosted JupyterLite site behind the Notebook panel, which is a
+    # separate app embedded in an iframe and needs its own policy.
+    #
+    # ^~ so this wins over the static-asset regex location below and every
+    # request under the prefix is handled here, documents and assets alike.
+    location ^~ /jupyterlite/ {
+        # No SPA fallback. `try_files $uri /index.html` in `location /` is what
+        # turned "JupyterLite was never built" into "the Notebook panel shows a
+        # second copy of GeoLibre": the iframe asks for
+        # /jupyterlite/lab/index.html, nginx cannot find it, and answers with the
+        # app. A 404 says what actually went wrong (GeoLibre#1851).
+        try_files $uri $uri/ =404;
+
+        # add_header does not inherit into a block that sets any header of its
+        # own, so the shared three are repeated rather than silently dropped.
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # The app policy plus 'unsafe-inline' for script-src, scoped to this
+        # prefix so the app itself keeps forbidding inline script. JupyterLab
+        # bootstraps from an inline <script>; under the app policy the site loads
+        # its HTML and then never boots -- no shell, no launcher, just the
+        # noscript fallback -- with a single "Executing inline script violates..."
+        # violation and no other symptom. Nothing here needs the Google or Clerk
+        # origins, so they are left out.
+        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/; worker-src blob: 'self'" always;
+    }
+
     location / {
         try_files $uri /index.html;
         add_header Cache-Control "no-cache, must-revalidate" always;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,3 +1,31 @@
+# Cache policy for the self-hosted JupyterLite site (the /jupyterlite/ location
+# below). Most of that site by weight is webpack output whose filename carries a
+# content hash (`build/1053.75981ec.js`, `.../remoteEntry.<hash>.js`) -- ~276
+# files, ~12 MB of a 58 MB build -- but because that location claims the whole
+# prefix, none of it reaches the immutable-asset location at the bottom of this
+# file. So the split `location /` already makes ("revalidate the entrypoint,
+# cache the hashed assets forever") is restated here for the prefix.
+#
+# A map rather than a nested location because add_header does not inherit into a
+# block that sets any header of its own: a nested location would have to restate
+# the whole /jupyterlite/ CSP as well, leaving two copies of a long policy to
+# drift apart. This way one add_header covers both cases and the headers around
+# it are untouched.
+#
+# Matching the hash rather than the extension is deliberate: the build also
+# emits ~80 static files whose names are stable across rebuilds --
+# service-worker.js, lab/bundle.js, bootstrap.js, the bundled themes'
+# index.js/index.css, the MathJax and FontAwesome fonts. Pinning those for a
+# year would strand a stale service worker and stale bundles after a redeploy,
+# exactly what the `location = /sw.js` block below exists to prevent, so they
+# fall to the revalidating default. The leading `[./-]` (or the `/` before a
+# bare-hash filename) keeps the hex run from matching an ordinary word; no
+# stable name in the build output is seven or more hex characters long.
+map $uri $geolibre_jupyterlite_cache {
+    default "no-cache, must-revalidate";
+    "~*^/jupyterlite/.*[./-][0-9a-f]{7,}\.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf|eot)$" "public, max-age=31536000, immutable";
+}
+
 server {
     listen 80;
     server_name _;
@@ -61,8 +89,8 @@ server {
     #
     # ^~ so this wins over the static-asset regex location below and every
     # request under the prefix is handled here, documents and assets alike --
-    # which is also why the immutable-asset policy has to be restated inside
-    # (see the nested location).
+    # which is also why the immutable-asset policy has to be restated for it
+    # (see $geolibre_jupyterlite_cache at the top of this file).
     #
     # The panel's iframe always requests a path under the prefix, but a bare
     # /jupyterlite typed by hand would otherwise miss this block and hit the SPA
@@ -84,7 +112,10 @@ server {
 
         # add_header does not inherit into a block that sets any header of its
         # own, so the shared three are repeated rather than silently dropped.
-        add_header Cache-Control "no-cache, must-revalidate" always;
+        # Cache-Control is per-request here: the site's content-hashed assets get
+        # the immutable policy and everything else revalidates (see the map at
+        # the top of this file).
+        add_header Cache-Control $geolibre_jupyterlite_cache always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
@@ -96,35 +127,6 @@ server {
         # violation and no other symptom. Nothing here needs the Google or Clerk
         # origins, so they are left out.
         add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/; worker-src blob: 'self'" always;
-
-        # Most of the site by weight is webpack output whose filename carries a
-        # content hash (`build/1053.75981ec.js`, `.../remoteEntry.<hash>.js`) --
-        # ~276 files, ~12 MB of a 58 MB build. Because ^~ above claims the whole
-        # prefix, they would never reach the immutable-asset regex location at
-        # the bottom of this file and would revalidate on every panel open, so
-        # the same split `location /` makes ("revalidate the entrypoint, cache
-        # the hashed assets forever") is restated here.
-        #
-        # Matching on the hash rather than on the extension alone is deliberate:
-        # the JupyterLite build also emits ~80 static files whose names are
-        # stable across rebuilds -- service-worker.js, lab/bundle.js,
-        # bootstrap.js, the bundled themes' index.js/index.css, the MathJax and
-        # FontAwesome fonts. Pinning those for a year would strand a stale
-        # service worker and stale bundles after a redeploy, exactly what the
-        # `location = /sw.js` block below exists to prevent. Those names do not
-        # match, so they keep the revalidating policy of the block above.
-        #
-        # A leading `[./-]` (or the `/` before a bare-hash filename) keeps the
-        # hex run from matching an ordinary word; no stable filename in the
-        # build output is seven or more hex characters long. The pattern must
-        # stay quoted -- unquoted, nginx reads the `{7,}` quantifier as a block
-        # delimiter and fails to start with `unknown directive`.
-        location ~* "^/jupyterlite/.*[./-][0-9a-f]{7,}\.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf|eot)$" {
-            try_files $uri =404;
-            add_header Cache-Control "public, max-age=31536000, immutable";
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        }
     }
 
     location / {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -60,7 +60,20 @@ server {
     # separate app embedded in an iframe and needs its own policy.
     #
     # ^~ so this wins over the static-asset regex location below and every
-    # request under the prefix is handled here, documents and assets alike.
+    # request under the prefix is handled here, documents and assets alike --
+    # which is also why the immutable-asset policy has to be restated inside
+    # (see the nested location).
+    #
+    # The panel's iframe always requests a path under the prefix, but a bare
+    # /jupyterlite typed by hand would otherwise miss this block and hit the SPA
+    # fallback, reproducing the very bug below.
+    location = /jupyterlite {
+        # Relative Location, so a TLS reverse proxy in front of the container
+        # does not see the redirect point back at http:// on the listen port.
+        absolute_redirect off;
+        return 301 /jupyterlite/;
+    }
+
     location ^~ /jupyterlite/ {
         # No SPA fallback. `try_files $uri /index.html` in `location /` is what
         # turned "JupyterLite was never built" into "the Notebook panel shows a
@@ -83,6 +96,35 @@ server {
         # violation and no other symptom. Nothing here needs the Google or Clerk
         # origins, so they are left out.
         add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/; worker-src blob: 'self'" always;
+
+        # Most of the site by weight is webpack output whose filename carries a
+        # content hash (`build/1053.75981ec.js`, `.../remoteEntry.<hash>.js`) --
+        # ~276 files, ~12 MB of a 58 MB build. Because ^~ above claims the whole
+        # prefix, they would never reach the immutable-asset regex location at
+        # the bottom of this file and would revalidate on every panel open, so
+        # the same split `location /` makes ("revalidate the entrypoint, cache
+        # the hashed assets forever") is restated here.
+        #
+        # Matching on the hash rather than on the extension alone is deliberate:
+        # the JupyterLite build also emits ~80 static files whose names are
+        # stable across rebuilds -- service-worker.js, lab/bundle.js,
+        # bootstrap.js, the bundled themes' index.js/index.css, the MathJax and
+        # FontAwesome fonts. Pinning those for a year would strand a stale
+        # service worker and stale bundles after a redeploy, exactly what the
+        # `location = /sw.js` block below exists to prevent. Those names do not
+        # match, so they keep the revalidating policy of the block above.
+        #
+        # A leading `[./-]` (or the `/` before a bare-hash filename) keeps the
+        # hex run from matching an ordinary word; no stable filename in the
+        # build output is seven or more hex characters long. The pattern must
+        # stay quoted -- unquoted, nginx reads the `{7,}` quantifier as a block
+        # delimiter and fails to start with `unknown directive`.
+        location ~* "^/jupyterlite/.*[./-][0-9a-f]{7,}\.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf|eot)$" {
+            try_files $uri =404;
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        }
     }
 
     location / {

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -148,11 +148,22 @@ Both `npm run dev` and `npm run build` run this automatically:
 - `npm run build` always rebuilds it (via `prebuild`) so a changed client/config
   is picked up.
 
-Both **skip gracefully** when `jupyter lite` is not installed — a Node-only build
-still succeeds and the web Notebook panel shows a "not built" message until the
-site is generated (install the deps above and re-run). The desktop (Tauri) dev
-and build paths skip it entirely (they use the real JupyterLab server), so the
-static site never bloats the installer.
+Both **skip with a warning** when `jupyter lite` is not installed, so a Node-only
+build still succeeds. Be aware of what that produces: the panel does *not* show a
+"not built" message. Its iframe asks for `/jupyterlite/lab/index.html`, and both
+nginx (`try_files $uri /index.html`) and Tauri's asset resolver answer an unknown
+path with `index.html`, so the panel renders **a second copy of GeoLibre**
+instead (GeoLibre#1851, GeoLibre#1658). Install the deps above and rebuild.
+
+Two builds therefore treat a missing CLI as fatal rather than skippable, because
+they serve the site and cannot degrade: the Mac App Store build, and any build
+that sets `GEOLIBRE_JUPYTERLITE_REQUIRED=1` (the Docker image does). The desktop
+(Tauri) dev and build paths skip it entirely (they use the real JupyterLab
+server), so the static site never bloats the installer.
+
+The Docker image builds and serves the site, and gives `/jupyterlite/` its own
+CSP: JupyterLab bootstraps from an inline `<script>`, which the app's policy
+forbids, so under the app policy the site loads its HTML and then never boots.
 
 Build config lives in `apps/geolibre-desktop/jupyterlite/` (a
 `jupyter_lite_config.json`, the build `requirements.txt`, and a starter

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -150,9 +150,10 @@ Both `npm run dev` and `npm run build` run this automatically:
 
 Both **skip with a warning** when `jupyter lite` is not installed, so a Node-only
 build still succeeds. Be aware of what that produces: the panel does *not* show a
-"not built" message. Its iframe asks for `/jupyterlite/lab/index.html`, and both
-nginx (`try_files $uri /index.html`) and Tauri's asset resolver answer an unknown
-path with `index.html`, so the panel renders **a second copy of GeoLibre**
+"not built" message. Its iframe asks for `/jupyterlite/lab/index.html`, and
+anything that answers an unknown path with `index.html` — Tauri's asset
+resolver, or a static host with an SPA fallback such as
+`try_files $uri /index.html` — hands the panel **a second copy of GeoLibre**
 instead (GeoLibre#1851, GeoLibre#1658). Install the deps above and rebuild.
 
 Two builds therefore treat a missing CLI as fatal rather than skippable, because
@@ -162,8 +163,16 @@ that sets `GEOLIBRE_JUPYTERLITE_REQUIRED=1` (the Docker image does). The desktop
 server), so the static site never bloats the installer.
 
 The Docker image builds and serves the site, and gives `/jupyterlite/` its own
-CSP: JupyterLab bootstraps from an inline `<script>`, which the app's policy
-forbids, so under the app policy the site loads its HTML and then never boots.
+block in `docker/nginx.conf`:
+
+- Its own CSP — JupyterLab bootstraps from an inline `<script>`, which the app's
+  policy forbids, so under the app policy the site loads its HTML and then never
+  boots.
+- No SPA fallback (`try_files $uri $uri/ =404`), so in this image the failure
+  above surfaces as a plain **404** rather than as the duplicated app. The
+  duplicate remains what Tauri and SPA-fallback hosts produce.
+- The long-lived immutable cache policy for the content-hashed assets, which the
+  prefix match would otherwise take away from them.
 
 Build config lives in `apps/geolibre-desktop/jupyterlite/` (a
 `jupyter_lite_config.json`, the build `requirements.txt`, and a starter

--- a/scripts/build-jupyterlite.mjs
+++ b/scripts/build-jupyterlite.mjs
@@ -43,6 +43,15 @@ const isWin = process.platform === "win32";
 // inherits, so this is visible here.
 const IS_MAS_BUILD = process.env.GEOLIBRE_MAS_BUILD === "1";
 
+// Builds whose output *serves* the site and therefore cannot degrade gracefully
+// when it is missing. The Docker image sets this: nginx answers an unknown path
+// with index.html (`try_files $uri /index.html`), exactly as Tauri does, so a
+// missing site makes the Notebook panel render a second copy of GeoLibre inside
+// its iframe rather than fail visibly (GeoLibre#1851). Warning and exiting 0
+// there ships that silently, which is how the official image shipped without the
+// site for as long as it did.
+const IS_REQUIRED = IS_MAS_BUILD || process.env.GEOLIBRE_JUPYTERLITE_REQUIRED === "1";
+
 // Every other desktop (Tauri) build launches a real JupyterLab server, so the
 // static site is dead weight in the installer. Tauri sets TAURI_ENV_* on its
 // beforeBuildCommand; skip the build there. The plain web build and the embed
@@ -85,11 +94,17 @@ if (probe.status !== 0) {
   // Notebook panel pointing at a missing asset, and Tauri's asset resolver
   // serves index.html for anything it cannot find, so the panel would render a
   // second copy of GeoLibre inside its iframe. Fail the build instead.
-  if (IS_MAS_BUILD) {
+  if (IS_REQUIRED) {
+    const why = IS_MAS_BUILD
+      ? "the Mac App Store build embeds the JupyterLite site (it cannot spawn a " +
+        "Jupyter server)"
+      : "this build serves the JupyterLite site and GEOLIBRE_JUPYTERLITE_REQUIRED=1";
     console.error(
-      "[build-jupyterlite] `jupyter lite` is not available, but the Mac App " +
-        "Store build embeds the JupyterLite site (it cannot spawn a Jupyter " +
-        "server). Install the build deps:\n" +
+      "[build-jupyterlite] `jupyter lite` is not available, but " +
+        why +
+        ". Shipping without the site leaves the Notebook panel pointing at a " +
+        "missing asset, which is answered with index.html and renders a second " +
+        "copy of GeoLibre inside the iframe. Install the build deps:\n" +
         install,
     );
     process.exit(1);


### PR DESCRIPTION
Fixes #1851

Processing → Jupyter Notebook opened a second copy of the GeoLibre map instead of a notebook in the Docker image. **Two independent faults**, both of which had to be fixed for the panel to work.

## 1. The site was never built

The build stage was `node:22-alpine`, which has no Python, so the `prebuild` hook (`scripts/build-jupyterlite.mjs`) could not find the `jupyter lite` CLI. That script is best-effort: it warns and exits 0, and the build succeeds. `apps/geolibre-desktop/public/jupyterlite/` is git-ignored, so a clean CI checkout has no copy either.

nginx then answers the panel's iframe URL through its SPA fallback (`try_files $uri /index.html`) with the app itself. That is the duplicated view users see.

This is the same failure #1658 fixed for the Mac App Store build, where Tauri's asset resolver does exactly what nginx does here. The script's own comment already described the mechanism, scoped only to Tauri.

## 2. The CSP blocked it even when present

JupyterLab bootstraps from an inline `<script>`, which the app policy forbids. Measured under the app CSP with the site present:

| CSP | JupyterLite boots? | Violations |
| --- | --- | --- |
| app policy (current) | **no** — no shell, no launcher | 1 (`Executing inline script violates…`) |
| app policy + `'unsafe-inline'` | yes — shell + launcher | 0 |

So fixing only the build would still have shipped a Notebook panel that does not work. The reporter hit both and worked around both.

## Changes

- **`Dockerfile`** — build stage moves to `node:22-bookworm-slim` and installs Python in a venv, so the JupyterLite dependency tree resolves to prebuilt manylinux wheels instead of compiling against musl. Only `dist/` is copied into the runtime image, so the larger builder costs nothing in the shipped image. Sets `GEOLIBRE_JUPYTERLITE_REQUIRED=1` and asserts `dist/jupyterlite/lab/index.html` exists, so this cannot regress silently again.
- **`scripts/build-jupyterlite.mjs`** — generalises the existing MAS hard-failure into `GEOLIBRE_JUPYTERLITE_REQUIRED`, for any build that *serves* the site and so cannot degrade. MAS behaviour unchanged.
- **`docker/nginx.conf`** — a `location ^~ /jupyterlite/` block giving the site the app policy plus `'unsafe-inline'` for `script-src` **only**, scoped to that prefix so the app keeps forbidding inline script. It also drops the SPA fallback there (`try_files $uri $uri/ =404`), so a missing site 404s instead of silently returning the app.
- **`docs/notebook.md`** — the claim that the panel "shows a *not built* message" was simply wrong, which is part of why this went unnoticed. Now documents the real behaviour and the new flag.

## Verification

Against **real containers**, not just the source.

**The bug, in the shipped artifact:**
```
$ docker run ghcr.io/opengeos/geolibre:latest
$ curl .../jupyterlite/lab/index.html
<title>GeoLibre</title>     # id="root" present — the app, not a notebook
```

**This branch:**
```
$ curl .../jupyterlite/lab/index.html
<title>JupyterLite</title>
```

Driving the running container through Processing → Jupyter Notebook with Playwright:

| Theme | Panel contents | CSP violations |
| --- | --- | --- |
| light | JupyterLab shell + launcher, `isSecondCopyOfApp: false` | 0 |
| dark | JupyterLab shell + launcher, `isSecondCopyOfApp: false` | 0 |

Also confirmed:

- `/jupyterlite/` responds with the relaxed `script-src`; `/` still responds with the strict one, so the relaxation is genuinely scoped.
- `nginx -t` passes on the rendered template.
- The required flag exits 1 with the CLI absent, exits 0 when unset, and MAS still exits 1 (#1658 behaviour preserved).
- `pre-commit run --files <changed>` passes.

## Note

The image grows: the build stage installs Python and the JupyterLite tree, and the runtime image gains the ~70 MB site. That is the cost of the Notebook panel working at all, and it only affects the layer copied from `dist/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for serving an embedded JupyterLite workspace from the application.
  * JupyterLite content now uses dedicated security and caching policies for reliable browser-based notebook access.

* **Bug Fixes**
  * Required builds now fail clearly when JupyterLite components are unavailable, while optional builds retain a fallback experience.
  * Missing notebook assets return an appropriate “not found” response instead of loading the application shell.
  * JupyterLite paths now consistently support trailing-slash navigation.

* **Documentation**
  * Updated guidance for JupyterLite availability, build behavior, fallbacks, and security configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->