### PR TITLE
feat(postgis): select geometry columns

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -16,6 +16,7 @@ import {
   stopMartinServer,
 } from "../../../../lib/martin";
 import { postgisFeatureKeys, registerPostgisConnection } from "../../../../lib/postgis-connections";
+import { postgisTableKey, postgisTableLabel } from "../../../../lib/postgis-table-selection";
 import { IS_MAS_BUILD } from "../../../../lib/build-flags";
 import { startGeoLibreSidecar } from "../../../../lib/sidecar";
 import { isTauri } from "../../../../lib/tauri-io";
@@ -31,10 +32,6 @@ import { martinSourceMatchesTable } from "../martin-source-match";
 import type { OpenAddDataPostgres } from "../open-add-data";
 
 type PostgresLoadMode = "tiles" | "editable";
-
-function postgisTableKey(table: PostgisTableInfo): string {
-  return `${table.schema}.${table.table}`;
-}
 
 interface PostgresSourceProps {
   /** Prefill from the Browser panel (saved connection / clicked table). */
@@ -598,12 +595,15 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
             >
               {uniquePostgisTables.map((table) => {
                 const key = postgisTableKey(table);
+                const label = postgisTableLabel(table);
                 // Tables without a usable key stay visible (so the user sees
                 // why they are missing) but cannot be picked: this mode exists
                 // to save edits back, which needs a primary key.
                 return (
                   <option key={key} value={key} disabled={!table.primary_key}>
-                    {table.primary_key ? key : t("addData.postgres.tableReadOnly", { table: key })}
+                    {table.primary_key
+                      ? label
+                      : t("addData.postgres.tableReadOnly", { table: label })}
                   </option>
                 );
               })}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -33,7 +33,7 @@ import type { OpenAddDataPostgres } from "../open-add-data";
 type PostgresLoadMode = "tiles" | "editable";
 
 function postgisTableKey(table: PostgisTableInfo): string {
-  return `${table.schema}.${table.table}`;
+  return `${table.schema}.${table.table} [${table.geometry_column}]`;
 }
 
 interface PostgresSourceProps {
@@ -165,17 +165,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
         // not revive a table list that belongs to the previous string.
         return;
       }
-      // geometry_columns lists one row per geometry column, so a table with
-      // several geometry columns appears several times; keep the first entry
-      // (the /postgis/read endpoint edits that table's first geometry column)
-      // so the select has unique keys.
-      const seen = new Set<string>();
-      const tables = listed.filter((table) => {
-        const key = postgisTableKey(table);
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      });
+      const tables = listed;
       setSavedPostgresConnections(rememberPostgresConnection(connectionString));
       setPostgisConnection(connectionString);
       setPostgisTables(tables);
@@ -372,6 +362,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
       connection: connectionString,
       schema_name: table.schema,
       table: table.table,
+      geometry_column: table.geometry_column,
     });
     const layer = {
       ...createBaseLayer(

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -36,6 +36,15 @@ function postgisTableKey(table: PostgisTableInfo): string {
   return `${table.schema}.${table.table} [${table.geometry_column}]`;
 }
 
+function postgisTableLabel(table: PostgisTableInfo, tables: PostgisTableInfo[]): string {
+  const tableName = `${table.schema}.${table.table}`;
+  const hasMultipleGeometries = tables.some(
+    (candidate) =>
+      candidate !== table && candidate.schema === table.schema && candidate.table === table.table,
+  );
+  return hasMultipleGeometries ? `${tableName} [${table.geometry_column}]` : tableName;
+}
+
 interface PostgresSourceProps {
   /** Prefill from the Browser panel (saved connection / clicked table). */
   initialPostgres?: OpenAddDataPostgres;
@@ -569,12 +578,15 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
             >
               {postgisTables.map((table) => {
                 const key = postgisTableKey(table);
+                const label = postgisTableLabel(table, postgisTables);
                 // Tables without a usable key stay visible (so the user sees
                 // why they are missing) but cannot be picked: this mode exists
                 // to save edits back, which needs a primary key.
                 return (
                   <option key={key} value={key} disabled={!table.primary_key}>
-                    {table.primary_key ? key : t("addData.postgres.tableReadOnly", { table: key })}
+                    {table.primary_key
+                      ? label
+                      : t("addData.postgres.tableReadOnly", { table: label })}
                   </option>
                 );
               })}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -33,16 +33,7 @@ import type { OpenAddDataPostgres } from "../open-add-data";
 type PostgresLoadMode = "tiles" | "editable";
 
 function postgisTableKey(table: PostgisTableInfo): string {
-  return `${table.schema}.${table.table} [${table.geometry_column}]`;
-}
-
-function postgisTableLabel(table: PostgisTableInfo, tables: PostgisTableInfo[]): string {
-  const tableName = `${table.schema}.${table.table}`;
-  const hasMultipleGeometries = tables.some(
-    (candidate) =>
-      candidate !== table && candidate.schema === table.schema && candidate.table === table.table,
-  );
-  return hasMultipleGeometries ? `${tableName} [${table.geometry_column}]` : tableName;
+  return `${table.schema}.${table.table}`;
 }
 
 interface PostgresSourceProps {
@@ -72,6 +63,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
   const [loadMode, setLoadMode] = useState<PostgresLoadMode>("tiles");
   const [postgisTables, setPostgisTables] = useState<PostgisTableInfo[]>([]);
   const [selectedTableKey, setSelectedTableKey] = useState("");
+  const [selectedGeometryColumn, setSelectedGeometryColumn] = useState("");
   const [postgisStatus, setPostgisStatus] = useState<string | null>(null);
   // The connection string the table list was fetched with. The submit uses
   // this snapshot (not the live input) so editing the field after a Connect
@@ -138,6 +130,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
     source.shell.setIsSubmitting(true);
     setPostgisTables([]);
     setSelectedTableKey("");
+    setSelectedGeometryColumn("");
 
     try {
       if (!isTauri()) {
@@ -193,12 +186,15 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
         : undefined;
       const defaultTable = desiredTable ?? tables.find((table) => table.primary_key);
       setSelectedTableKey(defaultTable ? postgisTableKey(defaultTable) : "");
+      setSelectedGeometryColumn(defaultTable?.geometry_column ?? "");
       // Consumed once: a later reconnect on the same connection must not undo a
       // manual table pick by re-applying the originally-clicked table.
       desiredTableRef.current = null;
       setPostgisStatus(
         tables.length > 0
-          ? t("addData.postgres.statusTablesFound", { count: tables.length })
+          ? t("addData.postgres.statusTablesFound", {
+              count: new Set(tables.map(postgisTableKey)).size,
+            })
           : t("addData.postgres.statusNoTables"),
       );
     } catch (err) {
@@ -358,7 +354,11 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
   // the layer metadata) so "Save edits to PostGIS table" can commit changes
   // back without persisting credentials in the project file.
   const addEditableTable = async (tableKey: string) => {
-    const table = postgisTables.find((candidate) => postgisTableKey(candidate) === tableKey);
+    const table = postgisTables.find(
+      (candidate) =>
+        postgisTableKey(candidate) === tableKey &&
+        candidate.geometry_column === selectedGeometryColumn,
+    );
     if (!table) {
       throw new Error(t("addData.postgres.errorSelectTable"));
     }
@@ -423,6 +423,15 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
     }
     await addMartinSource(martin.selectedSourceId);
   });
+
+  const uniquePostgisTables = postgisTables.filter(
+    (table, index, tables) =>
+      tables.findIndex((candidate) => postgisTableKey(candidate) === postgisTableKey(table)) ===
+      index,
+  );
+  const selectedTableGeometries = postgisTables.filter(
+    (table) => postgisTableKey(table) === selectedTableKey,
+  );
 
   return (
     <AddDataSourceForm
@@ -574,22 +583,42 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
             <Select
               id="postgis-table"
               value={selectedTableKey}
-              onChange={(event) => setSelectedTableKey(event.target.value)}
+              onChange={(event) => {
+                const tableKey = event.target.value;
+                setSelectedTableKey(tableKey);
+                setSelectedGeometryColumn(
+                  postgisTables.find((table) => postgisTableKey(table) === tableKey)
+                    ?.geometry_column ?? "",
+                );
+              }}
             >
-              {postgisTables.map((table) => {
+              {uniquePostgisTables.map((table) => {
                 const key = postgisTableKey(table);
-                const label = postgisTableLabel(table, postgisTables);
                 // Tables without a usable key stay visible (so the user sees
                 // why they are missing) but cannot be picked: this mode exists
                 // to save edits back, which needs a primary key.
                 return (
                   <option key={key} value={key} disabled={!table.primary_key}>
-                    {table.primary_key
-                      ? label
-                      : t("addData.postgres.tableReadOnly", { table: label })}
+                    {table.primary_key ? key : t("addData.postgres.tableReadOnly", { table: key })}
                   </option>
                 );
               })}
+            </Select>
+          </div>
+        ) : null}
+        {loadMode === "editable" && selectedTableGeometries.length > 1 ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="postgis-geometry-column">{t("addData.postgres.geometryColumn")}</Label>
+            <Select
+              id="postgis-geometry-column"
+              value={selectedGeometryColumn}
+              onChange={(event) => setSelectedGeometryColumn(event.target.value)}
+            >
+              {selectedTableGeometries.map((table) => (
+                <option key={table.geometry_column} value={table.geometry_column}>
+                  {table.geometry_column} ({table.geometry_type}, EPSG:{table.srid})
+                </option>
+              ))}
             </Select>
           </div>
         ) : null}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -424,11 +424,15 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
     await addMartinSource(martin.selectedSourceId);
   });
 
-  const uniquePostgisTables = postgisTables.filter(
-    (table, index, tables) =>
-      tables.findIndex((candidate) => postgisTableKey(candidate) === postgisTableKey(table)) ===
-      index,
-  );
+  const uniquePostgisTables = (() => {
+    const seen = new Set<string>();
+    return postgisTables.filter((table) => {
+      const key = postgisTableKey(table);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  })();
   const selectedTableGeometries = postgisTables.filter(
     (table) => postgisTableKey(table) === selectedTableKey,
   );

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -194,8 +194,8 @@ export function BrowserPanel({
         .then((tables) => {
           // geometry_columns returns one row per geometry column, so a table
           // with several geometry columns appears several times; keep the first
-          // (mirrors PostgresSource.handleConnectEditable's dedup) so the tree
-          // doesn't emit duplicate node ids.
+          // because the Browser tree represents tables, while the Add Data
+          // dialog provides the geometry-column picker after a table is chosen.
           const seen = new Set<string>();
           const deduped: { schema: string; table: string }[] = [];
           for (const tbl of tables) {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1964,10 +1964,15 @@ export function LayerPanel({
               ? layer.metadata.postgisSchema
               : "public";
           const table = layer.metadata.postgisTable as string;
+          const geometryColumn =
+            typeof layer.metadata.postgisGeometryColumn === "string"
+              ? layer.metadata.postgisGeometryColumn
+              : undefined;
           const result = await writePostgisTable({
             connection,
             schema_name: schema,
             table,
+            geometry_column: geometryColumn,
             geojson,
             // Scope deletions to the rows this session actually read so a
             // save cannot sweep away rows inserted concurrently elsewhere.
@@ -1984,6 +1989,7 @@ export function LayerPanel({
               connection,
               schema_name: schema,
               table,
+              geometry_column: geometryColumn,
               excluded_fields: layer.fieldVisibility
                 ? Object.keys(layer.fieldVisibility).filter(
                     (k) => layer.fieldVisibility![k] === "excluded",

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -763,6 +763,7 @@
       "statusTablesFound_other": "تم العثور على {{count}} جدول مكاني.",
       "statusNoTables": "لم يُعثر على جداول مكانية في قاعدة البيانات هذه.",
       "editableTable": "الجدول",
+      "geometryColumn": "عمود الشكل الهندسي",
       "tableReadOnly": "{{table}} (للقراءة فقط: بلا مفتاح أساسي)",
       "errorSelectTable": "حدد جدولًا لتحميله.",
       "errorRuntimeMissing": "لا تتوفر لدى خادم المعالجة بيئة تشغيل PostGIS (حزمة psycopg). ثبّت إضافة 'postgis' الخاصة بـ geolibre-server لتحميل طبقات قابلة للتحرير."

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} räumliche Tabellen gefunden.",
       "statusNoTables": "In dieser Datenbank wurden keine räumlichen Tabellen gefunden.",
       "editableTable": "Tabelle",
+      "geometryColumn": "Geometriespalte",
       "tableReadOnly": "{{table}} (schreibgeschützt: kein Primärschlüssel)",
       "errorSelectTable": "Wählen Sie eine zu ladende Tabelle aus.",
       "errorRuntimeMissing": "Der Verarbeitungsserver hat die PostGIS-Laufzeitumgebung (psycopg) nicht installiert. Installieren Sie das Extra „postgis“ von geolibre-server, um bearbeitbare Ebenen zu laden."

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "Found {{count}} spatial tables.",
       "statusNoTables": "No spatial tables were found in this database.",
       "editableTable": "Table",
+      "geometryColumn": "Geometry column",
       "tableReadOnly": "{{table}} (read-only: no primary key)",
       "errorSelectTable": "Select a table to load.",
       "errorRuntimeMissing": "The processing server does not have the PostGIS runtime (psycopg) installed. Install the geolibre-server 'postgis' extra to load editable layers."

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "Se encontraron {{count}} tablas espaciales.",
       "statusNoTables": "No se encontraron tablas espaciales en esta base de datos.",
       "editableTable": "Tabla",
+      "geometryColumn": "Columna de geometría",
       "tableReadOnly": "{{table}} (solo lectura: sin clave primaria)",
       "errorSelectTable": "Seleccione una tabla para cargar.",
       "errorRuntimeMissing": "El servidor de procesamiento no tiene instalado el entorno de ejecución de PostGIS (psycopg). Instale el extra «postgis» de geolibre-server para cargar capas editables."

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} جدول مکانی یافت شد.",
       "statusNoTables": "در این پایگاه داده هیچ جدول مکانی یافت نشد.",
       "editableTable": "جدول",
+      "geometryColumn": "ستون هندسه",
       "tableReadOnly": "{{table}} (فقط‌خواندنی: بدون کلید اصلی)",
       "errorSelectTable": "یک جدول را برای بارگیری برگزینید.",
       "errorRuntimeMissing": "سرور پردازش، زمان اجرای PostGIS (psycopg) را نصب ندارد. برای بارگیری لایه‌های ویرایش‌پذیر، افزودنی «postgis» بستهٔ geolibre-server را نصب کنید."

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} tables spatiales trouvées.",
       "statusNoTables": "Aucune table spatiale n'a été trouvée dans cette base de données.",
       "editableTable": "Table",
+      "geometryColumn": "Colonne de géométrie",
       "tableReadOnly": "{{table}} (lecture seule : pas de clé primaire)",
       "errorSelectTable": "Sélectionnez une table à charger.",
       "errorRuntimeMissing": "Le serveur de traitement ne dispose pas de l'environnement d'exécution PostGIS (psycopg). Installez l'extra « postgis » de geolibre-server pour charger des couches modifiables."

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} स्थानिक टेबल मिलीं।",
       "statusNoTables": "इस डेटाबेस में कोई स्थानिक टेबल नहीं मिली।",
       "editableTable": "टेबल",
+      "geometryColumn": "ज्यामिति स्तंभ",
       "tableReadOnly": "{{table}} (केवल पढ़ने योग्य: कोई प्राइमरी की नहीं)",
       "errorSelectTable": "लोड करने के लिए एक टेबल चुनें।",
       "errorRuntimeMissing": "प्रोसेसिंग सर्वर में PostGIS रनटाइम (psycopg) इंस्टॉल नहीं है। संपादन योग्य लेयर लोड करने के लिए geolibre-server का 'postgis' एक्स्ट्रा इंस्टॉल करें।"

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -683,6 +683,7 @@
       "statusTablesFound_other": "Menemukan {{count}} tabel spasial.",
       "statusNoTables": "Tidak ada tabel spasial yang ditemukan dalam database ini.",
       "editableTable": "Tabel",
+      "geometryColumn": "Kolom geometri",
       "tableReadOnly": "{{table}} (hanya baca: tanpa kunci utama)",
       "errorSelectTable": "Pilih tabel untuk dimuat.",
       "errorRuntimeMissing": "Server pemrosesan tidak memiliki runtime PostGIS (psycopg) terpasang. Pasang ekstra 'postgis' pada geolibre-server untuk memuat layer yang dapat diedit."

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "Trovate {{count}} tabelle spaziali.",
       "statusNoTables": "Nessuna tabella spaziale trovata in questo database.",
       "editableTable": "Tabella",
+      "geometryColumn": "Colonna geometria",
       "tableReadOnly": "{{table}} (sola lettura: nessuna chiave primaria)",
       "errorSelectTable": "Seleziona una tabella da caricare.",
       "errorRuntimeMissing": "Il server di elaborazione non ha installato il runtime PostGIS (psycopg). Installa l'estensione opzionale 'postgis' di geolibre-server per caricare livelli modificabili."

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -683,6 +683,7 @@
       "statusTablesFound_other": "{{count}}件の空間テーブルが見つかりました。",
       "statusNoTables": "このデータベースには空間テーブルが見つかりませんでした。",
       "editableTable": "テーブル",
+      "geometryColumn": "ジオメトリ列",
       "tableReadOnly": "{{table}} (読み取り専用: 主キーなし)",
       "errorSelectTable": "読み込むテーブルを選択してください。",
       "errorRuntimeMissing": "処理サーバーにPostGISランタイム(psycopg)がインストールされていません。編集可能なレイヤーを読み込むには、geolibre-serverの'postgis'エクストラをインストールしてください。"

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "ნაპოვნია {{count}} სივრცითი ცხრილი.",
       "statusNoTables": "ამ მონაცემთა ბაზაში სივრცითი ცხრილები ვერ მოიძებნა.",
       "editableTable": "ცხრილი",
+      "geometryColumn": "გეომეტრიის სვეტი",
       "tableReadOnly": "{{table}} (მხოლოდ წასაკითხად: არ აქვს პირველადი გასაღები)",
       "errorSelectTable": "აირჩიეთ ჩასატვირთი ცხრილი.",
       "errorRuntimeMissing": "დამუშავების სერვერზე დაყენებული არ არის PostGIS-ის გარემო (psycopg). რედაქტირებადი შრეების ჩასატვირთად დააყენეთ geolibre-server-ის „postgis“ დანამატი."

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -683,7 +683,7 @@
       "statusTablesFound_other": "공간 테이블 {{count}}개를 찾았습니다.",
       "statusNoTables": "이 데이터베이스에서 공간 테이블을 찾을 수 없습니다.",
       "editableTable": "테이블",
-      "geometryColumn": "도형 열",
+      "geometryColumn": "지오메트리 열",
       "tableReadOnly": "{{table}}(읽기 전용: 기본 키 없음)",
       "errorSelectTable": "불러올 테이블을 선택하세요.",
       "errorRuntimeMissing": "처리 서버에 PostGIS 런타임(psycopg)이 설치되어 있지 않습니다. 편집 가능한 레이어를 불러오려면 geolibre-server의 'postgis' 추가 패키지를 설치하세요."

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -683,6 +683,7 @@
       "statusTablesFound_other": "공간 테이블 {{count}}개를 찾았습니다.",
       "statusNoTables": "이 데이터베이스에서 공간 테이블을 찾을 수 없습니다.",
       "editableTable": "테이블",
+      "geometryColumn": "도형 열",
       "tableReadOnly": "{{table}}(읽기 전용: 기본 키 없음)",
       "errorSelectTable": "불러올 테이블을 선택하세요.",
       "errorRuntimeMissing": "처리 서버에 PostGIS 런타임(psycopg)이 설치되어 있지 않습니다. 편집 가능한 레이어를 불러오려면 geolibre-server의 'postgis' 추가 패키지를 설치하세요."

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} ruimtelijke tabellen gevonden.",
       "statusNoTables": "Er zijn geen ruimtelijke tabellen gevonden in deze database.",
       "editableTable": "Tabel",
+      "geometryColumn": "Geometriekolom",
       "tableReadOnly": "{{table}} (alleen-lezen: geen primaire sleutel)",
       "errorSelectTable": "Selecteer een tabel om te laden.",
       "errorRuntimeMissing": "De verwerkingsserver heeft de PostGIS-runtime (psycopg) niet geïnstalleerd. Installeer de 'postgis'-extra van geolibre-server om bewerkbare lagen te laden."

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} tabelas espaciais encontradas.",
       "statusNoTables": "Nenhuma tabela espacial foi encontrada neste banco de dados.",
       "editableTable": "Tabela",
+      "geometryColumn": "Coluna de geometria",
       "tableReadOnly": "{{table}} (somente leitura: sem chave primária)",
       "errorSelectTable": "Selecione uma tabela para carregar.",
       "errorRuntimeMissing": "O servidor de processamento não tem o runtime do PostGIS (psycopg) instalado. Instale o extra \"postgis\" do geolibre-server para carregar camadas editáveis."

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -731,6 +731,7 @@
       "statusTablesFound_other": "Найдено {{count}} пространственной таблицы.",
       "statusNoTables": "В этой базе данных не найдено пространственных таблиц.",
       "editableTable": "Таблица",
+      "geometryColumn": "Столбец геометрии",
       "tableReadOnly": "{{table}} (только чтение: нет первичного ключа)",
       "errorSelectTable": "Выберите таблицу для загрузки.",
       "errorRuntimeMissing": "У сервера обработки не установлен рантайм PostGIS (psycopg). Установите дополнение 'postgis' для geolibre-server, чтобы загружать редактируемые слои."

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -683,6 +683,7 @@
       "statusTablesFound_other": "พบตารางเชิงพื้นที่ {{count}} ตาราง",
       "statusNoTables": "ไม่พบตารางเชิงพื้นที่ในฐานข้อมูลนี้",
       "editableTable": "ตาราง",
+      "geometryColumn": "คอลัมน์เรขาคณิต",
       "tableReadOnly": "{{table}} (อ่านอย่างเดียว: ไม่มีคีย์หลัก)",
       "errorSelectTable": "เลือกตารางที่ต้องการโหลด",
       "errorRuntimeMissing": "เซิร์ฟเวอร์ประมวลผลไม่ได้ติดตั้งรันไทม์ PostGIS (psycopg) ไว้ กรุณาติดตั้งส่วนเสริม 'postgis' ของ geolibre-server เพื่อโหลดเลเยอร์ที่แก้ไขได้"

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -699,6 +699,7 @@
       "statusTablesFound_other": "{{count}} konumsal tablo bulundu.",
       "statusNoTables": "Bu veritabanında konumsal tablo bulunamadı.",
       "editableTable": "Tablo",
+      "geometryColumn": "Geometri sütunu",
       "tableReadOnly": "{{table}} (salt okunur: birincil anahtar yok)",
       "errorSelectTable": "Yüklenecek bir tablo seçin.",
       "errorRuntimeMissing": "İşleme sunucusunda PostGIS çalışma zamanı (psycopg) yüklü değil. Düzenlenebilir katmanları yüklemek için geolibre-server 'postgis' ek paketini yükleyin."

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -608,6 +608,7 @@
       "errorStop": "Không thể ngăn cản Martin.",
       "statusNoTables": "Không có bảng không gian nào được tìm thấy trong cơ sở dữ liệu này.",
       "editableTable": "Bàn",
+      "geometryColumn": "Cột hình học",
       "tableReadOnly": "{{table}} (chỉ đọc: không có khóa chính)",
       "errorSelectTable": "Chọn một bảng để tải.",
       "errorRuntimeMissing": "Máy chủ xử lý chưa cài đặt thời gian chạy PostGIS (psycopg). Cài đặt thêm 'postgis' máy chủ địa lý để tải các lớp có thể chỉnh sửa."

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -683,6 +683,7 @@
       "statusTablesFound_other": "已找到 {{count}} 个空间表。",
       "statusNoTables": "在此数据库中未找到任何空间表。",
       "editableTable": "表",
+      "geometryColumn": "几何列",
       "tableReadOnly": "{{table}}（只读：无主键）",
       "errorSelectTable": "请选择要加载的表。",
       "errorRuntimeMissing": "处理服务器未安装 PostGIS 运行时（psycopg）。请安装 geolibre-server 的 “postgis” 扩展以加载可编辑图层。"

--- a/apps/geolibre-desktop/src/lib/postgis-table-selection.ts
+++ b/apps/geolibre-desktop/src/lib/postgis-table-selection.ts
@@ -1,0 +1,12 @@
+export interface PostgisTableIdentity {
+  schema: string;
+  table: string;
+}
+
+export function postgisTableKey(table: PostgisTableIdentity): string {
+  return JSON.stringify([table.schema, table.table]);
+}
+
+export function postgisTableLabel(table: PostgisTableIdentity): string {
+  return `${table.schema}.${table.table}`;
+}

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -365,7 +365,7 @@ def _table_info(
                 status_code=400,
                 detail=(f"Geometry column not found on {schema}.{table}: {geometry_column}"),
             )
-        geometry_column = geometry_column or geom_rows[0][0]
+        geometry_column = geom_rows[0][0] if geometry_column is None else geometry_column
         srid = geometry_by_name[geometry_column]
         # A table can register several geometry columns; the layer edits only
         # the selected one, and the others must not leak into the attribute

--- a/backend/geolibre_server/geolibre_server/app/postgis.py
+++ b/backend/geolibre_server/geolibre_server/app/postgis.py
@@ -256,6 +256,7 @@ class PostgisReadRequest(BaseModel):
     connection: str
     schema_name: str = "public"
     table: str
+    geometry_column: Optional[str] = None
     excluded_fields: list[str] = []
 
 
@@ -265,6 +266,7 @@ class PostgisWriteRequest(BaseModel):
     connection: str
     schema_name: str = "public"
     table: str
+    geometry_column: Optional[str] = None
     geojson: dict
     # Primary-key values the edit session started from (the last read). When
     # provided, deletions are scoped to these keys, so rows inserted by another
@@ -317,7 +319,9 @@ def _connect(connection: str) -> Any:
         ) from exc
 
 
-def _table_info(conn: Any, schema: str, table: str) -> dict[str, Any]:
+def _table_info(
+    conn: Any, schema: str, table: str, geometry_column: Optional[str] = None
+) -> dict[str, Any]:
     """Resolve geometry column, SRID, primary key and columns from the catalogs.
 
     The client only names the schema and table; every identifier used in the
@@ -328,6 +332,8 @@ def _table_info(conn: Any, schema: str, table: str) -> dict[str, Any]:
         conn: An open psycopg connection.
         schema: Schema name as stored in ``geometry_columns``.
         table: Table name as stored in ``geometry_columns``.
+        geometry_column: Requested registered geometry column, or None to use
+            the alphabetically first column for backward compatibility.
 
     Returns:
         A dict with ``geometry_column``, ``srid``, ``primary_key`` (None when
@@ -353,10 +359,17 @@ def _table_info(conn: Any, schema: str, table: str) -> dict[str, Any]:
                 status_code=404,
                 detail=f"Spatial table not found: {schema}.{table}",
             )
-        geometry_column, srid = geom_rows[0][0], int(geom_rows[0][1] or 0)
+        geometry_by_name = {row[0]: int(row[1] or 0) for row in geom_rows}
+        if geometry_column is not None and geometry_column not in geometry_by_name:
+            raise HTTPException(
+                status_code=400,
+                detail=(f"Geometry column not found on {schema}.{table}: {geometry_column}"),
+            )
+        geometry_column = geometry_column or geom_rows[0][0]
+        srid = geometry_by_name[geometry_column]
         # A table can register several geometry columns; the layer edits only
-        # the first, and the others must not leak into the attribute list (they
-        # would be read as WKB hex and written back as text).
+        # the selected one, and the others must not leak into the attribute
+        # list (they would be read as WKB hex and written back as text).
         all_geometry_columns = {row[0] for row in geom_rows}
 
         # Single-column primary key, if any. Composite keys are unsupported for
@@ -529,7 +542,7 @@ def postgis_read(request: PostgisReadRequest) -> dict[str, Any]:
 
     try:
         with _connect(request.connection) as conn:
-            info = _table_info(conn, request.schema_name, request.table)
+            info = _table_info(conn, request.schema_name, request.table, request.geometry_column)
             geom = sql.Identifier(info["geometry_column"])
             # A zero/unknown SRID cannot be transformed; serve the coordinates
             # as stored (the common convention for srid 0 data is lon/lat
@@ -657,7 +670,7 @@ def postgis_write(request: PostgisWriteRequest) -> dict[str, Any]:
         )
 
     with _connect(request.connection) as conn:
-        info = _table_info(conn, request.schema_name, request.table)
+        info = _table_info(conn, request.schema_name, request.table, request.geometry_column)
         pk = info["primary_key"]
         if pk is None:
             raise HTTPException(

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -581,6 +581,41 @@ def test_read_excludes_secondary_geometry_columns(live_table) -> None:
 
 
 @requires_live_postgis
+def test_multi_geometry_omitted_column_uses_first(live_table) -> None:
+    """Omitted read and write selectors consistently use the first geometry."""
+    with psycopg.connect(LIVE_DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"ALTER TABLE {TABLE} ADD COLUMN geom2 geometry(Point, 4326)")
+            cur.execute(f"UPDATE {TABLE} SET geom2 = ST_Translate(ST_Transform(geom, 4326), 10, 0)")
+        conn.commit()
+
+    read = postgis_read(PostgisReadRequest(connection=LIVE_DSN, table=TABLE))
+    assert read["geometry_column"] == "geom"
+    edited = read["geojson"]["features"][0]
+    edited_id = edited["id"]
+    original_secondary = _rows(
+        f"SELECT ST_AsEWKT(geom2) FROM {TABLE} WHERE gid = %s", (edited_id,)
+    )[0][0]
+    edited["geometry"] = _point(41, 42)
+
+    postgis_write(
+        PostgisWriteRequest(
+            connection=LIVE_DSN,
+            table=TABLE,
+            geojson=read["geojson"],
+        )
+    )
+    written = _rows(
+        f"SELECT ST_X(ST_Transform(geom, 4326)), "
+        f"ST_Y(ST_Transform(geom, 4326)), ST_AsEWKT(geom2) "
+        f"FROM {TABLE} WHERE gid = %s",
+        (edited_id,),
+    )[0]
+    assert written[:2] == pytest.approx((41, 42))
+    assert written[2] == original_secondary
+
+
+@requires_live_postgis
 @pytest.mark.parametrize("geometry_column", ["not_a_geometry", ""])
 def test_read_rejects_unknown_geometry_column(live_table, geometry_column: str) -> None:
     with pytest.raises(HTTPException) as exc:

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -581,13 +581,14 @@ def test_read_excludes_secondary_geometry_columns(live_table) -> None:
 
 
 @requires_live_postgis
-def test_read_rejects_unknown_geometry_column(live_table) -> None:
+@pytest.mark.parametrize("geometry_column", ["not_a_geometry", ""])
+def test_read_rejects_unknown_geometry_column(live_table, geometry_column: str) -> None:
     with pytest.raises(HTTPException) as exc:
         postgis_read(
             PostgisReadRequest(
                 connection=LIVE_DSN,
                 table=TABLE,
-                geometry_column="not_a_geometry",
+                geometry_column=geometry_column,
             )
         )
     assert exc.value.status_code == 400

--- a/backend/geolibre_server/tests/test_postgis.py
+++ b/backend/geolibre_server/tests/test_postgis.py
@@ -530,24 +530,68 @@ def test_write_keyless_insert_needs_pk_default(live_table) -> None:
 
 @requires_live_postgis
 def test_read_excludes_secondary_geometry_columns(live_table) -> None:
-    """Extra geometry columns must not surface as (hex WKB) attributes."""
+    """A requested geometry is loaded while the others stay out of attributes."""
     with psycopg.connect(LIVE_DSN) as conn:
         with conn.cursor() as cur:
             cur.execute(f"ALTER TABLE {TABLE} ADD COLUMN geom2 geometry(Point, 4326)")
-            cur.execute(f"UPDATE {TABLE} SET geom2 = ST_Transform(geom, 4326)")
+            cur.execute(f"UPDATE {TABLE} SET geom2 = ST_Translate(ST_Transform(geom, 4326), 10, 0)")
         conn.commit()
-    read = postgis_read(PostgisReadRequest(connection=LIVE_DSN, table=TABLE))
+    read = postgis_read(
+        PostgisReadRequest(
+            connection=LIVE_DSN,
+            table=TABLE,
+            geometry_column="geom2",
+        )
+    )
+    assert read["geometry_column"] == "geom2"
     properties = read["geojson"]["features"][0]["properties"]
     assert "geom2" not in properties
-    # And a round-trip write must leave the secondary geometry untouched.
+    assert "geom" not in properties
+    # The selected secondary geometry is the translated lon/lat point, not the
+    # alphabetically first column.
+    source_lon = _rows(f"SELECT ST_X(ST_Transform(geom, 4326)) FROM {TABLE} ORDER BY gid LIMIT 1")[
+        0
+    ][0]
+    assert read["geojson"]["features"][0]["geometry"]["coordinates"][0] == pytest.approx(
+        source_lon + 10
+    )
+    edited = read["geojson"]["features"][0]
+    edited_id = edited["id"]
+    original_primary = _rows(f"SELECT ST_AsEWKT(geom) FROM {TABLE} WHERE gid = %s", (edited_id,))[
+        0
+    ][0]
+    edited["geometry"] = _point(42, 43)
+    # Write-back updates the selected geometry and leaves the other registered
+    # geometry column untouched.
     postgis_write(
         PostgisWriteRequest(
             connection=LIVE_DSN,
             table=TABLE,
+            geometry_column="geom2",
             geojson=read["geojson"],
         )
     )
     assert _rows(f"SELECT count(*) FROM {TABLE} WHERE geom2 IS NOT NULL")[0][0] == 3
+    written = _rows(
+        f"SELECT ST_X(geom2), ST_Y(geom2), ST_AsEWKT(geom) FROM {TABLE} WHERE gid = %s",
+        (edited_id,),
+    )[0]
+    assert written[:2] == pytest.approx((42, 43))
+    assert written[2] == original_primary
+
+
+@requires_live_postgis
+def test_read_rejects_unknown_geometry_column(live_table) -> None:
+    with pytest.raises(HTTPException) as exc:
+        postgis_read(
+            PostgisReadRequest(
+                connection=LIVE_DSN,
+                table=TABLE,
+                geometry_column="not_a_geometry",
+            )
+        )
+    assert exc.value.status_code == 400
+    assert "Geometry column not found" in str(exc.value.detail)
 
 
 @requires_live_postgis

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -796,6 +796,8 @@ export interface ReadPostgisTableRequest {
   connection: string;
   schema_name?: string;
   table: string;
+  /** Geometry column to load when the table registers more than one. */
+  geometry_column?: string;
   excluded_fields?: string[];
 }
 
@@ -814,6 +816,8 @@ export interface WritePostgisTableRequest {
   connection: string;
   schema_name?: string;
   table: string;
+  /** Geometry column backing this editable layer. */
+  geometry_column?: string;
   /** The edited layer as a GeoJSON FeatureCollection (WGS84). */
   geojson: FeatureCollection;
   /**

--- a/tests/postgis-table-selection.test.ts
+++ b/tests/postgis-table-selection.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  postgisTableKey,
+  postgisTableLabel,
+} from "../apps/geolibre-desktop/src/lib/postgis-table-selection";
+
+describe("PostGIS table selection", () => {
+  it("distinguishes dotted identifiers that have the same display label", () => {
+    const dottedSchema = { schema: "a.b", table: "c" };
+    const dottedTable = { schema: "a", table: "b.c" };
+
+    assert.equal(postgisTableLabel(dottedSchema), "a.b.c");
+    assert.equal(postgisTableLabel(dottedTable), "a.b.c");
+    assert.notEqual(postgisTableKey(dottedSchema), postgisTableKey(dottedTable));
+  });
+});


### PR DESCRIPTION
## Summary
- list each registered PostGIS geometry column as a distinct editable-layer choice
- carry the selected geometry column through reads, writes, and post-save refreshes
- validate geometry-column requests against the database catalog while preserving the existing fallback for older clients

Fixes #1892

## Test plan
- [x] Run all 37 PostGIS endpoint tests against PostGIS 17 / 3.5 in Docker
- [x] Verify a table with centroid and footprint columns in the real app
- [x] Load the footprint geometry and confirm polygon rendering
- [x] Verify the selector in light and dark themes
- [x] Run scoped pre-commit hooks, including lint and production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a specific geometry column when viewing and editing PostGIS tables with multiple geometry columns.
  * Preserved the selected geometry column during edits and refreshes.
  * Displayed geometry-column labels when needed to distinguish table options.
* **Bug Fixes**
  * Fixed table listings and geometry handling for multi-geometry PostGIS tables.
  * Added validation with a clear error when an unknown geometry column is selected.
* **Localization**
  * Added geometry-column labels across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->