### PR TITLE
fix(ci): re-measure a line-only coverage shortfall before failing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,31 @@ a few points under the current numbers as a **ratchet** — regressions fail CI,
 and when coverage rises comfortably above a floor, raise the floor to lock in the
 gain. The frontend
 report only counts files a test actually imports, so a module with no test does
-not appear at all rather than as 0%. The backend coverage run (and `npm run ci`,
+not appear at all rather than as 0%.
+
+That last point is the one that bites: writing the *first* test for a large
+untested module reads as a coverage **regression**, because the module and
+everything it imports enter the denominator at once. GeoLibre#1784 added a test
+that imported `usePlugins.ts` and so pulled in the whole built-in plugin
+registry, 39 files, dropping function coverage 72.90% → 60.36% and reddening
+`main`. The fix is to test against a leaf module rather than to lower the floor
+(GeoLibre#1888 extracted `lib/plugin-layer-queries.ts`; `geo-editor-geometry.ts`
+in `@geolibre/plugins` is the same pattern). Check what a new test *transitively*
+imports before assuming a coverage drop means the code got worse.
+
+`test:frontend:coverage` runs through `scripts/coverage-check.mjs` rather than
+calling `node --test` directly. Node still enforces all three floors; the wrapper
+only re-measures once when **line** coverage alone comes up short with every test
+passing. Line coverage is nondeterministic on CI (GeoLibre#1889: two runs over
+byte-identical sources reported 81.82% and 76.47%, 114 of 444 files differing on
+lines and *none* on branches or functions), and it is not reproducible locally on
+either Node 22 or 26. Branch and function shortfalls, and any test failure, fail
+on the spot with no retry, so a real regression still fails fast. `classify()` is
+exported and covered by `tests/coverage-check.test.ts` — change the retry policy
+there, not by loosening a floor. If the retry starts firing regularly, fix the
+measurement instead of widening the mitigation.
+
+The backend coverage run (and `npm run ci`,
 which calls the `:coverage` variants) needs `pytest-cov` from the backend `dev`
 extra. Install the **`test`** extra to run the *full* backend suite — without
 the optional engines (geopandas/rasterio/sedona/httpx) the vector/raster/SQL/ML

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint apps packages workers tests",
     "test": "npm run test:frontend",
     "test:frontend": "node --import tsx --test tests/*.test.ts",
-    "test:frontend:coverage": "node --import tsx --test --experimental-test-coverage --test-coverage-lines=78 --test-coverage-branches=78 --test-coverage-functions=63 --test-coverage-exclude=\"tests/**\" --test-coverage-exclude=\"e2e/**\" --test-coverage-exclude=\"**/*.config.*\" tests/*.test.ts",
+    "test:frontend:coverage": "node scripts/coverage-check.mjs",
     "test:backend": "python -m pytest backend/geolibre_server/tests",
     "test:backend:coverage": "python -m pytest backend/geolibre_server/tests --cov=geolibre_server --cov-report=term-missing --cov-fail-under=55",
     "test:worker": "npm run typecheck -w geolibre-viewer-worker && npm run typecheck -w geolibre-collab-worker && npm run typecheck -w geolibre-collab-node && npm test -w geolibre-collab-node && npm run typecheck -w geolibre-tiles-worker && npm run typecheck -w geolibre-ai-proxy-worker",

--- a/scripts/coverage-check.mjs
+++ b/scripts/coverage-check.mjs
@@ -1,0 +1,158 @@
+// CI frontend coverage gate: the `node --test` coverage floors, with one retry
+// reserved for the line metric.
+// Run with: node scripts/coverage-check.mjs  (or `npm run test:frontend:coverage`)
+//
+// Node enforces all three floors itself; this wrapper only decides whether a
+// failure is worth a second opinion. Line coverage is the one metric observed
+// to be nondeterministic on CI: two runs over byte-identical sources reported
+// 81.82% and 76.47%, with 114 of 444 files differing on lines while *zero*
+// differed on branches or functions, and the same 5935 tests passing in both.
+// The low run failed a floor that the identical tree cleared minutes earlier.
+// See https://github.com/opengeos/GeoLibre/issues/1889.
+//
+// So: a line-only shortfall is re-measured once, and only a second shortfall
+// fails the build. Branch and function shortfalls fail immediately, as does any
+// actual test failure. That keeps every floor at full strength against a real
+// regression (which reproduces on the re-run) while not reddening a PR over an
+// accounting artifact nobody can act on.
+//
+// If the retry ever starts firing regularly, that is the signal to stop
+// mitigating and fix the measurement: the retry logs both numbers precisely so
+// #1889 can accumulate evidence.
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Kept in sync with the floors documented in CLAUDE.md. Raise them when
+// coverage rises comfortably above, which is what makes this a ratchet.
+const LINES = 78;
+const BRANCHES = 78;
+const FUNCTIONS = 63;
+
+// Expanded here rather than left to a shell glob, so the gate behaves the same
+// under zsh, bash, and cmd.exe.
+const testFiles = readdirSync("tests")
+  .filter((name) => name.endsWith(".test.ts"))
+  .sort()
+  .map((name) => path.posix.join("tests", name));
+
+if (testFiles.length === 0) {
+  console.error("coverage-check: no tests/*.test.ts files found.");
+  process.exit(1);
+}
+
+const args = [
+  "--import",
+  "tsx",
+  "--test",
+  "--experimental-test-coverage",
+  `--test-coverage-lines=${LINES}`,
+  `--test-coverage-branches=${BRANCHES}`,
+  `--test-coverage-functions=${FUNCTIONS}`,
+  "--test-coverage-exclude=tests/**",
+  "--test-coverage-exclude=e2e/**",
+  "--test-coverage-exclude=**/*.config.*",
+  ...testFiles,
+];
+
+/**
+ * Run the suite once, echoing output as it is captured so the CI log reads
+ * exactly as it did before this wrapper existed.
+ */
+function runSuite() {
+  const result = spawnSync(process.execPath, args, {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  return { status: result.status ?? 1, output: `${stdout}\n${stderr}` };
+}
+
+/**
+ * Classify a run. The reporter prefixes summary lines with `#` (tap) or `ℹ`
+ * (spec) depending on whether stdout is a TTY, so both are accepted.
+ *
+ * Exported for `tests/coverage-check.test.ts`: deciding when to re-measure is
+ * the part of this gate that can silently swallow a real regression, so it is
+ * pinned by tests rather than trusted.
+ */
+export function classify({ status, output }) {
+  const failedTests = Number(/(?:^|[#ℹ]\s*)fail\s+(\d+)/m.exec(output)?.[1] ?? 0);
+  const thresholds = [
+    ...output.matchAll(
+      /([\d.]+)% (line|branch|function) coverage does not meet threshold of ([\d.]+)%/g,
+    ),
+  ].map((match) => ({ actual: Number(match[1]), metric: match[2], floor: Number(match[3]) }));
+  return {
+    ok: status === 0,
+    failedTests,
+    thresholds,
+    // The one case worth a second measurement: the suite passed, and lines are
+    // the only floor that came up short.
+    lineOnly:
+      status !== 0 &&
+      failedTests === 0 &&
+      thresholds.length > 0 &&
+      thresholds.every((entry) => entry.metric === "line"),
+  };
+}
+
+function main() {
+  const first = classify(runSuite());
+  if (first.ok) process.exit(0);
+
+  if (!first.lineOnly) {
+    if (first.failedTests > 0) {
+      console.error(`\ncoverage-check: ${first.failedTests} test(s) failed. Not retrying.`);
+    } else if (first.thresholds.length > 0) {
+      const stable = first.thresholds
+        .filter((entry) => entry.metric !== "line")
+        .map((entry) => `${entry.metric} ${entry.actual}% < ${entry.floor}%`)
+        .join(", ");
+      console.error(
+        `\ncoverage-check: ${stable || "coverage"} below floor. Branch and function coverage are ` +
+          "reproducible run to run, so this is a real regression and is not retried.",
+      );
+    }
+    process.exit(1);
+  }
+
+  const firstLine = first.thresholds[0];
+  console.error(
+    `\ncoverage-check: line coverage came in at ${firstLine.actual}%, under the ${firstLine.floor}% floor, ` +
+      "with every test passing and branch and function coverage fine.\n" +
+      "coverage-check: that is the signature of the nondeterministic line accounting in " +
+      "https://github.com/opengeos/GeoLibre/issues/1889, so re-measuring once before failing.\n",
+  );
+
+  const second = classify(runSuite());
+  if (second.ok) {
+    console.error(
+      `\ncoverage-check: the re-run cleared the floor, so the ${firstLine.actual}% reading was a ` +
+        "measurement artifact rather than a coverage regression.\n" +
+        `coverage-check: please add the pair (${firstLine.actual}% then passing) to issue #1889. ` +
+        "If this is happening often, the gate needs fixing rather than retrying.",
+    );
+    process.exit(0);
+  }
+
+  const secondLine = second.thresholds.find((entry) => entry.metric === "line");
+  console.error(
+    `\ncoverage-check: line coverage was short twice in a row (${firstLine.actual}% then ` +
+      `${secondLine ? `${secondLine.actual}%` : "short again"}, floor ${firstLine.floor}%). ` +
+      "A real regression reproduces; this is one. Add tests or, if the drop is a module newly " +
+      "pulled into the report rather than code getting less tested, see the coverage notes in CLAUDE.md.",
+  );
+  process.exit(1);
+}
+
+// Only run the gate when invoked directly, so the test file can import
+// `classify` without spawning the whole suite.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/coverage-check.mjs
+++ b/scripts/coverage-check.mjs
@@ -19,7 +19,7 @@
 // If the retry ever starts firing regularly, that is the signal to stop
 // mitigating and fix the measurement: the retry logs both numbers precisely so
 // #1889 can accumulate evidence.
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,47 +30,61 @@ const LINES = 78;
 const BRANCHES = 78;
 const FUNCTIONS = 63;
 
-// Expanded here rather than left to a shell glob, so the gate behaves the same
-// under zsh, bash, and cmd.exe.
-const testFiles = readdirSync("tests")
-  .filter((name) => name.endsWith(".test.ts"))
-  .sort()
-  .map((name) => path.posix.join("tests", name));
-
-if (testFiles.length === 0) {
-  console.error("coverage-check: no tests/*.test.ts files found.");
-  process.exit(1);
+/** The `node --test` invocation this gate wraps. */
+function testRunnerArgs() {
+  // Expanded here rather than left to a shell glob, so the gate behaves the
+  // same under zsh, bash, and cmd.exe.
+  const testFiles = readdirSync("tests")
+    .filter((name) => name.endsWith(".test.ts"))
+    .sort()
+    .map((name) => path.posix.join("tests", name));
+  if (testFiles.length === 0) throw new Error("no tests/*.test.ts files found");
+  return [
+    "--import",
+    "tsx",
+    "--test",
+    "--experimental-test-coverage",
+    `--test-coverage-lines=${LINES}`,
+    `--test-coverage-branches=${BRANCHES}`,
+    `--test-coverage-functions=${FUNCTIONS}`,
+    "--test-coverage-exclude=tests/**",
+    "--test-coverage-exclude=e2e/**",
+    "--test-coverage-exclude=**/*.config.*",
+    ...testFiles,
+  ];
 }
 
-const args = [
-  "--import",
-  "tsx",
-  "--test",
-  "--experimental-test-coverage",
-  `--test-coverage-lines=${LINES}`,
-  `--test-coverage-branches=${BRANCHES}`,
-  `--test-coverage-functions=${FUNCTIONS}`,
-  "--test-coverage-exclude=tests/**",
-  "--test-coverage-exclude=e2e/**",
-  "--test-coverage-exclude=**/*.config.*",
-  ...testFiles,
-];
-
 /**
- * Run the suite once, echoing output as it is captured so the CI log reads
- * exactly as it did before this wrapper existed.
+ * Run the suite once, streaming its output through as it arrives while also
+ * accumulating it for {@link classify}.
+ *
+ * Deliberately streamed rather than buffered and written at the end.
+ * `process.stdout` is asynchronous when it is a pipe, which is what it is under
+ * a CI runner (but not when redirected to a file locally, which is how this hid
+ * at first). Writing a multi-megabyte string and then exiting drops whatever had
+ * not flushed: the run that caught this lost ~42,000 lines of test output and
+ * the entire coverage summary, cut off mid-line, while still exiting 0.
  */
-function runSuite() {
-  const result = spawnSync(process.execPath, args, {
-    encoding: "utf8",
-    maxBuffer: 256 * 1024 * 1024,
-    stdio: ["inherit", "pipe", "pipe"],
+function runSuite(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, { stdio: ["inherit", "pipe", "pipe"] });
+    let output = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+      process.stdout.write(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      output += chunk;
+      process.stderr.write(chunk);
+    });
+    child.on("error", (error) => {
+      console.error(`coverage-check: could not start the test runner: ${error.message}`);
+      resolve({ status: 1, output });
+    });
+    child.on("close", (code) => resolve({ status: code ?? 1, output }));
   });
-  const stdout = result.stdout ?? "";
-  const stderr = result.stderr ?? "";
-  process.stdout.write(stdout);
-  process.stderr.write(stderr);
-  return { status: result.status ?? 1, output: `${stdout}\n${stderr}` };
 }
 
 /**
@@ -92,7 +106,7 @@ export function classify({ status, output }) {
     ok: status === 0,
     failedTests,
     thresholds,
-    // The one case worth a second measurement: the suite passed, and lines are
+    // The one case worth a second measurement: every test passed, and lines are
     // the only floor that came up short.
     lineOnly:
       status !== 0 &&
@@ -102,9 +116,14 @@ export function classify({ status, output }) {
   };
 }
 
-function main() {
-  const first = classify(runSuite());
-  if (first.ok) process.exit(0);
+/**
+ * Returns the process exit code. Never calls `process.exit`, which would cut
+ * off streamed output that has not flushed yet.
+ */
+async function main() {
+  const args = testRunnerArgs();
+  const first = classify(await runSuite(args));
+  if (first.ok) return 0;
 
   if (!first.lineOnly) {
     if (first.failedTests > 0) {
@@ -119,7 +138,7 @@ function main() {
           "reproducible run to run, so this is a real regression and is not retried.",
       );
     }
-    process.exit(1);
+    return 1;
   }
 
   const firstLine = first.thresholds[0];
@@ -130,7 +149,7 @@ function main() {
       "https://github.com/opengeos/GeoLibre/issues/1889, so re-measuring once before failing.\n",
   );
 
-  const second = classify(runSuite());
+  const second = classify(await runSuite(args));
   if (second.ok) {
     console.error(
       `\ncoverage-check: the re-run cleared the floor, so the ${firstLine.actual}% reading was a ` +
@@ -138,7 +157,7 @@ function main() {
         `coverage-check: please add the pair (${firstLine.actual}% then passing) to issue #1889. ` +
         "If this is happening often, the gate needs fixing rather than retrying.",
     );
-    process.exit(0);
+    return 0;
   }
 
   const secondLine = second.thresholds.find((entry) => entry.metric === "line");
@@ -148,11 +167,21 @@ function main() {
       "A real regression reproduces; this is one. Add tests or, if the drop is a module newly " +
       "pulled into the report rather than code getting less tested, see the coverage notes in CLAUDE.md.",
   );
-  process.exit(1);
+  return 1;
 }
 
 // Only run the gate when invoked directly, so the test file can import
 // `classify` without spawning the whole suite.
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  main();
+  main().then(
+    (code) => {
+      // Set exitCode rather than calling process.exit, so Node exits once the
+      // streamed output has drained instead of truncating it.
+      process.exitCode = code;
+    },
+    (error) => {
+      console.error(`coverage-check: ${error.message}`);
+      process.exitCode = 1;
+    },
+  );
 }

--- a/tests/coverage-check.test.ts
+++ b/tests/coverage-check.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classify } from "../scripts/coverage-check.mjs";
+
+// `scripts/coverage-check.mjs` re-measures the suite when line coverage alone
+// comes up short, because that metric is nondeterministic on CI (#1889). The
+// risk in a retry is that it also swallows a real regression, so these pin
+// exactly which failures earn a second run and which fail on the spot.
+
+const summary = (fail: number) =>
+  ["# tests 5935", "# suites 1297", "# pass 5934", `# fail ${fail}`, "# skipped 1"].join("\n");
+
+const shortfall = (actual: number, metric: string, floor: number) =>
+  `Error: ${actual}% ${metric} coverage does not meet threshold of ${floor}%.`;
+
+describe("coverage-check classify", () => {
+  it("treats a clean run as passing with nothing to retry", () => {
+    const result = classify({
+      status: 0,
+      output: `${summary(0)}\n# all files | 82.81 | 84.46 | 72.94 |`,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.lineOnly, false);
+    assert.deepEqual(result.thresholds, []);
+  });
+
+  it("re-measures when lines alone are short and every test passed", () => {
+    // The exact shape of the run that reddened PR #1887.
+    const result = classify({
+      status: 1,
+      output: `${summary(0)}\n${shortfall(76.47, "line", 78)}`,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.lineOnly, true);
+    assert.deepEqual(result.thresholds, [{ actual: 76.47, metric: "line", floor: 78 }]);
+  });
+
+  it("does not retry a function-coverage shortfall", () => {
+    // The real regression from #1784: deterministic, so a retry would only
+    // waste a run and, if it ever flapped, hide it.
+    const result = classify({
+      status: 1,
+      output: `${summary(0)}\n${shortfall(60.36, "function", 63)}`,
+    });
+    assert.equal(result.lineOnly, false);
+  });
+
+  it("does not retry a branch-coverage shortfall", () => {
+    const result = classify({
+      status: 1,
+      output: `${summary(0)}\n${shortfall(70.1, "branch", 78)}`,
+    });
+    assert.equal(result.lineOnly, false);
+  });
+
+  it("does not retry when lines are short alongside another metric", () => {
+    const result = classify({
+      status: 1,
+      output: `${summary(0)}\n${shortfall(76.47, "line", 78)}\n${shortfall(60.36, "function", 63)}`,
+    });
+    assert.equal(result.lineOnly, false);
+    assert.equal(result.thresholds.length, 2);
+  });
+
+  it("does not retry when a test failed, even if lines are also short", () => {
+    // A failing test can itself drag line coverage down, so the failure is the
+    // thing to report rather than something to re-roll.
+    const result = classify({
+      status: 1,
+      output: `${summary(3)}\n${shortfall(76.47, "line", 78)}`,
+    });
+    assert.equal(result.failedTests, 3);
+    assert.equal(result.lineOnly, false);
+  });
+
+  it("reads the spec reporter's summary as well as the tap one", () => {
+    // Node prefixes with `ℹ` on a TTY and `#` otherwise; CI sees `#`, a
+    // developer running it locally sees `ℹ`.
+    const result = classify({
+      status: 1,
+      output: `ℹ fail 2\n${shortfall(76.47, "line", 78)}`,
+    });
+    assert.equal(result.failedTests, 2);
+    assert.equal(result.lineOnly, false);
+  });
+
+  it("does not retry a non-zero exit that reported no threshold at all", () => {
+    // A crash, an unresolved import, an out-of-memory kill: nothing here says
+    // the measurement was unlucky, so re-running is not justified.
+    const result = classify({ status: 1, output: "SyntaxError: Unexpected token" });
+    assert.equal(result.lineOnly, false);
+    assert.deepEqual(result.thresholds, []);
+  });
+});

--- a/tests/coverage-check.test.ts
+++ b/tests/coverage-check.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import { classify } from "../scripts/coverage-check.mjs";
 
@@ -82,6 +83,23 @@ describe("coverage-check classify", () => {
     });
     assert.equal(result.failedTests, 2);
     assert.equal(result.lineOnly, false);
+  });
+
+  it("never calls process.exit, which would truncate the streamed output", () => {
+    // `process.stdout` is async when it is a pipe, which is what CI gives it.
+    // An earlier version buffered the whole run and then called process.exit,
+    // which dropped ~42,000 lines and the entire coverage summary from the CI
+    // log, mid-line, while still exiting 0. The gate looked green and reported
+    // nothing. Only `process.exitCode` is safe here, and the failure is
+    // invisible when stdout is a file (as it is when a developer redirects it),
+    // so pin it at the source rather than hope someone notices.
+    const source = readFileSync(new URL("../scripts/coverage-check.mjs", import.meta.url), "utf8");
+    assert.equal(
+      /(?<!\.)\bprocess\.exit\s*\(/.test(source),
+      false,
+      "coverage-check.mjs must set process.exitCode instead of calling process.exit()",
+    );
+    assert.ok(source.includes("process.exitCode"));
   });
 
   it("does not retry a non-zero exit that reported no threshold at all", () => {


### PR DESCRIPTION
Fixes #1889.

## The problem

Line coverage is nondeterministic on CI. Two runs over byte-identical sources:

| run | files | lines | branches | functions |
|---|---|---|---|---|
| `main` push | 444 | **81.82%** | 84.30% | 60.36% |
| PR #1887 | 444 | **76.47%** | 84.30% | 60.36% |

Same 5935 tests, 1297 suites, 5934 pass, 0 fail, 1 skipped in both. Comparing the per-file tables by full path: **114 of 444 files differ on lines, zero differ on branches or functions**, and no file entered or left the report. Swings are large, not rounding: `storymap-sample.ts` 99.21% to 34.65%, `qml-import.ts` 97.53% to 48.48%.

The practical result is that PR #1887, a release bump touching only version strings, docs, and lockfiles, failed a floor that the identical sources had cleared minutes earlier.

## What I ruled out

Not reproducible locally, across 11 runs:

- Node 26.4.0 (local default) and Node **22.23.2**, the exact version all four CI runs used: 82.81% three times running
- 24 cores, and pinned to 4 with `taskset` to match the runner: 82.84% twice
- default `--test-concurrency` vs `--test-concurrency=1`: identical numbers (82.80 / 84.46 / 72.94), at 107s serial vs 47s parallel

So pinning concurrency costs 2.3x wall time and buys nothing measurable, and I could not manufacture the collapse to verify a deterministic fix against it. Branch and function coverage have never varied in any observation, CI or local.

## The fix

Mitigate narrowly rather than lower the floor. `test:frontend:coverage` now runs through `scripts/coverage-check.mjs`, following the `scripts/audit-check.mjs` precedent of wrapping a tool that cannot express the policy we need.

Node still enforces all three floors. The wrapper only decides whether a failure deserves a second opinion:

| failure | behavior |
|---|---|
| line floor only, all tests passed | re-measure once; fail only if short again |
| branch or function floor | fail immediately, no retry |
| any test failure | fail immediately, no retry |
| non-zero exit with no threshold reported (crash, OOM) | fail immediately, no retry |

A real line regression reproduces and so fails on the second run. Nothing is retried away, and the deterministic metrics keep failing fast.

## Why the retry logic is tested

A retry that quietly swallowed a genuine regression would be worse than the flake it works around, so `classify()` is exported and pinned by `tests/coverage-check.test.ts` (8 cases, including the exact output shape that reddened #1887 and the exact one from the #1784 function regression). It also covers the `ℹ` vs `#` reporter prefixes, since Node switches on whether stdout is a TTY.

Verified end to end with impossible floors:

- `LINES=99`: suite runs **twice** (34s), logs both readings, exits 1
- `FUNCTIONS=99`: suite runs **once** (18s), exits 1, no retry
- unmodified: exits 0, one run, 82.79% / 84.45% / 72.96%

The one path not exercised end to end is "retry recovers, exit 0", because I cannot reproduce the flake on demand. Its two components are covered separately: the retry executes (shown above) and `classify().ok` on a clean run is unit-tested.

## Also in CLAUDE.md

Documented the wrapper, and separately the denominator trap behind the #1784 regression: writing the *first* test for a large untested module reads as a coverage drop, because the module and everything it imports enter the denominator at once. The fix is to test against a leaf module (as #1888 did), not to lower a floor. That one will recur, so it is worth writing down.

## If the retry starts firing regularly

It logs both numbers precisely so #1889 can accumulate evidence. Frequent retries are the signal to fix the measurement rather than widen the mitigation, and I have left #1889 open for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Testing**
  * Improved frontend coverage validation with line, branch, and function thresholds.
  * Added a limited retry for line-coverage shortfalls when all tests pass.
  * Coverage failures involving branches, functions, test failures, or other errors now fail immediately with clearer reporting.
  * Added tests for validation outcomes, coverage reporting, and retry behavior.

* **Documentation**
  * Expanded guidance for interpreting coverage changes and addressing measurement issues.
  * Documented how to update tests when coverage retry behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->