### PR TITLE
fix(chrome-extension): resolve Hugging Face file URLs

### DIFF
--- a/extensions/geolibre-chrome/scanner.mjs
+++ b/extensions/geolibre-chrome/scanner.mjs
@@ -39,12 +39,13 @@ export function scanDocumentForDatasets() {
   const huggingFaceFileUrl = (url) => {
     if (!huggingFaceHost(url)) return null;
     const parts = url.pathname.split("/").filter(Boolean);
+    const isRoute = (part) => /^(?:blob|raw|blame|edit|delete|commits|resolve)$/.test(part ?? "");
     // /<owner>/<repo>/<route>/<revision>/<path> for models, one segment deeper
-    // for /datasets and /spaces. Anything else is not a file route.
-    const route = parts.findIndex((part) =>
-      /^(?:blob|raw|blame|edit|delete|commits|resolve)$/.test(part),
-    );
-    if (route < 2 || route > 3 || parts.length < route + 3) return null;
+    // for /datasets and /spaces (which still carry namespaceless legacy repos).
+    // Read the route from its fixed position rather than scanning, so an owner
+    // or repository named after a route cannot stand in for one.
+    const route = /^(?:datasets|spaces)$/.test(parts[0]) && isRoute(parts[3]) ? 3 : 2;
+    if (!isRoute(parts[route]) || parts.length < route + 3) return null;
     parts[route] = "resolve";
     const canonical = new URL(url.href);
     canonical.pathname = `/${parts.join("/")}`;
@@ -119,14 +120,15 @@ export function scanDocumentForDatasets() {
     // Every Hub route other than a file route is a UI page -- tree, viewer, the
     // "Auto-converted to Parquet" branch -- so a hint-based match there would
     // offer HTML as data.
-    if (huggingFaceHost(url) && !huggingFaceFileUrl(url)) return;
+    const onHub = huggingFaceHost(url);
+    if (onHub && !huggingFaceFileUrl(url)) return;
 
     const kind = classify(url, hint);
     if (!kind) return;
     const existing = datasets.get(url.href);
     // Hub links carry UI chrome as their text ("Download", "History", "308 kB
     // xet"), so the file name has to come from the path.
-    const name = (huggingFaceHost(url) ? "" : label.trim()) || cleanName(url);
+    const name = (onHub ? "" : label.trim()) || cleanName(url);
     const candidate = {
       url: url.href,
       name,

--- a/extensions/geolibre-chrome/scanner.mjs
+++ b/extensions/geolibre-chrome/scanner.mjs
@@ -30,7 +30,30 @@ export function scanDocumentForDatasets() {
     }
   };
 
+  const huggingFaceHost = (url) => /^(?:huggingface\.co|hf\.co)$/i.test(url.hostname);
+
+  // The Hub links one file from seven routes -- blob, raw, blame, edit, delete,
+  // commits and the ?download=true button -- and every one of them ends in the
+  // file's own extension, so a repository page yields near-duplicate hits where
+  // only `resolve` (which 302s to the CDN) serves bytes a map source can read.
+  const huggingFaceFileUrl = (url) => {
+    if (!huggingFaceHost(url)) return null;
+    const parts = url.pathname.split("/").filter(Boolean);
+    // /<owner>/<repo>/<route>/<revision>/<path> for models, one segment deeper
+    // for /datasets and /spaces. Anything else is not a file route.
+    const route = parts.findIndex((part) =>
+      /^(?:blob|raw|blame|edit|delete|commits|resolve)$/.test(part),
+    );
+    if (route < 2 || route > 3 || parts.length < route + 3) return null;
+    parts[route] = "resolve";
+    const canonical = new URL(url.href);
+    canonical.pathname = `/${parts.join("/")}`;
+    canonical.searchParams.delete("download");
+    return canonical;
+  };
+
   const canonicalUrl = (url) => {
+    if (huggingFaceHost(url)) return huggingFaceFileUrl(url) ?? url;
     if (url.hostname !== "source.coop") return url;
     const parts = url.pathname.split("/").filter(Boolean);
     if (parts.length < 3) return url;
@@ -93,10 +116,17 @@ export function scanDocumentForDatasets() {
       return;
     }
 
+    // Every Hub route other than a file route is a UI page -- tree, viewer, the
+    // "Auto-converted to Parquet" branch -- so a hint-based match there would
+    // offer HTML as data.
+    if (huggingFaceHost(url) && !huggingFaceFileUrl(url)) return;
+
     const kind = classify(url, hint);
     if (!kind) return;
     const existing = datasets.get(url.href);
-    const name = label.trim() || cleanName(url);
+    // Hub links carry UI chrome as their text ("Download", "History", "308 kB
+    // xet"), so the file name has to come from the path.
+    const name = (huggingFaceHost(url) ? "" : label.trim()) || cleanName(url);
     const candidate = {
       url: url.href,
       name,

--- a/extensions/geolibre-chrome/scanner.mjs
+++ b/extensions/geolibre-chrome/scanner.mjs
@@ -41,15 +41,22 @@ export function scanDocumentForDatasets() {
     const parts = url.pathname.split("/").filter(Boolean);
     const isRoute = (part) => /^(?:blob|raw|blame|edit|delete|commits|resolve)$/.test(part ?? "");
     // /<owner>/<repo>/<route>/<revision>/<path> for models, one segment deeper
-    // for /datasets and /spaces (which still carry namespaceless legacy repos).
-    // Read the route from its fixed position rather than scanning, so an owner
-    // or repository named after a route cannot stand in for one.
-    const route = /^(?:datasets|spaces)$/.test(parts[0]) && isRoute(parts[3]) ? 3 : 2;
-    if (!isRoute(parts[route]) || parts.length < route + 3) return null;
+    // under /datasets and /spaces, and one shallower for the namespaceless
+    // legacy repos both shapes still carry. Read the route from the positions
+    // the grammar allows rather than scanning for the first keyword, so an
+    // owner, repository or revision named after a route cannot stand in for
+    // one, and prefer the deeper position since namespaced repos are the norm.
+    const route = (/^(?:datasets|spaces)$/.test(parts[0]) ? [3, 2] : [2, 1]).find(
+      (index) => isRoute(parts[index]) && parts.length >= index + 3,
+    );
+    if (route === undefined) return null;
     parts[route] = "resolve";
     const canonical = new URL(url.href);
     canonical.pathname = `/${parts.join("/")}`;
     canonical.searchParams.delete("download");
+    // A line anchor off a blob page would otherwise split one file into two
+    // entries that the CDN serves identically.
+    canonical.hash = "";
     return canonical;
   };
 

--- a/tests/chrome-extension.test.ts
+++ b/tests/chrome-extension.test.ts
@@ -160,6 +160,38 @@ describe("GeoLibre Chrome extension scanner", () => {
     );
   });
 
+  it("falls back to a shallower Hugging Face route when the deeper one cannot parse", () => {
+    const found = scan(
+      `
+        <a href="https://huggingface.co/gpt2/blob/main/grid.geojson">namespaceless model</a>
+        <a href="https://huggingface.co/datasets/glue/blob/resolve/legacy.tif">revision named resolve</a>
+      `,
+      "https://huggingface.co/gpt2",
+    );
+    assert.deepEqual(
+      found.map((dataset) => dataset.url),
+      [
+        "https://huggingface.co/gpt2/resolve/main/grid.geojson",
+        "https://huggingface.co/datasets/glue/resolve/resolve/legacy.tif",
+      ],
+    );
+  });
+
+  it("drops a Hugging Face line anchor so it does not split one file in two", () => {
+    const repo = "https://huggingface.co/datasets/giswqs/opengeos";
+    const found = scan(
+      `
+        <a href="${repo}/blob/main/roads.geojson#L10">roads</a>
+        <a href="${repo}/resolve/main/roads.geojson?download=true">Download</a>
+      `,
+      `${repo}/tree/main`,
+    );
+    assert.deepEqual(
+      found.map((dataset) => dataset.url),
+      [`${repo}/resolve/main/roads.geojson`],
+    );
+  });
+
   it("pairs a Hugging Face style file with its dataset across routes", () => {
     const repo = "https://huggingface.co/datasets/giswqs/opengeos";
     const [found] = scan(

--- a/tests/chrome-extension.test.ts
+++ b/tests/chrome-extension.test.ts
@@ -96,6 +96,64 @@ describe("GeoLibre Chrome extension scanner", () => {
     assert.equal(found.styleUrl, "https://data.source.coop/giswqs/opengeos/roads.style.json");
   });
 
+  it("collapses every Hugging Face file route onto the direct resolve URL", () => {
+    const repo = "https://huggingface.co/datasets/giswqs/PACE-Water-Quality";
+    const file = "main/cogs/PACE_OCI-20260103-chla.tif";
+    const found = scan(
+      `
+        <a href="${repo}/blob/${file}">PACE_OCI-20260103-chla.tif</a>
+        <a href="${repo}/raw/${file}">Raw pointer file</a>
+        <a href="${repo}/blame/${file}">Blame</a>
+        <a href="${repo}/edit/${file}">Contribute</a>
+        <a href="${repo}/delete/${file}">Delete</a>
+        <a href="${repo}/commits/${file}">History</a>
+        <a href="${repo}/resolve/${file}?download=true">Download</a>
+      `,
+      `${repo}/blob/${file}`,
+    );
+    assert.deepEqual(found, [
+      {
+        url: `${repo}/resolve/${file}`,
+        name: "PACE_OCI-20260103-chla.tif",
+        format: "GeoTIFF",
+        kind: "raster",
+        styleUrl: null,
+      },
+    ]);
+  });
+
+  it("canonicalizes Hugging Face model and Space files but leaves other Hub links alone", () => {
+    const found = scan(
+      `
+        <a href="https://hf.co/giswqs/model/blob/main/grid.geojson">grid</a>
+        <a href="https://huggingface.co/spaces/giswqs/demo/blob/main/roads.pmtiles">roads</a>
+        <a href="https://huggingface.co/datasets/giswqs/PACE-Water-Quality/tree/main/cogs">cogs</a>
+        <a href="https://huggingface.co/datasets/giswqs/PACE-Water-Quality/tree/refs%2Fconvert%2Fparquet/default">Auto-converted to Parquet</a>
+      `,
+      "https://huggingface.co/giswqs",
+    );
+    assert.deepEqual(
+      found.map((dataset) => dataset.url),
+      [
+        "https://hf.co/giswqs/model/resolve/main/grid.geojson",
+        "https://huggingface.co/spaces/giswqs/demo/resolve/main/roads.pmtiles",
+      ],
+    );
+  });
+
+  it("pairs a Hugging Face style file with its dataset across routes", () => {
+    const repo = "https://huggingface.co/datasets/giswqs/opengeos";
+    const [found] = scan(
+      `
+        <a href="${repo}/resolve/main/roads.geojson?download=true">Download</a>
+        <a href="${repo}/blob/main/roads.style.json">roads.style.json</a>
+      `,
+      `${repo}/tree/main`,
+    );
+    assert.equal(found.url, `${repo}/resolve/main/roads.geojson`);
+    assert.equal(found.styleUrl, `${repo}/resolve/main/roads.style.json`);
+  });
+
   it("preserves a discovered style when stronger metadata replaces a dataset", () => {
     const target = new URL("https://web.geolibre.app/");
     target.searchParams.append("data", "https://data.example.com/roads.json");

--- a/tests/chrome-extension.test.ts
+++ b/tests/chrome-extension.test.ts
@@ -141,6 +141,25 @@ describe("GeoLibre Chrome extension scanner", () => {
     );
   });
 
+  it("reads the Hugging Face route from its position, not the first matching segment", () => {
+    const found = scan(
+      `
+        <a href="https://huggingface.co/datasets/giswqs/blob/resolve/main/roads.geojson">repo named blob</a>
+        <a href="https://huggingface.co/raw/model/blob/main/dem.tif">owner named raw</a>
+        <a href="https://huggingface.co/datasets/glue/blob/main/grid.pmtiles">legacy repo</a>
+      `,
+      "https://huggingface.co/giswqs",
+    );
+    assert.deepEqual(
+      found.map((dataset) => dataset.url),
+      [
+        "https://huggingface.co/raw/model/resolve/main/dem.tif",
+        "https://huggingface.co/datasets/glue/resolve/main/grid.pmtiles",
+        "https://huggingface.co/datasets/giswqs/blob/resolve/main/roads.geojson",
+      ],
+    );
+  });
+
   it("pairs a Hugging Face style file with its dataset across routes", () => {
     const repo = "https://huggingface.co/datasets/giswqs/opengeos";
     const [found] = scan(


### PR DESCRIPTION
## Summary
- Rewrite every Hugging Face file route (`blob`, `raw`, `blame`, `edit`, `delete`, `commits`) onto `resolve` and drop `?download=true`, so the seven links the Hub renders per file collapse into the single direct URL GeoLibre can open. Covers datasets, models and Spaces on both `huggingface.co` and `hf.co`.
- Take dataset names from the file path on the Hub, where link text is UI chrome ("Download", "History", "308 kB xet") rather than the file name.
- Skip non-file Hub routes entirely, so the repository landing page no longer offers its "Auto-converted to Parquet" tree link as a GeoParquet dataset.

## Test plan
- [x] `node --import tsx --test tests/chrome-extension.test.ts` (three new Hugging Face cases)
- [x] Scanner run inside Chromium against the live pages: 1 dataset on a `blob` file page, 50 on `tree/main/cogs` (was 7 and 100), 0 on the repository landing page
- [x] The resulting deep link renders the COG in the web app
- [x] `pre-commit run --files extensions/geolibre-chrome/scanner.mjs tests/chrome-extension.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recognition and canonicalization of Hugging Face dataset, model, and Space file links.
  * Removes download parameters and fragments from supported file URLs.
  * Derives dataset names from file paths for consistent discovery.
  * Supports pairing dataset files with related style files across Hugging Face routes.

* **Bug Fixes**
  * Excludes non-file, directory, and conversion pages from dataset discovery.
  * Handles repository names containing route-like segments more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->