### PR TITLE
fix(sidecar): append explicit unit 'degrees' to simplify result message

### DIFF
--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -195,7 +195,7 @@ def _simplify(
     result["geometry"] = gdf.geometry.simplify(tolerance)
     return (
         _to_feature_collection(result),
-        [f"Simplified {len(result)} feature(s) (tolerance {tolerance})"],
+        [f"Simplified {len(result)} feature(s) (tolerance {tolerance} degrees)"],
     )
 
 


### PR DESCRIPTION
### Summary

Appends `" degrees"` to the returned message string in `_simplify` (`vector_ops.py`).

### Motivation

`_simplify` operates on geometries in WGS84 coordinates where the Douglas-Peucker `tolerance` parameter is specified in degrees. Returning `"Simplified N feature(s) (tolerance 0.01)"` without specifying the unit led users to assume metric units (e.g. 0.01 meters instead of ~1.1 km at the equator). Explicitly stating `"degrees"` makes the output unit clear and aligned with the UI tooltip.

### Changes
- Updated `_simplify` message string in `vector_ops.py` to `Simplified {len(result)} feature(s) (tolerance {tolerance} degrees)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified in the Simplify tool’s status message that the tolerance value is measured in degrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->