### PR TITLE
fix(measure): add advanced precision tools

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl": "^6.3.0",
     "maplibre-gl-3d-tiles": "^0.5.6",
     "maplibre-gl-basemap-control": "^0.14.0",
-    "maplibre-gl-components": "^0.31.0",
+    "maplibre-gl-components": "^0.31.1",
     "maplibre-gl-duckdb": "^0.2.4",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "maplibre-gl": "^6.3.0",
         "maplibre-gl-3d-tiles": "^0.5.6",
         "maplibre-gl-basemap-control": "^0.14.0",
-        "maplibre-gl-components": "^0.31.0",
+        "maplibre-gl-components": "^0.31.1",
         "maplibre-gl-duckdb": "^0.2.4",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -17797,9 +17797,9 @@
       }
     },
     "node_modules/maplibre-gl-components": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.31.0.tgz",
-      "integrity": "sha512-M3pbXa7TIygQreyW/KzYPo2DlnugW22YpvbsTJO18IrQ0j15QHMN6jVNwFAERGsfNkLoUaY3sy+ftQv0GrxdnA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.31.1.tgz",
+      "integrity": "sha512-eGKHzDkaRwlvLq01esmGMHKR/HA9AWhuXv2k7IV4j6FIfcIQKIKc8CMeAgg4NzDAx2nNmwHb0ezfDqESORrSdg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -23660,7 +23660,7 @@
         "maplibre-gl": "^6.3.0",
         "maplibre-gl-3d-tiles": "^0.5.6",
         "maplibre-gl-basemap-control": "^0.14.0",
-        "maplibre-gl-components": "^0.31.0",
+        "maplibre-gl-components": "^0.31.1",
         "maplibre-gl-duckdb": "^0.2.4",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -50,7 +50,7 @@
     "maplibre-gl": "^6.3.0",
     "maplibre-gl-3d-tiles": "^0.5.6",
     "maplibre-gl-basemap-control": "^0.14.0",
-    "maplibre-gl-components": "^0.31.0",
+    "maplibre-gl-components": "^0.31.1",
     "maplibre-gl-duckdb": "^0.2.4",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",


### PR DESCRIPTION
## Summary

- upgrade `maplibre-gl-components` to 0.31.1
- add live segment distance, bearing, and running-total feedback
- add center-radius circle measurement with live radius and area
- enable draggable measurement vertices with automatic recalculation
- add exact length and bearing input for geodesic segments

## Verification

- verified the registry-installed package in the real GeoLibre app
- confirmed live preview, a 100 km segment at 90 degrees, vertex dragging, and circle measurement
- verified readable rendering in light and dark themes
- `npm run build`
- targeted pre-commit hooks

Upstream: https://github.com/opengeos/maplibre-gl-components/pull/132
Release: https://github.com/opengeos/maplibre-gl-components/releases/tag/v0.31.1

Fixes #2039