### PR TITLE
feat(elevation): profile selected line features

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -3777,7 +3777,14 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   stroke-width: 1.5;
 }
 
-/* Hover readout */
+/* Hover readout. Its box must measure exactly one line whether or not it holds
+   text: the chart above it is `flex: 1 1 auto`, so any height the readout gains
+   on hover is taken out of the chart, which retriggers the chart's
+   ResizeObserver, which redraws and clears the readout again — the pointer sees
+   a flickering chart and a value that never settles. Hence an explicit
+   line-height matching min-height (the inherited 1.4 would make a filled line
+   15.4px against a 14px empty box) and nowrap, so a long
+   "distance · elevation" string in a narrow panel cannot wrap to two lines. */
 .elevation-profile-readout {
   margin-top: 6px;
   text-align: center;
@@ -3785,6 +3792,10 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
   font-weight: 500;
   color: var(--ep-text);
   min-height: 14px;
+  line-height: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .elevation-profile-readout:empty {

--- a/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
+++ b/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
@@ -110,6 +110,10 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   private _chartResizeObserver?: ResizeObserver;
   private _chartRenderQueued = false;
   private _styleReadyQueued = false;
+  /** Host size the current chart was drawn at, used to skip no-op redraws. */
+  private _renderedChartSize?: { width: number; height: number };
+  /** Sample index under the pointer, so a redraw can restore the hover marker. */
+  private _hoverIndex: number | null = null;
 
   // Drawing / profiling runtime state (not serialized).
   private _drawing = false;
@@ -195,6 +199,8 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     this._styleReadyQueued = false;
     this._chartResizeObserver?.disconnect();
     this._chartResizeObserver = undefined;
+    this._renderedChartSize = undefined;
+    this._hoverIndex = null;
 
     if (this._resizeHandler) {
       window.removeEventListener("resize", this._resizeHandler);
@@ -774,6 +780,20 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     this._chartRenderQueued = true;
     requestAnimationFrame(() => {
       this._chartRenderQueued = false;
+      // Skip the redraw when the host still measures what the chart was drawn
+      // at. ResizeObserver reports sub-pixel changes, and redrawing rebuilds the
+      // SVG (dropping the hover marker), so an observation that carries no new
+      // pixels must not disturb a pointer that is sitting on the chart.
+      const host = this._chartEl;
+      const last = this._renderedChartSize;
+      if (
+        host &&
+        last &&
+        Math.round(host.clientWidth) === last.width &&
+        Math.round(host.clientHeight) === last.height
+      ) {
+        return;
+      }
       this._renderChart();
     });
   }
@@ -817,6 +837,8 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     if (this._profilePoints.length < 2) {
       host.textContent = "";
       host.style.display = "none"; // hide so it does not reserve empty space
+      this._renderedChartSize = undefined;
+      this._hoverIndex = null;
       return;
     }
 
@@ -829,8 +851,11 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     const fallbackWidth = this._panel
       ? this._panel.clientWidth - 20
       : this._options.panelWidth - 24;
-    const width = Math.max(160, Math.round(host.clientWidth) || fallbackWidth);
-    const height = Math.max(120, Math.round(host.clientHeight) || CHART_HEIGHT);
+    const hostWidth = Math.round(host.clientWidth);
+    const hostHeight = Math.round(host.clientHeight);
+    const width = Math.max(160, hostWidth || fallbackWidth);
+    const height = Math.max(120, hostHeight || CHART_HEIGHT);
+    this._renderedChartSize = { width: hostWidth, height: hostHeight };
     const geometry = buildChartGeometry(this._profilePoints, width, height);
     const system = this._state.unitSystem;
 
@@ -880,12 +905,9 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     svg.append(area, line, maxLabel, minLabel, hoverGroup);
     host.appendChild(svg);
 
-    const onMove = (event: MouseEvent): void => {
-      const rect = svg.getBoundingClientRect();
-      const px = ((event.clientX - rect.left) / rect.width) * width;
-      const index = geometry.indexForX(px);
-      if (index < 0) return;
+    const showHoverAtIndex = (index: number): void => {
       const point = this._profilePoints[index];
+      if (!point) return;
       const x = geometry.xScale(point.distance);
       const y = geometry.yScale(point.elevation);
       hoverGroup.style.display = "";
@@ -898,6 +920,15 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
         this._readoutEl.textContent = `${formatDistance(point.distance, system)} · ${formatElevation(point.elevation, system)}`;
       }
     };
+
+    const onMove = (event: MouseEvent): void => {
+      const rect = svg.getBoundingClientRect();
+      const px = ((event.clientX - rect.left) / rect.width) * width;
+      const index = geometry.indexForX(px);
+      if (index < 0) return;
+      this._hoverIndex = index;
+      showHoverAtIndex(index);
+    };
     const onLeave = (): void => {
       hoverGroup.style.display = "none";
       this._clearHover();
@@ -905,6 +936,15 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     };
     svg.addEventListener("mousemove", onMove);
     svg.addEventListener("mouseleave", onLeave);
+
+    // A resize (or any other redraw) replaces the SVG built above, so re-apply
+    // the marker for the sample the pointer is still on. Without this the
+    // readout blanks until the pointer happens to move again.
+    if (this._hoverIndex !== null && this._hoverIndex < this._profilePoints.length) {
+      showHoverAtIndex(this._hoverIndex);
+    } else {
+      this._hoverIndex = null;
+    }
   }
 
   private _axisLabel(
@@ -923,6 +963,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   }
 
   private _clearHover(): void {
+    this._hoverIndex = null;
     this._setHoverPoint(null);
   }
 

--- a/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
+++ b/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
@@ -2,8 +2,9 @@ import type { IControl, Map as MapLibreMap, MapMouseEvent, GeoJSONSource } from 
 import type { Feature, FeatureCollection, LineString, Point } from "geojson";
 
 import type { LngLat, ProfileStats } from "../elevation/geometry";
-import { resampleLine, computeStats } from "../elevation/geometry";
+import { resampleLine, computeStats, cumulativeDistances } from "../elevation/geometry";
 import { fetchElevations, MAX_POINTS_PER_REQUEST, ElevationFetchError } from "../elevation/client";
+import { selectedProfileLine } from "../elevation/selection";
 import { buildChartGeometry, type ProfilePoint } from "../chart/profileChart";
 import { profileToCsv } from "../export/csv";
 import {
@@ -36,7 +37,12 @@ const HOVER_COLOR = "#ef4444";
 
 const CHART_HEIGHT = 132;
 
-const DEFAULT_OPTIONS: Required<Omit<ElevationProfileControlOptions, "exportTextFile">> = {
+const DEFAULT_OPTIONS: Required<
+  Omit<
+    ElevationProfileControlOptions,
+    "exportTextFile" | "getSelectedFeatures" | "onSelectionChange"
+  >
+> = {
   collapsed: true,
   title: "Elevation Profile",
   panelWidth: 320,
@@ -76,8 +82,15 @@ const pointCollection = (coords: LngLat[]): FeatureCollection<Point> => ({
  * persistence.
  */
 export class ElevationProfileControl implements IControl, DeepLinkConsumer {
-  private _options: Required<Omit<ElevationProfileControlOptions, "exportTextFile">>;
+  private _options: Required<
+    Omit<
+      ElevationProfileControlOptions,
+      "exportTextFile" | "getSelectedFeatures" | "onSelectionChange"
+    >
+  >;
   private _exportTextFile?: ExportTextFile;
+  private _getSelectedFeatures?: ElevationProfileControlOptions["getSelectedFeatures"];
+  private _onSelectionChange?: ElevationProfileControlOptions["onSelectionChange"];
   private _state: ElevationProfileState;
 
   private _map?: MapLibreMap;
@@ -88,6 +101,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   private _statsEl?: HTMLElement;
   private _chartEl?: HTMLElement;
   private _drawButton?: HTMLButtonElement;
+  private _selectedButton?: HTMLButtonElement;
   private _clearButton?: HTMLButtonElement;
   private _unitButton?: HTMLButtonElement;
   private _readoutEl?: HTMLElement;
@@ -104,6 +118,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   private _sampledCoords: LngLat[] = [];
   private _stats: ProfileStats | null = null;
   private _requestToken = 0;
+  private _busy = false;
 
   // Bound handlers retained so they can be detached.
   private _onMapClick = (e: MapMouseEvent): void => this._handleMapClick(e);
@@ -112,13 +127,16 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   private _resizeHandler: (() => void) | null = null;
   private _mapResizeHandler: (() => void) | null = null;
   private _clickOutsideHandler: ((e: MouseEvent) => void) | null = null;
+  private _unsubscribeSelection: (() => void) | null = null;
 
   /**
    * @param options - Optional configuration overrides
    */
   constructor(options?: Partial<ElevationProfileControlOptions>) {
-    const { exportTextFile, ...visual } = options ?? {};
+    const { exportTextFile, getSelectedFeatures, onSelectionChange, ...visual } = options ?? {};
     this._exportTextFile = exportTextFile;
+    this._getSelectedFeatures = getSelectedFeatures;
+    this._onSelectionChange = onSelectionChange;
     this._options = { ...DEFAULT_OPTIONS, ...visual };
     this._options.maxSamples = Math.min(
       MAX_POINTS_PER_REQUEST,
@@ -128,6 +146,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
       collapsed: this._options.collapsed,
       unitSystem: this._options.unitSystem,
       line: null,
+      elevations: null,
     };
   }
 
@@ -141,6 +160,9 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     this._panel = this._createPanel();
     this._mapContainer.appendChild(this._panel);
     this._setupPanelListeners();
+    this._unsubscribeSelection =
+      this._onSelectionChange?.(() => this._syncSelectedButton()) ?? null;
+    this._syncSelectedButton();
 
     if (!this._state.collapsed) {
       this._panel.classList.add("expanded");
@@ -157,7 +179,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
         // the cached stats/chart.
         this._renderLineGeometry(this._state.line);
       } else {
-        void this._profileLine(this._state.line, { fit: false });
+        void this._profileLine(this._state.line, { fit: false }, this._state.elevations);
       }
     }
 
@@ -186,6 +208,8 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
       document.removeEventListener("click", this._clickOutsideHandler);
       this._clickOutsideHandler = null;
     }
+    this._unsubscribeSelection?.();
+    this._unsubscribeSelection = null;
 
     this._panel?.parentNode?.removeChild(this._panel);
     this._container?.parentNode?.removeChild(this._container);
@@ -197,6 +221,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     this._statusEl = undefined;
     this._statsEl = undefined;
     this._chartEl = undefined;
+    this._selectedButton = undefined;
     this._exportEl = undefined;
     this._svgEl = undefined;
   }
@@ -209,6 +234,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
       collapsed: this._state.collapsed,
       unitSystem: this._state.unitSystem,
       line: this._state.line ? this._state.line.map((c) => [...c] as LngLat) : null,
+      elevations: this._state.elevations ? [...this._state.elevations] : null,
     };
   }
 
@@ -219,7 +245,9 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
    * @param newState - Partial state to apply
    */
   setState(newState: Partial<ElevationProfileState>): void {
-    const lineChanged = "line" in newState && newState.line !== this._state.line;
+    const lineChanged =
+      ("line" in newState && newState.line !== this._state.line) ||
+      ("elevations" in newState && newState.elevations !== this._state.elevations);
     this._state = { ...this._state, ...newState };
 
     if (newState.unitSystem) this._syncUnitButton();
@@ -229,7 +257,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
 
     if (lineChanged && this._map) {
       if (this._state.line && this._state.line.length >= 2) {
-        void this._profileLine(this._state.line, { fit: false });
+        void this._profileLine(this._state.line, { fit: false }, this._state.elevations);
       } else {
         this._clearProfile();
       }
@@ -248,7 +276,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   async loadLine(coords: LngLat[]): Promise<void> {
     if (coords.length < 2) return;
     this.expand();
-    await this._profileLine(coords, { fit: true });
+    await this._profileLine(coords, { fit: true }, null);
   }
 
   // --- Panel collapse / expand ------------------------------------------
@@ -350,20 +378,51 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
       this._setStatus("Need at least two points to build a profile.");
       return;
     }
-    void this._profileLine(vertices, { fit: false });
+    void this._profileLine(vertices, { fit: false }, null);
+  }
+
+  private _profileSelection(): void {
+    const selected = selectedProfileLine(this._getSelectedFeatures?.());
+    if (!selected) {
+      this._setStatus("Select a line feature to build its elevation profile.");
+      this._syncSelectedButton();
+      return;
+    }
+    void this._profileLine(selected.coords, { fit: true }, selected.elevations);
   }
 
   // --- Profiling ---------------------------------------------------------
 
-  private async _profileLine(coords: LngLat[], opts: { fit: boolean }): Promise<void> {
+  private async _profileLine(
+    coords: LngLat[],
+    opts: { fit: boolean },
+    embeddedElevations: number[] | null = null,
+  ): Promise<void> {
     if (!this._map) return;
     this._state.line = coords.map((c) => [...c] as LngLat);
+    this._state.elevations =
+      embeddedElevations?.length === coords.length ? [...embeddedElevations] : null;
     this._renderLineGeometry(coords);
     if (opts.fit) this._fitToLine(coords);
 
     const token = ++this._requestToken;
     this._setStatus("Sampling elevation…");
     this._setBusy(true);
+
+    if (this._state.elevations) {
+      const distances = cumulativeDistances(coords);
+      this._sampledCoords = coords.map((coord) => [...coord] as LngLat);
+      this._profilePoints = distances.map((distance, index) => ({
+        distance,
+        elevation: this._state.elevations?.[index] ?? 0,
+      }));
+      this._stats = computeStats(this._state.elevations, distances);
+      this._setStatus("");
+      this._setBusy(false);
+      this._renderProfile();
+      this._syncButtons();
+      return;
+    }
 
     const sampled = resampleLine(coords, this._options.maxSamples);
     try {
@@ -395,6 +454,7 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
   private _clearProfile(): void {
     this._requestToken += 1;
     this._state.line = null;
+    this._state.elevations = null;
     this._drawVertices = [];
     this._profilePoints = [];
     this._sampledCoords = [];
@@ -491,7 +551,15 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     const lineSource = map.getSource(SOURCE_LINE) as GeoJSONSource | undefined;
     const vertexSource = map.getSource(SOURCE_VERTICES) as GeoJSONSource | undefined;
     if (lineSource) lineSource.setData(lineFeature(coords));
-    if (vertexSource) vertexSource.setData(pointCollection(coords));
+    if (vertexSource) {
+      // Dense imported routes such as GPX tracks can contain thousands of
+      // vertices. Drawing a circle at every one obscures the line itself, so a
+      // finished dense route marks only its endpoints. In-progress and typical
+      // hand-drawn lines remain small enough to show every editable vertex.
+      const visibleVertices =
+        !this._drawing && coords.length > 50 ? [coords[0], coords[coords.length - 1]] : coords;
+      vertexSource.setData(pointCollection(visibleVertices));
+    }
   }
 
   /** Render in-progress drawing vertices (line through the clicked points). */
@@ -623,13 +691,20 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     clear.addEventListener("click", () => this._clearProfile());
     this._clearButton = clear;
 
+    const selected = document.createElement("button");
+    selected.type = "button";
+    selected.className = "elevation-profile-button";
+    selected.textContent = "Use selected";
+    selected.addEventListener("click", () => this._profileSelection());
+    this._selectedButton = selected;
+
     const unit = document.createElement("button");
     unit.type = "button";
     unit.className = "elevation-profile-button elevation-profile-unit";
     unit.addEventListener("click", () => this._cycleUnits());
     this._unitButton = unit;
 
-    actions.append(draw, clear, unit);
+    actions.append(draw, selected, clear, unit);
 
     // Status
     const status = document.createElement("div");
@@ -984,10 +1059,22 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     if (this._clearButton) {
       this._clearButton.disabled = !this._state.line && !this._drawing;
     }
+    this._syncSelectedButton();
+  }
+
+  private _syncSelectedButton(): void {
+    if (!this._selectedButton) return;
+    const hasSelectedLine = Boolean(selectedProfileLine(this._getSelectedFeatures?.()));
+    this._selectedButton.disabled = this._busy || this._drawing || !hasSelectedLine;
+    this._selectedButton.title = hasSelectedLine
+      ? "Build a profile from the selected line feature"
+      : "Select a line feature first";
   }
 
   private _setBusy(busy: boolean): void {
+    this._busy = busy;
     if (this._drawButton) this._drawButton.disabled = busy;
+    this._syncSelectedButton();
   }
 
   private _setStatus(message: string): void {

--- a/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
+++ b/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
@@ -2,7 +2,12 @@ import type { IControl, Map as MapLibreMap, MapMouseEvent, GeoJSONSource } from 
 import type { Feature, FeatureCollection, LineString, Point } from "geojson";
 
 import type { LngLat, ProfileStats } from "../elevation/geometry";
-import { resampleLine, computeStats, cumulativeDistances } from "../elevation/geometry";
+import {
+  resampleLine,
+  computeStats,
+  cumulativeDistances,
+  thinIndices,
+} from "../elevation/geometry";
 import { fetchElevations, MAX_POINTS_PER_REQUEST, ElevationFetchError } from "../elevation/client";
 import { selectedProfileLine } from "../elevation/selection";
 import { buildChartGeometry, type ProfilePoint } from "../chart/profileChart";
@@ -36,6 +41,15 @@ const LINE_COLOR = "#f97316";
 const HOVER_COLOR = "#ef4444";
 
 const CHART_HEIGHT = 132;
+
+/**
+ * Most points the chart will plot for a line that carries its own elevations.
+ * The panel is at most a few hundred CSS pixels wide, so this is far more
+ * detail than the SVG can show while keeping the path and the per-mousemove
+ * nearest-sample scan bounded. Lines without embedded elevations are already
+ * capped by `resampleLine(coords, maxSamples)`.
+ */
+const MAX_CHART_POINTS = 2000;
 
 const DEFAULT_OPTIONS: Required<
   Omit<
@@ -420,13 +434,23 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     this._setBusy(true);
 
     if (this._state.elevations) {
+      const elevations = this._state.elevations;
       const distances = cumulativeDistances(coords);
-      this._sampledCoords = coords.map((coord) => [...coord] as LngLat);
-      this._profilePoints = distances.map((distance, index) => ({
-        distance,
-        elevation: this._state.elevations?.[index] ?? 0,
+      // Stats read every recorded vertex, so ascent/descent are not understated
+      // by the thinning below.
+      this._stats = computeStats(elevations, distances);
+      // The chart is capped the way the fetched path is capped by resampleLine.
+      // A multi-day GPX track can carry tens of thousands of trackpoints, and
+      // each one costs an SVG path segment plus a step of the linear
+      // nearest-sample scan that runs on every mousemove — enough to make
+      // hovering janky. The cap sits well above the chart's pixel width, so
+      // nothing visible is lost.
+      const indices = thinIndices(coords.length, MAX_CHART_POINTS);
+      this._sampledCoords = indices.map((index) => [...coords[index]] as LngLat);
+      this._profilePoints = indices.map((index) => ({
+        distance: distances[index],
+        elevation: elevations[index] ?? 0,
       }));
-      this._stats = computeStats(this._state.elevations, distances);
       this._setStatus("");
       this._setBusy(false);
       this._renderProfile();

--- a/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
+++ b/packages/plugins/src/plugins/elevation-profile/core/ElevationProfileControl.ts
@@ -405,6 +405,10 @@ export class ElevationProfileControl implements IControl, DeepLinkConsumer {
     embeddedElevations: number[] | null = null,
   ): Promise<void> {
     if (!this._map) return;
+    // A different line means the remembered hover index no longer refers to
+    // anything the pointer is on, so drop it before the new chart is drawn (a
+    // redraw restores the marker for whatever index is still set).
+    this._clearHover();
     this._state.line = coords.map((c) => [...c] as LngLat);
     this._state.elevations =
       embeddedElevations?.length === coords.length ? [...embeddedElevations] : null;

--- a/packages/plugins/src/plugins/elevation-profile/core/types.ts
+++ b/packages/plugins/src/plugins/elevation-profile/core/types.ts
@@ -1,3 +1,5 @@
+import type { Feature, Geometry } from "geojson";
+
 import type { LngLat } from "../elevation/geometry";
 import type { UnitSystem } from "../elevation/format";
 
@@ -55,6 +57,10 @@ export interface ElevationProfileControlOptions {
    * browser. Falls back to a browser download when not provided.
    */
   exportTextFile?: ExportTextFile;
+  /** Read the features currently selected in the host application. */
+  getSelectedFeatures?: () => Feature<Geometry | null>[];
+  /** Subscribe to host selection changes. Returns a function that unsubscribes. */
+  onSelectionChange?: (callback: () => void) => () => void;
 }
 
 /** Serializable state persisted with a GeoLibre project. */
@@ -65,4 +71,6 @@ export interface ElevationProfileState {
   unitSystem: UnitSystem;
   /** The profiled line as `[lng, lat]` vertices, or `null` when none is drawn. */
   line: LngLat[] | null;
+  /** Embedded elevations aligned with {@link line}, or null for sampled terrain. */
+  elevations: number[] | null;
 }

--- a/packages/plugins/src/plugins/elevation-profile/elevation/geometry.ts
+++ b/packages/plugins/src/plugins/elevation-profile/elevation/geometry.ts
@@ -115,6 +115,32 @@ export function resampleLine(coords: LngLat[], maxPoints: number): ResampledLine
   return { coords: sampledCoords, distances: sampledDistances };
 }
 
+/**
+ * Pick at most `maxPoints` evenly spaced indices out of `count`, always keeping
+ * the first and last.
+ *
+ * Used to thin a line that already carries its own elevations (a GPX track, for
+ * example) down to a drawable number of chart points. Unlike
+ * {@link resampleLine} this selects original vertices rather than interpolating
+ * between them, so the plotted elevations stay the recorded ones.
+ *
+ * @param count - Number of available samples
+ * @param maxPoints - Maximum number of indices to return (coerced to at least 2)
+ * @returns Ascending indices into the source array; all of them when
+ *   `count <= maxPoints`
+ */
+export function thinIndices(count: number, maxPoints: number): number[] {
+  if (count <= 0) return [];
+  const target = Math.max(2, Math.floor(maxPoints));
+  if (count <= target) return Array.from({ length: count }, (_, index) => index);
+
+  const indices: number[] = [];
+  for (let i = 0; i < target; i += 1) {
+    indices.push(Math.round((i * (count - 1)) / (target - 1)));
+  }
+  return indices;
+}
+
 /** Summary statistics for an elevation profile. */
 export interface ProfileStats {
   /** Lowest sampled elevation in meters. */

--- a/packages/plugins/src/plugins/elevation-profile/elevation/selection.ts
+++ b/packages/plugins/src/plugins/elevation-profile/elevation/selection.ts
@@ -49,7 +49,8 @@ export function selectedProfileLine(
     if (coords.length >= 2) {
       return {
         coords,
-        elevations: hasCompleteElevations && elevations.length === coords.length ? elevations : null,
+        elevations:
+          hasCompleteElevations && elevations.length === coords.length ? elevations : null,
       };
     }
   }

--- a/packages/plugins/src/plugins/elevation-profile/elevation/selection.ts
+++ b/packages/plugins/src/plugins/elevation-profile/elevation/selection.ts
@@ -16,8 +16,15 @@ export interface SelectedProfileLine {
  * LineString and MultiLineString geometries are supported. Multi-part lines are
  * concatenated in their source order, matching how GeoLibre's route tools treat
  * them. Embedded elevations are returned only when every retained vertex has a
- * finite Z value. This lets GPX tracks use their recorded `<ele>` values while
- * ordinary two-dimensional lines fall back to the elevation service.
+ * finite Z value and at least one of them is non-zero. This lets GPX tracks use
+ * their recorded `<ele>` values while ordinary two-dimensional lines fall back
+ * to the elevation service.
+ *
+ * The all-zero exclusion matters because many GPX/GeoJSON producers write `0`
+ * as a placeholder Z instead of omitting the third ordinate, so a genuinely 2D
+ * line arrives as `[x, y, 0]` vertices. Charting those would draw a flat 0 m
+ * profile instead of the real terrain. `geojsonHasZCoordinates` in
+ * `@geolibre/core` rejects all-zero Z for the same reason.
  *
  * @param features - The features currently selected in GeoLibre.
  * @returns The first usable selected line, or null when none is selected.
@@ -33,6 +40,7 @@ export function selectedProfileLine(
     const coords: LngLat[] = [];
     const elevations: number[] = [];
     let hasCompleteElevations = true;
+    let hasNonZeroElevation = false;
     for (const position of positions) {
       const longitude = position[0];
       const latitude = position[1];
@@ -41,6 +49,7 @@ export function selectedProfileLine(
       const elevation = position[2];
       if (typeof elevation === "number" && Number.isFinite(elevation)) {
         elevations.push(elevation);
+        if (elevation !== 0) hasNonZeroElevation = true;
       } else {
         hasCompleteElevations = false;
       }
@@ -50,7 +59,9 @@ export function selectedProfileLine(
       return {
         coords,
         elevations:
-          hasCompleteElevations && elevations.length === coords.length ? elevations : null,
+          hasCompleteElevations && hasNonZeroElevation && elevations.length === coords.length
+            ? elevations
+            : null,
       };
     }
   }

--- a/packages/plugins/src/plugins/elevation-profile/elevation/selection.ts
+++ b/packages/plugins/src/plugins/elevation-profile/elevation/selection.ts
@@ -1,0 +1,63 @@
+import type { Feature, Geometry, Position } from "geojson";
+
+import type { LngLat } from "./geometry";
+
+/** A selected line prepared for elevation profiling. */
+export interface SelectedProfileLine {
+  /** Two-dimensional vertices used for distance calculations and map rendering. */
+  coords: LngLat[];
+  /** Embedded Z values in meters, or null when any vertex has no usable Z value. */
+  elevations: number[] | null;
+}
+
+/**
+ * Find the first selected line feature and split its positions into XY and Z.
+ *
+ * LineString and MultiLineString geometries are supported. Multi-part lines are
+ * concatenated in their source order, matching how GeoLibre's route tools treat
+ * them. Embedded elevations are returned only when every retained vertex has a
+ * finite Z value. This lets GPX tracks use their recorded `<ele>` values while
+ * ordinary two-dimensional lines fall back to the elevation service.
+ *
+ * @param features - The features currently selected in GeoLibre.
+ * @returns The first usable selected line, or null when none is selected.
+ */
+export function selectedProfileLine(
+  features: Feature<Geometry | null>[] | null | undefined,
+): SelectedProfileLine | null {
+  if (!features) return null;
+  for (const feature of features) {
+    const positions = linePositions(feature.geometry);
+    if (positions.length < 2) continue;
+
+    const coords: LngLat[] = [];
+    const elevations: number[] = [];
+    let hasCompleteElevations = true;
+    for (const position of positions) {
+      const longitude = position[0];
+      const latitude = position[1];
+      if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) continue;
+      coords.push([longitude, latitude]);
+      const elevation = position[2];
+      if (typeof elevation === "number" && Number.isFinite(elevation)) {
+        elevations.push(elevation);
+      } else {
+        hasCompleteElevations = false;
+      }
+    }
+
+    if (coords.length >= 2) {
+      return {
+        coords,
+        elevations: hasCompleteElevations && elevations.length === coords.length ? elevations : null,
+      };
+    }
+  }
+  return null;
+}
+
+function linePositions(geometry: Geometry | null | undefined): Position[] {
+  if (geometry?.type === "LineString") return geometry.coordinates;
+  if (geometry?.type === "MultiLineString") return geometry.coordinates.flat();
+  return [];
+}

--- a/packages/plugins/src/plugins/elevation-profile/index.ts
+++ b/packages/plugins/src/plugins/elevation-profile/index.ts
@@ -39,6 +39,10 @@ function createControl(app: GeoLibreAppAPI): ElevationProfileControl {
     exportTextFile: app.exportTextFile
       ? (filename, content, options) => app.exportTextFile?.(filename, content, options)
       : undefined,
+    getSelectedFeatures: app.getSelectedFeatures,
+    onSelectionChange: app.onSelectionChange
+      ? (callback) => app.onSelectionChange?.(() => callback()) ?? (() => undefined)
+      : undefined,
   });
   if (pendingState) next.setState(pendingState);
   return next;
@@ -71,6 +75,16 @@ function isPluginState(value: unknown): value is Partial<ElevationProfileState> 
     return false;
   }
   if ("line" in candidate && candidate.line !== null && !isLngLatArray(candidate.line)) {
+    return false;
+  }
+  if (
+    "elevations" in candidate &&
+    candidate.elevations !== null &&
+    (!Array.isArray(candidate.elevations) ||
+      !candidate.elevations.every(
+        (elevation) => typeof elevation === "number" && Number.isFinite(elevation),
+      ))
+  ) {
     return false;
   }
   return true;
@@ -137,6 +151,7 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
         collapsed: true,
         unitSystem: "metric",
         line: null,
+        elevations: null,
       };
       pendingState = cleared;
       control?.setState(cleared);

--- a/packages/plugins/src/plugins/elevation-profile/index.ts
+++ b/packages/plugins/src/plugins/elevation-profile/index.ts
@@ -100,6 +100,17 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
   version: "0.1.0",
   urlParameterNames: [ELEVATION_LINE_PARAM],
 
+  // The panel's `collapsed` flag round-trips through getProjectState, so the
+  // saved project decides whether it opens. Without this exemption the host's
+  // restore-time collapse sweep (`collapseRestoredPanel` in plugin-manager.ts)
+  // closes the panel on every project load — it defers its collapse twice
+  // precisely to land after a plugin's own `setTimeout(0)` expand, so the
+  // `openPanel` logic in `activate` below would always lose. Worse, `collapse()`
+  // mutates the control, so the next save would write `collapsed: true` back and
+  // the user's preference would be lost for good. maplibre-time-slider carries
+  // the same flag for the same reason.
+  restoresPanelCollapseState: true,
+
   activate(app) {
     // Whether the panel should end up open. Only a project file can ask for it
     // closed: `restoreProjectState` calls applyProjectState immediately before

--- a/packages/plugins/src/plugins/elevation-profile/index.ts
+++ b/packages/plugins/src/plugins/elevation-profile/index.ts
@@ -118,8 +118,16 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
     // still propagating, and the control's click-outside handler (registered
     // during onAdd) would see it land outside the panel and collapse it again.
     // The other panel plugins (Street View, EnviroAtlas, National Map…) defer
-    // their expand for the same reason.
-    if (openPanel) setTimeout(() => control?.expand(), 0);
+    // their expand for the same reason. Pin the expand to the control this call
+    // activated: a deactivate (or a deactivate plus a project restore that asks
+    // for a collapsed panel) landing inside that tick would otherwise open the
+    // replacement control against its own restored state.
+    const activated = control;
+    if (openPanel) {
+      setTimeout(() => {
+        if (control === activated) activated.expand();
+      }, 0);
+    }
   },
 
   // Deep link: GeoLibre auto-activates the plugin for a URL like
@@ -173,6 +181,10 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
       };
       pendingState = cleared;
       control?.setState(cleared);
+      // setState only toggles the expanded class; expand() also re-anchors the
+      // panel to its control button, which a panel that was collapsed until now
+      // has never had done.
+      control?.expand();
       return;
     }
     pendingState = state as Partial<ElevationProfileState> & {

--- a/packages/plugins/src/plugins/elevation-profile/index.ts
+++ b/packages/plugins/src/plugins/elevation-profile/index.ts
@@ -31,7 +31,11 @@ let pendingState: Partial<ElevationProfileState> | null = null;
 
 function createControl(app: GeoLibreAppAPI): ElevationProfileControl {
   const next = new ElevationProfileControl({
-    collapsed: pendingState?.collapsed ?? true,
+    // The panel always mounts closed and `activate` opens it a tick later (see
+    // there). Mounting it already expanded would show it for a frame before the
+    // control's own click-outside handler saw the very click that enabled the
+    // plugin and closed it again.
+    collapsed: true,
     unitSystem: pendingState?.unitSystem ?? "metric",
     // Bind the host's file save so CSV/SVG export uses Tauri's native dialog on
     // the desktop (and a browser download on the web); the control falls back
@@ -44,7 +48,7 @@ function createControl(app: GeoLibreAppAPI): ElevationProfileControl {
       ? (callback) => app.onSelectionChange?.(() => callback()) ?? (() => undefined)
       : undefined,
   });
-  if (pendingState) next.setState(pendingState);
+  if (pendingState) next.setState({ ...pendingState, collapsed: true });
   return next;
 }
 
@@ -97,12 +101,25 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
   urlParameterNames: [ELEVATION_LINE_PARAM],
 
   activate(app) {
+    // Whether the panel should end up open. Only a project file can ask for it
+    // closed: `restoreProjectState` calls applyProjectState immediately before
+    // activate, so a saved `collapsed: true` is already in pendingState here.
+    // Every other route in (a first activation, a session deactivate, a New
+    // Project reset) leaves it open, so enabling the plugin shows the panel
+    // instead of just the collapsed mountain button.
+    const openPanel = !(pendingState?.collapsed ?? false);
     control = control ?? createControl(app);
     const added = app.addMapControl(control, position);
     if (!added) {
       control = null;
       return false;
     }
+    // Deferred a tick: the click that chose "Activate" in the Plugins menu is
+    // still propagating, and the control's click-outside handler (registered
+    // during onAdd) would see it land outside the panel and collapse it again.
+    // The other panel plugins (Street View, EnviroAtlas, National Map…) defer
+    // their expand for the same reason.
+    if (openPanel) setTimeout(() => control?.expand(), 0);
   },
 
   // Deep link: GeoLibre auto-activates the plugin for a URL like
@@ -113,8 +130,9 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
 
   deactivate(app) {
     if (!control) return;
-    // Capture the drawn line / unit / collapse so re-activating restores it.
-    pendingState = control.getState();
+    // Capture the drawn line / unit so re-activating restores it, but not the
+    // collapse: turning the plugin back on is a request to see the panel.
+    pendingState = { ...control.getState(), collapsed: false };
     app.removeMapControl(control);
     control = null;
   },
@@ -148,7 +166,7 @@ export const maplibreElevationProfilePlugin: GeoLibrePlugin = {
       // the previous project's profile. Mirrors maplibre-swipe /
       // maplibre-graticule, whose normalizers reset to defaults on undefined.
       const cleared: ElevationProfileState = {
-        collapsed: true,
+        collapsed: false,
         unitSystem: "metric",
         line: null,
         elevations: null,

--- a/tests/elevation-profile.test.ts
+++ b/tests/elevation-profile.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../packages/plugins/src/plugins/elevation-profile/elevation/client";
 import { profileToCsv } from "../packages/plugins/src/plugins/elevation-profile/export/csv";
 import { buildChartGeometry } from "../packages/plugins/src/plugins/elevation-profile/chart/profileChart";
+import { selectedProfileLine } from "../packages/plugins/src/plugins/elevation-profile/elevation/selection";
 import {
   encodeLine,
   parseLine,
@@ -103,6 +104,91 @@ describe("elevation-profile geometry", () => {
       loss: 0,
       totalDistance: 0,
     });
+  });
+});
+
+describe("elevation-profile selected lines", () => {
+  it("uses embedded elevations from a selected GPX-style LineString", () => {
+    const selected = selectedProfileLine([
+      {
+        type: "Feature",
+        properties: { gpx_kind: "track" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [4.87, 45.82, 267.8],
+            [4.88, 45.83, 274.2],
+          ],
+        },
+      },
+    ]);
+    assert.deepEqual(selected, {
+      coords: [
+        [4.87, 45.82],
+        [4.88, 45.83],
+      ],
+      elevations: [267.8, 274.2],
+    });
+  });
+
+  it("falls back to sampled elevations for a two-dimensional line", () => {
+    const selected = selectedProfileLine([
+      {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [1, 1],
+          ],
+        },
+      },
+    ]);
+    assert.deepEqual(selected, {
+      coords: [
+        [0, 0],
+        [1, 1],
+      ],
+      elevations: null,
+    });
+  });
+
+  it("skips non-line selections and concatenates a selected multi-part line", () => {
+    const selected = selectedProfileLine([
+      {
+        type: "Feature",
+        properties: {},
+        geometry: { type: "Point", coordinates: [0, 0] },
+      },
+      {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "MultiLineString",
+          coordinates: [
+            [
+              [1, 1, 10],
+              [2, 2, 20],
+            ],
+            [
+              [2, 2, 20],
+              [3, 3, 30],
+            ],
+          ],
+        },
+      },
+    ]);
+    assert.deepEqual(selected, {
+      coords: [
+        [1, 1],
+        [2, 2],
+        [2, 2],
+        [3, 3],
+      ],
+      elevations: [10, 20, 20, 30],
+    });
+    assert.equal(selectedProfileLine(undefined), null);
   });
 });
 

--- a/tests/elevation-profile.test.ts
+++ b/tests/elevation-profile.test.ts
@@ -6,6 +6,7 @@ import {
   cumulativeDistances,
   resampleLine,
   computeStats,
+  thinIndices,
   type LngLat,
 } from "../packages/plugins/src/plugins/elevation-profile/elevation/geometry";
 import {
@@ -68,6 +69,24 @@ describe("elevation-profile geometry", () => {
     assert.deepEqual(sampled[4], [0, 2]);
     assert.equal(distances[0], 0);
     assert.ok(distances[4] > distances[3]);
+  });
+
+  it("thinIndices caps a dense line at the target, keeping both endpoints", () => {
+    const indices = thinIndices(10_000, 2000);
+    assert.equal(indices.length, 2000);
+    assert.equal(indices[0], 0);
+    assert.equal(indices[indices.length - 1], 9999);
+    // Strictly ascending, so the thinned profile stays in along-line order.
+    for (let i = 1; i < indices.length; i += 1) {
+      assert.ok(indices[i] > indices[i - 1], `index ${i} is not ascending`);
+    }
+  });
+
+  it("thinIndices returns every index when the line is already short enough", () => {
+    assert.deepEqual(thinIndices(4, 2000), [0, 1, 2, 3]);
+    assert.deepEqual(thinIndices(0, 2000), []);
+    // A target below two still yields the two endpoints.
+    assert.deepEqual(thinIndices(5, 1), [0, 4]);
   });
 
   it("resampleLine handles degenerate (single / identical-vertex) lines", () => {
@@ -189,6 +208,48 @@ describe("elevation-profile selected lines", () => {
       elevations: [10, 20, 20, 30],
     });
     assert.equal(selectedProfileLine(undefined), null);
+  });
+
+  it("treats an all-zero Z as placeholder padding and falls back to the service", () => {
+    // Many GPX/GeoJSON producers write 0 rather than omitting the third
+    // ordinate, so [x, y, 0] vertices describe a 2D line, not a sea-level one.
+    const selected = selectedProfileLine([
+      {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0, 0],
+            [1, 1, 0],
+            [2, 2, 0],
+          ],
+        },
+      },
+    ]);
+    assert.deepEqual(selected?.coords, [
+      [0, 0],
+      [1, 1],
+      [2, 2],
+    ]);
+    assert.equal(selected?.elevations, null);
+  });
+
+  it("keeps embedded elevations when only some vertices sit at zero", () => {
+    const selected = selectedProfileLine([
+      {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0, 0],
+            [1, 1, 12],
+          ],
+        },
+      },
+    ]);
+    assert.deepEqual(selected?.elevations, [0, 12]);
   });
 });
 


### PR DESCRIPTION
## Summary

- add a Use selected action to Elevation Profile for LineString and MultiLineString features
- use embedded Z values from GPX tracks when available, with the existing elevation service fallback for 2D lines
- persist embedded elevations with the project and keep dense imported routes readable

## Testing

- loaded the GPX track from discussion 1952 and profiled the selected 1,199-point segment
- verified the profile in light and dark themes
- `node --import tsx --test tests/elevation-profile.test.ts`
- `npm run build`
- `pre-commit run --all-files`

Related to https://github.com/opengeos/GeoLibre/discussions/1952

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create elevation profiles from selected line features.
  * Use the “Use selected” action with clear availability and loading states.
  * Reuse embedded elevation data when available.
  * Support multi-part lines and preserve valid vertex elevation data.
  * Restore profile data and panel state when reopening the tool.

* **Bug Fixes**
  * Improved handling of invalid or incomplete selected geometries.
  * Optimized dense completed routes while preserving endpoints.
  * Preserved chart hover information during redraws and improved hover text display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->