### PR TITLE
fix(processing): make the Whitebox toolbox usable on a narrow panel

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -2745,7 +2745,17 @@ function LayerOrPathInput({
   const usingLayer = value.startsWith(LAYER_TOKEN_PREFIX);
   return (
     <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2 @sm/params:grid-cols-[minmax(150px,200px)_minmax(0,1fr)_2.25rem]">
-      <Select value={usingLayer ? value : ""} onChange={(event) => onChange(event.target.value)}>
+      {/* Three children, but the narrow template has only two columns, so the
+          picker has to claim the whole first row explicitly. Left to
+          auto-placement it lands in column 1, the path Input gets squeezed into
+          the 2.25rem browse-button track, and the button wraps to a row of its
+          own. The other two converted rows stack to a single column, where any
+          child count is fine; this is the one that needs saying. */}
+      <Select
+        className="col-span-2 @sm/params:col-span-1"
+        value={usingLayer ? value : ""}
+        onChange={(event) => onChange(event.target.value)}
+      >
         <option value="">{t("processing.whitebox.optionPath")}</option>
         {layers.map((layer) => (
           <option key={layer.id} value={`${LAYER_TOKEN_PREFIX}${layer.id}`}>

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1630,7 +1630,14 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
         // Height leaves room for the top offset (top-16) plus a bottom margin so
         // the whole panel - including the bottom-right resize grip - stays on
         // screen at small viewport heights.
-        "fixed z-40 flex h-[min(760px,calc(100vh-6rem))] w-[min(72rem,95vw)] flex-col overflow-hidden rounded-lg border bg-background shadow-xl",
+        //
+        // `@container/panel`: the responsive breakpoints inside measure this
+        // panel, not the viewport. They cannot use `sm:`/`md:` because the panel
+        // is draggable *and* resizable - `style.width` above overrides the
+        // w-[min(72rem,95vw)] class - so a viewport media query would keep the
+        // two-column layout after the user has dragged the panel down to 400px
+        // on a desktop, which is the same squeeze as a phone.
+        "@container/panel fixed z-40 flex h-[min(760px,calc(100vh-6rem))] w-[min(72rem,95vw)] flex-col overflow-hidden rounded-lg border bg-background shadow-xl",
         pos ? "" : "left-1/2 top-16 -translate-x-1/2",
       )}
     >
@@ -1701,8 +1708,17 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
         </button>
       </div>
 
-      <div className="grid min-h-0 flex-1 grid-cols-[minmax(260px,320px)_minmax(0,1fr)] gap-4 overflow-hidden p-5">
-        <div className="flex min-h-0 flex-col gap-3 border-e pe-4">
+      {/* Tool list beside the parameter form, but only while the panel is wide
+          enough for both. The list column's 260px floor is a hard minimum, so
+          below roughly 576px it ate everything and left the form ~120px, where
+          the label/value rows overflowed the panel entirely (a parameter label
+          wrapped to one word per line and its input ran off the right edge).
+          Under @xl the two stack into equal-height rows instead, each scrolling
+          on its own. */}
+      <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)_minmax(0,1fr)] gap-4 overflow-hidden p-5 @xl/panel:grid-cols-[minmax(260px,320px)_minmax(0,1fr)] @xl/panel:grid-rows-[minmax(0,1fr)]">
+        {/* Divider follows the axis: a bottom rule between stacked rows, an end
+            rule between side-by-side columns. */}
+        <div className="flex min-h-0 flex-col gap-3 border-b pb-4 @xl/panel:border-b-0 @xl/panel:border-e @xl/panel:pb-0 @xl/panel:pe-4">
           <div className="flex gap-2">
             <div className="relative min-w-0 flex-1">
               <Search className="pointer-events-none absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -1756,38 +1772,61 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
             </Button>
           )}
 
-          <Select value={category} onChange={(e) => setCategory(e.target.value)}>
-            {categories.map((item) => (
-              <option key={item.value} value={item.value}>
-                {item.label}
-              </option>
-            ))}
-          </Select>
-
-          {hasGeolibreTools && (
+          {/* Side by side while the panel is stacked, so the two filters cost
+              one row of height instead of two and the tool list keeps most of
+              its half. Back to a column once the list has a column of its own,
+              which is narrower than the panel. Flex, not a 2-col grid, so the
+              category select still fills the row when the source filter is
+              absent (no GeoLibre-authored tools in the catalog). */}
+          <div className="flex gap-2 @xl/panel:flex-col @xl/panel:gap-3">
             <Select
-              value={source}
-              // Reset the category too: a category with no tools in the newly
-              // chosen source would otherwise leave the list empty.
-              onChange={(e) => {
-                setSource(e.target.value);
-                setCategory("All");
-              }}
-              aria-label={t("processing.whitebox.filterBySource")}
+              className="min-w-0 flex-1"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
             >
-              <option value="All">
-                {t("processing.whitebox.allSources")} ({sourceCounts.all})
-              </option>
-              <option value="geolibre">
-                {t("processing.whitebox.geolibreTools")} ({sourceCounts.geolibre})
-              </option>
-              <option value="whitebox">
-                {t("processing.whitebox.whiteboxTools")} ({sourceCounts.whitebox})
-              </option>
+              {categories.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
             </Select>
-          )}
 
-          <ScrollArea className="min-h-0 flex-1 rounded-md border">
+            {hasGeolibreTools && (
+              <Select
+                className="min-w-0 flex-1"
+                value={source}
+                // Reset the category too: a category with no tools in the newly
+                // chosen source would otherwise leave the list empty.
+                onChange={(e) => {
+                  setSource(e.target.value);
+                  setCategory("All");
+                }}
+                aria-label={t("processing.whitebox.filterBySource")}
+              >
+                <option value="All">
+                  {t("processing.whitebox.allSources")} ({sourceCounts.all})
+                </option>
+                <option value="geolibre">
+                  {t("processing.whitebox.geolibreTools")} ({sourceCounts.geolibre})
+                </option>
+                <option value="whitebox">
+                  {t("processing.whitebox.whiteboxTools")} ({sourceCounts.whitebox})
+                </option>
+              </Select>
+            )}
+          </div>
+
+          {/* `[&>div>div]:!block` targets the wrapper Radix puts inside the
+              ScrollArea viewport, which ships as `display: table; min-width:
+              100%`. Table layout sizes to content, so the widest tool name set
+              the list's width and the rows' `truncate` never engaged - at a
+              260px column, "Build Object Hierarchy Multiscale" laid out 330px
+              wide and only the scrollport's clip hid it. As a block it fills the
+              viewport instead and the names ellipsize as intended. Applied here
+              rather than in the shared primitive: 129 call sites use ScrollArea
+              and some legitimately want the content-sized, horizontally
+              scrollable behaviour (the log pane below is one). */}
+          <ScrollArea className="min-h-0 flex-1 rounded-md border [&>div>div]:!block">
             <div className="divide-y">
               {loadingTools ? (
                 <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">
@@ -1827,8 +1866,16 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
 
         <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] gap-3">
           <div className="min-w-0 border-b pb-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
+            {/* Wraps rather than overflowing: the run-local toggle and the two
+                buttons need ~250px between them, so on a narrow panel they drop
+                to their own line under the tool name instead of running past
+                the panel edge. The name asks for 12rem (`basis-48`) so that
+                wrap actually triggers - with `flex-1` its basis is 0, and it
+                would shrink to "Build..." to keep everything on one line rather
+                than let the controls move down. `grow` still lets it take the
+                slack on a wide panel. */}
+            <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
+              <div className="min-w-0 grow basis-48">
                 <h3 className="truncate text-base font-semibold">
                   {selectedTool ? toolLabel(selectedTool) : t("processing.whitebox.noToolSelected")}
                 </h3>
@@ -1841,7 +1888,10 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
                   local/server toggle is dropped (WASM is the only runtime). */}
               {!IS_MAS_BUILD && (
                 <label
-                  className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                  // whitespace-nowrap: the label is short enough to keep on one
+                  // line, and letting it wrap turned "Run locally (WASM)" into a
+                  // three-line stack squeezed against the buttons.
+                  className="flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground"
                   title={t("processing.whitebox.runLocalHint")}
                 >
                   <input
@@ -1896,7 +1946,11 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
           </div>
 
           <ScrollArea className="min-h-0">
-            <div className="grid gap-4 pb-2 pe-5">
+            {/* A second container, because the picker/input rows below care
+                about the width of this form, not of the whole panel: once the
+                layout stacks, the form is full width even though the panel is
+                narrow. */}
+            <div className="@container/params grid gap-4 pb-2 pe-5">
               {/* The chosen layers are WGS84 and this tool takes a ground
                   distance, so its distance fields carry a unit picker
                   (GeoLibre#1540). Say once, up front, that the layers are
@@ -2329,7 +2383,7 @@ function ParameterField({
         // above) so a `url` description that happens to contain a word
         // isPathParameter matches (path/file/…) can't shadow this picker into a
         // local file-browse control.
-        <div className="grid grid-cols-[minmax(150px,200px)_minmax(0,1fr)] gap-2">
+        <div className="grid grid-cols-[minmax(0,1fr)] gap-2 @sm/params:grid-cols-[minmax(150px,200px)_minmax(0,1fr)]">
           <Select
             aria-label={t("processing.whitebox.fromLayer")}
             value=""
@@ -2388,7 +2442,7 @@ function ParameterField({
         // that layer's attribute names so the column need not be typed from
         // memory (GeoLibre#1459). The text box stays editable alongside the
         // picker, so a column the property sample missed can still be typed.
-        <div className="grid grid-cols-[minmax(150px,200px)_minmax(0,1fr)] gap-2">
+        <div className="grid grid-cols-[minmax(0,1fr)] gap-2 @sm/params:grid-cols-[minmax(150px,200px)_minmax(0,1fr)]">
           <Select
             aria-label={t("processing.whitebox.selectField")}
             value={fieldOptions.includes(valueText) ? valueText : ""}
@@ -2690,7 +2744,7 @@ function LayerOrPathInput({
   const { t } = useTranslation();
   const usingLayer = value.startsWith(LAYER_TOKEN_PREFIX);
   return (
-    <div className="grid grid-cols-[minmax(150px,200px)_minmax(0,1fr)_2.25rem] gap-2">
+    <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2 @sm/params:grid-cols-[minmax(150px,200px)_minmax(0,1fr)_2.25rem]">
       <Select value={usingLayer ? value : ""} onChange={(event) => onChange(event.target.value)}>
         <option value="">{t("processing.whitebox.optionPath")}</option>
         {layers.map((layer) => (

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1816,17 +1816,20 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
             )}
           </div>
 
-          {/* `[&>div>div]:!block` targets the wrapper Radix puts inside the
+          {/* `[&>div>div]:block!` targets the wrapper Radix puts inside the
               ScrollArea viewport, which ships as `display: table; min-width:
               100%`. Table layout sizes to content, so the widest tool name set
               the list's width and the rows' `truncate` never engaged - at a
               260px column, "Build Object Hierarchy Multiscale" laid out 330px
               wide and only the scrollport's clip hid it. As a block it fills the
-              viewport instead and the names ellipsize as intended. Applied here
-              rather than in the shared primitive: 129 call sites use ScrollArea
-              and some legitimately want the content-sized, horizontally
-              scrollable behaviour (the log pane below is one). */}
-          <ScrollArea className="min-h-0 flex-1 rounded-md border [&>div>div]:!block">
+              viewport instead and the names ellipsize as intended. The bang is
+              load-bearing (Radix sets that display inline) and trails the
+              utility, which is Tailwind v4's syntax and matches the same
+              override in LayerPanel. Applied here rather than in the shared
+              primitive: 129 call sites use ScrollArea and some legitimately want
+              the content-sized, horizontally scrollable behaviour (the log pane
+              below is one). */}
+          <ScrollArea className="min-h-0 flex-1 rounded-md border [&>div>div]:block!">
             <div className="divide-y">
               {loadingTools ? (
                 <div className="flex items-center gap-2 p-3 text-sm text-muted-foreground">


### PR DESCRIPTION
## What

The Whitebox toolbox panel breaks apart on a small screen: the parameter form overflows the panel entirely, a label wraps to one word per line, its input runs off the right edge, and the run-local toggle collides with the tool name.

| before (482px) | after (482px) |
| --- | --- |
| form squeezed to ~120px, 24 elements laid out past the viewport | everything inside the panel |

## Why

The split was `grid-cols-[minmax(260px,320px)_minmax(0,1fr)]`. The 260px is a hard floor, so once the panel dropped under ~570px the tool list kept its 260px and the form got whatever was left, around 120px. The form's own rows have a `minmax(150px,200px)` label column, so they could not fit and spilled out of the panel.

## Container queries, not `sm:`/`md:`

The panel is draggable **and** resizable, and its inline `style.width` overrides the `w-[min(72rem,95vw)]` class. A viewport media query would keep the two-column layout after a user drags the panel down to 400px on a 1440px desktop, which is the same squeeze without a narrow viewport to signal it. Tailwind v4 has container queries built in, so the breakpoints below measure the panel (`@container/panel`) and, for the picker rows, the form (`@container/params`).

## Changes

- **Split stacks below `@xl`** into two equal, independently scrolling rows. The divider follows the axis: a bottom rule when stacked, an end rule when side by side.
- **Tool-name row wraps**, so the toggle and the two buttons drop to their own line. The name asks for `12rem` so that wrap actually fires; with `flex-1` its basis is 0 and it shrank to `Build...` to keep everything on one line instead. The toggle gets `whitespace-nowrap` so it stops becoming a three-line stack.
- **The three picker rows** with a 150px label column stack below `@sm`, measured against the form, since the form is full width once the layout stacks.
- **Category and source filters share a row while stacked**, so they cost one row of height rather than two and the list keeps most of its half. Flex, not a 2-col grid, so category still fills the row when the source filter is absent (no GeoLibre-authored tools).
- **`[&>div>div]:!block` on the tool list's ScrollArea.** Radix ships that wrapper as `display: table; min-width: 100%`, which sizes to content, so the rows' `truncate` never engaged: at a 260px column `Build Object Hierarchy Multiscale` laid out 330px wide. Applied locally rather than in the shared primitive — 129 call sites use `ScrollArea` and some legitimately want the content-sized, horizontally scrollable behaviour (the log pane in this same file is one).

## Measured

Elements laid out past the viewport, with a tool selected:

| viewport | before | after |
| --- | --- | --- |
| 320px | many | **0** |
| 390px | 40 | **0** |
| 482px | 24 | **0** |
| 768px | 0 | 0 |
| 1024px | 0 | 0 |
| 1440px | 0 | 0 |

## Desktop

Not untouched, but both differences are fixes the ScrollArea change brought with it: the tool list no longer shows a spurious horizontal scrollbar, and its last row is no longer clipped by it. Pixel-diffed `main` against this branch at 1024px and 1440px; the changed regions are exactly the list rows and the tool-name row.

## Testing

- Drove the real app in a browser at 320 / 390 / 482 / 768 / 1024 / 1440px, in **both light and dark themes**, asserting no element inside the panel lays out past the viewport.
- `npm run test:frontend` — 5975 passed, 1 skipped (pre-existing), 0 failed
- `npm run typecheck` (full build) — succeeds
- `pre-commit run --files apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx` — all hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the processing dialog layout to adapt smoothly to different panel widths.
  * Narrow panels now stack tool and parameter sections, while wider panels display them side by side.
  * Filter controls, metadata, inputs, selectors, and action areas adjust responsively for better usability and content visibility.
  * Long tool lists and form content now use available space more effectively across desktop window sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->