### PR TITLE
fix(menu): rename GeoLibre's Conversion submenu to "Convert Files"

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -183,14 +183,18 @@ export function ProcessingMenu({
             models, and AI segmentation. Grouped under a single "GeoLibre"
             submenu so their category names don't collide with the Whitebox
             category submenus above. Each child keeps its own visibility gate;
-            the parent shows when any child does. */}
+            the parent shows when any child does. The file-conversion child is
+            labeled "Convert Files", not "Conversion" -- the Whitebox catalog
+            already has its own top-level "Conversion" category (with a
+            "GeoLibre" subcategory of its own), and a same-named child here
+            let users land in the wrong tool. */}
         {showGeolibre && (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>{t("toolbar.item.geolibre")}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {!mobile && show("processing.conversion") && (
                 <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>{t("toolbar.item.conversion")}</DropdownMenuSubTrigger>
+                  <DropdownMenuSubTrigger>{t("toolbar.item.convertFiles")}</DropdownMenuSubTrigger>
                   <DropdownMenuSubContent>
                     <DropdownMenuItem onSelect={() => setConversionOpen("vector-to-vector")}>
                       {t("toolbar.conversion.vectorToVector")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -2550,6 +2550,7 @@
       "modelBuilder": "Batch & Models",
       "processingHistory": "History",
       "conversion": "Conversion",
+      "convertFiles": "Convert Files",
       "vector": "Vector",
       "network": "Network",
       "statistics": "Spatial Statistics",

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -423,7 +423,7 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   {
     id: "processing.conversion",
     menuId: "processing",
-    labelKey: "toolbar.item.conversion",
+    labelKey: "toolbar.item.convertFiles",
     tier: "intermediate",
   },
   {


### PR DESCRIPTION
## What

The Processing menu has two items both labeled **"Conversion"**, reachable via different paths, doing completely different things:

- `Processing → Whitebox → Conversion` — the WhiteboxTools catalog's own category (auto-generated from `whitebox-menu-catalog.ts`), which itself has a subcategory literally called **"GeoLibre"**.
- `Processing → GeoLibre → Conversion` — GeoLibre's own format-conversion dialog (Vector to GeoPackage/PMTiles, Raster to COG, etc.), defined in `ProcessingMenu.tsx`.

The identical label makes it easy to open the wrong tool — I hit this myself trying to convert a large GeoTIFF to COG and landed in the Whitebox nodata/raster↔vector tools instead.

## Fix

Renamed GeoLibre's own submenu to **"Convert Files"** (new `toolbar.item.convertFiles` i18n key) so it no longer collides with the Whitebox catalog's auto-generated "Conversion" category, which is not hand-editable. Threaded the same key through the settings customize-menu label (`ui-profile.ts`) so the two stay in sync.

Only `en.json` gets the new key; other locales fall back to English until translated, matching how new strings are rolled out elsewhere in this repo.

## Testing

- `npm run test:frontend` — 5941 passed, 1 skipped (pre-existing), 0 failed
- `npm run typecheck` (full build) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Renamed the toolbar’s “Conversion” submenu to “Convert Files” for clearer file-conversion actions.
  * Updated the English translation to reflect the new label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->