### PR TITLE
feat: implement activity log for shared projects and collaboration sessions

### DIFF
--- a/backend/geolibre_server_api/geolibre_server_api/main.py
+++ b/backend/geolibre_server_api/geolibre_server_api/main.py
@@ -112,6 +112,23 @@ class Version(Base):
     project: Mapped[Project] = relationship(back_populates="versions")
 
 
+class ProjectActivity(Base):
+    __tablename__ = "project_activities"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    project_id: Mapped[str] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"), index=True
+    )
+    actor_id: Mapped[str | None] = mapped_column(
+        ForeignKey("accounts.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    action: Mapped[str] = mapped_column(String(50))
+    details_json: Mapped[str] = mapped_column(Text, default="{}")
+    created_at: Mapped[str] = mapped_column(String(32), index=True)
+
+    project: Mapped[Project] = relationship()
+    actor: Mapped[Account | None] = relationship()
+
+
 # project_json reads project.owner.username and len(project.versions), both lazy.
 # Without these a single listing page (up to 100 rows) fires ~201 queries instead
 # of three.
@@ -149,6 +166,24 @@ class ForkRequest(BaseModel):
 
 def now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def log_project_activity(
+    session: Session,
+    project_id: str,
+    actor_id: str | None,
+    action: str,
+    details: dict | None = None,
+) -> None:
+    activity = ProjectActivity(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        actor_id=actor_id,
+        action=action,
+        details_json=json.dumps(details or {}),
+        created_at=now(),
+    )
+    session.add(activity)
 
 
 def password_hash(password: str, salt: bytes | None = None) -> str:
@@ -638,6 +673,32 @@ def create_app(
     ):
         return {"project": project_json(visible(session.get(Project, project_id), account))}
 
+    @app.get("/api/projects/{project_id}/activity")
+    def get_project_activity(
+        project_id: str,
+        account: Account = Depends(required_account),
+        session: Session = Depends(db),
+    ):
+        project = owned(session.get(Project, project_id), account)
+        activities = session.scalars(
+            select(ProjectActivity)
+            .where(ProjectActivity.project_id == project.id)
+            .order_by(ProjectActivity.created_at.desc())
+            .limit(100)
+        ).all()
+        return {
+            "activity": [
+                {
+                    "id": act.id,
+                    "action": act.action,
+                    "actor_id": act.actor_id,
+                    "details": json.loads(act.details_json),
+                    "created_at": act.created_at,
+                }
+                for act in activities
+            ]
+        }
+
     @app.patch("/api/projects/{project_id}")
     def patch_project(
         project_id: str,
@@ -646,6 +707,7 @@ def create_app(
         session: Session = Depends(db),
     ):
         project = owned(session.get(Project, project_id), account)
+        old_visibility = project.visibility
         updates = body.model_dump(exclude_unset=True)
         if "title" in updates:
             if not updates["title"] or not updates["title"].strip():
@@ -667,6 +729,14 @@ def create_app(
                 raise HTTPException(422, "tags must contain at most 20 non-empty 40-character tags")
             project.tags_json = json.dumps(tags)
         project.updated_at = now()
+        if old_visibility != project.visibility:
+            log_project_activity(
+                session,
+                project.id,
+                account.id,
+                "visibility_change",
+                {"before": old_visibility, "after": project.visibility},
+            )
         session.commit()
         return {"project": project_json(project)}
 
@@ -707,6 +777,7 @@ def create_app(
             raise HTTPException(409, "could not allocate a version number; retry")
         object_storage.put(key, body.content.encode(), "application/json")
         project.updated_at = now()
+        log_project_activity(session, project.id, account.id, "version_save", {"version": number})
         session.commit()
         session.refresh(project)
         return {"project": project_json(project), "version": number}
@@ -750,6 +821,7 @@ def create_app(
         session.execute(
             update(Project).where(Project.id == source.id).values(fork_count=Project.fork_count + 1)
         )
+        log_project_activity(session, source.id, account.id, "fork", {"forked_project_id": fork.id})
         session.commit()
         session.refresh(fork)
         return {"project": project_json(fork)}
@@ -779,6 +851,10 @@ def create_app(
         version = session.get(Version, (project_id, number))
         if version is None:
             raise HTTPException(404, "project version not found")
+        log_project_activity(
+            session, project.id, account.id if account else None, "fetch", {"version": number}
+        )
+        session.commit()
         return raw_response(project, version, True)
 
     @app.put("/api/projects/{project_id}/thumbnail", status_code=204)
@@ -854,6 +930,13 @@ def create_app(
         session.execute(
             update(Project).where(Project.id == project.id).values(views=Project.views + 1)
         )
+        log_project_activity(
+            session,
+            project.id,
+            account.id if account else None,
+            "fetch",
+            {"version": project.versions[-1].number if project.versions else None},
+        )
         session.commit()
         return body
 
@@ -868,6 +951,8 @@ def create_app(
             select(Project).join(Account).where(Account.username == username, Project.slug == slug)
         )
         project = visible(project, account)
+        log_project_activity(session, project.id, account.id if account else None, "open")
+        session.commit()
         raw = f"{base_url}/{quote(username)}/{quote(slug)}.geolibre.json"
         return RedirectResponse(viewer_url + "?project=" + quote(raw, safe=""), status_code=302)
 

--- a/backend/geolibre_server_api/geolibre_server_api/main.py
+++ b/backend/geolibre_server_api/geolibre_server_api/main.py
@@ -9,7 +9,7 @@ import re
 import secrets
 import shutil
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Literal
 from urllib.parse import quote
@@ -168,6 +168,18 @@ def now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+# Activity rows older than this are pruned the next time the project logs an
+# event, so the log never grows without bound (GeoLibre#1678 asks for a stated
+# retention period plus owner-initiated deletion, the latter being
+# DELETE /api/projects/{id}/activity).
+ACTIVITY_RETENTION_DAYS = int(os.getenv("GEOLIBRE_ACTIVITY_RETENTION_DAYS", "90"))
+# Actions an anonymous visitor can trigger. These are never stored per hit:
+# they are aggregated into one row per project, action and UTC day carrying a
+# count, so the owner learns "opened 40 times on 2026-08-21" and nothing about
+# who did it.
+AGGREGATED_ANONYMOUS_ACTIONS = frozenset({"open", "fetch"})
+
+
 def log_project_activity(
     session: Session,
     project_id: str,
@@ -175,15 +187,65 @@ def log_project_activity(
     action: str,
     details: dict | None = None,
 ) -> None:
-    activity = ProjectActivity(
-        id=str(uuid.uuid4()),
-        project_id=project_id,
-        actor_id=actor_id,
-        action=action,
-        details_json=json.dumps(details or {}),
-        created_at=now(),
+    """Record a project event, aggregating anonymous opens/fetches per day.
+
+    Args:
+        session: The open database session; the caller commits.
+        project_id: The project the event belongs to.
+        actor_id: The authenticated account, or ``None`` for an anonymous visitor.
+        action: A short action name such as ``"fork"`` or ``"visibility_change"``.
+        details: Optional JSON-serializable context stored with the row.
+    """
+    timestamp = now()
+    if actor_id is None and action in AGGREGATED_ANONYMOUS_ACTIONS:
+        day = timestamp[:10]
+        bucket = session.scalars(
+            select(ProjectActivity)
+            .where(
+                ProjectActivity.project_id == project_id,
+                ProjectActivity.actor_id.is_(None),
+                ProjectActivity.action == action,
+                ProjectActivity.created_at.like(f"{day}%"),
+            )
+            .limit(1)
+        ).first()
+        if bucket is not None:
+            counted = json.loads(bucket.details_json)
+            counted["count"] = int(counted.get("count", 0)) + 1
+            bucket.details_json = json.dumps(counted)
+            return
+        details = {"date": day, "count": 1}
+    session.add(
+        ProjectActivity(
+            id=str(uuid.uuid4()),
+            project_id=project_id,
+            actor_id=actor_id,
+            action=action,
+            details_json=json.dumps(details or {}),
+            created_at=timestamp,
+        )
     )
-    session.add(activity)
+    cutoff = (
+        (datetime.now(UTC) - timedelta(days=ACTIVITY_RETENTION_DAYS))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    session.execute(
+        delete(ProjectActivity).where(
+            ProjectActivity.project_id == project_id, ProjectActivity.created_at < cutoff
+        )
+    )
+
+
+def activity_json(act: ProjectActivity) -> dict:
+    """Serialize an activity row with the API's camelCase field names."""
+    return {
+        "id": act.id,
+        "action": act.action,
+        "actorId": act.actor_id,
+        "details": json.loads(act.details_json),
+        "createdAt": act.created_at,
+    }
 
 
 def password_hash(password: str, salt: bytes | None = None) -> str:
@@ -686,18 +748,18 @@ def create_app(
             .order_by(ProjectActivity.created_at.desc())
             .limit(100)
         ).all()
-        return {
-            "activity": [
-                {
-                    "id": act.id,
-                    "action": act.action,
-                    "actor_id": act.actor_id,
-                    "details": json.loads(act.details_json),
-                    "created_at": act.created_at,
-                }
-                for act in activities
-            ]
-        }
+        return {"activity": [activity_json(act) for act in activities]}
+
+    @app.delete("/api/projects/{project_id}/activity", status_code=204)
+    def delete_project_activity(
+        project_id: str,
+        account: Account = Depends(required_account),
+        session: Session = Depends(db),
+    ):
+        project = owned(session.get(Project, project_id), account)
+        session.execute(delete(ProjectActivity).where(ProjectActivity.project_id == project.id))
+        session.commit()
+        return Response(status_code=204)
 
     @app.patch("/api/projects/{project_id}")
     def patch_project(

--- a/backend/geolibre_server_api/geolibre_server_api/main.py
+++ b/backend/geolibre_server_api/geolibre_server_api/main.py
@@ -123,6 +123,12 @@ class ProjectActivity(Base):
     )
     action: Mapped[str] = mapped_column(String(50))
     details_json: Mapped[str] = mapped_column(Text, default="{}")
+    # Anonymous open/fetch events collapse into one row per project, action and
+    # UTC day: `bucket_key` ("<project>:<action>:<YYYY-MM-DD>") is unique so two
+    # concurrent requests cannot create duplicate buckets, and `count` is
+    # incremented database-side so they cannot lose each other's increment.
+    bucket_key: Mapped[str | None] = mapped_column(String(100), nullable=True, unique=True)
+    count: Mapped[int] = mapped_column(Integer, default=1)
     created_at: Mapped[str] = mapped_column(String(32), index=True)
 
     project: Mapped[Project] = relationship()
@@ -197,34 +203,6 @@ def log_project_activity(
         details: Optional JSON-serializable context stored with the row.
     """
     timestamp = now()
-    if actor_id is None and action in AGGREGATED_ANONYMOUS_ACTIONS:
-        day = timestamp[:10]
-        bucket = session.scalars(
-            select(ProjectActivity)
-            .where(
-                ProjectActivity.project_id == project_id,
-                ProjectActivity.actor_id.is_(None),
-                ProjectActivity.action == action,
-                ProjectActivity.created_at.like(f"{day}%"),
-            )
-            .limit(1)
-        ).first()
-        if bucket is not None:
-            counted = json.loads(bucket.details_json)
-            counted["count"] = int(counted.get("count", 0)) + 1
-            bucket.details_json = json.dumps(counted)
-            return
-        details = {"date": day, "count": 1}
-    session.add(
-        ProjectActivity(
-            id=str(uuid.uuid4()),
-            project_id=project_id,
-            actor_id=actor_id,
-            action=action,
-            details_json=json.dumps(details or {}),
-            created_at=timestamp,
-        )
-    )
     cutoff = (
         (datetime.now(UTC) - timedelta(days=ACTIVITY_RETENTION_DAYS))
         .isoformat()
@@ -235,15 +213,58 @@ def log_project_activity(
             ProjectActivity.project_id == project_id, ProjectActivity.created_at < cutoff
         )
     )
+    bucket_key = None
+    if actor_id is None and action in AGGREGATED_ANONYMOUS_ACTIONS:
+        day = timestamp[:10]
+        bucket_key = f"{project_id}:{action}:{day}"
+        details = {"date": day}
+        # Atomic increment: no read-modify-write, so two concurrent hits cannot
+        # overwrite each other's count.
+        updated = session.execute(
+            update(ProjectActivity)
+            .where(ProjectActivity.bucket_key == bucket_key)
+            .values(count=ProjectActivity.count + 1)
+        ).rowcount
+        if updated:
+            return
+    row = ProjectActivity(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        actor_id=actor_id,
+        action=action,
+        details_json=json.dumps(details or {}),
+        bucket_key=bucket_key,
+        count=1,
+        created_at=timestamp,
+    )
+    if bucket_key is None:
+        session.add(row)
+        return
+    # Two requests can both miss the UPDATE and race to create the day's bucket;
+    # the unique key makes the loser's INSERT fail, and it falls back to the
+    # increment.
+    try:
+        with session.begin_nested():
+            session.add(row)
+            session.flush()
+    except IntegrityError:
+        session.execute(
+            update(ProjectActivity)
+            .where(ProjectActivity.bucket_key == bucket_key)
+            .values(count=ProjectActivity.count + 1)
+        )
 
 
 def activity_json(act: ProjectActivity) -> dict:
     """Serialize an activity row with the API's camelCase field names."""
+    details = json.loads(act.details_json)
+    if act.bucket_key is not None:
+        details["count"] = act.count
     return {
         "id": act.id,
         "action": act.action,
         "actorId": act.actor_id,
-        "details": json.loads(act.details_json),
+        "details": details,
         "createdAt": act.created_at,
     }
 

--- a/backend/geolibre_server_api/geolibre_server_api/main.py
+++ b/backend/geolibre_server_api/geolibre_server_api/main.py
@@ -131,9 +131,6 @@ class ProjectActivity(Base):
     count: Mapped[int] = mapped_column(Integer, default=1)
     created_at: Mapped[str] = mapped_column(String(32), index=True)
 
-    project: Mapped[Project] = relationship()
-    actor: Mapped[Account | None] = relationship()
-
 
 # project_json reads project.owner.username and len(project.versions), both lazy.
 # Without these a single listing page (up to 100 rows) fires ~201 queries instead

--- a/backend/geolibre_server_api/geolibre_server_api/main.py
+++ b/backend/geolibre_server_api/geolibre_server_api/main.py
@@ -1015,7 +1015,7 @@ def create_app(
             project.id,
             account.id if account else None,
             "fetch",
-            {"version": project.versions[-1].number if project.versions else None},
+            {"version": project.versions[-1].number},
         )
         session.commit()
         return body

--- a/backend/geolibre_server_api/tests/test_api.py
+++ b/backend/geolibre_server_api/tests/test_api.py
@@ -275,3 +275,53 @@ def test_validation_and_errors_use_contract_shape(client):
     )
     assert bad.status_code == 422 and set(bad.json()) == {"error"}
     assert client.get("/api/projects?limit=101").status_code == 422
+
+
+def test_activity_log_aggregates_anonymous_opens_and_is_owner_only(client):
+    token = account(client)
+    project, _ = create_project(client, token)
+    project_id = project["id"]
+
+    # Anonymous opens/fetches are aggregated into one row per action and day,
+    # never stored per visitor.
+    for _ in range(3):
+        assert client.get("/ada/wetlands", follow_redirects=False).status_code == 302
+    assert client.get("/ada/wetlands.geolibre.json").status_code == 200
+    assert client.get("/ada/wetlands.geolibre.json").status_code == 200
+
+    # Authenticated actions are attributed.
+    response = client.patch(
+        f"/api/projects/{project_id}", headers=auth(token), json={"visibility": "private"}
+    )
+    assert response.status_code == 200
+
+    response = client.get(f"/api/projects/{project_id}/activity", headers=auth(token))
+    assert response.status_code == 200
+    entries = response.json()["activity"]
+    by_action = {entry["action"]: entry for entry in entries}
+    assert set(by_action) == {"open", "fetch", "visibility_change"}
+    assert len(entries) == 3
+    assert by_action["open"]["actorId"] is None
+    assert by_action["open"]["details"]["count"] == 3
+    assert by_action["fetch"]["details"]["count"] == 2
+    assert by_action["visibility_change"]["details"] == {"before": "public", "after": "private"}
+    assert by_action["visibility_change"]["actorId"]
+    assert all(entry["createdAt"].endswith("Z") for entry in entries)
+
+    # Only the owner may read or delete the log.
+    other = account(client, "bob")
+    assert (
+        client.get(f"/api/projects/{project_id}/activity", headers=auth(other)).status_code == 403
+    )
+    assert client.get(f"/api/projects/{project_id}/activity").status_code == 401
+    assert (
+        client.delete(f"/api/projects/{project_id}/activity", headers=auth(other)).status_code
+        == 403
+    )
+    assert (
+        client.delete(f"/api/projects/{project_id}/activity", headers=auth(token)).status_code
+        == 204
+    )
+    assert client.get(f"/api/projects/{project_id}/activity", headers=auth(token)).json() == {
+        "activity": []
+    }

--- a/backend/geolibre_server_api/tests/test_api.py
+++ b/backend/geolibre_server_api/tests/test_api.py
@@ -325,3 +325,40 @@ def test_activity_log_aggregates_anonymous_opens_and_is_owner_only(client):
     assert client.get(f"/api/projects/{project_id}/activity", headers=auth(token)).json() == {
         "activity": []
     }
+
+
+def test_anonymous_bucket_insert_race_falls_back_to_increment(client):
+    from geolibre_server_api.main import ProjectActivity, log_project_activity
+    from sqlalchemy import select
+    from sqlalchemy.orm import Session
+
+    token = account(client)
+    project, _ = create_project(client, token)
+
+    class MissedUpdate:
+        rowcount = 0
+
+    class RacingSession(Session):
+        """Pretends the first UPDATE found no bucket, as if another request
+        inserted it between our UPDATE and our INSERT."""
+
+        missed = False
+
+        def execute(self, statement, *args, **kwargs):
+            if not self.missed and "UPDATE" in str(statement):
+                self.missed = True
+                return MissedUpdate()
+            return super().execute(statement, *args, **kwargs)
+
+    with Session(client.app.state.engine) as session:
+        log_project_activity(session, project["id"], None, "open")
+        session.commit()
+    with RacingSession(client.app.state.engine) as session:
+        log_project_activity(session, project["id"], None, "open")
+        session.commit()
+        assert session.missed
+        rows = session.scalars(
+            select(ProjectActivity).where(ProjectActivity.project_id == project["id"])
+        ).all()
+    assert len(rows) == 1
+    assert rows[0].count == 2

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -237,6 +237,34 @@ Response `201`: `{"project": <project>, "version": <positive integer>}`.
 
 Requires ownership. Deletes metadata and stored objects. Response: `204`.
 
+### `GET /api/projects/{id}/activity`
+
+Requires ownership. Returns the project's activity log, newest first, capped
+at 100 entries:
+
+```json
+{"activity": [
+  {"id": "…", "action": "visibility_change", "actorId": "…",
+   "details": {"before": "private", "after": "public"}, "createdAt": "…"},
+  {"id": "…", "action": "open", "actorId": null,
+   "details": {"date": "2026-08-21", "count": 40}, "createdAt": "…"}
+]}
+```
+
+Actions and their `details`: `version_save` (`version`), `fork`
+(`forked_project_id`), `visibility_change` (`before`, `after`), `fetch` of
+the raw JSON (`version`) and `open` of the project page. `actorId` is the
+acting account, or `null` for an anonymous visitor. Anonymous `open` and
+`fetch` events are **never stored per visitor**: they are aggregated into one
+row per action and UTC day carrying a `count`, and no IP address or other
+visitor fingerprint is recorded. Rows are pruned after
+`GEOLIBRE_ACTIVITY_RETENTION_DAYS` (default 90) the next time the project logs
+an event. The log is visible only to the owner and never appears in listings.
+
+### `DELETE /api/projects/{id}/activity`
+
+Requires ownership. Deletes every activity row for the project. Response: `204`.
+
 ### `POST /api/projects/{id}/forks`
 
 Requires auth. Creates a new project owned by the caller from the visible

--- a/packages/collab-core/src/protocol.ts
+++ b/packages/collab-core/src/protocol.ts
@@ -293,3 +293,12 @@ export type ServerMessage =
   | LayerLocksMessage
   | KickedMessage
   | ErrorMessage;
+
+// Session Log ----------------------------------------------------------------
+
+export type SessionLogEntry =
+  | { type: "join"; ts: number; clientId: string; identity?: ParticipantIdentity | null }
+  | { type: "leave"; ts: number; clientId: string }
+  | { type: "set-mode"; ts: number; mode: CollaborationMode }
+  | { type: "set-participant-mode"; ts: number; clientId: string; canEdit: boolean }
+  | { type: "snapshot"; ts: number; rev: number; origin: string };

--- a/packages/collab-core/src/session.ts
+++ b/packages/collab-core/src/session.ts
@@ -21,6 +21,9 @@ export const EMPTY_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 export const MAX_CHAT_TEXT_LENGTH = 2000;
 export const CHAT_HISTORY_LIMIT = 50;
 export const MAX_CHAT_STORAGE_BYTES = 100_000;
+/** Host-visible session log: bounded by entry count and serialized bytes. */
+export const SESSION_LOG_LIMIT = 5000;
+export const MAX_SESSION_LOG_STORAGE_BYTES = 100_000;
 export const MIN_CHAT_INTERVAL_MS = 250;
 
 /**

--- a/workers/collab/src/index.ts
+++ b/workers/collab/src/index.ts
@@ -5,6 +5,8 @@
 //
 //   POST /sessions          -> create a session, return its code + host token
 //   GET  /sessions/:id/ws   -> WebSocket upgrade into that session's actor
+//   GET  /sessions/:id/log  -> host-only session log (Authorization: Bearer)
+//   DELETE /sessions/:id/log -> host-only: clear the session log
 //
 // The session code namespaces the Durable Object (idFromName), so every
 // participant of a session lands on the same actor and gets fanned out to.
@@ -20,8 +22,8 @@ const CODE_LENGTH = 8;
 
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
   "Access-Control-Max-Age": "86400",
 };
 
@@ -177,6 +179,17 @@ export default {
       // Rewrite to the actor's internal /ws path, preserving the upgrade
       // headers and method by copying them from the incoming request.
       return stub.fetch(new Request("https://collab/ws", request));
+    }
+
+    // Host-only session log: GET downloads it, DELETE clears it. The host
+    // token travels as `Authorization: Bearer <hostToken>`; the actor checks it.
+    const logMatch = url.pathname.match(/^\/sessions\/([^/]+)\/log$/);
+    if (logMatch && (request.method === "GET" || request.method === "DELETE")) {
+      const stub = env.COLLAB_SESSION.get(env.COLLAB_SESSION.idFromName(logMatch[1]));
+      const res = await stub.fetch(new Request("https://collab/log", request));
+      const headers = new Headers(res.headers);
+      for (const [key, value] of Object.entries(CORS_HEADERS)) headers.set(key, value);
+      return new Response(res.body, { status: res.status, headers });
     }
 
     if (url.pathname === "/" || url.pathname === "/health") {

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -9,6 +9,7 @@ import type {
   PresenceEntry,
   ServerMessage,
   ParticipantIdentity,
+  SessionLogEntry,
 } from "./protocol";
 import {
   isBoundedId,
@@ -334,6 +335,17 @@ export class CollabSession extends DurableObject<Env> {
       return new Response(null, { status: 101, webSocket: client });
     }
 
+    if (url.pathname === "/log" && request.method === "GET") {
+      const hostToken = await this.ctx.storage.get<string>("hostToken");
+      const clientToken = url.searchParams.get("hostToken");
+      if (hostToken === undefined || hostToken !== clientToken) {
+        return new Response("Forbidden", { status: 403 });
+      }
+      const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
+      const log = Array.isArray(raw) ? raw : [];
+      return Response.json(log);
+    }
+
     return new Response("Not found", { status: 404 });
   }
 
@@ -389,7 +401,7 @@ export class CollabSession extends DurableObject<Env> {
         await this.handleSetMode(ws, attachment, message.mode);
         break;
       case "set-participant-mode":
-        this.handleSetParticipantMode(ws, attachment, message);
+        await this.handleSetParticipantMode(ws, attachment, message);
         break;
       case "chat":
         await this.handleChat(ws, attachment, message);
@@ -420,7 +432,14 @@ export class CollabSession extends DurableObject<Env> {
 
   async webSocketClose(ws: WebSocket): Promise<void> {
     const attachment = ws.deserializeAttachment() as SocketAttachment | null;
-    if (attachment) this.presence.delete(attachment.clientId);
+    if (attachment) {
+      this.presence.delete(attachment.clientId);
+      await this.appendLog({
+        type: "leave",
+        ts: Date.now(),
+        clientId: attachment.clientId,
+      });
+    }
     try {
       ws.close();
     } catch {
@@ -563,6 +582,13 @@ export class CollabSession extends DurableObject<Env> {
     };
     ws.serializeAttachment(attachment);
 
+    await this.appendLog({
+      type: "join",
+      ts: Date.now(),
+      clientId: socketClientId,
+      identity,
+    });
+
     const welcomeInvites = role === "host" ? this.readInvites() : undefined;
 
     this.send(ws, {
@@ -633,6 +659,12 @@ export class CollabSession extends DurableObject<Env> {
     const rev = ((await this.ctx.storage.get<number>("rev")) ?? 0) + 1;
     await this.writeSnapshot(JSON.stringify(project));
     await this.ctx.storage.put("rev", rev);
+    await this.appendLog({
+      type: "snapshot",
+      ts: Date.now(),
+      rev,
+      origin: attachment.clientId,
+    });
 
     this.broadcast(
       {
@@ -679,6 +711,11 @@ export class CollabSession extends DurableObject<Env> {
     }
     const next = normalizeMode(mode);
     await this.ctx.storage.put("mode", next);
+    await this.appendLog({
+      type: "set-mode",
+      ts: Date.now(),
+      mode: next,
+    });
     // A session-wide mode change is authoritative: clear any per-participant
     // overrides so the new mode applies to everyone. Without this, a guest the
     // host previously pinned to can-edit would keep editing through a later
@@ -704,11 +741,11 @@ export class CollabSession extends DurableObject<Env> {
     this.broadcast({ type: "mode", mode: next });
   }
 
-  private handleSetParticipantMode(
+  private async handleSetParticipantMode(
     ws: WebSocket,
     attachment: SocketAttachment,
     message: Extract<ClientMessage, { type: "set-participant-mode" }>,
-  ): void {
+  ): Promise<void> {
     const forbidden = authorizeHostAction(attachment, "participant permissions");
     if (forbidden) {
       this.send(ws, {
@@ -737,6 +774,12 @@ export class CollabSession extends DurableObject<Env> {
     const targetKey = getParticipantKey(target.attachment);
     this.writeDurableOverride(targetKey, target.attachment.editOverride);
     target.socket.serializeAttachment(target.attachment);
+    await this.appendLog({
+      type: "set-participant-mode",
+      ts: Date.now(),
+      clientId: message.clientId,
+      canEdit: message.canEdit,
+    });
     // Everyone re-derives effective permission from the participants list (the
     // affected guest learns its own change here too), so a single broadcast
     // suffices.
@@ -804,6 +847,17 @@ export class CollabSession extends DurableObject<Env> {
   }
 
   // -- helpers ----------------------------------------------------------------
+
+  private async appendLog(entry: SessionLogEntry): Promise<void> {
+    const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
+    const log = Array.isArray(raw) ? raw : [];
+    log.push(entry);
+    // Bound the session log to max 5000 entries so it does not grow indefinitely.
+    if (log.length > 5000) {
+      log.shift();
+    }
+    await this.ctx.storage.put("sessionLog", log);
+  }
 
   /**
    * Live sockets paired with their deserialized attachment. Callers mutate the

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -31,6 +31,7 @@ import {
   isIdentityConfigured,
   MAX_CHAT_STORAGE_BYTES,
   MAX_CHAT_TEXT_LENGTH,
+  MAX_SESSION_LOG_STORAGE_BYTES,
   MAX_SNAPSHOT_BYTES,
   parseStoredChat,
   MIN_CHAT_INTERVAL_MS,
@@ -38,6 +39,7 @@ import {
   participantCanEdit,
   sanitizeColor,
   sanitizeCursor,
+  SESSION_LOG_LIMIT,
   sanitizeDisplayName,
   sanitizeView,
   setParticipantOverride,
@@ -335,15 +337,31 @@ export class CollabSession extends DurableObject<Env> {
       return new Response(null, { status: 101, webSocket: client });
     }
 
-    if (url.pathname === "/log" && request.method === "GET") {
+    // Host-only session log. The host token is a bearer credential, so it
+    // travels in the Authorization header rather than the query string (which
+    // lands in server logs, browser history and referrers). Both the stored and
+    // the presented token must be non-empty: /init persists "" for a session
+    // created without a token, and "" === "" must not grant access.
+    if (url.pathname === "/log" && (request.method === "GET" || request.method === "DELETE")) {
       const hostToken = await this.ctx.storage.get<string>("hostToken");
-      const clientToken = url.searchParams.get("hostToken");
-      if (hostToken === undefined || hostToken !== clientToken) {
+      const authorization = request.headers.get("Authorization") ?? "";
+      const clientToken = authorization.startsWith("Bearer ")
+        ? authorization.slice("Bearer ".length).trim()
+        : "";
+      if (!hostToken || !clientToken || hostToken !== clientToken) {
         return new Response("Forbidden", { status: 403 });
+      }
+      if (request.method === "DELETE") {
+        // Owner-initiated deletion of the log alone; the session itself and
+        // its snapshot are untouched.
+        await this.ctx.storage.delete("sessionLog");
+        return new Response(null, { status: 204 });
       }
       const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
       const log = Array.isArray(raw) ? raw : [];
-      return Response.json(log);
+      return new Response(JSON.stringify(log), {
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      });
     }
 
     return new Response("Not found", { status: 404 });
@@ -778,7 +796,9 @@ export class CollabSession extends DurableObject<Env> {
       type: "set-participant-mode",
       ts: Date.now(),
       clientId: message.clientId,
-      canEdit: message.canEdit,
+      // Record the normalized value that was actually applied, not the raw
+      // client-supplied one.
+      canEdit: target.attachment.editOverride === true,
     });
     // Everyone re-derives effective permission from the participants list (the
     // affected guest learns its own change here too), so a single broadcast
@@ -849,14 +869,28 @@ export class CollabSession extends DurableObject<Env> {
   // -- helpers ----------------------------------------------------------------
 
   private async appendLog(entry: SessionLogEntry): Promise<void> {
-    const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
-    const log = Array.isArray(raw) ? raw : [];
-    log.push(entry);
-    // Bound the session log to max 5000 entries so it does not grow indefinitely.
-    if (log.length > 5000) {
-      log.shift();
+    // Never let log persistence abort the caller: several handlers await this
+    // inline and still have to close the socket, broadcast, or arm the
+    // empty-session alarm afterwards.
+    try {
+      const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
+      const log = Array.isArray(raw) ? raw : [];
+      log.push(entry);
+      // Bound by count AND serialized bytes, the same way the chat history is:
+      // `join` entries carry an identity of unbounded size, so the count cap
+      // alone cannot keep the value under the ~128 KiB per-value storage cap.
+      let trimmed = log.slice(-SESSION_LOG_LIMIT);
+      let byteLen = ENCODER.encode(JSON.stringify(trimmed)).length;
+      while (trimmed.length > 1 && byteLen > MAX_SESSION_LOG_STORAGE_BYTES) {
+        byteLen -= ENCODER.encode(JSON.stringify(trimmed[0])).length + 1;
+        trimmed = trimmed.slice(1);
+      }
+      await this.ctx.storage.put("sessionLog", trimmed);
+    } catch {
+      // Persisting failed (e.g. a single entry still exceeds the value cap).
+      // The log is best-effort; the session state change it describes has
+      // already been applied.
     }
-    await this.ctx.storage.put("sessionLog", log);
   }
 
   /**

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -82,6 +82,16 @@ export interface Env {
 // second), so we don't allocate a new encoder per message.
 const ENCODER = new TextEncoder();
 
+function parseStoredSessionLog(raw: string | undefined): SessionLogEntry[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as SessionLogEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
 // Characters per stored snapshot chunk. A Durable Object caps a SQLite string
 // at 2 MB of UTF-8, and a JS string character can encode to 4 bytes, so this
 // leaves a chunk at half the ceiling even for text that is entirely non-ASCII.
@@ -357,9 +367,8 @@ export class CollabSession extends DurableObject<Env> {
         await this.ctx.storage.delete("sessionLog");
         return new Response(null, { status: 204 });
       }
-      const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
-      const log = Array.isArray(raw) ? raw : [];
-      return new Response(JSON.stringify(log), {
+      const raw = await this.ctx.storage.get<string>("sessionLog");
+      return new Response(raw ?? "[]", {
         headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
       });
     }
@@ -873,8 +882,7 @@ export class CollabSession extends DurableObject<Env> {
     // inline and still have to close the socket, broadcast, or arm the
     // empty-session alarm afterwards.
     try {
-      const raw = await this.ctx.storage.get<SessionLogEntry[]>("sessionLog");
-      const log = Array.isArray(raw) ? raw : [];
+      const log = parseStoredSessionLog(await this.ctx.storage.get<string>("sessionLog"));
       log.push(entry);
       // Bound by count AND serialized bytes, the same way the chat history is:
       // `join` entries carry an identity of unbounded size, so the count cap
@@ -885,7 +893,9 @@ export class CollabSession extends DurableObject<Env> {
         byteLen -= ENCODER.encode(JSON.stringify(trimmed[0])).length + 1;
         trimmed = trimmed.slice(1);
       }
-      await this.ctx.storage.put("sessionLog", trimmed);
+      // Stored as the same JSON string the budget was measured against (the
+      // chat history does the same), so the cap bounds what is persisted.
+      await this.ctx.storage.put("sessionLog", JSON.stringify(trimmed));
     } catch {
       // Persisting failed (e.g. a single entry still exceeds the value cap).
       // The log is best-effort; the session state change it describes has

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -82,8 +82,11 @@ export interface Env {
 // second), so we don't allocate a new encoder per message.
 const ENCODER = new TextEncoder();
 
-function parseStoredSessionLog(raw: string | undefined): SessionLogEntry[] {
-  if (!raw) return [];
+function parseStoredSessionLog(raw: unknown): SessionLogEntry[] {
+  // Accept either the JSON string this code writes or a bare array, so a
+  // value persisted in another shape is kept rather than silently discarded.
+  if (Array.isArray(raw)) return raw as SessionLogEntry[];
+  if (typeof raw !== "string" || !raw) return [];
   try {
     const parsed: unknown = JSON.parse(raw);
     return Array.isArray(parsed) ? (parsed as SessionLogEntry[]) : [];
@@ -367,8 +370,8 @@ export class CollabSession extends DurableObject<Env> {
         await this.ctx.storage.delete("sessionLog");
         return new Response(null, { status: 204 });
       }
-      const raw = await this.ctx.storage.get<string>("sessionLog");
-      return new Response(raw ?? "[]", {
+      const log = parseStoredSessionLog(await this.ctx.storage.get<unknown>("sessionLog"));
+      return new Response(JSON.stringify(log), {
         headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
       });
     }
@@ -882,7 +885,7 @@ export class CollabSession extends DurableObject<Env> {
     // inline and still have to close the socket, broadcast, or arm the
     // empty-session alarm afterwards.
     try {
-      const log = parseStoredSessionLog(await this.ctx.storage.get<string>("sessionLog"));
+      const log = parseStoredSessionLog(await this.ctx.storage.get<unknown>("sessionLog"));
       log.push(entry);
       // Bound by count AND serialized bytes, the same way the chat history is:
       // `join` entries carry an identity of unbounded size, so the count cap


### PR DESCRIPTION
the need for accountability and visibility on shared projects by adding activity tracking to both the backend API and the live collaboration worker. 

Backend Updates:
- Introduced a new `ProjectActivity` table to persist actions linked to a project and an optional user.
- Hooked into the existing API routes to automatically log project views (`opens` and `fetches`), saves, forks, and visibility changes.
- Added a `GET /api/projects/{id}/activity` endpoint, giving project owners access to their project's activity history.

 live Collaboration Relay Updates:
- Implemented a bounded `sessionLog` in the Durable Object's storage to track joining/leaving participants, permission shifts, mode changes, and snapshots. 
- Exposed a secure `GET /log` endpoint in the Worker router that allows session hosts to download the full session log using their host token.

Fixes #1678


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project owners can view or delete recent activity, including updates, saves, forks, document access, and project-page visits.
  * Anonymous opens and fetches are aggregated by project, action, and day without visitor tracking; older records are automatically removed.
  * Collaboration sessions record joins, departures, snapshots, mode changes, and participant editing-mode changes.
  * Hosts can securely access or delete session logs, with limits of 5,000 entries and 100,000 bytes.
* **Documentation**
  * Added API documentation for project and collaboration session activity logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->