### PR TITLE
fix(map): allow grabbing the map during inertial pan

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1121,6 +1121,8 @@ export class MapController {
 
   applyView(view: MapViewState): void {
     if (!this.map) return;
+    // jumpTo stop()s drag handlers, so skip while the user is still panning.
+    if (this.map.dragPan.isActive() || this.map.dragRotate.isActive()) return;
     this.map.jumpTo(constrainMapView(view, this.mapPreferences, this.map));
   }
 

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -180,6 +180,9 @@ function makeFakeMap(initialBasemapLayers: string[] = ["basemap-bg"]): {
     // A laid-out viewport, so the camera helpers that scale with the canvas
     // (the globe-safe fit ceiling) have a real size to work from.
     getCanvas: () => ({ clientWidth: 576, clientHeight: 648 }),
+    jumpTo: record("jumpTo"),
+    dragPan: { isActive: () => false },
+    dragRotate: { isActive: () => false },
     flyTo: record("flyTo"),
     fitBounds: record("fitBounds"),
     cameraForBounds: (...args: unknown[]) => {
@@ -866,6 +869,40 @@ describe("MapController camera and query helpers", () => {
       pitch: 0,
       bbox: [-120, 30, -80, 50],
     });
+  });
+
+  it("does not jumpTo while the user is dragging, so inertia can be grabbed", () => {
+    const { map, fake } = makeFakeMap();
+    (map as { dragPan: { isActive: () => boolean } }).dragPan = { isActive: () => true };
+    const controller = controllerWith(map);
+
+    controller.applyView({
+      center: [12, 48],
+      zoom: 6,
+      bearing: 0,
+      pitch: 0,
+    });
+
+    assert.ok(
+      !fake.calls.some((c) => c.method === "jumpTo"),
+      "jumpTo would Camera.stop() the in-progress drag",
+    );
+  });
+
+  it("jumps when the user is not dragging", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+
+    controller.applyView({
+      center: [12, 48],
+      zoom: 6,
+      bearing: 0,
+      pitch: 0,
+    });
+
+    const jump = fake.calls.find((c) => c.method === "jumpTo");
+    assert.ok(jump);
+    assert.deepEqual((jump.args[0] as { center: [number, number] }).center, [12, 48]);
   });
 
   it("normalizes the projection to globe/mercator", () => {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -889,6 +889,23 @@ describe("MapController camera and query helpers", () => {
     );
   });
 
+  it("does not jumpTo while the user is rotating", () => {
+    const { map, fake } = makeFakeMap();
+    (map as { dragRotate: { isActive: () => boolean } }).dragRotate = {
+      isActive: () => true,
+    };
+    const controller = controllerWith(map);
+
+    controller.applyView({
+      center: [12, 48],
+      zoom: 6,
+      bearing: 0,
+      pitch: 0,
+    });
+
+    assert.ok(!fake.calls.some((c) => c.method === "jumpTo"));
+  });
+
   it("jumps when the user is not dragging", () => {
     const { map, fake } = makeFakeMap();
     const controller = controllerWith(map);


### PR DESCRIPTION
## Summary
- Skip `applyView` → `jumpTo` while `dragPan` or `dragRotate` is active, so grabbing the map during inertial coasting does not abort the new drag (`jumpTo` calls `Camera.stop()` and resets handlers).
- Fixes #1959.

## Test plan
- [x] `tests/map-controller.test.ts`: no `jumpTo` while dragging or rotating; `jumpTo` still runs when idle
- [x] `npm run test:frontend` (6200 pass, 0 fail)
- [ ] Drag the map, release with inertia, grab again before it stops — the pan should continue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic map repositioning from interrupting active dragging or rotation.
  * Map view synchronization continues normally once user interactions are inactive.

* **Tests**
  * Added coverage for map behavior during active and inactive dragging and rotation.
  * Verified that requested map centers are applied when no interaction is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->