### PR TITLE
fix(raster): render JPEG COGs with the WASM engine

### DIFF
--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -823,10 +823,7 @@ function patchJpegCogSource(source: unknown): unknown {
             : directory?.getValue?.(tag);
           return value as ArrayLike<number> | undefined;
         };
-        const [coefficients, referenceBlackWhite] = await Promise.all([
-          readTag(529),
-          readTag(532),
-        ]);
+        const [coefficients, referenceBlackWhite] = await Promise.all([readTag(529), readTag(532)]);
         return convertTiffYCbCrToRgb(
           rasters[0],
           rasters[1],

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -132,10 +132,39 @@ type RasterLayerManagerInternals = {
     createOverlay?: (map: MapControlHost, options: OverlayFactoryOptions) => OverlayLike;
     removeOverlay?: (map: MapControlHost, overlay: OverlayLike) => void;
     loadGeoTIFF?: (url: string) => Promise<unknown>;
+    loadCogTiler?: () => Promise<CogTilerModule>;
+    geolibreJpegTablesPatched?: boolean;
     geolibreTransparentOverlayPatched?: boolean;
     geolibreTauriNodataPatched?: boolean;
     geolibreSharedOverlayPatched?: boolean;
   };
+};
+type CogTilerModule = {
+  openCog: (source: unknown) => Promise<unknown>;
+  [key: string]: unknown;
+};
+type GeoTiffImage = {
+  fileDirectory?: {
+    PhotometricInterpretation?: number;
+    getValue?: (tag: number) => unknown;
+  };
+  readRasters: (options: {
+    window: [number, number, number, number];
+  }) => Promise<ArrayLike<ArrayLike<number>>>;
+};
+type CogSourceInternals = {
+  levels?: Array<{ compression?: string }>;
+  tiff?: unknown;
+  _tiffImage?: (level: number) => Promise<GeoTiffImage>;
+  _assembleWindow?: (
+    level: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    band?: number,
+  ) => Promise<ArrayLike<number>>;
+  geolibreJpegTablesPatched?: boolean;
 };
 type RasterTileArray = {
   bands?: unknown[];
@@ -707,6 +736,7 @@ async function ensureRasterControl(app: GeoLibreAppAPI): Promise<RasterControl |
     // The control mounts hidden: project restore must not surface a map
     // button the user never asked for. openRasterLayerPanel shows it.
     await patchTauriRasterOverlayFactory(rasterControl);
+    patchCogTilerJpegTables(rasterControl);
     await warmTauriWasmEngine(rasterControl);
     // On web the control renders interleaved, which shares deck.gl's per-map
     // Deck with the other interleaved overlays; route it through the shared
@@ -724,6 +754,89 @@ async function ensureRasterControl(app: GeoLibreAppAPI): Promise<RasterControl |
   }
 
   return rasterControl;
+}
+
+/**
+ * Decode abbreviated JPEG-in-TIFF tiles through geotiff.js.
+ *
+ * GDAL commonly stores the quantization/Huffman tables once in TIFF tag 347
+ * (`JPEGTables`) and omits them from each compressed tile. The whitebox-wasm
+ * streaming decoder used by cog-tiler-wasm 0.3.1 treats each tile as a complete
+ * JPEG, so these otherwise valid COGs fail with "use of unset quantization
+ * table" and the protocol returns transparent tiles. cog-tiler-wasm already
+ * opens multi-band projected rasters with geotiff.js for their CRS metadata;
+ * use that same range-aware reader for JPEG windows because it joins JPEGTables
+ * to the tile payload before decoding.
+ */
+function patchCogTilerJpegTables(control: RasterControl): void {
+  const manager = (control as unknown as RasterControlInternals)._layerManager;
+  const deps = manager?._deps;
+  if (!deps?.loadCogTiler || deps.geolibreJpegTablesPatched) return;
+
+  const loadCogTiler = deps.loadCogTiler;
+  deps.loadCogTiler = async () => {
+    const module = await loadCogTiler();
+    return {
+      ...module,
+      openCog: async (input: unknown) => patchJpegCogSource(await module.openCog(input)),
+    };
+  };
+  deps.geolibreJpegTablesPatched = true;
+}
+
+function patchJpegCogSource(source: unknown): unknown {
+  const cog = source as CogSourceInternals;
+  if (
+    cog.geolibreJpegTablesPatched ||
+    !/jpeg/i.test(cog.levels?.[0]?.compression ?? "") ||
+    !cog.tiff ||
+    !cog._tiffImage ||
+    !cog._assembleWindow
+  ) {
+    return source;
+  }
+
+  const windowCache = new Map<string, Promise<ArrayLike<ArrayLike<number>>>>();
+  cog._assembleWindow = async (level, x, y, width, height, band = 0) => {
+    const key = `${level}/${x}/${y}/${width}/${height}`;
+    let decoded = windowCache.get(key);
+    if (!decoded) {
+      decoded = cog._tiffImage!(level).then(async (image) => {
+        const rasters = await image.readRasters({ window: [x, y, x + width, y + height] });
+        // geotiff.js expands the chroma subsampling but deliberately returns
+        // the TIFF's native Y/Cb/Cr samples. The renderer expects RGB bands,
+        // like the GPU engine, so perform the TIFF/JPEG color transform once
+        // for the shared three-band window.
+        const photometric =
+          image.fileDirectory?.PhotometricInterpretation ?? image.fileDirectory?.getValue?.(262);
+        if (photometric !== 6 || rasters.length < 3) {
+          return rasters;
+        }
+        const size = width * height;
+        const red = new Float64Array(size);
+        const green = new Float64Array(size);
+        const blue = new Float64Array(size);
+        for (let index = 0; index < size; index += 1) {
+          const yValue = Number(rasters[0][index]);
+          const cb = Number(rasters[1][index]) - 128;
+          const cr = Number(rasters[2][index]) - 128;
+          red[index] = Math.max(0, Math.min(255, yValue + 1.402 * cr));
+          green[index] = Math.max(
+            0,
+            Math.min(255, yValue - 0.344136 * cb - 0.714136 * cr),
+          );
+          blue[index] = Math.max(0, Math.min(255, yValue + 1.772 * cb));
+        }
+        return [red, green, blue];
+      });
+      windowCache.set(key, decoded);
+      if (windowCache.size > 32) windowCache.delete(windowCache.keys().next().value!);
+    }
+    const rasters = await decoded;
+    return rasters[band] ?? rasters[0];
+  };
+  cog.geolibreJpegTablesPatched = true;
+  return source;
 }
 
 function getRasterControlClass(): Promise<RasterControlConstructor> {

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -833,6 +833,9 @@ function patchJpegCogSource(source: unknown): unknown {
         );
       });
       windowCache.set(key, decoded);
+      void decoded.catch(() => {
+        if (windowCache.get(key) === decoded) windowCache.delete(key);
+      });
       if (windowCache.size > 32) windowCache.delete(windowCache.keys().next().value!);
     }
     const rasters = await decoded;

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -821,10 +821,7 @@ function patchJpegCogSource(source: unknown): unknown {
           const cb = Number(rasters[1][index]) - 128;
           const cr = Number(rasters[2][index]) - 128;
           red[index] = Math.max(0, Math.min(255, yValue + 1.402 * cr));
-          green[index] = Math.max(
-            0,
-            Math.min(255, yValue - 0.344136 * cb - 0.714136 * cr),
-          );
+          green[index] = Math.max(0, Math.min(255, yValue - 0.344136 * cb - 0.714136 * cr));
           blue[index] = Math.max(0, Math.min(255, yValue + 1.772 * cb));
         }
         return [red, green, blue];

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -33,6 +33,7 @@ import {
 } from "./raster-symbology-texture";
 import { disposeAllPaletteLegends, disposePaletteLegend } from "./raster-palette";
 import { isNonTiledRasterError } from "./non-tiled-raster-error";
+import { convertTiffYCbCrToRgb } from "./tiff-ycbcr";
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
@@ -147,6 +148,8 @@ type GeoTiffImage = {
   fileDirectory?: {
     PhotometricInterpretation?: number;
     getValue?: (tag: number) => unknown;
+    hasTag?: (tag: number) => boolean;
+    loadValue?: (tag: number) => Promise<unknown>;
   };
   readRasters: (options: {
     window: [number, number, number, number];
@@ -812,19 +815,25 @@ function patchJpegCogSource(source: unknown): unknown {
         if (photometric !== 6 || rasters.length < 3) {
           return rasters;
         }
-        const size = width * height;
-        const red = new Float64Array(size);
-        const green = new Float64Array(size);
-        const blue = new Float64Array(size);
-        for (let index = 0; index < size; index += 1) {
-          const yValue = Number(rasters[0][index]);
-          const cb = Number(rasters[1][index]) - 128;
-          const cr = Number(rasters[2][index]) - 128;
-          red[index] = Math.max(0, Math.min(255, yValue + 1.402 * cr));
-          green[index] = Math.max(0, Math.min(255, yValue - 0.344136 * cb - 0.714136 * cr));
-          blue[index] = Math.max(0, Math.min(255, yValue + 1.772 * cb));
-        }
-        return [red, green, blue];
+        const directory = image.fileDirectory;
+        const readTag = async (tag: number): Promise<ArrayLike<number> | undefined> => {
+          if (directory?.hasTag?.(tag) === false) return undefined;
+          const value = directory?.loadValue
+            ? await directory.loadValue(tag)
+            : directory?.getValue?.(tag);
+          return value as ArrayLike<number> | undefined;
+        };
+        const [coefficients, referenceBlackWhite] = await Promise.all([
+          readTag(529),
+          readTag(532),
+        ]);
+        return convertTiffYCbCrToRgb(
+          rasters[0],
+          rasters[1],
+          rasters[2],
+          coefficients,
+          referenceBlackWhite,
+        );
       });
       windowCache.set(key, decoded);
       if (windowCache.size > 32) windowCache.delete(windowCache.keys().next().value!);

--- a/packages/plugins/src/plugins/tiff-ycbcr.ts
+++ b/packages/plugins/src/plugins/tiff-ycbcr.ts
@@ -18,8 +18,7 @@ export function convertTiffYCbCrToRgb(
   referenceBlackWhite?: NumericArray,
 ): [Float64Array, Float64Array, Float64Array] {
   const [kr, kg, kb] = finiteValues(coefficients, 3) ?? DEFAULT_COEFFICIENTS;
-  const reference =
-    finiteValues(referenceBlackWhite, 6) ?? DEFAULT_REFERENCE_BLACK_WHITE;
+  const reference = finiteValues(referenceBlackWhite, 6) ?? DEFAULT_REFERENCE_BLACK_WHITE;
   const [blackY, whiteY, blackCb, whiteCb, blackCr, whiteCr] = reference;
   const yRange = whiteY - blackY || 255;
   const cbRange = whiteCb - blackCb || 127;

--- a/packages/plugins/src/plugins/tiff-ycbcr.ts
+++ b/packages/plugins/src/plugins/tiff-ycbcr.ts
@@ -9,6 +9,24 @@ function finiteValues(values: NumericArray, length: number): number[] | null {
   return result.every(Number.isFinite) ? result : null;
 }
 
+function validCoefficients(values: NumericArray): number[] | null {
+  const coefficients = finiteValues(values, 3);
+  if (!coefficients) return null;
+  const [kr, kg, kb] = coefficients;
+  const sum = kr + kg + kb;
+  return kr >= 0 && kg > 0 && kb >= 0 && kr <= 1 && kg <= 1 && kb <= 1 && Math.abs(sum - 1) <= 1e-6
+    ? coefficients
+    : null;
+}
+
+function validReference(values: NumericArray): number[] | null {
+  const reference = finiteValues(values, 6);
+  if (!reference) return null;
+  return reference[1] > reference[0] && reference[3] > reference[2] && reference[5] > reference[4]
+    ? reference
+    : null;
+}
+
 /** Convert separate TIFF Y/Cb/Cr planes to RGB using tags 529 and 532. */
 export function convertTiffYCbCrToRgb(
   yPlane: ArrayLike<number>,
@@ -17,13 +35,12 @@ export function convertTiffYCbCrToRgb(
   coefficients?: NumericArray,
   referenceBlackWhite?: NumericArray,
 ): [Float64Array, Float64Array, Float64Array] {
-  const [kr, kg, kb] = finiteValues(coefficients, 3) ?? DEFAULT_COEFFICIENTS;
-  const reference = finiteValues(referenceBlackWhite, 6) ?? DEFAULT_REFERENCE_BLACK_WHITE;
+  const [kr, kg, kb] = validCoefficients(coefficients) ?? DEFAULT_COEFFICIENTS;
+  const reference = validReference(referenceBlackWhite) ?? DEFAULT_REFERENCE_BLACK_WHITE;
   const [blackY, whiteY, blackCb, whiteCb, blackCr, whiteCr] = reference;
-  const yRange = whiteY - blackY || 255;
-  const cbRange = whiteCb - blackCb || 127;
-  const crRange = whiteCr - blackCr || 127;
-  const safeKg = kg || DEFAULT_COEFFICIENTS[1];
+  const yRange = whiteY - blackY;
+  const cbRange = whiteCb - blackCb;
+  const crRange = whiteCr - blackCr;
   const size = Math.min(yPlane.length, cbPlane.length, crPlane.length);
   const red = new Float64Array(size);
   const green = new Float64Array(size);
@@ -35,7 +52,7 @@ export function convertTiffYCbCrToRgb(
     const cr = ((Number(crPlane[index]) - blackCr) * 127) / crRange;
     const r = y + (2 - 2 * kr) * cr;
     const b = y + (2 - 2 * kb) * cb;
-    const g = (y - kr * r - kb * b) / safeKg;
+    const g = (y - kr * r - kb * b) / kg;
     red[index] = Math.max(0, Math.min(255, r));
     green[index] = Math.max(0, Math.min(255, g));
     blue[index] = Math.max(0, Math.min(255, b));

--- a/packages/plugins/src/plugins/tiff-ycbcr.ts
+++ b/packages/plugins/src/plugins/tiff-ycbcr.ts
@@ -1,0 +1,46 @@
+const DEFAULT_COEFFICIENTS = [0.299, 0.587, 0.114] as const;
+const DEFAULT_REFERENCE_BLACK_WHITE = [0, 255, 128, 255, 128, 255] as const;
+
+type NumericArray = ArrayLike<number> | undefined;
+
+function finiteValues(values: NumericArray, length: number): number[] | null {
+  if (!values || values.length < length) return null;
+  const result = Array.from({ length }, (_, index) => Number(values[index]));
+  return result.every(Number.isFinite) ? result : null;
+}
+
+/** Convert separate TIFF Y/Cb/Cr planes to RGB using tags 529 and 532. */
+export function convertTiffYCbCrToRgb(
+  yPlane: ArrayLike<number>,
+  cbPlane: ArrayLike<number>,
+  crPlane: ArrayLike<number>,
+  coefficients?: NumericArray,
+  referenceBlackWhite?: NumericArray,
+): [Float64Array, Float64Array, Float64Array] {
+  const [kr, kg, kb] = finiteValues(coefficients, 3) ?? DEFAULT_COEFFICIENTS;
+  const reference =
+    finiteValues(referenceBlackWhite, 6) ?? DEFAULT_REFERENCE_BLACK_WHITE;
+  const [blackY, whiteY, blackCb, whiteCb, blackCr, whiteCr] = reference;
+  const yRange = whiteY - blackY || 255;
+  const cbRange = whiteCb - blackCb || 127;
+  const crRange = whiteCr - blackCr || 127;
+  const safeKg = kg || DEFAULT_COEFFICIENTS[1];
+  const size = Math.min(yPlane.length, cbPlane.length, crPlane.length);
+  const red = new Float64Array(size);
+  const green = new Float64Array(size);
+  const blue = new Float64Array(size);
+
+  for (let index = 0; index < size; index += 1) {
+    const y = ((Number(yPlane[index]) - blackY) * 255) / yRange;
+    const cb = ((Number(cbPlane[index]) - blackCb) * 127) / cbRange;
+    const cr = ((Number(crPlane[index]) - blackCr) * 127) / crRange;
+    const r = y + (2 - 2 * kr) * cr;
+    const b = y + (2 - 2 * kb) * cb;
+    const g = (y - kr * r - kb * b) / safeKg;
+    red[index] = Math.max(0, Math.min(255, r));
+    green[index] = Math.max(0, Math.min(255, g));
+    blue[index] = Math.max(0, Math.min(255, b));
+  }
+
+  return [red, green, blue];
+}

--- a/tests/tiff-ycbcr.test.ts
+++ b/tests/tiff-ycbcr.test.ts
@@ -30,4 +30,14 @@ describe("TIFF YCbCr conversion", () => {
       [220.273, 17.866, 135.228],
     );
   });
+
+  it("falls back to defaults for malformed color metadata", () => {
+    const expected = rounded(convertTiffYCbCrToRgb([100], [150], [200]));
+    assert.deepEqual(
+      rounded(
+        convertTiffYCbCrToRgb([100], [150], [200], [0.5, 0, 0.5], [255, 0, 128, 128, 255, 128]),
+      ),
+      expected,
+    );
+  });
 });

--- a/tests/tiff-ycbcr.test.ts
+++ b/tests/tiff-ycbcr.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { convertTiffYCbCrToRgb } from "../packages/plugins/src/plugins/tiff-ycbcr";
+
+function rounded(planes: [Float64Array, Float64Array, Float64Array]): number[] {
+  return planes.map((plane) => Math.round(plane[0] * 1_000) / 1_000);
+}
+
+describe("TIFF YCbCr conversion", () => {
+  it("uses the TIFF defaults when color metadata is absent", () => {
+    assert.deepEqual(
+      rounded(convertTiffYCbCrToRgb([100], [150], [200])),
+      [200.944, 41.011, 138.984],
+    );
+  });
+
+  it("honors non-default coefficients and reference ranges", () => {
+    // Fixture equivalent to tags YCbCrCoefficients=0.25,0.5,0.25 and
+    // ReferenceBlackWhite=16,235,128,240,128,240.
+    assert.deepEqual(
+      rounded(
+        convertTiffYCbCrToRgb(
+          [100],
+          [150],
+          [200],
+          [0.25, 0.5, 0.25],
+          [16, 235, 128, 240, 128, 240],
+        ),
+      ),
+      [220.273, 17.866, 135.228],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- decode abbreviated JPEG-in-TIFF tiles through the range-aware GeoTIFF reader when the WASM streaming decoder cannot apply shared JPEG tables
- convert native YCbCr samples to RGB and reuse each decoded window across all three bands
- restore WASM rendering for the Libya JPEG COG while preserving the existing GPU path

## Test plan
- [x] Run ESLint on `packages/plugins/src/plugins/maplibre-raster.ts`
- [x] Run the desktop TypeScript check
- [x] Build the production web app
- [x] Load `https://data.source.coop/giswqs/opengeos/Libya-2023-07-01.tif` with the WASM engine in Chromium and compare it with the GPU engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of JPEG-compressed Cloud Optimized GeoTIFF (COG) raster imagery.
  * Added more reliable TIFF YCbCr color conversion and raster band selection.
  * Improved handling of tiled image windows for smoother map rendering.
  * Added safer handling of missing or incomplete color metadata.
  * Preserved existing behavior for unsupported imagery and failed reads.

* **Performance**
  * Added caching for repeatedly requested raster regions, reducing redundant image decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->