### PR TITLE
docs: link the GeoLibre + GeoLens video in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Switch bodies from the planet switcher in the Layers panel. See [Demos](https://
 
 - [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 - [Geoprocessing in the Browser: 700+ Free GIS Tools in GeoLibre, Zero Install](https://youtu.be/W32bIQO_nG8)
+- [GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data](https://youtu.be/kQqgrxXGd4o)
 
 ## Geoprocessing: 1,000+ tools, zero install
 


### PR DESCRIPTION
## Summary
- Add the "GeoLibre + GeoLens: A Modern GIS Stack for Self-Hosting Geospatial Data" video to the README video list, matching the docs site pages that already link it.

## Test plan
- [ ] README renders on GitHub with the new bullet in the video list.
- [ ] The video link opens the correct YouTube page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a video tutorial link covering GeoLibre and GeoLens for self-hosting geospatial data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->