### PR TITLE
fix(qgis): ignore Print Layout legend trees when importing a project

### DIFF
--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -152,18 +152,20 @@ export function importQgisProject(
   const project = createEmptyProject(projectName, {
     mapView: parseMapView(document),
   });
-  const parsedGroups = parseLayerGroups(document);
-  const groupByLayerId = layerGroupAssignments(document, parsedGroups.ids);
-  const visibilityByLayerId = layerVisibility(document);
+  const treeRoot = layerTreeRoot(document);
+  const parsedGroups = parseLayerGroups(treeRoot);
+  const groupByLayerId = layerGroupAssignments(treeRoot, parsedGroups.ids);
+  const visibilityByLayerId = layerVisibility(treeRoot);
   const mapLayers = Array.from(document.querySelectorAll("projectlayers > maplayer"));
   const byId = new Map(
     mapLayers.map((element) => [text(element.querySelector(":scope > id")), element]),
   );
+  const orderedIds = layerOrder(treeRoot, mapLayers);
   const warnings: QgisProjectImportWarning[] = [];
   const layers: GeoLibreLayer[] = [];
   const rasters: QgisRasterImport[] = [];
 
-  for (const id of layerOrder(document, mapLayers)) {
+  for (const id of orderedIds) {
     const element = byId.get(id);
     if (!element) continue;
     const name = text(element.querySelector(":scope > layername")) || id || "QGIS layer";
@@ -173,7 +175,7 @@ export function importQgisProject(
     if (
       isOpenStreetMapBasemap(element, provider, dataSource) &&
       !groupByLayerId.has(id) &&
-      id === layerOrder(document, mapLayers)[0]
+      id === orderedIds[0]
     ) {
       project.basemapStyleUrl = DEFAULT_BASEMAP;
       project.basemapVisible = visibilityByLayerId.get(id) ?? true;
@@ -192,9 +194,7 @@ export function importQgisProject(
         visible: visibilityByLayerId.get(id) ?? true,
         opacity: parseOpacity(element),
         ...(groupByLayerId.get(id) ? { groupId: groupByLayerId.get(id) } : {}),
-        ...(nextLayerId(id, layerOrder(document, mapLayers))
-          ? { beforeId: nextLayerId(id, layerOrder(document, mapLayers)) }
-          : {}),
+        ...(nextLayerId(id, orderedIds) ? { beforeId: nextLayerId(id, orderedIds) } : {}),
         ...(state ? { state } : {}),
       });
       continue;
@@ -392,11 +392,21 @@ function zoomForBounds(west: number, south: number, east: number, north: number)
   return Math.max(0, Math.min(20, Math.log2(360 / span) - 0.75));
 }
 
-function parseLayerGroups(document: Document): {
+/**
+ * The project's own layer tree: the `<layer-tree-group>` that is a direct child
+ * of `<qgis>`. A Print Layout legend with `autoUpdateModel="0"` stores its own
+ * frozen `<layer-tree-group>` snapshot under `<Layouts>`, so a document-wide
+ * query would treat every layer those legends reference as another layer to
+ * import and duplicate it once per legend (GeoLibre#1964).
+ */
+function layerTreeRoot(document: Document): Element | null {
+  return document.documentElement.querySelector(":scope > layer-tree-group");
+}
+
+function parseLayerGroups(root: Element | null): {
   groups: LayerGroup[];
   ids: Map<Element, string>;
 } {
-  const root = document.querySelector("layer-tree-group");
   if (!root) return { groups: [], ids: new Map() };
   const ids = new Map<Element, string>();
   const groups = Array.from(root.querySelectorAll("layer-tree-group")).map((element, index) => {
@@ -433,9 +443,12 @@ function groupDisplayName(element: Element, root: Element): string {
   return element.getAttribute("name")?.trim() || "Group";
 }
 
-function layerGroupAssignments(document: Document, ids: Map<Element, string>): Map<string, string> {
+function layerGroupAssignments(
+  root: Element | null,
+  ids: Map<Element, string>,
+): Map<string, string> {
   const assignments = new Map<string, string>();
-  document.querySelectorAll("layer-tree-layer[id]").forEach((layer) => {
+  root?.querySelectorAll("layer-tree-layer[id]").forEach((layer) => {
     const layerId = layer.getAttribute("id");
     const parentGroup = layer.parentElement?.closest("layer-tree-group");
     const groupId = parentGroup ? ids.get(parentGroup) : undefined;
@@ -444,20 +457,21 @@ function layerGroupAssignments(document: Document, ids: Map<Element, string>): M
   return assignments;
 }
 
-function layerVisibility(document: Document): Map<string, boolean> {
+function layerVisibility(root: Element | null): Map<string, boolean> {
   const result = new Map<string, boolean>();
-  document.querySelectorAll("layer-tree-layer[id]").forEach((element) => {
+  root?.querySelectorAll("layer-tree-layer[id]").forEach((element) => {
     const id = element.getAttribute("id");
     if (id) result.set(id, element.getAttribute("checked") !== "Qt::Unchecked");
   });
   return result;
 }
 
-function layerOrder(document: Document, mapLayers: Element[]): string[] {
-  const ids = Array.from(document.querySelectorAll("layer-tree-layer[id]"))
+function layerOrder(root: Element | null, mapLayers: Element[]): string[] {
+  const ids = Array.from(root?.querySelectorAll("layer-tree-layer[id]") ?? [])
     .map((element) => element.getAttribute("id") ?? "")
     .filter(Boolean);
-  if (ids.length > 0) return ids.reverse();
+  const unique = Array.from(new Set(ids));
+  if (unique.length > 0) return unique.reverse();
   return mapLayers
     .map((element) => text(element.querySelector(":scope > id")))
     .filter(Boolean)

--- a/apps/geolibre-desktop/src/lib/qgis-project-import.ts
+++ b/apps/geolibre-desktop/src/lib/qgis-project-import.ts
@@ -187,6 +187,7 @@ export function importQgisProject(
 
     if (isSupportedRasterLayer(element, provider, source)) {
       const state = parseRasterState(element);
+      const beforeId = nextLayerId(id, orderedIds);
       rasters.push({
         id,
         name,
@@ -194,7 +195,7 @@ export function importQgisProject(
         visible: visibilityByLayerId.get(id) ?? true,
         opacity: parseOpacity(element),
         ...(groupByLayerId.get(id) ? { groupId: groupByLayerId.get(id) } : {}),
-        ...(nextLayerId(id, orderedIds) ? { beforeId: nextLayerId(id, orderedIds) } : {}),
+        ...(beforeId ? { beforeId } : {}),
         ...(state ? { state } : {}),
       });
       continue;

--- a/tests/qgis-project-import.test.ts
+++ b/tests/qgis-project-import.test.ts
@@ -299,6 +299,36 @@ describe("QGIS project import", () => {
     assert.equal(rendered.find((layer) => layer.name === "Cities")?.visible, false);
   });
 
+  it("ignores the frozen layer trees inside Print Layout legends", () => {
+    const legend = (name: string, entries: string) => `
+      <Layout name="${name}" units="mm">
+        <LayoutItem type="65642" autoUpdateModel="0">
+          <layer-tree-group name="" checked="Qt::Checked">${entries}</layer-tree-group>
+        </LayoutItem>
+      </Layout>`;
+    const xml = projectXml().replace(
+      "</qgis>",
+      `<Layouts>
+        ${legend(
+          "Baseline",
+          `<layer-tree-layer id="roads" checked="Qt::Checked"/>
+           <layer-tree-layer id="cities" checked="Qt::Unchecked"/>`,
+        )}
+        ${legend("Proposed", '<layer-tree-layer id="cities" checked="Qt::Unchecked"/>')}
+        ${legend("Stale template", '<layer-tree-layer id="deleted" checked="Qt::Checked"/>')}
+      </Layouts></qgis>`,
+    );
+    const result = importQgisProject(xml, "/work/example.qgs");
+
+    assert.deepEqual(
+      result.project.layers.map((layer) => [layer.id, layer.name, layer.visible]),
+      [
+        ["cities", "Cities", true],
+        ["roads", "Roads", false],
+      ],
+    );
+  });
+
   it("normalizes Windows file URLs, query strings, encoded delimiters, and bare names", () => {
     const windows = importQgisProject(
       projectXml({


### PR DESCRIPTION
Fixes #1964

## The bug

Importing a `.qgs`/`.qgz` with Print Layouts duplicated layers in the layer panel: a layer showed up once for its real place in the layer tree, plus once more for every Print Layout legend that referenced it.

A legend item with `autoUpdateModel="0"` does not mirror the live layer tree. It stores its own frozen `<layer-tree-group>` snapshot inside `<Layouts>`. The importer read layer references with a document-wide `querySelectorAll("layer-tree-layer[id]")`, so those snapshots were walked as if they were part of the project's layer tree.

The reporter's counts match exactly: a layer referenced by two still-resolvable legends came in three times, one referenced by one legend came in twice. Layouts whose legends only hold stale ids contributed nothing, because those ids no longer resolve against `<projectlayers>` and were skipped, not because a whole layout was dropped.

The same document-wide query had a second, unreported effect: a legend's frozen `Qt::Unchecked` state overwrote the layer's real visibility, so a checked layer could import hidden.

## The fix

Resolve the project's own layer tree once (the `<layer-tree-group>` that is a direct child of `<qgis>`) and scope the order, visibility, and group lookups to it. Each physical layer now imports exactly once, with the visibility its layer tree records. `layerOrder` also de-duplicates ids as a guard, and the ordered id list is computed once instead of four times per layer.

## Verification

Built a `.qgs` shaped like the report: two layers in the main tree, three Print Layouts, two of whose legends reference those layers (one twice, one once, with a stale `Qt::Unchecked`) and one referencing only a deleted id.

Before: 5 entries in the layer panel (`World Cities` x3, `US Cities` x2), and `World Cities` imported hidden despite being checked in the layer tree.
After: 2 entries, both visible and rendering, verified in the running app in both light and dark themes with remote GeoJSON from source.coop, and against local files in `~/Documents/GitHub/data` through the importer directly.

New regression test `ignores the frozen layer trees inside Print Layout legends` fails on `main` and passes here. Full frontend suite (6232 tests) and `npm run build` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed QGIS project imports so layer visibility, grouping, and ordering are determined by the main layer tree.
  - Prevented outdated Print Layout legend snapshots from affecting imported layer visibility.
  - Improved consistency for imported layer and basemap placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->