### PR TITLE
Fix cumulative Time Slider rendering lag

### DIFF
--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -53,13 +53,19 @@ export { STORE_LAYER_SOURCE_KIND as TIME_SLIDER_SOURCE_KIND };
  * range out of the box rather than against an unrelated span (which would
  * request tiles for years the data does not cover).
  */
-function buildDefaultOptions(): TimeSliderOptions {
+export function buildDefaultOptions(): TimeSliderOptions {
   return {
     startDate: "1984-01-01",
     endDate: "2013-01-01",
     granularity: "year",
     granularities: ["year", "month", "day"],
     speed: 800,
+    // Reaching the end should leave the map on the final frame. Apart from
+    // being the less surprising default, this prevents a slow vector-tile
+    // filter from finishing an old end-of-range render after the marker has
+    // already wrapped to the beginning. A user can still enable looping, and
+    // an explicitly saved `loop` value continues to round-trip unchanged.
+    loop: false,
     collapsible: true,
     collapsed: false,
     // Match the in-app light/dark toggle rather than the system
@@ -477,6 +483,17 @@ let applyingBoundFilters = false;
 // re-write the store. Cleared when a layer is unbound or the dock detaches.
 const appliedFilterKeys = new Map<string, string>();
 
+// Changing a MapLibre filter invalidates the loaded vector-tile buckets and
+// sends them back through the workers. At fast playback speeds a large bound
+// layer can take longer to rebuild than one timeline step; sending every
+// intermediate year then creates a worker backlog, so the map continues
+// painting old cumulative frames after the marker has moved elsewhere. Keep a
+// short leading/trailing throttle and retain only the newest requested date.
+// The ordinary 800 ms default cadence remains completely unaffected.
+const BOUND_FILTER_APPLY_INTERVAL_MS = 250;
+let boundFilterApplyTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingBoundFilterControl: TimeSliderControl | null = null;
+
 // Guards the store writes made by overlay-frame visibility toggling (mirrors
 // `applyingBoundFilters`) so they do not re-trigger the store subscription.
 let applyingOverlayVisibility = false;
@@ -609,6 +626,50 @@ function applyBoundFilters(control: TimeSliderControl, bound: BoundLayer[]): voi
   } finally {
     applyingBoundFilters = false;
   }
+}
+
+/**
+ * Apply bound vector filters at a rate MapLibre's tile workers can sustain.
+ * The first change after an idle period is immediate; changes during the
+ * cooldown collapse into one trailing apply that reads the control's latest
+ * date when it runs.
+ */
+function scheduleBoundFilters(control: TimeSliderControl): void {
+  const bound = getBoundLayers();
+  if (bound.length === 0) {
+    pendingBoundFilterControl = null;
+    return;
+  }
+  pendingBoundFilterControl = control;
+  if (boundFilterApplyTimer !== null) return;
+
+  pendingBoundFilterControl = null;
+  applyBoundFilters(control, bound);
+  boundFilterApplyTimer = setTimeout(flushPendingBoundFilters, BOUND_FILTER_APPLY_INTERVAL_MS);
+}
+
+function flushPendingBoundFilters(): void {
+  boundFilterApplyTimer = null;
+  const control = pendingBoundFilterControl;
+  pendingBoundFilterControl = null;
+  if (control) scheduleBoundFilters(control);
+}
+
+function clearBoundFilterSchedule(): void {
+  if (boundFilterApplyTimer !== null) clearTimeout(boundFilterApplyTimer);
+  boundFilterApplyTimer = null;
+  pendingBoundFilterControl = null;
+}
+
+/** Test seam for the latest-date throttle used by bound vector layers. */
+export function __scheduleBoundFiltersForTests(control: TimeSliderControl): void {
+  scheduleBoundFilters(control);
+}
+
+/** Reset the module-level throttle between tests. */
+export function __resetBoundFilterScheduleForTests(): void {
+  clearBoundFilterSchedule();
+  appliedFilterKeys.clear();
 }
 
 // Last time index *requested* per selector-bound layer, so a tick that lands on
@@ -809,7 +870,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
     if (!selectorIds.has(id)) appliedTimeIndices.delete(id);
   }
   scheduleSelectorTimes(control);
-  applyBoundFilters(control, bound);
+  scheduleBoundFilters(control);
   applyTimeOverlayVisibility(control, frames);
 }
 
@@ -827,6 +888,7 @@ export function __reconcileBoundLayersForTests(control: TimeSliderControl): void
  * @returns A teardown function.
  */
 function attachBindingSync(control: TimeSliderControl): () => void {
+  clearBoundFilterSchedule();
   lastBoundRangeKey = null;
   preBindingRange = null;
   appliedTimeIndices.clear();
@@ -837,7 +899,7 @@ function attachBindingSync(control: TimeSliderControl): () => void {
   // and overlay frames must update.
   const onStateChange = () => {
     scheduleSelectorTimes(control);
-    applyBoundFilters(control, getBoundLayers());
+    scheduleBoundFilters(control);
     applyTimeOverlayVisibility(control, getTimeOverlayFrames());
   };
   control.on("statechange", onStateChange);
@@ -874,6 +936,7 @@ function attachBindingSync(control: TimeSliderControl): () => void {
       clearTimeout(selectorApplyTimer);
       selectorApplyTimer = null;
     }
+    clearBoundFilterSchedule();
     unsubscribe();
     clearBoundFilters(getBoundLayers().map((entry) => entry.id));
     // A cube stays on the slice it was last stepped to: unlike a filter, that is

--- a/tests/time-slider-config.test.ts
+++ b/tests/time-slider-config.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import {
+  __resetBoundFilterScheduleForTests,
   __reconcileBoundLayersForTests,
+  __scheduleBoundFiltersForTests,
+  buildDefaultOptions,
   configToOptions,
   getLayerTimeBinding,
   createStoreLayer,
@@ -37,7 +40,69 @@ function baseConfig(overrides: Record<string, unknown> = {}): Record<string, unk
 // Clear the plugin's persisted config between tests (no control is active, so a
 // null state simply resets savedConfig to null).
 afterEach(() => {
+  __resetBoundFilterScheduleForTests();
   apply(null);
+});
+
+describe("Time Slider playback defaults", () => {
+  it("stops at the end unless the user explicitly enables looping", () => {
+    assert.equal(buildDefaultOptions().loop, false);
+  });
+});
+
+describe("Time Slider bound-filter backpressure", () => {
+  it("applies the first date immediately and collapses rapid ticks to the latest date", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const previousLayers = useAppStore.getState().layers;
+    const layer = {
+      id: "buildings",
+      name: "Buildings",
+      type: "vector-tiles",
+      source: { type: "vector" },
+      visible: true,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {
+        timeBinding: {
+          property: "construction_year",
+          valueKind: "year",
+          min: Date.UTC(1719, 0, 1),
+          max: Date.UTC(2026, 0, 1),
+          granularity: "year",
+          cumulative: true,
+          window: { unit: "year", before: 0, after: 1 },
+        },
+      },
+    } satisfies GeoLibreLayer;
+    let currentDate = "1900-01-01T00:00:00.000Z";
+    const control = {
+      getConfig: () => ({ currentDate }),
+    } as unknown as TimeSliderControl;
+    const upperYear = (): number | undefined => {
+      const filter = useAppStore.getState().layers[0]?.timeFilter;
+      return Array.isArray(filter) ? ((filter.at(-1) as unknown[])?.at(-1) as number) : undefined;
+    };
+
+    try {
+      useAppStore.setState({ layers: [layer] });
+      __scheduleBoundFiltersForTests(control);
+      assert.equal(upperYear(), 1901, "the leading date should render immediately");
+
+      currentDate = "1901-01-01T00:00:00.000Z";
+      __scheduleBoundFiltersForTests(control);
+      currentDate = "1902-01-01T00:00:00.000Z";
+      __scheduleBoundFiltersForTests(control);
+      assert.equal(upperYear(), 1901, "intermediate worker-invalidating filters are held back");
+
+      t.mock.timers.tick(249);
+      assert.equal(upperYear(), 1901);
+      t.mock.timers.tick(1);
+      assert.equal(upperYear(), 1903, "the trailing apply should use only the newest date");
+    } finally {
+      __resetBoundFilterScheduleForTests();
+      useAppStore.setState({ layers: previousLayers });
+    }
+  });
 });
 
 describe("Time Slider open-ended end date persistence", () => {


### PR DESCRIPTION
## Summary

- make new Time Slider controls stop at the end instead of looping by default
- throttle bound vector-layer filter updates and collapse rapid ticks to the latest requested date
- clear pending filter work when the control detaches
- add regression tests for the non-looping default and latest-date backpressure

## Why

Each MapLibre `setFilter` update reloads the vector source tile buckets. During fast cumulative playback on a large vector-tile layer, intermediate yearly filters could enter the worker queue faster than they rendered. After the marker wrapped to the start, older end-of-range work could therefore continue painting buildings.

The throttle keeps the first update responsive, caps worker-invalidating updates at four per second, and always applies the latest pending date on the trailing edge. The normal 800 ms playback cadence is unchanged. Saved projects that explicitly enable looping continue to preserve that setting.

## Verification

- `node --import tsx --test --test-name-pattern="Time Slider (playback defaults|bound-filter backpressure)" tests/time-slider-config.test.ts`
- full frontend suite: 6,762 passed, 1 pre-existing skip
- `npm run build`
- ESLint and oxfmt checks on the changed files
- production browser build with the NYC buildings dataset, cumulative mode, 100 ms/step from 2000 through 2026: playback stopped at 2026 and map screenshots at the end and +1 s, +3 s, and +5 s were pixel-identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time slider playback now defaults to stopping at the end instead of looping.
  * Rapid time changes update map filters more smoothly, applying the latest selected date after a short delay.

* **Bug Fixes**
  * Improved cleanup and state handling for time-slider filter updates to prevent stale or excessive refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->