### PR TITLE
fix(stac): label asset formats in search results

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -936,6 +936,12 @@ export function TopToolbar({
       addFailed: t("stacPlugin.addFailed"),
       addNoSourceLayers: t("stacPlugin.addNoSourceLayers"),
       cogUnsupported: t("stacPlugin.cogUnsupported"),
+      formatCog: t("stacPlugin.formatCog"),
+      formatGeoJson: t("stacPlugin.formatGeoJson"),
+      formatPmtiles: t("stacPlugin.formatPmtiles"),
+      formatParquet: t("stacPlugin.formatParquet"),
+      formatUnknown: t("stacPlugin.formatUnknown"),
+      notAddable: t("stacPlugin.notAddable"),
     });
   }, [t]);
 

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -3644,7 +3644,13 @@
     "addUnsupported": "يمكن إضافة أصول GeoTIFF/COG وGeoJSON وPMTiles فقط إلى الخريطة",
     "addFailed": "تعذّرت إضافة الأصل",
     "addNoSourceLayers": "لا يسرد هذا الأرشيف أي طبقات لرسمها",
-    "cogUnsupported": "لا يستطيع مضيف GeoLibre هذا عرض أصول GeoTIFF البعيدة"
+    "cogUnsupported": "لا يستطيع مضيف GeoLibre هذا عرض أصول GeoTIFF البعيدة",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "تنسيق غير معروف",
+    "notAddable": "غير قابل للإضافة"
   },
   "earthdataGis": {
     "hint": "ابحث في NASA Earthdata GIS عن خدمات الصور والخرائط والمعالم.",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Nur GeoTIFF/COG-, GeoJSON- und PMTiles-Assets können zur Karte hinzugefügt werden",
     "addFailed": "Asset konnte nicht hinzugefügt werden",
     "addNoSourceLayers": "Dieses Archiv führt keine zeichenbaren Ebenen auf",
-    "cogUnsupported": "Dieser GeoLibre-Host kann entfernte GeoTIFF-Assets nicht darstellen"
+    "cogUnsupported": "Dieser GeoLibre-Host kann entfernte GeoTIFF-Assets nicht darstellen",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Unbekanntes Format",
+    "notAddable": "nicht hinzufügbar"
   },
   "earthdataGis": {
     "hint": "Durchsuchen Sie NASA Earthdata GIS nach Bild-, Karten- und Feature-Diensten.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3431,7 +3431,13 @@
     "addUnsupported": "Only GeoTIFF/COG, GeoJSON, and PMTiles assets can be added to the map",
     "addFailed": "Could not add asset",
     "addNoSourceLayers": "This archive lists no layers to draw",
-    "cogUnsupported": "This GeoLibre host cannot visualize remote GeoTIFF assets"
+    "cogUnsupported": "This GeoLibre host cannot visualize remote GeoTIFF assets",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Unknown format",
+    "notAddable": "not addable"
   },
   "earthdataGis": {
     "hint": "Search NASA Earthdata GIS for imagery, map, and feature services.",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Solo se pueden añadir al mapa recursos GeoTIFF/COG, GeoJSON y PMTiles",
     "addFailed": "No se pudo añadir el recurso",
     "addNoSourceLayers": "Este archivo no incluye capas que dibujar",
-    "cogUnsupported": "Este host de GeoLibre no puede visualizar recursos GeoTIFF remotos"
+    "cogUnsupported": "Este host de GeoLibre no puede visualizar recursos GeoTIFF remotos",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Formato desconocido",
+    "notAddable": "no se puede añadir"
   },
   "earthdataGis": {
     "hint": "Busque en NASA Earthdata GIS servicios de imágenes, de mapas y de entidades.",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "تنها دارایی‌های GeoTIFF/COG، GeoJSON و PMTiles را می‌توان به نقشه افزود",
     "addFailed": "افزودن دارایی با شکست مواجه شد",
     "addNoSourceLayers": "این بایگانی هیچ لایه‌ای برای ترسیم فهرست نکرده است",
-    "cogUnsupported": "این میزبان GeoLibre نمی‌تواند دارایی‌های GeoTIFF دوردست را نمایش دهد"
+    "cogUnsupported": "این میزبان GeoLibre نمی‌تواند دارایی‌های GeoTIFF دوردست را نمایش دهد",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "قالب ناشناخته",
+    "notAddable": "قابل افزودن نیست"
   },
   "earthdataGis": {
     "hint": "NASA Earthdata GIS را برای سرویس‌های تصویری، نقشه و عارضه جستجو کنید.",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Seules les ressources GeoTIFF/COG, GeoJSON et PMTiles peuvent être ajoutées à la carte",
     "addFailed": "Impossible d'ajouter la ressource",
     "addNoSourceLayers": "Cette archive ne répertorie aucune couche à dessiner",
-    "cogUnsupported": "Cet hôte GeoLibre ne peut pas visualiser les ressources GeoTIFF distantes"
+    "cogUnsupported": "Cet hôte GeoLibre ne peut pas visualiser les ressources GeoTIFF distantes",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Format inconnu",
+    "notAddable": "non ajoutable"
   },
   "earthdataGis": {
     "hint": "Recherchez dans NASA Earthdata GIS des services d'imagerie, de cartes et d'entités.",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "मानचित्र में केवल GeoTIFF/COG, GeoJSON और PMTiles एसेट जोड़ी जा सकती हैं",
     "addFailed": "एसेट नहीं जोड़ी जा सकी",
     "addNoSourceLayers": "इस संग्रह में बनाने के लिए कोई लेयर सूचीबद्ध नहीं है",
-    "cogUnsupported": "यह GeoLibre होस्ट दूरस्थ GeoTIFF एसेट प्रदर्शित नहीं कर सकता"
+    "cogUnsupported": "यह GeoLibre होस्ट दूरस्थ GeoTIFF एसेट प्रदर्शित नहीं कर सकता",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "अज्ञात प्रारूप",
+    "notAddable": "जोड़ा नहीं जा सकता"
   },
   "earthdataGis": {
     "hint": "इमेजरी, मानचित्र और फ़ीचर सेवाओं के लिए NASA Earthdata GIS खोजें।",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -3365,7 +3365,13 @@
     "addUnsupported": "Hanya aset GeoTIFF/COG, GeoJSON, dan PMTiles yang dapat ditambahkan ke peta",
     "addFailed": "Tidak dapat menambahkan aset",
     "addNoSourceLayers": "Arsip ini tidak mencantumkan lapisan untuk digambar",
-    "cogUnsupported": "Host GeoLibre ini tidak dapat memvisualisasikan aset GeoTIFF jarak jauh"
+    "cogUnsupported": "Host GeoLibre ini tidak dapat memvisualisasikan aset GeoTIFF jarak jauh",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Format tidak dikenal",
+    "notAddable": "tidak dapat ditambahkan"
   },
   "earthdataGis": {
     "hint": "Cari layanan citra, peta, dan fitur di NASA Earthdata GIS.",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Solo le risorse GeoTIFF/COG, GeoJSON e PMTiles possono essere aggiunte alla mappa",
     "addFailed": "Impossibile aggiungere la risorsa",
     "addNoSourceLayers": "Questo archivio non elenca livelli da disegnare",
-    "cogUnsupported": "Questo host GeoLibre non può visualizzare risorse GeoTIFF remote"
+    "cogUnsupported": "Questo host GeoLibre non può visualizzare risorse GeoTIFF remote",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Formato sconosciuto",
+    "notAddable": "non aggiungibile"
   },
   "earthdataGis": {
     "hint": "Cerca servizi di immagini, mappe ed elementi in NASA Earthdata GIS.",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -3365,7 +3365,13 @@
     "addUnsupported": "地図に追加できるのは GeoTIFF/COG、GeoJSON、PMTiles のアセットのみです",
     "addFailed": "アセットを追加できませんでした",
     "addNoSourceLayers": "このアーカイブには描画できるレイヤーがありません",
-    "cogUnsupported": "この GeoLibre ホストはリモートの GeoTIFF アセットを表示できません"
+    "cogUnsupported": "この GeoLibre ホストはリモートの GeoTIFF アセットを表示できません",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "不明な形式",
+    "notAddable": "追加不可"
   },
   "earthdataGis": {
     "hint": "NASA Earthdata GIS で画像・地図・フィーチャの各サービスを検索します。",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "რუკაზე შეიძლება დაემატოს მხოლოდ GeoTIFF/COG, GeoJSON და PMTiles აქტივები",
     "addFailed": "აქტივის დამატება ვერ მოხერხდა",
     "addNoSourceLayers": "ეს არქივი არ შეიცავს დასახატ ფენებს",
-    "cogUnsupported": "ამ GeoLibre ჰოსტს არ შეუძლია დისტანციური GeoTIFF აქტივების ვიზუალიზაცია"
+    "cogUnsupported": "ამ GeoLibre ჰოსტს არ შეუძლია დისტანციური GeoTIFF აქტივების ვიზუალიზაცია",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "უცნობი ფორმატი",
+    "notAddable": "დამატება შეუძლებელია"
   },
   "earthdataGis": {
     "hint": "მოძებნეთ NASA Earthdata GIS-ში სურათების, რუკებისა და ობიექტების სერვისები.",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -3365,7 +3365,13 @@
     "addUnsupported": "GeoTIFF/COG, GeoJSON 및 PMTiles 자산만 지도에 추가할 수 있습니다",
     "addFailed": "자산을 추가하지 못했습니다",
     "addNoSourceLayers": "이 아카이브에는 그릴 레이어가 없습니다",
-    "cogUnsupported": "이 GeoLibre 호스트는 원격 GeoTIFF 자산을 표시할 수 없습니다"
+    "cogUnsupported": "이 GeoLibre 호스트는 원격 GeoTIFF 자산을 표시할 수 없습니다",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "알 수 없는 형식",
+    "notAddable": "추가할 수 없음"
   },
   "earthdataGis": {
     "hint": "NASA Earthdata GIS에서 영상, 지도, 피처 서비스를 검색하세요.",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Alleen GeoTIFF/COG-, GeoJSON- en PMTiles-assets kunnen aan de kaart worden toegevoegd",
     "addFailed": "Kan asset niet toevoegen",
     "addNoSourceLayers": "Dit archief bevat geen tekenbare lagen",
-    "cogUnsupported": "Deze GeoLibre-host kan externe GeoTIFF-assets niet weergeven"
+    "cogUnsupported": "Deze GeoLibre-host kan externe GeoTIFF-assets niet weergeven",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Onbekend formaat",
+    "notAddable": "kan niet worden toegevoegd"
   },
   "earthdataGis": {
     "hint": "Doorzoek NASA Earthdata GIS naar beeld-, kaart- en featureservices.",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Apenas recursos GeoTIFF/COG, GeoJSON e PMTiles podem ser adicionados ao mapa",
     "addFailed": "Não foi possível adicionar o recurso",
     "addNoSourceLayers": "Este arquivo não lista camadas para desenhar",
-    "cogUnsupported": "Este host do GeoLibre não consegue visualizar recursos GeoTIFF remotos"
+    "cogUnsupported": "Este host do GeoLibre não consegue visualizar recursos GeoTIFF remotos",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Formato desconhecido",
+    "notAddable": "não pode ser adicionado"
   },
   "earthdataGis": {
     "hint": "Pesquise no NASA Earthdata GIS por serviços de imagens, de mapas e de feições.",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -3533,7 +3533,13 @@
     "addUnsupported": "На карту можно добавить только ресурсы GeoTIFF/COG, GeoJSON и PMTiles",
     "addFailed": "Не удалось добавить ресурс",
     "addNoSourceLayers": "В этом архиве нет слоёв для отрисовки",
-    "cogUnsupported": "Этот хост GeoLibre не может отображать удалённые ресурсы GeoTIFF"
+    "cogUnsupported": "Этот хост GeoLibre не может отображать удалённые ресурсы GeoTIFF",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Неизвестный формат",
+    "notAddable": "нельзя добавить"
   },
   "earthdataGis": {
     "hint": "Ищите в NASA Earthdata GIS сервисы изображений, карт и объектов.",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -3365,7 +3365,13 @@
     "addUnsupported": "เพิ่มลงแผนที่ได้เฉพาะแอสเซตแบบ GeoTIFF/COG, GeoJSON และ PMTiles เท่านั้น",
     "addFailed": "ไม่สามารถเพิ่มแอสเซตได้",
     "addNoSourceLayers": "ไฟล์เก็บถาวรนี้ไม่มีเลเยอร์ให้วาด",
-    "cogUnsupported": "โฮสต์ GeoLibre นี้ไม่สามารถแสดงผลแอสเซต GeoTIFF จากระยะไกลได้"
+    "cogUnsupported": "โฮสต์ GeoLibre นี้ไม่สามารถแสดงผลแอสเซต GeoTIFF จากระยะไกลได้",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "รูปแบบที่ไม่รู้จัก",
+    "notAddable": "ไม่สามารถเพิ่มได้"
   },
   "earthdataGis": {
     "hint": "ค้นหาบริการภาพถ่าย แผนที่ และฟีเจอร์จาก NASA Earthdata GIS",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -3421,7 +3421,13 @@
     "addUnsupported": "Haritaya yalnızca GeoTIFF/COG, GeoJSON ve PMTiles varlıkları eklenebilir",
     "addFailed": "Varlık eklenemedi",
     "addNoSourceLayers": "Bu arşiv çizilecek katman listelemiyor",
-    "cogUnsupported": "Bu GeoLibre ana bilgisayarı uzak GeoTIFF varlıklarını görselleştiremiyor"
+    "cogUnsupported": "Bu GeoLibre ana bilgisayarı uzak GeoTIFF varlıklarını görselleştiremiyor",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Bilinmeyen biçim",
+    "notAddable": "eklenemez"
   },
   "earthdataGis": {
     "hint": "NASA Earthdata GIS içinde görüntü, harita ve öğe servislerini arayın.",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -3375,7 +3375,13 @@
     "startDate": "Ngày bắt đầu",
     "noMatchesHere": "Không có kết quả phù hợp ở phần đó của danh mục. Tải thêm để tiếp tục tìm kiếm.",
     "treeEmpty": "Trống",
-    "treeOpenFailed": "Không thể mở danh mục này"
+    "treeOpenFailed": "Không thể mở danh mục này",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "Định dạng không xác định",
+    "notAddable": "không thể thêm"
   },
   "earthdataGis": {
     "showing": "Đang hiển thị {{shown}} trong số {{total}} dịch vụ.",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -3365,7 +3365,13 @@
     "addUnsupported": "只有 GeoTIFF/COG、GeoJSON 和 PMTiles 资源可以添加到地图",
     "addFailed": "无法添加资源",
     "addNoSourceLayers": "此归档未列出可绘制的图层",
-    "cogUnsupported": "此 GeoLibre 主机无法可视化远程 GeoTIFF 资源"
+    "cogUnsupported": "此 GeoLibre 主机无法可视化远程 GeoTIFF 资源",
+    "formatCog": "COG",
+    "formatGeoJson": "GeoJSON",
+    "formatPmtiles": "PMTiles",
+    "formatParquet": "Parquet",
+    "formatUnknown": "未知格式",
+    "notAddable": "无法添加"
   },
   "earthdataGis": {
     "hint": "在 NASA Earthdata GIS 中搜索影像服务、地图服务和要素服务。",

--- a/e2e/stac-api-panel.spec.ts
+++ b/e2e/stac-api-panel.spec.ts
@@ -8,11 +8,23 @@ import { waitForMap } from "./helpers";
 const API = "https://api.stac.test/v1";
 
 const COLLECTIONS = [
-  { id: "sentinel-2", title: "Sentinel-2 L2A", extent: { spatial: { bbox: [[4, 50, 6, 52]] } } },
-  { id: "landsat-9", title: "Landsat 9", extent: { spatial: { bbox: [[-114, 37, -109, 42]] } } },
+  {
+    id: "sentinel-2",
+    title: "Sentinel-2 L2A",
+    extent: { spatial: { bbox: [[4, 50, 6, 52]] } },
+  },
+  {
+    id: "landsat-9",
+    title: "Landsat 9",
+    extent: { spatial: { bbox: [[-114, 37, -109, 42]] } },
+  },
 ];
 
-function item(id: string, collection: string): Record<string, unknown> {
+function item(
+  id: string,
+  collection: string,
+  assets: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     type: "Feature",
     stac_version: "1.0.0",
@@ -32,18 +44,26 @@ function item(id: string, collection: string): Record<string, unknown> {
       ],
     },
     properties: { datetime: "2024-05-01T00:00:00Z" },
-    assets: {},
+    assets,
     links: [],
   };
 }
 
 /** A STAC API that answers item search, and a hierarchy underneath it that must not be offered. */
-async function serveApi(page: Page, searches: string[]): Promise<void> {
+async function serveApi(
+  page: Page,
+  searches: string[],
+  assets: Record<string, unknown> = {},
+): Promise<void> {
   await page.route("https://api.stac.test/**", async (route) => {
     const request = route.request();
     const url = request.url();
     const json = (body: unknown) =>
-      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
 
     if (url.endsWith("/collections")) return json({ collections: COLLECTIONS });
     if (url.includes("/search")) {
@@ -52,7 +72,10 @@ async function serveApi(page: Page, searches: string[]): Promise<void> {
       const collection = asked.collections?.[0] ?? "sentinel-2";
       return json({
         type: "FeatureCollection",
-        features: [item(`${collection}-1`, collection), item(`${collection}-2`, collection)],
+        features: [
+          item(`${collection}-1`, collection, assets),
+          item(`${collection}-2`, collection, assets),
+        ],
         numberMatched: 2,
         links: [],
       });
@@ -74,6 +97,50 @@ async function serveApi(page: Page, searches: string[]): Promise<void> {
     });
   });
 }
+
+test("asset options identify their format and whether they can be added", async ({ page }) => {
+  const searches: string[] = [];
+  await serveApi(page, searches, {
+    red: {
+      href: "https://data.test/red.tif",
+      type: "image/tiff",
+      title: "Red Band",
+    },
+    boundaries: {
+      href: "https://data.test/boundaries.geojson",
+      type: "application/geo+json",
+      title: "Boundaries",
+    },
+    tiles: {
+      href: "https://data.test/tiles.pmtiles",
+      type: "application/vnd.pmtiles",
+      title: "Vector tiles",
+    },
+    data: {
+      href: "https://data.test/data.parquet",
+      type: "application/vnd.apache.parquet",
+      title: "Dataset root",
+    },
+    metadata: { href: "https://data.test/metadata.bin", title: "Metadata" },
+  });
+  await waitForMap(page);
+  await connect(page, API);
+
+  await page.getByLabel("Limit search to the current map extent").uncheck();
+  await page.getByRole("button", { name: "Search items" }).click();
+
+  const assets = page
+    .locator("select")
+    .filter({ has: page.locator('option[value="red"]') })
+    .first();
+  await expect(assets.getByRole("option")).toHaveText([
+    "Red Band — COG",
+    "Boundaries — GeoJSON",
+    "Vector tiles — PMTiles",
+    "Dataset root — Parquet (not addable)",
+    "Metadata — Unknown format (not addable)",
+  ]);
+});
 
 async function connect(page: Page, url: string): Promise<void> {
   await page.getByRole("button", { name: "Plugins", exact: true }).click();
@@ -157,7 +224,13 @@ test("connecting to an API after a static catalog clears the tree", async ({ pag
               type: "Catalog",
               id: "static",
               title: "E2E Static",
-              links: [{ rel: "child", href: "./hazards/collection.json", title: "Hazards" }],
+              links: [
+                {
+                  rel: "child",
+                  href: "./hazards/collection.json",
+                  title: "Hazards",
+                },
+              ],
             },
       ),
     });

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -476,6 +476,7 @@ export {
   type StacLabels,
 } from "./plugins/maplibre-stac";
 export {
+  assetDisplayFormat,
   assetFormat,
   connectStac,
   isVisualizableAsset,
@@ -494,6 +495,7 @@ export {
   type StacItem,
   type StacNextPage,
   type StacAssetFormat,
+  type StacAssetDisplayFormat,
   type StacSearchOptions,
   type StacSearchResult,
 } from "./plugins/stac-api";

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -352,7 +352,11 @@ function showDrawBox(map: MapLibreMap, bbox: [number, number, number, number]): 
     id: DRAW_LINE,
     type: "line",
     source: DRAW_SOURCE,
-    paint: { "line-color": "#f59e0b", "line-width": 2, "line-dasharray": [2, 1] },
+    paint: {
+      "line-color": "#f59e0b",
+      "line-width": 2,
+      "line-dasharray": [2, 1],
+    },
   });
 }
 
@@ -499,6 +503,27 @@ function footprintStyleLayers(map: MapLibreMap): string[] {
 
 function assetLabel(key: string, asset: StacAsset): string {
   return asset.title || key;
+}
+
+function assetFormatLabel(asset: StacAsset): string {
+  switch (assetFormat(asset)) {
+    case "cog":
+      return "COG";
+    case "geojson":
+      return "GeoJSON";
+    case "pmtiles":
+      return "PMTiles";
+    case null: {
+      const mediaType = (asset.type ?? "").toLowerCase();
+      if (mediaType.includes("parquet") || /\.parquet($|\?)/i.test(asset.href)) return "Parquet";
+      return "Unknown format";
+    }
+  }
+}
+
+function assetOptionLabel(key: string, asset: StacAsset): string {
+  const addability = isVisualizableAsset(asset) ? "" : " (not addable)";
+  return `${assetLabel(key, asset)} — ${assetFormatLabel(asset)}${addability}`;
 }
 
 async function visualizeAsset(
@@ -822,7 +847,7 @@ function buildPanel(container: HTMLElement): () => void {
         const assetSelect = el("select");
         assetSelect.style.cssText = `${style.input}flex:1 1 140px;width:auto;`;
         for (const [key, asset] of assets) {
-          const option = el("option", assetLabel(key, asset));
+          const option = el("option", assetOptionLabel(key, asset));
           option.value = key;
           assetSelect.append(option);
         }

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -5,6 +5,7 @@ import type { GeoJSONSource, MapMouseEvent, Map as MapLibreMap } from "maplibre-
 import type { GeoLibreAppAPI, GeoLibreCogLayerOptions, GeoLibrePlugin } from "../types";
 import { addPMTilesAsset } from "./stac-layers";
 import {
+  assetDisplayFormat,
   assetFormat,
   connectStac,
   horizontalBbox,
@@ -143,6 +144,12 @@ export interface StacLabels {
   addFailed: string;
   addNoSourceLayers: string;
   cogUnsupported: string;
+  formatCog: string;
+  formatGeoJson: string;
+  formatPmtiles: string;
+  formatParquet: string;
+  formatUnknown: string;
+  notAddable: string;
   showing: (count: number) => string;
   showingOfMatched: (count: number, matched: number) => string;
   adding: (asset: string) => string;
@@ -216,6 +223,12 @@ let labels: StacLabels = {
   addFailed: "Could not add asset",
   addNoSourceLayers: "This archive lists no layers to draw",
   cogUnsupported: "This GeoLibre host cannot visualize remote GeoTIFF assets",
+  formatCog: "COG",
+  formatGeoJson: "GeoJSON",
+  formatPmtiles: "PMTiles",
+  formatParquet: "Parquet",
+  formatUnknown: "Unknown format",
+  notAddable: "not addable",
   showing: (count) => `Showing ${count} items.`,
   showingOfMatched: (count, matched) => `Showing ${count} of ${matched} items.`,
   adding: (asset) => `Adding ${asset}…`,
@@ -506,23 +519,22 @@ function assetLabel(key: string, asset: StacAsset): string {
 }
 
 function assetFormatLabel(asset: StacAsset): string {
-  switch (assetFormat(asset)) {
+  switch (assetDisplayFormat(asset)) {
     case "cog":
-      return "COG";
+      return labels.formatCog;
     case "geojson":
-      return "GeoJSON";
+      return labels.formatGeoJson;
     case "pmtiles":
-      return "PMTiles";
-    case null: {
-      const mediaType = (asset.type ?? "").toLowerCase();
-      if (mediaType.includes("parquet") || /\.parquet($|\?)/i.test(asset.href)) return "Parquet";
-      return "Unknown format";
-    }
+      return labels.formatPmtiles;
+    case "parquet":
+      return labels.formatParquet;
+    case null:
+      return labels.formatUnknown;
   }
 }
 
 function assetOptionLabel(key: string, asset: StacAsset): string {
-  const addability = isVisualizableAsset(asset) ? "" : " (not addable)";
+  const addability = isVisualizableAsset(asset) ? "" : ` (${labels.notAddable})`;
   return `${assetLabel(key, asset)} — ${assetFormatLabel(asset)}${addability}`;
 }
 

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -551,35 +551,39 @@ export function itemBbox(item: StacItem): [number, number, number, number] | und
 
 /** A format {@link assetFormat} recognizes, and {@link visualizeAsset} knows how to add. */
 export type StacAssetFormat = "pmtiles" | "geojson" | "cog";
+export type StacAssetDisplayFormat = StacAssetFormat | "parquet";
 
 interface AssetFormatRule {
-  format: StacAssetFormat;
+  format: StacAssetDisplayFormat;
   /** Matched within the asset's media type, which catalogs write with varying parameters. */
   mediaType: string;
   /** Read only when no rule's media type matched, for a catalog that omits the type. */
   extension: RegExp;
 }
 
-/** The formats the panel can put on the map, and the two ways an asset can name each of them. */
-const VISUALIZABLE_FORMATS: readonly AssetFormatRule[] = [
+/** Formats the panel labels, and the two ways an asset can name each of them. */
+const ASSET_FORMATS: readonly AssetFormatRule[] = [
   { format: "pmtiles", mediaType: "pmtiles", extension: /\.pmtiles($|\?)/i },
   { format: "geojson", mediaType: "geo+json", extension: /\.geojson($|\?)/i },
   { format: "cog", mediaType: "geotiff", extension: /\.tiff?($|\?)/i },
+  { format: "parquet", mediaType: "parquet", extension: /\.parquet($|\?)/i },
 ];
+
+export function assetDisplayFormat(asset: StacAsset): StacAssetDisplayFormat | null {
+  const mediaType = (asset.type ?? "").toLowerCase();
+  const declared = ASSET_FORMATS.find((rule) => mediaType.includes(rule.mediaType));
+  if (declared) return declared.format;
+
+  return ASSET_FORMATS.find((rule) => rule.extension.test(asset.href))?.format ?? null;
+}
 
 /**
  * Which format an asset is, or null when the panel cannot draw it. Both the enabled state of Add
  * and the routing behind it read this, so the button and the click cannot disagree.
  */
 export function assetFormat(asset: StacAsset): StacAssetFormat | null {
-  const mediaType = (asset.type ?? "").toLowerCase();
-
-  // Every declared media type outranks every extension: a catalog calling a `.pmtiles` href
-  // GeoJSON is describing its own asset.
-  const declared = VISUALIZABLE_FORMATS.find((rule) => mediaType.includes(rule.mediaType));
-  if (declared) return declared.format;
-
-  return VISUALIZABLE_FORMATS.find((rule) => rule.extension.test(asset.href))?.format ?? null;
+  const format = assetDisplayFormat(asset);
+  return format === "parquet" ? null : format;
 }
 
 export function isVisualizableAsset(asset: StacAsset): boolean {

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   browserAssetHref,
   connectStac,
+  assetDisplayFormat,
   assetFormat,
   isVisualizableAsset,
   itemBbox,
@@ -1155,6 +1156,14 @@ test("an asset's format comes from its media type, or its extension when there i
     "geojson",
   );
   assert.equal(assetFormat({ href: "https://example.com/data.bin" }), null);
+  assert.equal(
+    assetDisplayFormat({
+      href: "https://example.com/data.bin",
+      type: "application/vnd.apache.parquet",
+    }),
+    "parquet",
+  );
+  assert.equal(assetDisplayFormat({ href: "https://example.com/data.parquet" }), "parquet");
 
   // Archives under a directory named for another format are read by the asset, not the path.
   assert.equal(assetFormat({ href: "https://example.com/geotiff/a.pmtiles" }), "pmtiles");


### PR DESCRIPTION
## Summary

- label STAC asset options with COG, GeoJSON, PMTiles, or Parquet format names
- mark unsupported and unknown asset formats as not addable before selection
- add browser coverage for supported, unsupported, and unknown assets

## Testing

- `npx playwright test e2e/stac-api-panel.spec.ts`
- `pre-commit run --files packages/plugins/src/plugins/maplibre-stac.ts e2e/stac-api-panel.spec.ts`
- verified the Planetary Computer `us-census` collection in light and dark themes

Fixes #1971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset selectors now display detected formats, including COG, GeoJSON, PMTiles, and Parquet.
  * Assets that cannot be visualized are clearly marked as unavailable for adding.
  * Parquet assets are recognized from their media type or URL.
  * STAC search results preserve and display configured asset information.
* **Localization**
  * Added translated format and availability labels across supported languages.
* **Bug Fixes**
  * Improved static catalog child-link formatting for more consistent navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->