### PR TITLE
fix(html-export): add sandbox attribute to restrict iframe permissions

### DIFF
--- a/apps/geolibre-desktop/src/lib/html-export.ts
+++ b/apps/geolibre-desktop/src/lib/html-export.ts
@@ -102,6 +102,18 @@ export function buildProjectHtml(options: BuildProjectHtmlOptions): string {
   // Escape "<" so a property value can't break out of the JSON <script> block.
   const projectJson = JSON.stringify(redactCredentials(project)).replace(/</g, "\\u003c");
 
+  // The iframe sandbox below withholds top-navigation and popups, but each of
+  // the tokens it does grant is load-bearing - don't trim them:
+  //   allow-scripts       the framed page is the app itself
+  //   allow-same-origin   without it the frame's origin is opaque ("null"), so
+  //                       the event.origin === viewerOrigin check below never
+  //                       matches and the ready/load-project handshake dies
+  //                       (it also keeps the app's storage/IndexedDB working)
+  //   allow-forms         in-app form submits
+  //   allow-downloads     the framed app is the full viewer, so anchor-download
+  //                       exports (Save Project, chart/processing/georeferencer
+  //                       output) run from inside the frame; browsers block
+  //                       those silently without this token
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -114,7 +126,7 @@ export function buildProjectHtml(options: BuildProjectHtmlOptions): string {
 </style>
 </head>
 <body>
-<iframe id="geolibre-frame" src="${escapeHtml(iframeSrc)}" sandbox="allow-scripts allow-same-origin allow-forms" allow="fullscreen" allowfullscreen></iframe>
+<iframe id="geolibre-frame" src="${escapeHtml(iframeSrc)}" sandbox="allow-scripts allow-same-origin allow-forms allow-downloads" allow="fullscreen" allowfullscreen></iframe>
 <script type="application/json" id="geolibre-project">${projectJson}</script>
 <script>
 (function () {

--- a/apps/geolibre-desktop/src/lib/html-export.ts
+++ b/apps/geolibre-desktop/src/lib/html-export.ts
@@ -114,7 +114,7 @@ export function buildProjectHtml(options: BuildProjectHtmlOptions): string {
 </style>
 </head>
 <body>
-<iframe id="geolibre-frame" src="${escapeHtml(iframeSrc)}" allow="fullscreen" allowfullscreen></iframe>
+<iframe id="geolibre-frame" src="${escapeHtml(iframeSrc)}" sandbox="allow-scripts allow-same-origin allow-forms" allow="fullscreen" allowfullscreen></iframe>
 <script type="application/json" id="geolibre-project">${projectJson}</script>
 <script>
 (function () {

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -26,7 +26,7 @@ describe("buildProjectHtml", () => {
     // "&" is HTML-escaped to "&amp;" in the attribute (decoded back by browsers).
     assert.match(
       html,
-      /<iframe id="geolibre-frame" src="https:\/\/web\.geolibre\.app\/\?embed=1&amp;welcome=0" sandbox="allow-scripts allow-same-origin allow-forms"/,
+      /<iframe id="geolibre-frame" src="https:\/\/web\.geolibre\.app\/\?embed=1&amp;welcome=0" sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"/,
     );
     // The project rides in a JSON <script> block and is replayed over the bridge.
     assert.match(html, /id="geolibre-project"/);
@@ -170,7 +170,7 @@ describe("buildProjectHtml", () => {
   it("includes a sandbox attribute that restricts top-navigation and popups", () => {
     const html = buildProjectHtml({ project: PROJECT, title: "T" });
     // The sandbox must be present with only the minimal set of permissions.
-    assert.match(html, /sandbox="allow-scripts allow-same-origin allow-forms"/);
+    assert.match(html, /sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"/);
     // Dangerous permissions must NOT be present.
     assert.ok(!html.includes("allow-top-navigation"));
     assert.ok(!html.includes("allow-popups"));

--- a/tests/html-export.test.ts
+++ b/tests/html-export.test.ts
@@ -26,7 +26,7 @@ describe("buildProjectHtml", () => {
     // "&" is HTML-escaped to "&amp;" in the attribute (decoded back by browsers).
     assert.match(
       html,
-      /<iframe id="geolibre-frame" src="https:\/\/web\.geolibre\.app\/\?embed=1&amp;welcome=0"/,
+      /<iframe id="geolibre-frame" src="https:\/\/web\.geolibre\.app\/\?embed=1&amp;welcome=0" sandbox="allow-scripts allow-same-origin allow-forms"/,
     );
     // The project rides in a JSON <script> block and is replayed over the bridge.
     assert.match(html, /id="geolibre-project"/);
@@ -165,6 +165,15 @@ describe("buildProjectHtml", () => {
       () => buildProjectHtml({ project: PROJECT, title: "T", height: "1px;color:red" }),
       /Invalid CSS height/,
     );
+  });
+
+  it("includes a sandbox attribute that restricts top-navigation and popups", () => {
+    const html = buildProjectHtml({ project: PROJECT, title: "T" });
+    // The sandbox must be present with only the minimal set of permissions.
+    assert.match(html, /sandbox="allow-scripts allow-same-origin allow-forms"/);
+    // Dangerous permissions must NOT be present.
+    assert.ok(!html.includes("allow-top-navigation"));
+    assert.ok(!html.includes("allow-popups"));
   });
 });
 


### PR DESCRIPTION
- Add a `sandbox` attribute to the exported page's viewer iframe. Granted tokens: `allow-scripts`, `allow-same-origin`, `allow-forms`, `allow-downloads`, `allow-popups` — each is load-bearing and documented in the code next to the token list.
- Withhold `allow-top-navigation` (the frame can no longer navigate the host page) and `allow-popups-to-escape-sandbox` (popups inherit the sandbox instead of escaping it).
- `allow-same-origin` is required: without it the frame's origin is opaque (`"null"`) and the `event.origin !== viewerOrigin` guard kills the `geolibre:ready`/`geolibre:load-project` handshake.
- `allow-downloads` and `allow-popups` keep the framed viewer's anchor-download exports and its `target="_blank"` basemap-attribution links working; both fail silently under a sandbox without them.
- Update the test to verify the token list and that the withheld permissions are absent.
- Improves security of exported HTML projects by sandboxing embedded content.