### PR TITLE
fix(legend): show derived geometry

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -509,7 +509,18 @@ export function PrintLayoutDialog({
     [],
   );
 
-  const baseLegend = useMemo(() => buildLegend(layers), [layers]);
+  const baseLegend = useMemo(
+    () =>
+      buildLegend(layers, {
+        labels: {
+          centroid: t("style.generator.typeCentroid"),
+          "bounding-box": t("style.generator.typeBoundingBox"),
+          "convex-hull": t("style.generator.typeConvexHull"),
+          buffer: t("style.generator.typeBuffer"),
+        },
+      }),
+    [layers, t],
+  );
   const legend = useMemo(
     () => applyLegendConfig(baseLegend, legendConfig),
     [baseLegend, legendConfig],

--- a/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
+++ b/apps/geolibre-desktop/src/components/legend/MapLegendPanel.tsx
@@ -258,6 +258,12 @@ export function MapLegendPanel({
       buildAutoLegend(layers, legend, {
         locale: i18n.language,
         resolveColormapColors: colormapColors,
+        geometryGeneratorLabels: {
+          centroid: t("style.generator.typeCentroid"),
+          "bounding-box": t("style.generator.typeBoundingBox"),
+          "convex-hull": t("style.generator.typeConvexHull"),
+          buffer: t("style.generator.typeBuffer"),
+        },
       }),
     // colormapGeneration re-derives once an async colormap sample lands.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/geolibre-desktop/src/lib/auto-legend.ts
+++ b/apps/geolibre-desktop/src/lib/auto-legend.ts
@@ -30,9 +30,11 @@ import {
 import { isRasterLike, layerSwatchShape, type LayerSwatchShape } from "./layer-swatch";
 import {
   diagramSwatches,
+  geometryGeneratorLegendParts,
   isVectorStyledLayer,
   NON_LEGEND_TYPES,
   pointMarkerSwatch,
+  type GeometryGeneratorLegendLabels,
 } from "./print-legend";
 import type { LegendMarker } from "./print-layout";
 import { savedRasterAttributeTable } from "./raster-attribute-table";
@@ -130,6 +132,8 @@ export interface AutoLegendOptions {
    * `colormapColors` from `@geolibre/plugins`); null falls back to grayscale.
    */
   resolveColormapColors?: (name: string) => readonly string[] | null;
+  /** Localized names for derived centroid / polygon legend rows. */
+  geometryGeneratorLabels?: Partial<GeometryGeneratorLegendLabels>;
 }
 
 /** Prefix for standalone custom-section ids (not tied to a layer). */
@@ -654,6 +658,7 @@ function vectorParts(
   layer: GeoLibreLayer,
   shape: LayerSwatchShape,
   locale: string | undefined,
+  geometryGeneratorLabels: Partial<GeometryGeneratorLegendLabels> | undefined,
 ): {
   rows: RawRow[];
   gradient: AutoLegendGradient | null;
@@ -668,11 +673,26 @@ function vectorParts(
     color: swatch.color,
     shape: "square" as const,
   }));
+  const generated = geometryGeneratorLegendParts(layer, {
+    labels: geometryGeneratorLabels,
+    formatValue: (value) => formatLegendNumber(value, locale),
+  });
+  const generatorRows: RawRow[] = generated
+    ? generated.swatches.map((swatch, index) => ({
+        label: generated.fieldLabel ? (swatch.label ?? "") : generated.label,
+        color: swatch.color,
+        shape: generated.shape,
+        ...(swatch.size !== undefined ? { size: swatch.size } : {}),
+        ...(index === 0 && generated.fieldLabel
+          ? { caption: `${generated.label} · ${generated.fieldLabel}` }
+          : {}),
+      }))
+    : [];
 
   // A density heatmap renders no per-feature symbols: the entry is the ramp.
   if (shape === "circle" && styleValue(style, "pointRenderer") === "heatmap") {
     return {
-      rows: diagrams,
+      rows: [...diagrams, ...generatorRows],
       gradient: { colors: [...HEATMAP_RAMP_COLORS], minLabel: null, maxLabel: null },
       headerSwatch: null,
     };
@@ -713,6 +733,7 @@ function vectorParts(
             )
           : []),
         ...diagrams,
+        ...generatorRows,
       ],
       gradient: null,
       headerSwatch: null,
@@ -736,6 +757,7 @@ function vectorParts(
               )
             : []),
           ...diagrams,
+          ...generatorRows,
         ],
         gradient: null,
         headerSwatch: null,
@@ -759,6 +781,7 @@ function vectorParts(
               )
             : []),
           ...diagrams,
+          ...generatorRows,
         ],
         gradient: parts.gradient,
         headerSwatch: null,
@@ -784,7 +807,12 @@ function vectorParts(
     ? { color: marker.color, marker: marker.marker }
     : { color: styleValue(style, "fillColor") || NEUTRAL };
   const fieldLabel = sizeRange ? sizeRange.property : undefined;
-  return { rows: [...sizeRows, ...diagrams], gradient: null, headerSwatch, fieldLabel };
+  return {
+    rows: [...sizeRows, ...diagrams, ...generatorRows],
+    gradient: null,
+    headerSwatch,
+    fieldLabel,
+  };
 }
 
 /**
@@ -866,7 +894,7 @@ export function buildAutoLegend(
       gradient = parts.gradient;
       fieldLabel = parts.fieldLabel;
     } else {
-      const parts = vectorParts(layer, shape, locale);
+      const parts = vectorParts(layer, shape, locale, options.geometryGeneratorLabels);
       rows = parts.rows;
       gradient = parts.gradient;
       headerSwatch = parts.headerSwatch;

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -21,6 +21,7 @@ import {
   type ProportionalSizeRange,
   type VectorStyleStop,
 } from "@geolibre/core";
+import { buildGeneratedGeometry } from "@geolibre/map/derived-geometry";
 import type { LegendEntry, LegendMarker, LegendSwatch } from "./print-layout";
 
 /** Layer types styled as vectors (colored fills the legend can represent). */
@@ -244,18 +245,33 @@ export function geometryGeneratorLegendParts(
     ruleBasedVisibilityFilter(layer.style) !== null;
   const hasExternalNativeLayers =
     Array.isArray(layer.metadata.nativeLayerIds) && layer.metadata.nativeLayerIds.length > 0;
+  const isVectorControlLayer =
+    layer.metadata.sourceKind === "maplibre-gl-vector" &&
+    typeof layer.metadata.customLayerType === "string";
   if (
     generator === "none" ||
     layer.type !== "geojson" ||
     !layer.geojson ||
-    layer.geojson.features.length === 0 ||
     layer.metadata.externalDeckLayer === true ||
     hasExternalNativeLayers ||
+    isVectorControlLayer ||
     layer.style.extrusionEnabled ||
     hasFeatureFilter
   ) {
     return null;
   }
+
+  // Ask the same cached derivation the renderer uses whether any companion
+  // geometry exists. A non-empty source can still derive nothing, including a
+  // zero-distance buffer, invalid/degenerate features, or a collection above
+  // the synchronous safety cap.
+  const derived = buildGeneratedGeometry(
+    layer.geojson,
+    generator,
+    styleValue(layer.style, "geometryGeneratorBufferDistance"),
+    styleValue(layer.style, "geometryGeneratorBufferProperty"),
+  );
+  if (!derived || derived.features.length === 0) return null;
 
   const label = options.labels?.[generator] ?? DEFAULT_GEOMETRY_GENERATOR_LEGEND_LABELS[generator];
   const color = styleValue(layer.style, "geometryGeneratorFillColor") || NEUTRAL_SWATCH;

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -5,11 +5,14 @@
 import {
   diagramsSuppressedByPointRenderer,
   effectiveVectorRules,
+  generatorSizeRange,
   isHexColor,
   normalizeHexColor,
   proportionalSizeRange,
+  ruleBasedVisibilityFilter,
   styleValue,
   type GeoLibreLayer,
+  type GeometryGeneratorType,
   type LayerStyle,
   type LayerType,
   type LegendConfig,
@@ -42,6 +45,34 @@ export const NON_LEGEND_TYPES: ReadonlySet<LayerType> = new Set<LayerType>([
 
 const NEUTRAL_SWATCH = "#94a3b8";
 const MAX_RAMP_SWATCHES = 6;
+
+type ActiveGeometryGeneratorType = Exclude<GeometryGeneratorType, "none">;
+
+/** Localized names for the geometry-generator legend rows. */
+export type GeometryGeneratorLegendLabels = Record<ActiveGeometryGeneratorType, string>;
+
+/** English fallbacks for pure callers and tests that do not have an i18n context. */
+export const DEFAULT_GEOMETRY_GENERATOR_LEGEND_LABELS: GeometryGeneratorLegendLabels = {
+  centroid: "Centroids",
+  "bounding-box": "Bounding boxes",
+  "convex-hull": "Convex hulls",
+  buffer: "Buffers",
+};
+
+/** Options shared by the Print Layout and on-map legend derivations. */
+export interface GeometryGeneratorLegendOptions {
+  labels?: Partial<GeometryGeneratorLegendLabels>;
+  formatValue?: (value: number) => string;
+}
+
+/** Display-ready description of a geometry-generator symbol layer. */
+export interface GeometryGeneratorLegendParts {
+  label: string;
+  shape: "circle" | "square";
+  fieldLabel?: string;
+  swatches: LegendSwatch[];
+}
+
 /**
  * Upper bound on categorized class rows. Categories are nominal values, so
  * dropping one loses information no neighbouring row implies (unlike a
@@ -61,14 +92,18 @@ export const MAX_CATEGORY_SWATCHES = 100;
  * omitted.
  *
  * @param layers - All layers from the store, in render order (bottom first).
+ * @param options - Localized generator labels and optional value formatting.
  * @returns Legend entries in top-of-stack-first order.
  */
-export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
+export function buildLegend(
+  layers: GeoLibreLayer[],
+  options: GeometryGeneratorLegendOptions = {},
+): LegendEntry[] {
   const entries: LegendEntry[] = [];
   // Render order in the store is bottom-first; legends read top-first.
   for (const layer of [...layers].reverse()) {
     if (!layer.visible) continue;
-    const swatches = legendSwatchesForLayer(layer);
+    const swatches = legendSwatchesForLayer(layer, options);
     // No swatches means a type with no meaningful legend representation.
     if (swatches.length === 0) continue;
     entries.push({ id: layer.id, name: layer.name, swatches });
@@ -83,10 +118,30 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
  * an empty array for types with no meaningful legend representation
  * ({@link NON_LEGEND_TYPES}); every legend-able layer yields at least one swatch.
  */
-export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
+export function legendSwatchesForLayer(
+  layer: GeoLibreLayer,
+  options: GeometryGeneratorLegendOptions = {},
+): LegendSwatch[] {
   if (NON_LEGEND_TYPES.has(layer.type)) return [];
 
   if (isVectorStyledLayer(layer)) {
+    const generator = geometryGeneratorLegendParts(layer, options);
+    const withGenerator = (base: LegendSwatch[]): LegendSwatch[] => {
+      if (!generator) return base;
+      // A formerly single-symbol entry becomes a grouped entry once the
+      // generated geometry is appended. Give its otherwise-unlabelled base
+      // swatch a useful caption so Print Layout never draws a blank row.
+      const labelledBase = base.map((swatch) =>
+        swatch.label === undefined ? { ...swatch, label: layer.name } : swatch,
+      );
+      const generated = generator.swatches.map((swatch) => ({
+        ...swatch,
+        label: generator.fieldLabel
+          ? `${generator.label} (${generator.fieldLabel}): ${swatch.label ?? ""}`
+          : generator.label,
+      }));
+      return [...labelledBase, ...generated];
+    };
     const mode = styleValue(layer.style, "vectorStyleMode");
     const stops = styleValue(layer.style, "vectorStyleStops");
     // Diagram symbology adds one labeled swatch per charted attribute after the
@@ -123,47 +178,117 @@ export function legendSwatchesForLayer(layer: GeoLibreLayer): LegendSwatch[] {
       // Same field classified and sized: merge sizes into the class rows so the
       // print legend matches the on-map auto-legend (one block, not two).
       if (sizeRange && mode === "graduated" && sizeRange.property === classProperty) {
-        return [...sizeClassSwatches(ramp, displayedStops, sizeRange, sizeMarker), ...diagrams];
+        return withGenerator([
+          ...sizeClassSwatches(ramp, displayedStops, sizeRange, sizeMarker),
+          ...diagrams,
+        ]);
       }
-      return [
+      return withGenerator([
         ...ramp,
         ...(sizeRange
           ? proportionalSizeSwatches(sizeRange, sizeRampColor(ramp, layer.style), sizeMarker)
           : []),
         ...diagrams,
-      ];
+      ]);
     }
     if (mode === "rule-based") {
       const swatches = ruleSwatches(layer);
       if (swatches.length > 0) {
-        return [
+        return withGenerator([
           ...swatches,
           ...(sizeRange
             ? proportionalSizeSwatches(sizeRange, sizeRampColor(swatches, layer.style), sizeMarker)
             : []),
           ...diagrams,
-        ];
+        ]);
       }
     }
     // Single symbology with proportional sizing: the size ramp IS the legend.
     if (sizeRange) {
-      return [
+      return withGenerator([
         ...proportionalSizeSwatches(
           sizeRange,
           styleValue(layer.style, "fillColor") || NEUTRAL_SWATCH,
           sizeMarker,
         ),
         ...diagrams,
-      ];
+      ]);
     }
     const primary = pointMarkerSwatch(layer.style) ?? {
       color: styleValue(layer.style, "fillColor"),
     };
-    return [primary, ...diagrams];
+    return withGenerator([primary, ...diagrams]);
   }
 
   // Raster / service layers: a single neutral marker swatch.
   return [{ color: NEUTRAL_SWATCH }];
+}
+
+/**
+ * Derive legend symbols for the companion geometry-generator layers.
+ *
+ * The visibility guards mirror `applyGeometryGeneratorLayers`: generators
+ * require local features and are suppressed while extrusion or a transient
+ * feature filter is active. Centroids carry their actual fixed radius or the
+ * same validated proportional-size range used by the map. Other generator
+ * types are represented by their generated polygon fill.
+ */
+export function geometryGeneratorLegendParts(
+  layer: GeoLibreLayer,
+  options: GeometryGeneratorLegendOptions = {},
+): GeometryGeneratorLegendParts | null {
+  const generator = styleValue(layer.style, "geometryGenerator");
+  const hasFeatureFilter =
+    (Array.isArray(layer.timeFilter) && layer.timeFilter.length > 0) ||
+    (Array.isArray(layer.embedFilter) && layer.embedFilter.length > 0) ||
+    ruleBasedVisibilityFilter(layer.style) !== null;
+  const hasExternalNativeLayers =
+    Array.isArray(layer.metadata.nativeLayerIds) && layer.metadata.nativeLayerIds.length > 0;
+  if (
+    generator === "none" ||
+    layer.type !== "geojson" ||
+    !layer.geojson ||
+    layer.geojson.features.length === 0 ||
+    layer.metadata.externalDeckLayer === true ||
+    hasExternalNativeLayers ||
+    layer.style.extrusionEnabled ||
+    hasFeatureFilter
+  ) {
+    return null;
+  }
+
+  const label = options.labels?.[generator] ?? DEFAULT_GEOMETRY_GENERATOR_LEGEND_LABELS[generator];
+  const color = styleValue(layer.style, "geometryGeneratorFillColor") || NEUTRAL_SWATCH;
+  if (generator !== "centroid") {
+    return { label, shape: "square", swatches: [{ color, label }] };
+  }
+
+  const range = generatorSizeRange(layer.style);
+  if (!range) {
+    return {
+      label,
+      shape: "circle",
+      swatches: [
+        {
+          color,
+          label,
+          size: Math.max(1, styleValue(layer.style, "geometryGeneratorCircleRadius")),
+        },
+      ],
+    };
+  }
+
+  const formatValue = options.formatValue ?? formatStopValue;
+  return {
+    label,
+    shape: "circle",
+    fieldLabel: range.property,
+    swatches: [0, 0.5, 1].map((ratio) => ({
+      color,
+      label: formatValue(lerp(range.minValue, range.maxValue, ratio)),
+      size: lerp(range.minRadius, range.maxRadius, ratio),
+    })),
+  };
 }
 
 /**

--- a/tests/auto-legend.test.ts
+++ b/tests/auto-legend.test.ts
@@ -195,6 +195,24 @@ describe("buildAutoLegend — vector layers", () => {
       { ...base, metadata: { ...base.metadata, nativeLayerIds: ["external-fill"] } },
       {
         ...base,
+        metadata: {
+          ...base.metadata,
+          sourceKind: "maplibre-gl-vector",
+          customLayerType: "fill",
+          nativeLayerIds: [],
+        },
+      },
+      {
+        ...base,
+        style: {
+          ...base.style,
+          geometryGenerator: "buffer" as const,
+          geometryGeneratorBufferDistance: 0,
+          geometryGeneratorBufferProperty: "",
+        },
+      },
+      {
+        ...base,
         style: {
           ...base.style,
           vectorStyleMode: "rule-based" as const,

--- a/tests/auto-legend.test.ts
+++ b/tests/auto-legend.test.ts
@@ -38,6 +38,30 @@ function config(over: Partial<LegendConfig> = {}): LegendConfig {
 
 const EN = { locale: "en" };
 
+function polygonGeojson(): NonNullable<GeoLibreLayer["geojson"]> {
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { count: 10 },
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 1],
+              [0, 0],
+            ],
+          ],
+        },
+      },
+    ],
+  };
+}
+
 describe("formatLegendNumber", () => {
   it("abbreviates large values but keeps 4-digit values (years) exact", () => {
     assert.equal(formatLegendNumber(8918925.75, "en"), "8.9M");
@@ -64,6 +88,141 @@ describe("buildAutoLegend — vector layers", () => {
     );
     assert.equal(entries[0].shape, "line");
     assert.equal(entries[1].shape, "circle");
+  });
+
+  it("adds a fixed-size generated centroid after the parent symbol", () => {
+    const [entry] = buildAutoLegend(
+      [
+        layer({
+          name: "Regions",
+          geojson: polygonGeojson(),
+          metadata: { geometryType: "polygon" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            geometryGenerator: "centroid",
+            geometryGeneratorFillColor: "#f59e0b",
+            geometryGeneratorCircleRadius: 7,
+          },
+        }),
+      ],
+      config(),
+      EN,
+    );
+
+    assert.equal(entry.headerSwatch?.color, DEFAULT_LAYER_STYLE.fillColor);
+    assert.deepEqual(
+      entry.rows.map((row) => [row.label, row.color, row.shape, row.size]),
+      [["Centroids", "#f59e0b", "circle", 7]],
+    );
+  });
+
+  it("adds the generated centroid's proportional-size ramp and field caption", () => {
+    const [entry] = buildAutoLegend(
+      [
+        layer({
+          geojson: polygonGeojson(),
+          metadata: { geometryType: "polygon" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            geometryGenerator: "centroid",
+            geometryGeneratorFillColor: "#ef4444",
+            geometryGeneratorSizeProperty: "count",
+            geometryGeneratorSizeMinValue: 0,
+            geometryGeneratorSizeMaxValue: 100,
+            geometryGeneratorSizeMinRadius: 4,
+            geometryGeneratorSizeMaxRadius: 24,
+          },
+        }),
+      ],
+      config(),
+      {
+        ...EN,
+        geometryGeneratorLabels: { centroid: "Centroides" },
+      },
+    );
+
+    assert.deepEqual(
+      entry.rows.map((row) => [row.label, row.size, row.shape, row.caption]),
+      [
+        ["0", 4, "circle", "Centroides · count"],
+        ["50", 14, "circle", undefined],
+        ["100", 24, "circle", undefined],
+      ],
+    );
+    assert.ok(entry.rows.every((row) => row.color === "#ef4444"));
+  });
+
+  it("adds generated polygon types with their own fill and label", () => {
+    for (const [geometryGenerator, expectedLabel] of [
+      ["bounding-box", "Bounding boxes"],
+      ["convex-hull", "Convex hulls"],
+      ["buffer", "Buffers"],
+    ] as const) {
+      const [entry] = buildAutoLegend(
+        [
+          layer({
+            geojson: polygonGeojson(),
+            metadata: { geometryType: "polygon" },
+            style: {
+              ...DEFAULT_LAYER_STYLE,
+              geometryGenerator,
+              geometryGeneratorFillColor: "#22c55e",
+            },
+          }),
+        ],
+        config(),
+        EN,
+      );
+      const generated = entry.rows.at(-1);
+      assert.deepEqual(
+        [generated?.label, generated?.color, generated?.shape],
+        [expectedLabel, "#22c55e", "square"],
+      );
+    }
+  });
+
+  it("omits generated geometry while the renderer suppresses it", () => {
+    const base = layer({
+      geojson: polygonGeojson(),
+      metadata: { geometryType: "polygon" },
+      style: { ...DEFAULT_LAYER_STYLE, geometryGenerator: "centroid" },
+    });
+    const suppressed = [
+      { ...base, style: { ...base.style, extrusionEnabled: true } },
+      { ...base, timeFilter: ["==", ["get", "year"], 2026] },
+      { ...base, embedFilter: ["==", ["get", "kind"], "active"] },
+      { ...base, metadata: { ...base.metadata, externalDeckLayer: true } },
+      { ...base, metadata: { ...base.metadata, nativeLayerIds: ["external-fill"] } },
+      {
+        ...base,
+        style: {
+          ...base.style,
+          vectorStyleMode: "rule-based" as const,
+          vectorRules: [
+            {
+              id: "active",
+              label: "Active",
+              filter: '["==", ["get", "kind"], "active"]',
+              color: "#22c55e",
+              isElse: false,
+            },
+            {
+              id: "else",
+              label: "Other",
+              filter: "",
+              color: "#94a3b8",
+              isElse: true,
+              enabled: false,
+            },
+          ],
+        },
+      },
+    ];
+
+    for (const candidate of suppressed) {
+      const [entry] = buildAutoLegend([candidate], config(), EN);
+      assert.ok(entry.rows.every((row) => row.label !== "Centroids"));
+    }
   });
 
   it("renders a graduated layer as range-labelled class rows with a field caption", () => {

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  DEFAULT_LAYER_STYLE,
   DEFAULT_LEGEND_CONFIG,
   type GeoLibreLayer,
   type LayerStyle,
@@ -34,6 +35,148 @@ function makeLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
     ...overrides,
   } as unknown as GeoLibreLayer;
 }
+
+function polygonGeojson(): NonNullable<GeoLibreLayer["geojson"]> {
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { count: 10 },
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 1],
+              [0, 0],
+            ],
+          ],
+        },
+      },
+    ],
+  };
+}
+
+describe("buildLegend geometry generators", () => {
+  it("lists a fixed-size generated centroid after the parent geometry", () => {
+    const [entry] = buildLegend([
+      makeLayer({
+        name: "Regions",
+        geojson: polygonGeojson(),
+        metadata: { geometryType: "polygon" },
+        style: {
+          ...DEFAULT_LAYER_STYLE,
+          geometryGenerator: "centroid",
+          geometryGeneratorFillColor: "#f59e0b",
+          geometryGeneratorCircleRadius: 7,
+        },
+      }),
+    ]);
+
+    assert.deepEqual(entry.swatches, [
+      { color: DEFAULT_LAYER_STYLE.fillColor, label: "Regions" },
+      { color: "#f59e0b", label: "Centroids", size: 7 },
+    ]);
+  });
+
+  it("lists an attribute-sized generated centroid ramp with localized labels", () => {
+    const [entry] = buildLegend(
+      [
+        makeLayer({
+          geojson: polygonGeojson(),
+          metadata: { geometryType: "polygon" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            geometryGenerator: "centroid",
+            geometryGeneratorFillColor: "#ef4444",
+            geometryGeneratorSizeProperty: "count",
+            geometryGeneratorSizeMinValue: 0,
+            geometryGeneratorSizeMaxValue: 100,
+            geometryGeneratorSizeMinRadius: 4,
+            geometryGeneratorSizeMaxRadius: 24,
+          },
+        }),
+      ],
+      { labels: { centroid: "Centroides" } },
+    );
+
+    assert.deepEqual(
+      entry.swatches.slice(1).map((swatch) => [swatch.label, swatch.size, swatch.color]),
+      [
+        ["Centroides (count): 0", 4, "#ef4444"],
+        ["Centroides (count): 50", 14, "#ef4444"],
+        ["Centroides (count): 100", 24, "#ef4444"],
+      ],
+    );
+  });
+
+  it("lists generated polygon types and omits renderer-suppressed generators", () => {
+    for (const [geometryGenerator, expectedLabel] of [
+      ["bounding-box", "Bounding boxes"],
+      ["convex-hull", "Convex hulls"],
+      ["buffer", "Buffers"],
+    ] as const) {
+      const [entry] = buildLegend([
+        makeLayer({
+          geojson: polygonGeojson(),
+          metadata: { geometryType: "polygon" },
+          style: {
+            ...DEFAULT_LAYER_STYLE,
+            geometryGenerator,
+            geometryGeneratorFillColor: "#22c55e",
+          },
+        }),
+      ]);
+      assert.deepEqual(entry.swatches.at(-1), {
+        color: "#22c55e",
+        label: expectedLabel,
+      });
+    }
+
+    const base = makeLayer({
+      geojson: polygonGeojson(),
+      metadata: { geometryType: "polygon" },
+      style: { ...DEFAULT_LAYER_STYLE, geometryGenerator: "centroid" },
+    });
+    for (const candidate of [
+      { ...base, style: { ...base.style, extrusionEnabled: true } },
+      { ...base, timeFilter: ["==", ["get", "year"], 2026] },
+      { ...base, embedFilter: ["==", ["get", "kind"], "active"] },
+      { ...base, metadata: { ...base.metadata, externalDeckLayer: true } },
+      { ...base, metadata: { ...base.metadata, nativeLayerIds: ["external-fill"] } },
+      {
+        ...base,
+        style: {
+          ...base.style,
+          vectorStyleMode: "rule-based" as const,
+          vectorRules: [
+            {
+              id: "active",
+              label: "Active",
+              filter: '["==", ["get", "kind"], "active"]',
+              color: "#22c55e",
+              isElse: false,
+            },
+            {
+              id: "else",
+              label: "Other",
+              filter: "",
+              color: "#94a3b8",
+              isElse: true,
+              enabled: false,
+            },
+          ],
+        },
+      },
+    ]) {
+      const [entry] = buildLegend([candidate]);
+      assert.equal(entry.swatches.length, 1);
+    }
+  });
+});
 
 describe("buildLegend rule-based swatches", () => {
   it("lists drawable rules plus the else rule, skipping disabled and group rules", () => {

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -149,6 +149,24 @@ describe("buildLegend geometry generators", () => {
       { ...base, metadata: { ...base.metadata, nativeLayerIds: ["external-fill"] } },
       {
         ...base,
+        metadata: {
+          ...base.metadata,
+          sourceKind: "maplibre-gl-vector",
+          customLayerType: "fill",
+          nativeLayerIds: [],
+        },
+      },
+      {
+        ...base,
+        style: {
+          ...base.style,
+          geometryGenerator: "buffer" as const,
+          geometryGeneratorBufferDistance: 0,
+          geometryGeneratorBufferProperty: "",
+        },
+      },
+      {
+        ...base,
         style: {
           ...base.style,
           vectorStyleMode: "rule-based" as const,


### PR DESCRIPTION
## Summary

- show fixed and attribute-sized derived centroids in the on-map and Print Layout legends
- add localized swatches for generated buffers, bounding boxes, and convex hulls
- mirror renderer suppression rules and preserve existing legend row ordering
- add regression coverage for both legend builders

## Tests

- `pre-commit run --all-files`
- `npx tsx --test tests/auto-legend.test.ts tests/print-legend.test.ts`

Discussion: https://github.com/opengeos/GeoLibre/discussions/1877#discussioncomment-18029680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized legend labels for generated geometry types, including centroids, bounding boxes, convex hulls, and buffers.
  * Legends now display generated geometry symbols with appropriate colors, shapes, sizes, and captions.
  * Added support for fixed and proportional centroid sizing, including localized field captions.
  * Unsupported or inactive generated geometry is automatically omitted from legends.

* **Bug Fixes**
  * Improved legend accuracy across heatmaps, classified layers, rules, expressions, single-symbol styles, and print layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->