### PR TITLE
Hide AppImage update metadata from download mirror

### DIFF
--- a/scripts/build-download-mirror.sh
+++ b/scripts/build-download-mirror.sh
@@ -10,7 +10,8 @@ readonly OMITTED_ASSET_PATTERNS_JSON='[
   "^geolibre-android\\.aab$",
   "^GeoLibre\\.Desktop_[^/]+_universal_mas\\.pkg$",
   "^GeoLibre_[^/]+_ios_app-store\\.ipa$",
-  "\\.msix$"
+  "\\.msix$",
+  "\\.AppImage\\.zsync$"
 ]'
 
 if [[ $# -lt 1 || $# -gt 2 ]]; then


### PR DESCRIPTION
## Summary

- exclude `.AppImage.zsync` metadata from the public download directory
- retain it on the canonical GitHub release for automatic AppImage update tools

## Verification

- generated the v2.7.0 candidate manifest
- confirmed the public set contains 19 artifacts: 18 mirrored and one oversized GitHub link
- confirmed maintainer-only packages, MSIX, and AppImage zsync metadata are absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated download packaging to exclude `.AppImage.zsync` files from mirrored assets, preventing unintended files from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->