### PR TITLE
Preserve globe projection for COG deep links

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
@@ -9,7 +9,7 @@ import {
   mapboxStyleForDataLayer,
   parseRasterUrlStyle,
 } from "../lib/data-url";
-import { DEEP_LINK_COG_ENGINE } from "../lib/cog-render-engine";
+import { deepLinkCogDefaults } from "../lib/cog-render-engine";
 import type { createAppAPI } from "./usePlugins";
 import type { ProjectUrlLoadState } from "./useProjectUrlLoader";
 
@@ -47,10 +47,10 @@ export async function loadDataUrl(
     const rasterStyle = rawStyle === null ? null : parseRasterUrlStyle(rawStyle);
     const id = await addRasterToMap(mapAppAPI, remote.url, {
       name: remote.name,
-      // The native WASM renderer draws as a MapLibre raster layer and therefore
-      // preserves the workspace's globe projection. The deck.gl renderer cannot
-      // draw on the globe and switches the entire map to Mercator when it loads.
-      defaults: { engine: DEEP_LINK_COG_ENGINE },
+      // A URL loader starts an empty workspace, whose raster control defaults
+      // to the native, globe-compatible WASM renderer. Do not override the
+      // control-wide engine when adding this layer.
+      defaults: deepLinkCogDefaults(),
       zoomTo: fit,
       ...(rasterStyle ? { state: rasterStyle } : {}),
     });

--- a/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts
@@ -9,6 +9,7 @@ import {
   mapboxStyleForDataLayer,
   parseRasterUrlStyle,
 } from "../lib/data-url";
+import { DEEP_LINK_COG_ENGINE } from "../lib/cog-render-engine";
 import type { createAppAPI } from "./usePlugins";
 import type { ProjectUrlLoadState } from "./useProjectUrlLoader";
 
@@ -46,7 +47,10 @@ export async function loadDataUrl(
     const rasterStyle = rawStyle === null ? null : parseRasterUrlStyle(rawStyle);
     const id = await addRasterToMap(mapAppAPI, remote.url, {
       name: remote.name,
-      defaults: { engine: "maplibre-gl-raster" },
+      // The native WASM renderer draws as a MapLibre raster layer and therefore
+      // preserves the workspace's globe projection. The deck.gl renderer cannot
+      // draw on the globe and switches the entire map to Mercator when it loads.
+      defaults: { engine: DEEP_LINK_COG_ENGINE },
       zoomTo: fit,
       ...(rasterStyle ? { state: rasterStyle } : {}),
     });

--- a/apps/geolibre-desktop/src/lib/cog-render-engine.ts
+++ b/apps/geolibre-desktop/src/lib/cog-render-engine.ts
@@ -8,9 +8,6 @@ import type { GeoLibreCogLayerOptions, GeoLibreCogRenderEngine } from "@geolibre
  */
 export const LEGACY_COG_ENGINE: GeoLibreCogRenderEngine = "maplibre-gl-raster";
 
-/** Native renderer used by URL deep links so opening a COG preserves globe view. */
-export const DEEP_LINK_COG_ENGINE: GeoLibreCogRenderEngine = "cog-tiler-wasm";
-
 /**
  * Resolve the `defaults` fragment `addCogLayer` hands the raster control.
  *
@@ -28,4 +25,15 @@ export function cogEngineDefaults(engine: GeoLibreCogLayerOptions["engine"]): {
 } {
   if (engine === "auto") return {};
   return { engine: engine ?? LEGACY_COG_ENGINE };
+}
+
+/**
+ * Leave the raster control on its native, globe-compatible default for URL
+ * deep links. A deep link starts an empty workspace, so the first COG mounts a
+ * fresh control whose default is `cog-tiler-wasm`; later entries in the same
+ * link keep that engine. Omitting the key also avoids re-rendering every layer
+ * if this loader is reused with an existing control.
+ */
+export function deepLinkCogDefaults(): { engine?: GeoLibreCogRenderEngine } {
+  return cogEngineDefaults("auto");
 }

--- a/apps/geolibre-desktop/src/lib/cog-render-engine.ts
+++ b/apps/geolibre-desktop/src/lib/cog-render-engine.ts
@@ -8,6 +8,9 @@ import type { GeoLibreCogLayerOptions, GeoLibreCogRenderEngine } from "@geolibre
  */
 export const LEGACY_COG_ENGINE: GeoLibreCogRenderEngine = "maplibre-gl-raster";
 
+/** Native renderer used by URL deep links so opening a COG preserves globe view. */
+export const DEEP_LINK_COG_ENGINE: GeoLibreCogRenderEngine = "cog-tiler-wasm";
+
 /**
  * Resolve the `defaults` fragment `addCogLayer` hands the raster control.
  *

--- a/tests/cog-render-engine.test.ts
+++ b/tests/cog-render-engine.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
-  DEEP_LINK_COG_ENGINE,
   LEGACY_COG_ENGINE,
   cogEngineDefaults,
+  deepLinkCogDefaults,
 } from "../apps/geolibre-desktop/src/lib/cog-render-engine";
 
 // The raster control holds one engine for every raster it manages, so the
@@ -11,8 +11,10 @@ import {
 // adding a COG silently re-renders layers another panel put on the map. That
 // only shows up as a UI side effect, hence these assertions.
 describe("cogEngineDefaults", () => {
-  it("uses a globe-compatible native renderer for URL deep links", () => {
-    assert.equal(DEEP_LINK_COG_ENGINE, "cog-tiler-wasm");
+  it("leaves URL deep links on the fresh control's globe-compatible default", () => {
+    const defaults = deepLinkCogDefaults();
+    assert.deepEqual(defaults, {});
+    assert.equal("engine" in defaults, false);
   });
 
   it('omits the engine entirely for "auto" so the control is left alone', () => {

--- a/tests/cog-render-engine.test.ts
+++ b/tests/cog-render-engine.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  DEEP_LINK_COG_ENGINE,
   LEGACY_COG_ENGINE,
   cogEngineDefaults,
 } from "../apps/geolibre-desktop/src/lib/cog-render-engine";
@@ -10,6 +11,10 @@ import {
 // adding a COG silently re-renders layers another panel put on the map. That
 // only shows up as a UI side effect, hence these assertions.
 describe("cogEngineDefaults", () => {
+  it("uses a globe-compatible native renderer for URL deep links", () => {
+    assert.equal(DEEP_LINK_COG_ENGINE, "cog-tiler-wasm");
+  });
+
   it('omits the engine entirely for "auto" so the control is left alone', () => {
     const defaults = cogEngineDefaults("auto");
     assert.deepEqual(defaults, {});


### PR DESCRIPTION
## Summary

- load COG deep links with the native WebAssembly renderer
- preserve the globe projection when a `?data=` raster finishes loading
- keep the existing default for other programmatic COG callers

## Verification

- `node --test --import tsx tests/cog-render-engine.test.ts tests/raster-layer-sync.test.ts`
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/src/hooks/useDataUrlLoader.ts apps/geolibre-desktop/src/lib/cog-render-engine.ts tests/cog-render-engine.test.ts`
- reproduced the Mercator switch on production with the Libya COG deep link
- loaded the same URL locally and confirmed the raster renders while globe view remains enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL deep links now preserve the native COG renderer by default.
  * Improved compatibility and rendering consistency when opening Cloud Optimized GeoTIFF data from links.

* **Tests**
  * Added coverage confirming deep links preserve the expected default COG rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->