### PR TITLE
Omit maintainer-only MSIX from download mirror

### DIFF
--- a/scripts/build-download-mirror.sh
+++ b/scripts/build-download-mirror.sh
@@ -9,7 +9,8 @@ readonly METADATA_ONLY="${DOWNLOAD_MIRROR_METADATA_ONLY:-false}"
 readonly OMITTED_ASSET_PATTERNS_JSON='[
   "^geolibre-android\\.aab$",
   "^GeoLibre\\.Desktop_[^/]+_universal_mas\\.pkg$",
-  "^GeoLibre_[^/]+_ios_app-store\\.ipa$"
+  "^GeoLibre_[^/]+_ios_app-store\\.ipa$",
+  "\\.msix$"
 ]'
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then


### PR DESCRIPTION
## Summary

- exclude all `.msix` release assets from the public download mirror
- retain MSIX files on the canonical GitHub release for maintainers

## Verification

- generated the v2.7.0 candidate manifest
- confirmed the public artifact count drops from 21 to 20
- confirmed no AAB, store PKG, App Store IPA, or MSIX names remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `.msix` files from being included in download mirror assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->