### PR TITLE
chore: ignore Android Gradle cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ apps/geolibre-desktop/src-tauri/mas/embedded.provisionprofile
 # defaults to sqlite:///./geolibre-server-api.db, so running it from the repo root
 # (the obvious place) drops the file here.
 /geolibre-server-api.db
+
+# Local Android Gradle cache for the vendored Tauri geolocation plugin.
+apps/geolibre-desktop/src-tauri/vendor/tauri-plugin-geolocation/android/.gradle/


### PR DESCRIPTION
## Summary
- ignore the local Android Gradle cache generated under the vendored Tauri geolocation plugin

## Testing
- git diff --check

This is a standalone follow-up for the .gitignore item discussed in #2049; it intentionally contains no i18n changes.