### PR TITLE
feat(basemap): add a Regional section with China basemaps to both pickers

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.6",
-    "maplibre-gl-basemap-control": "^0.13.0",
+    "maplibre-gl-basemap-control": "^0.14.0",
     "maplibre-gl-components": "^0.30.0",
     "maplibre-gl-duckdb": "^0.2.4",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -6,6 +6,7 @@ import {
   PLANETARY_BASEMAP_GROUPS,
   PLANETARY_BASEMAPS,
   PROTOMAPS_BASEMAPS,
+  REGIONAL_BASEMAPS,
   useAppStore,
   type MapViewState,
 } from "@geolibre/core";
@@ -19,6 +20,7 @@ import { planetaryBasemapLabel, planetaryBasemapSectionKey } from "../../lib/pla
 import { buildRemotePmtilesBasemap, isPmtilesStyleUrl } from "../../lib/pmtiles-basemap-url";
 import { clearProjectSnapshots } from "../../lib/project-history-store";
 import { CollapsibleSection } from "../CollapsibleSection";
+import { RegionalBasemapSection } from "../panels/RegionalBasemapSection";
 import {
   Button,
   cn,
@@ -54,6 +56,7 @@ type BasemapChoice =
   | (typeof OPENFREEMAP_BASEMAPS)[number]["id"]
   | (typeof PROTOMAPS_BASEMAPS)[number]["id"]
   | (typeof PLANETARY_BASEMAPS)[number]["id"]
+  | (typeof REGIONAL_BASEMAPS)[number]["id"]
   | typeof CUSTOM_BASEMAP_ID
   | typeof BLANK_BASEMAP_ID;
 
@@ -154,6 +157,12 @@ export function NewProjectDialog({
     () => PLANETARY_BASEMAPS.find((basemap) => basemap.id === selectedBasemapId),
     [selectedBasemapId],
   );
+  // Regional basemaps are their own list too, but unlike the planetary ones
+  // they cover Earth, so selecting one leaves the project's ellipsoid alone.
+  const selectedRegional = useMemo(
+    () => REGIONAL_BASEMAPS.find((basemap) => basemap.id === selectedBasemapId),
+    [selectedBasemapId],
+  );
   const isCustomUrlValid = useMemo(() => {
     if (!customStyleUrl) return false;
     try {
@@ -165,7 +174,10 @@ export function NewProjectDialog({
   }, [customStyleUrl]);
   const canCreate = isCustomSelected
     ? isCustomUrlValid
-    : isBlankSelected || Boolean(selectedPreset) || Boolean(selectedPlanetary);
+    : isBlankSelected ||
+      Boolean(selectedPreset) ||
+      Boolean(selectedPlanetary) ||
+      Boolean(selectedRegional);
 
   const resetForm = () => {
     setSelectedBasemapId(DEFAULT_BASEMAP_ID);
@@ -190,7 +202,7 @@ export function NewProjectDialog({
         : customStyleUrl
       : isBlankSelected
         ? BLANK_BASEMAP
-        : (selectedPreset ?? selectedPlanetary)?.styleUrl;
+        : (selectedPreset ?? selectedPlanetary ?? selectedRegional)?.styleUrl;
     if (basemapStyleUrl == null) return;
 
     newProject({
@@ -378,6 +390,11 @@ export function NewProjectDialog({
                     </div>
                   </div>
                 ) : null}
+
+                <RegionalBasemapSection
+                  selectedId={selectedBasemapId}
+                  onSelect={(basemap) => setSelectedBasemapId(basemap.id)}
+                />
 
                 {PLANETARY_BASEMAP_GROUPS.map((group) => {
                   const heading = t(planetaryBasemapSectionKey(group.id));

--- a/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
@@ -1,9 +1,11 @@
 import {
   BLANK_BASEMAP,
+  REGIONAL_BASEMAPS,
   PLANETARY_BASEMAP_GROUPS,
   PLANETARY_BASEMAPS,
   useAppStore,
   type PlanetaryBasemap,
+  type RegionalBasemap,
 } from "@geolibre/core";
 import {
   Button,
@@ -30,6 +32,7 @@ import { isOfflineBasemapSentinel, PROTOMAPS_FLAVORS, type ProtomapsFlavor } fro
 import { planetaryBasemapLabel, planetaryBasemapSectionKey } from "../../lib/planetary-sections";
 import { buildRemotePmtilesBasemap, isPmtilesStyleUrl } from "../../lib/pmtiles-basemap-url";
 import { CollapsibleSection } from "../CollapsibleSection";
+import { RegionalBasemapSection } from "./RegionalBasemapSection";
 
 // Picking the "Liberty 3D" preset applies the Liberty style and tilts the
 // current camera into a 3D perspective in place (matching the New Project
@@ -134,6 +137,11 @@ export function BasemapPickerDialog({ open, onOpenChange }: BasemapPickerDialogP
         name: b.name,
         styleUrl: b.styleUrl,
       })),
+      ...REGIONAL_BASEMAPS.map((b) => ({
+        id: b.id,
+        name: b.name,
+        styleUrl: b.styleUrl,
+      })),
     ],
     [openFreeMapPresets, protomapsPresets],
   );
@@ -189,6 +197,13 @@ export function BasemapPickerDialog({ open, onOpenChange }: BasemapPickerDialogP
   // control renders it as the correct sphere.
   const applyPlanetary = (basemap: PlanetaryBasemap) => {
     applyPlanetaryBasemap(basemap);
+    onOpenChange(false);
+  };
+
+  // A regional basemap is a plain raster style for Earth, so unlike the
+  // planetary ones it only swaps the style and leaves the ellipsoid alone.
+  const applyRegional = (basemap: RegionalBasemap) => {
+    setBasemapStyleUrl(basemap.styleUrl);
     onOpenChange(false);
   };
 
@@ -260,6 +275,8 @@ export function BasemapPickerDialog({ open, onOpenChange }: BasemapPickerDialogP
               </div>
             </div>
           ) : null}
+
+          <RegionalBasemapSection selectedId={activeChoice} onSelect={applyRegional} />
 
           {PLANETARY_BASEMAP_GROUPS.map((group) => {
             const heading = t(planetaryBasemapSectionKey(group.id));

--- a/apps/geolibre-desktop/src/components/panels/RegionalBasemapSection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RegionalBasemapSection.tsx
@@ -1,0 +1,68 @@
+import { REGIONAL_BASEMAP_GROUPS, type RegionalBasemap } from "@geolibre/core";
+import { cn } from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+import { regionalBasemapRegionKey } from "../../lib/regional-sections";
+import { CollapsibleSection } from "../CollapsibleSection";
+
+interface RegionalBasemapSectionProps {
+  /** Id of the currently selected basemap, so one button highlights. */
+  selectedId?: string;
+  onSelect: (basemap: RegionalBasemap) => void;
+}
+
+/**
+ * The Regional basemaps section shared by the New Project and Change Basemap
+ * panels, so the two cannot drift.
+ *
+ * These are basemaps for places the default catalog does not serve well —
+ * today, providers reachable from inside mainland China, where OpenFreeMap and
+ * Protomaps are slow or unreachable. One collapsed section holds every region,
+ * each under its own heading, so a future region is an entry in
+ * {@link REGIONAL_BASEMAP_GROUPS} rather than another top-level section.
+ *
+ * Collapsed by default, since most users never need a regional basemap, but
+ * auto-expanded when one of them is the current selection so an active choice
+ * is never hidden behind a closed heading.
+ */
+export function RegionalBasemapSection({ selectedId, onSelect }: RegionalBasemapSectionProps) {
+  const { t } = useTranslation();
+  const selectionIsRegional = REGIONAL_BASEMAP_GROUPS.some((group) =>
+    group.basemaps.some((basemap) => basemap.id === selectedId),
+  );
+
+  return (
+    <CollapsibleSection
+      title={t("basemapPicker.sectionRegional")}
+      defaultOpen={selectionIsRegional}
+    >
+      <div className="space-y-4">
+        {REGIONAL_BASEMAP_GROUPS.map((group) => (
+          <div key={group.id} className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t(regionalBasemapRegionKey(group.id))}
+            </p>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {group.basemaps.map((basemap) => (
+                <button
+                  key={basemap.id}
+                  type="button"
+                  aria-pressed={basemap.id === selectedId}
+                  className={cn(
+                    "flex min-h-10 items-center justify-center rounded-md border px-3 py-1.5 text-center text-sm font-medium leading-tight transition-colors",
+                    "hover:bg-accent hover:text-accent-foreground",
+                    basemap.id === selectedId
+                      ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
+                      : "border-input bg-background",
+                  )}
+                  onClick={() => onSelect(basemap)}
+                >
+                  {basemap.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -239,7 +239,9 @@
     "invalidUrl": "أدخل عنوان URL صالحًا للنمط يبدأ بـ HTTP أو HTTPS.",
     "sectionMoon": "القمر",
     "sectionMars": "المريخ",
-    "sectionOther": "أجرام سماوية أخرى"
+    "sectionOther": "أجرام سماوية أخرى",
+    "sectionRegional": "إقليمية",
+    "regionChina": "الصين (中国)"
   },
   "planetSwitcher": {
     "label": "الجرم السماوي",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Geben Sie eine gültige HTTP- oder HTTPS-Style-URL ein.",
     "sectionMoon": "Der Mond",
     "sectionMars": "Mars",
-    "sectionOther": "Andere Himmelskörper"
+    "sectionOther": "Andere Himmelskörper",
+    "sectionRegional": "Regional",
+    "regionChina": "China (中国)"
   },
   "planetSwitcher": {
     "label": "Himmelskörper",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Enter a valid HTTP or HTTPS style URL.",
     "sectionMoon": "The Moon",
     "sectionMars": "Mars",
-    "sectionOther": "Other celestial bodies"
+    "sectionOther": "Other celestial bodies",
+    "sectionRegional": "Regional",
+    "regionChina": "China (中国)"
   },
   "planetSwitcher": {
     "label": "Celestial body",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Introduzca una URL de estilo HTTP o HTTPS válida.",
     "sectionMoon": "La Luna",
     "sectionMars": "Marte",
-    "sectionOther": "Otros cuerpos celestes"
+    "sectionOther": "Otros cuerpos celestes",
+    "sectionRegional": "Regional",
+    "regionChina": "China (中国)"
   },
   "planetSwitcher": {
     "label": "Cuerpo celeste",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -231,7 +231,9 @@
     "invalidUrl": "یک نشانی شیوهٔ نمایش معتبر HTTP یا HTTPS وارد کنید.",
     "sectionMoon": "ماه",
     "sectionMars": "مریخ",
-    "sectionOther": "دیگر اجرام آسمانی"
+    "sectionOther": "دیگر اجرام آسمانی",
+    "sectionRegional": "منطقه‌ای",
+    "regionChina": "چین (中国)"
   },
   "planetSwitcher": {
     "label": "جرم آسمانی",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Entrez une URL de style HTTP ou HTTPS valide.",
     "sectionMoon": "La Lune",
     "sectionMars": "Mars",
-    "sectionOther": "Autres corps célestes"
+    "sectionOther": "Autres corps célestes",
+    "sectionRegional": "Régional",
+    "regionChina": "Chine (中国)"
   },
   "planetSwitcher": {
     "label": "Corps céleste",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -231,7 +231,9 @@
     "invalidUrl": "एक मान्य HTTP या HTTPS स्टाइल URL दर्ज करें।",
     "sectionMoon": "चंद्रमा",
     "sectionMars": "मंगल",
-    "sectionOther": "अन्य खगोलीय पिंड"
+    "sectionOther": "अन्य खगोलीय पिंड",
+    "sectionRegional": "क्षेत्रीय",
+    "regionChina": "चीन (中国)"
   },
   "planetSwitcher": {
     "label": "खगोलीय पिंड",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -229,7 +229,9 @@
     "invalidUrl": "Masukkan URL gaya HTTP atau HTTPS yang valid.",
     "sectionMoon": "Bulan",
     "sectionMars": "Mars",
-    "sectionOther": "Benda langit lainnya"
+    "sectionOther": "Benda langit lainnya",
+    "sectionRegional": "Regional",
+    "regionChina": "Tiongkok (中国)"
   },
   "planetSwitcher": {
     "label": "Benda langit",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Inserisci un URL di stile valido, in formato HTTP o HTTPS.",
     "sectionMoon": "La Luna",
     "sectionMars": "Marte",
-    "sectionOther": "Altri corpi celesti"
+    "sectionOther": "Altri corpi celesti",
+    "sectionRegional": "Regionale",
+    "regionChina": "Cina (中国)"
   },
   "planetSwitcher": {
     "label": "Corpo celeste",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -231,7 +231,7 @@
     "sectionMars": "火星",
     "sectionOther": "その他の天体",
     "sectionRegional": "地域",
-    "regionChina": "中国 (中国)"
+    "regionChina": "中国"
   },
   "planetSwitcher": {
     "label": "天体",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -229,7 +229,9 @@
     "invalidUrl": "有効なHTTPまたはHTTPSのスタイルURLを入力してください。",
     "sectionMoon": "月",
     "sectionMars": "火星",
-    "sectionOther": "その他の天体"
+    "sectionOther": "その他の天体",
+    "sectionRegional": "地域",
+    "regionChina": "中国 (中国)"
   },
   "planetSwitcher": {
     "label": "天体",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -231,7 +231,9 @@
     "invalidUrl": "შეიყვანეთ სწორი HTTP ან HTTPS სტილის URL.",
     "sectionMoon": "მთვარე",
     "sectionMars": "მარსი",
-    "sectionOther": "სხვა ციური სხეულები"
+    "sectionOther": "სხვა ციური სხეულები",
+    "sectionRegional": "რეგიონული",
+    "regionChina": "ჩინეთი (中国)"
   },
   "planetSwitcher": {
     "label": "ციური სხეული",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -229,7 +229,9 @@
     "invalidUrl": "유효한 HTTP 또는 HTTPS 스타일 URL을 입력하세요.",
     "sectionMoon": "달",
     "sectionMars": "화성",
-    "sectionOther": "기타 천체"
+    "sectionOther": "기타 천체",
+    "sectionRegional": "지역",
+    "regionChina": "중국 (中国)"
   },
   "planetSwitcher": {
     "label": "천체",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Voer een geldige HTTP- of HTTPS-stijl-URL in.",
     "sectionMoon": "De Maan",
     "sectionMars": "Mars",
-    "sectionOther": "Andere hemellichamen"
+    "sectionOther": "Andere hemellichamen",
+    "sectionRegional": "Regionaal",
+    "regionChina": "China (中国)"
   },
   "planetSwitcher": {
     "label": "Hemellichaam",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Digite uma URL de estilo HTTP ou HTTPS válida.",
     "sectionMoon": "A Lua",
     "sectionMars": "Marte",
-    "sectionOther": "Outros corpos celestes"
+    "sectionOther": "Outros corpos celestes",
+    "sectionRegional": "Regional",
+    "regionChina": "China (中国)"
   },
   "planetSwitcher": {
     "label": "Corpo celeste",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -235,7 +235,9 @@
     "invalidUrl": "Введите корректный URL стиля (HTTP или HTTPS).",
     "sectionMoon": "Луна",
     "sectionMars": "Марс",
-    "sectionOther": "Другие небесные тела"
+    "sectionOther": "Другие небесные тела",
+    "sectionRegional": "Региональные",
+    "regionChina": "Китай (中国)"
   },
   "planetSwitcher": {
     "label": "Небесное тело",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -229,7 +229,9 @@
     "invalidUrl": "ป้อน URL สไตล์แบบ HTTP หรือ HTTPS ที่ถูกต้อง",
     "sectionMoon": "ดวงจันทร์",
     "sectionMars": "ดาวอังคาร",
-    "sectionOther": "เทหวัตถุอื่น ๆ"
+    "sectionOther": "เทหวัตถุอื่น ๆ",
+    "sectionRegional": "ระดับภูมิภาค",
+    "regionChina": "จีน (中国)"
   },
   "planetSwitcher": {
     "label": "เทหวัตถุ",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -231,7 +231,9 @@
     "invalidUrl": "Geçerli bir HTTP veya HTTPS stil URL'si girin.",
     "sectionMoon": "Ay",
     "sectionMars": "Mars",
-    "sectionOther": "Diğer gök cisimleri"
+    "sectionOther": "Diğer gök cisimleri",
+    "sectionRegional": "Bölgesel",
+    "regionChina": "Çin (中国)"
   },
   "planetSwitcher": {
     "label": "Gök cismi",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -735,6 +735,8 @@
     "sectionMoon": "Mặt Trăng",
     "sectionMars": "Sao Hỏa",
     "sectionOther": "Các thiên thể khác",
+    "sectionRegional": "Khu vực",
+    "regionChina": "Trung Quốc (中国)",
     "title": "Thay đổi bản đồ cơ sở",
     "applyCustom": "Áp dụng"
   },

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -229,7 +229,9 @@
     "invalidUrl": "请输入有效的 HTTP 或 HTTPS 样式 URL。",
     "sectionMoon": "月球",
     "sectionMars": "火星",
-    "sectionOther": "其他天体"
+    "sectionOther": "其他天体",
+    "sectionRegional": "区域",
+    "regionChina": "中国"
   },
   "planetSwitcher": {
     "label": "天体",

--- a/apps/geolibre-desktop/src/lib/regional-sections.ts
+++ b/apps/geolibre-desktop/src/lib/regional-sections.ts
@@ -1,0 +1,17 @@
+import type { RegionalBasemapRegionId } from "@geolibre/core";
+
+/**
+ * The i18n key for a region's heading inside the Regional basemaps section.
+ * Shared by the New Project and Change Basemap panels.
+ *
+ * Returns a literal key so the typed `t()` accepts it. The switch is exhaustive
+ * over {@link RegionalBasemapRegionId}, so a new region fails to compile until
+ * a heading is added here — the same guard `planetaryBasemapSectionKey` gives
+ * the celestial-body sections.
+ */
+export function regionalBasemapRegionKey(regionId: RegionalBasemapRegionId) {
+  switch (regionId) {
+    case "china":
+      return "basemapPicker.regionChina" as const;
+  }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -644,6 +644,38 @@ VITE_STADIA_API_KEY=your_stadia_api_key         # https://client.stadiamaps.com
 
 Protomaps reuses the key described in [Optional basemap credentials](#optional-basemap-credentials) above — set it once and both places pick it up. Until each key is set, the panel shows a "Get a … API key" prompt in place of the basemap rather than loading tiles.
 
+## Basemaps in mainland China
+
+GeoLibre's default basemaps (OpenFreeMap, Protomaps) are hosted outside mainland China with no presence inside it, so from there they range from slow to unreachable, as does most of the Basemaps control's catalog. Two places offer basemaps served from inside China.
+
+### The Regional section (no key)
+
+**New project** and **Change basemap** both carry a collapsed **Regional → China (中国)** section with five keyless basemaps: 高德地图, 高德卫星, 高德混合 (Amap street, satellite, and satellite-with-labels) and 腾讯地图, 腾讯深色 (Tencent street and dark). Pick one and it applies like any other basemap. Nothing to configure.
+
+### The Basemaps control (adds Tianditu)
+
+The Basemaps control plugin carries the same Amap and Tencent tiles plus **Tianditu (天地图)**, China's official National Platform for Common Geospatial Information Services: vector, imagery, and terrain, each with a separate label overlay. Search the panel for `Tianditu`, `Amap`, or `Tencent`, or for their Chinese names.
+
+Tianditu needs a free key from [console.tianditu.gov.cn](https://console.tianditu.gov.cn/api/key). Set it in **Settings → Environment Variables** (or type it into the panel's **API keys** view):
+
+```env
+VITE_TIANDITU_API_KEY=your_tianditu_api_key   # https://console.tianditu.gov.cn/api/key
+```
+
+Tianditu ships each basemap and its labels as separate layers. Turn on **Add basemaps (stack instead of replace)** in the panel to lay a label overlay over its base.
+
+### Which to pick
+
+| Provider | Datum | Key | Where |
+|----------|-------|-----|-------|
+| Tianditu (天地图) | CGCS2000 | required | Basemaps control |
+| Amap (高德地图) | GCJ-02 | none | Regional section, Basemaps control |
+| Tencent Maps (腾讯地图) | GCJ-02 | none | Regional section, Basemaps control |
+
+**Prefer Tianditu whenever the map also carries your own data.** Chinese law requires public map services to publish in GCJ-02, an offset datum that displaces features by roughly 100 to 700 m from WGS84; nothing in GeoLibre or MapLibre applies the shift, so your layers will visibly misalign over Amap or Tencent. Tianditu publishes in CGCS2000, which is close enough to WGS84 that ordinary data lines up.
+
+The Amap and Tencent tile endpoints are not documented public APIs. They are fine for exploration, but obtain a commercial key from the provider before building a product on either.
+
 Keys set via **Settings → Environment Variables**, or typed directly into the panel's **API keys** view (the key button in the panel header), apply at runtime without reopening the project. A key baked into `apps/geolibre-desktop/.env.local` is read at build time and needs a dev server restart. When `VITE_AMAZON_LOCATION_API_KEY` is set in the environment it takes precedence over a key typed in the panel; removing it from the environment clears it on the next page reload.
 
 ## Optional 3D globe credentials (Cesium Ion)

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.6",
-        "maplibre-gl-basemap-control": "^0.13.0",
+        "maplibre-gl-basemap-control": "^0.14.0",
         "maplibre-gl-components": "^0.30.0",
         "maplibre-gl-duckdb": "^0.2.4",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17332,9 +17332,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.13.0.tgz",
-      "integrity": "sha512-rxeqZFjGDqh93UiP2Y6C9Emb/HqfamnW0TOBpjPH+h70Syz1QhycOKp4limqmqSRNaZ/zNN3KhOi/uq2as6frw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.14.0.tgz",
+      "integrity": "sha512-ZRXy7A+q096B1icHO4ghdp3ldJgfL+z/exch9GPm1dFsT1gooWUplZ03wVrzfxFKA6PZ42AmuSBhPxjRupyGKQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23149,7 +23149,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.6",
-        "maplibre-gl-basemap-control": "^0.13.0",
+        "maplibre-gl-basemap-control": "^0.14.0",
         "maplibre-gl-components": "^0.30.0",
         "maplibre-gl-duckdb": "^0.2.4",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./marker-shape";
 export * from "./hyperlink";
 export * from "./photo";
 export * from "./ellipsoids";
+export * from "./regional-basemaps";
 export * from "./geojson-z";
 export * from "./color-ramp";
 export * from "./paths";

--- a/packages/core/src/regional-basemaps.ts
+++ b/packages/core/src/regional-basemaps.ts
@@ -1,0 +1,183 @@
+/**
+ * Raster basemaps for regions the default catalog does not serve well.
+ *
+ * Today that means mainland China: GeoLibre's defaults (OpenFreeMap, Protomaps)
+ * and almost every provider in the Basemaps control are hosted outside it with
+ * no presence inside, so from there they range from slow to unreachable. These
+ * entries are served from inside China and give those users a basemap that
+ * loads.
+ *
+ * The mechanism mirrors {@link PlanetaryBasemap}: `styleUrl` is a
+ * `geolibre://regional-basemap/<id>` sentinel that the map controller's
+ * `resolveMapStyle` expands into a raster style at apply time (it is not a
+ * fetchable URL). A separate sentinel prefix from the planetary one keeps the
+ * two apart, because selecting a planetary basemap also switches the project's
+ * celestial body, which must not happen here.
+ */
+
+/**
+ * The regions the pickers group these basemaps under. Each gets its own
+ * heading and explanatory note inside the single "Regional" section, so a
+ * future region slots in without the section itself becoming country-specific.
+ */
+export type RegionalBasemapRegionId = "china";
+
+/**
+ * A raster basemap for a region, rendered from XYZ (or TMS) tiles.
+ */
+export interface RegionalBasemap {
+  id: string;
+  /** Which region heading this basemap sits under. */
+  region: RegionalBasemapRegionId;
+  /**
+   * Display name, in the language of the region the basemap serves. These are
+   * Chinese-market services whose users know them by their Chinese names, and
+   * the section heading already says which region they belong to, so the labels
+   * are not translated the way UI strings are.
+   */
+  name: string;
+  /** Sentinel stored as the basemap style URL. */
+  styleUrl: string;
+  /** XYZ (or TMS, see {@link scheme}) tile template. */
+  tileUrl: string;
+  /**
+   * An optional transparent overlay drawn above {@link tileUrl}, so a satellite
+   * basemap can ship with its roads and labels burnt in as one selectable
+   * basemap rather than something the user has to stack by hand.
+   */
+  overlayTileUrl?: string;
+  /**
+   * Tile row ordering. Tencent numbers rows from the bottom (**TMS**); Amap is
+   * standard XYZ. Omit for XYZ; MapLibre defaults to `"xyz"` when absent.
+   */
+  scheme?: "tms";
+  /** Max native zoom of the source (MapLibre overzooms beyond this). */
+  maxZoom: number;
+  /** Attribution shown on the map. */
+  attribution: string;
+  /**
+   * True when the tiles are drawn in GCJ-02, the offset datum Chinese law
+   * mandates for public map services. Neither GeoLibre nor MapLibre applies the
+   * shift, so WGS84 data laid over these lands roughly 100 to 700 m off (see
+   * docs/getting-started.md). Not every regional basemap is offset — Tianditu
+   * publishes in CGCS2000 and lines up — so this records which are, rather than
+   * leaving a caveat that applies to some entries implied by the region.
+   */
+  gcj02?: boolean;
+}
+
+export const REGIONAL_BASEMAP_SENTINEL_PREFIX = "geolibre://regional-basemap/";
+
+const AMAP_ATTRIBUTION = '&copy; <a href="https://www.amap.com">高德地图 Amap</a>';
+const TENCENT_ATTRIBUTION = '&copy; <a href="https://map.qq.com">腾讯地图 Tencent Maps</a>';
+
+const sentinel = (id: string) => `${REGIONAL_BASEMAP_SENTINEL_PREFIX}${id}`;
+
+// Amap serves each product from four numbered hosts; MapLibre takes a single
+// template per source, so pin host 01. Browsers multiplex over HTTP/2, which
+// makes the sharding a non-issue. `style` selects the product: 7 street, 6
+// imagery, 8 roads-and-labels.
+const AMAP_STREET_URL =
+  "https://wprd01.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scl=1&style=7&x={x}&y={y}&z={z}";
+const AMAP_SATELLITE_URL = "https://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}";
+const AMAP_LABELS_URL = "https://webst01.is.autonavi.com/appmaptile?style=8&x={x}&y={y}&z={z}";
+
+const tencentUrl = (styleId: number) =>
+  `https://rt0.map.gtimg.com/tile?z={z}&x={x}&y={y}&styleid=${styleId}&scene=0`;
+
+/**
+ * Basemaps served from inside mainland China.
+ *
+ * Zoom limits are each source's probed maximum, so MapLibre overzooms (blurs)
+ * rather than painting a placeholder: Amap's imagery returns a "no imagery"
+ * tile rather than a 404 past zoom 18, and Tencent 400s past 19 with zoom 19
+ * already blank.
+ */
+export const CHINA_BASEMAPS: readonly RegionalBasemap[] = [
+  {
+    id: "amap-street",
+    region: "china",
+    name: "高德地图",
+    styleUrl: sentinel("amap-street"),
+    tileUrl: AMAP_STREET_URL,
+    maxZoom: 19,
+    attribution: AMAP_ATTRIBUTION,
+    gcj02: true,
+  },
+  {
+    id: "amap-satellite",
+    region: "china",
+    name: "高德卫星",
+    styleUrl: sentinel("amap-satellite"),
+    tileUrl: AMAP_SATELLITE_URL,
+    maxZoom: 18,
+    attribution: AMAP_ATTRIBUTION,
+    gcj02: true,
+  },
+  {
+    id: "amap-hybrid",
+    region: "china",
+    name: "高德混合",
+    styleUrl: sentinel("amap-hybrid"),
+    tileUrl: AMAP_SATELLITE_URL,
+    overlayTileUrl: AMAP_LABELS_URL,
+    maxZoom: 18,
+    attribution: AMAP_ATTRIBUTION,
+    gcj02: true,
+  },
+  {
+    id: "tencent-street",
+    region: "china",
+    name: "腾讯地图",
+    styleUrl: sentinel("tencent-street"),
+    tileUrl: tencentUrl(1),
+    scheme: "tms",
+    maxZoom: 18,
+    attribution: TENCENT_ATTRIBUTION,
+    gcj02: true,
+  },
+  {
+    id: "tencent-dark",
+    region: "china",
+    name: "腾讯深色",
+    styleUrl: sentinel("tencent-dark"),
+    tileUrl: tencentUrl(4),
+    scheme: "tms",
+    maxZoom: 18,
+    attribution: TENCENT_ATTRIBUTION,
+    gcj02: true,
+  },
+];
+
+/** Every regional basemap, across all regions. */
+export const REGIONAL_BASEMAPS: readonly RegionalBasemap[] = CHINA_BASEMAPS;
+
+/**
+ * The regional basemaps grouped for display, one entry per region. Both the New
+ * Project and Change Basemap panels render this inside a single collapsible
+ * "Regional" section, so adding a region is a change here rather than in two
+ * dialogs.
+ */
+export const REGIONAL_BASEMAP_GROUPS: readonly {
+  id: RegionalBasemapRegionId;
+  basemaps: readonly RegionalBasemap[];
+}[] = [{ id: "china", basemaps: CHINA_BASEMAPS }];
+
+/** Look up a regional basemap by its `geolibre://regional-basemap/<id>` sentinel. */
+export function getRegionalBasemapByStyleUrl(
+  styleUrl: string | undefined,
+): RegionalBasemap | undefined {
+  if (!styleUrl) return undefined;
+  return REGIONAL_BASEMAPS.find((basemap) => basemap.styleUrl === styleUrl);
+}
+
+/** Look up a regional basemap by id. */
+export function getRegionalBasemapById(id: string | undefined): RegionalBasemap | undefined {
+  if (!id) return undefined;
+  return REGIONAL_BASEMAPS.find((basemap) => basemap.id === id);
+}
+
+/** Whether a style URL is a regional-basemap sentinel, resolvable or not. */
+export function isRegionalBasemapSentinel(styleUrl: string | undefined): boolean {
+  return Boolean(styleUrl?.startsWith(REGIONAL_BASEMAP_SENTINEL_PREFIX));
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -3,7 +3,10 @@ import {
   DEFAULT_BASEMAP,
   DEFAULT_PROJECT_PREFERENCES,
   getPlanetaryBasemapByStyleUrl,
+  getRegionalBasemapByStyleUrl,
+  isRegionalBasemapSentinel,
   PLANETARY_BASEMAP_SENTINEL_PREFIX,
+  type RegionalBasemap,
   scaleAltitudeToActiveBody,
   useAppStore,
 } from "@geolibre/core";
@@ -219,6 +222,21 @@ function createBlankMapStyle(): maplibregl.StyleSpecification {
   };
 }
 
+/**
+ * Whether a basemap style URL is one of GeoLibre's internal sentinels rather
+ * than something fetchable. Every sentinel kind — planetary (`geolibre://
+ * basemap/`), offline (`geolibre://offline-basemap/`), and regional
+ * (`geolibre://regional-basemap/`) — is expanded to an inline style by
+ * {@link resolveMapStyle} and would throw if handed to `fetch`.
+ *
+ * Matching on the scheme rather than enumerating the three prefixes keeps a
+ * fourth sentinel kind from silently reintroducing that fetch, and covers a
+ * sentinel whose id no longer resolves (which the per-kind lookups miss).
+ */
+function isGeoLibreSentinelStyleUrl(styleUrl: string | undefined): boolean {
+  return Boolean(styleUrl?.startsWith("geolibre://"));
+}
+
 function resolveMapStyle(styleUrl: string | undefined): string | maplibregl.StyleSpecification {
   if (styleUrl === BLANK_BASEMAP) return createBlankMapStyle();
   const offline = getOfflineBasemapStyle(styleUrl);
@@ -247,7 +265,66 @@ function resolveMapStyle(styleUrl: string | undefined): string | maplibregl.Styl
     console.warn(`Unknown planetary basemap "${styleUrl}"; falling back to the default basemap.`);
     return DEFAULT_BASEMAP;
   }
+  const regional = getRegionalBasemapByStyleUrl(styleUrl);
+  if (regional) return createRegionalMapStyle(regional);
+  // Same guard as the planetary path: a regional sentinel that no longer
+  // resolves must not be handed to MapLibre as a style URL.
+  if (isRegionalBasemapSentinel(styleUrl)) {
+    console.warn(`Unknown regional basemap "${styleUrl}"; falling back to the default basemap.`);
+    return DEFAULT_BASEMAP;
+  }
   return styleUrl ?? DEFAULT_BASEMAP;
+}
+
+/**
+ * A raster style for a {@link RegionalBasemap} — today the mainland-China
+ * providers, whose tiles are ordinary Web-Mercator images (XYZ, or TMS when
+ * `scheme` says so). A basemap with an `overlayTileUrl` (Amap Hybrid) stacks
+ * its transparent roads-and-labels tiles above the imagery, so one selection
+ * gives a labeled satellite basemap.
+ *
+ * Unlike the planetary styles this uses a light background rather than black:
+ * these cover Earth, so a gap should read as missing map, not as space.
+ */
+function createRegionalMapStyle(basemap: RegionalBasemap): maplibregl.StyleSpecification {
+  const rasterSource = (tiles: string, withAttribution: boolean) =>
+    ({
+      type: "raster",
+      tiles: [tiles],
+      tileSize: 256,
+      maxzoom: basemap.maxZoom,
+      ...(basemap.scheme ? { scheme: basemap.scheme } : {}),
+      // Credit the provider once; repeating it on the overlay would print the
+      // same attribution twice in the map's attribution control.
+      ...(withAttribution ? { attribution: basemap.attribution } : {}),
+    }) satisfies maplibregl.RasterSourceSpecification;
+
+  return {
+    version: 8,
+    sources: {
+      "regional-basemap": rasterSource(basemap.tileUrl, true),
+      ...(basemap.overlayTileUrl
+        ? { "regional-basemap-overlay": rasterSource(basemap.overlayTileUrl, false) }
+        : {}),
+    },
+    layers: [
+      {
+        id: BLANK_BACKGROUND_LAYER_ID,
+        type: "background",
+        paint: { "background-color": BLANK_BACKGROUND_COLOR },
+      },
+      { id: "regional-basemap", type: "raster", source: "regional-basemap" },
+      ...(basemap.overlayTileUrl
+        ? [
+            {
+              id: "regional-basemap-overlay",
+              type: "raster" as const,
+              source: "regional-basemap-overlay",
+            },
+          ]
+        : []),
+    ],
+  };
 }
 
 /**
@@ -1773,16 +1850,14 @@ export class MapController {
     this.layerControlSignature = this.createLayerControlSignature(layerControlConfig);
     this.layerControl = new LayerControl({
       // The layer control fetches this URL to introspect the basemap's layers.
-      // Both planetary and offline basemaps use a non-fetchable `geolibre://`
-      // sentinel (expanded to an inline style by resolveMapStyle), so hand the
-      // control the blank sentinel instead — like blank/raster basemaps it then
-      // skips the fetch (which would otherwise throw "Failed to fetch" on the
+      // Planetary, offline, and regional basemaps all use a non-fetchable
+      // `geolibre://` sentinel (expanded to an inline style by resolveMapStyle),
+      // so hand the control the blank sentinel instead — like blank/raster
+      // basemaps it then skips the fetch (which would otherwise throw on the
       // sentinel URL) and shows a single background entry.
-      basemapStyleUrl:
-        getPlanetaryBasemapByStyleUrl(this.basemapStyleUrl) ||
-        isOfflineBasemapSentinel(this.basemapStyleUrl)
-          ? BLANK_BASEMAP
-          : this.basemapStyleUrl,
+      basemapStyleUrl: isGeoLibreSentinelStyleUrl(this.basemapStyleUrl)
+        ? BLANK_BASEMAP
+        : this.basemapStyleUrl,
       collapsed: true,
       panelWidth: 340,
       panelMinWidth: 240,

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -46,7 +46,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.6",
-    "maplibre-gl-basemap-control": "^0.13.0",
+    "maplibre-gl-basemap-control": "^0.14.0",
     "maplibre-gl-components": "^0.30.0",
     "maplibre-gl-duckdb": "^0.2.4",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -82,6 +82,7 @@ function getStyleProviderCredentials(): {
   protomapsApiKey?: string;
   stadiaApiKey?: string;
   mapboxAccessToken?: string;
+  tiandituApiKey?: string;
 } {
   const env = getRuntimeEnvironment();
   const protomapsApiKey = getProtomapsApiKey(env);
@@ -90,10 +91,16 @@ function getStyleProviderCredentials(): {
   // the others: the panel's API keys view has a Mapbox field, so pushing an
   // empty string would clobber a token typed there.
   const mapboxAccessToken = getMapboxAccessToken(env);
+  // Tianditu (added in maplibre-gl-basemap-control 0.14.0) is the only basemap
+  // provider in the catalog reachable from mainland China that also aligns with
+  // WGS84 data, so its key gets the same env route as every other provider
+  // rather than being panel-only.
+  const tiandituApiKey = env.VITE_TIANDITU_API_KEY?.trim() || undefined;
   return {
     ...(protomapsApiKey ? { protomapsApiKey } : {}),
     ...(stadiaApiKey ? { stadiaApiKey } : {}),
     ...(mapboxAccessToken ? { mapboxAccessToken } : {}),
+    ...(tiandituApiKey ? { tiandituApiKey } : {}),
   };
 }
 
@@ -286,10 +293,12 @@ function addRuntimeEnvListener(): void {
       basemapControl.setAmazonCredentials(amazon.amazonApiKey, amazon.awsRegion);
     }
     // Same rule for the style-provider keys: push only what the user actually set.
-    const { protomapsApiKey, stadiaApiKey, mapboxAccessToken } = getStyleProviderCredentials();
+    const { protomapsApiKey, stadiaApiKey, mapboxAccessToken, tiandituApiKey } =
+      getStyleProviderCredentials();
     if (protomapsApiKey) basemapControl.setProtomapsApiKey(protomapsApiKey);
     if (stadiaApiKey) basemapControl.setStadiaApiKey(stadiaApiKey);
     if (mapboxAccessToken) basemapControl.setMapboxAccessToken(mapboxAccessToken);
+    if (tiandituApiKey) basemapControl.setTiandituApiKey(tiandituApiKey);
   };
 
   window.addEventListener("geolibre:runtime-env-change", handleRuntimeEnvChange);

--- a/tests/regional-basemaps.test.ts
+++ b/tests/regional-basemaps.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  PLANETARY_BASEMAP_SENTINEL_PREFIX,
+  PLANETARY_BASEMAPS,
+} from "../packages/core/src/ellipsoids";
+import {
+  CHINA_BASEMAPS,
+  getRegionalBasemapById,
+  getRegionalBasemapByStyleUrl,
+  isRegionalBasemapSentinel,
+  REGIONAL_BASEMAP_GROUPS,
+  REGIONAL_BASEMAP_SENTINEL_PREFIX,
+  REGIONAL_BASEMAPS,
+} from "../packages/core/src/regional-basemaps";
+
+describe("regional basemap catalog invariants", () => {
+  it("basemap ids are unique", () => {
+    const ids = REGIONAL_BASEMAPS.map((basemap) => basemap.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  it("every basemap's styleUrl is its id under the regional sentinel prefix", () => {
+    for (const basemap of REGIONAL_BASEMAPS) {
+      assert.equal(basemap.styleUrl, `${REGIONAL_BASEMAP_SENTINEL_PREFIX}${basemap.id}`);
+      assert.ok(isRegionalBasemapSentinel(basemap.styleUrl));
+    }
+  });
+
+  it("every tile template carries the {z}/{x}/{y} placeholders MapLibre substitutes", () => {
+    for (const basemap of REGIONAL_BASEMAPS) {
+      for (const template of [basemap.tileUrl, basemap.overlayTileUrl].filter(Boolean)) {
+        for (const placeholder of ["{z}", "{x}", "{y}"]) {
+          assert.ok(
+            template?.includes(placeholder),
+            `${basemap.id} tile template is missing ${placeholder}`,
+          );
+        }
+      }
+    }
+  });
+
+  it("serves every basemap over https, so the desktop CSP and the web build accept it", () => {
+    for (const basemap of REGIONAL_BASEMAPS) {
+      assert.ok(basemap.tileUrl.startsWith("https://"), `${basemap.id} is not https`);
+    }
+  });
+
+  // A regional basemap must never collide with the planetary sentinel: the
+  // planetary path also switches the project's celestial body, which would
+  // reproject measurements onto the wrong radius for an Earth basemap.
+  it("uses a sentinel prefix distinct from the planetary one", () => {
+    assert.notEqual(REGIONAL_BASEMAP_SENTINEL_PREFIX, PLANETARY_BASEMAP_SENTINEL_PREFIX);
+    for (const basemap of REGIONAL_BASEMAPS) {
+      assert.ok(!basemap.styleUrl.startsWith(PLANETARY_BASEMAP_SENTINEL_PREFIX));
+    }
+    const planetaryIds = new Set(PLANETARY_BASEMAPS.map((basemap) => basemap.id));
+    for (const basemap of REGIONAL_BASEMAPS) {
+      assert.ok(
+        !planetaryIds.has(basemap.id),
+        `${basemap.id} collides with a planetary basemap id`,
+      );
+    }
+  });
+
+  it("resolves a basemap by style URL and by id, and rejects an unknown one", () => {
+    const street = getRegionalBasemapById("amap-street");
+    assert.equal(street?.name, "高德地图");
+    assert.equal(getRegionalBasemapByStyleUrl(street?.styleUrl)?.id, "amap-street");
+
+    // An unresolvable sentinel (e.g. a project saved with an id since renamed)
+    // still reads as a sentinel, so the map controller falls back to the
+    // default basemap rather than fetching `geolibre://` as a URL.
+    const stale = `${REGIONAL_BASEMAP_SENTINEL_PREFIX}gone`;
+    assert.equal(getRegionalBasemapByStyleUrl(stale), undefined);
+    assert.ok(isRegionalBasemapSentinel(stale));
+    assert.ok(!isRegionalBasemapSentinel("https://tiles.openfreemap.org/styles/liberty"));
+    assert.equal(getRegionalBasemapByStyleUrl(undefined), undefined);
+    assert.equal(getRegionalBasemapById(undefined), undefined);
+  });
+});
+
+describe("China basemaps", () => {
+  it("groups every China basemap under the china region", () => {
+    assert.ok(CHINA_BASEMAPS.length > 0);
+    for (const basemap of CHINA_BASEMAPS) {
+      assert.equal(basemap.region, "china");
+    }
+  });
+
+  // Tencent numbers tile rows from the bottom; Amap uses standard xyz. Getting
+  // this backwards renders the world vertically mirrored.
+  it("marks the Tencent basemaps as TMS and leaves Amap on xyz", () => {
+    for (const basemap of CHINA_BASEMAPS) {
+      const expected = basemap.id.startsWith("tencent-") ? "tms" : undefined;
+      assert.equal(basemap.scheme, expected, `${basemap.id} has the wrong tile scheme`);
+    }
+  });
+
+  it("gives Amap Hybrid a label overlay and no other basemap one", () => {
+    for (const basemap of CHINA_BASEMAPS) {
+      if (basemap.id === "amap-hybrid") {
+        assert.ok(basemap.overlayTileUrl, "amap-hybrid should stack the roads-and-labels tiles");
+        // The hybrid is the satellite imagery plus labels, so its base tiles
+        // must be the same source the plain satellite basemap uses.
+        assert.equal(
+          basemap.tileUrl,
+          CHINA_BASEMAPS.find((b) => b.id === "amap-satellite")?.tileUrl,
+        );
+      } else {
+        assert.equal(basemap.overlayTileUrl, undefined);
+      }
+    }
+  });
+
+  // Probed against the live endpoints: Amap's imagery serves a "no imagery"
+  // placeholder rather than a 404 past 18, and Tencent 400s past 19 with 19
+  // already blank. Capping here makes MapLibre overzoom (blur) instead.
+  it("caps each source at its probed native zoom", () => {
+    const expected: Record<string, number> = {
+      "amap-street": 19,
+      "amap-satellite": 18,
+      "amap-hybrid": 18,
+      "tencent-street": 18,
+      "tencent-dark": 18,
+    };
+    for (const basemap of CHINA_BASEMAPS) {
+      assert.equal(
+        basemap.maxZoom,
+        expected[basemap.id],
+        `${basemap.id} has an unexpected maxZoom`,
+      );
+    }
+  });
+
+  // Not every regional basemap is offset (Tianditu publishes in CGCS2000), so
+  // the flag records which are rather than being implied by the region.
+  it("flags every China basemap as GCJ-02", () => {
+    for (const basemap of CHINA_BASEMAPS) {
+      assert.equal(basemap.gcj02, true, `${basemap.id} is missing the GCJ-02 flag`);
+    }
+  });
+
+  it("credits the provider on every basemap", () => {
+    for (const basemap of CHINA_BASEMAPS) {
+      const expected = basemap.id.startsWith("amap-") ? "Amap" : "Tencent Maps";
+      assert.ok(basemap.attribution.includes(expected), `${basemap.id} is missing its credit`);
+    }
+  });
+});
+
+describe("REGIONAL_BASEMAP_GROUPS (picker section)", () => {
+  it("covers every regional basemap exactly once", () => {
+    const grouped = REGIONAL_BASEMAP_GROUPS.flatMap((group) => group.basemaps.map((b) => b.id));
+    assert.deepEqual([...grouped].sort(), [...REGIONAL_BASEMAPS.map((b) => b.id)].sort());
+    assert.equal(new Set(grouped).size, grouped.length);
+  });
+
+  it("puts every basemap in the group matching its own region", () => {
+    for (const group of REGIONAL_BASEMAP_GROUPS) {
+      for (const basemap of group.basemaps) {
+        assert.equal(basemap.region, group.id);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Why

GeoLibre's default basemaps (OpenFreeMap, Protomaps) are hosted outside mainland China with no presence inside it, so from there the basemap picker offers nothing that loads.

## What

**New project** and **Change basemap** now both carry a collapsed **Regional → China (中国)** section with five keyless basemaps:

| Button | Source |
|--------|--------|
| 高德地图 | Amap street |
| 高德卫星 | Amap satellite |
| 高德混合 | Amap satellite + labels |
| 腾讯地图 | Tencent street |
| 腾讯深色 | Tencent dark |

Also bumps `maplibre-gl-basemap-control` to **0.14.0**, which adds the same providers to the Basemaps control plugin plus **Tianditu (天地图)**, and routes Tianditu's key through the plugin's existing env-var pattern (`VITE_TIANDITU_API_KEY`) so it isn't the only keyed provider without one.

## How it works

`styleUrl` is a `geolibre://regional-basemap/<id>` sentinel that `resolveMapStyle` expands into a raster style, mirroring the planetary basemaps. The **separate sentinel prefix is load bearing**: selecting a planetary basemap also switches the project's celestial body, which must not happen for an Earth basemap. Amap Hybrid composes two raster sources so its labels are burnt in rather than something the user has to stack by hand.

One collapsible section holds every region, each under its own heading driven by `REGIONAL_BASEMAP_GROUPS`, so adding a second region is an entry in core rather than another top-level section in two dialogs. The section component is shared between the dialogs for the same reason.

## Bug found while verifying

The layer control fetches the basemap style URL to introspect its layers, and its guard enumerated the planetary and offline sentinels by hand. The new regional sentinel therefore reached `fetch` and threw ``URL scheme "geolibre" is not supported``. It now matches on the `geolibre://` scheme, which cannot drift when a fourth sentinel kind is added — and also covers a sentinel whose id no longer resolves, a case the per-kind lookups already missed.

## Zoom caps came from probing, not docs

Amap serves a "no imagery" placeholder rather than a 404 past zoom 18, and Tencent 400s past 19 with zoom 19 already blank. Capping at the probed maximum makes MapLibre overzoom (blur) instead of painting placeholder tiles.

## The GCJ-02 caveat

Amap and Tencent publish in GCJ-02, the offset datum Chinese law mandates, which displaces WGS84 overlays by roughly 100 to 700 m. The picker stays uncluttered, so this lives in `docs/getting-started.md` (which recommends Tianditu, in CGCS2000, whenever the map also carries the user's own data) and in the `gcj02` flag on each basemap — a flag rather than an assumption about the region, since Tianditu is the likely next addition here and is *not* offset.

## Verification

14 new tests (5,893 total, all passing), plus a Chromium run against the live endpoints:

- The section renders in both dialogs and all five Chinese labels appear.
- Selecting 高德地图 loads tiles `200` from Amap and paints correctly oriented (which is also what proves Tencent's TMS flip).
- Console is clean — this is how the sentinel-fetch bug above surfaced.
- Translated into all 19 locales; confirmed `sectionRegional` ships as 区域 in the built `zh` chunk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added regional basemap support for mainland China, including Amap, Tencent, and Tianditu options.
  - Regional basemaps can be selected when creating projects or changing the active basemap.
  - Added support for overlays, attribution, zoom limits, and coordinate-system handling.
  - Added runtime configuration for Tianditu API keys.

- **Localization**
  - Added regional and China basemap labels across supported languages.

- **Documentation**
  - Documented China basemap providers, API key setup, overlays, and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->