### PR TITLE
feat(layers): add Style panel button to layer cards

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -3210,6 +3210,10 @@ export function LayerPanel({
                     aria-pressed={selectedLayerIds.has(layer.id)}
                     onClick={(e) => handleLayerSelection(e, layer.id)}
                     onKeyDown={(e) => {
+                      // Only act on the card itself: preventDefault here would
+                      // otherwise cancel the Enter activation of the action
+                      // buttons nested inside it.
+                      if (e.target !== e.currentTarget) return;
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();
                         setSelectedLayerIds(new Set([layer.id]));

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -3389,7 +3389,7 @@ export function LayerPanel({
                         onChange={(v) => setLayerOpacity(layer.id, v)}
                       />
                     )}
-                    <div className="mt-2 flex gap-1">
+                    <div className="mt-2 flex flex-wrap gap-1">
                       <Button
                         variant="ghost"
                         size="icon"
@@ -3449,6 +3449,22 @@ export function LayerPanel({
                       >
                         <MousePointerClick className="h-3.5 w-3.5" />
                       </Button>
+                      {onOpenStylePanel && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          title={t("layers.openStylePanel")}
+                          aria-label={t("layers.openStylePanel")}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            selectLayer(layer.id);
+                            onOpenStylePanel();
+                          }}
+                        >
+                          <Palette className="h-3.5 w-3.5" />
+                        </Button>
+                      )}
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button

--- a/docs/user-guide/layers.md
+++ b/docs/user-guide/layers.md
@@ -14,7 +14,7 @@ The **Layers panel** on the left lists every layer in the project, from the topm
 
 Each layer exposes a set of actions:
 
-- **Open Style panel**: use the palette button on the layer card to select the layer and open its styling controls.
+- **Open Style panel**: when the built-in Style panel is enabled, use the palette button on the layer card to select the layer and open its styling controls.
 - **Zoom to layer**: fit the map to the layer's extent (for layers whose bounds are known).
 - **Identify features**: click features on the map to see their attributes in a popup. On a raster layer this reads the pixel value instead, and on a multiband raster it also builds a [spectral profile](styling.md#spectral-profile).
 - **Labels**: toggle text labels for vector layers that have a label field.

--- a/docs/user-guide/layers.md
+++ b/docs/user-guide/layers.md
@@ -14,6 +14,7 @@ The **Layers panel** on the left lists every layer in the project, from the topm
 
 Each layer exposes a set of actions:
 
+- **Open Style panel**: use the palette button on the layer card to select the layer and open its styling controls.
 - **Zoom to layer**: fit the map to the layer's extent (for layers whose bounds are known).
 - **Identify features**: click features on the map to see their attributes in a popup. On a raster layer this reads the pixel value instead, and on a multiband raster it also builds a [spectral profile](styling.md#spectral-profile).
 - **Labels**: toggle text labels for vector layers that have a label field.

--- a/e2e/layer-panel.spec.ts
+++ b/e2e/layer-panel.spec.ts
@@ -117,11 +117,37 @@ test("opens the selected layer in the Style panel from its card", async ({ page 
   await dropGeoJson(page, "second", FIXTURE_TEXT);
   await expect(layerRow(page, "second")).toBeVisible();
 
-  const stylePanel = page.getByRole("complementary", { name: "Layer style" });
+  // Exact, so the collapsed rail ("Layer style (collapsed)") cannot satisfy the
+  // default substring match.
+  const stylePanel = page.getByRole("complementary", { name: "Layer style", exact: true });
   await expect(stylePanel).toHaveCount(0);
 
   await layerRow(page, "first").getByRole("button", { name: "Open Style panel" }).click();
 
   await expect(stylePanel).toBeVisible();
   await expect(stylePanel.getByText("Style - first", { exact: true })).toBeVisible();
+});
+
+test("opens the Style panel from the layer card by keyboard", async ({ page }) => {
+  await page.setViewportSize({ width: 768, height: 720 });
+  await waitForMap(page);
+  await dropGeoJson(page, "first", FIXTURE_TEXT);
+  await expect(layerRow(page, "first")).toBeVisible();
+  await dropGeoJson(page, "second", FIXTURE_TEXT);
+  await expect(layerRow(page, "second")).toBeVisible();
+
+  const stylePanel = page.getByRole("complementary", { name: "Layer style", exact: true });
+  const styleButton = (name: string) =>
+    layerRow(page, name).getByRole("button", { name: "Open Style panel" });
+
+  // The card is a role="button" wrapper; its key handler must not swallow the
+  // activation of the action buttons nested inside it.
+  await styleButton("first").focus();
+  await page.keyboard.press("Enter");
+  await expect(stylePanel).toBeVisible();
+  await expect(stylePanel.getByText("Style - first", { exact: true })).toBeVisible();
+
+  await styleButton("second").focus();
+  await page.keyboard.press("Space");
+  await expect(stylePanel.getByText("Style - second", { exact: true })).toBeVisible();
 });

--- a/e2e/layer-panel.spec.ts
+++ b/e2e/layer-panel.spec.ts
@@ -108,3 +108,20 @@ test("long layer names truncate without widening the layer panel", async ({ page
     .poll(() => name.evaluate((element) => element.scrollWidth > element.clientWidth))
     .toBe(true);
 });
+
+test("opens the selected layer in the Style panel from its card", async ({ page }) => {
+  await page.setViewportSize({ width: 768, height: 720 });
+  await waitForMap(page);
+  await dropGeoJson(page, "first", FIXTURE_TEXT);
+  await expect(layerRow(page, "first")).toBeVisible();
+  await dropGeoJson(page, "second", FIXTURE_TEXT);
+  await expect(layerRow(page, "second")).toBeVisible();
+
+  const stylePanel = page.getByRole("complementary", { name: "Layer style" });
+  await expect(stylePanel).toHaveCount(0);
+
+  await layerRow(page, "first").getByRole("button", { name: "Open Style panel" }).click();
+
+  await expect(stylePanel).toBeVisible();
+  await expect(stylePanel.getByText("Style - first", { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Add a palette button to each layer card that selects the layer and opens the Style panel, so styling no longer requires digging into the overflow menu.
- Let the layer card action row wrap so the extra button does not overflow on narrow panel widths.
- Document the new action in the Layers user guide.

## Test plan
- [x] `pre-commit run --files apps/geolibre-desktop/src/components/panels/LayerPanel.tsx docs/user-guide/layers.md e2e/layer-panel.spec.ts` (build + eslint clean)
- [x] `npx playwright test e2e/layer-panel.spec.ts` (3 passed, including the new "opens the selected layer in the Style panel from its card" spec)
- [ ] Manually confirm the button appears and the action row wraps at a narrow layer panel width

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an **Open Style panel** action to each layer card.
  - Selecting the action selects the layer and opens its styling controls.
  - Layer action controls now wrap when space is limited.
  - Improved keyboard interaction for layer cards and action buttons.

- **Documentation**
  - Updated the layer guide with instructions for opening a layer’s Style panel.

- **Tests**
  - Added end-to-end coverage for mouse and keyboard activation of the Style panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->