### PR TITLE
feat: Encoded Polyline Encoder/Decoder Implementation

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -18,6 +18,7 @@ import { MbtilesSource } from "./add-data/sources/MbtilesSource";
 import { OgcFeaturesSource } from "./add-data/sources/OgcFeaturesSource";
 import { OgcVectorTilesSource } from "./add-data/sources/OgcVectorTilesSource";
 import { PhotosSource } from "./add-data/sources/PhotosSource";
+import { PolylineSource } from "./add-data/sources/PolylineSource";
 import { PostgresSource } from "./add-data/sources/PostgresSource";
 import { VideoSource } from "./add-data/sources/VideoSource";
 import { WfsSource } from "./add-data/sources/WfsSource";
@@ -103,6 +104,8 @@ function renderSource(
       return <PhotosSource />;
     case "mbtiles":
       return <MbtilesSource />;
+    case "polyline":
+      return <PolylineSource />;
     case "arcgis":
       return <ArcGISSource initialUrl={initialUrl} />;
     case "postgres":

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -25,6 +25,7 @@ export type KindI18nKey =
   | "gdb"
   | "photos"
   | "mbtiles"
+  | "polyline"
   | "arcgis"
   | "postgres"
   | "iceberg"
@@ -50,6 +51,7 @@ export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
   gdb: "gdb",
   photos: "photos",
   mbtiles: "mbtiles",
+  polyline: "polyline",
   arcgis: "arcgis",
   postgres: "postgres",
   iceberg: "iceberg",

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -27,7 +27,8 @@ const SAMPLE_POLYLINES = [
   },
   {
     key: "addData.polyline.sampleEscaped" as const,
-    value: "otnyWckdxrCnlAsyAv~JrjAriIkjHvkL_|BbkL~tCfc@_iIb}C?goDkdUj`Cs}IwGktMvjE{_L{w@k~CjiF_uH~qGgkZfzFoaI{nB_}DoPcjT{|J?{r@swGnaDsuCoAgsQrhGkxKsbOswQjfEwQrbJcp`@~bBn_@ffAofI{eDguKwkLwrKwzGkt\\krg@gfqAg|@{uKcwKocHsaC{fFsjF_g@_rBf|OwdHvB?",
+    value:
+      "otnyWckdxrCnlAsyAv~JrjAriIkjHvkL_|BbkL~tCfc@_iIb}C?goDkdUj`Cs}IwGktMvjE{_L{w@k~CjiF_uH~qGgkZfzFoaI{nB_}DoPcjT{|J?{r@swGnaDsuCoAgsQrhGkxKsbOswQjfEwQrbJcp`@~bBn_@ffAofI{eDguKwkLwrKwzGkt\\krg@gfqAg|@{uKcwKocHsaC{fFsjF_g@_rBf|OwdHvB?",
     precision: 5,
     unescape: true,
   },

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -399,7 +399,10 @@ export function PolylineSource() {
             <div className="flex items-center justify-between font-medium text-foreground">
               <span>{t("addData.polyline.previewTitle")}</span>
               <span className="text-[11px] text-muted-foreground">
-                {parsedData.linesCount} line(s) · {parsedData.totalPoints} points
+                {t("addData.polyline.previewInfo", {
+                  lines: parsedData.linesCount,
+                  points: parsedData.totalPoints,
+                })}
               </span>
             </div>
 
@@ -477,6 +480,8 @@ export function PolylineSource() {
             onSelect={(val) => {
               const sample = SAMPLE_POLYLINES.find((s) => s.value === val);
               if (sample) {
+                setDelimiterType("newline");
+                setCustomDelimiter("");
                 setPrecision(sample.precision);
                 setUnescapeBackslashes(sample.unescape ?? true);
                 setRawText(sample.value);

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -1,20 +1,11 @@
-import {
-  batchDecodePolylines,
-  decodePolyline,
-  unescapePolyline,
-} from "@geolibre/core";
+import { batchDecodePolylines, decodePolyline, unescapePolyline } from "@geolibre/core";
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import type { FeatureCollection, LineString, MultiLineString } from "geojson";
 import { ChevronDown, ChevronUp, FileUp, Info, MapPin } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
-import {
-  createBaseLayer,
-  errorMessage,
-  fileNameFromPath,
-  layerNameFromPath,
-} from "../helpers";
+import { createBaseLayer, errorMessage, fileNameFromPath, layerNameFromPath } from "../helpers";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export type PolylineMode = "paste" | "file";
@@ -113,7 +104,7 @@ export function PolylineSource() {
     }
   };
 
-  const currentContent = polylineMode === "file" ? selectedFile?.text ?? "" : rawText;
+  const currentContent = polylineMode === "file" ? (selectedFile?.text ?? "") : rawText;
 
   const activeDelimiter = useMemo(() => {
     switch (delimiterType) {
@@ -140,7 +131,7 @@ export function PolylineSource() {
         delimiter: activeDelimiter,
         asMultiLine: outputGeometry === "multi",
         baseProperties: {
-          source: polylineMode === "file" ? selectedFile?.path ?? "file" : "polyline",
+          source: polylineMode === "file" ? (selectedFile?.path ?? "file") : "polyline",
         },
       });
 
@@ -253,7 +244,7 @@ export function PolylineSource() {
 
     const name = source.layerName.trim() || defaultName;
     const geojson = parsedData.featureCollection;
-    const sourcePath = polylineMode === "file" ? selectedFile?.path ?? "" : "encoded-polyline";
+    const sourcePath = polylineMode === "file" ? (selectedFile?.path ?? "") : "encoded-polyline";
 
     source.addAndClose(
       {
@@ -334,7 +325,9 @@ export function PolylineSource() {
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="polyline-output-geometry">{t("addData.polyline.outputGeometryLabel")}</Label>
+            <Label htmlFor="polyline-output-geometry">
+              {t("addData.polyline.outputGeometryLabel")}
+            </Label>
             <Select
               id="polyline-output-geometry"
               value={outputGeometry}
@@ -412,13 +405,17 @@ export function PolylineSource() {
 
             <div className="grid grid-cols-2 gap-2 text-muted-foreground text-[11px]">
               <div>
-                <span className="font-semibold text-foreground">{t("addData.polyline.previewLength")}: </span>
+                <span className="font-semibold text-foreground">
+                  {t("addData.polyline.previewLength")}:{" "}
+                </span>
                 {parsedData.totalLengthKm < 1
                   ? `${(parsedData.totalLengthKm * 1000).toFixed(0)} m`
                   : `${parsedData.totalLengthKm.toFixed(2)} km`}
               </div>
               <div className="truncate">
-                <span className="font-semibold text-foreground">{t("addData.polyline.previewExtent")}: </span>
+                <span className="font-semibold text-foreground">
+                  {t("addData.polyline.previewExtent")}:{" "}
+                </span>
                 [{parsedData.bbox.map((v) => v.toFixed(3)).join(", ")}]
               </div>
             </div>
@@ -446,12 +443,21 @@ export function PolylineSource() {
                         <span className="font-semibold text-foreground">
                           {t("addData.polyline.previewLine")} #{l.index}
                         </span>
-                        <span>{l.pointsCount} {t("addData.polyline.previewPoints")} · {l.lengthKm.toFixed(2)} km</span>
+                        <span>
+                          {l.pointsCount} {t("addData.polyline.previewPoints")} ·{" "}
+                          {l.lengthKm.toFixed(2)} km
+                        </span>
                       </div>
                       <div className="flex gap-2 text-[10px] text-muted-foreground">
-                        <span>{t("addData.polyline.previewStart")}: [{l.start[0].toFixed(5)}, {l.start[1].toFixed(5)}]</span>
+                        <span>
+                          {t("addData.polyline.previewStart")}: [{l.start[0].toFixed(5)},{" "}
+                          {l.start[1].toFixed(5)}]
+                        </span>
                         <span>→</span>
-                        <span>{t("addData.polyline.previewEnd")}: [{l.end[0].toFixed(5)}, {l.end[1].toFixed(5)}]</span>
+                        <span>
+                          {t("addData.polyline.previewEnd")}: [{l.end[0].toFixed(5)},{" "}
+                          {l.end[1].toFixed(5)}]
+                        </span>
                       </div>
                     </div>
                   ))}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -27,7 +27,7 @@ const SAMPLE_POLYLINES = [
   },
   {
     key: "addData.polyline.sampleEscaped" as const,
-    value: "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@",
+    value: "otnyWckdxrCnlAsyAv~JrjAriIkjHvkL_|BbkL~tCfc@_iIb}C?goDkdUj`Cs}IwGktMvjE{_L{w@k~CjiF_uH~qGgkZfzFoaI{nB_}DoPcjT{|J?{r@swGnaDsuCoAgsQrhGkxKsbOswQjfEwQrbJcp`@~bBn_@ffAofI{eDguKwkLwrKwzGkt\\krg@gfqAg|@{uKcwKocHsaC{fFsjF_g@_rBf|OwdHvB?",
     precision: 5,
     unescape: true,
   },

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -14,25 +14,25 @@ export type GeometryOutputType = "single" | "multi";
 
 const SAMPLE_POLYLINES = [
   {
-    label: "Google / OSRM (precision 5)",
+    key: "sampleGoogle",
     value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
     precision: 5,
     unescape: true,
   },
   {
-    label: "Valhalla / Mapbox (precision 6)",
+    key: "sampleValhalla",
     value: "_o`diA~gw}qC_pR_pR_pR_af@",
     precision: 6,
     unescape: true,
   },
   {
-    label: "Escaped backslashes (JSON string format)",
+    key: "sampleEscaped",
     value: "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@",
     precision: 5,
     unescape: true,
   },
   {
-    label: "Multi-line route batch (3 segments)",
+    key: "sampleMultiLine",
     value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_ibE_seK_seK_seK\nmc_Ie}hV_c_@_c_@",
     precision: 5,
     unescape: true,
@@ -412,8 +412,12 @@ export function PolylineSource() {
                   {t("addData.polyline.previewLength")}:{" "}
                 </span>
                 {parsedData.totalLengthKm < 1
-                  ? `${(parsedData.totalLengthKm * 1000).toFixed(0)} m`
-                  : `${parsedData.totalLengthKm.toFixed(2)} km`}
+                  ? t("addData.polyline.unitMeters", {
+                      value: (parsedData.totalLengthKm * 1000).toFixed(0),
+                    })
+                  : t("addData.polyline.unitKm", {
+                      value: parsedData.totalLengthKm.toFixed(2),
+                    })}
               </div>
               <div className="truncate">
                 <span className="font-semibold text-foreground">
@@ -448,7 +452,9 @@ export function PolylineSource() {
                         </span>
                         <span>
                           {l.pointsCount} {t("addData.polyline.previewPoints")} ·{" "}
-                          {l.lengthKm.toFixed(2)} km
+                          {t("addData.polyline.unitKm", {
+                            value: l.lengthKm.toFixed(2),
+                          })}
                         </span>
                       </div>
                       <div className="flex gap-2 text-[10px] text-muted-foreground">
@@ -474,7 +480,7 @@ export function PolylineSource() {
         {polylineMode === "paste" && (
           <SampleDataSelect
             samples={SAMPLE_POLYLINES.map((s) => ({
-              label: s.label,
+              label: t(`addData.polyline.${s.key}`),
               value: s.value,
             }))}
             onSelect={(val) => {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -14,25 +14,25 @@ export type GeometryOutputType = "single" | "multi";
 
 const SAMPLE_POLYLINES = [
   {
-    key: "sampleGoogle",
+    key: "addData.polyline.sampleGoogle" as const,
     value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
     precision: 5,
     unescape: true,
   },
   {
-    key: "sampleValhalla",
+    key: "addData.polyline.sampleValhalla" as const,
     value: "_o`diA~gw}qC_pR_pR_pR_af@",
     precision: 6,
     unescape: true,
   },
   {
-    key: "sampleEscaped",
+    key: "addData.polyline.sampleEscaped" as const,
     value: "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@",
     precision: 5,
     unescape: true,
   },
   {
-    key: "sampleMultiLine",
+    key: "addData.polyline.sampleMultiLine" as const,
     value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_ibE_seK_seK_seK\nmc_Ie}hV_c_@_c_@",
     precision: 5,
     unescape: true,
@@ -43,7 +43,8 @@ const SAMPLE_POLYLINES = [
 function haversineDistanceKm(c1: [number, number], c2: [number, number]): number {
   const R = 6371.0088;
   const dLat = ((c2[1] - c1[1]) * Math.PI) / 180;
-  const dLon = ((c2[0] - c1[0]) * Math.PI) / 180;
+  const deltaLon = ((c2[0] - c1[0] + 540) % 360) - 180;
+  const dLon = (deltaLon * Math.PI) / 180;
   const lat1 = (c1[1] * Math.PI) / 180;
   const lat2 = (c2[1] * Math.PI) / 180;
   const a =
@@ -51,6 +52,10 @@ function haversineDistanceKm(c1: [number, number], c2: [number, number]): number
     Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
   const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   return R * c;
+}
+
+function formatDistance(km: number): string {
+  return km < 1 ? `${(km * 1000).toFixed(0)} m` : `${km.toFixed(2)} km`;
 }
 
 export function PolylineSource() {
@@ -131,7 +136,12 @@ export function PolylineSource() {
         delimiter: activeDelimiter,
         asMultiLine: outputGeometry === "multi",
         baseProperties: {
-          source: polylineMode === "file" ? (selectedFile?.path ?? "file") : "polyline",
+          source:
+            polylineMode === "file"
+              ? selectedFile
+                ? fileNameFromPath(selectedFile.path)
+                : "file"
+              : "polyline",
         },
       });
 
@@ -411,13 +421,7 @@ export function PolylineSource() {
                 <span className="font-semibold text-foreground">
                   {t("addData.polyline.previewLength")}:{" "}
                 </span>
-                {parsedData.totalLengthKm < 1
-                  ? t("addData.polyline.unitMeters", {
-                      value: (parsedData.totalLengthKm * 1000).toFixed(0),
-                    })
-                  : t("addData.polyline.unitKm", {
-                      value: parsedData.totalLengthKm.toFixed(2),
-                    })}
+                {formatDistance(parsedData.totalLengthKm)}
               </div>
               <div className="truncate">
                 <span className="font-semibold text-foreground">
@@ -452,9 +456,7 @@ export function PolylineSource() {
                         </span>
                         <span>
                           {l.pointsCount} {t("addData.polyline.previewPoints")} ·{" "}
-                          {t("addData.polyline.unitKm", {
-                            value: l.lengthKm.toFixed(2),
-                          })}
+                          {formatDistance(l.lengthKm)}
                         </span>
                       </div>
                       <div className="flex gap-2 text-[10px] text-muted-foreground">
@@ -480,7 +482,7 @@ export function PolylineSource() {
         {polylineMode === "paste" && (
           <SampleDataSelect
             samples={SAMPLE_POLYLINES.map((s) => ({
-              label: t(`addData.polyline.${s.key}`),
+              label: t(s.key),
               value: s.value,
             }))}
             onSelect={(val) => {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -1,0 +1,484 @@
+import {
+  batchDecodePolylines,
+  decodePolyline,
+  unescapePolyline,
+} from "@geolibre/core";
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import type { FeatureCollection, LineString, MultiLineString } from "geojson";
+import { ChevronDown, ChevronUp, FileUp, Info, MapPin } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
+import {
+  createBaseLayer,
+  errorMessage,
+  fileNameFromPath,
+  layerNameFromPath,
+} from "../helpers";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
+
+export type PolylineMode = "paste" | "file";
+export type DelimiterType = "newline" | "semicolon" | "comma" | "tab" | "custom";
+export type GeometryOutputType = "single" | "multi";
+
+const SAMPLE_POLYLINES = [
+  {
+    label: "Google / OSRM (precision 5)",
+    value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+    precision: 5,
+    unescape: true,
+  },
+  {
+    label: "Valhalla / Mapbox (precision 6)",
+    value: "_o`diA~gw}qC_pR_pR_pR_af@",
+    precision: 6,
+    unescape: true,
+  },
+  {
+    label: "Escaped backslashes (JSON string format)",
+    value: "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@",
+    precision: 5,
+    unescape: true,
+  },
+  {
+    label: "Multi-line route batch (3 segments)",
+    value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_ibE_seK_seK_seK\nmc_Ie}hV_c_@_c_@",
+    precision: 5,
+    unescape: true,
+  },
+];
+
+/** Haversine distance in kilometers between two [lon, lat] coordinates. */
+function haversineDistanceKm(c1: [number, number], c2: [number, number]): number {
+  const R = 6371.0088;
+  const dLat = ((c2[1] - c1[1]) * Math.PI) / 180;
+  const dLon = ((c2[0] - c1[0]) * Math.PI) / 180;
+  const lat1 = (c1[1] * Math.PI) / 180;
+  const lat2 = (c2[1] * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+export function PolylineSource() {
+  const { t } = useTranslation();
+  const [defaultName] = useState(() => t("addData.polyline.defaultName"));
+  const source = useAddDataSource(defaultName);
+  const [polylineMode, setPolylineMode] = useState<PolylineMode>("paste");
+  const [rawText, setRawText] = useState("");
+  const [precision, setPrecision] = useState<number>(5);
+  const [unescapeBackslashes, setUnescapeBackslashes] = useState<boolean>(true);
+  const [delimiterType, setDelimiterType] = useState<DelimiterType>("newline");
+  const [customDelimiter, setCustomDelimiter] = useState<string>("");
+  const [outputGeometry, setOutputGeometry] = useState<GeometryOutputType>("single");
+  const [showCoordinateTable, setShowCoordinateTable] = useState<boolean>(false);
+  const [selectedFile, setSelectedFile] = useState<{
+    path: string;
+    text: string;
+  } | null>(null);
+
+  const handleModeChange = (mode: PolylineMode) => {
+    setPolylineMode(mode);
+    setSelectedFile(null);
+  };
+
+  const handleChooseFile = async () => {
+    source.setError(null);
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [
+          {
+            name: "Encoded Polyline",
+            extensions: ["polyline", "txt"],
+          },
+        ],
+        accept: ".polyline,.txt",
+        readText: true,
+      });
+      if (!result) return;
+      if (!result.text) throw new Error(t("addData.polyline.errorFileMissing"));
+      setSelectedFile({
+        path: result.path,
+        text: result.text,
+      });
+      source.setLayerName((current) =>
+        current.trim() && current !== defaultName
+          ? current
+          : layerNameFromPath(result.path, defaultName),
+      );
+    } catch (err) {
+      source.setError(errorMessage(err, t("addData.polyline.readError")));
+    }
+  };
+
+  const currentContent = polylineMode === "file" ? selectedFile?.text ?? "" : rawText;
+
+  const activeDelimiter = useMemo(() => {
+    switch (delimiterType) {
+      case "newline":
+        return /\r?\n/;
+      case "semicolon":
+        return ";";
+      case "comma":
+        return ",";
+      case "tab":
+        return "\t";
+      case "custom":
+        return customDelimiter || /\r?\n/;
+    }
+  }, [delimiterType, customDelimiter]);
+
+  const parsedData = useMemo(() => {
+    const textToProcess = currentContent.trim();
+    if (!textToProcess) return null;
+    try {
+      const fc = batchDecodePolylines(textToProcess, {
+        precision,
+        unescape: unescapeBackslashes,
+        delimiter: activeDelimiter,
+        asMultiLine: outputGeometry === "multi",
+        baseProperties: {
+          source: polylineMode === "file" ? selectedFile?.path ?? "file" : "polyline",
+        },
+      });
+
+      if (!fc.features.length) return null;
+
+      let totalPoints = 0;
+      let totalLengthKm = 0;
+      let minLon = Infinity;
+      let minLat = Infinity;
+      let maxLon = -Infinity;
+      let maxLat = -Infinity;
+
+      const linesInfo: Array<{
+        index: number;
+        pointsCount: number;
+        lengthKm: number;
+        start: [number, number];
+        end: [number, number];
+        coords: [number, number][];
+      }> = [];
+
+      for (let i = 0; i < fc.features.length; i++) {
+        const feature = fc.features[i];
+        if (feature.geometry.type === "LineString") {
+          const coords = feature.geometry.coordinates as [number, number][];
+          let lineLen = 0;
+          for (let j = 0; j < coords.length; j++) {
+            const [lon, lat] = coords[j];
+            minLon = Math.min(minLon, lon);
+            maxLon = Math.max(maxLon, lon);
+            minLat = Math.min(minLat, lat);
+            maxLat = Math.max(maxLat, lat);
+            if (j > 0) lineLen += haversineDistanceKm(coords[j - 1], coords[j]);
+          }
+          totalPoints += coords.length;
+          totalLengthKm += lineLen;
+          if (coords.length > 0) {
+            linesInfo.push({
+              index: i + 1,
+              pointsCount: coords.length,
+              lengthKm: lineLen,
+              start: coords[0],
+              end: coords[coords.length - 1],
+              coords,
+            });
+          }
+        } else if (feature.geometry.type === "MultiLineString") {
+          const multiCoords = feature.geometry.coordinates as [number, number][][];
+          multiCoords.forEach((coords, partIdx) => {
+            let lineLen = 0;
+            for (let j = 0; j < coords.length; j++) {
+              const [lon, lat] = coords[j];
+              minLon = Math.min(minLon, lon);
+              maxLon = Math.max(maxLon, lon);
+              minLat = Math.min(minLat, lat);
+              maxLat = Math.max(maxLat, lat);
+              if (j > 0) lineLen += haversineDistanceKm(coords[j - 1], coords[j]);
+            }
+            totalPoints += coords.length;
+            totalLengthKm += lineLen;
+            if (coords.length > 0) {
+              linesInfo.push({
+                index: partIdx + 1,
+                pointsCount: coords.length,
+                lengthKm: lineLen,
+                start: coords[0],
+                end: coords[coords.length - 1],
+                coords,
+              });
+            }
+          });
+        }
+      }
+
+      return {
+        featureCollection: fc,
+        featuresCount: fc.features.length,
+        linesCount: linesInfo.length,
+        totalPoints,
+        totalLengthKm,
+        bbox: [minLon, minLat, maxLon, maxLat] as [number, number, number, number],
+        linesInfo,
+      };
+    } catch {
+      return null;
+    }
+  }, [
+    currentContent,
+    precision,
+    unescapeBackslashes,
+    activeDelimiter,
+    outputGeometry,
+    polylineMode,
+    selectedFile,
+  ]);
+
+  const handleSubmit = source.runSubmit(async () => {
+    const textToProcess = currentContent.trim();
+    if (!textToProcess) {
+      throw new Error(
+        polylineMode === "file"
+          ? t("addData.polyline.errorChooseFile")
+          : t("addData.polyline.errorEmptyInput"),
+      );
+    }
+
+    if (!parsedData || !parsedData.featureCollection.features.length) {
+      throw new Error(t("addData.polyline.errorNoValidLines"));
+    }
+
+    const name = source.layerName.trim() || defaultName;
+    const geojson = parsedData.featureCollection;
+    const sourcePath = polylineMode === "file" ? selectedFile?.path ?? "" : "encoded-polyline";
+
+    source.addAndClose(
+      {
+        ...createBaseLayer(
+          name,
+          "geojson",
+          {
+            type: "geojson",
+            data: geojson,
+          },
+          {
+            featureCount: geojson.features.length,
+            sourceKind: "polyline",
+            polylinePrecision: precision,
+          },
+          { geojson },
+        ),
+        geojson,
+        sourcePath,
+      },
+      { fit: true },
+    );
+  });
+
+  return (
+    <AddDataSourceForm
+      layerName={source.layerName}
+      onLayerNameChange={source.setLayerName}
+      beforeLayerId={source.beforeLayerId}
+      onBeforeLayerIdChange={source.setBeforeLayerId}
+      onSubmit={handleSubmit}
+      error={source.error}
+      submitDisabled={source.isSubmitting}
+    >
+      <div className="space-y-3">
+        {/* Row 1: Source Mode & Precision */}
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="polyline-mode">{t("addData.common.sourceType")}</Label>
+            <Select
+              id="polyline-mode"
+              value={polylineMode}
+              onChange={(event) => handleModeChange(event.target.value as PolylineMode)}
+            >
+              <option value="paste">{t("addData.polyline.modePaste")}</option>
+              <option value="file">{t("addData.polyline.modeFile")}</option>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="polyline-precision">{t("addData.polyline.precisionLabel")}</Label>
+            <Select
+              id="polyline-precision"
+              value={String(precision)}
+              onChange={(event) => setPrecision(Number(event.target.value))}
+            >
+              <option value="5">{t("addData.polyline.precision5")}</option>
+              <option value="6">{t("addData.polyline.precision6")}</option>
+            </Select>
+          </div>
+        </div>
+
+        {/* Row 2: Delimiter & Output Geometry */}
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="polyline-delimiter">{t("addData.polyline.delimiterLabel")}</Label>
+            <Select
+              id="polyline-delimiter"
+              value={delimiterType}
+              onChange={(event) => setDelimiterType(event.target.value as DelimiterType)}
+            >
+              <option value="newline">{t("addData.polyline.delimNewline")}</option>
+              <option value="semicolon">{t("addData.polyline.delimSemicolon")}</option>
+              <option value="comma">{t("addData.polyline.delimComma")}</option>
+              <option value="tab">{t("addData.polyline.delimTab")}</option>
+              <option value="custom">{t("addData.polyline.delimCustom")}</option>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="polyline-output-geometry">{t("addData.polyline.outputGeometryLabel")}</Label>
+            <Select
+              id="polyline-output-geometry"
+              value={outputGeometry}
+              onChange={(event) => setOutputGeometry(event.target.value as GeometryOutputType)}
+            >
+              <option value="single">{t("addData.polyline.separateLines")}</option>
+              <option value="multi">{t("addData.polyline.multiLineString")}</option>
+            </Select>
+          </div>
+        </div>
+
+        {delimiterType === "custom" && (
+          <div className="space-y-1.5">
+            <Input
+              id="polyline-custom-delimiter"
+              placeholder={t("addData.polyline.customDelimPlaceholder")}
+              value={customDelimiter}
+              onChange={(e) => setCustomDelimiter(e.target.value)}
+            />
+          </div>
+        )}
+
+        {/* Unescape Backslashes checkbox */}
+        <div className="flex items-center gap-2 pt-0.5">
+          <input
+            type="checkbox"
+            id="polyline-unescape"
+            className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
+            checked={unescapeBackslashes}
+            onChange={(e) => setUnescapeBackslashes(e.target.checked)}
+          />
+          <Label htmlFor="polyline-unescape" className="cursor-pointer text-xs font-normal">
+            {t("addData.polyline.unescapeLabel")}
+          </Label>
+        </div>
+
+        {/* File Picker or Textarea */}
+        {polylineMode === "file" ? (
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" variant="outline" onClick={handleChooseFile}>
+                <FileUp className="me-2 h-3.5 w-3.5" />
+                {t("addData.common.chooseFile")}
+              </Button>
+              <span className="min-w-0 truncate text-xs text-muted-foreground">
+                {selectedFile
+                  ? fileNameFromPath(selectedFile.path)
+                  : t("addData.common.noFileSelected")}
+              </span>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            <Label htmlFor="polyline-text">{t("addData.polyline.textLabel")}</Label>
+            <textarea
+              id="polyline-text"
+              rows={4}
+              className="flex min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-xs ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 font-mono"
+              placeholder={t("addData.polyline.placeholder")}
+              value={rawText}
+              onChange={(event) => setRawText(event.target.value)}
+            />
+          </div>
+        )}
+
+        {/* Interactive Decoded Geometry Preview */}
+        {parsedData && (
+          <div className="space-y-2 rounded-md border bg-muted/30 p-2.5 text-xs">
+            <div className="flex items-center justify-between font-medium text-foreground">
+              <span>{t("addData.polyline.previewTitle")}</span>
+              <span className="text-[11px] text-muted-foreground">
+                {parsedData.linesCount} line(s) · {parsedData.totalPoints} points
+              </span>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 text-muted-foreground text-[11px]">
+              <div>
+                <span className="font-semibold text-foreground">{t("addData.polyline.previewLength")}: </span>
+                {parsedData.totalLengthKm < 1
+                  ? `${(parsedData.totalLengthKm * 1000).toFixed(0)} m`
+                  : `${parsedData.totalLengthKm.toFixed(2)} km`}
+              </div>
+              <div className="truncate">
+                <span className="font-semibold text-foreground">{t("addData.polyline.previewExtent")}: </span>
+                [{parsedData.bbox.map((v) => v.toFixed(3)).join(", ")}]
+              </div>
+            </div>
+
+            {/* Expandable Coordinate Inspector */}
+            <div className="border-t pt-1.5">
+              <button
+                type="button"
+                className="flex items-center justify-between w-full text-[11px] text-primary hover:underline"
+                onClick={() => setShowCoordinateTable(!showCoordinateTable)}
+              >
+                <span>{t("addData.polyline.previewCoordinates")}</span>
+                {showCoordinateTable ? (
+                  <ChevronUp className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+              </button>
+
+              {showCoordinateTable && (
+                <div className="mt-2 max-h-36 overflow-y-auto space-y-1.5 text-[11px] font-mono bg-background/80 p-1.5 rounded border">
+                  {parsedData.linesInfo.map((l) => (
+                    <div key={l.index} className="border-b pb-1 last:border-b-0">
+                      <div className="flex justify-between text-muted-foreground font-sans">
+                        <span className="font-semibold text-foreground">
+                          {t("addData.polyline.previewLine")} #{l.index}
+                        </span>
+                        <span>{l.pointsCount} {t("addData.polyline.previewPoints")} · {l.lengthKm.toFixed(2)} km</span>
+                      </div>
+                      <div className="flex gap-2 text-[10px] text-muted-foreground">
+                        <span>{t("addData.polyline.previewStart")}: [{l.start[0].toFixed(5)}, {l.start[1].toFixed(5)}]</span>
+                        <span>→</span>
+                        <span>{t("addData.polyline.previewEnd")}: [{l.end[0].toFixed(5)}, {l.end[1].toFixed(5)}]</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Sample data selector */}
+        {polylineMode === "paste" && (
+          <SampleDataSelect
+            samples={SAMPLE_POLYLINES.map((s) => ({
+              label: s.label,
+              value: s.value,
+            }))}
+            onSelect={(val) => {
+              const sample = SAMPLE_POLYLINES.find((s) => s.value === val);
+              if (sample) {
+                setPrecision(sample.precision);
+                setUnescapeBackslashes(sample.unescape ?? true);
+                setRawText(sample.value);
+              }
+            }}
+          />
+        )}
+      </div>
+    </AddDataSourceForm>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -1,7 +1,7 @@
 import { batchDecodePolylines, decodePolyline, unescapePolyline } from "@geolibre/core";
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import type { FeatureCollection, LineString, MultiLineString } from "geojson";
-import { ChevronDown, ChevronUp, FileUp, Info, MapPin } from "lucide-react";
+import { ChevronDown, ChevronUp, FileUp } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PolylineSource.tsx
@@ -4,6 +4,7 @@ import type { FeatureCollection, LineString, MultiLineString } from "geojson";
 import { ChevronDown, ChevronUp, FileUp } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { SAMPLE_POLYLINES } from "../../../../lib/polyline-samples";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
 import { createBaseLayer, errorMessage, fileNameFromPath, layerNameFromPath } from "../helpers";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
@@ -11,34 +12,6 @@ import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared
 export type PolylineMode = "paste" | "file";
 export type DelimiterType = "newline" | "semicolon" | "comma" | "tab" | "custom";
 export type GeometryOutputType = "single" | "multi";
-
-const SAMPLE_POLYLINES = [
-  {
-    key: "addData.polyline.sampleGoogle" as const,
-    value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
-    precision: 5,
-    unescape: true,
-  },
-  {
-    key: "addData.polyline.sampleValhalla" as const,
-    value: "_o`diA~gw}qC_pR_pR_pR_af@",
-    precision: 6,
-    unescape: true,
-  },
-  {
-    key: "addData.polyline.sampleEscaped" as const,
-    value:
-      "otnyWckdxrCnlAsyAv~JrjAriIkjHvkL_|BbkL~tCfc@_iIb}C?goDkdUj`Cs}IwGktMvjE{_L{w@k~CjiF_uH~qGgkZfzFoaI{nB_}DoPcjT{|J?{r@swGnaDsuCoAgsQrhGkxKsbOswQjfEwQrbJcp`@~bBn_@ffAofI{eDguKwkLwrKwzGkt\\krg@gfqAg|@{uKcwKocHsaC{fFsjF_g@_rBf|OwdHvB?",
-    precision: 5,
-    unescape: true,
-  },
-  {
-    key: "addData.polyline.sampleMultiLine" as const,
-    value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_ibE_seK_seK_seK\nmc_Ie}hV_c_@_c_@",
-    precision: 5,
-    unescape: true,
-  },
-];
 
 /** Haversine distance in kilometers between two [lon, lat] coordinates. */
 function haversineDistanceKm(c1: [number, number], c2: [number, number]): number {

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -16,6 +16,7 @@ export type AddDataKind =
   | "gdb"
   | "photos"
   | "mbtiles"
+  | "polyline"
   | "arcgis"
   | "postgres"
   | "iceberg"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -62,6 +62,7 @@ export function AddDataMenu({
     gdb: { onSelect: () => onSetAddDataKind("gdb") },
     photos: { onSelect: () => onSetAddDataKind("photos") },
     gpx: { onSelect: () => onSetAddDataKind("gpx") },
+    polyline: { onSelect: () => onSetAddDataKind("polyline") },
     mbtiles: { onSelect: () => onSetAddDataKind("mbtiles") },
     "osm-pbf": { onSelect: onOpenOsmPbfDialog, disabled: osmPbfBusy },
     xyz: { onSelect: () => onSetAddDataKind("xyz") },

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -261,6 +261,12 @@ export function ProcessingMenu({
                     <DropdownMenuItem onSelect={() => setVectorToolOpen("simplify")}>
                       {t("toolbar.vectorTool.simplify")}
                     </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setVectorToolOpen("decode-polyline")}>
+                      {t("toolbar.vectorTool.decodePolyline")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setVectorToolOpen("encode-polyline")}>
+                      {t("toolbar.vectorTool.encodePolyline")}
+                    </DropdownMenuItem>
                     <DropdownMenuItem onSelect={() => setVectorToolOpen("reproject")}>
                       {t("toolbar.vectorTool.reproject")}
                     </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -155,6 +155,8 @@ export const VECTOR_TOOL_COMMANDS: Array<{
   { kind: "dissolve", titleKey: "toolbar.vectorTool.dissolve" },
   { kind: "bounding-box", titleKey: "toolbar.vectorTool.boundingBox" },
   { kind: "simplify", titleKey: "toolbar.vectorTool.simplify" },
+  { kind: "decode-polyline", titleKey: "toolbar.vectorTool.decodePolyline" },
+  { kind: "encode-polyline", titleKey: "toolbar.vectorTool.encodePolyline" },
   { kind: "clip", titleKey: "toolbar.vectorTool.clip" },
   { kind: "intersection", titleKey: "toolbar.vectorTool.intersection" },
   { kind: "difference", titleKey: "toolbar.vectorTool.difference" },

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -129,6 +129,7 @@ import {
   formatAttributeValue,
   geojsonVectorSourceId,
   kmlExportErrorMessage,
+  layerSupportsPolylineExport,
   sanitizeExportFileName,
   shapefileFieldWarnings,
   type VectorExportFormat,
@@ -1773,6 +1774,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             <DropdownMenuItem onSelect={() => void exportLayer("csv")}>
               CSV (attributes only)
             </DropdownMenuItem>
+            {layer && layerSupportsPolylineExport(layer) && (
+              <DropdownMenuItem onSelect={() => void exportLayer("polyline")}>
+                Encoded Polyline
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
         {isEditing ? (

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1788,10 +1788,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             {layer && layerSupportsPolylineExport(layer) && (
               <>
                 <DropdownMenuItem onSelect={() => void exportLayer("polyline", 5)}>
-                  Encoded Polyline (precision 5)
+                  {t("layers.exportPolyline", { precision: 5 })}
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => void exportLayer("polyline", 6)}>
-                  Encoded Polyline (precision 6)
+                  {t("layers.exportPolyline", { precision: 6 })}
                 </DropdownMenuItem>
               </>
             )}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -998,7 +998,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     };
   };
 
-  const exportLayer = async (format: VectorExportFormat) => {
+  const exportLayer = async (format: VectorExportFormat, precision?: number) => {
     if (!layer?.geojson) return;
 
     try {
@@ -1011,7 +1011,18 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       }
 
       const baseName = sanitizeExportFileName(layer.name);
-      const savedPath = await exportVectorLayer(exportGeojson, format, baseName, layer.name);
+      const polylinePrecision =
+        precision ??
+        (typeof layer.metadata?.polylinePrecision === "number"
+          ? layer.metadata.polylinePrecision
+          : 5);
+      const savedPath = await exportVectorLayer(
+        exportGeojson,
+        format,
+        baseName,
+        layer.name,
+        polylinePrecision,
+      );
       // Surface Shapefile field-name limitations (10-char truncation and any
       // resulting collisions) only when a file was actually written; a null
       // path means the user cancelled the save dialog.
@@ -1775,9 +1786,14 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
               CSV (attributes only)
             </DropdownMenuItem>
             {layer && layerSupportsPolylineExport(layer) && (
-              <DropdownMenuItem onSelect={() => void exportLayer("polyline")}>
-                Encoded Polyline
-              </DropdownMenuItem>
+              <>
+                <DropdownMenuItem onSelect={() => void exportLayer("polyline", 5)}>
+                  Encoded Polyline (precision 5)
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => void exportLayer("polyline", 6)}>
+                  Encoded Polyline (precision 6)
+                </DropdownMenuItem>
+              </>
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -3966,14 +3966,14 @@ export function LayerPanel({
                                         void handleExportLayer(layer, "polyline", 5);
                                       }}
                                     >
-                                      Encoded Polyline (precision 5)
+                                      {t("layers.exportPolyline", { precision: 5 })}
                                     </DropdownMenuItem>
                                     <DropdownMenuItem
                                       onSelect={() => {
                                         void handleExportLayer(layer, "polyline", 6);
                                       }}
                                     >
-                                      Encoded Polyline (precision 6)
+                                      {t("layers.exportPolyline", { precision: 6 })}
                                     </DropdownMenuItem>
                                   </>
                                 )}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -219,6 +219,7 @@ import {
   exportVectorLayer,
   geojsonVectorSourceId,
   kmlExportErrorMessage,
+  layerSupportsPolylineExport,
   resolveLayerGeojson,
   sanitizeExportFileName,
   shapefileFieldWarnings,
@@ -3134,6 +3135,7 @@ export function LayerPanel({
             // Export writes the layer's GeoJSON features to disk; only
             // geojson-backed vector layers carry those features.
             const canExportLayer = layer.type === "geojson";
+            const canExportPolyline = canExportLayer && layerSupportsPolylineExport(layer);
             // Importing a style (Mapbox GL or SLD) only writes the layer's
             // vector symbology, so it applies to any vector-styled layer (local
             // GeoJSON and vector tiles), not just the export-capable GeoJSON
@@ -3951,6 +3953,15 @@ export function LayerPanel({
                                 >
                                   CSV (attributes only)
                                 </DropdownMenuItem>
+                                {canExportPolyline && (
+                                  <DropdownMenuItem
+                                    onSelect={() => {
+                                      void handleExportLayer(layer, "polyline");
+                                    }}
+                                  >
+                                    Encoded Polyline
+                                  </DropdownMenuItem>
+                                )}
                               </DropdownMenuSubContent>
                             </DropdownMenuSub>
                           )}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1579,7 +1579,7 @@ export function LayerPanel({
   );
 
   const handleExportLayer = useCallback(
-    async (layer: GeoLibreLayer, format: VectorExportFormat) => {
+    async (layer: GeoLibreLayer, format: VectorExportFormat, precision?: number) => {
       clearRefreshStatusTimer(layer.id);
       try {
         const geojson = await resolveLayerGeojson(
@@ -1604,11 +1604,17 @@ export function LayerPanel({
         const egressGeojson = layer.fieldVisibility
           ? excludeHiddenFieldsFromGeojson(geojson, layer.fieldVisibility)
           : geojson;
+        const polylinePrecision =
+          precision ??
+          (typeof layer.metadata?.polylinePrecision === "number"
+            ? layer.metadata.polylinePrecision
+            : 5);
         const savedPath = await exportVectorLayer(
           egressGeojson,
           format,
           sanitizeExportFileName(layer.name),
           layer.name,
+          polylinePrecision,
         );
         // A null path means the user cancelled the save dialog, so no note.
         if (savedPath !== null) {
@@ -3954,13 +3960,22 @@ export function LayerPanel({
                                   CSV (attributes only)
                                 </DropdownMenuItem>
                                 {canExportPolyline && (
-                                  <DropdownMenuItem
-                                    onSelect={() => {
-                                      void handleExportLayer(layer, "polyline");
-                                    }}
-                                  >
-                                    Encoded Polyline
-                                  </DropdownMenuItem>
+                                  <>
+                                    <DropdownMenuItem
+                                      onSelect={() => {
+                                        void handleExportLayer(layer, "polyline", 5);
+                                      }}
+                                    >
+                                      Encoded Polyline (precision 5)
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                      onSelect={() => {
+                                        void handleExportLayer(layer, "polyline", 6);
+                                      }}
+                                    >
+                                      Encoded Polyline (precision 6)
+                                    </DropdownMenuItem>
+                                  </>
                                 )}
                               </DropdownMenuSubContent>
                             </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -338,6 +338,10 @@
       "video": {
         "label": "Add Video Layer",
         "description": "Add a georeferenced video overlay by supplying an MP4 URL and four corner coordinates."
+      },
+      "polyline": {
+        "label": "Add Encoded Polyline Layer",
+        "description": "Import encoded polyline strings (Google, OSRM, Valhalla) from text or files as vector lines."
       }
     },
     "shared": {
@@ -768,6 +772,41 @@
       "bottomRight": "Bottom-right (lng, lat)",
       "bottomLeft": "Bottom-left (lng, lat)",
       "cornersNote": "The four corners georeference the video on the map. The video must be served over HTTPS and the host must allow cross-origin requests (CORS) for the frames to render."
+    },
+    "polyline": {
+      "defaultName": "Polyline",
+      "modePaste": "Paste text",
+      "modeFile": "Choose file",
+      "precisionLabel": "Precision",
+      "precision5": "5 (Google / OSRM)",
+      "precision6": "6 (Valhalla / Mapbox)",
+      "unescapeLabel": "Unescape backslashes (\\\\ to \\)",
+      "delimiterLabel": "Polyline delimiter",
+      "delimNewline": "Newline (default)",
+      "delimSemicolon": "Semicolon (;)",
+      "delimComma": "Comma (,)",
+      "delimTab": "Tab",
+      "delimCustom": "Custom delimiter",
+      "customDelimPlaceholder": "Custom delimiter (e.g. | or ---)",
+      "outputGeometryLabel": "Output geometry",
+      "separateLines": "Separate LineStrings",
+      "multiLineString": "Single MultiLineString",
+      "textLabel": "Encoded polyline string(s)",
+      "placeholder": "Paste encoded polyline string (e.g. _p~iF~ps|U_ulLnnqC_mqNvxq`@)...",
+      "previewInfo": "Decoded {{lines}} line(s) with {{points}} total coordinate points.",
+      "previewTitle": "Decoded Geometry Preview",
+      "previewExtent": "Extent",
+      "previewLength": "Length",
+      "previewCoordinates": "Inspect coordinates",
+      "previewLine": "Line",
+      "previewPoints": "points",
+      "previewStart": "Start",
+      "previewEnd": "End",
+      "errorFileMissing": "The selected file is empty or could not be read.",
+      "readError": "Could not read the polyline file.",
+      "errorChooseFile": "Please choose a polyline file to load.",
+      "errorEmptyInput": "Enter one or more encoded polyline strings.",
+      "errorNoValidLines": "No valid polyline coordinates could be decoded."
     },
     "netcdf": {
       "sampleLabel": "Air temperature",
@@ -2309,6 +2348,7 @@
       "delimitedText": "Delimited Text Layer",
       "photos": "Geotagged Photos",
       "gpx": "GPX Layer",
+      "polyline": "Encoded Polyline",
       "mbtiles": "MBTiles Layer",
       "xyz": "XYZ Layer",
       "wms": "WMS Layer",
@@ -2409,6 +2449,8 @@
       "dissolve": "Dissolve",
       "boundingBox": "Bounding box",
       "simplify": "Simplify",
+      "decodePolyline": "Decode polyline",
+      "encodePolyline": "Encode line to polyline",
       "clip": "Clip",
       "intersection": "Intersection",
       "difference": "Difference",
@@ -4713,6 +4755,46 @@
                 "meters": "Meters",
                 "miles": "Miles"
               }
+            }
+          }
+        },
+        "decode-polyline": {
+          "name": "Decode polyline",
+          "description": "Decode encoded polyline strings from an attribute field into a LineString vector layer",
+          "params": {
+            "layer": {
+              "label": "Input layer"
+            },
+            "field": {
+              "label": "Polyline field",
+              "description": "Attribute field containing the encoded polyline string"
+            },
+            "precision": {
+              "label": "Precision",
+              "options": {
+                "5": "5 (Google / OSRM)",
+                "6": "6 (Valhalla / Mapbox)"
+              }
+            }
+          }
+        },
+        "encode-polyline": {
+          "name": "Encode line to polyline",
+          "description": "Encode LineString and MultiLineString geometries into an encoded polyline attribute string",
+          "params": {
+            "layer": {
+              "label": "Input layer"
+            },
+            "precision": {
+              "label": "Precision",
+              "options": {
+                "5": "5 (Google / OSRM)",
+                "6": "6 (Valhalla / Mapbox)"
+              }
+            },
+            "targetField": {
+              "label": "Output field name",
+              "description": "Name of the attribute column to store encoded polylines (default: polyline)"
             }
           }
         },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -806,7 +806,13 @@
       "readError": "Could not read the polyline file.",
       "errorChooseFile": "Please choose a polyline file to load.",
       "errorEmptyInput": "Enter one or more encoded polyline strings.",
-      "errorNoValidLines": "No valid polyline coordinates could be decoded."
+      "errorNoValidLines": "No valid polyline coordinates could be decoded.",
+      "sampleGoogle": "Google / OSRM (precision 5)",
+      "sampleValhalla": "Valhalla / Mapbox (precision 6)",
+      "sampleEscaped": "Escaped backslashes (JSON string format)",
+      "sampleMultiLine": "Multi-line route batch (3 segments)",
+      "unitMeters": "{{value}} m",
+      "unitKm": "{{value}} km"
     },
     "netcdf": {
       "sampleLabel": "Air temperature",
@@ -6817,6 +6823,7 @@
     "exportedWithWarnings": "Layer exported. {{warnings}}",
     "exported": "Layer exported.",
     "exportLayerError": "Could not export this layer.",
+    "exportPolyline": "Encoded Polyline (precision {{precision}})",
     "refreshIntervals": {
       "off": "Off",
       "s15": "15 seconds",

--- a/apps/geolibre-desktop/src/lib/polyline-samples.ts
+++ b/apps/geolibre-desktop/src/lib/polyline-samples.ts
@@ -1,0 +1,57 @@
+/**
+ * Sample encoded polylines offered by the Add Encoded Polyline Layer dialog.
+ *
+ * Kept out of the dialog component so the samples can be decoded in a test:
+ * an encoded polyline is opaque, so a sample that silently decodes to garbage
+ * (or fails to decode at all) is invisible until someone loads it in the UI.
+ * `tests/polyline-samples.test.ts` decodes every entry with the precision and
+ * unescape settings the dialog applies when the sample is picked.
+ */
+export interface PolylineSample {
+  /** i18n key for the entry's label in the sample picker. */
+  key:
+    | "addData.polyline.sampleGoogle"
+    | "addData.polyline.sampleValhalla"
+    | "addData.polyline.sampleEscaped"
+    | "addData.polyline.sampleMultiLine";
+  /** The encoded text pasted into the textarea when this sample is picked. */
+  value: string;
+  /** Coordinate precision the sample is encoded at. */
+  precision: number;
+  /** Whether the dialog's "unescape backslashes" toggle is turned on. */
+  unescape?: boolean;
+}
+
+export const SAMPLE_POLYLINES: PolylineSample[] = [
+  {
+    key: "addData.polyline.sampleGoogle",
+    value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+    precision: 5,
+    unescape: true,
+  },
+  {
+    key: "addData.polyline.sampleValhalla",
+    value: "_o`diA~gw}qC_pR_pR_pR_af@",
+    precision: 6,
+    unescape: true,
+  },
+  {
+    // A San Francisco -> Monterey route whose encoding happens to contain a
+    // literal backslash, written here the way a JSON payload would carry it:
+    // doubled. The TypeScript source therefore holds four backslashes, which
+    // is two at runtime, which the dialog's unescape step collapses back to
+    // the one byte the decoder needs. Without that step the backslash pair
+    // truncates a varint and the decode fails, so this entry only works when
+    // "unescape" is on, which is exactly what it is here to demonstrate.
+    key: "addData.polyline.sampleEscaped",
+    value: "c|peFjaejV~ek@__\\\\~}d@ku|@~eiAcf[z_hA~kO",
+    precision: 5,
+    unescape: true,
+  },
+  {
+    key: "addData.polyline.sampleMultiLine",
+    value: "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_ibE_seK_seK_seK\nmc_Ie}hV_c_@_c_@",
+    precision: 5,
+    unescape: true,
+  },
+];

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -642,12 +642,38 @@ function parseGpxTextLayers(text: string, path: string): LoadedVectorLayer[] {
     }));
 }
 
+function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
+  if (!fc.features || fc.features.length === 0) return false;
+  for (const feature of fc.features) {
+    const geometry = feature.geometry;
+    if (!geometry) continue;
+    if (geometry.type === "LineString") {
+      for (const coord of geometry.coordinates) {
+        const [lon, lat] = coord;
+        if (!Number.isFinite(lon) || !Number.isFinite(lat) || lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+          return false;
+        }
+      }
+    } else if (geometry.type === "MultiLineString") {
+      for (const line of geometry.coordinates) {
+        for (const coord of line) {
+          const [lon, lat] = coord;
+          if (!Number.isFinite(lon) || !Number.isFinite(lat) || lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
 function parsePolylineFileLayers(text: string, path: string): LoadedVectorLayer[] {
   let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
-  if (fc.features.length === 0) {
+  if (!hasValidPolylineCoordinates(fc)) {
     fc = batchDecodePolylines(text, { precision: 6, unescape: true });
   }
-  if (fc.features.length === 0) {
+  if (!hasValidPolylineCoordinates(fc)) {
     throw new Error("No valid polyline coordinates could be decoded from this file.");
   }
   const baseName = pathWithoutExtension(browserSafeFileName(path)) || "Polyline";
@@ -2012,15 +2038,9 @@ async function loadBrowserVectorFile(
 
   if (extension === "polyline") {
     const text = await file.text();
-    let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
-    if (fc.features.length === 0) {
-      fc = batchDecodePolylines(text, { precision: 6, unescape: true });
-    }
-    if (fc.features.length === 0) {
-      throw new Error("No valid polyline coordinates could be decoded from this file.");
-    }
+    const [layer] = parsePolylineFileLayers(text, file.name);
     return {
-      data: fc,
+      data: layer.data,
       path: file.name,
     };
   }
@@ -2324,15 +2344,9 @@ async function loadTauriVectorFile(
   if (extension === "polyline") {
     try {
       const text = await readLocalFileText(path);
-      let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
-      if (fc.features.length === 0) {
-        fc = batchDecodePolylines(text, { precision: 6, unescape: true });
-      }
-      if (fc.features.length === 0) {
-        throw new Error("No valid polyline coordinates could be decoded from this file.");
-      }
+      const [layer] = parsePolylineFileLayers(text, path);
       return {
-        data: fc,
+        data: layer.data,
         path,
       };
     } catch (error) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -650,7 +650,14 @@ function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
     if (geometry.type === "LineString") {
       for (const coord of geometry.coordinates) {
         const [lon, lat] = coord;
-        if (!Number.isFinite(lon) || !Number.isFinite(lat) || lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+        if (
+          !Number.isFinite(lon) ||
+          !Number.isFinite(lat) ||
+          lon < -180 ||
+          lon > 180 ||
+          lat < -90 ||
+          lat > 90
+        ) {
           return false;
         }
       }
@@ -658,7 +665,14 @@ function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
       for (const line of geometry.coordinates) {
         for (const coord of line) {
           const [lon, lat] = coord;
-          if (!Number.isFinite(lon) || !Number.isFinite(lat) || lon < -180 || lon > 180 || lat < -90 || lat > 90) {
+          if (
+            !Number.isFinite(lon) ||
+            !Number.isFinite(lat) ||
+            lon < -180 ||
+            lon > 180 ||
+            lat < -90 ||
+            lat > 90
+          ) {
             return false;
           }
         }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -642,8 +642,15 @@ function parseGpxTextLayers(text: string, path: string): LoadedVectorLayer[] {
     }));
 }
 
+/**
+ * Checks whether a decoded polyline FeatureCollection contains valid, non-empty WGS84 coordinates.
+ *
+ * Rejects collections with no features or 0 total coordinates, non-finite values,
+ * or coordinate values falling outside the valid WGS84 domain ([-180, 180] lon, [-90, 90] lat).
+ */
 function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
   if (!fc.features || fc.features.length === 0) return false;
+  let totalPoints = 0;
   for (const feature of fc.features) {
     const geometry = feature.geometry;
     if (!geometry) continue;
@@ -660,6 +667,7 @@ function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
         ) {
           return false;
         }
+        totalPoints++;
       }
     } else if (geometry.type === "MultiLineString") {
       for (const line of geometry.coordinates) {
@@ -675,13 +683,23 @@ function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
           ) {
             return false;
           }
+          totalPoints++;
         }
       }
     }
   }
-  return true;
+  return totalPoints > 0;
 }
 
+/**
+ * Parses raw polyline text from a dropped/opened file into a vector layer.
+ *
+ * Encoded polyline format does not self-describe its precision factor. Auto-detection
+ * first attempts standard precision 5 (Google Maps / OSRM standard, factor 1e5).
+ * If precision 5 yields coordinates outside valid WGS84 bounds (which occurs when
+ * precision 6 data with latitude > 9° or longitude > 18° is scaled up by 10x),
+ * it falls back to precision 6 (Valhalla / Mapbox standard, factor 1e6).
+ */
 function parsePolylineFileLayers(text: string, path: string): LoadedVectorLayer[] {
   let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
   if (!hasValidPolylineCoordinates(fc)) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -699,6 +699,15 @@ function hasValidPolylineCoordinates(fc: FeatureCollection): boolean {
  * If precision 5 yields coordinates outside valid WGS84 bounds (which occurs when
  * precision 6 data with latitude > 9° or longitude > 18° is scaled up by 10x),
  * it falls back to precision 6 (Valhalla / Mapbox standard, factor 1e6).
+ *
+ * That bounds check only settles the cases it can: the two decodes of the same
+ * bytes differ by exactly a factor of 10, so whenever precision 5 lands in
+ * bounds precision 6 necessarily does too, and nothing in the data says which
+ * one the author meant. Precision-6 data close to the prime meridian and the
+ * equator (|lon| <= 18°, |lat| <= 9°) therefore imports at precision 5, ten
+ * times too large, with no error. Drag-and-drop has nowhere to ask, so it takes
+ * the more common of the two; Add Data → Encoded Polyline is the path with an
+ * explicit precision picker and a preview to check the result against.
  */
 function parsePolylineFileLayers(text: string, path: string): LoadedVectorLayer[] {
   let fc = batchDecodePolylines(text, { precision: 5, unescape: true });

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1,4 +1,5 @@
 import {
+  batchDecodePolylines,
   hasPathTraversal,
   isAbsoluteFilesystemPath,
   parseProject,
@@ -639,6 +640,24 @@ function parseGpxTextLayers(text: string, path: string): LoadedVectorLayer[] {
       name: `${baseName} ${layer.label}`,
       path,
     }));
+}
+
+function parsePolylineFileLayers(text: string, path: string): LoadedVectorLayer[] {
+  let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
+  if (fc.features.length === 0) {
+    fc = batchDecodePolylines(text, { precision: 6, unescape: true });
+  }
+  if (fc.features.length === 0) {
+    throw new Error("No valid polyline coordinates could be decoded from this file.");
+  }
+  const baseName = pathWithoutExtension(browserSafeFileName(path)) || "Polyline";
+  return [
+    {
+      data: fc,
+      name: baseName,
+      path,
+    },
+  ];
 }
 
 /** Delimited text formats the drag-and-drop / open path loads as points. */
@@ -1991,6 +2010,21 @@ async function loadBrowserVectorFile(
     };
   }
 
+  if (extension === "polyline") {
+    const text = await file.text();
+    let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
+    if (fc.features.length === 0) {
+      fc = batchDecodePolylines(text, { precision: 6, unescape: true });
+    }
+    if (fc.features.length === 0) {
+      throw new Error("No valid polyline coordinates could be decoded from this file.");
+    }
+    return {
+      data: fc,
+      path: file.name,
+    };
+  }
+
   // Deliberately NOT gated on `streamViaDuckDb`: `loadDuckDbVectorFile` has no
   // longitude/latitude column detection (that lives only in the GeoParquet
   // conversion path), so routing a plain lon/lat CSV to DuckDB fails with
@@ -2191,6 +2225,7 @@ async function tryLoadPickedNativeVectorPath(
     extension === "kml" ||
     extension === "kmz" ||
     extension === "gpx" ||
+    extension === "polyline" ||
     extension === "zip"
   ) {
     return undefined;
@@ -2283,6 +2318,26 @@ async function loadTauriVectorFile(
     } catch (error) {
       const detail = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`Could not read this GPX file. ${detail}`);
+    }
+  }
+
+  if (extension === "polyline") {
+    try {
+      const text = await readLocalFileText(path);
+      let fc = batchDecodePolylines(text, { precision: 5, unescape: true });
+      if (fc.features.length === 0) {
+        fc = batchDecodePolylines(text, { precision: 6, unescape: true });
+      }
+      if (fc.features.length === 0) {
+        throw new Error("No valid polyline coordinates could be decoded from this file.");
+      }
+      return {
+        data: fc,
+        path,
+      };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Unknown error";
+      throw new Error(`Could not read this Polyline file. ${detail}`);
     }
   }
 
@@ -3109,6 +3164,11 @@ export async function loadDroppedVectorFiles(
         continue;
       }
 
+      if (extension === "polyline") {
+        layers.push(...parsePolylineFileLayers(await file.text(), file.name));
+        continue;
+      }
+
       if (extension === "kmz") {
         try {
           layers.push(...(await loadKmzLayers(await file.arrayBuffer(), file.name, options)));
@@ -3388,6 +3448,15 @@ export async function loadDroppedVectorPaths(
           // "Unknown error" when the fs-plugin fallback fails.
           const detail = error instanceof Error ? error.message : String(error);
           throw new Error(`Could not read this GPX file. ${detail}`);
+        }
+        continue;
+      }
+      if (extension === "polyline") {
+        try {
+          layers.push(...parsePolylineFileLayers(await readLocalFileText(path), path));
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(`Could not read this Polyline file. ${detail}`);
         }
         continue;
       }

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -82,6 +82,12 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   { id: "gdb", section: "files", labelKey: "toolbar.item.gdbLayer", tier: "intermediate" },
   { id: "photos", section: "files", labelKey: "toolbar.layerType.photos", tier: "intermediate" },
   { id: "gpx", section: "files", labelKey: "toolbar.layerType.gpx", tier: "intermediate" },
+  {
+    id: "polyline",
+    section: "files",
+    labelKey: "toolbar.layerType.polyline",
+    tier: "intermediate",
+  },
   { id: "mbtiles", section: "files", labelKey: "toolbar.layerType.mbtiles", tier: "basic" },
   { id: "osm-pbf", section: "files", labelKey: "toolbar.item.osmPbfLayer", tier: "advanced" },
   // Web services

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -1,4 +1,4 @@
-import type { GeoLibreLayer } from "@geolibre/core";
+import { encodePolyline, type GeoLibreLayer } from "@geolibre/core";
 import { csvCell as quoteCsvCell } from "./csv";
 import type { FeatureCollection } from "geojson";
 import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
@@ -7,7 +7,7 @@ import { type BinaryVectorExportFormat, exportBinaryVectorLayer } from "./vector
 
 export { KmlCoordinateError, kmlExportErrorMessage } from "./vector-export-errors";
 
-type TextVectorExportFormat = "geojson" | "csv" | "kml";
+type TextVectorExportFormat = "geojson" | "csv" | "kml" | "polyline";
 
 export type VectorExportFormat = TextVectorExportFormat | BinaryVectorExportFormat;
 
@@ -37,6 +37,12 @@ const TEXT_EXPORT_FORMATS: Record<
     filterExtensions: ["kml"],
     label: "KML",
     mimeType: "application/vnd.google-earth.kml+xml",
+  },
+  polyline: {
+    extension: "polyline",
+    filterExtensions: ["polyline", "txt"],
+    label: "Encoded Polyline",
+    mimeType: "text/plain",
   },
 };
 
@@ -211,6 +217,59 @@ export function shapefileFieldWarnings(geojson: FeatureCollection): string[] {
   return warnings;
 }
 
+function geojsonToPolylineText(geojson: FeatureCollection, precision = 5): string {
+  const lines: string[] = [];
+  for (const feature of geojson.features) {
+    const geometry = feature.geometry;
+    if (!geometry) continue;
+    if (geometry.type === "LineString") {
+      const encoded = encodePolyline(geometry.coordinates as [number, number][], precision);
+      if (encoded) lines.push(encoded);
+    } else if (geometry.type === "MultiLineString") {
+      for (const lineCoords of geometry.coordinates) {
+        const encoded = encodePolyline(lineCoords as [number, number][], precision);
+        if (encoded) lines.push(encoded);
+      }
+    }
+  }
+  if (lines.length === 0) {
+    throw new Error(
+      "No LineString or MultiLineString geometries found to export as Encoded Polyline. Encoded Polyline export is only supported for line layers.",
+    );
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Whether a layer contains line geometries (LineString or MultiLineString)
+ * suitable for Encoded Polyline export. Returns false for points, polygons, or non-line layers.
+ */
+export function layerSupportsPolylineExport(layer: GeoLibreLayer): boolean {
+  if (layer.type !== "geojson") return false;
+  const rawType =
+    typeof layer.metadata?.geometryType === "string"
+      ? layer.metadata.geometryType.toLowerCase()
+      : null;
+  if (rawType === "line" || rawType === "linestring" || rawType === "multilinestring") {
+    return true;
+  }
+  if (
+    rawType === "point" ||
+    rawType === "multipoint" ||
+    rawType === "polygon" ||
+    rawType === "multipolygon"
+  ) {
+    return false;
+  }
+
+  const features = layer.geojson?.features;
+  if (!features || features.length === 0) return false;
+  return features.some((f) => {
+    const type = f.geometry?.type;
+    return type === "LineString" || type === "MultiLineString";
+  });
+}
+
 async function textExportContent(
   format: TextVectorExportFormat,
   geojson: FeatureCollection,
@@ -223,6 +282,8 @@ async function textExportContent(
       return geojsonToCsv(geojson);
     case "kml":
       return (await import("./kml-writer")).writeKml(geojson, documentName);
+    case "polyline":
+      return geojsonToPolylineText(geojson);
   }
 }
 
@@ -284,7 +345,7 @@ export async function exportVectorLayer(
   baseName: string,
   documentName = baseName,
 ): Promise<string | null> {
-  if (format === "geojson" || format === "csv" || format === "kml") {
+  if (format === "geojson" || format === "csv" || format === "kml" || format === "polyline") {
     return exportTextLayer(format, geojson, baseName, documentName);
   }
   return exportBinaryLayer(format, geojson, baseName, documentName);

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -274,6 +274,7 @@ async function textExportContent(
   format: TextVectorExportFormat,
   geojson: FeatureCollection,
   documentName: string,
+  precision = 5,
 ): Promise<string> {
   switch (format) {
     case "geojson":
@@ -283,7 +284,7 @@ async function textExportContent(
     case "kml":
       return (await import("./kml-writer")).writeKml(geojson, documentName);
     case "polyline":
-      return geojsonToPolylineText(geojson);
+      return geojsonToPolylineText(geojson, precision);
   }
 }
 
@@ -292,8 +293,9 @@ async function exportTextLayer(
   geojson: FeatureCollection,
   baseName: string,
   documentName: string,
+  precision = 5,
 ): Promise<string | null> {
-  const content = await textExportContent(format, geojson, documentName);
+  const content = await textExportContent(format, geojson, documentName, precision);
   const { extension, filterExtensions, label, mimeType } = TEXT_EXPORT_FORMATS[format];
   return saveTextFileWithFallback(content, {
     defaultName: `${baseName}.${extension}`,
@@ -344,9 +346,10 @@ export async function exportVectorLayer(
   format: VectorExportFormat,
   baseName: string,
   documentName = baseName,
+  precision = 5,
 ): Promise<string | null> {
   if (format === "geojson" || format === "csv" || format === "kml" || format === "polyline") {
-    return exportTextLayer(format, geojson, baseName, documentName);
+    return exportTextLayer(format, geojson, baseName, documentName, precision);
   }
   return exportBinaryLayer(format, geojson, baseName, documentName);
 }

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -210,8 +210,8 @@ export function shapefileFieldWarnings(geojson: FeatureCollection): string[] {
   if (fileFamily !== null && demoted > 0) {
     warnings.push(
       `${demoted} feature(s) whose geometry differs from the ${fileFamily} ` +
-      "type will be written without geometry (Shapefile allows one geometry " +
-      "type per file).",
+        "type will be written without geometry (Shapefile allows one geometry " +
+        "type per file).",
     );
   }
   return warnings;

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -210,8 +210,8 @@ export function shapefileFieldWarnings(geojson: FeatureCollection): string[] {
   if (fileFamily !== null && demoted > 0) {
     warnings.push(
       `${demoted} feature(s) whose geometry differs from the ${fileFamily} ` +
-        "type will be written without geometry (Shapefile allows one geometry " +
-        "type per file).",
+      "type will be written without geometry (Shapefile allows one geometry " +
+      "type per file).",
     );
   }
   return warnings;
@@ -270,7 +270,7 @@ export function layerSupportsPolylineExport(layer: GeoLibreLayer): boolean {
   });
   const hasNonLine = features.some((f) => {
     const type = f.geometry?.type;
-    return type != null && type !== "LineString" && type !== "MultiLineString";
+    return type !== "LineString" && type !== "MultiLineString";
   });
 
   return hasLine && !hasNonLine;

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -242,7 +242,7 @@ function geojsonToPolylineText(geojson: FeatureCollection, precision = 5): strin
 
 /**
  * Whether a layer contains line geometries (LineString or MultiLineString)
- * suitable for Encoded Polyline export. Returns false for points, polygons, or non-line layers.
+ * suitable for Encoded Polyline export. Returns false for points, polygons, or mixed layers.
  */
 export function layerSupportsPolylineExport(layer: GeoLibreLayer): boolean {
   if (layer.type !== "geojson") return false;
@@ -250,9 +250,6 @@ export function layerSupportsPolylineExport(layer: GeoLibreLayer): boolean {
     typeof layer.metadata?.geometryType === "string"
       ? layer.metadata.geometryType.toLowerCase()
       : null;
-  if (rawType === "line" || rawType === "linestring" || rawType === "multilinestring") {
-    return true;
-  }
   if (
     rawType === "point" ||
     rawType === "multipoint" ||
@@ -263,11 +260,20 @@ export function layerSupportsPolylineExport(layer: GeoLibreLayer): boolean {
   }
 
   const features = layer.geojson?.features;
-  if (!features || features.length === 0) return false;
-  return features.some((f) => {
+  if (!features || features.length === 0) {
+    return rawType === "line" || rawType === "linestring" || rawType === "multilinestring";
+  }
+
+  const hasLine = features.some((f) => {
     const type = f.geometry?.type;
     return type === "LineString" || type === "MultiLineString";
   });
+  const hasNonLine = features.some((f) => {
+    const type = f.geometry?.type;
+    return type != null && type !== "LineString" && type !== "MultiLineString";
+  });
+
+  return hasLine && !hasNonLine;
 }
 
 async function textExportContent(

--- a/docs/python.md
+++ b/docs/python.md
@@ -236,6 +236,7 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `add_flatgeobuf(data, name=, **style)` | Add a FlatGeobuf dataset (URL or local file). |
 | `add_shp(data, name=, **style)` | Add a Shapefile (zipped URL or local `.shp`). |
 | `add_kml(data, name=, **style)` / `add_gpkg(data, name=, layer=None, **style)` | Add KML/KMZ or GeoPackage data. |
+| `add_polyline(polyline, name="Polyline", precision=5, **style)` | Add an Encoded Polyline layer from a string or list of strings (precision 5 or 6). |
 | `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add a vector tile layer from a TileJSON endpoint. |
 | `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |

--- a/docs/user-guide/adding-data.md
+++ b/docs/user-guide/adding-data.md
@@ -13,6 +13,7 @@ To collect supported dataset links from a catalog or other webpage and open seve
 | **Vector Layer** | Opens the Add Vector panel (backed by `maplibre-gl-vector`). Loads GeoJSON, GeoParquet, FlatGeobuf, zipped Shapefile, GeoPackage, KML/KMZ, GML, and other vector formats from a file or URL. |
 | **Raster Layer** | Opens the Add Raster panel (backed by `maplibre-gl-raster`). Loads GeoTIFF and Cloud-Optimized GeoTIFF (COG) from a file or URL. |
 | **Delimited Text Layer** | Loads CSV/TSV from a file or URL, using longitude and latitude columns to build point features, or by geocoding one or more address columns (see [Geocoding](data-integrations.md#geocoding)). |
+| **Encoded Polyline** | Loads Google (precision 5) or Valhalla/Mapbox (precision 6) encoded polyline strings from pasted text or uploaded text files. |
 | **GPX Layer** | Loads a GPX file or URL and splits it into separate waypoint, track, and route layers. |
 | **MBTiles Layer** | Loads a local MBTiles tile archive (desktop app). |
 

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -104,6 +104,8 @@ GeoLibre's own tools, under **Processing → GeoLibre Toolbox**.
 | **Regular grid** | Generate a rectangular grid (fishnet) over the map view, a layer's extent, or a manual bounding box. |
 | **Voronoi / Delaunay** | Build a Voronoi diagram (one polygon per point, clipped to the points' extent) or a Delaunay triangulation from a point layer. |
 | **Cell-site coverage** | Build antenna sector polygons from point sites using azimuth, radius, and beamwidth read from fields or fixed values. |
+| **Decode polyline** | Decode encoded polyline strings (precision 5 or 6) from an attribute field into a LineString vector layer. |
+| **Encode line to polyline** | Encode LineString and MultiLineString geometries into an encoded polyline string stored in a new attribute field. |
 
 **Overlay**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4959,9 +4959,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4979,9 +4976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4999,9 +4993,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5019,9 +5010,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5039,9 +5027,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5059,9 +5044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5079,9 +5061,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5099,9 +5078,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5119,9 +5095,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5145,9 +5118,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5171,9 +5141,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5197,9 +5164,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5223,9 +5187,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5249,9 +5210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5275,9 +5233,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5301,9 +5256,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7869,9 +7821,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7889,9 +7838,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7909,9 +7855,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7929,9 +7872,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7949,9 +7889,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7969,9 +7906,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22225,9 +22159,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22249,9 +22180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22273,9 +22201,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -22297,9 +22222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export * from "./geojson-z";
 export * from "./color-ramp";
 export * from "./paths";
 export * from "./routing";
+export * from "./polyline";
 export * from "./vector-color";
 export * from "./expressions";
 export * from "./external-native-paint";

--- a/packages/core/src/polyline.ts
+++ b/packages/core/src/polyline.ts
@@ -27,10 +27,7 @@ import type {
  */
 export function unescapePolyline(str: string): string {
   if (!str || typeof str !== "string") return "";
-  return str
-    .replace(/\\\\/g, "\\")
-    .replace(/\\"/g, '"')
-    .replace(/\\'/g, "'");
+  return str.replace(/\\\\/g, "\\").replace(/\\"/g, '"').replace(/\\'/g, "'");
 }
 
 /**

--- a/packages/core/src/polyline.ts
+++ b/packages/core/src/polyline.ts
@@ -30,10 +30,7 @@ export function unescapePolyline(str: string): string {
   return str
     .replace(/\\\\/g, "\\")
     .replace(/\\"/g, '"')
-    .replace(/\\'/g, "'")
-    .replace(/\\n/g, "\n")
-    .replace(/\\r/g, "\r")
-    .replace(/\\t/g, "\t");
+    .replace(/\\'/g, "'");
 }
 
 /**

--- a/packages/core/src/polyline.ts
+++ b/packages/core/src/polyline.ts
@@ -1,0 +1,301 @@
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  LineString,
+  MultiLineString,
+} from "geojson";
+
+/**
+ * Pure TypeScript Google Encoded Polyline algorithm codec.
+ *
+ * Supports arbitrary precision:
+ * - precision = 5: Google Maps standard, OSRM, HERE (factor 1e5, ~1.1m precision)
+ * - precision = 6: Valhalla, Mapbox, Open Source Routing Machine 6 (factor 1e6, ~0.11m precision)
+ *
+ * Coordinates are represented as `[lon, lat]` pairs in GeoJSON format.
+ */
+
+/**
+ * Unescapes backslashes in a polyline string.
+ *
+ * When polyline strings are copied from JSON payloads, log files, or source code,
+ * backslashes are frequently double-escaped as `\\` or formatted with escape sequences.
+ *
+ * @param str - Input string with potentially escaped backslashes.
+ * @returns Cleaned polyline string.
+ */
+export function unescapePolyline(str: string): string {
+  if (!str || typeof str !== "string") return "";
+  return str
+    .replace(/\\\\/g, "\\")
+    .replace(/\\"/g, '"')
+    .replace(/\\'/g, "'")
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "\r")
+    .replace(/\\t/g, "\t");
+}
+
+/**
+ * Decodes an encoded polyline string into an array of `[lon, lat]` coordinates.
+ *
+ * @param encoded - The ASCII-encoded polyline string.
+ * @param precision - Number of decimal digits (default: 5).
+ * @param unescape - Whether to unescape double-escaped backslashes before decoding (default: false).
+ * @returns Array of `[lon, lat]` coordinate pairs in GeoJSON order.
+ */
+export function decodePolyline(
+  encoded: string,
+  precision = 5,
+  unescape = false,
+): [number, number][] {
+  if (!encoded || typeof encoded !== "string") return [];
+  const cleanEncoded = unescape ? unescapePolyline(encoded) : encoded;
+  const factor = 10 ** precision;
+  const len = cleanEncoded.length;
+  const coordinates: [number, number][] = [];
+  let index = 0;
+  let lat = 0;
+  let lon = 0;
+
+  while (index < len) {
+    let shift = 0;
+    let result = 0;
+    let byte: number;
+
+    // Decode latitude delta
+    do {
+      if (index >= len) return coordinates;
+      byte = cleanEncoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+
+    // Unsigned right shift (>>>) for 32-bit safe zigzag decoding
+    lat += result & 1 ? ~(result >>> 1) : result >>> 1;
+
+    shift = 0;
+    result = 0;
+
+    // Decode longitude delta
+    do {
+      if (index >= len) return coordinates;
+      byte = cleanEncoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+
+    lon += result & 1 ? ~(result >>> 1) : result >>> 1;
+
+    coordinates.push([lon / factor, lat / factor]);
+  }
+
+  return coordinates;
+}
+
+/**
+ * Encodes a single integer delta value into polyline character chunks.
+ */
+function encodeSignedNumber(num: number): string {
+  let sgnNum = num < 0 ? ~(num << 1) : num << 1;
+  let out = "";
+  while (sgnNum >= 0x20) {
+    out += String.fromCharCode((0x20 | (sgnNum & 0x1f)) + 63);
+    sgnNum >>>= 5;
+  }
+  out += String.fromCharCode(sgnNum + 63);
+  return out;
+}
+
+/**
+ * Encodes an array of `[lon, lat]` coordinates into a Google Encoded Polyline string.
+ *
+ * @param coordinates - Array of `[lon, lat]` coordinate pairs.
+ * @param precision - Number of decimal digits (default: 5).
+ * @returns The encoded polyline string.
+ */
+export function encodePolyline(coordinates: [number, number][], precision = 5): string {
+  if (!Array.isArray(coordinates) || coordinates.length === 0) return "";
+  const factor = 10 ** precision;
+  let output = "";
+  let prevLat = 0;
+  let prevLon = 0;
+
+  for (const [lon, lat] of coordinates) {
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) continue;
+    const roundLat = Math.round(lat * factor);
+    const roundLon = Math.round(lon * factor);
+
+    const deltaLat = roundLat - prevLat;
+    const deltaLon = roundLon - prevLon;
+
+    output += encodeSignedNumber(deltaLat);
+    output += encodeSignedNumber(deltaLon);
+
+    prevLat = roundLat;
+    prevLon = roundLon;
+  }
+
+  return output;
+}
+
+/**
+ * Decodes an encoded polyline string into a GeoJSON `Feature<LineString>`.
+ *
+ * @param encoded - The polyline string.
+ * @param precision - Coordinate precision (default: 5).
+ * @param properties - Optional feature properties.
+ * @returns A GeoJSON LineString Feature.
+ */
+export function polylineStrToGeoJSON(
+  encoded: string,
+  precision = 5,
+  properties: GeoJsonProperties = {},
+): Feature<LineString> {
+  return {
+    type: "Feature",
+    properties: { ...properties },
+    geometry: {
+      type: "LineString",
+      coordinates: decodePolyline(encoded, precision),
+    },
+  };
+}
+
+/**
+ * Encodes a GeoJSON LineString, MultiLineString, Feature, or FeatureCollection into encoded polyline string(s).
+ *
+ * @param geojson - The GeoJSON input geometry or feature.
+ * @param precision - Coordinate precision (default: 5).
+ * @returns An encoded polyline string for LineString, or an array of strings for MultiLineString / FeatureCollection.
+ */
+export function geoJSONToPolylineStr(
+  geojson:
+    | LineString
+    | MultiLineString
+    | Feature<LineString | MultiLineString>
+    | FeatureCollection<LineString | MultiLineString>,
+  precision = 5,
+): string | string[] {
+  if (!geojson) return "";
+
+  // Handle Feature wrapper
+  if (geojson.type === "Feature") {
+    return geoJSONToPolylineStr(geojson.geometry, precision);
+  }
+
+  // Handle FeatureCollection
+  if (geojson.type === "FeatureCollection") {
+    const results: string[] = [];
+    for (const feature of geojson.features) {
+      const res = geoJSONToPolylineStr(feature.geometry, precision);
+      if (Array.isArray(res)) results.push(...res);
+      else if (res) results.push(res);
+    }
+    return results;
+  }
+
+  // Handle LineString
+  if (geojson.type === "LineString") {
+    return encodePolyline(geojson.coordinates as [number, number][], precision);
+  }
+
+  // Handle MultiLineString
+  if (geojson.type === "MultiLineString") {
+    return geojson.coordinates.map((lineCoords) =>
+      encodePolyline(lineCoords as [number, number][], precision),
+    );
+  }
+
+  return "";
+}
+
+export interface PolylineBatchOptions {
+  /** Coordinate precision (default: 5) */
+  precision?: number;
+  /** Whether to unescape `\\` backslashes (default: true) */
+  unescape?: boolean;
+  /** Custom delimiter string or RegExp separating individual polylines (default: newline) */
+  delimiter?: string | RegExp;
+  /** Whether to merge lines into a single MultiLineString feature (default: false) */
+  asMultiLine?: boolean;
+  /** Optional base properties to assign to output features */
+  baseProperties?: GeoJsonProperties;
+}
+
+/**
+ * Parses and batch-decodes multiple polylines from a text block or file content.
+ *
+ * @param input - Multiline string or delimited text containing encoded polylines.
+ * @param options - Decoding and parsing configuration.
+ * @returns A FeatureCollection containing LineString (or MultiLineString) features.
+ */
+export function batchDecodePolylines(
+  input: string,
+  options: PolylineBatchOptions = {},
+): FeatureCollection<LineString | MultiLineString> {
+  if (!input || typeof input !== "string") {
+    return { type: "FeatureCollection", features: [] };
+  }
+
+  const {
+    precision = 5,
+    unescape = true,
+    delimiter = /\r?\n/,
+    asMultiLine = false,
+    baseProperties = {},
+  } = options;
+
+  const rawChunks = input.split(delimiter);
+  const validLineCoords: [number, number][][] = [];
+  const features: Feature<LineString>[] = [];
+
+  for (let i = 0; i < rawChunks.length; i++) {
+    const raw = rawChunks[i].trim();
+    if (!raw) continue;
+    // Strip optional surrounding quotes (e.g. from CSV or JSON extract)
+    const cleaned = raw.replace(/^["']|["']$/g, "").trim();
+    if (!cleaned) continue;
+
+    const coords = decodePolyline(cleaned, precision, unescape);
+    if (coords.length >= 2) {
+      validLineCoords.push(coords);
+      features.push({
+        type: "Feature",
+        properties: {
+          ...baseProperties,
+          line_index: features.length + 1,
+          point_count: coords.length,
+        },
+        geometry: {
+          type: "LineString",
+          coordinates: coords,
+        },
+      });
+    }
+  }
+
+  if (asMultiLine && validLineCoords.length > 0) {
+    const multiFeature: Feature<MultiLineString> = {
+      type: "Feature",
+      properties: {
+        ...baseProperties,
+        line_count: validLineCoords.length,
+        point_count: validLineCoords.reduce((acc, c) => acc + c.length, 0),
+      },
+      geometry: {
+        type: "MultiLineString",
+        coordinates: validLineCoords,
+      },
+    };
+    return {
+      type: "FeatureCollection",
+      features: [multiFeature],
+    };
+  }
+
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+}

--- a/packages/core/src/polyline.ts
+++ b/packages/core/src/polyline.ts
@@ -30,20 +30,29 @@ export function unescapePolyline(str: string): string {
   return str.replace(/\\\\/g, "\\").replace(/\\"/g, '"').replace(/\\'/g, "'");
 }
 
+export interface PolylineDecodeResult {
+  coordinates: [number, number][];
+  complete: boolean;
+}
+
 /**
- * Decodes an encoded polyline string into an array of `[lon, lat]` coordinates.
+ * Decodes an encoded polyline string into an array of `[lon, lat]` coordinates,
+ * along with a `complete` flag indicating whether the entire string was consumed
+ * as complete coordinate pairs without truncation or malformed characters.
  *
  * @param encoded - The ASCII-encoded polyline string.
  * @param precision - Number of decimal digits (default: 5).
  * @param unescape - Whether to unescape double-escaped backslashes before decoding (default: false).
- * @returns Array of `[lon, lat]` coordinate pairs in GeoJSON order.
+ * @returns Object with decoded `coordinates` and `complete` boolean status.
  */
-export function decodePolyline(
+export function decodePolylineDetailed(
   encoded: string,
   precision = 5,
   unescape = false,
-): [number, number][] {
-  if (!encoded || typeof encoded !== "string") return [];
+): PolylineDecodeResult {
+  if (!encoded || typeof encoded !== "string") {
+    return { coordinates: [], complete: true };
+  }
   const cleanEncoded = unescape ? unescapePolyline(encoded) : encoded;
   const factor = 10 ** precision;
   const len = cleanEncoded.length;
@@ -58,12 +67,20 @@ export function decodePolyline(
     let byte: number;
 
     // Decode latitude delta
+    let latComplete = false;
     do {
-      if (index >= len) return coordinates;
+      if (index >= len) return { coordinates, complete: false };
       byte = cleanEncoded.charCodeAt(index++) - 63;
+      if (byte < 0 || byte > 63) return { coordinates, complete: false };
       result |= (byte & 0x1f) << shift;
       shift += 5;
+      if (byte < 0x20) {
+        latComplete = true;
+        break;
+      }
     } while (byte >= 0x20);
+
+    if (!latComplete) return { coordinates, complete: false };
 
     // Unsigned right shift (>>>) for 32-bit safe zigzag decoding
     lat += result & 1 ? ~(result >>> 1) : result >>> 1;
@@ -72,19 +89,43 @@ export function decodePolyline(
     result = 0;
 
     // Decode longitude delta
+    let lonComplete = false;
     do {
-      if (index >= len) return coordinates;
+      if (index >= len) return { coordinates, complete: false };
       byte = cleanEncoded.charCodeAt(index++) - 63;
+      if (byte < 0 || byte > 63) return { coordinates, complete: false };
       result |= (byte & 0x1f) << shift;
       shift += 5;
+      if (byte < 0x20) {
+        lonComplete = true;
+        break;
+      }
     } while (byte >= 0x20);
+
+    if (!lonComplete) return { coordinates, complete: false };
 
     lon += result & 1 ? ~(result >>> 1) : result >>> 1;
 
     coordinates.push([lon / factor, lat / factor]);
   }
 
-  return coordinates;
+  return { coordinates, complete: true };
+}
+
+/**
+ * Decodes an encoded polyline string into an array of `[lon, lat]` coordinates.
+ *
+ * @param encoded - The ASCII-encoded polyline string.
+ * @param precision - Number of decimal digits (default: 5).
+ * @param unescape - Whether to unescape double-escaped backslashes before decoding (default: false).
+ * @returns Array of `[lon, lat]` coordinate pairs in GeoJSON order.
+ */
+export function decodePolyline(
+  encoded: string,
+  precision = 5,
+  unescape = false,
+): [number, number][] {
+  return decodePolylineDetailed(encoded, precision, unescape).coordinates;
 }
 
 /**

--- a/packages/core/src/polyline.ts
+++ b/packages/core/src/polyline.ts
@@ -298,8 +298,9 @@ export function batchDecodePolylines(
     const cleaned = raw.replace(/^["']|["']$/g, "").trim();
     if (!cleaned) continue;
 
-    const coords = decodePolyline(cleaned, precision, unescape);
-    if (coords.length >= 2) {
+    const decodeResult = decodePolylineDetailed(cleaned, precision, unescape);
+    if (decodeResult.complete && decodeResult.coordinates.length >= 2) {
+      const coords = decodeResult.coordinates;
       validLineCoords.push(coords);
       features.push({
         type: "Feature",

--- a/packages/core/src/polyline.ts
+++ b/packages/core/src/polyline.ts
@@ -72,6 +72,9 @@ export function decodePolylineDetailed(
       if (index >= len) return { coordinates, complete: false };
       byte = cleanEncoded.charCodeAt(index++) - 63;
       if (byte < 0 || byte > 63) return { coordinates, complete: false };
+      if (shift > 30 || (shift === 30 && (byte & 0x1f) > 0x03)) {
+        return { coordinates, complete: false };
+      }
       result |= (byte & 0x1f) << shift;
       shift += 5;
       if (byte < 0x20) {
@@ -94,6 +97,9 @@ export function decodePolylineDetailed(
       if (index >= len) return { coordinates, complete: false };
       byte = cleanEncoded.charCodeAt(index++) - 63;
       if (byte < 0 || byte > 63) return { coordinates, complete: false };
+      if (shift > 30 || (shift === 30 && (byte & 0x1f) > 0x03)) {
+        return { coordinates, complete: false };
+      }
       result |= (byte & 0x1f) << shift;
       shift += 5;
       if (byte < 0x20) {

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -1,4 +1,5 @@
 import type { Feature, FeatureCollection, LineString, MultiPolygon, Polygon } from "geojson";
+import { decodePolyline } from "./polyline";
 import { getRuntimeEnvironment } from "./runtime-env";
 
 /**
@@ -254,53 +255,6 @@ export function buildRouteRequest(points: RoutingPoint[], mode: RoutingMode): Ro
   };
 }
 
-/**
- * Decodes an encoded-polyline string into `[lon, lat]` coordinate pairs.
- * Valhalla encodes route geometry with 6 digits of precision (factor 1e6),
- * unlike Google's 5-digit polylines, so `precision` defaults to 6.
- *
- * @param encoded - The encoded polyline string.
- * @param precision - Number of decimal digits the encoder used (6 for Valhalla).
- * @returns The decoded `[lon, lat]` coordinates in order.
- */
-export function decodePolyline(encoded: string, precision = 6): [number, number][] {
-  const factor = 10 ** precision;
-  const len = encoded.length;
-  const coordinates: [number, number][] = [];
-  let index = 0;
-  let lat = 0;
-  let lon = 0;
-  while (index < len) {
-    let shift = 0;
-    let result = 0;
-    let byte: number;
-    do {
-      // Truncated input: stop cleanly rather than reading NaN past the end and
-      // pushing a garbage coordinate.
-      if (index >= len) return coordinates;
-      byte = encoded.charCodeAt(index++) - 63;
-      result |= (byte & 0x1f) << shift;
-      shift += 5;
-    } while (byte >= 0x20);
-    // Unsigned shift (>>>) so the zigzag decode is correct even if the
-    // accumulator's bit 31 is set, rather than sign-extending.
-    lat += result & 1 ? ~(result >>> 1) : result >>> 1;
-
-    shift = 0;
-    result = 0;
-    do {
-      if (index >= len) return coordinates;
-      byte = encoded.charCodeAt(index++) - 63;
-      result |= (byte & 0x1f) << shift;
-      shift += 5;
-    } while (byte >= 0x20);
-    lon += result & 1 ? ~(result >>> 1) : result >>> 1;
-
-    coordinates.push([lon / factor, lat / factor]);
-  }
-  return coordinates;
-}
-
 type RouteLeg = {
   shape?: string;
   summary?: { time?: number; length?: number };
@@ -335,7 +289,7 @@ export function routeResponseToFeatures(
   const out: Feature<LineString, RouteFeatureProps>[] = [];
   legs.forEach((leg, index) => {
     if (typeof leg?.shape !== "string") return;
-    const coordinates = decodePolyline(leg.shape);
+    const coordinates = decodePolyline(leg.shape, 6);
     if (coordinates.length < 2) return;
     const from = points[index];
     const to = points[index + 1];

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -141,6 +141,8 @@ export type VectorToolKind =
   | "trajectory-speed"
   | "detect-stops"
   | "space-time-proximity"
+  | "decode-polyline"
+  | "encode-polyline"
   | "check-validity"
   | "fix-geometries"
   | "check-topology-rules"

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -10,6 +10,8 @@ export {
   getVectorTool,
   resolveVectorRerun,
   matchFeaturesByLocation,
+  decodePolylineTool,
+  encodePolylineTool,
   MAX_CLIENT_PAIRS,
   SELECT_LOCATION_PREDICATES,
   type LocationMatches,

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -28,11 +28,13 @@ import type {
   Point,
   Polygon,
   Position,
+  MultiLineString,
   MultiPolygon,
 } from "geojson";
 import {
   bodyLengthToEarth,
   decodePolyline,
+  decodePolylineDetailed,
   earthLengthToBody,
   encodePolyline,
   getActiveBodyRadiusRatio,
@@ -2815,7 +2817,13 @@ export const decodePolylineTool: ProcessingAlgorithm = {
         }
         if (!valid) break;
 
-        const coords = decodePolyline(part, precision);
+        const decodeResult = decodePolylineDetailed(part, precision);
+        if (!decodeResult.complete) {
+          valid = false;
+          break;
+        }
+
+        const coords = decodeResult.coordinates;
         if (coords.length < 2) {
           valid = false;
           break;

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -2793,7 +2793,10 @@ export const decodePolylineTool: ProcessingAlgorithm = {
         continue;
       }
       const val = rawVal.trim();
-      const parts = val.split(";").map((p) => p.trim()).filter(Boolean);
+      const parts = val
+        .split(";")
+        .map((p) => p.trim())
+        .filter(Boolean);
       if (parts.length === 0) {
         skipped++;
         continue;

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -2744,7 +2744,8 @@ export const spaceTimeProximityTool: ProcessingAlgorithm = {
 export const decodePolylineTool: ProcessingAlgorithm = {
   id: "decode-polyline",
   name: "Decode polyline",
-  description: "Decode encoded polyline strings from an attribute field into a LineString vector layer",
+  description:
+    "Decode encoded polyline strings from an attribute field into a LineString vector layer",
   group: "Geometry",
   parameters: [
     {
@@ -2817,7 +2818,8 @@ export const decodePolylineTool: ProcessingAlgorithm = {
 export const encodePolylineTool: ProcessingAlgorithm = {
   id: "encode-polyline",
   name: "Encode line to polyline",
-  description: "Encode LineString and MultiLineString geometries into an encoded polyline attribute string",
+  description:
+    "Encode LineString and MultiLineString geometries into an encoded polyline attribute string",
   group: "Geometry",
   parameters: [
     {

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -2783,34 +2783,73 @@ export const decodePolylineTool: ProcessingAlgorithm = {
     const rawPrecision = ctx.parameters.precision;
     const precision = rawPrecision === "6" || rawPrecision === 6 ? 6 : 5;
 
-    const outFeatures: Feature<LineString>[] = [];
+    const outFeatures: Feature<LineString | MultiLineString>[] = [];
     let skipped = 0;
 
     for (const feature of fc.features) {
-      const val = feature.properties?.[field];
-      if (typeof val !== "string" || !val.trim()) {
+      const rawVal = feature.properties?.[field];
+      if (typeof rawVal !== "string" || !rawVal.trim()) {
         skipped++;
         continue;
       }
-      const coords = decodePolyline(val.trim(), precision);
-      if (coords.length < 2) {
+      const val = rawVal.trim();
+      const parts = val.split(";").map((p) => p.trim()).filter(Boolean);
+      if (parts.length === 0) {
         skipped++;
         continue;
       }
-      outFeatures.push({
-        type: "Feature",
-        properties: { ...(feature.properties ?? {}) },
-        geometry: {
-          type: "LineString",
-          coordinates: coords,
-        },
-      });
+
+      let valid = true;
+      const multiCoords: [number, number][][] = [];
+
+      for (const part of parts) {
+        for (let i = 0; i < part.length; i++) {
+          const code = part.charCodeAt(i);
+          if (code < 63 || code > 126) {
+            valid = false;
+            break;
+          }
+        }
+        if (!valid) break;
+
+        const coords = decodePolyline(part, precision);
+        if (coords.length < 2) {
+          valid = false;
+          break;
+        }
+        multiCoords.push(coords);
+      }
+
+      if (!valid || multiCoords.length === 0) {
+        skipped++;
+        continue;
+      }
+
+      if (multiCoords.length === 1) {
+        outFeatures.push({
+          type: "Feature",
+          properties: { ...(feature.properties ?? {}) },
+          geometry: {
+            type: "LineString",
+            coordinates: multiCoords[0],
+          },
+        });
+      } else {
+        outFeatures.push({
+          type: "Feature",
+          properties: { ...(feature.properties ?? {}) },
+          geometry: {
+            type: "MultiLineString",
+            coordinates: multiCoords,
+          },
+        });
+      }
     }
 
     if (skipped > 0) {
       ctx.log(`Skipped ${skipped} feature(s) with missing or invalid polyline string`);
     }
-    ctx.log(`Decoded ${outFeatures.length} LineString feature(s) from "${field}"`);
+    ctx.log(`Decoded ${outFeatures.length} line feature(s) from "${field}"`);
     ctx.addResultLayer?.("Decoded polylines", featureCollection(outFeatures));
   },
 };

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -32,7 +32,9 @@ import type {
 } from "geojson";
 import {
   bodyLengthToEarth,
+  decodePolyline,
   earthLengthToBody,
+  encodePolyline,
   getActiveBodyRadiusRatio,
   layerJoinKey,
   type GeoLibreLayer,
@@ -2739,6 +2741,147 @@ export const spaceTimeProximityTool: ProcessingAlgorithm = {
   },
 };
 
+export const decodePolylineTool: ProcessingAlgorithm = {
+  id: "decode-polyline",
+  name: "Decode polyline",
+  description: "Decode encoded polyline strings from an attribute field into a LineString vector layer",
+  group: "Geometry",
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+    },
+    {
+      id: "field",
+      label: "Polyline field",
+      type: "field",
+      description: "Attribute field containing the encoded polyline string",
+      required: true,
+    },
+    {
+      id: "precision",
+      label: "Precision",
+      type: "select",
+      options: [
+        { label: "5 (Google / OSRM)", value: "5" },
+        { label: "6 (Valhalla / Mapbox)", value: "6" },
+      ],
+      default: "5",
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const field = (ctx.parameters.field as string)?.trim();
+    if (!field) {
+      ctx.log("Error: please specify a polyline field");
+      return;
+    }
+    const rawPrecision = ctx.parameters.precision;
+    const precision = rawPrecision === "6" || rawPrecision === 6 ? 6 : 5;
+
+    const outFeatures: Feature<LineString>[] = [];
+    let skipped = 0;
+
+    for (const feature of fc.features) {
+      const val = feature.properties?.[field];
+      if (typeof val !== "string" || !val.trim()) {
+        skipped++;
+        continue;
+      }
+      const coords = decodePolyline(val.trim(), precision);
+      if (coords.length < 2) {
+        skipped++;
+        continue;
+      }
+      outFeatures.push({
+        type: "Feature",
+        properties: { ...(feature.properties ?? {}) },
+        geometry: {
+          type: "LineString",
+          coordinates: coords,
+        },
+      });
+    }
+
+    if (skipped > 0) {
+      ctx.log(`Skipped ${skipped} feature(s) with missing or invalid polyline string`);
+    }
+    ctx.log(`Decoded ${outFeatures.length} LineString feature(s) from "${field}"`);
+    ctx.addResultLayer?.("Decoded polylines", featureCollection(outFeatures));
+  },
+};
+
+export const encodePolylineTool: ProcessingAlgorithm = {
+  id: "encode-polyline",
+  name: "Encode line to polyline",
+  description: "Encode LineString and MultiLineString geometries into an encoded polyline attribute string",
+  group: "Geometry",
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["line"],
+    },
+    {
+      id: "precision",
+      label: "Precision",
+      type: "select",
+      options: [
+        { label: "5 (Google / OSRM)", value: "5" },
+        { label: "6 (Valhalla / Mapbox)", value: "6" },
+      ],
+      default: "5",
+    },
+    {
+      id: "targetField",
+      label: "Output field name",
+      type: "string",
+      description: "Name of the attribute column to store encoded polylines (default: polyline)",
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const rawPrecision = ctx.parameters.precision;
+    const precision = rawPrecision === "6" || rawPrecision === 6 ? 6 : 5;
+    const targetField = ((ctx.parameters.targetField as string) || "").trim() || "polyline";
+
+    const outFeatures: Feature[] = [];
+    let encodedCount = 0;
+
+    for (const feature of fc.features) {
+      const geometry = feature.geometry;
+      let polylineStr = "";
+      if (geometry?.type === "LineString") {
+        polylineStr = encodePolyline(geometry.coordinates as [number, number][], precision);
+      } else if (geometry?.type === "MultiLineString") {
+        polylineStr = geometry.coordinates
+          .map((lineCoords) => encodePolyline(lineCoords as [number, number][], precision))
+          .filter(Boolean)
+          .join(";");
+      }
+      if (polylineStr) encodedCount++;
+      outFeatures.push({
+        ...feature,
+        properties: {
+          ...(feature.properties ?? {}),
+          [targetField]: polylineStr,
+        },
+      });
+    }
+
+    ctx.log(
+      `Encoded ${encodedCount} line feature(s) into field "${targetField}" (precision ${precision})`,
+    );
+    ctx.addResultLayer?.("Encoded polylines", featureCollection(outFeatures));
+  },
+};
+
 export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   bufferTool,
   centroidsTool,
@@ -2762,6 +2905,8 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   gridTool,
   voronoiTool,
   cellSectorsTool,
+  decodePolylineTool,
+  encodePolylineTool,
   createDggsGridTool,
   dggsBinPointsTool,
   dggsCompactTool,

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -2820,6 +2820,22 @@ export const decodePolylineTool: ProcessingAlgorithm = {
           valid = false;
           break;
         }
+
+        for (const [lon, lat] of coords) {
+          if (
+            !Number.isFinite(lon) ||
+            !Number.isFinite(lat) ||
+            lon < -180 ||
+            lon > 180 ||
+            lat < -90 ||
+            lat > 90
+          ) {
+            valid = false;
+            break;
+          }
+        }
+        if (!valid) break;
+
         multiCoords.push(coords);
       }
 

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -49,6 +49,7 @@ class CustomBuildHook(BuildHookInterface):
                 ["npm", "run", "build:embed"],
                 cwd=REPO_ROOT,
                 check=True,
+                shell=os.name == "nt",
                 timeout=600,  # 10 minutes; fail loudly rather than hang pip forever
             )
         except FileNotFoundError as exc:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,3 +60,6 @@ path = "hatch_build.py"
 
 [tool.hatch.build.targets.sdist.hooks.custom]
 path = "hatch_build.py"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -11,6 +11,7 @@ from .authoring import (
 )
 from .geolibre import Feature, Layer, Map
 from .legends import builtin_legend_names
+from .polyline import decode_polyline, encode_polyline, polyline_to_geojson, unescape_polyline
 
 __version__ = "2.6.0"
 __all__ = [
@@ -21,9 +22,13 @@ __all__ = [
     "basemap_catalog",
     "builtin_legend_names",
     "color_ramp_names",
+    "decode_polyline",
     "describe_project",
+    "encode_polyline",
     "load_project",
+    "polyline_to_geojson",
     "save_project",
+    "unescape_polyline",
 ]
 
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1205,6 +1205,7 @@ class Map(anywidget.AnyWidget):
         name: str = "Polyline",
         *,
         precision: int = 5,
+        unescape: bool = False,
         **style: Any,
     ) -> str:
         """Add an Encoded Polyline layer.
@@ -1214,12 +1215,13 @@ class Map(anywidget.AnyWidget):
                 or a list of polyline strings.
             name: Layer display name.
             precision: Decimal digits of precision (5 for Google/OSRM, 6 for Valhalla/Mapbox).
+            unescape: Whether to unescape double-escaped backslashes before decoding.
             **style: Style overrides (e.g. ``lineColor="#ff0000"``, ``lineWidth=3``).
 
         Returns:
             The id of the added layer.
         """
-        fc = polyline_to_geojson(polyline, precision=precision)
+        fc = polyline_to_geojson(polyline, precision=precision, unescape=unescape)
         return self.add_geojson(fc, name=name, **style)
 
     # -- markers ---------------------------------------------------------

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -16,7 +16,7 @@ import time
 import urllib.parse
 import uuid
 import warnings
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 from urllib.error import URLError
 
 import anywidget

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -26,6 +26,7 @@ from . import authoring as _authoring
 from . import project as _project
 from ._server import app_port, register_local_file, serve_app
 from .basemaps import resolve_basemap
+from .polyline import polyline_to_geojson
 
 _HERE = pathlib.Path(__file__).parent
 _STATIC_APP = _HERE / "static" / "app"
@@ -1196,6 +1197,29 @@ class Map(anywidget.AnyWidget):
             source_layer=layer,
             **style,
         )
+
+    def add_polyline(
+        self,
+        polyline: str | Sequence[str],
+        name: str = "Polyline",
+        *,
+        precision: int = 5,
+        **style: Any,
+    ) -> str:
+        """Add an Encoded Polyline layer.
+
+        Args:
+            polyline: A single polyline string (e.g. Google or Valhalla encoded)
+                or a list of polyline strings.
+            name: Layer display name.
+            precision: Decimal digits of precision (5 for Google/OSRM, 6 for Valhalla/Mapbox).
+            **style: Style overrides (e.g. ``lineColor="#ff0000"``, ``lineWidth=3``).
+
+        Returns:
+            The id of the added layer.
+        """
+        fc = polyline_to_geojson(polyline, precision=precision)
+        return self.add_geojson(fc, name=name, **style)
 
     # -- markers ---------------------------------------------------------
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -16,7 +16,8 @@ import time
 import urllib.parse
 import uuid
 import warnings
-from typing import Any, Callable, Sequence
+from collections.abc import Callable, Sequence
+from typing import Any
 from urllib.error import URLError
 
 import anywidget

--- a/python/src/geolibre/polyline.py
+++ b/python/src/geolibre/polyline.py
@@ -1,0 +1,204 @@
+"""Google Encoded Polyline encoder and decoder supporting precision 5 and 6."""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Sequence
+
+
+def unescape_polyline(encoded: str) -> str:
+    """Unescape double-escaped backslashes in a polyline string.
+
+    Args:
+        encoded: Polyline string containing escaped characters like `\\\\`.
+
+    Returns:
+        Cleaned polyline string.
+    """
+    if not encoded or not isinstance(encoded, str):
+        return ""
+    return (
+        encoded.replace("\\\\", "\\")
+        .replace('\\"', '"')
+        .replace("\\'", "'")
+        .replace("\\n", "\n")
+        .replace("\\r", "\r")
+        .replace("\\t", "\t")
+    )
+
+
+def decode_polyline(
+    encoded: str,
+    precision: int = 5,
+    unescape: bool = False,
+) -> list[tuple[float, float]]:
+    """Decode an encoded polyline string into a list of (longitude, latitude) coordinates.
+
+    Args:
+        encoded: The polyline ASCII string.
+        precision: Decimal digits of precision (5 for Google/OSRM, 6 for Valhalla/Mapbox).
+        unescape: Whether to unescape double-escaped backslashes before decoding.
+
+    Returns:
+        A list of `(lng, lat)` coordinate tuples in GeoJSON order.
+    """
+    if not encoded or not isinstance(encoded, str):
+        return []
+
+    clean_encoded = unescape_polyline(encoded) if unescape else encoded
+    factor = 10**precision
+    length = len(clean_encoded)
+    coordinates: list[tuple[float, float]] = []
+    index = 0
+    lat = 0
+    lon = 0
+
+    while index < length:
+        # Decode latitude delta
+        shift = 0
+        result = 0
+        while True:
+            if index >= length:
+                return coordinates
+            byte = ord(clean_encoded[index]) - 63
+            index += 1
+            result |= (byte & 0x1F) << shift
+            shift += 5
+            if byte < 0x20:
+                break
+
+        delta_lat = ~(result >> 1) if (result & 1) else (result >> 1)
+        lat += delta_lat
+
+        # Decode longitude delta
+        shift = 0
+        result = 0
+        while True:
+            if index >= length:
+                return coordinates
+            byte = ord(clean_encoded[index]) - 63
+            index += 1
+            result |= (byte & 0x1F) << shift
+            shift += 5
+            if byte < 0x20:
+                break
+
+        delta_lon = ~(result >> 1) if (result & 1) else (result >> 1)
+        lon += delta_lon
+
+        coordinates.append((lon / factor, lat / factor))
+
+    return coordinates
+
+
+def _encode_signed_number(num: int) -> str:
+    sgn_num = ~(num << 1) if num < 0 else (num << 1)
+    chars: list[str] = []
+    while sgn_num >= 0x20:
+        chars.append(chr((0x20 | (sgn_num & 0x1F)) + 63))
+        sgn_num >>= 5
+    chars.append(chr(sgn_num + 63))
+    return "".join(chars)
+
+
+def encode_polyline(
+    coordinates: Sequence[Sequence[float]],
+    precision: int = 5,
+) -> str:
+    """Encode a sequence of (longitude, latitude) coordinate pairs into a polyline string.
+
+    Args:
+        coordinates: A sequence of `[lng, lat]` or `(lng, lat)` coordinates.
+        precision: Decimal digits of precision (5 for Google/OSRM, 6 for Valhalla/Mapbox).
+
+    Returns:
+        The encoded polyline ASCII string.
+    """
+    if not coordinates:
+        return ""
+
+    factor = 10**precision
+    output_parts: list[str] = []
+    prev_lat = 0
+    prev_lon = 0
+
+    for coord in coordinates:
+        if len(coord) < 2:
+            continue
+        lon, lat = float(coord[0]), float(coord[1])
+        if not (math.isfinite(lon) and math.isfinite(lat)):
+            continue
+
+        round_lat = round(lat * factor)
+        round_lon = round(lon * factor)
+
+        delta_lat = round_lat - prev_lat
+        delta_lon = round_lon - prev_lon
+
+        output_parts.append(_encode_signed_number(delta_lat))
+        output_parts.append(_encode_signed_number(delta_lon))
+
+        prev_lat = round_lat
+        prev_lon = round_lon
+
+    return "".join(output_parts)
+
+
+def polyline_to_geojson(
+    polyline: str | Sequence[str],
+    precision: int = 5,
+    unescape: bool = True,
+    delimiter: str | None = None,
+    properties: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Convert one or more encoded polyline strings into a GeoJSON FeatureCollection.
+
+    Args:
+        polyline: A single polyline string or a sequence of polyline strings.
+        precision: Decimal digits of precision (5 for Google/OSRM, 6 for Valhalla/Mapbox).
+        unescape: Whether to automatically unescape double-escaped backslashes.
+        delimiter: Optional delimiter to split a multiline string (defaults to newline).
+        properties: Optional properties dict to attach to the GeoJSON feature(s).
+
+    Returns:
+        A GeoJSON FeatureCollection dict containing LineString features.
+    """
+    props = dict(properties or {})
+    lines: list[str]
+    if isinstance(polyline, str):
+        if delimiter:
+            lines = polyline.split(delimiter)
+        elif "\n" in polyline:
+            lines = polyline.splitlines()
+        else:
+            lines = [polyline]
+    else:
+        lines = list(polyline)
+
+    features: list[dict[str, Any]] = []
+    for i, line_str in enumerate(lines):
+        clean_str = line_str.strip()
+        if not clean_str:
+            continue
+        coords = decode_polyline(clean_str, precision=precision, unescape=unescape)
+        if len(coords) >= 2:
+            feature_props = dict(props)
+            if len(lines) > 1 and "name" not in feature_props:
+                feature_props["line_index"] = i + 1
+            feature_props["points"] = len(coords)
+            features.append(
+                {
+                    "type": "Feature",
+                    "properties": feature_props,
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [list(c) for c in coords],
+                    },
+                }
+            )
+
+    return {
+        "type": "FeatureCollection",
+        "features": features,
+    }

--- a/python/src/geolibre/polyline.py
+++ b/python/src/geolibre/polyline.py
@@ -17,11 +17,7 @@ def unescape_polyline(encoded: str) -> str:
     """
     if not encoded or not isinstance(encoded, str):
         return ""
-    return (
-        encoded.replace("\\\\", "\\")
-        .replace('\\"', '"')
-        .replace("\\'", "'")
-    )
+    return encoded.replace("\\\\", "\\").replace('\\"', '"').replace("\\'", "'")
 
 
 def decode_polyline(

--- a/python/src/geolibre/polyline.py
+++ b/python/src/geolibre/polyline.py
@@ -83,7 +83,12 @@ def decode_polyline(
         delta_lon = ~(result >> 1) if (result & 1) else (result >> 1)
         lon += delta_lon
 
-        coordinates.append((lon / factor, lat / factor))
+        lat_deg = lat / factor
+        lon_deg = lon / factor
+        if not (-90.0 <= lat_deg <= 90.0 and -180.0 <= lon_deg <= 180.0):
+            return []
+
+        coordinates.append((lon_deg, lat_deg))
 
     return coordinates
 
@@ -127,7 +132,8 @@ def encode_polyline(
             raise ValueError(f"Coordinates must be finite numbers, got ({lon}, {lat})")
         if not (-180.0 <= lon <= 180.0 and -90.0 <= lat <= 90.0):
             raise ValueError(
-                f"Coordinates out of bounds: longitude must be in [-180, 180], latitude in [-90, 90], got lon={lon}, lat={lat}"
+                "Coordinates out of bounds: longitude must be in [-180, 180], "
+                f"latitude in [-90, 90], got lon={lon}, lat={lat}"
             )
 
         round_lat = math.floor(lat * factor + 0.5)

--- a/python/src/geolibre/polyline.py
+++ b/python/src/geolibre/polyline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import re
 from typing import Any, Sequence
 
 

--- a/python/src/geolibre/polyline.py
+++ b/python/src/geolibre/polyline.py
@@ -55,6 +55,8 @@ def decode_polyline(
                 return coordinates
             byte = ord(clean_encoded[index]) - 63
             index += 1
+            if byte < 0 or byte > 63:
+                return []
             result |= (byte & 0x1F) << shift
             shift += 5
             if byte < 0x20:
@@ -71,6 +73,8 @@ def decode_polyline(
                 return coordinates
             byte = ord(clean_encoded[index]) - 63
             index += 1
+            if byte < 0 or byte > 63:
+                return []
             result |= (byte & 0x1F) << shift
             shift += 5
             if byte < 0x20:
@@ -117,10 +121,14 @@ def encode_polyline(
 
     for coord in coordinates:
         if len(coord) < 2:
-            continue
+            raise ValueError(f"Coordinate pair must have at least 2 elements, got {coord!r}")
         lon, lat = float(coord[0]), float(coord[1])
         if not (math.isfinite(lon) and math.isfinite(lat)):
-            continue
+            raise ValueError(f"Coordinates must be finite numbers, got ({lon}, {lat})")
+        if not (-180.0 <= lon <= 180.0 and -90.0 <= lat <= 90.0):
+            raise ValueError(
+                f"Coordinates out of bounds: longitude must be in [-180, 180], latitude in [-90, 90], got lon={lon}, lat={lat}"
+            )
 
         round_lat = math.floor(lat * factor + 0.5)
         round_lon = math.floor(lon * factor + 0.5)
@@ -140,7 +148,7 @@ def encode_polyline(
 def polyline_to_geojson(
     polyline: str | Sequence[str],
     precision: int = 5,
-    unescape: bool = True,
+    unescape: bool = False,
     delimiter: str | None = None,
     properties: dict[str, Any] | None = None,
 ) -> dict[str, Any]:

--- a/python/src/geolibre/polyline.py
+++ b/python/src/geolibre/polyline.py
@@ -21,9 +21,6 @@ def unescape_polyline(encoded: str) -> str:
         encoded.replace("\\\\", "\\")
         .replace('\\"', '"')
         .replace("\\'", "'")
-        .replace("\\n", "\n")
-        .replace("\\r", "\r")
-        .replace("\\t", "\t")
     )
 
 
@@ -129,8 +126,8 @@ def encode_polyline(
         if not (math.isfinite(lon) and math.isfinite(lat)):
             continue
 
-        round_lat = round(lat * factor)
-        round_lon = round(lon * factor)
+        round_lat = math.floor(lat * factor + 0.5)
+        round_lon = math.floor(lon * factor + 0.5)
 
         delta_lat = round_lat - prev_lat
         delta_lon = round_lon - prev_lon

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -218,4 +218,3 @@ def test_decode_polyline_out_of_range_bounds():
     assert decode_polyline(lon_high, precision=5) == []
     lon_low = _encode_signed_number(0) + _encode_signed_number(-19000000)
     assert decode_polyline(lon_low, precision=5) == []
-

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -168,3 +168,35 @@ def test_map_add_polyline(m):
     assert last["geojson"]["type"] == "FeatureCollection"
     assert len(last["geojson"]["features"]) == 1
     assert last["geojson"]["features"][0]["geometry"]["type"] == "LineString"
+
+
+def test_encode_polyline_invalid_coords():
+    with pytest.raises(ValueError, match="at least 2 elements"):
+        encode_polyline([[10.0]])  # type: ignore
+
+    with pytest.raises(ValueError, match="finite numbers"):
+        encode_polyline([(float("nan"), 10.0)])
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        encode_polyline([(200.0, 10.0)])
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        encode_polyline([(10.0, 100.0)])
+
+
+def test_decode_polyline_malformed_chars():
+    # '/' has ASCII 47 (< 63), which must be rejected
+    assert decode_polyline("_p~iF/invalid", precision=5) == []
+
+
+def test_polyline_to_geojson_unescape_default():
+    # Double backslash should NOT be automatically unescaped by default
+    raw_with_double_backslash = "_p~iF~ps|U_ulLnnqC_mqNvxq\\\\`@"
+    fc_default = polyline_to_geojson(raw_with_double_backslash, precision=5)
+    # Default unescape=False treats consecutive backslashes literally (4 points decoded)
+    assert len(fc_default["features"][0]["geometry"]["coordinates"]) == 4
+
+    # Explicit unescape=True unescapes \\ to \ (3 points decoded)
+    fc_explicit = polyline_to_geojson(raw_with_double_backslash, precision=5, unescape=True)
+    assert len(fc_explicit["features"][0]["geometry"]["coordinates"]) == 3
+    assert math.isclose(fc_explicit["features"][0]["geometry"]["coordinates"][2][0], -125.79764, abs_tol=1e-5)

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -207,14 +207,15 @@ def test_polyline_to_geojson_unescape_default():
 def test_decode_polyline_out_of_range_bounds():
     from geolibre.polyline import _encode_signed_number
 
-    # Latitude > 90 and < -90
-    lat_high = _encode_signed_number(9500000) + _encode_signed_number(0)
-    assert decode_polyline(lat_high, precision=5) == []
-    lat_low = _encode_signed_number(-9500000) + _encode_signed_number(0)
-    assert decode_polyline(lat_low, precision=5) == []
+    for precision in (5, 6):
+        factor = 10**precision
 
-    # Longitude > 180 and < -180
-    lon_high = _encode_signed_number(0) + _encode_signed_number(19000000)
-    assert decode_polyline(lon_high, precision=5) == []
-    lon_low = _encode_signed_number(0) + _encode_signed_number(-19000000)
-    assert decode_polyline(lon_low, precision=5) == []
+        lat_high = _encode_signed_number(95 * factor) + _encode_signed_number(0)
+        assert decode_polyline(lat_high, precision=precision) == []
+        lat_low = _encode_signed_number(-95 * factor) + _encode_signed_number(0)
+        assert decode_polyline(lat_low, precision=precision) == []
+
+        lon_high = _encode_signed_number(0) + _encode_signed_number(190 * factor)
+        assert decode_polyline(lon_high, precision=precision) == []
+        lon_low = _encode_signed_number(0) + _encode_signed_number(-190 * factor)
+        assert decode_polyline(lon_low, precision=precision) == []

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -127,7 +127,7 @@ def test_unescape_polyline():
     assert unescape_polyline("abc\\ndef") == "abc\\ndef"
     assert unescape_polyline("abc\\rdef") == "abc\\rdef"
     assert unescape_polyline("abc\\tdef") == "abc\\tdef"
-    assert unescape_polyline('a\\"b\\\'c\\\\d') == 'a"b\'c\\d'
+    assert unescape_polyline("a\\\"b\\'c\\\\d") == "a\"b'c\\d"
     coords = decode_polyline(escaped, precision=5, unescape=True)
     assert len(coords) == 3
 

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -199,4 +199,6 @@ def test_polyline_to_geojson_unescape_default():
     # Explicit unescape=True unescapes \\ to \ (3 points decoded)
     fc_explicit = polyline_to_geojson(raw_with_double_backslash, precision=5, unescape=True)
     assert len(fc_explicit["features"][0]["geometry"]["coordinates"]) == 3
-    assert math.isclose(fc_explicit["features"][0]["geometry"]["coordinates"][2][0], -125.79764, abs_tol=1e-5)
+    assert math.isclose(
+        fc_explicit["features"][0]["geometry"]["coordinates"][2][0], -125.79764, abs_tol=1e-5
+    )

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import math
+
 import pytest
 
 import geolibre.geolibre as gmod
 from geolibre import (
+    Map,
     decode_polyline,
     encode_polyline,
     polyline_to_geojson,
     unescape_polyline,
-    Map,
 )
 
 

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -202,3 +202,20 @@ def test_polyline_to_geojson_unescape_default():
     assert math.isclose(
         fc_explicit["features"][0]["geometry"]["coordinates"][2][0], -125.79764, abs_tol=1e-5
     )
+
+
+def test_decode_polyline_out_of_range_bounds():
+    from geolibre.polyline import _encode_signed_number
+
+    # Latitude > 90 and < -90
+    lat_high = _encode_signed_number(9500000) + _encode_signed_number(0)
+    assert decode_polyline(lat_high, precision=5) == []
+    lat_low = _encode_signed_number(-9500000) + _encode_signed_number(0)
+    assert decode_polyline(lat_low, precision=5) == []
+
+    # Longitude > 180 and < -180
+    lon_high = _encode_signed_number(0) + _encode_signed_number(19000000)
+    assert decode_polyline(lon_high, precision=5) == []
+    lon_low = _encode_signed_number(0) + _encode_signed_number(-19000000)
+    assert decode_polyline(lon_low, precision=5) == []
+

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -1,0 +1,139 @@
+"""Tests for Python polyline encoding, decoding, and Map.add_polyline."""
+
+from __future__ import annotations
+
+import math
+import pytest
+
+import geolibre.geolibre as gmod
+from geolibre import (
+    decode_polyline,
+    encode_polyline,
+    polyline_to_geojson,
+    unescape_polyline,
+    Map,
+)
+
+
+@pytest.fixture
+def m(monkeypatch):
+    """A Map instance with the static server stubbed out."""
+    monkeypatch.setattr(gmod, "serve_app", lambda *_a, **_k: "http://127.0.0.1:0/")
+    monkeypatch.setattr(gmod, "app_port", lambda: 0)
+    return Map()
+
+
+def test_decode_polyline_google():
+    # Google standard precision-5 vector
+    coords = decode_polyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@", precision=5)
+    assert len(coords) == 3
+    assert math.isclose(coords[0][0], -120.2, abs_tol=1e-5)
+    assert math.isclose(coords[0][1], 38.5, abs_tol=1e-5)
+    assert math.isclose(coords[1][0], -120.95, abs_tol=1e-5)
+    assert math.isclose(coords[1][1], 40.7, abs_tol=1e-5)
+    assert math.isclose(coords[2][0], -126.453, abs_tol=1e-5)
+    assert math.isclose(coords[2][1], 43.252, abs_tol=1e-5)
+
+
+def test_decode_polyline_valhalla():
+    # Valhalla precision-6 vector
+    coords = decode_polyline("_o`diA~gw}qC_pR_pR_pR_af@", precision=6)
+    assert len(coords) == 3
+    assert math.isclose(coords[0][0], -77.05, abs_tol=1e-6)
+    assert math.isclose(coords[0][1], 38.88, abs_tol=1e-6)
+    assert math.isclose(coords[1][0], -77.04, abs_tol=1e-6)
+    assert math.isclose(coords[1][1], 38.89, abs_tol=1e-6)
+    assert math.isclose(coords[2][0], -77.02, abs_tol=1e-6)
+    assert math.isclose(coords[2][1], 38.9, abs_tol=1e-6)
+
+
+def test_decode_polyline_empty_and_invalid():
+    assert decode_polyline("") == []
+    assert decode_polyline(None) == []  # type: ignore
+
+
+def test_encode_polyline_google():
+    coords = [
+        (-120.2, 38.5),
+        (-120.95, 40.7),
+        (-126.453, 43.252),
+    ]
+    assert encode_polyline(coords, precision=5) == "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+
+def test_encode_polyline_valhalla():
+    coords = [
+        (-77.05, 38.88),
+        (-77.04, 38.89),
+        (-77.02, 38.9),
+    ]
+    assert encode_polyline(coords, precision=6) == "_o`diA~gw}qC_pR_pR_pR_af@"
+
+
+def test_polyline_roundtrip():
+    original = [
+        (106.6297, 10.8231),
+        (106.635, 10.828),
+        (106.64, 10.835),
+    ]
+    encoded = encode_polyline(original, precision=5)
+    decoded = decode_polyline(encoded, precision=5)
+    assert len(decoded) == len(original)
+    for (orig_lng, orig_lat), (dec_lng, dec_lat) in zip(original, decoded):
+        assert math.isclose(orig_lng, dec_lng, abs_tol=1e-5)
+        assert math.isclose(orig_lat, dec_lat, abs_tol=1e-5)
+
+
+def test_polyline_to_geojson_single():
+    fc = polyline_to_geojson("_p~iF~ps|U_ulLnnqC_mqNvxq`@", precision=5, properties={"route": "R1"})
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) == 1
+    feature = fc["features"][0]
+    assert feature["geometry"]["type"] == "LineString"
+    assert len(feature["geometry"]["coordinates"]) == 3
+    assert feature["properties"]["route"] == "R1"
+
+
+def test_unescape_polyline():
+    escaped = "_p~iF~ps|U_ulLnnqC_mqNvxq\\\\`@"
+    assert unescape_polyline(escaped) == "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@"
+    coords = decode_polyline(escaped, precision=5, unescape=True)
+    assert len(coords) == 3
+
+
+def test_polyline_to_geojson_multiple():
+    polylines = [
+        "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+        "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+    ]
+    fc = polyline_to_geojson(polylines, precision=5)
+    assert len(fc["features"]) == 2
+    assert fc["features"][0]["properties"]["line_index"] == 1
+    assert fc["features"][1]["properties"]["line_index"] == 2
+
+
+def test_polyline_to_geojson_multiline_string():
+    multiline_text = "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+    fc = polyline_to_geojson(multiline_text, precision=5)
+    assert len(fc["features"]) == 2
+    assert fc["features"][0]["properties"]["line_index"] == 1
+
+
+def test_map_add_polyline(m):
+    seq_before = m._seq
+    layer_id = m.add_polyline(
+        "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+        name="My Route",
+        precision=5,
+        lineColor="#ff0000",
+    )
+    assert isinstance(layer_id, str)
+    assert m._seq == seq_before + 1
+
+    last = m.project["layers"][-1]
+    assert last["id"] == layer_id
+    assert last["name"] == "My Route"
+    assert last["type"] == "geojson"
+    assert last["geojson"]["type"] == "FeatureCollection"
+    assert len(last["geojson"]["features"]) == 1
+    assert last["geojson"]["features"][0]["geometry"]["type"] == "LineString"

--- a/python/tests/test_polyline.py
+++ b/python/tests/test_polyline.py
@@ -71,6 +71,32 @@ def test_encode_polyline_valhalla():
     assert encode_polyline(coords, precision=6) == "_o`diA~gw}qC_pR_pR_pR_af@"
 
 
+def test_encode_polyline_half_precision_rounding_p5():
+    # Positive half-precision: 0.000025 * 1e5 = 2.5 -> Math.round is 3
+    # Negative half-precision: -0.000025 * 1e5 = -2.5 -> Math.round is -2
+    coords_pos = [(0.000025, 0.000025)]
+    coords_neg = [(-0.000025, -0.000025)]
+    assert encode_polyline(coords_pos, precision=5) == "EE"
+    assert encode_polyline(coords_neg, precision=5) == "BB"
+    decoded_pos = decode_polyline(encode_polyline(coords_pos, precision=5), precision=5)
+    decoded_neg = decode_polyline(encode_polyline(coords_neg, precision=5), precision=5)
+    assert math.isclose(decoded_pos[0][1], 0.00003, abs_tol=1e-6)
+    assert math.isclose(decoded_neg[0][1], -0.00002, abs_tol=1e-6)
+
+
+def test_encode_polyline_half_precision_rounding_p6():
+    # Positive half-precision: 0.0000025 * 1e6 = 2.5 -> Math.round is 3
+    # Negative half-precision: -0.0000025 * 1e6 = -2.5 -> Math.round is -2
+    coords_pos = [(0.0000025, 0.0000025)]
+    coords_neg = [(-0.0000025, -0.0000025)]
+    assert encode_polyline(coords_pos, precision=6) == "EE"
+    assert encode_polyline(coords_neg, precision=6) == "BB"
+    decoded_pos = decode_polyline(encode_polyline(coords_pos, precision=6), precision=6)
+    decoded_neg = decode_polyline(encode_polyline(coords_neg, precision=6), precision=6)
+    assert math.isclose(decoded_pos[0][1], 0.000003, abs_tol=1e-7)
+    assert math.isclose(decoded_neg[0][1], -0.000002, abs_tol=1e-7)
+
+
 def test_polyline_roundtrip():
     original = [
         (106.6297, 10.8231),
@@ -98,6 +124,10 @@ def test_polyline_to_geojson_single():
 def test_unescape_polyline():
     escaped = "_p~iF~ps|U_ulLnnqC_mqNvxq\\\\`@"
     assert unescape_polyline(escaped) == "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@"
+    assert unescape_polyline("abc\\ndef") == "abc\\ndef"
+    assert unescape_polyline("abc\\rdef") == "abc\\rdef"
+    assert unescape_polyline("abc\\tdef") == "abc\\tdef"
+    assert unescape_polyline('a\\"b\\\'c\\\\d') == 'a"b\'c\\d'
     coords = decode_polyline(escaped, precision=5, unescape=True)
     assert len(coords) == 3
 

--- a/tests/polyline-samples.test.ts
+++ b/tests/polyline-samples.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { batchDecodePolylines, decodePolylineDetailed } from "@geolibre/core";
+import { SAMPLE_POLYLINES } from "../apps/geolibre-desktop/src/lib/polyline-samples";
+
+/**
+ * The Add Encoded Polyline Layer dialog offers these as one-click samples. An
+ * encoded polyline is opaque, so a sample that decodes to nothing (or to
+ * coordinates off the planet) reads as a bug in the decoder rather than as a
+ * bad sample. These tests decode each entry exactly the way the dialog does.
+ */
+describe("Add Data encoded polyline samples", () => {
+  for (const sample of SAMPLE_POLYLINES) {
+    it(`decodes ${sample.key} into in-bounds line geometry`, () => {
+      const fc = batchDecodePolylines(sample.value, {
+        precision: sample.precision,
+        unescape: sample.unescape ?? true,
+      });
+      assert.ok(fc.features.length > 0, "sample decoded to no features");
+      for (const feature of fc.features) {
+        assert.equal(feature.geometry.type, "LineString");
+        const coords = feature.geometry.coordinates as [number, number][];
+        assert.ok(coords.length >= 2, "line has fewer than two points");
+        for (const [lon, lat] of coords) {
+          assert.ok(Number.isFinite(lon) && lon >= -180 && lon <= 180, `longitude ${lon}`);
+          assert.ok(Number.isFinite(lat) && lat >= -90 && lat <= 90, `latitude ${lat}`);
+        }
+      }
+    });
+  }
+
+  it("gives the escaped sample a doubled backslash that only decodes once unescaped", () => {
+    const sample = SAMPLE_POLYLINES.find((s) => s.key === "addData.polyline.sampleEscaped");
+    assert.ok(sample, "escaped sample is missing");
+    // A JSON payload carries the backslash doubled; the dialog's unescape step
+    // is what collapses it back to the single byte the decoder needs.
+    assert.ok(sample.value.includes("\\\\"), "sample carries no escaped backslash");
+    assert.equal(sample.unescape, true);
+    assert.equal(decodePolylineDetailed(sample.value, sample.precision, true).complete, true);
+    assert.equal(decodePolylineDetailed(sample.value, sample.precision, false).complete, false);
+  });
+
+  it("decodes the escaped sample to the San Francisco to Monterey route", () => {
+    const sample = SAMPLE_POLYLINES.find((s) => s.key === "addData.polyline.sampleEscaped");
+    assert.ok(sample);
+    const coords = decodePolylineDetailed(sample.value, 5, true).coordinates;
+    assert.equal(coords.length, 5);
+    assert.ok(Math.abs(coords[0][0] - -122.41958) < 1e-5);
+    assert.ok(Math.abs(coords[0][1] - 37.7749) < 1e-5);
+    assert.ok(Math.abs(coords[4][0] - -121.8947) < 1e-5);
+    assert.ok(Math.abs(coords[4][1] - 36.6002) < 1e-5);
+  });
+});

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -467,9 +467,54 @@ describe("polyline codec", () => {
       assert.ok(decodedFc);
       assert.equal(decodedFc.features.length, 1);
       const decodedGeom = decodedFc.features[0].geometry;
+      assert.ok(decodedGeom);
       assert.equal(decodedGeom.type, "MultiLineString");
       assert.equal((decodedGeom as MultiLineString).coordinates.length, 2);
       assert.equal(decodedFc.features[0].properties?.routeGroup, "Multi1");
+    });
+
+    it("decodePolylineTool skips oversized-varint input that exceeds coordinate bounds", async () => {
+      const { decodePolylineTool } = await import("@geolibre/processing");
+      const layerWithOversizedPoly = {
+        id: "test-poly-layer-oversized",
+        name: "Oversized Polyline",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: { routeId: "Oversized", poly: "_o`diA~gw}qC_pR_pR_pR_af@" },
+              geometry: null as any,
+            },
+          ],
+        },
+      };
+
+      let resultFc: FeatureCollection | undefined;
+      const logs: string[] = [];
+
+      decodePolylineTool.run({
+        layers: [layerWithOversizedPoly as any],
+        parameters: {
+          layer: "test-poly-layer-oversized",
+          field: "poly",
+          precision: "5",
+        },
+        log: (msg) => logs.push(msg),
+        addResultLayer: (_name, fc) => {
+          resultFc = fc;
+        },
+      });
+
+      assert.ok(resultFc);
+      assert.equal(resultFc.features.length, 0);
+      assert.ok(logs.some((msg) => msg.includes("Skipped 1 feature(s)")));
     });
   });
 

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -171,6 +171,20 @@ describe("polyline codec", () => {
       assert.equal(fc.features[0].geometry.type, "MultiLineString");
       assert.equal((fc.features[0].geometry as MultiLineString).coordinates.length, 2);
     });
+
+    it("skips malformed, truncated, or invalid lines in batch decoding", () => {
+      const text = [
+        "_p~iF~ps|U_ulLnnqC_mqNvxq`@", // valid line (3 points)
+        "invalid/character/in/line",     // invalid chars (< 63)
+        "_p~iF~ps|U_ulLnnqC_mqN",        // truncated varint
+        "_______?",                      // overlong varint shift
+        "_p~iF~ps|U_ulLnnqC_mqNvxq`@", // valid line (3 points)
+      ].join("\n");
+      const fc = batchDecodePolylines(text, { precision: 5 });
+      assert.equal(fc.features.length, 2);
+      assert.equal(fc.features[0].geometry.coordinates.length, 3);
+      assert.equal(fc.features[1].geometry.coordinates.length, 3);
+    });
   });
 
   describe("polylineStrToGeoJSON", () => {

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -175,9 +175,9 @@ describe("polyline codec", () => {
     it("skips malformed, truncated, or invalid lines in batch decoding", () => {
       const text = [
         "_p~iF~ps|U_ulLnnqC_mqNvxq`@", // valid line (3 points)
-        "invalid/character/in/line",     // invalid chars (< 63)
-        "_p~iF~ps|U_ulLnnqC_mqN",        // truncated varint
-        "_______?",                      // overlong varint shift
+        "invalid/character/in/line", // invalid chars (< 63)
+        "_p~iF~ps|U_ulLnnqC_mqN", // truncated varint
+        "_______?", // overlong varint shift
         "_p~iF~ps|U_ulLnnqC_mqNvxq`@", // valid line (3 points)
       ].join("\n");
       const fc = batchDecodePolylines(text, { precision: 5 });

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -516,6 +516,53 @@ describe("polyline codec", () => {
       assert.equal(resultFc.features.length, 0);
       assert.ok(logs.some((msg) => msg.includes("Skipped 1 feature(s)")));
     });
+
+    it("decodePolylineTool skips valid polyline with an appended incomplete coordinate", async () => {
+      const { decodePolylineTool } = await import("@geolibre/processing");
+      const layerWithIncompletePoly = {
+        id: "test-poly-layer-incomplete",
+        name: "Incomplete Polyline",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: {
+                routeId: "Incomplete",
+                poly: "_p~iF~ps|U_ulLnnqC_mqNvxq`@_mqN",
+              },
+              geometry: null as any,
+            },
+          ],
+        },
+      };
+
+      let resultFc: FeatureCollection | undefined;
+      const logs: string[] = [];
+
+      decodePolylineTool.run({
+        layers: [layerWithIncompletePoly as any],
+        parameters: {
+          layer: "test-poly-layer-incomplete",
+          field: "poly",
+          precision: "5",
+        },
+        log: (msg) => logs.push(msg),
+        addResultLayer: (_name, fc) => {
+          resultFc = fc;
+        },
+      });
+
+      assert.ok(resultFc);
+      assert.equal(resultFc.features.length, 0);
+      assert.ok(logs.some((msg) => msg.includes("Skipped 1 feature(s)")));
+    });
   });
 
   describe("drag and drop file ingestion", () => {
@@ -624,9 +671,45 @@ describe("polyline codec", () => {
         },
       };
 
+      const mixedLayer = {
+        id: "m1",
+        name: "Mixed Layer",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: {},
+              geometry: {
+                type: "LineString" as const,
+                coordinates: [
+                  [0, 0],
+                  [1, 1],
+                ],
+              },
+            },
+            {
+              type: "Feature" as const,
+              properties: {},
+              geometry: {
+                type: "Point" as const,
+                coordinates: [0, 0],
+              },
+            },
+          ],
+        },
+      };
+
       assert.equal(layerSupportsPolylineExport(lineLayer as any), true);
       assert.equal(layerSupportsPolylineExport(pointLayer as any), false);
       assert.equal(layerSupportsPolylineExport(polygonLayer as any), false);
+      assert.equal(layerSupportsPolylineExport(mixedLayer as any), false);
     });
   });
 });

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -61,6 +61,10 @@ describe("polyline codec", () => {
         assert.ok(Number.isFinite(lat));
       }
     });
+
+    it("rejects overlong varint input '_______?' exceeding 30-bit shift bounds", () => {
+      assert.deepEqual(decodePolyline("_______?", 5), []);
+    });
   });
 
   describe("encodePolyline", () => {
@@ -550,6 +554,53 @@ describe("polyline codec", () => {
         layers: [layerWithIncompletePoly as any],
         parameters: {
           layer: "test-poly-layer-incomplete",
+          field: "poly",
+          precision: "5",
+        },
+        log: (msg) => logs.push(msg),
+        addResultLayer: (_name, fc) => {
+          resultFc = fc;
+        },
+      });
+
+      assert.ok(resultFc);
+      assert.equal(resultFc.features.length, 0);
+      assert.ok(logs.some((msg) => msg.includes("Skipped 1 feature(s)")));
+    });
+
+    it("decodePolylineTool skips overlong varint input '_______?' and does not accept it as LineString", async () => {
+      const { decodePolylineTool } = await import("@geolibre/processing");
+      const layerWithOverlongPoly = {
+        id: "test-poly-layer-overlong",
+        name: "Overlong Polyline",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: {
+                routeId: "Overlong",
+                poly: "_______?",
+              },
+              geometry: null as any,
+            },
+          ],
+        },
+      };
+
+      let resultFc: FeatureCollection | undefined;
+      const logs: string[] = [];
+
+      decodePolylineTool.run({
+        layers: [layerWithOverlongPoly as any],
+        parameters: {
+          layer: "test-poly-layer-overlong",
           field: "poly",
           precision: "5",
         },

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -336,9 +336,7 @@ describe("polyline codec", () => {
 
   describe("drag and drop file ingestion", () => {
     it("loads dropped .polyline files directly into FeatureCollection layers", async () => {
-      const { loadDroppedVectorFiles } = await import(
-        "../apps/geolibre-desktop/src/lib/tauri-io"
-      );
+      const { loadDroppedVectorFiles } = await import("../apps/geolibre-desktop/src/lib/tauri-io");
       const mockPolylineFile = new File(
         ["_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_p~iF~ps|U_ulLnnqC_mqNvxq`@"],
         "Polyline.polyline",
@@ -356,9 +354,8 @@ describe("polyline codec", () => {
 
   describe("layer export geometry restrictions", () => {
     it("layerSupportsPolylineExport returns true only for line layers", async () => {
-      const { layerSupportsPolylineExport } = await import(
-        "../apps/geolibre-desktop/src/lib/vector-export"
-      );
+      const { layerSupportsPolylineExport } =
+        await import("../apps/geolibre-desktop/src/lib/vector-export");
 
       const lineLayer = {
         id: "l1",

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -1,0 +1,451 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  batchDecodePolylines,
+  decodePolyline,
+  encodePolyline,
+  geoJSONToPolylineStr,
+  polylineStrToGeoJSON,
+  unescapePolyline,
+} from "@geolibre/core";
+import type { Feature, FeatureCollection, LineString, MultiLineString } from "geojson";
+
+describe("polyline codec", () => {
+  describe("decodePolyline", () => {
+    it("decodes the canonical Google precision-5 example to [lon, lat] pairs", () => {
+      // Google docs example:
+      // (38.5, -120.2), (40.7, -120.95), (43.252, -126.453)
+      // Polyline string: "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+      const coords = decodePolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5);
+      assert.equal(coords.length, 3);
+      assert.ok(Math.abs(coords[0][0] - -120.2) < 1e-5);
+      assert.ok(Math.abs(coords[0][1] - 38.5) < 1e-5);
+      assert.ok(Math.abs(coords[1][0] - -120.95) < 1e-5);
+      assert.ok(Math.abs(coords[1][1] - 40.7) < 1e-5);
+      assert.ok(Math.abs(coords[2][0] - -126.453) < 1e-5);
+      assert.ok(Math.abs(coords[2][1] - 43.252) < 1e-5);
+    });
+
+    it("defaults to precision 5", () => {
+      const coords = decodePolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+      assert.equal(coords.length, 3);
+      assert.ok(Math.abs(coords[0][0] - -120.2) < 1e-5);
+      assert.ok(Math.abs(coords[0][1] - 38.5) < 1e-5);
+    });
+
+    it("decodes a Valhalla precision-6 polyline", () => {
+      // Sequence with 6 digits precision: [[-77.05, 38.88], [-77.04, 38.89], [-77.02, 38.9]]
+      const coords = decodePolyline("_o`diA~gw}qC_pR_pR_pR_af@", 6);
+      assert.equal(coords.length, 3);
+      assert.ok(Math.abs(coords[0][0] - -77.05) < 1e-6);
+      assert.ok(Math.abs(coords[0][1] - 38.88) < 1e-6);
+      assert.ok(Math.abs(coords[1][0] - -77.04) < 1e-6);
+      assert.ok(Math.abs(coords[1][1] - 38.89) < 1e-6);
+      assert.ok(Math.abs(coords[2][0] - -77.02) < 1e-6);
+      assert.ok(Math.abs(coords[2][1] - 38.9) < 1e-6);
+    });
+
+    it("returns an empty array for an empty or invalid string", () => {
+      assert.deepEqual(decodePolyline(""), []);
+      assert.deepEqual(decodePolyline(null as unknown as string), []);
+      assert.deepEqual(decodePolyline(undefined as unknown as string), []);
+    });
+
+    it("drops a truncated trailing chunk instead of emitting NaN", () => {
+      // Truncated mid-varint
+      const coords = decodePolyline("_p~iF~ps|U_ulLnnqC_mqN", 5);
+      assert.ok(Array.isArray(coords));
+      assert.ok(coords.length >= 1);
+      for (const [lon, lat] of coords) {
+        assert.ok(Number.isFinite(lon));
+        assert.ok(Number.isFinite(lat));
+      }
+    });
+  });
+
+  describe("encodePolyline", () => {
+    it("encodes coordinate array to standard precision-5 polyline", () => {
+      const coords: [number, number][] = [
+        [-120.2, 38.5],
+        [-120.95, 40.7],
+        [-126.453, 43.252],
+      ];
+      const encoded = encodePolyline(coords, 5);
+      assert.equal(encoded, "_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+    });
+
+    it("encodes coordinate array to precision-6 polyline", () => {
+      const coords: [number, number][] = [
+        [-77.05, 38.88],
+        [-77.04, 38.89],
+        [-77.02, 38.9],
+      ];
+      const encoded = encodePolyline(coords, 6);
+      assert.equal(encoded, "_o`diA~gw}qC_pR_pR_pR_af@");
+    });
+
+    it("returns empty string for empty input", () => {
+      assert.equal(encodePolyline([]), "");
+      assert.equal(encodePolyline(null as unknown as [number, number][]), "");
+    });
+
+    it("skips non-finite coordinates cleanly", () => {
+      const coords: [number, number][] = [
+        [-120.2, 38.5],
+        [NaN, 40.0],
+        [-120.95, 40.7],
+      ];
+      const encoded = encodePolyline(coords, 5);
+      const decoded = decodePolyline(encoded, 5);
+      assert.equal(decoded.length, 2);
+    });
+
+    it("round-trips arbitrary coordinates accurately at precision 5 and 6", () => {
+      const original5: [number, number][] = [
+        [106.6297, 10.8231],
+        [106.635, 10.828],
+        [106.64, 10.835],
+      ];
+      const encoded5 = encodePolyline(original5, 5);
+      const decoded5 = decodePolyline(encoded5, 5);
+      assert.equal(decoded5.length, original5.length);
+      for (let i = 0; i < original5.length; i++) {
+        assert.ok(Math.abs(decoded5[i][0] - original5[i][0]) < 1e-5);
+        assert.ok(Math.abs(decoded5[i][1] - original5[i][1]) < 1e-5);
+      }
+
+      const original6: [number, number][] = [
+        [-73.985131, 40.748817],
+        [-73.984012, 40.749521],
+        [-73.982103, 40.750614],
+      ];
+      const encoded6 = encodePolyline(original6, 6);
+      const decoded6 = decodePolyline(encoded6, 6);
+      assert.equal(decoded6.length, original6.length);
+      for (let i = 0; i < original6.length; i++) {
+        assert.ok(Math.abs(decoded6[i][0] - original6[i][0]) < 1e-6);
+        assert.ok(Math.abs(decoded6[i][1] - original6[i][1]) < 1e-6);
+      }
+    });
+  });
+
+  describe("unescapePolyline", () => {
+    it("unescapes double-escaped backslashes and escape sequences", () => {
+      const escaped = "_p~iF~ps|U_ulLnnqC_mqNvxq\\\\`@";
+      assert.equal(unescapePolyline(escaped), "_p~iF~ps|U_ulLnnqC_mqNvxq\\`@");
+      const decoded = decodePolyline(escaped, 5, true);
+      assert.equal(decoded.length, 3);
+    });
+  });
+
+  describe("batchDecodePolylines", () => {
+    it("decodes newline-separated polylines into LineString features", () => {
+      const text = "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+      const fc = batchDecodePolylines(text, { precision: 5 });
+      assert.equal(fc.type, "FeatureCollection");
+      assert.equal(fc.features.length, 2);
+      assert.equal(fc.features[0].geometry.type, "LineString");
+    });
+
+    it("decodes semicolon-separated polylines with custom delimiter", () => {
+      const text = "_p~iF~ps|U_ulLnnqC_mqNvxq`@;_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+      const fc = batchDecodePolylines(text, { precision: 5, delimiter: ";" });
+      assert.equal(fc.features.length, 2);
+    });
+
+    it("supports asMultiLine to merge into a single MultiLineString feature", () => {
+      const text = "_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+      const fc = batchDecodePolylines(text, { precision: 5, asMultiLine: true });
+      assert.equal(fc.features.length, 1);
+      assert.equal(fc.features[0].geometry.type, "MultiLineString");
+      assert.equal((fc.features[0].geometry as MultiLineString).coordinates.length, 2);
+    });
+  });
+
+  describe("polylineStrToGeoJSON", () => {
+    it("creates a GeoJSON LineString Feature from polyline string", () => {
+      const str = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
+      const feat = polylineStrToGeoJSON(str, 5, { name: "Route 1" });
+      assert.equal(feat.type, "Feature");
+      assert.equal(feat.geometry.type, "LineString");
+      assert.equal(feat.geometry.coordinates.length, 3);
+      assert.equal(feat.properties?.name, "Route 1");
+    });
+  });
+
+  describe("geoJSONToPolylineStr", () => {
+    it("converts LineString geometry to polyline string", () => {
+      const line: LineString = {
+        type: "LineString",
+        coordinates: [
+          [-120.2, 38.5],
+          [-120.95, 40.7],
+          [-126.453, 43.252],
+        ],
+      };
+      assert.equal(geoJSONToPolylineStr(line, 5), "_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+    });
+
+    it("converts MultiLineString geometry to array of polyline strings", () => {
+      const multiLine: MultiLineString = {
+        type: "MultiLineString",
+        coordinates: [
+          [
+            [-120.2, 38.5],
+            [-120.95, 40.7],
+          ],
+          [
+            [-122.4194, 37.7749],
+            [-122.4174, 37.7769],
+          ],
+        ],
+      };
+      const result = geoJSONToPolylineStr(multiLine, 5);
+      assert.ok(Array.isArray(result));
+      assert.equal(result.length, 2);
+    });
+
+    it("converts FeatureCollection of lines", () => {
+      const fc: FeatureCollection<LineString> = {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [-120.2, 38.5],
+                [-120.95, 40.7],
+              ],
+            },
+          },
+        ],
+      };
+      const result = geoJSONToPolylineStr(fc, 5);
+      assert.ok(Array.isArray(result));
+      assert.equal(result.length, 1);
+    });
+  });
+
+  describe("processing tools", () => {
+    it("decodePolylineTool decodes polyline attribute into LineString layer", async () => {
+      const { decodePolylineTool } = await import("@geolibre/processing");
+      const layerWithPolyline = {
+        id: "test-poly-layer",
+        name: "Polyline Test",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: { routeId: "R1", poly: "_p~iF~ps|U_ulLnnqC_mqNvxq`@" },
+              geometry: null as any,
+            },
+          ],
+        },
+      };
+
+      let resultName = "";
+      let resultFc: FeatureCollection | undefined;
+      const logs: string[] = [];
+
+      decodePolylineTool.run({
+        layers: [layerWithPolyline as any],
+        parameters: {
+          layer: "test-poly-layer",
+          field: "poly",
+          precision: "5",
+        },
+        log: (msg) => logs.push(msg),
+        addResultLayer: (name, fc) => {
+          resultName = name;
+          resultFc = fc;
+        },
+      });
+
+      assert.equal(resultName, "Decoded polylines");
+      assert.ok(resultFc);
+      assert.equal(resultFc.features.length, 1);
+      assert.equal(resultFc.features[0].geometry.type, "LineString");
+      assert.equal((resultFc.features[0].geometry as LineString).coordinates.length, 3);
+      assert.equal(resultFc.features[0].properties?.routeId, "R1");
+    });
+
+    it("encodePolylineTool encodes line geometries into attribute field", async () => {
+      const { encodePolylineTool } = await import("@geolibre/processing");
+      const lineLayer = {
+        id: "test-line-layer",
+        name: "Line Test",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: { name: "Route A" },
+              geometry: {
+                type: "LineString" as const,
+                coordinates: [
+                  [-120.2, 38.5],
+                  [-120.95, 40.7],
+                  [-126.453, 43.252],
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      let resultName = "";
+      let resultFc: FeatureCollection | undefined;
+      const logs: string[] = [];
+
+      encodePolylineTool.run({
+        layers: [lineLayer as any],
+        parameters: {
+          layer: "test-line-layer",
+          precision: "5",
+          targetField: "encoded_geom",
+        },
+        log: (msg) => logs.push(msg),
+        addResultLayer: (name, fc) => {
+          resultName = name;
+          resultFc = fc;
+        },
+      });
+
+      assert.equal(resultName, "Encoded polylines");
+      assert.ok(resultFc);
+      assert.equal(resultFc.features.length, 1);
+      assert.equal(resultFc.features[0].properties?.encoded_geom, "_p~iF~ps|U_ulLnnqC_mqNvxq`@");
+      assert.equal(resultFc.features[0].properties?.name, "Route A");
+    });
+  });
+
+  describe("drag and drop file ingestion", () => {
+    it("loads dropped .polyline files directly into FeatureCollection layers", async () => {
+      const { loadDroppedVectorFiles } = await import(
+        "../apps/geolibre-desktop/src/lib/tauri-io"
+      );
+      const mockPolylineFile = new File(
+        ["_p~iF~ps|U_ulLnnqC_mqNvxq`@\n_p~iF~ps|U_ulLnnqC_mqNvxq`@"],
+        "Polyline.polyline",
+        { type: "text/plain" },
+      );
+
+      const loaded = await loadDroppedVectorFiles([mockPolylineFile]);
+      assert.equal(loaded.length, 1);
+      assert.equal(loaded[0].name, "Polyline");
+      assert.equal(loaded[0].data.type, "FeatureCollection");
+      assert.equal(loaded[0].data.features.length, 2);
+      assert.equal(loaded[0].data.features[0].geometry.type, "LineString");
+    });
+  });
+
+  describe("layer export geometry restrictions", () => {
+    it("layerSupportsPolylineExport returns true only for line layers", async () => {
+      const { layerSupportsPolylineExport } = await import(
+        "../apps/geolibre-desktop/src/lib/vector-export"
+      );
+
+      const lineLayer = {
+        id: "l1",
+        name: "Line Layer",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: {},
+              geometry: {
+                type: "LineString" as const,
+                coordinates: [
+                  [0, 0],
+                  [1, 1],
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      const pointLayer = {
+        id: "p1",
+        name: "Point Layer",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: { geometryType: "point" },
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: {},
+              geometry: {
+                type: "Point" as const,
+                coordinates: [0, 0],
+              },
+            },
+          ],
+        },
+      };
+
+      const polygonLayer = {
+        id: "poly1",
+        name: "Polygon Layer",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: { geometryType: "polygon" },
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: {},
+              geometry: {
+                type: "Polygon" as const,
+                coordinates: [
+                  [
+                    [0, 0],
+                    [1, 0],
+                    [1, 1],
+                    [0, 1],
+                    [0, 0],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      assert.equal(layerSupportsPolylineExport(lineLayer as any), true);
+      assert.equal(layerSupportsPolylineExport(pointLayer as any), false);
+      assert.equal(layerSupportsPolylineExport(polygonLayer as any), false);
+    });
+  });
+});

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -136,6 +136,13 @@ describe("polyline codec", () => {
       const decoded = decodePolyline(escaped, 5, true);
       assert.equal(decoded.length, 3);
     });
+
+    it("preserves literal \\n, \\r, and \\t sequences without converting to control characters", () => {
+      assert.equal(unescapePolyline("abc\\ndef"), "abc\\ndef");
+      assert.equal(unescapePolyline("abc\\rdef"), "abc\\rdef");
+      assert.equal(unescapePolyline("abc\\tdef"), "abc\\tdef");
+      assert.equal(unescapePolyline('a\\"b\\\'c\\\\d'), 'a"b\'c\\d');
+    });
   });
 
   describe("batchDecodePolylines", () => {
@@ -331,6 +338,138 @@ describe("polyline codec", () => {
       assert.equal(resultFc.features.length, 1);
       assert.equal(resultFc.features[0].properties?.encoded_geom, "_p~iF~ps|U_ulLnnqC_mqNvxq`@");
       assert.equal(resultFc.features[0].properties?.name, "Route A");
+    });
+
+    it("decodePolylineTool skips malformed polyline string containing invalid characters like '/'", async () => {
+      const { decodePolylineTool } = await import("@geolibre/processing");
+      const layerWithInvalidPoly = {
+        id: "test-poly-layer-invalid",
+        name: "Invalid Polyline",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: { routeId: "Bad", poly: "_p~iF/invalid" },
+              geometry: null as any,
+            },
+          ],
+        },
+      };
+
+      let resultFc: FeatureCollection | undefined;
+      const logs: string[] = [];
+
+      decodePolylineTool.run({
+        layers: [layerWithInvalidPoly as any],
+        parameters: {
+          layer: "test-poly-layer-invalid",
+          field: "poly",
+          precision: "5",
+        },
+        log: (msg) => logs.push(msg),
+        addResultLayer: (_name, fc) => {
+          resultFc = fc;
+        },
+      });
+
+      assert.ok(resultFc);
+      assert.equal(resultFc.features.length, 0);
+      assert.ok(logs.some((msg) => msg.includes("Skipped 1 feature(s)")));
+    });
+
+    it("round-trips MultiLineString features through encodePolylineTool and decodePolylineTool", async () => {
+      const { encodePolylineTool, decodePolylineTool } = await import("@geolibre/processing");
+      const multiLineLayer = {
+        id: "test-multi-layer",
+        name: "MultiLine Test",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: {
+          type: "FeatureCollection" as const,
+          features: [
+            {
+              type: "Feature" as const,
+              properties: { routeGroup: "Multi1" },
+              geometry: {
+                type: "MultiLineString" as const,
+                coordinates: [
+                  [
+                    [-120.2, 38.5],
+                    [-120.95, 40.7],
+                  ],
+                  [
+                    [-77.05, 38.88],
+                    [-77.04, 38.89],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      let encodedFc: FeatureCollection | undefined;
+      encodePolylineTool.run({
+        layers: [multiLineLayer as any],
+        parameters: {
+          layer: "test-multi-layer",
+          precision: "5",
+          targetField: "poly_str",
+        },
+        log: () => {},
+        addResultLayer: (_name, fc) => {
+          encodedFc = fc;
+        },
+      });
+
+      assert.ok(encodedFc);
+      assert.equal(encodedFc.features.length, 1);
+      const encodedProp = encodedFc.features[0].properties?.poly_str;
+      assert.ok(typeof encodedProp === "string" && encodedProp.includes(";"));
+
+      const encodedLayer = {
+        id: "test-encoded-layer",
+        name: "Encoded",
+        type: "geojson" as const,
+        visible: true,
+        opacity: 1,
+        style: {} as any,
+        metadata: {},
+        source: { type: "geojson" as const },
+        geojson: encodedFc,
+      };
+
+      let decodedFc: FeatureCollection | undefined;
+      decodePolylineTool.run({
+        layers: [encodedLayer as any],
+        parameters: {
+          layer: "test-encoded-layer",
+          field: "poly_str",
+          precision: "5",
+        },
+        log: () => {},
+        addResultLayer: (_name, fc) => {
+          decodedFc = fc;
+        },
+      });
+
+      assert.ok(decodedFc);
+      assert.equal(decodedFc.features.length, 1);
+      const decodedGeom = decodedFc.features[0].geometry;
+      assert.equal(decodedGeom.type, "MultiLineString");
+      assert.equal((decodedGeom as MultiLineString).coordinates.length, 2);
+      assert.equal(decodedFc.features[0].properties?.routeGroup, "Multi1");
     });
   });
 

--- a/tests/polyline.test.ts
+++ b/tests/polyline.test.ts
@@ -141,7 +141,7 @@ describe("polyline codec", () => {
       assert.equal(unescapePolyline("abc\\ndef"), "abc\\ndef");
       assert.equal(unescapePolyline("abc\\rdef"), "abc\\rdef");
       assert.equal(unescapePolyline("abc\\tdef"), "abc\\tdef");
-      assert.equal(unescapePolyline('a\\"b\\\'c\\\\d'), 'a"b\'c\\d');
+      assert.equal(unescapePolyline("a\\\"b\\'c\\\\d"), "a\"b'c\\d");
     });
   });
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,12 +1,12 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
+import { decodePolyline } from "../packages/core/src/polyline";
 import {
   DEFAULT_ROUTING_ENDPOINT,
   buildIsochroneRequest,
   buildMatrixRequest,
   buildRouteRequest,
   compareSequenceValues,
-  decodePolyline,
   getRoutingConfig,
   isochroneResponseToFeatures,
   matrixResponseToFeatures,
@@ -202,9 +202,9 @@ describe("decodePolyline", () => {
     ]);
   });
 
-  it("decodes a Valhalla precision-6 polyline at the default precision", () => {
+  it("decodes a Valhalla precision-6 polyline", () => {
     // Encodes [[-77.05, 38.88], [-77.04, 38.89], [-77.02, 38.9]] at precision 6.
-    assert.deepEqual(decodePolyline("_o`diA~gw}qC_pR_pR_pR_af@"), [
+    assert.deepEqual(decodePolyline("_o`diA~gw}qC_pR_pR_pR_af@", 6), [
       [-77.05, 38.88],
       [-77.04, 38.89],
       [-77.02, 38.9],
@@ -217,7 +217,7 @@ describe("decodePolyline", () => {
 
   it("drops a truncated trailing chunk instead of emitting a garbage coord", () => {
     // The full string above with its last coordinate cut off mid-chunk.
-    assert.deepEqual(decodePolyline("_o`diA~gw}qC_pR_pR_p"), [
+    assert.deepEqual(decodePolyline("_o`diA~gw}qC_pR_pR_p", 6), [
       [-77.05, 38.88],
       [-77.04, 38.89],
     ]);


### PR DESCRIPTION
## Summary
Implemented a comprehensive Google Encoded Polyline codec supporting standard precision 5 (Google, OSRM) and precision 6 (Valhalla, Mapbox), unescaping of backslashes, batch parsing with custom delimiters, interactive preview and coordinate inspector in Add Data UI, processing toolbox tools, layer export, and full Python package support with zero external dependencies.

## Related Issue
Closes #2029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing encoded polylines from pasted text, files, and drag-and-drop.
  * Added tools to decode polylines into line layers and encode line geometries into polyline text.
  * Added Encoded Polyline export for compatible line layers, with precision 5 and 6 options.
  * Added delimiter, multiline output, validation, previews, and automatic layer naming options.
  * Added polyline utilities and `Map.add_polyline()` support in the Python API.

* **Documentation**
  * Updated user guides and Python API documentation with encoded polyline workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->