### PR TITLE
feat(basemap): remember the selected basemap

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -11,6 +11,7 @@ import { useDataUrlLoader } from "./hooks/useDataUrlLoader";
 import { useBeforeUnloadGuard } from "./hooks/useBeforeUnloadGuard";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useLayerLibraryPersistence } from "./hooks/useLayerLibraryPersistence";
+import { useLastBasemapPersistence } from "./hooks/useLastBasemapPersistence";
 import { useStyleLibraryPersistence } from "./hooks/useStyleLibraryPersistence";
 import { useTemplateLibraryPersistence } from "./hooks/useTemplateLibraryPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
@@ -25,6 +26,7 @@ import { createAppAPI } from "./hooks/usePlugins";
 import { languageDirection } from "./i18n/languages";
 
 export default function App() {
+  useLastBasemapPersistence();
   // Re-renders on language change, so Radix primitives (menus, sliders, tabs)
   // pick up the right-to-left direction together with the document `dir`.
   const { i18n } = useTranslation();

--- a/apps/geolibre-desktop/src/hooks/useLastBasemapPersistence.ts
+++ b/apps/geolibre-desktop/src/hooks/useLastBasemapPersistence.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_ELLIPSOID_ID, getPlanetaryBasemapByStyleUrl, useAppStore } from "@geolibre/core";
+import { useLayoutEffect } from "react";
+import { readLastBasemap, writeLastBasemap } from "../lib/last-basemap";
+
+/** Restore the last basemap into the empty startup workspace and track changes. */
+export function useLastBasemapPersistence(): void {
+  useLayoutEffect(() => {
+    const state = useAppStore.getState();
+    const storedBasemap = readLastBasemap();
+
+    // Never replace a project that another startup source already loaded.
+    if (
+      storedBasemap !== null &&
+      state.projectGeneration === 0 &&
+      state.projectPath === null &&
+      !state.isDirty
+    ) {
+      const ellipsoidId =
+        getPlanetaryBasemapByStyleUrl(storedBasemap)?.ellipsoidId ?? DEFAULT_ELLIPSOID_ID;
+      useAppStore.setState({
+        basemapStyleUrl: storedBasemap,
+        preferences: {
+          ...state.preferences,
+          map: { ...state.preferences.map, ellipsoidId },
+        },
+      });
+    }
+
+    writeLastBasemap(useAppStore.getState().basemapStyleUrl);
+    return useAppStore.subscribe((next, previous) => {
+      if (next.basemapStyleUrl !== previous.basemapStyleUrl) {
+        writeLastBasemap(next.basemapStyleUrl);
+      }
+    });
+  }, []);
+}

--- a/apps/geolibre-desktop/src/lib/last-basemap.ts
+++ b/apps/geolibre-desktop/src/lib/last-basemap.ts
@@ -1,0 +1,21 @@
+import { LAST_BASEMAP_STORAGE_KEY } from "./storage-keys";
+
+/** Read the last selected basemap. An empty string is the valid blank basemap. */
+export function readLastBasemap(storage?: Storage): string | null {
+  try {
+    const target = storage ?? globalThis.localStorage;
+    return target.getItem(LAST_BASEMAP_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the current basemap without making storage availability app-critical. */
+export function writeLastBasemap(styleUrl: string, storage?: Storage): void {
+  try {
+    const target = storage ?? globalThis.localStorage;
+    target.setItem(LAST_BASEMAP_STORAGE_KEY, styleUrl);
+  } catch {
+    // Persistence is best-effort; storage can be disabled or full.
+  }
+}

--- a/apps/geolibre-desktop/src/lib/storage-keys.ts
+++ b/apps/geolibre-desktop/src/lib/storage-keys.ts
@@ -8,6 +8,9 @@
 /** Persisted desktop settings blob (layout, language, plugin sources, …). */
 export const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
 
+/** Basemap used to seed the empty workspace on the next app launch. */
+export const LAST_BASEMAP_STORAGE_KEY = "geolibre.lastBasemap";
+
 /**
  * Latest version the user dismissed via "Skip this version" in the automated
  * startup update prompt. Suppresses the prompt for that one version so it does

--- a/tests/last-basemap.test.ts
+++ b/tests/last-basemap.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readLastBasemap, writeLastBasemap } from "../apps/geolibre-desktop/src/lib/last-basemap";
+import { LAST_BASEMAP_STORAGE_KEY } from "../apps/geolibre-desktop/src/lib/storage-keys";
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe("last basemap persistence", () => {
+  it("round-trips a selected basemap", () => {
+    const storage = memoryStorage();
+    writeLastBasemap("https://example.com/style.json", storage);
+    assert.equal(readLastBasemap(storage), "https://example.com/style.json");
+    assert.equal(storage.getItem(LAST_BASEMAP_STORAGE_KEY), "https://example.com/style.json");
+  });
+
+  it("preserves the empty string used by the blank basemap", () => {
+    const storage = memoryStorage();
+    writeLastBasemap("", storage);
+    assert.equal(readLastBasemap(storage), "");
+  });
+
+  it("treats unavailable storage as no saved preference", () => {
+    const storage = memoryStorage();
+    storage.getItem = () => {
+      throw new Error("blocked");
+    };
+    assert.equal(readLastBasemap(storage), null);
+  });
+});


### PR DESCRIPTION
## Summary
- remember the current basemap in device-local storage
- restore it into the empty workspace on the next launch without overriding loaded projects
- keep planetary basemaps synchronized with their ellipsoid and handle unavailable storage safely

## Test plan
- [x] Run scoped pre-commit hooks
- [x] Run the desktop TypeScript build
- [x] Run focused basemap persistence tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The desktop app now remembers the last selected basemap and restores it when starting a new workspace.
  - Basemap selections are saved automatically, including blank basemap choices.
  - Storage failures are handled gracefully without disrupting the app.

- **Tests**
  - Added coverage for basemap restoration, persistence, blank values, and unavailable storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->