### PR TITLE
fix(stac): make disabled panel buttons look disabled

### DIFF
--- a/packages/plugins/src/panel-dom.ts
+++ b/packages/plugins/src/panel-dom.ts
@@ -12,3 +12,26 @@ export function el<K extends keyof HTMLElementTagNameMap>(
   if (text !== undefined) node.textContent = text;
   return node;
 }
+
+/**
+ * Toggles a button's disabled state *and* its appearance.
+ *
+ * Panels style their buttons with inline `background`/`color`/`cursor:pointer`,
+ * which overrides the browser's own disabled rendering, so setting `.disabled`
+ * alone leaves the control looking exactly like an enabled one (GeoLibre#1970: a
+ * STAC item whose only asset is GeoParquet has Add disabled, and it was
+ * indistinguishable from the Zoom and Download buttons beside it). Dimming it
+ * and dropping the pointer cursor makes an unusable control read as unusable
+ * before it is clicked.
+ *
+ * Call this *after* any `style.cssText` assignment on the same element: cssText
+ * replaces the whole inline declaration and would wipe these two properties.
+ *
+ * @param button Button to update.
+ * @param disabled Whether the button should be disabled.
+ */
+export function setDisabled(button: HTMLButtonElement, disabled: boolean): void {
+  button.disabled = disabled;
+  button.style.opacity = disabled ? "0.5" : "1";
+  button.style.cursor = disabled ? "not-allowed" : "pointer";
+}

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -23,7 +23,7 @@ import {
   type StacSearchCursor,
 } from "./stac-api";
 import { buildCatalogTree } from "./stac-catalog-tree";
-import { el } from "../panel-dom";
+import { el, setDisabled } from "../panel-dom";
 
 export const STAC_PLUGIN_ID = "geolibre-stac-catalogs";
 const PANEL_ID = STAC_PLUGIN_ID;
@@ -623,8 +623,10 @@ function buildPanel(container: HTMLElement): () => void {
   searchButton.style.cssText = `${style.primary}flex:1 1 0;`;
   const clearResultsButton = el("button", labels.clearResults);
   clearResultsButton.type = "button";
-  clearResultsButton.disabled = true;
+  // cssText first: it replaces the whole inline declaration, so setting the
+  // disabled look before it would be wiped out.
   clearResultsButton.style.cssText = `${style.button}flex:1 1 0;`;
+  setDisabled(clearResultsButton, true);
   searchActions.append(searchButton, clearResultsButton);
   searchSection.append(
     catalogInfo,
@@ -761,8 +763,8 @@ function buildPanel(container: HTMLElement): () => void {
     selectItem(null, false);
     removeFootprints();
     loadMore.hidden = true;
-    clearResultsButton.disabled = true;
-    searchButton.disabled = false;
+    setDisabled(clearResultsButton, true);
+    setDisabled(searchButton, false);
     if (announce) setStatus(labels.resultsCleared);
   };
 
@@ -842,7 +844,7 @@ function buildPanel(container: HTMLElement): () => void {
           const addable = isVisualizableAsset(asset);
           assetSelect.title = asset.href;
           download.title = asset.href;
-          add.disabled = adding || !addable;
+          setDisabled(add, adding || !addable);
           add.title = addable ? asset.href : labels.addUnsupported;
         };
 
@@ -939,8 +941,8 @@ function buildPanel(container: HTMLElement): () => void {
     if (!connection) return;
     const search = generation ?? ++searchGeneration;
 
-    searchButton.disabled = true;
-    loadMore.disabled = true;
+    setDisabled(searchButton, true);
+    setDisabled(loadMore, true);
     setStatus(append ? labels.loadingMore : labels.searching);
     try {
       const selectedCollections = Array.from(collectionSelect.selectedOptions)
@@ -976,7 +978,7 @@ function buildPanel(container: HTMLElement): () => void {
       showFootprints(allItems);
       applySelection(false);
       loadMore.hidden = !nextPage && !searchCursor;
-      clearResultsButton.disabled = allItems.length === 0;
+      setDisabled(clearResultsButton, allItems.length === 0);
       setStatus(searchStatus(response));
     } catch (error) {
       // A search the user has moved on from must not report its failure over the current one.
@@ -984,8 +986,8 @@ function buildPanel(container: HTMLElement): () => void {
       setStatus(error instanceof Error ? error.message : labels.searchFailed, true);
     } finally {
       if (search === searchGeneration) {
-        searchButton.disabled = false;
-        loadMore.disabled = false;
+        setDisabled(searchButton, false);
+        setDisabled(loadMore, false);
       }
     }
   }
@@ -996,7 +998,7 @@ function buildPanel(container: HTMLElement): () => void {
   });
   connectButton.addEventListener("click", async () => {
     const url = urlField.input.value.trim();
-    connectButton.disabled = true;
+    setDisabled(connectButton, true);
     setStatus(labels.connecting);
     try {
       connection = await connectStac(url, fetch, controller.signal);
@@ -1028,7 +1030,7 @@ function buildPanel(container: HTMLElement): () => void {
       renderSection.hidden = true;
       setStatus(error instanceof Error ? error.message : labels.connectFailed, true);
     } finally {
-      connectButton.disabled = false;
+      setDisabled(connectButton, false);
     }
   });
   searchButton.addEventListener("click", () => void runSearch(false));

--- a/tests/panel-dom.test.ts
+++ b/tests/panel-dom.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import { el, setDisabled } from "../packages/plugins/src/panel-dom";
+
+// Panels are built by hand against the DOM, so these tests need real elements.
+// A minimal stub is enough: the helpers only touch createElement, textContent,
+// `disabled`, and inline style properties.
+class StubStyle {
+  cssText = "";
+  opacity = "";
+  cursor = "";
+}
+
+class StubElement {
+  textContent: string | undefined;
+  disabled = false;
+  style = new StubStyle();
+  constructor(readonly tagName: string) {}
+}
+
+beforeEach(() => {
+  (globalThis as { document?: unknown }).document = {
+    createElement: (tag: string) => new StubElement(tag),
+  };
+});
+
+describe("el", () => {
+  it("creates an element and sets text only when given", () => {
+    const withText = el("button", "Add") as unknown as StubElement;
+    assert.equal(withText.tagName, "button");
+    assert.equal(withText.textContent, "Add");
+    assert.equal((el("div") as unknown as StubElement).textContent, undefined);
+  });
+});
+
+describe("setDisabled", () => {
+  // GeoLibre#1970: the STAC panel styles its buttons with inline
+  // background/color/cursor, which overrides the browser's own disabled
+  // rendering. Setting `.disabled` alone left a disabled Add button pixel
+  // identical to the enabled Zoom and Download buttons beside it, so the
+  // disabled state has to carry its own visual treatment.
+  it("gives a disabled button a visual treatment an enabled one does not have", () => {
+    const button = el("button", "Add") as unknown as StubElement;
+    setDisabled(button as unknown as HTMLButtonElement, true);
+
+    assert.equal(button.disabled, true);
+    assert.equal(button.style.opacity, "0.5");
+    assert.equal(button.style.cursor, "not-allowed");
+  });
+
+  it("restores the enabled look, so a re-enabled button is not left dimmed", () => {
+    const button = el("button", "Clear results") as unknown as StubElement;
+    setDisabled(button as unknown as HTMLButtonElement, true);
+    setDisabled(button as unknown as HTMLButtonElement, false);
+
+    assert.equal(button.disabled, false);
+    assert.equal(button.style.opacity, "1");
+    assert.equal(button.style.cursor, "pointer");
+  });
+
+  it("leaves the disabled and enabled looks distinguishable in both directions", () => {
+    const enabled = el("button", "Zoom") as unknown as StubElement;
+    const disabled = el("button", "Add") as unknown as StubElement;
+    setDisabled(enabled as unknown as HTMLButtonElement, false);
+    setDisabled(disabled as unknown as HTMLButtonElement, true);
+
+    assert.notEqual(enabled.style.opacity, disabled.style.opacity);
+    assert.notEqual(enabled.style.cursor, disabled.style.cursor);
+  });
+});

--- a/tests/panel-dom.test.ts
+++ b/tests/panel-dom.test.ts
@@ -1,47 +1,49 @@
 import assert from "node:assert/strict";
-import { beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { parseHTML } from "linkedom";
 import { el, setDisabled } from "../packages/plugins/src/panel-dom";
 
-// Panels are built by hand against the DOM, so these tests need real elements.
-// A minimal stub is enough: the helpers only touch createElement, textContent,
-// `disabled`, and inline style properties.
-class StubStyle {
-  cssText = "";
-  opacity = "";
-  cursor = "";
-}
+/**
+ * Plugin panels are built by hand against the ambient `document`, so these run
+ * against a real DOM rather than a stub: `setDisabled` writes inline style
+ * properties, and the point of the helper is how those interact with the
+ * `style.cssText` the panels assign.
+ */
 
-class StubElement {
-  textContent: string | undefined;
-  disabled = false;
-  style = new StubStyle();
-  constructor(readonly tagName: string) {}
-}
+let restoreGlobals: () => void;
 
 beforeEach(() => {
-  (globalThis as { document?: unknown }).document = {
-    createElement: (tag: string) => new StubElement(tag),
+  const { document, window } = parseHTML("<html><body></body></html>");
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  Object.assign(globalThis, { document, window });
+  restoreGlobals = () => {
+    Object.assign(globalThis, { document: previousDocument, window: previousWindow });
   };
 });
 
+afterEach(() => restoreGlobals());
+
 describe("el", () => {
   it("creates an element and sets text only when given", () => {
-    const withText = el("button", "Add") as unknown as StubElement;
-    assert.equal(withText.tagName, "button");
+    const withText = el("button", "Add");
+    assert.equal(withText.tagName.toLowerCase(), "button");
     assert.equal(withText.textContent, "Add");
-    assert.equal((el("div") as unknown as StubElement).textContent, undefined);
+    assert.equal(el("div").textContent, "");
   });
 });
 
 describe("setDisabled", () => {
-  // GeoLibre#1970: the STAC panel styles its buttons with inline
-  // background/color/cursor, which overrides the browser's own disabled
-  // rendering. Setting `.disabled` alone left a disabled Add button pixel
-  // identical to the enabled Zoom and Download buttons beside it, so the
-  // disabled state has to carry its own visual treatment.
+  /**
+   * GeoLibre#1970: the STAC panel styles its buttons with inline
+   * background/color/cursor, which overrides the browser's own disabled
+   * rendering. Setting `.disabled` alone left a disabled Add button looking
+   * exactly like the enabled Zoom and Download buttons beside it, so the
+   * disabled state has to carry its own visual treatment.
+   */
   it("gives a disabled button a visual treatment an enabled one does not have", () => {
-    const button = el("button", "Add") as unknown as StubElement;
-    setDisabled(button as unknown as HTMLButtonElement, true);
+    const button = el("button", "Add");
+    setDisabled(button, true);
 
     assert.equal(button.disabled, true);
     assert.equal(button.style.opacity, "0.5");
@@ -49,9 +51,9 @@ describe("setDisabled", () => {
   });
 
   it("restores the enabled look, so a re-enabled button is not left dimmed", () => {
-    const button = el("button", "Clear results") as unknown as StubElement;
-    setDisabled(button as unknown as HTMLButtonElement, true);
-    setDisabled(button as unknown as HTMLButtonElement, false);
+    const button = el("button", "Clear results");
+    setDisabled(button, true);
+    setDisabled(button, false);
 
     assert.equal(button.disabled, false);
     assert.equal(button.style.opacity, "1");
@@ -59,12 +61,30 @@ describe("setDisabled", () => {
   });
 
   it("leaves the disabled and enabled looks distinguishable in both directions", () => {
-    const enabled = el("button", "Zoom") as unknown as StubElement;
-    const disabled = el("button", "Add") as unknown as StubElement;
-    setDisabled(enabled as unknown as HTMLButtonElement, false);
-    setDisabled(disabled as unknown as HTMLButtonElement, true);
+    const enabled = el("button", "Zoom");
+    const disabled = el("button", "Add");
+    setDisabled(enabled, false);
+    setDisabled(disabled, true);
 
     assert.notEqual(enabled.style.opacity, disabled.style.opacity);
     assert.notEqual(enabled.style.cursor, disabled.style.cursor);
+  });
+
+  // The panels set `style.cssText` to a shared button style, which replaces the
+  // whole inline declaration. Calling the helper first would leave no trace, so
+  // the ordering the doc comment requires is pinned here rather than left to a
+  // reader to rediscover.
+  it("is overwritten by a later cssText assignment, the ordering the panels rely on", () => {
+    const button = el("button", "Add");
+    setDisabled(button, true);
+    button.style.cssText = "background:red;cursor:pointer;";
+
+    assert.equal(button.style.opacity, "");
+    assert.equal(button.disabled, true, "the property survives; only the styling is wiped");
+
+    // Applied in the supported order, the treatment sticks.
+    setDisabled(button, true);
+    assert.equal(button.style.opacity, "0.5");
+    assert.equal(button.style.cursor, "not-allowed");
   });
 });


### PR DESCRIPTION
## Summary
- The STAC panel styles its buttons with inline `background`, `color` and `cursor:pointer`. Those inline properties override the browser's own disabled rendering, so setting `.disabled` changed nothing visible: an item whose only asset is GeoParquet showed an Add button with the same background, text color, opacity, border and pointer cursor as the Zoom and Download buttons beside it.
- Adds a `setDisabled` helper to `panel-dom` that sets the property and the appearance together (opacity 0.5 and `cursor:not-allowed`, matching the treatment `maplibre-dggal` already uses), and routes every disabled toggle in the panel through it, so Connect, Search items, Clear results and Load more get the same treatment as Add.
- The helper must run after any `style.cssText` assignment on the same element, since cssText replaces the whole inline declaration and would wipe the two properties. One call site needed reordering for this, and the constraint is documented.

The disabled logic itself was already correct; only the appearance was wrong. The helper lives in `panel-dom` rather than in the plugin so it can be tested against a leaf module.

Fixes #1970

## Test plan
- [x] Reproduced against the Planetary Computer STAC API (`us-census`, 20 items, every Add disabled) and confirmed the disabled Add button was pixel identical to Zoom and Download beforehand
- [x] Verified in the running app in both light and dark themes: disabled Add renders at opacity 0.5 with `cursor:not-allowed`, while Zoom and Download stay at opacity 1 with `cursor:pointer`
- [x] Verified the re-enable path, so a button that becomes usable again is not left dimmed (Clear results goes from disabled to enabled and resets cleanly)
- [x] New `tests/panel-dom.test.ts` covers both directions; reverting the fix fails 3 of its 4 tests
- [x] `npm run build`, `npm run test:frontend` (6289 passing) and pre-commit on the changed files all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved button state handling throughout the STAC panel, including search, results, asset, and connection controls.
  - Disabled buttons now consistently show appropriate opacity and cursor styling.
  - Button appearance is correctly restored when controls become enabled.

- **Tests**
  - Added coverage for button state behavior, visual styling, element creation, and style updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->