### PR TITLE
fix(collab): allow hosted app origins

### DIFF
--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -257,10 +257,11 @@ ephemeral and never written to a project file.
 
 > **Operator note:** `POST /sessions` validates the request `Origin` (or
 > `Referer`) against `ALLOWED_ORIGINS` via `isAllowedOrigin` (defaults to the
-> hosted app origins (`geolibre.app`, `web.geolibre.app`, its legacy
-> `viewer.geolibre.app` alias, and `studio.geolibre.app`) plus `localhost` for
-> development and the project-owned Cloudflare/GitHub Pages preview origins) as
-> browser-origin filtering
+> hosted origins (`geolibre.app`, `web.geolibre.app`, its legacy
+> `viewer.geolibre.app` alias, `studio.geolibre.app`, and
+> `collab.geolibre.app`), the project-owned Cloudflare/GitHub Pages preview
+> origins, loopback hosts (`localhost` and `127.0.0.1`), and
+> `tauri://localhost`) as browser-origin filtering
 > and defense-in-depth (not authentication or a general server-side access gate)
 > and enforces a per-IP `checkRateLimit` (10 requests / 60 s). `Access-Control-Allow-Origin: *` is
 > still sent on responses so non-browser clients (e.g. Tauri) are not blocked by

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -259,7 +259,8 @@ ephemeral and never written to a project file.
 > `Referer`) against `ALLOWED_ORIGINS` via `isAllowedOrigin` (defaults to the
 > hosted app origins (`geolibre.app`, `web.geolibre.app`, its legacy
 > `viewer.geolibre.app` alias, and `studio.geolibre.app`) plus `localhost` for
-> development) as browser-origin filtering
+> development and the project-owned Cloudflare/GitHub Pages preview origins) as
+> browser-origin filtering
 > and defense-in-depth (not authentication or a general server-side access gate)
 > and enforces a per-IP `checkRateLimit` (10 requests / 60 s). `Access-Control-Allow-Origin: *` is
 > still sent on responses so non-browser clients (e.g. Tauri) are not blocked by

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -259,9 +259,11 @@ ephemeral and never written to a project file.
 > `Referer`) against `ALLOWED_ORIGINS` via `isAllowedOrigin` (defaults to the
 > hosted origins (`geolibre.app`, `web.geolibre.app`, its legacy
 > `viewer.geolibre.app` alias, `studio.geolibre.app`, and
-> `collab.geolibre.app`), the project-owned Cloudflare/GitHub Pages preview
-> origins, loopback hosts (`localhost` and `127.0.0.1`), and
-> `tauri://localhost`) as browser-origin filtering
+> `collab.geolibre.app`), single-label HTTPS deployment hosts under
+> `*.geolibre-preview.pages.dev`, loopback hosts (`localhost` and
+> `127.0.0.1`), and `tauri://localhost`). Nested or custom-port preview hosts
+> and look-alike domains are rejected; the shared `opengeos.org` GitHub Pages
+> preview origin is deliberately not trusted) as browser-origin filtering
 > and defense-in-depth (not authentication or a general server-side access gate)
 > and enforces a per-IP `checkRateLimit` (10 requests / 60 s). `Access-Control-Allow-Origin: *` is
 > still sent on responses so non-browser clients (e.g. Tauri) are not blocked by

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -257,7 +257,9 @@ ephemeral and never written to a project file.
 
 > **Operator note:** `POST /sessions` validates the request `Origin` (or
 > `Referer`) against `ALLOWED_ORIGINS` via `isAllowedOrigin` (defaults to the
-> app's own domains plus `localhost` for development) as browser-origin filtering
+> hosted app origins (`geolibre.app`, `web.geolibre.app`, its legacy
+> `viewer.geolibre.app` alias, and `studio.geolibre.app`) plus `localhost` for
+> development) as browser-origin filtering
 > and defense-in-depth (not authentication or a general server-side access gate)
 > and enforces a per-IP `checkRateLimit` (10 requests / 60 s). `Access-Control-Allow-Origin: *` is
 > still sent on responses so non-browser clients (e.g. Tauri) are not blocked by

--- a/workers/collab-node/src/server.ts
+++ b/workers/collab-node/src/server.ts
@@ -65,6 +65,9 @@ function isAllowedOrigin(
         .filter(Boolean)
     : [
         "https://geolibre.app",
+        "https://web.geolibre.app",
+        "https://viewer.geolibre.app",
+        "https://studio.geolibre.app",
         "https://collab.geolibre.app",
         "http://localhost",
         "http://127.0.0.1",

--- a/workers/collab-node/src/server.ts
+++ b/workers/collab-node/src/server.ts
@@ -78,6 +78,13 @@ function isAllowedOrigin(
     const originUrl = new URL(originHeader);
     const host = originUrl.hostname;
     if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return true;
+    if (
+      !envAllowed &&
+      originUrl.protocol === "https:" &&
+      (host === "opengeos.org" || host.endsWith(".geolibre-preview.pages.dev"))
+    ) {
+      return true;
+    }
     return allowedList.some((allowed) => {
       if (allowed === "*") return true;
       try {

--- a/workers/collab-node/src/server.ts
+++ b/workers/collab-node/src/server.ts
@@ -77,13 +77,18 @@ function isAllowedOrigin(
   try {
     const originUrl = new URL(originHeader);
     const host = originUrl.hostname;
-    if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return true;
-    if (
-      !envAllowed &&
-      originUrl.protocol === "https:" &&
-      (host === "opengeos.org" || host.endsWith(".geolibre-preview.pages.dev"))
-    ) {
-      return true;
+    if (!envAllowed) {
+      if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return true;
+      const previewSuffix = ".geolibre-preview.pages.dev";
+      const previewLabel = host.endsWith(previewSuffix) ? host.slice(0, -previewSuffix.length) : "";
+      if (
+        originUrl.protocol === "https:" &&
+        !originUrl.port &&
+        previewLabel &&
+        !previewLabel.includes(".")
+      ) {
+        return true;
+      }
     }
     return allowedList.some((allowed) => {
       if (allowed === "*") return true;

--- a/workers/collab-node/test/relay.test.ts
+++ b/workers/collab-node/test/relay.test.ts
@@ -109,6 +109,8 @@ describe("Node collaboration relay", () => {
       "https://web.geolibre.app",
       "https://viewer.geolibre.app",
       "https://studio.geolibre.app",
+      "https://opengeos.org",
+      "https://50e58010.geolibre-preview.pages.dev",
     ]) {
       const response = await fetch(`${http}/sessions`, {
         method: "POST",
@@ -122,6 +124,12 @@ describe("Node collaboration relay", () => {
       headers: { origin: "https://web.geolibre.app.example.com" },
     });
     assert.equal(rejected.status, 403);
+
+    const rejectedPreviewLookalike = await fetch(`${http}/sessions`, {
+      method: "POST",
+      headers: { origin: "https://preview.geolibre-preview.pages.dev.example.com" },
+    });
+    assert.equal(rejectedPreviewLookalike.status, 403);
   });
 
   it("rejects an oversized session-create body by declared length and by count", async () => {

--- a/workers/collab-node/test/relay.test.ts
+++ b/workers/collab-node/test/relay.test.ts
@@ -101,6 +101,29 @@ describe("Node collaboration relay", () => {
     await assert.rejects(connect(http, "NOTFOUND"), /Unexpected server response: 404/);
   });
 
+  it("allows the hosted GeoLibre web origins to create sessions", async () => {
+    const { http } = await start();
+
+    for (const origin of [
+      "https://geolibre.app",
+      "https://web.geolibre.app",
+      "https://viewer.geolibre.app",
+      "https://studio.geolibre.app",
+    ]) {
+      const response = await fetch(`${http}/sessions`, {
+        method: "POST",
+        headers: { origin },
+      });
+      assert.equal(response.status, 200, `${origin} should be allowed`);
+    }
+
+    const rejected = await fetch(`${http}/sessions`, {
+      method: "POST",
+      headers: { origin: "https://web.geolibre.app.example.com" },
+    });
+    assert.equal(rejected.status, 403);
+  });
+
   it("rejects an oversized session-create body by declared length and by count", async () => {
     const { http } = await start();
 

--- a/workers/collab-node/test/relay.test.ts
+++ b/workers/collab-node/test/relay.test.ts
@@ -109,7 +109,6 @@ describe("Node collaboration relay", () => {
       "https://web.geolibre.app",
       "https://viewer.geolibre.app",
       "https://studio.geolibre.app",
-      "https://opengeos.org",
       "https://50e58010.geolibre-preview.pages.dev",
     ]) {
       const response = await fetch(`${http}/sessions`, {
@@ -130,6 +129,42 @@ describe("Node collaboration relay", () => {
       headers: { origin: "https://preview.geolibre-preview.pages.dev.example.com" },
     });
     assert.equal(rejectedPreviewLookalike.status, 403);
+
+    for (const origin of [
+      "https://opengeos.org",
+      "https://a.b.geolibre-preview.pages.dev",
+      "https://preview.geolibre-preview.pages.dev:8443",
+    ]) {
+      const response = await fetch(`${http}/sessions`, {
+        method: "POST",
+        headers: { origin },
+      });
+      assert.equal(response.status, 403, `${origin} should be rejected`);
+    }
+  });
+
+  it("makes a configured origin allowlist authoritative", async () => {
+    const { http } = await start();
+    const previous = process.env.ALLOWED_ORIGINS;
+    process.env.ALLOWED_ORIGINS = "https://allowed.example";
+    try {
+      const allowed = await fetch(`${http}/sessions`, {
+        method: "POST",
+        headers: { origin: "https://allowed.example" },
+      });
+      assert.equal(allowed.status, 200);
+
+      for (const origin of ["http://localhost:5173", "https://pr-1.geolibre-preview.pages.dev"]) {
+        const response = await fetch(`${http}/sessions`, {
+          method: "POST",
+          headers: { origin },
+        });
+        assert.equal(response.status, 403, `${origin} should require explicit configuration`);
+      }
+    } finally {
+      if (previous === undefined) delete process.env.ALLOWED_ORIGINS;
+      else process.env.ALLOWED_ORIGINS = previous;
+    }
   });
 
   it("rejects an oversized session-create body by declared length and by count", async () => {

--- a/workers/collab/src/index.ts
+++ b/workers/collab/src/index.ts
@@ -63,13 +63,18 @@ function isAllowedOrigin(originHeader: string | null, envAllowed?: string): bool
   try {
     const originUrl = new URL(originHeader);
     const host = originUrl.hostname;
-    if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return true;
-    if (
-      !envAllowed &&
-      originUrl.protocol === "https:" &&
-      (host === "opengeos.org" || host.endsWith(".geolibre-preview.pages.dev"))
-    ) {
-      return true;
+    if (!envAllowed) {
+      if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return true;
+      const previewSuffix = ".geolibre-preview.pages.dev";
+      const previewLabel = host.endsWith(previewSuffix) ? host.slice(0, -previewSuffix.length) : "";
+      if (
+        originUrl.protocol === "https:" &&
+        !originUrl.port &&
+        previewLabel &&
+        !previewLabel.includes(".")
+      ) {
+        return true;
+      }
     }
     return allowedList.some((allowed) => {
       if (allowed === "*") return true;

--- a/workers/collab/src/index.ts
+++ b/workers/collab/src/index.ts
@@ -64,6 +64,13 @@ function isAllowedOrigin(originHeader: string | null, envAllowed?: string): bool
     const originUrl = new URL(originHeader);
     const host = originUrl.hostname;
     if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost")) return true;
+    if (
+      !envAllowed &&
+      originUrl.protocol === "https:" &&
+      (host === "opengeos.org" || host.endsWith(".geolibre-preview.pages.dev"))
+    ) {
+      return true;
+    }
     return allowedList.some((allowed) => {
       if (allowed === "*") return true;
       try {

--- a/workers/collab/src/index.ts
+++ b/workers/collab/src/index.ts
@@ -51,6 +51,9 @@ function isAllowedOrigin(originHeader: string | null, envAllowed?: string): bool
         .filter(Boolean)
     : [
         "https://geolibre.app",
+        "https://web.geolibre.app",
+        "https://viewer.geolibre.app",
+        "https://studio.geolibre.app",
         "https://collab.geolibre.app",
         "http://localhost",
         "http://127.0.0.1",


### PR DESCRIPTION
## Summary
- allow the production web, legacy viewer, and studio origins to create live collaboration sessions
- keep the Cloudflare and self-hosted Node relay defaults aligned
- add regression coverage that permits hosted origins while rejecting look-alike domains

## Test plan
- [x] Run the Node collaboration relay test suite
- [x] Typecheck the Cloudflare collaboration relay
- [x] Typecheck the Node collaboration relay
- [x] Run scoped pre-commit hooks, including the production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Session creation now supports hosted GeoLibre web, viewer, studio, and main site origins.
  * HTTPS `opengeos.org` and single-label GeoLibre preview origins are accepted by default, along with supported local development origins.
  * Custom origin configurations now restrict access exclusively to explicitly listed origins.
  * Unauthorized, deceptive lookalike, nested, and custom-port preview domains remain rejected.

* **Documentation**
  * Updated collaboration documentation with supported hosted, preview, and local origins.

* **Tests**
  * Added coverage for accepted origins, custom restrictions, and rejected domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->