### PR TITLE
fix(geolens): request MVT attribute columns so tile layers keep their fields

### DIFF
--- a/packages/plugins/src/plugins/geolens-api.ts
+++ b/packages/plugins/src/plugins/geolens-api.ts
@@ -406,17 +406,112 @@ export async function mintTileToken(
 export function vectorTileTemplate(
   options: GeoLensClientOptions,
   token: GeoLensTileToken,
+  columns?: Iterable<string>,
 ): GeoLensVectorTiles {
   const table = `data.${token.scope}`;
-  const query = new URLSearchParams({
+  const params = new URLSearchParams({
     sig: token.sig,
     exp: String(token.exp),
     scope: token.scope,
-  }).toString();
+  });
+  const cols = columns ? normalizeTileColumns(columns) : [];
+  if (cols.length > 0) params.set(GEOLENS_TILE_COLUMNS_PARAM, cols.join(","));
   return {
-    tiles: `${options.baseUrl}/api/tiles/${table}/{z}/{x}/{y}.pbf?${query}`,
+    tiles: `${options.baseUrl}/api/tiles/${table}/{z}/{x}/{y}.pbf?${params.toString()}`,
     sourceLayer: table,
   };
+}
+
+/**
+ * Query parameter that opts individual attribute columns into the MVT.
+ *
+ * GeoLens projects **no** attribute columns below zoom 10 by default (its tile
+ * service's `_DEFAULT_NO_ATTR_BELOW_ZOOM`) to bound tile size for wide tables,
+ * so a dataset viewed at world/basin zoom hands MapLibre features whose
+ * `properties` is `{}`. Everything that reads a tile layer's attributes off the
+ * map — categorized/graduated styling, the Time Slider bind dialog, labels,
+ * popups — then sees nothing to work with and reports the layer as having no
+ * usable fields. `cols=` is the server's documented runtime opt-in: the listed
+ * columns are unioned in at *every* zoom, and are validated server-side against
+ * the dataset's real columns, so an unknown name is dropped rather than
+ * erroring the tile.
+ *
+ * Signature validation ignores unknown/extra parameters, so this rides along
+ * with a signed token the same way {@link GEOLENS_TILE_VERSION_PARAM} does.
+ */
+export const GEOLENS_TILE_COLUMNS_PARAM = "cols";
+
+/**
+ * Column names GeoLens accepts. Mirrors its `_COLUMN_NAME_RE`; the server drops
+ * anything else, so filtering here keeps the cache key (and the URL) clean
+ * rather than adding a defense.
+ */
+const TILE_COLUMN_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Normalize column names for `cols=`: valid identifiers only, deduplicated and
+ * sorted.
+ *
+ * The sort is not cosmetic. GeoLens keys its tile cache on the normalized
+ * parameter (`parse_cols_param` sorts and dedupes there too), so `cols=a,b` and
+ * `cols=b,a` are the same entry server-side while being two different URLs to
+ * MapLibre and the browser cache — emitting a stable order keeps one tile to
+ * one URL.
+ *
+ * @param names - Candidate column names, in any order.
+ * @returns Sorted, deduplicated, valid column names.
+ */
+export function normalizeTileColumns(names: Iterable<string>): string[] {
+  const valid = new Set<string>();
+  for (const name of names) {
+    if (typeof name !== "string") continue;
+    const trimmed = name.trim();
+    if (TILE_COLUMN_NAME_RE.test(trimmed)) valid.add(trimmed);
+  }
+  return [...valid].sort();
+}
+
+/**
+ * Read the columns a signed tile template currently opts into, so a caller can
+ * tell whether it needs restamping without rebuilding the URL.
+ *
+ * @param template - A tile template built by {@link vectorTileTemplate}.
+ * @returns The normalized column names, or an empty array when there are none.
+ */
+export function tileColumnsOf(template: string): string[] {
+  const split = template.indexOf("?");
+  if (split === -1) return [];
+  const raw = new URLSearchParams(template.slice(split + 1)).get(GEOLENS_TILE_COLUMNS_PARAM);
+  return raw ? normalizeTileColumns(raw.split(",")) : [];
+}
+
+/**
+ * Stamp (or clear) the `cols=` opt-in on an existing signed tile template,
+ * leaving the signature and the literal `{z}/{x}/{y}` path placeholders alone.
+ *
+ * Used when the set of attributes a layer needs changes after it was added —
+ * the user styles by an attribute, binds it to the Time Slider — so the tiles
+ * can start carrying that column without re-minting the token.
+ *
+ * @param template - The current tile template.
+ * @param columns - The columns to request; empty removes the parameter.
+ * @returns The restamped template.
+ */
+export function withTileColumns(template: string, columns: Iterable<string>): string {
+  const cols = normalizeTileColumns(columns);
+  const split = template.indexOf("?");
+  if (split === -1) {
+    // Encoded through URLSearchParams like every other branch: the URL is the
+    // tile cache key, so `cols` must serialize identically however it was added.
+    return cols.length === 0
+      ? template
+      : `${template}?${new URLSearchParams({ [GEOLENS_TILE_COLUMNS_PARAM]: cols.join(",") })}`;
+  }
+  const params = new URLSearchParams(template.slice(split + 1));
+  if (cols.length === 0) params.delete(GEOLENS_TILE_COLUMNS_PARAM);
+  else params.set(GEOLENS_TILE_COLUMNS_PARAM, cols.join(","));
+  const query = params.toString();
+  return query ? `${template.slice(0, split)}?${query}` : template.slice(0, split);
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -20,7 +20,7 @@
  * here and inputs are plain elements styled with the shadcn HSL theme tokens.
  */
 
-import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import { DEFAULT_LAYER_STYLE, styleValue, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { Map as MapLibreMap, RequestParameters, ResourceType } from "maplibre-gl";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 import {
@@ -36,12 +36,15 @@ import {
   isEditPlanEmpty,
   mintTileToken,
   normalizeBaseUrl,
+  normalizeTileColumns,
   rasterTemplatesForServer,
   rasterTileAuthHeaders,
   resolveRasterTiles,
   searchDatasets,
+  tileColumnsOf,
   tileUrlPrefix,
   vectorTileTemplate,
+  withTileColumns,
   withTileVersion,
   type GeoLensBbox,
   type GeoLensClientOptions,
@@ -540,6 +543,157 @@ function clearRasterApiKeys(): void {
   installedOnMap = null;
 }
 
+// ---------------------------------------------------------------------------
+// MVT attribute columns (`cols=`).
+// ---------------------------------------------------------------------------
+
+/**
+ * Field-count ceiling for opting a dataset's whole attribute table into its
+ * tiles.
+ *
+ * GeoLens serves attribute-free tiles below zoom 10 (see the `cols=` opt-in in
+ * `geolens-api.ts`), and the host reads a tile layer's attributes from the
+ * tiles themselves: the Style panel scans loaded features for a property's
+ * distinct values, the Time Slider bind dialog scans them for a timestamp
+ * column, popups show what a feature carries. None of those can
+ * name the column they need up front — the user picks it *after* seeing it — so
+ * an opt-in limited to columns already in use cannot bootstrap any of them.
+ * Requesting the dataset's fields is therefore the default.
+ *
+ * The ceiling is what keeps that from re-creating the tile bloat the server's
+ * own budget exists to prevent (its docs cite a 137-column table producing
+ * 824 KB tiles). A table wider than this stays on the server default and opts
+ * in only the columns the layer actually uses, which is enough to *render* a
+ * style the user has already applied, just not to discover one.
+ */
+export const MAX_GEOLENS_TILE_COLUMNS = 24;
+
+/** Datasets already reported as too wide for the full opt-in, so the warning fires once. */
+const wideDatasetsWarned = new Set<string>();
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+}
+
+/**
+ * The attribute names a layer's own state points at: its classification
+ * property, label field, proportional-size and extrusion fields, diagram
+ * fields, and the Time Slider binding. Each is read only when the feature that
+ * uses it is switched on, so a default style contributes nothing.
+ *
+ * Rule filters and free-form expressions are deliberately not parsed — the
+ * columns they reference are recovered by the dataset-wide opt-in above, and
+ * for a table too wide for that, an expression the user wrote against a column
+ * they could not see is not the case worth carrying a parser for.
+ */
+function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
+  const style = layer.style;
+  const names: string[] = [];
+  const add = (value: unknown): void => {
+    if (typeof value === "string" && value.trim()) names.push(value.trim());
+  };
+
+  add(styleValue(style, "vectorStyleProperty"));
+  const labels = styleValue(style, "labels");
+  if (labels?.enabled) add(labels.field);
+  if (styleValue(style, "proportionalSizeEnabled")) {
+    add(styleValue(style, "proportionalSizeProperty"));
+  }
+  if (styleValue(style, "extrusionEnabled")) add(styleValue(style, "extrusionHeightProperty"));
+  if (styleValue(style, "diagramType") !== "none") {
+    for (const field of styleValue(style, "diagramFields")) add(field?.property);
+  }
+  const timeBinding = layer.metadata.timeBinding;
+  if (timeBinding && typeof timeBinding === "object") {
+    add((timeBinding as { property?: unknown }).property);
+  }
+  return names;
+}
+
+/**
+ * The `cols=` set a GeoLens vector-tile layer should be requesting right now:
+ * the dataset's fields when the table is narrow enough for the whole-table
+ * opt-in, plus whatever the layer's style and bindings currently point at.
+ *
+ * Recomputed from the layer rather than remembered, so it stays right across a
+ * token re-mint and a project reload (`metadata.fields` is persisted with the
+ * layer).
+ *
+ * @param layer - A `geolens-vector-tiles` store layer.
+ * @returns Normalized column names (sorted, deduplicated); empty when the
+ *   dataset is too wide and the layer uses no attributes yet.
+ */
+export function desiredTileColumns(layer: GeoLibreLayer): string[] {
+  const datasetId = layer.metadata.geolensDatasetId;
+  return tileColumnsFor(
+    stringArray(layer.metadata.fields),
+    attributePropertiesInUse(layer),
+    typeof datasetId === "string" ? datasetId : layer.id,
+    layer.name,
+  );
+}
+
+/**
+ * Resolve the `cols=` set from a dataset's field list and the columns a layer
+ * currently uses. Shared by the add path (which has the field list but no layer
+ * yet) and {@link desiredTileColumns}, so both apply the width budget the same
+ * way and a too-wide dataset is reported once rather than per call site.
+ *
+ * @param fields - Every attribute column the dataset has, per its OGC items.
+ * @param inUse - Columns the layer styles or binds by (empty on a fresh add).
+ * @param datasetKey - Identity used to report a too-wide dataset only once.
+ * @param label - Human-readable dataset/layer name for that report.
+ * @returns Normalized column names to request.
+ */
+function tileColumnsFor(
+  fields: readonly string[],
+  inUse: readonly string[],
+  datasetKey: string,
+  label: string,
+): string[] {
+  const wide = fields.length > MAX_GEOLENS_TILE_COLUMNS;
+  if (wide && !wideDatasetsWarned.has(datasetKey)) {
+    wideDatasetsWarned.add(datasetKey);
+    console.info(
+      `[GeoLibre] GeoLens dataset "${label}" has ${fields.length} fields (over the ` +
+        `${MAX_GEOLENS_TILE_COLUMNS}-field tile budget), so its tiles carry only the ` +
+        `attributes this layer styles or binds by. Below zoom 10 the rest are absent ` +
+        `from popups and the Style panel; load the dataset as GeoJSON to work with all ` +
+        `of them.`,
+    );
+  }
+  return normalizeTileColumns([...(wide ? [] : fields), ...inUse]);
+}
+
+/**
+ * Restamp GeoLens vector-tile layers whose `cols=` no longer matches what they
+ * need — the user styled by an attribute the tiles don't carry, bound one to
+ * the Time Slider, or the project was saved before this opt-in existed. The
+ * token is untouched (only the query is rewritten), so this costs a tile
+ * refetch and no network round trip of its own.
+ *
+ * Layers mid-remint are skipped: that path rebuilds the URL from the fresh
+ * token with the same desired columns, so restamping the doomed URL first would
+ * only queue a wasted refetch.
+ */
+function syncGeoLensTileColumns(): void {
+  for (const layer of useAppStore.getState().layers) {
+    if (layer.metadata.sourceKind !== "geolens-vector-tiles") continue;
+    if (restoringLayerIds.has(layer.id)) continue;
+    const tiles = layer.source.tiles;
+    const url = Array.isArray(tiles) && typeof tiles[0] === "string" ? tiles[0] : "";
+    if (!url) continue;
+    const desired = desiredTileColumns(layer);
+    const current = tileColumnsOf(url);
+    if (desired.length === current.length && desired.every((c, i) => c === current[i])) continue;
+    useAppStore.getState().updateLayer(layer.id, {
+      source: { ...layer.source, tiles: [withTileColumns(url, desired)] },
+    });
+  }
+}
+
 /** True when the layer's signed tile URL carries an expired (or near-expiry) token. */
 function tileTokenExpired(layer: GeoLibreLayer): boolean {
   const tiles = layer.source.tiles;
@@ -576,7 +730,10 @@ function healRestoredGeoLensLayers(): void {
       .then((token) => {
         const current = useAppStore.getState().layers.find((l) => l.id === layer.id);
         if (!current) return;
-        const { tiles } = vectorTileTemplate(client, token);
+        // Columns come from the layer as it is now: a restored project may
+        // already be styled by (or time-bound to) an attribute, and the fresh
+        // URL has to carry it or the restored style renders against nothing.
+        const { tiles } = vectorTileTemplate(client, token, desiredTileColumns(current));
         useAppStore
           .getState()
           .updateLayer(layer.id, { source: { ...current.source, tiles: [tiles] } });
@@ -591,13 +748,18 @@ function healRestoredGeoLensLayers(): void {
 // plus once now for layers already present when this module loads. Guarded on
 // the `layers` reference so unrelated store churn (pointer, selection, map view)
 // doesn't re-run the scan — useAppStore has no selector-subscribe middleware.
+// The same subscription keeps each layer's `cols=` opt-in in step with what it
+// styles and binds by: a style edit replaces the layer (and so the `layers`
+// array), which is exactly the signal the column sync needs.
 let lastLayersRef: readonly GeoLibreLayer[] | null = null;
 useAppStore.subscribe((state) => {
   if (state.layers === lastLayersRef) return;
   lastLayersRef = state.layers;
   healRestoredGeoLensLayers();
+  syncGeoLensTileColumns();
 });
 healRestoredGeoLensLayers();
+syncGeoLensTileColumns();
 
 /**
  * Schedule a re-mint of the signed tile token shortly before it expires and
@@ -626,10 +788,10 @@ function scheduleTokenRefresh(
     if (!layer) return; // removed from the Layers panel — nothing to refresh.
     void mintTileToken(client, datasetId, fetchImpl)
       .then((token) => {
-        const { tiles } = vectorTileTemplate(client, token);
         // Re-read: the layer may have been removed while the mint was in flight.
         const current = useAppStore.getState().layers.find((l) => l.id === layerId);
         if (!current) return;
+        const { tiles } = vectorTileTemplate(client, token, desiredTileColumns(current));
         useAppStore
           .getState()
           .updateLayer(layerId, { source: { ...current.source, tiles: [tiles] } });
@@ -671,7 +833,13 @@ async function addVectorTilesLayer(
     mintTileToken(client, dataset.id, fetchImpl),
     fetchDatasetFields(client, dataset.id, fetchImpl).catch(() => [] as string[]),
   ]);
-  const { tiles, sourceLayer } = vectorTileTemplate(client, token);
+  // The same field list doubles as the tiles' `cols=` opt-in, so those dropdowns
+  // lead somewhere: without it the tiles carry no attributes at all below zoom
+  // 10 and every attribute-driven feature reads an empty property bag. A table
+  // too wide for the budget requests nothing here and picks columns up as the
+  // layer starts using them (see `desiredTileColumns`).
+  const columns = tileColumnsFor(fields, [], dataset.id, dataset.title);
+  const { tiles, sourceLayer } = vectorTileTemplate(client, token, columns);
   const layer: GeoLibreLayer = {
     id: createLayerId(),
     name: dataset.title,

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -599,6 +599,9 @@ function expressionPropertyRefs(expression: string): string[] {
   const refs: string[] = [];
   const walk = (node: unknown): void => {
     if (!Array.isArray(node)) return;
+    // `["literal", …]` wraps data, not a sub-expression, so a `get`-shaped array
+    // inside it is an array element and names no column.
+    if (node[0] === "literal") return;
     if (
       node.length === 2 &&
       (node[0] === "get" || node[0] === "has") &&

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -584,21 +584,52 @@ function stringArray(value: unknown): string[] {
 }
 
 /**
+ * Feature properties a MapLibre expression reads, i.e. the string-literal
+ * argument of every `["get", …]` / `["has", …]` in it.
+ *
+ * Only the two-argument forms count: `["get", key, object]` reads from a
+ * supplied object rather than the feature, and a computed key
+ * (`["get", ["concat", …]]`) names a column that is not knowable until render
+ * time. An unparseable expression yields nothing, matching the renderer, which
+ * ignores it.
+ */
+function expressionPropertyRefs(expression: string): string[] {
+  const parsed = parseJsonExpression(expression);
+  if (!parsed) return [];
+  const refs: string[] = [];
+  const walk = (node: unknown): void => {
+    if (!Array.isArray(node)) return;
+    if (
+      node.length === 2 &&
+      (node[0] === "get" || node[0] === "has") &&
+      typeof node[1] === "string"
+    ) {
+      refs.push(node[1]);
+    }
+    for (const child of node) walk(child);
+  };
+  walk(parsed);
+  return refs;
+}
+
+/**
  * The attribute names a layer's own state points at: its classification
  * property, label field, proportional-size and extrusion fields, diagram
- * fields, and the Time Slider binding. Each is read only when the feature that
- * uses it is switched on, so a default style contributes nothing.
- *
- * Rule filters and free-form expressions are deliberately not parsed — the
- * columns they reference are recovered by the dataset-wide opt-in above, and
- * for a table too wide for that, an expression the user wrote against a column
- * they could not see is not the case worth carrying a parser for.
+ * fields, the Time Slider binding, and the properties read by whichever of its
+ * expressions are in effect (the expression renderer, rule filters, label
+ * overrides, advanced extrusion). Each is read only when the feature that uses
+ * it is switched on, so a default style contributes nothing.
  */
 function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
   const style = layer.style;
   const names: string[] = [];
   const add = (value: unknown): void => {
     if (typeof value === "string" && value.trim()) names.push(value.trim());
+  };
+  /** Add every feature property an in-effect expression reads. */
+  const addRefs = (expression: unknown): void => {
+    if (typeof expression === "string")
+      for (const ref of expressionPropertyRefs(expression)) add(ref);
   };
 
   const mode = styleValue(style, "vectorStyleMode");
@@ -607,20 +638,35 @@ function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
   // their own expressions), so an ungated read would keep requesting a column
   // nothing paints from.
   if (mode === "categorized" || mode === "graduated") add(styleValue(style, "vectorStyleProperty"));
+  if (mode === "expression") addRefs(styleValue(style, "vectorStyleExpression"));
+  if (mode === "rule-based") {
+    for (const rule of styleValue(style, "vectorRules")) addRefs(rule?.filter);
+  }
   const labels = styleValue(style, "labels");
-  if (labels?.enabled) add(labels.field);
+  if (labels?.enabled) {
+    add(labels.field);
+    // The text expression and the data-defined overrides all read attributes.
+    addRefs(labels.expression);
+    addRefs(labels.sizeExpression);
+    addRefs(labels.colorExpression);
+    addRefs(labels.opacityExpression);
+    addRefs(labels.visibilityExpression);
+    addRefs(labels.priorityExpression);
+  }
   if (styleValue(style, "proportionalSizeEnabled")) {
     add(styleValue(style, "proportionalSizeProperty"));
   }
   if (styleValue(style, "extrusionEnabled")) {
-    // Advanced mode's height expression wins over the property, but only when
-    // it parses — a blank or invalid one falls back to the property (see
-    // `extrusionHeightValue`), so gating on the flag alone would drop a column
-    // the renderer still reads.
-    const advancedHeight = styleValue(style, "extrusionAdvancedStyleEnabled")
-      ? parseJsonExpression(styleValue(style, "extrusionHeightExpression"))
-      : null;
-    if (!advancedHeight) add(styleValue(style, "extrusionHeightProperty"));
+    const advanced = styleValue(style, "extrusionAdvancedStyleEnabled");
+    const heightExpression = advanced ? styleValue(style, "extrusionHeightExpression") : "";
+    if (advanced) {
+      addRefs(heightExpression);
+      addRefs(styleValue(style, "extrusionColorExpression"));
+    }
+    // The height expression wins over the property, but only when it parses: a
+    // blank or half-typed one falls back to the property (`extrusionHeightValue`),
+    // so gating on the advanced flag alone would drop a column still being read.
+    if (!parseJsonExpression(heightExpression)) add(styleValue(style, "extrusionHeightProperty"));
   }
   if (styleValue(style, "diagramType") !== "none") {
     for (const field of styleValue(style, "diagramFields")) add(field?.property);

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -688,6 +688,18 @@ function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
 }
 
 /**
+ * Resolved column sets, keyed by the layer object.
+ *
+ * The sync below runs on every store update that replaces the `layers` array —
+ * an opacity drag on an *unrelated* layer fires it per frame — and resolving a
+ * set re-parses the layer's expressions. `updateLayer` keeps the identity of
+ * every layer it did not patch, so keying on the object skips that work with
+ * no invalidation to get wrong: a layer that changed is a different object.
+ * (`layer-sync.ts` memoizes its own label overrides for the same reason.)
+ */
+const tileColumnsByLayer = new WeakMap<GeoLibreLayer, string[]>();
+
+/**
  * The `cols=` set a GeoLens vector-tile layer should be requesting right now:
  * the dataset's fields when the table is narrow enough for the whole-table
  * opt-in, plus whatever the layer's style and bindings currently point at.
@@ -701,13 +713,17 @@ function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
  *   dataset is too wide and the layer uses no attributes yet.
  */
 export function desiredTileColumns(layer: GeoLibreLayer): string[] {
+  const memoized = tileColumnsByLayer.get(layer);
+  if (memoized) return memoized;
   const datasetId = layer.metadata.geolensDatasetId;
-  return tileColumnsFor(
+  const columns = tileColumnsFor(
     stringArray(layer.metadata.fields),
     attributePropertiesInUse(layer),
     typeof datasetId === "string" ? datasetId : layer.id,
     layer.name,
   );
+  tileColumnsByLayer.set(layer, columns);
+  return columns;
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -595,7 +595,12 @@ function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
     if (typeof value === "string" && value.trim()) names.push(value.trim());
   };
 
-  add(styleValue(style, "vectorStyleProperty"));
+  const mode = styleValue(style, "vectorStyleMode");
+  // Only the two attribute-driven modes read the property; it survives a switch
+  // back to "single" (and is unused by the rule/expression modes, which carry
+  // their own expressions), so an ungated read would keep requesting a column
+  // nothing paints from.
+  if (mode === "categorized" || mode === "graduated") add(styleValue(style, "vectorStyleProperty"));
   const labels = styleValue(style, "labels");
   if (labels?.enabled) add(labels.field);
   if (styleValue(style, "proportionalSizeEnabled")) {
@@ -667,6 +672,11 @@ function tileColumnsFor(
   return normalizeTileColumns([...(wide ? [] : fields), ...inUse]);
 }
 
+/** Guards the apply phase against the store notification it triggers itself. */
+let syncingTileColumns = false;
+/** Set when a store change was dropped by that guard, so the batch rescans. */
+let pendingTileColumnSync = false;
+
 /**
  * Restamp GeoLens vector-tile layers whose `cols=` no longer matches what they
  * need — the user styled by an attribute the tiles don't carry, bound one to
@@ -679,18 +689,50 @@ function tileColumnsFor(
  * only queue a wasted refetch.
  */
 function syncGeoLensTileColumns(): void {
-  for (const layer of useAppStore.getState().layers) {
-    if (layer.metadata.sourceKind !== "geolens-vector-tiles") continue;
-    if (restoringLayerIds.has(layer.id)) continue;
-    const tiles = layer.source.tiles;
-    const url = Array.isArray(tiles) && typeof tiles[0] === "string" ? tiles[0] : "";
-    if (!url) continue;
-    const desired = desiredTileColumns(layer);
-    const current = tileColumnsOf(url);
-    if (desired.length === current.length && desired.every((c, i) => c === current[i])) continue;
-    useAppStore.getState().updateLayer(layer.id, {
-      source: { ...layer.source, tiles: [withTileColumns(url, desired)] },
-    });
+  // `updateLayer` notifies Zustand's subscribers synchronously, and one of them
+  // is the subscription that calls this function — so patching inside the scan
+  // would re-enter here mid-loop, and the outer loop would go on to spread a
+  // `layer.source` the nested pass has already replaced. Scan first, then apply
+  // behind a guard, re-reading each layer at the moment it is patched.
+  if (syncingTileColumns) {
+    // A change landed while a batch was applying; that notification is being
+    // dropped here, so ask the running pass for one more scan instead.
+    pendingTileColumnSync = true;
+    return;
+  }
+  syncingTileColumns = true;
+  try {
+    do {
+      pendingTileColumnSync = false;
+      const patches: Array<{ id: string; columns: string[] }> = [];
+      for (const layer of useAppStore.getState().layers) {
+        if (layer.metadata.sourceKind !== "geolens-vector-tiles") continue;
+        if (restoringLayerIds.has(layer.id)) continue;
+        const tiles = layer.source.tiles;
+        const url = Array.isArray(tiles) && typeof tiles[0] === "string" ? tiles[0] : "";
+        if (!url) continue;
+        const desired = desiredTileColumns(layer);
+        const current = tileColumnsOf(url);
+        if (desired.length === current.length && desired.every((c, i) => c === current[i])) {
+          continue;
+        }
+        patches.push({ id: layer.id, columns: desired });
+      }
+      for (const { id, columns } of patches) {
+        const layer = useAppStore.getState().layers.find((l) => l.id === id);
+        if (!layer) continue; // removed while the batch was applying
+        const tiles = layer.source.tiles;
+        const url = Array.isArray(tiles) && typeof tiles[0] === "string" ? tiles[0] : "";
+        if (!url) continue;
+        useAppStore.getState().updateLayer(id, {
+          source: { ...layer.source, tiles: [withTileColumns(url, columns)] },
+        });
+      }
+      // A pass that patched nothing cannot have re-entered, so this terminates
+      // after one extra scan at most.
+    } while (pendingTileColumnSync);
+  } finally {
+    syncingTileColumns = false;
   }
 }
 
@@ -1253,12 +1295,17 @@ async function refreshVectorTilesForDataset(
   for (const target of targets) {
     try {
       const token = await mintTileToken(client, datasetId, fetchImpl);
-      // The token alone is not enough: GeoLens hands back the same signature
-      // for the rest of its time bucket, so the URL would be unchanged and the
-      // caches would answer with the pre-save tiles.
-      const tiles = withTileVersion(vectorTileTemplate(client, token).tiles, Date.now());
       const current = useAppStore.getState().layers.find((l) => l.id === target.id);
       if (!current) continue;
+      // The token alone is not enough: GeoLens hands back the same signature
+      // for the rest of its time bucket, so the URL would be unchanged and the
+      // caches would answer with the pre-save tiles. The columns are rebuilt
+      // here too — dropping them would serve attribute-free tiles until the
+      // store subscription restamped them, costing a second refetch.
+      const tiles = withTileVersion(
+        vectorTileTemplate(client, token, desiredTileColumns(current)).tiles,
+        Date.now(),
+      );
       useAppStore.getState().updateLayer(target.id, {
         source: { ...current.source, tiles: [tiles] },
       });

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -20,7 +20,13 @@
  * here and inputs are plain elements styled with the shadcn HSL theme tokens.
  */
 
-import { DEFAULT_LAYER_STYLE, styleValue, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import {
+  DEFAULT_LAYER_STYLE,
+  parseJsonExpression,
+  styleValue,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
 import type { Map as MapLibreMap, RequestParameters, ResourceType } from "maplibre-gl";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 import {
@@ -606,7 +612,16 @@ function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
   if (styleValue(style, "proportionalSizeEnabled")) {
     add(styleValue(style, "proportionalSizeProperty"));
   }
-  if (styleValue(style, "extrusionEnabled")) add(styleValue(style, "extrusionHeightProperty"));
+  if (styleValue(style, "extrusionEnabled")) {
+    // Advanced mode's height expression wins over the property, but only when
+    // it parses — a blank or invalid one falls back to the property (see
+    // `extrusionHeightValue`), so gating on the flag alone would drop a column
+    // the renderer still reads.
+    const advancedHeight = styleValue(style, "extrusionAdvancedStyleEnabled")
+      ? parseJsonExpression(styleValue(style, "extrusionHeightExpression"))
+      : null;
+    if (!advancedHeight) add(styleValue(style, "extrusionHeightProperty"));
+  }
   if (styleValue(style, "diagramType") !== "none") {
     for (const field of styleValue(style, "diagramFields")) add(field?.property);
   }

--- a/packages/plugins/src/plugins/maplibre-geolens.ts
+++ b/packages/plugins/src/plugins/maplibre-geolens.ts
@@ -624,6 +624,12 @@ function attributePropertiesInUse(layer: GeoLibreLayer): string[] {
   }
   if (styleValue(style, "diagramType") !== "none") {
     for (const field of styleValue(style, "diagramFields")) add(field?.property);
+    // Attribute sizing reads its own property alongside the slice fields
+    // (`collectDiagramData`); without it every diagram would size from a value
+    // that is not in the tile and collapse to the floor.
+    if (styleValue(style, "diagramSizeMode") === "attribute") {
+      add(styleValue(style, "diagramSizeProperty"));
+    }
   }
   const timeBinding = layer.metadata.timeBinding;
   if (timeBinding && typeof timeBinding === "object") {

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -22,6 +22,7 @@ import {
   itemsUrl,
   mintTileToken,
   normalizeBaseUrl,
+  normalizeTileColumns,
   parseDataset,
   rasterTemplatesForServer,
   rasterTileAuthHeaders,
@@ -29,8 +30,10 @@ import {
   searchDatasets,
   stacCatalogUrl,
   stacCollectionsUrl,
+  tileColumnsOf,
   tileUrlPrefix,
   vectorTileTemplate,
+  withTileColumns,
   withTileVersion,
   type GeoLensFetch,
   type GeoLensHttpResponse,
@@ -152,6 +155,75 @@ describe("vectorTileTemplate", () => {
     assert.ok(out.tiles.includes("sig=abc123"));
     assert.ok(out.tiles.includes("exp=1784668500"));
     assert.ok(out.tiles.includes("scope=world_countries"));
+    // No columns requested: the parameter is absent rather than empty, so the
+    // URL matches what GeoLens caches for a plain tile request.
+    assert.ok(!out.tiles.includes("cols="));
+  });
+
+  it("stamps requested attribute columns onto the signed template", () => {
+    const out = vectorTileTemplate(
+      { baseUrl: "http://localhost:8080" },
+      { kind: "vector", sig: "abc123", exp: 1784668500, scope: "tracks", expiresIn: 465 },
+      ["year", "nature", "year"],
+    );
+    assert.ok(out.tiles.includes("/{z}/{x}/{y}.pbf?"), "placeholders must stay literal");
+    assert.deepEqual(tileColumnsOf(out.tiles), ["nature", "year"]);
+    assert.ok(out.tiles.includes("sig=abc123"));
+  });
+});
+
+describe("normalizeTileColumns", () => {
+  it("sorts and deduplicates so one tile keeps one URL", () => {
+    // GeoLens sorts and dedupes server-side for its tile cache key, so an
+    // unsorted client would spend two cache entries on the same tile.
+    assert.deepEqual(normalizeTileColumns(["year", "nature", "year"]), ["nature", "year"]);
+    assert.deepEqual(normalizeTileColumns(["b", "a"]), normalizeTileColumns(["a", "b"]));
+  });
+
+  it("drops names GeoLens would reject", () => {
+    assert.deepEqual(
+      normalizeTileColumns(["ok_1", "1bad", "also bad", "", "  spaced  ", "geom;drop"]),
+      ["ok_1", "spaced"],
+    );
+  });
+});
+
+describe("withTileColumns / tileColumnsOf", () => {
+  const template =
+    "https://demo.example.com/api/tiles/data.b/{z}/{x}/{y}.pbf?sig=abc&exp=1&scope=b";
+
+  it("reads back nothing when the template opts into no columns", () => {
+    assert.deepEqual(tileColumnsOf(template), []);
+    assert.deepEqual(tileColumnsOf("https://h/api/tiles/t/{z}/{x}/{y}.pbf"), []);
+  });
+
+  it("stamps columns while leaving the signature and placeholders intact", () => {
+    const out = withTileColumns(template, ["nature", "year"]);
+    assert.ok(out.includes("/{z}/{x}/{y}.pbf?"), "placeholders must stay literal");
+    assert.ok(out.includes("sig=abc"));
+    assert.ok(out.includes("exp=1"));
+    assert.deepEqual(tileColumnsOf(out), ["nature", "year"]);
+  });
+
+  it("replaces a previous opt-in rather than appending a second one", () => {
+    const once = withTileColumns(template, ["nature"]);
+    const twice = withTileColumns(once, ["year", "month"]);
+    assert.equal(twice.match(/cols=/g)?.length, 1);
+    assert.deepEqual(tileColumnsOf(twice), ["month", "year"]);
+  });
+
+  it("clears the parameter when nothing is requested", () => {
+    const stamped = withTileColumns(template, ["nature"]);
+    const cleared = withTileColumns(stamped, []);
+    assert.ok(!cleared.includes("cols="));
+    assert.ok(cleared.includes("sig=abc"));
+  });
+
+  it("handles a template that carries no query at all", () => {
+    assert.equal(
+      withTileColumns("https://h/api/tiles/t/{z}/{x}/{y}.pbf", ["a"]),
+      "https://h/api/tiles/t/{z}/{x}/{y}.pbf?cols=a",
+    );
   });
 });
 

--- a/tests/geolens-api.test.ts
+++ b/tests/geolens-api.test.ts
@@ -224,6 +224,16 @@ describe("withTileColumns / tileColumnsOf", () => {
       withTileColumns("https://h/api/tiles/t/{z}/{x}/{y}.pbf", ["a"]),
       "https://h/api/tiles/t/{z}/{x}/{y}.pbf?cols=a",
     );
+    // That branch builds its query separately from the one above, so a
+    // multi-column case pins them to one serialization: the URL is the tile
+    // cache key, and `cols` has to look the same however it was added.
+    const noQuery = withTileColumns("https://h/api/tiles/t/{z}/{x}/{y}.pbf", ["b", "a"]);
+    const withQuery = withTileColumns("https://h/api/tiles/t/{z}/{x}/{y}.pbf?sig=abc", ["b", "a"]);
+    assert.equal(
+      noQuery.slice(noQuery.indexOf("cols=")),
+      withQuery.slice(withQuery.indexOf("cols=")),
+    );
+    assert.deepEqual(tileColumnsOf(noQuery), ["a", "b"]);
   });
 });
 

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -215,6 +215,20 @@ describe("desiredTileColumns", () => {
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_7"]);
   });
 
+  it("resolves a layer once and re-resolves when it changes", () => {
+    // The sync runs on every store update that replaces the layers array — an
+    // opacity drag on another layer included — so an untouched layer must not
+    // re-parse its expressions.
+    const id = addTileLayer();
+    const first = desiredTileColumns(storedLayer(id));
+    assert.equal(desiredTileColumns(storedLayer(id)), first, "same layer object, same result");
+
+    useAppStore.getState().setLayerStyle(id, { vectorStyleMode: "categorized" });
+    const after = desiredTileColumns(storedLayer(id));
+    assert.notEqual(after, first, "a patched layer is a new object, so it resolves again");
+    assert.deepEqual(after, first);
+  });
+
   it("falls back to the columns in use when the field list is unknown", () => {
     // A project saved before the field list was recorded still styles by name.
     const id = addTileLayer({}, []);

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -95,7 +95,9 @@ describe("desiredTileColumns", () => {
     const id = addTileLayer({}, wide);
     assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
 
-    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "col_3" });
+    useAppStore
+      .getState()
+      .setLayerStyle(id, { vectorStyleMode: "categorized", vectorStyleProperty: "col_3" });
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_3"]);
   });
 
@@ -116,6 +118,20 @@ describe("desiredTileColumns", () => {
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_1"]);
   });
 
+  it("drops the classification property when nothing paints from it", () => {
+    // The property survives a switch back to a fixed color, so reading it
+    // ungated would keep a column alive for a style that no longer uses it.
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({}, wide);
+    useAppStore
+      .getState()
+      .setLayerStyle(id, { vectorStyleMode: "categorized", vectorStyleProperty: "col_5" });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_5"]);
+
+    useAppStore.getState().setLayerStyle(id, { vectorStyleMode: "single" });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
+  });
+
   it("includes the Time Slider binding's property", () => {
     const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
     const id = addTileLayer({}, wide);
@@ -129,7 +145,9 @@ describe("desiredTileColumns", () => {
   it("falls back to the columns in use when the field list is unknown", () => {
     // A project saved before the field list was recorded still styles by name.
     const id = addTileLayer({}, []);
-    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "nature" });
+    useAppStore
+      .getState()
+      .setLayerStyle(id, { vectorStyleMode: "categorized", vectorStyleProperty: "nature" });
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["nature"]);
   });
 });
@@ -142,7 +160,9 @@ describe("tile column sync", () => {
     const id = addTileLayer({ source: { type: "vector", tiles: [tileUrl()] } }, wide);
     assert.deepEqual(storedTileColumns(id), []);
 
-    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "col_3" });
+    useAppStore
+      .getState()
+      .setLayerStyle(id, { vectorStyleMode: "categorized", vectorStyleProperty: "col_3" });
 
     assert.deepEqual(storedTileColumns(id), ["col_3"]);
     // The signature rides along untouched — restamping must not cost a re-mint.
@@ -154,7 +174,9 @@ describe("tile column sync", () => {
   it("leaves a layer alone once its tiles already carry what it needs", () => {
     const id = addTileLayer();
     const before = (storedLayer(id).source.tiles as string[])[0];
-    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "nature" });
+    useAppStore
+      .getState()
+      .setLayerStyle(id, { vectorStyleMode: "categorized", vectorStyleProperty: "nature" });
     // `nature` is already in the opt-in, so the URL must not churn — a changed
     // URL is a full tile refetch.
     assert.equal((storedLayer(id).source.tiles as string[])[0], before);
@@ -165,7 +187,30 @@ describe("tile column sync", () => {
       metadata: { sourceKind: "ogc-vector-tiles", fields: FIELDS },
       source: { type: "vector", tiles: [tileUrl()] },
     });
-    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "nature" });
+    useAppStore
+      .getState()
+      .setLayerStyle(id, { vectorStyleMode: "categorized", vectorStyleProperty: "nature" });
     assert.deepEqual(storedTileColumns(id), []);
+  });
+
+  it("restamps every stale layer in one pass", () => {
+    // `updateLayer` notifies the sync's own subscription synchronously, so a
+    // second stale layer is the case where a mid-loop patch would spread a
+    // `source` the nested pass already replaced.
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const a = addTileLayer({ source: { type: "vector", tiles: [tileUrl()] } }, wide);
+    const b = addTileLayer({ source: { type: "vector", tiles: [tileUrl()] } }, wide);
+    useAppStore
+      .getState()
+      .setLayerStyle(a, { vectorStyleMode: "categorized", vectorStyleProperty: "col_3" });
+    useAppStore
+      .getState()
+      .setLayerStyle(b, { vectorStyleMode: "categorized", vectorStyleProperty: "col_4" });
+
+    assert.deepEqual(storedTileColumns(a), ["col_3"]);
+    assert.deepEqual(storedTileColumns(b), ["col_4"]);
+    for (const id of [a, b]) {
+      assert.ok((storedLayer(id).source.tiles as string[])[0].includes("sig=abc"));
+    }
   });
 });

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -117,17 +117,48 @@ describe("desiredTileColumns", () => {
     useAppStore.getState().setLayerStyle(id, { extrusionEnabled: true });
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_1"]);
 
-    // An advanced height expression replaces the property outright...
+    // An advanced height expression replaces the property, and the column it
+    // reads is requested in its place.
     useAppStore.getState().setLayerStyle(id, {
       extrusionAdvancedStyleEnabled: true,
       extrusionHeightExpression: '["get", "col_9"]',
     });
-    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_9"]);
 
-    // ...but only while it parses; an unfinished one still renders from the
-    // property, so the column has to come back.
+    // ...but it only wins while it parses; an unfinished one still renders from
+    // the property, so that column has to come back.
     useAppStore.getState().setLayerStyle(id, { extrusionHeightExpression: "[" });
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_1"]);
+  });
+
+  it("follows the properties an in-effect expression reads", () => {
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({}, wide);
+    useAppStore.getState().setLayerStyle(id, {
+      vectorStyleMode: "expression",
+      vectorStyleExpression:
+        '["case", ["<", ["get", "col_2"], 10], "#111111", ["has", "col_6"], "#222222", "#333333"]',
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_2", "col_6"]);
+
+    // Rule filters drive the paint the same way in rule-based mode.
+    useAppStore.getState().setLayerStyle(id, {
+      vectorStyleMode: "rule-based",
+      vectorRules: [
+        { id: "r1", label: "a", filter: '["==", ["get", "col_4"], "x"]', color: "#2563eb" },
+        { id: "r2", label: "else", filter: "", color: "#dc2626", isElse: true },
+      ],
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_4"]);
+
+    // A key computed at render time names no column, and `["get", key, object]`
+    // reads from a supplied object rather than the feature.
+    useAppStore.getState().setLayerStyle(id, {
+      vectorStyleMode: "expression",
+      vectorStyleExpression:
+        '["case", ["==", ["get", ["concat", "col", "_1"]], 1], "#111111", ["get", "k", ["literal", {"k": "#222222"}]]]',
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
   });
 
   it("drops the classification property when nothing paints from it", () => {

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import { tileColumnsOf } from "../packages/plugins/src/plugins/geolens-api";
+import {
+  desiredTileColumns,
+  MAX_GEOLENS_TILE_COLUMNS,
+} from "../packages/plugins/src/plugins/maplibre-geolens";
+
+/**
+ * The `cols=` opt-in that makes a GeoLens vector-tile layer carry attributes.
+ *
+ * GeoLens projects no attribute columns below zoom 10, so without this a layer
+ * viewed at world zoom hands MapLibre `properties: {}` on every feature and
+ * everything that reads attributes off the map — categorized styling, the Time
+ * Slider bind dialog, labels, popups — finds nothing (GeoLibre#1854).
+ */
+
+const BASE_URL = "https://datasets.example.com";
+const DATASET = "ds-1";
+const FIELDS = ["name", "nature", "year", "month", "day"];
+
+function tileUrl(cols?: string): string {
+  const query = `sig=abc&exp=9999999999&scope=tracks${cols ? `&cols=${cols}` : ""}`;
+  return `${BASE_URL}/api/tiles/data.tracks/{z}/{x}/{y}.pbf?${query}`;
+}
+
+/** A GeoLens vector-tile layer as `addVectorTilesLayer` builds it. */
+function addTileLayer(overrides: Partial<GeoLibreLayer> = {}, fields = FIELDS): string {
+  const layer: GeoLibreLayer = {
+    id: `layer-${Math.random().toString(36).slice(2)}`,
+    name: "Hurricane tracks",
+    type: "vector-tiles",
+    source: {
+      type: "vector",
+      tiles: [tileUrl(fields.join(","))],
+      sourceLayer: "data.tracks",
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      sourceKind: "geolens-vector-tiles",
+      geolensBaseUrl: BASE_URL,
+      geolensDatasetId: DATASET,
+      fields,
+    },
+    ...overrides,
+  } as GeoLibreLayer;
+  useAppStore.getState().addLayer(layer);
+  return layer.id;
+}
+
+function storedLayer(id: string): GeoLibreLayer {
+  const layer = useAppStore.getState().layers.find((l) => l.id === id);
+  assert.ok(layer);
+  return layer;
+}
+
+function storedTileColumns(id: string): string[] {
+  const tiles = storedLayer(id).source.tiles;
+  assert.ok(Array.isArray(tiles) && typeof tiles[0] === "string");
+  return tileColumnsOf(tiles[0]);
+}
+
+beforeEach(() => {
+  for (const layer of [...useAppStore.getState().layers]) {
+    useAppStore.getState().removeLayer(layer.id);
+  }
+});
+
+describe("desiredTileColumns", () => {
+  it("requests the whole attribute table for an ordinary dataset", () => {
+    // Nothing has been styled yet: this is exactly the case the opt-in has to
+    // cover, since the user cannot pick a column they cannot see.
+    const id = addTileLayer();
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), [...FIELDS].sort());
+  });
+
+  it("adds the attributes the layer's own style points at", () => {
+    const id = addTileLayer();
+    useAppStore.getState().setLayerStyle(id, {
+      vectorStyleMode: "categorized",
+      vectorStyleProperty: "nature",
+      labels: { ...DEFAULT_LAYER_STYLE.labels, enabled: true, field: "name" },
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), [...FIELDS].sort());
+  });
+
+  it("keeps a too-wide dataset on the server's own budget", () => {
+    // The whole-table opt-in is what the server's low-zoom budget exists to
+    // prevent for wide tables, so past the ceiling only what is in use is asked
+    // for — enough to render an applied style, not to discover a new one.
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({}, wide);
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
+
+    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "col_3" });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_3"]);
+  });
+
+  it("ignores style fields whose feature is switched off", () => {
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({}, wide);
+    // `extrusionHeightProperty` defaults to "height" and the label field can
+    // outlive the labels being turned off; neither is being drawn, so neither
+    // is worth a column.
+    useAppStore.getState().setLayerStyle(id, {
+      extrusionEnabled: false,
+      extrusionHeightProperty: "col_1",
+      labels: { ...DEFAULT_LAYER_STYLE.labels, enabled: false, field: "col_2" },
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
+
+    useAppStore.getState().setLayerStyle(id, { extrusionEnabled: true });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_1"]);
+  });
+
+  it("includes the Time Slider binding's property", () => {
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({}, wide);
+    const layer = storedLayer(id);
+    useAppStore.getState().updateLayer(id, {
+      metadata: { ...layer.metadata, timeBinding: { property: "col_7", valueKind: "year" } },
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_7"]);
+  });
+
+  it("falls back to the columns in use when the field list is unknown", () => {
+    // A project saved before the field list was recorded still styles by name.
+    const id = addTileLayer({}, []);
+    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "nature" });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["nature"]);
+  });
+});
+
+describe("tile column sync", () => {
+  it("restamps a layer whose tiles do not carry the attribute it needs", () => {
+    // A layer restored from a project saved before the opt-in: its URL asks for
+    // nothing, so its categorized style renders against empty properties.
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({ source: { type: "vector", tiles: [tileUrl()] } }, wide);
+    assert.deepEqual(storedTileColumns(id), []);
+
+    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "col_3" });
+
+    assert.deepEqual(storedTileColumns(id), ["col_3"]);
+    // The signature rides along untouched — restamping must not cost a re-mint.
+    const tiles = storedLayer(id).source.tiles as string[];
+    assert.ok(tiles[0].includes("sig=abc"));
+    assert.ok(tiles[0].includes("/{z}/{x}/{y}.pbf?"));
+  });
+
+  it("leaves a layer alone once its tiles already carry what it needs", () => {
+    const id = addTileLayer();
+    const before = (storedLayer(id).source.tiles as string[])[0];
+    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "nature" });
+    // `nature` is already in the opt-in, so the URL must not churn — a changed
+    // URL is a full tile refetch.
+    assert.equal((storedLayer(id).source.tiles as string[])[0], before);
+  });
+
+  it("does not touch layers from other sources", () => {
+    const id = addTileLayer({
+      metadata: { sourceKind: "ogc-vector-tiles", fields: FIELDS },
+      source: { type: "vector", tiles: [tileUrl()] },
+    });
+    useAppStore.getState().setLayerStyle(id, { vectorStyleProperty: "nature" });
+    assert.deepEqual(storedTileColumns(id), []);
+  });
+});

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -116,6 +116,18 @@ describe("desiredTileColumns", () => {
 
     useAppStore.getState().setLayerStyle(id, { extrusionEnabled: true });
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_1"]);
+
+    // An advanced height expression replaces the property outright...
+    useAppStore.getState().setLayerStyle(id, {
+      extrusionAdvancedStyleEnabled: true,
+      extrusionHeightExpression: '["get", "col_9"]',
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
+
+    // ...but only while it parses; an unfinished one still renders from the
+    // property, so the column has to come back.
+    useAppStore.getState().setLayerStyle(id, { extrusionHeightExpression: "[" });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_1"]);
   });
 
   it("drops the classification property when nothing paints from it", () => {

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -144,6 +144,22 @@ describe("desiredTileColumns", () => {
     assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
   });
 
+  it("includes a diagram's slice fields and its attribute size property", () => {
+    const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
+    const id = addTileLayer({}, wide);
+    useAppStore.getState().setLayerStyle(id, {
+      diagramType: "pie",
+      diagramFields: [{ property: "col_2", color: "#2563eb" }],
+      diagramSizeMode: "attribute",
+      diagramSizeProperty: "col_8",
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_2", "col_8"]);
+
+    // Sizing from the slice total reads no extra column.
+    useAppStore.getState().setLayerStyle(id, { diagramSizeMode: "sum" });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_2"]);
+  });
+
   it("includes the Time Slider binding's property", () => {
     const wide = Array.from({ length: MAX_GEOLENS_TILE_COLUMNS + 1 }, (_, i) => `col_${i}`);
     const id = addTileLayer({}, wide);

--- a/tests/geolens-tile-columns.test.ts
+++ b/tests/geolens-tile-columns.test.ts
@@ -151,6 +151,20 @@ describe("desiredTileColumns", () => {
     });
     assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_4"]);
 
+    // A `literal` payload is data: the expression matches `col_3` against a
+    // fixed list, and a `get`-shaped array inside that list is just an element.
+    useAppStore.getState().setLayerStyle(id, {
+      vectorStyleMode: "expression",
+      vectorStyleExpression:
+        '["case", ["in", ["get", "col_3"], ["literal", ["a", "b"]]], "#111111", "#222222"]',
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), ["col_3"]);
+    useAppStore.getState().setLayerStyle(id, {
+      vectorStyleExpression:
+        '["case", ["==", ["literal", ["get", "col_9"]], 1], "#111111", "#222222"]',
+    });
+    assert.deepEqual(desiredTileColumns(storedLayer(id)), []);
+
     // A key computed at render time names no column, and `["get", key, object]`
     // reads from a supplied object rather than the feature.
     useAppStore.getState().setLayerStyle(id, {


### PR DESCRIPTION
## The bug

A GeoLens dataset added as **vector tiles** loses every attribute at normal viewing zooms:

- Style panel → Categorized on any attribute → *"Categorized style requires at least one category."*
- Layer menu → Bind to Time Slider → *"No date or timestamp property was found in this layer."*
- Labels and popups come up empty too.

GeoLens projects **no** attribute columns below zoom 10 (`_DEFAULT_NO_ATTR_BELOW_ZOOM` in its tile service) to bound tile size for wide tables, so MapLibre gets `properties: {}` on every feature. Decoded straight from `datasets.geolibre.app`:

| request | keys in the MVT |
|---|---|
| `…/5/9/13.pbf` | `[]` |
| `…/9/156/219.pbf` | `[]` |
| `…/10/312/438.pbf` | `name, nature, lat, lon, usa_sshs, storm_spd, storm_dr, year, month, day, hour, min` |
| `…/5/9/13.pbf&cols=nature,year` | `["nature","year"]` |

Everything host-side that reads a tile layer's attributes reads them from the loaded tiles, so all of it fails. The Style panel still *lists* the columns, because `metadata.fields` comes from the OGC items endpoint rather than the tiles — which is what makes this read as a GeoLibre bug rather than a tile-budget tradeoff.

## The fix

Stamp the server's documented `cols=` opt-in (unioned in at every zoom, validated server-side) onto the signed tile template:

- `vectorTileTemplate` accepts the columns; `withTileColumns` restamps an existing template without re-minting the token. `normalizeTileColumns` sorts and dedupes so one tile keeps one URL — GeoLens keys its tile cache on the normalized parameter.
- A layer requests its dataset's whole field list. That is deliberate: the Style panel and bind dialog cannot name the column they need before the user has seen it, so an opt-in limited to columns already in use cannot bootstrap either of them.
- Past a **24-field ceiling** it falls back to only what the layer's style and bindings point at, so a wide table stays on the server's budget (the case its docs cite is a 137-column table producing 824 KB tiles). That fallback is reported to the console once per dataset rather than being silent.
- The set is recomputed from the layer on every store change, so styling by an attribute, binding one to the Time Slider, a token re-mint, and a project reload all keep the tiles carrying what the layer needs.

## Verification

Driven in the real app against `datasets.geolibre.app` with the 124,820-feature IBTrACS NA layer:

- tile requests now carry `cols=day,hour,lat,lon,min,month,name,nature,storm_dr,storm_spd,usa_sshs,year` from z1;
- **Categorized → `nature`** populates its categories and paints the tracks at z1.4 (ET / TS / SS);
- **Bind to Time Slider** offers `year` instead of reporting no time property.

Plus `tests/geolens-tile-columns.test.ts` (column selection, the width ceiling, the switched-off style fields, the time binding, and the store-driven restamp) and new `cols=` cases in `tests/geolens-api.test.ts`. Full frontend suite: 5833 passing. `pre-commit run --files …` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting attribute fields included in GeoLens vector tiles.
  * Automatically requests fields needed for styling, diagrams, labels, extrusion, and time-based features while respecting server limits.
  * Keeps tile URLs synchronized when layers, styles, restored maps, or access tokens change.
  * Supports reading, updating, replacing, and clearing selected tile columns while preserving existing URL details.

* **Bug Fixes**
  * Prevented unnecessary tile URL updates and ignored unrelated layers.

* **Tests**
  * Added coverage for column selection, URL handling, field discovery, limits, and layer synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->