### PR TITLE
fix(layout): persist Browser and Comments panel toggles

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -12,12 +12,6 @@ import {
   type RuntimeEnvironmentVariable,
 } from "@geolibre/core";
 import {
-  closeRightPanel,
-  collapseRightPanel,
-  isRightPanelVisible,
-  openRightPanel,
-} from "@geolibre/plugins";
-import {
   Button,
   Dialog,
   DialogContent,
@@ -96,6 +90,7 @@ import { COMMENTS_PANEL_ID } from "../../hooks/useRegisterCommentsPanel";
 import { useRightPanelState } from "../../hooks/useRightPanels";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/is-tauri";
+import { applyRightPanelVisibility } from "../../lib/persisted-right-panel";
 import { COORDINATE_FORMATS, normalizeCoordinateFormat } from "../../lib/coordinate-format";
 import { THEME_SCHEMES, normalizeHexColor, type ThemeScheme } from "../../lib/theme-schemes";
 import { IS_MAS_BUILD } from "../../lib/build-flags";
@@ -423,45 +418,16 @@ export function SettingsDialog({
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("map");
   // Browser and Comments are dockable right panels: the registry owns whether
-  // they are on screen, and `layout.browserPanelVisible` /
-  // `layout.commentsPanelVisible` persist that across restarts so the toggle no
-  // longer resets on every launch (#1935). The dropdown's checkboxes read the
-  // live registry (they apply on the spot, with no Save to wait for); the
-  // dialog's read its draft like every other row there.
+  // they are on screen and `registerPersistedRightPanel` mirrors that into
+  // `layout.browserPanelVisible` / `layout.commentsPanelVisible`, so the toggle
+  // no longer resets on every launch (#1935). Because the mirror is the single
+  // writer, moving the panel is all these controls have to do: the setting
+  // follows, so the two can never disagree about what the checkbox should say.
   const rightPanelState = useRightPanelState();
   const browserPanelOpen = rightPanelState.visibleIds.includes(BROWSER_PANEL_ID);
   const commentsPanelOpen = rightPanelState.visibleIds.includes(COMMENTS_PANEL_ID);
-  // Show it collapsed on the shared Layers rail, matching its default state, so
-  // re-enabling from Settings doesn't jump to an expanded panel that buries the
-  // Layers panel.
-  // Bails out when the panel is already where it is being asked to go, so
-  // saving the dialog without touching these rows cannot collapse a panel the
-  // user had expanded.
-  const applyPanelVisibility = (panelId: string, show: boolean) => {
-    if (isRightPanelVisible(panelId) === show) return;
-    if (show) {
-      openRightPanel(panelId);
-      collapseRightPanel(panelId);
-    } else {
-      closeRightPanel(panelId);
-    }
-  };
-  const applyBrowserPanelVisibility = (show: boolean) =>
-    applyPanelVisibility(BROWSER_PANEL_ID, show);
-  // Collapsed for the same reason as Browser above, and to match the state
-  // Comments registers itself in on mount.
-  const applyCommentsPanelVisibility = (show: boolean) =>
-    applyPanelVisibility(COMMENTS_PANEL_ID, show);
-  // The dropdown toggles have no Save step, so they move the panel and persist
-  // the preference in one go, matching the other live entries in that menu.
-  const toggleBrowserPanel = (show: boolean) => {
-    applyBrowserPanelVisibility(show);
-    updateSavedLayoutSettings({ browserPanelVisible: show });
-  };
-  const toggleCommentsPanel = (show: boolean) => {
-    applyCommentsPanelVisibility(show);
-    updateSavedLayoutSettings({ commentsPanelVisible: show });
-  };
+  const toggleBrowserPanel = (show: boolean) => applyRightPanelVisibility(BROWSER_PANEL_ID, show);
+  const toggleCommentsPanel = (show: boolean) => applyRightPanelVisibility(COMMENTS_PANEL_ID, show);
   // A field a deep-link asked us to focus once its section renders; cleared
   // after the focus lands so a later open without a focus request stays put.
   const [pendingFocus, setPendingFocus] = useState<SettingsFocusTarget | null>(null);
@@ -620,18 +586,9 @@ export function SettingsDialog({
     }
     const seededPreferences = clonePreferences(useAppStore.getState().preferences);
     setDraftPreferences(seededPreferences);
-    const seededSettings = cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings);
-    // Browser and Comments are dockable panels the user can also close from the
-    // panel's own header, which is a session action that writes no setting. Seed
-    // those two rows from the live registry rather than the stored value so the
-    // dialog opens showing what is actually on screen; Save then persists
-    // exactly what the checkboxes showed.
-    seededSettings.layout = {
-      ...seededSettings.layout,
-      browserPanelVisible: isRightPanelVisible(BROWSER_PANEL_ID),
-      commentsPanelVisible: isRightPanelVisible(COMMENTS_PANEL_ID),
-    };
-    setDraftDesktopSettings(seededSettings);
+    setDraftDesktopSettings(
+      cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings),
+    );
     // Land the AI section on the first profile's provider, or the first
     // available provider if no profiles exist, so the user sees something
     // relevant without extra clicks.
@@ -1232,11 +1189,12 @@ export function SettingsDialog({
       updates: draftDesktopSettings.updates,
       startup: draftDesktopSettings.startup,
     });
-    // The dockable panels are the one layout row the store cannot apply on its
-    // own: their registration hooks only read the setting at mount, so move the
-    // registry here to match what was just saved.
-    applyBrowserPanelVisibility(draftDesktopSettings.layout.browserPanelVisible);
-    applyCommentsPanelVisibility(draftDesktopSettings.layout.commentsPanelVisible);
+    // The dockable panels are the one layout row nothing renders from the store:
+    // the registry owns what is on screen, so move it to match what was just
+    // saved (a no-op for a panel already there, so an untouched Save cannot
+    // collapse one the user had expanded).
+    applyRightPanelVisibility(BROWSER_PANEL_ID, draftDesktopSettings.layout.browserPanelVisible);
+    applyRightPanelVisibility(COMMENTS_PANEL_ID, draftDesktopSettings.layout.commentsPanelVisible);
     setOpen(false);
   };
 

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -11,7 +11,12 @@ import {
   type ProjectPreferences,
   type RuntimeEnvironmentVariable,
 } from "@geolibre/core";
-import { closeRightPanel, collapseRightPanel, openRightPanel } from "@geolibre/plugins";
+import {
+  closeRightPanel,
+  collapseRightPanel,
+  isRightPanelVisible,
+  openRightPanel,
+} from "@geolibre/plugins";
 import {
   Button,
   Dialog,
@@ -417,47 +422,45 @@ export function SettingsDialog({
   const showSettingsItem = (id: string) => isMenuItemVisible(desktopSettings.uiProfile, id);
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("map");
-  // Browser and Comments are dockable right panels, so their checkboxes read the
-  // live registry state (the user can also close them from their own header)
-  // while the toggle writes the matching persisted layout setting. The setting
-  // is what their registration hooks seed from on the next launch, so the
-  // toggle survives a restart (#1935).
+  // Browser and Comments are dockable right panels: the registry owns whether
+  // they are on screen, and `layout.browserPanelVisible` /
+  // `layout.commentsPanelVisible` persist that across restarts so the toggle no
+  // longer resets on every launch (#1935). The dropdown's checkboxes read the
+  // live registry (they apply on the spot, with no Save to wait for); the
+  // dialog's read its draft like every other row there.
   const rightPanelState = useRightPanelState();
   const browserPanelOpen = rightPanelState.visibleIds.includes(BROWSER_PANEL_ID);
   const commentsPanelOpen = rightPanelState.visibleIds.includes(COMMENTS_PANEL_ID);
-  // These apply live rather than on Save, so the draft is patched alongside the
-  // saved settings: the draft was snapshotted when the dialog opened, and Save
-  // writes it wholesale, which would otherwise revert the toggle the user just
-  // made in this same dialog.
-  const applyPanelVisibility = (
-    key: "browserPanelVisible" | "commentsPanelVisible",
-    visible: boolean,
-  ) => {
-    updateSavedLayoutSettings({ [key]: visible });
-    updateDraftLayoutSettings({ [key]: visible });
-  };
   // Show it collapsed on the shared Layers rail, matching its default state, so
   // re-enabling from Settings doesn't jump to an expanded panel that buries the
   // Layers panel.
-  const toggleBrowserPanel = (show: boolean) => {
+  // Bails out when the panel is already where it is being asked to go, so
+  // saving the dialog without touching these rows cannot collapse a panel the
+  // user had expanded.
+  const applyPanelVisibility = (panelId: string, show: boolean) => {
+    if (isRightPanelVisible(panelId) === show) return;
     if (show) {
-      openRightPanel(BROWSER_PANEL_ID);
-      collapseRightPanel(BROWSER_PANEL_ID);
+      openRightPanel(panelId);
+      collapseRightPanel(panelId);
     } else {
-      closeRightPanel(BROWSER_PANEL_ID);
+      closeRightPanel(panelId);
     }
-    applyPanelVisibility("browserPanelVisible", show);
   };
+  const applyBrowserPanelVisibility = (show: boolean) =>
+    applyPanelVisibility(BROWSER_PANEL_ID, show);
   // Collapsed for the same reason as Browser above, and to match the state
   // Comments registers itself in on mount.
+  const applyCommentsPanelVisibility = (show: boolean) =>
+    applyPanelVisibility(COMMENTS_PANEL_ID, show);
+  // The dropdown toggles have no Save step, so they move the panel and persist
+  // the preference in one go, matching the other live entries in that menu.
+  const toggleBrowserPanel = (show: boolean) => {
+    applyBrowserPanelVisibility(show);
+    updateSavedLayoutSettings({ browserPanelVisible: show });
+  };
   const toggleCommentsPanel = (show: boolean) => {
-    if (show) {
-      openRightPanel(COMMENTS_PANEL_ID);
-      collapseRightPanel(COMMENTS_PANEL_ID);
-    } else {
-      closeRightPanel(COMMENTS_PANEL_ID);
-    }
-    applyPanelVisibility("commentsPanelVisible", show);
+    applyCommentsPanelVisibility(show);
+    updateSavedLayoutSettings({ commentsPanelVisible: show });
   };
   // A field a deep-link asked us to focus once its section renders; cleared
   // after the focus lands so a later open without a focus request stays put.
@@ -617,9 +620,18 @@ export function SettingsDialog({
     }
     const seededPreferences = clonePreferences(useAppStore.getState().preferences);
     setDraftPreferences(seededPreferences);
-    setDraftDesktopSettings(
-      cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings),
-    );
+    const seededSettings = cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings);
+    // Browser and Comments are dockable panels the user can also close from the
+    // panel's own header, which is a session action that writes no setting. Seed
+    // those two rows from the live registry rather than the stored value so the
+    // dialog opens showing what is actually on screen; Save then persists
+    // exactly what the checkboxes showed.
+    seededSettings.layout = {
+      ...seededSettings.layout,
+      browserPanelVisible: isRightPanelVisible(BROWSER_PANEL_ID),
+      commentsPanelVisible: isRightPanelVisible(COMMENTS_PANEL_ID),
+    };
+    setDraftDesktopSettings(seededSettings);
     // Land the AI section on the first profile's provider, or the first
     // available provider if no profiles exist, so the user sees something
     // relevant without extra clicks.
@@ -947,11 +959,6 @@ export function SettingsDialog({
 
   const resetLayoutSettings = () => {
     updateDraftLayoutSettings(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
-    // The Browser/Comments checkboxes render the live registry state, not the
-    // draft, so reset has to move the panels themselves or those two rows would
-    // ignore the button.
-    toggleBrowserPanel(DEFAULT_DESKTOP_LAYOUT_SETTINGS.browserPanelVisible);
-    toggleCommentsPanel(DEFAULT_DESKTOP_LAYOUT_SETTINGS.commentsPanelVisible);
   };
 
   // The accent scheme applies live (instant preview) rather than waiting for
@@ -1225,6 +1232,11 @@ export function SettingsDialog({
       updates: draftDesktopSettings.updates,
       startup: draftDesktopSettings.startup,
     });
+    // The dockable panels are the one layout row the store cannot apply on its
+    // own: their registration hooks only read the setting at mount, so move the
+    // registry here to match what was just saved.
+    applyBrowserPanelVisibility(draftDesktopSettings.layout.browserPanelVisible);
+    applyCommentsPanelVisibility(draftDesktopSettings.layout.commentsPanelVisible);
     setOpen(false);
   };
 
@@ -1847,8 +1859,12 @@ export function SettingsDialog({
                       <input
                         className="h-4 w-4"
                         type="checkbox"
-                        checked={browserPanelOpen}
-                        onChange={(event) => toggleBrowserPanel(event.target.checked)}
+                        checked={draftDesktopSettings.layout.browserPanelVisible}
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            browserPanelVisible: event.target.checked,
+                          })
+                        }
                       />
                       <FolderTree className="h-4 w-4 text-muted-foreground" />
                       <span>{t("settings.layout.showBrowserPanel")}</span>
@@ -1857,8 +1873,12 @@ export function SettingsDialog({
                       <input
                         className="h-4 w-4"
                         type="checkbox"
-                        checked={commentsPanelOpen}
-                        onChange={(event) => toggleCommentsPanel(event.target.checked)}
+                        checked={draftDesktopSettings.layout.commentsPanelVisible}
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            commentsPanelVisible: event.target.checked,
+                          })
+                        }
                       />
                       <MessageSquare className="h-4 w-4 text-muted-foreground" />
                       <span>{t("settings.layout.showCommentsPanel")}</span>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -417,12 +417,25 @@ export function SettingsDialog({
   const showSettingsItem = (id: string) => isMenuItemVisible(desktopSettings.uiProfile, id);
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("map");
-  // The Browser is a dockable right panel (open/close via the registry), not a
-  // persisted layout preference, so its Layout toggle acts on the live registry
-  // state directly rather than through the draft settings.
+  // Browser and Comments are dockable right panels, so their checkboxes read the
+  // live registry state (the user can also close them from their own header)
+  // while the toggle writes the matching persisted layout setting. The setting
+  // is what their registration hooks seed from on the next launch, so the
+  // toggle survives a restart (#1935).
   const rightPanelState = useRightPanelState();
   const browserPanelOpen = rightPanelState.visibleIds.includes(BROWSER_PANEL_ID);
   const commentsPanelOpen = rightPanelState.visibleIds.includes(COMMENTS_PANEL_ID);
+  // These apply live rather than on Save, so the draft is patched alongside the
+  // saved settings: the draft was snapshotted when the dialog opened, and Save
+  // writes it wholesale, which would otherwise revert the toggle the user just
+  // made in this same dialog.
+  const applyPanelVisibility = (
+    key: "browserPanelVisible" | "commentsPanelVisible",
+    visible: boolean,
+  ) => {
+    updateSavedLayoutSettings({ [key]: visible });
+    updateDraftLayoutSettings({ [key]: visible });
+  };
   // Show it collapsed on the shared Layers rail, matching its default state, so
   // re-enabling from Settings doesn't jump to an expanded panel that buries the
   // Layers panel.
@@ -433,6 +446,7 @@ export function SettingsDialog({
     } else {
       closeRightPanel(BROWSER_PANEL_ID);
     }
+    applyPanelVisibility("browserPanelVisible", show);
   };
   // Collapsed for the same reason as Browser above, and to match the state
   // Comments registers itself in on mount.
@@ -443,6 +457,7 @@ export function SettingsDialog({
     } else {
       closeRightPanel(COMMENTS_PANEL_ID);
     }
+    applyPanelVisibility("commentsPanelVisible", show);
   };
   // A field a deep-link asked us to focus once its section renders; cleared
   // after the focus lands so a later open without a focus request stays put.
@@ -932,6 +947,11 @@ export function SettingsDialog({
 
   const resetLayoutSettings = () => {
     updateDraftLayoutSettings(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    // The Browser/Comments checkboxes render the live registry state, not the
+    // draft, so reset has to move the panels themselves or those two rows would
+    // ignore the button.
+    toggleBrowserPanel(DEFAULT_DESKTOP_LAYOUT_SETTINGS.browserPanelVisible);
+    toggleCommentsPanel(DEFAULT_DESKTOP_LAYOUT_SETTINGS.commentsPanelVisible);
   };
 
   // The accent scheme applies live (instant preview) rather than waiting for

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -110,6 +110,17 @@ export interface UpdateSettings {
 }
 
 export interface DesktopLayoutSettings {
+  /**
+   * Whether the Browser (Data Source Manager) right panel is registered as
+   * visible. Unlike {@link layerPanelVisible} this does not describe a fixed
+   * dock slot: the Browser is a dockable right panel, so the flag is the
+   * persisted seed its registration hook applies on mount (open + collapsed onto
+   * its rail, or closed). Without it the panel reopened on every launch no
+   * matter what the Settings toggle said (#1935).
+   */
+  browserPanelVisible: boolean;
+  /** Same as {@link browserPanelVisible}, for the Comments right panel. */
+  commentsPanelVisible: boolean;
   layerPanelVisible: boolean;
   showProjectInfo: boolean;
   stylePanelVisible: boolean;
@@ -157,6 +168,8 @@ interface DesktopSettingsState {
 }
 
 export const DEFAULT_DESKTOP_LAYOUT_SETTINGS: DesktopLayoutSettings = {
+  browserPanelVisible: true,
+  commentsPanelVisible: true,
   layerPanelVisible: true,
   showProjectInfo: true,
   stylePanelVisible: true,
@@ -410,6 +423,14 @@ function normalizeDesktopLayoutSettings(layout: unknown): DesktopLayoutSettings 
   // cannot smuggle non-boolean values into the layout settings.
   const candidate = layout as Partial<DesktopLayoutSettings>;
   return {
+    browserPanelVisible:
+      typeof candidate.browserPanelVisible === "boolean"
+        ? candidate.browserPanelVisible
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.browserPanelVisible,
+    commentsPanelVisible:
+      typeof candidate.commentsPanelVisible === "boolean"
+        ? candidate.commentsPanelVisible
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.commentsPanelVisible,
     layerPanelVisible:
       typeof candidate.layerPanelVisible === "boolean"
         ? candidate.layerPanelVisible

--- a/apps/geolibre-desktop/src/hooks/useRegisterBrowserPanel.ts
+++ b/apps/geolibre-desktop/src/hooks/useRegisterBrowserPanel.ts
@@ -1,6 +1,7 @@
 import { collapseRightPanel, openRightPanel, registerRightPanel } from "@geolibre/plugins";
 import { useEffect } from "react";
 import i18n from "../i18n";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 /** Stable id of the Browser (Data Source Manager) right panel. */
 export const BROWSER_PANEL_ID = "browser";
@@ -24,8 +25,10 @@ export const BROWSER_PANEL_ID = "browser";
  * The panel is **on by default but collapsed** onto the shared Layers rail: on
  * mount it is opened and immediately collapsed, so it shows as a rail entry
  * beside Layers rather than covering the map. The user expands it from that
- * rail (or toggles it off in Settings → Layout). It reopens collapsed on the
- * next load, matching the "on by default" behavior of the Layout toggle.
+ * rail (or toggles it off in Settings → Layout). "By default" means the default
+ * of the persisted `layout.browserPanelVisible` setting: turning the panel off
+ * in Settings → Layout keeps it off across restarts rather than having the
+ * toggle silently reset (#1935).
  */
 export function useRegisterBrowserPanel(): void {
   useEffect(() => {
@@ -38,9 +41,15 @@ export function useRegisterBrowserPanel(): void {
       render: () => {},
     });
     // Default on, but docked collapsed to the Layers rail (open then collapse),
-    // so it is present without burying the map on first load.
-    openRightPanel(BROWSER_PANEL_ID);
-    collapseRightPanel(BROWSER_PANEL_ID);
+    // so it is present without burying the map on first load. Read the setting
+    // here rather than subscribing: this seeds the panel's startup state only.
+    // Once mounted the Settings toggle drives the registry directly, so the
+    // user can also close the panel from its own header without that being
+    // written back as a preference.
+    if (useDesktopSettingsStore.getState().desktopSettings.layout.browserPanelVisible) {
+      openRightPanel(BROWSER_PANEL_ID);
+      collapseRightPanel(BROWSER_PANEL_ID);
+    }
     return dispose;
   }, []);
 }

--- a/apps/geolibre-desktop/src/hooks/useRegisterBrowserPanel.ts
+++ b/apps/geolibre-desktop/src/hooks/useRegisterBrowserPanel.ts
@@ -1,7 +1,6 @@
-import { collapseRightPanel, openRightPanel, registerRightPanel } from "@geolibre/plugins";
 import { useEffect } from "react";
 import i18n from "../i18n";
-import { useDesktopSettingsStore } from "./useDesktopSettings";
+import { registerPersistedRightPanel } from "../lib/persisted-right-panel";
 
 /** Stable id of the Browser (Data Source Manager) right panel. */
 export const BROWSER_PANEL_ID = "browser";
@@ -26,30 +25,25 @@ export const BROWSER_PANEL_ID = "browser";
  * mount it is opened and immediately collapsed, so it shows as a rail entry
  * beside Layers rather than covering the map. The user expands it from that
  * rail (or toggles it off in Settings → Layout). "By default" means the default
- * of the persisted `layout.browserPanelVisible` setting: turning the panel off
- * in Settings → Layout keeps it off across restarts rather than having the
- * toggle silently reset (#1935).
+ * of the persisted `layout.browserPanelVisible` setting, which
+ * {@link registerPersistedRightPanel} seeds from and then keeps in step with the
+ * panel: turning it off stays off across restarts instead of the toggle silently
+ * resetting on every launch (#1935).
  */
 export function useRegisterBrowserPanel(): void {
-  useEffect(() => {
-    // i18n.t (not the useTranslation hook) so registration carries no
-    // render-time dependency; the body still localizes live via useTranslation.
-    const dispose = registerRightPanel({
-      id: BROWSER_PANEL_ID,
-      title: () => i18n.t("browser.title"),
-      dock: "replace-layers",
-      render: () => {},
-    });
-    // Default on, but docked collapsed to the Layers rail (open then collapse),
-    // so it is present without burying the map on first load. Read the setting
-    // here rather than subscribing: this seeds the panel's startup state only.
-    // Once mounted the Settings toggle drives the registry directly, so the
-    // user can also close the panel from its own header without that being
-    // written back as a preference.
-    if (useDesktopSettingsStore.getState().desktopSettings.layout.browserPanelVisible) {
-      openRightPanel(BROWSER_PANEL_ID);
-      collapseRightPanel(BROWSER_PANEL_ID);
-    }
-    return dispose;
-  }, []);
+  useEffect(
+    () =>
+      registerPersistedRightPanel(
+        {
+          id: BROWSER_PANEL_ID,
+          // i18n.t (not the useTranslation hook) so registration carries no
+          // render-time dependency; the body localizes live via useTranslation.
+          title: () => i18n.t("browser.title"),
+          dock: "replace-layers",
+          render: () => {},
+        },
+        "browserPanelVisible",
+      ),
+    [],
+  );
 }

--- a/apps/geolibre-desktop/src/hooks/useRegisterCommentsPanel.ts
+++ b/apps/geolibre-desktop/src/hooks/useRegisterCommentsPanel.ts
@@ -1,6 +1,7 @@
 import { collapseRightPanel, openRightPanel, registerRightPanel } from "@geolibre/plugins";
 import { useEffect } from "react";
 import i18n from "../i18n";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 /** Stable id of the Comments right panel. */
 export const COMMENTS_PANEL_ID = "comments";
@@ -10,7 +11,10 @@ export const COMMENTS_PANEL_ID = "comments";
  * sidebar's rail (`replace-style`).
  *
  * Comments is enabled by default but collapsed onto the Style rail, so it is
- * discoverable without taking map space.
+ * discoverable without taking map space. "By default" means the default of the
+ * persisted `layout.commentsPanelVisible` setting: a user who turned the panel
+ * off in Settings → Layout gets it back off on the next launch instead of having
+ * the toggle silently reset (#1935).
  */
 export function useRegisterCommentsPanel(): void {
   useEffect(() => {
@@ -22,8 +26,14 @@ export function useRegisterCommentsPanel(): void {
       dock: "replace-style",
       render: () => {},
     });
-    openRightPanel(COMMENTS_PANEL_ID);
-    collapseRightPanel(COMMENTS_PANEL_ID);
+    // Read the setting here rather than subscribing: this seeds the panel's
+    // startup state only. Once mounted the Settings toggle drives the registry
+    // directly, so the user can also close the panel from its own header
+    // without that being written back as a preference.
+    if (useDesktopSettingsStore.getState().desktopSettings.layout.commentsPanelVisible) {
+      openRightPanel(COMMENTS_PANEL_ID);
+      collapseRightPanel(COMMENTS_PANEL_ID);
+    }
     return dispose;
   }, []);
 }

--- a/apps/geolibre-desktop/src/hooks/useRegisterCommentsPanel.ts
+++ b/apps/geolibre-desktop/src/hooks/useRegisterCommentsPanel.ts
@@ -1,7 +1,6 @@
-import { collapseRightPanel, openRightPanel, registerRightPanel } from "@geolibre/plugins";
 import { useEffect } from "react";
 import i18n from "../i18n";
-import { useDesktopSettingsStore } from "./useDesktopSettings";
+import { registerPersistedRightPanel } from "../lib/persisted-right-panel";
 
 /** Stable id of the Comments right panel. */
 export const COMMENTS_PANEL_ID = "comments";
@@ -12,28 +11,25 @@ export const COMMENTS_PANEL_ID = "comments";
  *
  * Comments is enabled by default but collapsed onto the Style rail, so it is
  * discoverable without taking map space. "By default" means the default of the
- * persisted `layout.commentsPanelVisible` setting: a user who turned the panel
- * off in Settings → Layout gets it back off on the next launch instead of having
- * the toggle silently reset (#1935).
+ * persisted `layout.commentsPanelVisible` setting, which
+ * {@link registerPersistedRightPanel} seeds from and then keeps in step with the
+ * panel: turning it off stays off across restarts instead of the toggle silently
+ * resetting on every launch (#1935).
  */
 export function useRegisterCommentsPanel(): void {
-  useEffect(() => {
-    // i18n.t (not the useTranslation hook) so registration carries no
-    // render-time dependency; the rail entry re-resolves the getter on render.
-    const dispose = registerRightPanel({
-      id: COMMENTS_PANEL_ID,
-      title: () => i18n.t("comments.title"),
-      dock: "replace-style",
-      render: () => {},
-    });
-    // Read the setting here rather than subscribing: this seeds the panel's
-    // startup state only. Once mounted the Settings toggle drives the registry
-    // directly, so the user can also close the panel from its own header
-    // without that being written back as a preference.
-    if (useDesktopSettingsStore.getState().desktopSettings.layout.commentsPanelVisible) {
-      openRightPanel(COMMENTS_PANEL_ID);
-      collapseRightPanel(COMMENTS_PANEL_ID);
-    }
-    return dispose;
-  }, []);
+  useEffect(
+    () =>
+      registerPersistedRightPanel(
+        {
+          id: COMMENTS_PANEL_ID,
+          // i18n.t (not the useTranslation hook) so registration carries no
+          // render-time dependency; the rail entry re-resolves it on render.
+          title: () => i18n.t("comments.title"),
+          dock: "replace-style",
+          render: () => {},
+        },
+        "commentsPanelVisible",
+      ),
+    [],
+  );
 }

--- a/apps/geolibre-desktop/src/lib/persisted-right-panel.ts
+++ b/apps/geolibre-desktop/src/lib/persisted-right-panel.ts
@@ -1,0 +1,98 @@
+// The registry subpath rather than the package barrel: this module is a leaf the
+// test suite imports directly, and the barrel pulls in the whole built-in plugin
+// registry (including CSS imports Node cannot load). See CLAUDE.md on testing
+// against a leaf module.
+import {
+  collapseRightPanel,
+  closeRightPanel,
+  getRightPanel,
+  isRightPanelVisible,
+  openRightPanel,
+  registerRightPanel,
+  subscribeRightPanels,
+} from "@geolibre/plugins/right-panel-registry";
+import type { GeoLibreRightPanelRegistration } from "@geolibre/plugins";
+import { useDesktopSettingsStore, type DesktopLayoutSettings } from "../hooks/useDesktopSettings";
+
+/**
+ * Layout settings that persist a dockable right panel's visibility. The Browser
+ * and Comments panels are the two built-in panels that work this way; plugin
+ * panels are owned by their plugin and are not persisted here.
+ */
+export type PersistedPanelKey = Extract<
+  keyof DesktopLayoutSettings,
+  "browserPanelVisible" | "commentsPanelVisible"
+>;
+
+/** Read a panel's persisted visibility, bypassing React so callers can seed. */
+export function isPanelVisibleInSettings(key: PersistedPanelKey): boolean {
+  return useDesktopSettingsStore.getState().desktopSettings.layout[key];
+}
+
+/** Persist a panel's visibility. A no-op when the value already matches. */
+export function setPanelVisibleInSettings(key: PersistedPanelKey, visible: boolean): void {
+  const { desktopSettings, setDesktopSettings } = useDesktopSettingsStore.getState();
+  if (desktopSettings.layout[key] === visible) return;
+  setDesktopSettings({
+    ...desktopSettings,
+    layout: { ...desktopSettings.layout, [key]: visible },
+  });
+}
+
+/**
+ * Move a panel to `visible`, showing it collapsed on its rail so re-enabling it
+ * does not jump to an expanded panel that buries its neighbour. Bails out when
+ * the panel is already where it is being asked to go, so a caller re-applying an
+ * unchanged value cannot collapse a panel the user had expanded.
+ */
+export function applyRightPanelVisibility(panelId: string, visible: boolean): void {
+  if (isRightPanelVisible(panelId) === visible) return;
+  if (visible) {
+    openRightPanel(panelId);
+    collapseRightPanel(panelId);
+  } else {
+    closeRightPanel(panelId);
+  }
+}
+
+/**
+ * Register a dockable right panel whose visibility is a persisted layout
+ * setting, and keep the two in step. Returns a disposer that unsubscribes
+ * before unregistering.
+ *
+ * Visibility is seeded from the setting at registration, so a panel the user
+ * turned off stays off across restarts instead of reopening on every launch
+ * (GeoLibre#1935). From then on the setting mirrors the registry, which matters
+ * because the panel can be closed from its own header as well as from Settings
+ * → Layout: for these panels closing is not a transient collapse, it removes
+ * the rail entry entirely and only Settings can bring it back, so it is a
+ * preference either way. Mirroring is what keeps the Settings checkbox, the
+ * panel on screen, and the stored value from ever disagreeing.
+ *
+ * Two registry events are deliberately *not* mirrored:
+ *
+ * - The `emit` from registration itself, because the panel is legitimately not
+ *   visible yet. The subscription is therefore attached after the seed.
+ * - The `emit` from unregistering on unmount, which would otherwise persist
+ *   `false` every time the shell tears down. `unregisterRightPanel` removes the
+ *   panel from the registry before it emits, so the `getRightPanel` guard
+ *   catches it; the disposer unsubscribing first makes that belt-and-braces.
+ *
+ * Being displaced by another panel is not a close (the registry keeps a
+ * displaced panel in `visibleIds`), so it correctly writes nothing.
+ */
+export function registerPersistedRightPanel(
+  registration: GeoLibreRightPanelRegistration,
+  key: PersistedPanelKey,
+): () => void {
+  const dispose = registerRightPanel(registration);
+  applyRightPanelVisibility(registration.id, isPanelVisibleInSettings(key));
+  const unsubscribe = subscribeRightPanels(() => {
+    if (!getRightPanel(registration.id)) return;
+    setPanelVisibleInSettings(key, isRightPanelVisible(registration.id));
+  });
+  return () => {
+    unsubscribe();
+    dispose();
+  };
+}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -12,6 +12,7 @@
     "./local-netcdf": "./src/plugins/local-netcdf.ts",
     "./maplibre-graticule": "./src/plugins/maplibre-graticule.ts",
     "./raster-symbology": "./src/plugins/raster-symbology.ts",
+    "./right-panel-registry": "./src/right-panel-registry.ts",
     "./zarr-time-axis": "./src/plugins/zarr-time-axis.ts"
   },
   "dependencies": {

--- a/tests/layout-panel-settings.test.ts
+++ b/tests/layout-panel-settings.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_DESKTOP_LAYOUT_SETTINGS,
+  normalizeDesktopSettings,
+} from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+
+// The Browser and Comments right panels used to be session-only: their Settings
+// → Layout toggles moved the panel registry but nothing was persisted, so every
+// launch reopened them (GeoLibre#1935). They are now layout settings like the
+// Layers/Style panels, which means they have to round-trip through
+// normalizeDesktopSettings and keep defaulting to on for existing users whose
+// stored settings predate the keys.
+describe("dockable panel layout settings", () => {
+  it("defaults both dockable panels to visible", () => {
+    assert.equal(DEFAULT_DESKTOP_LAYOUT_SETTINGS.browserPanelVisible, true);
+    assert.equal(DEFAULT_DESKTOP_LAYOUT_SETTINGS.commentsPanelVisible, true);
+  });
+
+  it("keeps a disabled panel disabled across a load", () => {
+    const layout = normalizeDesktopSettings({
+      layout: { browserPanelVisible: false, commentsPanelVisible: false },
+    }).layout;
+    assert.equal(layout.browserPanelVisible, false);
+    assert.equal(layout.commentsPanelVisible, false);
+  });
+
+  it("falls back to the defaults for settings saved before the keys existed", () => {
+    const layout = normalizeDesktopSettings({
+      layout: { layerPanelVisible: false, stylePanelVisible: true, toolbarLabels: true },
+    }).layout;
+    assert.equal(layout.layerPanelVisible, false);
+    assert.equal(layout.browserPanelVisible, true);
+    assert.equal(layout.commentsPanelVisible, true);
+  });
+
+  it("rejects non-boolean values from tampered storage", () => {
+    const layout = normalizeDesktopSettings({
+      layout: { browserPanelVisible: "no", commentsPanelVisible: 0 },
+    }).layout;
+    assert.equal(layout.browserPanelVisible, true);
+    assert.equal(layout.commentsPanelVisible, true);
+  });
+});

--- a/tests/persisted-right-panel.test.ts
+++ b/tests/persisted-right-panel.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  __resetRightPanelRegistryForTests,
+  closeRightPanel,
+  collapseRightPanel,
+  isRightPanelCollapsed,
+  isRightPanelVisible,
+  openRightPanel,
+  registerRightPanel,
+} from "../packages/plugins/src/right-panel-registry";
+import {
+  applyRightPanelVisibility,
+  registerPersistedRightPanel,
+} from "../apps/geolibre-desktop/src/lib/persisted-right-panel";
+import { useDesktopSettingsStore } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+
+// The Browser and Comments right panels persist their visibility so a panel the
+// user turned off stays off across restarts (GeoLibre#1935). The setting and the
+// registry have to agree in both directions: the panel is seeded from the
+// setting at registration, and every later visibility change (Settings toggle or
+// the panel's own close button) is written back.
+const PANEL_ID = "comments";
+const KEY = "commentsPanelVisible";
+
+function registration(id = PANEL_ID) {
+  return { id, title: "Comments", dock: "replace-style" as const, render: () => {} };
+}
+
+function setStoredVisibility(visible: boolean): void {
+  const { desktopSettings, setDesktopSettings } = useDesktopSettingsStore.getState();
+  setDesktopSettings({
+    ...desktopSettings,
+    layout: { ...desktopSettings.layout, [KEY]: visible },
+  });
+}
+
+function storedVisibility(): boolean {
+  return useDesktopSettingsStore.getState().desktopSettings.layout[KEY];
+}
+
+beforeEach(() => {
+  __resetRightPanelRegistryForTests();
+  setStoredVisibility(true);
+});
+
+afterEach(() => {
+  __resetRightPanelRegistryForTests();
+  setStoredVisibility(true);
+});
+
+describe("applyRightPanelVisibility", () => {
+  it("opens the panel collapsed onto its rail", () => {
+    registerRightPanel(registration());
+    applyRightPanelVisibility(PANEL_ID, true);
+    assert.equal(isRightPanelVisible(PANEL_ID), true);
+    assert.equal(isRightPanelCollapsed(), true);
+  });
+
+  it("leaves an expanded panel expanded when re-applying `true`", () => {
+    registerRightPanel(registration());
+    openRightPanel(PANEL_ID);
+    assert.equal(isRightPanelCollapsed(), false);
+    // Saving the Settings dialog re-applies every layout row, including rows the
+    // user never touched; that must not collapse a panel they had expanded.
+    applyRightPanelVisibility(PANEL_ID, true);
+    assert.equal(isRightPanelCollapsed(), false);
+  });
+
+  it("closes the panel", () => {
+    registerRightPanel(registration());
+    applyRightPanelVisibility(PANEL_ID, true);
+    applyRightPanelVisibility(PANEL_ID, false);
+    assert.equal(isRightPanelVisible(PANEL_ID), false);
+  });
+});
+
+describe("registerPersistedRightPanel", () => {
+  it("seeds a visible panel from the setting, collapsed", () => {
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    assert.equal(isRightPanelVisible(PANEL_ID), true);
+    assert.equal(isRightPanelCollapsed(), true);
+    dispose();
+  });
+
+  it("leaves a disabled panel closed instead of reopening it on every launch", () => {
+    setStoredVisibility(false);
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    assert.equal(isRightPanelVisible(PANEL_ID), false);
+    assert.equal(storedVisibility(), false);
+    dispose();
+  });
+
+  it("persists a close that came from the panel's own header", () => {
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    closeRightPanel(PANEL_ID);
+    assert.equal(storedVisibility(), false);
+    dispose();
+  });
+
+  it("persists a reopen", () => {
+    setStoredVisibility(false);
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    applyRightPanelVisibility(PANEL_ID, true);
+    assert.equal(storedVisibility(), true);
+    dispose();
+  });
+
+  it("does not treat collapsing to the rail as turning the panel off", () => {
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    openRightPanel(PANEL_ID);
+    collapseRightPanel(PANEL_ID);
+    assert.equal(storedVisibility(), true);
+    dispose();
+  });
+
+  it("does not treat being displaced by another panel as a close", () => {
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    registerRightPanel(registration("other"));
+    openRightPanel("other");
+    assert.equal(storedVisibility(), true);
+    dispose();
+  });
+
+  it("does not persist `false` when the shell unmounts", () => {
+    // The disposer unregisters, which emits a snapshot with the panel gone. That
+    // teardown must not be mistaken for the user turning the panel off, or the
+    // setting would flip to false on every reload.
+    const dispose = registerPersistedRightPanel(registration(), KEY);
+    dispose();
+    assert.equal(storedVisibility(), true);
+  });
+});


### PR DESCRIPTION
Fixes #1935

## Problem

The **Settings → Layout** toggles for the **Browser** and **Comments** panels acted only on the live right-panel registry. Nothing was written to `desktopSettings.layout`, and both registration hooks unconditionally called `openRightPanel(...)` on mount, so every launch reopened a panel the user had turned off.

The startup mode was a red herring: "Reopen the last project" restores layers and the camera, never these two panels. The other Layout settings (Layers panel, Style panel, toolbar labels, project info) were already persisted and did survive a restart.

## Fix

- `DesktopLayoutSettings` gains `browserPanelVisible` and `commentsPanelVisible`, both defaulting to `true` and normalized with the same strict-boolean rule as the existing keys, so settings saved before these keys existed keep today's behavior.
- `useRegisterBrowserPanel` / `useRegisterCommentsPanel` seed the panel from that setting on mount instead of always opening it. They read the store rather than subscribing, so closing a panel from its own header is still a session-level action and is not written back as a preference.
- The Settings toggles write the setting alongside the registry call. They apply live rather than on Save, so they patch the dialog draft too: the draft is snapshotted when the dialog opens and Save writes `layout` wholesale, which would otherwise revert the toggle the user just made in that same dialog.
- Layout **Reset** now moves the two panels as well, since those rows render the live registry state rather than the draft.

## Verification

Driven in the real app with Playwright, with `us_cities.geojson` loaded, in **both dark and light themes**:

- Fresh settings: both rails present (defaults unchanged).
- Toggle Comments off from the Settings → Layout submenu → `commentsPanelVisible: false` in storage; after reload the Comments rail is gone and Browser is untouched.
- Uncheck Browser in the Layout dialog and press **Save Settings** → the setting stays `false` (the stale-draft path that would have reverted it).
- Reload with both off: neither rail returns, the Layers panel is unaffected.
- Re-enable each from Settings → the panel comes back collapsed on its rail and survives the next reload.
- No new console warnings (no `openRightPanel: no right panel registered`).

`tests/layout-panel-settings.test.ts` covers the defaults, the round-trip of a disabled panel, the back-compat fallback for settings saved before the keys existed, and rejection of non-boolean values. Full frontend suite (6040 passing), `npm run build`, and pre-commit are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser and Comments panel visibility preferences are saved and restored across app restarts.
  * Settings changes are applied when saved and remain synchronized with the active layout.
  * Settings displays the current panel visibility, and resetting the layout restores both panels to visible.

* **Bug Fixes**
  * Invalid or legacy visibility settings safely fall back to the default configuration.
  * Panel state is preserved when panels are collapsed, reopened, or removed during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->