### PR TITLE
fix(plugins): exempt bundled drop-ins from remote-bundle SHA-256 pinning

### DIFF
--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -77,10 +77,19 @@ export async function loadExternalPlugins(
   pluginManifestUrls: string[] = [],
   options: {
     /**
-     * Manifest URLs of bundled drop-ins (public/plugins/<id>/). Only manifests
-     * fetched from these URLs may use `activeByDefault`; deployer-baked
-     * drop-ins are as trusted as built-ins, while runtime-installed zips and
-     * URL plugins must not force themselves active.
+     * Manifest URLs of bundled drop-ins (public/plugins/<id>/). Deployer-baked
+     * drop-ins are as trusted as built-ins: they are served by the same
+     * deployment as the app, so anyone able to swap one could equally swap the
+     * app's own chunks. Two privileges follow, and only these URLs get them.
+     *
+     * They may use `activeByDefault`, while runtime-installed zips and URL
+     * plugins must not force themselves active.
+     *
+     * They are exempt from the SHA-256 pin (see plugin-integrity.ts), which
+     * cannot detect the attack it was written for when the bundle and the app
+     * share an origin, and whose cost is real: the hash changes on every
+     * redeploy that touches the plugin, so a returning user's baked-in plugin
+     * would stop loading until they reloaded it from Settings.
      */
     bundledManifestUrls?: readonly string[];
   } = {},
@@ -225,18 +234,8 @@ async function loadPluginUrlBundles(
   for (const [index, result] of results.entries()) {
     if (result.status === "fulfilled") {
       const bundle = result.value;
-      // A bundled drop-in (public/plugins/<id>/) ships inside the very
-      // deployment that serves the app, so pinning it buys no security: anyone
-      // who can swap the plugin entry can equally swap the app's own chunks,
-      // and the pin would be verifying the attacker's build against itself.
-      // It does cost something real — every redeploy changes the bundle hash,
-      // so a returning user's baked-in plugin would silently stop loading until
-      // they re-accepted it in Settings, which for a deployer-shipped plugin is
-      // a broken release, not a security prompt. The rest of this module
-      // already treats these as trusted as built-ins (see bundledManifestUrls
-      // and the activeByDefault gate below), so exempt them here too. The pin
-      // still guards what it was written for: third-party manifest URLs on
-      // hosts we do not control.
+      // Bundled drop-ins are exempt from the pin; see `bundledManifestUrls` in
+      // loadExternalPlugins for why. Everything else still goes through it.
       if (!bundledUrls.has(manifestUrls[index])) {
         // Refuse to auto-execute a URL bundle whose code changed since it was
         // last trusted (a silent-update / compromised-host vector). First sight

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -100,7 +100,7 @@ export async function loadExternalPlugins(
           bundles: [],
           errors: [],
         }),
-    loadPluginUrlBundles(pluginManifestUrls, issues),
+    loadPluginUrlBundles(pluginManifestUrls, issues, bundledUrls),
     loadWebInstalledPluginBundles(),
   ]);
   for (const error of filesystemResult.errors) {
@@ -215,6 +215,8 @@ async function loadFilesystemPluginBundles(
 async function loadPluginUrlBundles(
   manifestUrls: string[],
   issues: ExternalPluginLoadIssue[],
+  /** Manifest URLs of deployer-baked drop-ins, exempt from SHA-256 pinning. */
+  bundledUrls: ReadonlySet<string>,
 ): Promise<ExternalPluginBundle[]> {
   const bundles: ExternalPluginBundle[] = [];
   const results = await Promise.allSettled(
@@ -223,34 +225,48 @@ async function loadPluginUrlBundles(
   for (const [index, result] of results.entries()) {
     if (result.status === "fulfilled") {
       const bundle = result.value;
-      // Refuse to auto-execute a URL bundle whose code changed since it was
-      // last trusted (a silent-update / compromised-host vector). First sight
-      // pins it; a changed hash is held back until the user reloads it
-      // explicitly (which re-pins). Isolate a verification failure (e.g.
-      // crypto.subtle unavailable) to this one URL — letting it throw here would
-      // reject the whole loadExternalPlugins Promise.all and drop every plugin.
-      try {
-        const integrity = await verifyPluginBundleIntegrity(manifestUrls[index], bundle);
-        if (integrity.status === "changed") {
+      // A bundled drop-in (public/plugins/<id>/) ships inside the very
+      // deployment that serves the app, so pinning it buys no security: anyone
+      // who can swap the plugin entry can equally swap the app's own chunks,
+      // and the pin would be verifying the attacker's build against itself.
+      // It does cost something real — every redeploy changes the bundle hash,
+      // so a returning user's baked-in plugin would silently stop loading until
+      // they re-accepted it in Settings, which for a deployer-shipped plugin is
+      // a broken release, not a security prompt. The rest of this module
+      // already treats these as trusted as built-ins (see bundledManifestUrls
+      // and the activeByDefault gate below), so exempt them here too. The pin
+      // still guards what it was written for: third-party manifest URLs on
+      // hosts we do not control.
+      if (!bundledUrls.has(manifestUrls[index])) {
+        // Refuse to auto-execute a URL bundle whose code changed since it was
+        // last trusted (a silent-update / compromised-host vector). First sight
+        // pins it; a changed hash is held back until the user reloads it
+        // explicitly (which re-pins). Isolate a verification failure (e.g.
+        // crypto.subtle unavailable) to this one URL — letting it throw here would
+        // reject the whole loadExternalPlugins Promise.all and drop every plugin.
+        try {
+          const integrity = await verifyPluginBundleIntegrity(manifestUrls[index], bundle);
+          if (integrity.status === "changed") {
+            issues.push({
+              archiveName: bundle.archiveName,
+              sourceUrl: bundle.sourceUrl,
+              message:
+                `Plugin at '${bundle.sourceUrl}' changed since you last trusted it and was not loaded. ` +
+                "Open Settings → Plugins and reload it to review and accept the update.",
+            });
+            continue;
+          }
+        } catch (error) {
           issues.push({
             archiveName: bundle.archiveName,
             sourceUrl: bundle.sourceUrl,
             message:
-              `Plugin at '${bundle.sourceUrl}' changed since you last trusted it and was not loaded. ` +
-              "Open Settings → Plugins and reload it to review and accept the update.",
+              error instanceof Error
+                ? `Could not verify plugin integrity: ${error.message}`
+                : "Could not verify plugin bundle integrity.",
           });
           continue;
         }
-      } catch (error) {
-        issues.push({
-          archiveName: bundle.archiveName,
-          sourceUrl: bundle.sourceUrl,
-          message:
-            error instanceof Error
-              ? `Could not verify plugin integrity: ${error.message}`
-              : "Could not verify plugin bundle integrity.",
-        });
-        continue;
       }
       bundles.push(bundle);
     } else {


### PR DESCRIPTION
## The problem

`loadExternalPlugins` passes every manifest URL to `loadPluginUrlBundles`, which pins each bundle's SHA-256 on first sight and refuses to execute it once the hash changes. That list includes the bundled drop-ins discovered under `public/plugins/<id>/`.

For a deployer-baked drop-in the pin cannot detect the attack it was written for. The plugin is served by the same deployment as the app, so anyone able to replace `public/plugins/<id>/dist/index.js` can equally replace the app's own chunks under `assets/` — the pin would be verifying their build against itself.

It does have a cost. The bundle hash changes on any redeploy that touches the plugin, so a returning user's baked-in plugin silently stops loading and waits for them to reload it from Settings → Plugins. For a plugin the deployer shipped as part of the build, that is a broken release rather than a useful security prompt.

## Why this is the intended line, not a new one

The surrounding code already distinguishes these two cases:

- `loadExternalPlugins` takes `bundledManifestUrls` with the comment *"deployer-baked drop-ins are as trusted as built-ins"*, and honours the manifest-level `activeByDefault` flag only for them.
- `plugin-integrity.ts` states the pin exists for remote fetch-and-execute, and that *"Local plugins (installed zips, filesystem drop-ins) are not pinned here"*.

A bundled drop-in is local in every sense that matters — it just happens to be reached over a same-origin URL rather than the filesystem, so it fell into the remote path. This change makes the integrity gate agree with both comments.

Manifest URLs on hosts the deployer does not control keep the pin exactly as before, which is the case it was written for.

## Verification

Manually, in the web build, using a bundled drop-in under `public/plugins/`:

- With a deliberately wrong hash stored under `geolibre.pluginBundlePins` for the drop-in's manifest URL: before this change the console reported *"changed since you last trusted it and was not loaded"* and the plugin was absent from the Plugins menu. After it, the plugin registers, injects its stylesheet, and appears in the menu.
- Rebuilding the drop-in so its hash genuinely changes — the redeploy case — now loads cleanly where it previously did not.
- A third-party manifest URL still goes through the unchanged pin path.

Local gate on this branch (macOS): `npm run lint` clean (0 errors), `npm run build` passes, `npm run test:frontend` 5998/6000 with the one failure — `render-linux-metainfo.sh committed copies` — reproducing identically on an unmodified `upstream/main` checkout, so it is pre-existing and platform-related rather than caused by this change. I did not run the Python or `cargo check` steps of `npm run ci`; this change touches neither.

## On tests

No unit test is included. Nothing currently covers `loadExternalPlugins`, and exercising it needs `URL.createObjectURL` plus a blob `import()`, which the plain-node test runner does not provide. If you would like coverage here, I am happy to add it — tell me which seam you would accept (extracting the pin decision into a pure predicate would be the smallest one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of bundled plugins from their configured manifest URLs.
  * Bundled plugins now load reliably without unnecessary integrity verification failures.
  * Preserved integrity checks and changed-bundle rejection for externally loaded plugins.
  * Improved error reporting when verification fails for URL-based plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->