### PR TITLE
Mirror release downloads to GitHub Pages

### DIFF
--- a/.github/workflows/sync-download-mirror.yml
+++ b/.github/workflows/sync-download-mirror.yml
@@ -89,13 +89,23 @@ jobs:
           } > "$HOME/.ssh/config"
           chmod 600 "$HOME/.ssh/config"
 
-      - name: Build mirror
+      - name: Resolve release tag
+        id: release
         env:
           REQUESTED_TAG: ${{ inputs.tag }}
           WORKFLOW_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           tag="${REQUESTED_TAG:-${WORKFLOW_TAG:-}}"
-          scripts/build-download-mirror.sh "$RUNNER_TEMP/site" "$tag"
+          if [[ -z "$tag" ]]; then
+            tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build candidate manifest
+        env:
+          DOWNLOAD_MIRROR_METADATA_ONLY: "true"
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: scripts/build-download-mirror.sh "$RUNNER_TEMP/candidate" "$RELEASE_TAG"
 
       - name: Skip an unchanged mirror
         id: changes
@@ -106,8 +116,8 @@ jobs:
             "git@github.com:$DESTINATION_REPOSITORY.git" current
           if git -C current show HEAD:manifest.json > current-manifest.json 2>/dev/null; then
             jq 'del(.generated_at)' current-manifest.json > current-normalized.json
-            jq 'del(.generated_at)' site/manifest.json > site-normalized.json
-            if cmp -s current-normalized.json site-normalized.json; then
+            jq 'del(.generated_at)' candidate/manifest.json > candidate-normalized.json
+            if cmp -s current-normalized.json candidate-normalized.json; then
               echo "The mirror already contains this release and asset set."
               echo "publish=false" >> "$GITHUB_OUTPUT"
               exit 0
@@ -115,11 +125,17 @@ jobs:
           fi
           echo "publish=true" >> "$GITHUB_OUTPUT"
 
+      - name: Build mirror
+        if: steps.changes.outputs.publish == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: scripts/build-download-mirror.sh "$RUNNER_TEMP/site" "$RELEASE_TAG"
+
       - name: Publish an orphan snapshot
         if: steps.changes.outputs.publish == 'true'
         working-directory: ${{ runner.temp }}/site
         env:
-          RELEASE_TAG: ${{ inputs.tag || github.event.workflow_run.head_branch || 'latest' }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
           git init --initial-branch=main

--- a/.github/workflows/sync-download-mirror.yml
+++ b/.github/workflows/sync-download-mirror.yml
@@ -1,0 +1,133 @@
+name: Sync download mirror
+
+on:
+  workflow_run:
+    workflows:
+      - Release Desktop App
+      - Android
+      - iOS
+      - Build Mac App Store package
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to mirror (defaults to latest)
+        required: false
+        type: string
+  schedule:
+    # Safety net for release assets added or replaced outside the build workflows.
+    - cron: "17 7 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: download-mirror
+  # Each completed release workflow starts this job. The final producer cancels
+  # earlier waiters and performs one upload after every producer has settled.
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Publish latest artifacts
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.event == 'release' &&
+       github.event.workflow_run.conclusion != 'cancelled')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DOWNLOADS_DEPLOY_KEY: ${{ secrets.DOWNLOADS_DEPLOY_KEY }}
+      DESTINATION_REPOSITORY: opengeos/geolibre-downloads
+    steps:
+      - name: Check out GeoLibre
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Wait for release asset producers
+        if: github.event_name == 'workflow_run'
+        env:
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          required=("Release Desktop App" "Android" "iOS" "Build Mac App Store package")
+          for attempt in {1..90}; do
+            runs="$(gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/runs?event=release&head_sha=$RELEASE_SHA&per_page=100")"
+            pending=()
+            for workflow in "${required[@]}"; do
+              status="$(jq -r --arg workflow "$workflow" \
+                '[.workflow_runs[] | select(.name == $workflow)][0].status // "missing"' <<< "$runs")"
+              [[ "$status" == "completed" ]] || pending+=("$workflow ($status)")
+            done
+            if (( ${#pending[@]} == 0 )); then
+              echo "All release asset producers have completed."
+              exit 0
+            fi
+            echo "Waiting for: ${pending[*]}"
+            sleep 60
+          done
+          echo "::warning::Timed out waiting for every release workflow; publishing the assets available now."
+
+      - name: Configure destination deploy key
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOWNLOADS_DEPLOY_KEY:-}" ]]; then
+            echo "::error::DOWNLOADS_DEPLOY_KEY is not configured."
+            exit 1
+          fi
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DOWNLOADS_DEPLOY_KEY" > "$HOME/.ssh/geolibre-downloads"
+          chmod 600 "$HOME/.ssh/geolibre-downloads"
+          gh api meta --jq '.ssh_keys[] | "github.com " + .' > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/known_hosts"
+          {
+            echo 'Host github.com'
+            echo '  IdentityFile ~/.ssh/geolibre-downloads'
+            echo '  IdentitiesOnly yes'
+          } > "$HOME/.ssh/config"
+          chmod 600 "$HOME/.ssh/config"
+
+      - name: Build mirror
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+          WORKFLOW_TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          tag="${REQUESTED_TAG:-${WORKFLOW_TAG:-}}"
+          scripts/build-download-mirror.sh "$RUNNER_TEMP/site" "$tag"
+
+      - name: Skip an unchanged mirror
+        id: changes
+        working-directory: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          git clone --depth 1 --filter=blob:none --no-checkout \
+            "git@github.com:$DESTINATION_REPOSITORY.git" current
+          if git -C current show HEAD:manifest.json > current-manifest.json 2>/dev/null; then
+            jq 'del(.generated_at)' current-manifest.json > current-normalized.json
+            jq 'del(.generated_at)' site/manifest.json > site-normalized.json
+            if cmp -s current-normalized.json site-normalized.json; then
+              echo "The mirror already contains this release and asset set."
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish an orphan snapshot
+        if: steps.changes.outputs.publish == 'true'
+        working-directory: ${{ runner.temp }}/site
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.event.workflow_run.head_branch || 'latest' }}
+        run: |
+          set -euo pipefail
+          git init --initial-branch=main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add origin "git@github.com:$DESTINATION_REPOSITORY.git"
+          git add --all
+          git commit -m "Mirror GeoLibre ${RELEASE_TAG}"
+          # Parentless snapshots prevent old release binaries accumulating in
+          # the reachable history of this latest-release-only repository.
+          git push --force origin HEAD:main

--- a/scripts/build-download-mirror.sh
+++ b/scripts/build-download-mirror.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 readonly SOURCE_REPOSITORY="opengeos/GeoLibre"
 readonly MIRROR_ORIGIN="https://downloads.geolibre.app"
 readonly MAX_MIRRORED_BYTES=$((100 * 1024 * 1024))
+readonly OMITTED_ASSET_PATTERNS_JSON='[
+  "^geolibre-android\\.aab$",
+  "^GeoLibre\\.Desktop_[^/]+_universal_mas\\.pkg$",
+  "^GeoLibre_[^/]+_ios_app-store\\.ipa$"
+]'
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Usage: $0 OUTPUT_DIRECTORY [RELEASE_TAG]" >&2
@@ -42,6 +47,7 @@ jq \
   --arg generated_at "$generated_at" \
   --arg mirror_origin "$MIRROR_ORIGIN" \
   --argjson max_mirrored_bytes "$MAX_MIRRORED_BYTES" \
+  --argjson omitted_asset_patterns "$OMITTED_ASSET_PATTERNS_JSON" \
   '{
     schema_version: 1,
     product: "GeoLibre",
@@ -56,6 +62,7 @@ jq \
     artifacts: [
       .assets[]
       | . as $asset
+      | select(([$omitted_asset_patterns[] as $pattern | $asset.name | test($pattern)] | any) | not)
       | ($asset.size <= $max_mirrored_bytes) as $mirrored
       | {
           name: $asset.name,
@@ -109,7 +116,12 @@ while IFS= read -r encoded_asset; do
 done < <(
   jq -r \
     --argjson max_mirrored_bytes "$MAX_MIRRORED_BYTES" \
-    '.assets[] | select(.size <= $max_mirrored_bytes) | @base64' \
+    --argjson omitted_asset_patterns "$OMITTED_ASSET_PATTERNS_JSON" \
+    '.assets[]
+     | . as $asset
+     | select(([$omitted_asset_patterns[] as $pattern | $asset.name | test($pattern)] | any) | not)
+     | select(.size <= $max_mirrored_bytes)
+     | @base64' \
     "$release_json"
 )
 

--- a/scripts/build-download-mirror.sh
+++ b/scripts/build-download-mirror.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SOURCE_REPOSITORY="opengeos/GeoLibre"
+readonly MIRROR_ORIGIN="https://downloads.geolibre.app"
+readonly MAX_MIRRORED_BYTES=$((100 * 1024 * 1024))
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 OUTPUT_DIRECTORY [RELEASE_TAG]" >&2
+  exit 2
+fi
+
+output_directory="$1"
+release_tag="${2:-}"
+script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+template_directory="$script_directory/download-mirror"
+
+if [[ -e "$output_directory" ]]; then
+  echo "Output path already exists: $output_directory" >&2
+  exit 1
+fi
+
+mkdir -p "$output_directory/artifacts"
+
+release_json="$output_directory/.release.json"
+if [[ -n "$release_tag" ]]; then
+  gh api "repos/$SOURCE_REPOSITORY/releases/tags/$release_tag" > "$release_json"
+else
+  gh api "repos/$SOURCE_REPOSITORY/releases/latest" > "$release_json"
+  release_tag="$(jq -r '.tag_name' "$release_json")"
+fi
+
+if [[ "$(jq -r '.draft' "$release_json")" == "true" ]]; then
+  echo "Refusing to mirror draft release $release_tag." >&2
+  exit 1
+fi
+
+generated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+jq \
+  --arg generated_at "$generated_at" \
+  --arg mirror_origin "$MIRROR_ORIGIN" \
+  --argjson max_mirrored_bytes "$MAX_MIRRORED_BYTES" \
+  '{
+    schema_version: 1,
+    product: "GeoLibre",
+    generated_at: $generated_at,
+    max_mirrored_bytes: $max_mirrored_bytes,
+    release: {
+      tag: .tag_name,
+      name: .name,
+      published_at: .published_at,
+      github_url: .html_url
+    },
+    artifacts: [
+      .assets[]
+      | . as $asset
+      | ($asset.size <= $max_mirrored_bytes) as $mirrored
+      | {
+          name: $asset.name,
+          size: $asset.size,
+          content_type: $asset.content_type,
+          digest: $asset.digest,
+          mirrored: $mirrored,
+          download_url: (
+            if $mirrored then
+              $mirror_origin + "/artifacts/" + ($asset.name | @uri)
+            else
+              $asset.browser_download_url
+            end
+          ),
+          github_url: $asset.browser_download_url
+        }
+    ] | sort_by(.name | ascii_downcase)
+  }
+  | .mirrored_bytes = ([.artifacts[] | select(.mirrored) | .size] | add // 0)
+  | .mirrored_count = ([.artifacts[] | select(.mirrored)] | length)
+  | .github_only_count = ([.artifacts[] | select(.mirrored | not)] | length)' \
+  "$release_json" > "$output_directory/manifest.json"
+
+while IFS= read -r encoded_asset; do
+  asset="$(base64 --decode <<< "$encoded_asset")"
+  asset_id="$(jq -r '.id' <<< "$asset")"
+  asset_name="$(jq -r '.name' <<< "$asset")"
+  expected_size="$(jq -r '.size' <<< "$asset")"
+  expected_digest="$(jq -r '.digest // empty' <<< "$asset")"
+  destination="$output_directory/artifacts/$asset_name"
+
+  echo "Downloading $asset_name"
+  gh api \
+    -H 'Accept: application/octet-stream' \
+    "repos/$SOURCE_REPOSITORY/releases/assets/$asset_id" > "$destination"
+
+  actual_size="$(stat -c '%s' "$destination")"
+  if [[ "$actual_size" != "$expected_size" ]]; then
+    echo "Size mismatch for $asset_name: expected $expected_size, got $actual_size" >&2
+    exit 1
+  fi
+
+  if [[ "$expected_digest" == sha256:* ]]; then
+    expected_sha256="${expected_digest#sha256:}"
+    actual_sha256="$(sha256sum "$destination" | cut -d' ' -f1)"
+    if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+      echo "SHA-256 mismatch for $asset_name" >&2
+      exit 1
+    fi
+  fi
+done < <(
+  jq -r \
+    --argjson max_mirrored_bytes "$MAX_MIRRORED_BYTES" \
+    '.assets[] | select(.size <= $max_mirrored_bytes) | @base64' \
+    "$release_json"
+)
+
+jq -r '
+  .artifacts[]
+  | select((.digest // "") | startswith("sha256:"))
+  | "\(.digest | sub("^sha256:"; ""))  \(.name)"
+' "$output_directory/manifest.json" > "$output_directory/SHA256SUMS.txt"
+
+cp "$template_directory/index.html" "$output_directory/index.html"
+cp "$template_directory/styles.css" "$output_directory/styles.css"
+cp "$template_directory/app.js" "$output_directory/app.js"
+cp "$template_directory/404.html" "$output_directory/404.html"
+cp "$template_directory/favicon.svg" "$output_directory/favicon.svg"
+cp "$template_directory/README.md" "$output_directory/README.md"
+touch "$output_directory/.nojekyll"
+printf '%s\n' 'downloads.geolibre.app' > "$output_directory/CNAME"
+rm "$release_json"
+
+echo "Built mirror for $release_tag: $(jq -r '.mirrored_count' "$output_directory/manifest.json") mirrored, $(jq -r '.github_only_count' "$output_directory/manifest.json") linked to GitHub."

--- a/scripts/build-download-mirror.sh
+++ b/scripts/build-download-mirror.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 readonly SOURCE_REPOSITORY="opengeos/GeoLibre"
 readonly MIRROR_ORIGIN="https://downloads.geolibre.app"
 readonly MAX_MIRRORED_BYTES=$((100 * 1024 * 1024))
+readonly METADATA_ONLY="${DOWNLOAD_MIRROR_METADATA_ONLY:-false}"
 readonly OMITTED_ASSET_PATTERNS_JSON='[
   "^geolibre-android\\.aab$",
   "^GeoLibre\\.Desktop_[^/]+_universal_mas\\.pkg$",
@@ -85,6 +86,12 @@ jq \
   | .mirrored_count = ([.artifacts[] | select(.mirrored)] | length)
   | .github_only_count = ([.artifacts[] | select(.mirrored | not)] | length)' \
   "$release_json" > "$output_directory/manifest.json"
+
+if [[ "$METADATA_ONLY" == "true" ]]; then
+  rm "$release_json"
+  echo "Built candidate manifest for $release_tag."
+  exit 0
+fi
 
 while IFS= read -r encoded_asset; do
   asset="$(base64 --decode <<< "$encoded_asset")"

--- a/scripts/download-mirror/404.html
+++ b/scripts/download-mirror/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>File not found · GeoLibre downloads</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="release-intro">
+      <div class="release-heading">
+        <p class="eyebrow">404 · File not found</p>
+        <h1>This map<br /><span>ends here.</span></h1>
+      </div>
+      <div class="release-note">
+        <p>
+          The file may belong to an older release. This mirror keeps only the
+          latest GeoLibre release.
+        </p>
+        <p><a href="/">Return to all downloads</a></p>
+      </div>
+    </main>
+  </body>
+</html>

--- a/scripts/download-mirror/README.md
+++ b/scripts/download-mirror/README.md
@@ -1,0 +1,9 @@
+# GeoLibre downloads
+
+This branch is generated automatically from the latest
+[`opengeos/GeoLibre`](https://github.com/opengeos/GeoLibre/releases/latest)
+release. Files up to 100 MiB are mirrored for GitHub Pages; larger files link
+to their original GitHub Release assets.
+
+Do not edit this repository by hand. The source templates and synchronization
+workflow live in the main GeoLibre repository.

--- a/scripts/download-mirror/README.md
+++ b/scripts/download-mirror/README.md
@@ -3,7 +3,8 @@
 This branch is generated automatically from the latest
 [`opengeos/GeoLibre`](https://github.com/opengeos/GeoLibre/releases/latest)
 release. Files up to 100 MiB are mirrored for GitHub Pages; larger files link
-to their original GitHub Release assets.
+to their original GitHub Release assets. Store-submission packages intended
+only for maintainers are omitted from the public directory.
 
 Do not edit this repository by hand. The source templates and synchronization
 workflow live in the main GeoLibre repository.

--- a/scripts/download-mirror/app.js
+++ b/scripts/download-mirror/app.js
@@ -1,0 +1,173 @@
+const list = document.querySelector("#artifact-list");
+const filter = document.querySelector("#artifact-filter");
+const emptyState = document.querySelector("#empty-state");
+const platformNav = document.querySelector("#platform-nav");
+let artifacts = [];
+
+const platformOrder = [
+  "Windows",
+  "macOS",
+  "Linux",
+  "Android",
+  "iOS",
+  "Browser",
+  "Other",
+];
+
+const bytes = new Intl.NumberFormat("en", {
+  style: "unit",
+  unit: "megabyte",
+  unitDisplay: "short",
+  maximumFractionDigits: 1,
+});
+
+function formatBytes(value) {
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(1)} KB`;
+  return bytes.format(value / 1_000_000);
+}
+
+function platformFor(name) {
+  const value = name.toLowerCase();
+  if (value.includes("android") || /\.(apk|aab)$/.test(value)) return "Android";
+  if (value.includes("ios") || value.endsWith(".ipa")) return "iOS";
+  if (value.includes("chrome")) return "Browser";
+  if (
+    /\.(exe|msi|msix)$/.test(value) ||
+    value.includes("windows") ||
+    value.includes("portable")
+  )
+    return "Windows";
+  if (
+    /\.(dmg|pkg)$/.test(value) ||
+    value.includes("darwin") ||
+    value.includes(".app.")
+  )
+    return "macOS";
+  if (/\.(deb|rpm|appimage|zsync)$/.test(value) || value.includes("linux"))
+    return "Linux";
+  return "Other";
+}
+
+function artifactRow(artifact) {
+  const link = document.createElement("a");
+  const platform = platformFor(artifact.name);
+  link.className = "artifact-row";
+  link.href = artifact.download_url;
+  link.setAttribute("download", artifact.mirrored ? "" : artifact.name);
+  link.dataset.search = `${artifact.name} ${platform}`.toLowerCase();
+  if (!artifact.mirrored) {
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+  }
+
+  const platformLabel = document.createElement("span");
+  platformLabel.className = "artifact-platform";
+  platformLabel.textContent = platform;
+
+  const name = document.createElement("span");
+  name.className = "artifact-name";
+  name.textContent = artifact.name;
+
+  const size = document.createElement("span");
+  size.className = "artifact-size";
+  size.textContent = formatBytes(artifact.size);
+
+  const source = document.createElement("span");
+  source.className = `source-badge${artifact.mirrored ? "" : " github"}`;
+  source.textContent = artifact.mirrored ? "Mirrored" : "GitHub only";
+
+  const arrow = document.createElement("span");
+  arrow.className = "download-arrow";
+  arrow.setAttribute("aria-hidden", "true");
+  arrow.textContent = artifact.mirrored ? "↓" : "↗";
+
+  link.append(platformLabel, name, size, source, arrow);
+  return link;
+}
+
+function render(query = "") {
+  const normalizedQuery = query.trim().toLowerCase();
+  const visible = artifacts.filter(({ element }) =>
+    element.dataset.search.includes(normalizedQuery)
+  );
+  const groups = platformOrder
+    .map((platform) => {
+      const matches = visible.filter((item) => item.platform === platform);
+      if (matches.length === 0) return null;
+
+      const section = document.createElement("section");
+      section.className = "platform-group";
+      section.id = `platform-${platform.toLowerCase()}`;
+
+      const heading = document.createElement("header");
+      heading.className = "platform-heading";
+      const title = document.createElement("h3");
+      title.textContent = platform;
+      const count = document.createElement("span");
+      count.className = "platform-count";
+      count.textContent = `— ${matches.length} ${
+        matches.length === 1 ? "file" : "files"
+      }`;
+      title.append(count);
+      heading.append(title);
+      section.append(heading, ...matches.map(({ element }) => element));
+      return section;
+    })
+    .filter(Boolean);
+
+  list.replaceChildren(...groups);
+  emptyState.hidden = visible.length !== 0;
+}
+
+function renderPlatformNav() {
+  const counts = new Map(platformOrder.map((platform) => [platform, 0]));
+  artifacts.forEach(({ platform }) =>
+    counts.set(platform, counts.get(platform) + 1)
+  );
+  const links = platformOrder
+    .filter((platform) => counts.get(platform) > 0)
+    .map((platform) => {
+      const link = document.createElement("a");
+      link.href = `#platform-${platform.toLowerCase()}`;
+      link.textContent = platform;
+      const count = document.createElement("span");
+      count.textContent = ` ${counts.get(platform)}`;
+      link.append(count);
+      return link;
+    });
+  platformNav.replaceChildren(...links);
+}
+
+async function loadManifest() {
+  try {
+    const response = await fetch("/manifest.json", { cache: "no-cache" });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const manifest = await response.json();
+
+    document.querySelector("#release-version").textContent =
+      manifest.release.tag;
+    document.querySelector("#published-at").textContent =
+      new Intl.DateTimeFormat("en", {
+        dateStyle: "medium",
+      }).format(new Date(manifest.release.published_at));
+    document.querySelector("#file-count").textContent =
+      manifest.artifacts.length;
+    document.querySelector("#mirror-size").textContent = formatBytes(
+      manifest.mirrored_bytes
+    );
+    document.title = `${manifest.release.tag} · GeoLibre downloads`;
+
+    artifacts = manifest.artifacts.map((artifact) => {
+      const platform = platformFor(artifact.name);
+      return { artifact, platform, element: artifactRow(artifact) };
+    });
+    renderPlatformNav();
+    render();
+  } catch (error) {
+    list.innerHTML = `<p class="error">The release manifest could not be loaded. Reload the page or use the project’s GitHub releases page.</p>`;
+    console.error(error);
+  }
+}
+
+filter.addEventListener("input", () => render(filter.value));
+loadManifest();

--- a/scripts/download-mirror/app.js
+++ b/scripts/download-mirror/app.js
@@ -4,15 +4,7 @@ const emptyState = document.querySelector("#empty-state");
 const platformNav = document.querySelector("#platform-nav");
 let artifacts = [];
 
-const platformOrder = [
-  "Windows",
-  "macOS",
-  "Linux",
-  "Android",
-  "iOS",
-  "Browser",
-  "Other",
-];
+const platformOrder = ["Windows", "macOS", "Linux", "Android", "iOS", "Browser", "Other"];
 
 const bytes = new Intl.NumberFormat("en", {
   style: "unit",
@@ -31,20 +23,11 @@ function platformFor(name) {
   if (value.includes("android") || /\.(apk|aab)$/.test(value)) return "Android";
   if (value.includes("ios") || value.endsWith(".ipa")) return "iOS";
   if (value.includes("chrome")) return "Browser";
-  if (
-    /\.(exe|msi|msix)$/.test(value) ||
-    value.includes("windows") ||
-    value.includes("portable")
-  )
+  if (/\.(exe|msi|msix)$/.test(value) || value.includes("windows") || value.includes("portable"))
     return "Windows";
-  if (
-    /\.(dmg|pkg)$/.test(value) ||
-    value.includes("darwin") ||
-    value.includes(".app.")
-  )
+  if (/\.(dmg|pkg)$/.test(value) || value.includes("darwin") || value.includes(".app."))
     return "macOS";
-  if (/\.(deb|rpm|appimage|zsync)$/.test(value) || value.includes("linux"))
-    return "Linux";
+  if (/\.(deb|rpm|appimage|zsync)$/.test(value) || value.includes("linux")) return "Linux";
   return "Other";
 }
 
@@ -88,7 +71,7 @@ function artifactRow(artifact) {
 function render(query = "") {
   const normalizedQuery = query.trim().toLowerCase();
   const visible = artifacts.filter(({ element }) =>
-    element.dataset.search.includes(normalizedQuery)
+    element.dataset.search.includes(normalizedQuery),
   );
   const groups = platformOrder
     .map((platform) => {
@@ -105,9 +88,7 @@ function render(query = "") {
       title.textContent = platform;
       const count = document.createElement("span");
       count.className = "platform-count";
-      count.textContent = `— ${matches.length} ${
-        matches.length === 1 ? "file" : "files"
-      }`;
+      count.textContent = `— ${matches.length} ${matches.length === 1 ? "file" : "files"}`;
       title.append(count);
       heading.append(title);
       section.append(heading, ...matches.map(({ element }) => element));
@@ -121,9 +102,7 @@ function render(query = "") {
 
 function renderPlatformNav() {
   const counts = new Map(platformOrder.map((platform) => [platform, 0]));
-  artifacts.forEach(({ platform }) =>
-    counts.set(platform, counts.get(platform) + 1)
-  );
+  artifacts.forEach(({ platform }) => counts.set(platform, counts.get(platform) + 1));
   const links = platformOrder
     .filter((platform) => counts.get(platform) > 0)
     .map((platform) => {
@@ -144,17 +123,12 @@ async function loadManifest() {
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const manifest = await response.json();
 
-    document.querySelector("#release-version").textContent =
-      manifest.release.tag;
-    document.querySelector("#published-at").textContent =
-      new Intl.DateTimeFormat("en", {
-        dateStyle: "medium",
-      }).format(new Date(manifest.release.published_at));
-    document.querySelector("#file-count").textContent =
-      manifest.artifacts.length;
-    document.querySelector("#mirror-size").textContent = formatBytes(
-      manifest.mirrored_bytes
-    );
+    document.querySelector("#release-version").textContent = manifest.release.tag;
+    document.querySelector("#published-at").textContent = new Intl.DateTimeFormat("en", {
+      dateStyle: "medium",
+    }).format(new Date(manifest.release.published_at));
+    document.querySelector("#file-count").textContent = manifest.artifacts.length;
+    document.querySelector("#mirror-size").textContent = formatBytes(manifest.mirrored_bytes);
     document.title = `${manifest.release.tag} · GeoLibre downloads`;
 
     artifacts = manifest.artifacts.map((artifact) => {

--- a/scripts/download-mirror/favicon.svg
+++ b/scripts/download-mirror/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <path fill="#0d5c4d" d="M24 3 42 13v22L24 45 6 35V13Z"/>
+  <path fill="#ccebe4" d="m15 28 9-15 9 15-9 7Z"/>
+</svg>

--- a/scripts/download-mirror/index.html
+++ b/scripts/download-mirror/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Direct downloads for the latest GeoLibre release."
+    />
+    <meta name="theme-color" content="#0d5c4d" />
+    <title>GeoLibre downloads</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="/styles.css" />
+    <script src="/app.js" defer></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#downloads">Skip to downloads</a>
+
+    <header class="masthead">
+      <a
+        class="wordmark"
+        href="https://geolibre.app"
+        aria-label="GeoLibre home"
+      >
+        <svg class="mark" viewBox="0 0 48 48" aria-hidden="true">
+          <path d="M24 3 42 13v22L24 45 6 35V13Z" />
+          <path d="m15 28 9-15 9 15-9 7Z" />
+        </svg>
+        <span>GeoLibre</span>
+      </a>
+      <span class="site-label">Download mirror</span>
+    </header>
+
+    <main>
+      <section class="release-intro" aria-labelledby="page-title">
+        <div class="release-heading">
+          <p class="eyebrow">Latest stable release</p>
+          <h1 id="page-title">
+            Get GeoLibre<br /><span id="release-version">…</span>
+          </h1>
+        </div>
+        <div class="release-note">
+          <p>
+            Choose the package for your system. Files up to 100 MB are served
+            directly by this mirror; larger files keep their original GitHub
+            link.
+          </p>
+          <dl class="release-facts" aria-live="polite">
+            <div>
+              <dt>Published</dt>
+              <dd id="published-at">—</dd>
+            </div>
+            <div>
+              <dt>Files</dt>
+              <dd id="file-count">—</dd>
+            </div>
+            <div>
+              <dt>Mirrored</dt>
+              <dd id="mirror-size">—</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section
+        class="directory"
+        id="downloads"
+        aria-labelledby="directory-title"
+      >
+        <div class="directory-bar">
+          <div>
+            <p class="eyebrow">Release directory</p>
+            <h2 id="directory-title">All artifacts</h2>
+          </div>
+          <label class="search">
+            <span class="visually-hidden">Filter artifacts</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="11" cy="11" r="6.5" />
+              <path d="m16 16 4 4" />
+            </svg>
+            <input
+              id="artifact-filter"
+              type="search"
+              placeholder="Filter by name or platform"
+              autocomplete="off"
+            />
+          </label>
+        </div>
+
+        <div class="legend" aria-label="Download source legend">
+          <span><i class="source-dot mirror"></i>This mirror</span>
+          <span><i class="source-dot github"></i>GitHub, over 100 MB</span>
+          <a href="/SHA256SUMS.txt">SHA-256 checksums</a>
+          <a href="/manifest.json">JSON manifest</a>
+        </div>
+
+        <nav
+          class="platform-nav"
+          id="platform-nav"
+          aria-label="Jump to a platform"
+        ></nav>
+
+        <div class="artifact-list" id="artifact-list" aria-live="polite">
+          <p class="loading">Reading the release manifest…</p>
+        </div>
+        <p class="empty" id="empty-state" hidden>
+          No artifacts match that filter.
+        </p>
+      </section>
+    </main>
+
+    <footer>
+      <p>Free and open-source geospatial software.</p>
+      <nav aria-label="Project links">
+        <a href="https://geolibre.app">Website</a>
+        <a href="https://docs.geolibre.app">Documentation</a>
+        <a href="https://github.com/opengeos/GeoLibre">Source</a>
+      </nav>
+    </footer>
+  </body>
+</html>

--- a/scripts/download-mirror/styles.css
+++ b/scripts/download-mirror/styles.css
@@ -1,0 +1,479 @@
+:root {
+  --ink: #102a29;
+  --muted: #526b68;
+  --paper: #f2f7f5;
+  --surface: #ffffff;
+  --line: #cbdcd7;
+  --brand: #0d5c4d;
+  --brand-bright: #16a085;
+  --map-water: #ccebe4;
+  --github: #76562b;
+  color-scheme: light;
+  font-family: "Avenir Next", Avenir, "Segoe UI", sans-serif;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background: linear-gradient(rgba(13, 92, 77, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(13, 92, 77, 0.04) 1px, transparent 1px),
+    var(--paper);
+  background-size: 32px 32px;
+}
+
+a {
+  color: inherit;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 10;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.7rem 1rem;
+  background: var(--ink);
+  color: white;
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.masthead,
+main,
+footer {
+  width: min(1180px, calc(100% - 40px));
+  margin-inline: auto;
+}
+
+.masthead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 92px;
+  border-bottom: 1px solid var(--line);
+}
+
+.wordmark {
+  display: inline-flex;
+  gap: 0.7rem;
+  align-items: center;
+  text-decoration: none;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  font-size: 1.15rem;
+}
+
+.mark {
+  width: 34px;
+  fill: var(--brand);
+}
+.mark path + path {
+  fill: var(--map-water);
+}
+
+.site-label,
+.eyebrow,
+.artifact-platform,
+.source-badge,
+.release-facts dt {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.site-label {
+  color: var(--muted);
+}
+
+.release-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(290px, 0.75fr);
+  gap: clamp(3rem, 10vw, 9rem);
+  align-items: end;
+  padding: clamp(4rem, 9vw, 8.5rem) 0 clamp(4rem, 8vw, 7rem);
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--brand);
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(3.4rem, 9vw, 7.4rem);
+  font-weight: 400;
+  line-height: 0.86;
+  letter-spacing: -0.07em;
+}
+
+h1 span {
+  display: inline-block;
+  color: var(--brand);
+  font-style: italic;
+  letter-spacing: -0.04em;
+}
+
+.release-note > p {
+  max-width: 40rem;
+  color: var(--muted);
+  line-height: 1.7;
+  font-size: 1.02rem;
+}
+
+.release-facts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 2rem 0 0;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--line);
+}
+
+.release-facts div {
+  min-width: 0;
+}
+.release-facts dt {
+  color: var(--muted);
+}
+.release-facts dd {
+  margin: 0.35rem 0 0;
+  font-weight: 650;
+}
+
+.directory {
+  overflow: hidden;
+  margin-bottom: 5rem;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: 0 22px 70px rgba(16, 42, 41, 0.09);
+}
+
+.directory-bar {
+  display: flex;
+  gap: 2rem;
+  align-items: end;
+  justify-content: space-between;
+  padding: 2rem;
+  background: var(--ink);
+  color: white;
+}
+
+.directory-bar .eyebrow {
+  color: #8fe2cf;
+  margin-bottom: 0.4rem;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 400;
+  font-size: clamp(2rem, 4vw, 3.2rem);
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  width: min(420px, 48%);
+  border-bottom: 1px solid #718986;
+}
+
+.search:focus-within {
+  border-color: #8fe2cf;
+}
+
+.search svg {
+  flex: 0 0 auto;
+  width: 19px;
+  fill: none;
+  stroke: #a8bfbb;
+  stroke-width: 1.8;
+}
+
+.search input {
+  width: 100%;
+  padding: 0.8rem 0.65rem;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: white;
+  font: inherit;
+}
+
+.search input::placeholder {
+  color: #a8bfbb;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem 1.4rem;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.legend span {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+}
+.legend a {
+  margin-left: auto;
+  text-underline-offset: 0.18em;
+}
+.legend a + a {
+  margin-left: 0;
+}
+
+.source-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.source-dot.mirror {
+  background: var(--brand-bright);
+}
+.source-dot.github {
+  background: var(--github);
+}
+
+.platform-nav {
+  display: flex;
+  gap: 0.55rem;
+  overflow-x: auto;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--line);
+  scrollbar-width: thin;
+}
+
+.platform-nav a {
+  flex: 0 0 auto;
+  padding: 0.48rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+
+.platform-nav a:hover,
+.platform-nav a:focus-visible {
+  border-color: var(--brand);
+  color: var(--brand);
+  outline: none;
+}
+
+.platform-nav span {
+  color: #82938f;
+  font-variant-numeric: tabular-nums;
+}
+
+.artifact-list {
+  padding: 0 2rem 1.5rem;
+}
+
+.platform-group {
+  scroll-margin-top: 1rem;
+}
+
+.platform-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 2.4rem 0 0.75rem;
+  border-bottom: 2px solid var(--ink);
+}
+
+.platform-heading h3 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.7rem;
+  font-weight: 400;
+}
+
+.platform-count {
+  margin-left: 0.5rem;
+  color: var(--muted);
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 400;
+}
+
+.artifact-row {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr) 100px 150px 30px;
+  gap: 1rem;
+  align-items: center;
+  min-height: 82px;
+  border-bottom: 1px solid var(--line);
+  text-decoration: none;
+  transition: background 140ms ease, padding 140ms ease;
+}
+
+.artifact-row:last-child {
+  border-bottom: 0;
+}
+.artifact-row:hover {
+  margin-inline: -0.75rem;
+  padding-inline: 0.75rem;
+  background: #f1faf7;
+}
+.artifact-row:focus-visible {
+  outline: 3px solid var(--brand-bright);
+  outline-offset: -3px;
+}
+
+.artifact-platform {
+  color: var(--brand);
+}
+.artifact-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 650;
+}
+.artifact-size {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.source-badge {
+  color: var(--brand);
+}
+.source-badge.github {
+  color: var(--github);
+}
+
+.download-arrow {
+  font-size: 1.45rem;
+  color: var(--brand);
+  transition: transform 140ms ease;
+}
+.artifact-row:hover .download-arrow {
+  transform: translateY(3px);
+}
+
+.loading,
+.empty,
+.error {
+  padding: 3rem 0;
+  color: var(--muted);
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.75rem 0 3rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
+footer p {
+  margin-bottom: 0;
+}
+footer nav {
+  display: flex;
+  gap: 1.4rem;
+}
+footer a {
+  text-underline-offset: 0.2em;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 760px) {
+  .masthead,
+  main,
+  footer {
+    width: min(100% - 24px, 1180px);
+  }
+  .release-intro {
+    grid-template-columns: 1fr;
+    gap: 2.5rem;
+  }
+  .directory-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .search {
+    width: 100%;
+  }
+  .legend {
+    padding-inline: 1rem;
+  }
+  .legend a {
+    margin-left: 0;
+  }
+  .platform-nav {
+    padding-inline: 1rem;
+  }
+  .artifact-list {
+    padding-inline: 1rem;
+  }
+  .artifact-row {
+    grid-template-columns: 74px minmax(0, 1fr) 28px;
+    gap: 0.7rem;
+    padding-block: 0.75rem;
+  }
+  .artifact-size,
+  .source-badge {
+    grid-column: 2;
+  }
+  .artifact-size {
+    font-size: 0.86rem;
+  }
+  .source-badge {
+    grid-row: 2;
+  }
+  .download-arrow {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+  }
+  footer {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/scripts/download-mirror/styles.css
+++ b/scripts/download-mirror/styles.css
@@ -24,9 +24,9 @@ html {
 body {
   margin: 0;
   color: var(--ink);
-  background: linear-gradient(rgba(13, 92, 77, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(13, 92, 77, 0.04) 1px, transparent 1px),
-    var(--paper);
+  background:
+    linear-gradient(rgba(13, 92, 77, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(13, 92, 77, 0.04) 1px, transparent 1px), var(--paper);
   background-size: 32px 32px;
 }
 
@@ -330,7 +330,9 @@ h2 {
   min-height: 82px;
   border-bottom: 1px solid var(--line);
   text-decoration: none;
-  transition: background 140ms ease, padding 140ms ease;
+  transition:
+    background 140ms ease,
+    padding 140ms ease;
 }
 
 .artifact-row:last-child {


### PR DESCRIPTION
## Summary

- add a latest-release download mirror builder with SHA-256 verification
- add a responsive platform-grouped directory for downloads.geolibre.app
- sync completed release assets to opengeos/geolibre-downloads using a write-scoped deploy key
- link assets over 100 MiB back to their original GitHub Release URLs
- publish parentless snapshots so binary history stays below GitHub Pages limits

## Verification

- built and checksum-verified the v2.7.0 mirror (21 mirrored files, 3 GitHub-only files)
- tested desktop and mobile layouts in Chromium
- tested platform search/filter behavior and empty state
- checked shell and JavaScript syntax and Prettier formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GeoLibre download mirror with release metadata, platform-based artifact listings, filtering, checksums, and download-source indicators.
  * Added responsive, accessible styling with loading, empty, and error states.
  * Added automated synchronization of release artifacts and support for scheduled or manual updates.
  * Added a dedicated 404 page for unavailable downloads.

* **Documentation**
  * Documented mirror contents, inclusion rules, and automated maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->