### PR TITLE
fix(map): silence noisy MapLibre fallbacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY packages/map/package.json packages/map/package.json
 COPY packages/plugins/package.json packages/plugins/package.json
 COPY packages/processing/package.json packages/processing/package.json
 COPY packages/ui/package.json packages/ui/package.json
+COPY scripts/patch-maplibre-read-buffer.mjs scripts/patch-maplibre-read-buffer.mjs
 
 RUN npm ci
 

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "postinstall": "node ../../scripts/patch-maplibre-read-buffer.mjs",
     "dev": "vite",
     "predev": "npm run build -w @geolibre/embed && node ../../scripts/build-jupyterlite.mjs --if-missing",
     "prebuild": "npm run build -w @geolibre/embed && node ../../scripts/build-jupyterlite.mjs",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "workers/*"
   ],
   "scripts": {
-    "postinstall": "node scripts/patch-maplibre-read-buffer.mjs",
     "dev": "npm run dev -w geolibre-desktop",
     "build": "npm run build -w geolibre-desktop",
     "lite:build": "node scripts/lite-build.mjs",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "workers/*"
   ],
   "scripts": {
+    "postinstall": "node scripts/patch-maplibre-read-buffer.mjs",
     "dev": "npm run dev -w geolibre-desktop",
     "build": "npm run build -w geolibre-desktop",
     "lite:build": "node scripts/lite-build.mjs",

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1035,7 +1035,11 @@ export class MapController {
 
     if (!isMapboxStyleUrl(url)) {
       this.beginStyleSwap();
-      map.setStyle(resolveMapStyle(url));
+      // GeoLibre deliberately rebuilds every style-owned control and layer in
+      // style.load, so diffing cannot preserve any work for us. Disabling it
+      // also avoids MapLibre's noisy fallback when a second basemap arrives
+      // before the current style has finished loading.
+      map.setStyle(resolveMapStyle(url), { diff: false });
       return;
     }
 
@@ -1045,7 +1049,7 @@ export class MapController {
       .then((style) => {
         if (this.map !== map || this.styleGeneration !== generation) return;
         this.beginStyleSwap();
-        map.setStyle(style, { validate: false });
+        map.setStyle(style, { diff: false, validate: false });
       })
       .catch((error: unknown) => {
         if (this.map !== map || this.styleGeneration !== generation) return;

--- a/scripts/patch-maplibre-read-buffer.mjs
+++ b/scripts/patch-maplibre-read-buffer.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rename, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 const MAPLIBRE_BUNDLE_URL = new URL(
@@ -16,17 +16,29 @@ const MAPLIBRE_BUNDLE_URL = new URL(
 export function patchMapLibreReadBuffer(bundle) {
   const target = ".STREAM_READ";
   const occurrences = bundle.split(target).length - 1;
-  if (occurrences === 0) return { bundle, changed: false };
+  if (occurrences === 0) return { bundle, changed: false, occurrences };
   if (occurrences !== 1) {
-    throw new Error(`Expected one MapLibre STREAM_READ usage, found ${occurrences}`);
+    return { bundle, changed: false, occurrences };
   }
-  return { bundle: bundle.replace(target, ".STREAM_DRAW"), changed: true };
+  return { bundle: bundle.replace(target, ".STREAM_DRAW"), changed: true, occurrences };
 }
 
 async function main() {
   const source = await readFile(MAPLIBRE_BUNDLE_URL, "utf8");
   const result = patchMapLibreReadBuffer(source);
-  if (result.changed) await writeFile(MAPLIBRE_BUNDLE_URL, result.bundle);
+  if (result.occurrences > 1) {
+    console.warn(
+      `Skipping MapLibre read-buffer patch: expected one STREAM_READ usage, found ${result.occurrences}`,
+    );
+    return;
+  }
+  if (result.changed) {
+    // Replacing the directory entry instead of rewriting the existing inode is
+    // safe when Bun populated node_modules with hardlinks to its global cache.
+    const temporaryUrl = new URL(`${MAPLIBRE_BUNDLE_URL.href}.${process.pid}.tmp`);
+    await writeFile(temporaryUrl, result.bundle);
+    await rename(temporaryUrl, MAPLIBRE_BUNDLE_URL);
+  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/patch-maplibre-read-buffer.mjs
+++ b/scripts/patch-maplibre-read-buffer.mjs
@@ -1,7 +1,10 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-const MAPLIBRE_BUNDLE_URL = new URL("../node_modules/maplibre-gl/dist/maplibre-gl.js", import.meta.url);
+const MAPLIBRE_BUNDLE_URL = new URL(
+  "../node_modules/maplibre-gl/dist/maplibre-gl.js",
+  import.meta.url,
+);
 
 /**
  * MapLibre 5.24 labels its globe projection pixel-pack buffer STREAM_READ.

--- a/scripts/patch-maplibre-read-buffer.mjs
+++ b/scripts/patch-maplibre-read-buffer.mjs
@@ -1,0 +1,34 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const MAPLIBRE_BUNDLE_URL = new URL("../node_modules/maplibre-gl/dist/maplibre-gl.js", import.meta.url);
+
+/**
+ * MapLibre 5.24 labels its globe projection pixel-pack buffer STREAM_READ.
+ * Chromium treats READ-usage buffers specially and repeatedly reports that its
+ * readback shadow copy was discarded when MapLibre reuses the buffer. The GL
+ * usage value is only a performance hint; STREAM_DRAW avoids that incompatible
+ * Chromium optimization while preserving the fenced asynchronous readback.
+ */
+export function patchMapLibreReadBuffer(bundle) {
+  const target = ".STREAM_READ";
+  const occurrences = bundle.split(target).length - 1;
+  if (occurrences === 0) return { bundle, changed: false };
+  if (occurrences !== 1) {
+    throw new Error(`Expected one MapLibre STREAM_READ usage, found ${occurrences}`);
+  }
+  return { bundle: bundle.replace(target, ".STREAM_DRAW"), changed: true };
+}
+
+async function main() {
+  const source = await readFile(MAPLIBRE_BUNDLE_URL, "utf8");
+  const result = patchMapLibreReadBuffer(source);
+  if (result.changed) await writeFile(MAPLIBRE_BUNDLE_URL, result.bundle);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1708,6 +1708,26 @@ describe("MapController Mapbox descriptor requests", () => {
     });
   });
 
+  it("disables validation and diffing for a loaded Mapbox descriptor", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ version: 8, sources: {}, layers: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof globalThis.fetch;
+    const { controller, styles } = mapboxController();
+    try {
+      controller.setStyle(MAPBOX_STREETS);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      assert.equal(styles.length, 1);
+      assert.deepEqual(styles[0]?.options, { diff: false, validate: false });
+    } finally {
+      globalThis.fetch = originalFetch;
+      controller.destroy();
+    }
+  });
+
   it("aborts a pending descriptor request when a non-Mapbox style is applied", async () => {
     await withPendingFetch((signals) => {
       const { controller, styles } = mapboxController();

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1632,11 +1632,14 @@ describe("MapController Mapbox descriptor requests", () => {
   const OPENFREEMAP = "https://tiles.openfreemap.org/styles/liberty";
 
   /** Minimal map stub: setStyle/remove are all the Mapbox path touches. */
-  function mapboxController(): { controller: MapController; styles: unknown[] } {
-    const styles: unknown[] = [];
+  function mapboxController(): {
+    controller: MapController;
+    styles: Array<{ style: unknown; options: unknown }>;
+  } {
+    const styles: Array<{ style: unknown; options: unknown }> = [];
     const map = {
-      setStyle: (style: unknown) => {
-        styles.push(style);
+      setStyle: (style: unknown, options?: unknown) => {
+        styles.push({ style, options });
       },
       remove: () => {},
       addControl: () => {},
@@ -1713,7 +1716,7 @@ describe("MapController Mapbox descriptor requests", () => {
         controller.setStyle(OPENFREEMAP);
 
         // The plain URL resolves synchronously, and no second fetch is made.
-        assert.deepEqual(styles, [OPENFREEMAP]);
+        assert.deepEqual(styles, [{ style: OPENFREEMAP, options: { diff: false } }]);
         assert.equal(signals.length, 1);
         assert.equal(signals[0]?.aborted, true);
       } finally {

--- a/tests/patch-maplibre-read-buffer.test.ts
+++ b/tests/patch-maplibre-read-buffer.test.ts
@@ -14,10 +14,11 @@ describe("MapLibre read-buffer patch", () => {
     assert.equal(result.changed, false);
   });
 
-  it("fails if the dependency gains another READ usage that needs review", () => {
-    assert.throws(
-      () => patchMapLibreReadBuffer("gl.STREAM_READ; gl.STREAM_READ"),
-      /Expected one MapLibre STREAM_READ usage, found 2/,
-    );
+  it("does not alter an unexpected dependency shape", () => {
+    const bundle = "gl.STREAM_READ; gl.STREAM_READ";
+    const result = patchMapLibreReadBuffer(bundle);
+    assert.equal(result.bundle, bundle);
+    assert.equal(result.changed, false);
+    assert.equal(result.occurrences, 2);
   });
 });

--- a/tests/patch-maplibre-read-buffer.test.ts
+++ b/tests/patch-maplibre-read-buffer.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { patchMapLibreReadBuffer } from "../scripts/patch-maplibre-read-buffer.mjs";
+
+describe("MapLibre read-buffer patch", () => {
+  it("changes the Chromium-tracked READ usage hint", () => {
+    const result = patchMapLibreReadBuffer("gl.bufferData(target, 4, gl.STREAM_READ)");
+    assert.equal(result.bundle, "gl.bufferData(target, 4, gl.STREAM_DRAW)");
+    assert.equal(result.changed, true);
+  });
+
+  it("is a no-op after the patch or an upstream fix", () => {
+    const result = patchMapLibreReadBuffer("gl.bufferData(target, 4, gl.STREAM_DRAW)");
+    assert.equal(result.changed, false);
+  });
+
+  it("fails if the dependency gains another READ usage that needs review", () => {
+    assert.throws(
+      () => patchMapLibreReadBuffer("gl.STREAM_READ; gl.STREAM_READ"),
+      /Expected one MapLibre STREAM_READ usage, found 2/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- prevent Chromium from enabling a readback shadow optimization that MapLibre 5.24 invalidates during globe projection measurements
- disable MapLibre style diffing because GeoLibre already rebuilds style-owned controls and layers on every basemap swap
- cover the dependency patch and style-swap options with focused tests

## Test plan
- [x] Run the desktop production build
- [x] Run focused MapController and dependency-patch tests
- [x] Verify in Chrome that the READ-usage warning is absent
- [x] Switch basemaps in the real app and verify the style-diff fallback is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved basemap style handling by disabling style diffing for more consistent map updates.
  - Preserved Mapbox style validation while applying consistent style update behavior across basemap types.
  - Improved MapLibre rendering compatibility during application installation and builds.

- **Tests**
  - Added coverage for style update behavior and MapLibre compatibility, including already-patched bundles and unexpected duplicate matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->