### PR TITLE
fix(dxf): recode TEXT from $DWGCODEPAGE after ST_Read

### DIFF
--- a/apps/geolibre-desktop/src/lib/cad-encoding.ts
+++ b/apps/geolibre-desktop/src/lib/cad-encoding.ts
@@ -14,7 +14,17 @@
 
 import type { Feature, FeatureCollection, GeoJsonProperties } from "geojson";
 
-const HEADER_PROBE_BYTES = 64 * 1024;
+/**
+ * How much of the file to decode when looking for the HEADER section.
+ *
+ * `$ACADVER` and `$DWGCODEPAGE` are the first two variables AutoCAD writes, so
+ * a much smaller probe would do for its own files — but a generator that emits
+ * an unusually large HEADER before them would fail *silently*, leaving the
+ * mojibake unrecoded with no error. A megabyte is far past any real HEADER
+ * while still costing one bounded decode, and {@link readDxfHeaderVariables}
+ * stops at the section's `ENDSEC`, so the extra room is never walked.
+ */
+const HEADER_PROBE_BYTES = 1024 * 1024;
 const BINARY_DXF_MAGIC = "AutoCAD Binary DXF";
 /** `$ACADVER` numeric suffix at which DXF switched from codepage to UTF-8. */
 const UTF8_DXF_VERSION = 1021;

--- a/apps/geolibre-desktop/src/lib/cad-encoding.ts
+++ b/apps/geolibre-desktop/src/lib/cad-encoding.ts
@@ -60,14 +60,18 @@ const CODEPAGE_LABELS: Record<string, string> = {
  *
  * The `latin1` label is windows-1252 in disguise (see {@link CODEPAGE_LABELS}),
  * which is harmless here: the header variables and values this scans are ASCII.
+ * A leading UTF-8 BOM (`EF BB BF`, which that decode turns into `ï»¿`) is
+ * dropped so it cannot glue itself to the file's first group code — a DXF
+ * re-saved as UTF-8 by a text editor is exactly the case this module exists for.
  *
  * @param bytes The DXF file bytes.
  * @returns The first {@link HEADER_PROBE_BYTES} decoded as Latin-1.
  */
 function headerLatin1(bytes: Uint8Array): string {
-  return new TextDecoder("latin1").decode(
+  const text = new TextDecoder("latin1").decode(
     bytes.subarray(0, Math.min(bytes.length, HEADER_PROBE_BYTES)),
   );
+  return text.replace(/^(?:\uFEFF|ï»¿)/, "");
 }
 
 /**
@@ -84,21 +88,87 @@ function isBinaryDxf(bytes: Uint8Array): boolean {
   return true;
 }
 
+/** One HEADER variable: its value records, keyed by DXF group code. */
+type DxfHeaderVariable = Map<number, string>;
+
 /**
- * Read one HEADER variable from an ASCII DXF prefix.
+ * Parse the HEADER variables out of an ASCII DXF prefix.
+ *
+ * DXF is a flat stream of (group code, value) line pairs. A HEADER variable is
+ * introduced by a group-9 record naming it, followed by the value records that
+ * belong to it. Walking those pairs — rather than pattern-matching the text —
+ * is what keeps an entity from impersonating a variable: an `MTEXT` whose own
+ * content reads `$DWGCODEPAGE` sits under group 1, not group 9, and the scan
+ * stops at the HEADER section's `ENDSEC` before reaching ENTITIES anyway.
+ *
+ * A pair whose group code is not a number is skipped rather than treated as a
+ * value; pair alignment is fixed by the format, so one unreadable code does not
+ * desync the ones after it.
  *
  * @param header Latin-1 text of the file prefix.
- * @param name The variable without `$`, such as `ACADVER`.
- * @param groupCode The DXF group code of the value line (`1` or `3`).
- * @returns The trimmed value, or null when the variable is absent.
+ * @returns Each variable name (uppercased, without `$`) mapped to its records.
  */
-function readDxfTaggedValue(header: string, name: string, groupCode: number): string | null {
-  const pattern = new RegExp(
-    `\\$${name}[ \\t]*\\r?\\n[ \\t]*0*${groupCode}[ \\t]*\\r?\\n([^\\r\\n]+)`,
-    "i",
-  );
-  const value = pattern.exec(header)?.[1]?.trim();
-  return value || null;
+function readDxfHeaderVariables(header: string): Map<string, DxfHeaderVariable> {
+  const lines = header.split(/\r?\n/);
+  const variables = new Map<string, DxfHeaderVariable>();
+  let awaitingSectionName = false;
+  let inHeader = false;
+  let current: DxfHeaderVariable | null = null;
+
+  for (let i = 0; i + 1 < lines.length; i += 2) {
+    const code = Number.parseInt(lines[i]!.trim(), 10);
+    const value = lines[i + 1]!.trim();
+    if (!Number.isInteger(code)) continue;
+
+    if (code === 0 && value.toUpperCase() === "SECTION") {
+      awaitingSectionName = true;
+      inHeader = false;
+      current = null;
+      continue;
+    }
+    if (awaitingSectionName) {
+      // The `2` record right after `0/SECTION` names the section.
+      if (code === 2) {
+        inHeader = value.toUpperCase() === "HEADER";
+        awaitingSectionName = false;
+      }
+      continue;
+    }
+    if (!inHeader) continue;
+    // HEADER is the first section, so its end is the end of anything readable.
+    if (code === 0 && value.toUpperCase() === "ENDSEC") break;
+
+    if (code === 9) {
+      const name = value.startsWith("$") ? value.slice(1).toUpperCase() : "";
+      if (!name) {
+        current = null;
+        continue;
+      }
+      current = variables.get(name) ?? new Map<number, string>();
+      variables.set(name, current);
+      continue;
+    }
+    // First record of a given code wins, so a repeated variable cannot shadow
+    // the value AutoCAD wrote first.
+    if (current && !current.has(code)) current.set(code, value);
+  }
+  return variables;
+}
+
+/**
+ * Read one HEADER variable's value record.
+ *
+ * @param variables From {@link readDxfHeaderVariables}.
+ * @param name The variable without `$`, such as `ACADVER`.
+ * @param groupCode The DXF group code of the value record (`1` or `3`).
+ * @returns The trimmed value, or null when the variable or record is absent.
+ */
+function readDxfHeaderValue(
+  variables: Map<string, DxfHeaderVariable>,
+  name: string,
+  groupCode: number,
+): string | null {
+  return variables.get(name)?.get(groupCode) || null;
 }
 
 /**
@@ -152,10 +222,10 @@ function normalizeCodepageToken(raw: string): string {
  */
 export function readDxfCodepage(bytes: Uint8Array): string | null {
   if (bytes.length === 0 || isBinaryDxf(bytes)) return null;
-  const header = headerLatin1(bytes);
-  const acadver = readDxfTaggedValue(header, "ACADVER", 1);
+  const variables = readDxfHeaderVariables(headerLatin1(bytes));
+  const acadver = readDxfHeaderValue(variables, "ACADVER", 1);
   if (acadver && isUtf8DxfVersion(acadver)) return "UTF-8";
-  const codepage = readDxfTaggedValue(header, "DWGCODEPAGE", 3);
+  const codepage = readDxfHeaderValue(variables, "DWGCODEPAGE", 3);
   return codepage ? normalizeCodepageToken(codepage) : null;
 }
 

--- a/apps/geolibre-desktop/src/lib/cad-encoding.ts
+++ b/apps/geolibre-desktop/src/lib/cad-encoding.ts
@@ -19,7 +19,19 @@ const BINARY_DXF_MAGIC = "AutoCAD Binary DXF";
 /** `$ACADVER` numeric suffix at which DXF switched from codepage to UTF-8. */
 const UTF8_DXF_VERSION = 1021;
 
-/** AutoCAD `$DWGCODEPAGE` → WHATWG `TextDecoder` label. */
+/**
+ * AutoCAD `$DWGCODEPAGE` → WHATWG `TextDecoder` label.
+ *
+ * `ISO8859-1` / `ISO-8859-1` / `ASCII` / `US-ASCII` are deliberately absent:
+ * WASM GDAL already turns each file byte into the matching Latin-1 code point,
+ * which *is* the correct Unicode for those codepages, so recoding has nothing
+ * to repair. Mapping them through `TextDecoder` would instead corrupt bytes
+ * 0x80–0x9F, because the WHATWG Encoding Standard aliases every `latin1` /
+ * `iso-8859-1` label to windows-1252, where that range holds printable
+ * characters rather than ISO-8859-1's C1 controls. `ANSI_1252` is a different
+ * matter and stays mapped: there the file really is windows-1252, so those
+ * bytes do need recoding.
+ */
 const CODEPAGE_LABELS: Record<string, string> = {
   "UTF-8": "utf-8",
   UTF8: "utf-8",
@@ -33,10 +45,6 @@ const CODEPAGE_LABELS: Record<string, string> = {
   SHIFT_JIS: "shift_jis",
   ANSI_949: "euc-kr",
   ANSI_1252: "windows-1252",
-  "ISO8859-1": "latin1",
-  "ISO-8859-1": "latin1",
-  ASCII: "latin1",
-  "US-ASCII": "latin1",
   ANSI_1250: "windows-1250",
   ANSI_1251: "windows-1251",
   ANSI_1253: "windows-1253",
@@ -49,6 +57,9 @@ const CODEPAGE_LABELS: Record<string, string> = {
 
 /**
  * Decode a Latin-1 prefix so ASCII DXF headers can be scanned.
+ *
+ * The `latin1` label is windows-1252 in disguise (see {@link CODEPAGE_LABELS}),
+ * which is harmless here: the header variables and values this scans are ASCII.
  *
  * @param bytes The DXF file bytes.
  * @returns The first {@link HEADER_PROBE_BYTES} decoded as Latin-1.

--- a/apps/geolibre-desktop/src/lib/cad-encoding.ts
+++ b/apps/geolibre-desktop/src/lib/cad-encoding.ts
@@ -1,0 +1,239 @@
+/**
+ * Repair DXF string fields after DuckDB-WASM `ST_Read`.
+ *
+ * AutoCAD TEXT in R2004 and earlier is stored in `$DWGCODEPAGE`; R2007
+ * (`AC1021`) and later is UTF-8. Desktop GDAL recodes to UTF-8; WASM GDAL has
+ * no iconv, so each file byte becomes a Latin-1 character. Recode those
+ * strings — recover the original bytes, then decode with the drawing
+ * codepage — at the GeoJSON boundary. Rewriting the file as UTF-8 does not
+ * help: WASM GDAL still copies bytes as Latin-1. Binary DXF is left unchanged.
+ *
+ * Kept free of the DuckDB-WASM import so `node --test` can cover it without
+ * pulling the engine into the coverage denominator.
+ */
+
+import type { Feature, FeatureCollection, GeoJsonProperties } from "geojson";
+
+const HEADER_PROBE_BYTES = 64 * 1024;
+const BINARY_DXF_MAGIC = "AutoCAD Binary DXF";
+/** `$ACADVER` numeric suffix at which DXF switched from codepage to UTF-8. */
+const UTF8_DXF_VERSION = 1021;
+
+/** AutoCAD `$DWGCODEPAGE` → WHATWG `TextDecoder` label. */
+const CODEPAGE_LABELS: Record<string, string> = {
+  "UTF-8": "utf-8",
+  UTF8: "utf-8",
+  ANSI_936: "gb18030",
+  GBK: "gb18030",
+  GB2312: "gb18030",
+  GB18030: "gb18030",
+  ANSI_950: "big5",
+  BIG5: "big5",
+  ANSI_932: "shift_jis",
+  SHIFT_JIS: "shift_jis",
+  ANSI_949: "euc-kr",
+  ANSI_1252: "windows-1252",
+  "ISO8859-1": "latin1",
+  "ISO-8859-1": "latin1",
+  ASCII: "latin1",
+  "US-ASCII": "latin1",
+  ANSI_1250: "windows-1250",
+  ANSI_1251: "windows-1251",
+  ANSI_1253: "windows-1253",
+  ANSI_1254: "windows-1254",
+  ANSI_1255: "windows-1255",
+  ANSI_1256: "windows-1256",
+  ANSI_1257: "windows-1257",
+  ANSI_1258: "windows-1258",
+};
+
+/**
+ * Decode a Latin-1 prefix so ASCII DXF headers can be scanned.
+ *
+ * @param bytes The DXF file bytes.
+ * @returns The first {@link HEADER_PROBE_BYTES} decoded as Latin-1.
+ */
+function headerLatin1(bytes: Uint8Array): string {
+  return new TextDecoder("latin1").decode(
+    bytes.subarray(0, Math.min(bytes.length, HEADER_PROBE_BYTES)),
+  );
+}
+
+/**
+ * True when the buffer is a binary DXF (not the ASCII/ANSI text form).
+ *
+ * @param bytes The file bytes.
+ * @returns True when the AutoCAD binary-DXF magic is present.
+ */
+function isBinaryDxf(bytes: Uint8Array): boolean {
+  if (bytes.length < BINARY_DXF_MAGIC.length) return false;
+  for (let i = 0; i < BINARY_DXF_MAGIC.length; i += 1) {
+    if (bytes[i] !== BINARY_DXF_MAGIC.charCodeAt(i)) return false;
+  }
+  return true;
+}
+
+/**
+ * Read one HEADER variable from an ASCII DXF prefix.
+ *
+ * @param header Latin-1 text of the file prefix.
+ * @param name The variable without `$`, such as `ACADVER`.
+ * @param groupCode The DXF group code of the value line (`1` or `3`).
+ * @returns The trimmed value, or null when the variable is absent.
+ */
+function readDxfTaggedValue(header: string, name: string, groupCode: number): string | null {
+  const pattern = new RegExp(
+    `\\$${name}[ \\t]*\\r?\\n[ \\t]*0*${groupCode}[ \\t]*\\r?\\n([^\\r\\n]+)`,
+    "i",
+  );
+  const value = pattern.exec(header)?.[1]?.trim();
+  return value || null;
+}
+
+/**
+ * True when `$ACADVER` is R2007 or later (UTF-8 DXF).
+ *
+ * @param acadver A value such as `AC1021`.
+ * @returns True when the numeric suffix is >= {@link UTF8_DXF_VERSION}.
+ */
+function isUtf8DxfVersion(acadver: string): boolean {
+  const match = /^AC(\d+)$/i.exec(acadver.trim());
+  return match !== null && Number(match[1]) >= UTF8_DXF_VERSION;
+}
+
+/**
+ * Map an AutoCAD codepage name to a `TextDecoder` label, if supported.
+ *
+ * @param codepage An uppercased `$DWGCODEPAGE` value.
+ * @returns A WHATWG encoding label, or null when unknown/unsupported.
+ */
+function decoderLabelForCodepage(codepage: string): string | null {
+  const mapped = CODEPAGE_LABELS[codepage];
+  if (!mapped) return null;
+  try {
+    new TextDecoder(mapped);
+    return mapped;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize a `$DWGCODEPAGE` value to a CODEPAGE_LABELS key.
+ *
+ * @param raw A token such as `ansi_936` or `utf8`.
+ * @returns The uppercased key, with `UTF8` folded to `UTF-8`.
+ */
+function normalizeCodepageToken(raw: string): string {
+  const upper = raw.trim().toUpperCase();
+  return upper === "UTF8" ? "UTF-8" : upper;
+}
+
+/**
+ * Read the drawing codepage from an ASCII DXF header.
+ *
+ * R2007+ (`$ACADVER` >= AC1021) is UTF-8 even when `$DWGCODEPAGE` still names
+ * a legacy ANSI_* page. Earlier versions use `$DWGCODEPAGE`. Binary DXF and
+ * files with neither variable are left unlabelled.
+ *
+ * @param bytes The file bytes (must be read before DuckDB detaches the buffer).
+ * @returns An AutoCAD codepage name, or null when recoding should not run.
+ */
+export function readDxfCodepage(bytes: Uint8Array): string | null {
+  if (bytes.length === 0 || isBinaryDxf(bytes)) return null;
+  const header = headerLatin1(bytes);
+  const acadver = readDxfTaggedValue(header, "ACADVER", 1);
+  if (acadver && isUtf8DxfVersion(acadver)) return "UTF-8";
+  const codepage = readDxfTaggedValue(header, "DWGCODEPAGE", 3);
+  return codepage ? normalizeCodepageToken(codepage) : null;
+}
+
+/**
+ * Rebuild the DXF bytes WASM GDAL copied into a JS string as Latin-1.
+ *
+ * @param value A DuckDB string field.
+ * @returns The original bytes, or null when `value` is already real Unicode.
+ */
+function duckDbStringBytes(value: string): Uint8Array | null {
+  const bytes = new Uint8Array(value.length);
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code > 255) return null;
+    bytes[i] = code;
+  }
+  return bytes;
+}
+
+/**
+ * Recode one DXF string with an already-constructed decoder.
+ *
+ * @param value The raw DuckDB/OGR string (or already-correct Unicode).
+ * @param decoder A `TextDecoder` for the drawing codepage.
+ * @returns Unicode text, or `value` when recoding does not apply.
+ */
+function recodeWithDecoder(value: string, decoder: TextDecoder): string {
+  if (!value) return value;
+  const bytes = duckDbStringBytes(value);
+  if (!bytes) return value;
+  try {
+    return decoder.decode(bytes);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Recode one DXF attribute that WASM GDAL exposed as Latin-1 mojibake.
+ *
+ * @param value The raw DuckDB/OGR string (or already-correct Unicode).
+ * @param codepage From {@link readDxfCodepage}, or null.
+ * @returns Unicode text, or `value` when recoding does not apply.
+ */
+export function recodeCadString(value: string, codepage: string | null): string {
+  if (!value || !codepage) return value;
+  const label = decoderLabelForCodepage(codepage);
+  if (!label) return value;
+  return recodeWithDecoder(value, new TextDecoder(label, { fatal: true }));
+}
+
+/**
+ * Recode string properties on one feature.
+ *
+ * @param properties The feature properties object, or null.
+ * @param decoder A `TextDecoder` for the drawing codepage.
+ * @returns Properties with DXF strings recoded; non-strings left unchanged.
+ */
+function recodeCadProperties(
+  properties: GeoJsonProperties,
+  decoder: TextDecoder,
+): GeoJsonProperties {
+  if (!properties) return properties;
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    next[key] = typeof value === "string" ? recodeWithDecoder(value, decoder) : value;
+  }
+  return next;
+}
+
+/**
+ * Recode string properties on every feature in a DXF-derived collection.
+ *
+ * @param collection The FeatureCollection `ST_Read` materialized.
+ * @param codepage From {@link readDxfCodepage}, or null.
+ * @returns A new collection when recoding ran; `collection` when it did not.
+ */
+export function recodeCadFeatureCollection(
+  collection: FeatureCollection,
+  codepage: string | null,
+): FeatureCollection {
+  const label = codepage ? decoderLabelForCodepage(codepage) : null;
+  if (!label) return collection;
+  const decoder = new TextDecoder(label, { fatal: true });
+  return {
+    ...collection,
+    features: collection.features.map((feature: Feature) => ({
+      ...feature,
+      properties: recodeCadProperties(feature.properties, decoder),
+    })),
+  };
+}

--- a/apps/geolibre-desktop/src/lib/cad-encoding.ts
+++ b/apps/geolibre-desktop/src/lib/cad-encoding.ts
@@ -53,6 +53,12 @@ const CODEPAGE_LABELS: Record<string, string> = {
   BIG5: "big5",
   ANSI_932: "shift_jis",
   SHIFT_JIS: "shift_jis",
+  // `euc-kr` is the full Windows-949 (UHC) superset here, not bare KS X 1001:
+  // WHATWG defines the euc-kr decoder over lead 0x81-0xFE / trail 0x41-0xFE and
+  // lists `windows-949` as one of its labels, so a browser decodes the
+  // UHC-only syllables too (verified in Chromium: 0x81 0x41 -> 갂). Node's
+  // ICU-backed `TextDecoder` is the narrower KS X 1001 and rejects those bytes,
+  // so cover Korean recoding in an `e2e/` spec rather than under `node --test`.
   ANSI_949: "euc-kr",
   ANSI_1252: "windows-1252",
   ANSI_1250: "windows-1250",

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -685,7 +685,15 @@ export async function loadDuckDbVectorFile(
       if (isParquetExtension(file.extension) || !isSurfaceError) {
         throw error;
       }
-      return loadViaKeepWkbFallback(db, file, options, sourceCrs, error, guardConfirmed);
+      return loadViaKeepWkbFallback(
+        db,
+        file,
+        options,
+        sourceCrs,
+        error,
+        guardConfirmed,
+        dxfCodepage,
+      );
     }
   } finally {
     await connection.close();
@@ -708,6 +716,10 @@ export async function loadDuckDbVectorFile(
  * @param guardConfirmed Whether the normal path already confirmed the
  *   large-dataset guard; when false (the error fired on the count guard) it is
  *   re-run here so a huge file is not loaded without confirmation.
+ * @param dxfCodepage The drawing codepage the normal path read from the DXF
+ *   header, or null. A DXF with a 3DFACE/PolyfaceMesh entity can reach this
+ *   fallback too, so its TEXT is recoded here as well; without it the
+ *   attributes would keep the Latin-1 mojibake the normal path repairs.
  */
 async function loadViaKeepWkbFallback(
   db: duckdb.AsyncDuckDB,
@@ -716,6 +728,7 @@ async function loadViaKeepWkbFallback(
   sourceCrs: string | null,
   originalError: unknown,
   guardConfirmed: boolean,
+  dxfCodepage: string | null,
 ): Promise<FeatureCollection> {
   // Read on a fresh connection: re-running ST_Read on the connection that
   // already scanned the file trips a "Missing DB manager" GDAL assertion in the
@@ -762,8 +775,14 @@ async function loadViaKeepWkbFallback(
     }
     // The decoded geometry is in the file's own CRS; reproject to WGS84 with the
     // same source CRS the normal path resolved. Reuses the shared ST_Transform
-    // path, which handles the MultiPolygon the TIN decoded to.
-    return reprojectFeatureCollectionToWgs84(collection, sourceCrs);
+    // path, which handles the MultiPolygon the TIN decoded to. Recode first, at
+    // this `ST_Read` boundary: reprojection re-reads the collection as GeoJSON,
+    // which OGR already treats as UTF-8, so it is not the layer that mangled
+    // the strings and must not be handed mojibake to round-trip.
+    return reprojectFeatureCollectionToWgs84(
+      recodeCadFeatureCollection(collection, dxfCodepage),
+      sourceCrs,
+    );
   } finally {
     await connection.close();
   }

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -15,6 +15,7 @@ import {
   wkbRowsToFeatureCollection,
 } from "./duckdb-geometry";
 import { confirmLargeDataset, type DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
+import { readDxfCodepage, recodeCadFeatureCollection } from "./cad-encoding";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { isLikelyGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";
 import { prjSidecarCrs } from "./prj-sidecar";
@@ -606,6 +607,10 @@ export async function loadDuckDbVectorFile(
     // Inside the try so the finally still closes the connection if it throws.
     // `prjSidecarCrs` is `.shp`-scoped, so a non-shapefile's siblings are safe.
     const prjCrs = prjSidecarCrs(file);
+    // Read $DWGCODEPAGE / $ACADVER before registerFileBuffer transfers (and
+    // detaches) the bytes. WASM GDAL has no iconv, so DXF TEXT is recoded
+    // after ST_Read. Other formats skip this (null → no-op).
+    const dxfCodepage = file.extension === "dxf" ? readDxfCodepage(file.data) : null;
 
     await registerVectorFileBuffers(db, file);
     await ensureSpatialExtension(
@@ -655,7 +660,10 @@ export async function loadDuckDbVectorFile(
       );
       // Features may carry a null geometry; the app's layer model treats them
       // as a regular FeatureCollection and the map ignores null geometries.
-      return toFeatureCollection(rowsFromResult(result), detected.column) as FeatureCollection;
+      return recodeCadFeatureCollection(
+        toFeatureCollection(rowsFromResult(result), detected.column) as FeatureCollection,
+        dxfCodepage,
+      );
     } catch (error) {
       // DuckDB Spatial's WKB reader rejects surface geometries (TIN /
       // PolyhedralSurface), which its bundled GDAL emits for ESRI MultiPatch

--- a/tests/cad-encoding.test.ts
+++ b/tests/cad-encoding.test.ts
@@ -209,6 +209,18 @@ describe("recodeCadString", () => {
     assert.equal(recodeCadString(mojibake, "ANSI_9999"), mojibake);
   });
 
+  it("leaves ISO-8859-1 and ASCII drawings byte-identical", () => {
+    // WASM GDAL already maps each byte to the matching Latin-1 code point, so
+    // the string is correct as-is. Byte 0x92 is the case that would break if
+    // these were routed through a `TextDecoder`: WHATWG aliases every
+    // `latin1` / `iso-8859-1` label to windows-1252, which decodes it as `’`.
+    const latin1 = duckDbLatin1(Uint8Array.from([0x63, 0x61, 0x66, 0xe9, 0x92]));
+    assert.equal(latin1, "caf\u00e9\u0092");
+    for (const codepage of ["ISO8859-1", "ISO-8859-1", "ASCII", "US-ASCII"]) {
+      assert.equal(recodeCadString(latin1, codepage), latin1);
+    }
+  });
+
   it("is idempotent after a successful GBK recode", () => {
     const once = recodeCadString(duckDbLatin1(GONGCHENG_GBK), "ANSI_936");
     assert.equal(recodeCadString(once, "ANSI_936"), "工程名称");

--- a/tests/cad-encoding.test.ts
+++ b/tests/cad-encoding.test.ts
@@ -137,6 +137,47 @@ describe("readDxfCodepage", () => {
     assert.equal(readDxfCodepage(utf8Bytes("  0\nSECTION\n  0\nEOF\n")), null);
   });
 
+  it("ignores an MTEXT entity whose own content reads $DWGCODEPAGE", () => {
+    // The variable name only counts under group code 9, inside HEADER. Here it
+    // is group-1 entity text in ENTITIES, so the drawing stays unlabelled.
+    const bytes = utf8Bytes(
+      [
+        "  0",
+        "SECTION",
+        "  2",
+        "HEADER",
+        "  9",
+        "$ACADVER",
+        "  1",
+        "AC1018",
+        "  0",
+        "ENDSEC",
+        "  0",
+        "SECTION",
+        "  2",
+        "ENTITIES",
+        "  0",
+        "MTEXT",
+        "  1",
+        "$DWGCODEPAGE",
+        "  3",
+        "ANSI_936",
+        "  0",
+        "ENDSEC",
+        "  0",
+        "EOF",
+        "",
+      ].join("\n"),
+    );
+    assert.equal(readDxfCodepage(bytes), null);
+  });
+
+  it("reads a header behind a UTF-8 BOM", () => {
+    const bom = Uint8Array.from([0xef, 0xbb, 0xbf]);
+    const bytes = concatBytes([bom, dxfWithText("ANSI_936", utf8Bytes("x"))]);
+    assert.equal(readDxfCodepage(bytes), "ANSI_936");
+  });
+
   it("accepts unpadded and zero-padded HEADER group codes", () => {
     const unpadded = [
       "0",

--- a/tests/cad-encoding.test.ts
+++ b/tests/cad-encoding.test.ts
@@ -172,6 +172,39 @@ describe("readDxfCodepage", () => {
     assert.equal(readDxfCodepage(bytes), null);
   });
 
+  it("finds $DWGCODEPAGE behind a HEADER larger than 64 KiB", () => {
+    // A generator that writes many variables before $DWGCODEPAGE used to push
+    // it past the probe, and detection then failed silently.
+    const padding: string[] = [];
+    for (let i = 0; i < 4000; i += 1) {
+      padding.push("  9", `$GEOLIBREPAD${i}`, "  1", "x".repeat(16));
+    }
+    const bytes = utf8Bytes(
+      [
+        "  0",
+        "SECTION",
+        "  2",
+        "HEADER",
+        "  9",
+        "$ACADVER",
+        "  1",
+        "AC1018",
+        ...padding,
+        "  9",
+        "$DWGCODEPAGE",
+        "  3",
+        "ANSI_936",
+        "  0",
+        "ENDSEC",
+        "  0",
+        "EOF",
+        "",
+      ].join("\n"),
+    );
+    assert.ok(bytes.length > 64 * 1024);
+    assert.equal(readDxfCodepage(bytes), "ANSI_936");
+  });
+
   it("reads a header behind a UTF-8 BOM", () => {
     const bom = Uint8Array.from([0xef, 0xbb, 0xbf]);
     const bytes = concatBytes([bom, dxfWithText("ANSI_936", utf8Bytes("x"))]);

--- a/tests/cad-encoding.test.ts
+++ b/tests/cad-encoding.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Feature, FeatureCollection } from "geojson";
+import {
+  readDxfCodepage,
+  recodeCadFeatureCollection,
+  recodeCadString,
+} from "../apps/geolibre-desktop/src/lib/cad-encoding.ts";
+
+const TEXT_ENCODER = new TextEncoder();
+
+/** GBK bytes for `工程名称` (title-block TEXT in the user's DXF). */
+const GONGCHENG_GBK = Uint8Array.from([185, 164, 179, 204, 195, 251, 179, 198]);
+/** GBK bytes for `集电线路` (Layer field). */
+const JIDIAN_GBK = Uint8Array.from([188, 175, 181, 231, 207, 223, 194, 183]);
+/** GBK bytes for `×` (U+00D7); Latin-1 mojibake is `¡Á`. */
+const TIMES_GBK = Uint8Array.from([161, 193]);
+/** GBK bytes for `兴业大平山风电项目`. */
+const XINGYE_GBK = Uint8Array.from([
+  208, 203, 210, 181, 180, 243, 198, 189, 201, 189, 183, 231, 181, 231, 207, 238, 196, 191,
+]);
+/** Big5 bytes for `中`. */
+const ZHONG_BIG5 = Uint8Array.from([164, 164]);
+
+/**
+ * Concatenate byte arrays into one ArrayBuffer-backed view.
+ *
+ * @param parts The pieces to join, in order.
+ * @returns A single buffer containing every part.
+ */
+function concatBytes(parts: readonly Uint8Array[]): Uint8Array<ArrayBuffer> {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/**
+ * Encode ASCII/UTF-8 text as bytes.
+ *
+ * @param text The text to encode.
+ * @returns UTF-8 bytes.
+ */
+function utf8Bytes(text: string): Uint8Array<ArrayBuffer> {
+  return TEXT_ENCODER.encode(text);
+}
+
+/**
+ * Simulate WASM GDAL: each file byte becomes a Latin-1 codepoint in DuckDB.
+ * Built with `fromCharCode` rather than `TextDecoder("latin1")`, which the
+ * WHATWG encoding spec aliases to Windows-1252 (bytes 0x80–0x9F diverge).
+ *
+ * @param bytes Raw DXF TEXT bytes (GBK, UTF-8, …).
+ * @returns The mojibake string the attribute table would show without recode.
+ */
+function duckDbLatin1(bytes: Uint8Array): string {
+  let text = "";
+  for (const byte of bytes) text += String.fromCharCode(byte);
+  return text;
+}
+
+/**
+ * Build a minimal ASCII DXF header plus a TEXT entity payload.
+ *
+ * @param codepage The `$DWGCODEPAGE` value, or omitted to leave the variable out.
+ * @param textBytes The group-1 TEXT payload.
+ * @param newline The DXF line ending.
+ * @param acadver The `$ACADVER` value.
+ * @returns The DXF bytes.
+ */
+function dxfWithText(
+  codepage: string | undefined,
+  textBytes: Uint8Array,
+  newline = "\n",
+  acadver = "AC1018",
+): Uint8Array<ArrayBuffer> {
+  const nl = newline;
+  const head = ["  0", "SECTION", "  2", "HEADER", "  9", "$ACADVER", "  1", acadver];
+  if (codepage !== undefined) {
+    head.push("  9", "$DWGCODEPAGE", "  3", codepage);
+  }
+  head.push("  0", "ENDSEC", "  0", "TEXT", "  1", "");
+  return concatBytes([utf8Bytes(head.join(nl)), textBytes, utf8Bytes(`${nl}  0${nl}EOF${nl}`)]);
+}
+
+/**
+ * A point feature whose properties match a DXF TEXT row in the attribute table.
+ *
+ * @param properties The OGR fields (`Text`, `Layer`, …), or null.
+ * @returns A GeoJSON Feature.
+ */
+function textFeature(properties: Record<string, unknown> | null): Feature {
+  return {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties,
+  };
+}
+
+describe("readDxfCodepage", () => {
+  it("reads ANSI_936 from a Unix-newline DXF header", () => {
+    assert.equal(readDxfCodepage(dxfWithText("ANSI_936", utf8Bytes("x"))), "ANSI_936");
+  });
+
+  it("reads a CRLF DXF header and uppercases the value", () => {
+    const bytes = dxfWithText("ansi_936", utf8Bytes("x"), "\r\n");
+    assert.equal(readDxfCodepage(bytes), "ANSI_936");
+  });
+
+  it("reads UTF-8 and ANSI_950 $DWGCODEPAGE values", () => {
+    assert.equal(readDxfCodepage(dxfWithText("UTF-8", utf8Bytes("x"))), "UTF-8");
+    assert.equal(readDxfCodepage(dxfWithText("utf8", utf8Bytes("x"))), "UTF-8");
+    assert.equal(readDxfCodepage(dxfWithText("ANSI_950", utf8Bytes("x"))), "ANSI_950");
+  });
+
+  it("treats R2007+ as UTF-8 even when $DWGCODEPAGE is still ANSI_936", () => {
+    assert.equal(readDxfCodepage(dxfWithText("ANSI_936", utf8Bytes("x"), "\n", "AC1021")), "UTF-8");
+    assert.equal(readDxfCodepage(dxfWithText("ANSI_936", utf8Bytes("x"), "\n", "AC1024")), "UTF-8");
+    assert.equal(readDxfCodepage(dxfWithText("ANSI_936", utf8Bytes("x"), "\n", "ac1032")), "UTF-8");
+    assert.equal(readDxfCodepage(dxfWithText(undefined, utf8Bytes("x"), "\n", "AC1021")), "UTF-8");
+  });
+
+  it("honours $DWGCODEPAGE on R2004 and earlier", () => {
+    const r2000 = dxfWithText("ANSI_936", utf8Bytes("x"), "\n", "AC1015");
+    assert.equal(readDxfCodepage(r2000), "ANSI_936");
+    assert.equal(readDxfCodepage(dxfWithText(undefined, utf8Bytes("x"), "\n", "AC1018")), null);
+  });
+
+  it("returns null for a binary DXF, empty bytes, or a missing header", () => {
+    const magic = utf8Bytes("AutoCAD Binary DXF\r\n\u001a\u0000");
+    assert.equal(readDxfCodepage(magic), null);
+    assert.equal(readDxfCodepage(new Uint8Array()), null);
+    assert.equal(readDxfCodepage(utf8Bytes("  0\nSECTION\n  0\nEOF\n")), null);
+  });
+
+  it("accepts unpadded and zero-padded HEADER group codes", () => {
+    const unpadded = [
+      "0",
+      "SECTION",
+      "2",
+      "HEADER",
+      "9",
+      "$ACADVER",
+      "1",
+      "AC1018",
+      "9",
+      "$DWGCODEPAGE",
+      "3",
+      "ANSI_936",
+      "0",
+      "EOF",
+    ].join("\n");
+    const padded = [
+      "  0",
+      "SECTION",
+      "  2",
+      "HEADER",
+      "  9",
+      "$ACADVER",
+      "001",
+      "AC1018",
+      "  9",
+      "$DWGCODEPAGE",
+      "003",
+      "GBK",
+      "  0",
+      "EOF",
+    ].join("\n");
+    assert.equal(readDxfCodepage(utf8Bytes(unpadded)), "ANSI_936");
+    assert.equal(readDxfCodepage(utf8Bytes(padded)), "GBK");
+  });
+});
+
+describe("recodeCadString", () => {
+  it("repairs GBK TEXT that WASM GDAL exposes as Latin-1", () => {
+    assert.equal(recodeCadString(duckDbLatin1(GONGCHENG_GBK), "ANSI_936"), "工程名称");
+    assert.equal(recodeCadString(duckDbLatin1(JIDIAN_GBK), "GBK"), "集电线路");
+    assert.equal(recodeCadString(duckDbLatin1(XINGYE_GBK), "GB2312"), "兴业大平山风电项目");
+  });
+
+  it("repairs the GBK multiplication sign shown as ¡Á in the attribute table", () => {
+    const cable = concatBytes([utf8Bytes("ZC-YJLV22-26/35kV-3"), TIMES_GBK, utf8Bytes("95mm2")]);
+    assert.equal(duckDbLatin1(TIMES_GBK), "¡Á");
+    assert.equal(recodeCadString(duckDbLatin1(cable), "ANSI_936"), "ZC-YJLV22-26/35kV-3×95mm2");
+  });
+
+  it("repairs UTF-8 TEXT copied as Latin-1 (Ãæè mojibake after a UTF-8 rewrite)", () => {
+    const utf8Times = duckDbLatin1(utf8Bytes("×"));
+    assert.match(utf8Times, /Ã/);
+    assert.equal(recodeCadString(utf8Times, "UTF-8"), "×");
+    assert.equal(recodeCadString(duckDbLatin1(utf8Bytes("工程名称")), "UTF-8"), "工程名称");
+  });
+
+  it("repairs Big5 TEXT labelled ANSI_950", () => {
+    assert.equal(recodeCadString(duckDbLatin1(ZHONG_BIG5), "ANSI_950"), "中");
+  });
+
+  it("leaves ASCII, already-Unicode, and unknown-codepage strings unchanged", () => {
+    assert.equal(recodeCadString("XZ01", "ANSI_936"), "XZ01");
+    assert.equal(recodeCadString("工程名称", "ANSI_936"), "工程名称");
+    assert.equal(recodeCadString("Hello—World", "ANSI_936"), "Hello—World");
+    assert.equal(recodeCadString("café", "UTF-8"), "café");
+    const mojibake = duckDbLatin1(GONGCHENG_GBK);
+    assert.equal(recodeCadString(mojibake, null), mojibake);
+    assert.equal(recodeCadString(mojibake, "ANSI_9999"), mojibake);
+  });
+
+  it("is idempotent after a successful GBK recode", () => {
+    const once = recodeCadString(duckDbLatin1(GONGCHENG_GBK), "ANSI_936");
+    assert.equal(recodeCadString(once, "ANSI_936"), "工程名称");
+  });
+});
+
+describe("recodeCadFeatureCollection", () => {
+  it("recodes Text and Layer on every feature", () => {
+    const cable = concatBytes([utf8Bytes("ZC-YJLV22-26/35kV-3"), TIMES_GBK, utf8Bytes("95mm2")]);
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        textFeature({
+          Text: duckDbLatin1(GONGCHENG_GBK),
+          Layer: duckDbLatin1(JIDIAN_GBK),
+          EntityHandle: "2A14",
+          PaperSpace: 0,
+        }),
+        textFeature({ Text: duckDbLatin1(cable), Layer: "0" }),
+      ],
+    };
+    const recoded = recodeCadFeatureCollection(collection, "ANSI_936");
+    assert.equal(recoded.features[0]?.properties?.Text, "工程名称");
+    assert.equal(recoded.features[0]?.properties?.Layer, "集电线路");
+    assert.equal(recoded.features[0]?.properties?.EntityHandle, "2A14");
+    assert.equal(recoded.features[0]?.properties?.PaperSpace, 0);
+    assert.equal(recoded.features[1]?.properties?.Text, "ZC-YJLV22-26/35kV-3×95mm2");
+  });
+
+  it("does not mutate the input collection", () => {
+    const original = duckDbLatin1(GONGCHENG_GBK);
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [textFeature({ Text: original })],
+    };
+    const recoded = recodeCadFeatureCollection(collection, "ANSI_936");
+    assert.notEqual(recoded, collection);
+    assert.equal(collection.features[0]?.properties?.Text, original);
+    assert.equal(recoded.features[0]?.properties?.Text, "工程名称");
+  });
+
+  it("keeps null properties and leaves geometry on the same object", () => {
+    const geometry = { type: "Point" as const, coordinates: [1, 2] };
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [{ type: "Feature", geometry, properties: null }],
+    };
+    const recoded = recodeCadFeatureCollection(collection, "ANSI_936");
+    assert.equal(recoded.features[0]?.properties, null);
+    assert.equal(recoded.features[0]?.geometry, geometry);
+  });
+
+  it("returns the same collection when the codepage is missing or unknown", () => {
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [textFeature({ Text: duckDbLatin1(GONGCHENG_GBK) })],
+    };
+    assert.equal(recodeCadFeatureCollection(collection, null), collection);
+    assert.equal(recodeCadFeatureCollection(collection, "ANSI_9999"), collection);
+  });
+});


### PR DESCRIPTION
## Summary
- Recode DXF `Text` / `Layer` after DuckDB-WASM `ST_Read`, using `$ACADVER` and `$DWGCODEPAGE`. WASM GDAL has no iconv, so codepage bytes arrive as Latin-1 mojibake.
- R2007+ (`AC1021` and later) is treated as UTF-8 even when `$DWGCODEPAGE` still names a legacy page.

Fixes #1973

## Test plan
- [x] `tests/cad-encoding.test.ts`
- [x] Add CAD Layer with an AC1018 `$DWGCODEPAGE = ANSI_936` Chinese DXF; `Text` / `Layer` in the attribute table should be Unicode (`工程名称`, `集电线路`, `×`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DXF imports to correctly interpret supported character encodings.
  * Preserved accented, Asian, and other non-Latin characters in CAD attribute data.
  * Maintained geometry, null values, and non-text properties during import.
  * Added safer handling for binary, malformed, empty, and unsupported DXF files.

* **Tests**
  * Added comprehensive coverage for encoding detection, text conversion, and data preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->