### PR TITLE
chore(deps): bump maplibre-gl-raster to 0.14.7

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -88,7 +88,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.5",
+    "maplibre-gl-raster": "^0.14.7",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.5",
+        "maplibre-gl-raster": "^0.14.7",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",
@@ -17775,9 +17775,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.5.tgz",
-      "integrity": "sha512-RrHIQbKmhwukloUs6+Ug1luUcCJQOLzF5eROZ/EspCvCUI6PdLXPUYtdWiVU0ikQoDmgI8IPTWPf/3HCQqDdOw==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.14.7.tgz",
+      "integrity": "sha512-LrQWuqENvWoHigi4vmk6FOo1SE3E+iW3OOyipRemCLPceTDpETdxfW3pVqA6Um8C6povLMpHgprGkpS3TOs0ag==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -23164,7 +23164,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.2",
         "maplibre-gl-planetary-computer": "^0.4.0",
-        "maplibre-gl-raster": "^0.14.5",
+        "maplibre-gl-raster": "^0.14.7",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -61,7 +61,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.2",
     "maplibre-gl-planetary-computer": "^0.4.0",
-    "maplibre-gl-raster": "^0.14.5",
+    "maplibre-gl-raster": "^0.14.7",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.1",


### PR DESCRIPTION
Picks up opengeos/maplibre-gl-raster#67 + #69, which fix the GeoTIFF decode worker URL in that package's published build.

## What was wrong

`@developmentseed/geotiff`'s `DecoderPool` creates its worker with `new Worker(new URL("./worker.js", import.meta.url))`. maplibre-gl-raster bundled that package, so Vite emitted the worker as one of **its** assets and rewrote the reference to a root-absolute path, wrapped in `@vite-ignore` so our bundler could not touch it:

```js
new Worker(new URL(/* @vite-ignore */ "/assets/worker-CcHZ_QZT.js", "" + import.meta.url), { type: "module" })
```

Nothing serves that package's own `dist/assets/` at our site root, so the browser asked **GeoLibre** for `/assets/worker-CcHZ_QZT.js`, got the SPA fallback `index.html`, and the module worker died on the MIME type:

> Failed to load module script: The server responded with a non-JavaScript MIME type of "text/html".

Every worker in the pool then closed immediately and COG decoding silently fell back to the main thread. Confirmed on both the dev server and a production build (`200 text/html` for that path in both), and present in every maplibre-gl-raster back to 0.13.0.

Nothing looked broken, which is why it sat here: rasters still rendered, they just decoded on the UI thread instead of off it.

## After the bump

The worker is emitted as one of **our** assets and served as `text/javascript`.

- Real browser, production build via `vite preview`: the NLCD land-cover COG renders through the `maplibre-gl-raster (GPU)` engine with a clean console and no diagnostics.
- `test:frontend` 5943 pass / 0 fail. `npm run build` and `lint` clean.

## Skip 0.14.6

0.14.6 was the first attempt and externalized the whole `@developmentseed` scope, which turned `deck.gl-raster`'s `colormaps.png` into a bare import that plain Node cannot load, breaking two suites here on import (`SyntaxError: Invalid or unexpected token` reading the PNG header). 0.14.7 scopes the externalization to the one package that owns the worker and inlines the PNG again. Worth deprecating 0.14.6 on npm; I do not have publish credentials locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the map rendering component to improve compatibility and reliability.
  - Applied the latest patch-level update across desktop and plugin experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->