### PR TITLE
Fix Layer Swipe for restored raster projects

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -91,7 +91,7 @@
     "maplibre-gl-raster": "^0.14.7",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.11.1",
+    "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "maplibre-gl-raster": "^0.14.7",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.11.1",
+        "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.11",
@@ -17877,9 +17877,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.11.1.tgz",
-      "integrity": "sha512-BuJhwubtuUwgzUx74cCv1fdL8OBOs4aIM4HGGokXKCxNDHg0J+OASTcq774/ftWciZ+L1d2oPCOu5WbjRglSXQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.11.2.tgz",
+      "integrity": "sha512-QjbQsQnz+FPjHmYiieuWmp0aD40lKaZXZL4pocd09nbnmqtbuzpQqQeu4jknui6xdIsWfvO2KUgTrdATpKWQbw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23143,7 +23143,7 @@
         "maplibre-gl-raster": "^0.14.7",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.11.1",
+        "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
         "maplibre-gl-usgs-lidar": "^0.11.1",
         "maplibre-gl-vector": "^0.10.11",

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2400,9 +2400,9 @@ export class MapController {
       // style, so getNamedStyleLayers (which filters to existing style layers)
       // skips them. Publish their store id -> name directly so the Layer Swipe
       // panel, which lists them by store id via its COG layerProvider, shows a
-      // friendly name instead of the raw id. Scoped to "cog-url" (the
-      // CogLayerControl rasters the provider lists) to match that scope. See
-      // opengeos/GeoLibre#1240.
+      // friendly name instead of the raw id. Scoped to the two kinds that
+      // provider lists -- "cog-url" (CogLayerControl) and "maplibre-gl-raster"
+      // (RasterControl) -- to match that scope. See opengeos/GeoLibre#1240.
       ...layers
         .filter(
           (layer) =>

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2407,7 +2407,8 @@ export class MapController {
         .filter(
           (layer) =>
             layer.type === "cog" &&
-            layer.metadata.sourceKind === "cog-url" &&
+            (layer.metadata.sourceKind === "cog-url" ||
+              layer.metadata.sourceKind === "maplibre-gl-raster") &&
             layer.metadata.externalNativeLayer === true,
         )
         .map((layer): [string, string] => [layer.id, layer.name]),

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -64,7 +64,7 @@
     "maplibre-gl-raster": "^0.14.7",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.11.1",
+    "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
     "maplibre-gl-usgs-lidar": "^0.11.1",
     "maplibre-gl-vector": "^0.10.11",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -3598,6 +3598,11 @@ function swipeCogFingerprint(layers: GeoLibreLayer[]): string {
       source.rescaleMin,
       source.rescaleMax,
       source.nodata,
+      // maplibre-gl-raster layers keep their visualization (mode/bands/
+      // colormap/rescale/nodata/...) in metadata.rasterState, not on `source`;
+      // without it a restyle of a mirrored raster would not notify. Always
+      // undefined for cog-url layers, so this is a no-op there.
+      layer.metadata.rasterState,
     ]);
   }
   return JSON.stringify(parts);

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -70,7 +70,6 @@ import type {
   ZarrLocalStoreProvider,
   ZarrLayerInfo,
 } from "maplibre-gl-components";
-import type { RasterLayerState } from "maplibre-gl-raster";
 import type { GaussianSplatControl, GaussianSplatLayerAdapter } from "maplibre-gl-splat";
 import type { LidarControlEventHandler, PointCloudInfo } from "maplibre-gl-lidar";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
@@ -78,6 +77,8 @@ import { ensureMercatorProjection } from "./map-projection-utils";
 import { ensureSharedDeckOverlay, setSharedDeckLayers } from "./shared-deck-overlay";
 import { attachTerrainMeasure, measurePanelElement, type TerrainMapLike } from "./terrain-measure";
 import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
+import { savedRasterState } from "./raster-layer-sync";
+import type { SwipeRasterSnapshot } from "./swipe-raster-mirror";
 import {
   KerchunkReferenceStore,
   loadKerchunkReference,
@@ -3542,14 +3543,10 @@ export interface SwipeCogRasterSnapshot {
   nodata?: number;
 }
 
-export interface SwipeMaplibreRasterSnapshot {
-  id: string;
-  name: string;
-  url: string;
-  visible: boolean;
-  opacity: number;
-  state: Partial<RasterLayerState>;
-}
+// The snapshot getSwipeMaplibreRasters produces is exactly what SwipeRasterMirror
+// consumes, so the mirror owns the shape and this is an alias rather than a
+// second copy to keep in sync by hand.
+export type SwipeMaplibreRasterSnapshot = SwipeRasterSnapshot;
 
 // Notified when the set/state of CogLayerControl rasters changes, so the swipe
 // provider can refresh its list and re-mirror. Backed by a single store
@@ -3693,7 +3690,6 @@ export function getSwipeMaplibreRasters(): SwipeMaplibreRasterSnapshot[] {
     .flatMap((layer) => {
       const url = (layer.source as { url?: unknown }).url;
       if (typeof url !== "string") return [];
-      const state = layer.metadata.rasterState;
       return [
         {
           id: layer.id,
@@ -3701,7 +3697,10 @@ export function getSwipeMaplibreRasters(): SwipeMaplibreRasterSnapshot[] {
           url,
           visible: layer.visible,
           opacity: layer.opacity,
-          state: state && typeof state === "object" ? (state as Partial<RasterLayerState>) : {},
+          // Sanitized the same way the normal restore path does, so a
+          // hand-edited project file cannot push malformed fields straight
+          // into the mirror control's addRaster.
+          state: savedRasterState(layer),
         },
       ];
     });

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -70,6 +70,7 @@ import type {
   ZarrLocalStoreProvider,
   ZarrLayerInfo,
 } from "maplibre-gl-components";
+import type { RasterLayerState } from "maplibre-gl-raster";
 import type { GaussianSplatControl, GaussianSplatLayerAdapter } from "maplibre-gl-splat";
 import type { LidarControlEventHandler, PointCloudInfo } from "maplibre-gl-lidar";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition, GeoLibrePlugin } from "../types";
@@ -3541,6 +3542,15 @@ export interface SwipeCogRasterSnapshot {
   nodata?: number;
 }
 
+export interface SwipeMaplibreRasterSnapshot {
+  id: string;
+  name: string;
+  url: string;
+  visible: boolean;
+  opacity: number;
+  state: Partial<RasterLayerState>;
+}
+
 // Notified when the set/state of CogLayerControl rasters changes, so the swipe
 // provider can refresh its list and re-mirror. Backed by a single store
 // subscription while at least one listener is registered.
@@ -3566,7 +3576,7 @@ function notifySwipeCogChange(): void {
 function swipeCogFingerprint(layers: GeoLibreLayer[]): string {
   const parts: unknown[][] = [];
   for (const layer of layers) {
-    if (!isCogRasterControlLayer(layer)) continue;
+    if (!isCogRasterControlLayer(layer) && !isMaplibreRasterControlLayer(layer)) continue;
     const source = layer.source as {
       url?: unknown;
       bands?: unknown;
@@ -3668,6 +3678,28 @@ export function getSwipeCogRasters(): SwipeCogRasterSnapshot[] {
     });
   }
   return snapshots;
+}
+
+/** Snapshot the newer maplibre-gl-raster layers, including project restores. */
+export function getSwipeMaplibreRasters(): SwipeMaplibreRasterSnapshot[] {
+  return useAppStore
+    .getState()
+    .layers.filter(isMaplibreRasterControlLayer)
+    .flatMap((layer) => {
+      const url = (layer.source as { url?: unknown }).url;
+      if (typeof url !== "string") return [];
+      const state = layer.metadata.rasterState;
+      return [
+        {
+          id: layer.id,
+          name: layer.name,
+          url,
+          visible: layer.visible,
+          opacity: layer.opacity,
+          state: state && typeof state === "object" ? (state as Partial<RasterLayerState>) : {},
+        },
+      ];
+    });
 }
 
 /**
@@ -5583,6 +5615,14 @@ function isCogRasterControlLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "cog" &&
     layer.metadata.sourceKind === "cog-url" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+function isMaplibreRasterControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "cog" &&
+    layer.metadata.sourceKind === "maplibre-gl-raster" &&
     layer.metadata.externalNativeLayer === true
   );
 }

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -22,6 +22,7 @@ import {
   resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
+  setTransientRasterVisibility,
   syncRasterLayersToStoreWithOptions,
   unwireRasterStoreSync,
   wireRasterStoreSync,
@@ -487,6 +488,18 @@ function applyRgbBandDefaults(
  */
 export function applyRasterLayerOrder(layerId: string, beforeId: string | undefined): void {
   rasterControl?.setRasterBeforeId(layerId, beforeId ?? null);
+}
+
+/** Change the live main-map visibility without mutating the persisted store. */
+export function setRasterMainVisibility(layerId: string, visible: boolean): void {
+  setTransientRasterVisibility(layerId, !visible);
+  rememberControlRasterRenderState(layerId, { visible });
+  runWithRasterStoreSyncSuspended(() => rasterControl?.setVisible(layerId, visible));
+}
+
+/** Read the live main-map visibility used by Layer Swipe. */
+export function getRasterMainVisibility(layerId: string): boolean {
+  return rasterControl?.getRaster(layerId)?.state.visible ?? true;
 }
 
 export function closeRasterLayerPanel(app: GeoLibreAppAPI): void {

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -47,8 +47,15 @@ let cogMirror: SwipeCogMirror | null = null;
 let rasterMirror: SwipeRasterMirror | null = null;
 // The main-map visibility this provider last forced per raster id (with the
 // opacity to restore when showing it again), so it only toggles on change and
-// can restore visibility on teardown.
-const cogMainForced = new Map<string, { visible: boolean; opacity: number }>();
+// can restore visibility on teardown. `kind` records which control owns the
+// raster -- CogLayerControl or maplibre-gl-raster's RasterControl -- so teardown
+// restores through that one instead of poking both and relying on the other to
+// no-op an id it never managed.
+type ForcedRasterKind = "cog" | "raster";
+const cogMainForced = new Map<
+  string,
+  { kind: ForcedRasterKind; visible: boolean; opacity: number }
+>();
 // Side assignments accumulated during one _updateLayerVisibility pass (the
 // control calls applySide once per provider layer); reconciled together so the
 // comparison mirror syncs in a single pass.
@@ -111,7 +118,7 @@ function reconcileCogSwipe(): void {
   // Drop bookkeeping for rasters removed from the store while swiping (the loop
   // below only visits still-present rasters, so their entries would otherwise
   // linger until teardown).
-  const rasterIds = new Set(rasters.map((raster) => raster.id));
+  const rasterIds = new Set([...rasters, ...maplibreRasters].map((raster) => raster.id));
   for (const id of [...cogMainForced.keys()]) {
     if (!rasterIds.has(id)) cogMainForced.delete(id);
   }
@@ -152,6 +159,7 @@ function reconcileCogSwipe(): void {
       setCogRasterMainVisibility(raster.id, wantVisible, raster.opacity);
     }
     cogMainForced.set(raster.id, {
+      kind: "cog",
       visible: wantVisible,
       opacity: raster.opacity,
     });
@@ -169,7 +177,11 @@ function reconcileCogSwipe(): void {
     if (getRasterMainVisibility(raster.id) !== wantVisible) {
       setRasterMainVisibility(raster.id, wantVisible);
     }
-    cogMainForced.set(raster.id, { visible: wantVisible, opacity: raster.opacity });
+    cogMainForced.set(raster.id, {
+      kind: "raster",
+      visible: wantVisible,
+      opacity: raster.opacity,
+    });
   }
 }
 
@@ -181,12 +193,12 @@ function teardownCogSwipe(): void {
   cogPendingSides.clear();
   cogPendingComparisonMap = undefined;
   cogReconcileScheduled = false;
-  // Restore any raster this provider hid on the main map.
+  // Restore any raster this provider hid on the main map, through the control
+  // that owns it.
   for (const [id, forced] of cogMainForced) {
-    if (!forced.visible) {
-      setCogRasterMainVisibility(id, true, forced.opacity);
-      setRasterMainVisibility(id, true);
-    }
+    if (forced.visible) continue;
+    if (forced.kind === "cog") setCogRasterMainVisibility(id, true, forced.opacity);
+    else setRasterMainVisibility(id, true);
   }
   cogMainForced.clear();
 }

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -18,6 +18,7 @@ import {
 } from "./maplibre-components";
 import { SwipeCogMirror } from "./swipe-cog-mirror";
 import { getRasterMainVisibility, setRasterMainVisibility } from "./maplibre-raster";
+import { setTransientRasterVisibility } from "./raster-layer-sync";
 import { SwipeRasterMirror } from "./swipe-raster-mirror";
 
 /**
@@ -156,7 +157,14 @@ function reconcileCogSwipe(): void {
     });
   }
   for (const raster of maplibreRasters) {
-    if (!raster.visible) continue;
+    if (!raster.visible) {
+      // The user hid it: drop this provider's bookkeeping so teardown does not
+      // show it again, and clear the transient marker so the next control-side
+      // visibility change is mirrored back to the store as a real edit.
+      cogMainForced.delete(raster.id);
+      setTransientRasterVisibility(raster.id, false);
+      continue;
+    }
     const wantVisible = sideFor(raster) !== "right";
     if (getRasterMainVisibility(raster.id) !== wantVisible) {
       setRasterMainVisibility(raster.id, wantVisible);

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -11,11 +11,14 @@ import { INTERNAL_HELPER_LAYER_PATTERNS } from "./internal-layers";
 import {
   getCogRasterMainVisibility,
   getSwipeCogRasters,
+  getSwipeMaplibreRasters,
   setCogRasterMainVisibility,
   subscribeSwipeCogChanges,
   type SwipeCogRasterSnapshot,
 } from "./maplibre-components";
 import { SwipeCogMirror } from "./swipe-cog-mirror";
+import { getRasterMainVisibility, setRasterMainVisibility } from "./maplibre-raster";
+import { SwipeRasterMirror } from "./swipe-raster-mirror";
 
 /**
  * Plugin id for the Layer Swipe control. Exported so the app can coordinate it
@@ -40,6 +43,7 @@ let unsubscribeBasemap: (() => void) | null = null;
 // The comparison-map raster mirror, recreated whenever the swipe control makes a
 // fresh comparison map (basemap change, re-activation).
 let cogMirror: SwipeCogMirror | null = null;
+let rasterMirror: SwipeRasterMirror | null = null;
 // The main-map visibility this provider last forced per raster id (with the
 // opacity to restore when showing it again), so it only toggles on change and
 // can restore visibility on teardown.
@@ -54,7 +58,7 @@ let unsubscribeCogRasterChanges: (() => void) | null = null;
 
 const cogSwipeProvider: SwipeLayerProvider = {
   getLayers: () =>
-    getSwipeCogRasters().map((raster) => ({
+    [...getSwipeCogRasters(), ...getSwipeMaplibreRasters()].map((raster) => ({
       id: raster.id,
       type: "raster",
       visible: raster.visible,
@@ -92,8 +96,16 @@ function reconcileCogSwipe(): void {
     cogMirror?.destroy();
     cogMirror = new SwipeCogMirror(comparisonMap);
   }
+  if (!comparisonMap) {
+    rasterMirror?.destroy();
+    rasterMirror = null;
+  } else if (!rasterMirror || rasterMirror.getMap() !== comparisonMap) {
+    rasterMirror?.destroy();
+    rasterMirror = new SwipeRasterMirror(comparisonMap);
+  }
 
   const rasters = getSwipeCogRasters();
+  const maplibreRasters = getSwipeMaplibreRasters();
 
   // Drop bookkeeping for rasters removed from the store while swiping (the loop
   // below only visits still-present rasters, so their entries would otherwise
@@ -117,6 +129,11 @@ function reconcileCogSwipe(): void {
       rasters.filter((raster) => raster.visible && onComparison(sideFor(raster))),
     );
   }
+  if (rasterMirror) {
+    void rasterMirror.sync(
+      maplibreRasters.filter((raster) => raster.visible && onComparison(sideFor(raster))),
+    );
+  }
 
   // Main map: hide right-only rasters (shown on the comparison side instead);
   // keep every other visible raster on the main map. Rasters the user hid are
@@ -138,17 +155,30 @@ function reconcileCogSwipe(): void {
       opacity: raster.opacity,
     });
   }
+  for (const raster of maplibreRasters) {
+    if (!raster.visible) continue;
+    const wantVisible = sideFor(raster) !== "right";
+    if (getRasterMainVisibility(raster.id) !== wantVisible) {
+      setRasterMainVisibility(raster.id, wantVisible);
+    }
+    cogMainForced.set(raster.id, { visible: wantVisible, opacity: raster.opacity });
+  }
 }
 
 function teardownCogSwipe(): void {
   cogMirror?.destroy();
   cogMirror = null;
+  rasterMirror?.destroy();
+  rasterMirror = null;
   cogPendingSides.clear();
   cogPendingComparisonMap = undefined;
   cogReconcileScheduled = false;
   // Restore any raster this provider hid on the main map.
   for (const [id, forced] of cogMainForced) {
-    if (!forced.visible) setCogRasterMainVisibility(id, true, forced.opacity);
+    if (!forced.visible) {
+      setCogRasterMainVisibility(id, true, forced.opacity);
+      setRasterMainVisibility(id, true);
+    }
   }
   cogMainForced.clear();
 }

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -99,6 +99,13 @@ let storeSyncSuspended = 0;
 // and back would land on the pushed value again and have that second edit
 // misread as an echo and dropped.
 const controlRenderState = new Map<string, { visible?: boolean; opacity?: number }>();
+const transientControlVisibility = new Set<string>();
+
+/** Mark visibility changes made only for a swipe comparison, not by the user. */
+export function setTransientRasterVisibility(id: string, transient: boolean): void {
+  if (transient) transientControlVisibility.add(id);
+  else transientControlVisibility.delete(id);
+}
 
 /**
  * Record what the control now holds for a raster, so the next control->store
@@ -323,7 +330,10 @@ export function syncRasterLayersToStoreWithOptions(
       const visibleIsEcho = known?.visible !== undefined && layer.visible === known.visible;
       const opacityIsEcho =
         known?.opacity !== undefined && numbersEqual(layer.opacity, known.opacity);
-      const visible = visibleIsEcho ? existing.visible : layer.visible;
+      const visible =
+        transientControlVisibility.has(layer.id) || visibleIsEcho
+          ? existing.visible
+          : layer.visible;
       const opacity = opacityIsEcho ? existing.opacity : layer.opacity;
       if (!visibleIsEcho || !opacityIsEcho) {
         rememberControlRasterRenderState(layer.id, {

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -288,6 +288,11 @@ export function syncRasterLayersToStoreWithOptions(
   for (const id of controlRenderState.keys()) {
     if (!infoIds.has(id)) controlRenderState.delete(id);
   }
+  // Same for a swipe's transient hide: a stale id would make a later raster
+  // added under it ignore genuine control-side visibility changes.
+  for (const id of transientControlVisibility) {
+    if (!infoIds.has(id)) transientControlVisibility.delete(id);
+  }
 
   syncingLayersToStore = true;
   try {

--- a/packages/plugins/src/plugins/swipe-raster-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-raster-mirror.ts
@@ -1,0 +1,109 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+import type { RasterControl, RasterLayerState } from "maplibre-gl-raster";
+
+export interface SwipeRasterSnapshot {
+  id: string;
+  name: string;
+  url: string;
+  visible: boolean;
+  opacity: number;
+  state: Partial<RasterLayerState>;
+}
+
+/** Mirrors maplibre-gl-raster's deck.gl rasters onto the swipe comparison map. */
+export class SwipeRasterMirror {
+  private control: RasterControl | null = null;
+  private controlPromise: Promise<RasterControl | null> | null = null;
+  private applied = new Map<string, { mirrorId: string; fingerprint: string }>();
+  private syncChain: Promise<void> = Promise.resolve();
+  private destroyed = false;
+
+  constructor(private readonly map: MapLibreMap) {}
+
+  getMap(): MapLibreMap {
+    return this.map;
+  }
+
+  sync(desired: SwipeRasterSnapshot[]): Promise<void> {
+    this.syncChain = this.syncChain.catch(() => {}).then(() => this.reconcile(desired));
+    return this.syncChain;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.applied.clear();
+    const control = this.control;
+    this.control = null;
+    this.controlPromise = null;
+    if (control) {
+      try {
+        this.map.removeControl(control);
+      } catch (error) {
+        console.debug("[GeoLibre] swipe raster mirror: removeControl", error);
+      }
+    }
+  }
+
+  private ensureControl(): Promise<RasterControl | null> {
+    if (this.destroyed) return Promise.resolve(null);
+    this.controlPromise ??= import("maplibre-gl-raster").then(
+      ({ RasterControl }) => {
+        if (this.destroyed) return null;
+        const control = new RasterControl({
+          collapsed: true,
+          engine: "maplibre-gl-raster",
+          interleaved: true,
+        });
+        this.map.addControl(control);
+        control.getContainer()?.remove();
+        this.control = control;
+        return control;
+      },
+      (error: unknown) => {
+        this.controlPromise = null;
+        console.warn("[GeoLibre] swipe raster mirror: control load", error);
+        return null;
+      },
+    );
+    return this.controlPromise;
+  }
+
+  private async reconcile(desired: SwipeRasterSnapshot[]): Promise<void> {
+    if (this.destroyed) return;
+    if (desired.length === 0) {
+      if (this.control) {
+        for (const { mirrorId } of this.applied.values()) this.control.removeRaster(mirrorId);
+        this.applied.clear();
+      }
+      return;
+    }
+
+    const control = await this.ensureControl();
+    if (!control || this.destroyed) return;
+    const desiredIds = new Set(desired.map(({ id }) => id));
+    for (const [id, entry] of [...this.applied]) {
+      if (!desiredIds.has(id)) {
+        control.removeRaster(entry.mirrorId);
+        this.applied.delete(id);
+      }
+    }
+
+    for (const raster of desired) {
+      if (this.destroyed) return;
+      const fingerprint = JSON.stringify([raster.url, raster.state, raster.opacity]);
+      const existing = this.applied.get(raster.id);
+      if (existing?.fingerprint === fingerprint) continue;
+      if (existing) control.removeRaster(existing.mirrorId);
+      try {
+        const mirrorId = await control.addRaster(raster.url, {
+          name: raster.name,
+          state: { ...raster.state, visible: true, opacity: raster.opacity },
+          zoomTo: false,
+        });
+        if (!this.destroyed) this.applied.set(raster.id, { mirrorId, fingerprint });
+      } catch (error) {
+        console.debug("[GeoLibre] swipe raster mirror: addRaster", error);
+      }
+    }
+  }
+}

--- a/packages/plugins/src/plugins/swipe-raster-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-raster-mirror.ts
@@ -19,8 +19,17 @@ export interface SwipeRasterSnapshot {
 export interface SwipeRasterMirrorDeps {
   createControl: (map: MapLibreMap) => Promise<RasterControl | null>;
   addRaster: (control: RasterControl, snapshot: SwipeRasterSnapshot) => Promise<string | null>;
+  setOpacity: (control: RasterControl, mirrorId: string, opacity: number) => void;
   removeRaster: (control: RasterControl, mirrorId: string) => void;
   removeControl: (map: MapLibreMap, control: RasterControl) => void;
+}
+
+// The non-opacity part of a mirrored raster; a change here needs a reload
+// (re-add), whereas an opacity-only change is applied in place. The store keeps
+// opacity on the layer, not in metadata.rasterState (see serializableRasterState
+// in raster-layer-sync.ts), so the two never overlap.
+function structuralFingerprint(raster: SwipeRasterSnapshot): string {
+  return JSON.stringify([raster.url, raster.state]);
 }
 
 const DEFAULT_DEPS: SwipeRasterMirrorDeps = {
@@ -45,6 +54,7 @@ const DEFAULT_DEPS: SwipeRasterMirrorDeps = {
       state: { ...snapshot.state, visible: true, opacity: snapshot.opacity },
       zoomTo: false,
     }),
+  setOpacity: (control, mirrorId, opacity) => control.setRasterState(mirrorId, { opacity }),
   removeRaster: (control, mirrorId) => control.removeRaster(mirrorId),
   removeControl: (map, control) => map.removeControl(control),
 };
@@ -53,7 +63,7 @@ const DEFAULT_DEPS: SwipeRasterMirrorDeps = {
 export class SwipeRasterMirror {
   private control: RasterControl | null = null;
   private controlPromise: Promise<RasterControl | null> | null = null;
-  private applied = new Map<string, { mirrorId: string; fingerprint: string }>();
+  private applied = new Map<string, { mirrorId: string; fingerprint: string; opacity: number }>();
   private syncChain: Promise<void> = Promise.resolve();
   private destroyed = false;
 
@@ -135,9 +145,17 @@ export class SwipeRasterMirror {
 
     for (const raster of desired) {
       if (this.destroyed) return;
-      const fingerprint = JSON.stringify([raster.url, raster.state, raster.opacity]);
+      const fingerprint = structuralFingerprint(raster);
       const existing = this.applied.get(raster.id);
-      if (existing?.fingerprint === fingerprint) continue;
+      if (existing?.fingerprint === fingerprint) {
+        // Same data and visualization; only opacity may have changed, and that
+        // is a live patch rather than a reload (no re-fetch, no flash).
+        if (existing.opacity !== raster.opacity) {
+          this.deps.setOpacity(control, existing.mirrorId, raster.opacity);
+          existing.opacity = raster.opacity;
+        }
+        continue;
+      }
       if (existing) {
         // Drop the entry with the mirror it names: leaving it would let a later
         // sync with the same fingerprint skip a raster whose re-add failed
@@ -147,7 +165,9 @@ export class SwipeRasterMirror {
       }
       try {
         const mirrorId = await this.deps.addRaster(control, raster);
-        if (mirrorId && !this.destroyed) this.applied.set(raster.id, { mirrorId, fingerprint });
+        if (mirrorId && !this.destroyed) {
+          this.applied.set(raster.id, { mirrorId, fingerprint, opacity: raster.opacity });
+        }
       } catch (error) {
         console.debug("[GeoLibre] swipe raster mirror: addRaster", error);
       }

--- a/packages/plugins/src/plugins/swipe-raster-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-raster-mirror.ts
@@ -10,6 +10,45 @@ export interface SwipeRasterSnapshot {
   state: Partial<RasterLayerState>;
 }
 
+/**
+ * The mirror-control operations {@link SwipeRasterMirror} depends on. Injectable
+ * so tests can exercise the diffing logic with fakes instead of a real
+ * RasterControl + deck.gl overlay (the same seam SwipeCogMirrorDeps gives the
+ * sibling COG mirror).
+ */
+export interface SwipeRasterMirrorDeps {
+  createControl: (map: MapLibreMap) => Promise<RasterControl | null>;
+  addRaster: (control: RasterControl, snapshot: SwipeRasterSnapshot) => Promise<string | null>;
+  removeRaster: (control: RasterControl, mirrorId: string) => void;
+  removeControl: (map: MapLibreMap, control: RasterControl) => void;
+}
+
+const DEFAULT_DEPS: SwipeRasterMirrorDeps = {
+  createControl: async (map) => {
+    const { RasterControl: RasterControlClass } = await import("maplibre-gl-raster");
+    const control = new RasterControlClass({
+      collapsed: true,
+      engine: "maplibre-gl-raster",
+      interleaved: true,
+    });
+    map.addControl(control);
+    // Hide the panel rather than detaching it, matching hideRasterControl in
+    // maplibre-raster.ts: the mirror only contributes its deck overlay, and
+    // onRemove expects to unmount its own container.
+    const container = control.getContainer();
+    if (container) container.style.display = "none";
+    return control;
+  },
+  addRaster: (control, snapshot) =>
+    control.addRaster(snapshot.url, {
+      name: snapshot.name,
+      state: { ...snapshot.state, visible: true, opacity: snapshot.opacity },
+      zoomTo: false,
+    }),
+  removeRaster: (control, mirrorId) => control.removeRaster(mirrorId),
+  removeControl: (map, control) => map.removeControl(control),
+};
+
 /** Mirrors maplibre-gl-raster's deck.gl rasters onto the swipe comparison map. */
 export class SwipeRasterMirror {
   private control: RasterControl | null = null;
@@ -18,7 +57,10 @@ export class SwipeRasterMirror {
   private syncChain: Promise<void> = Promise.resolve();
   private destroyed = false;
 
-  constructor(private readonly map: MapLibreMap) {}
+  constructor(
+    private readonly map: MapLibreMap,
+    private readonly deps: SwipeRasterMirrorDeps = DEFAULT_DEPS,
+  ) {}
 
   getMap(): MapLibreMap {
     return this.map;
@@ -37,7 +79,7 @@ export class SwipeRasterMirror {
     this.controlPromise = null;
     if (control) {
       try {
-        this.map.removeControl(control);
+        this.deps.removeControl(this.map, control);
       } catch (error) {
         console.debug("[GeoLibre] swipe raster mirror: removeControl", error);
       }
@@ -46,16 +88,9 @@ export class SwipeRasterMirror {
 
   private ensureControl(): Promise<RasterControl | null> {
     if (this.destroyed) return Promise.resolve(null);
-    this.controlPromise ??= import("maplibre-gl-raster").then(
-      ({ RasterControl }) => {
+    this.controlPromise ??= this.deps.createControl(this.map).then(
+      (control) => {
         if (this.destroyed) return null;
-        const control = new RasterControl({
-          collapsed: true,
-          engine: "maplibre-gl-raster",
-          interleaved: true,
-        });
-        this.map.addControl(control);
-        control.getContainer()?.remove();
         this.control = control;
         return control;
       },
@@ -72,7 +107,9 @@ export class SwipeRasterMirror {
     if (this.destroyed) return;
     if (desired.length === 0) {
       if (this.control) {
-        for (const { mirrorId } of this.applied.values()) this.control.removeRaster(mirrorId);
+        for (const { mirrorId } of this.applied.values()) {
+          this.deps.removeRaster(this.control, mirrorId);
+        }
         this.applied.clear();
       }
       return;
@@ -83,7 +120,7 @@ export class SwipeRasterMirror {
     const desiredIds = new Set(desired.map(({ id }) => id));
     for (const [id, entry] of [...this.applied]) {
       if (!desiredIds.has(id)) {
-        control.removeRaster(entry.mirrorId);
+        this.deps.removeRaster(control, entry.mirrorId);
         this.applied.delete(id);
       }
     }
@@ -93,14 +130,16 @@ export class SwipeRasterMirror {
       const fingerprint = JSON.stringify([raster.url, raster.state, raster.opacity]);
       const existing = this.applied.get(raster.id);
       if (existing?.fingerprint === fingerprint) continue;
-      if (existing) control.removeRaster(existing.mirrorId);
+      if (existing) {
+        // Drop the entry with the mirror it names: leaving it would let a later
+        // sync with the same fingerprint skip a raster whose re-add failed
+        // below, so the comparison map would stay missing it.
+        this.deps.removeRaster(control, existing.mirrorId);
+        this.applied.delete(raster.id);
+      }
       try {
-        const mirrorId = await control.addRaster(raster.url, {
-          name: raster.name,
-          state: { ...raster.state, visible: true, opacity: raster.opacity },
-          zoomTo: false,
-        });
-        if (!this.destroyed) this.applied.set(raster.id, { mirrorId, fingerprint });
+        const mirrorId = await this.deps.addRaster(control, raster);
+        if (mirrorId && !this.destroyed) this.applied.set(raster.id, { mirrorId, fingerprint });
       } catch (error) {
         console.debug("[GeoLibre] swipe raster mirror: addRaster", error);
       }

--- a/packages/plugins/src/plugins/swipe-raster-mirror.ts
+++ b/packages/plugins/src/plugins/swipe-raster-mirror.ts
@@ -77,12 +77,15 @@ export class SwipeRasterMirror {
     const control = this.control;
     this.control = null;
     this.controlPromise = null;
-    if (control) {
-      try {
-        this.deps.removeControl(this.map, control);
-      } catch (error) {
-        console.debug("[GeoLibre] swipe raster mirror: removeControl", error);
-      }
+    if (control) this.tryRemoveControl(control);
+  }
+
+  private tryRemoveControl(control: RasterControl): void {
+    try {
+      this.deps.removeControl(this.map, control);
+    } catch (error) {
+      // The comparison map may already be gone (removed by the swipe control).
+      console.debug("[GeoLibre] swipe raster mirror: removeControl", error);
     }
   }
 
@@ -90,7 +93,12 @@ export class SwipeRasterMirror {
     if (this.destroyed) return Promise.resolve(null);
     this.controlPromise ??= this.deps.createControl(this.map).then(
       (control) => {
-        if (this.destroyed) return null;
+        if (this.destroyed) {
+          // Mounted after destroy(): that call saw no control to remove, so
+          // this one has to unmount itself or its overlay stays on the map.
+          if (control) this.tryRemoveControl(control);
+          return null;
+        }
         this.control = control;
         return control;
       },

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -11,6 +11,7 @@ import {
   rendersNativeMapLibreLayer,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
+  setTransientRasterVisibility,
   syncRasterLayersToStore,
   syncRasterLayersToStoreWithOptions,
   unwireRasterStoreSync,
@@ -784,6 +785,61 @@ describe("removeRasterStoreLayers", () => {
     assert.equal(layers.length, 1);
     assert.equal(layers[0].id, "unrelated");
     assert.deepEqual(calls, []);
+  });
+});
+
+// Layer Swipe hides a right-only raster on the main map through the control
+// without touching the store, and marks the id transient so the control's
+// report of that hide is not mirrored back as a user edit (which would burn
+// the swipe's temporary state into the saved project).
+describe("transient raster visibility", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  afterEach(() => {
+    setTransientRasterVisibility("raster-1", false);
+    unwireRasterStoreSync();
+    useAppStore.setState({ layers: [] });
+  });
+
+  it("keeps the store's visibility when a transient hide is reported back", () => {
+    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
+    setTransientRasterVisibility("raster-1", true);
+
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ visible: false }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].visible, true);
+  });
+
+  it("mirrors a real visibility change once the mark is cleared", () => {
+    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
+    setTransientRasterVisibility("raster-1", true);
+    setTransientRasterVisibility("raster-1", false);
+
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ visible: false }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].visible, false);
+  });
+
+  it("forgets the mark when the control drops the raster", () => {
+    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
+    setTransientRasterVisibility("raster-1", true);
+
+    // The raster is removed (its store layer goes with it), so the mark cannot
+    // apply to anything; a later raster reusing the id must not inherit it and
+    // have its genuine visibility changes discarded.
+    syncRasterLayersToStore(fakeControl([]).control);
+    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo({ state: rasterState({ visible: false }) })]).control,
+    );
+
+    assert.equal(useAppStore.getState().layers[0].visible, false);
   });
 });
 

--- a/tests/swipe-raster-mirror.test.ts
+++ b/tests/swipe-raster-mirror.test.ts
@@ -140,6 +140,37 @@ describe("SwipeRasterMirror", () => {
     assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add-fail:a", "add-fail:a"]);
   });
 
+  it("removes a control that finishes mounting after destroy", async () => {
+    const rec = makeDeps();
+    let release: (() => void) | undefined;
+    let started: (() => void) | undefined;
+    const mounted = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const creating = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const deps: SwipeRasterMirrorDeps = {
+      ...rec.deps,
+      createControl: async (map) => {
+        started?.();
+        await mounted;
+        return rec.deps.createControl(map);
+      },
+    };
+    const mirror = new SwipeRasterMirror(fakeMap, deps);
+    const pending = mirror.sync([raster("a")]);
+    await creating;
+    mirror.destroy();
+    // Nothing was mounted when destroy() ran, so it had no control to remove.
+    assert.equal(rec.removedControl, 0);
+    release?.();
+    await pending;
+    assert.equal(rec.created, 1);
+    assert.equal(rec.removedControl, 1);
+    assert.deepEqual(rec.calls, []);
+  });
+
   it("removes the control and stops rendering after destroy", async () => {
     const rec = makeDeps();
     const mirror = new SwipeRasterMirror(fakeMap, rec.deps);

--- a/tests/swipe-raster-mirror.test.ts
+++ b/tests/swipe-raster-mirror.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Map as MapLibreMap } from "maplibre-gl";
+import type { RasterControl } from "maplibre-gl-raster";
+import {
+  SwipeRasterMirror,
+  type SwipeRasterMirrorDeps,
+  type SwipeRasterSnapshot,
+} from "../packages/plugins/src/plugins/swipe-raster-mirror";
+
+// A fake RasterControl is opaque to the mirror (only passed through deps), so a
+// plain object stands in.
+const fakeControl = {} as RasterControl;
+const fakeMap = {} as MapLibreMap;
+
+interface Recorder {
+  deps: SwipeRasterMirrorDeps;
+  calls: string[];
+  created: number;
+  removedControl: number;
+}
+
+function makeDeps(failAdd?: (snapshot: SwipeRasterSnapshot) => boolean): Recorder {
+  const calls: string[] = [];
+  let created = 0;
+  let removedControl = 0;
+  let idCounter = 0;
+  const deps: SwipeRasterMirrorDeps = {
+    createControl: async () => {
+      created += 1;
+      return fakeControl;
+    },
+    addRaster: async (_control, snapshot) => {
+      if (failAdd?.(snapshot)) {
+        calls.push(`add-fail:${snapshot.id}`);
+        throw new Error("addRaster failed");
+      }
+      idCounter += 1;
+      const id = `m${idCounter}`;
+      calls.push(`add:${snapshot.id}=>${id}`);
+      return id;
+    },
+    removeRaster: (_control, mirrorId) => {
+      calls.push(`remove:${mirrorId}`);
+    },
+    removeControl: () => {
+      removedControl += 1;
+    },
+  };
+  return {
+    deps,
+    calls,
+    get created() {
+      return created;
+    },
+    get removedControl() {
+      return removedControl;
+    },
+  };
+}
+
+function raster(id: string, patch: Partial<SwipeRasterSnapshot> = {}): SwipeRasterSnapshot {
+  return {
+    id,
+    name: id,
+    url: `https://example.com/${id}.tif`,
+    visible: true,
+    opacity: 1,
+    state: { mode: "single", bands: [1] },
+    ...patch,
+  };
+}
+
+describe("SwipeRasterMirror", () => {
+  it("adds a new raster and mounts the control once", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    assert.equal(rec.created, 1);
+    assert.deepEqual(rec.calls, ["add:a=>m1"]);
+  });
+
+  it("reloads a raster when its renderer state changes", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a", { state: { mode: "single", colormap: "viridis" } })]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add:a=>m2"]);
+  });
+
+  it("reloads a raster when its opacity changes", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a", { opacity: 0.5 })]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add:a=>m2"]);
+  });
+
+  it("removes a raster dropped from the desired set", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a"), raster("b")]);
+    await mirror.sync([raster("a")]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "add:b=>m2", "remove:m2"]);
+  });
+
+  it("does nothing (and never mounts a control) when desired is empty", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([]);
+    assert.equal(rec.created, 0);
+    assert.deepEqual(rec.calls, []);
+  });
+
+  it("removes mounted rasters when the desired set becomes empty", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1"]);
+  });
+
+  it("skips redundant work when nothing changed", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a")]);
+    assert.deepEqual(rec.calls, ["add:a=>m1"]);
+  });
+
+  it("retries the add on the next sync when a reload fails", async () => {
+    // The reload triggered by the opacity change fails, so the old mirror is
+    // gone with nothing in its place. An unchanged follow-up sync must retry
+    // rather than skip the raster as already-applied.
+    const rec = makeDeps((snapshot) => snapshot.opacity === 0.5);
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    await mirror.sync([raster("a", { opacity: 0.5 })]);
+    await mirror.sync([raster("a", { opacity: 0.5 })]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add-fail:a", "add-fail:a"]);
+  });
+
+  it("removes the control and stops rendering after destroy", async () => {
+    const rec = makeDeps();
+    const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
+    await mirror.sync([raster("a")]);
+    mirror.destroy();
+    assert.equal(rec.removedControl, 1);
+    await mirror.sync([raster("b")]);
+    // No further adds after destroy.
+    assert.deepEqual(rec.calls, ["add:a=>m1"]);
+  });
+});

--- a/tests/swipe-raster-mirror.test.ts
+++ b/tests/swipe-raster-mirror.test.ts
@@ -40,6 +40,9 @@ function makeDeps(failAdd?: (snapshot: SwipeRasterSnapshot) => boolean): Recorde
       calls.push(`add:${snapshot.id}=>${id}`);
       return id;
     },
+    setOpacity: (_control, mirrorId, opacity) => {
+      calls.push(`opacity:${mirrorId}=${opacity}`);
+    },
     removeRaster: (_control, mirrorId) => {
       calls.push(`remove:${mirrorId}`);
     },
@@ -88,12 +91,13 @@ describe("SwipeRasterMirror", () => {
     assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add:a=>m2"]);
   });
 
-  it("reloads a raster when its opacity changes", async () => {
+  it("applies an opacity-only change in place without re-adding", async () => {
     const rec = makeDeps();
     const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
     await mirror.sync([raster("a")]);
     await mirror.sync([raster("a", { opacity: 0.5 })]);
-    assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add:a=>m2"]);
+    assert.deepEqual(rec.calls, ["add:a=>m1", "opacity:m1=0.5"]);
+    assert.equal(rec.created, 1);
   });
 
   it("removes a raster dropped from the desired set", async () => {
@@ -129,14 +133,15 @@ describe("SwipeRasterMirror", () => {
   });
 
   it("retries the add on the next sync when a reload fails", async () => {
-    // The reload triggered by the opacity change fails, so the old mirror is
-    // gone with nothing in its place. An unchanged follow-up sync must retry
-    // rather than skip the raster as already-applied.
-    const rec = makeDeps((snapshot) => snapshot.opacity === 0.5);
+    // The reload triggered by the restyle fails, so the old mirror is gone with
+    // nothing in its place. An unchanged follow-up sync must retry rather than
+    // skip the raster as already-applied.
+    const restyled = { state: { mode: "single", colormap: "viridis" } } as const;
+    const rec = makeDeps((snapshot) => snapshot.state.colormap === "viridis");
     const mirror = new SwipeRasterMirror(fakeMap, rec.deps);
     await mirror.sync([raster("a")]);
-    await mirror.sync([raster("a", { opacity: 0.5 })]);
-    await mirror.sync([raster("a", { opacity: 0.5 })]);
+    await mirror.sync([raster("a", restyled)]);
+    await mirror.sync([raster("a", restyled)]);
     assert.deepEqual(rec.calls, ["add:a=>m1", "remove:m1", "add-fail:a", "add-fail:a"]);
   });
 


### PR DESCRIPTION
## Summary

- restore `maplibre-gl-raster` layers into the Layer Swipe panel with their display names
- mirror right-side GPU rasters onto the comparison map while keeping swipe-only visibility out of persisted project state
- preserve saved left/right assignments and make restored raster checkboxes functional
- consume `maplibre-gl-swipe` 0.11.2 to deduplicate interleaved native/provider layer IDs

## Verification

- reproduced with `https://share.geolibre.app/giswqs/layer-swipe.geolibre.json`
- verified two raster rows plus Background on each side, without duplicates, in light and dark themes
- verified checkbox changes and persistent Layers-panel visibility
- `npm run build`
- `npm run test:frontend` (5,980 passed, 1 skipped)
- `pre-commit run --files ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Layer Swipe support for MapLibre raster layers alongside COG raster layers.
  * Raster layers can now be mirrored to comparison maps, controlled by side selection, and restored when comparisons end.
  * Added live visibility handling without permanently changing saved layer settings.

* **Bug Fixes**
  * Improved support for external native raster layers in layer labeling and swipe comparisons.
  * Improved reliability when raster comparison maps are refreshed or temporarily unavailable.
  * Improved raster synchronization when layers change, reload, or become temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->