### PR TITLE
Fix embedded GeoPackage project restore

### DIFF
--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -492,11 +492,16 @@ export function replayVectorLayer(
 ): Promise<unknown> {
   const effective = effectiveLayerRenderState(layer, groups);
   const replayState = savedVectorState(layer);
-  // Embedded data is always a GeoJSON FeatureCollection, even when it was
-  // materialized from a GeoPackage or another source format. The effective
-  // replay format must follow the data being passed to addData, not the
-  // original file format retained in the project metadata.
-  if (typeof source !== "string" && source.type === "FeatureCollection") {
+  // Embedded data and desktop-native reads are already materialized as
+  // GeoJSON, even when they came from a GeoPackage or another source format.
+  // The effective replay format must follow the data being passed to addData,
+  // not the original file format retained in the project metadata.
+  if (
+    typeof source !== "string" &&
+    (source.type === "FeatureCollection" ||
+      (source instanceof File &&
+        (source.type === "application/geo+json" || /\.geojson$/i.test(source.name))))
+  ) {
     replayState.format = "geojson";
   }
   // Record the folded values before addData so its first layer event is treated

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -491,12 +491,20 @@ export function replayVectorLayer(
   } = {},
 ): Promise<unknown> {
   const effective = effectiveLayerRenderState(layer, groups);
+  const replayState = savedVectorState(layer);
+  // Embedded data is always a GeoJSON FeatureCollection, even when it was
+  // materialized from a GeoPackage or another source format. The effective
+  // replay format must follow the data being passed to addData, not the
+  // original file format retained in the project metadata.
+  if (typeof source !== "string" && source.type === "FeatureCollection") {
+    replayState.format = "geojson";
+  }
   // Record the folded values before addData so its first layer event is treated
   // as a restore echo rather than as an edit to the child's own state.
   rememberControlVectorRenderState(layer.id, effective);
   return control
     .addData(source, {
-      ...savedVectorState(layer),
+      ...replayState,
       ...(options.companionFiles?.length ? { companionFiles: options.companionFiles } : {}),
       ...(options.localPath ? { sourcePath: options.localPath } : {}),
       fitBounds: false,

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -1022,6 +1022,26 @@ describe("replayVectorLayer with layer groups", () => {
     });
   }
 
+  it("replays embedded GeoJSON with its effective format instead of the original file format", async () => {
+    const info = vectorInfo({
+      format: "geopackage",
+      source: { kind: "file", fileName: "countries.gpkg" },
+    });
+    const layer = createVectorStoreLayer(info);
+    let addDataOptions: VectorLayerOptions | undefined;
+    const control = {
+      addData: async (_source: unknown, options?: VectorLayerOptions) => {
+        addDataOptions = options;
+        return info;
+      },
+    } as unknown as VectorControl;
+
+    await replayVectorLayer(control, layer, embedded, groups);
+
+    assert.equal((layer.metadata.vectorState as { format?: string }).format, "geopackage");
+    assert.equal(addDataOptions?.format, "geojson");
+  });
+
   it("clears restored render tracking after group overrides are removed", async () => {
     const info = vectorInfo();
     const layer = {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -1022,24 +1022,40 @@ describe("replayVectorLayer with layer groups", () => {
     });
   }
 
-  it("replays embedded GeoJSON with its effective format instead of the original file format", async () => {
+  it("replays materialized GeoJSON with its effective format instead of the original file format", async () => {
     const info = vectorInfo({
       format: "geopackage",
       source: { kind: "file", fileName: "countries.gpkg" },
     });
     const layer = createVectorStoreLayer(info);
-    let addDataOptions: VectorLayerOptions | undefined;
-    const control = {
-      addData: async (_source: unknown, options?: VectorLayerOptions) => {
-        addDataOptions = options;
-        return info;
+    const cases = [
+      { source: embedded, expectedFormat: "geojson" },
+      {
+        source: new File([JSON.stringify(embedded)], "countries.geojson", {
+          type: "application/geo+json",
+        }),
+        expectedFormat: "geojson",
       },
-    } as unknown as VectorControl;
+      {
+        source: new File(["geopackage"], "countries.gpkg"),
+        expectedFormat: "geopackage",
+      },
+    ];
 
-    await replayVectorLayer(control, layer, embedded, groups);
+    for (const restoreCase of cases) {
+      let addDataOptions: VectorLayerOptions | undefined;
+      const control = {
+        addData: async (_source: unknown, options?: VectorLayerOptions) => {
+          addDataOptions = options;
+          return info;
+        },
+      } as unknown as VectorControl;
 
-    assert.equal((layer.metadata.vectorState as { format?: string }).format, "geopackage");
-    assert.equal(addDataOptions?.format, "geojson");
+      await replayVectorLayer(control, layer, restoreCase.source, groups);
+
+      assert.equal((layer.metadata.vectorState as { format?: string }).format, "geopackage");
+      assert.equal(addDataOptions?.format, restoreCase.expectedFormat);
+    }
   });
 
   it("clears restored render tracking after group overrides are removed", async () => {


### PR DESCRIPTION
## Summary

- restore embedded vector FeatureCollections using the effective GeoJSON format
- handle desktop-native data already materialized as GeoJSON while leaving actual GeoPackage files unchanged
- add regression coverage for embedded and desktop-native GeoPackage-derived layers

## Testing

- `node --import tsx --test tests/vector-layer-sync.test.ts`
- `npm run build`
- `pre-commit run --all-files`
- reopened an embedded two-layer GeoPackage project in light and dark themes

Fixes #2034