### PR TITLE
fix(desktop): scrub Print Layout blocks when their layer is deleted

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1678,9 +1678,15 @@ export function PrintLayoutDialog({
 
   // Fixed scale is only meaningful on physical paper (like the manual scale
   // input); fall back to margin mode when the page switches to pixel sizes.
+  // `open`-gated for the same reason as the defaulting effects above: this also
+  // runs on the mount that every project load triggers, so a hand-edited file
+  // pairing a pixel page with scale mode would be corrected — and the project
+  // marked dirty — before the composer had ever been opened. Nothing acts on
+  // the pairing until the composer is open, and opening it runs this.
   useEffect(() => {
+    if (!open) return;
     if (!isMmPage && atlasExtentMode === "scale") setAtlasExtentMode("margin");
-  }, [isMmPage, atlasExtentMode]);
+  }, [open, isMmPage, atlasExtentMode]);
 
   // Two-way scale sync: reflect the captured view's scale into the input unless
   // the user is actively editing it.

--- a/packages/core/src/print-layout-config.ts
+++ b/packages/core/src/print-layout-config.ts
@@ -21,6 +21,8 @@
  * a corner on one side without the other fails the build.
  */
 
+import { removedLayerIdSet } from "./layer-ref-scrub";
+
 /** A page corner an overlay block can be pinned to. */
 export type PrintLayoutCorner = "top-left" | "top-right" | "bottom-left" | "bottom-right";
 
@@ -490,6 +492,28 @@ export function printLayoutConfigsEqual(a: PrintLayoutConfig, b: PrintLayoutConf
 }
 
 /**
+ * Clear each data/atlas block whose layer `missing` rejects. Shared by the two
+ * entry points below, which differ only in how they decide what is gone.
+ *
+ * @returns The same object when every block's layer survives.
+ */
+function clearBlocksForMissingLayers(
+  config: PrintLayoutConfig,
+  missing: (layerId: string) => boolean,
+): PrintLayoutConfig {
+  const gone = (id: string) => id !== "" && missing(id);
+  if (!gone(config.tableLayerId) && !gone(config.chartLayerId) && !gone(config.atlasLayerId)) {
+    return config;
+  }
+  return {
+    ...config,
+    ...(gone(config.tableLayerId) ? { tableLayerId: "", showDataTable: false } : {}),
+    ...(gone(config.chartLayerId) ? { chartLayerId: "", showDataChart: false } : {}),
+    ...(gone(config.atlasLayerId) ? { atlasLayerId: "", atlasEnabled: false } : {}),
+  };
+}
+
+/**
  * Drop references to layers the project no longer carries, so a composer that
  * pointed at a since-deleted layer opens with the block cleared instead of
  * rendering nothing from a dangling id. Mirrors the widget/comment/legend
@@ -503,18 +527,23 @@ export function scrubPrintLayoutForLayers(
   config: PrintLayoutConfig,
   existingLayerIds: ReadonlySet<string>,
 ): PrintLayoutConfig {
-  const missing = (id: string) => id !== "" && !existingLayerIds.has(id);
-  if (
-    !missing(config.tableLayerId) &&
-    !missing(config.chartLayerId) &&
-    !missing(config.atlasLayerId)
-  ) {
-    return config;
-  }
-  return {
-    ...config,
-    ...(missing(config.tableLayerId) ? { tableLayerId: "", showDataTable: false } : {}),
-    ...(missing(config.chartLayerId) ? { chartLayerId: "", showDataChart: false } : {}),
-    ...(missing(config.atlasLayerId) ? { atlasLayerId: "", atlasEnabled: false } : {}),
-  };
+  return clearBlocksForMissingLayers(config, (id) => !existingLayerIds.has(id));
+}
+
+/**
+ * The delete-time counterpart, matching `scrubLegendForRemovedLayers` and its
+ * siblings: called when layers are removed from the open project so the saved
+ * file never carries a block pointing at a layer that is already gone.
+ *
+ * @param config - The config to scrub.
+ * @param layerIds - The removed layer id, or ids.
+ * @returns The same object when no block referenced a removed layer.
+ */
+export function scrubPrintLayoutForRemovedLayers(
+  config: PrintLayoutConfig,
+  layerIds: string | Iterable<string>,
+): PrintLayoutConfig {
+  const removed = removedLayerIdSet(layerIds);
+  if (removed.size === 0) return config;
+  return clearBlocksForMissingLayers(config, (id) => removed.has(id));
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -20,6 +20,7 @@ import { initialLayerStyle } from "./layer-defaults";
 import {
   createDefaultPrintLayout,
   printLayoutConfigsEqual,
+  scrubPrintLayoutForRemovedLayers,
   type PrintLayoutConfig,
 } from "./print-layout-config";
 import {
@@ -1700,6 +1701,9 @@ export const useAppStore = create<AppState>()(
           widgets: scrubWidgetsForRemovedLayers(s.widgets, id),
           comments: scrubCommentsForRemovedLayers(s.comments, id),
           legend: scrubLegendForRemovedLayers(s.legend, id),
+          // Clear a Print Layout data/atlas block built on the removed layer,
+          // so a save that follows the delete cannot write a dangling id.
+          printLayout: scrubPrintLayoutForRemovedLayers(s.printLayout, id),
           selectedLayerId:
             s.selectedLayerId === id
               ? (s.layers.find((l) => l.id !== id)?.id ?? null)
@@ -2045,6 +2049,9 @@ export const useAppStore = create<AppState>()(
               ? scrubCommentsForRemovedLayers(s.comments, removedIds)
               : s.comments,
             legend: removeChildren ? scrubLegendForRemovedLayers(s.legend, removedIds) : s.legend,
+            printLayout: removeChildren
+              ? scrubPrintLayoutForRemovedLayers(s.printLayout, removedIds)
+              : s.printLayout,
             selectedLayerId: selectionRemoved
               ? (layers[layers.length - 1]?.id ?? null)
               : s.selectedLayerId,

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -1556,6 +1556,31 @@ describe("print layout persistence", () => {
     assert.equal(applied.printLayout.chartLayerId, "kept");
   });
 
+  it("clears a composer block when its layer is deleted from the open project", () => {
+    const store = useAppStore.getState();
+    const kept = store.addGeoJsonLayer("Kept", { type: "FeatureCollection", features: [] });
+    const doomed = useAppStore
+      .getState()
+      .addGeoJsonLayer("Doomed", { type: "FeatureCollection", features: [] });
+    useAppStore.getState().setPrintLayout({
+      ...createDefaultPrintLayout(),
+      showDataTable: true,
+      tableLayerId: doomed,
+      showDataChart: true,
+      chartLayerId: kept,
+    });
+
+    useAppStore.getState().removeLayer(doomed);
+
+    // Otherwise a save taken before the composer is next opened would write a
+    // block pointing at a layer the file no longer carries.
+    const after = useAppStore.getState().printLayout;
+    assert.equal(after.tableLayerId, "");
+    assert.equal(after.showDataTable, false);
+    assert.equal(after.chartLayerId, kept);
+    assert.equal(after.showDataChart, true);
+  });
+
   it("ignores a write that changes nothing, so opening the composer is not an edit", () => {
     assert.equal(useAppStore.getState().isDirty, false);
     // The dialog replays its seeded values into the store on mount.

--- a/tests/print-layout-config.test.ts
+++ b/tests/print-layout-config.test.ts
@@ -7,6 +7,7 @@ import {
   normalizePrintLayoutConfig,
   printLayoutConfigsEqual,
   scrubPrintLayoutForLayers,
+  scrubPrintLayoutForRemovedLayers,
   type PrintLayoutConfig,
 } from "../packages/core/src/print-layout-config";
 
@@ -265,5 +266,38 @@ describe("scrubPrintLayoutForLayers", () => {
   it("treats an unset block as nothing to scrub", () => {
     const config = createDefaultPrintLayout();
     assert.equal(scrubPrintLayoutForLayers(config, new Set()), config);
+  });
+});
+
+describe("scrubPrintLayoutForRemovedLayers", () => {
+  it("clears the blocks built on a removed layer and leaves the rest alone", () => {
+    const config = withOverrides({
+      showDataTable: true,
+      tableLayerId: "gone",
+      showDataChart: true,
+      chartLayerId: "kept",
+      atlasEnabled: true,
+      atlasLayerId: "gone",
+    });
+    const scrubbed = scrubPrintLayoutForRemovedLayers(config, "gone");
+    assert.equal(scrubbed.tableLayerId, "");
+    assert.equal(scrubbed.showDataTable, false);
+    assert.equal(scrubbed.atlasLayerId, "");
+    assert.equal(scrubbed.atlasEnabled, false);
+    assert.equal(scrubbed.chartLayerId, "kept");
+    assert.equal(scrubbed.showDataChart, true);
+  });
+
+  it("accepts a set of ids, as a group delete passes", () => {
+    const config = withOverrides({ showDataChart: true, chartLayerId: "b" });
+    const scrubbed = scrubPrintLayoutForRemovedLayers(config, new Set(["a", "b"]));
+    assert.equal(scrubbed.chartLayerId, "");
+    assert.equal(scrubbed.showDataChart, false);
+  });
+
+  it("returns the same object when no block named a removed layer", () => {
+    const config = withOverrides({ showDataTable: true, tableLayerId: "kept" });
+    assert.equal(scrubPrintLayoutForRemovedLayers(config, "gone"), config);
+    assert.equal(scrubPrintLayoutForRemovedLayers(config, []), config);
   });
 });


### PR DESCRIPTION
Follow-up to #1994. Its last review round raised two findings after the PR had already been merged, so they land here instead.

## Dangling layer id in a saved project

`removeLayer` and `deleteLayerGroup` already scrub `storymap`, `widgets`, `comments` and `legend` for the layers being deleted, but not the new `printLayout`. Deleting a layer that a Print Layout data or atlas block referenced, then saving without reopening the composer, wrote a block pointing at a layer the file no longer carries. It self-healed on the next project load (via the load-time scrub) or the next time the composer was opened, leaving a window where the saved file disagreed with its own layer set, unlike every sibling section.

Adds `scrubPrintLayoutForRemovedLayers`, the delete-time counterpart of the existing load-time `scrubPrintLayoutForLayers`, taking `string | Iterable<string>` to match `scrubLegendForRemovedLayers` and its siblings. Both entry points now share one block-clearing helper, so they cannot drift.

## Opening a project could mark it dirty

One effect writing a persisted field was still ungated on `open`:

```ts
if (!isMmPage && atlasExtentMode === "scale") setAtlasExtentMode("margin");
```

The dialog is mounted for the whole session and remounts on every project load, so this ran before the composer had ever been opened. A project pairing a pixel page size with `atlasExtentMode: "scale"` (only reachable by hand-editing today, since the live UI keeps the two in sync) would be corrected on load, which pushed the corrected config into the store and marked the project dirty purely from opening it. Gated on `open`, like the three layer-defaulting effects in #1994. Nothing acts on the pairing while the composer is closed, and opening it runs the correction.

I audited every `useEffect` in the file that writes one of the persisted fields; this was the last ungated one, and all four are now gated.

## Verification

`npm run build` and `npm run test:frontend` (6348 pass) are green. New tests cover the delete-time scrub (single id, id set, and the no-op case) and the store path: deleting a layer a block references clears that block and leaves a block on a surviving layer alone.

Refs #1992


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed print layout settings not updating correctly when layers are removed.
  * Removed layers are now automatically cleared from related tables, charts, and atlas settings.
  * Preserved unrelated print layout configurations during layer deletion.
  * Corrected pixel-sized page handling when opening the print layout dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->