### PR TITLE
fix(toolbar): size the Project and Add Data menus to their content

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -120,7 +120,12 @@ export function AddDataMenu({
           {chrome.renderLabel(t("toolbar.menu.addData"))}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-64">
+      {/* No width class: the primitive's min-w-[8rem] floor plus shrink-to-fit
+          sizes the menu to its longest label, the way Processing/Controls/Help
+          already do. A fixed w-64 pinned it to 256px whatever it held, which
+          left ~100px of dead space to the right of every entry, and would clip
+          a locale whose labels run past 256px instead of growing. */}
+      <DropdownMenuContent align="start">
         <DropdownMenuLabel>{t("toolbar.menu.addData")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {sections.map((group, index) => (

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -143,7 +143,8 @@ export function ProjectMenu({
           {chrome.renderLabel(t("toolbar.menu.project"))}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-64">
+      {/* No width class — see AddDataMenu: shrink-to-fit over a fixed w-64. */}
+      <DropdownMenuContent align="start">
         <DropdownMenuLabel>{t("toolbar.menu.project")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {show("project.new") && (


### PR DESCRIPTION
## What

`Project` and `Add Data` render much wider than anything in them. Both set a fixed `w-64` on `DropdownMenuContent`, so they are pinned at 256px whatever they hold. Add Data's longest label, "File Geodatabase (GDB)", is 151px, leaving roughly 100px of dead space to the right of all 31 entries.

## Why these two

They were the only toolbar menus doing it. `View` and `Edit` use a `min-w-*` **floor**; `Processing`, `Controls`, `Help` and `Plugins` pass no width class at all and shrink to fit over the primitive's own `min-w-[8rem]`. Dropping the class puts these two on that majority path.

A `min-w-64` would not have helped: the complaint is that the menus are too wide for their content, and a 256px floor keeps them at 256px.

## Measured

Built app at 1440x900, identical in light and dark:

| Menu | before | after | longest label |
| --- | --- | --- | --- |
| Project | 256px | **167px** | "Save as template..." (119px) |
| Add Data | 256px | **177px** | "File Geodatabase (GDB)" (151px) |

Project keeps ~24px of slack for the chevrons on its three submenu rows.

Shrink-to-fit also means a locale with longer labels grows instead of staying pinned. Add Data measures 180px in German, 287px in Vietnamese and 182px in Arabic (RTL), with no horizontal overflow in any of them, still capped by the primitive's `max-w-[calc(100vw-1rem)]`.

## Left alone

`ControlsMenu`'s two `w-64` `DropdownMenuSubContent`s: they hold sliders, which need a width to be usable.

## Testing

- Drove the real app in a browser and measured every menu above, in **both light and dark themes**, plus `de` / `vi` / `ar`.
- `npm run test:frontend` - 5975 passed, 1 skipped (pre-existing), 0 failed
- `npm run typecheck` (full build) - succeeds
- `pre-commit run --files <changed paths>` - all hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved toolbar menu sizing so dropdowns adjust to their content.
  * Long localized labels are less likely to be truncated or constrained by fixed widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->