### PR TITLE
Fix Source Cooperative tag detection

### DIFF
--- a/extensions/geolibre-chrome/scanner.mjs
+++ b/extensions/geolibre-chrome/scanner.mjs
@@ -143,6 +143,12 @@ export function scanDocumentForDatasets() {
     const url = canonicalHttpUrl(raw);
     if (!url) return;
 
+    // Source Cooperative data objects have already been rewritten to the
+    // data.source.coop host by canonicalUrl. Anything left on source.coop is
+    // site navigation, such as `/products?tags=cloud%20optimised%20geotiff`,
+    // whose label can otherwise look like a raster format hint.
+    if (url.hostname === "source.coop") return;
+
     // A page may link to an existing GeoLibre deep link. Unpack it so users can
     // combine its datasets with other links found on the same page.
     const nestedData = url.searchParams.getAll("data");

--- a/tests/chrome-extension.test.ts
+++ b/tests/chrome-extension.test.ts
@@ -135,6 +135,27 @@ describe("GeoLibre Chrome extension scanner", () => {
     assert.equal(found.styleUrl, "https://data.source.coop/giswqs/opengeos/roads.style.json");
   });
 
+  it("ignores Source Cooperative product tag links that resemble file formats", () => {
+    assert.deepEqual(
+      scan(
+        `
+          <a href="/products?tags=cloud%20optimised%20geotiff">cloud optimised geotiff</a>
+          <a href="/alexgleith/gebco-2024/GEBCO_2024.tif">GEBCO_2024.tif</a>
+        `,
+        "https://source.coop/alexgleith/gebco-2024/GEBCO_2024.tif",
+      ),
+      [
+        {
+          url: "https://data.source.coop/alexgleith/gebco-2024/GEBCO_2024.tif",
+          name: "GEBCO_2024.tif",
+          format: "GeoTIFF",
+          kind: "raster",
+          styleUrl: null,
+        },
+      ],
+    );
+  });
+
   it("collapses every Hugging Face file route onto the direct resolve URL", () => {
     const repo = "https://huggingface.co/datasets/giswqs/PACE-Water-Quality";
     const file = "main/cogs/PACE_OCI-20260103-chla.tif";


### PR DESCRIPTION
## Summary

- ignore Source Cooperative navigation links that resemble dataset formats
- keep canonicalized `data.source.coop` object links discoverable
- add a regression test for the reported product tag URL

## Verification

- `node --test --import tsx tests/chrome-extension.test.ts`
- `npm run build:chrome-extension`
- `npm run build`
- `pre-commit run --files extensions/geolibre-chrome/scanner.mjs tests/chrome-extension.test.ts`
- loaded the live GEBCO GeoTIFF in GeoLibre in light and dark themes

Fixes #2002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset scanning by ignoring Source Cooperative navigation links that resemble file formats.
  * Ensured valid GeoTIFF dataset links continue to be detected and canonicalized correctly.

* **Tests**
  * Added regression coverage for filtering invalid product-tag links while recognizing actual dataset files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->