### PR TITLE
Preserve text field types in attribute summaries

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -67,6 +67,7 @@ import {
 } from "../../lib/print-data-blocks";
 import {
   categoricalColumns,
+  coerceNumericStringRows,
   numericColumns,
   type BarAggregation,
   type ChartRow,
@@ -977,10 +978,13 @@ export function PrintLayoutDialog({
     () => (tableLayer?.geojson ? layerRows(tableLayer.geojson) : []),
     [tableLayer],
   );
-  const chartAllRows = useMemo(
-    () => (chartLayer?.geojson ? layerRows(chartLayer.geojson) : []),
-    [chartLayer],
-  );
+  const chartAllRows = useMemo(() => {
+    if (!chartLayer?.geojson) return [];
+    const rows = layerRows(chartLayer.geojson);
+    return chartLayer.metadata.sourceKind === "delimited-text"
+      ? coerceNumericStringRows(rows)
+      : rows;
+  }, [chartLayer]);
   // Per-feature bounds for the page-extent filter, walked once per layer so
   // stepping/exporting an N-page atlas does not redo the vertex walk N times
   // (the same precompute pattern the atlas page builder uses).

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -461,15 +461,26 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     () => new Set([...joinDerivedColumns, ...virtualFieldColumns]),
     [joinDerivedColumns, virtualFieldColumns],
   );
-  const features = layer?.geojson?.features ?? [];
+  const features = useMemo(() => layer?.geojson?.features ?? [], [layer?.geojson]);
   const isDuckDBLayer = isDuckDBQueryLayer(layer);
   const duckdbRows = layer && isDuckDBLayer ? getDuckDBLayerRows(layer.id) : [];
-  const attributeRows: AttributeTableRow[] = isDuckDBLayer
-    ? duckDBRowsToAttributeRows(duckdbRows)
-    : features.map((feature, index) => ({
+  // Memoized so the analysis adapters below (and everything else keyed on these
+  // rows) only rebuild when the layer's features actually change, not on every
+  // render caused by scrolling, filtering or selection. The DuckDB branch stays
+  // unmemoized because `getDuckDBLayerRows` reads a mutable store and returns a
+  // fresh array each call; delimited-text layers — the ones that pay for the
+  // numeric-string adapter below — are geojson-backed and take this path.
+  const geojsonRows: AttributeTableRow[] = useMemo(
+    () =>
+      features.map((feature, index) => ({
         featureId: String(feature.id ?? index),
         properties: (feature.properties ?? {}) as Record<string, unknown>,
-      }));
+      })),
+    [features],
+  );
+  const attributeRows: AttributeTableRow[] = isDuckDBLayer
+    ? duckDBRowsToAttributeRows(duckdbRows)
+    : geojsonRows;
   const hasAttributeSource = Boolean(layer?.geojson || isDuckDBLayer);
   // Add Vector Layer (geojson-mode) layers render from a MapLibre source the
   // control owns, and their `layer.geojson` is dropped when a project is saved.

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -614,23 +614,32 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // O(1) lookups for the multi-selection while rendering thousands of rows.
   const selectedIdSet = useMemo(() => new Set(selectedFeatureIds), [selectedFeatureIds]);
 
-  const filterLower = attributeFilter.toLowerCase();
-  const filtered = attributeRows.filter(({ properties, featureId }) => {
-    // "Show Selected Features" restricts the table to the current selection.
-    if (featureView === "selected" && !selectedIdSet.has(featureId)) return false;
-    if (!filterLower) return true;
-    const props = JSON.stringify(properties).toLowerCase();
-    return featureId.includes(filterLower) || props.includes(filterLower);
-  });
+  const filtered = useMemo(() => {
+    const filterLower = attributeFilter.toLowerCase();
+    return attributeRows.filter(({ properties, featureId }) => {
+      // "Show Selected Features" restricts the table to the current selection.
+      if (featureView === "selected" && !selectedIdSet.has(featureId)) return false;
+      if (!filterLower) return true;
+      const props = JSON.stringify(properties).toLowerCase();
+      return featureId.includes(filterLower) || props.includes(filterLower);
+    });
+  }, [attributeFilter, attributeRows, featureView, selectedIdSet]);
   // Delimited-text imports preserve every cell as a string. Adapt only the rows
   // sent to analysis dialogs, leaving the table and exported source data intact.
   const adaptAnalysisRows = coerceNumericStrings && (chartOpen || statsOpen || explorerOpen);
-  const analysisRows = adaptAnalysisRows ? coerceNumericStringRows(attributeRows) : attributeRows;
-  const analysisFilteredRows = adaptAnalysisRows
-    ? filtered.length === attributeRows.length
-      ? analysisRows
-      : coerceNumericStringRows(filtered)
-    : filtered;
+  const analysisRows = useMemo(
+    () => (adaptAnalysisRows ? coerceNumericStringRows(attributeRows) : attributeRows),
+    [adaptAnalysisRows, attributeRows],
+  );
+  const analysisFilteredRows = useMemo(
+    () =>
+      adaptAnalysisRows
+        ? filtered.length === attributeRows.length
+          ? analysisRows
+          : coerceNumericStringRows(filtered)
+        : filtered,
+    [adaptAnalysisRows, analysisRows, attributeRows.length, filtered],
+  );
   const sorted = [...filtered].sort((a, b) => {
     const aValue = sort.key === "__featureId" ? a.featureId : a.properties[sort.key];
     const bValue = sort.key === "__featureId" ? b.featureId : b.properties[sort.key];

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -106,6 +106,7 @@ import {
   type CalcOutputType,
 } from "../../lib/attribute-expression";
 import { attributeFormErrorMessage } from "../../lib/attribute-form-messages";
+import { coerceNumericStringRows } from "../../lib/attribute-charts";
 import { computeRowSelection } from "../../lib/attribute-selection";
 import { RESERVED_PROPERTY_KEYS } from "../../lib/field-collection";
 import {
@@ -436,6 +437,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const calcExpressionRef = useRef<HTMLTextAreaElement>(null);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
+  const coerceNumericStrings = layer?.metadata.sourceKind === "delimited-text";
   const hasLayer = Boolean(layer);
   // Columns materialized by persistent joins are derived data: every save
   // re-derives them from the join table, so an edit, rename, or delete here
@@ -620,6 +622,15 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     const props = JSON.stringify(properties).toLowerCase();
     return featureId.includes(filterLower) || props.includes(filterLower);
   });
+  // Delimited-text imports preserve every cell as a string. Adapt only the rows
+  // sent to analysis dialogs, leaving the table and exported source data intact.
+  const adaptAnalysisRows = coerceNumericStrings && (chartOpen || statsOpen || explorerOpen);
+  const analysisRows = adaptAnalysisRows ? coerceNumericStringRows(attributeRows) : attributeRows;
+  const analysisFilteredRows = adaptAnalysisRows
+    ? filtered.length === attributeRows.length
+      ? analysisRows
+      : coerceNumericStringRows(filtered)
+    : filtered;
   const sorted = [...filtered].sort((a, b) => {
     const aValue = sort.key === "__featureId" ? a.featureId : a.properties[sort.key];
     const bValue = sort.key === "__featureId" ? b.featureId : b.properties[sort.key];
@@ -2320,23 +2331,23 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       <AttributeChartDialog
         open={chartOpen}
         onOpenChange={setChartOpen}
-        rows={attributeRows}
+        rows={analysisRows}
         columns={discoveredColumns}
         layerName={layer?.name ?? ""}
       />
       <AttributeStatsDialog
         open={statsOpen}
         onOpenChange={setStatsOpen}
-        rows={attributeRows}
-        filteredRows={filtered}
+        rows={analysisRows}
+        filteredRows={analysisFilteredRows}
         columns={discoveredColumns}
         layerName={layer?.name ?? ""}
       />
       <ColumnExplorerDialog
         open={explorerOpen}
         onOpenChange={setExplorerOpen}
-        rows={attributeRows}
-        filteredRows={filtered}
+        rows={analysisRows}
+        filteredRows={analysisFilteredRows}
         columns={discoveredColumns}
         layerName={layer?.name ?? ""}
       />

--- a/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
@@ -1,7 +1,7 @@
 import { isDuckDBQueryLayer, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import { getDuckDBLayerRows } from "@geolibre/plugins";
 import { useMemo } from "react";
-import type { ChartRow } from "../lib/attribute-charts";
+import { coerceNumericStringRows, type ChartRow } from "../lib/attribute-charts";
 
 export interface LayerChartData {
   /** Attribute rows for charting (just the property bag each chart needs). */
@@ -35,11 +35,15 @@ function buildLayerChartData(layer: GeoLibreLayer | null): LayerChartData {
   // Mirror the attribute table's two row sources: DuckDB query layers fetch
   // their rows from the plugin's cache, every other vector layer reads its
   // features straight off `layer.geojson`.
-  const rows: ChartRow[] = isDuckDBQueryLayer(layer)
+  const sourceRows: ChartRow[] = isDuckDBQueryLayer(layer)
     ? getDuckDBLayerRows(layer.id).map((row) => ({ properties: row.properties }))
     : (layer.geojson?.features ?? []).map((feature) => ({
         properties: (feature.properties ?? {}) as Record<string, unknown>,
       }));
+  const rows =
+    layer.metadata.sourceKind === "delimited-text"
+      ? coerceNumericStringRows(sourceRows)
+      : sourceRows;
 
   const keys = new Set<string>();
   for (const row of rows) {
@@ -58,8 +62,8 @@ function buildLayerChartData(layer: GeoLibreLayer | null): LayerChartData {
 }
 
 /**
- * Resolve a layer id to the rows, columns, and name a chart widget renders
- * from. Recomputes when the layer record changes (e.g. attribute edits replace
+ * Resolve a layer id to the rows, columns, and name a chart widget uses.
+ * Recomputes when the layer record changes (e.g. attribute edits replace
  * `layer.geojson`). DuckDB query rows come from the plugin cache and are read
  * once per layer-identity change, matching the attribute table's behavior.
  *

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -41,6 +41,37 @@ export function toFiniteNumber(value: unknown): number | null {
 }
 
 /**
+ * Test whether a stored field value contributes to numeric type inference.
+ * Only explicit numeric values qualify. Callers handling string-only data
+ * sources adapt their analysis rows with {@link coerceNumericStringRows} first.
+ */
+export function isNumericFieldValue(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Convert numeric-looking strings in analysis rows without changing the source
+ * data. Delimited-text layers use this adapter because their parser preserves
+ * every cell as a string, including measurements that summaries should treat as
+ * numeric.
+ */
+export function coerceNumericStringRows(rows: ChartRow[]): ChartRow[] {
+  return rows.map((row) => {
+    let changed = false;
+    const properties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(row.properties)) {
+      const numeric = typeof value === "string" ? toFiniteNumber(value) : null;
+      if (numeric === null) properties[key] = value;
+      else {
+        properties[key] = numeric;
+        changed = true;
+      }
+    }
+    return changed ? { ...row, properties } : row;
+  });
+}
+
+/**
  * The distinct non-empty values of a category field, sorted for display. Used
  * by the selector widget to build its list of value chips.
  *
@@ -109,7 +140,7 @@ export function numericColumns(rows: ChartRow[], columns: string[]): string[] {
       const raw = row.properties[key];
       if (raw == null || raw === "") continue;
       nonNull += 1;
-      if (toFiniteNumber(raw) !== null) numeric += 1;
+      if (isNumericFieldValue(raw)) numeric += 1;
     }
     return numeric >= 2 && numeric >= nonNull / 2;
   });

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -45,29 +45,48 @@ export function toFiniteNumber(value: unknown): number | null {
  * Only explicit numeric values qualify. Callers handling string-only data
  * sources adapt their analysis rows with {@link coerceNumericStringRows} first.
  */
-export function isNumericFieldValue(value: unknown): boolean {
+export function isNumericFieldValue(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
+}
+
+/** True when a string encodes an integer with meaningful leading zeroes. */
+function hasLeadingZeroes(value: string): boolean {
+  return /^[+-]?0\d+$/.test(value.trim());
+}
+
+/** True for common delimited-text headers that conventionally hold identifiers. */
+function isIdentifierFieldName(key: string): boolean {
+  const normalized = key.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase();
+  return /(^|[\s_-])(id|code|fips|zip|zipcode|postal)([\s_-]|$)/.test(normalized);
 }
 
 /**
  * Convert numeric-looking strings in analysis rows without changing the source
  * data. Delimited-text layers use this adapter because their parser preserves
  * every cell as a string, including measurements that summaries should treat as
- * numeric.
+ * numeric. Because delimited text carries no declared field types, common
+ * identifier headers and integer strings with leading zeroes remain text.
  */
 export function coerceNumericStringRows(rows: ChartRow[]): ChartRow[] {
-  return rows.map((row) => {
-    let changed = false;
-    const properties: Record<string, unknown> = {};
+  const textKeys = new Set<string>();
+  for (const row of rows) {
     for (const [key, value] of Object.entries(row.properties)) {
-      const numeric = typeof value === "string" ? toFiniteNumber(value) : null;
-      if (numeric === null) properties[key] = value;
-      else {
-        properties[key] = numeric;
-        changed = true;
+      if (typeof value === "string" && (isIdentifierFieldName(key) || hasLeadingZeroes(value))) {
+        textKeys.add(key);
       }
     }
-    return changed ? { ...row, properties } : row;
+  }
+
+  return rows.map((row) => {
+    let properties: Record<string, unknown> | null = null;
+    for (const [key, value] of Object.entries(row.properties)) {
+      if (textKeys.has(key) || typeof value !== "string") continue;
+      const numeric = toFiniteNumber(value);
+      if (numeric === null) continue;
+      properties ??= { ...row.properties };
+      properties[key] = numeric;
+    }
+    return properties ? { ...row, properties } : row;
   });
 }
 
@@ -150,8 +169,8 @@ export function numericColumns(rows: ChartRow[], columns: string[]): string[] {
 export function numericValues(rows: ChartRow[], key: string): number[] {
   const values: number[] = [];
   for (const row of rows) {
-    const next = toFiniteNumber(row.properties[key]);
-    if (next !== null) values.push(next);
+    const value = row.properties[key];
+    if (isNumericFieldValue(value)) values.push(value);
   }
   return values;
 }
@@ -264,9 +283,9 @@ export function computeScatter(
   let yMin = 0;
   let yMax = 0;
   for (const row of rows) {
-    const x = toFiniteNumber(row.properties[xKey]);
-    const y = toFiniteNumber(row.properties[yKey]);
-    if (x === null || y === null) continue;
+    const x = row.properties[xKey];
+    const y = row.properties[yKey];
+    if (!isNumericFieldValue(x) || !isNumericFieldValue(y)) continue;
     if (all.length === 0) {
       xMin = xMax = x;
       yMin = yMax = y;
@@ -387,8 +406,8 @@ export function computeBar(
     const group = groups.get(label) ?? { count: 0, sum: 0, numericCount: 0 };
     group.count += 1;
     if (aggregation !== "count" && valueKey) {
-      const value = toFiniteNumber(row.properties[valueKey]);
-      if (value !== null) {
+      const value = row.properties[valueKey];
+      if (isNumericFieldValue(value)) {
         group.sum += value;
         group.numericCount += 1;
       }
@@ -459,8 +478,8 @@ export function computePie(
     const group = groups.get(label) ?? { count: 0, sum: 0 };
     group.count += 1;
     if (aggregation !== "count" && valueKey) {
-      const value = toFiniteNumber(row.properties[valueKey]);
-      if (value !== null) group.sum += value;
+      const value = row.properties[valueKey];
+      if (isNumericFieldValue(value)) group.sum += value;
     }
     groups.set(label, group);
   }
@@ -528,8 +547,8 @@ export function computeLine(rows: ChartRow[], key: string): LineResult | null {
   let max = -Infinity;
   let index = 0;
   for (const row of rows) {
-    const value = toFiniteNumber(row.properties[key]);
-    if (value !== null) {
+    const value = row.properties[key];
+    if (isNumericFieldValue(value)) {
       points.push({ index, value });
       if (value < min) min = value;
       if (value > max) max = value;

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -66,21 +66,45 @@ function isIdentifierFieldName(key: string): boolean {
  * every cell as a string, including measurements that summaries should treat as
  * numeric. Because delimited text carries no declared field types, common
  * identifier headers and integer strings with leading zeroes remain text.
+ *
+ * The decision is per column, not per value: a column is converted only when its
+ * numeric-looking values would carry it past the same threshold the summaries
+ * apply (at least two of them, and at least half of the populated rows). A
+ * mostly-free-text column holding a stray `"3.0"` therefore keeps that cell
+ * verbatim, so its distinct-value counts and top-value labels stay faithful to
+ * what the file says.
  */
 export function coerceNumericStringRows(rows: ChartRow[]): ChartRow[] {
   const textKeys = new Set<string>();
+  const populatedCounts = new Map<string, number>();
+  const numericCounts = new Map<string, number>();
   for (const row of rows) {
     for (const [key, value] of Object.entries(row.properties)) {
+      if (value == null || value === "") continue;
+      populatedCounts.set(key, (populatedCounts.get(key) ?? 0) + 1);
       if (typeof value === "string" && (isIdentifierFieldName(key) || hasLeadingZeroes(value))) {
         textKeys.add(key);
+        continue;
       }
+      // Values already stored as numbers count toward the threshold too, since
+      // they are what the summaries will see after this pass.
+      const countsAsNumeric =
+        isNumericFieldValue(value) || (typeof value === "string" && toFiniteNumber(value) !== null);
+      if (countsAsNumeric) numericCounts.set(key, (numericCounts.get(key) ?? 0) + 1);
     }
   }
+
+  const numericKeys = new Set<string>();
+  for (const [key, numeric] of numericCounts) {
+    if (textKeys.has(key)) continue;
+    if (numeric >= 2 && numeric >= (populatedCounts.get(key) ?? 0) / 2) numericKeys.add(key);
+  }
+  if (numericKeys.size === 0) return rows;
 
   return rows.map((row) => {
     let properties: Record<string, unknown> | null = null;
     for (const [key, value] of Object.entries(row.properties)) {
-      if (textKeys.has(key) || typeof value !== "string") continue;
+      if (!numericKeys.has(key) || typeof value !== "string") continue;
       const numeric = toFiniteNumber(value);
       if (numeric === null) continue;
       properties ??= { ...row.properties };

--- a/apps/geolibre-desktop/src/lib/attribute-stats.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-stats.ts
@@ -6,9 +6,10 @@
  * any rendering or React so they can be unit-tested in isolation. Field type
  * detection respects the primitive types stored in `{ properties }`, so a text
  * field is not reclassified just because every string parses as a number.
+ * String-only sources can explicitly retain their numeric inference behavior.
  */
 
-import { toFiniteNumber, type ChartRow } from "./attribute-charts";
+import { isNumericFieldValue, toFiniteNumber, type ChartRow } from "./attribute-charts";
 
 export interface NumericFieldStats {
   kind: "numeric";
@@ -54,11 +55,6 @@ export const DEFAULT_TOP_VALUES = 5;
 /** True when a value reads as null for statistics: nullish or a blank string. */
 export function isBlank(value: unknown): boolean {
   return value == null || (typeof value === "string" && value.trim() === "");
-}
-
-/** True when a stored value is a finite JavaScript number, without coercion. */
-export function isFiniteNumberValue(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
 }
 
 /**
@@ -156,9 +152,9 @@ export function computeTextStats(
  * Summary statistics for one field, choosing the numeric or text shape from its
  * stored primitive values. A field counts as numeric when at least two populated
  * rows contain finite JavaScript numbers and those values make up at least half
- * of the populated rows. Numeric-looking strings alone therefore remain text.
- * Numeric fields fold their blank and non-numeric row counts into the result.
- * Returns null when a numeric field has no values to summarize.
+ * of the populated rows. Numeric-looking strings alone therefore remain text
+ * unless the caller adapts a string-only source before summarizing it. Numeric
+ * fields fold their blank and non-numeric row counts into the result.
  */
 export function computeFieldStats(
   rows: ChartRow[],
@@ -171,7 +167,7 @@ export function computeFieldStats(
     const raw = row.properties[key];
     if (raw == null || raw === "") continue;
     populated += 1;
-    if (isFiniteNumberValue(raw)) numeric += 1;
+    if (isNumericFieldValue(raw)) numeric += 1;
   }
   const isNumeric = numeric >= 2 && numeric >= populated / 2;
   if (!isNumeric) return computeTextStats(rows, key, topCount);

--- a/apps/geolibre-desktop/src/lib/attribute-stats.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-stats.ts
@@ -9,7 +9,7 @@
  * String-only sources can explicitly retain their numeric inference behavior.
  */
 
-import { isNumericFieldValue, toFiniteNumber, type ChartRow } from "./attribute-charts";
+import { isNumericFieldValue, type ChartRow } from "./attribute-charts";
 
 export interface NumericFieldStats {
   kind: "numeric";
@@ -181,9 +181,8 @@ export function computeFieldStats(
       nulls += 1;
       continue;
     }
-    const next = toFiniteNumber(raw);
-    if (next === null) nonNumeric += 1;
-    else values.push(next);
+    if (isNumericFieldValue(raw)) values.push(raw);
+    else nonNumeric += 1;
   }
   return computeNumericStats(values, nulls, nonNumeric);
 }

--- a/apps/geolibre-desktop/src/lib/attribute-stats.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-stats.ts
@@ -3,12 +3,12 @@
  * detect whether a field reads as numeric or text and compute a compact summary
  * for it (count / nulls / min / max / mean / median / std / sum / unique for
  * numbers; count / nulls / unique / most-frequent values for text). Kept free of
- * any rendering or React so they can be unit-tested in isolation, and built on
- * the same `{ properties }` rows and numeric coercion the Charts panel uses so
- * the two panels agree on what counts as a number.
+ * any rendering or React so they can be unit-tested in isolation. Field type
+ * detection respects the primitive types stored in `{ properties }`, so a text
+ * field is not reclassified just because every string parses as a number.
  */
 
-import { numericColumns, toFiniteNumber, type ChartRow } from "./attribute-charts";
+import { toFiniteNumber, type ChartRow } from "./attribute-charts";
 
 export interface NumericFieldStats {
   kind: "numeric";
@@ -54,6 +54,11 @@ export const DEFAULT_TOP_VALUES = 5;
 /** True when a value reads as null for statistics: nullish or a blank string. */
 export function isBlank(value: unknown): boolean {
   return value == null || (typeof value === "string" && value.trim() === "");
+}
+
+/** True when a stored value is a finite JavaScript number, without coercion. */
+export function isFiniteNumberValue(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 /**
@@ -148,18 +153,27 @@ export function computeTextStats(
 }
 
 /**
- * Summary statistics for one field, choosing the numeric or text shape from the
- * same heuristic the Charts panel uses (`numericColumns`): a field counts as
- * numeric when enough of its populated rows parse as finite numbers. Numeric
- * fields fold their blank and non-numeric row counts into the result. Returns
- * null when `key` is not present, so callers can show an empty state.
+ * Summary statistics for one field, choosing the numeric or text shape from its
+ * stored primitive values. A field counts as numeric when at least two populated
+ * rows contain finite JavaScript numbers and those values make up at least half
+ * of the populated rows. Numeric-looking strings alone therefore remain text.
+ * Numeric fields fold their blank and non-numeric row counts into the result.
+ * Returns null when a numeric field has no values to summarize.
  */
 export function computeFieldStats(
   rows: ChartRow[],
   key: string,
   topCount: number = DEFAULT_TOP_VALUES,
 ): FieldStats | null {
-  const isNumeric = numericColumns(rows, [key]).length > 0;
+  let numeric = 0;
+  let populated = 0;
+  for (const row of rows) {
+    const raw = row.properties[key];
+    if (raw == null || raw === "") continue;
+    populated += 1;
+    if (isFiniteNumberValue(raw)) numeric += 1;
+  }
+  const isNumeric = numeric >= 2 && numeric >= populated / 2;
   if (!isNumeric) return computeTextStats(rows, key, topCount);
 
   const values: number[] = [];

--- a/apps/geolibre-desktop/src/lib/column-explorer.ts
+++ b/apps/geolibre-desktop/src/lib/column-explorer.ts
@@ -12,7 +12,6 @@
 import {
   computeHistogram,
   isNumericFieldValue,
-  toFiniteNumber,
   type ChartRow,
   type HistogramResult,
 } from "./attribute-charts";
@@ -72,10 +71,10 @@ export function summarizeColumn(rows: ChartRow[], key: string): ColumnSummary | 
       continue;
     }
     populated += 1;
-    if (isNumericFieldValue(raw)) numeric += 1;
-    const next = toFiniteNumber(raw);
-    if (next === null) nonNumeric += 1;
-    else values.push(next);
+    if (isNumericFieldValue(raw)) {
+      numeric += 1;
+      values.push(raw);
+    } else nonNumeric += 1;
   }
 
   const isNumeric = numeric >= 2 && numeric >= populated / 2;

--- a/apps/geolibre-desktop/src/lib/column-explorer.ts
+++ b/apps/geolibre-desktop/src/lib/column-explorer.ts
@@ -4,23 +4,19 @@
  * numeric range, and a small distribution) the way MotherDuck's column explorer
  * does. This composes the existing field-statistics and chart helpers rather
  * than recomputing anything. Like Statistics, it respects the primitive value
- * types stored by the layer, so numeric-looking text remains text. Kept free of
- * rendering and React so it can be unit-tested in isolation.
+ * types stored by the layer, so numeric-looking text remains text. String-only
+ * sources can explicitly retain numeric inference. Kept free of rendering and
+ * React so it can be unit-tested in isolation.
  */
 
 import {
   computeHistogram,
+  isNumericFieldValue,
   toFiniteNumber,
   type ChartRow,
   type HistogramResult,
 } from "./attribute-charts";
-import {
-  computeNumericStats,
-  computeTextStats,
-  isBlank,
-  isFiniteNumberValue,
-  type FieldStats,
-} from "./attribute-stats";
+import { computeNumericStats, computeTextStats, isBlank, type FieldStats } from "./attribute-stats";
 
 /** Bins used for a numeric column's distribution sparkline. */
 export const COLUMN_EXPLORER_BINS = 12;
@@ -54,8 +50,8 @@ export interface ColumnSummary {
  * `numericColumns`) and again to extract, which doubled the row-property lookups
  * before the dialog first rendered. Populated means not null and not the empty
  * string. Numeric means at least two finite number-typed values that make up at
- * least half of those populated rows. Numeric-looking strings do not contribute
- * to classification.
+ * least half of those populated rows. Numeric-looking strings contribute only
+ * when the caller adapts a string-only source before summarizing it.
  */
 export function summarizeColumn(rows: ChartRow[], key: string): ColumnSummary | null {
   const values: number[] = [];
@@ -76,7 +72,7 @@ export function summarizeColumn(rows: ChartRow[], key: string): ColumnSummary | 
       continue;
     }
     populated += 1;
-    if (isFiniteNumberValue(raw)) numeric += 1;
+    if (isNumericFieldValue(raw)) numeric += 1;
     const next = toFiniteNumber(raw);
     if (next === null) nonNumeric += 1;
     else values.push(next);

--- a/apps/geolibre-desktop/src/lib/column-explorer.ts
+++ b/apps/geolibre-desktop/src/lib/column-explorer.ts
@@ -3,9 +3,9 @@
  * into a compact, at-a-glance summary (type, populated vs null, unique count,
  * numeric range, and a small distribution) the way MotherDuck's column explorer
  * does. This composes the existing field-statistics and chart helpers rather
- * than recomputing anything, so the explorer agrees with the Statistics and
- * Charts panels on what counts as a number. Kept free of any rendering or React
- * so it can be unit-tested in isolation.
+ * than recomputing anything. Like Statistics, it respects the primitive value
+ * types stored by the layer, so numeric-looking text remains text. Kept free of
+ * rendering and React so it can be unit-tested in isolation.
  */
 
 import {
@@ -14,7 +14,13 @@ import {
   type ChartRow,
   type HistogramResult,
 } from "./attribute-charts";
-import { computeNumericStats, computeTextStats, isBlank, type FieldStats } from "./attribute-stats";
+import {
+  computeNumericStats,
+  computeTextStats,
+  isBlank,
+  isFiniteNumberValue,
+  type FieldStats,
+} from "./attribute-stats";
 
 /** Bins used for a numeric column's distribution sparkline. */
 export const COLUMN_EXPLORER_BINS = 12;
@@ -37,44 +43,46 @@ export interface ColumnSummary {
 }
 
 /**
- * Summarize one field across `rows`: its statistics (numeric or text, chosen by
- * the same heuristic the Statistics/Charts panels use) plus a numeric
- * distribution when the field reads as numeric. Returns null only when the field
- * yields no statistics at all, so callers can skip it.
+ * Summarize one field across `rows`: its statistics (numeric or text, chosen
+ * from the stored primitive values) plus a numeric distribution when the field
+ * reads as numeric. Returns null only when the field yields no statistics at
+ * all, so callers can skip it.
  *
  * A single pass both classifies the field and, when it reads as numeric,
  * collects its finite values for `computeNumericStats` and `computeHistogram` —
  * so a numeric column is no longer scanned once to classify (via
  * `numericColumns`) and again to extract, which doubled the row-property lookups
- * before the dialog first rendered. The classification mirrors `numericColumns`
- * exactly (populated means not null and not the empty string; numeric means at
- * least two finite values that make up at least half of those populated rows),
- * so the explorer still agrees with the Charts panel on what counts as a number.
+ * before the dialog first rendered. Populated means not null and not the empty
+ * string. Numeric means at least two finite number-typed values that make up at
+ * least half of those populated rows. Numeric-looking strings do not contribute
+ * to classification.
  */
 export function summarizeColumn(rows: ChartRow[], key: string): ColumnSummary | null {
   const values: number[] = [];
   let nulls = 0;
   let nonNumeric = 0;
-  // Populated rows by `numericColumns`' rule (no whitespace trim), which is the
-  // denominator of its numeric ratio — kept separate from the trimming `nulls`
-  // count the statistics use so classification stays identical to that helper.
+  let numeric = 0;
+  // Populated rows exclude null and empty strings. Keep this separate from the
+  // trimming `nulls` count used by statistics so whitespace remains populated
+  // for field-type classification.
   let populated = 0;
   for (const row of rows) {
     const raw = row.properties[key];
     if (isBlank(raw)) {
       nulls += 1;
-      // A whitespace-only string is blank for the statistics but still a
-      // populated, non-numeric row for classification, matching numericColumns.
+      // A whitespace-only string is blank for statistics but still a populated,
+      // non-numeric row for classification.
       if (raw != null && raw !== "") populated += 1;
       continue;
     }
     populated += 1;
+    if (isFiniteNumberValue(raw)) numeric += 1;
     const next = toFiniteNumber(raw);
     if (next === null) nonNumeric += 1;
     else values.push(next);
   }
 
-  const isNumeric = values.length >= 2 && values.length >= populated / 2;
+  const isNumeric = numeric >= 2 && numeric >= populated / 2;
   if (!isNumeric) {
     const stats = computeTextStats(rows, key, COLUMN_EXPLORER_TOP_VALUES);
     return { key, stats, histogram: null, total: rows.length };

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -36,10 +36,30 @@ describe("toFiniteNumber", () => {
 
 describe("coerceNumericStringRows", () => {
   it("adapts numeric strings without mutating text or source rows", () => {
-    const data = rows({ population: "42", code: "A01", blank: "" });
+    const data = rows({ population: "42", label: "A01", blank: "" });
     const adapted = coerceNumericStringRows(data);
-    assert.deepEqual(adapted[0].properties, { population: 42, code: "A01", blank: "" });
+    assert.deepEqual(adapted[0].properties, { population: 42, label: "A01", blank: "" });
     assert.equal(data[0].properties.population, "42");
+  });
+
+  it("preserves common identifiers and columns containing leading zeroes", () => {
+    const data = rows(
+      { FIPS: "37009", population: "42", district: "037009" },
+      { FIPS: "37005", population: "84", district: "37005" },
+    );
+    const adapted = coerceNumericStringRows(data);
+    assert.deepEqual(adapted[0].properties, {
+      FIPS: "37009",
+      population: 42,
+      district: "037009",
+    });
+    assert.equal(adapted[1].properties.FIPS, "37005");
+    assert.equal(adapted[1].properties.district, "37005");
+  });
+
+  it("reuses rows that have no values to coerce", () => {
+    const data = rows({ name: "Alpha", code: "37009" });
+    assert.equal(coerceNumericStringRows(data)[0], data[0]);
   });
 });
 
@@ -72,7 +92,7 @@ describe("numericColumns", () => {
 describe("numericValues", () => {
   it("collects only the finite numeric values", () => {
     const data = rows({ a: 1 }, { a: "2" }, { a: "x" }, { a: null });
-    assert.deepEqual(numericValues(data, "a"), [1, 2]);
+    assert.deepEqual(numericValues(data, "a"), [1]);
   });
 });
 

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   categoricalColumns,
+  coerceNumericStringRows,
   computeBar,
   computeBox,
   computeHistogram,
@@ -33,6 +34,15 @@ describe("toFiniteNumber", () => {
   });
 });
 
+describe("coerceNumericStringRows", () => {
+  it("adapts numeric strings without mutating text or source rows", () => {
+    const data = rows({ population: "42", code: "A01", blank: "" });
+    const adapted = coerceNumericStringRows(data);
+    assert.deepEqual(adapted[0].properties, { population: 42, code: "A01", blank: "" });
+    assert.equal(data[0].properties.population, "42");
+  });
+});
+
 describe("numericColumns", () => {
   it("keeps columns that are mostly numeric, drops text/id-like ones", () => {
     const data = rows(
@@ -48,9 +58,14 @@ describe("numericColumns", () => {
     assert.deepEqual(numericColumns(data, ["a"]), []);
   });
 
-  it("accepts numeric strings as numeric", () => {
+  it("keeps numeric strings out of numeric columns by default", () => {
     const data = rows({ a: "1" }, { a: "2" }, { a: "3" });
-    assert.deepEqual(numericColumns(data, ["a"]), ["a"]);
+    assert.deepEqual(numericColumns(data, ["a"]), []);
+  });
+
+  it("infers numeric strings after adapting a string-only source", () => {
+    const data = rows({ a: "1" }, { a: "2" }, { a: "3" });
+    assert.deepEqual(numericColumns(coerceNumericStringRows(data), ["a"]), ["a"]);
   });
 });
 

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -9,6 +9,7 @@ import {
   computeLine,
   computePie,
   computeScatter,
+  distinctCategoryValues,
   formatAxisValue,
   numericColumns,
   numericValues,
@@ -36,10 +37,27 @@ describe("toFiniteNumber", () => {
 
 describe("coerceNumericStringRows", () => {
   it("adapts numeric strings without mutating text or source rows", () => {
-    const data = rows({ population: "42", label: "A01", blank: "" });
+    const data = rows(
+      { population: "42", label: "A01", blank: "" },
+      { population: "84", label: "A02", blank: "" },
+    );
     const adapted = coerceNumericStringRows(data);
     assert.deepEqual(adapted[0].properties, { population: 42, label: "A01", blank: "" });
     assert.equal(data[0].properties.population, "42");
+  });
+
+  it("leaves a mostly-text column verbatim, stray numeric cells included", () => {
+    const data = rows(
+      { notes: "3" },
+      { notes: "3.0" },
+      { notes: "yes" },
+      { notes: "n/a" },
+      { notes: "pending" },
+    );
+    const adapted = coerceNumericStringRows(data);
+    assert.equal(adapted[0].properties.notes, "3");
+    assert.equal(adapted[1].properties.notes, "3.0");
+    assert.equal(distinctCategoryValues(adapted, "notes").length, 5);
   });
 
   it("preserves common identifiers and columns containing leading zeroes", () => {

--- a/tests/attribute-stats.test.ts
+++ b/tests/attribute-stats.test.ts
@@ -96,9 +96,10 @@ describe("computeFieldStats", () => {
     const data = rows({ pop: 10 }, { pop: "20" }, { pop: 30 }, { pop: null }, { pop: "" });
     const stats = computeFieldStats(data, "pop") as NumericFieldStats;
     assert.equal(stats.kind, "numeric");
-    assert.equal(stats.count, 3);
+    assert.equal(stats.count, 2);
     assert.equal(stats.nulls, 2);
-    assert.equal(stats.sum, 60);
+    assert.equal(stats.nonNumeric, 1);
+    assert.equal(stats.sum, 40);
   });
 
   it("counts non-numeric non-blank values separately for a numeric field", () => {

--- a/tests/attribute-stats.test.ts
+++ b/tests/attribute-stats.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
+import {
+  coerceNumericStringRows,
+  type ChartRow,
+} from "../apps/geolibre-desktop/src/lib/attribute-charts";
 import {
   computeFieldStats,
   computeNumericStats,
@@ -121,9 +124,16 @@ describe("computeFieldStats", () => {
     assert.equal(stats.unique, 3);
   });
 
-  it("returns null for a numeric field with no values", () => {
+  it("infers numeric strings for a string-only source", () => {
+    const data = rows({ population: "10" }, { population: "20" }, { population: "30" });
+    const stats = computeFieldStats(coerceNumericStringRows(data), "population");
+    assert.ok(stats);
+    assert.equal(stats.kind, "numeric");
+    if (stats.kind === "numeric") assert.equal(stats.sum, 60);
+  });
+
+  it("treats a field with fewer than two numeric values as text", () => {
     const data = rows({ v: 1 }, { v: null });
-    // Only one numeric value → not detected as numeric → text stats, not null.
     const stats = computeFieldStats(data, "v");
     assert.equal(stats?.kind, "text");
   });

--- a/tests/attribute-stats.test.ts
+++ b/tests/attribute-stats.test.ts
@@ -116,6 +116,7 @@ describe("computeFieldStats", () => {
   it("keeps numeric-looking strings as text", () => {
     const data = rows({ fips: "37009" }, { fips: "37005" }, { fips: "37171" });
     const stats = computeFieldStats(data, "fips");
+    assert.ok(stats);
     assert.equal(stats.kind, "text");
     assert.equal(stats.unique, 3);
   });

--- a/tests/attribute-stats.test.ts
+++ b/tests/attribute-stats.test.ts
@@ -113,6 +113,13 @@ describe("computeFieldStats", () => {
     assert.equal(stats.kind, "text");
   });
 
+  it("keeps numeric-looking strings as text", () => {
+    const data = rows({ fips: "37009" }, { fips: "37005" }, { fips: "37171" });
+    const stats = computeFieldStats(data, "fips");
+    assert.equal(stats.kind, "text");
+    assert.equal(stats.unique, 3);
+  });
+
   it("returns null for a numeric field with no values", () => {
     const data = rows({ v: 1 }, { v: null });
     // Only one numeric value → not detected as numeric → text stats, not null.

--- a/tests/column-explorer.test.ts
+++ b/tests/column-explorer.test.ts
@@ -34,6 +34,18 @@ describe("summarizeColumn", () => {
     assert.equal(summary.total, 5);
   });
 
+  it("excludes numeric-looking text from a mixed numeric field", () => {
+    const data = rows({ pop: 10 }, { pop: "20" }, { pop: 30 });
+    const summary = summarizeColumn(data, "pop");
+    assert.ok(summary);
+    assert.equal(summary.stats.kind, "numeric");
+    assert.equal(summary.histogram?.total, 2);
+    if (summary.stats.kind === "numeric") {
+      assert.equal(summary.stats.sum, 40);
+      assert.equal(summary.stats.nonNumeric, 1);
+    }
+  });
+
   it("summarizes a text field with top values and no histogram", () => {
     const data = rows({ kind: "a" }, { kind: "a" }, { kind: "b" }, { kind: "" });
     const summary = summarizeColumn(data, "kind");

--- a/tests/column-explorer.test.ts
+++ b/tests/column-explorer.test.ts
@@ -44,6 +44,14 @@ describe("summarizeColumn", () => {
     }
   });
 
+  it("keeps numeric-looking strings as text without a histogram", () => {
+    const data = rows({ fips: "37009" }, { fips: "37005" }, { fips: "37171" });
+    const summary = summarizeColumn(data, "fips");
+    assert.ok(summary);
+    assert.equal(summary.stats.kind, "text");
+    assert.equal(summary.histogram, null);
+  });
+
   it("lists up to COLUMN_EXPLORER_TOP_VALUES distinct text values", () => {
     const data = rows(...Array.from({ length: 20 }, (_, i) => ({ id: `v${i}` })));
     const summary = summarizeColumn(data, "id");

--- a/tests/column-explorer.test.ts
+++ b/tests/column-explorer.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
+import {
+  coerceNumericStringRows,
+  type ChartRow,
+} from "../apps/geolibre-desktop/src/lib/attribute-charts";
 import type { NumericFieldStats } from "../apps/geolibre-desktop/src/lib/attribute-stats";
 import {
   COLUMN_EXPLORER_TOP_VALUES,
@@ -50,6 +53,14 @@ describe("summarizeColumn", () => {
     assert.ok(summary);
     assert.equal(summary.stats.kind, "text");
     assert.equal(summary.histogram, null);
+  });
+
+  it("infers numeric strings for a string-only source", () => {
+    const data = rows({ population: "10" }, { population: "20" }, { population: "30" });
+    const summary = summarizeColumn(coerceNumericStringRows(data), "population");
+    assert.ok(summary);
+    assert.equal(summary.stats.kind, "numeric");
+    assert.equal(summary.histogram?.total, 3);
   });
 
   it("lists up to COLUMN_EXPLORER_TOP_VALUES distinct text values", () => {


### PR DESCRIPTION
## Summary

- classify attribute summary fields from their stored primitive values
- keep numeric-looking strings as text in Explore and Statistics
- add regression coverage for FIPS-like string fields

## Verification

- `node --import tsx --test tests/attribute-stats.test.ts tests/column-explorer.test.ts`
- `npm run build`
- `pre-commit run --all-files`
- verified the attached `nc.json` in Explore and Statistics in light and dark themes

Fixes #1933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field type detection so numeric-looking text, such as codes, remains classified as text by default.
  * Prevented text fields from generating numeric histograms.
  * Improved numeric statistics by requiring sufficient genuine numeric values before classifying a field as numeric.
  * Enabled charts and analysis tools to interpret numeric text from delimited files without changing the original table data.

* **Tests**
  * Added coverage for numeric-looking strings, explicit numeric conversion, field statistics, column summaries, and histograms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->