### PR TITLE
fix(deps): preserve vectors across basemap swaps

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -93,7 +93,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.10",
+    "maplibre-gl-vector": "^0.10.11",
     "openai": "^7.3.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.10",
+        "maplibre-gl-vector": "^0.10.11",
         "openai": "^7.3.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.8",
@@ -17930,9 +17930,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.10.tgz",
-      "integrity": "sha512-5ArHVPuZWkhGFoG/QLC1P9Vzg3FOZOdMHdR2chuvHQ4NTFHvaRi+kSdg959ZlZBSYBojAclwTOiliCqKH6aSSw==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.10.11.tgz",
+      "integrity": "sha512-gUnXlXioQXgr8dh3QBV/QgKn1j4U2CLvHzV9CVCZT6OCcD0n+jwACWqkg3NpgkyIYXEczOx9BYDSNQxM/IgNnQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -23133,7 +23133,7 @@
         "maplibre-gl-swipe": "^0.11.1",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
-        "maplibre-gl-vector": "^0.10.10",
+        "maplibre-gl-vector": "^0.10.11",
         "netcdfjs": "^4.0.0",
         "ngeohash": "^0.6.4",
         "open-location-code-typescript": "^1.5.0",

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -550,7 +550,16 @@ function syncExternalNativeLayer(
     return;
   }
 
-  ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
+  // maplibre-gl-vector owns both the source and presentation layers and, since
+  // v0.10.11, restores them from its retained layer record after setStyle.
+  // Rebuilding its missing layer here races that style.load handler: the host
+  // circle is drawn first with GeoLibre's generic paint, then the control adds
+  // its own circle, leaving concentric point rings after a basemap swap. Other
+  // external GeoJSON registrations do not provide a restore handler, so retain
+  // the host fallback for them.
+  if (layer.metadata.sourceKind !== "maplibre-gl-vector") {
+    ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
+  }
 
   if (
     !controlOwnsPaint(layer) &&

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -385,7 +385,7 @@ function intersectZoomRange(
 }
 
 export function syncLayer(map: maplibregl.Map, layer: GeoLibreLayer, beforeId?: string): void {
-  if (isExternalNativeLayer(layer)) {
+  if (isExternalNativeLayer(layer) || isVectorControlLayer(layer)) {
     syncExternalNativeLayer(map, layer, beforeId);
     return;
   }
@@ -449,6 +449,32 @@ export function syncLayer(map: maplibregl.Map, layer: GeoLibreLayer, beforeId?: 
 
 function isExternalNativeLayer(layer: GeoLibreLayer): boolean {
   return getExternalNativeLayerIds(layer).length > 0;
+}
+
+/** `metadata.sourceKind` for the layers maplibre-gl-vector owns. */
+const VECTOR_CONTROL_SOURCE_KIND = "maplibre-gl-vector";
+
+/**
+ * A layer the Add Vector Layer control owns, matched by `sourceKind` rather
+ * than by having native layer ids.
+ *
+ * Restoring after a style change, the control clears its retained record's
+ * `layerIds` and then *awaits* re-reading the source data before it can fill
+ * them back in. GeoLibre mirrors the control's layer list into the store, so a
+ * sync landing inside that window sees `nativeLayerIds: []`, no longer
+ * recognizes the layer as external, and rebuilds it down the ordinary GeoJSON
+ * path: a second source and circle layer carrying GeoLibre's own paint,
+ * stacked under the one the control restores a moment later. That is the
+ * concentric point ring of opengeos/GeoLibre#1902, which the guard in
+ * {@link syncExternalNativeLayer} does not catch because it only runs once the
+ * ids are already back.
+ *
+ * The control owns these layers in either window, so route them to the
+ * external path throughout; with no ids to work on it no-ops until the control
+ * brings its layers back and the next sync reconciles them normally.
+ */
+function isVectorControlLayer(layer: GeoLibreLayer): boolean {
+  return layer.metadata.sourceKind === VECTOR_CONTROL_SOURCE_KIND;
 }
 
 function syncExternalNativeLayer(
@@ -557,7 +583,7 @@ function syncExternalNativeLayer(
   // its own circle, leaving concentric point rings after a basemap swap. Other
   // external GeoJSON registrations do not provide a restore handler, so retain
   // the host fallback for them.
-  if (layer.metadata.sourceKind !== "maplibre-gl-vector") {
+  if (!isVectorControlLayer(layer)) {
     ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
   }
 
@@ -1632,7 +1658,7 @@ function syncVectorControlPointSymbology(
   layer: GeoLibreLayer,
   beforeId?: string,
 ): void {
-  if (layer.metadata.sourceKind !== "maplibre-gl-vector") return;
+  if (!isVectorControlLayer(layer)) return;
   const syntheticMarkerId = markerLayerId(layer.id);
   const singleRenderer = styleValue(layer.style, "pointRenderer") === "single";
   const circleNativeId = getExternalNativeLayerIds(layer).find(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -455,7 +455,7 @@ function isExternalNativeLayer(layer: GeoLibreLayer): boolean {
 const VECTOR_CONTROL_SOURCE_KIND = "maplibre-gl-vector";
 
 /**
- * A layer the Add Vector Layer control owns, matched by `sourceKind` rather
+ * A layer the Add Vector Layer control owns, matched by its metadata rather
  * than by having native layer ids.
  *
  * Restoring after a style change, the control clears its retained record's
@@ -465,16 +465,26 @@ const VECTOR_CONTROL_SOURCE_KIND = "maplibre-gl-vector";
  * recognizes the layer as external, and rebuilds it down the ordinary GeoJSON
  * path: a second source and circle layer carrying GeoLibre's own paint,
  * stacked under the one the control restores a moment later. That is the
- * concentric point ring of opengeos/GeoLibre#1902, which the guard in
- * {@link syncExternalNativeLayer} does not catch because it only runs once the
- * ids are already back.
+ * concentric point ring of opengeos/GeoLibre#1902.
  *
  * The control owns these layers in either window, so route them to the
- * external path throughout; with no ids to work on it no-ops until the control
- * brings its layers back and the next sync reconciles them normally.
+ * external path throughout. There they take the {@link isExternalCustomLayer}
+ * branch, which already tolerates an empty id list: it no-ops until the
+ * control brings its layers back and the next sync reconciles them normally.
+ *
+ * `customLayerType` is part of the match because
+ * `createVectorStoreLayer` always sets it (`vectorCustomLayerType` falls back
+ * to `"custom"`), so every genuine control layer carries it at every point in
+ * its lifecycle. Requiring it leaves a layer that claims the `sourceKind`
+ * without it — a hand-edited or pre-`customLayerType` project file, which no
+ * live control will ever hand native layer ids — on the ordinary GeoJSON path,
+ * where its embedded `geojson` still renders.
  */
 function isVectorControlLayer(layer: GeoLibreLayer): boolean {
-  return layer.metadata.sourceKind === VECTOR_CONTROL_SOURCE_KIND;
+  return (
+    layer.metadata.sourceKind === VECTOR_CONTROL_SOURCE_KIND &&
+    typeof layer.metadata.customLayerType === "string"
+  );
 }
 
 function syncExternalNativeLayer(
@@ -576,16 +586,7 @@ function syncExternalNativeLayer(
     return;
   }
 
-  // maplibre-gl-vector owns both the source and presentation layers and, since
-  // v0.10.11, restores them from its retained layer record after setStyle.
-  // Rebuilding its missing layer here races that style.load handler: the host
-  // circle is drawn first with GeoLibre's generic paint, then the control adds
-  // its own circle, leaving concentric point rings after a basemap swap. Other
-  // external GeoJSON registrations do not provide a restore handler, so retain
-  // the host fallback for them.
-  if (!isVectorControlLayer(layer)) {
-    ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
-  }
+  ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
 
   if (
     !controlOwnsPaint(layer) &&

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-swipe": "^0.11.1",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
-    "maplibre-gl-vector": "^0.10.10",
+    "maplibre-gl-vector": "^0.10.11",
     "netcdfjs": "^4.0.0",
     "ngeohash": "^0.6.4",
     "open-location-code-typescript": "^1.5.0",

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -81,6 +81,41 @@ describe("controlOwnsPaint external native layers", () => {
     );
   });
 
+  it("waits through the window where the control has cleared its layer ids", () => {
+    // Mid-restore the control empties its record's layerIds and awaits a
+    // re-read of the source data, and the store mirrors that empty list. The
+    // layer must still be recognized as the control's, or the ordinary GeoJSON
+    // path rebuilds it underneath the one the control is about to restore
+    // (opengeos/GeoLibre#1902).
+    const { map, calls } = makeMapStub("some-other-layer", "circle");
+    const layer = externalNativeLayer({
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [0, 0] },
+          },
+        ],
+      },
+      metadata: {
+        externalNativeLayer: true,
+        nativeLayerIds: [],
+        sourceIds: [],
+        sourceKind: "maplibre-gl-vector",
+        controlOwnsPaint: true,
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    assert.ok(
+      !calls.some((call) => call.method === "addSource" || call.method === "addLayer"),
+      "expected no duplicate source or layer while the control's ids are empty",
+    );
+  });
+
   it("syncs visibility and ordering but never overwrites the control's paint", () => {
     const { map, calls } = makeMapStub("mub-deliveries", "circle");
     const layer = externalNativeLayer({

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -51,6 +51,36 @@ function externalNativeLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer 
 }
 
 describe("controlOwnsPaint external native layers", () => {
+  it("waits for maplibre-gl-vector to restore its own source and layers", () => {
+    const { map, calls } = makeMapStub("some-other-layer", "circle");
+    const layer = externalNativeLayer({
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [0, 0] },
+          },
+        ],
+      },
+      metadata: {
+        externalNativeLayer: true,
+        nativeLayerIds: ["mub-deliveries-circle"],
+        sourceIds: ["mub-deliveries-source"],
+        sourceKind: "maplibre-gl-vector",
+        controlOwnsPaint: true,
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    assert.ok(
+      !calls.some((call) => call.method === "addSource" || call.method === "addLayer"),
+      "expected the host not to race the control's style-load restoration",
+    );
+  });
+
   it("syncs visibility and ordering but never overwrites the control's paint", () => {
     const { map, calls } = makeMapStub("mub-deliveries", "circle");
     const layer = externalNativeLayer({

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -65,6 +65,10 @@ describe("controlOwnsPaint external native layers", () => {
         ],
       },
       metadata: {
+        // Every store layer the control creates carries customLayerType, so
+        // the fixture must too: without it the layer takes a branch of
+        // syncExternalNativeLayer that no real control layer reaches.
+        customLayerType: "circle",
         externalNativeLayer: true,
         nativeLayerIds: ["mub-deliveries-circle"],
         sourceIds: ["mub-deliveries-source"],
@@ -100,6 +104,7 @@ describe("controlOwnsPaint external native layers", () => {
         ],
       },
       metadata: {
+        customLayerType: "circle",
         externalNativeLayer: true,
         nativeLayerIds: [],
         sourceIds: [],


### PR DESCRIPTION
## Summary

- update `maplibre-gl-vector` to 0.10.11 in both GeoLibre consumers
- consume upstream style-reload restoration so imported vectors survive basemap changes

Fixes #1902

Upstream: https://github.com/opengeos/maplibre-gl-vector/pull/65
Release: https://github.com/opengeos/maplibre-gl-vector/releases/tag/v0.10.11

## Verification

- imported `las-vegas-buildings.geojson`
- switched from the initial raster basemap to OpenFreeMap Positron
- confirmed polygons remain visible in light and dark themes
- browser console: 0 errors
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/package.json packages/plugins/package.json package-lock.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map rendering compatibility and stability with the latest patch update.
  * Fixed restoration of externally managed vector layers, preventing duplicate native sources and layers during synchronization.
  * Preserved correct handling for other external GeoJSON layers, including point styling.
  * Improved reliability when restoring map styles while native layer resources are temporarily unavailable.

* **Chores**
  * Applied the map rendering update consistently across desktop and plugin components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->