### PR TITLE
fix(processing): close polygon rings in Polygons To Lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14806,9 +14806,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.5.0.tgz",
-      "integrity": "sha512-/YsnN1P5glqVsnwLiRRHd+6wC3RK0Dp3erHtbvPnMs/5llOXE/cMW0Bt/nkZwNf6+iwJPLGVECb4tEoh4EHw5g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-1.5.1.tgz",
+      "integrity": "sha512-axGG7xfuFsFiyk1Y1SkrmjXwzHu0/LfO1WX/xw4rrVbFbdTenqAs7VdDlpnIjBn4+Enm9hhINqq3p40f+87bRQ==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -23326,7 +23326,7 @@
         "@turf/voronoi": "^7.4.0",
         "dggal": "^0.0.6",
         "fflate": "^0.8.3",
-        "geolibre-wasm": "^1.5.0",
+        "geolibre-wasm": "^1.5.1",
         "geotiff": "^3.0.5",
         "onnxruntime-web": "1.27.0",
         "s2js": "^1.44.0"

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -34,7 +34,7 @@
     "@turf/voronoi": "^7.4.0",
     "dggal": "^0.0.6",
     "fflate": "^0.8.3",
-    "geolibre-wasm": "^1.5.0",
+    "geolibre-wasm": "^1.5.1",
     "geotiff": "^3.0.5",
     "onnxruntime-web": "1.27.0",
     "s2js": "^1.44.0"


### PR DESCRIPTION
Reported in discussion #1958: converting a polygon to a polyline with **Processing → Conversion → Geometry & Topology → Polygons To Lines** leaves the last segment missing.

## Root cause

The bug was upstream, in `opengeos/whitebox-wasm`. `wbvector::Ring` stores polygon rings **open**, without the closing duplicate vertex, and the GeoJSON reader strips that vertex on input. `polygons_to_lines` copied `ring.0` straight into a `MultiLineString`, so the segment from each ring's last vertex back to its first was never emitted.

Reproduced against the `geolibre-wasm@1.5.0` this repo shipped, on a 10x10 square:

```json
"coordinates": [[[0,0],[10,0],[10,10],[0,10]]]     // 4 points, open
```

Two other tools walked rings the same way and are fixed too: `vector_lines_to_raster` (which documents polygon input and burns boundaries) and the watershed boundary rasterizer in `hydrology`, both of which left a matching gap in their output masks.

## The change here

One dependency bump: `geolibre-wasm` `^1.5.0` → `^1.5.1` in `packages/processing/package.json`, plus the lockfile. No GeoLibre source change is needed.

Release chain:
- opengeos/whitebox-wasm#18 — the fix and 6 new unit tests (merged)
- opengeos/geolibre-rust#557 — lockfile bump + 1.5.1 (merged), released as `v1.5.1`, published as `geolibre-wasm@1.5.1`

## Verification

Against the newly installed `geolibre-wasm@1.5.1`, the same square now returns the closed ring:

```json
"coordinates": [[[0,0],[10,0],[10,10],[0,10],[0,0]]]   // 5 points, closed
```

Driven in the real app on `http://localhost:5173` with Playwright, in **both light and dark themes**:

- `us_regions.geojson` (4 MultiPolygons) — ran the tool from the menu, boundaries render as continuous linework.
- A single 10x10 square polygon, with the source layer hidden so only the line output draws — the outline closes on all four sides, including the closing edge that used to be missing. 0 console errors.

`npm run build` and `npm run test:frontend` (6215 passing) are green, and `pre-commit run --files` passes on both changed files.

## CLAUDE.md mirror checks

CLAUDE.md requires three mirror re-checks on every `geolibre-wasm` bump. All three were run, and all three are clean:

1. **Menu catalog** — `node scripts/gen-whitebox-menu-catalog.mjs` regenerates `whitebox-menu-catalog.ts` and `whitebox-catalog-snapshot.json` **byte-identical** (775 tools, 1066 menu entries across 9 categories; `git status` clean afterwards). 1.5.1 is a behavior-only fix, so no tool was added or renamed and nothing is missing from the menu.
2. **`MAX_VECTOR_PMTILES_ZOOM`** — still 18. `tests/wasm-convert.test.ts` passes 22/22, including "accepts the documented maximum zoom and rejects one deeper".
3. **`NON_DISTANCE_NAMES`** — re-scanned the regenerated catalog for `double` parameters matching `DISTANCE_SEGMENTS` whose description reads as a fraction, ratio, angle or weight. The only dimensionless hit is `corridor_mapping_intelligence`'s `corridor_tolerance`, which is already excluded alongside `densify_spacing`. Every other match (`max_triangle_edge_length`, `snap_tolerance`, `output_resolution`) is a genuine length by its description. Since the catalog is byte-identical to 1.5.0's, the parameter surface is unchanged and no new collision can have been introduced.
