### PR TITLE
Add building massing authoring workflow

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -82,7 +82,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.10.3",
+    "maplibre-gl-geo-editor": "^0.10.4",
     "maplibre-gl-geoagent": "^0.5.6",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -27,6 +27,7 @@ import {
   openVectorLayerPanel,
   setAnnotationLabels,
   setBasemapControlLabels,
+  setGeoEditorLabels,
   setGraticuleLabels,
   setH3Labels,
   setS2Labels,
@@ -584,6 +585,10 @@ export function TopToolbar({
       engineWasm: t("huggingFace.engineWasm"),
       engineTitiler: t("huggingFace.engineTitiler"),
       resetDefaults: t("huggingFace.resetDefaults"),
+    });
+    setGeoEditorLabels({
+      attributePanelTitle: t("geoEditorPlugin.attributePanelTitle"),
+      massingHeight: t("geoEditorPlugin.massingHeight"),
     });
     setGraticuleLabels({
       title: t("graticule.title"),

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -3677,6 +3677,10 @@
     "confirmStyleReplace_one": "Switching to \"{{name}}\" replaces the whole map style and will remove the stacked basemap you added. Continue?",
     "confirmStyleReplace_other": "Switching to \"{{name}}\" replaces the whole map style and will remove the {{count}} stacked basemaps you added. Continue?"
   },
+  "geoEditorPlugin": {
+    "attributePanelTitle": "Feature properties",
+    "massingHeight": "Height (m)"
+  },
   "annotations": {
     "toolbar": "Annotation tools",
     "layerName": "Annotations",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.10.3",
+        "maplibre-gl-geo-editor": "^0.10.4",
         "maplibre-gl-geoagent": "^0.5.6",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",
@@ -18019,9 +18019,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.3.tgz",
-      "integrity": "sha512-Ab5USKUbau3CKnKf/daAahKgxXm/+EpwqKRaRtD7+0ikHvRFHggPCIQAOz2NDjpFTNqD8pSUTipLMVAHbfCvWQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.10.4.tgz",
+      "integrity": "sha512-WvE5CBnU9NICWEp9uZkBxm1aF+Eg1PpwfQWhshFg/7n6pGwGlV5CCXRwFiDjhQJCohiIC/YG8N4m6sEWFXOIAA==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -23713,7 +23713,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.10.3",
+        "maplibre-gl-geo-editor": "^0.10.4",
         "maplibre-gl-geoagent": "^0.5.6",
         "maplibre-gl-lidar": "^0.16.2",
         "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -367,6 +367,33 @@ function styleLayerZoomRange(style: LayerStyle): {
   };
 }
 
+/**
+ * Return the first zoom where a zoom-stepped extrusion becomes non-flat.
+ * A zero-height fill-extrusion is still triangulated as 3D geometry by
+ * MapLibre and can produce large tile-boundary shards on the globe. Callers
+ * use this cutoff to render an ordinary fill below it instead.
+ */
+function flatExtrusionCutoff(style: LayerStyle): number | null {
+  if (!style.extrusionAdvancedStyleEnabled || !style.extrusionHeightExpression) return null;
+  try {
+    const expression: unknown = JSON.parse(style.extrusionHeightExpression);
+    if (
+      Array.isArray(expression) &&
+      expression[0] === "step" &&
+      Array.isArray(expression[1]) &&
+      expression[1][0] === "zoom" &&
+      expression[2] === 0 &&
+      typeof expression[3] === "number" &&
+      Number.isFinite(expression[3])
+    ) {
+      return clampLayerZoom(expression[3], MIN_LAYER_ZOOM);
+    }
+  } catch {
+    // Invalid expressions are handled by the existing style-expression path.
+  }
+  return null;
+}
+
 // Intersect a native layer's source-declared zoom range with the user-configured
 // style range, taking the tighter bound on each end. This keeps a tile
 // service's zoom floor/ceiling intact while still letting the user narrow the
@@ -1908,7 +1935,37 @@ function applyVectorDataRenderLayers(
 
   if (profile.hasPolygon) {
     if (layer.style.extrusionEnabled) {
-      removeIfExists(map, fillLayerId(layer.id));
+      const zoomRange = styleLayerZoomRange(layer.style);
+      const flatBelowZoom = flatExtrusionCutoff(layer.style);
+      const hasFlatRange = flatBelowZoom !== null && zoomRange.minzoom < flatBelowZoom;
+      if (hasFlatRange) {
+        ensureLayer(
+          map,
+          fillLayerId(layer.id),
+          {
+            id: fillLayerId(layer.id),
+            type: "fill",
+            ...sourceSpec,
+            minzoom: zoomRange.minzoom,
+            maxzoom: Math.min(zoomRange.maxzoom, flatBelowZoom),
+            filter: withFeatureFilters(layer, [
+              "match",
+              ["geometry-type"],
+              ["Polygon", "MultiPolygon"],
+              true,
+              false,
+            ]),
+            paint: {
+              ...fillPaint(layer.style, opacity),
+              "fill-pattern": (fillPatternId ?? null) as unknown as string,
+            },
+            layout: { visibility },
+          },
+          beforeId,
+        );
+      } else {
+        removeIfExists(map, fillLayerId(layer.id));
+      }
       ensureLayer(
         map,
         fillExtrusionLayerId(layer.id),
@@ -1916,7 +1973,15 @@ function applyVectorDataRenderLayers(
           id: fillExtrusionLayerId(layer.id),
           type: "fill-extrusion",
           ...sourceSpec,
-          ...styleLayerZoomRange(layer.style),
+          ...zoomRange,
+          ...(flatBelowZoom !== null
+            ? {
+                minzoom: Math.min(
+                  zoomRange.maxzoom,
+                  Math.max(zoomRange.minzoom, flatBelowZoom),
+                ),
+              }
+            : {}),
           filter: withFeatureFilters(layer, [
             "match",
             ["geometry-type"],

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -2020,7 +2020,7 @@ function applyVectorDataRenderLayers(
     removeSourceIfExists(map, invertedSourceId(layer.id));
   }
 
-  if (!layer.style.extrusionEnabled && (profile.hasLine || profile.hasPolygon)) {
+  if (profile.hasLine || (!layer.style.extrusionEnabled && profile.hasPolygon)) {
     ensureLayer(
       map,
       lineLayerId(layer.id),
@@ -2032,7 +2032,9 @@ function applyVectorDataRenderLayers(
         filter: withFeatureFilters(layer, [
           "match",
           ["geometry-type"],
-          ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+          layer.style.extrusionEnabled
+            ? ["LineString", "MultiLineString"]
+            : ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
           true,
           false,
         ]),
@@ -2092,7 +2094,7 @@ function applyVectorDataRenderLayers(
     removeIfExists(map, lineDecorationLayerId(layer.id));
   }
 
-  if (!layer.style.extrusionEnabled && profile.hasPoint && renderer === "heatmap") {
+  if (profile.hasPoint && renderer === "heatmap") {
     // Heatmap renderer: one density layer, no circle/cluster/marker layers.
     removeIfExists(map, circleLayerId(layer.id));
     removeIfExists(map, markerLayerId(layer.id));
@@ -2117,7 +2119,7 @@ function applyVectorDataRenderLayers(
       },
       beforeId,
     );
-  } else if (!layer.style.extrusionEnabled && profile.hasPoint && renderer === "cluster") {
+  } else if (profile.hasPoint && renderer === "cluster") {
     // Cluster renderer: a bubble + count for aggregated clusters, plus a circle
     // for the individual (unclustered) points. The source carries clusters
     // (geojson source-level clustering, or supercluster tiles on the tiled path).
@@ -2177,7 +2179,7 @@ function applyVectorDataRenderLayers(
       },
       beforeId,
     );
-  } else if (!layer.style.extrusionEnabled && profile.hasPoint) {
+  } else if (profile.hasPoint) {
     // Single (default) renderer: a marker icon per point when a marker is
     // configured, otherwise one circle per point.
     removeIfExists(map, heatmapLayerId(layer.id));
@@ -2259,7 +2261,7 @@ function applyVectorDataRenderLayers(
     removeIfExists(map, clusterCountLayerId(layer.id));
   }
 
-  if (!layer.style.extrusionEnabled && hasTextMarkers) {
+  if (hasTextMarkers) {
     ensureLayer(
       map,
       textLayerId(layer.id),

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1976,10 +1976,7 @@ function applyVectorDataRenderLayers(
           ...zoomRange,
           ...(flatBelowZoom !== null
             ? {
-                minzoom: Math.min(
-                  zoomRange.maxzoom,
-                  Math.max(zoomRange.minzoom, flatBelowZoom),
-                ),
+                minzoom: Math.min(zoomRange.maxzoom, Math.max(zoomRange.minzoom, flatBelowZoom)),
               }
             : {}),
           filter: withFeatureFilters(layer, [

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -55,7 +55,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.10.3",
+    "maplibre-gl-geo-editor": "^0.10.4",
     "maplibre-gl-geoagent": "^0.5.6",
     "maplibre-gl-lidar": "^0.16.2",
     "maplibre-gl-nasa-earthdata": "^0.1.4",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -387,6 +387,9 @@ export { maplibreFemaWmsPlugin } from "./plugins/maplibre-fema-wms";
 export {
   maplibreGeoEditorPlugin,
   GEO_EDITOR_PLUGIN_ID,
+  DEFAULT_GEO_EDITOR_LABELS,
+  setGeoEditorLabels,
+  type GeoEditorLabels,
   canEditLayerGeometry,
   SKETCHES_SOURCE_KIND,
   startLayerGeometryEdit,

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -502,7 +502,7 @@ function syncSketchesToStore(): void {
 export function hasMassingFeatures(collection: FeatureCollection): boolean {
   return collection.features.some(
     (feature) =>
-      (feature.geometry.type === "Polygon" || feature.geometry.type === "MultiPolygon") &&
+      (feature.geometry?.type === "Polygon" || feature.geometry?.type === "MultiPolygon") &&
       typeof feature.properties?.height === "number" &&
       Number.isFinite(feature.properties.height),
   );
@@ -526,6 +526,7 @@ export function sketchesStyleForMassing(
 
   return {
     ...layer.style,
+    elevation3dEnabled: false,
     extrusionEnabled: true,
     extrusionHeightProperty: "height",
     extrusionAdvancedStyleEnabled: true,

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1232,10 +1232,10 @@ function applySketchesMapDisplay(): void {
   }
 
   if (isGeoEditorInteractionMode()) {
-    showGeomanDisplayLayers();
+    applyGeomanInteractionDisplay();
     positionGeoEditorOverlayLayers();
     scheduleShowGeomanDisplayLayersOnStyleData();
-    setSketchesMapLayerSuppressed(true);
+    setSketchesMapLayerSuppressed(!isMassingDrawDisplay());
     return;
   }
 
@@ -1276,7 +1276,7 @@ function scheduleShowGeomanDisplayLayersOnStyleData(): void {
   pendingStyleDataListener = () => {
     pendingStyleDataListener = null;
     if (editTargetLayerId || isGeoEditorInteractionMode()) {
-      showGeomanDisplayLayers();
+      applyGeomanInteractionDisplay();
       positionGeoEditorOverlayLayers();
     }
   };
@@ -1311,7 +1311,10 @@ function setSketchesMapLayersVisibility(layer: GeoLibreLayer): void {
   }
 }
 
-function setGeomanDisplayLayersVisibility(visibility: "visible" | "none"): void {
+function setGeomanDisplayLayersVisibility(
+  visibility: "visible" | "none",
+  matches: (layer: maplibregl.LayerSpecification) => boolean = isGeomanDisplayLayer,
+): void {
   const map = appApi?.getMap?.();
   if (!map) return;
   const sketchesLayer = activeEditableLayer(useAppStore.getState().layers);
@@ -1331,13 +1334,62 @@ function setGeomanDisplayLayersVisibility(visibility: "visible" | "none"): void 
   if (!style?.layers) return;
 
   for (const layer of style.layers) {
-    if (!isGeomanDisplayLayer(layer)) continue;
+    if (!matches(layer)) continue;
     try {
       map.setLayoutProperty(layer.id, "visibility", effectiveVisibility);
     } catch {
       // Layer may have been removed with the current style.
     }
   }
+}
+
+/**
+ * Geoman's `gm_main-*` layers draw its committed features; every other `gm_*`
+ * layer is a transient drawing aid (the in-progress rubber band, vertex, edge
+ * and snap markers).
+ */
+export function isGeomanCommittedDisplayLayer(layer: maplibregl.LayerSpecification): boolean {
+  if (!isGeomanDisplayLayer(layer)) return false;
+  const source = "source" in layer && typeof layer.source === "string" ? layer.source : "";
+  return layer.id.toLowerCase().startsWith("gm_main") || source.startsWith("gm_main");
+}
+
+/**
+ * Whether the Sketches layer's auto-managed massing extrusion is what the user
+ * should be seeing right now: a draw tool is armed — so the display would
+ * otherwise fall back to Geoman's flat rendering for as long as the tool stays
+ * armed for the next footprint — and the layer carries the extrusion this
+ * plugin manages.
+ *
+ * Edit modes are excluded: their handles hit-test against Geoman's committed
+ * layers, which this state hides.
+ */
+function isMassingDrawDisplay(): boolean {
+  if (editTargetLayerId || !geoEditorControl) return false;
+  const { activeDrawMode, activeEditMode } = geoEditorControl.getState();
+  if (activeDrawMode === null || activeEditMode !== null) return false;
+  const layer = activeEditableLayer(useAppStore.getState().layers);
+  return (
+    layer?.style.extrusionEnabled === true &&
+    layer.style.extrusionHeightExpression === MASSING_HEIGHT_EXPRESSION
+  );
+}
+
+/**
+ * Show Geoman for an active interaction. While a massing extrusion is what the
+ * user should see, Geoman's committed-feature layers stay hidden so the
+ * extruded Sketches layer is not covered by a flat copy of itself, and the
+ * transient aids stay visible so the next footprint still rubber-bands as it is
+ * drawn — showing Sketches by hiding *all* of Geoman is what e8bd03bf had to
+ * revert.
+ */
+function applyGeomanInteractionDisplay(): void {
+  if (!isMassingDrawDisplay()) {
+    showGeomanDisplayLayers();
+    return;
+  }
+  setGeomanDisplayLayersVisibility("visible", (layer) => !isGeomanCommittedDisplayLayer(layer));
+  setGeomanDisplayLayersVisibility("none", isGeomanCommittedDisplayLayer);
 }
 
 function hideGeomanDisplayLayers(): void {

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -41,6 +41,17 @@ const GEOMAN_TEXT_PROPERTY = "__gm_text";
 const MASSING_HEIGHT_EXPRESSION =
   '["step",["zoom"],0.01,12,["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]]';
 
+type PreMassingExtrusionStyle = Pick<
+  GeoLibreLayer["style"],
+  | "elevation3dEnabled"
+  | "extrusionEnabled"
+  | "extrusionHeightProperty"
+  | "extrusionAdvancedStyleEnabled"
+  | "extrusionHeightExpression"
+>;
+
+const preMassingExtrusionStyles = new Map<string, PreMassingExtrusionStyle>();
+
 let geoEditorPosition: GeoLibreMapControlPosition = "top-left";
 
 const GEO_EDITOR_OPTIONS = {
@@ -501,12 +512,19 @@ function syncSketchesToStore(): void {
 }
 
 export function hasMassingFeatures(collection: FeatureCollection): boolean {
-  return collection.features.some(
-    (feature) =>
+  return collection.features.some((feature) => {
+    const height = feature.properties?.height;
+    const numericHeight =
+      typeof height === "number"
+        ? height
+        : typeof height === "string" && height.trim() !== ""
+          ? Number(height)
+          : Number.NaN;
+    return (
       (feature.geometry?.type === "Polygon" || feature.geometry?.type === "MultiPolygon") &&
-      typeof feature.properties?.height === "number" &&
-      Number.isFinite(feature.properties.height),
-  );
+      Number.isFinite(numericHeight)
+    );
+  });
 }
 
 export function sketchesStyleForMassing(
@@ -517,12 +535,36 @@ export function sketchesStyleForMassing(
     if (layer.style.extrusionHeightExpression !== MASSING_HEIGHT_EXPRESSION) {
       return layer.style;
     }
+    const previous = preMassingExtrusionStyles.get(layer.id);
+    preMassingExtrusionStyles.delete(layer.id);
     return {
       ...layer.style,
-      extrusionEnabled: false,
-      extrusionAdvancedStyleEnabled: false,
-      extrusionHeightExpression: "",
+      ...(previous ?? {
+        elevation3dEnabled: false,
+        extrusionEnabled: false,
+        extrusionHeightProperty: "height",
+        extrusionAdvancedStyleEnabled: false,
+        extrusionHeightExpression: "",
+      }),
     };
+  }
+
+  if (
+    layer.style.extrusionEnabled &&
+    layer.style.extrusionHeightExpression !== "" &&
+    layer.style.extrusionHeightExpression !== MASSING_HEIGHT_EXPRESSION
+  ) {
+    return layer.style;
+  }
+
+  if (!preMassingExtrusionStyles.has(layer.id)) {
+    preMassingExtrusionStyles.set(layer.id, {
+      elevation3dEnabled: layer.style.elevation3dEnabled,
+      extrusionEnabled: layer.style.extrusionEnabled,
+      extrusionHeightProperty: layer.style.extrusionHeightProperty,
+      extrusionAdvancedStyleEnabled: layer.style.extrusionAdvancedStyleEnabled,
+      extrusionHeightExpression: layer.style.extrusionHeightExpression,
+    });
   }
 
   return {

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -561,6 +561,14 @@ export function sketchesStyleForMassing(
     if (layer.style.extrusionHeightExpression !== MASSING_HEIGHT_EXPRESSION) {
       return layer.style;
     }
+    // The user switched the layer out of extrusion while massing features were
+    // still present (the same signal the enable path below honors). That later,
+    // explicit choice outranks the pre-massing snapshot, which would otherwise
+    // turn extrusion back on as the last footprint goes away.
+    if (!layer.style.extrusionEnabled) {
+      preMassingExtrusionStyles.delete(layer.id);
+      return layer.style;
+    }
     const previous = preMassingExtrusionStyles.get(layer.id);
     preMassingExtrusionStyles.delete(layer.id);
     return {

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -125,8 +125,6 @@ let pushingSketchesToStore = false;
 let appApi: GeoLibreAppAPI | null = null;
 /** Map-only hide of Sketches while GeoEditor interacts; does not touch store.visible. */
 let sketchesMapLayerSuppressed = false;
-/** After a draw completes, show Sketches even if draw mode stays active for another shape. */
-let sketchesIdleDisplayOverride = false;
 /** Union store + editor on the next sync so a partial getAll cannot drop prior sketches. */
 let unionSketchesWithStoreOnNextSync = false;
 /** Pending one-shot `styledata` listener, so repeated draw events don't pile up listeners. */
@@ -230,8 +228,8 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
     if (editTargetLayerId) void endLayerGeometryEdit(app, { save: true });
     pluginActive = false;
     viewImportBaseline = null;
-    sketchesIdleDisplayOverride = false;
     unionSketchesWithStoreOnNextSync = false;
+    preMassingExtrusionStyles.clear();
     setSketchesMapLayerSuppressed(false);
     showGeomanDisplayLayers();
     appApi = null;
@@ -282,10 +280,7 @@ function getGeoEditorOptions(): GeoEditorOptions {
     },
     onAttributeChange: () => syncSketchesToStore(),
     onHistoryChange: () => syncSketchesToStore(),
-    onModeChange: () => {
-      sketchesIdleDisplayOverride = false;
-      applySketchesMapDisplay();
-    },
+    onModeChange: () => applySketchesMapDisplay(),
     onSelectionChange: () => applySketchesMapDisplay(),
   };
 }
@@ -506,9 +501,7 @@ function syncSketchesToStore(): void {
     pushingSketchesToStore = false;
   }
 
-  if (!sketchesIdleDisplayOverride) {
-    scheduleApplySketchesMapDisplay();
-  }
+  scheduleApplySketchesMapDisplay();
 }
 
 export function hasMassingFeatures(collection: FeatureCollection): boolean {
@@ -549,11 +542,14 @@ export function sketchesStyleForMassing(
     };
   }
 
-  if (
-    layer.style.extrusionEnabled &&
-    layer.style.extrusionHeightExpression !== "" &&
-    layer.style.extrusionHeightExpression !== MASSING_HEIGHT_EXPRESSION
-  ) {
+  // Leave a style the user has taken over alone. Two shapes count as taken over:
+  // a hand-written extrusion height expression, and the auto-managed expression
+  // with extrusion switched off — the Style panel's 2D / 3D-elevation radios
+  // clear `extrusionEnabled` without clearing the expression, so that pairing can
+  // only come from the user picking another visualization mode.
+  if (layer.style.extrusionHeightExpression === MASSING_HEIGHT_EXPRESSION) {
+    if (!layer.style.extrusionEnabled) return layer.style;
+  } else if (layer.style.extrusionEnabled && layer.style.extrusionHeightExpression !== "") {
     return layer.style;
   }
 
@@ -863,7 +859,6 @@ export async function startLayerGeometryEdit(
   // The store layer is left untouched until save, so Cancel simply discards the
   // editor's copy and the original geojson is still in the store.
   editTargetLayerId = layerId;
-  sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
 
   // Hide the target's normal rendering through the store, not via a map-layer
@@ -957,7 +952,6 @@ export async function endLayerGeometryEdit(
     editTargetOriginalVisible = null;
     editTargetOriginalProperties = null;
     editTargetOriginalGeometries = null;
-    sketchesIdleDisplayOverride = false;
     unionSketchesWithStoreOnNextSync = false;
     notifyGeometryEdit();
     return;
@@ -971,7 +965,6 @@ export async function endLayerGeometryEdit(
     if (save) syncEditTargetToStore();
   } finally {
     editTargetLayerId = null;
-    sketchesIdleDisplayOverride = false;
     unionSketchesWithStoreOnNextSync = false;
     // Restore the target layer's normal rendering (it now reflects the saved
     // edits, or the untouched original on cancel).
@@ -1004,7 +997,6 @@ function abortGeometryEditSession(): void {
   editTargetOriginalProperties = null;
   editTargetOriginalGeometries = null;
   editTargetLayerId = null;
-  sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
   void restoreSketchesAfterSession();
   applySketchesMapDisplay();
@@ -1162,7 +1154,6 @@ function teardownSketchesStoreSync(): void {
 
 function isGeoEditorInteractionMode(): boolean {
   if (!geoEditorControl) return false;
-  if (sketchesIdleDisplayOverride) return false;
   const { activeDrawMode, activeEditMode } = geoEditorControl.getState();
   return activeDrawMode !== null || activeEditMode !== null;
 }

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -38,6 +38,8 @@ export { canEditLayerGeometry, SKETCHES_SOURCE_KIND } from "./geo-editor-geometr
 const SKETCHES_LAYER_NAME = "Sketches";
 const SKETCHES_SOURCE_PATH = "geoeditor://sketches";
 const GEOMAN_TEXT_PROPERTY = "__gm_text";
+const MASSING_HEIGHT_EXPRESSION =
+  '["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]';
 
 let geoEditorPosition: GeoLibreMapControlPosition = "top-left";
 
@@ -81,7 +83,6 @@ const GEO_EDITOR_OPTIONS = {
         name: "height",
         label: "Height (m)",
         type: "number",
-        defaultValue: 10,
         min: 0,
         step: 0.5,
       },
@@ -469,7 +470,7 @@ function syncSketchesToStore(): void {
       sketchesLayerId = existing.id;
       store.updateLayer(existing.id, {
         geojson: collection,
-        ...(hasMassingFeatures(collection) ? { style: massingSketchStyle(existing) } : {}),
+        style: sketchesStyleForMassing(existing, collection),
       });
     } else {
       if (collection.features.length === 0) {
@@ -483,13 +484,10 @@ function syncSketchesToStore(): void {
           ...useAppStore.getState().layers.find((layer) => layer.id === id)?.metadata,
           sourceKind: SKETCHES_SOURCE_KIND,
         },
-        ...(hasMassingFeatures(collection)
-          ? {
-              style: massingSketchStyle(
-                useAppStore.getState().layers.find((layer) => layer.id === id)!,
-              ),
-            }
-          : {}),
+        style: sketchesStyleForMassing(
+          useAppStore.getState().layers.find((layer) => layer.id === id)!,
+          collection,
+        ),
       });
     }
   } finally {
@@ -501,7 +499,7 @@ function syncSketchesToStore(): void {
   }
 }
 
-function hasMassingFeatures(collection: FeatureCollection): boolean {
+export function hasMassingFeatures(collection: FeatureCollection): boolean {
   return collection.features.some(
     (feature) =>
       (feature.geometry.type === "Polygon" || feature.geometry.type === "MultiPolygon") &&
@@ -510,14 +508,28 @@ function hasMassingFeatures(collection: FeatureCollection): boolean {
   );
 }
 
-function massingSketchStyle(layer: GeoLibreLayer): GeoLibreLayer["style"] {
+export function sketchesStyleForMassing(
+  layer: GeoLibreLayer,
+  collection: FeatureCollection,
+): GeoLibreLayer["style"] {
+  if (!hasMassingFeatures(collection)) {
+    if (layer.style.extrusionHeightExpression !== MASSING_HEIGHT_EXPRESSION) {
+      return layer.style;
+    }
+    return {
+      ...layer.style,
+      extrusionEnabled: false,
+      extrusionAdvancedStyleEnabled: false,
+      extrusionHeightExpression: "",
+    };
+  }
+
   return {
     ...layer.style,
     extrusionEnabled: true,
     extrusionHeightProperty: "height",
     extrusionAdvancedStyleEnabled: true,
-    extrusionHeightExpression:
-      '["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]',
+    extrusionHeightExpression: MASSING_HEIGHT_EXPRESSION,
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -39,7 +39,7 @@ const SKETCHES_LAYER_NAME = "Sketches";
 const SKETCHES_SOURCE_PATH = "geoeditor://sketches";
 const GEOMAN_TEXT_PROPERTY = "__gm_text";
 const MASSING_HEIGHT_EXPRESSION =
-  '["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]';
+  '["step",["zoom"],0.01,12,["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]]';
 
 let geoEditorPosition: GeoLibreMapControlPosition = "top-left";
 
@@ -77,6 +77,8 @@ const GEO_EDITOR_OPTIONS = {
   showFeatureProperties: true,
   enableAttributeEditing: true,
   attributePanelTitle: "Feature properties",
+  // Leave the right-side MapLibre controls clickable while the form is open.
+  attributePanelSideOffset: 54,
   attributeSchema: {
     polygon: [
       {
@@ -247,7 +249,6 @@ function getGeoEditorOptions(): GeoEditorOptions {
     ...GEO_EDITOR_OPTIONS,
     position: geoEditorPosition,
     onFeatureCreate: () => {
-      sketchesIdleDisplayOverride = true;
       unionSketchesWithStoreOnNextSync = true;
       // Defer until Geoman commits the new feature to its feature store.
       queueMicrotask(() => {

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -45,7 +45,16 @@ const GEO_EDITOR_OPTIONS = {
   collapsed: false,
   toolbarOrientation: "vertical",
   columns: 2,
-  drawModes: ["polygon", "line", "rectangle", "circle", "marker", "freehand", "text_marker"],
+  drawModes: [
+    "polygon",
+    "massing",
+    "line",
+    "rectangle",
+    "circle",
+    "marker",
+    "freehand",
+    "text_marker",
+  ],
   editModes: [
     "select",
     "drag",
@@ -64,6 +73,20 @@ const GEO_EDITOR_OPTIONS = {
   fileModes: ["open", "save"],
   hideGeomanControl: true,
   showFeatureProperties: true,
+  enableAttributeEditing: true,
+  attributePanelTitle: "Feature properties",
+  attributeSchema: {
+    polygon: [
+      {
+        name: "height",
+        label: "Height (m)",
+        type: "number",
+        defaultValue: 10,
+        min: 0,
+        step: 0.5,
+      },
+    ],
+  },
   // Avoid zoom/fit on Sketches restore — it retriggers style churn and races with draw.
   fitBoundsOnLoad: false,
 } satisfies Omit<
@@ -444,7 +467,10 @@ function syncSketchesToStore(): void {
   try {
     if (existing) {
       sketchesLayerId = existing.id;
-      store.updateLayer(existing.id, { geojson: collection });
+      store.updateLayer(existing.id, {
+        geojson: collection,
+        ...(hasMassingFeatures(collection) ? { style: massingSketchStyle(existing) } : {}),
+      });
     } else {
       if (collection.features.length === 0) {
         return;
@@ -457,6 +483,13 @@ function syncSketchesToStore(): void {
           ...useAppStore.getState().layers.find((layer) => layer.id === id)?.metadata,
           sourceKind: SKETCHES_SOURCE_KIND,
         },
+        ...(hasMassingFeatures(collection)
+          ? {
+              style: massingSketchStyle(
+                useAppStore.getState().layers.find((layer) => layer.id === id)!,
+              ),
+            }
+          : {}),
       });
     }
   } finally {
@@ -466,6 +499,26 @@ function syncSketchesToStore(): void {
   if (!sketchesIdleDisplayOverride) {
     scheduleApplySketchesMapDisplay();
   }
+}
+
+function hasMassingFeatures(collection: FeatureCollection): boolean {
+  return collection.features.some(
+    (feature) =>
+      (feature.geometry.type === "Polygon" || feature.geometry.type === "MultiPolygon") &&
+      typeof feature.properties?.height === "number" &&
+      Number.isFinite(feature.properties.height),
+  );
+}
+
+function massingSketchStyle(layer: GeoLibreLayer): GeoLibreLayer["style"] {
+  return {
+    ...layer.style,
+    extrusionEnabled: true,
+    extrusionHeightProperty: "height",
+    extrusionAdvancedStyleEnabled: true,
+    extrusionHeightExpression:
+      '["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]',
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -39,7 +39,7 @@ const SKETCHES_LAYER_NAME = "Sketches";
 const SKETCHES_SOURCE_PATH = "geoeditor://sketches";
 const GEOMAN_TEXT_PROPERTY = "__gm_text";
 const MASSING_HEIGHT_EXPRESSION =
-  '["step",["zoom"],0.01,12,["case",["has","height"],["max",0,["to-number",["get","height"],0]],0.01]]';
+  '["step",["zoom"],0,12,["case",["has","height"],["max",0,["to-number",["get","height"],0]],0]]';
 
 type PreMassingExtrusionStyle = Pick<
   GeoLibreLayer["style"],

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -52,6 +52,37 @@ type PreMassingExtrusionStyle = Pick<
 
 const preMassingExtrusionStyles = new Map<string, PreMassingExtrusionStyle>();
 
+/**
+ * User-facing strings the editor renders as copy (the draw/edit mode entries in
+ * {@link GEO_EDITOR_OPTIONS} are keys, not display text). This package is
+ * framework-agnostic and cannot call react-i18next's `t()` directly, so the host
+ * pushes translated values via {@link setGeoEditorLabels}, the pattern used by
+ * `maplibre-graticule` and `maplibre-reverse-geocode`. Defaults are English.
+ */
+export interface GeoEditorLabels {
+  /** Header of the feature-attribute form. */
+  attributePanelTitle: string;
+  /** Label of the massing footprint's height field, in metres. */
+  massingHeight: string;
+}
+
+export const DEFAULT_GEO_EDITOR_LABELS: GeoEditorLabels = {
+  attributePanelTitle: "Feature properties",
+  massingHeight: "Height (m)",
+};
+
+let geoEditorLabels: GeoEditorLabels = { ...DEFAULT_GEO_EDITOR_LABELS };
+
+/**
+ * Replace the user-facing strings (the host calls this with translations on
+ * every language change). The third-party control reads its options once at
+ * construction, so a language switch while the editor is open takes effect the
+ * next time the plugin is activated rather than live.
+ */
+export function setGeoEditorLabels(next: Partial<GeoEditorLabels>): void {
+  geoEditorLabels = { ...geoEditorLabels, ...next };
+}
+
 let geoEditorPosition: GeoLibreMapControlPosition = "top-left";
 
 const GEO_EDITOR_OPTIONS = {
@@ -87,25 +118,15 @@ const GEO_EDITOR_OPTIONS = {
   hideGeomanControl: true,
   showFeatureProperties: true,
   enableAttributeEditing: true,
-  attributePanelTitle: "Feature properties",
   // Leave the right-side MapLibre controls clickable while the form is open.
   attributePanelSideOffset: 54,
-  attributeSchema: {
-    polygon: [
-      {
-        name: "height",
-        label: "Height (m)",
-        type: "number",
-        min: 0,
-        step: 0.5,
-      },
-    ],
-  },
   // Avoid zoom/fit on Sketches restore — it retriggers style churn and races with draw.
   fitBoundsOnLoad: false,
 } satisfies Omit<
   GeoEditorOptions,
   | "position"
+  | "attributePanelTitle"
+  | "attributeSchema"
   | "onFeatureCreate"
   | "onFeatureEdit"
   | "onFeatureDelete"
@@ -257,6 +278,18 @@ function getGeoEditorOptions(): GeoEditorOptions {
   return {
     ...GEO_EDITOR_OPTIONS,
     position: geoEditorPosition,
+    attributePanelTitle: geoEditorLabels.attributePanelTitle,
+    attributeSchema: {
+      polygon: [
+        {
+          name: "height",
+          label: geoEditorLabels.massingHeight,
+          type: "number",
+          min: 0,
+          step: 0.5,
+        },
+      ],
+    },
     onFeatureCreate: () => {
       unionSketchesWithStoreOnNextSync = true;
       // Defer until Geoman commits the new feature to its feature store.
@@ -543,13 +576,23 @@ export function sketchesStyleForMassing(
   }
 
   // Leave a style the user has taken over alone. Two shapes count as taken over:
-  // a hand-written extrusion height expression, and the auto-managed expression
-  // with extrusion switched off — the Style panel's 2D / 3D-elevation radios
-  // clear `extrusionEnabled` without clearing the expression, so that pairing can
-  // only come from the user picking another visualization mode.
+  // an extrusion height the user's own expression is currently driving, and the
+  // auto-managed expression with extrusion switched off — the Style panel's 2D /
+  // 3D-elevation radios clear `extrusionEnabled` without clearing the expression,
+  // so that pairing can only come from the user picking another visualization
+  // mode. The first test mirrors `extrusionHeightValue`, which ignores the
+  // expression unless `extrusionAdvancedStyleEnabled` is on, so a stray
+  // expression left behind by a since-disabled advanced mode does not block
+  // auto-management. A custom expression that is not rendering yet (extrusion
+  // still off) is overwritten but recoverable: `preMassingExtrusionStyles`
+  // restores it when the last massing feature goes away.
   if (layer.style.extrusionHeightExpression === MASSING_HEIGHT_EXPRESSION) {
     if (!layer.style.extrusionEnabled) return layer.style;
-  } else if (layer.style.extrusionEnabled && layer.style.extrusionHeightExpression !== "") {
+  } else if (
+    layer.style.extrusionEnabled &&
+    layer.style.extrusionAdvancedStyleEnabled &&
+    layer.style.extrusionHeightExpression !== ""
+  ) {
     return layer.style;
   }
 

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -45,6 +45,13 @@ describe("maplibreGeoEditorPlugin", () => {
   it("only identifies polygons with a finite numeric height as massing", () => {
     assert.equal(hasMassingFeatures({ type: "FeatureCollection", features: [polygon({})] }), false);
     assert.equal(
+      hasMassingFeatures({
+        type: "FeatureCollection",
+        features: [{ type: "Feature", properties: { height: 10 }, geometry: null }],
+      }),
+      false,
+    );
+    assert.equal(
       hasMassingFeatures({ type: "FeatureCollection", features: [polygon({ height: 10 })] }),
       true,
     );
@@ -57,6 +64,7 @@ describe("maplibreGeoEditorPlugin", () => {
 
     layer.style = sketchesStyleForMassing(layer, massing);
     assert.equal(layer.style.extrusionEnabled, true);
+    assert.equal(layer.style.elevation3dEnabled, false);
 
     layer.style = sketchesStyleForMassing(layer, flat);
     assert.equal(layer.style.extrusionEnabled, false);

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -2,13 +2,67 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   GEO_EDITOR_PLUGIN_ID,
+  hasMassingFeatures,
   maplibreGeoEditorPlugin as plugin,
+  sketchesStyleForMassing,
 } from "../packages/plugins/src/plugins/maplibre-geo-editor";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "../packages/core/src";
+
+const polygon = (properties: Record<string, unknown>) => ({
+  type: "Feature" as const,
+  properties,
+  geometry: {
+    type: "Polygon" as const,
+    coordinates: [
+      [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 0],
+      ],
+    ],
+  },
+});
+
+const sketchesLayer = (): GeoLibreLayer => ({
+  id: "sketches",
+  name: "Sketches",
+  type: "geojson",
+  visible: true,
+  opacity: 1,
+  style: structuredClone(DEFAULT_LAYER_STYLE),
+  metadata: {},
+  geojson: { type: "FeatureCollection", features: [] },
+});
 
 describe("maplibreGeoEditorPlugin", () => {
   // The Layers panel toggle keys its active-state highlight on the exported
   // constant, so the two must never drift apart.
   it("has the exported id", () => {
     assert.equal(plugin.id, GEO_EDITOR_PLUGIN_ID);
+  });
+
+  it("only identifies polygons with a finite numeric height as massing", () => {
+    assert.equal(hasMassingFeatures({ type: "FeatureCollection", features: [polygon({})] }), false);
+    assert.equal(
+      hasMassingFeatures({ type: "FeatureCollection", features: [polygon({ height: 10 })] }),
+      true,
+    );
+  });
+
+  it("enables and then resets only the auto-managed massing style", () => {
+    const layer = sketchesLayer();
+    const massing = { type: "FeatureCollection" as const, features: [polygon({ height: 10 })] };
+    const flat = { type: "FeatureCollection" as const, features: [polygon({})] };
+
+    layer.style = sketchesStyleForMassing(layer, massing);
+    assert.equal(layer.style.extrusionEnabled, true);
+
+    layer.style = sketchesStyleForMassing(layer, flat);
+    assert.equal(layer.style.extrusionEnabled, false);
+    assert.equal(layer.style.extrusionHeightExpression, "");
+
+    layer.style = { ...layer.style, extrusionEnabled: true, extrusionHeightExpression: "custom" };
+    assert.equal(sketchesStyleForMassing(layer, flat), layer.style);
   });
 });

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -156,6 +156,21 @@ describe("maplibreGeoEditorPlugin", () => {
     );
   });
 
+  it("keeps a manual 2D switch when the last massing feature is removed", () => {
+    const layer = sketchesLayer();
+    layer.id = "2d-then-emptied";
+    // A pre-existing property-driven extrusion, so the snapshot has something to
+    // restore that would visibly contradict the user's later choice.
+    layer.style = { ...layer.style, extrusionEnabled: true, extrusionHeightProperty: "floors" };
+    const massing = { type: "FeatureCollection" as const, features: [polygon({ height: 10 })] };
+    const flat = { type: "FeatureCollection" as const, features: [polygon({})] };
+
+    layer.style = sketchesStyleForMassing(layer, massing);
+    layer.style = { ...layer.style, extrusionEnabled: false, elevation3dEnabled: false };
+
+    assert.equal(sketchesStyleForMassing(layer, flat), layer.style);
+  });
+
   it("restores the complete pre-massing extrusion style", () => {
     const layer = sketchesLayer();
     layer.id = "custom-before-massing";

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -30,6 +30,7 @@ const sketchesLayer = (): GeoLibreLayer => ({
   type: "geojson",
   visible: true,
   opacity: 1,
+  source: {},
   style: structuredClone(DEFAULT_LAYER_STYLE),
   metadata: {},
   geojson: { type: "FeatureCollection", features: [] },
@@ -55,6 +56,14 @@ describe("maplibreGeoEditorPlugin", () => {
       hasMassingFeatures({ type: "FeatureCollection", features: [polygon({ height: 10 })] }),
       true,
     );
+    assert.equal(
+      hasMassingFeatures({ type: "FeatureCollection", features: [polygon({ height: "10" })] }),
+      true,
+    );
+    assert.equal(
+      hasMassingFeatures({ type: "FeatureCollection", features: [polygon({ height: "ten" })] }),
+      false,
+    );
   });
 
   it("enables and then resets only the auto-managed massing style", () => {
@@ -72,5 +81,22 @@ describe("maplibreGeoEditorPlugin", () => {
 
     layer.style = { ...layer.style, extrusionEnabled: true, extrusionHeightExpression: "custom" };
     assert.equal(sketchesStyleForMassing(layer, flat), layer.style);
+  });
+
+  it("restores the complete pre-massing extrusion style", () => {
+    const layer = sketchesLayer();
+    layer.id = "custom-before-massing";
+    layer.style = {
+      ...layer.style,
+      elevation3dEnabled: true,
+      extrusionHeightProperty: "floors",
+    };
+    const original = structuredClone(layer.style);
+    const massing = { type: "FeatureCollection" as const, features: [polygon({ height: 10 })] };
+    const flat = { type: "FeatureCollection" as const, features: [polygon({})] };
+
+    layer.style = sketchesStyleForMassing(layer, massing);
+    layer.style = sketchesStyleForMassing(layer, flat);
+    assert.deepEqual(layer.style, original);
   });
 });

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   GEO_EDITOR_PLUGIN_ID,
   hasMassingFeatures,
+  isGeomanCommittedDisplayLayer,
   maplibreGeoEditorPlugin as plugin,
   sketchesStyleForMassing,
 } from "../packages/plugins/src/plugins/maplibre-geo-editor";
@@ -124,6 +125,35 @@ describe("maplibreGeoEditorPlugin", () => {
       extrusionHeightExpression: "custom",
     };
     assert.equal(sketchesStyleForMassing(live, massing), live.style);
+  });
+
+  // A massing draw hides only Geoman's committed-feature layers, so the extruded
+  // Sketches layer is what the user sees while the transient aids keep drawing
+  // the next footprint's rubber band.
+  it("separates Geoman's committed layers from its transient drawing aids", () => {
+    const layer = (id: string, source: string) =>
+      ({ id, source, type: "fill" }) as unknown as Parameters<
+        typeof isGeomanCommittedDisplayLayer
+      >[0];
+
+    assert.equal(
+      isGeomanCommittedDisplayLayer(layer("gm_main-polygon__fill-layer-0", "gm_main")),
+      true,
+    );
+    assert.equal(
+      isGeomanCommittedDisplayLayer(layer("gm_temporary-polygon__fill-layer-0", "gm_temporary")),
+      false,
+    );
+    assert.equal(
+      isGeomanCommittedDisplayLayer(
+        layer("gm_internal-vertex_marker__circle-layer-0", "gm_internal"),
+      ),
+      false,
+    );
+    assert.equal(
+      isGeomanCommittedDisplayLayer(layer("layer-sketches-extrusion", "source-sketches")),
+      false,
+    );
   });
 
   it("restores the complete pre-massing extrusion style", () => {

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -83,6 +83,19 @@ describe("maplibreGeoEditorPlugin", () => {
     assert.equal(sketchesStyleForMassing(layer, flat), layer.style);
   });
 
+  it("keeps the auto-managed style off once the user switches the layer to 2D", () => {
+    const layer = sketchesLayer();
+    layer.id = "switched-to-2d";
+    const massing = { type: "FeatureCollection" as const, features: [polygon({ height: 10 })] };
+
+    layer.style = sketchesStyleForMassing(layer, massing);
+    assert.equal(layer.style.extrusionEnabled, true);
+
+    // The Style panel's 2D radio clears the flags but leaves the expression.
+    layer.style = { ...layer.style, extrusionEnabled: false, elevation3dEnabled: false };
+    assert.equal(sketchesStyleForMassing(layer, massing), layer.style);
+  });
+
   it("restores the complete pre-massing extrusion style", () => {
     const layer = sketchesLayer();
     layer.id = "custom-before-massing";

--- a/tests/geo-editor-plugin.test.ts
+++ b/tests/geo-editor-plugin.test.ts
@@ -96,6 +96,36 @@ describe("maplibreGeoEditorPlugin", () => {
     assert.equal(sketchesStyleForMassing(layer, massing), layer.style);
   });
 
+  it("only defers to a custom height expression that is actually rendering", () => {
+    const massing = { type: "FeatureCollection" as const, features: [polygon({ height: 10 })] };
+
+    // Advanced mode off: the expression is inert (`extrusionHeightValue` ignores
+    // it), so massing may take the layer over.
+    const stray = sketchesLayer();
+    stray.id = "stray-expression";
+    stray.style = {
+      ...stray.style,
+      extrusionEnabled: true,
+      extrusionAdvancedStyleEnabled: false,
+      extrusionHeightExpression: "custom",
+    };
+    assert.equal(
+      sketchesStyleForMassing(stray, massing).extrusionHeightExpression !== "custom",
+      true,
+    );
+
+    // Advanced mode on: the user's expression is driving the render, so it stands.
+    const live = sketchesLayer();
+    live.id = "live-expression";
+    live.style = {
+      ...live.style,
+      extrusionEnabled: true,
+      extrusionAdvancedStyleEnabled: true,
+      extrusionHeightExpression: "custom",
+    };
+    assert.equal(sketchesStyleForMassing(live, massing), live.style);
+  });
+
   it("restores the complete pre-massing extrusion style", () => {
     const layer = sketchesLayer();
     layer.id = "custom-before-massing";

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -578,6 +578,58 @@ describe("MapController.syncLayers reconciliation", () => {
     assert.ok(fake.layers.has("layer-r-raster"), "raster layer added");
     assert.deepEqual(internals(controller).layerIds, ["r"]);
   });
+
+  it("keeps line and point sketches visible beside extruded polygons", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    const mixed = pointLayer("mixed", {
+      style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          { type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [0, 0] } },
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [0, 0],
+                [1, 1],
+              ],
+            },
+          },
+          {
+            type: "Feature",
+            properties: { height: 10 },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [1, 0],
+                  [1, 1],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    controller.syncLayers([mixed]);
+
+    assert.ok(fake.layers.has("layer-mixed-extrusion"));
+    assert.ok(fake.layers.has("layer-mixed-circle"));
+    assert.deepEqual(fake.layers.get("layer-mixed-line")?.filter, [
+      "match",
+      ["geometry-type"],
+      ["LineString", "MultiLineString"],
+      true,
+      false,
+    ]);
+  });
 });
 
 function vectorTileLayer(id: string, patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -630,6 +630,45 @@ describe("MapController.syncLayers reconciliation", () => {
       false,
     ]);
   });
+
+  it("renders zoom-gated extrusions as flat fills below their cutoff", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    const layer = pointLayer("massing", {
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        extrusionEnabled: true,
+        extrusionAdvancedStyleEnabled: true,
+        extrusionHeightExpression:
+          '["step",["zoom"],0,12,["max",0,["to-number",["get","height"],0]]]',
+      },
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { height: 10 },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [1, 0],
+                  [1, 1],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    controller.syncLayers([layer]);
+
+    assert.equal(fake.layers.get("layer-massing-fill")?.maxzoom, 12);
+    assert.equal(fake.layers.get("layer-massing-extrusion")?.minzoom, 12);
+  });
 });
 
 function vectorTileLayer(id: string, patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {


### PR DESCRIPTION
Fixes #1819

Adds a direct building massing workflow to GeoEditor:

- exposes the new Building massing footprint tool from maplibre-gl-geo-editor 0.10.4
- opens a focused Height (m) editor after drawing and on later selection
- renders height-bearing Sketches as data-driven 3D extrusions
- keeps globe rendering flat below zoom 12 to avoid low-zoom extrusion artifacts
- preserves the drawing preview for consecutive footprints
- keeps the attribute panel clear of the top-right map controls

Upstream:
- opengeos/maplibre-gl-geo-editor#42
- opengeos/maplibre-gl-geo-editor#43
- maplibre-gl-geo-editor v0.10.4

Verification:
- drew consecutive massing footprints with the published npm package
- confirmed the second footprint rubber band remains visible
- confirmed the height panel does not overlap the map controls
- verified artifact-free globe rendering plus light and dark themes
- verified zero browser console errors
- ran focused tests, the GeoLibre production build, and pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for massing drawings with numeric, nonnegative height values.
  * Polygon and multipolygon features can display 3D extrusion based on height.
  * Sketch styling updates automatically as qualifying features are added or removed.
  * Extruded maps now continue displaying point, line, heatmap, cluster, and text-marker layers alongside 3D features.

* **Bug Fixes**
  * Prevented outdated extrusion styling from persisting when features no longer include valid heights.
  * Preserved custom layer styling when resetting automatically managed effects.
  * Prevented polygon boundaries from appearing in line-rendered layers during extrusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->