### PR TITLE
fix(processing): preserve dissolve attribute groups

### DIFF
--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -98,7 +98,7 @@ function explodeToPolygons(features: Feature[]): Feature<Polygon>[] {
 function collectDissolveParts(
   dissolved: FeatureCollection<Polygon>,
   field?: string,
-  originalValues?: ReadonlyMap<string, unknown>,
+  originalProperties?: ReadonlyMap<string, GeoJsonProperties>,
 ): FeatureCollection<Polygon | MultiPolygon> {
   const groups = new Map<string, Feature<Polygon>[]>();
   for (const feature of dissolved.features) {
@@ -108,24 +108,25 @@ function collectDissolveParts(
     else groups.set(key, [feature]);
   }
 
-  const features: Feature<Polygon | MultiPolygon>[] = [...groups.entries()].map(
-    ([value, parts]) => {
-      const fieldValue = originalValues?.has(value)
-        ? originalValues.get(value)
-        : parts[0].properties?.[field ?? ""];
-      if (parts.length === 1) {
-        return field ? { ...parts[0], properties: { [field]: fieldValue } } : parts[0];
-      }
-      return {
-        type: "Feature" as const,
-        properties: field ? { [field]: fieldValue } : {},
-        geometry: {
-          type: "MultiPolygon" as const,
-          coordinates: parts.map((part) => part.geometry.coordinates),
-        },
-      };
-    },
-  );
+  const features: Feature<Polygon | MultiPolygon>[] = [...groups.entries()].map(([key, parts]) => {
+    // Mirror GeoPandas' `dissolve` (aggfunc="first"): every merged feature keeps
+    // the first source feature's whole attribute set, so the dissolve field keeps
+    // its original type and the other attributes survive the merge — whether or
+    // not the group happened to stay connected.
+    const source = originalProperties?.get(key) ?? parts[0].properties;
+    const properties: GeoJsonProperties = source ? { ...source } : {};
+    if (parts.length === 1) {
+      return { ...parts[0], properties };
+    }
+    return {
+      type: "Feature" as const,
+      properties,
+      geometry: {
+        type: "MultiPolygon" as const,
+        coordinates: parts.map((part) => part.geometry.coordinates),
+      },
+    };
+  });
   return featureCollection(features);
 }
 
@@ -301,18 +302,17 @@ export const dissolveTool: ProcessingAlgorithm = {
       return;
     }
     const field = (ctx.parameters.field as string)?.trim();
-    const originalValues = new Map<string, unknown>();
-    if (field) {
-      for (const polygon of polys) {
-        const value = polygon.properties?.[field];
-        const key = String(value);
-        if (!originalValues.has(key)) originalValues.set(key, value);
-      }
+    // Remember the first source feature of each group so the merged output can
+    // carry its attributes through, the way the sidecar's GeoPandas dissolve does.
+    const originalProperties = new Map<string, GeoJsonProperties>();
+    for (const polygon of polys) {
+      const key = field ? String(polygon.properties?.[field]) : "";
+      if (!originalProperties.has(key)) originalProperties.set(key, polygon.properties);
     }
     const dissolvedParts = dissolve(featureCollection(polys), {
       propertyName: field || undefined,
     });
-    const dissolved = collectDissolveParts(dissolvedParts, field || undefined, originalValues);
+    const dissolved = collectDissolveParts(dissolvedParts, field || undefined, originalProperties);
     ctx.log(`Dissolved ${polys.length} polygon(s) into ${dissolved.features.length} feature(s)`);
     ctx.addResultLayer?.("Dissolve", dissolved);
   },

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -94,6 +94,35 @@ function explodeToPolygons(features: Feature[]): Feature<Polygon>[] {
   return result;
 }
 
+/** Reassemble Turf dissolve parts into one Polygon/MultiPolygon per group. */
+function collectDissolveParts(
+  dissolved: FeatureCollection<Polygon>,
+  field?: string,
+): FeatureCollection<Polygon | MultiPolygon> {
+  const groups = new Map<string, Feature<Polygon>[]>();
+  for (const feature of dissolved.features) {
+    const key = field ? String(feature.properties?.[field]) : "";
+    const group = groups.get(key);
+    if (group) group.push(feature);
+    else groups.set(key, [feature]);
+  }
+
+  const features: Feature<Polygon | MultiPolygon>[] = [...groups.entries()].map(
+    ([value, parts]) => {
+      if (parts.length === 1) return parts[0];
+      return {
+        type: "Feature" as const,
+        properties: field ? { [field]: value } : {},
+        geometry: {
+          type: "MultiPolygon" as const,
+          coordinates: parts.map((part) => part.geometry.coordinates),
+        },
+      };
+    },
+  );
+  return featureCollection(features);
+}
+
 /** Merge all polygons of a collection into a single (multi)polygon feature. */
 function mergePolygons(fc: FeatureCollection): Feature<Polygon | MultiPolygon> | null {
   const polys = polygonFeatures(fc);
@@ -266,9 +295,10 @@ export const dissolveTool: ProcessingAlgorithm = {
       return;
     }
     const field = (ctx.parameters.field as string)?.trim();
-    const dissolved = dissolve(featureCollection(polys), {
+    const dissolvedParts = dissolve(featureCollection(polys), {
       propertyName: field || undefined,
     });
+    const dissolved = collectDissolveParts(dissolvedParts, field || undefined);
     ctx.log(`Dissolved ${polys.length} polygon(s) into ${dissolved.features.length} feature(s)`);
     ctx.addResultLayer?.("Dissolve", dissolved);
   },

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -98,6 +98,7 @@ function explodeToPolygons(features: Feature[]): Feature<Polygon>[] {
 function collectDissolveParts(
   dissolved: FeatureCollection<Polygon>,
   field?: string,
+  originalValues?: ReadonlyMap<string, unknown>,
 ): FeatureCollection<Polygon | MultiPolygon> {
   const groups = new Map<string, Feature<Polygon>[]>();
   for (const feature of dissolved.features) {
@@ -109,10 +110,15 @@ function collectDissolveParts(
 
   const features: Feature<Polygon | MultiPolygon>[] = [...groups.entries()].map(
     ([value, parts]) => {
-      if (parts.length === 1) return parts[0];
+      const fieldValue = originalValues?.has(value)
+        ? originalValues.get(value)
+        : parts[0].properties?.[field ?? ""];
+      if (parts.length === 1) {
+        return field ? { ...parts[0], properties: { [field]: fieldValue } } : parts[0];
+      }
       return {
         type: "Feature" as const,
-        properties: field ? { [field]: value } : {},
+        properties: field ? { [field]: fieldValue } : {},
         geometry: {
           type: "MultiPolygon" as const,
           coordinates: parts.map((part) => part.geometry.coordinates),
@@ -295,10 +301,18 @@ export const dissolveTool: ProcessingAlgorithm = {
       return;
     }
     const field = (ctx.parameters.field as string)?.trim();
+    const originalValues = new Map<string, unknown>();
+    if (field) {
+      for (const polygon of polys) {
+        const value = polygon.properties?.[field];
+        const key = String(value);
+        if (!originalValues.has(key)) originalValues.set(key, value);
+      }
+    }
     const dissolvedParts = dissolve(featureCollection(polys), {
       propertyName: field || undefined,
     });
-    const dissolved = collectDissolveParts(dissolvedParts, field || undefined);
+    const dissolved = collectDissolveParts(dissolvedParts, field || undefined, originalValues);
     ctx.log(`Dissolved ${polys.length} polygon(s) into ${dissolved.features.length} feature(s)`);
     ctx.addResultLayer?.("Dissolve", dissolved);
   },

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -53,9 +53,9 @@ describe("processing registry", () => {
   });
 
   it("dissolves disconnected polygons into one feature per attribute value", () => {
-    const square = (x: number, group: string | number) => ({
+    const square = (x: number, group: string | number, name = `square-${x}`) => ({
       type: "Feature" as const,
-      properties: { group },
+      properties: { group, name },
       geometry: {
         type: "Polygon" as const,
         coordinates: [
@@ -93,6 +93,11 @@ describe("processing registry", () => {
     const numericGroup = result!.features.find((feature) => feature.properties?.group === 5);
     assert.equal(numericGroup?.properties?.group, 5);
     assert.equal(numericGroup?.geometry.type, "MultiPolygon");
+    // Merged groups keep the first source feature's other attributes, matching
+    // the sidecar's GeoPandas dissolve.
+    assert.equal(numericGroup?.properties?.name, "square-0");
+    const connectedGroup = result!.features.find((feature) => feature.properties?.group === "B");
+    assert.equal(connectedGroup?.properties?.name, "square-6");
     assert.deepEqual(messages, ["Dissolved 3 polygon(s) into 2 feature(s)"]);
   });
 
@@ -151,6 +156,7 @@ describe("processing registry", () => {
 
     assert.equal(result!.features.length, 1);
     assert.equal(result!.features[0].geometry.type, "MultiPolygon");
+    assert.equal(result!.features[0].properties?.name, "first");
   });
 
   it("spatially joins zone attributes onto points", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -53,7 +53,7 @@ describe("processing registry", () => {
   });
 
   it("dissolves disconnected polygons into one feature per attribute value", () => {
-    const square = (x: number, group: string) => ({
+    const square = (x: number, group: string | number) => ({
       type: "Feature" as const,
       properties: { group },
       geometry: {
@@ -74,7 +74,7 @@ describe("processing registry", () => {
       id: "polygons",
       geojson: {
         type: "FeatureCollection",
-        features: [square(0, "A"), square(3, "A"), square(6, "B")],
+        features: [square(0, 5), square(3, 5), square(6, "B")],
       },
     };
     const messages: string[] = [];
@@ -90,11 +90,67 @@ describe("processing registry", () => {
     });
 
     assert.equal(result!.features.length, 2);
-    assert.equal(
-      result!.features.find((feature) => feature.properties?.group === "A")?.geometry.type,
-      "MultiPolygon",
-    );
+    const numericGroup = result!.features.find((feature) => feature.properties?.group === 5);
+    assert.equal(numericGroup?.properties?.group, 5);
+    assert.equal(numericGroup?.geometry.type, "MultiPolygon");
     assert.deepEqual(messages, ["Dissolved 3 polygon(s) into 2 feature(s)"]);
+  });
+
+  it("dissolves all disconnected polygons into one feature without a field", () => {
+    const polygons: GeoLibreLayer = {
+      ...layer,
+      id: "polygons",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { name: "first" },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [1, 0],
+                  [1, 1],
+                  [0, 1],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+          {
+            type: "Feature",
+            properties: { name: "second" },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [3, 0],
+                  [4, 0],
+                  [4, 1],
+                  [3, 1],
+                  [3, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    };
+    let result: FeatureCollection | null = null;
+
+    getVectorTool("dissolve")!.run({
+      layers: [polygons],
+      parameters: { layer: "polygons" },
+      log: () => {},
+      addResultLayer: (_name, geojson) => {
+        result = geojson;
+      },
+    });
+
+    assert.equal(result!.features.length, 1);
+    assert.equal(result!.features[0].geometry.type, "MultiPolygon");
   });
 
   it("spatially joins zone attributes onto points", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -52,6 +52,51 @@ describe("processing registry", () => {
     assert.deepEqual(messages, ["Feature count: 2"]);
   });
 
+  it("dissolves disconnected polygons into one feature per attribute value", () => {
+    const square = (x: number, group: string) => ({
+      type: "Feature" as const,
+      properties: { group },
+      geometry: {
+        type: "Polygon" as const,
+        coordinates: [
+          [
+            [x, 0],
+            [x + 1, 0],
+            [x + 1, 1],
+            [x, 1],
+            [x, 0],
+          ],
+        ],
+      },
+    });
+    const polygons: GeoLibreLayer = {
+      ...layer,
+      id: "polygons",
+      geojson: {
+        type: "FeatureCollection",
+        features: [square(0, "A"), square(3, "A"), square(6, "B")],
+      },
+    };
+    const messages: string[] = [];
+    let result: FeatureCollection | null = null;
+
+    getVectorTool("dissolve")!.run({
+      layers: [polygons],
+      parameters: { layer: "polygons", field: "group" },
+      log: (message) => messages.push(message),
+      addResultLayer: (_name, geojson) => {
+        result = geojson;
+      },
+    });
+
+    assert.equal(result!.features.length, 2);
+    assert.equal(
+      result!.features.find((feature) => feature.properties?.group === "A")?.geometry.type,
+      "MultiPolygon",
+    );
+    assert.deepEqual(messages, ["Dissolved 3 polygon(s) into 2 feature(s)"]);
+  });
+
   it("spatially joins zone attributes onto points", () => {
     const zone: GeoLibreLayer = {
       ...layer,


### PR DESCRIPTION
## Summary

- collect disconnected Turf dissolve fragments into one Polygon or MultiPolygon per attribute value
- report the number of attribute groups instead of the number of disconnected parts
- add regression coverage for disconnected polygons sharing a dissolve value

Addresses https://github.com/opengeos/GeoLibre/discussions/1977

## Verification

- `node --import tsx --test --test-name-pattern="dissolves disconnected polygons" tests/processing.test.ts`
- `npm run build`
- `pre-commit run --files packages/processing/src/vector-tools.ts tests/processing.test.ts`
- browser-tested the reporter's `OTEX-Cher-WGS.geojson`: 290 polygons dissolve into 12 features for the 12 unique `OTEX` values
- visually verified the result in light and dark themes