### PR TITLE
fix(raster): pick up the NaN nodata fix for Windows D3D11

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -87,7 +87,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.4",
+    "maplibre-gl-raster": "^0.14.5",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.4",
+        "maplibre-gl-raster": "^0.14.5",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",
@@ -17774,9 +17774,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.4.tgz",
-      "integrity": "sha512-v6hL7+LbzxZ3h6Uc8yCvsICNjanu3Vu/vN+eYyDcq735PlnLYCx3nguvi69vqtCV7qrBPStVD9nW6nP5CvdhQg==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.5.tgz",
+      "integrity": "sha512-RrHIQbKmhwukloUs6+Ug1luUcCJQOLzF5eROZ/EspCvCUI6PdLXPUYtdWiVU0ikQoDmgI8IPTWPf/3HCQqDdOw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -23163,7 +23163,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.2",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.4",
+        "maplibre-gl-raster": "^0.14.5",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.2",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.4",
+    "maplibre-gl-raster": "^0.14.5",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",


### PR DESCRIPTION
Picks up `maplibre-gl-raster` 0.14.5, which fixes opengeos/maplibre-gl-raster#64.

## The bug

On Windows, a float raster whose nodata is IEEE `NaN` rendered as an opaque, colormap-colored rectangle covering the layer's full bounding box instead of a transparent gap. Reported against both GeoLibre Desktop and web.geolibre.app with the built-in sample DEM on the default `maplibre-gl-raster` (deck.gl) engine, and Inspect confirmed the raw band value in the colored border was `NaN`.

## Root cause

Nothing on the GeoLibre side, and nothing in the plugin's nodata logic either - `pushNodataFilters` was already pushing `FilterNaN` for every float texture. The shader used the GLSL `isnan()` intrinsic. Windows' default graphics path is ANGLE targeting Direct3D 11, for Chrome and for the Tauri/WebView2 desktop shell alike, which translates GLSL to HLSL, and the HLSL compiler is free to fold `isnan()` to a constant `false` under fast-math assumptions. The discard never fired and the NaN pixels fell through the rescale and colormap chain. That is why the reporter's `--use-angle=gl` workaround helped: the OpenGL backend never does that translation.

Upstream now tests the raw IEEE-754 bit pattern instead - all-ones exponent with a non-zero mantissa, via `floatBitsToUint`, which lowers to HLSL `asuint`, a pure reinterpret with nothing left for the optimizer to remove: opengeos/maplibre-gl-raster#65.

## Changes

Version bump only, in the two manifests that list the package, plus the lockfile. No wiring changes.

## Verification

Drove the dev app with the sample DEM (`https://data.source.coop/giswqs/opengeos/dem.tif`) on the `maplibre-gl-raster` engine against the npm-published 0.14.5, in both light and dark themes: the NaN border is transparent with the basemap showing through, and the console is clean of shader errors. `npm run build` and `pre-commit` pass.

As a control, inverting the shader's mantissa test to disable the discard reproduced the reported symptom exactly - a solid black bounding-box rectangle - which confirms `FilterNaN` is the module doing the work on this dataset rather than a mask or the tile footprint.

One caveat worth stating plainly: I have no Windows/D3D11 machine, so the ANGLE Direct3D backend that miscompiles `isnan()` was not exercised directly. The fix removes that intrinsic, and the replacement was checked through a real WebGL2 pipeline, but final confirmation on the reporter's hardware is still worth having.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the raster map rendering component to version 0.14.5, improving compatibility and reliability across the desktop app and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->