### PR TITLE
feat(embed): support hiding the top toolbar

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -27,6 +27,7 @@ export interface LayoutOptions {
 
 const COMPACT_LAYOUT_VALUES = new Set(["compact", "embed", "iframe"]);
 const ICON_TOOLBAR_VALUES = new Set(["icon", "icons", "icon-only"]);
+const HIDDEN_TOOLBAR_VALUES = new Set(["hidden", "hide", "none", "off"]);
 const HIDDEN_PANEL_VALUES = new Set(["hidden", "hide", "none", "off"]);
 const MAP_ONLY_VALUES = new Set(["", "true", "1", "yes", "on"]);
 
@@ -91,7 +92,7 @@ export function layoutOptionsFromLocation(layoutSettings: DesktopLayoutSettings)
     statusBarVisible: !mapOnly,
     stylePanelVisible,
     toolbarLabels,
-    toolbarVisible: !mapOnly,
+    toolbarVisible: !mapOnly && !HIDDEN_TOOLBAR_VALUES.has(toolbar),
     viewer,
   };
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,7 +163,7 @@ For map-focused embeds, add `&panels=none` to hide the Layers, Style, and Attrib
 https://web.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
 ```
 
-Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
+Use `toolbar=icons` when you only want icon-only toolbar buttons, or `toolbar=none` to hide the top toolbar while retaining panels and the status bar. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
 
 Use `panels=collapsed` to keep the Layers and Style icon rails visible while
 starting both panels collapsed.

--- a/docs/tutorials/sharing-embedding.md
+++ b/docs/tutorials/sharing-embedding.md
@@ -52,6 +52,7 @@ Adjust the look with parameters (they combine):
 - `layout=viewer` gives a read-only map: Layers, View, Controls, basemaps, and
   search/identify stay, while everything that edits the project is hidden.
 - `layout=compact` keeps a slim, icon-only toolbar.
+- `toolbar=none` hides the top toolbar while keeping panels and the status bar.
 - `panels=none` hides the side and bottom panels but keeps the toolbar.
 - `theme=dark` forces the dark theme on load.
 

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -26,7 +26,7 @@ A chrome-free `maponly` embed shows only the map, as in this shared 3D Tiles pro
 | `data`       | `data=https://assets.geolibre.app/data/places.geojson`     | Loads public GeoJSON, GeoParquet, PMTiles, a COG, or a ZIP/REST response containing multiple GeoJSON files.                           |
 | `style`      | `style=https://assets.geolibre.app/data/sample.style.json` | Applies a GeoLibre/MapLibre vector style or raster-style JSON to the data loaded by `data`.                                            |
 | `layout`     | `layout=viewer`                                            | `viewer` provides read-only chrome: Layers, View, Controls, basemaps, search/identify, and Help, with authoring UI hidden. `compact` is the icon-only full-app layout; `embed` and `iframe` are aliases. |
-| `toolbar`    | `toolbar=icons`                                            | Icon-only toolbar buttons without the full compact layout. `icon` and `icon-only` are aliases.                                        |
+| `toolbar`    | `toolbar=none`                                             | Hides the top toolbar while keeping panels and the status bar. Use `icons` for icon-only buttons; `icon` and `icon-only` are aliases. `hidden`, `hide`, and `off` are aliases for `none`. |
 | `panels`     | `panels=collapsed`                                         | Starts Layers and Style collapsed to their icon rails. Use `none` to hide all panels; `hidden`, `hide`, and `off` are aliases.         |
 | `hidePanels` | `hidePanels=true`                                          | Alternative way to hide those panels.                                                                                                 |
 | `maponly`    | `maponly`                                                  | Hides all chrome (toolbar, panels, and status bar), leaving only the map. The bare flag or `true`, `1`, `yes`, `on` enable it.        |
@@ -85,7 +85,8 @@ Drop the viewer into an `<iframe>`:
 ></iframe>
 ```
 
-Use `layout=viewer` for a read-only map with layer toggles, search/identify, and
+Use `toolbar=none` to hide the top toolbar while retaining the configured side
+panels and status bar. Use `layout=viewer` for a read-only map with layer toggles, search/identify, and
 basemap switching. Its layer list mirrors the authoring Layers panel, folders
 and all, so group names carry over. The Controls menu is part of the viewer
 chrome, minus the two entries that write to the project (Field Collection and

--- a/tests/layout-options.test.ts
+++ b/tests/layout-options.test.ts
@@ -89,6 +89,26 @@ describe("layoutOptionsFromLocation", () => {
     assert.equal(options.panelsHidden, true);
   });
 
+  it("hides only the toolbar for toolbar=none", () => {
+    withSearch("?toolbar=none");
+    const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    assert.equal(options.toolbarVisible, false);
+    assert.equal(options.statusBarVisible, true);
+    assert.equal(options.layerPanelVisible, true);
+    assert.equal(options.stylePanelVisible, true);
+    assert.equal(options.attributePanelVisible, true);
+    assert.equal(options.panelsHidden, false);
+  });
+
+  it("accepts hidden toolbar aliases", () => {
+    for (const value of ["hidden", "hide", "off"]) {
+      withSearch(`?toolbar=${value}`);
+      const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+      assert.equal(options.toolbarVisible, false, `toolbar=${value}`);
+      assert.equal(options.layerPanelVisible, true, `toolbar=${value}`);
+    }
+  });
+
   it("starts side panels collapsed without hiding their rails", () => {
     withSearch("?panels=collapsed");
     const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);


### PR DESCRIPTION
## Summary
- add `toolbar=none` to hide the top toolbar while retaining panels and the status bar
- accept `hidden`, `hide`, and `off` aliases and cover the behavior with layout tests
- document the new embedding option

Addresses https://github.com/opengeos/GeoLibre/discussions/1879

## Test plan
- [x] Run the frontend test suite
- [x] Run the production build
- [x] Run ESLint and scoped pre-commit checks
- [x] Verify `toolbar=none` with a real GeoJSON dataset in light and dark themes
- [x] Confirm Layers and the status bar remain visible while the top toolbar is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hiding the top toolbar through embedding options, including `toolbar=none` and aliases such as `hidden`, `hide`, and `off`.
  * Panels, panel rails, and the status bar remain visible when the toolbar is hidden.
  * Clarified toolbar display options, including icon-only mode.

* **Documentation**
  * Updated embedding guides and tutorials with the new toolbar options and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->