### PR TITLE
docs: correct the Whitebox per-category tool counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ the Processing menu:
 
 | Category | Tools | Examples |
 | --- | --- | --- |
-| **Vector** | 280 | overlays, buffers, joins, cleaning, topology, generalization |
-| **Raster** | 232 | algebra, filters, reclassification, zonal and focal statistics |
+| **Vector** | 313 | overlays, buffers, joins, cleaning, topology, generalization |
+| **Raster** | 256 | algebra, filters, reclassification, zonal and focal statistics |
 | **Remote sensing** | 154 | spectral indices, band math, classification, change detection |
 | **Hydrology** | 100 | flow accumulation, watersheds, stream networks, depression filling |
 | **Terrain** | 99 | slope, aspect, hillshade, curvature, ruggedness, viewsheds |

--- a/docs/features.md
+++ b/docs/features.md
@@ -173,7 +173,7 @@ kepler.gl, see the [Comparison](comparison.md).
     - The desktop app prefers the Python sidecar, whose GDAL/rio-cogeo stack reads more input formats and tiles deeper
 - **1,000+ geoprocessing tools** in the Whitebox toolbox, running entirely in the browser through a WebAssembly runtime with raster and vector I/O — no Python sidecar required, so the full set works on the web, desktop, and Android
     - Surfaces both the Whitebox Next Gen suite and GeoLibre's own WASM tools, filterable by source
-    - Nine categories: vector (~280 tools), raster (~230), remote sensing (~150), hydrology (~100), terrain (~100), LiDAR (~65), conversion (~50), network (~25), and projection (4)
+    - Nine categories: vector (~315 tools), raster (~255), remote sensing (~155), hydrology (~100), terrain (~100), LiDAR (~65), conversion (~50), network (~25), and projection (4)
     - Browsable by category directly in the Processing menu, with nested subcategory submenus and an offline-bundled tool catalog
     - A **Run locally (WASM)** toggle switches any tool between the in-browser runtime and the Python sidecar, which reads native file paths for batch runs over a directory
     - Deep-linkable through a `?tool=` URL parameter that preselects a tool and pre-fills its form, with a Copy link button that builds the shareable link


### PR DESCRIPTION
## Summary
- The README table of Whitebox tools per category listed 280 vector and 232 raster tools; the generated menu catalog has 313 and 256. The nine rows now sum to 1,066, matching the catalog.
- The matching approximate counts on the features page were updated the same way (vector ~315, raster ~255, remote sensing ~155).

## Test plan
- [ ] Counts match the per-category totals in `apps/geolibre-desktop/src/lib/whitebox-menu-catalog.ts` (1,066 tools across 9 categories).
- [ ] README table and the features page render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documented geoprocessing tool counts for vector and raster tools.
  * Revised Whitebox toolbox category counts, including vector, raster, and remote-sensing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->