### PR TITLE
fix(charts): allow explicit category and value fields

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -67,7 +67,7 @@ import {
   type PageFilterMode,
 } from "../../lib/print-data-blocks";
 import {
-  categoricalColumns,
+  categoryColumnOptions,
   coerceNumericStringRows,
   numericColumns,
   type BarAggregation,
@@ -1193,10 +1193,11 @@ export function PrintLayoutDialog({
   );
   const chartAllRows = useMemo(() => {
     if (!chartLayer?.geojson) return [];
-    const rows = layerRows(chartLayer.geojson);
-    return chartLayer.metadata.sourceKind === "delimited-text"
-      ? coerceNumericStringRows(rows)
-      : rows;
+    // GeoJSON properties can also encode measurements as strings (for
+    // example, data exported from a GIS form or database). Analyze a guarded
+    // copy so those fields remain available as chart values without mutating
+    // the layer or converting identifiers and leading-zero codes.
+    return coerceNumericStringRows(layerRows(chartLayer.geojson));
   }, [chartLayer]);
   // Per-feature bounds for the page-extent filter, walked once per layer so
   // stepping/exporting an N-page atlas does not redo the vertex walk N times
@@ -1209,18 +1210,14 @@ export function PrintLayoutDialog({
     () => (chartLayer?.geojson ? collectAtlasFeatures(chartLayer.geojson) : []),
     [chartLayer],
   );
-  const chartCategoricalFields = useMemo(
-    () => categoricalColumns(chartAllRows, chartFields),
+  const chartCategoryOptions = useMemo(
+    () => categoryColumnOptions(chartAllRows, chartFields),
     [chartAllRows, chartFields],
   );
   const chartNumericFields = useMemo(
     () => numericColumns(chartAllRows, chartFields),
     [chartAllRows, chartFields],
   );
-  // Category options prefer detected low-cardinality fields but fall back to
-  // every field, so an unusual layer can still be charted.
-  const chartCategoryOptions =
-    chartCategoricalFields.length > 0 ? chartCategoricalFields : chartFields;
   // Effective selections: the first suitable field stands in until the user
   // picks one, so enabling a block gives instant feedback.
   const effectiveCategoryField =

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from "react-i18next";
 import { downloadChartPng, downloadChartSvg } from "../../lib/chart-export";
 import { sanitizeExportFileName } from "../../lib/vector-export";
 import {
-  categoricalColumns,
+  categoryColumnOptions,
   DEFAULT_HISTOGRAM_BINS,
   MAX_HISTOGRAM_BINS,
   MIN_HISTOGRAM_BINS,
@@ -54,7 +54,7 @@ export function AttributeChartDialog({
 }: AttributeChartDialogProps) {
   const { t } = useTranslation();
   const numericCols = useMemo(() => numericColumns(rows, columns), [rows, columns]);
-  const categoryCols = useMemo(() => categoricalColumns(rows, columns), [rows, columns]);
+  const categoryCols = useMemo(() => categoryColumnOptions(rows, columns), [rows, columns]);
 
   const [chartType, setChartType] = useState<ChartType>("histogram");
   const [field, setField] = useState("");

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -450,7 +450,6 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const calcExpressionRef = useRef<HTMLTextAreaElement>(null);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
-  const coerceNumericStrings = layer?.metadata.sourceKind === "delimited-text";
   const hasLayer = Boolean(layer);
   // Columns materialized by persistent joins are derived data: every save
   // re-derives them from the join table, so an edit, rename, or delete here
@@ -661,9 +660,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       return featureId.includes(filterLower) || props.includes(filterLower);
     });
   }, [attributeFilter, attributeRows, featureView, selectedIdSet]);
-  // Delimited-text imports preserve every cell as a string. Adapt only the rows
-  // sent to analysis dialogs, leaving the table and exported source data intact.
-  const adaptAnalysisRows = coerceNumericStrings && (chartOpen || statsOpen || explorerOpen);
+  // String-oriented sources can encode measurements as text. Adapt only the
+  // rows sent to analysis dialogs, leaving the table and source data intact.
+  const adaptAnalysisRows = chartOpen || statsOpen || explorerOpen;
   const analysisRows = useMemo(
     () => (adaptAnalysisRows ? coerceNumericStringRows(attributeRows) : attributeRows),
     [adaptAnalysisRows, attributeRows],

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  categoricalColumns,
+  categoryColumnOptions,
   DEFAULT_HISTOGRAM_BINS,
   MAX_HISTOGRAM_BINS,
   MIN_HISTOGRAM_BINS,
@@ -105,7 +105,7 @@ export function WidgetEditorDialog({
 
   const data = useLayerChartData(layerId);
   const numericCols = useMemo(() => numericColumns(data.rows, data.columns), [data]);
-  const categoryCols = useMemo(() => categoricalColumns(data.rows, data.columns), [data]);
+  const categoryCols = useMemo(() => categoryColumnOptions(data.rows, data.columns), [data]);
   const hasNumeric = numericCols.length > 0;
   const hasCategory = categoryCols.length > 0;
   const hasChartable = hasNumeric || hasCategory;

--- a/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
@@ -40,10 +40,7 @@ function buildLayerChartData(layer: GeoLibreLayer | null): LayerChartData {
     : (layer.geojson?.features ?? []).map((feature) => ({
         properties: (feature.properties ?? {}) as Record<string, unknown>,
       }));
-  const rows =
-    layer.metadata.sourceKind === "delimited-text"
-      ? coerceNumericStringRows(sourceRows)
-      : sourceRows;
+  const rows = coerceNumericStringRows(sourceRows);
 
   const keys = new Set<string>();
   for (const row of rows) {

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -57,12 +57,14 @@ function hasLeadingZeroes(value: string): boolean {
 /** True for common delimited-text headers that conventionally hold identifiers. */
 function isIdentifierFieldName(key: string): boolean {
   const normalized = key.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase();
-  if (/(^|[\s_-])(id|code|fips|zip|zipcode|postal)([\s_-]|$)/.test(normalized)) return true;
+  if (/(^|[\s_-])(id|fid|code|fips|zip|zipcode|postal)([\s_-]|$)/.test(normalized)) {
+    return true;
+  }
   const compact = normalized.replace(/[\s_-]/g, "");
   return (
-    /^(geo|object|feature|row)id$/.test(compact) ||
-    /^(state|county|place)fp$/.test(compact) ||
-    /^(tract|block)ce$/.test(compact)
+    /^(geo|object|feature|row)id\d*$/.test(compact) ||
+    /^(state|county|place)fp\d*$/.test(compact) ||
+    /^(tract|block)ce\d*$/.test(compact)
   );
 }
 

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -62,10 +62,10 @@ function isIdentifierFieldName(key: string): boolean {
 
 /**
  * Convert numeric-looking strings in analysis rows without changing the source
- * data. Delimited-text layers use this adapter because their parser preserves
- * every cell as a string, including measurements that summaries should treat as
- * numeric. Because delimited text carries no declared field types, common
- * identifier headers and integer strings with leading zeroes remain text.
+ * data. String-oriented sources use this adapter because measurements may be
+ * stored as text even though summaries should treat them as numeric. Since the
+ * values carry no declared field types, common identifier headers and integer
+ * strings with leading zeroes remain text.
  *
  * The decision is per column, not per value: a column is converted only when its
  * numeric-looking values would carry it past the same threshold the summaries
@@ -385,6 +385,18 @@ export function categoricalColumns(
     const limit = Math.max(CATEGORY_ABSOLUTE_LIMIT, nonNull * CATEGORY_RATIO);
     return distinct.size <= limit;
   });
+}
+
+/**
+ * Every field that can label a chart category, with detected low-cardinality
+ * fields first so the automatic selection remains useful. Unique labels such
+ * as names and IDs must stay available for explicitly configured charts.
+ */
+export function categoryColumnOptions(rows: ChartRow[], columns: string[]): string[] {
+  const preferred = categoricalColumns(rows, columns);
+  if (preferred.length === 0) return columns;
+  const preferredSet = new Set(preferred);
+  return [...preferred, ...columns.filter((column) => !preferredSet.has(column))];
 }
 
 export type BarAggregation = "count" | "sum" | "mean";

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -57,7 +57,12 @@ function hasLeadingZeroes(value: string): boolean {
 /** True for common delimited-text headers that conventionally hold identifiers. */
 function isIdentifierFieldName(key: string): boolean {
   const normalized = key.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase();
-  return /(^|[\s_-])(id|code|fips|zip|zipcode|postal)([\s_-]|$)/.test(normalized);
+  if (/(^|[\s_-])(id|code|fips|zip|zipcode|postal)([\s_-]|$)/.test(normalized)) return true;
+  const compact = normalized.replace(/[\s_-]/g, "");
+  return (
+    /^(geo|object|feature|row)id$/.test(compact) ||
+    /^(state|county|tract|block|place)fp$/.test(compact)
+  );
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -61,7 +61,8 @@ function isIdentifierFieldName(key: string): boolean {
   const compact = normalized.replace(/[\s_-]/g, "");
   return (
     /^(geo|object|feature|row)id$/.test(compact) ||
-    /^(state|county|tract|block|place)fp$/.test(compact)
+    /^(state|county|place)fp$/.test(compact) ||
+    /^(tract|block)ce$/.test(compact)
   );
 }
 

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   categoricalColumns,
+  categoryColumnOptions,
   coerceNumericStringRows,
   computeBar,
   computeBox,
@@ -220,6 +221,28 @@ describe("categoricalColumns", () => {
       properties: { name: `n${i}`, kind: i % 2 === 0 ? "x" : "y" },
     }));
     assert.deepEqual(categoricalColumns(data, ["name", "kind"]), ["kind"]);
+  });
+});
+
+describe("categoryColumnOptions", () => {
+  it("keeps unique label fields selectable after preferred categories", () => {
+    const data = rows(
+      { name: "Alpha", region: "North", population: 10 },
+      { name: "Beta", region: "North", population: 20 },
+      { name: "Gamma", region: "South", population: 30 },
+    );
+
+    assert.deepEqual(categoryColumnOptions(data, ["name", "region", "population"]), [
+      "region",
+      "name",
+      "population",
+    ]);
+  });
+
+  it("preserves field order when no preferred category is detected", () => {
+    const data = rows({ name: "Alpha" }, { name: "Beta" }, { name: "Gamma" });
+
+    assert.deepEqual(categoryColumnOptions(data, ["name"]), ["name"]);
   });
 });
 

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -80,6 +80,8 @@ describe("coerceNumericStringRows", () => {
     const data = rows(
       {
         GEOID: "6",
+        GEOID10: "60",
+        FID: "1",
         OBJECTID: "10",
         STATEFP: "36",
         TRACTCE: "100",
@@ -88,6 +90,8 @@ describe("coerceNumericStringRows", () => {
       },
       {
         GEOID: "12",
+        GEOID10: "120",
+        FID: "2",
         OBJECTID: "20",
         STATEFP: "48",
         TRACTCE: "300",
@@ -102,6 +106,8 @@ describe("coerceNumericStringRows", () => {
       [
         {
           GEOID: "6",
+          GEOID10: "60",
+          FID: "1",
           OBJECTID: "10",
           STATEFP: "36",
           TRACTCE: "100",
@@ -110,6 +116,8 @@ describe("coerceNumericStringRows", () => {
         },
         {
           GEOID: "12",
+          GEOID10: "120",
+          FID: "2",
           OBJECTID: "20",
           STATEFP: "48",
           TRACTCE: "300",

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -240,9 +240,13 @@ describe("categoryColumnOptions", () => {
   });
 
   it("preserves field order when no preferred category is detected", () => {
-    const data = rows({ name: "Alpha" }, { name: "Beta" }, { name: "Gamma" });
+    const data = rows(
+      { name: "Alpha", region: "North" },
+      { name: "Beta", region: "South" },
+      { name: "Gamma", region: "East" },
+    );
 
-    assert.deepEqual(categoryColumnOptions(data, ["name"]), ["name"]);
+    assert.deepEqual(categoryColumnOptions(data, ["name", "region"]), ["name", "region"]);
   });
 });
 

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -76,6 +76,21 @@ describe("coerceNumericStringRows", () => {
     assert.equal(adapted[1].properties.district, "37005");
   });
 
+  it("preserves compact GIS identifier fields without leading zeroes", () => {
+    const data = rows(
+      { GEOID: "6", OBJECTID: "10", STATEFP: "36", population: "42" },
+      { GEOID: "12", OBJECTID: "20", STATEFP: "48", population: "84" },
+    );
+
+    const adapted = coerceNumericStringRows(data);
+    assert.deepEqual(adapted[0].properties, {
+      GEOID: "6",
+      OBJECTID: "10",
+      STATEFP: "36",
+      population: 42,
+    });
+  });
+
   it("reuses rows that have no values to coerce", () => {
     const data = rows({ name: "Alpha", code: "37009" });
     assert.equal(coerceNumericStringRows(data)[0], data[0]);

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -78,17 +78,46 @@ describe("coerceNumericStringRows", () => {
 
   it("preserves compact GIS identifier fields without leading zeroes", () => {
     const data = rows(
-      { GEOID: "6", OBJECTID: "10", STATEFP: "36", population: "42" },
-      { GEOID: "12", OBJECTID: "20", STATEFP: "48", population: "84" },
+      {
+        GEOID: "6",
+        OBJECTID: "10",
+        STATEFP: "36",
+        TRACTCE: "100",
+        BLOCKCE: "200",
+        population: "42",
+      },
+      {
+        GEOID: "12",
+        OBJECTID: "20",
+        STATEFP: "48",
+        TRACTCE: "300",
+        BLOCKCE: "400",
+        population: "84",
+      },
     );
 
     const adapted = coerceNumericStringRows(data);
-    assert.deepEqual(adapted[0].properties, {
-      GEOID: "6",
-      OBJECTID: "10",
-      STATEFP: "36",
-      population: 42,
-    });
+    assert.deepEqual(
+      adapted.map(({ properties }) => properties),
+      [
+        {
+          GEOID: "6",
+          OBJECTID: "10",
+          STATEFP: "36",
+          TRACTCE: "100",
+          BLOCKCE: "200",
+          population: 42,
+        },
+        {
+          GEOID: "12",
+          OBJECTID: "20",
+          STATEFP: "48",
+          TRACTCE: "300",
+          BLOCKCE: "400",
+          population: 84,
+        },
+      ],
+    );
   });
 
   it("reuses rows that have no values to coerce", () => {


### PR DESCRIPTION
## Summary

- keep every layer field available as a chart category while prioritizing detected low-cardinality fields
- recognize guarded numeric-string measurements in GeoJSON chart data
- apply the behavior consistently to Attribute Table Charts, dashboard widgets, and Print Layout charts
- add regression tests for category option ordering and unique label fields

Addresses https://github.com/opengeos/GeoLibre/discussions/1992#discussioncomment-18079609

## Verification

- loaded the reported `test_MEP_2.json` project in the real app
- configured `Nom` as the category field and `Population_2018` as the summed value field in Attribute Table Charts
- verified the resulting pie chart in light and dark themes
- verified the same field configuration in the Print Layout chart
- `npm run test:frontend` (6,375 passed, 1 skipped)
- `npm run build`
- pre-commit hooks on changed files