### PR TITLE
fix: support multiple Whitebox dataset inputs

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -48,7 +48,9 @@ import { useTranslation } from "react-i18next";
 import {
   isTauri,
   openLocalDataFileWithFallback,
+  openLocalDataFilesWithFallback,
   pickLocalPathWithFallback,
+  pickLocalPathsWithFallback,
   pickSavePathWithFallback,
   type FileDialogFilter,
 } from "../../lib/tauri-io";
@@ -660,7 +662,7 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
   // the in-browser WASM runner. GeoJSON files are parsed up front so vector
   // tools receive a FeatureCollection, matching the layer-input path.
   const browsedInputsRef = useRef<
-    Map<string, { name: string; bytes: Uint8Array; geojson?: FeatureCollection }>
+    Map<string, Array<{ name: string; bytes: Uint8Array; geojson?: FeatureCollection }>>
   >(new Map());
   // Parameters passed to each run, keyed by the resulting job id, so output
   // naming can honor the output path the user actually typed (which the finished
@@ -1376,12 +1378,28 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
           // not valid JSON; fall back to raw bytes
         }
       }
-      browsedInputsRef.current.set(paramName, {
-        name: fileName,
-        bytes,
-        geojson,
-      });
+      browsedInputsRef.current.set(paramName, [{ name: fileName, bytes, geojson }]);
       setValues((prev) => ({ ...prev, [paramName]: fileName }));
+    },
+    [],
+  );
+
+  const handlePickInputFiles = useCallback(
+    (paramName: string, files: Array<{ fileName: string; bytes: Uint8Array }>) => {
+      const inputs = files.map(({ fileName, bytes }) => {
+        let geojson: FeatureCollection | undefined;
+        if (/\.(geojson|json)$/i.test(fileName)) {
+          try {
+            const parsed = JSON.parse(new TextDecoder().decode(bytes));
+            if (isFeatureCollection(parsed)) geojson = parsed;
+          } catch {
+            // Leave non-GeoJSON vector formats as raw bytes.
+          }
+        }
+        return { name: fileName, bytes, geojson };
+      });
+      browsedInputsRef.current.set(paramName, inputs);
+      setValues((prev) => ({ ...prev, [paramName]: inputs.map((input) => input.name).join(", ") }));
     },
     [],
   );
@@ -1497,11 +1515,14 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
       // A file browsed from disk in the web build: feed its bytes (or parsed
       // GeoJSON) straight to the WASM runner instead of an unresolvable path.
       const browsed = browsedInputsRef.current.get(param.name);
-      if (browsed && isDataInputParameter(param)) {
+      if (browsed?.length && isDataInputParameter(param)) {
         const kind = parameterKind(param);
-        layerInputs[param.name] = browsed.geojson
-          ? { name: browsed.name, kind, geojson: browsed.geojson }
-          : { name: browsed.name, kind, bytes: browsed.bytes };
+        const inputs = browsed.map((input) =>
+          input.geojson
+            ? { name: input.name, kind, geojson: input.geojson }
+            : { name: input.name, kind, bytes: input.bytes },
+        );
+        layerInputs[param.name] = inputs.length === 1 ? inputs[0] : inputs;
         continue;
       }
 
@@ -2069,6 +2090,7 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
                       onPickFile={(fileName, bytes) =>
                         handlePickInputFile(param.name, fileName, bytes)
                       }
+                      onPickFiles={(files) => handlePickInputFiles(param.name, files)}
                       onUseMapExtent={
                         isBboxExtentParameter(selectedTool, param) ? handleUseMapExtent : undefined
                       }
@@ -2305,6 +2327,7 @@ interface ParameterFieldProps {
   degreeLatitude?: number;
   onChange: (value: unknown) => void;
   onPickFile?: (fileName: string, bytes: Uint8Array) => void;
+  onPickFiles?: (files: Array<{ fileName: string; bytes: Uint8Array }>) => void;
   /** When set, renders a "Use map extent" button that fills this bbox field
    * (and its companion CRS) from the current map view. */
   onUseMapExtent?: () => void;
@@ -2328,6 +2351,7 @@ function ParameterField({
   degreeLatitude,
   onChange,
   onPickFile,
+  onPickFiles,
   onUseMapExtent,
   onDrawMapExtent,
   drawingMapExtent,
@@ -2455,24 +2479,24 @@ function ParameterField({
             onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
           />
         </div>
+      ) : isDataInputParameter(param) && isMultipleDatasetParameter(param) ? (
+        <MultiLayerOrPathInput
+          id={`whitebox-${param.name}`}
+          layers={availableLayers}
+          param={param}
+          value={value}
+          onChange={onChange}
+          onPickFiles={onPickFiles}
+        />
       ) : isDataInputParameter(param) && availableLayers.length > 0 ? (
-        isMultipleDatasetParameter(param) ? (
-          <MultiLayerOrPathInput
-            id={`whitebox-${param.name}`}
-            layers={availableLayers}
-            value={value}
-            onChange={onChange}
-          />
-        ) : (
-          <LayerOrPathInput
-            id={`whitebox-${param.name}`}
-            layers={availableLayers}
-            param={param}
-            value={valueText}
-            onChange={onChange}
-            onPickFile={onPickFile}
-          />
-        )
+        <LayerOrPathInput
+          id={`whitebox-${param.name}`}
+          layers={availableLayers}
+          param={param}
+          value={valueText}
+          onChange={onChange}
+          onPickFile={onPickFile}
+        />
       ) : kind === "vector_out" && runLocal ? (
         // In WASM mode a vector output is either a WGS84 map layer (GeoJSON) or a
         // downloaded file in a CRS-preserving format that keeps a reprojection's
@@ -2798,11 +2822,20 @@ interface MultiLayerOrPathInputProps {
   id: string;
   layers: GeoLibreLayer[];
   onChange: (value: unknown) => void;
+  onPickFiles?: (files: Array<{ fileName: string; bytes: Uint8Array }>) => void;
+  param: WhiteboxToolParameter;
   value: unknown;
 }
 
 /** Dataset-list picker used by merge, overlay, statistics, and stack tools. */
-function MultiLayerOrPathInput({ id, layers, onChange, value }: MultiLayerOrPathInputProps) {
+function MultiLayerOrPathInput({
+  id,
+  layers,
+  onChange,
+  onPickFiles,
+  param,
+  value,
+}: MultiLayerOrPathInputProps) {
   const { t } = useTranslation();
   const selected = Array.isArray(value)
     ? value.filter((item): item is string => typeof item === "string")
@@ -2810,35 +2843,47 @@ function MultiLayerOrPathInput({ id, layers, onChange, value }: MultiLayerOrPath
   const usingLayers = Array.isArray(value);
   return (
     <div className="grid gap-2">
-      <div id={id} className="grid max-h-40 gap-1 overflow-y-auto rounded-md border p-2">
-        {layers.map((layer) => {
-          const token = `${LAYER_TOKEN_PREFIX}${layer.id}`;
-          return (
-            <label key={layer.id} className="flex items-center gap-2 rounded px-1 py-1 text-sm">
-              <input
-                type="checkbox"
-                checked={selected.includes(token)}
-                onChange={(event) =>
-                  onChange(
-                    event.target.checked
-                      ? [...selected, token]
-                      : selected.filter((item) => item !== token),
-                  )
-                }
-              />
-              <span className="truncate">{layer.name}</span>
-            </label>
-          );
-        })}
+      {layers.length > 0 ? (
+        <div id={id} className="grid max-h-40 gap-1 overflow-y-auto rounded-md border p-2">
+          {layers.map((layer) => {
+            const token = `${LAYER_TOKEN_PREFIX}${layer.id}`;
+            return (
+              <label key={layer.id} className="flex items-center gap-2 rounded px-1 py-1 text-sm">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(token)}
+                  onChange={(event) =>
+                    onChange(
+                      event.target.checked
+                        ? [...selected, token]
+                        : selected.filter((item) => item !== token),
+                    )
+                  }
+                />
+                <span className="truncate">{layer.name}</span>
+              </label>
+            );
+          })}
+        </div>
+      ) : null}
+      <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
+        <Input
+          value={usingLayers ? "" : String(value ?? "")}
+          placeholder={
+            usingLayers ? t("processing.whitebox.selectedLayer") : t("processing.whitebox.filePath")
+          }
+          disabled={usingLayers && selected.length > 0}
+          onChange={(event) => onChange(event.target.value)}
+        />
+        <PathBrowseButton
+          disabled={usingLayers && selected.length > 0}
+          mode="open"
+          multiple
+          param={param}
+          onPick={(paths) => onChange(paths)}
+          onPickFiles={onPickFiles}
+        />
       </div>
-      <Input
-        value={usingLayers ? "" : String(value ?? "")}
-        placeholder={
-          usingLayers ? t("processing.whitebox.selectedLayer") : t("processing.whitebox.filePath")
-        }
-        disabled={usingLayers && selected.length > 0}
-        onChange={(event) => onChange(event.target.value)}
-      />
     </div>
   );
 }
@@ -2930,8 +2975,10 @@ function PathPickerInput({ id, onChange, onPickFile, param, toolId, value }: Pat
 interface PathBrowseButtonProps {
   disabled?: boolean;
   mode: "open" | "save";
+  multiple?: boolean;
   onPick: (path: string) => void;
   onPickFile?: (fileName: string, bytes: Uint8Array) => void;
+  onPickFiles?: (files: Array<{ fileName: string; bytes: Uint8Array }>) => void;
   param: WhiteboxToolParameter;
   toolId?: string;
 }
@@ -2939,8 +2986,10 @@ interface PathBrowseButtonProps {
 function PathBrowseButton({
   disabled = false,
   mode,
+  multiple = false,
   onPick,
   onPickFile,
+  onPickFiles,
   param,
   toolId = "whitebox",
 }: PathBrowseButtonProps) {
@@ -2953,6 +3002,30 @@ function PathBrowseButton({
         filters,
       });
       if (path) onPick(path);
+      return;
+    }
+
+    if (multiple) {
+      const paths = await pickLocalPathsWithFallback({
+        accept: acceptForParameter(param),
+        filters,
+      });
+      if (paths.length > 0) {
+        onPick(paths.join(","));
+        return;
+      }
+      if (!isTauri() && onPickFiles) {
+        const picked = await openLocalDataFilesWithFallback({
+          accept: acceptForParameter(param),
+          filters,
+          readBinary: true,
+        });
+        if (picked.length > 0) {
+          onPickFiles(
+            picked.map((file) => ({ fileName: file.path, bytes: new Uint8Array(file.data) })),
+          );
+        }
+      }
       return;
     }
 

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -70,7 +70,7 @@ import {
   wgs84VectorLayerIds,
   type DistanceUnit,
 } from "../../lib/whitebox-distance-params";
-import { parameterKind } from "../../lib/whitebox-param-kind";
+import { isMultipleDatasetParameter, parameterKind } from "../../lib/whitebox-param-kind";
 import { isTiff } from "../../lib/scripting/binary-output";
 import {
   canUseLayerForParameter,
@@ -250,7 +250,10 @@ function wgs84ToolLayerIds(tool: WhiteboxTool | null, values: ParameterValues): 
   const vectorInputs = params.filter((_, index) => kinds[index] === "vector_in");
   if (!vectorInputs.length) return null;
   return wgs84VectorLayerIds(
-    vectorInputs.map((param) => ({ required: param.required, value: values[param.name] })),
+    vectorInputs.map((param) => ({
+      required: param.required,
+      value: values[param.name],
+    })),
     LAYER_TOKEN_PREFIX,
   );
 }
@@ -1373,7 +1376,11 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
           // not valid JSON; fall back to raw bytes
         }
       }
-      browsedInputsRef.current.set(paramName, { name: fileName, bytes, geojson });
+      browsedInputsRef.current.set(paramName, {
+        name: fileName,
+        bytes,
+        geojson,
+      });
       setValues((prev) => ({ ...prev, [paramName]: fileName }));
     },
     [],
@@ -1470,14 +1477,17 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
     // blocks the main thread).
     setRunningLocal(true);
     const parameters: Record<string, unknown> = {};
-    const layerInputs: Record<string, WhiteboxLayerInput> = {};
+    const layerInputs: Record<string, WhiteboxLayerInput | WhiteboxLayerInput[]> = {};
 
     for (const param of selectedTool.params ?? []) {
       const value = values[param.name];
       if (
         param.required &&
         !isOutputParameter(param) &&
-        (value === undefined || value === null || value === "")
+        (value === undefined ||
+          value === null ||
+          value === "" ||
+          (Array.isArray(value) && value.length === 0))
       ) {
         setError(`Missing required parameter: ${parameterLabel(param)}`);
         setRunningLocal(false);
@@ -1495,7 +1505,35 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
         continue;
       }
 
-      if (typeof value === "string" && value.startsWith(LAYER_TOKEN_PREFIX)) {
+      if (isMultipleDatasetParameter(param) && Array.isArray(value)) {
+        const selectedLayers = value
+          .filter(
+            (item): item is string =>
+              typeof item === "string" && item.startsWith(LAYER_TOKEN_PREFIX),
+          )
+          .map((item) => layers.find((layer) => layer.id === item.slice(LAYER_TOKEN_PREFIX.length)))
+          .filter((layer): layer is GeoLibreLayer => Boolean(layer));
+        const kind = parameterKind(param);
+        if (runLocal && kind === "vector_in") {
+          layerInputs[param.name] = selectedLayers.map((layer) => ({
+            name: layer.name,
+            kind,
+            geojson: layer.geojson,
+          }));
+        } else if (runLocal) {
+          layerInputs[param.name] = await Promise.all(
+            selectedLayers.map(async (layer) => ({
+              name: layer.name,
+              kind,
+              bytes: (await fetchLayerBytes(layer)) ?? undefined,
+            })),
+          );
+        } else {
+          // Whitebox list arguments use comma-delimited paths. The browser
+          // runner builds the same form after staging each selected dataset.
+          parameters[param.name] = selectedLayers.map(layerPath).filter(Boolean).join(",");
+        }
+      } else if (typeof value === "string" && value.startsWith(LAYER_TOKEN_PREFIX)) {
         const layerId = value.slice(LAYER_TOKEN_PREFIX.length);
         const layer = layers.find((item) => item.id === layerId);
         if (!layer) continue;
@@ -2418,14 +2456,23 @@ function ParameterField({
           />
         </div>
       ) : isDataInputParameter(param) && availableLayers.length > 0 ? (
-        <LayerOrPathInput
-          id={`whitebox-${param.name}`}
-          layers={availableLayers}
-          param={param}
-          value={valueText}
-          onChange={onChange}
-          onPickFile={onPickFile}
-        />
+        isMultipleDatasetParameter(param) ? (
+          <MultiLayerOrPathInput
+            id={`whitebox-${param.name}`}
+            layers={availableLayers}
+            value={value}
+            onChange={onChange}
+          />
+        ) : (
+          <LayerOrPathInput
+            id={`whitebox-${param.name}`}
+            layers={availableLayers}
+            param={param}
+            value={valueText}
+            onChange={onChange}
+            onPickFile={onPickFile}
+          />
+        )
       ) : kind === "vector_out" && runLocal ? (
         // In WASM mode a vector output is either a WGS84 map layer (GeoJSON) or a
         // downloaded file in a CRS-preserving format that keeps a reprojection's
@@ -2695,7 +2742,10 @@ function DistanceInput({ id, latitude, onChange, value }: DistanceInputProps) {
       ? t("processing.distance.convertedEmpty", { latitude: latitudeLabel })
       : draftValue === null
         ? t("processing.distance.notANumber")
-        : t("processing.distance.converted", { degrees: value, latitude: latitudeLabel });
+        : t("processing.distance.converted", {
+            degrees: value,
+            latitude: latitudeLabel,
+          });
 
   return (
     <div className="grid gap-1.5">
@@ -2742,6 +2792,55 @@ interface LayerOrPathInputProps {
   onPickFile?: (fileName: string, bytes: Uint8Array) => void;
   param: WhiteboxToolParameter;
   value: string;
+}
+
+interface MultiLayerOrPathInputProps {
+  id: string;
+  layers: GeoLibreLayer[];
+  onChange: (value: unknown) => void;
+  value: unknown;
+}
+
+/** Dataset-list picker used by merge, overlay, statistics, and stack tools. */
+function MultiLayerOrPathInput({ id, layers, onChange, value }: MultiLayerOrPathInputProps) {
+  const { t } = useTranslation();
+  const selected = Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+  const usingLayers = Array.isArray(value);
+  return (
+    <div className="grid gap-2">
+      <div id={id} className="grid max-h-40 gap-1 overflow-y-auto rounded-md border p-2">
+        {layers.map((layer) => {
+          const token = `${LAYER_TOKEN_PREFIX}${layer.id}`;
+          return (
+            <label key={layer.id} className="flex items-center gap-2 rounded px-1 py-1 text-sm">
+              <input
+                type="checkbox"
+                checked={selected.includes(token)}
+                onChange={(event) =>
+                  onChange(
+                    event.target.checked
+                      ? [...selected, token]
+                      : selected.filter((item) => item !== token),
+                  )
+                }
+              />
+              <span className="truncate">{layer.name}</span>
+            </label>
+          );
+        })}
+      </div>
+      <Input
+        value={usingLayers ? "" : String(value ?? "")}
+        placeholder={
+          usingLayers ? t("processing.whitebox.selectedLayer") : t("processing.whitebox.filePath")
+        }
+        disabled={usingLayers && selected.length > 0}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </div>
+  );
 }
 
 function LayerOrPathInput({

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1517,6 +1517,13 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
       const browsed = browsedInputsRef.current.get(param.name);
       if (browsed?.length && isDataInputParameter(param)) {
         const kind = parameterKind(param);
+        if (!runLocal && browsed.some((input) => !input.geojson)) {
+          setError(
+            `The sidecar cannot read browser-selected files for ${parameterLabel(param)}. Run locally (WASM), or enter filesystem paths available to the sidecar.`,
+          );
+          setRunningLocal(false);
+          return;
+        }
         const inputs = browsed.map((input) =>
           input.geojson
             ? { name: input.name, kind, geojson: input.geojson }
@@ -1536,23 +1543,50 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
           .filter((layer): layer is GeoLibreLayer => Boolean(layer));
         const kind = parameterKind(param);
         if (runLocal && kind === "vector_in") {
+          const missing = selectedLayers.find((layer) => !layer.geojson);
+          if (missing) {
+            setError(
+              `Layer "${missing.name}" has no in-memory GeoJSON for ${parameterLabel(param)}.`,
+            );
+            setRunningLocal(false);
+            return;
+          }
           layerInputs[param.name] = selectedLayers.map((layer) => ({
             name: layer.name,
             kind,
             geojson: layer.geojson,
           }));
         } else if (runLocal) {
-          layerInputs[param.name] = await Promise.all(
-            selectedLayers.map(async (layer) => ({
-              name: layer.name,
-              kind,
-              bytes: (await fetchLayerBytes(layer)) ?? undefined,
-            })),
-          );
+          const inputs: WhiteboxLayerInput[] = [];
+          for (const layer of selectedLayers) {
+            const bytes = await fetchLayerBytes(layer);
+            if (!bytes) {
+              setError(`Layer "${layer.name}" is not fetchable for ${parameterLabel(param)}.`);
+              setRunningLocal(false);
+              return;
+            }
+            inputs.push({ name: layer.name, kind, bytes });
+          }
+          layerInputs[param.name] = inputs;
+        } else if (kind === "vector_in" && selectedLayers.every((layer) => layer.geojson)) {
+          layerInputs[param.name] = selectedLayers.map((layer) => ({
+            name: layer.name,
+            kind,
+            geojson: layer.geojson,
+          }));
         } else {
           // Whitebox list arguments use comma-delimited paths. The browser
           // runner builds the same form after staging each selected dataset.
-          parameters[param.name] = selectedLayers.map(layerPath).filter(Boolean).join(",");
+          const paths = selectedLayers.map(layerPath);
+          const missingIndex = paths.findIndex((path) => !path);
+          if (missingIndex >= 0) {
+            setError(
+              `Layer "${selectedLayers[missingIndex].name}" has no filesystem path for ${parameterLabel(param)}.`,
+            );
+            setRunningLocal(false);
+            return;
+          }
+          parameters[param.name] = paths.join(",");
         }
       } else if (typeof value === "string" && value.startsWith(LAYER_TOKEN_PREFIX)) {
         const layerId = value.slice(LAYER_TOKEN_PREFIX.length);
@@ -2482,6 +2516,7 @@ function ParameterField({
       ) : isDataInputParameter(param) && isMultipleDatasetParameter(param) ? (
         <MultiLayerOrPathInput
           id={`whitebox-${param.name}`}
+          label={label}
           layers={availableLayers}
           param={param}
           value={value}
@@ -2820,6 +2855,7 @@ interface LayerOrPathInputProps {
 
 interface MultiLayerOrPathInputProps {
   id: string;
+  label: string;
   layers: GeoLibreLayer[];
   onChange: (value: unknown) => void;
   onPickFiles?: (files: Array<{ fileName: string; bytes: Uint8Array }>) => void;
@@ -2830,6 +2866,7 @@ interface MultiLayerOrPathInputProps {
 /** Dataset-list picker used by merge, overlay, statistics, and stack tools. */
 function MultiLayerOrPathInput({
   id,
+  label,
   layers,
   onChange,
   onPickFiles,
@@ -2844,7 +2881,11 @@ function MultiLayerOrPathInput({
   return (
     <div className="grid gap-2">
       {layers.length > 0 ? (
-        <div id={id} className="grid max-h-40 gap-1 overflow-y-auto rounded-md border p-2">
+        <div
+          role="group"
+          aria-label={label}
+          className="grid max-h-40 gap-1 overflow-y-auto rounded-md border p-2"
+        >
           {layers.map((layer) => {
             const token = `${LAYER_TOKEN_PREFIX}${layer.id}`;
             return (
@@ -2868,6 +2909,7 @@ function MultiLayerOrPathInput({
       ) : null}
       <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
         <Input
+          id={id}
           value={usingLayers ? "" : String(value ?? "")}
           placeholder={
             usingLayers ? t("processing.whitebox.selectedLayer") : t("processing.whitebox.filePath")

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1541,6 +1541,11 @@ export function ProcessingDialog({ mapControllerRef, onAddRaster }: ProcessingDi
           )
           .map((item) => layers.find((layer) => layer.id === item.slice(LAYER_TOKEN_PREFIX.length)))
           .filter((layer): layer is GeoLibreLayer => Boolean(layer));
+        if (selectedLayers.length !== value.length) {
+          setError(`One or more selected layers for ${parameterLabel(param)} no longer exist.`);
+          setRunningLocal(false);
+          return;
+        }
         const kind = parameterKind(param);
         if (runLocal && kind === "vector_in") {
           const missing = selectedLayers.find((layer) => !layer.geojson);

--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -336,37 +336,47 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
       if (!tool) throw new Error(`Unknown Whitebox tool "${id}"`);
       const supplied = (params.params as Record<string, unknown>) ?? {};
       const parameters: Record<string, unknown> = { ...supplied };
-      const layerInputs: Record<string, WhiteboxLayerInput> = {};
+      const layerInputs: Record<string, WhiteboxLayerInput | WhiteboxLayerInput[]> = {};
       const layers = useAppStore.getState().layers;
 
       for (const param of tool.params ?? []) {
         const kind = parameterKind(param);
         if (!kind.endsWith("_in")) continue;
         const value = supplied[param.name];
-        if (typeof value !== "string") continue;
-        const layer = layers.find((item) => item.id === value);
-        if (!layer) continue;
-        // Same eligibility rule the Processing dialog filters its layer picker
-        // by, so a wrong-type layer reports that rather than failing later with
-        // a vaguer "not fetchable".
-        if (!canUseLayerForParameter(layer, param)) {
-          throw new Error(
-            `Layer "${layer.name}" (${layer.type}) cannot be used as ${kind} for "${param.name}"`,
-          );
+        const values = Array.isArray(value) ? value : [value];
+        const resolvedLayers = values.map((item) =>
+          typeof item === "string" ? layers.find((layer) => layer.id === item) : undefined,
+        );
+        if (resolvedLayers.every((layer) => !layer)) continue;
+        if (resolvedLayers.some((layer) => !layer)) {
+          throw new Error(`Not every layer supplied for "${param.name}" could be resolved`);
+        }
+        const resolved = resolvedLayers.filter((layer) => layer !== undefined);
+        const inputs: WhiteboxLayerInput[] = [];
+        for (const layer of resolved) {
+          // Same eligibility rule the Processing dialog filters its layer picker
+          // by, so a wrong-type layer reports that rather than failing later with
+          // a vaguer "not fetchable".
+          if (!canUseLayerForParameter(layer, param)) {
+            throw new Error(
+              `Layer "${layer.name}" (${layer.type}) cannot be used as ${kind} for "${param.name}"`,
+            );
+          }
+          if (kind === "vector_in") {
+            if (!layer.geojson) {
+              throw new Error(`Layer "${layer.name}" has no in-memory GeoJSON for "${param.name}"`);
+            }
+            inputs.push({ name: layer.name, kind, geojson: layer.geojson });
+          } else {
+            const bytes = await fetchLayerBytes(layer);
+            if (!bytes) {
+              throw new Error(`Layer "${layer.name}" is not fetchable for "${param.name}"`);
+            }
+            inputs.push({ name: layer.name, kind, bytes });
+          }
         }
         delete parameters[param.name];
-        if (kind === "vector_in") {
-          if (!layer.geojson) {
-            throw new Error(`Layer "${layer.name}" has no in-memory GeoJSON for "${param.name}"`);
-          }
-          layerInputs[param.name] = { name: layer.name, kind, geojson: layer.geojson };
-        } else {
-          const bytes = await fetchLayerBytes(layer);
-          if (!bytes) {
-            throw new Error(`Layer "${layer.name}" is not fetchable for "${param.name}"`);
-          }
-          layerInputs[param.name] = { name: layer.name, kind, bytes };
-        }
+        layerInputs[param.name] = inputs.length === 1 ? inputs[0] : inputs;
       }
 
       const tracker = beginProcessingRun({

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -2612,6 +2612,43 @@ export async function openLocalDataFileWithFallback(options: LocalDataFileOption
   });
 }
 
+/** Open a multi-file picker and read every selected file as bytes. */
+export async function openLocalDataFilesWithFallback(
+  options: LocalDataFileOptions,
+): Promise<Array<{ data: ArrayBuffer; path: string }>> {
+  if (isTauri()) {
+    const selected = await open({
+      multiple: true,
+      filters: nativeFileDialogFilters(options.filters, options.androidFilters),
+    });
+    const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
+    return Promise.all(
+      paths.map(async (path) => ({ data: toArrayBuffer(await readFile(path)), path })),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = true;
+    input.accept = options.accept;
+    input.onchange = async () => {
+      try {
+        const files = Array.from(input.files ?? []);
+        resolve(
+          await Promise.all(
+            files.map(async (file) => ({ data: await file.arrayBuffer(), path: file.name })),
+          ),
+        );
+      } catch (error) {
+        reject(error);
+      }
+    };
+    input.addEventListener("cancel", () => resolve([]));
+    input.click();
+  });
+}
+
 export async function pickLocalPathWithFallback(
   options: PickLocalPathOptions = {},
 ): Promise<string | null> {
@@ -2628,6 +2665,19 @@ export async function pickLocalPathWithFallback(
   // require a real path. Return null so callers surface the desktop-only
   // message rather than passing a non-resolvable bare file name.
   return null;
+}
+
+/** Pick several native filesystem paths (desktop only). */
+export async function pickLocalPathsWithFallback(
+  options: PickLocalPathOptions = {},
+): Promise<string[]> {
+  if (!isTauri()) return [];
+  const selected = await open({
+    directory: options.directory ?? false,
+    filters: options.filters,
+    multiple: true,
+  });
+  return Array.isArray(selected) ? selected : selected ? [selected] : [];
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/whitebox-distance-params.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-distance-params.ts
@@ -187,13 +187,18 @@ export function wgs84VectorLayerIds(
 ): string[] | null {
   const ids: string[] = [];
   for (const input of inputs) {
-    const value = input.value;
-    if (typeof value !== "string" || value.trim() === "") {
+    const values = Array.isArray(input.value) ? input.value : [input.value];
+    const selected = values.filter(
+      (value): value is string => typeof value === "string" && value.trim() !== "",
+    );
+    if (!selected.length) {
       if (input.required) return null;
       continue;
     }
-    if (!value.startsWith(layerTokenPrefix)) return null;
-    ids.push(value.slice(layerTokenPrefix.length));
+    for (const value of selected) {
+      if (!value.startsWith(layerTokenPrefix)) return null;
+      ids.push(value.slice(layerTokenPrefix.length));
+    }
   }
   return ids.length ? ids : null;
 }

--- a/apps/geolibre-desktop/src/lib/whitebox-param-kind.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-param-kind.ts
@@ -42,3 +42,23 @@ export function parameterKind(param: WhiteboxToolParameter): string {
   }
   return "string";
 }
+
+/** Whether a dataset input accepts a stack/list rather than one dataset. */
+export function isMultipleDatasetParameter(param: WhiteboxToolParameter): boolean {
+  if (!parameterKind(param).endsWith("_in")) return false;
+  const schema =
+    param.schema && typeof param.schema === "object"
+      ? (param.schema as Record<string, unknown>)
+      : {};
+  if (String(schema.cardinality ?? "").toLowerCase() === "multiple") return true;
+
+  // Some upstream Whitebox manifests currently say cardinality=single even
+  // though the argument is explicitly an array/list of dataset paths (notably
+  // merge_vectors). Keep these usable until their catalog metadata is fixed.
+  const description = param.description ?? "";
+  return (
+    /\b(array|list|stack) of (?:input )?(?:[\w-]+ )?(?:paths?|rasters?|vectors?|layers?|files?)\b/i.test(
+      description,
+    ) || /\b(?:paths?|rasters?|vectors?|layers?|files?) (?:as|in) an array\b/i.test(description)
+  );
+}

--- a/apps/geolibre-desktop/src/lib/whitebox-param-kind.ts
+++ b/apps/geolibre-desktop/src/lib/whitebox-param-kind.ts
@@ -1,4 +1,7 @@
-import type { WhiteboxToolParameter } from "@geolibre/processing";
+import {
+  isMultipleWhiteboxDatasetParameter,
+  type WhiteboxToolParameter,
+} from "@geolibre/processing";
 
 function datasetParameterKind(dataKind: string, suffix: "in" | "out"): string {
   if (["raster", "vector", "lidar", "file"].includes(dataKind)) {
@@ -45,20 +48,5 @@ export function parameterKind(param: WhiteboxToolParameter): string {
 
 /** Whether a dataset input accepts a stack/list rather than one dataset. */
 export function isMultipleDatasetParameter(param: WhiteboxToolParameter): boolean {
-  if (!parameterKind(param).endsWith("_in")) return false;
-  const schema =
-    param.schema && typeof param.schema === "object"
-      ? (param.schema as Record<string, unknown>)
-      : {};
-  if (String(schema.cardinality ?? "").toLowerCase() === "multiple") return true;
-
-  // Some upstream Whitebox manifests currently say cardinality=single even
-  // though the argument is explicitly an array/list of dataset paths (notably
-  // merge_vectors). Keep these usable until their catalog metadata is fixed.
-  const description = param.description ?? "";
-  return (
-    /\b(array|list|stack) of (?:input )?(?:[\w-]+ )?(?:paths?|rasters?|vectors?|layers?|files?)\b/i.test(
-      description,
-    ) || /\b(?:paths?|rasters?|vectors?|layers?|files?) (?:as|in) an array\b/i.test(description)
-  );
+  return parameterKind(param).endsWith("_in") && isMultipleWhiteboxDatasetParameter(param);
 }

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -883,15 +883,18 @@ def _prepare_arguments(
             else:
                 value = _write_layer_input(name, embedded, temp_paths)
         elif isinstance(value, str) and "," in value:
-            # The tool metadata is untrusted. When any comma-delimited member
-            # looks path-shaped, validate every member independently rather than
-            # trusting `kind` or treating the list as one opaque path.
-            path_values = [item.strip() for item in value.split(",") if item.strip()]
-            if any(_looks_like_fs_path(path_value) for path_value in path_values):
-                for path_value in path_values:
-                    _ensure_within_roots(path_value)
-                    if Path(path_value).expanduser().is_absolute():
-                        absolute_paths.append(path_value)
+            # The tool metadata is untrusted. Validate each escape-shaped
+            # comma-delimited member independently rather than trusting `kind`
+            # or treating the list as one opaque path. Plain relative members
+            # are deferred to the defense-in-depth pass below, which resolves
+            # them against the pinned working directory (checking them here
+            # would resolve against the sidecar's own cwd and wrongly reject).
+            for path_value in (item.strip() for item in value.split(",")):
+                if not _looks_like_fs_path(path_value):
+                    continue
+                _ensure_within_roots(path_value)
+                if Path(path_value).expanduser().is_absolute():
+                    absolute_paths.append(path_value)
         elif isinstance(value, str) and _looks_like_fs_path(value):
             # A path-shaped value must stay inside the allowlisted roots,
             # regardless of the client-declared `kind`. `request.tool` is

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -111,7 +111,7 @@ class WhiteboxRunRequest(BaseModel):
     tool_id: str
     parameters: dict[str, Any] = {}
     tool: dict[str, Any] | None = None
-    layer_inputs: dict[str, dict[str, Any]] = {}
+    layer_inputs: dict[str, dict[str, Any] | list[dict[str, Any]]] = {}
     include_pro: bool = False
     tier: str = "open"
 
@@ -870,7 +870,24 @@ def _prepare_arguments(
         if name in request.layer_inputs:
             # Embedded layers are materialized to a server-owned temp file, so
             # the caller never controls this path.
-            value = _write_layer_input(name, request.layer_inputs[name], temp_paths)
+            embedded = request.layer_inputs[name]
+            if isinstance(embedded, list):
+                value = ",".join(
+                    _write_layer_input(f"{name}_{index + 1}", layer, temp_paths)
+                    for index, layer in enumerate(embedded)
+                )
+            else:
+                value = _write_layer_input(name, embedded, temp_paths)
+        elif isinstance(value, str) and kind.endswith("_in") and "," in value:
+            # Multi-dataset parameters use a comma-delimited path list. Validate
+            # every member independently; treating the whole list as one path
+            # both rejects valid inputs and weakens the root-boundary check.
+            for path_value in (item.strip() for item in value.split(",")):
+                if not path_value:
+                    continue
+                _ensure_within_roots(path_value)
+                if Path(path_value).expanduser().is_absolute():
+                    absolute_paths.append(path_value)
         elif isinstance(value, str) and _looks_like_fs_path(value):
             # A path-shaped value must stay inside the allowlisted roots,
             # regardless of the client-declared `kind`. `request.tool` is
@@ -1167,16 +1184,20 @@ def whitebox_run(request: WhiteboxRunRequest):
     # Reject oversized embedded layers before enqueueing work, matching the
     # 413 vector/PostGIS/Sedona feature cap (defense-in-depth also lives in
     # ``_write_layer_input``).
-    for name, layer in request.layer_inputs.items():
-        geojson = layer.get("geojson") if isinstance(layer, dict) else None
-        if not isinstance(geojson, dict):
-            continue
-        features = geojson.get("features") or []
-        if isinstance(features, list) and len(features) > MAX_LAYER_FEATURES:
-            raise HTTPException(
-                status_code=413,
-                detail=(f"Layer input for {name} exceeds the {MAX_LAYER_FEATURES}-feature limit"),
-            )
+    for name, value in request.layer_inputs.items():
+        layers = value if isinstance(value, list) else [value]
+        for layer in layers:
+            geojson = layer.get("geojson") if isinstance(layer, dict) else None
+            if not isinstance(geojson, dict):
+                continue
+            features = geojson.get("features") or []
+            if isinstance(features, list) and len(features) > MAX_LAYER_FEATURES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        f"Layer input for {name} exceeds the {MAX_LAYER_FEATURES}-feature limit"
+                    ),
+                )
     job_id = str(uuid.uuid4())
     now = _utc_now()
     with _JOBS_LOCK:

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -864,7 +864,11 @@ def _prepare_arguments(
     args: dict[str, Any] = {}
     working_directory: str | None = None
     absolute_paths: list[str] = []
-    for name, value in request.parameters.items():
+    # Preserve parameter order, then append embedded-only inputs. Browser and
+    # in-memory layers intentionally have no matching filesystem parameter.
+    names = dict.fromkeys((*request.parameters, *request.layer_inputs))
+    for name in names:
+        value = request.parameters.get(name)
         spec = specs.get(str(name), {})
         kind = str(spec.get("kind") or "")
         if name in request.layer_inputs:
@@ -878,16 +882,16 @@ def _prepare_arguments(
                 )
             else:
                 value = _write_layer_input(name, embedded, temp_paths)
-        elif isinstance(value, str) and kind.endswith("_in") and "," in value:
-            # Multi-dataset parameters use a comma-delimited path list. Validate
-            # every member independently; treating the whole list as one path
-            # both rejects valid inputs and weakens the root-boundary check.
-            for path_value in (item.strip() for item in value.split(",")):
-                if not path_value:
-                    continue
-                _ensure_within_roots(path_value)
-                if Path(path_value).expanduser().is_absolute():
-                    absolute_paths.append(path_value)
+        elif isinstance(value, str) and "," in value:
+            # The tool metadata is untrusted. When any comma-delimited member
+            # looks path-shaped, validate every member independently rather than
+            # trusting `kind` or treating the list as one opaque path.
+            path_values = [item.strip() for item in value.split(",") if item.strip()]
+            if any(_looks_like_fs_path(path_value) for path_value in path_values):
+                for path_value in path_values:
+                    _ensure_within_roots(path_value)
+                    if Path(path_value).expanduser().is_absolute():
+                        absolute_paths.append(path_value)
         elif isinstance(value, str) and _looks_like_fs_path(value):
             # A path-shaped value must stay inside the allowlisted roots,
             # regardless of the client-declared `kind`. `request.tool` is

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -941,12 +941,17 @@ def _prepare_arguments(
     if working_directory is not None and conversion._CONVERSION_ROOTS:
         base = Path(working_directory)
         for value in args.values():
+            if not isinstance(value, str):
+                continue
             # Every non-absolute string arg — including a bare filename like
             # "pwned.tif", which could itself be a symlink planted at the root —
             # is resolved against the pinned cwd and checked. Absolute / `..`
-            # values were already validated in the loop above.
-            if isinstance(value, str) and not Path(value).is_absolute():
-                _ensure_within_roots(str(base / value))
+            # values were already validated in the loop above. Whitebox splits a
+            # multi-dataset arg on commas, so check each member rather than the
+            # joined string (`safe.tif,escape/evil.tif` is not one path).
+            for member in (item.strip() for item in value.split(",")):
+                if member and not Path(member).is_absolute():
+                    _ensure_within_roots(str(base / member))
     return args, working_directory
 
 

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -308,6 +308,43 @@ def test_whitebox_relative_path_through_symlink_is_rejected(
     assert args["output"] == "subdir/out.tif"
 
 
+def test_whitebox_relative_path_list_member_through_symlink_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Each member of an all-relative path list is checked against the pinned cwd.
+
+    Whitebox splits a multi-dataset arg on commas, so a safe first member must
+    not shield a later member that traverses a symlink out of the root.
+    """
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import WhiteboxRunRequest, _prepare_arguments
+
+    root = tmp_path / "data"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "escape").symlink_to(outside)
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+
+    tool = {"id": "merge_vectors", "params": [{"name": "inputs", "kind": "vector_in"}]}
+    request = WhiteboxRunRequest(
+        tool_id="merge_vectors",
+        parameters={"inputs": "safe.geojson,escape/secret.geojson"},
+        tool=tool,
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        _prepare_arguments(request, [])
+    assert excinfo.value.status_code == 403
+
+    ok = WhiteboxRunRequest(
+        tool_id="merge_vectors",
+        parameters={"inputs": "safe.geojson,subdir/other.geojson"},
+        tool=tool,
+    )
+    args, _ = _prepare_arguments(ok, [])
+    assert args["inputs"] == "safe.geojson,subdir/other.geojson"
+
+
 def test_whitebox_null_byte_path_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """An embedded NUL byte yields a clean 403, not an uncaught 500."""
     from geolibre_server.app import conversion

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -344,6 +344,17 @@ def test_whitebox_relative_path_list_member_through_symlink_is_rejected(
     args, _ = _prepare_arguments(ok, [])
     assert args["inputs"] == "safe.geojson,subdir/other.geojson"
 
+    # A relative member alongside an absolute in-root member is resolved
+    # against the pinned root, not the sidecar's own cwd.
+    mixed = WhiteboxRunRequest(
+        tool_id="merge_vectors",
+        parameters={"inputs": f"safe.geojson,{root / 'other.geojson'}"},
+        tool=tool,
+    )
+    args, cwd = _prepare_arguments(mixed, [])
+    assert cwd == str(root.resolve())
+    assert args["inputs"] == f"safe.geojson,{root / 'other.geojson'}"
+
 
 def test_whitebox_null_byte_path_is_rejected(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """An embedded NUL byte yields a clean 403, not an uncaught 500."""

--- a/backend/geolibre_server/tests/test_security.py
+++ b/backend/geolibre_server/tests/test_security.py
@@ -183,6 +183,27 @@ def test_whitebox_path_check_ignores_mislabeled_kind(
     assert args["input"] == "EPSG:4326"
 
 
+def test_whitebox_multi_path_check_ignores_mislabeled_kind(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Every path-list member stays confined even when its kind is mislabeled."""
+    from geolibre_server.app import conversion
+    from geolibre_server.app.whitebox import WhiteboxRunRequest, _prepare_arguments
+
+    root = tmp_path / "data"
+    root.mkdir()
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(root.resolve())])
+    request = WhiteboxRunRequest(
+        tool_id="merge_vectors",
+        parameters={"inputs": "a.geojson,/etc/passwd"},
+        tool={"params": [{"name": "inputs", "kind": "string"}]},
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        _prepare_arguments(request, [])
+    assert excinfo.value.status_code == 403
+
+
 def test_whitebox_relative_path_confined_by_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     """A relative path arg is confined by pinning the subprocess cwd to a root.
 

--- a/backend/geolibre_server/tests/test_whitebox_arguments.py
+++ b/backend/geolibre_server/tests/test_whitebox_arguments.py
@@ -14,7 +14,6 @@ def test_prepare_arguments_materializes_multiple_embedded_layers(tmp_path: Path)
     feature_collection = {"type": "FeatureCollection", "features": []}
     request = WhiteboxRunRequest(
         tool_id="merge_vectors",
-        parameters={"inputs": ""},
         tool={"params": [{"name": "inputs", "kind": "vector_in"}]},
         layer_inputs={
             "inputs": [

--- a/backend/geolibre_server/tests/test_whitebox_arguments.py
+++ b/backend/geolibre_server/tests/test_whitebox_arguments.py
@@ -8,6 +8,31 @@ from geolibre_server.app.whitebox import (
     _prepare_arguments,
 )
 
+
+def test_prepare_arguments_materializes_multiple_embedded_layers(tmp_path: Path) -> None:
+    """Verify embedded multi-vector inputs become a comma-delimited path list."""
+    feature_collection = {"type": "FeatureCollection", "features": []}
+    request = WhiteboxRunRequest(
+        tool_id="merge_vectors",
+        parameters={"inputs": ""},
+        tool={"params": [{"name": "inputs", "kind": "vector_in"}]},
+        layer_inputs={
+            "inputs": [
+                {"name": "a", "kind": "vector_in", "geojson": feature_collection},
+                {"name": "b", "kind": "vector_in", "geojson": feature_collection},
+            ]
+        },
+    )
+
+    temp_paths: list[Path] = []
+    args, _ = _prepare_arguments(request, temp_paths)
+
+    paths = args["inputs"].split(",")
+    assert len(paths) == 2
+    assert all(Path(path).exists() for path in paths)
+    assert len(temp_paths) == 2
+
+
 _BATCH_DESCRIPTION = (
     "Input LiDAR path or typed LiDAR object. If omitted, runs "
     "in batch mode over LiDAR files in current directory."

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -211,6 +211,7 @@ export {
   runWhiteboxTool,
   WHITEBOX_CATALOG_URL,
   VECTOR_OUTPUT_FORMATS,
+  isMultipleWhiteboxDatasetParameter,
   normalizeVectorOutputFormat,
   type ConversionJob,
   type ConversionStatus,

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -206,7 +206,7 @@ export interface RunWhiteboxToolRequest {
   tool_id: string;
   parameters: Record<string, unknown>;
   tool?: WhiteboxTool;
-  layer_inputs?: Record<string, WhiteboxLayerInput>;
+  layer_inputs?: Record<string, WhiteboxLayerInput | WhiteboxLayerInput[]>;
   include_pro?: boolean;
   tier?: string;
   /** WASM runner only: format for `vector_out` outputs (default `"geojson"`). */

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -123,6 +123,24 @@ export interface WhiteboxToolParameter {
   schema?: unknown;
 }
 
+/** Whether a dataset input accepts several datasets rather than one. */
+export function isMultipleWhiteboxDatasetParameter(param: WhiteboxToolParameter): boolean {
+  const kind = String(param.kind ?? "").toLowerCase();
+  const schema =
+    param.schema && typeof param.schema === "object"
+      ? (param.schema as Record<string, unknown>)
+      : {};
+  const role = String(param.io_role ?? schema.kind ?? "").toLowerCase();
+  if (!(kind.endsWith("_in") || role === "input")) return false;
+  if (String(schema.cardinality ?? "").toLowerCase() === "multiple") return true;
+  const description = param.description ?? "";
+  return (
+    /\b(array|list|stack) of (?:[\w-]+\s+)*(?:paths?|rasters?|vectors?|layers?|files?)\b/i.test(
+      description,
+    ) || /\b(?:paths?|rasters?|vectors?|layers?|files?) (?:as|in) an array\b/i.test(description)
+  );
+}
+
 export interface WhiteboxTool {
   id: string;
   display_name?: string;

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -694,7 +694,7 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
     if (kind === "vector_in") {
       const supplied = request.layer_inputs?.[name];
       const layerInputs = Array.isArray(supplied) ? supplied : supplied ? [supplied] : [];
-      if (!layerInputs.length || layerInputs.some((item) => !item.geojson)) {
+      if (!layerInputs.length || layerInputs.some((item) => !item.geojson && !item.bytes)) {
         throw new Error(`Missing vector input for "${name}"`);
       }
       // A map layer is RFC 7946 WGS84, while Whitebox's buffer tools are
@@ -702,9 +702,13 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
       // writer return WGS84.
       const files = layerInputs.map((item, index) => {
         const geojson =
-          name === "input" && geographicBufferInput ? geographicBufferInput : item.geojson!;
-        const file = layerInputs.length === 1 ? `${name}.geojson` : `${name}_${index + 1}.geojson`;
-        input[file] = encoder.encode(JSON.stringify(geojson));
+          name === "input" && geographicBufferInput ? geographicBufferInput : item.geojson;
+        const extension = item.geojson
+          ? "geojson"
+          : (item.name.match(/\.([A-Za-z0-9]+)$/)?.[1]?.toLowerCase() ?? "dat");
+        const file =
+          layerInputs.length === 1 ? `${name}.${extension}` : `${name}_${index + 1}.${extension}`;
+        input[file] = geojson ? encoder.encode(JSON.stringify(geojson)) : item.bytes!;
         return `/work/${file}`;
       });
       args.push(`--${name}=${files.join(",")}`);

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -7,7 +7,7 @@
 // single-threaded execution (use the sidecar for very large data).
 import type { FeatureCollection } from "geojson";
 import { convertGeoTiffToCog } from "./cog-convert";
-import { normalizeVectorOutputFormat } from "./sidecar-client";
+import { isMultipleWhiteboxDatasetParameter, normalizeVectorOutputFormat } from "./sidecar-client";
 import { runWasmToolInBackground } from "./wasm-tool-runner";
 import type {
   RunWhiteboxToolRequest,
@@ -693,7 +693,26 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
 
     if (kind === "vector_in") {
       const supplied = request.layer_inputs?.[name];
-      const layerInputs = Array.isArray(supplied) ? supplied : supplied ? [supplied] : [];
+      let layerInputs = Array.isArray(supplied) ? supplied : supplied ? [supplied] : [];
+      if (!layerInputs.length) {
+        const provided = request.parameters[name];
+        const paths =
+          isMultipleWhiteboxDatasetParameter(param) && typeof provided === "string"
+            ? provided
+                .split(/[;,]/)
+                .map((path) => path.trim())
+                .filter(Boolean)
+            : provided == null || provided === ""
+              ? []
+              : [String(provided)];
+        layerInputs = await Promise.all(
+          paths.map(async (path) => ({
+            name: path,
+            kind,
+            bytes: (await fetchBytes(path)) ?? undefined,
+          })),
+        );
+      }
       if (!layerInputs.length || layerInputs.some((item) => !item.geojson && !item.bytes)) {
         throw new Error(`Missing vector input for "${name}"`);
       }
@@ -719,16 +738,25 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
       const hasValue = typeof provided === "string" ? provided.length > 0 : provided != null;
       const supplied = request.layer_inputs?.[name];
       const suppliedInputs = Array.isArray(supplied) ? supplied : supplied ? [supplied] : [];
+      const paths =
+        isMultipleWhiteboxDatasetParameter(param) && typeof provided === "string"
+          ? provided
+              .split(/[;,]/)
+              .map((path) => path.trim())
+              .filter(Boolean)
+          : hasValue
+            ? [provided]
+            : [];
       const byteInputs = suppliedInputs.length
         ? suppliedInputs.map((item) => item.bytes ?? null)
-        : [hasValue ? await fetchBytes(provided) : null];
-      if (byteInputs.some((bytes) => !bytes)) {
+        : await Promise.all(paths.map((path) => fetchBytes(path)));
+      if (!byteInputs.length || byteInputs.some((bytes) => !bytes)) {
         // An optional data input the user left blank is simply omitted rather
         // than force-fetched: e.g. extract_cog_subset's `input` when a `url` is
         // supplied instead (the tool reads the COG by byte-range from that url).
         // Only a required input, or one with a value that could not be fetched,
         // is a hard error.
-        if (!param.required && !hasValue) continue;
+        if (!param.required && !hasValue && !suppliedInputs.length) continue;
         throw new Error(
           `Could not read input "${name}" in the browser. Its data is not fetchable here (only available via the sidecar); turn off "Run locally (WASM)" to use the sidecar.`,
         );

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -714,6 +714,9 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
         );
       }
       if (!layerInputs.length || layerInputs.some((item) => !item.geojson && !item.bytes)) {
+        // An optional vector input the user left blank (no layer and no path)
+        // is omitted, mirroring the raster/lidar/file branch below.
+        if (!param.required && !layerInputs.length) continue;
         throw new Error(`Missing vector input for "${name}"`);
       }
       // A map layer is RFC 7946 WGS84, while Whitebox's buffer tools are

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -706,11 +706,25 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
               ? []
               : [String(provided)];
         layerInputs = await Promise.all(
-          paths.map(async (path) => ({
-            name: path,
-            kind,
-            bytes: (await fetchBytes(path)) ?? undefined,
-          })),
+          paths.map(async (path) => {
+            const bytes = (await fetchBytes(path)) ?? undefined;
+            // A fetched URL is untyped: parse it as GeoJSON when it is one, and
+            // fail fast on an unrecognised payload (e.g. an HTML error page)
+            // rather than handing Whitebox an opaque `.dat`.
+            let geojson: FeatureCollection | undefined;
+            if (bytes) {
+              try {
+                const parsed = JSON.parse(new TextDecoder().decode(bytes));
+                if (isFeatureCollection(parsed)) geojson = parsed;
+              } catch {
+                // not JSON; fall through to the extension check
+              }
+              if (!geojson && !/\.[A-Za-z0-9]+$/.test(path.split(/[?#]/)[0])) {
+                throw new Error(`Input "${name}" at ${path} is not a readable vector file.`);
+              }
+            }
+            return { name: path, kind, bytes, geojson };
+          }),
         );
       }
       if (!layerInputs.length || layerInputs.some((item) => !item.geojson && !item.bytes)) {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -657,7 +657,8 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
   const args: string[] = [];
   const parameterOverrides: Record<string, unknown> = {};
   let geographicBufferInput: FeatureCollection | null = null;
-  const geojson = request.layer_inputs?.input?.geojson;
+  const rawInput = request.layer_inputs?.input;
+  const geojson = (Array.isArray(rawInput) ? rawInput[0] : rawInput)?.geojson;
   if (request.tool_id === "buffer_vector" && geojson) {
     const prepared = prepareGeographicBufferInput(geojson, request.parameters.distance);
     if (prepared) {
@@ -691,23 +692,33 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
     const name = param.name;
 
     if (kind === "vector_in") {
-      let geojson = request.layer_inputs?.[name]?.geojson;
-      if (!geojson) throw new Error(`Missing vector input for "${name}"`);
+      const supplied = request.layer_inputs?.[name];
+      const layerInputs = Array.isArray(supplied) ? supplied : supplied ? [supplied] : [];
+      if (!layerInputs.length || layerInputs.some((item) => !item.geojson)) {
+        throw new Error(`Missing vector input for "${name}"`);
+      }
       // A map layer is RFC 7946 WGS84, while Whitebox's buffer tools are
       // Cartesian. Run them in Web Mercator; the EPSG tag makes the GeoJSON
       // writer return WGS84.
-      if (name === "input" && geographicBufferInput) geojson = geographicBufferInput;
-      const file = `${name}.geojson`;
-      input[file] = encoder.encode(JSON.stringify(geojson));
-      args.push(`--${name}=/work/${file}`);
+      const files = layerInputs.map((item, index) => {
+        const geojson =
+          name === "input" && geographicBufferInput ? geographicBufferInput : item.geojson!;
+        const file = layerInputs.length === 1 ? `${name}.geojson` : `${name}_${index + 1}.geojson`;
+        input[file] = encoder.encode(JSON.stringify(geojson));
+        return `/work/${file}`;
+      });
+      args.push(`--${name}=${files.join(",")}`);
     } else if (kind === "raster_in" || kind === "lidar_in" || kind === "file_in") {
       // Prefer bytes the caller resolved (the dialog fetches the layer's data);
       // otherwise try to fetch the parameter as a URL.
       const provided = request.parameters[name];
       const hasValue = typeof provided === "string" ? provided.length > 0 : provided != null;
-      const bytes =
-        request.layer_inputs?.[name]?.bytes ?? (hasValue ? await fetchBytes(provided) : null);
-      if (!bytes) {
+      const supplied = request.layer_inputs?.[name];
+      const suppliedInputs = Array.isArray(supplied) ? supplied : supplied ? [supplied] : [];
+      const byteInputs = suppliedInputs.length
+        ? suppliedInputs.map((item) => item.bytes ?? null)
+        : [hasValue ? await fetchBytes(provided) : null];
+      if (byteInputs.some((bytes) => !bytes)) {
         // An optional data input the user left blank is simply omitted rather
         // than force-fetched: e.g. extract_cog_subset's `input` when a `url` is
         // supplied instead (the tool reads the COG by byte-range from that url).
@@ -718,20 +729,23 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
           `Could not read input "${name}" in the browser. Its data is not fetchable here (only available via the sidecar); turn off "Run locally (WASM)" to use the sidecar.`,
         );
       }
-      if (kind === "raster_in" && !isTiff(bytes)) {
+      if (kind === "raster_in" && byteInputs.some((bytes) => !isTiff(bytes!))) {
         throw new Error(
-          `Input "${name}" is not a readable GeoTIFF in the browser (received ${describeBytes(bytes)}). Load the raster as a COG/GeoTIFF, or use the sidecar.`,
+          `Input "${name}" is not a readable GeoTIFF in the browser. Load the rasters as COG/GeoTIFF, or use the sidecar.`,
         );
       }
-      if (kind === "lidar_in" && !isLas(bytes)) {
+      if (kind === "lidar_in" && byteInputs.some((bytes) => !isLas(bytes!))) {
         throw new Error(
-          `Input "${name}" is not a readable LAS/LAZ file in the browser (received ${describeBytes(bytes)}). Load a LAS/LAZ file, or use the sidecar.`,
+          `Input "${name}" is not a readable LAS/LAZ file in the browser. Load LAS/LAZ files, or use the sidecar.`,
         );
       }
       const ext = kind === "lidar_in" ? "las" : kind === "file_in" ? "dat" : "tif";
-      const file = `${name}.${ext}`;
-      input[file] = bytes;
-      args.push(`--${name}=/work/${file}`);
+      const files = byteInputs.map((bytes, index) => {
+        const file = byteInputs.length === 1 ? `${name}.${ext}` : `${name}_${index + 1}.${ext}`;
+        input[file] = bytes!;
+        return `/work/${file}`;
+      });
+      args.push(`--${name}=${files.join(",")}`);
     } else if (kind === "vector_out") {
       const base = outputBaseName(request.tool_id, name);
       // GeoJSON is reprojected to WGS84 on write (a map layer); the other formats
@@ -760,7 +774,11 @@ export async function runWhiteboxToolWasm(request: RunWhiteboxToolRequest): Prom
       const ext =
         kind === "file_out" ? fileOutputTargetExtension(param, request.parameters[name]) : "tif";
       const file = `${outputBaseName(request.tool_id, name)}.${ext}`;
-      outputs.push({ name, file, kind: kind === "raster_out" ? "raster" : "bytes" });
+      outputs.push({
+        name,
+        file,
+        kind: kind === "raster_out" ? "raster" : "bytes",
+      });
       args.push(`--${name}=/work/${file}`);
     } else {
       const value = parameterOverrides[name] ?? request.parameters[name];

--- a/tests/wasm-multiple-inputs.test.ts
+++ b/tests/wasm-multiple-inputs.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { runWhiteboxToolWasm, type WhiteboxLayerInput } from "@geolibre/processing";
+import { releaseIdleWasmToolWorkers } from "../packages/processing/src/wasm-tool-runner";
+
+const originalWorker = globalThis.Worker;
+const originalFetch = globalThis.fetch;
+let posted: { args: string[]; input: Record<string, Uint8Array> } | undefined;
+
+class FakeWorker {
+  private listeners = new Map<string, Set<(event: MessageEvent) => void>>();
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+  removeEventListener(type: string, listener: (event: MessageEvent) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+  postMessage(request: { args: string[]; input: Record<string, Uint8Array> }) {
+    posted = request;
+    const output = new TextEncoder().encode(
+      JSON.stringify({ type: "FeatureCollection", features: [] }),
+    );
+    queueMicrotask(() => {
+      for (const listener of this.listeners.get("message") ?? []) {
+        listener({
+          data: {
+            ok: true,
+            result: {
+              exitCode: 0,
+              stdout: [],
+              files: { "merge_vectors_output.geojson": output },
+            },
+          },
+        } as MessageEvent);
+      }
+    });
+  }
+  terminate() {}
+}
+
+afterEach(() => {
+  releaseIdleWasmToolWorkers();
+  if (originalWorker === undefined) delete (globalThis as { Worker?: typeof Worker }).Worker;
+  else globalThis.Worker = originalWorker;
+  globalThis.fetch = originalFetch;
+  posted = undefined;
+});
+
+describe("runWhiteboxToolWasm multi-input staging", () => {
+  it("stages every vector and passes one comma-delimited argument", async () => {
+    globalThis.Worker = FakeWorker as unknown as typeof Worker;
+
+    const collection = { type: "FeatureCollection", features: [] } as const;
+    const inputs: WhiteboxLayerInput[] = ["a", "b"].map((name) => ({
+      name,
+      kind: "vector_in",
+      geojson: collection,
+    }));
+    const result = await runWhiteboxToolWasm({
+      tool_id: "merge_vectors",
+      parameters: {},
+      layer_inputs: { inputs },
+      tool: {
+        id: "merge_vectors",
+        params: [
+          { name: "inputs", kind: "vector_in", required: true },
+          { name: "output", kind: "vector_out", required: true },
+        ],
+      },
+    });
+
+    assert.equal(result.status, "succeeded");
+    assert.ok(posted);
+    assert.deepEqual(Object.keys(posted.input), ["inputs_1.geojson", "inputs_2.geojson"]);
+    assert.ok(posted.args.includes("--inputs=/work/inputs_1.geojson,/work/inputs_2.geojson"));
+  });
+
+  it("splits and fetches a typed comma-delimited vector path list", async () => {
+    globalThis.Worker = FakeWorker as unknown as typeof Worker;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ type: "FeatureCollection", features: [] }), {
+        status: 200,
+      });
+
+    const result = await runWhiteboxToolWasm({
+      tool_id: "merge_vectors",
+      parameters: { inputs: "https://example.com/a.geojson,https://example.com/b.geojson" },
+      tool: {
+        id: "merge_vectors",
+        params: [
+          {
+            name: "inputs",
+            description: "Array of input vector paths.",
+            kind: "vector_in",
+            required: true,
+          },
+          { name: "output", kind: "vector_out", required: true },
+        ],
+      },
+    });
+
+    assert.equal(result.status, "succeeded");
+    assert.ok(posted);
+    assert.deepEqual(Object.keys(posted.input), ["inputs_1.geojson", "inputs_2.geojson"]);
+    assert.ok(posted.args.includes("--inputs=/work/inputs_1.geojson,/work/inputs_2.geojson"));
+  });
+});

--- a/tests/whitebox-distance-params.test.ts
+++ b/tests/whitebox-distance-params.test.ts
@@ -227,6 +227,13 @@ describe("wgs84VectorLayerIds", () => {
     );
   });
 
+  it("flattens a multi-dataset layer selection", () => {
+    assert.deepEqual(
+      wgs84VectorLayerIds([{ required: true, value: ["layer:a", "layer:b"] }], PREFIX),
+      ["a", "b"],
+    );
+  });
+
   it("rejects any input left on a file path, required or not", () => {
     // The file is read from disk in whatever CRS it carries, so the tool's units
     // are unknowable even when the path is on an optional input.

--- a/tests/whitebox-param-kind.test.ts
+++ b/tests/whitebox-param-kind.test.ts
@@ -28,6 +28,18 @@ describe("isMultipleDatasetParameter", () => {
     );
   });
 
+  it("recognizes descriptions with several dataset qualifiers", () => {
+    assert.equal(
+      isMultipleDatasetParameter({
+        name: "tiles",
+        description: "Array of LiDAR tile paths or a directory containing LAS/LAZ tiles.",
+        data_kind: "lidar",
+        io_role: "input",
+      }),
+      true,
+    );
+  });
+
   it("does not turn ordinary dataset inputs or scalar lists into dataset pickers", () => {
     assert.equal(isMultipleDatasetParameter({ name: "input", kind: "vector_in" }), false);
     assert.equal(

--- a/tests/whitebox-param-kind.test.ts
+++ b/tests/whitebox-param-kind.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isMultipleDatasetParameter } from "../apps/geolibre-desktop/src/lib/whitebox-param-kind";
+
+describe("isMultipleDatasetParameter", () => {
+  it("uses explicit multiple cardinality", () => {
+    assert.equal(
+      isMultipleDatasetParameter({
+        name: "inputs",
+        data_kind: "raster",
+        io_role: "input",
+        schema: { kind: "input", cardinality: "multiple" },
+      }),
+      true,
+    );
+  });
+
+  it("repairs Merge Vectors' incorrect single cardinality from its description", () => {
+    assert.equal(
+      isMultipleDatasetParameter({
+        name: "inputs",
+        description: "Array of input vector paths (at least two required).",
+        data_kind: "vector",
+        io_role: "input",
+        schema: { kind: "input", cardinality: "single" },
+      }),
+      true,
+    );
+  });
+
+  it("does not turn ordinary dataset inputs or scalar lists into dataset pickers", () => {
+    assert.equal(isMultipleDatasetParameter({ name: "input", kind: "vector_in" }), false);
+    assert.equal(
+      isMultipleDatasetParameter({
+        name: "fields",
+        description: "List of field names.",
+        kind: "string",
+      }),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- render a checkbox picker for Whitebox parameters that accept multiple datasets
- stage and pass every selected vector, raster, LiDAR, or file input to the WASM runner and preserve sidecar path-list support
- recognize explicit multi-input cardinality and compensate for incorrect upstream metadata used by Merge Vectors

## Test plan
- [x] Run `node --import tsx --test tests/whitebox-param-kind.test.ts tests/wasm-tool-manifests.test.ts`
- [x] Run scoped pre-commit hooks, including ESLint and the production npm build
- [x] Verify the Whitebox WASM CLI merges two staged GeoJSON inputs passed as a comma-delimited list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and process multiple datasets in a single operation.
  * Support multiple vector, raster, lidar, and file inputs across execution modes.
  * Preserve metadata and parsed content when selecting local datasets.
  * Distance conversion messages now include the converted degree value and latitude context.

* **Bug Fixes**
  * Improved validation for empty selections and input formats.
  * Better recognition of tools that accept dataset lists, including those with incomplete metadata.
  * Enhanced security and path validation for multi-file inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->