### PR TITLE
fix(import): consult the .gdb workspace suffix only as a last resort

### DIFF
--- a/apps/geolibre-desktop/src/lib/arcgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/arcgis-project-import.ts
@@ -447,20 +447,28 @@ function resolveRasterSource(
   const dataset = stringValue(connection.dataset);
   if (!workspace && !dataset) return { reason: "missing-source" };
   if (isNetworkPath(workspace)) return { reason: "network-path" };
-  // Recognized by either the factory or the workspace path, the way a
-  // geodatabase feature class is (see {@link resolveDataSource}), but reported
-  // under its own reason: the desktop build's Add Data -> File Geodatabase
-  // source lists only feature classes that carry geometry, so pointing a
-  // raster at it would send the user somewhere that cannot open their data.
-  if (
-    stringValue(connection.workspaceFactory).toLowerCase().includes("filegdb") ||
-    extension(workspace) === "gdb"
-  ) {
+  // Reported under its own reason rather than the feature class one: the
+  // desktop build's Add Data -> File Geodatabase source lists only feature
+  // classes that carry geometry, so pointing a raster at it would send the
+  // user somewhere that cannot open their data.
+  if (stringValue(connection.workspaceFactory).toLowerCase().includes("filegdb")) {
     return { reason: "file-geodatabase-raster" };
   }
-  if (!workspace || !dataset) return { reason: "missing-source" };
+  // Past this point the factory did not name a geodatabase, so only the
+  // workspace suffix is left to go on -- and it is consulted last, after the
+  // joined path fails. A readable GeoTIFF is therefore still loaded from a
+  // plain folder that happens to be named "*.gdb"; only a dataset the app
+  // cannot open falls through to the suffix, where naming the geodatabase
+  // beats a bare "format".
+  const looksLikeGeodatabase = extension(workspace) === "gdb";
+  if (!workspace || !dataset) {
+    return looksLikeGeodatabase
+      ? { reason: "file-geodatabase-raster" }
+      : { reason: "missing-source" };
+  }
   const path = resolveRelativePath(joinPath(workspace, dataset), projectPath);
-  return ["tif", "tiff"].includes(extension(path)) ? { path } : { reason: "format" };
+  if (["tif", "tiff"].includes(extension(path))) return { path };
+  return looksLikeGeodatabase ? { reason: "file-geodatabase-raster" } : { reason: "format" };
 }
 
 function resolveDataSource(

--- a/tests/arcgis-project-import.test.ts
+++ b/tests/arcgis-project-import.test.ts
@@ -248,6 +248,31 @@ describe("ArcGIS Pro project import", () => {
     );
   });
 
+  it("still loads a GeoTIFF from a plain folder whose name ends in .gdb", () => {
+    // The workspace suffix is a last resort, not a short circuit: a readable
+    // dataset wins over a folder that merely looks like a geodatabase. ArcGIS
+    // reserves .gdb for real geodatabases, so this is unlikely -- but the
+    // suffix check must not cost a raster that would otherwise have loaded.
+    const mapx = {
+      type: "CIMMap",
+      name: "Elevation",
+      defaultExtent: { xmin: -80, ymin: 30, xmax: -70, ymax: 40, spatialReference: { wkid: 4326 } },
+      layerDefinitions: [
+        {
+          type: "CIMRasterLayer",
+          name: "DEM",
+          dataConnection: {
+            workspaceConnectionString: "DATABASE=C:\\data\\rasters.gdb",
+            dataset: "dem.tif",
+          },
+        },
+      ],
+    };
+    const result = importArcgisProject(JSON.stringify(mapx), "C:\\projects\\main.mapx");
+    assert.deepEqual(result.warnings, []);
+    assert.equal(result.rasters[0].sourcePath, "C:/data/rasters.gdb/dem.tif");
+  });
+
   it("reports a geodatabase raster with no dataset name as a geodatabase", () => {
     // The geodatabase check deliberately precedes the missing-dataset guard,
     // so this matches what the vector resolver already did for the same


### PR DESCRIPTION
## Summary

Follow-up to #1910, which was merged while its last review comment was still being addressed. This is that fix, rebased onto `main`.

The reviewer's point on #1910 ([thread](https://github.com/opengeos/GeoLibre/pull/1910#discussion_r3787602122)) was correct: `resolveRasterSource`'s geodatabase short circuit checked `extension(workspace)` before the `dataset` was looked at, so a raster whose containing folder merely ends in `.gdb` — a plain folder someone named `rasters.gdb` — but whose dataset names a real `.tif`, stopped resolving where it previously loaded.

The `workspaceFactory` check still returns immediately, since a connection that names `FileGDB` is a geodatabase whatever the dataset says. The workspace *suffix* is now a last resort, consulted only after the joined path fails to name a GeoTIFF, so a readable raster still wins and only a dataset the app cannot open falls through to it. The behavior the previous PR deliberately kept — a `.gdb` workspace with no dataset name reporting the geodatabase rather than `missing-source` — is unchanged.

The doc comment no longer claims parity with `resolveDataSource`. As the reviewer noted, that function's own suffix check sits in a branch whose `path` stays equal to the workspace and so could not have resolved anyway, which is why it carries no equivalent regression.

## Verification

- New test: "still loads a GeoTIFF from a plain folder whose name ends in .gdb" — asserts no warning and the resolved `sourcePath`.
- The existing geodatabase tests (factory-named, suffix-only, no-dataset) all still pass, so the reported cases are unaffected.
- `node --import tsx --test tests/arcgis-project-import.test.ts` — 18 pass, 0 fail; full `npm run test:frontend` 5973 pass, 0 fail; `pre-commit run --files <changed>` clean.

Ref #1904 (item 2)
