### PR TITLE
feat(stac): add GeoParquet assets to map

### DIFF
--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -3641,7 +3641,7 @@
     "download": "تنزيل",
     "adding": "جارٍ إضافة {{asset}}…",
     "added": "تمت إضافة {{asset}} إلى الخريطة.",
-    "addUnsupported": "يمكن إضافة أصول GeoTIFF/COG وGeoJSON وPMTiles فقط إلى الخريطة",
+    "addUnsupported": "يمكن إضافة أصول GeoTIFF/COG وGeoJSON وGeoParquet وPMTiles فقط إلى الخريطة",
     "addFailed": "تعذّرت إضافة الأصل",
     "addNoSourceLayers": "لا يسرد هذا الأرشيف أي طبقات لرسمها",
     "cogUnsupported": "لا يستطيع مضيف GeoLibre هذا عرض أصول GeoTIFF البعيدة",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -3418,7 +3418,7 @@
     "download": "Herunterladen",
     "adding": "{{asset}} wird hinzugefügt…",
     "added": "{{asset}} zur Karte hinzugefügt.",
-    "addUnsupported": "Nur GeoTIFF/COG-, GeoJSON- und PMTiles-Assets können zur Karte hinzugefügt werden",
+    "addUnsupported": "Nur GeoTIFF/COG-, GeoJSON-, GeoParquet- und PMTiles-Assets können zur Karte hinzugefügt werden",
     "addFailed": "Asset konnte nicht hinzugefügt werden",
     "addNoSourceLayers": "Dieses Archiv führt keine zeichenbaren Ebenen auf",
     "cogUnsupported": "Dieser GeoLibre-Host kann entfernte GeoTIFF-Assets nicht darstellen",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3428,7 +3428,7 @@
     "download": "Download",
     "adding": "Adding {{asset}}…",
     "added": "Added {{asset}} to the map.",
-    "addUnsupported": "Only GeoTIFF/COG, GeoJSON, and PMTiles assets can be added to the map",
+    "addUnsupported": "Only GeoTIFF/COG, GeoJSON, GeoParquet, and PMTiles assets can be added to the map",
     "addFailed": "Could not add asset",
     "addNoSourceLayers": "This archive lists no layers to draw",
     "cogUnsupported": "This GeoLibre host cannot visualize remote GeoTIFF assets",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -3418,7 +3418,7 @@
     "download": "Descargar",
     "adding": "Añadiendo {{asset}}…",
     "added": "{{asset}} añadido al mapa.",
-    "addUnsupported": "Solo se pueden añadir al mapa recursos GeoTIFF/COG, GeoJSON y PMTiles",
+    "addUnsupported": "Solo se pueden añadir al mapa recursos GeoTIFF/COG, GeoJSON, GeoParquet y PMTiles",
     "addFailed": "No se pudo añadir el recurso",
     "addNoSourceLayers": "Este archivo no incluye capas que dibujar",
     "cogUnsupported": "Este host de GeoLibre no puede visualizar recursos GeoTIFF remotos",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -3418,7 +3418,7 @@
     "download": "دانلود",
     "adding": "در حال افزودن {{asset}}…",
     "added": "{{asset}} به نقشه افزوده شد.",
-    "addUnsupported": "تنها دارایی‌های GeoTIFF/COG، GeoJSON و PMTiles را می‌توان به نقشه افزود",
+    "addUnsupported": "تنها دارایی‌های GeoTIFF/COG، GeoJSON، GeoParquet و PMTiles را می‌توان به نقشه افزود",
     "addFailed": "افزودن دارایی با شکست مواجه شد",
     "addNoSourceLayers": "این بایگانی هیچ لایه‌ای برای ترسیم فهرست نکرده است",
     "cogUnsupported": "این میزبان GeoLibre نمی‌تواند دارایی‌های GeoTIFF دوردست را نمایش دهد",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -3418,7 +3418,7 @@
     "download": "Télécharger",
     "adding": "Ajout de {{asset}}…",
     "added": "{{asset}} ajouté à la carte.",
-    "addUnsupported": "Seules les ressources GeoTIFF/COG, GeoJSON et PMTiles peuvent être ajoutées à la carte",
+    "addUnsupported": "Seules les ressources GeoTIFF/COG, GeoJSON, GeoParquet et PMTiles peuvent être ajoutées à la carte",
     "addFailed": "Impossible d'ajouter la ressource",
     "addNoSourceLayers": "Cette archive ne répertorie aucune couche à dessiner",
     "cogUnsupported": "Cet hôte GeoLibre ne peut pas visualiser les ressources GeoTIFF distantes",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -3418,7 +3418,7 @@
     "download": "डाउनलोड करें",
     "adding": "{{asset}} जोड़ा जा रहा है…",
     "added": "{{asset}} मानचित्र में जोड़ा गया।",
-    "addUnsupported": "मानचित्र में केवल GeoTIFF/COG, GeoJSON और PMTiles एसेट जोड़ी जा सकती हैं",
+    "addUnsupported": "मानचित्र में केवल GeoTIFF/COG, GeoJSON, GeoParquet और PMTiles एसेट जोड़ी जा सकती हैं",
     "addFailed": "एसेट नहीं जोड़ी जा सकी",
     "addNoSourceLayers": "इस संग्रह में बनाने के लिए कोई लेयर सूचीबद्ध नहीं है",
     "cogUnsupported": "यह GeoLibre होस्ट दूरस्थ GeoTIFF एसेट प्रदर्शित नहीं कर सकता",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -3362,7 +3362,7 @@
     "download": "Unduh",
     "adding": "Menambahkan {{asset}}…",
     "added": "{{asset}} ditambahkan ke peta.",
-    "addUnsupported": "Hanya aset GeoTIFF/COG, GeoJSON, dan PMTiles yang dapat ditambahkan ke peta",
+    "addUnsupported": "Hanya aset GeoTIFF/COG, GeoJSON, GeoParquet, dan PMTiles yang dapat ditambahkan ke peta",
     "addFailed": "Tidak dapat menambahkan aset",
     "addNoSourceLayers": "Arsip ini tidak mencantumkan lapisan untuk digambar",
     "cogUnsupported": "Host GeoLibre ini tidak dapat memvisualisasikan aset GeoTIFF jarak jauh",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -3418,7 +3418,7 @@
     "download": "Scarica",
     "adding": "Aggiunta di {{asset}}…",
     "added": "{{asset}} aggiunto alla mappa.",
-    "addUnsupported": "Solo le risorse GeoTIFF/COG, GeoJSON e PMTiles possono essere aggiunte alla mappa",
+    "addUnsupported": "Solo le risorse GeoTIFF/COG, GeoJSON, GeoParquet e PMTiles possono essere aggiunte alla mappa",
     "addFailed": "Impossibile aggiungere la risorsa",
     "addNoSourceLayers": "Questo archivio non elenca livelli da disegnare",
     "cogUnsupported": "Questo host GeoLibre non può visualizzare risorse GeoTIFF remote",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -3362,7 +3362,7 @@
     "download": "ダウンロード",
     "adding": "{{asset}} を追加しています…",
     "added": "{{asset}} を地図に追加しました。",
-    "addUnsupported": "地図に追加できるのは GeoTIFF/COG、GeoJSON、PMTiles のアセットのみです",
+    "addUnsupported": "地図に追加できるのは GeoTIFF/COG、GeoJSON、GeoParquet、PMTiles のアセットのみです",
     "addFailed": "アセットを追加できませんでした",
     "addNoSourceLayers": "このアーカイブには描画できるレイヤーがありません",
     "cogUnsupported": "この GeoLibre ホストはリモートの GeoTIFF アセットを表示できません",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -3418,7 +3418,7 @@
     "download": "ჩამოტვირთვა",
     "adding": "მიმდინარეობს {{asset}}-ის დამატება…",
     "added": "{{asset}} დაემატა რუკაზე.",
-    "addUnsupported": "რუკაზე შეიძლება დაემატოს მხოლოდ GeoTIFF/COG, GeoJSON და PMTiles აქტივები",
+    "addUnsupported": "რუკაზე შეიძლება დაემატოს მხოლოდ GeoTIFF/COG, GeoJSON, GeoParquet და PMTiles აქტივები",
     "addFailed": "აქტივის დამატება ვერ მოხერხდა",
     "addNoSourceLayers": "ეს არქივი არ შეიცავს დასახატ ფენებს",
     "cogUnsupported": "ამ GeoLibre ჰოსტს არ შეუძლია დისტანციური GeoTIFF აქტივების ვიზუალიზაცია",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -3362,7 +3362,7 @@
     "download": "다운로드",
     "adding": "{{asset}} 추가 중…",
     "added": "{{asset}}을(를) 지도에 추가했습니다.",
-    "addUnsupported": "GeoTIFF/COG, GeoJSON 및 PMTiles 자산만 지도에 추가할 수 있습니다",
+    "addUnsupported": "GeoTIFF/COG, GeoJSON, GeoParquet 및 PMTiles 자산만 지도에 추가할 수 있습니다",
     "addFailed": "자산을 추가하지 못했습니다",
     "addNoSourceLayers": "이 아카이브에는 그릴 레이어가 없습니다",
     "cogUnsupported": "이 GeoLibre 호스트는 원격 GeoTIFF 자산을 표시할 수 없습니다",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -3418,7 +3418,7 @@
     "download": "Downloaden",
     "adding": "{{asset}} wordt toegevoegd…",
     "added": "{{asset}} toegevoegd aan de kaart.",
-    "addUnsupported": "Alleen GeoTIFF/COG-, GeoJSON- en PMTiles-assets kunnen aan de kaart worden toegevoegd",
+    "addUnsupported": "Alleen GeoTIFF/COG-, GeoJSON-, GeoParquet- en PMTiles-assets kunnen aan de kaart worden toegevoegd",
     "addFailed": "Kan asset niet toevoegen",
     "addNoSourceLayers": "Dit archief bevat geen tekenbare lagen",
     "cogUnsupported": "Deze GeoLibre-host kan externe GeoTIFF-assets niet weergeven",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -3418,7 +3418,7 @@
     "download": "Baixar",
     "adding": "Adicionando {{asset}}…",
     "added": "{{asset}} adicionado ao mapa.",
-    "addUnsupported": "Apenas recursos GeoTIFF/COG, GeoJSON e PMTiles podem ser adicionados ao mapa",
+    "addUnsupported": "Apenas recursos GeoTIFF/COG, GeoJSON, GeoParquet e PMTiles podem ser adicionados ao mapa",
     "addFailed": "Não foi possível adicionar o recurso",
     "addNoSourceLayers": "Este arquivo não lista camadas para desenhar",
     "cogUnsupported": "Este host do GeoLibre não consegue visualizar recursos GeoTIFF remotos",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -3530,7 +3530,7 @@
     "download": "Скачать",
     "adding": "Добавление {{asset}}…",
     "added": "{{asset}} добавлен на карту.",
-    "addUnsupported": "На карту можно добавить только ресурсы GeoTIFF/COG, GeoJSON и PMTiles",
+    "addUnsupported": "На карту можно добавить только ресурсы GeoTIFF/COG, GeoJSON, GeoParquet и PMTiles",
     "addFailed": "Не удалось добавить ресурс",
     "addNoSourceLayers": "В этом архиве нет слоёв для отрисовки",
     "cogUnsupported": "Этот хост GeoLibre не может отображать удалённые ресурсы GeoTIFF",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -3362,7 +3362,7 @@
     "download": "ดาวน์โหลด",
     "adding": "กำลังเพิ่ม {{asset}}…",
     "added": "เพิ่ม {{asset}} ลงในแผนที่แล้ว",
-    "addUnsupported": "เพิ่มลงแผนที่ได้เฉพาะแอสเซตแบบ GeoTIFF/COG, GeoJSON และ PMTiles เท่านั้น",
+    "addUnsupported": "เพิ่มลงแผนที่ได้เฉพาะแอสเซตแบบ GeoTIFF/COG, GeoJSON, GeoParquet และ PMTiles เท่านั้น",
     "addFailed": "ไม่สามารถเพิ่มแอสเซตได้",
     "addNoSourceLayers": "ไฟล์เก็บถาวรนี้ไม่มีเลเยอร์ให้วาด",
     "cogUnsupported": "โฮสต์ GeoLibre นี้ไม่สามารถแสดงผลแอสเซต GeoTIFF จากระยะไกลได้",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -3418,7 +3418,7 @@
     "download": "İndir",
     "adding": "{{asset}} ekleniyor…",
     "added": "{{asset}} haritaya eklendi.",
-    "addUnsupported": "Haritaya yalnızca GeoTIFF/COG, GeoJSON ve PMTiles varlıkları eklenebilir",
+    "addUnsupported": "Haritaya yalnızca GeoTIFF/COG, GeoJSON, GeoParquet ve PMTiles varlıkları eklenebilir",
     "addFailed": "Varlık eklenemedi",
     "addNoSourceLayers": "Bu arşiv çizilecek katman listelemiyor",
     "cogUnsupported": "Bu GeoLibre ana bilgisayarı uzak GeoTIFF varlıklarını görselleştiremiyor",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -3349,7 +3349,7 @@
     "collectionsHint": "Giữ Ctrl/Cmd để chọn nhiều bộ sưu tập; kéo cạnh dưới để thay đổi kích thước",
     "limitToExtent": "Giới hạn tìm kiếm trong phạm vi bản đồ hiện tại",
     "bboxLabel": "Hộp giới hạn (tây, nam, đông, bắc)",
-    "addUnsupported": "Chỉ có thể thêm nội dung GeoTIFF/COG, GeoJSON và PMTiles vào bản đồ",
+    "addUnsupported": "Chỉ có thể thêm nội dung GeoTIFF/COG, GeoJSON, GeoParquet và PMTiles vào bản đồ",
     "addFailed": "Không thể thêm nội dung",
     "addNoSourceLayers": "Kho lưu trữ này không liệt kê lớp nào để vẽ",
     "cogUnsupported": "Máy chủ GeoLibre này không thể hiển thị nội dung GeoTIFF từ xa",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -3362,7 +3362,7 @@
     "download": "下载",
     "adding": "正在添加 {{asset}}…",
     "added": "已将 {{asset}} 添加到地图。",
-    "addUnsupported": "只有 GeoTIFF/COG、GeoJSON 和 PMTiles 资源可以添加到地图",
+    "addUnsupported": "只有 GeoTIFF/COG、GeoJSON、GeoParquet 和 PMTiles 资源可以添加到地图",
     "addFailed": "无法添加资源",
     "addNoSourceLayers": "此归档未列出可绘制的图层",
     "cogUnsupported": "此 GeoLibre 主机无法可视化远程 GeoTIFF 资源",

--- a/e2e/stac-api-panel.spec.ts
+++ b/e2e/stac-api-panel.spec.ts
@@ -137,7 +137,7 @@ test("asset options identify their format and whether they can be added", async 
     "Red Band — COG",
     "Boundaries — GeoJSON",
     "Vector tiles — PMTiles",
-    "Dataset root — Parquet (not addable)",
+    "Dataset root — Parquet",
     "Metadata — Unknown format (not addable)",
   ]);
 });

--- a/e2e/stac-pmtiles.spec.ts
+++ b/e2e/stac-pmtiles.spec.ts
@@ -114,7 +114,14 @@ test("a PMTiles asset from a STAC item reaches the map", async ({ page }) => {
   await collection.dblclick();
   await expect(page.getByText(/Showing \d+ of \d+ items\./)).toBeVisible();
 
-  // The panel offers the archive rather than the parquet beside it, and Add is live.
+  // The parquet beside the archive is addable too, and being listed first it is the one the
+  // panel preselects, so the archive is chosen explicitly rather than taken as the default.
+  const assets = page
+    .locator("select")
+    .filter({ has: page.locator('option[value="pmtiles"]') })
+    .first();
+  await assets.selectOption("pmtiles");
+
   const add = page.getByRole("button", { name: "Add", exact: true }).first();
   await expect(add).toBeEnabled();
   await add.click();

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -9,6 +9,7 @@ import {
   assetFormat,
   connectStac,
   horizontalBbox,
+  isAzureBlobHref,
   isVisualizableAsset,
   itemBbox,
   loadStacIndex,
@@ -540,6 +541,36 @@ function assetOptionLabel(key: string, asset: StacAsset): string {
   return `${assetLabel(key, asset)} — ${assetFormatLabel(asset)}${addability}`;
 }
 
+type SasSigner = { signUrl(url: string, collectionId: string): Promise<string> };
+let sasManager: Promise<SasSigner> | null = null;
+
+function planetaryComputerSigner(): Promise<SasSigner> {
+  sasManager ??= import("maplibre-gl-planetary-computer")
+    .then((module) => new module.SASTokenManager())
+    .catch((error) => {
+      // Don't let one failed import disable signing for the rest of the session.
+      sasManager = null;
+      throw error;
+    });
+  return sasManager;
+}
+
+/**
+ * Planetary Computer serves several collections — most of the GeoParquet ones — from private
+ * containers that answer 409 without a SAS token, while others (NAIP) read fine anonymously.
+ * Tokens are per-collection and expire within the hour, so they are minted when the asset is
+ * added rather than when the item is parsed, and the upstream manager caches them. Anything
+ * that is not an Azure blob, or that cannot be signed, is read unsigned.
+ */
+async function readableHref(item: StacItem, href: string): Promise<string> {
+  if (!isAzureBlobHref(href) || !item.collection) return href;
+  try {
+    return await (await planetaryComputerSigner()).signUrl(href, item.collection);
+  } catch {
+    return href;
+  }
+}
+
 async function visualizeAsset(
   item: StacItem,
   key: string,
@@ -549,35 +580,37 @@ async function visualizeAsset(
 ): Promise<void> {
   const name = `${item.id} — ${assetLabel(key, asset)}`;
   const format = assetFormat(asset);
+  const href = await readableHref(item, asset.href);
   switch (format) {
     case "pmtiles": {
       // No appRef check: the layer goes to the store, not through the app API.
-      if (!(await addPMTilesAsset(asset.href, name, signal))) {
+      if (!(await addPMTilesAsset(href, name, signal))) {
         throw new Error(labels.addNoSourceLayers);
       }
       return;
     }
     case "geojson": {
       if (!appRef) throw new Error(labels.addFailed);
-      const response = await fetch(asset.href, {
+      const response = await fetch(href, {
         headers: { Accept: "application/geo+json, application/json" },
         signal,
       });
       if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
       const data = (await response.json()) as FeatureCollection;
+      // Provenance keeps the unsigned href so no expiring token is saved into the project.
       appRef.addGeoJsonLayer(name, data, asset.href);
       return;
     }
     case "parquet": {
       if (!appRef) throw new Error(labels.addFailed);
-      if (!(await addVectorLayerFromUrl(appRef, asset.href, { name }))) {
+      if (!(await addVectorLayerFromUrl(appRef, href, { name }))) {
         throw new Error(labels.addFailed);
       }
       return;
     }
     case "cog": {
       if (!appRef?.addCogLayer) throw new Error(labels.cogUnsupported);
-      await appRef.addCogLayer(name, asset.href, cogOptions);
+      await appRef.addCogLayer(name, href, cogOptions);
       return;
     }
     case null:

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -562,10 +562,16 @@ function planetaryComputerSigner(): Promise<SasSigner> {
  * added rather than when the item is parsed, and the upstream manager caches them. Anything
  * that is not an Azure blob, or that cannot be signed, is read unsigned.
  *
- * Only the GeoParquet path signs. The formats that keep a URL as their layer source — PMTiles
- * and COG store the href verbatim in the store, which is what a saved project is written from —
- * would bake an expiring token into `.geolibre.json`, so they read unsigned exactly as they did
- * before GeoParquet was addable. Signing those wants the token minted per request instead.
+ * Only the GeoParquet path signs, because that is the one this branch made addable and it cannot
+ * read a private container at all unsigned. PMTiles and COG read unsigned exactly as they did
+ * before, rather than gaining a token they never had.
+ *
+ * Every one of these formats persists whatever URL it is handed: PMTiles and COG through the
+ * store layer they create, and the vector control through `createVectorStoreLayer`, which records
+ * the URL as both `source.url` and `sourcePath`. A project saved with a signed GeoParquet layer
+ * therefore holds a token that `restoreVectorLayers` replays as-is and never re-signs, so the
+ * layer stops reloading once the token lapses (about an hour). Fixing that properly means minting
+ * the token per request, or re-signing on restore, rather than baking one in at add time.
  */
 async function readableHref(item: StacItem, href: string): Promise<string> {
   if (!isAzureBlobHref(href) || !item.collection) return href;

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -561,6 +561,11 @@ function planetaryComputerSigner(): Promise<SasSigner> {
  * Tokens are per-collection and expire within the hour, so they are minted when the asset is
  * added rather than when the item is parsed, and the upstream manager caches them. Anything
  * that is not an Azure blob, or that cannot be signed, is read unsigned.
+ *
+ * Only the GeoParquet path signs. The formats that keep a URL as their layer source — PMTiles
+ * and COG store the href verbatim in the store, which is what a saved project is written from —
+ * would bake an expiring token into `.geolibre.json`, so they read unsigned exactly as they did
+ * before GeoParquet was addable. Signing those wants the token minted per request instead.
  */
 async function readableHref(item: StacItem, href: string): Promise<string> {
   if (!isAzureBlobHref(href) || !item.collection) return href;
@@ -580,37 +585,35 @@ async function visualizeAsset(
 ): Promise<void> {
   const name = `${item.id} — ${assetLabel(key, asset)}`;
   const format = assetFormat(asset);
-  const href = await readableHref(item, asset.href);
   switch (format) {
     case "pmtiles": {
       // No appRef check: the layer goes to the store, not through the app API.
-      if (!(await addPMTilesAsset(href, name, signal))) {
+      if (!(await addPMTilesAsset(asset.href, name, signal))) {
         throw new Error(labels.addNoSourceLayers);
       }
       return;
     }
     case "geojson": {
       if (!appRef) throw new Error(labels.addFailed);
-      const response = await fetch(href, {
+      const response = await fetch(asset.href, {
         headers: { Accept: "application/geo+json, application/json" },
         signal,
       });
       if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
       const data = (await response.json()) as FeatureCollection;
-      // Provenance keeps the unsigned href so no expiring token is saved into the project.
       appRef.addGeoJsonLayer(name, data, asset.href);
       return;
     }
     case "parquet": {
       if (!appRef) throw new Error(labels.addFailed);
-      if (!(await addVectorLayerFromUrl(appRef, href, { name }))) {
+      if (!(await addVectorLayerFromUrl(appRef, await readableHref(item, asset.href), { name }))) {
         throw new Error(labels.addFailed);
       }
       return;
     }
     case "cog": {
       if (!appRef?.addCogLayer) throw new Error(labels.cogUnsupported);
-      await appRef.addCogLayer(name, href, cogOptions);
+      await appRef.addCogLayer(name, asset.href, cogOptions);
       return;
     }
     case null:

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -25,6 +25,7 @@ import {
 } from "./stac-api";
 import { buildCatalogTree } from "./stac-catalog-tree";
 import { el, setDisabled } from "../panel-dom";
+import { addVectorLayerFromUrl } from "./maplibre-vector";
 
 export const STAC_PLUGIN_ID = "geolibre-stac-catalogs";
 const PANEL_ID = STAC_PLUGIN_ID;
@@ -219,7 +220,8 @@ let labels: StacLabels = {
   zoom: "Zoom",
   add: "Add",
   download: "Download",
-  addUnsupported: "Only GeoTIFF/COG, GeoJSON, and PMTiles assets can be added to the map",
+  addUnsupported:
+    "Only GeoTIFF/COG, GeoJSON, GeoParquet, and PMTiles assets can be added to the map",
   addFailed: "Could not add asset",
   addNoSourceLayers: "This archive lists no layers to draw",
   cogUnsupported: "This GeoLibre host cannot visualize remote GeoTIFF assets",
@@ -564,6 +566,13 @@ async function visualizeAsset(
       if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
       const data = (await response.json()) as FeatureCollection;
       appRef.addGeoJsonLayer(name, data, asset.href);
+      return;
+    }
+    case "parquet": {
+      if (!appRef) throw new Error(labels.addFailed);
+      if (!(await addVectorLayerFromUrl(appRef, asset.href, { name }))) {
+        throw new Error(labels.addFailed);
+      }
       return;
     }
     case "cog": {

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -614,9 +614,25 @@ export function assetDisplayFormat(asset: StacAsset): StacAssetDisplayFormat | n
 /**
  * Which format an asset is, or null when the panel cannot draw it. Both the enabled state of Add
  * and the routing behind it read this, so the button and the click cannot disagree.
+ *
+ * Narrower than {@link assetDisplayFormat}: an asset is named by its format even when it cannot
+ * be reached. {@link browserAssetHref} leaves an object-store URI alone when nothing resolves it
+ * — an `abfs://` href whose catalog omits `table:storage_options`, say — and none of the readers
+ * behind Add speak those schemes, so such an asset is labelled but not offered.
  */
 export function assetFormat(asset: StacAsset): StacAssetFormat | null {
+  if (!isFetchableHref(asset.href)) return null;
   return assetDisplayFormat(asset);
+}
+
+/** Whether an href is one the readers behind Add can actually open. */
+function isFetchableHref(href: string): boolean {
+  try {
+    const { protocol } = new URL(href);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
 }
 
 export function isVisualizableAsset(asset: StacAsset): boolean {

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -550,8 +550,8 @@ export function itemBbox(item: StacItem): [number, number, number, number] | und
 }
 
 /** A format {@link assetFormat} recognizes, and {@link visualizeAsset} knows how to add. */
-export type StacAssetFormat = "pmtiles" | "geojson" | "cog";
-export type StacAssetDisplayFormat = StacAssetFormat | "parquet";
+export type StacAssetFormat = "pmtiles" | "geojson" | "cog" | "parquet";
+export type StacAssetDisplayFormat = StacAssetFormat;
 
 interface AssetFormatRule {
   format: StacAssetDisplayFormat;
@@ -582,8 +582,7 @@ export function assetDisplayFormat(asset: StacAsset): StacAssetDisplayFormat | n
  * and the routing behind it read this, so the button and the click cannot disagree.
  */
 export function assetFormat(asset: StacAsset): StacAssetFormat | null {
-  const format = assetDisplayFormat(asset);
-  return format === "parquet" ? null : format;
+  return assetDisplayFormat(asset);
 }
 
 export function isVisualizableAsset(asset: StacAsset): boolean {

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -29,6 +29,11 @@ export interface StacAsset {
   title?: string;
   type?: string;
   roles?: string[];
+  /**
+   * Table extension storage options. Catalogs that publish `abfs://` hrefs keep the Azure
+   * account out of the URL and name it here — the href's first segment is the *container*.
+   */
+  "table:storage_options"?: { account_name?: string };
 }
 
 export interface StacItem extends Feature<Geometry | null> {
@@ -137,17 +142,41 @@ function absoluteHref(href: string, base: string): string {
 }
 
 /**
- * Converts an anonymous S3 object URI into the HTTPS form browsers and raster
+ * Converts an anonymous object-store URI into the HTTPS form browsers and raster
  * range readers can fetch. STAC APIs such as Earth Search legitimately return
- * `s3://` asset hrefs even though the catalog itself is accessed over HTTPS.
+ * `s3://` asset hrefs even though the catalog itself is accessed over HTTPS, and
+ * Planetary Computer publishes GeoParquet as `abfs://`.
+ *
+ * `accountName` comes from the asset's `table:storage_options`. Azure hrefs name the
+ * *container* first and carry the account out of band, so without an account name there
+ * is nothing to resolve against and the href is returned untouched.
  */
-export function browserAssetHref(href: string, base: string): string {
+export function browserAssetHref(href: string, base: string, accountName?: string): string {
   const resolved = absoluteHref(href, base);
   const url = new URL(resolved);
-  if (url.protocol !== "s3:") return resolved;
-  const bucket = url.hostname;
-  if (!bucket) return resolved;
-  return `https://${bucket}.s3.amazonaws.com${url.pathname}${url.search}${url.hash}`;
+  if (url.protocol === "s3:") {
+    const bucket = url.hostname;
+    if (!bucket) return resolved;
+    return `https://${bucket}.s3.amazonaws.com${url.pathname}${url.search}${url.hash}`;
+  }
+  if (AZURE_SCHEMES.has(url.protocol)) {
+    const container = url.hostname;
+    if (!container || !accountName) return resolved;
+    return `https://${accountName}.blob.core.windows.net/${container}${url.pathname}${url.search}${url.hash}`;
+  }
+  return resolved;
+}
+
+/** fsspec/adlfs spellings for an Azure blob path, all container-first. */
+const AZURE_SCHEMES = new Set(["abfs:", "abfss:", "az:"]);
+
+/** Whether an href points at Azure blob storage, which may need a SAS token to read. */
+export function isAzureBlobHref(href: string): boolean {
+  try {
+    return new URL(href).hostname.endsWith(".blob.core.windows.net");
+  } catch {
+    return false;
+  }
 }
 
 async function fetchJson<T>(url: string, init: RequestInit, fetcher: FetchLike): Promise<T> {
@@ -197,11 +226,16 @@ function isStacItem(value: unknown): value is StacItem {
 }
 
 function normalizeItem(item: StacItem, base: string): StacItem {
+  // The table extension allows the storage options to sit on the item instead of on each asset.
+  const itemAccount = (
+    item.properties?.["table:storage_options"] as { account_name?: string } | undefined
+  )?.account_name;
   const assets = Object.fromEntries(
     Object.entries(item.assets ?? {}).flatMap(([key, asset]) => {
       if (!asset?.href) return [];
+      const account = asset["table:storage_options"]?.account_name ?? itemAccount;
       try {
-        return [[key, { ...asset, href: browserAssetHref(asset.href, base) }]];
+        return [[key, { ...asset, href: browserAssetHref(asset.href, base, account) }]];
       } catch {
         return [];
       }

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -160,12 +160,18 @@ export function browserAssetHref(href: string, base: string, accountName?: strin
     return `https://${bucket}.s3.amazonaws.com${url.pathname}${url.search}${url.hash}`;
   }
   if (AZURE_SCHEMES.has(url.protocol)) {
-    const container = url.hostname;
-    if (!container || !accountName) return resolved;
-    return `https://${accountName}.blob.core.windows.net/${container}${url.pathname}${url.search}${url.hash}`;
+    // Canonical form names both parts: abfs[s]://<container>@<account>.dfs.core.windows.net/<path>.
+    // The shorthand names only the container and leans on the account beside it.
+    const canonical = url.hostname.endsWith(DFS_SUFFIX);
+    const container = canonical ? decodeURIComponent(url.username) : url.hostname;
+    const account = canonical ? url.hostname.slice(0, -DFS_SUFFIX.length) : accountName;
+    if (!container || !account) return resolved;
+    return `https://${account}.blob.core.windows.net/${container}${url.pathname}${url.search}${url.hash}`;
   }
   return resolved;
 }
+
+const DFS_SUFFIX = ".dfs.core.windows.net";
 
 /** fsspec/adlfs spellings for an Azure blob path, all container-first. */
 const AZURE_SCHEMES = new Set(["abfs:", "abfss:", "az:"]);

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -54,6 +54,18 @@ test("browserAssetHref resolves Azure hrefs against the account named beside the
   );
 });
 
+test("an Azure asset with nothing to resolve it against is named but not offered", () => {
+  // browserAssetHref leaves the href alone when no account names the container, and none of the
+  // readers behind Add speak abfs://, so the panel must not enable Add for it.
+  const asset = { href: "abfs://us-census/2020/x.parquet", type: "application/x-parquet" };
+  assert.equal(assetDisplayFormat(asset), "parquet");
+  assert.equal(assetFormat(asset), null);
+  assert.equal(isVisualizableAsset(asset), false);
+  // Once resolved, the same asset is addable.
+  const resolved = { ...asset, href: browserAssetHref(asset.href, "https://x.test/", "acct") };
+  assert.equal(assetFormat(resolved), "parquet");
+});
+
 test("isAzureBlobHref recognizes only blob-storage URLs", () => {
   assert.equal(
     isAzureBlobHref("https://ai4edataeuwest.blob.core.windows.net/us-census/x.parquet"),
@@ -739,6 +751,46 @@ test("a searched item's Azure asset arrives resolved against its storage options
   assert.equal(
     result.items[0].assets.data.href,
     "https://ai4edataeuwest.blob.core.windows.net/us-census/2020/cb_2020_us_state_500k.parquet",
+  );
+});
+
+test("storage options on the item resolve an asset that carries none of its own", async () => {
+  // The table extension allows the options to sit once on the item rather than on every asset.
+  const fetcher = (async () =>
+    jsonResponse({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "shared-options",
+          geometry: null,
+          collection: "us-census",
+          properties: {
+            datetime: "2021-08-01T00:00:00Z",
+            "table:storage_options": { account_name: "ai4edataeuwest" },
+          },
+          assets: {
+            data: { href: "abfs://us-census/2020/a.parquet", type: "application/x-parquet" },
+          },
+        },
+      ],
+      links: [],
+    })) as typeof fetch;
+  const result = await searchStacApi(
+    {
+      url: "https://planetarycomputer.microsoft.com/api/stac/v1/",
+      title: "Planetary Computer",
+      isApi: true,
+      searchUrl: "https://planetarycomputer.microsoft.com/api/stac/v1/search",
+      collections: [],
+      root: {},
+    },
+    { limit: 10 },
+    fetcher,
+  );
+  assert.equal(
+    result.items[0].assets.data.href,
+    "https://ai4edataeuwest.blob.core.windows.net/us-census/2020/a.parquet",
   );
 });
 

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -1164,6 +1164,11 @@ test("an asset's format comes from its media type, or its extension when there i
     "parquet",
   );
   assert.equal(assetDisplayFormat({ href: "https://example.com/data.parquet" }), "parquet");
+  assert.equal(
+    assetFormat({ href: "https://example.com/data.bin", type: "application/vnd.apache.parquet" }),
+    "parquet",
+  );
+  assert.equal(assetFormat({ href: "https://example.com/data.parquet" }), "parquet");
 
   // Archives under a directory named for another format are read by the asset, not the path.
   assert.equal(assetFormat({ href: "https://example.com/geotiff/a.pmtiles" }), "pmtiles");
@@ -1180,6 +1185,13 @@ test("an asset's format comes from its media type, or its extension when there i
 
   assert.equal(
     isVisualizableAsset({ href: "https://example.com/a.pmtiles", type: "application/vnd.pmtiles" }),
+    true,
+  );
+  assert.equal(
+    isVisualizableAsset({
+      href: "https://example.com/data.bin",
+      type: "application/vnd.apache.parquet",
+    }),
     true,
   );
 });

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -5,6 +5,7 @@ import {
   connectStac,
   assetDisplayFormat,
   assetFormat,
+  isAzureBlobHref,
   isVisualizableAsset,
   itemBbox,
   openCatalogNode,
@@ -28,6 +29,40 @@ test("browserAssetHref converts anonymous S3 STAC assets to fetchable HTTPS URLs
     browserAssetHref("./data.tif", "https://example.com/catalog/item.json"),
     "https://example.com/catalog/data.tif",
   );
+});
+
+test("browserAssetHref resolves Azure hrefs against the account named beside them", () => {
+  // abfs names the container first and carries the account in table:storage_options, so the
+  // account is prepended as the host rather than read out of the href (GeoLibre#1976).
+  assert.equal(
+    browserAssetHref(
+      "abfs://us-census/2020/cb_2020_us_state_500k.parquet",
+      "https://planetarycomputer.microsoft.com/api/stac/v1/",
+      "ai4edataeuwest",
+    ),
+    "https://ai4edataeuwest.blob.core.windows.net/us-census/2020/cb_2020_us_state_500k.parquet",
+  );
+  assert.equal(
+    browserAssetHref("az://container/a.parquet", "https://example.com/", "acct"),
+    "https://acct.blob.core.windows.net/container/a.parquet",
+  );
+  // With no account there is nothing to resolve against, so the href is left alone rather
+  // than guessed at.
+  assert.equal(
+    browserAssetHref("abfs://us-census/2020/x.parquet", "https://example.com/"),
+    "abfs://us-census/2020/x.parquet",
+  );
+});
+
+test("isAzureBlobHref recognizes only blob-storage URLs", () => {
+  assert.equal(
+    isAzureBlobHref("https://ai4edataeuwest.blob.core.windows.net/us-census/x.parquet"),
+    true,
+  );
+  assert.equal(isAzureBlobHref("https://example.com/x.parquet"), false);
+  // A host merely ending in the suffix as a substring must not match.
+  assert.equal(isAzureBlobHref("https://notblob.core.windows.net.evil.com/x"), false);
+  assert.equal(isAzureBlobHref("not a url"), false);
 });
 
 test("connectStac discovers relative API links and collections", async () => {
@@ -664,6 +699,46 @@ test("a tree selection narrows where the search starts without voiding the colle
     narrowed.items.map((item) => item.id),
     ["L9"],
     "both filters apply; neither is silently dropped",
+  );
+});
+
+test("a searched item's Azure asset arrives resolved against its storage options", async () => {
+  const fetcher = (async () =>
+    jsonResponse({
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: "2020-census-states",
+          geometry: null,
+          collection: "us-census",
+          properties: { datetime: "2021-08-01T00:00:00Z" },
+          assets: {
+            data: {
+              href: "abfs://us-census/2020/cb_2020_us_state_500k.parquet",
+              type: "application/x-parquet",
+              "table:storage_options": { account_name: "ai4edataeuwest" },
+            },
+          },
+        },
+      ],
+      links: [],
+    })) as typeof fetch;
+  const result = await searchStacApi(
+    {
+      url: "https://planetarycomputer.microsoft.com/api/stac/v1/",
+      title: "Planetary Computer",
+      isApi: true,
+      searchUrl: "https://planetarycomputer.microsoft.com/api/stac/v1/search",
+      collections: [],
+      root: {},
+    },
+    { limit: 10 },
+    fetcher,
+  );
+  assert.equal(
+    result.items[0].assets.data.href,
+    "https://ai4edataeuwest.blob.core.windows.net/us-census/2020/cb_2020_us_state_500k.parquet",
   );
 });
 

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -54,6 +54,32 @@ test("browserAssetHref resolves Azure hrefs against the account named beside the
   );
 });
 
+test("browserAssetHref reads the canonical ABFS form, which names its own account", () => {
+  // abfs[s]://<container>@<account>.dfs.core.windows.net/<path> carries both parts, so it
+  // resolves without storage options and must not be read as if the host were the container.
+  assert.equal(
+    browserAssetHref(
+      "abfss://container@acct.dfs.core.windows.net/dir/a.parquet",
+      "https://x.test/",
+    ),
+    "https://acct.blob.core.windows.net/container/dir/a.parquet",
+  );
+  // An account named beside it does not override the one the URI states.
+  assert.equal(
+    browserAssetHref(
+      "abfs://container@acct.dfs.core.windows.net/a.parquet",
+      "https://x.test/",
+      "other",
+    ),
+    "https://acct.blob.core.windows.net/container/a.parquet",
+  );
+  // The canonical host with no container is not resolvable, so it is left alone.
+  assert.equal(
+    browserAssetHref("abfss://acct.dfs.core.windows.net/a.parquet", "https://x.test/"),
+    "abfss://acct.dfs.core.windows.net/a.parquet",
+  );
+});
+
 test("an Azure asset with nothing to resolve it against is named but not offered", () => {
   // browserAssetHref leaves the href alone when no account names the container, and none of the
   // readers behind Add speak abfs://, so the panel must not enable Add for it.


### PR DESCRIPTION
## Summary

- recognize GeoParquet STAC assets by media type or file extension
- load GeoParquet assets through the shared DuckDB-WASM vector URL path
- keep the asset tied to its STAC item in the resulting layer name
- update the supported-format message across all shipped locales

## Verification

- reproduced with a local static STAC catalog and `us_cities.parquet`
- verified adding the asset in the real app in light and dark themes
- `node --import tsx --test tests/stac-api.test.ts tests/i18n-catalogs.test.ts tests/i18n-languages.test.ts tests/add-data-i18n.test.ts`
- `npm run build`
- scoped pre-commit hooks

Fixes #1968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing and adding GeoParquet assets to the map.
  * Improved support for Parquet assets referenced through STAC metadata.
  * Added Azure Blob Storage URL handling, including secure access signing where available.

* **Bug Fixes**
  * Added fallback behavior when secure Azure URL signing fails.
  * Improved handling of unsupported or inaccessible object-storage assets.
  * Updated localized messages to list GeoParquet as a supported format.

* **Tests**
  * Expanded coverage for GeoParquet and Azure Blob Storage workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->