### PR TITLE
fix(desktop): capture timer refs inside LayerPanel unmount effect

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2504,19 +2504,21 @@ export function LayerPanel({
 
   useEffect(() => {
     const watchers = watchUnsubsRef.current;
+    const refreshTimers = refreshTimersRef.current;
+    const refreshStatusTimers = refreshStatusTimersRef.current;
     return () => {
       for (const entry of watchers.values()) {
         entry.unwatch();
       }
       watchers.clear();
-      for (const entry of refreshTimersRef.current.values()) {
+      for (const entry of refreshTimers.values()) {
         window.clearInterval(entry.timer);
       }
-      refreshTimersRef.current.clear();
-      for (const timer of refreshStatusTimersRef.current.values()) {
+      refreshTimers.clear();
+      for (const timer of refreshStatusTimers.values()) {
         window.clearTimeout(timer);
       }
-      refreshStatusTimersRef.current.clear();
+      refreshStatusTimers.clear();
     };
   }, []);
 


### PR DESCRIPTION
### Summary
- In `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx`, capture `refreshTimersRef.current` and `refreshStatusTimersRef.current` in local constants within `useEffect`.
- Ensures cleanup functions execute against the exact ref instances from effect setup and satisfies React exhaustive-deps rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of map layer watchers and refresh timers when the layer panel is closed.
  * Helps prevent lingering background updates and resource usage after leaving the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->