### PR TITLE
docs: link the GeoLibre + GeoLens video tutorial

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -103,6 +103,7 @@ See [Embedding & Sharing](user-guide/embedding.md) for every URL parameter.
 
 - [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI) — a tour of the browser, desktop, and Jupyter builds.
 - [Geoprocessing in the Browser: 700+ Free GIS Tools in GeoLibre, Zero Install](https://youtu.be/W32bIQO_nG8) — the Whitebox toolbox running entirely on WebAssembly.
+- [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o) — pairing GeoLibre with GeoLens for a self-hosted geospatial data stack.
 
 ## Try it yourself
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,6 +82,7 @@ Signed APKs are also attached to each [GitHub release](https://github.com/openge
 
 - [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 - [Geoprocessing in the Browser: 700+ Free GIS Tools in GeoLibre, Zero Install](https://youtu.be/W32bIQO_nG8)
+- [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o)
 
 ## Run from source
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -25,3 +25,4 @@ Work through them in order for a guided tour, or jump to the one that matches yo
 
 - [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 - [Geoprocessing in the Browser: 700+ Free GIS Tools in GeoLibre, Zero Install](https://youtu.be/W32bIQO_nG8)
+- [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o)


### PR DESCRIPTION
## Summary
- Add the "GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data" video to the video lists in the demos, getting started, and tutorials pages.

## Test plan
- [ ] Docs build renders the three pages with the new bullet in each video list.
- [ ] The video link opens the correct YouTube page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a video tutorial introducing GeoLibre and GeoLens as a self-hosted geospatial data stack.
  * Linked the tutorial from the demos, getting started, and tutorials documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->