### PR TITLE
fix(style): preserve Mapbox color classes

### DIFF
--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -351,9 +351,14 @@ function isLegacyLayerFilter(filter: unknown[]): boolean {
     return child !== null && isLegacyLayerFilter(child);
   }
   if (operator === "!has") return true;
+  if (operator === "!in") return true;
+  if (operator === "in") {
+    // Modern `in` is exactly ["in", needle, haystack]. An expression-array
+    // haystack is unambiguously modern even when the needle is a string.
+    return filter.length !== 3 || (typeof filter[1] === "string" && !Array.isArray(filter[2]));
+  }
   return (
-    ["==", "!=", ">", ">=", "<", "<=", "in", "!in"].includes(String(operator)) &&
-    typeof filter[1] === "string"
+    ["==", "!=", ">", ">=", "<", "<="].includes(String(operator)) && typeof filter[1] === "string"
   );
 }
 

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -56,6 +56,7 @@ export interface MapboxStyleImportResult {
 
 /** A minimal structural view of a Mapbox GL layer, so tests need no full spec. */
 interface RawStyleLayer {
+  id?: unknown;
   type?: unknown;
   paint?: Record<string, unknown> | null;
   layout?: Record<string, unknown> | null;
@@ -151,7 +152,7 @@ function parseColorValue(value: unknown, warnings: string[]): ParsedColor {
 
   // Unwrap the simplestyle per-feature override the exporter wraps colors in
   // (`["coalesce", ["get", key], base]`) and read the base renderer.
-  if (array[0] === "coalesce" && array.length === 3) {
+  if (array[0] === "coalesce" && array.length === 3 && getProperty(array[1]) !== null) {
     return parseColorValue(array[2], warnings);
   }
 
@@ -326,6 +327,46 @@ function parseCase(array: unknown[]): ParsedColor {
 }
 
 /**
+ * Combine a stack of filtered, flat-color Mapbox layers into GeoLibre rules.
+ * Mapbox draws later layers over earlier ones, so reverse the stack to preserve
+ * that precedence in GeoLibre's first-match-wins rule evaluator. An off else
+ * rule keeps features outside every source-layer filter hidden.
+ */
+function parseStackedLayerColors(
+  layers: RawStyleLayer[],
+  paintProperty: string,
+): ParsedColor | null {
+  if (layers.length < 2) return null;
+  const entries = layers.map((layer) => ({
+    id: asString(layer.id),
+    filter: asArray(layer.filter),
+    color: asString((layer.paint ?? {})[paintProperty]),
+    minZoom: clampZoom(layer.minzoom),
+    maxZoom: clampZoom(layer.maxzoom),
+  }));
+  if (entries.some((entry) => !entry.filter || entry.color === null)) return null;
+
+  const rules: NonNullable<LayerStyle["vectorRules"]> = entries.reverse().map((entry, index) => ({
+    id: `import-layer-${index}`,
+    label: entry.id ?? "",
+    filter: JSON.stringify(entry.filter),
+    color: entry.color!,
+    isElse: false,
+    ...(entry.minZoom === null ? {} : { minZoom: entry.minZoom }),
+    ...(entry.maxZoom === null ? {} : { maxZoom: entry.maxZoom }),
+  }));
+  rules.push({
+    id: "import-layer-else",
+    label: "",
+    filter: "",
+    color: DEFAULT_LAYER_STYLE.fillColor,
+    isElse: true,
+    enabled: false,
+  });
+  return { mode: "rule-based", rules };
+}
+
+/**
  * Apply a parsed color renderer to the style patch. `single`/`expression` leave
  * the flat fallback in `fillColor`; the attribute-driven modes carry the
  * property, stops, or rules across.
@@ -347,7 +388,7 @@ function parseStrokeColor(value: unknown): string | null {
   // Unwrap the simplestyle per-feature override the exporter wraps line/outline
   // colors in (`["coalesce", ["get","stroke"], base]`) when simpleStyleEnabled,
   // matching parseColorValue, so the flat stroke is still recovered.
-  if (array && array[0] === "coalesce" && array.length === 3) {
+  if (array && array[0] === "coalesce" && array.length === 3 && getProperty(array[1]) !== null) {
     return parseStrokeColor(array[2]);
   }
   const flat = asString(value);
@@ -635,12 +676,23 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   // stroke/radius. Track whether the color mode has been claimed.
   let colorClaimed = false;
 
-  // Only the first render layer of each type feeds the single GeoLibre style, so
-  // warn when a style stacks several (a sub-styled fill, multiple label configs)
-  // rather than dropping the extras silently.
+  const stackedFill = parseStackedLayerColors(byType("fill"), "fill-color");
+  const stackedLine = parseStackedLayerColors(byType("line"), "line-color");
+  const stackedCircle = parseStackedLayerColors(byType("circle"), "circle-color");
+
+  // Filtered flat-color stacks can be represented exactly as rules. Other
+  // same-type stacks still contribute only their first layer, so flag the loss.
   for (const type of ["fill", "fill-extrusion", "line", "circle", "symbol"]) {
-    if (byType(type).length > 1) {
+    const recoveredAsRules =
+      (type === "fill" && stackedFill !== null) ||
+      (type === "line" && stackedLine !== null) ||
+      (type === "circle" && stackedCircle !== null);
+    if (byType(type).length > 1 && !recoveredAsRules) {
       warnings.push(`The style has multiple ${type} layers; only the first was imported.`);
+    } else if (byType(type).length > 1) {
+      warnings.push(
+        `The style's multiple ${type} layers were combined as rules; paint properties other than color come from the first layer.`,
+      );
     }
   }
 
@@ -675,10 +727,10 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     if (base !== null) patch.extrusionBase = base;
     applyZoomRange(extrusion, patch);
   } else if (fill) {
-    matchedLayerCount += 1;
+    matchedLayerCount += stackedFill ? byType("fill").length : 1;
     patch.extrusionEnabled = false;
     const paint = fill.paint ?? {};
-    const fillColor = parseColorValue(paint["fill-color"], warnings);
+    const fillColor = stackedFill ?? parseColorValue(paint["fill-color"], warnings);
     applyColorRenderer(fillColor, patch);
     // Only claim the shared renderer when fill-color actually yielded one, so a
     // fill layer with a missing/unparseable color does not block a later
@@ -697,7 +749,7 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   }
 
   if (line) {
-    matchedLayerCount += 1;
+    matchedLayerCount += stackedLine ? byType("line").length : 1;
     const paint = line.paint ?? {};
     const stroke = parseStrokeColor(paint["line-color"]);
     if (stroke) patch.strokeColor = stroke;
@@ -707,7 +759,7 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     // point+line export's circle claim the renderer keeps fillColor correct; a
     // line-only layer still claims here (its fillColor is not rendered anyway).
     if (!colorClaimed && !circle) {
-      const color = parseColorValue(paint["line-color"], warnings);
+      const color = stackedLine ?? parseColorValue(paint["line-color"], warnings);
       if (color.mode && color.mode !== "single") {
         // Take the renderer (mode/property/stops/rules), but not the fallback
         // color: line-color's baked fallback is strokeColor (already recovered
@@ -723,11 +775,11 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   }
 
   if (circle) {
-    matchedLayerCount += 1;
+    matchedLayerCount += stackedCircle ? byType("circle").length : 1;
     patch.pointRenderer = "single";
     const paint = circle.paint ?? {};
     if (!colorClaimed) {
-      applyColorRenderer(parseColorValue(paint["circle-color"], warnings), patch);
+      applyColorRenderer(stackedCircle ?? parseColorValue(paint["circle-color"], warnings), patch);
       colorClaimed = true;
     }
     const radius = paint["circle-radius"];

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -346,6 +346,7 @@ function isLegacyLayerFilter(filter: unknown[]): boolean {
       return array !== null && isLegacyLayerFilter(array);
     });
   }
+  if (operator === "!has") return true;
   return (
     ["==", "!=", ">", ">=", "<", "<=", "in", "!in"].includes(String(operator)) &&
     typeof filter[1] === "string"

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -346,6 +346,10 @@ function isLegacyLayerFilter(filter: unknown[]): boolean {
       return array !== null && isLegacyLayerFilter(array);
     });
   }
+  if (operator === "!") {
+    const child = asArray(filter[1]);
+    return child !== null && isLegacyLayerFilter(child);
+  }
   if (operator === "!has") return true;
   return (
     ["==", "!=", ">", ">=", "<", "<=", "in", "!in"].includes(String(operator)) &&
@@ -898,7 +902,7 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     if (byType(type).length < 2) continue;
     if (appliedStackTypes.has(type)) {
       warnings.push(
-        `The style's multiple ${type} layers were combined as rules; paint properties other than color come from the first layer.`,
+        `The style's multiple ${type} layers were combined as rules; paint properties other than color come from the bottom-most layer.`,
       );
     } else {
       warnings.push(`The style has multiple ${type} layers; only the first was imported.`);

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -334,6 +334,25 @@ function parseCase(array: unknown[]): ParsedColor {
 }
 
 /**
+ * Whether a top-level layer filter uses the legacy property-name syntax, such
+ * as `["==", "class", "park"]`. GeoLibre rules are MapLibre expressions, where
+ * that property must instead be `["get", "class"]`.
+ */
+function isLegacyLayerFilter(filter: unknown[]): boolean {
+  const operator = filter[0];
+  if (operator === "all" || operator === "any" || operator === "none") {
+    return filter.slice(1).some((child) => {
+      const array = asArray(child);
+      return array !== null && isLegacyLayerFilter(array);
+    });
+  }
+  return (
+    ["==", "!=", ">", ">=", "<", "<=", "in", "!in"].includes(String(operator)) &&
+    typeof filter[1] === "string"
+  );
+}
+
+/**
  * Combine a stack of filtered, flat-color Mapbox layers into GeoLibre rules.
  * Mapbox draws later layers over earlier ones, so reverse the stack to preserve
  * that precedence in GeoLibre's first-match-wins rule evaluator. An off else
@@ -351,7 +370,13 @@ function parseStackedLayerColors(
     minZoom: clampZoom(layer.minzoom),
     maxZoom: clampZoom(layer.maxzoom),
   }));
-  if (entries.some((entry) => !entry.filter || entry.color === null)) return null;
+  if (
+    entries.some(
+      (entry) => !entry.filter || isLegacyLayerFilter(entry.filter) || entry.color === null,
+    )
+  ) {
+    return null;
+  }
 
   const rules: NonNullable<LayerStyle["vectorRules"]> = entries.reverse().map((entry, index) => ({
     id: `import-layer-${index}`,

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -340,7 +340,9 @@ function parseCase(array: unknown[]): ParsedColor {
  */
 function isLegacyLayerFilter(filter: unknown[]): boolean {
   const operator = filter[0];
-  if (operator === "all" || operator === "any" || operator === "none") {
+  // `none` has no expression counterpart, so it is legacy whatever it wraps.
+  if (operator === "none") return true;
+  if (operator === "all" || operator === "any") {
     return filter.slice(1).some((child) => {
       const array = asArray(child);
       return array !== null && isLegacyLayerFilter(array);

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -588,6 +588,23 @@ function applyZoomRange(layer: RawStyleLayer, patch: Partial<Omit<LayerStyle, "l
   if (max !== null) patch.maxZoom = max;
 }
 
+/** Keep the outer layer window wide enough for every recovered stacked rule. */
+function applyStackedZoomRange(
+  layers: RawStyleLayer[],
+  patch: Partial<Omit<LayerStyle, "labels">>,
+): void {
+  const ranges = layers.map((layer) => {
+    const rawMin = clampZoom(layer.minzoom);
+    const rawMax = clampZoom(layer.maxzoom);
+    if (rawMin !== null && rawMax !== null) {
+      return { min: Math.min(rawMin, rawMax), max: Math.max(rawMin, rawMax) };
+    }
+    return { min: rawMin ?? MIN_LAYER_ZOOM, max: rawMax ?? MAX_LAYER_ZOOM };
+  });
+  patch.minZoom = Math.min(...ranges.map((range) => range.min));
+  patch.maxZoom = Math.max(...ranges.map((range) => range.max));
+}
+
 /** Build the label patch from a `symbol` layer's layout/paint. */
 function parseLabelLayer(layer: RawStyleLayer, warnings: string[]): Partial<LabelStyle> {
   const layout = layer.layout ?? {};
@@ -768,7 +785,8 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     }
     const outline = parseStrokeColor(paint["fill-outline-color"]);
     if (outline) patch.strokeColor = outline;
-    applyZoomRange(fill, patch);
+    if (stackedFill) applyStackedZoomRange(byType("fill"), patch);
+    else applyZoomRange(fill, patch);
   }
 
   if (line) {
@@ -798,7 +816,8 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     if (paint["line-width"] !== undefined) {
       parseLineWidth(paint["line-width"], patch, warnings);
     }
-    applyZoomRange(line, patch);
+    if (appliedStackTypes.has("line")) applyStackedZoomRange(byType("line"), patch);
+    else applyZoomRange(line, patch);
   }
 
   if (circle) {
@@ -845,7 +864,8 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     } else {
       warnUnreadableNumber(paint["circle-stroke-width"], "point stroke width", warnings);
     }
-    applyZoomRange(circle, patch);
+    if (appliedStackTypes.has("circle")) applyStackedZoomRange(byType("circle"), patch);
+    else applyZoomRange(circle, patch);
   }
 
   if (heatmap) {

--- a/packages/map/src/mapbox-style-import.ts
+++ b/packages/map/src/mapbox-style-import.ts
@@ -108,6 +108,13 @@ function getProperty(node: unknown): string | null {
   return asString(array[1]);
 }
 
+/** Match a feature-property `get`, excluding the 3-argument object lookup. */
+function getFeatureProperty(node: unknown): string | null {
+  const array = asArray(node);
+  if (!array || array.length !== 2) return null;
+  return getProperty(array);
+}
+
 /**
  * Match the field text-field / categorized input shapes the exporter emits,
  * returning the underlying property name:
@@ -152,7 +159,7 @@ function parseColorValue(value: unknown, warnings: string[]): ParsedColor {
 
   // Unwrap the simplestyle per-feature override the exporter wraps colors in
   // (`["coalesce", ["get", key], base]`) and read the base renderer.
-  if (array[0] === "coalesce" && array.length === 3 && getProperty(array[1]) !== null) {
+  if (array[0] === "coalesce" && array.length === 3 && getFeatureProperty(array[1]) !== null) {
     return parseColorValue(array[2], warnings);
   }
 
@@ -388,7 +395,12 @@ function parseStrokeColor(value: unknown): string | null {
   // Unwrap the simplestyle per-feature override the exporter wraps line/outline
   // colors in (`["coalesce", ["get","stroke"], base]`) when simpleStyleEnabled,
   // matching parseColorValue, so the flat stroke is still recovered.
-  if (array && array[0] === "coalesce" && array.length === 3 && getProperty(array[1]) !== null) {
+  if (
+    array &&
+    array[0] === "coalesce" &&
+    array.length === 3 &&
+    getFeatureProperty(array[1]) !== null
+  ) {
     return parseStrokeColor(array[2]);
   }
   const flat = asString(value);
@@ -679,22 +691,7 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   const stackedFill = parseStackedLayerColors(byType("fill"), "fill-color");
   const stackedLine = parseStackedLayerColors(byType("line"), "line-color");
   const stackedCircle = parseStackedLayerColors(byType("circle"), "circle-color");
-
-  // Filtered flat-color stacks can be represented exactly as rules. Other
-  // same-type stacks still contribute only their first layer, so flag the loss.
-  for (const type of ["fill", "fill-extrusion", "line", "circle", "symbol"]) {
-    const recoveredAsRules =
-      (type === "fill" && stackedFill !== null) ||
-      (type === "line" && stackedLine !== null) ||
-      (type === "circle" && stackedCircle !== null);
-    if (byType(type).length > 1 && !recoveredAsRules) {
-      warnings.push(`The style has multiple ${type} layers; only the first was imported.`);
-    } else if (byType(type).length > 1) {
-      warnings.push(
-        `The style's multiple ${type} layers were combined as rules; paint properties other than color come from the first layer.`,
-      );
-    }
-  }
+  const appliedStackTypes = new Set<string>();
 
   const [fill] = byType("fill");
   const [extrusion] = byType("fill-extrusion");
@@ -728,6 +725,7 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     applyZoomRange(extrusion, patch);
   } else if (fill) {
     matchedLayerCount += stackedFill ? byType("fill").length : 1;
+    if (stackedFill) appliedStackTypes.add("fill");
     patch.extrusionEnabled = false;
     const paint = fill.paint ?? {};
     const fillColor = stackedFill ?? parseColorValue(paint["fill-color"], warnings);
@@ -749,7 +747,7 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   }
 
   if (line) {
-    matchedLayerCount += stackedLine ? byType("line").length : 1;
+    matchedLayerCount += 1;
     const paint = line.paint ?? {};
     const stroke = parseStrokeColor(paint["line-color"]);
     if (stroke) patch.strokeColor = stroke;
@@ -761,6 +759,10 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
     if (!colorClaimed && !circle) {
       const color = stackedLine ?? parseColorValue(paint["line-color"], warnings);
       if (color.mode && color.mode !== "single") {
+        if (stackedLine) {
+          appliedStackTypes.add("line");
+          matchedLayerCount += byType("line").length - 1;
+        }
         // Take the renderer (mode/property/stops/rules), but not the fallback
         // color: line-color's baked fallback is strokeColor (already recovered
         // above), whereas applyColorRenderer would route it into fillColor.
@@ -775,11 +777,15 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   }
 
   if (circle) {
-    matchedLayerCount += stackedCircle ? byType("circle").length : 1;
+    matchedLayerCount += 1;
     patch.pointRenderer = "single";
     const paint = circle.paint ?? {};
     if (!colorClaimed) {
       applyColorRenderer(stackedCircle ?? parseColorValue(paint["circle-color"], warnings), patch);
+      if (stackedCircle) {
+        appliedStackTypes.add("circle");
+        matchedLayerCount += byType("circle").length - 1;
+      }
       colorClaimed = true;
     }
     const radius = paint["circle-radius"];
@@ -838,6 +844,19 @@ export function parseMapboxStyle(input: unknown): MapboxStyleImportResult {
   if (symbol) {
     matchedLayerCount += 1;
     labels = parseLabelLayer(symbol, warnings);
+  }
+
+  // Filtered flat-color stacks can be represented exactly as rules only when
+  // that geometry actually claims the shared renderer. Flag every other stack.
+  for (const type of ["fill", "fill-extrusion", "line", "circle", "symbol"]) {
+    if (byType(type).length < 2) continue;
+    if (appliedStackTypes.has(type)) {
+      warnings.push(
+        `The style's multiple ${type} layers were combined as rules; paint properties other than color come from the first layer.`,
+      );
+    } else {
+      warnings.push(`The style has multiple ${type} layers; only the first was imported.`);
+    }
   }
 
   if (matchedLayerCount === 0) {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -679,6 +679,26 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.equal(result.style.strokeColor, "#123456");
   });
 
+  it("preserves a coalesce color lookup instead of replacing it with its fallback", () => {
+    const color = [
+      "coalesce",
+      [
+        "get",
+        ["coalesce", ["get", "unitsymbol"], ""],
+        ["literal", { Qa: "#fdfced", Qb: "#9b86c5" }],
+      ],
+      "rgba(0,0,0,0)",
+    ];
+    const result = parseMapboxStyle({
+      layers: [{ id: "units", type: "fill", paint: { "fill-color": color } }],
+    });
+
+    assert.equal(result.style.vectorStyleMode, "expression");
+    assert.equal(result.style.vectorStyleExpression, JSON.stringify(color));
+    assert.equal(result.style.fillColor, undefined);
+    assert.deepEqual(result.warnings, []);
+  });
+
   it("recovers fill opacity from a point layer's circle-opacity", () => {
     const { style: result } = roundTrip(style({ fillOpacity: 0.5 }), points());
     assert.equal(result.fillOpacity, 0.5);
@@ -771,19 +791,74 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.ok(result.warnings.some((w) => /constant extrusion height/.test(w)));
   });
 
-  it("warns when the style stacks multiple layers of one type", () => {
+  it("combines filtered flat-color layers of one type into rules", () => {
     const external = {
       version: 8,
       sources: {},
       layers: [
-        { id: "f1", type: "fill", source: "s", paint: { "fill-color": "#111111" } },
-        { id: "f2", type: "fill", source: "s", paint: { "fill-color": "#222222" } },
+        {
+          id: "class-a",
+          type: "fill",
+          source: "s",
+          filter: ["==", ["get", "class"], "a"],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "class-b",
+          type: "fill",
+          source: "s",
+          filter: ["==", ["get", "class"], "b"],
+          paint: { "fill-color": "#222222" },
+        },
       ],
     };
     const result = parseMapboxStyle(external);
-    assert.ok(result.warnings.some((w) => /multiple fill layers/.test(w)));
-    // The first layer still wins.
+    assert.equal(result.matchedLayerCount, 2);
+    assert.equal(result.style.vectorStyleMode, "rule-based");
+    assert.deepEqual(
+      result.style.vectorRules?.map(({ label, filter, color, isElse, enabled }) => ({
+        label,
+        filter,
+        color,
+        isElse,
+        enabled,
+      })),
+      [
+        {
+          label: "class-b",
+          filter: '["==",["get","class"],"b"]',
+          color: "#222222",
+          isElse: false,
+          enabled: undefined,
+        },
+        {
+          label: "class-a",
+          filter: '["==",["get","class"],"a"]',
+          color: "#111111",
+          isElse: false,
+          enabled: undefined,
+        },
+        {
+          label: "",
+          filter: "",
+          color: DEFAULT_LAYER_STYLE.fillColor,
+          isElse: true,
+          enabled: false,
+        },
+      ],
+    );
+    assert.ok(result.warnings.some((w) => /combined as rules/.test(w)));
+  });
+
+  it("warns when unfiltered same-type layers cannot be combined as rules", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        { id: "f1", type: "fill", paint: { "fill-color": "#111111" } },
+        { id: "f2", type: "fill", paint: { "fill-color": "#222222" } },
+      ],
+    });
     assert.equal(result.style.fillColor, "#111111");
+    assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
   });
 
   it("recognizes a bare [get] match input and text-field", () => {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -950,6 +950,7 @@ describe("parseMapboxStyle imports hand-written styles", () => {
 
     assert.equal(result.matchedLayerCount, 1);
     assert.equal(result.style.vectorStyleMode, "single");
+    assert.equal(result.style.fillColor, "#111111");
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
   });
 
@@ -973,7 +974,31 @@ describe("parseMapboxStyle imports hand-written styles", () => {
 
     assert.equal(result.matchedLayerCount, 1);
     assert.equal(result.style.vectorStyleMode, "single");
+    assert.equal(result.style.fillColor, "#111111");
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
+  });
+
+  it("combines a modern in filter with a string needle", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "parks",
+          type: "fill",
+          filter: ["in", "park", ["get", "classes"]],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "schools",
+          type: "fill",
+          filter: ["in", "school", ["get", "classes"]],
+          paint: { "fill-color": "#222222" },
+        },
+      ],
+    });
+
+    assert.equal(result.matchedLayerCount, 2);
+    assert.equal(result.style.vectorStyleMode, "rule-based");
+    assert.ok(result.warnings.some((warning) => /combined as rules/.test(warning)));
   });
 
   it("does not report stacked line rules as combined when a circle claims color", () => {

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -860,6 +860,41 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.ok(result.warnings.some((w) => /combined as rules/.test(w)));
   });
 
+  it("uses the union of stacked rule zoom ranges for the outer layer", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "low-zoom",
+          type: "fill",
+          minzoom: 0,
+          maxzoom: 10,
+          filter: ["==", ["get", "class"], "a"],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "high-zoom",
+          type: "fill",
+          minzoom: 10,
+          maxzoom: 20,
+          filter: ["==", ["get", "class"], "b"],
+          paint: { "fill-color": "#222222" },
+        },
+      ],
+    });
+
+    assert.equal(result.style.minZoom, 0);
+    assert.equal(result.style.maxZoom, 20);
+    assert.deepEqual(
+      result.style.vectorRules
+        ?.filter((rule) => !rule.isElse)
+        .map((rule) => [rule.minZoom, rule.maxZoom]),
+      [
+        [10, 20],
+        [0, 10],
+      ],
+    );
+  });
+
   it("warns when unfiltered same-type layers cannot be combined as rules", () => {
     const result = parseMapboxStyle({
       layers: [

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -871,6 +871,30 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
   });
 
+  it("does not combine legacy layer filters into expression rules", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "legacy-a",
+          type: "fill",
+          filter: ["==", "class", "a"],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "legacy-b",
+          type: "fill",
+          filter: ["==", "class", "b"],
+          paint: { "fill-color": "#222222" },
+        },
+      ],
+    });
+
+    assert.equal(result.matchedLayerCount, 1);
+    assert.equal(result.style.vectorStyleMode, "single");
+    assert.equal(result.style.fillColor, "#111111");
+    assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
+  });
+
   it("does not report stacked line rules as combined when a circle claims color", () => {
     const result = parseMapboxStyle({
       layers: [

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -978,6 +978,30 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
   });
 
+  it("does not combine legacy none filters wrapping expression children", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "no-class",
+          type: "fill",
+          filter: ["none", ["has", "class"]],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "parks",
+          type: "fill",
+          filter: ["==", ["get", "class"], "park"],
+          paint: { "fill-color": "#222222" },
+        },
+      ],
+    });
+
+    assert.equal(result.matchedLayerCount, 1);
+    assert.equal(result.style.vectorStyleMode, "single");
+    assert.equal(result.style.fillColor, "#111111");
+    assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
+  });
+
   it("combines a modern in filter with a string needle", () => {
     const result = parseMapboxStyle({
       layers: [

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -930,6 +930,29 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
   });
 
+  it("does not combine legacy !has filters into expression rules", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "missing-class",
+          type: "fill",
+          filter: ["!has", "class"],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "parks",
+          type: "fill",
+          filter: ["==", ["get", "class"], "park"],
+          paint: { "fill-color": "#222222" },
+        },
+      ],
+    });
+
+    assert.equal(result.matchedLayerCount, 1);
+    assert.equal(result.style.vectorStyleMode, "single");
+    assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
+  });
+
   it("does not report stacked line rules as combined when a circle claims color", () => {
     const result = parseMapboxStyle({
       layers: [

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -953,6 +953,29 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
   });
 
+  it("detects legacy comparisons nested under expression negation", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "not-a",
+          type: "fill",
+          filter: ["!", ["==", "class", "a"]],
+          paint: { "fill-color": "#111111" },
+        },
+        {
+          id: "parks",
+          type: "fill",
+          filter: ["==", ["get", "class"], "park"],
+          paint: { "fill-color": "#222222" },
+        },
+      ],
+    });
+
+    assert.equal(result.matchedLayerCount, 1);
+    assert.equal(result.style.vectorStyleMode, "single");
+    assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
+  });
+
   it("does not report stacked line rules as combined when a circle claims color", () => {
     const result = parseMapboxStyle({
       layers: [

--- a/tests/mapbox-style-import.test.ts
+++ b/tests/mapbox-style-import.test.ts
@@ -699,6 +699,16 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     assert.deepEqual(result.warnings, []);
   });
 
+  it("preserves a coalesce object lookup with a literal property key", () => {
+    const color = ["coalesce", ["get", "Qa", ["literal", { Qa: "#fdfced" }]], "#000000"];
+    const result = parseMapboxStyle({
+      layers: [{ id: "units", type: "fill", paint: { "fill-color": color } }],
+    });
+
+    assert.equal(result.style.vectorStyleMode, "expression");
+    assert.equal(result.style.vectorStyleExpression, JSON.stringify(color));
+  });
+
   it("recovers fill opacity from a point layer's circle-opacity", () => {
     const { style: result } = roundTrip(style({ fillOpacity: 0.5 }), points());
     assert.equal(result.fillOpacity, 0.5);
@@ -859,6 +869,31 @@ describe("parseMapboxStyle imports hand-written styles", () => {
     });
     assert.equal(result.style.fillColor, "#111111");
     assert.ok(result.warnings.some((warning) => /only the first was imported/.test(warning)));
+  });
+
+  it("does not report stacked line rules as combined when a circle claims color", () => {
+    const result = parseMapboxStyle({
+      layers: [
+        {
+          id: "line-a",
+          type: "line",
+          filter: ["==", ["get", "class"], "a"],
+          paint: { "line-color": "#111111" },
+        },
+        {
+          id: "line-b",
+          type: "line",
+          filter: ["==", ["get", "class"], "b"],
+          paint: { "line-color": "#222222" },
+        },
+        { id: "points", type: "circle", paint: { "circle-color": "#333333" } },
+      ],
+    });
+
+    assert.equal(result.matchedLayerCount, 2);
+    assert.equal(result.style.vectorStyleMode, "single");
+    assert.ok(result.warnings.some((warning) => /multiple line layers/.test(warning)));
+    assert.ok(result.warnings.every((warning) => !/combined as rules/.test(warning)));
   });
 
   it("recognizes a bare [get] match input and text-field", () => {


### PR DESCRIPTION
## Summary

- preserve genuine `coalesce` color lookups as advanced expressions
- combine filtered same-type flat-color layers into rule-based symbology
- keep warnings when stacked paint properties cannot be represented exactly
- count every recovered class layer and add regression coverage

## Verification

- `node --import tsx --test tests/mapbox-style-import.test.ts`
- `npm run build`
- `pre-commit run --files packages/map/src/mapbox-style-import.ts tests/mapbox-style-import.test.ts`
- imported the reported expression and a filtered multi-layer style against `us_regions.geojson` in light and dark themes

Fixes #1951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Mapbox style import support for complex color and stroke expressions.
  * Combined compatible filtered fill, line, and circle layers into ordered rule-based renderers while preserving drawing order and zoom ranges.
  * Added support for modern layer filters and combined layer range tracking.

* **Bug Fixes**
  * Improved validation and warnings for unsupported layer combinations.
  * Prevented incorrect fallback colors and misleading combination warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->