### PR TITLE
fix(processing): count unwalkable features in the Points along geometry skip summary

### DIFF
--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1917,10 +1917,7 @@ export const pointsAlongGeometryTool: ProcessingAlgorithm = {
     for (const feature of fc.features) {
       const geometry = feature.geometry;
       const linear = geometry ? linearParts(geometry) : [];
-      if (!linear.length) {
-        skipped += 1;
-        continue;
-      }
+      let usable = 0;
       for (const part of linear) {
         if (part.length < 2) continue;
         // Interval multiples plus the closing end vertex.
@@ -1928,7 +1925,12 @@ export const pointsAlongGeometryTool: ProcessingAlgorithm = {
         const length = segmentLengths.reduce((total, segment) => total + segment, 0);
         estimated += Math.floor(length / turfInterval) + 2;
         parts.push({ feature, part, length, segmentLengths });
+        usable += 1;
       }
+      // A feature with no line or polygon geometry at all and one whose every
+      // part is a lone coordinate both contribute nothing, so both are counted
+      // here: the summary would otherwise under-report the second kind.
+      if (!usable) skipped += 1;
     }
     // Bail before allocating anything, the way gridTool does for its cells.
     if (estimated > POINTS_ALONG_HARD_CAP) {
@@ -1980,7 +1982,7 @@ export const pointsAlongGeometryTool: ProcessingAlgorithm = {
       ctx.log("Error: no line or polygon features found in the input layer");
       return;
     }
-    if (skipped) ctx.log(`Skipped ${skipped} feature(s) that are not lines or polygons`);
+    if (skipped) ctx.log(`Skipped ${skipped} feature(s) with no usable line or polygon geometry`);
     ctx.log(`Generated ${points.length} point(s) every ${interval} ${units}`);
     ctx.addResultLayer?.("Points along geometry", featureCollection(points));
   },

--- a/tests/vertices-points-along.test.ts
+++ b/tests/vertices-points-along.test.ts
@@ -437,6 +437,39 @@ describe("points along geometry tool", () => {
     assert.equal(vertices.results[0].features.length, 3);
   });
 
+  it("counts a feature whose every part is a lone coordinate as skipped", () => {
+    const degenerate = makeLayer("degenerate", "Degenerate", {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          // A line-family geometry, so it survives `linearParts`, but with too
+          // few coordinates to walk.
+          geometry: { type: "LineString", coordinates: [[0, 0]] },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: { type: "Point", coordinates: [5, 5] },
+        },
+        ...line.geojson.features,
+      ],
+    });
+    const { messages, results } = runTool("points-along-geometry", [degenerate], {
+      layer: "degenerate",
+      interval: 100,
+      units: "kilometers",
+    });
+    // Only the real line produces points; both the lone-coordinate line and
+    // the point feature are reported.
+    assert.equal(results[0].features.length, 5);
+    assert.ok(
+      messages.some((m) => m === "Skipped 2 feature(s) with no usable line or polygon geometry"),
+      messages.join(" | "),
+    );
+  });
+
   it("keeps a sample just past a very long segment's end on the next segment", () => {
     // A ~10,000 km first segment: a boundary tolerance proportional to the
     // segment is a centimetre wide there, so a sample landing millimetres


### PR DESCRIPTION
Follow-up to a review comment on #2031 that landed after the squash merge, so it could not be pushed to that branch.

`pointsAlongGeometryTool` incremented `skipped` only when a feature had no linear parts at all (`!linear.length`). A feature that *does* carry line or polygon geometry but whose every part is shorter than two coordinates (a degenerate single-coordinate `LineString`) survives `linearParts` and is then dropped by the `part.length < 2` guard, so it contributed zero points while never being counted. The "Skipped N feature(s)" summary under-reported it.

- Count a feature as skipped when it yields no usable part, rather than only when it has no line or polygon geometry at all.
- Generalize the message to "Skipped N feature(s) with no usable line or polygon geometry", since a degenerate `LineString` *is* a line, just not a walkable one.
- New test: a lone-coordinate `LineString` plus a `Point` alongside a real line, asserting five output points and `Skipped 2`.

Output is unchanged; this only fixes the log line.

Verified: `npm run test:frontend` (6736 pass, 0 fail), `npm run typecheck`, and `pre-commit run --files` on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved points-along-geometry processing to correctly skip features without usable line or polygon geometry, including lines that are too short.
  * Skip reporting now accurately includes all features lacking usable geometry.

* **Tests**
  * Added coverage confirming unusable line features are skipped while valid lines continue generating points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->