### PR TITLE
Remove web.geolibre.app from the viewer Worker

### DIFF
--- a/workers/viewer/src/index.ts
+++ b/workers/viewer/src/index.ts
@@ -1,4 +1,4 @@
-// web.geolibre.app (and viewer.geolibre.app, the original alias)
+// viewer.geolibre.app (legacy alias)
 //
 // Serves the GeoLibre web viewer at a clean subdomain by proxying to the build
 // already published at https://geolibre.app/demo (GitHub Pages). We proxy rather
@@ -6,9 +6,8 @@
 // which exceeds Cloudflare's 25 MiB per-asset limit for Workers/Pages. GitHub
 // Pages has no such limit, so it stays the origin of record.
 //
-// Both hostnames route to this worker. The viewer build uses relative asset
-// paths, so requests map 1:1 regardless of which host they arrive on:
-//   {web,viewer}.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
+// The viewer build uses relative asset paths, so requests map 1:1:
+//   viewer.geolibre.app/<path>?<query> -> geolibre.app/demo/<path>?<query>
 //
 // Origin redirects (e.g. trailing slash) are followed server-side only when the
 // Location stays on https://geolibre.app/demo/… — a cross-origin or off-prefix

--- a/workers/viewer/src/proxy.ts
+++ b/workers/viewer/src/proxy.ts
@@ -1,4 +1,4 @@
-// Shared helpers for the web.geolibre.app / viewer.geolibre.app proxy.
+// Shared helpers for the legacy viewer.geolibre.app proxy.
 // Kept free of the Worker `export default` so unit tests can import them
 // without Cloudflare runtime types.
 

--- a/workers/viewer/wrangler.toml
+++ b/workers/viewer/wrangler.toml
@@ -2,15 +2,9 @@ name = "geolibre-viewer"
 main = "src/index.ts"
 compatibility_date = "2025-03-01"
 
-# Binds the custom domains on deploy. Because geolibre.app is managed in this
-# Cloudflare account, the DNS records and TLS certificates are provisioned
-# automatically on the first deploy. web.geolibre.app is the current hostname;
-# viewer.geolibre.app is the original one, kept as an alias so existing links
-# and embeds keep working.
-[[routes]]
-pattern = "web.geolibre.app"
-custom_domain = true
-
+# viewer.geolibre.app is the original hostname and remains as a legacy alias.
+# web.geolibre.app is hosted directly by GitHub Pages; see
+# .github/workflows/web-deploy.yml in this repository.
 [[routes]]
 pattern = "viewer.geolibre.app"
 custom_domain = true


### PR DESCRIPTION
## Summary

- remove `web.geolibre.app` from the viewer Worker custom-domain configuration
- retain `viewer.geolibre.app` as the legacy Worker alias
- update comments to reflect that the primary web app is now published by `.github/workflows/web-deploy.yml`

The live hostname already points to GitHub Pages, its certificate is approved and enforced, and all four Pages edges serve the custom-domain certificate. This cleanup prevents a future Wrangler deploy from reclaiming the migrated hostname.