### PR TITLE
fix(plugins): keep the plugin query tests off the plugin registry

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -26,7 +26,6 @@ import {
   setEffectsSettings,
   type EffectsSettings,
   maplibreEarthdataGisPlugin,
-  SKETCHES_SOURCE_KIND,
   setEarthdataCogSaver,
   maplibreEnviroAtlasPlugin,
   maplibreEsriWaybackPlugin,
@@ -94,7 +93,6 @@ import type {
   GeoLibreExternalNativeLayerRegistration,
   GeoLibreFileDialogOptions,
   GeoLibreMapControlPosition,
-  GeoLibreSelection,
   GeoLibreTileLayerOptions,
   GeoLibreWmsLayerOptions,
   GeoLibreZarrLayerOptions,
@@ -132,6 +130,7 @@ import { partitionProjectPluginManifestUrls } from "../lib/plugin-trust";
 import { setTimeSliderOpenedByBinding, shouldCloseTimeSliderDock } from "../lib/time-slider-dock";
 import { createWmsTileUrl, normalizeWmsVersion } from "../components/layout/add-data/helpers";
 import { createExternalNativeStoreLayer } from "../lib/external-native-layer";
+import { createPluginLayerQueries } from "../lib/plugin-layer-queries";
 import { mergeStringLists } from "../lib/string-lists";
 import {
   browserSaveFallsBackToDownload,
@@ -831,21 +830,6 @@ export function useTimeSliderAutoClose(mapControllerRef: RefObject<MapController
   }, [mapControllerRef]);
 }
 
-function readPluginSelection(): GeoLibreSelection {
-  const state = useAppStore.getState();
-  const layer = state.layers.find((item) => item.id === state.selectedLayerId);
-  if (!layer || state.selectedFeatureIds.length === 0) {
-    return { layerId: state.selectedLayerId, features: [] };
-  }
-  const selected = new Set(state.selectedFeatureIds);
-  const features = structuredClone(
-    (layer.geojson?.features ?? []).filter((feature, index) =>
-      selected.has(String(feature.id ?? index)),
-    ),
-  );
-  return { layerId: state.selectedLayerId, features };
-}
-
 export function createAppAPI(mapControllerRef?: RefObject<MapController | null>) {
   const store = useAppStore.getState();
   // Captured so methods that delegate to plugin helpers taking the AppAPI
@@ -857,40 +841,7 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
       const id = store.addGeoJsonLayer(name, data, sourcePath);
       return id;
     },
-    listLayers: () =>
-      useAppStore.getState().layers.map(({ id, name, type, visible, opacity }) => ({
-        id,
-        name,
-        type,
-        visible,
-        opacity,
-      })),
-    getLayerFeatures: (layerId: string) => {
-      const layer = useAppStore.getState().layers.find((item) => item.id === layerId);
-      if (!layer) throw new Error(`No layer with id "${layerId}"`);
-      return structuredClone(layer.geojson?.features ?? []);
-    },
-    getSelectedFeatures: () => readPluginSelection().features,
-    getSelectedLayerId: () => useAppStore.getState().selectedLayerId,
-    getDrawnFeatures: () =>
-      structuredClone(
-        useAppStore
-          .getState()
-          .layers.flatMap((layer) =>
-            layer.metadata.sourceKind === SKETCHES_SOURCE_KIND
-              ? (layer.geojson?.features ?? [])
-              : [],
-          ),
-      ),
-    onSelectionChange: (callback: (selection: GeoLibreSelection) => void) =>
-      useAppStore.subscribe((state, previous) => {
-        if (
-          state.selectedLayerId !== previous.selectedLayerId ||
-          state.selectedFeatureIds !== previous.selectedFeatureIds
-        ) {
-          callback(readPluginSelection());
-        }
-      }),
+    ...createPluginLayerQueries(),
     addTileLayer: (name: string, url: string, options?: GeoLibreTileLayerOptions) =>
       store.addTileLayer(
         name,

--- a/apps/geolibre-desktop/src/lib/plugin-layer-queries.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-layer-queries.ts
@@ -1,0 +1,80 @@
+import { useAppStore } from "@geolibre/core";
+import { SKETCHES_SOURCE_KIND } from "@geolibre/plugins/geo-editor-geometry";
+import type { GeoLibreSelection } from "@geolibre/plugins";
+
+/**
+ * The read-only half of the external plugin API: everything a plugin may ask
+ * about the layers currently on the map, and nothing that writes to them.
+ *
+ * Kept out of `usePlugins.ts` on purpose. That module imports the whole
+ * built-in plugin registry (and through it MapCanvas, CesiumCanvas, and every
+ * `maplibre-*` plugin), so a unit test reaching these queries through
+ * `createAppAPI` had to stub `maplibre-gl`, `window`, and `localStorage` just
+ * to load the module, and dragged 39 browser-only files into the coverage
+ * report along the way. These functions need only the store, so they live
+ * here and `createAppAPI` spreads them in. Same reasoning as
+ * `geo-editor-geometry.ts` in `@geolibre/plugins`.
+ *
+ * Every accessor hands back a `structuredClone`, so a plugin holding a
+ * returned feature cannot reach into store state and mutate it.
+ */
+
+/** The current selection as plugins see it: the layer id and its selected features. */
+export function readPluginSelection(): GeoLibreSelection {
+  const state = useAppStore.getState();
+  const layer = state.layers.find((item) => item.id === state.selectedLayerId);
+  if (!layer || state.selectedFeatureIds.length === 0) {
+    return { layerId: state.selectedLayerId, features: [] };
+  }
+  const selected = new Set(state.selectedFeatureIds);
+  const features = structuredClone(
+    (layer.geojson?.features ?? []).filter((feature, index) =>
+      selected.has(String(feature.id ?? index)),
+    ),
+  );
+  return { layerId: state.selectedLayerId, features };
+}
+
+/**
+ * Build the read-only query methods that `createAppAPI` exposes to plugins.
+ * Reads the store on every call rather than closing over a snapshot, so a
+ * plugin holding the API sees the map as it is now.
+ */
+export function createPluginLayerQueries() {
+  return {
+    listLayers: () =>
+      useAppStore.getState().layers.map(({ id, name, type, visible, opacity }) => ({
+        id,
+        name,
+        type,
+        visible,
+        opacity,
+      })),
+    getLayerFeatures: (layerId: string) => {
+      const layer = useAppStore.getState().layers.find((item) => item.id === layerId);
+      if (!layer) throw new Error(`No layer with id "${layerId}"`);
+      return structuredClone(layer.geojson?.features ?? []);
+    },
+    getSelectedFeatures: () => readPluginSelection().features,
+    getSelectedLayerId: () => useAppStore.getState().selectedLayerId,
+    getDrawnFeatures: () =>
+      structuredClone(
+        useAppStore
+          .getState()
+          .layers.flatMap((layer) =>
+            layer.metadata.sourceKind === SKETCHES_SOURCE_KIND
+              ? (layer.geojson?.features ?? [])
+              : [],
+          ),
+      ),
+    onSelectionChange: (callback: (selection: GeoLibreSelection) => void) =>
+      useAppStore.subscribe((state, previous) => {
+        if (
+          state.selectedLayerId !== previous.selectedLayerId ||
+          state.selectedFeatureIds !== previous.selectedFeatureIds
+        ) {
+          callback(readPluginSelection());
+        }
+      }),
+  };
+}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./cog-spectral-profile": "./src/plugins/cog-spectral-profile.ts",
+    "./geo-editor-geometry": "./src/plugins/geo-editor-geometry.ts",
     "./local-netcdf": "./src/plugins/local-netcdf.ts",
     "./maplibre-graticule": "./src/plugins/maplibre-graticule.ts",
     "./raster-symbology": "./src/plugins/raster-symbology.ts",

--- a/tests/plugin-query-api.test.ts
+++ b/tests/plugin-query-api.test.ts
@@ -1,61 +1,17 @@
 import assert from "node:assert/strict";
-import { createRequire, registerHooks } from "node:module";
-import { before, beforeEach, describe, it } from "node:test";
+import { beforeEach, describe, it } from "node:test";
+import { useAppStore } from "@geolibre/core";
+import { SKETCHES_SOURCE_KIND } from "@geolibre/plugins/geo-editor-geometry";
 import type { GeoLibreSelection } from "@geolibre/plugins";
+import { createPluginLayerQueries } from "../apps/geolibre-desktop/src/lib/plugin-layer-queries";
 
-(globalThis as typeof globalThis & { window: typeof globalThis }).window = globalThis;
-(globalThis as typeof globalThis & { location: { search: string } }).location = { search: "" };
-const emptyStorage = { getItem: () => null };
-(globalThis as typeof globalThis & { sessionStorage: typeof emptyStorage }).sessionStorage =
-  emptyStorage;
-(globalThis as typeof globalThis & { localStorage: typeof emptyStorage }).localStorage =
-  emptyStorage;
-const maplibreGl = createRequire(`${process.cwd()}/package.json`)("maplibre-gl") as Record<
-  string,
-  unknown
->;
-(globalThis as typeof globalThis & { __maplibreGl: Record<string, unknown> }).__maplibreGl =
-  maplibreGl;
-const maplibreGlModuleSource = [
-  "export default globalThis.__maplibreGl;",
-  ...Object.keys(maplibreGl)
-    .filter((name) => name !== "default" && /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name))
-    .map((name) => `export const ${name} = globalThis.__maplibreGl[${JSON.stringify(name)}];`),
-].join("\n");
-registerHooks({
-  resolve(specifier, context, nextResolve) {
-    if (specifier === "maplibre-gl") {
-      return { url: "test:maplibre-gl", shortCircuit: true };
-    }
-    return nextResolve(specifier, context);
-  },
-  load(url, context, nextLoad) {
-    if (url === "test:maplibre-gl") {
-      return { format: "module", source: maplibreGlModuleSource, shortCircuit: true };
-    }
-    if (url.endsWith(".css")) {
-      return { format: "module", source: "", shortCircuit: true };
-    }
-    if (url === "virtual:bundled-plugins") {
-      return {
-        format: "module",
-        source: "export const bundledPluginManifestPaths = [];",
-        shortCircuit: true,
-      };
-    }
-    return nextLoad(url, context);
-  },
-});
-const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
-let useAppStore: typeof import("@geolibre/core").useAppStore;
-let createAppAPI: typeof import("../apps/geolibre-desktop/src/hooks/usePlugins").createAppAPI;
-
-before(async () => {
-  [{ useAppStore }, { createAppAPI }] = await Promise.all([
-    import("@geolibre/core"),
-    import("../apps/geolibre-desktop/src/hooks/usePlugins"),
-  ]);
-});
+// These exercise `createPluginLayerQueries`, which `createAppAPI` spreads into
+// the object it hands plugins, rather than reaching through `createAppAPI`
+// itself. Loading `usePlugins.ts` pulls in the whole built-in plugin registry
+// (and MapCanvas, CesiumCanvas, and every `maplibre-*` plugin with it), which
+// forced this file to stub `maplibre-gl`, `window`, and `localStorage` just to
+// import it, and put 39 browser-only modules into the coverage report. The
+// wiring itself is a typed spread, so `npm run build` is what holds it.
 
 describe("external plugin query API", () => {
   beforeEach(() => {
@@ -74,18 +30,18 @@ describe("external plugin query API", () => {
     store.selectLayer(layerId);
     store.selectFeatures(["A", "B"]);
 
-    const app = createAppAPI();
-    assert.equal(app.getSelectedLayerId?.(), layerId);
+    const app = createPluginLayerQueries();
+    assert.equal(app.getSelectedLayerId(), layerId);
     assert.deepEqual(
-      app.getSelectedFeatures?.().map((feature) => feature.id),
+      app.getSelectedFeatures().map((feature) => feature.id),
       ["A", "B"],
     );
   });
 
   it("notifies and unsubscribes selection listeners", () => {
-    const app = createAppAPI();
+    const app = createPluginLayerQueries();
     const events: unknown[] = [];
-    const unsubscribe = app.onSelectionChange?.((selection) => events.push(selection));
+    const unsubscribe = app.onSelectionChange((selection) => events.push(selection));
     assert.ok(unsubscribe);
     useAppStore.getState().selectFeatures(["A"]);
     assert.equal(events.length, 1);
@@ -109,8 +65,8 @@ describe("external plugin query API", () => {
     });
     const before = JSON.stringify(useAppStore.getState());
 
-    const app = createAppAPI();
-    assert.deepEqual(app.listLayers?.(), [
+    const app = createPluginLayerQueries();
+    assert.deepEqual(app.listLayers(), [
       {
         id: layerId,
         name: "Catchments",
@@ -119,7 +75,7 @@ describe("external plugin query API", () => {
         opacity: 1,
       },
     ]);
-    assert.deepEqual(app.getLayerFeatures?.(layerId), [
+    assert.deepEqual(app.getLayerFeatures(layerId), [
       {
         type: "Feature",
         id: "A",
@@ -127,9 +83,9 @@ describe("external plugin query API", () => {
         geometry: { type: "Point", coordinates: [101.7, 3.1] },
       },
     ]);
-    app.getSelectedFeatures?.();
-    app.getSelectedLayerId?.();
-    app.getDrawnFeatures?.();
+    app.getSelectedFeatures();
+    app.getSelectedLayerId();
+    app.getDrawnFeatures();
 
     assert.equal(JSON.stringify(useAppStore.getState()), before);
   });
@@ -152,9 +108,9 @@ describe("external plugin query API", () => {
     });
     store.selectLayer(layerId);
 
-    const app = createAppAPI();
+    const app = createPluginLayerQueries();
     let callbackSelection: GeoLibreSelection | undefined;
-    const unsubscribe = app.onSelectionChange?.((selection) => {
+    const unsubscribe = app.onSelectionChange((selection) => {
       callbackSelection = selection;
     });
     assert.ok(unsubscribe);
@@ -162,9 +118,9 @@ describe("external plugin query API", () => {
     assert.ok(callbackSelection);
 
     const returnedFeatures = [
-      app.getLayerFeatures?.(layerId)[0],
-      app.getSelectedFeatures?.()[0],
-      app.getDrawnFeatures?.()[0],
+      app.getLayerFeatures(layerId)[0],
+      app.getSelectedFeatures()[0],
+      app.getDrawnFeatures()[0],
       callbackSelection.features[0],
     ];
     for (const feature of returnedFeatures) {
@@ -184,8 +140,8 @@ describe("external plugin query API", () => {
   });
 
   it("throws when a requested layer does not exist", () => {
-    const app = createAppAPI();
-    assert.throws(() => app.getLayerFeatures?.("missing-layer"), {
+    const app = createPluginLayerQueries();
+    assert.throws(() => app.getLayerFeatures("missing-layer"), {
       message: 'No layer with id "missing-layer"',
     });
   });
@@ -203,8 +159,8 @@ describe("external plugin query API", () => {
     store.selectFeatures(["1"]);
 
     assert.deepEqual(
-      createAppAPI()
-        .getSelectedFeatures?.()
+      createPluginLayerQueries()
+        .getSelectedFeatures()
         .map((feature) => feature.properties?.NAME),
       ["Second"],
     );
@@ -218,9 +174,9 @@ describe("external plugin query API", () => {
     });
     store.selectLayer(layerId);
 
-    const app = createAppAPI();
-    assert.equal(app.getSelectedLayerId?.(), layerId);
-    assert.deepEqual(app.getSelectedFeatures?.(), []);
+    const app = createPluginLayerQueries();
+    assert.equal(app.getSelectedLayerId(), layerId);
+    assert.deepEqual(app.getSelectedFeatures(), []);
   });
 
   it("returns features from every sketch layer and excludes ordinary layers", () => {
@@ -244,7 +200,7 @@ describe("external plugin query API", () => {
       metadata: { sourceKind: SKETCHES_SOURCE_KIND },
     });
 
-    assert.deepEqual(createAppAPI().getDrawnFeatures?.(), [
+    assert.deepEqual(createPluginLayerQueries().getDrawnFeatures(), [
       {
         type: "Feature",
         id: "drawn-1",


### PR DESCRIPTION
`main` has been red since #1784. This restores it.

## What broke

#1784 added `tests/plugin-query-api.test.ts`, which reaches the new read-only query API through `createAppAPI` in `usePlugins.ts`. That module imports the entire built-in plugin registry, so loading it dragged in `MapCanvas`, `CesiumCanvas`, and every `maplibre-*` plugin.

Coverage is reported only over files a test actually imports (as `CLAUDE.md` notes, a module with no test does not appear at all rather than as 0%). So those **39 browser-only modules entered the denominator** at 1-30% function coverage:

| | files counted | lines | branches | functions |
|---|---|---|---|---|
| before #1784 (`3697baf8`) | 405 | 82.89% | 84.46% | **72.90%** |
| after #1784 (`6093aa80`) | 444 | 81.82% | 84.30% | **60.36%** |

That is under the 63% floor, so `npm run ci` fails. Worst offenders: `MapCanvas.tsx` at 2.50% functions, `maplibre-duckdb.ts` at 1.67%, `maplibre-openaerialmap.ts` at 2.38%.

Nothing got less tested. #1784 *added* 256 lines of tests. The metric moved because the denominator grew, so the gate was measuring module reachability rather than test quality.

## The fix

Move the six query methods and `readPluginSelection` into `apps/geolibre-desktop/src/lib/plugin-layer-queries.ts`, which needs only the store, and have `createAppAPI` spread them in. The test imports that module directly.

This follows the precedent already in the tree: `geo-editor-geometry.ts` is documented as "Kept free of the Geoman/MapLibre runtime imports ... so they can be unit-tested under Node without a browser environment."

Knock-on cleanups:

- The test drops its `maplibre-gl` module-hook shim and its `window` / `location` / `sessionStorage` / `localStorage` globals. It no longer needs a browser to load, and runs in ~7ms.
- `SKETCHES_SOURCE_KIND` gets a subpath export alongside the five already in `@geolibre/plugins`, so the test shares the constant instead of repeating the `"geoeditor-sketches"` literal as it did before.

## Trade-off

The test now covers `createPluginLayerQueries` rather than asserting that `createAppAPI` exposes these methods. That wiring is a typed spread, so `tsc` enforces it on every build. Testing it at runtime is what requires loading the whole registry, which is the thing this PR is removing.

## Result

| | files counted | lines | branches | functions |
|---|---|---|---|---|
| this PR | 406 | 82.84% | 84.45% | **72.55%** |

The single added file is the extracted module, at 100% lines / 95.45% functions. All 8 tests pass, `npm run lint` is unchanged (0 errors, the same 40 pre-existing warnings), `npm run build` is clean, and `pre-commit run --files ...` passes including the `npm-build` hook.

## Note on a separate flake

While diagnosing this I found that **line** coverage is nondeterministic run to run on identical sources: 81.82% (`main`'s CI), 76.47% (a PR's CI on the same tree), 79.78% locally. Per file, the function column is identical across runs while the line column swings, which is why one run reported an extra "76.47% line coverage does not meet threshold of 78%" error that another did not. The 78% line floor can therefore redden unrelated PRs. Out of scope here; worth its own issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin layer query capabilities for viewing layer metadata, features, selections, selected layers, drawn sketches, and selection changes.
  * Added a public export for Geo Editor geometry functionality.
  * Query results are safely isolated from application state, and invalid layer lookups provide clear errors.

* **Tests**
  * Expanded coverage for layer queries, selections, drawn features, empty results, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->