### PR TITLE
Enable USGS LiDAR clip pipeline export

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -93,7 +93,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
-    "maplibre-gl-usgs-lidar": "^0.11.3",
+    "maplibre-gl-usgs-lidar": "^0.11.5",
     "maplibre-gl-vector": "^0.10.12",
     "openai": "^7.3.0",
     "qrcode.react": "^4.2.0",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -93,7 +93,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
-    "maplibre-gl-usgs-lidar": "^0.11.2",
+    "maplibre-gl-usgs-lidar": "^0.11.3",
     "maplibre-gl-vector": "^0.10.12",
     "openai": "^7.3.0",
     "qrcode.react": "^4.2.0",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -93,7 +93,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
-    "maplibre-gl-usgs-lidar": "^0.11.1",
+    "maplibre-gl-usgs-lidar": "^0.11.2",
     "maplibre-gl-vector": "^0.10.12",
     "openai": "^7.3.0",
     "qrcode.react": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
-        "maplibre-gl-usgs-lidar": "^0.11.3",
+        "maplibre-gl-usgs-lidar": "^0.11.5",
         "maplibre-gl-vector": "^0.10.12",
         "openai": "^7.3.0",
         "qrcode.react": "^4.2.0",
@@ -18405,9 +18405,9 @@
       }
     },
     "node_modules/maplibre-gl-usgs-lidar": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.3.tgz",
-      "integrity": "sha512-uLoxWc72EAQenPo4zWGUXrjR0yzqPHLp8Elj8qEQ471svlxgLspTGWRE7Z39/tOIgyN9b58V8rf8diWEeZtsJw==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.5.tgz",
+      "integrity": "sha512-p11qM1MjZ+ean1kIdAKjyhSsZIVla8o/+izAp+Z5KShoK/WzDI+6XHUDW+1o7HRgPJQNV0XxVRv0nSi2XUIKmw==",
       "license": "MIT",
       "dependencies": {
         "maplibre-gl-layer-control": ">=0.14.1",
@@ -23725,7 +23725,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
-        "maplibre-gl-usgs-lidar": "^0.11.3",
+        "maplibre-gl-usgs-lidar": "^0.11.5",
         "maplibre-gl-vector": "^0.10.12",
         "netcdfjs": "^4.0.0",
         "ngeohash": "^0.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
-        "maplibre-gl-usgs-lidar": "^0.11.2",
+        "maplibre-gl-usgs-lidar": "^0.11.3",
         "maplibre-gl-vector": "^0.10.12",
         "openai": "^7.3.0",
         "qrcode.react": "^4.2.0",
@@ -18405,9 +18405,9 @@
       }
     },
     "node_modules/maplibre-gl-usgs-lidar": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.2.tgz",
-      "integrity": "sha512-QgdkBKgegO36Qsx8b/DsMOMeKo8LGNY7kEA1FvP39THDhTa8rGb8pL3UwzJOBN+vMSjKObCZndTdcw6khRjSVw==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.3.tgz",
+      "integrity": "sha512-uLoxWc72EAQenPo4zWGUXrjR0yzqPHLp8Elj8qEQ471svlxgLspTGWRE7Z39/tOIgyN9b58V8rf8diWEeZtsJw==",
       "license": "MIT",
       "dependencies": {
         "maplibre-gl-layer-control": ">=0.14.1",
@@ -23725,7 +23725,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
-        "maplibre-gl-usgs-lidar": "^0.11.2",
+        "maplibre-gl-usgs-lidar": "^0.11.3",
         "maplibre-gl-vector": "^0.10.12",
         "netcdfjs": "^4.0.0",
         "ngeohash": "^0.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
-        "maplibre-gl-usgs-lidar": "^0.11.1",
+        "maplibre-gl-usgs-lidar": "^0.11.2",
         "maplibre-gl-vector": "^0.10.12",
         "openai": "^7.3.0",
         "qrcode.react": "^4.2.0",
@@ -18405,9 +18405,9 @@
       }
     },
     "node_modules/maplibre-gl-usgs-lidar": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.1.tgz",
-      "integrity": "sha512-5xNKH6pDQwhHQyl4EO6axyF6knypR+7WZiVjVqP6WM8YxY9ULQVu+l/NitaMqf5qNK+lse4+4DAi/yzgD9MvxA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.11.2.tgz",
+      "integrity": "sha512-QgdkBKgegO36Qsx8b/DsMOMeKo8LGNY7kEA1FvP39THDhTa8rGb8pL3UwzJOBN+vMSjKObCZndTdcw6khRjSVw==",
       "license": "MIT",
       "dependencies": {
         "maplibre-gl-layer-control": ">=0.14.1",
@@ -23725,7 +23725,7 @@
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.11.2",
         "maplibre-gl-time-slider": "^1.8.4",
-        "maplibre-gl-usgs-lidar": "^0.11.1",
+        "maplibre-gl-usgs-lidar": "^0.11.2",
         "maplibre-gl-vector": "^0.10.12",
         "netcdfjs": "^4.0.0",
         "ngeohash": "^0.6.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
-    "maplibre-gl-usgs-lidar": "^0.11.3",
+    "maplibre-gl-usgs-lidar": "^0.11.5",
     "maplibre-gl-vector": "^0.10.12",
     "netcdfjs": "^4.0.0",
     "ngeohash": "^0.6.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
-    "maplibre-gl-usgs-lidar": "^0.11.2",
+    "maplibre-gl-usgs-lidar": "^0.11.3",
     "maplibre-gl-vector": "^0.10.12",
     "netcdfjs": "^4.0.0",
     "ngeohash": "^0.6.4",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.11.2",
     "maplibre-gl-time-slider": "^1.8.4",
-    "maplibre-gl-usgs-lidar": "^0.11.1",
+    "maplibre-gl-usgs-lidar": "^0.11.2",
     "maplibre-gl-vector": "^0.10.12",
     "netcdfjs": "^4.0.0",
     "ngeohash": "^0.6.4",

--- a/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
+++ b/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
@@ -131,7 +131,7 @@ const mountUsgsLidarControl = (app: GeoLibreAppAPI): boolean => {
 export const maplibreUsgsLidarPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-usgs-lidar",
   name: "USGS LiDAR",
-  version: "0.11.1",
+  version: "0.11.2",
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
 

--- a/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
+++ b/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
@@ -131,7 +131,7 @@ const mountUsgsLidarControl = (app: GeoLibreAppAPI): boolean => {
 export const maplibreUsgsLidarPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-usgs-lidar",
   name: "USGS LiDAR",
-  version: "0.11.2",
+  version: "0.11.3",
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
 

--- a/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
+++ b/packages/plugins/src/plugins/maplibre-usgs-lidar.ts
@@ -131,7 +131,7 @@ const mountUsgsLidarControl = (app: GeoLibreAppAPI): boolean => {
 export const maplibreUsgsLidarPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-usgs-lidar",
   name: "USGS LiDAR",
-  version: "0.11.3",
+  version: "0.11.5",
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
 


### PR DESCRIPTION
Fixes #2010.

Adds a real browser-side workflow for clipping selected USGS EPT datasets through the USA LiDAR processing service and downloading the generated `.copc.laz` attachment.

The final patch uses `maplibre-gl-usgs-lidar` 0.11.5. It avoids the expired user-activation problem by downloading through an in-page frame and keeps that frame inside the LiDAR panel so the outside-click handler does not collapse the control.

Verification:
- upstream: 21 tests, lint, production build, pre-commit, and CI pass
- GeoLibre: production build and pre-commit pass
- real GeoLibre browser test in light and dark themes using live USGS EPT data near Maryville, Tennessee
- downloaded a real 68 MB `.copc.laz`; LASF header and COPC VLR marker confirmed
- panel remained visible when the download started
- zero browser console errors

Upstream releases: `maplibre-gl-usgs-lidar` 0.11.4 and 0.11.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the USGS LiDAR map integration to version 0.11.5, bringing the latest improvements, fixes, and compatibility updates to the desktop mapping experience.
  * Improved consistency of the LiDAR integration across supported application components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->