### PR TITLE
docs: link the published Chrome Web Store listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Mac App Store](https://img.shields.io/badge/Mac%20App%20Store-GeoLibre-0D96F6?logo=apple&logoColor=white)](https://apps.apple.com/app/geolibre-desktop/id6796848769)
 [![App Store](https://img.shields.io/badge/App%20Store-GeoLibre-0D96F6?logo=appstore&logoColor=white)](https://apps.apple.com/app/geolibre/id6796039674)
 [![Google Play](https://img.shields.io/badge/Google%20Play-GeoLibre-01875F?logo=googleplay&logoColor=white)](https://play.google.com/store/apps/details?id=org.geolibre.app)
+[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-GeoLibre-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj)
 [![AUR version](https://img.shields.io/aur/version/geolibre-bin?logo=archlinux&label=AUR)](https://aur.archlinux.org/packages/geolibre-bin)
 [![FlatPark](https://img.shields.io/badge/FlatPark-GeoLibre-4A90D9?logo=flatpak)](https://flatpark.org/apps/app.geolibre.GeoLibre/)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -29,6 +30,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - **[Get it on the Mac App Store](https://apps.apple.com/app/geolibre-desktop/id6796848769)** — the sandboxed macOS build
 - **[Get it on the App Store](https://apps.apple.com/app/geolibre/id6796039674)** — the native iOS app for iPhone and iPad
 - **[Get it on Google Play](https://play.google.com/store/apps/details?id=org.geolibre.app)** — the native Android app
+- **[Get the Chrome extension](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj)** — open datasets you find on any webpage in GeoLibre
 - **[Use the Python package](https://geolibre.app/python/)** — embed and control the full app in Jupyter notebooks
 - **[Use the R package](https://r.geolibre.app/)** — build interactive maps in RStudio, Quarto, R Markdown, and Shiny
 - **[1,000+ geoprocessing tools](https://geolibre.app/user-guide/processing/#whitebox-toolbox)** — the full toolbox, in the browser

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -314,6 +314,22 @@ See [iOS](ios.md) for the full list.
     (`org.geolibre.desktop`); the two are different apps with different feature
     sets.
 
+## Chrome extension
+
+**Open data in GeoLibre** is a companion browser extension that finds supported
+geospatial dataset links and map services on the page you are viewing and opens
+the ones you pick in GeoLibre. It is published on the Chrome Web Store, so it
+installs in one click and updates automatically:
+
+[Get Open data in GeoLibre from the Chrome Web Store](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj){ .md-button .md-button--primary }
+
+It works in any Chromium-based browser that can install from the Chrome Web
+Store, including Chrome, Edge, Brave, Vivaldi, Opera, and Arc. A packaged ZIP is
+also attached to each [GitHub release](https://github.com/opengeos/GeoLibre/releases)
+(the asset whose name starts with `geolibre-chrome-`) if you prefer to load it
+unpacked. See the [Chrome Extension](user-guide/chrome-extension.md) guide for
+both installation paths and what the extension detects.
+
 ## Build from source
 
 ```bash

--- a/docs/features.md
+++ b/docs/features.md
@@ -67,6 +67,7 @@ kepler.gl, see the [Comparison](comparison.md).
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers, with the cadence, last-synchronized time, last error, and on-failure policy persisted with the project as a `connection` record — so a reopened project keeps refreshing on schedule and the Layers panel can show each live layer's synchronization status
 - ArcGIS Hub, Socrata, and CKAN (Humanitarian Data Exchange) open-data browsers under Plugins → Web Services: search public dataset catalogs by keyword (or restrict the ArcGIS Hub search to the current map area), page through results, and add a dataset to the map or download it
 - Drag and drop vector and GeoTIFF/COG raster files onto the map to add them as layers
+- **Open data in GeoLibre**, a [Chrome extension](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj) on the Chrome Web Store, that collects the supported dataset links and map services (WMS, WMTS, WFS, OGC API - Features, ArcGIS Feature Services, XYZ/TMS, and vector tiles) on the page you are viewing and opens the ones you pick together on one GeoLibre map
 
 ## Layers, styling, and labels
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,7 @@
 [![Mac App Store](https://img.shields.io/badge/Mac%20App%20Store-GeoLibre-0D96F6?logo=apple&logoColor=white)](https://apps.apple.com/app/geolibre-desktop/id6796848769)
 [![App Store](https://img.shields.io/badge/App%20Store-GeoLibre-0D96F6?logo=appstore&logoColor=white)](https://apps.apple.com/app/geolibre/id6796039674)
 [![Google Play](https://img.shields.io/badge/Google%20Play-GeoLibre-01875F?logo=googleplay&logoColor=white)](https://play.google.com/store/apps/details?id=org.geolibre.app)
+[![Chrome Web Store](https://img.shields.io/badge/Chrome%20Web%20Store-GeoLibre-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj)
 [![AUR version](https://img.shields.io/aur/version/geolibre-bin?logo=archlinux&label=AUR)](https://aur.archlinux.org/packages/geolibre-bin)
 [![FlatPark](https://img.shields.io/badge/FlatPark-GeoLibre-4A90D9?logo=flatpak)](https://flatpark.org/apps/app.geolibre.GeoLibre/)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/user-guide/adding-data.md
+++ b/docs/user-guide/adding-data.md
@@ -2,7 +2,7 @@
 
 The **Add Data** menu is the main way to bring layers into GeoLibre. It groups sources into Files, Web services, Cloud formats, 3D layers, and Databases. You can also drag files straight onto the map.
 
-To collect supported dataset links from a catalog or other webpage and open several at once, use the [GeoLibre Chrome extension](chrome-extension.md).
+To collect supported dataset links from a catalog or other webpage and open several at once, use the [GeoLibre Chrome extension](chrome-extension.md), available from the [Chrome Web Store](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj).
 
 ![Add Data menu](https://data.geolibre.app/images/geolibre-add-data-menu.webp)
 

--- a/docs/user-guide/chrome-extension.md
+++ b/docs/user-guide/chrome-extension.md
@@ -6,7 +6,19 @@ The **Open data in GeoLibre** Chrome extension finds supported geospatial data l
 
 ## Install the extension
 
-Until the extension is available from the Chrome Web Store, install the packaged release manually:
+The extension is published on the Chrome Web Store, so it installs in one click and updates automatically:
+
+[Get Open data in GeoLibre from the Chrome Web Store](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj){ .md-button .md-button--primary }
+
+1. Open the [Chrome Web Store listing](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj).
+2. Select **Add to Chrome**, then confirm.
+3. Pin **Open data in GeoLibre** to the Chrome toolbar for convenient access.
+
+It works in any Chromium-based browser that can install from the Chrome Web Store, including Chrome, Edge, Brave, Vivaldi, Opera, and Arc.
+
+### Install the packaged release manually
+
+Prefer not to install from the Store, or want to run a build that is newer than the reviewed listing? Load the packaged release as an unpacked extension:
 
 1. Open the [latest GeoLibre release](https://github.com/opengeos/GeoLibre/releases/latest) and download the ZIP asset whose name starts with `geolibre-chrome-`.
 2. Extract the ZIP archive to a folder you intend to keep. Chrome loads the extension from this folder, so do not delete it after installation.
@@ -15,7 +27,7 @@ Until the extension is available from the Chrome Web Store, install the packaged
 5. Select **Load unpacked** and choose the extracted `geolibre-chrome-<version>` folder.
 6. Pin **Open data in GeoLibre** to the Chrome toolbar for convenient access.
 
-To update a manually installed copy, download and extract the newer release asset, then select the extension's **Reload** button on `chrome://extensions`. If you extract it to a different folder, remove the old copy and load the new folder instead.
+A manually installed copy does not update itself. To update it, download and extract the newer release asset, then select the extension's **Reload** button on `chrome://extensions`. If you extract it to a different folder, remove the old copy and load the new folder instead.
 
 ## Open datasets from a webpage
 

--- a/extensions/geolibre-chrome/README.md
+++ b/extensions/geolibre-chrome/README.md
@@ -4,7 +4,13 @@ A Manifest V3 Chrome extension that finds supported geospatial dataset links on
 the current page, observes geospatial service requests made by interactive maps,
 and opens selected data in GeoLibre.
 
-## Install locally
+## Install
+
+The published extension is on the Chrome Web Store:
+
+[Open data in GeoLibre](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj)
+
+## Install locally (development)
 
 1. Open `chrome://extensions`.
 2. Enable **Developer mode**.

--- a/extensions/geolibre-chrome/STORE_LISTING.md
+++ b/extensions/geolibre-chrome/STORE_LISTING.md
@@ -1,5 +1,8 @@
 # Chrome Web Store listing
 
+Published listing:
+<https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj>
+
 ## Name
 
 Open data in GeoLibre


### PR DESCRIPTION
The **Open data in GeoLibre** Chrome extension is now published on the [Chrome Web Store](https://chromewebstore.google.com/detail/open-data-in-geolibre/joinecgbfoldanidcoakpjgkbaceaooj), so the docs no longer need to say it is unavailable there.

- README: Chrome Web Store badge next to the other store badges, plus a "Get the Chrome extension" bullet in the links list
- `docs/user-guide/chrome-extension.md`: store install is now the primary path (with a button), the unpacked release becomes "Install the packaged release manually"
- `docs/downloads.md`: new **Chrome extension** section alongside the platform installers
- `docs/features.md`: the extension listed under Adding data
- `docs/user-guide/adding-data.md`: links the store listing
- `extensions/geolibre-chrome/README.md` and `STORE_LISTING.md`: point at the published listing

Docs only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Chrome Web Store installation links and badges across project documentation.
  - Documented the Chrome extension’s ability to detect supported dataset links and map services, then open selected sources in GeoLibre.
  - Added installation guidance for Chrome and other Chromium-based browsers, including automatic updates and manual installation options.
  - Clarified local development installation, GitHub release ZIP availability, manual update requirements, and the published Chrome Web Store listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->