### PR TITLE
ci: attach mobile and Mac App Store builds to published releases

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -546,9 +546,7 @@ jobs:
 
       - name: Upload Play AAB
         # Separate artifact from the APKs: this is the file you upload to the
-        # Play Console, and it only exists on release-keystore runs. Deliberately
-        # NOT attached to the GitHub Release — an .aab is not user-installable
-        # and would only confuse people looking for a sideload download.
+        # Play Console, and it only exists on release-keystore runs.
         if: steps.sign.outputs.signed == 'release'
         uses: actions/upload-artifact@v7
         with:
@@ -557,19 +555,26 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Attach APKs to GitHub Release
-        # Only on a published release, and only when the APKs were signed with the
-        # real release keystore — never publish debug-signed builds as official
-        # downloads. workflow_dispatch runs still get the CI artifact above.
+      - name: Attach APKs and AAB to GitHub Release
+        # Only on a published release, and only when the artifacts were signed
+        # with the real release keystore — never publish debug-signed builds as
+        # official downloads (and Play rejects a debug-signed bundle anyway).
+        # workflow_dispatch runs still get the CI artifacts above.
+        #
+        # The APKs are the sideload download. The .aab is *not* user-installable
+        # — it is the Play Console upload — but it is attached so the exact
+        # bundle submitted for a tag stays recoverable after the 14-day CI
+        # artifact expires. The `.aab` extension is what distinguishes them on
+        # the releases page; docs/android.md spells the difference out.
         if: github.event_name == 'release' && steps.sign.outputs.signed == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG" "$RUNNER_TEMP"/apks/*.apk --clobber
+        run: gh release upload "$TAG" "$RUNNER_TEMP"/apks/*.apk "$RUNNER_TEMP"/aab/*.aab --clobber
 
       - name: Note skipped release upload
         # Surface why a release run did not attach APKs (missing keystore secrets),
         # so it does not look like a silent failure.
         if: github.event_name == 'release' && steps.sign.outputs.signed != 'release'
         run: |
-          echo "::warning::APKs were debug-signed (no ANDROID_KEYSTORE_BASE64 secret) and were NOT attached to the release. They are available as the CI artifact for testing only."
+          echo "::warning::APKs were debug-signed (no ANDROID_KEYSTORE_BASE64 secret) and were NOT attached to the release; no AAB was built at all. The APKs are available as the CI artifact for testing only."

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,9 +14,16 @@ on:
 permissions:
   contents: read
 
+# A release run must never be cancelled: it is the only producer of that tag's
+# release assets, and losing it mid-upload leaves the release incomplete with no
+# obvious sign of why. So the group separates release runs from manual ones (a
+# workflow_dispatch on the same tag would otherwise share the group and cancel
+# the release build), and cancel-in-progress is disabled for release runs
+# outright. Manual runs still supersede each other, which is what you want while
+# iterating.
 concurrency:
-  group: android-${{ github.ref }}
-  cancel-in-progress: true
+  group: android-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 env:
   # Keep these in sync with docs/android.md and the local setup.

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,6 +11,11 @@ name: iOS
 # + provisioning profile + team id). Without those secrets the job still runs a
 # no-signing compile check so CI catches iOS build breakage; it just can't
 # produce an installable .ipa.
+#
+# On a published release the signed .ipa is attached to that release as well as
+# uploaded as a CI artifact — see the "Attach IPA to GitHub Release" step for
+# what that asset is and is not (it is the App Store submission package, not a
+# sideload download).
 on:
   release:
     types: [published]
@@ -587,3 +592,37 @@ jobs:
           path: ${{ env.IPA_PATH }}
           if-no-files-found: error
           retention-days: 14
+
+      - name: Attach IPA to GitHub Release
+        # Only on a published release, and only when the build was actually
+        # signed — an unsigned compile-check run has no .ipa at all.
+        #
+        # Read the asset name before assuming this is a sideload download: on a
+        # release run EXPORT_METHOD is always `app-store-connect` (the choice
+        # input exists only for workflow_dispatch), and an App Store IPA cannot
+        # be installed on a device. It is the *submission* package — the exact
+        # bytes uploaded to App Store Connect / TestFlight for this tag — kept
+        # next to the release so a submission can be reproduced or re-uploaded
+        # later, long after the 14-day CI artifact has expired. End users get
+        # the app from the App Store listing.
+        if: github.event_name == 'release' && steps.signing.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Renamed rather than uploaded in place: xcodebuild names the export
+          # after the Xcode product ("geolibre-desktop.ipa"), which says nothing
+          # about the version or that this is the App Store build. Release assets
+          # are permanent and world-visible, so the name has to carry both.
+          asset="$RUNNER_TEMP/GeoLibre_${IOS_SHORT_VERSION}_ios_app-store.ipa"
+          cp "$IPA_PATH" "$asset"
+          gh release upload "$TAG" "$asset" --clobber
+
+      - name: Note skipped release upload
+        # Surface why a release run attached no .ipa (missing Apple signing
+        # secrets → the job ran the no-signing compile check), so it does not
+        # read as a silent failure.
+        if: github.event_name == 'release' && steps.signing.outputs.present != 'true'
+        run: |
+          echo "::warning::No Apple iOS signing secrets, so this release run produced only a compile check and attached no .ipa. Set APPLE_IOS_CERTIFICATE_BASE64, APPLE_IOS_CERTIFICATE_PASSWORD and APPLE_IOS_PROVISIONING_PROFILE_BASE64 to publish one."

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,9 +33,16 @@ on:
 permissions:
   contents: read
 
+# A release run must never be cancelled: it is the only producer of that tag's
+# release assets, and losing it mid-upload leaves the release incomplete with no
+# obvious sign of why. So the group separates release runs from manual ones (a
+# workflow_dispatch on the same tag would otherwise share the group and cancel
+# the release build), and cancel-in-progress is disabled for release runs
+# outright. Manual runs still supersede each other, which is what you want while
+# iterating.
 concurrency:
-  group: ios-${{ github.ref }}
-  cancel-in-progress: true
+  group: ios-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 env:
   # The Apple bundle identifier, asserted after the build. Comes from

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -226,6 +226,12 @@ jobs:
         # into an output and gated on below. All three are required to sign: a
         # partial set would spend the whole archive and only then fail.
         #
+        # APPLE_IOS_CERTIFICATE_PASSWORD is deliberately NOT in the set. A .p12
+        # can be exported without a password, and the import step passes
+        # `-P "${APPLE_IOS_CERTIFICATE_PASSWORD:-}"` precisely so that case
+        # works — requiring it here would refuse to sign a valid passwordless
+        # identity. An empty value is therefore not evidence of a partial set.
+        #
         # The iOS cert/profile use APPLE_IOS_* names, deliberately distinct from
         # the release.yml macOS secrets (APPLE_CERTIFICATE / APPLE_CERTIFICATE_
         # PASSWORD): that identity is a *Developer ID Application* cert for the
@@ -238,13 +244,19 @@ jobs:
           APPLE_IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_IOS_PROVISIONING_PROFILE_BASE64 }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if [ -n "${APPLE_IOS_CERTIFICATE_BASE64:-}" ] \
-            && [ -n "${APPLE_IOS_PROVISIONING_PROFILE_BASE64:-}" ] \
-            && [ -n "${APPLE_TEAM_ID:-}" ]; then
+          missing=()
+          for name in APPLE_IOS_CERTIFICATE_BASE64 \
+            APPLE_IOS_PROVISIONING_PROFILE_BASE64 APPLE_TEAM_ID; do
+            [ -n "${!name:-}" ] || missing+=("$name")
+          done
+          if [ "${#missing[@]}" -eq 0 ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No complete Apple iOS signing secret set — building an unsigned compile check only (no installable .ipa). Set APPLE_IOS_CERTIFICATE_BASE64, APPLE_IOS_CERTIFICATE_PASSWORD, APPLE_IOS_PROVISIONING_PROFILE_BASE64 (and reuse the existing APPLE_TEAM_ID) to produce a signed build."
+            # Carried to the release-note step below so it can name what was
+            # actually absent rather than reciting the whole required set.
+            echo "missing=${missing[*]}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Missing Apple iOS signing secrets (${missing[*]}) — building an unsigned compile check only (no installable .ipa). Set APPLE_IOS_CERTIFICATE_BASE64, APPLE_IOS_CERTIFICATE_PASSWORD, APPLE_IOS_PROVISIONING_PROFILE_BASE64 (and reuse the existing APPLE_TEAM_ID) to produce a signed build."
           fi
 
       # ---- No-signing path: prove the iOS build compiles ---------------------
@@ -624,5 +636,9 @@ jobs:
         # secrets → the job ran the no-signing compile check), so it does not
         # read as a silent failure.
         if: github.event_name == 'release' && steps.signing.outputs.present != 'true'
+        env:
+          # Secret *names*, not values — but passed via env rather than
+          # interpolated into the script, matching the rest of this workflow.
+          MISSING: ${{ steps.signing.outputs.missing }}
         run: |
-          echo "::warning::No Apple iOS signing secrets, so this release run produced only a compile check and attached no .ipa. Set APPLE_IOS_CERTIFICATE_BASE64, APPLE_IOS_CERTIFICATE_PASSWORD and APPLE_IOS_PROVISIONING_PROFILE_BASE64 to publish one."
+          echo "::warning::This release run produced only a compile check and attached no .ipa — missing Apple iOS signing secrets: ${MISSING:-unknown}. Set them (and reuse the existing APPLE_TEAM_ID) to publish one."

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -256,7 +256,7 @@ jobs:
             # Carried to the release-note step below so it can name what was
             # actually absent rather than reciting the whole required set.
             echo "missing=${missing[*]}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Missing Apple iOS signing secrets (${missing[*]}) — building an unsigned compile check only (no installable .ipa). Set APPLE_IOS_CERTIFICATE_BASE64, APPLE_IOS_CERTIFICATE_PASSWORD, APPLE_IOS_PROVISIONING_PROFILE_BASE64 (and reuse the existing APPLE_TEAM_ID) to produce a signed build."
+            echo "::notice::Missing Apple iOS signing secrets (${missing[*]}) — building an unsigned compile check only (no installable .ipa). Set the listed secrets to produce a signed build; APPLE_TEAM_ID is the one already used by the macOS release signing, and APPLE_IOS_CERTIFICATE_PASSWORD is needed only if the .p12 is password-protected."
           fi
 
       # ---- No-signing path: prove the iOS build compiles ---------------------

--- a/.github/workflows/mas-store.yml
+++ b/.github/workflows/mas-store.yml
@@ -1,9 +1,17 @@
 name: Build Mac App Store package
 
-# Manually builds the sandboxed Mac App Store variant and uploads the signed
-# .pkg as a workflow artifact for submission via Transporter or
-# `xcrun altool --upload-app`. Like msix-store.yml, this never touches a GitHub
-# release; it exists so a Store-ready package can be produced on demand.
+# Builds the sandboxed Mac App Store variant and produces the signed .pkg for
+# submission via Transporter or `xcrun altool --upload-app`. It runs on each
+# published release (matching release.yml / android.yml / ios.yml) and on demand
+# via the "Run workflow" button, and publishes the .pkg both as a workflow
+# artifact and — on release runs — as a release asset.
+#
+# That release asset is the *submission* package, not a download: a MAS-signed
+# .pkg is installable only through the App Store, so a user who grabs it from
+# the releases page cannot run it. It is attached so the exact bytes submitted
+# for a given tag stay recoverable after the CI artifact expires. macOS users
+# install GeoLibre from the App Store, the Homebrew cask, or the Developer
+# ID-signed .dmg that release.yml attaches.
 #
 # The MAS variant differs from the Developer ID builds in release.yml:
 #   - `mas` cargo feature: the Python sidecar, Jupyter, martin, and external
@@ -30,24 +38,33 @@ name: Build Mac App Store package
 #   APPLE_TEAM_ID                    already configured for release.yml
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
+# Least privilege at the workflow level; the build job below elevates to
+# contents: write only where it needs to attach the release asset.
 permissions:
   contents: read
 
-jobs:
-  build:
-    name: Build MAS pkg
-    runs-on: macos-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          # npm ci runs third-party lifecycle scripts; keep the checkout token
-          # out of the local git config they could read.
-          persist-credentials: false
+concurrency:
+  group: mas-store-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
+  # Split out of `build` so a release run with no MAS secrets skips the whole
+  # macOS job rather than gating a dozen steps individually — and, more to the
+  # point, so it does not redden an otherwise good release. A workflow_dispatch
+  # run is an explicit request for a .pkg, so there the same missing secrets are
+  # a hard error instead.
+  secrets-gate:
+    name: Check signing secrets
+    runs-on: ubuntu-latest
+    outputs:
+      present: ${{ steps.check.outputs.present }}
+    steps:
       - name: Verify signing secrets are configured
+        id: check
         env:
           APPLE_MAS_CERTIFICATE: ${{ secrets.APPLE_MAS_CERTIFICATE }}
           APPLE_MAS_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_MAS_CERTIFICATE_PASSWORD }}
@@ -55,6 +72,7 @@ jobs:
           APPLE_MAS_SIGNING_IDENTITY: ${{ secrets.APPLE_MAS_SIGNING_IDENTITY }}
           APPLE_MAS_INSTALLER_IDENTITY: ${{ secrets.APPLE_MAS_INSTALLER_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           missing=()
           for name in APPLE_MAS_CERTIFICATE APPLE_MAS_CERTIFICATE_PASSWORD \
@@ -62,10 +80,35 @@ jobs:
             APPLE_MAS_INSTALLER_IDENTITY APPLE_TEAM_ID; do
             [[ -n "${!name}" ]] || missing+=("$name")
           done
-          if (( ${#missing[@]} )); then
+          if (( ${#missing[@]} == 0 )); then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "::error::Missing secrets for the Mac App Store build: ${missing[*]}. See docs/mac-app-store.md."
             exit 1
           fi
+          # The whole set is unavailable to forks, and a repo that has not set
+          # them up yet should not get a red release. Warn and skip.
+          echo "::warning::Skipping the Mac App Store package for this release — missing secrets: ${missing[*]}. See docs/mac-app-store.md."
+
+  build:
+    name: Build MAS pkg
+    runs-on: macos-latest
+    needs: secrets-gate
+    if: needs.secrets-gate.outputs.present == 'true'
+    # Elevated here (not workflow-level) so only this job can write release
+    # assets; workflow_dispatch runs never attach but the grant is harmless.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # npm ci runs third-party lifecycle scripts; keep the checkout token
+          # out of the local git config they could read.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -172,6 +215,19 @@ jobs:
           name: geolibre-mas-pkg
           path: ${{ steps.build_pkg.outputs.pkg_path }}
           if-no-files-found: error
+
+      - name: Attach MAS package to GitHub Release
+        # Release runs only; a workflow_dispatch build has no release to attach
+        # to and stops at the artifact above. The `_mas` suffix in the filename
+        # is load-bearing — see the header comment: this .pkg installs only via
+        # the App Store, so it must not be mistaken for the Developer ID .dmg
+        # that release.yml publishes alongside it.
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          PKG_PATH: ${{ steps.build_pkg.outputs.pkg_path }}
+        run: gh release upload "$TAG" "$PKG_PATH" --clobber
 
       - name: Remove the temporary keychain
         if: always()

--- a/.github/workflows/mas-store.yml
+++ b/.github/workflows/mas-store.yml
@@ -47,9 +47,16 @@ on:
 permissions:
   contents: read
 
+# A release run must never be cancelled: it is the only producer of that tag's
+# release assets, and losing it mid-upload leaves the release incomplete with no
+# obvious sign of why. So the group separates release runs from manual ones (a
+# workflow_dispatch on the same tag would otherwise share the group and cancel
+# the release build), and cancel-in-progress is disabled for release runs
+# outright. Manual runs still supersede each other, which is what you want while
+# iterating.
 concurrency:
-  group: mas-store-${{ github.ref }}
-  cancel-in-progress: true
+  group: mas-store-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   # Split out of `build` so a release run with no MAS secrets skips the whole

--- a/.github/workflows/mas-store.yml
+++ b/.github/workflows/mas-store.yml
@@ -97,7 +97,12 @@ jobs:
     name: Build MAS pkg
     runs-on: macos-latest
     needs: secrets-gate
-    if: needs.secrets-gate.outputs.present == 'true'
+    # success() is explicit because a custom job `if:` REPLACES the default
+    # success() check on `needs:` rather than ANDing with it. Without it, this
+    # job's gating would rest on the invariant that secrets-gate writes
+    # present=false before any path that fails the step — true today, but not
+    # something Actions enforces against a future edit.
+    if: success() && needs.secrets-gate.outputs.present == 'true'
     # Elevated here (not workflow-level) so only this job can write release
     # assets; workflow_dispatch runs never attach but the grant is harmless.
     permissions:

--- a/docs/android.md
+++ b/docs/android.md
@@ -168,7 +168,11 @@ keytool -genkeypair -v -keystore upload.jks -alias upload -keyalg RSA \
 
 `.github/workflows/android.yml` builds **signed**, per-ABI release APKs on each
 published GitHub release (and on demand via the "Run workflow" button) and
-uploads them as the `geolibre-android-release-apks` artifact. It signs with your release keystore when these repository secrets are
+uploads them as the `geolibre-android-release-apks` artifact. On a published
+release the APKs are **also attached to that release** as downloadable assets —
+but only when they carry a real release signature; debug-signed APKs stay a CI
+artifact and the run logs a warning saying so. It signs with your release
+keystore when these repository secrets are
 set, and otherwise falls back to a throwaway debug key so the artifact is still
 installable for testing:
 
@@ -180,8 +184,13 @@ installable for testing:
 It also builds a universal **AAB** and uploads it as the separate
 `geolibre-android-play-aab` artifact — but *only* on runs that have the real
 release keystore, since Play rejects a debug-signed bundle. Without the keystore
-the AAB build is skipped entirely rather than built and discarded. The AAB is
-not attached to the GitHub Release (an `.aab` is not user-installable).
+the AAB build is skipped entirely rather than built and discarded. On a published
+release the `geolibre-android.aab` is attached to the release alongside the APKs,
+so the exact bundle submitted for a tag stays recoverable after the CI artifact
+expires.
+
+> Sideloading? Take an **`.apk`**. The `.aab` is the Google Play upload format
+> and cannot be installed on a device.
 
 ## Install / test
 
@@ -234,7 +243,8 @@ is one-time Play Console onboarding.
    the actual app signing key and re-signs each bundle. The repository's
    `ANDROID_KEYSTORE_*` secrets are that upload key — keep the keystore backed
    up, since losing it requires a Play support reset.
-3. **Upload the AAB** from the `geolibre-android-play-aab` CI artifact. The
+3. **Upload the AAB** from the `geolibre-android-play-aab` CI artifact, or from
+   the release's `geolibre-android.aab` asset once that artifact has expired. The
    `versionCode` is derived from the version in `tauri.conf.json` and must
    increase on every upload.
 4. **Store listing assets:** 512×512 icon, a **1024×500 feature graphic**, and

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -13,11 +13,13 @@ iPad. The Store build is signed and updates automatically:
 
 [Get GeoLibre on the App Store](https://apps.apple.com/app/geolibre/id6796039674){ .md-button .md-button--primary }
 
-GeoLibre does not publish a sideloadable `.ipa` for end users, so no iOS build is
-attached to GitHub releases the way the Android APKs are; the App Store listing,
-and TestFlight for beta builds, are how it is distributed. The rest of this page
-is for developers building the app themselves, which has to happen on a Mac (iOS
-cannot be cross-compiled from Linux).
+GeoLibre does not publish a sideloadable `.ipa` for end users; the App Store
+listing, and TestFlight for beta builds, are how it is distributed. Each release
+*does* carry a `GeoLibre_<version>_ios_app-store.ipa` asset, but unlike the
+Android APKs that is the App Store **submission** package — archived next to the
+tag so a submission stays reproducible — and it cannot be installed on a device.
+The rest of this page is for developers building the app themselves, which has to
+happen on a Mac (iOS cannot be cross-compiled from Linux).
 
 The signing and archiving pipeline behind that listing runs two ways, and either
 produces a submittable `.ipa` — bundle id `org.geolibre.app`, signed by *Apple
@@ -269,7 +271,9 @@ not free to choose — see the Xcode floor below.
 - **With Apple signing secrets set**, it imports the identity into a throwaway
   keychain, archives **unsigned**, exports a signed `.ipa` under manual signing,
   verifies the bundle id, the signature, the build number shape and the
-  `MinimumOSVersion`, and uploads it as the `geolibre-ios-ipa` artifact:
+  `MinimumOSVersion`, and uploads it as the `geolibre-ios-ipa` artifact — plus,
+  on a published release, as the `GeoLibre_<version>_ios_app-store.ipa` release
+  asset, which outlives the artifact's 14-day retention:
   - `APPLE_IOS_CERTIFICATE_BASE64` — `base64 -i dist.p12`
   - `APPLE_IOS_CERTIFICATE_PASSWORD`
   - `APPLE_IOS_PROVISIONING_PROFILE_BASE64` — `base64 -i profile.mobileprovision`
@@ -277,7 +281,9 @@ not free to choose — see the Xcode floor below.
     secrets; the Team ID is account-wide.
 - **Without them**, it falls back to a no-signing **compile check**
   (`cargo build --lib --target aarch64-apple-ios`) so CI still catches iOS build
-  breakage; it just can't produce an installable `.ipa`.
+  breakage; it just can't produce an installable `.ipa`. A release run in that
+  state attaches nothing and logs a warning saying which secrets were missing,
+  rather than failing the release.
 
 ### Reusing the macOS/Homebrew signing secrets?
 
@@ -362,9 +368,10 @@ App Store Connect.
    handling — not a wrapper that loads a remote URL. Keep it that way: ship the
    web assets in the binary (the default here), don't point the webview at
    `geolibre.app`.
-3. **Upload** the `.ipa` from the `geolibre-ios-ipa` CI artifact (or via
-   Transporter / Xcode Organizer) to a TestFlight build, then submit that build
-   for App Store review.
+3. **Upload** the `.ipa` from the `geolibre-ios-ipa` CI artifact — or, for an
+   older tag whose artifact has expired, the `GeoLibre_<version>_ios_app-store.ipa`
+   release asset — (or via Transporter / Xcode Organizer) to a TestFlight build,
+   then submit that build for App Store review.
 
    **Build numbers.** App Store Connect consumes a `CFBundleVersion`
    permanently per marketing version, and each upload must also sort above the

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -368,10 +368,10 @@ App Store Connect.
    handling — not a wrapper that loads a remote URL. Keep it that way: ship the
    web assets in the binary (the default here), don't point the webview at
    `geolibre.app`.
-3. **Upload** the `.ipa` from the `geolibre-ios-ipa` CI artifact — or, for an
-   older tag whose artifact has expired, the `GeoLibre_<version>_ios_app-store.ipa`
-   release asset — (or via Transporter / Xcode Organizer) to a TestFlight build,
-   then submit that build for App Store review.
+3. **Upload** the `.ipa` (via Transporter or Xcode Organizer) to a TestFlight
+   build, then submit that build for App Store review. Take it from the
+   `geolibre-ios-ipa` CI artifact, or — for an older tag whose artifact has
+   expired — from that release's `GeoLibre_<version>_ios_app-store.ipa` asset.
 
    **Build numbers.** App Store Connect consumes a `CFBundleVersion`
    permanently per marketing version, and each upload must also sort above the

--- a/docs/mac-app-store.md
+++ b/docs/mac-app-store.md
@@ -158,10 +158,23 @@ bundle should show `com.apple.security.app-sandbox`, and must **not** show
 
 ## CI: the `mas-store.yml` workflow
 
-`workflow_dispatch` only, mirroring `msix-store.yml`: it builds the universal
-sandboxed app, signs it, verifies the sandbox entitlement, produces the signed
-`.pkg`, and uploads it as the `geolibre-mas-pkg` artifact. It does not touch
-GitHub releases and does not upload to App Store Connect.
+Runs on each **published GitHub release** (matching `release.yml`, `android.yml`
+and `ios.yml`) and on demand via the "Run workflow" button: it builds the
+universal sandboxed app, signs it, verifies the sandbox entitlement, produces the
+signed `.pkg`, and uploads it as the `geolibre-mas-pkg` artifact. On a release
+run it also attaches that `.pkg` to the release, so the exact submitted bytes for
+a tag remain available after the CI artifact's retention window. It never uploads
+to App Store Connect — that step stays manual (see *Submitting* below).
+
+> A MAS-signed `.pkg` can only be installed through the App Store; downloading it
+> from the releases page gets you a package that will not install. It is attached
+> as a submission archive, not as a macOS download. Point users at the App Store
+> listing, the Homebrew cask, or the Developer ID `.dmg` from `release.yml`.
+
+A missing-secrets run is handled by the `secrets-gate` job: on a
+`workflow_dispatch` it is a hard error (you asked for a `.pkg` and cannot get
+one), while on a release it logs a warning and skips the macOS job so an
+otherwise-good release does not go red.
 
 Required repository secrets:
 
@@ -191,8 +204,10 @@ Creating the inputs (Apple Developer account required):
    apps). This is already done for GeoLibre Desktop, App Store ID `6796848769`
    (the numeric listing identifier App Store Connect labels "Apple ID" on the App
    Information page), so later releases start at step 2.
-2. Download the `geolibre-mas-pkg` artifact and upload the `.pkg` with the
-   **Transporter** app (or `xcrun altool --upload-app -f <pkg> -t macos`).
+2. Download the `.pkg` — from the `geolibre-mas-pkg` artifact of the release's
+   workflow run, or from the release's own `..._universal_mas.pkg` asset once the
+   artifact has expired — and upload it with the **Transporter** app (or
+   `xcrun altool --upload-app -f <pkg> -t macos`).
 3. Fill in screenshots, description, and the privacy questionnaire
    (see `docs/privacy.md`; the app makes no tracking calls).
 4. In the review notes, mention that processing engines run client-side as

--- a/docs/mac-app-store.md
+++ b/docs/mac-app-store.md
@@ -205,8 +205,9 @@ Creating the inputs (Apple Developer account required):
    (the numeric listing identifier App Store Connect labels "Apple ID" on the App
    Information page), so later releases start at step 2.
 2. Download the `.pkg` — from the `geolibre-mas-pkg` artifact of the release's
-   workflow run, or from the release's own `..._universal_mas.pkg` asset once the
-   artifact has expired — and upload it with the **Transporter** app (or
+   workflow run, or from the release's own
+   `GeoLibre.Desktop_<version>_universal_mas.pkg` asset once the artifact has
+   expired — and upload it with the **Transporter** app (or
    `xcrun altool --upload-app -f <pkg> -t macos`).
 3. Fill in screenshots, description, and the privacy questionnaire
    (see `docs/privacy.md`; the app makes no tracking calls).


### PR DESCRIPTION
## What

Makes all three store/mobile workflows run on a published release and put their signed output on that release, instead of only in 14-day CI artifacts.

| Workflow | Before | After |
| --- | --- | --- |
| `android.yml` | ran on release, attached signed APKs; AAB artifact-only | also attaches the signed universal `.aab` |
| `ios.yml` | ran on release, artifact-only | attaches `GeoLibre_<version>_ios_app-store.ipa` |
| `mas-store.yml` | `workflow_dispatch` only, artifact-only | runs on release too, attaches the signed `.pkg` |

## Notes

- **Two of these assets are submission packages, not downloads.** The `.aab` is the Play Console upload and the `.ipa` is the App Store Connect upload; neither can be installed by a user who grabs it from the releases page, and a MAS-signed `.pkg` installs only through the App Store. They are attached so the exact bytes submitted for a tag stay recoverable after the CI artifact expires. The docs for each platform now say this explicitly, and the iOS asset name carries `_app-store` so it reads correctly on the releases page. The sideload path remains the `.apk`.
- **A release must not go red for missing credentials.** iOS already degrades to an unsigned compile check without the `APPLE_IOS_*` secrets; it now attaches nothing and logs a warning in that state. `mas-store.yml`'s secrets check moved into a small `secrets-gate` job so a missing set is still a hard error on `workflow_dispatch` (an explicit request for a package) but merely skips the macOS job on a release.
- Each job keeps workflow-level `contents: read` and elevates to `contents: write` only where it writes the asset. `mas-store.yml` also gains the `concurrency` group the other two already had.

## Testing

YAML validated and `pre-commit run --files` clean. The release-triggered paths can only be exercised by a real published release — the `workflow_dispatch` paths are unchanged apart from the `mas-store.yml` secrets check, which keeps the same hard-fail behavior it had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published releases now include signed Android APKs, universal AABs, iOS App Store packages, and Mac App Store packages when signing credentials are available.
  * Mac App Store builds can run automatically for published releases or be triggered manually.
  * Release packages are available as workflow artifacts and matching GitHub release assets.
  * Manual build runs can replace older manual runs, while release builds are protected from cancellation.

* **Documentation**
  * Updated platform guides to clarify package usage, submission workflows, artifact availability, and signing-credential warnings.
  * Clarified that debug builds remain CI-only and unsigned fallback runs do not attach release packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->