### PR TITLE
fix(csv): stop a large delimited-text import from exhausting the renderer heap

### DIFF
--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -448,9 +448,16 @@ export function countDelimitedTextRows(text: string, delimiter: string): number 
  * instead would report a file that merely starts with a newline as empty, and
  * would hand delimiter detection a blank line to guess from.
  *
- * Line breaks are `\n` or `\r\n`, matching the rest of this module; a quoted
- * newline is not honored, since a header row containing one cannot be found
- * without parsing the whole file.
+ * A line ends at `\n`, `\r\n`, or a bare `\r`, the same three terminators
+ * {@link iterateDelimitedRows} recognizes. A bare `\r` matters here: a file
+ * written with classic-Mac endings has no `\n` at all, so looking only for that
+ * would hand back the entire file as its "header".
+ *
+ * A newline inside a *quoted* header cell is not honored, and the header is cut
+ * short at it. Honoring it is circular: whether a quote opens a quoted field
+ * depends on where the field boundaries are, which depends on the delimiter,
+ * which is what this line is read to detect. The consequence is contained;
+ * see the note in `parseDelimitedTextFile`.
  *
  * @param text - The delimited text, optionally starting with a BOM.
  * @returns The header line without its terminator, or `""` when every line is
@@ -459,28 +466,25 @@ export function countDelimitedTextRows(text: string, delimiter: string): number 
 export function firstDelimitedTextLine(text: string): string {
   let start = contentStart(text);
   while (start < text.length) {
-    const newline = text.indexOf("\n", start);
-    const lineEnd = newline < 0 ? text.length : newline;
-    const end =
-      lineEnd > start && text.charCodeAt(lineEnd - 1) === CARRIAGE_RETURN_CODE
-        ? lineEnd - 1
-        : lineEnd;
-    // Tested over the range rather than on a slice, so skipping past blank
-    // lines never copies, and neither does reaching the end of a file that has
-    // no line break at all.
-    if (!isBlankRange(text, start, end)) return text.slice(start, end);
-    if (newline < 0) return "";
-    start = newline + 1;
+    // Blankness is tracked during the same scan that finds the terminator, so
+    // skipping past blank lines never slices, and neither does reaching the end
+    // of a file that has no line break at all.
+    let end = start;
+    let hasContent = false;
+    while (end < text.length) {
+      const code = text.charCodeAt(end);
+      if (code === LINE_FEED_CODE || code === CARRIAGE_RETURN_CODE) break;
+      if (!hasContent && !isTrimmableCode(code, text, end)) hasContent = true;
+      end += 1;
+    }
+    if (hasContent) return text.slice(start, end);
+    if (end >= text.length) return "";
+    start =
+      text.charCodeAt(end) === CARRIAGE_RETURN_CODE && text.charCodeAt(end + 1) === LINE_FEED_CODE
+        ? end + 2
+        : end + 1;
   }
   return "";
-}
-
-/** Whether every character in `[start, end)` is one `trim` would strip. */
-function isBlankRange(text: string, start: number, end: number): boolean {
-  for (let index = start; index < end; index += 1) {
-    if (!isTrimmableCode(text.charCodeAt(index), text, index)) return false;
-  }
-  return true;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -220,6 +220,11 @@ function contentStart(text: string): number {
  *
  * A leading BOM is skipped by offset, so the source string is never copied.
  *
+ * SYNC: `countDelimitedTextRows` re-implements this scanner's quoting,
+ * escaping, and row rules without allocating. Any change to them has to land in
+ * both; the differential tests in `tests/data-parsing.test.ts` are what catch
+ * drift. Grep "SYNC:" to find the partner.
+ *
  * @param text - The delimited text, optionally starting with a BOM.
  * @param delimiter - The field delimiter; may be more than one character.
  * @yields Each row's raw field values, in column order.
@@ -377,6 +382,10 @@ function isTrimmableCode(code: number, text: string, index: number): boolean {
  * The blank-row test stops as soon as a row is known to have content, so it
  * runs on a handful of characters per row rather than on all of them.
  *
+ * SYNC: this duplicates `iterateDelimitedRows`' quoting, escaping, and row
+ * rules on purpose, for the zero-allocation win. Any change to them has to land
+ * in both. Grep "SYNC:" to find the partner.
+ *
  * @param text - The delimited text, optionally starting with a BOM.
  * @param delimiter - The field delimiter.
  * @returns The number of data rows, or 0 when the delimiter is blank.
@@ -505,7 +514,7 @@ function headerLineBounds(text: string): HeaderLineBounds | null {
     while (end < text.length) {
       const code = text.charCodeAt(end);
       if (code === LINE_FEED_CODE || code === CARRIAGE_RETURN_CODE) break;
-      if (!hasContent && !isTrimmableCode(code, text, end)) hasContent = true;
+      if (!hasContent && !isHeaderPadding(code, text, end)) hasContent = true;
       end += 1;
     }
     if (hasContent) return { start, end, terminated: end < text.length };
@@ -630,6 +639,26 @@ export const LATITUDE_FIELD_CANDIDATES = ["latitude", "lat", "y", "ycoord", "y_c
 
 /** Delimiters tried, in order, when auto-detecting a delimited file's format. */
 export const DELIMITER_CANDIDATES = [",", "\t", ";", "|"];
+
+const DELIMITER_CANDIDATE_CODES = new Set(
+  DELIMITER_CANDIDATES.map((delimiter) => delimiter.charCodeAt(0)),
+);
+
+/**
+ * Whether a character can be ruled out as header *content*: whitespace, or a
+ * character that could be the delimiter.
+ *
+ * The row parsers call a row blank when every field trims to nothing, which
+ * makes a line of nothing but separators (`,,,`) a blank row. That test needs
+ * the delimiter, which is not known while the header is being located, so
+ * {@link headerLineBounds} instead rules out every *candidate* delimiter at
+ * once: a line built only from those and whitespace has no content under any
+ * delimiter this module would go on to pick, so skipping it is safe and keeps
+ * the two notions of "blank" in agreement.
+ */
+function isHeaderPadding(code: number, text: string, index: number): boolean {
+  return isTrimmableCode(code, text, index) || DELIMITER_CANDIDATE_CODES.has(code);
+}
 
 /**
  * Guesses the field delimiter of a delimited text file by parsing its header

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -34,14 +34,14 @@ export const MIXED_COORDINATE_FIELDS_MESSAGE =
 export function parseDelimitedTextFields(text: string, delimiter: string): string[] {
   if (!delimiter) throw new Error("Enter a delimiter.");
 
-  const rows = parseDelimitedRows(text, delimiter).filter((row) =>
-    row.some((value) => value.trim()),
-  );
-  if (rows.length === 0) {
-    throw new Error("The delimited text must include a header row.");
+  // Only the header is needed, so stop at the first non-blank row instead of
+  // parsing the whole file — callers pass entire multi-hundred-MB files here.
+  for (const row of iterateDelimitedRows(text, delimiter)) {
+    if (!row.some((value) => value.trim())) continue;
+    return uniqueFieldNames(row.map((field) => field.trim()));
   }
 
-  return uniqueFieldNames(rows[0].map((field) => field.trim()));
+  throw new Error("The delimited text must include a header row.");
 }
 
 export function parseDelimitedTextLayer(
@@ -67,14 +67,11 @@ export function parseDelimitedTextLayer(
   // reproject the raw coordinates to WGS84.
   const geographic = isGeographicCrs(options.sourceCrs);
 
-  const rows = parseDelimitedRows(text, delimiter).filter((row) =>
-    row.some((value) => value.trim()),
-  );
-  if (rows.length < 2) {
+  const body = readDelimitedTextBody(text, delimiter);
+  if (!body) {
     throw new Error("The delimited text must include a header and data rows.");
   }
-
-  const fields = uniqueFieldNames(rows[0].map((field) => field.trim()));
+  const fields = body.fields;
 
   // When both coordinate fields are left blank the file is imported as a
   // non-spatial attribute table: every row becomes a feature with a null
@@ -89,13 +86,14 @@ export function parseDelimitedTextLayer(
     throw new Error(MIXED_COORDINATE_FIELDS_MESSAGE);
   }
   if (!wantsLatitude && !wantsLongitude) {
-    const tableFeatures: Feature<Geometry | null, GeoJsonProperties>[] = rows
-      .slice(1)
-      .map((row) => ({
+    const tableFeatures: Feature<Geometry | null, GeoJsonProperties>[] = [];
+    for (const row of body.rows()) {
+      tableFeatures.push({
         type: "Feature",
         geometry: null,
         properties: buildRowProperties(fields, row),
-      }));
+      });
+    }
 
     return {
       // GeoJSON Features may legally carry a null geometry; the app's layer
@@ -107,7 +105,7 @@ export function parseDelimitedTextLayer(
       } as FeatureCollection,
       fields,
       skippedRows: 0,
-      totalRows: rows.length - 1,
+      totalRows: tableFeatures.length,
       isTable: true,
     };
   }
@@ -123,9 +121,11 @@ export function parseDelimitedTextLayer(
   }
 
   let skippedRows = 0;
+  let totalRows = 0;
   const features: Feature<Point, GeoJsonProperties>[] = [];
 
-  for (const row of rows.slice(1)) {
+  for (const row of body.rows()) {
+    totalRows += 1;
     // For a projected CRS, treat a bare comma as a thousands separator (large
     // easting/northing) rather than a decimal point.
     const latitude = parseCoordinate(row[latitudeIndex], { grouped: !geographic });
@@ -160,7 +160,7 @@ export function parseDelimitedTextLayer(
     },
     fields,
     skippedRows,
-    totalRows: rows.length - 1,
+    totalRows,
     isTable: false,
   };
 }
@@ -181,73 +181,216 @@ export function parseDelimitedTextRows(
 ): { fields: string[]; rows: Record<string, string>[] } {
   if (!delimiter) throw new Error("Enter a delimiter.");
 
-  const rawRows = parseDelimitedRows(text, delimiter).filter((row) =>
-    row.some((value) => value.trim()),
-  );
-  if (rawRows.length < 2) {
+  const body = readDelimitedTextBody(text, delimiter);
+  if (!body) {
     throw new Error("The delimited text must include a header and data rows.");
   }
 
-  const fields = uniqueFieldNames(rawRows[0].map((field) => field.trim()));
-  const rows = rawRows.slice(1).map((row) => {
+  const fields = body.fields;
+  const rows: Record<string, string>[] = [];
+  for (const row of body.rows()) {
     const record: Record<string, string> = {};
     fields.forEach((field, index) => {
       record[field] = (row[index] ?? "").trim();
     });
-    return record;
-  });
+    rows.push(record);
+  }
 
   return { fields, rows };
 }
 
-function parseDelimitedRows(text: string, delimiter: string): string[][] {
-  const rows: string[][] = [];
-  let field = "";
-  let row: string[] = [];
-  let inQuotes = false;
-  const normalizedText = text.replace(/^\uFEFF/, "");
+/** The index the content starts at, skipping a leading BOM. */
+function contentStart(text: string): number {
+  return text.charCodeAt(0) === 0xfeff ? 1 : 0;
+}
 
-  for (let index = 0; index < normalizedText.length; index += 1) {
-    const char = normalizedText[index];
-    const next = normalizedText[index + 1];
+/**
+ * Yields the rows of delimited text one at a time.
+ *
+ * Two properties matter for large files, and both are why this is written as a
+ * generator over index arithmetic rather than the obvious string accumulation:
+ *
+ * - **Nothing is buffered.** Callers that build features row by row never hold
+ *   the whole file as a `string[][]` alongside the features they derive from it.
+ * - **Fields are slices of `text`, not characters appended one at a time.**
+ *   `field += char` builds a cons-string chain roughly one node per character,
+ *   so a 146 MB CSV of long free-text columns needed several GB of heap and
+ *   crashed the renderer with an out-of-memory error (GeoLibre#1854). A field
+ *   is only assembled from pieces when a quote actually interrupts it.
+ *
+ * A leading BOM is skipped by offset, so the source string is never copied.
+ *
+ * @param text - The delimited text, optionally starting with a BOM.
+ * @param delimiter - The field delimiter; may be more than one character.
+ * @yields Each row's raw field values, in column order.
+ */
+function* iterateDelimitedRows(text: string, delimiter: string): Generator<string[]> {
+  const start = contentStart(text);
+  const delimiterHead = delimiter.charAt(0);
+  const multiCharDelimiter = delimiter.length > 1;
+
+  let row: string[] = [];
+  // The field being read is `text.slice(fieldStart, index)`, unless a quote
+  // interrupted it \u2014 then the earlier pieces are held in `segments` and
+  // `segmentsLength` counts the characters already in them.
+  let segments: string[] | null = null;
+  let segmentsLength = 0;
+  let fieldStart = start;
+  let inQuotes = false;
+
+  // `extra` appends a literal that is not present in `text` as-is, namely the
+  // single `"` an escaped `""` pair stands for.
+  const pushSegment = (end: number, extra?: string): void => {
+    const parts = segments ?? (segments = []);
+    parts.push(text.slice(fieldStart, end));
+    segmentsLength += end - fieldStart;
+    if (extra !== undefined) {
+      parts.push(extra);
+      segmentsLength += extra.length;
+    }
+  };
+
+  const takeField = (end: number): string => {
+    if (segments === null) return text.slice(fieldStart, end);
+    pushSegment(end);
+    const field = segments.join("");
+    segments = null;
+    segmentsLength = 0;
+    return field;
+  };
+
+  let index = start;
+  for (; index < text.length; index += 1) {
+    const char = text[index];
 
     if (char === '"') {
-      if (inQuotes && next === '"') {
-        field += '"';
+      if (inQuotes && text[index + 1] === '"') {
+        // An escaped quote inside a quoted field: keep one literal `"` and
+        // resume the slice after the pair.
+        pushSegment(index, '"');
         index += 1;
-      } else if (inQuotes || field === "") {
+        fieldStart = index + 1;
+      } else if (inQuotes || (segmentsLength === 0 && index === fieldStart)) {
+        // Opens or closes a quoted field. The quote is not part of the value,
+        // so the slice restarts after it. Quoting only opens while the field is
+        // still empty; a quote further in is a literal character (below).
+        pushSegment(index);
+        fieldStart = index + 1;
         inQuotes = !inQuotes;
-      } else {
-        field += char;
       }
+      // A bare quote inside an unquoted field is literal, and already covered
+      // by the slice in progress \u2014 nothing to do.
       continue;
     }
 
-    if (!inQuotes && normalizedText.startsWith(delimiter, index)) {
-      row.push(field);
-      field = "";
+    if (
+      !inQuotes &&
+      char === delimiterHead &&
+      (!multiCharDelimiter || text.startsWith(delimiter, index))
+    ) {
+      row.push(takeField(index));
       index += delimiter.length - 1;
+      fieldStart = index + 1;
       continue;
     }
 
     if (!inQuotes && (char === "\n" || char === "\r")) {
-      row.push(field);
-      field = "";
-      rows.push(row);
+      row.push(takeField(index));
+      if (char === "\r" && text[index + 1] === "\n") index += 1;
+      fieldStart = index + 1;
+      yield row;
       row = [];
-      if (char === "\r" && next === "\n") index += 1;
+    }
+  }
+
+  // A final row with no trailing newline.
+  if (segmentsLength > 0 || index > fieldStart || row.length > 0) {
+    row.push(takeField(index));
+    yield row;
+  }
+}
+
+/**
+ * A delimited file split into its header and its data rows, with blank rows
+ * dropped. Returns `null` when the text has no header row or no data rows, so
+ * each caller can raise its own error.
+ *
+ * `rows()` streams from the same underlying scan and so can only be consumed
+ * once; that is what keeps a large file from being held in memory twice.
+ */
+interface DelimitedTextBody {
+  fields: string[];
+  rows: () => Generator<string[]>;
+}
+
+function readDelimitedTextBody(text: string, delimiter: string): DelimitedTextBody | null {
+  const iterator = iterateDelimitedRows(text, delimiter)[Symbol.iterator]();
+  const nextRow = (): string[] | null => {
+    for (let next = iterator.next(); !next.done; next = iterator.next()) {
+      if (next.value.some((value) => value.trim())) return next.value;
+    }
+    return null;
+  };
+
+  const headerRow = nextRow();
+  const firstDataRow = headerRow ? nextRow() : null;
+  if (!headerRow || !firstDataRow) return null;
+
+  return {
+    fields: uniqueFieldNames(headerRow.map((field) => field.trim())),
+    rows: function* () {
+      yield firstDataRow;
+      for (let row = nextRow(); row !== null; row = nextRow()) yield row;
+    },
+  };
+}
+
+/**
+ * Counts the data rows (header and blank rows excluded) without building any
+ * features, so a caller can warn about an oversized import before paying for
+ * the GeoJSON materialization. Quoting is respected, so a newline inside a
+ * quoted field does not inflate the count.
+ *
+ * This is a second full scan of the text, so call it only when the answer will
+ * be acted on \u2014 for a small file the parse itself is cheaper than the check.
+ *
+ * @param text - The delimited text, optionally starting with a BOM.
+ * @param delimiter - The field delimiter.
+ * @returns The number of data rows, or 0 when the delimiter is blank.
+ */
+export function countDelimitedTextRows(text: string, delimiter: string): number {
+  if (!delimiter) return 0;
+  let count = 0;
+  let sawHeader = false;
+  for (const row of iterateDelimitedRows(text, delimiter)) {
+    if (!row.some((value) => value.trim())) continue;
+    if (!sawHeader) {
+      sawHeader = true;
       continue;
     }
-
-    field += char;
+    count += 1;
   }
+  return count;
+}
 
-  if (field || row.length > 0) {
-    row.push(field);
-    rows.push(row);
-  }
-
-  return rows;
+/**
+ * Returns the first line of delimited text (the header, for a well-formed
+ * file), skipping a leading BOM. Slices rather than splitting, so reading the
+ * header of a large file does not copy it.
+ *
+ * Line breaks are `\n` or `\r\n`, matching the rest of this module; a quoted
+ * newline is not honored, since a header row containing one cannot be read
+ * without parsing the whole file.
+ *
+ * @param text - The delimited text, optionally starting with a BOM.
+ * @returns The first line, without its terminator.
+ */
+export function firstDelimitedTextLine(text: string): string {
+  const start = contentStart(text);
+  const newline = text.indexOf("\n", start);
+  if (newline < 0) return text.slice(start);
+  const end = newline > start && text.charCodeAt(newline - 1) === 13 ? newline - 1 : newline;
+  return text.slice(start, end);
 }
 
 /**
@@ -373,7 +516,7 @@ export const DELIMITER_CANDIDATES = [",", "\t", ";", "|"];
  * @returns The detected delimiter; defaults to a comma when none stands out.
  */
 export function detectDelimitedTextDelimiter(text: string): string {
-  const header = text.replace(/^\uFEFF/, "").split(/\r?\n/, 1)[0] ?? "";
+  const header = firstDelimitedTextLine(text);
   let best = ",";
   let bestCount = 0;
   for (const delimiter of DELIMITER_CANDIDATES) {

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -87,7 +87,7 @@ export function parseDelimitedTextLayer(
   }
   if (!wantsLatitude && !wantsLongitude) {
     const tableFeatures: Feature<Geometry | null, GeoJsonProperties>[] = [];
-    for (const row of body.rows()) {
+    for (const row of body.rows) {
       tableFeatures.push({
         type: "Feature",
         geometry: null,
@@ -124,7 +124,7 @@ export function parseDelimitedTextLayer(
   let totalRows = 0;
   const features: Feature<Point, GeoJsonProperties>[] = [];
 
-  for (const row of body.rows()) {
+  for (const row of body.rows) {
     totalRows += 1;
     // For a projected CRS, treat a bare comma as a thousands separator (large
     // easting/northing) rather than a decimal point.
@@ -188,7 +188,7 @@ export function parseDelimitedTextRows(
 
   const fields = body.fields;
   const rows: Record<string, string>[] = [];
-  for (const row of body.rows()) {
+  for (const row of body.rows) {
     const record: Record<string, string> = {};
     fields.forEach((field, index) => {
       record[field] = (row[index] ?? "").trim();
@@ -315,12 +315,14 @@ function* iterateDelimitedRows(text: string, delimiter: string): Generator<strin
  * dropped. Returns `null` when the text has no header row or no data rows, so
  * each caller can raise its own error.
  *
- * `rows()` streams from the same underlying scan and so can only be consumed
- * once; that is what keeps a large file from being held in memory twice.
+ * `rows` is the live generator over the same underlying scan, not a factory that
+ * restarts it: consuming it twice would split the rows between the consumers
+ * rather than replay them. It is exposed as the generator itself so that
+ * single-use contract is visible at every call site.
  */
 interface DelimitedTextBody {
   fields: string[];
-  rows: () => Generator<string[]>;
+  rows: Generator<string[]>;
 }
 
 function readDelimitedTextBody(text: string, delimiter: string): DelimitedTextBody | null {
@@ -338,10 +340,10 @@ function readDelimitedTextBody(text: string, delimiter: string): DelimitedTextBo
 
   return {
     fields: uniqueFieldNames(headerRow.map((field) => field.trim())),
-    rows: function* () {
+    rows: (function* () {
       yield firstDataRow;
       for (let row = nextRow(); row !== null; row = nextRow()) yield row;
-    },
+    })(),
   };
 }
 
@@ -464,6 +466,35 @@ export function countDelimitedTextRows(text: string, delimiter: string): number 
  *   blank.
  */
 export function firstDelimitedTextLine(text: string): string {
+  const bounds = headerLineBounds(text);
+  return bounds ? text.slice(bounds.start, bounds.end) : "";
+}
+
+/**
+ * Whether `text` holds a *complete* header line, meaning the first non-blank
+ * line ends at a line break within `text` rather than running off its end.
+ *
+ * A caller that read only a prefix of a file uses this to tell "the header fits
+ * in what I read" from "my prefix was cut mid-header". Merely testing the
+ * prefix for a line break is not equivalent: leading blank lines contribute
+ * line breaks of their own, so a header that overruns the prefix can still look
+ * terminated.
+ *
+ * @param text - A prefix of a delimited file, optionally starting with a BOM.
+ * @returns True when the header line's own terminator is present.
+ */
+export function hasCompleteHeaderLine(text: string): boolean {
+  return headerLineBounds(text)?.terminated ?? false;
+}
+
+/** The first non-blank line's span, and whether its terminator was reached. */
+interface HeaderLineBounds {
+  start: number;
+  end: number;
+  terminated: boolean;
+}
+
+function headerLineBounds(text: string): HeaderLineBounds | null {
   let start = contentStart(text);
   while (start < text.length) {
     // Blankness is tracked during the same scan that finds the terminator, so
@@ -477,14 +508,14 @@ export function firstDelimitedTextLine(text: string): string {
       if (!hasContent && !isTrimmableCode(code, text, end)) hasContent = true;
       end += 1;
     }
-    if (hasContent) return text.slice(start, end);
-    if (end >= text.length) return "";
+    if (hasContent) return { start, end, terminated: end < text.length };
+    if (end >= text.length) return null;
     start =
       text.charCodeAt(end) === CARRIAGE_RETURN_CODE && text.charCodeAt(end + 1) === LINE_FEED_CODE
         ? end + 2
         : end + 1;
   }
-  return "";
+  return null;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -35,7 +35,7 @@ export function parseDelimitedTextFields(text: string, delimiter: string): strin
   if (!delimiter) throw new Error("Enter a delimiter.");
 
   // Only the header is needed, so stop at the first non-blank row instead of
-  // parsing the whole file — callers pass entire multi-hundred-MB files here.
+  // parsing the whole file; callers pass entire multi-hundred-MB files here.
   for (const row of iterateDelimitedRows(text, delimiter)) {
     if (!row.some((value) => value.trim())) continue;
     return uniqueFieldNames(row.map((field) => field.trim()));
@@ -231,7 +231,7 @@ function* iterateDelimitedRows(text: string, delimiter: string): Generator<strin
 
   let row: string[] = [];
   // The field being read is `text.slice(fieldStart, index)`, unless a quote
-  // interrupted it \u2014 then the earlier pieces are held in `segments` and
+  // interrupted it; then the earlier pieces are held in `segments` and
   // `segmentsLength` counts the characters already in them.
   let segments: string[] | null = null;
   let segmentsLength = 0;
@@ -279,7 +279,7 @@ function* iterateDelimitedRows(text: string, delimiter: string): Generator<strin
         inQuotes = !inQuotes;
       }
       // A bare quote inside an unquoted field is literal, and already covered
-      // by the slice in progress \u2014 nothing to do.
+      // by the slice in progress, so there is nothing to do.
       continue;
     }
 
@@ -345,14 +345,35 @@ function readDelimitedTextBody(text: string, delimiter: string): DelimitedTextBo
   };
 }
 
+/** Character codes the scanners compare against. */
+const QUOTE_CODE = 34;
+const LINE_FEED_CODE = 10;
+const CARRIAGE_RETURN_CODE = 13;
+
+/**
+ * Whether a character is one `String.prototype.trim` would strip, which is what
+ * decides whether a row counts as blank. ASCII is settled by code alone; only a
+ * non-ASCII character needs the regex, whose set is exactly trim's.
+ */
+function isTrimmableCode(code: number, text: string, index: number): boolean {
+  if (code === 32 || (code >= 9 && code <= 13)) return true;
+  if (code < 127) return false;
+  return /\s/.test(text[index]);
+}
+
 /**
  * Counts the data rows (header and blank rows excluded) without building any
  * features, so a caller can warn about an oversized import before paying for
  * the GeoJSON materialization. Quoting is respected, so a newline inside a
  * quoted field does not inflate the count.
  *
- * This is a second full scan of the text, so call it only when the answer will
- * be acted on \u2014 for a small file the parse itself is cheaper than the check.
+ * This mirrors {@link iterateDelimitedRows}' row rules, but deliberately does
+ * not reuse it: it compares character codes and allocates nothing at all, where
+ * the iterator allocates an array and a slice per field. That keeps the count
+ * cheap enough to run on every guarded import rather than only on files past
+ * some size, which is what lets the guard key on rows rather than on bytes.
+ * The blank-row test stops as soon as a row is known to have content, so it
+ * runs on a handful of characters per row rather than on all of them.
  *
  * @param text - The delimited text, optionally starting with a BOM.
  * @param delimiter - The field delimiter.
@@ -360,37 +381,106 @@ function readDelimitedTextBody(text: string, delimiter: string): DelimitedTextBo
  */
 export function countDelimitedTextRows(text: string, delimiter: string): number {
   if (!delimiter) return 0;
-  let count = 0;
-  let sawHeader = false;
-  for (const row of iterateDelimitedRows(text, delimiter)) {
-    if (!row.some((value) => value.trim())) continue;
-    if (!sawHeader) {
-      sawHeader = true;
+  const start = contentStart(text);
+  const delimiterHead = delimiter.charCodeAt(0);
+  const multiCharDelimiter = delimiter.length > 1;
+
+  let rows = 0;
+  let rowHasContent = false;
+  // Counts the characters materialized into the current field, standing in for
+  // the iterator's `field === ""` test that decides whether a quote opens.
+  let fieldLength = 0;
+  let inQuotes = false;
+
+  for (let index = start; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+
+    if (code === QUOTE_CODE) {
+      if (inQuotes && text.charCodeAt(index + 1) === QUOTE_CODE) {
+        fieldLength += 1;
+        rowHasContent = true;
+        index += 1;
+      } else if (inQuotes || fieldLength === 0) {
+        inQuotes = !inQuotes;
+      } else {
+        fieldLength += 1;
+        rowHasContent = true;
+      }
       continue;
     }
-    count += 1;
+
+    if (
+      !inQuotes &&
+      code === delimiterHead &&
+      (!multiCharDelimiter || text.startsWith(delimiter, index))
+    ) {
+      fieldLength = 0;
+      index += delimiter.length - 1;
+      continue;
+    }
+
+    if (!inQuotes && (code === LINE_FEED_CODE || code === CARRIAGE_RETURN_CODE)) {
+      if (rowHasContent) rows += 1;
+      rowHasContent = false;
+      fieldLength = 0;
+      if (code === CARRIAGE_RETURN_CODE && text.charCodeAt(index + 1) === LINE_FEED_CODE) {
+        index += 1;
+      }
+      continue;
+    }
+
+    fieldLength += 1;
+    if (!rowHasContent && !isTrimmableCode(code, text, index)) rowHasContent = true;
   }
-  return count;
+
+  if (rowHasContent) rows += 1;
+  // The first non-blank row is the header, not data.
+  return rows > 0 ? rows - 1 : 0;
 }
 
 /**
- * Returns the first line of delimited text (the header, for a well-formed
- * file), skipping a leading BOM. Slices rather than splitting, so reading the
- * header of a large file does not copy it.
+ * Returns the header line of delimited text, skipping a leading BOM and any
+ * blank lines before it. Slices rather than splitting, so reading the header of
+ * a large file does not copy it.
+ *
+ * Leading blank lines are skipped because the row parsers drop blank rows and
+ * treat the first non-blank one as the header; taking the first *physical* line
+ * instead would report a file that merely starts with a newline as empty, and
+ * would hand delimiter detection a blank line to guess from.
  *
  * Line breaks are `\n` or `\r\n`, matching the rest of this module; a quoted
- * newline is not honored, since a header row containing one cannot be read
+ * newline is not honored, since a header row containing one cannot be found
  * without parsing the whole file.
  *
  * @param text - The delimited text, optionally starting with a BOM.
- * @returns The first line, without its terminator.
+ * @returns The header line without its terminator, or `""` when every line is
+ *   blank.
  */
 export function firstDelimitedTextLine(text: string): string {
-  const start = contentStart(text);
-  const newline = text.indexOf("\n", start);
-  if (newline < 0) return text.slice(start);
-  const end = newline > start && text.charCodeAt(newline - 1) === 13 ? newline - 1 : newline;
-  return text.slice(start, end);
+  let start = contentStart(text);
+  while (start < text.length) {
+    const newline = text.indexOf("\n", start);
+    const lineEnd = newline < 0 ? text.length : newline;
+    const end =
+      lineEnd > start && text.charCodeAt(lineEnd - 1) === CARRIAGE_RETURN_CODE
+        ? lineEnd - 1
+        : lineEnd;
+    // Tested over the range rather than on a slice, so skipping past blank
+    // lines never copies, and neither does reaching the end of a file that has
+    // no line break at all.
+    if (!isBlankRange(text, start, end)) return text.slice(start, end);
+    if (newline < 0) return "";
+    start = newline + 1;
+  }
+  return "";
+}
+
+/** Whether every character in `[start, end)` is one `trim` would strip. */
+function isBlankRange(text: string, start: number, end: number): boolean {
+  for (let index = start; index < end; index += 1) {
+    if (!isTrimmableCode(text.charCodeAt(index), text, index)) return false;
+  }
+  return true;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -636,6 +636,28 @@ function isDelimitedTextFileName(path: string): boolean {
 }
 
 /**
+ * How much of a delimited file to decode when only its header is wanted. Large
+ * enough for any realistic header (the widest seen in the wild are a few tens
+ * of KB), and the read falls back to the whole file if no line break turns up
+ * within it, so an unusual file loses efficiency rather than correctness.
+ */
+const DELIMITED_TEXT_HEADER_PROBE_BYTES = 1024 * 1024;
+
+/**
+ * Reads enough of a delimited file to contain its header row. Decoding a slice
+ * can split a multi-byte character at the cut, but the damage is confined to
+ * the truncated tail, which is past the header the caller reads.
+ *
+ * @param file - The delimited file.
+ * @returns Text guaranteed to contain the first line break, or the whole file.
+ */
+async function readDelimitedHeaderText(file: File): Promise<string> {
+  if (file.size <= DELIMITED_TEXT_HEADER_PROBE_BYTES) return file.text();
+  const probe = await file.slice(0, DELIMITED_TEXT_HEADER_PROBE_BYTES).text();
+  return probe.includes("\n") ? probe : file.text();
+}
+
+/**
  * Parses dropped/opened delimited text into a point FeatureCollection by
  * auto-detecting the delimiter and the longitude/latitude columns.
  *
@@ -645,37 +667,43 @@ function isDelimitedTextFileName(path: string): boolean {
  * the Add Data dialog) when the file is empty or the auto-detected columns hold
  * no usable WGS84 coordinates (e.g. a CSV whose `x`/`y` columns are projected).
  *
- * @param text - The file's full text.
+ * @param source - `headerText` needs only to reach the end of the header row;
+ *   `readFullText` is called solely once coordinate columns are confirmed, so a
+ *   CSV bound for the DuckDB fallback is never materialized as text first.
  * @param path - The file name or path, used in the messages.
- * @param context - `options` carries the caller's large-dataset guard;
- *   `largeFile` marks a file big enough to be worth counting its rows first.
+ * @param options - Carries the caller's large-dataset guard.
  */
 async function parseDelimitedTextFile(
-  text: string,
+  source: { headerText: string; readFullText: () => Promise<string> },
   path: string,
-  context?: { options?: DuckDbVectorLoadOptions; largeFile?: boolean },
+  options?: DuckDbVectorLoadOptions,
 ): Promise<FeatureCollection | null> {
   const name = browserSafeFileName(path);
   const pickColumns = `Use Add Data → Delimited Text to choose the coordinate columns for ${name}.`;
-  const delimiter = detectDelimitedTextDelimiter(text);
-  // Detect the coordinate columns from the header slice only;
-  // parseDelimitedTextLayer re-reads the header internally, so parsing the
-  // whole file here just to recover the column names would double the work.
-  const headerLine = firstDelimitedTextLine(text);
-  if (!headerLine.trim()) {
+  // Detect the delimiter and the coordinate columns from the header alone, so
+  // this preflight neither parses nor even reads the body. parseDelimitedText-
+  // Layer re-reads the header internally, so recovering the column names by
+  // parsing the whole file here would double the work.
+  const headerLine = firstDelimitedTextLine(source.headerText);
+  if (!headerLine) {
     throw new Error(`${name} appears to be empty. ${pickColumns}`);
   }
+  const delimiter = detectDelimitedTextDelimiter(headerLine);
   const fields = parseDelimitedTextFields(headerLine, delimiter);
   const coordinateFields = detectCoordinateFields(fields);
   if (!coordinateFields) return null;
+
+  const text = await source.readFullText();
   // Delimited text is the one vector path that never reaches the DuckDB loader
   // (which has no lon/lat column detection), so it was also the one path with
-  // no oversized-import guard at all. The count is a second scan of the text,
-  // so it only runs for a file already large enough for the answer to matter.
-  if (context?.largeFile) {
+  // no oversized-import guard at all. Counting is a scan that allocates
+  // nothing, unlike the materialization it guards, so it runs for every file
+  // rather than only past some size: a CSV of short rows can clear the warn
+  // threshold on row count while staying far below any byte threshold.
+  if (options?.onLargeDataset) {
     await confirmLargeDataset(
       { name, featureCount: countDelimitedTextRows(text, delimiter) },
-      context.options?.onLargeDataset,
+      options.onLargeDataset,
     );
   }
   try {
@@ -1927,14 +1955,20 @@ async function loadBrowserVectorFile(
   // longitude/latitude column detection (that lives only in the GeoParquet
   // conversion path), so routing a plain lon/lat CSV to DuckDB fails with
   // "DuckDB did not find a geometry column in this file." A big CSV therefore
-  // has to be parsed here rather than routed away, so `largeFile` passes the
-  // routing decision down as the trigger for the oversized-import guard
-  // instead.
+  // has to be parsed here rather than routed away, and carries its own
+  // oversized-import guard instead.
   if (isDelimitedTextFileName(file.name)) {
-    const points = await parseDelimitedTextFile(await file.text(), file.name, {
+    const points = await parseDelimitedTextFile(
+      {
+        // Only the header decides whether this is a lon/lat CSV, and a `File`
+        // can be read in part, so a CSV headed for the DuckDB fallback below is
+        // never decoded as text in full first.
+        headerText: await readDelimitedHeaderText(file),
+        readFullText: () => file.text(),
+      },
+      file.name,
       options,
-      largeFile: streamViaDuckDb,
-    });
+    );
     // No lon/lat columns: fall through to DuckDB so spatial CSV variants
     // (e.g. a WKT geometry column) still load.
     if (points) {
@@ -2218,10 +2252,14 @@ async function loadTauriVectorFile(
   // Not gated on `streamViaDuckDb` — see the note in `loadBrowserVectorFile`:
   // the DuckDB reader cannot build points from lon/lat columns.
   if (isDelimitedTextFileName(path)) {
-    const points = await parseDelimitedTextFile(await readLocalFileText(path), path, {
+    // Unlike the browser path there is no ranged read here, so the text is read
+    // once and serves as both the header probe and the body.
+    const text = await readLocalFileText(path);
+    const points = await parseDelimitedTextFile(
+      { headerText: text, readFullText: async () => text },
+      path,
       options,
-      largeFile: streamViaDuckDb,
-    });
+    );
     // No lon/lat columns: fall through to DuckDB so spatial CSV variants
     // (e.g. a WKT geometry column) still load.
     if (points) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -684,6 +684,14 @@ async function parseDelimitedTextFile(
   // this preflight neither parses nor even reads the body. parseDelimitedText-
   // Layer re-reads the header internally, so recovering the column names by
   // parsing the whole file here would double the work.
+  //
+  // A header cell containing a quoted newline is cut short here (see
+  // firstDelimitedTextLine for why that cannot be resolved before the delimiter
+  // is known). That only ever costs auto-detection, never correctness: the
+  // column names below are resolved against a full, quote-aware parse of the
+  // file, so the worst case is that lon/lat columns past the cut go unnoticed
+  // and the file falls through to DuckDB, whose failure points at Add Data ->
+  // Delimited Text, where the user picks the columns by hand.
   const headerLine = firstDelimitedTextLine(source.headerText);
   if (!headerLine) {
     throw new Error(`${name} appears to be empty. ${pickColumns}`);

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -26,6 +26,7 @@ import {
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
   firstDelimitedTextLine,
+  hasCompleteHeaderLine,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "./delimited-text";
@@ -654,7 +655,10 @@ const DELIMITED_TEXT_HEADER_PROBE_BYTES = 1024 * 1024;
 async function readDelimitedHeaderText(file: File): Promise<string> {
   if (file.size <= DELIMITED_TEXT_HEADER_PROBE_BYTES) return file.text();
   const probe = await file.slice(0, DELIMITED_TEXT_HEADER_PROBE_BYTES).text();
-  return probe.includes("\n") ? probe : file.text();
+  // Deliberately not "does the probe contain a line break": blank lines before
+  // the header contribute breaks of their own, so a header that overruns the
+  // probe would still look terminated and be handed back truncated.
+  return hasCompleteHeaderLine(probe) ? probe : file.text();
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -645,20 +645,34 @@ function isDelimitedTextFileName(path: string): boolean {
 const DELIMITED_TEXT_HEADER_PROBE_BYTES = 1024 * 1024;
 
 /**
- * Reads enough of a delimited file to contain its header row. Decoding a slice
- * can split a multi-byte character at the cut, but the damage is confined to
- * the truncated tail, which is past the header the caller reads.
+ * Reads enough of a delimited file to contain its header row, paired with a
+ * reader for the file's whole text.
+ *
+ * Only a genuine partial probe leaves a full read still to do. Whenever the
+ * header text *is* the whole file, which is every file under the probe size,
+ * it is handed back for reuse rather than decoded a second time.
+ *
+ * Decoding a slice can split a multi-byte character at the cut, but the damage
+ * is confined to the truncated tail, past the header the caller reads.
  *
  * @param file - The delimited file.
- * @returns Text guaranteed to contain the first line break, or the whole file.
+ * @returns The header text and a reader for the full text.
  */
-async function readDelimitedHeaderText(file: File): Promise<string> {
-  if (file.size <= DELIMITED_TEXT_HEADER_PROBE_BYTES) return file.text();
+async function readDelimitedTextSource(file: File): Promise<{
+  headerText: string;
+  readFullText: () => Promise<string>;
+}> {
+  const alreadyWhole = (text: string) => ({
+    headerText: text,
+    readFullText: async () => text,
+  });
+  if (file.size <= DELIMITED_TEXT_HEADER_PROBE_BYTES) return alreadyWhole(await file.text());
   const probe = await file.slice(0, DELIMITED_TEXT_HEADER_PROBE_BYTES).text();
   // Deliberately not "does the probe contain a line break": blank lines before
   // the header contribute breaks of their own, so a header that overruns the
   // probe would still look terminated and be handed back truncated.
-  return hasCompleteHeaderLine(probe) ? probe : file.text();
+  if (hasCompleteHeaderLine(probe)) return { headerText: probe, readFullText: () => file.text() };
+  return alreadyWhole(await file.text());
 }
 
 /**
@@ -673,7 +687,8 @@ async function readDelimitedHeaderText(file: File): Promise<string> {
  *
  * @param source - `headerText` needs only to reach the end of the header row;
  *   `readFullText` is called solely once coordinate columns are confirmed, so a
- *   CSV bound for the DuckDB fallback is never materialized as text first.
+ *   CSV large enough to have been probed rather than read whole is never
+ *   materialized as text just to be handed to the DuckDB fallback.
  * @param path - The file name or path, used in the messages.
  * @param options - Carries the caller's large-dataset guard.
  */
@@ -1970,14 +1985,11 @@ async function loadBrowserVectorFile(
   // has to be parsed here rather than routed away, and carries its own
   // oversized-import guard instead.
   if (isDelimitedTextFileName(file.name)) {
+    // Only the header decides whether this is a lon/lat CSV, and a `File` can
+    // be read in part, so a large CSV headed for the DuckDB fallback below is
+    // never decoded as text in full first.
     const points = await parseDelimitedTextFile(
-      {
-        // Only the header decides whether this is a lon/lat CSV, and a `File`
-        // can be read in part, so a CSV headed for the DuckDB fallback below is
-        // never decoded as text in full first.
-        headerText: await readDelimitedHeaderText(file),
-        readFullText: () => file.text(),
-      },
+      await readDelimitedTextSource(file),
       file.name,
       options,
     );

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -22,8 +22,10 @@ import { combine, parseDbf, parseShp } from "shpjs";
 import {
   DELIMITER_CANDIDATES,
   NO_VALID_COORDINATES_MESSAGE,
+  countDelimitedTextRows,
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
+  firstDelimitedTextLine,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "./delimited-text";
@@ -642,21 +644,40 @@ function isDelimitedTextFileName(path: string): boolean {
  * (e.g. a CSV with a WKT geometry column). Throws a helpful error (pointing at
  * the Add Data dialog) when the file is empty or the auto-detected columns hold
  * no usable WGS84 coordinates (e.g. a CSV whose `x`/`y` columns are projected).
+ *
+ * @param text - The file's full text.
+ * @param path - The file name or path, used in the messages.
+ * @param context - `options` carries the caller's large-dataset guard;
+ *   `largeFile` marks a file big enough to be worth counting its rows first.
  */
-function parseDelimitedTextFile(text: string, path: string): FeatureCollection | null {
+async function parseDelimitedTextFile(
+  text: string,
+  path: string,
+  context?: { options?: DuckDbVectorLoadOptions; largeFile?: boolean },
+): Promise<FeatureCollection | null> {
   const name = browserSafeFileName(path);
   const pickColumns = `Use Add Data → Delimited Text to choose the coordinate columns for ${name}.`;
   const delimiter = detectDelimitedTextDelimiter(text);
   // Detect the coordinate columns from the header slice only;
   // parseDelimitedTextLayer re-reads the header internally, so parsing the
   // whole file here just to recover the column names would double the work.
-  const headerLine = text.replace(/^\uFEFF/, "").split(/\r?\n/, 1)[0] ?? "";
+  const headerLine = firstDelimitedTextLine(text);
   if (!headerLine.trim()) {
     throw new Error(`${name} appears to be empty. ${pickColumns}`);
   }
   const fields = parseDelimitedTextFields(headerLine, delimiter);
   const coordinateFields = detectCoordinateFields(fields);
   if (!coordinateFields) return null;
+  // Delimited text is the one vector path that never reaches the DuckDB loader
+  // (which has no lon/lat column detection), so it was also the one path with
+  // no oversized-import guard at all. The count is a second scan of the text,
+  // so it only runs for a file already large enough for the answer to matter.
+  if (context?.largeFile) {
+    await confirmLargeDataset(
+      { name, featureCount: countDelimitedTextRows(text, delimiter) },
+      context.options?.onLargeDataset,
+    );
+  }
   try {
     return parseDelimitedTextLayer(text, {
       delimiter,
@@ -1905,11 +1926,15 @@ async function loadBrowserVectorFile(
   // Deliberately NOT gated on `streamViaDuckDb`: `loadDuckDbVectorFile` has no
   // longitude/latitude column detection (that lives only in the GeoParquet
   // conversion path), so routing a plain lon/lat CSV to DuckDB fails with
-  // "DuckDB did not find a geometry column in this file." Delimited text is
-  // line-oriented and cheap to parse, so size is not the concern it is for
-  // GeoJSON or shapefiles.
+  // "DuckDB did not find a geometry column in this file." A big CSV therefore
+  // has to be parsed here rather than routed away, so `largeFile` passes the
+  // routing decision down as the trigger for the oversized-import guard
+  // instead.
   if (isDelimitedTextFileName(file.name)) {
-    const points = parseDelimitedTextFile(await file.text(), file.name);
+    const points = await parseDelimitedTextFile(await file.text(), file.name, {
+      options,
+      largeFile: streamViaDuckDb,
+    });
     // No lon/lat columns: fall through to DuckDB so spatial CSV variants
     // (e.g. a WKT geometry column) still load.
     if (points) {
@@ -2193,7 +2218,10 @@ async function loadTauriVectorFile(
   // Not gated on `streamViaDuckDb` — see the note in `loadBrowserVectorFile`:
   // the DuckDB reader cannot build points from lon/lat columns.
   if (isDelimitedTextFileName(path)) {
-    const points = parseDelimitedTextFile(await readLocalFileText(path), path);
+    const points = await parseDelimitedTextFile(await readLocalFileText(path), path, {
+      options,
+      largeFile: streamViaDuckDb,
+    });
     // No lon/lat columns: fall through to DuckDB so spatial CSV variants
     // (e.g. a WKT geometry column) still load.
     if (points) {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -368,6 +368,26 @@ describe("delimited text row counting and header slicing", () => {
     assert.equal(firstDelimitedTextLine("a,b"), "a,b");
   });
 
+  it("skips a leading separator-only line, as the row parsers do", () => {
+    // The row parsers call a row blank when every field trims to nothing, so
+    // `,,,` is a blank row to them. The header scan cannot split on a delimiter
+    // it has not detected yet, so it rules out every candidate delimiter to
+    // reach the same answer.
+    assert.equal(
+      firstDelimitedTextLine(",,,\nname,longitude,latitude\nA,1,2"),
+      "name,longitude,latitude",
+    );
+    assert.equal(firstDelimitedTextLine(";;\n\na;b;c"), "a;b;c");
+    assert.equal(firstDelimitedTextLine("|||\nx|y"), "x|y");
+    assert.deepEqual(parseDelimitedTextFields(",,,\nname,longitude,latitude\nA,1,2", ","), [
+      "name",
+      "longitude",
+      "latitude",
+    ]);
+    // A line of separators with real content is still the header.
+    assert.equal(firstDelimitedTextLine(",,a,,\nb,c"), ",,a,,");
+  });
+
   it("reports whether a prefix holds the header's own terminator", () => {
     assert.equal(hasCompleteHeaderLine("a,b\n1,2"), true);
     assert.equal(hasCompleteHeaderLine("a,b\r\n1,2"), true);

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -361,11 +361,20 @@ describe("delimited text row counting and header slicing", () => {
     assert.equal(countDelimitedTextRows("name,note\nAlice,hello", ""), 0);
   });
 
-  it("returns the first line without its terminator, skipping a BOM", () => {
+  it("returns the header line without its terminator, skipping a BOM", () => {
     assert.equal(firstDelimitedTextLine("a,b\r\n1,2"), "a,b");
     assert.equal(firstDelimitedTextLine("﻿a,b\n1,2"), "a,b");
     assert.equal(firstDelimitedTextLine("a,b"), "a,b");
-    assert.equal(firstDelimitedTextLine("\na,b"), "");
+  });
+
+  it("skips blank lines before the header, matching the row parsers", () => {
+    // Taking the first physical line would report these as empty files and
+    // hand delimiter detection a blank line to guess from.
+    assert.equal(firstDelimitedTextLine("\na,b\n1,2"), "a,b");
+    assert.equal(firstDelimitedTextLine("\r\n  \r\na;b\r\n1;2"), "a;b");
+    assert.equal(firstDelimitedTextLine("﻿\n\na,b"), "a,b");
+    assert.equal(firstDelimitedTextLine("\n \n\t\n"), "");
+    assert.equal(firstDelimitedTextLine(""), "");
   });
 });
 

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -6,6 +6,7 @@ import {
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
   firstDelimitedTextLine,
+  hasCompleteHeaderLine,
   parseCoordinate,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
@@ -365,6 +366,21 @@ describe("delimited text row counting and header slicing", () => {
     assert.equal(firstDelimitedTextLine("a,b\r\n1,2"), "a,b");
     assert.equal(firstDelimitedTextLine("﻿a,b\n1,2"), "a,b");
     assert.equal(firstDelimitedTextLine("a,b"), "a,b");
+  });
+
+  it("reports whether a prefix holds the header's own terminator", () => {
+    assert.equal(hasCompleteHeaderLine("a,b\n1,2"), true);
+    assert.equal(hasCompleteHeaderLine("a,b\r\n1,2"), true);
+    assert.equal(hasCompleteHeaderLine("a,b\r1,2"), true);
+    // Cut mid-header: the prefix ends before any terminator.
+    assert.equal(hasCompleteHeaderLine("a,b,c"), false);
+    // The trap this exists for: the blank line supplies a line break, but the
+    // header after it is still unterminated, so a plain newline test would
+    // wrongly call this prefix complete.
+    assert.equal(hasCompleteHeaderLine("\n\na,b,c"), false);
+    assert.equal(hasCompleteHeaderLine("\n\na,b,c\n1,2,3"), true);
+    assert.equal(hasCompleteHeaderLine(""), false);
+    assert.equal(hasCompleteHeaderLine("\n \n"), false);
   });
 
   it("ends the header at a bare CR, so a classic-Mac file is not one long line", () => {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -367,6 +367,15 @@ describe("delimited text row counting and header slicing", () => {
     assert.equal(firstDelimitedTextLine("a,b"), "a,b");
   });
 
+  it("ends the header at a bare CR, so a classic-Mac file is not one long line", () => {
+    const bareCr = "name,longitude,latitude\rA,-78.6,35.7\rB,-80.1,36.2\r";
+    assert.equal(firstDelimitedTextLine(bareCr), "name,longitude,latitude");
+    // The delimiter guess is scored on column count, so feeding it the whole
+    // file as the "header" is what makes this worth pinning.
+    assert.equal(detectDelimitedTextDelimiter("a;b;c\r1;2;3\r"), ";");
+    assert.equal(countDelimitedTextRows(bareCr, ","), 2);
+  });
+
   it("skips blank lines before the header, matching the row parsers", () => {
     // Taking the first physical line would report these as empty files and
     // hand delimiter detection a blank line to guess from.

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { isGeographicCrs, projectedGeoJsonCrs } from "../apps/geolibre-desktop/src/lib/crs-utils";
 import {
+  countDelimitedTextRows,
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
+  firstDelimitedTextLine,
   parseCoordinate,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
@@ -279,6 +281,91 @@ describe("parseCoordinate", () => {
     // test pins that documented behavior so a future change to the heuristic is
     // a conscious one.
     assert.equal(parseCoordinate("45,123", { grouped: true }), 45123);
+  });
+});
+
+// The row scanner slices fields out of the source string and streams rows
+// instead of appending character by character into a fully materialized
+// `string[][]`, which is what made a 146 MB CSV exhaust the renderer heap
+// (GeoLibre#1854). These pin the scanner's behavior so that rewrite cannot
+// silently regress on the awkward inputs the slicing has to special-case.
+describe("delimited text row scanning", () => {
+  function table(text: string, delimiter = ",") {
+    return parseDelimitedTextLayer(text, {
+      delimiter,
+      longitudeField: "",
+      latitudeField: "",
+    });
+  }
+
+  it("keeps a newline inside a quoted field", () => {
+    const result = table('name,note\nAlice,"line one\nline two"\nBob,plain');
+    assert.equal(result.totalRows, 2);
+    assert.equal(result.data.features[0].properties?.note, "line one\nline two");
+    assert.equal(result.data.features[1].properties?.note, "plain");
+  });
+
+  it("unescapes doubled quotes and keeps a bare quote inside an unquoted field", () => {
+    const result = table('name,note\n"say ""hi""",6" pipe');
+    assert.equal(result.data.features[0].properties?.name, 'say "hi"');
+    assert.equal(result.data.features[0].properties?.note, '6" pipe');
+  });
+
+  it("strips a leading BOM from the first header name", () => {
+    const result = table("﻿name,note\nAlice,hello");
+    assert.deepEqual(result.fields, ["name", "note"]);
+    assert.equal(result.data.features[0].properties?.name, "Alice");
+  });
+
+  it("handles CRLF line endings and a final row with no trailing newline", () => {
+    const result = table("name,note\r\nAlice,hello\r\nBob,bye");
+    assert.equal(result.totalRows, 2);
+    assert.equal(result.data.features[1].properties?.name, "Bob");
+  });
+
+  it("skips blank lines between rows", () => {
+    const result = table("name,note\n\nAlice,hello\n \nBob,bye\n");
+    assert.equal(result.totalRows, 2);
+    assert.deepEqual(
+      result.data.features.map((feature) => feature.properties?.name),
+      ["Alice", "Bob"],
+    );
+  });
+
+  it("splits on a multi-character delimiter", () => {
+    const result = table("name||note\nAlice||hello", "||");
+    assert.deepEqual(result.fields, ["name", "note"]);
+    assert.equal(result.data.features[0].properties?.note, "hello");
+  });
+
+  it("pads short rows and drops columns past the header width", () => {
+    const result = table("a,b,c\n1,2\n1,2,3,4");
+    assert.equal(result.data.features[0].properties?.c, "");
+    assert.deepEqual(result.data.features[1].properties, { a: "1", b: "2", c: "3" });
+  });
+
+  it("reads only the header row when just the fields are wanted", () => {
+    // A whole file is passed here in practice, so this must not depend on the
+    // rest of the text being well-formed.
+    assert.deepEqual(parseDelimitedTextFields('name,note\n"unterminated', ","), ["name", "note"]);
+  });
+});
+
+describe("delimited text row counting and header slicing", () => {
+  it("counts data rows, ignoring the header, blank lines, and quoted newlines", () => {
+    assert.equal(countDelimitedTextRows('name,note\nAlice,"a\nb"\n\nBob,c\n', ","), 2);
+  });
+
+  it("counts nothing for a header-only file or a blank delimiter", () => {
+    assert.equal(countDelimitedTextRows("name,note\n", ","), 0);
+    assert.equal(countDelimitedTextRows("name,note\nAlice,hello", ""), 0);
+  });
+
+  it("returns the first line without its terminator, skipping a BOM", () => {
+    assert.equal(firstDelimitedTextLine("a,b\r\n1,2"), "a,b");
+    assert.equal(firstDelimitedTextLine("﻿a,b\n1,2"), "a,b");
+    assert.equal(firstDelimitedTextLine("a,b"), "a,b");
+    assert.equal(firstDelimitedTextLine("\na,b"), "");
   });
 });
 

--- a/tests/delimited-text-drop.test.ts
+++ b/tests/delimited-text-drop.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+
+// tauri-io statically pulls in shpjs, whose bundle reads the browser `self`
+// global at module-eval time; shim it before the dynamic import.
+(globalThis as { self?: unknown }).self ??= globalThis;
+
+type LoadDroppedVectorFiles = (
+  files: File[],
+) => Promise<
+  { data: { features: { properties: Record<string, unknown> | null }[] }; path: string }[]
+>;
+
+let loadDroppedVectorFiles: LoadDroppedVectorFiles;
+
+before(async () => {
+  const mod = await import("../apps/geolibre-desktop/src/lib/tauri-io");
+  loadDroppedVectorFiles = mod.loadDroppedVectorFiles as unknown as LoadDroppedVectorFiles;
+});
+
+/** Mirrors `DELIMITED_TEXT_HEADER_PROBE_BYTES`, which is module-private. */
+const HEADER_PROBE_BYTES = 1024 * 1024;
+
+/**
+ * Builds a CSV whose header is wider than the header probe, with the
+ * coordinate columns last so that a truncated probe could not find them.
+ */
+function wideHeaderCsv(leading: string): { text: string; headerLength: number } {
+  const padding: string[] = [];
+  // 21 bytes per name including its comma, so 55k names clears the 1 MB probe.
+  for (let index = 0; index < 55_000; index += 1) {
+    padding.push(`column_${String(index).padStart(6, "0")}_padded`);
+  }
+  const header = `${padding.join(",")},longitude,latitude`;
+  const row = `${padding.map(() => "x").join(",")},-78.638,35.779`;
+  return { text: `${leading}${header}\n${row}\n`, headerLength: header.length };
+}
+
+describe("dropped delimited text: header probe", () => {
+  it("reads past the probe when the header itself is wider than it", async () => {
+    const { text, headerLength } = wideHeaderCsv("");
+    assert.ok(headerLength > HEADER_PROBE_BYTES, "the header must exceed the probe to be a test");
+
+    const layers = await loadDroppedVectorFiles([new File([text], "wide.csv")]);
+
+    // Truncating the probe would drop the trailing longitude/latitude columns,
+    // coordinate detection would return null, and the file would fall through
+    // to DuckDB instead of loading as points.
+    assert.equal(layers.length, 1);
+    assert.equal(layers[0].data.features.length, 1);
+    assert.equal(layers[0].data.features[0].properties?.longitude, "-78.638");
+  });
+
+  it("still reads past the probe when blank lines precede that header", async () => {
+    // The blank lines put a line break inside the probe, so a check for "any
+    // newline" would call the probe complete and hand back a truncated header.
+    const { text } = wideHeaderCsv("\n\n");
+
+    const layers = await loadDroppedVectorFiles([new File([text], "wide-after-blanks.csv")]);
+
+    assert.equal(layers.length, 1);
+    assert.equal(layers[0].data.features.length, 1);
+    assert.equal(layers[0].data.features[0].properties?.latitude, "35.779");
+  });
+
+  it("loads an ordinary small CSV, which is read whole rather than probed", async () => {
+    const layers = await loadDroppedVectorFiles([
+      new File(["name,longitude,latitude\nRaleigh,-78.638,35.779\n"], "small.csv"),
+    ]);
+
+    assert.equal(layers.length, 1);
+    assert.equal(layers[0].data.features.length, 1);
+    assert.equal(layers[0].data.features[0].properties?.name, "Raleigh");
+  });
+});


### PR DESCRIPTION
Fixes #1854

## The bug

Dragging a ~146 MB CSV into GeoLibre crashes the app with a browser-level Out of Memory page instead of loading the data or failing gracefully.

## Root cause

Two compounding problems in the delimited-text reader (`apps/geolibre-desktop/src/lib/delimited-text.ts`):

1. **Fields were built one character at a time.** `parseDelimitedRows` accumulated each field with `field += char`, which produces a cons-string chain of roughly one node per character. A 500-character description field cost far more than 500 bytes.
2. **The whole file was materialized as a `string[][]` first,** then features were derived from it, so both the rows and the features were live at the same time.

Measured on the reporter's file (56,873 rows x 90 columns, several long free-text columns), the parse needed **4068 MB** of heap, past what the renderer allows, so it died before producing anything.

Separately, delimited text is the one vector path that never reaches the DuckDB loader (that loader has no longitude/latitude column detection, so a plain lon/lat CSV cannot be routed to it). That made it the one path with **no oversized-import guard at all**.

## The fix

- The row scanner is now a generator that **slices fields out of the source string** and **yields one row at a time**. Nothing is buffered, and a field is only assembled from pieces when a quote actually interrupts it. A leading BOM is skipped by offset rather than by copying the string.
- Reading just the header (`parseDelimitedTextFields`, and the new `firstDelimitedTextLine`) now stops at the first line instead of copying and parsing the entire file. The Add Data → Delimited Text panel passes whole files through that path.
- The delimited-text path now runs the **existing** large-dataset confirmation (`confirmLargeDataset`, already translated in all 19 locales, so no new strings). The row count is exact and is only taken for a file already large enough to route to DuckDB, so a normal CSV pays nothing for the check.

On the reporter's file:

| | before | after |
|---|---|---|
| heap used by the parse | 4068 MB | **582 MB** |
| parse time | 8.4 s | **2.1 s** |

## Behaviour compatibility

The rewritten scanner has to preserve some quirks of the original (a quote only opens quoting while the field is still empty; a quote further into an unquoted field is literal; `""` unescapes inside quotes; the trailing-row rule). It was **differentially fuzzed against the original implementation over 500,000 randomized inputs** built from quotes, escaped quotes, BOMs, `\n`/`\r`/`\r\n`, whitespace, multi-character delimiters, and blank and trailing rows, comparing full parsed output and the new row count. **No divergence.**

## Verification

Driven in the real app (`npm run dev`) with the reporter's exact dataset, the public Inside Airbnb Sicily 2026-06-30 `listings.csv` (153,660,796 bytes, 56,873 rows x 90 columns), dropped onto the window the same way the issue describes:

- **Before the fix:** the renderer dies and the tab goes to `about:blank` — the reported crash, reproduced.
- **After the fix:** the layer loads in **both light and dark themes**, 56,873 features, map fits Sicily's bbox, 0 console errors. Measured on a fresh page 20 s after the drop, the renderer sits at ~2.45 GB of its 4.19 GB limit (that is the whole app, including MapLibre's own copy of the data and uncollected garbage, not just the parse).
- Attribute values were spot-checked against the source file with Python's `csv` module: a row's `name`, `host_name`, empty `host_since`, and its long quoted `description` containing commas all match exactly, confirming column alignment holds across all 90 columns.
- The new guard was exercised with a synthetic 107 MB / 200,000-row CSV: the confirmation appears with an exact count, declining cancels cleanly (no layer, no error, heap back to 297 MB), and accepting loads the layer.

`npm run test:frontend:coverage` (5872 pass, 0 fail; `delimited-text.ts` at 98.4% lines), `npm run typecheck`, and `pre-commit` on the changed files all pass. Ten new unit tests pin the scanner on quoted newlines, escaped quotes, BOMs, CRLF, blank lines, multi-character delimiters, ragged rows, and the new counting and header-slicing helpers.

## Note on scope

This makes the reported file load, with roughly 1.7x headroom left in the renderer. It does not make delimited-text import cheap in absolute terms: a CSV substantially larger than the reporter's still will not fit, and while it now hits the confirmation rather than a crash page, accepting can still run the renderer out of memory. A truly streaming import that never materializes a full GeoJSON FeatureCollection would be a larger change and is not attempted here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved CSV and TSV imports for large datasets with lower memory usage.
  - Added confirmation safeguards before processing oversized files.
  - Added efficient streaming support for headers, rows, and feature creation.
  - Expanded support for quoted fields, escaped quotes, multiline values, multi-character delimiters, blank rows, BOMs, and varied line endings.
  - Preserved fallback handling for delimited data without geographic coordinates.

- **Bug Fixes**
  - Improved parsing of uneven rows, header-only files, and trailing rows.
  - Enhanced delimiter detection and row counting for more reliable imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
