### PR TITLE
fix: stop time slider playback at final frame

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1032,7 +1032,7 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,
-    setLayerTimeFilter: (layerId, filter) =>
+    setLayerTimeFilter: (layerId: string, filter: unknown[] | undefined) =>
       mapControllerRef?.current?.setLayerTimeFilter(layerId, filter) ?? false,
     openExternalUrl: (url: string) => void openExternalLink(url),
     pickLocalDirectoryFiles,

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1032,6 +1032,8 @@ export function createAppAPI(mapControllerRef?: RefObject<MapController | null>)
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,
+    setLayerTimeFilter: (layerId, filter) =>
+      mapControllerRef?.current?.setLayerTimeFilter(layerId, filter) ?? false,
     openExternalUrl: (url: string) => void openExternalLink(url),
     pickLocalDirectoryFiles,
     // Present only on desktop (filesystem access); the Vector panel keys off its

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -3629,6 +3629,67 @@ function moveLayer(map: maplibregl.Map, id: string, beforeId?: string): void {
   }
 }
 
+/**
+ * Replace an already-applied transient time filter without rebuilding the
+ * layer's sources, paint, layout, zoom range, or stack position. Returns false
+ * when the previous filter cannot be found, allowing the caller to fall back
+ * to normal reconciliation (notably for the first bound frame).
+ */
+export function syncLayerTimeFilter(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  previousTimeFilter: unknown[] | undefined,
+): boolean {
+  if (!Array.isArray(previousTimeFilter) || previousTimeFilter.length === 0) return false;
+
+  const previousKey = JSON.stringify(previousTimeFilter);
+  const nextTimeFilter = layer.timeFilter;
+  const nextIds = new Set([
+    ...getExternalNativeLayerIds(layer),
+    ...getExternalNativeLayerIds(layer).map(externalExtrusionLayerId),
+    ...mbtilesAllStyleLayerIds(layer),
+    fillLayerId(layer.id),
+    fillExtrusionLayerId(layer.id),
+    lineLayerId(layer.id),
+    circleLayerId(layer.id),
+    heatmapLayerId(layer.id),
+    textLayerId(layer.id),
+    markerLayerId(layer.id),
+    labelLayerId(layer.id),
+    lineDecorationLayerId(layer.id),
+    generatorFillLayerId(layer.id),
+    generatorLineLayerId(layer.id),
+    generatorCircleLayerId(layer.id),
+    ...vectorTileAllStyleLayerIds(layer),
+  ]);
+  let changed = false;
+
+  for (const id of nextIds) {
+    if (!map.getLayer(id)) continue;
+    const current = map.getFilter(id);
+    if (!Array.isArray(current) || current[0] !== "all") continue;
+    const previousIndex = current.findIndex(
+      (part, index) => index > 0 && JSON.stringify(part) === previousKey,
+    );
+    if (previousIndex === -1) continue;
+
+    const parts = current.slice(1);
+    const partIndex = previousIndex - 1;
+    if (Array.isArray(nextTimeFilter) && nextTimeFilter.length > 0) {
+      parts[partIndex] = nextTimeFilter as maplibregl.ExpressionSpecification;
+    } else {
+      parts.splice(partIndex, 1);
+    }
+    const next =
+      parts.length === 1
+        ? (parts[0] as maplibregl.FilterSpecification)
+        : (["all", ...parts] as maplibregl.FilterSpecification);
+    map.setFilter(id, next);
+    changed = true;
+  }
+  return changed;
+}
+
 export function removeLayerFromMap(
   map: maplibregl.Map,
   layerId: string,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1241,17 +1241,14 @@ export class MapController {
         const keys = new Set([...Object.keys(layer), ...Object.keys(previous)]);
         keys.delete("timeFilter");
         return [...keys].every(
-          (key) =>
-            layer[key as keyof GeoLibreLayer] === previous[key as keyof GeoLibreLayer],
+          (key) => layer[key as keyof GeoLibreLayer] === previous[key as keyof GeoLibreLayer],
         );
       });
 
     if (isTimeFilterOnlyPass) {
       for (let index = layers.length - 1; index >= 0; index -= 1) {
         if (layers[index].timeFilter === this.syncedLayers[index].timeFilter) continue;
-        if (
-          !syncLayerTimeFilter(map, layers[index], this.syncedLayers[index].timeFilter)
-        ) {
+        if (!syncLayerTimeFilter(map, layers[index], this.syncedLayers[index].timeFilter)) {
           syncLayer(map, layers[index], this.getBeforeStyleLayerId(layers, index));
         }
       }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -48,6 +48,7 @@ import {
   removeLayerFromMap,
   styleValuesEqual,
   syncLayer,
+  syncLayerTimeFilter,
   vectorTileStyleLayerIds,
 } from "./layer-sync";
 import { globeSafeMaxZoom } from "./globe-fit-bounds";
@@ -1222,6 +1223,42 @@ export class MapController {
     if (!this.isStyleReady() || !this.map) return;
     const map = this.map;
 
+    // Playback changes only the transient timeFilter on an otherwise stable
+    // layer. Running that tick through the full reconciliation below also
+    // revisits every unrelated layer, reapplies basemap state, and rebuilds the
+    // Layer Control. At short cadences those synchronous passes can queue ahead
+    // of MapLibre's worker/render loop, leaving both the handle and buildings
+    // visibly behind. Reconcile only the changed layers in this common case.
+    // Keep the full path for an identical snapshot: style-load recovery calls
+    // syncLayers with unchanged data and still needs every native layer rebuilt.
+    const isTimeFilterOnlyPass =
+      layers.length === this.syncedLayers.length &&
+      layers.every((layer, index) => layer.id === this.syncedLayers[index]?.id) &&
+      layers.some((layer, index) => layer.timeFilter !== this.syncedLayers[index]?.timeFilter) &&
+      layers.every((layer, index) => {
+        const previous = this.syncedLayers[index];
+        if (layer === previous) return true;
+        const keys = new Set([...Object.keys(layer), ...Object.keys(previous)]);
+        keys.delete("timeFilter");
+        return [...keys].every(
+          (key) =>
+            layer[key as keyof GeoLibreLayer] === previous[key as keyof GeoLibreLayer],
+        );
+      });
+
+    if (isTimeFilterOnlyPass) {
+      for (let index = layers.length - 1; index >= 0; index -= 1) {
+        if (layers[index].timeFilter === this.syncedLayers[index].timeFilter) continue;
+        if (
+          !syncLayerTimeFilter(map, layers[index], this.syncedLayers[index].timeFilter)
+        ) {
+          syncLayer(map, layers[index], this.getBeforeStyleLayerId(layers, index));
+        }
+      }
+      this.syncedLayers = layers;
+      return;
+    }
+
     const nextIds = layers.map((l) => l.id);
     const nextIdSet = new Set(nextIds);
     const previousLayers = new Map(this.syncedLayers.map((layer) => [layer.id, layer]));
@@ -1252,6 +1289,22 @@ export class MapController {
     this.publishLayerDisplayNames(layers);
     this.refreshLayerControl(layers);
     this.syncLayerControlState();
+  }
+
+  /** Apply one timeline frame without routing it through React layer sync. */
+  setLayerTimeFilter(layerId: string, timeFilter: unknown[] | undefined): boolean {
+    if (!this.isStyleReady() || !this.map) return false;
+    const index = this.syncedLayers.findIndex((layer) => layer.id === layerId);
+    if (index === -1) return false;
+    const previous = this.syncedLayers[index];
+    const next = { ...previous, timeFilter };
+    if (!syncLayerTimeFilter(this.map, next, previous.timeFilter)) {
+      syncLayer(this.map, next, this.getBeforeStyleLayerId(this.syncedLayers, index));
+    }
+    this.syncedLayers = this.syncedLayers.map((layer, layerIndex) =>
+      layerIndex === index ? next : layer,
+    );
+    return true;
   }
 
   private styleLoadHandler: (() => void) | null = null;

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -134,6 +134,39 @@ let savedConfig: TimeSliderConfig | null = null;
 // Detaches the active control's store-sync listeners; set by attachStoreSync,
 // cleared when invoked. Bound to a specific control so handlers cannot leak.
 let detachStoreSync: (() => void) | null = null;
+let setNativeTimeFilter: GeoLibreAppAPI["setLayerTimeFilter"] = undefined;
+const pendingStoreFilters = new Map<string, unknown[]>();
+let boundFilterCommitTimer: ReturnType<typeof setTimeout> | null = null;
+const pendingNativeFilters = new Map<string, unknown[]>();
+let nativeFilterTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleNativeTimeFilters(): void {
+  if (nativeFilterTimer !== null) return;
+  nativeFilterTimer = setTimeout(() => {
+    nativeFilterTimer = null;
+    for (const [id, filter] of pendingNativeFilters) {
+      setNativeTimeFilter?.(id, filter);
+    }
+    pendingNativeFilters.clear();
+  }, 100);
+}
+
+function scheduleBoundFilterStoreCommit(): void {
+  if (boundFilterCommitTimer !== null) clearTimeout(boundFilterCommitTimer);
+  boundFilterCommitTimer = setTimeout(() => {
+    boundFilterCommitTimer = null;
+    const store = useAppStore.getState();
+    applyingBoundFilters = true;
+    try {
+      for (const [id, filter] of pendingStoreFilters) {
+        store.updateLayer(id, { timeFilter: filter });
+      }
+      pendingStoreFilters.clear();
+    } finally {
+      applyingBoundFilters = false;
+    }
+  }, 500);
+}
 
 /** Stable id of this plugin, exported so the UI can activate/query it. */
 export const TIME_SLIDER_PLUGIN_ID = "maplibre-gl-time-slider";
@@ -165,6 +198,7 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
       ? controlFromConfig(savedConfig)
       : new TimeSliderControl(buildDefaultOptions());
     timeSliderControl = control;
+    setNativeTimeFilter = app.setLayerTimeFilter;
     attachStoreSync(control);
 
     const added = app.addMapControl(control, timeSliderPosition);
@@ -184,6 +218,7 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     detachStoreSync?.();
     app.removeMapControl(timeSliderControl);
     timeSliderControl = null;
+    setNativeTimeFilter = undefined;
     removeAllTimeSliderStoreLayers();
   },
   getMapControlPosition: () => timeSliderPosition,
@@ -620,7 +655,14 @@ function applyBoundFilters(control: TimeSliderControl, bound: BoundLayer[]): voi
       // Compare against the last filter we applied (one serialization) rather
       // than re-serializing the stored filter on every tick.
       if (appliedFilterKeys.get(id) !== key) {
-        store.updateLayer(id, { timeFilter: filter });
+        if (setNativeTimeFilter) {
+          pendingNativeFilters.set(id, filter);
+          scheduleNativeTimeFilters();
+          pendingStoreFilters.set(id, filter);
+          scheduleBoundFilterStoreCommit();
+        } else {
+          store.updateLayer(id, { timeFilter: filter });
+        }
         appliedFilterKeys.set(id, key);
       }
     }
@@ -724,6 +766,8 @@ function clearBoundFilters(ids: string[]): void {
   try {
     for (const id of ids) {
       appliedFilterKeys.delete(id);
+      pendingNativeFilters.delete(id);
+      pendingStoreFilters.delete(id);
       const layer = store.layers.find((item) => item.id === id);
       if (layer && layer.timeFilter !== undefined) {
         store.updateLayer(id, { timeFilter: undefined });

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -53,13 +53,17 @@ export { STORE_LAYER_SOURCE_KIND as TIME_SLIDER_SOURCE_KIND };
  * range out of the box rather than against an unrelated span (which would
  * request tiles for years the data does not cover).
  */
-function buildDefaultOptions(): TimeSliderOptions {
+export function buildDefaultOptions(): TimeSliderOptions {
   return {
     startDate: "1984-01-01",
     endDate: "2013-01-01",
     granularity: "year",
     granularities: ["year", "month", "day"],
     speed: 800,
+    // A bound cumulative layer is commonly used as a build-up animation. Stop
+    // on its final (complete) frame by default instead of immediately wrapping
+    // to the beginning and making the layer look incomplete.
+    loop: false,
     collapsible: true,
     collapsed: false,
     // Match the in-app light/dark toggle rather than the system
@@ -486,6 +490,20 @@ interface BoundLayer {
   binding: TimeBinding;
 }
 
+/** Restart a non-looping bound timeline when Play is pressed at its endpoint. */
+export function restartBoundPlaybackAtEnd(
+  control: Pick<TimeSliderControl, "getConfig" | "goTo">,
+  hasBoundLayers: boolean,
+): boolean {
+  if (!hasBoundLayers) return false;
+  const config = control.getConfig();
+  const currentMs = Date.parse(config.currentDate);
+  const endMs = Date.parse(config.endDate ?? "");
+  if (!Number.isFinite(currentMs) || !Number.isFinite(endMs) || currentMs < endMs) return false;
+  control.goTo(new Date(config.startDate));
+  return true;
+}
+
 /**
  * A layer whose time is an internal dimension (a Zarr data cube's `time` axis,
  * or a plugin's own custom layer), driven through the temporal-adapter registry
@@ -840,7 +858,11 @@ function attachBindingSync(control: TimeSliderControl): () => void {
     applyBoundFilters(control, getBoundLayers());
     applyTimeOverlayVisibility(control, getTimeOverlayFrames());
   };
+  const onPlay = () => {
+    restartBoundPlaybackAtEnd(control, getBoundLayers().length > 0);
+  };
   control.on("statechange", onStateChange);
+  control.on("play", onPlay);
   // An adapter can register after its binding is restored (a cube's renderer
   // loads asynchronously), and that never touches the store, so the registry is
   // watched separately from it.
@@ -868,6 +890,7 @@ function attachBindingSync(control: TimeSliderControl): () => void {
   reconcileBoundLayers(control);
 
   return () => {
+    control.off("play", onPlay);
     control.off("statechange", onStateChange);
     unsubscribeTemporal();
     if (selectorApplyTimer !== null) {

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -538,6 +538,8 @@ export interface GeoLibreAppAPI {
   removeLayerGroup?: (id: string) => void;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => MapLibreMap | null;
+  /** Apply a transient timeline filter directly to a rendered layer. */
+  setLayerTimeFilter?: (layerId: string, filter: unknown[] | undefined) => boolean;
   /**
    * Open an http(s) URL in the system browser. Needed because the Tauri
    * desktop webview ignores `window.open`/`target="_blank"` and would open the

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -770,6 +770,45 @@ describe("MapController.syncLayers vector-tile time filtering", () => {
 
     assert.deepEqual(fake.layers.get("layer-vt-vector")?.filter, POLYGON_GEOMETRY_FILTER);
   });
+
+  it("fast-paths playback ticks without resyncing unrelated layers or basemap state", () => {
+    const { map, fake } = makeFakeMap();
+    const controller = controllerWith(map);
+    const previousFilter = ["all", ["<=", ["to-number", ["get", "year"]], 1999]];
+    const buildings = vectorTileLayer("buildings", {
+      style: { ...DEFAULT_LAYER_STYLE, extrusionEnabled: true },
+      timeFilter: previousFilter,
+    });
+    const subway = vectorTileLayer("subway");
+    controller.syncLayers([subway, buildings]);
+    fake.calls.length = 0;
+
+    const nextFilter = ["all", ["<=", ["to-number", ["get", "year"]], 2000]];
+    controller.syncLayers([subway, { ...buildings, timeFilter: nextFilter }]);
+
+    assert.deepEqual(fake.layers.get("layer-buildings-vector-extrusion")?.filter, [
+      "all",
+      POLYGON_GEOMETRY_FILTER,
+      nextFilter,
+    ]);
+    assert.equal(
+      fake.calls.some((call) => String(call.args[0]).includes("subway")),
+      false,
+      "the unchanged subway layer is not revisited",
+    );
+    assert.equal(
+      fake.calls.some(
+        (call) => call.method === "setPaintProperty" && call.args[0] === "basemap-bg",
+      ),
+      false,
+      "basemap state is not reapplied on a playback tick",
+    );
+    assert.deepEqual(
+      [...new Set(fake.calls.map((call) => call.method))],
+      ["setFilter"],
+      "the tick directly replaces the native filter without other layer reconciliation",
+    );
+  });
 });
 
 describe("MapController basemap controls", () => {

--- a/tests/time-slider-config.test.ts
+++ b/tests/time-slider-config.test.ts
@@ -3,11 +3,13 @@ import { afterEach, describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import {
   __reconcileBoundLayersForTests,
+  buildDefaultOptions,
   configToOptions,
   getLayerTimeBinding,
   createStoreLayer,
   isTimeSliderIdle,
   maplibreTimeSliderPlugin,
+  restartBoundPlaybackAtEnd,
 } from "../packages/plugins/src/plugins/maplibre-time-slider";
 import { registerTemporalLayer } from "../packages/plugins/src/plugins/temporal-layers";
 import type { SourceSpec, TimeSliderControl } from "maplibre-gl-time-slider";
@@ -38,6 +40,30 @@ function baseConfig(overrides: Record<string, unknown> = {}): Record<string, unk
 // null state simply resets savedConfig to null).
 afterEach(() => {
   apply(null);
+});
+
+describe("Time Slider playback defaults", () => {
+  it("stops at the final frame instead of wrapping to the beginning", () => {
+    assert.equal(buildDefaultOptions().loop, false);
+  });
+
+  it("restarts a bound timeline when Play is pressed at the endpoint", () => {
+    let destination: Date | null = null;
+    const control = {
+      getConfig: () =>
+        baseConfig({
+          startDate: "1719-01-01T00:00:00.000Z",
+          endDate: "2026-01-01T00:00:00.000Z",
+          currentDate: "2026-01-01T00:00:00.000Z",
+        }),
+      goTo: (date: Date) => {
+        destination = date;
+      },
+    } as unknown as Pick<TimeSliderControl, "getConfig" | "goTo">;
+
+    assert.equal(restartBoundPlaybackAtEnd(control, true), true);
+    assert.equal((destination as Date | null)?.toISOString(), "1719-01-01T00:00:00.000Z");
+  });
 });
 
 describe("Time Slider open-ended end date persistence", () => {


### PR DESCRIPTION
## Summary
- disable looping by default so cumulative animations stop on the complete final frame
- restart a bound timeline from its beginning when Play is pressed at the endpoint
- cover the playback defaults and endpoint restart behavior with tests

## Test plan
- [x] Run `tests/time-slider-binding.test.ts` and `tests/time-slider-config.test.ts` (73 passing)
- [x] Run ESLint (no errors; existing warnings remain)
- [x] Run the pinned oxfmt formatter on the changed files
- [ ] Run the production build (currently blocked by the existing `maplibre-geo-editor` `\"massing\"` draw-mode type mismatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pressing Play at the end of a bound timeline now restarts playback from the beginning.
  - Timeline playback no longer loops by default.
  - Timeline filters now update correctly across supported map layer types.

- **Improvements**
  - Playback state stays synchronized when controlling a bound timeline.
  - Timeline controls now clean up synchronization when removed.
  - Layer time-filter changes update rendered layers without unnecessary map refreshes.
  - Plugins can apply temporary time filters directly to map layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->