### PR TITLE
Add remote data through the embed API

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -62,6 +62,7 @@ export default function App() {
         layoutOptions={layoutOptions}
         projectUrlLoadState={projectUrlLoadState}
         dataUrlLoadState={dataUrlLoadState}
+        mapAppAPI={mapAppAPI}
         themeMode={themeMode}
         onToggleThemeMode={toggleThemeMode}
         onMapReady={handleMapReady}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -487,6 +487,7 @@ interface DesktopShellProps {
   layoutOptions: LayoutOptions;
   projectUrlLoadState?: ProjectUrlLoadState;
   dataUrlLoadState?: DataUrlLoadState;
+  mapAppAPI: ReturnType<typeof createAppAPI> | null;
   themeMode: ThemeMode;
   onToggleThemeMode: () => void;
   onMapReady?: (app: ReturnType<typeof createAppAPI>) => void;
@@ -542,6 +543,7 @@ export function DesktopShell({
   layoutOptions,
   projectUrlLoadState,
   dataUrlLoadState,
+  mapAppAPI,
   themeMode,
   onToggleThemeMode,
   onMapReady,
@@ -888,7 +890,7 @@ export function DesktopShell({
   // Runtime postMessage API for a third-party host page that frames the app
   // (fly to a record, highlight it, open a tool; selection/view/tool events back
   // out). Off unless the deployment configured GEOLIBRE_EMBED_ORIGINS.
-  useEmbedApi(mapControllerRef);
+  useEmbedApi(mapControllerRef, mapAppAPI);
   // Same scripting surface, reached over the desktop Jupyter server's relay, so
   // a kernel driven from an EXTERNAL client (VS Code's Jupyter extension) can
   // control the map too. Inert until that server is running.

--- a/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
@@ -36,8 +36,9 @@ function layerPointsAt(layer: GeoLibreLayer, url: string): boolean {
 export async function loadDataUrl(
   mapAppAPI: ReturnType<typeof createAppAPI>,
   dataUrl: string,
-  options: { styleUrl?: string | null; signal?: AbortSignal } = {},
+  options: { styleUrl?: string | null; signal?: AbortSignal; fit?: boolean } = {},
 ): Promise<DataUrlLoadResult> {
+  const fit = options.fit ?? true;
   const [remote, rawStyle] = await Promise.all([
     fetchRemoteData(dataUrl, { signal: options.signal }),
     options.styleUrl ? fetchRemoteStyle(options.styleUrl, { signal: options.signal }) : null,
@@ -51,8 +52,13 @@ export async function loadDataUrl(
     const id = await addRasterToMap(mapAppAPI, remote.url, {
       name: remote.name,
       defaults: { engine: "maplibre-gl-raster" },
+      zoomTo: fit,
       ...(rasterStyle ? { state: rasterStyle } : {}),
     });
+    if (options.signal?.aborted) {
+      store.removeLayer(id);
+      throw new DOMException("The operation was aborted", "AbortError");
+    }
     layerIds.push(id);
   } else if (remote.kind === "pmtiles" || remote.kind === "vector") {
     const styleResult = rawStyle === null ? null : parseMapboxStyle(rawStyle);
@@ -62,10 +68,10 @@ export async function loadDataUrl(
     const previousIds = new Set(store.layers.map((layer) => layer.id));
     const added =
       remote.kind === "pmtiles"
-        ? await addPMTilesLayerFromUrl(mapAppAPI, remote.url)
+        ? await addPMTilesLayerFromUrl(mapAppAPI, remote.url, { fit })
         : await addVectorLayerFromUrl(mapAppAPI, remote.url, {
             name: remote.name,
-            fitBounds: true,
+            fitBounds: fit,
           });
     if (!added) throw new Error(`Could not add ${remote.name} to the map.`);
     const addedLayers = useAppStore
@@ -75,6 +81,10 @@ export async function loadDataUrl(
       throw new Error(
         `The ${remote.kind === "pmtiles" ? "PMTiles" : "GeoParquet"} loader did not create a layer for ${remote.url}.`,
       );
+    }
+    if (options.signal?.aborted) {
+      for (const layer of addedLayers) store.removeLayer(layer.id);
+      throw new DOMException("The operation was aborted", "AbortError");
     }
     if (styleResult && addedLayers.some((layer) => layer.metadata.tileType === "raster")) {
       for (const layer of addedLayers) store.removeLayer(layer.id);

--- a/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
@@ -20,11 +20,95 @@ import type { ProjectUrlLoadState } from "./useProjectUrlLoader";
  */
 export type DataUrlLoadState = ProjectUrlLoadState & { fitLayerIds?: string[] };
 
+export interface DataUrlLoadResult {
+  layerIds: string[];
+  fitLayerIds: string[];
+}
+
 /** Whether a store layer records the given URL as the data it was loaded from. */
 function layerPointsAt(layer: GeoLibreLayer, url: string): boolean {
   if (layer.sourcePath === url) return true;
   const source = layer.source as { url?: unknown };
   return source.url === url;
+}
+
+/** Load one URL through the same remote-data pipeline used by the `?data=` deep link. */
+export async function loadDataUrl(
+  mapAppAPI: ReturnType<typeof createAppAPI>,
+  dataUrl: string,
+  options: { styleUrl?: string | null; signal?: AbortSignal } = {},
+): Promise<DataUrlLoadResult> {
+  const [remote, rawStyle] = await Promise.all([
+    fetchRemoteData(dataUrl, { signal: options.signal }),
+    options.styleUrl ? fetchRemoteStyle(options.styleUrl, { signal: options.signal }) : null,
+  ]);
+  if (options.signal?.aborted) throw new DOMException("The operation was aborted", "AbortError");
+  const store = useAppStore.getState();
+  const layerIds: string[] = [];
+  const fitLayerIds: string[] = [];
+  if (remote.kind === "cog") {
+    const rasterStyle = rawStyle === null ? null : parseRasterUrlStyle(rawStyle);
+    const id = await addRasterToMap(mapAppAPI, remote.url, {
+      name: remote.name,
+      defaults: { engine: "maplibre-gl-raster" },
+      ...(rasterStyle ? { state: rasterStyle } : {}),
+    });
+    layerIds.push(id);
+  } else if (remote.kind === "pmtiles" || remote.kind === "vector") {
+    const styleResult = rawStyle === null ? null : parseMapboxStyle(rawStyle);
+    if (styleResult && styleResult.matchedLayerCount === 0) {
+      throw new Error("The remote style has no supported vector style layers.");
+    }
+    const previousIds = new Set(store.layers.map((layer) => layer.id));
+    const added =
+      remote.kind === "pmtiles"
+        ? await addPMTilesLayerFromUrl(mapAppAPI, remote.url)
+        : await addVectorLayerFromUrl(mapAppAPI, remote.url, {
+            name: remote.name,
+            fitBounds: true,
+          });
+    if (!added) throw new Error(`Could not add ${remote.name} to the map.`);
+    const addedLayers = useAppStore
+      .getState()
+      .layers.filter((layer) => !previousIds.has(layer.id) && layerPointsAt(layer, remote.url));
+    if (!addedLayers.length) {
+      throw new Error(
+        `The ${remote.kind === "pmtiles" ? "PMTiles" : "GeoParquet"} loader did not create a layer for ${remote.url}.`,
+      );
+    }
+    if (styleResult && addedLayers.some((layer) => layer.metadata.tileType === "raster")) {
+      for (const layer of addedLayers) store.removeLayer(layer.id);
+      throw new Error("MapLibre vector styles cannot be applied to a raster PMTiles archive.");
+    }
+    if (styleResult) {
+      for (const layer of addedLayers) {
+        store.setLayerStyle(layer.id, applyMapboxStyleImport(layer.style, styleResult));
+      }
+    }
+    layerIds.push(...addedLayers.map((layer) => layer.id));
+  } else {
+    const imports = remote.layers.map((layer) => {
+      if (rawStyle === null) return { layer, styleResult: null };
+      const styleResult = parseMapboxStyle(mapboxStyleForDataLayer(rawStyle, layer.name));
+      if (styleResult.matchedLayerCount === 0) {
+        throw new Error(
+          `The remote style has no supported layers for "${layer.name}.geojson". ` +
+            `Set each style layer's source to the matching filename stem (for example, "${layer.name}").`,
+        );
+      }
+      return { layer, styleResult };
+    });
+    for (const { layer, styleResult } of imports) {
+      const id = store.addGeoJsonLayer(layer.name, layer.data, layer.sourcePath);
+      layerIds.push(id);
+      fitLayerIds.push(id);
+      if (styleResult) {
+        const current = useAppStore.getState().layers.find((candidate) => candidate.id === id);
+        if (current) store.setLayerStyle(id, applyMapboxStyleImport(current.style, styleResult));
+      }
+    }
+  }
+  return { layerIds, fitLayerIds };
 }
 
 export function useDataUrlLoader(
@@ -45,104 +129,16 @@ export function useDataUrlLoader(
     if (!params || !mapAppAPI) return;
     const controller = new AbortController();
     setState({ error: null, message: "Loading data from URL...", status: "loading" });
-    void Promise.all([
-      fetchRemoteData(params.dataUrl, { signal: controller.signal }),
-      params.styleUrl ? fetchRemoteStyle(params.styleUrl, { signal: controller.signal }) : null,
-    ])
-      .then(async ([remote, rawStyle]) => {
+    void loadDataUrl(mapAppAPI, params.dataUrl, {
+      styleUrl: params.styleUrl,
+      signal: controller.signal,
+    })
+      .then(({ layerIds, fitLayerIds }) => {
         if (controller.signal.aborted) return;
-        const store = useAppStore.getState();
-        const fitLayerIds: string[] = [];
-        let count = 0;
-        if (remote.kind === "cog") {
-          const rasterStyle = rawStyle === null ? null : parseRasterUrlStyle(rawStyle);
-          await addRasterToMap(mapAppAPI, remote.url, {
-            name: remote.name,
-            defaults: { engine: "maplibre-gl-raster" },
-            ...(rasterStyle ? { state: rasterStyle } : {}),
-          });
-          count = 1;
-        } else if (remote.kind === "pmtiles" || remote.kind === "vector") {
-          // Validate the style before invoking a native loader. Those controls
-          // assign their own ids, so collect the newly synchronized store
-          // layers after the awaited add completes.
-          const styleResult = rawStyle === null ? null : parseMapboxStyle(rawStyle);
-          if (styleResult && styleResult.matchedLayerCount === 0) {
-            throw new Error("The remote style has no supported vector style layers.");
-          }
-          const previousIds = new Set(store.layers.map((layer) => layer.id));
-          const added =
-            remote.kind === "pmtiles"
-              ? await addPMTilesLayerFromUrl(mapAppAPI, remote.url)
-              : await addVectorLayerFromUrl(mapAppAPI, remote.url, {
-                  name: remote.name,
-                  fitBounds: true,
-                });
-          if (!added) throw new Error(`Could not add ${remote.name} to the map.`);
-          // These loaders assign their own ids, so the added layers have to be
-          // recovered from the store. Identify them by the data URL they record
-          // and not by an id diff alone: a concurrent `?url=` project load
-          // replaces the whole layer array, which would make every project
-          // layer look new here and hand this branch someone else's layers to
-          // restyle or remove. No match is treated as "could not identify",
-          // never as "take whatever is new".
-          const addedLayers = useAppStore
-            .getState()
-            .layers.filter(
-              (layer) => !previousIds.has(layer.id) && layerPointsAt(layer, remote.url),
-            );
-          if (!addedLayers.length) {
-            throw new Error(
-              `The ${remote.kind === "pmtiles" ? "PMTiles" : "GeoParquet"} loader did not create a layer for ${remote.url}.`,
-            );
-          }
-          // Check every added layer before styling any of them: the archive's
-          // tile type is only known once the control has read it, so a raster
-          // archive paired with a vector style has to be rolled back rather
-          // than left behind by a deep link that reports failure.
-          if (styleResult && addedLayers.some((layer) => layer.metadata.tileType === "raster")) {
-            for (const layer of addedLayers) store.removeLayer(layer.id);
-            throw new Error(
-              "MapLibre vector styles cannot be applied to a raster PMTiles archive.",
-            );
-          }
-          if (styleResult) {
-            for (const layer of addedLayers) {
-              store.setLayerStyle(layer.id, applyMapboxStyleImport(layer.style, styleResult));
-            }
-          }
-          count = addedLayers.length;
-        } else {
-          // Resolve and validate every per-file style before mutating the store.
-          // This keeps a misspelled source name from producing a partial import.
-          const imports = remote.layers.map((layer) => {
-            if (rawStyle === null) return { layer, styleResult: null };
-            const styleResult = parseMapboxStyle(mapboxStyleForDataLayer(rawStyle, layer.name));
-            if (styleResult.matchedLayerCount === 0) {
-              throw new Error(
-                `The remote style has no supported layers for "${layer.name}.geojson". ` +
-                  `Set each style layer's source to the matching filename stem (for example, "${layer.name}").`,
-              );
-            }
-            return { layer, styleResult };
-          });
-          for (const { layer, styleResult } of imports) {
-            const id = store.addGeoJsonLayer(layer.name, layer.data, layer.sourcePath);
-            fitLayerIds.push(id);
-            if (styleResult) {
-              const current = useAppStore
-                .getState()
-                .layers.find((candidate) => candidate.id === id);
-              if (current)
-                store.setLayerStyle(id, applyMapboxStyleImport(current.style, styleResult));
-            }
-            count += 1;
-          }
-        }
         setState({
           error: null,
           fitLayerIds,
-          message: `Loaded ${count} layer${count === 1 ? "" : "s"} from URL`,
+          message: `Loaded ${layerIds.length} layer${layerIds.length === 1 ? "" : "s"} from URL`,
           status: "loaded",
         });
         timeoutRef.current = window.setTimeout(() => {

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -122,19 +122,14 @@ export function useEmbedApi(
     let projectSourceUrl: string | null = projectUrlFromLocation();
     let loadAbort: AbortController | null = null;
     const dataLoadAborts = new Set<AbortController>();
-    const dataLoadQueues = new Map<string, Promise<void>>();
+    let dataLoadQueue: Promise<void> = Promise.resolve();
 
-    const queueDataLoad = <T>(url: string, operation: () => Promise<T>): Promise<T> => {
-      const previous = dataLoadQueues.get(url) ?? Promise.resolve();
-      const next = previous.then(operation, operation);
-      const settled = next.then(
+    const queueDataLoad = <T>(operation: () => Promise<T>): Promise<T> => {
+      const next = dataLoadQueue.then(operation, operation);
+      dataLoadQueue = next.then(
         () => undefined,
         () => undefined,
       );
-      dataLoadQueues.set(url, settled);
-      void settled.finally(() => {
-        if (dataLoadQueues.get(url) === settled) dataLoadQueues.delete(url);
-      });
       return next;
     };
 
@@ -253,7 +248,7 @@ export function useEmbedApi(
         case "addData": {
           const abort = new AbortController();
           dataLoadAborts.add(abort);
-          const result = await queueDataLoad(command.url, () =>
+          const result = await queueDataLoad(() =>
             loadDataUrl(mapAppAPI, command.url, {
               styleUrl: command.styleUrl,
               signal: abort.signal,

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import { type RefObject, useEffect } from "react";
-import type { MapController } from "@geolibre/map";
+import { getLayerBounds, type MapController } from "@geolibre/map";
 import { captureMapImage } from "../lib/print-layout-export";
 import {
   buildEmbedEvent,
@@ -20,6 +20,8 @@ import {
 import { fetchProjectFromUrl, projectUrlFromLocation } from "../lib/project-url";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 import { isKnownWhiteboxToolId } from "../lib/whitebox-tool-url";
+import { loadDataUrl } from "./useDataUrlLoader";
+import type { createAppAPI } from "./usePlugins";
 
 // Runtime `postMessage` API for a host page that frames GeoLibre (issue #1462).
 // Where `?url=`, `?maponly`, and `?tool=` configure the app once at load time,
@@ -52,9 +54,16 @@ const VIEW_THROTTLE_MS = 250;
  * @param mapControllerRef - Ref to the live map controller (shared with
  *   MapCanvas and the other bridges), used to drive and read the camera.
  */
-export function useEmbedApi(mapControllerRef: RefObject<MapController | null>): void {
+export function useEmbedApi(
+  mapControllerRef: RefObject<MapController | null>,
+  mapAppAPI: ReturnType<typeof createAppAPI> | null,
+): void {
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // `ready` promises that every command is usable. Plugin-backed data loaders
+    // join the API only after the map has initialized, so do not advertise the
+    // bridge during the earlier render where that API is still absent.
+    if (!mapAppAPI) return;
     const allowedOrigins = readEmbedOrigins();
     if (allowedOrigins.length === 0) return;
     const host = window.parent;
@@ -225,6 +234,27 @@ export function useEmbedApi(mapControllerRef: RefObject<MapController | null>): 
           state.addLayer(layer, command.spec.beforeId);
           return layer.id;
         }
+        case "addData": {
+          const result = await loadDataUrl(mapAppAPI, command.url, {
+            styleUrl: command.styleUrl,
+          });
+          if (command.fit) {
+            const bounds = useAppStore
+              .getState()
+              .layers.filter((layer) => result.fitLayerIds.includes(layer.id))
+              .map(getLayerBounds)
+              .filter((value) => value !== null);
+            if (bounds.length) {
+              controller()?.fitBounds([
+                Math.min(...bounds.map((value) => value[0])),
+                Math.min(...bounds.map((value) => value[1])),
+                Math.max(...bounds.map((value) => value[2])),
+                Math.max(...bounds.map((value) => value[3])),
+              ]);
+            }
+          }
+          return result.layerIds;
+        }
         case "exportImage": {
           const map = controller()?.getMap();
           if (!map) throw new Error("The map is not ready yet");
@@ -370,6 +400,5 @@ export function useEmbedApi(mapControllerRef: RefObject<MapController | null>): 
       viewMap?.off("move", onMapMove);
       viewMap?.off("moveend", onMapMove);
     };
-    // Mount-only: mapControllerRef is a stable ref read lazily inside handlers.
-  }, [mapControllerRef]);
+  }, [mapControllerRef, mapAppAPI]);
 }

--- a/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedApi.ts
@@ -121,6 +121,22 @@ export function useEmbedApi(
     // host can tell its own load from one the user triggered.
     let projectSourceUrl: string | null = projectUrlFromLocation();
     let loadAbort: AbortController | null = null;
+    const dataLoadAborts = new Set<AbortController>();
+    const dataLoadQueues = new Map<string, Promise<void>>();
+
+    const queueDataLoad = <T>(url: string, operation: () => Promise<T>): Promise<T> => {
+      const previous = dataLoadQueues.get(url) ?? Promise.resolve();
+      const next = previous.then(operation, operation);
+      const settled = next.then(
+        () => undefined,
+        () => undefined,
+      );
+      dataLoadQueues.set(url, settled);
+      void settled.finally(() => {
+        if (dataLoadQueues.get(url) === settled) dataLoadQueues.delete(url);
+      });
+      return next;
+    };
 
     const loadProjectFromUrl = async (url: string) => {
       // A second load supersedes the first; otherwise a slow fetch could land
@@ -235,9 +251,15 @@ export function useEmbedApi(
           return layer.id;
         }
         case "addData": {
-          const result = await loadDataUrl(mapAppAPI, command.url, {
-            styleUrl: command.styleUrl,
-          });
+          const abort = new AbortController();
+          dataLoadAborts.add(abort);
+          const result = await queueDataLoad(command.url, () =>
+            loadDataUrl(mapAppAPI, command.url, {
+              styleUrl: command.styleUrl,
+              signal: abort.signal,
+              fit: command.fit,
+            }),
+          ).finally(() => dataLoadAborts.delete(abort));
           if (command.fit) {
             const bounds = useAppStore
               .getState()
@@ -395,6 +417,8 @@ export function useEmbedApi(
       window.removeEventListener("message", handleMessage);
       unsubscribe();
       loadAbort?.abort();
+      for (const abort of dataLoadAborts) abort.abort();
+      dataLoadAborts.clear();
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (trailingTimer !== null) window.clearTimeout(trailingTimer);
       viewMap?.off("move", onMapMove);

--- a/apps/geolibre-desktop/src/lib/embed-api.ts
+++ b/apps/geolibre-desktop/src/lib/embed-api.ts
@@ -143,6 +143,7 @@ export type EmbedCommand =
   | { type: "setFilter"; layerId: string; expression: unknown[] | null }
   | { type: "getViewport" }
   | { type: "addLayer"; spec: AddLayerSpec }
+  | { type: "addData"; url: string; styleUrl: string | null; fit: boolean }
   | { type: "exportImage" };
 
 /** A parsed inbound message: the command plus the host's correlation id. */
@@ -580,6 +581,29 @@ export function parseEmbedRequest(
       }
       return {
         command: { type: "addLayer", spec: spec as unknown as AddLayerSpec },
+        requestId,
+      };
+    }
+    case "addData": {
+      if (!isFetchableUrl(payload.url) || !/^https?:/i.test(payload.url)) {
+        return fail("addData: url must be an http(s) URL");
+      }
+      if (
+        payload.styleUrl !== undefined &&
+        (!isFetchableUrl(payload.styleUrl) || !/^https?:/i.test(payload.styleUrl))
+      ) {
+        return fail("addData: styleUrl must be an http(s) URL");
+      }
+      if (payload.fit !== undefined && typeof payload.fit !== "boolean") {
+        return fail("addData: fit must be a boolean");
+      }
+      return {
+        command: {
+          type: "addData",
+          url: payload.url,
+          styleUrl: typeof payload.styleUrl === "string" ? payload.styleUrl : null,
+          fit: payload.fit ?? true,
+        },
         requestId,
       };
     }

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -233,6 +233,7 @@ const map = await connect(document.querySelector("iframe"), {
 });
 await map.setView({ center: [-95.7, 37.1], zoom: 5 });
 await map.setLayerVisibility("roads", false);
+const added = await map.addData("https://assets.geolibre.app/data/places.geojson");
 const layers = await map.listLayers();
 map.on("selectionChanged", ({ featureIds }) => console.log(featureIds));
 ```
@@ -304,6 +305,7 @@ other frame or origin is ignored. Pass the *app's* origin, not your own.
 | `setFilter(layerId, expression)`       | `void`                  | A MapLibre filter expression, or `null` to clear it.                    |
 | `getViewport()`                        | `Viewport`              | `{ bbox, center, zoom, bearing, pitch }`.                               |
 | `addLayer(spec)`                       | the new layer's `id`    | Takes a project-format layer specification.                             |
+| `addData(url, options?)`               | the new layer `id`s     | Loads remote data like `?data=`; options are `{ styleUrl, fit }`.        |
 | `exportImage()`                        | a PNG `data:` URL       | The map as currently rendered.                                          |
 | `on(event, listener)`                  | an unsubscribe function | Not a promise; events are the set the app posts (see below).            |
 | `disconnect()`                         | not a promise           | Removes the listener and rejects anything still in flight.              |
@@ -350,6 +352,7 @@ them out of the other `postMessage` traffic on your page.
 | `setFilter`        | `{ layerId, expression }`                                  | Applies a MapLibre filter expression; send `null` to clear it.                        |
 | `getViewport`      | `{}`                                                       | Returns the current camera and bounds in `result`.                                    |
 | `addLayer`         | `{ spec }`                                                 | Adds a project-format layer specification at runtime.                                 |
+| `addData`          | `{ url, styleUrl?, fit? }`                                 | Loads GeoJSON/API, ZIP, GeoParquet, PMTiles, or COG data without reloading the iframe. |
 | `exportImage`      | `{}`                                                       | Returns the rendered map as a PNG data URL in `result`.                               |
 
 Send `{ layerId }` alone to `highlightFeature` to clear the highlight. A request
@@ -366,6 +369,12 @@ or a non-empty `tiles`, or — for the two layer types drawn from inline feature
 `ack` rather than reporting success and rendering nothing. `addLayer` also
 refuses `javascript:`, `vbscript:`, `data:`, `file:`, and `blob:` URLs on a
 source; a custom map protocol such as `pmtiles://` is fine.
+
+`addData` uses the same format detection, CORS requirements, safety limits, and
+optional Mapbox/MapLibre style import as the [`data` URL parameter](#open-remote-data).
+It fits the newly loaded data by default; pass `fit: false` to preserve the
+current camera. Its acknowledgement returns every created layer id, including
+all layers extracted from a ZIP archive.
 
 Add a `requestId` to any message and the app answers with an `ack` (below)
 reporting whether it worked.

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -66,6 +66,7 @@ the target of every outbound message and the filter on inbound ones.
 | `setFilter(layerId, expression)`       | `void`                  |
 | `getViewport()`                        | `Viewport`              |
 | `addLayer(spec)`                       | the new layer's `id`    |
+| `addData(url, options?)`               | the new layer `id`s     |
 | `exportImage()`                        | a PNG `data:` URL       |
 | `on(event, listener)`                  | an unsubscribe function |
 | `disconnect()`                         | not a promise           |

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -43,7 +43,7 @@ export interface AddLayerSpec {
 
 export interface AddDataOptions {
   styleUrl?: string;
-  /** Fit the map to newly added GeoJSON layers. Defaults to true. */
+  /** Fit the map to the newly added data. Defaults to true. */
   fit?: boolean;
 }
 

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -41,6 +41,12 @@ export interface AddLayerSpec {
   beforeId?: string;
 }
 
+export interface AddDataOptions {
+  styleUrl?: string;
+  /** Fit the map to newly added GeoJSON layers. Defaults to true. */
+  fit?: boolean;
+}
+
 export type EmbedEventMap = {
   ready: { version: string };
   /**
@@ -84,6 +90,7 @@ export interface GeoLibreEmbedClient {
   setFilter(layerId: string, expression: unknown[] | null): Promise<void>;
   getViewport(): Promise<Viewport>;
   addLayer(spec: AddLayerSpec): Promise<string>;
+  addData(url: string, options?: AddDataOptions): Promise<string[]>;
   exportImage(): Promise<string>;
   on<K extends EventName>(type: K, listener: Listener<K>): () => void;
   disconnect(): void;
@@ -164,6 +171,7 @@ export function connect(
     setFilter: (layerId, expression) => send("setFilter", { layerId, expression }),
     getViewport: () => send<Viewport>("getViewport"),
     addLayer: (spec) => send<string>("addLayer", { spec }),
+    addData: (url, options = {}) => send<string[]>("addData", { url, ...options }),
     exportImage: () => send<string>("exportImage"),
     on: (type, listener) => {
       const set = listeners.get(type) ?? new Set();

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1744,7 +1744,11 @@ export function openPMTilesLayerPanel(app: GeoLibreAppAPI): void {
  * @returns True when the archive was added.
  * @throws If the archive could not be loaded (unreachable, not PMTiles, 403).
  */
-export async function addPMTilesLayerFromUrl(app: GeoLibreAppAPI, url: string): Promise<boolean> {
+export async function addPMTilesLayerFromUrl(
+  app: GeoLibreAppAPI,
+  url: string,
+  options: { fit?: boolean } = {},
+): Promise<boolean> {
   const { PMTilesLayerControl: PMTilesLayerControlClass } = await getComponentsConstructors();
 
   pmtilesControl ??= createPMTilesControl(PMTilesLayerControlClass);
@@ -1761,7 +1765,19 @@ export async function addPMTilesLayerFromUrl(app: GeoLibreAppAPI, url: string): 
     pmtilesControl.hide();
   }
 
+  const map = options.fit === false ? app.getMap?.() : undefined;
+  const camera = map
+    ? {
+        center: map.getCenter(),
+        zoom: map.getZoom(),
+        bearing: map.getBearing(),
+        pitch: map.getPitch(),
+      }
+    : null;
   await pmtilesControl.addLayer(url);
+  // The upstream PMTiles control always frames a newly added archive. Restore
+  // the host's camera when a programmatic caller explicitly opts out.
+  if (camera) map?.jumpTo(camera);
   // A failed load does NOT reject: the control catches it, records it on
   // `state.error`, and emits "error" (same convention as CogLayerControl, which
   // addLayerWithCogRasterControl has to check the same way). Without this a

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1766,15 +1766,37 @@ export async function addPMTilesLayerFromUrl(
   }
 
   const map = options.fit === false ? app.getMap?.() : undefined;
-  const camera = map
-    ? {
-        center: map.getCenter(),
-        zoom: map.getZoom(),
-        bearing: map.getBearing(),
-        pitch: map.getPitch(),
-      }
-    : null;
-  await pmtilesControl.addLayer(url);
+  const readCamera = () =>
+    map
+      ? {
+          center: map.getCenter(),
+          zoom: map.getZoom(),
+          bearing: map.getBearing(),
+          pitch: map.getPitch(),
+        }
+      : null;
+  let camera = readCamera();
+  let userMoving = false;
+  const onMoveStart = (event: { originalEvent?: unknown }) => {
+    if (event.originalEvent) userMoving = true;
+  };
+  const onMoveEnd = () => {
+    if (userMoving) {
+      camera = readCamera();
+      userMoving = false;
+    }
+  };
+  map?.on("movestart", onMoveStart);
+  map?.on("moveend", onMoveEnd);
+  try {
+    await pmtilesControl.addLayer(url);
+  } finally {
+    // Preserve a host user's camera interaction that happened while the archive
+    // header was loading, rather than restoring the older pre-load position.
+    if (userMoving) camera = readCamera();
+    map?.off("movestart", onMoveStart);
+    map?.off("moveend", onMoveEnd);
+  }
   // The upstream PMTiles control always frames a newly added archive. Restore
   // the host's camera when a programmatic caller explicitly opts out.
   if (camera) map?.jumpTo(camera);

--- a/tests/embed-api.test.ts
+++ b/tests/embed-api.test.ts
@@ -214,10 +214,54 @@ describe("parseEmbedRequest: v2 commands", () => {
         requestId: null,
       },
     );
+    assert.deepEqual(
+      parseEmbedRequest(
+        message("addData", {
+          url: "https://example.com/data.parquet",
+          styleUrl: "https://example.com/style.json",
+          fit: false,
+        }),
+      ),
+      {
+        command: {
+          type: "addData",
+          url: "https://example.com/data.parquet",
+          styleUrl: "https://example.com/style.json",
+          fit: false,
+        },
+        requestId: null,
+      },
+    );
+    assert.deepEqual(
+      parseEmbedRequest(message("addData", { url: "https://example.com/data.geojson" })),
+      {
+        command: {
+          type: "addData",
+          url: "https://example.com/data.geojson",
+          styleUrl: null,
+          fit: true,
+        },
+        requestId: null,
+      },
+    );
     assert.deepEqual(parseEmbedRequest(message("exportImage")), {
       command: { type: "exportImage" },
       requestId: null,
     });
+  });
+
+  it("rejects invalid addData URLs and options", () => {
+    for (const payload of [
+      { url: "file:///tmp/data.geojson" },
+      { url: "/relative.geojson" },
+      { url: "https://example.com/data.geojson", styleUrl: "data:text/json,{}" },
+      { url: "https://example.com/data.geojson", fit: "yes" },
+    ]) {
+      assert.match(
+        (parseEmbedRequest(message("addData", payload)) as { error: string }).error,
+        /^addData:/,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- add a typed `addData(url, options?)` embed-client method
- reuse the `?data=` ingestion pipeline for GeoJSON APIs, ZIP, GeoParquet, PMTiles, and COG sources
- return all created layer IDs and support optional remote styles and camera fitting
- delay the embed `ready` event until plugin-backed commands are available
- document and validate the new protocol command

Addresses https://github.com/opengeos/GeoLibre/discussions/1805#discussioncomment-18001564

## Verification

- `node --import tsx --test tests/embed-api.test.ts`
- `npm run build`
- `pre-commit run --files <changed files>`
- Playwright against `https://assets.geolibre.app/data/places.geojson` with the hosted sample style, immediately after `ready`, in dark and light themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an embed API for loading remote geospatial data.
  * Supports custom styles, automatic map fitting, and preserving the current view.
  * Returns IDs for newly added layers.
  * Supports GeoJSON/API, ZIP, GeoParquet, PMTiles, and COG sources.
  * Cancels interrupted loads and cleans up partial layers.

* **Documentation**
  * Added guidance for supported formats, validation, and client API usage.

* **Bug Fixes**
  * Improved validation for data and style URLs and fitting options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->