### PR TITLE
fix(maplibre-geo-editor): restore the text_marker mode textarea's appearance and stacking

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1100,6 +1100,21 @@ body,
 }
 
 /*
+ * Geoman's `text_marker` mode (via the GeoEditor plugin) appends a bare
+ * <textarea> into the map container with only inline position/opacity — no
+ * class, no appearance. `all: revert` undoes Tailwind's Preflight reset, which
+ * leaves it transparent and borderless (invisible while you type); its inline
+ * styles outrank the revert, so positioning survives. The z-index clears the
+ * Effects plugin's `z-index: 4` map canvas, and must come after `all`.
+ * Direct child only — that is the sole way to target the element, which carries
+ * no class, so re-check it on `@geoman-io/maplibre-geoman-free` bumps.
+ */
+.maplibregl-map > textarea {
+  all: revert;
+  z-index: 10;
+}
+
+/*
  * The overlaid deck.gl canvas (COG rasters via CogLayerControl, ArcGIS I3S, the
  * Tauri raster fallback) is map content and must sit UNDER the map-control
  * panels, not over them. It lives inside `.maplibregl-control-container` (pinned


### PR DESCRIPTION
Geoman's `text_marker` mode appends a bare <textarea> into the map container with only inline position/opacity — no class, no appearance. Two things in this app made it unusable:

- Tailwind's Preflight resets form controls to a transparent, borderless, unpadded box with `color: inherit`, so the field was invisible while typing and the label only appeared once the marker committed.
- The Effects plugin (activeByDefault) pins an inline `z-index: 4` on the map canvas, burying the `z-index: auto` textarea underneath it.

`all: revert` drops the element back to the browser default the upstream geo-editor demo shows; Geoman's inline styles outrank it in the cascade, so its positioning survives. The z-index clears the effects canvas and must follow `all`, which would otherwise reset it.

Scoped to a direct child: Geoman is the only thing that appends a raw textarea to the map container, so this matches that element alone and leaves every panel/control textarea in the map subtree untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance and usability of text markers on the map.
  * Text-entry areas now display with familiar browser styling and remain visible above the map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->