### PR TITLE
fix(processing): honor a tool's recommended output extension over the…

### DIFF
--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -432,7 +432,9 @@ export function outputTextFormatHint(param: WhiteboxToolParameter): string | nul
   // format dispatch (same as GeoParquet/GPKG tools), which has no CSV driver
   // -- defaulting a blank path to ".csv" made the tool reject its own default,
   // the same failure mode as #1074.
-  const recommended = (param.description ?? "").match(/\.([a-z0-9]+)\s+recommended/i);
+  // The capture must start with a letter so a decimal in the prose ("a
+  // tolerance of 0.5 recommended") cannot be mistaken for an extension.
+  const recommended = (param.description ?? "").match(/\.([a-z][a-z0-9]*)\s+recommended/i);
   if (recommended) return recommended[1].toLowerCase();
   const hint = `${param.name ?? ""} ${param.description ?? ""} ${param.type ?? ""}`;
   if (/\bcsv\b/i.test(hint)) return "csv";

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -417,14 +417,23 @@ export function fileOutputTargetExtension(
 /**
  * The text/tabular output format a `file_out` parameter declares through its
  * name, description, or `table` data kind, as a bare extension (`csv`/`html`/
- * `json`), or `null` when nothing recognizable is found. Shared by the WASM
- * runner's {@link fileOutputTargetExtension} and the dialog's default-name and
- * download-naming code so the two hint lists cannot drift apart.
+ * `json`/...), or `null` when nothing recognizable is found. Shared by the
+ * WASM runner's {@link fileOutputTargetExtension} and the dialog's
+ * default-name and download-naming code so the two hint lists cannot drift
+ * apart.
  *
  * @param param - The output parameter.
- * @returns `"csv" | "html" | "json"`, or `null` if no text format is implied.
+ * @returns A bare extension, or `null` if no text format is implied.
  */
 export function outputTextFormatHint(param: WhiteboxToolParameter): string | null {
+  // An explicit "<ext> recommended" in the description is the tool author's
+  // own guidance and wins over every heuristic below. `excel_to_table`'s
+  // output is `data_kind: "table"` but its writer is the generic vector
+  // format dispatch (same as GeoParquet/GPKG tools), which has no CSV driver
+  // -- defaulting a blank path to ".csv" made the tool reject its own default,
+  // the same failure mode as #1074.
+  const recommended = (param.description ?? "").match(/\.([a-z0-9]+)\s+recommended/i);
+  if (recommended) return recommended[1].toLowerCase();
   const hint = `${param.name ?? ""} ${param.description ?? ""} ${param.type ?? ""}`;
   if (/\bcsv\b/i.test(hint)) return "csv";
   if (/\bhtml\b/i.test(hint)) return "html";

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -459,4 +459,14 @@ describe("fileOutputTargetExtension", () => {
     // An explicit user-chosen path still wins.
     assert.equal(fileOutputTargetExtension(excelToTable, "report.gpkg"), "gpkg");
   });
+
+  it("ignores a decimal in the prose rather than reading it as an extension", () => {
+    const decimalProse = {
+      name: "file_out",
+      description: "Optional CSV output path; a tolerance of 0.5 recommended for noisy inputs.",
+      data_kind: "table",
+      io_role: "output",
+    };
+    assert.equal(fileOutputTargetExtension(decimalProse, undefined), "csv");
+  });
 });

--- a/tests/wasm-tool-manifests.test.ts
+++ b/tests/wasm-tool-manifests.test.ts
@@ -441,4 +441,22 @@ describe("fileOutputTargetExtension", () => {
     const opaque = { name: "output", data_kind: "file", io_role: "output" };
     assert.equal(fileOutputTargetExtension(opaque, undefined), "dat");
   });
+
+  it("honors a recommended extension in the description over the table default", () => {
+    // excel_to_table's output param, as the WASM manifest reports it: data_kind
+    // "table" would otherwise default to .csv, but the writer is the generic
+    // vector format dispatch (no CSV driver) and the description already names
+    // the extension that does work.
+    const excelToTable = {
+      name: "file_out",
+      description:
+        "Optional output table path (driver from its extension; GeoParquet .parquet recommended). If omitted, stored in memory.",
+      data_kind: "table",
+      io_role: "output",
+    };
+    assert.equal(fileOutputTargetExtension(excelToTable, undefined), "parquet");
+    assert.equal(fileOutputTargetExtension(excelToTable, ""), "parquet");
+    // An explicit user-chosen path still wins.
+    assert.equal(fileOutputTargetExtension(excelToTable, "report.gpkg"), "gpkg");
+  });
 });


### PR DESCRIPTION
… table default

excel_to_table's output param is data_kind "table", so leaving the output path blank made the WASM runner default it to .csv. Its writer is the generic vector-format dispatch (same as GeoParquet/GPKG tools), which has no CSV driver, so the tool failed its own default with "unsupported output path" -- readable input (21542 rows x 10 columns from a legacy .xls), unusable default output. Same failure shape as #1074.

The param's own description already names the extension that works ("GeoParquet .parquet recommended"); outputTextFormatHint now honors an explicit "<ext> recommended" in the description before falling back to the generic csv/html/json/table heuristics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output file formats can now follow an explicitly recommended extension in the output description.
  * Supports any bare file extension, beyond previously recognized formats.
  * Recommended extensions are normalized to lowercase.

* **Bug Fixes**
  * Recommended extensions now take priority over the default CSV format for table outputs.
  * Explicitly selected output paths continue to be honored.
  * Decimal values in descriptions are no longer mistaken for file extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->