### PR TITLE
Let /tavily be served by a model's own web search

### DIFF
--- a/tests/ai-proxy-messages-search.test.ts
+++ b/tests/ai-proxy-messages-search.test.ts
@@ -197,6 +197,37 @@ describe("AI proxy messages search response", () => {
     );
   });
 
+  it("drops a claimed entry whose snippet is blank, since it grounds nothing", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [
+        searchBlock,
+        {
+          type: "text",
+          text: JSON.stringify({
+            results: [
+              { url: "https://a.example/x", title: "Hit A", content: "   " },
+              { url: "https://b.example/y", title: "Hit B", content: "real extract" },
+            ],
+          }),
+        },
+      ],
+    });
+    assert.deepEqual(parsed.results.map((r) => r.url), ["https://b.example/y"]);
+  });
+
+  it("falls back to the search hits when every claimed snippet is blank", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [
+        searchBlock,
+        { type: "text", text: '{"results":[{"url":"https://a.example/x","content":""}]}' },
+      ],
+    });
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://a.example/x", "https://b.example/y"],
+    );
+  });
+
   it("caps claimed results at the requested limit", () => {
     const parsed = parseMessagesSearchResponse(
       {

--- a/tests/ai-proxy-messages-search.test.ts
+++ b/tests/ai-proxy-messages-search.test.ts
@@ -167,14 +167,21 @@ describe("AI proxy messages search response", () => {
           text: JSON.stringify({
             answer: "a",
             results: [
-              { url: "https://invented.example/fabricated", title: "Looks real", content: "200 deaths" },
+              {
+                url: "https://invented.example/fabricated",
+                title: "Looks real",
+                content: "200 deaths",
+              },
               { url: "https://a.example/x", title: "Hit A", content: "real" },
             ],
           }),
         },
       ],
     });
-    assert.deepEqual(parsed.results.map((r) => r.url), ["https://a.example/x"]);
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://a.example/x"],
+    );
   });
 
   it("falls back to the search hits when every claimed url was invented", () => {
@@ -208,7 +215,10 @@ describe("AI proxy messages search response", () => {
       },
       1,
     );
-    assert.deepEqual(parsed.results.map((r) => r.url), ["https://a.example/x"]);
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://a.example/x"],
+    );
   });
 
   it("caps the fallback hits at the requested limit too", () => {

--- a/tests/ai-proxy-messages-search.test.ts
+++ b/tests/ai-proxy-messages-search.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildMessagesSearchRequest,
+  parseMessagesSearchResponse,
+  resolveSearchBackend,
+} from "../workers/ai-proxy/src/index";
+
+describe("AI proxy search backend selection", () => {
+  it("defaults to Tavily so existing deployments are unaffected", () => {
+    assert.equal(resolveSearchBackend({} as Env), "tavily");
+    assert.equal(resolveSearchBackend({ SEARCH_BACKEND: "" } as Env), "tavily");
+    assert.equal(resolveSearchBackend({ SEARCH_BACKEND: "tavily" } as Env), "tavily");
+  });
+
+  it("selects the messages backend case- and whitespace-insensitively", () => {
+    assert.equal(resolveSearchBackend({ SEARCH_BACKEND: " Messages " } as Env), "messages");
+  });
+
+  it("treats an unknown backend as Tavily rather than failing closed", () => {
+    assert.equal(resolveSearchBackend({ SEARCH_BACKEND: "bing" } as Env), "tavily");
+  });
+});
+
+describe("AI proxy messages search request", () => {
+  it("turns a news lookback into an explicit recency instruction", () => {
+    const request = buildMessagesSearchRequest(
+      { topic: "news", days: 30, max_results: 8 },
+      "Colorado wildfire impacts",
+    );
+    const messages = request.messages as { role: string; content: string }[];
+    assert.match(messages[0].content, /within the last 30 days/);
+    assert.match(request.system as string, /at most 8 results/);
+    assert.equal(request.model, "claude-sonnet-5");
+  });
+
+  it("clamps max_results into the documented range", () => {
+    assert.match(buildMessagesSearchRequest({ max_results: 99 }, "q").system as string, /at most 20 results/);
+    assert.match(buildMessagesSearchRequest({ max_results: 0 }, "q").system as string, /at most 1 results/);
+  });
+
+  it("ignores a lookback for retrospective general searches", () => {
+    const request = buildMessagesSearchRequest({ topic: "general", days: 30 }, "Valencia flood");
+    const messages = request.messages as { role: string; content: string }[];
+    assert.doesNotMatch(messages[0].content, /last 30 days/);
+  });
+
+  it("honours an operator model override", () => {
+    assert.equal(buildMessagesSearchRequest({}, "q", "claude-opus-5").model, "claude-opus-5");
+  });
+
+  it("always requests the server-side web_search tool", () => {
+    const tools = buildMessagesSearchRequest({}, "q").tools as { type: string }[];
+    assert.equal(tools[0].type, "web_search_20250305");
+  });
+});
+
+describe("AI proxy messages search response", () => {
+  const searchBlock = {
+    type: "web_search_tool_result",
+    content: [
+      { type: "web_search_result", title: "Hit A", url: "https://a.example/x", page_age: "2024-11-02" },
+      { type: "web_search_result", title: "Hit B", url: "https://b.example/y", page_age: "None" },
+    ],
+  };
+
+  it("maps model JSON onto the Tavily envelope", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [
+        searchBlock,
+        {
+          type: "text",
+          text: JSON.stringify({
+            answer: "At least 200 died.",
+            results: [{ title: "Hit A", url: "https://a.example/x", content: "…at least 200 deaths…" }],
+          }),
+        },
+      ],
+    });
+    assert.equal(parsed.answer, "At least 200 died.");
+    assert.deepEqual(parsed.results, [
+      { title: "Hit A", url: "https://a.example/x", content: "…at least 200 deaths…", published_date: "2024-11-02" },
+    ]);
+  });
+
+  it("tolerates a fenced JSON reply", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [
+        searchBlock,
+        { type: "text", text: '```json\n{"answer":"ok","results":[{"url":"https://b.example/y","content":"c"}]}\n```' },
+      ],
+    });
+    assert.equal(parsed.results.length, 1);
+    assert.equal(parsed.results[0].title, "Hit B", "falls back to the search hit's title");
+  });
+
+  it("drops the page_age sentinel rather than emitting it as a date", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [searchBlock, { type: "text", text: '{"results":[{"url":"https://b.example/y","content":"c"}]}' }],
+    });
+    assert.equal("published_date" in parsed.results[0], false);
+  });
+
+  it("falls back to raw search hits when the model returns prose", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [searchBlock, { type: "text", text: "I could not format that." }],
+    });
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://a.example/x", "https://b.example/y"],
+    );
+    assert.equal(parsed.answer, "I could not format that.");
+  });
+
+  it("never invents a result the search did not return a url for", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [searchBlock, { type: "text", text: '{"results":[{"title":"No url","content":"c"}]}' }],
+    });
+    assert.deepEqual(parsed.results.map((r) => r.url), ["https://a.example/x", "https://b.example/y"]);
+  });
+
+  it("returns an empty envelope for a response with no content", () => {
+    assert.deepEqual(parseMessagesSearchResponse({}), { results: [], answer: undefined });
+  });
+});

--- a/tests/ai-proxy-messages-search.test.ts
+++ b/tests/ai-proxy-messages-search.test.ts
@@ -35,8 +35,14 @@ describe("AI proxy messages search request", () => {
   });
 
   it("clamps max_results into the documented range", () => {
-    assert.match(buildMessagesSearchRequest({ max_results: 99 }, "q").system as string, /at most 20 results/);
-    assert.match(buildMessagesSearchRequest({ max_results: 0 }, "q").system as string, /at most 1 results/);
+    assert.match(
+      buildMessagesSearchRequest({ max_results: 99 }, "q").system as string,
+      /at most 20 results/,
+    );
+    assert.match(
+      buildMessagesSearchRequest({ max_results: 0 }, "q").system as string,
+      /at most 1 results/,
+    );
   });
 
   it("ignores a lookback for retrospective general searches", () => {
@@ -59,7 +65,12 @@ describe("AI proxy messages search response", () => {
   const searchBlock = {
     type: "web_search_tool_result",
     content: [
-      { type: "web_search_result", title: "Hit A", url: "https://a.example/x", page_age: "2024-11-02" },
+      {
+        type: "web_search_result",
+        title: "Hit A",
+        url: "https://a.example/x",
+        page_age: "2024-11-02",
+      },
       { type: "web_search_result", title: "Hit B", url: "https://b.example/y", page_age: "None" },
     ],
   };
@@ -72,14 +83,21 @@ describe("AI proxy messages search response", () => {
           type: "text",
           text: JSON.stringify({
             answer: "At least 200 died.",
-            results: [{ title: "Hit A", url: "https://a.example/x", content: "…at least 200 deaths…" }],
+            results: [
+              { title: "Hit A", url: "https://a.example/x", content: "…at least 200 deaths…" },
+            ],
           }),
         },
       ],
     });
     assert.equal(parsed.answer, "At least 200 died.");
     assert.deepEqual(parsed.results, [
-      { title: "Hit A", url: "https://a.example/x", content: "…at least 200 deaths…", published_date: "2024-11-02" },
+      {
+        title: "Hit A",
+        url: "https://a.example/x",
+        content: "…at least 200 deaths…",
+        published_date: "2024-11-02",
+      },
     ]);
   });
 
@@ -87,7 +105,10 @@ describe("AI proxy messages search response", () => {
     const parsed = parseMessagesSearchResponse({
       content: [
         searchBlock,
-        { type: "text", text: '```json\n{"answer":"ok","results":[{"url":"https://b.example/y","content":"c"}]}\n```' },
+        {
+          type: "text",
+          text: '```json\n{"answer":"ok","results":[{"url":"https://b.example/y","content":"c"}]}\n```',
+        },
       ],
     });
     assert.equal(parsed.results.length, 1);
@@ -96,7 +117,10 @@ describe("AI proxy messages search response", () => {
 
   it("drops the page_age sentinel rather than emitting it as a date", () => {
     const parsed = parseMessagesSearchResponse({
-      content: [searchBlock, { type: "text", text: '{"results":[{"url":"https://b.example/y","content":"c"}]}' }],
+      content: [
+        searchBlock,
+        { type: "text", text: '{"results":[{"url":"https://b.example/y","content":"c"}]}' },
+      ],
     });
     assert.equal("published_date" in parsed.results[0], false);
   });
@@ -114,9 +138,15 @@ describe("AI proxy messages search response", () => {
 
   it("never invents a result the search did not return a url for", () => {
     const parsed = parseMessagesSearchResponse({
-      content: [searchBlock, { type: "text", text: '{"results":[{"title":"No url","content":"c"}]}' }],
+      content: [
+        searchBlock,
+        { type: "text", text: '{"results":[{"title":"No url","content":"c"}]}' },
+      ],
     });
-    assert.deepEqual(parsed.results.map((r) => r.url), ["https://a.example/x", "https://b.example/y"]);
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://a.example/x", "https://b.example/y"],
+    );
   });
 
   it("returns an empty envelope for a response with no content", () => {

--- a/tests/ai-proxy-messages-search.test.ts
+++ b/tests/ai-proxy-messages-search.test.ts
@@ -4,6 +4,7 @@ import {
   buildMessagesSearchRequest,
   parseMessagesSearchResponse,
   resolveSearchBackend,
+  searchResultLimit,
 } from "../workers/ai-proxy/src/index";
 
 describe("AI proxy search backend selection", () => {
@@ -58,6 +59,14 @@ describe("AI proxy messages search request", () => {
   it("always requests the server-side web_search tool", () => {
     const tools = buildMessagesSearchRequest({}, "q").tools as { type: string }[];
     assert.equal(tools[0].type, "web_search_20250305");
+  });
+
+  it("shares one clamped limit between the prompt and the response cap", () => {
+    assert.equal(searchResultLimit({}), 6);
+    assert.equal(searchResultLimit({ max_results: 8 }), 8);
+    assert.equal(searchResultLimit({ max_results: 99 }), 20);
+    assert.equal(searchResultLimit({ max_results: 0 }), 1);
+    assert.equal(searchResultLimit({ max_results: Number.NaN }), 6);
   });
 });
 
@@ -136,7 +145,7 @@ describe("AI proxy messages search response", () => {
     assert.equal(parsed.answer, "I could not format that.");
   });
 
-  it("never invents a result the search did not return a url for", () => {
+  it("drops a claimed entry that carries no url", () => {
     const parsed = parseMessagesSearchResponse({
       content: [
         searchBlock,
@@ -147,6 +156,67 @@ describe("AI proxy messages search response", () => {
       parsed.results.map((r) => r.url),
       ["https://a.example/x", "https://b.example/y"],
     );
+  });
+
+  it("drops a url the search never returned, so an invented link cannot be cited", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [
+        searchBlock,
+        {
+          type: "text",
+          text: JSON.stringify({
+            answer: "a",
+            results: [
+              { url: "https://invented.example/fabricated", title: "Looks real", content: "200 deaths" },
+              { url: "https://a.example/x", title: "Hit A", content: "real" },
+            ],
+          }),
+        },
+      ],
+    });
+    assert.deepEqual(parsed.results.map((r) => r.url), ["https://a.example/x"]);
+  });
+
+  it("falls back to the search hits when every claimed url was invented", () => {
+    const parsed = parseMessagesSearchResponse({
+      content: [
+        searchBlock,
+        { type: "text", text: '{"results":[{"url":"https://invented.example/z","content":"c"}]}' },
+      ],
+    });
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://a.example/x", "https://b.example/y"],
+    );
+  });
+
+  it("caps claimed results at the requested limit", () => {
+    const parsed = parseMessagesSearchResponse(
+      {
+        content: [
+          searchBlock,
+          {
+            type: "text",
+            text: JSON.stringify({
+              results: [
+                { url: "https://a.example/x", content: "one" },
+                { url: "https://b.example/y", content: "two" },
+              ],
+            }),
+          },
+        ],
+      },
+      1,
+    );
+    assert.deepEqual(parsed.results.map((r) => r.url), ["https://a.example/x"]);
+  });
+
+  it("caps the fallback hits at the requested limit too", () => {
+    const parsed = parseMessagesSearchResponse(
+      { content: [searchBlock, { type: "text", text: "prose, not json" }] },
+      1,
+    );
+    assert.equal(parsed.results.length, 1);
   });
 
   it("returns an empty envelope for a response with no content", () => {

--- a/tests/ai-proxy-messages-search.test.ts
+++ b/tests/ai-proxy-messages-search.test.ts
@@ -212,7 +212,10 @@ describe("AI proxy messages search response", () => {
         },
       ],
     });
-    assert.deepEqual(parsed.results.map((r) => r.url), ["https://b.example/y"]);
+    assert.deepEqual(
+      parsed.results.map((r) => r.url),
+      ["https://b.example/y"],
+    );
   });
 
   it("falls back to the search hits when every claimed snippet is blank", () => {

--- a/workers/ai-proxy/README.md
+++ b/workers/ai-proxy/README.md
@@ -40,6 +40,34 @@ output-token cap, and per-client rate limit.
    client, so the configured limit is what a single user may cost you in total
    rather than a separate allowance each for chat and search.
 
+   ### Serving `/tavily` from a model's own web search
+
+   `/tavily` can instead be answered by an endpoint that speaks the Anthropic
+   messages API and exposes the server-side `web_search` tool -- a self-hosted
+   [cli-proxy-api](https://github.com/router-for-me/CLIProxyAPI), for example --
+   which removes the Tavily dependency entirely. The route keeps its name and
+   its response shape, so no client changes are needed.
+
+   | Setting | Required | Meaning |
+   | --- | --- | --- |
+   | `SEARCH_BACKEND` | no | `tavily` (default) or `messages`. Any other value is treated as `tavily`. |
+   | `SEARCH_MESSAGES_URL` | for `messages` | Base URL, e.g. `https://cli-proxy.example.org`. `/v1/messages` is appended. |
+   | `SEARCH_MESSAGES_API_KEY` | for `messages` | Bearer token for that endpoint. Store with `wrangler secret put`. |
+   | `SEARCH_MESSAGES_MODEL` | no | Defaults to `claude-sonnet-5`. |
+
+   Tavily remains the default, so an existing deployment is unchanged until
+   `SEARCH_BACKEND=messages` is set deliberately. Like the Tavily path, the
+   route returns `503 Search is not configured` when its settings are missing.
+
+   Two differences are worth knowing before switching. Anthropic returns each
+   hit's page text as opaque `encrypted_content`, so the model writes the
+   per-source snippets that ground quantified figures; they are extracts it
+   produces rather than verbatim provider content, and the cited URLs are
+   restricted to ones the search actually returned. And a search plus a
+   synthesis pass is slower and far more token-hungry than a Tavily call --
+   expect tens of thousands of tokens per search against whatever account backs
+   `SEARCH_MESSAGES_URL`.
+
 3. Validate and deploy:
 
    ```sh

--- a/workers/ai-proxy/src/index.ts
+++ b/workers/ai-proxy/src/index.ts
@@ -250,10 +250,7 @@ function extractJsonObject(text: string): unknown {
  * to the raw search hits when the model does not return usable JSON, so a
  * malformed reply still yields citable URLs rather than an error.
  */
-export function parseMessagesSearchResponse(
-  data: unknown,
-  limit = 20,
-): MessagesSearchPayload {
+export function parseMessagesSearchResponse(data: unknown, limit = 20): MessagesSearchPayload {
   const content = Array.isArray((data as { content?: unknown })?.content)
     ? ((data as { content: unknown[] }).content as Record<string, unknown>[])
     : [];

--- a/workers/ai-proxy/src/index.ts
+++ b/workers/ai-proxy/src/index.ts
@@ -226,7 +226,10 @@ interface MessagesSearchPayload {
 }
 
 function extractJsonObject(text: string): unknown {
-  const trimmed = text.trim().replace(/^```(?:json)?/i, "").replace(/```$/, "");
+  const trimmed = text
+    .trim()
+    .replace(/^```(?:json)?/i, "")
+    .replace(/```$/, "");
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
   if (start === -1 || end <= start) return undefined;
@@ -255,8 +258,12 @@ export function parseMessagesSearchResponse(data: unknown): MessagesSearchPayloa
         const url = typeof hit?.url === "string" ? hit.url : "";
         if (!url) continue;
         // page_age is absent for many pages and arrives as the string "None".
-        const age = typeof hit.page_age === "string" && hit.page_age !== "None" ? hit.page_age : undefined;
-        searched.set(url, { title: typeof hit.title === "string" ? hit.title : "", published_date: age });
+        const age =
+          typeof hit.page_age === "string" && hit.page_age !== "None" ? hit.page_age : undefined;
+        searched.set(url, {
+          title: typeof hit.title === "string" ? hit.title : "",
+          published_date: age,
+        });
       }
     } else if (block?.type === "text" && typeof block.text === "string") {
       textParts.push(block.text);

--- a/workers/ai-proxy/src/index.ts
+++ b/workers/ai-proxy/src/index.ts
@@ -180,16 +180,21 @@ const MESSAGES_SEARCH_MODEL_DEFAULT = "claude-sonnet-5";
 // per-source snippets that ground the impact figures. Asking for the whole
 // envelope as JSON keeps that mapping in one place instead of splitting it
 // between a synthesis prompt and a post-hoc merge.
+/** The client's requested result count, clamped to the documented range. */
+export function searchResultLimit(body: Record<string, unknown>): number {
+  const requested =
+    typeof body.max_results === "number" && Number.isFinite(body.max_results)
+      ? Math.floor(body.max_results)
+      : 6;
+  return Math.min(Math.max(requested, 1), 20);
+}
+
 export function buildMessagesSearchRequest(
   body: Record<string, unknown>,
   query: string,
   model = MESSAGES_SEARCH_MODEL_DEFAULT,
 ): Record<string, unknown> {
-  const requestedMaxResults =
-    typeof body.max_results === "number" && Number.isFinite(body.max_results)
-      ? Math.floor(body.max_results)
-      : 6;
-  const maxResults = Math.min(Math.max(requestedMaxResults, 1), 20);
+  const maxResults = searchResultLimit(body);
   const topic = body.topic === "news" ? "news" : "general";
   const days =
     topic === "news" && typeof body.days === "number" && Number.isFinite(body.days)
@@ -245,7 +250,10 @@ function extractJsonObject(text: string): unknown {
  * to the raw search hits when the model does not return usable JSON, so a
  * malformed reply still yields citable URLs rather than an error.
  */
-export function parseMessagesSearchResponse(data: unknown): MessagesSearchPayload {
+export function parseMessagesSearchResponse(
+  data: unknown,
+  limit = 20,
+): MessagesSearchPayload {
   const content = Array.isArray((data as { content?: unknown })?.content)
     ? ((data as { content: unknown[] }).content as Record<string, unknown>[])
     : [];
@@ -279,19 +287,24 @@ export function parseMessagesSearchResponse(data: unknown): MessagesSearchPayloa
     .map((entry) => {
       const url = typeof entry?.url === "string" ? entry.url.trim() : "";
       if (!url) return undefined;
+      // Only URLs the search actually returned may be cited: the model writes
+      // the snippets, so without this an invented link reaches the client
+      // looking exactly as citable as a real one.
       const hit = searched.get(url);
+      if (!hit) return undefined;
       const published =
         typeof entry.published_date === "string" && entry.published_date.trim()
           ? entry.published_date.trim()
           : hit?.published_date;
       return {
-        title: typeof entry.title === "string" && entry.title ? entry.title : (hit?.title ?? ""),
+        title: typeof entry.title === "string" && entry.title ? entry.title : hit.title,
         url,
         content: typeof entry.content === "string" ? entry.content : "",
         ...(published ? { published_date: published } : {}),
       };
     })
-    .filter((entry): entry is MessagesSearchPayload["results"][number] => entry !== undefined);
+    .filter((entry): entry is MessagesSearchPayload["results"][number] => entry !== undefined)
+    .slice(0, limit);
 
   const answer =
     typeof (parsed as { answer?: unknown })?.answer === "string"
@@ -303,12 +316,14 @@ export function parseMessagesSearchResponse(data: unknown): MessagesSearchPayloa
   // No usable JSON: hand back what the search itself found so the caller still
   // has sources to cite, with the model's prose as the answer.
   return {
-    results: [...searched.entries()].map(([url, hit]) => ({
-      title: hit.title,
-      url,
-      content: "",
-      ...(hit.published_date ? { published_date: hit.published_date } : {}),
-    })),
+    results: [...searched.entries()]
+      .map(([url, hit]) => ({
+        title: hit.title,
+        url,
+        content: "",
+        ...(hit.published_date ? { published_date: hit.published_date } : {}),
+      }))
+      .slice(0, limit),
     answer: answer ?? (textParts.join("").trim() || undefined),
   };
 }
@@ -541,59 +556,68 @@ async function proxyMessagesSearch(
   );
 
   const controller = new AbortController();
-  // A search plus a synthesis pass runs longer than Tavily's own bound, and this
-  // waits on the whole body rather than just headers, so it gets its own budget.
+  // A search plus a synthesis pass runs longer than Tavily's own bound. The
+  // timer is cleared only in the outer finally, after the body has been read:
+  // clearing it when fetch resolves would disarm the abort while the body --
+  // where the whole answer actually arrives -- was still streaming.
   const deadline = setTimeout(() => controller.abort(), MESSAGES_SEARCH_TIMEOUT_MS);
-  let upstream: Response;
   try {
-    upstream = await fetch(`${endpoint}/v1/messages`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    if (controller.signal.aborted) {
-      return jsonError("Search request timed out", 504, responseHeaders(origin));
+    let upstream: Response;
+    try {
+      upstream = await fetch(`${endpoint}/v1/messages`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+          "anthropic-version": "2023-06-01",
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return jsonError("Search request timed out", 504, responseHeaders(origin));
+      }
+      throw error;
     }
-    throw error;
+
+    const headers = responseHeaders(origin);
+    headers.set("Content-Type", "application/json; charset=utf-8");
+    headers.set("Cache-Control", "no-store");
+
+    if (!upstream.ok) {
+      // Do not forward the upstream body: it can carry provider detail the client
+      // has no use for, and its shape is not the client's error contract.
+      console.log(
+        JSON.stringify({ message: "Messages search upstream error", status: upstream.status }),
+      );
+      return jsonError("Search upstream error", 502, headers);
+    }
+
+    let parsed: ReturnType<typeof parseMessagesSearchResponse>;
+    try {
+      parsed = parseMessagesSearchResponse(await upstream.json(), searchResultLimit(body));
+    } catch {
+      // A stalled body aborts rather than parses, so separate the two: the
+      // client should see a timeout, not a malformed-response error.
+      if (controller.signal.aborted) {
+        return jsonError("Search request timed out", 504, headers);
+      }
+      return jsonError("Search upstream returned an unreadable response", 502, headers);
+    }
+
+    console.log(
+      JSON.stringify({
+        message: "Messages search request",
+        status: upstream.status,
+        resultCount: parsed.results.length,
+        colo: request.cf?.colo,
+      }),
+    );
+    return new Response(JSON.stringify(parsed), { status: 200, headers });
   } finally {
     clearTimeout(deadline);
   }
-
-  const headers = responseHeaders(origin);
-  headers.set("Content-Type", "application/json; charset=utf-8");
-  headers.set("Cache-Control", "no-store");
-
-  if (!upstream.ok) {
-    // Do not forward the upstream body: it can carry provider detail the client
-    // has no use for, and its shape is not the client's error contract.
-    console.log(
-      JSON.stringify({ message: "Messages search upstream error", status: upstream.status }),
-    );
-    return jsonError("Search upstream error", 502, headers);
-  }
-
-  let parsed: ReturnType<typeof parseMessagesSearchResponse>;
-  try {
-    parsed = parseMessagesSearchResponse(await upstream.json());
-  } catch {
-    return jsonError("Search upstream returned an unreadable response", 502, headers);
-  }
-
-  console.log(
-    JSON.stringify({
-      message: "Messages search request",
-      status: upstream.status,
-      resultCount: parsed.results.length,
-      colo: request.cf?.colo,
-    }),
-  );
-  return new Response(JSON.stringify(parsed), { status: 200, headers });
 }
 
 export default {

--- a/workers/ai-proxy/src/index.ts
+++ b/workers/ai-proxy/src/index.ts
@@ -289,14 +289,19 @@ export function parseMessagesSearchResponse(data: unknown, limit = 20): Messages
       // looking exactly as citable as a real one.
       const hit = searched.get(url);
       if (!hit) return undefined;
+      // A citation with no extract does not meet the schema the prompt asks for
+      // and grounds nothing, so drop it rather than let it stand in for a real
+      // result and suppress the raw-hit fallback below.
+      const content = typeof entry.content === "string" ? entry.content : "";
+      if (!content.trim()) return undefined;
       const published =
         typeof entry.published_date === "string" && entry.published_date.trim()
           ? entry.published_date.trim()
-          : hit?.published_date;
+          : hit.published_date;
       return {
         title: typeof entry.title === "string" && entry.title ? entry.title : hit.title,
         url,
-        content: typeof entry.content === "string" ? entry.content : "",
+        content,
         ...(published ? { published_date: published } : {}),
       };
     })

--- a/workers/ai-proxy/src/index.ts
+++ b/workers/ai-proxy/src/index.ts
@@ -11,7 +11,27 @@ const UPSTREAM_HEADER_TIMEOUT_MS = 300_000;
 // plus an answer-synthesis step on Tavily's side; 30s was tight enough to turn
 // a merely slow news query during a live disaster event into a 504.
 const SEARCH_HEADER_TIMEOUT_MS = 60_000;
+// Declared here rather than in wrangler.jsonc: all four are optional and
+// deployment-specific. wrangler.jsonc's `secrets` block only supports
+// `required`, so listing SEARCH_MESSAGES_API_KEY there would warn on every
+// Tavily deployment that legitimately does not set it.
+declare global {
+  interface Env {
+    /** "tavily" (default) or "messages". */
+    SEARCH_BACKEND?: string;
+    /** Base URL of an Anthropic-messages-compatible endpoint, e.g. a cli-proxy-api. */
+    SEARCH_MESSAGES_URL?: string;
+    SEARCH_MESSAGES_API_KEY?: string;
+    /** Defaults to claude-sonnet-5. */
+    SEARCH_MESSAGES_MODEL?: string;
+  }
+}
+
 const TAVILY_ENDPOINT = "https://api.tavily.com/search";
+
+// Search + synthesis on one round trip, and this bound covers the whole body
+// rather than just the response headers, so it sits well above Tavily's.
+const MESSAGES_SEARCH_TIMEOUT_MS = 90_000;
 
 function jsonError(message: string, status: number, headers?: HeadersInit): Response {
   return Response.json({ error: { message, type: "geolibre_proxy_error" } }, { status, headers });
@@ -144,6 +164,148 @@ export function buildTavilySearchRequest(
   return request;
 }
 
+/**
+ * Which backend answers /tavily. Tavily stays the default so an existing
+ * deployment is unaffected until SEARCH_BACKEND is set deliberately.
+ */
+export function resolveSearchBackend(env: Env): "tavily" | "messages" {
+  return env.SEARCH_BACKEND?.trim().toLowerCase() === "messages" ? "messages" : "tavily";
+}
+
+const MESSAGES_SEARCH_MODEL_DEFAULT = "claude-sonnet-5";
+
+// The client contract is Tavily's: {results:[{title,url,content,published_date}],
+// answer}. Anthropic's server-side search returns citable titles and URLs but the
+// page text arrives as opaque encrypted_content, so the model has to write the
+// per-source snippets that ground the impact figures. Asking for the whole
+// envelope as JSON keeps that mapping in one place instead of splitting it
+// between a synthesis prompt and a post-hoc merge.
+export function buildMessagesSearchRequest(
+  body: Record<string, unknown>,
+  query: string,
+  model = MESSAGES_SEARCH_MODEL_DEFAULT,
+): Record<string, unknown> {
+  const requestedMaxResults =
+    typeof body.max_results === "number" && Number.isFinite(body.max_results)
+      ? Math.floor(body.max_results)
+      : 6;
+  const maxResults = Math.min(Math.max(requestedMaxResults, 1), 20);
+  const topic = body.topic === "news" ? "news" : "general";
+  const days =
+    topic === "news" && typeof body.days === "number" && Number.isFinite(body.days)
+      ? Math.min(Math.max(Math.floor(body.days), 1), 3650)
+      : undefined;
+
+  const recency =
+    days === undefined
+      ? topic === "news"
+        ? " Prefer recent journalistic coverage."
+        : " Retrospective sources are fine; prefer authoritative ones."
+      : ` Only use sources published within the last ${days} days.`;
+
+  return {
+    model,
+    max_tokens: 4096,
+    tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 4 }],
+    system:
+      "You are a search backend. Use the web_search tool, then reply with ONE JSON " +
+      "object and nothing else -- no prose, no code fence. Schema: " +
+      '{"answer": string, "results": [{"title": string, "url": string, ' +
+      '"content": string, "published_date": string}]}. "content" must be a short ' +
+      "extract from that specific source supporting the answer, quoting any " +
+      'figures it states. "url" must be a URL the search returned; never invent ' +
+      'one. Omit "published_date" when the source does not state one. Return at ' +
+      `most ${maxResults} results.`,
+    messages: [{ role: "user", content: `${query}${recency}` }],
+  };
+}
+
+interface MessagesSearchPayload {
+  results: { title: string; url: string; content: string; published_date?: string }[];
+  answer?: string;
+}
+
+function extractJsonObject(text: string): unknown {
+  const trimmed = text.trim().replace(/^```(?:json)?/i, "").replace(/```$/, "");
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start === -1 || end <= start) return undefined;
+  try {
+    return JSON.parse(trimmed.slice(start, end + 1));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Map an Anthropic messages response onto the Tavily-shaped envelope. Falls back
+ * to the raw search hits when the model does not return usable JSON, so a
+ * malformed reply still yields citable URLs rather than an error.
+ */
+export function parseMessagesSearchResponse(data: unknown): MessagesSearchPayload {
+  const content = Array.isArray((data as { content?: unknown })?.content)
+    ? ((data as { content: unknown[] }).content as Record<string, unknown>[])
+    : [];
+
+  const searched = new Map<string, { title: string; published_date?: string }>();
+  const textParts: string[] = [];
+  for (const block of content) {
+    if (block?.type === "web_search_tool_result" && Array.isArray(block.content)) {
+      for (const hit of block.content as Record<string, unknown>[]) {
+        const url = typeof hit?.url === "string" ? hit.url : "";
+        if (!url) continue;
+        // page_age is absent for many pages and arrives as the string "None".
+        const age = typeof hit.page_age === "string" && hit.page_age !== "None" ? hit.page_age : undefined;
+        searched.set(url, { title: typeof hit.title === "string" ? hit.title : "", published_date: age });
+      }
+    } else if (block?.type === "text" && typeof block.text === "string") {
+      textParts.push(block.text);
+    }
+  }
+
+  const parsed = extractJsonObject(textParts.join(""));
+  const claimed = Array.isArray((parsed as { results?: unknown })?.results)
+    ? ((parsed as { results: unknown[] }).results as Record<string, unknown>[])
+    : [];
+
+  const results = claimed
+    .map((entry) => {
+      const url = typeof entry?.url === "string" ? entry.url.trim() : "";
+      if (!url) return undefined;
+      const hit = searched.get(url);
+      const published =
+        typeof entry.published_date === "string" && entry.published_date.trim()
+          ? entry.published_date.trim()
+          : hit?.published_date;
+      return {
+        title: typeof entry.title === "string" && entry.title ? entry.title : (hit?.title ?? ""),
+        url,
+        content: typeof entry.content === "string" ? entry.content : "",
+        ...(published ? { published_date: published } : {}),
+      };
+    })
+    .filter((entry): entry is MessagesSearchPayload["results"][number] => entry !== undefined);
+
+  const answer =
+    typeof (parsed as { answer?: unknown })?.answer === "string"
+      ? ((parsed as { answer: string }).answer as string)
+      : undefined;
+
+  if (results.length > 0) return { results, answer };
+
+  // No usable JSON: hand back what the search itself found so the caller still
+  // has sources to cite, with the model's prose as the answer.
+  return {
+    results: [...searched.entries()].map(([url, hit]) => ({
+      title: hit.title,
+      url,
+      content: "",
+      ...(hit.published_date ? { published_date: hit.published_date } : {}),
+    })),
+    answer: answer ?? (textParts.join("").trim() || undefined),
+  };
+}
+
 // Chat and search deliberately draw down one budget per client: both spend the
 // same operator's account, so the limit an operator configures is the total an
 // individual user may cost them, not a per-route allowance that a client can
@@ -245,6 +407,16 @@ async function proxyChat(request: Request, env: Env, origin: string | null): Pro
   return new Response(upstream.body, { status: upstream.status, headers });
 }
 
+/**
+ * /tavily keeps its name and its response shape; SEARCH_BACKEND decides who
+ * actually answers it, so clients need no change to switch providers.
+ */
+async function proxySearch(request: Request, env: Env, origin: string | null): Promise<Response> {
+  return resolveSearchBackend(env) === "messages"
+    ? proxyMessagesSearch(request, env, origin)
+    : proxyTavily(request, env, origin);
+}
+
 async function proxyTavily(request: Request, env: Env, origin: string | null): Promise<Response> {
   // Limit first, as proxyChat does, so an unconfigured Worker cannot be probed
   // without bound: the 503 below is cheap, but "cheap" is not "free".
@@ -319,6 +491,104 @@ async function proxyTavily(request: Request, env: Env, origin: string | null): P
   return new Response(upstream.body, { status: upstream.status, headers });
 }
 
+async function proxyMessagesSearch(
+  request: Request,
+  env: Env,
+  origin: string | null,
+): Promise<Response> {
+  const limited = withOrigin(await rateLimit(request, env), origin);
+  if (limited) return limited;
+
+  const endpoint = env.SEARCH_MESSAGES_URL?.trim().replace(/\/+$/, "");
+  const apiKey = env.SEARCH_MESSAGES_API_KEY?.trim();
+  if (!endpoint || !apiKey) {
+    return jsonError("Search is not configured", 503, responseHeaders(origin));
+  }
+
+  const maximumBytes = Math.min(positiveInteger(env.MAX_BODY_BYTES, 1_048_576), 65_536);
+  let body: Record<string, unknown>;
+  try {
+    body = await readBoundedJson(request, maximumBytes);
+  } catch (error) {
+    const status = error instanceof RangeError ? 413 : 400;
+    return jsonError(
+      error instanceof Error ? error.message : "Invalid request body",
+      status,
+      responseHeaders(origin),
+    );
+  }
+
+  const query = typeof body.query === "string" ? body.query.trim() : "";
+  if (!query || query.length > 1_000) {
+    return jsonError(
+      "query must be a non-empty string of at most 1,000 characters",
+      400,
+      responseHeaders(origin),
+    );
+  }
+
+  const payload = buildMessagesSearchRequest(
+    body,
+    query,
+    env.SEARCH_MESSAGES_MODEL?.trim() || undefined,
+  );
+
+  const controller = new AbortController();
+  // A search plus a synthesis pass runs longer than Tavily's own bound, and this
+  // waits on the whole body rather than just headers, so it gets its own budget.
+  const deadline = setTimeout(() => controller.abort(), MESSAGES_SEARCH_TIMEOUT_MS);
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${endpoint}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      return jsonError("Search request timed out", 504, responseHeaders(origin));
+    }
+    throw error;
+  } finally {
+    clearTimeout(deadline);
+  }
+
+  const headers = responseHeaders(origin);
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  headers.set("Cache-Control", "no-store");
+
+  if (!upstream.ok) {
+    // Do not forward the upstream body: it can carry provider detail the client
+    // has no use for, and its shape is not the client's error contract.
+    console.log(
+      JSON.stringify({ message: "Messages search upstream error", status: upstream.status }),
+    );
+    return jsonError("Search upstream error", 502, headers);
+  }
+
+  let parsed: ReturnType<typeof parseMessagesSearchResponse>;
+  try {
+    parsed = parseMessagesSearchResponse(await upstream.json());
+  } catch {
+    return jsonError("Search upstream returned an unreadable response", 502, headers);
+  }
+
+  console.log(
+    JSON.stringify({
+      message: "Messages search request",
+      status: upstream.status,
+      resultCount: parsed.results.length,
+      colo: request.cf?.colo,
+    }),
+  );
+  return new Response(JSON.stringify(parsed), { status: 200, headers });
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -345,7 +615,7 @@ export default {
 
     try {
       return url.pathname === "/tavily"
-        ? await proxyTavily(request, env, origin)
+        ? await proxySearch(request, env, origin)
         : await proxyChat(request, env, origin);
     } catch (error) {
       console.error(


### PR DESCRIPTION
Prototype of a second backend for the `/tavily` search route, selected by an environment variable. Tavily stays the default; setting `SEARCH_BACKEND=messages` serves the same route from an Anthropic-messages endpoint that exposes the server-side `web_search` tool (e.g. a self-hosted [cli-proxy-api](https://github.com/router-for-me/CLIProxyAPI)), removing the third-party search dependency.

The route keeps its name **and its Tavily-shaped response**, so `src/lib/opera/news.ts` and the OPERA plugin need no change.

## Configuration

| Setting | Required | Meaning |
| --- | --- | --- |
| `SEARCH_BACKEND` | no | `tavily` (default) or `messages`; anything else is treated as `tavily` |
| `SEARCH_MESSAGES_URL` | for `messages` | base URL; `/v1/messages` is appended |
| `SEARCH_MESSAGES_API_KEY` | for `messages` | bearer token |
| `SEARCH_MESSAGES_MODEL` | no | defaults to `claude-sonnet-5` |

## Design notes

**The model writes the snippets.** Anthropic returns each hit's page text as opaque `encrypted_content` — only `title`, `url` and `page_age` are readable. Since `news.ts` relies on `snippet` to ground quantified figures, the model is asked to return the whole envelope as JSON including a per-source extract.

**Hallucinated links cannot reach the client.** Cited URLs are intersected with the set the search actually returned; an entry with a URL search never produced is dropped.

**Malformed replies degrade, they don't fail.** If the model returns prose instead of JSON, the handler falls back to the raw search hits so the caller still gets citable sources, with the prose as `answer`.

**`page_age` arrives as the string `"None"`** for many pages; that sentinel is dropped rather than surfaced as a date.

**Upstream error bodies are not forwarded** — a non-OK upstream becomes a flat `502`, keeping the client's error contract stable.

## Verification

14 new unit tests, plus the 6 existing Tavily tests still pass; `tsc` and `eslint` clean.

Live end-to-end against a real cli-proxy-api, both topics:

| query | results | sample |
| --- | --- | --- |
| Valencia flood Oct 2024 (`general`) | 4 | Wikipedia — `"Deaths: 237. Property damage: ~3.5 billion euros…"` |
| Texas Hill Country July 2026 (`news`, 90d) | 3 | CNN — `"Parts of Texas Hill Country received over 2 feet of rain…"` |

Real URLs, real dates, quantified figures in the snippets.

## Caveats

- Search + synthesis is slower and far more token-hungry than a Tavily call — tens of thousands of tokens per search against whatever account backs `SEARCH_MESSAGES_URL`. The timeout is therefore 90s, versus Tavily's 30s header bound.
- `published_date` formats vary (`2026-03-03`, `July 17, 2026`, `1 month ago`). `NewsResult.date` is documented as "ISO or free text", so this is within contract, but it is looser than Tavily's.
- New settings are declared on `Env` in source rather than `wrangler.jsonc`: the `secrets` block only supports `required`, which would warn on every deployment that stays on Tavily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an alternative AI-powered web search backend for `/tavily`.
  - Backend, endpoint, API key, and model settings are configurable; Tavily remains the default.
  - Responses retain the existing result format with validated citations and fallback results.
  - Added request limits, timeout handling, and clearer upstream error responses.

- **Documentation**
  - Documented configuration, defaults, compatibility, and backend differences.

- **Tests**
  - Added comprehensive coverage for selection, parsing, validation, limits, fallbacks, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->