### PR TITLE
Fix raster calculator comparison outputs

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -1,7 +1,7 @@
 import { useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
-import { addCogRasterLayer } from "@geolibre/plugins";
+import { addRasterToMap } from "@geolibre/plugins";
 import {
   RASTER_TOOLS,
   getRasterTool,
@@ -10,6 +10,7 @@ import {
   runRasterTool,
   readRasterData,
   runRasterToolClient,
+  convertGeoTiffToCog,
   buildSpectralIndexExpression,
   type AlgorithmParameter,
   type ConversionJob,
@@ -558,7 +559,7 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
         ]);
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
       }
-      const { raster: result, bytes } = runRasterToolClient(tool.id, raster, params);
+      const { bytes } = runRasterToolClient(tool.id, raster, params);
       setClientLog((prev) => [
         ...prev,
         t("toolbar.rasterTool.computedInBrowser", { tool: tool.name }),
@@ -569,14 +570,14 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
       setClientResult({ name: outName, bytes });
       const app = createAppAPI(mapControllerRef);
       try {
-        await addCogRasterLayer(app, {
-          url: outName,
-          data: bytes,
-          name: outName.replace(/\.tiff?$/i, ""),
-          // The renderer reads NoData from options (not the file's tag), so pass
-          // it explicitly for correct transparency of masked/edge cells.
-          ...(result.nodata != null ? { nodata: result.nodata } : {}),
-        });
+        const cogBytes = await convertGeoTiffToCog(new Uint8Array(bytes));
+        await addRasterToMap(
+          app,
+          new File([cogBytes as Uint8Array<ArrayBuffer>], outName, { type: "image/tiff" }),
+          {
+            name: outName.replace(/\.tiff?$/i, ""),
+          },
+        );
         setClientLog((prev) => [...prev, t("toolbar.rasterTool.addedToMap", { name: outName })]);
         tracker.addOutputLayer(outName);
       } catch (mapError) {

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -11,6 +11,7 @@ import {
   readRasterData,
   runRasterToolClient,
   convertGeoTiffToCog,
+  exceedsBrowserCogConversionLimit,
   buildSpectralIndexExpression,
   type AlgorithmParameter,
   type ConversionJob,
@@ -550,6 +551,13 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
       // thread blocks; a Web Worker would be the full fix for very large rasters.
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
       const pixelCount = raster.width * raster.height;
+      if (exceedsBrowserCogConversionLimit(pixelCount)) {
+        const message = t("raster.cogConvertTooLarge", { name: tool.defaultOutputName });
+        setError(message);
+        setClientLog((prev) => [...prev, message]);
+        tracker.finish("error", message);
+        return;
+      }
       if (pixelCount > 2_000_000) {
         setClientLog((prev) => [
           ...prev,
@@ -573,6 +581,8 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
         const cogBytes = await convertGeoTiffToCog(new Uint8Array(bytes));
         await addRasterToMap(
           app,
+          // TypeScript widens wasm byte buffers to ArrayBufferLike, which is
+          // not directly assignable to BlobPart's ArrayBufferView.
           new File([cogBytes as Uint8Array<ArrayBuffer>], outName, { type: "image/tiff" }),
           {
             name: outName.replace(/\.tiff?$/i, ""),

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -551,13 +551,6 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
       // thread blocks; a Web Worker would be the full fix for very large rasters.
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
       const pixelCount = raster.width * raster.height;
-      if (exceedsBrowserCogConversionLimit(pixelCount)) {
-        const message = t("raster.cogConvertTooLarge", { name: tool.defaultOutputName });
-        setError(message);
-        setClientLog((prev) => [...prev, message]);
-        tracker.finish("error", message);
-        return;
-      }
       if (pixelCount > 2_000_000) {
         setClientLog((prev) => [
           ...prev,
@@ -567,7 +560,7 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
         ]);
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
       }
-      const { bytes } = runRasterToolClient(tool.id, raster, params);
+      const { raster: result, bytes } = runRasterToolClient(tool.id, raster, params);
       setClientLog((prev) => [
         ...prev,
         t("toolbar.rasterTool.computedInBrowser", { tool: tool.name }),
@@ -576,6 +569,14 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
       // Persist the result before the map add so the Download button survives a
       // render failure (the compute already succeeded — don't discard it).
       setClientResult({ name: outName, bytes });
+      const resultSampleCount = result.width * result.height * result.bands.length;
+      if (exceedsBrowserCogConversionLimit(resultSampleCount)) {
+        const message = t("raster.cogConvertTooLarge", { name: outName });
+        setError(message);
+        setClientLog((prev) => [...prev, message]);
+        tracker.finish("error", message);
+        return;
+      }
       const app = createAppAPI(mapControllerRef);
       try {
         const cogBytes = await convertGeoTiffToCog(new Uint8Array(bytes));

--- a/packages/processing/src/raster-client.ts
+++ b/packages/processing/src/raster-client.ts
@@ -75,8 +75,6 @@ const PRESERVED_GEO_KEYS = [
   "GTRasterTypeGeoKey",
   "GeographicTypeGeoKey",
   "ProjectedCSTypeGeoKey",
-  "GeogCitationGeoKey",
-  "GTCitationGeoKey",
 ] as const;
 
 /**
@@ -544,7 +542,7 @@ export function rasterCalc(input: RasterData, params: RasterCalcParams): RasterD
       continue;
     }
     args[0] = args[1]; // A === band 1
-    const value = fn(...args, ...(helpers as unknown as number[]));
+    const value = Number(fn(...args, ...(helpers as unknown as number[])));
     out[p] = Number.isFinite(value) ? value : outNoData;
   }
   return singleBandResult(input, out, outNoData);

--- a/tests/raster-client.test.ts
+++ b/tests/raster-client.test.ts
@@ -140,6 +140,12 @@ describe("raster-client compute", () => {
     assert.ok(Math.abs(out.bands[0][1] - (6 - 2) / (6 + 2)) < 1e-6);
   });
 
+  it("converts comparison results to a numeric raster mask", () => {
+    const raster = makeRaster([[100, 200, 201, 300]], 4, 1);
+    const out = rasterCalc(raster, { expression: "A > 200" });
+    assert.deepEqual([...out.bands[0]], [0, 0, 1, 1]);
+  });
+
   it("rejects multi-raster references in client band math", () => {
     const raster = makeRaster([[1, 2]], 2, 1);
     assert.throws(() => rasterCalc(raster, { expression: "A + B" }), /single input/);


### PR DESCRIPTION
## Summary

- coerce boolean raster calculator results to numeric 0/1 values instead of treating them as NoData
- omit redundant GeoTIFF citation keys that corrupt generated GeoKey offsets while preserving numeric EPSG keys
- convert browser-generated outputs to COGs and add them through the shared raster control so symbology and pixel inspection remain available
- add regression coverage for comparison expressions

Related to https://github.com/opengeos/GeoLibre/discussions/2032

## Verification

- `node --import tsx --test tests/raster-client.test.ts`
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx packages/processing/src/raster-client.ts tests/raster-client.test.ts`
- Playwright with `dem.tif` and `A > 200` in light and dark themes
- confirmed raster symbology opens and pixel inspection activates for the generated layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-based raster processing so converted results are added to the map reliably.
  * Added clear failure handling when rasters exceed browser conversion limits.
  * Raster calculations now represent comparison results as numeric masks: false values as 0 and true values as 1.
  * Streamlined GeoTIFF output metadata handling for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->