### PR TITLE
feat: maximize the Model Builder panel

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/model-builder/ModelBuilderPanel.tsx
+++ b/apps/geolibre-desktop/src/components/processing/model-builder/ModelBuilderPanel.tsx
@@ -36,6 +36,8 @@ import {
   Download,
   GripVertical,
   LayoutGrid,
+  Maximize2,
+  Minimize2,
   PanelLeft,
   PanelRight,
   Loader2,
@@ -279,6 +281,7 @@ export function ModelBuilderPanel({
 
   const [position, setPosition] = useState({ x: 48, y: 48 });
   const [size, setSize] = useState({ width: 980, height: 560 });
+  const [maximized, setMaximized] = useState(false);
   const [paletteWidth, setPaletteWidth] = useState(DEFAULT_PALETTE_WIDTH);
   const [inspectorWidth, setInspectorWidth] = useState(DEFAULT_INSPECTOR_WIDTH);
   const [logHeight, setLogHeight] = useState(DEFAULT_LOG_HEIGHT);
@@ -319,6 +322,10 @@ export function ModelBuilderPanel({
   const sectionRef = useRef<HTMLElement | null>(null);
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const importRef = useRef<HTMLInputElement | null>(null);
+  const restoredGeometryRef = useRef<{
+    position: { x: number; y: number };
+    size: { width: number; height: number };
+  } | null>(null);
 
   const appendLog = useCallback((line: string) => setLog((prev) => [...prev, line]), []);
 
@@ -334,6 +341,11 @@ export function ModelBuilderPanel({
   const fitToContainer = useCallback(() => {
     const bounds = sectionRef.current?.parentElement?.getBoundingClientRect();
     if (!bounds) return;
+    if (maximized) {
+      setPosition({ x: 0, y: 0 });
+      setSize({ width: bounds.width, height: bounds.height });
+      return;
+    }
     const maxWidth = Math.max(FLOOR_WIDTH, bounds.width - EDGE_MARGIN * 2);
     const maxHeight = Math.max(FLOOR_HEIGHT, bounds.height - EDGE_MARGIN * 2);
     const width = clamp(size.width, Math.min(MIN_WIDTH, maxWidth), maxWidth);
@@ -343,7 +355,7 @@ export function ModelBuilderPanel({
       x: clamp(current.x, 0, Math.max(0, bounds.width - width - EDGE_MARGIN)),
       y: clamp(current.y, 0, Math.max(0, bounds.height - height - EDGE_MARGIN)),
     }));
-  }, [size.width, size.height]);
+  }, [maximized, size.width, size.height]);
 
   // Re-fit whenever the map area changes, not just when the panel opens: a
   // resized window or a side panel opening would otherwise leave the panel
@@ -1011,6 +1023,7 @@ export function ModelBuilderPanel({
   // --- Panel chrome -------------------------------------------------------
 
   const handleDragStart = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (maximized) return;
     if ((event.target as HTMLElement).closest("button, input")) return;
     event.preventDefault();
     const handle = event.currentTarget;
@@ -1222,6 +1235,27 @@ export function ModelBuilderPanel({
     handle.addEventListener("pointercancel", handleEnd);
   };
 
+  const toggleMaximized = useCallback(() => {
+    if (maximized) {
+      const restored = restoredGeometryRef.current;
+      if (restored) {
+        setPosition(restored.position);
+        setSize(restored.size);
+      }
+      restoredGeometryRef.current = null;
+      setMaximized(false);
+      return;
+    }
+
+    const bounds = sectionRef.current?.parentElement?.getBoundingClientRect();
+    if (!bounds) return;
+    restoredGeometryRef.current = { position, size };
+    setMinimized(false);
+    setPosition({ x: 0, y: 0 });
+    setSize({ width: bounds.width, height: bounds.height });
+    setMaximized(true);
+  }, [maximized, position, size]);
+
   if (!open) return null;
 
   const canvasExtent = graph.nodes.reduce(
@@ -1244,7 +1278,10 @@ export function ModelBuilderPanel({
     <section
       ref={sectionRef}
       aria-label={t("processing.modelBuilder.title")}
-      className="pointer-events-auto absolute z-20 flex flex-col overflow-hidden rounded-lg border bg-card shadow-xl"
+      className={cn(
+        "pointer-events-auto absolute z-20 flex flex-col overflow-hidden border bg-card shadow-xl",
+        maximized ? "rounded-none" : "rounded-lg",
+      )}
       style={
         {
           left: position.x,
@@ -1304,6 +1341,25 @@ export function ModelBuilderPanel({
           </>
         )}
         <div className="ms-auto flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 shrink-0 p-0"
+            onClick={toggleMaximized}
+            aria-pressed={maximized}
+            aria-label={
+              maximized
+                ? t("processing.modelBuilder.restorePanelSize")
+                : t("processing.modelBuilder.maximizePanel")
+            }
+            title={
+              maximized
+                ? t("processing.modelBuilder.restorePanelSize")
+                : t("processing.modelBuilder.maximizePanel")
+            }
+          >
+            {maximized ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </Button>
           <Button
             size="sm"
             variant="ghost"
@@ -1776,7 +1832,7 @@ export function ModelBuilderPanel({
       )}
 
       {/* Resize grip */}
-      {!minimized && (
+      {!minimized && !maximized && (
         <div
           onPointerDown={handleResizeStart}
           onKeyDown={handleResizeKey}

--- a/apps/geolibre-desktop/src/components/processing/model-builder/ModelBuilderPanel.tsx
+++ b/apps/geolibre-desktop/src/components/processing/model-builder/ModelBuilderPanel.tsx
@@ -1344,25 +1344,6 @@ export function ModelBuilderPanel({
           <Button
             size="sm"
             variant="ghost"
-            className="h-7 w-7 shrink-0 p-0"
-            onClick={toggleMaximized}
-            aria-pressed={maximized}
-            aria-label={
-              maximized
-                ? t("processing.modelBuilder.restorePanelSize")
-                : t("processing.modelBuilder.maximizePanel")
-            }
-            title={
-              maximized
-                ? t("processing.modelBuilder.restorePanelSize")
-                : t("processing.modelBuilder.maximizePanel")
-            }
-          >
-            {maximized ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
             className="h-7 shrink-0 gap-1 px-2"
             onClick={handleNewModel}
             aria-label={t("processing.modelBuilder.newModel")}
@@ -1476,6 +1457,25 @@ export function ModelBuilderPanel({
             }
           >
             {minimized ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 w-7 shrink-0 p-0"
+            onClick={toggleMaximized}
+            aria-pressed={maximized}
+            aria-label={
+              maximized
+                ? t("processing.modelBuilder.restorePanelSize")
+                : t("processing.modelBuilder.maximizePanel")
+            }
+            title={
+              maximized
+                ? t("processing.modelBuilder.restorePanelSize")
+                : t("processing.modelBuilder.maximizePanel")
+            }
+          >
+            {maximized ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
           </Button>
           <Button
             size="sm"

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -4488,6 +4488,8 @@
       "removeConnection": "إزالة الاتصال",
       "removeNode": "إزالة العقدة",
       "resizePanel": "تغيير حجم اللوحة",
+      "maximizePanel": "تكبير اللوحة",
+      "restorePanelSize": "استعادة الحجم السابق",
       "minimizePanel": "تصغير اللوحة",
       "restorePanel": "استعادة اللوحة",
       "resizePalette": "تغيير حجم لوحة الأدوات",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Verbindung entfernen",
       "removeNode": "Knoten entfernen",
       "resizePanel": "Bereichsgröße ändern",
+      "maximizePanel": "Bereich maximieren",
+      "restorePanelSize": "Vorherige Größe wiederherstellen",
       "minimizePanel": "Bereich minimieren",
       "restorePanel": "Bereich wiederherstellen",
       "resizePalette": "Werkzeugpalette in der Größe ändern",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Remove connection",
       "removeNode": "Remove node",
       "resizePanel": "Resize panel",
+      "maximizePanel": "Maximize panel",
+      "restorePanelSize": "Restore previous size",
       "minimizePanel": "Minimize panel",
       "restorePanel": "Restore panel",
       "resizePalette": "Resize the tool palette",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Quitar conexión",
       "removeNode": "Quitar nodo",
       "resizePanel": "Cambiar el tamaño del panel",
+      "maximizePanel": "Maximizar el panel",
+      "restorePanelSize": "Restaurar el tamaño anterior",
       "minimizePanel": "Minimizar el panel",
       "restorePanel": "Restaurar el panel",
       "resizePalette": "Cambiar el tamaño de la paleta de herramientas",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "حذف اتصال",
       "removeNode": "حذف گره",
       "resizePanel": "تغییر اندازهٔ پنل",
+      "maximizePanel": "بیشینه کردن پنل",
+      "restorePanelSize": "بازگرداندن اندازهٔ قبلی",
       "minimizePanel": "کوچک‌کردن پنل",
       "restorePanel": "بازگرداندن پنل",
       "resizePalette": "تغییر اندازهٔ پالت ابزارها",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Supprimer la connexion",
       "removeNode": "Supprimer le nœud",
       "resizePanel": "Redimensionner le panneau",
+      "maximizePanel": "Agrandir le panneau",
+      "restorePanelSize": "Restaurer la taille précédente",
       "minimizePanel": "Réduire le panneau",
       "restorePanel": "Restaurer le panneau",
       "resizePalette": "Redimensionner la palette d'outils",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "कनेक्शन हटाएँ",
       "removeNode": "नोड हटाएँ",
       "resizePanel": "पैनल का आकार बदलें",
+      "maximizePanel": "पैनल को अधिकतम करें",
+      "restorePanelSize": "पिछला आकार पुनर्स्थापित करें",
       "minimizePanel": "पैनल छोटा करें",
       "restorePanel": "पैनल पुनर्स्थापित करें",
       "resizePalette": "उपकरण पैलेट का आकार बदलें",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -4149,6 +4149,8 @@
       "removeConnection": "Hapus koneksi",
       "removeNode": "Hapus simpul",
       "resizePanel": "Ubah ukuran panel",
+      "maximizePanel": "Maksimalkan panel",
+      "restorePanelSize": "Pulihkan ukuran sebelumnya",
       "minimizePanel": "Perkecil panel",
       "restorePanel": "Pulihkan panel",
       "resizePalette": "Ubah ukuran palet alat",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Rimuovi collegamento",
       "removeNode": "Rimuovi nodo",
       "resizePanel": "Ridimensiona il pannello",
+      "maximizePanel": "Massimizza il pannello",
+      "restorePanelSize": "Ripristina la dimensione precedente",
       "minimizePanel": "Riduci il pannello",
       "restorePanel": "Ripristina il pannello",
       "resizePalette": "Ridimensiona la tavolozza degli strumenti",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -4149,6 +4149,8 @@
       "removeConnection": "接続を削除",
       "removeNode": "ノードを削除",
       "resizePanel": "パネルのサイズを変更",
+      "maximizePanel": "パネルを最大化",
+      "restorePanelSize": "以前のサイズに戻す",
       "minimizePanel": "パネルを最小化",
       "restorePanel": "パネルを元に戻す",
       "resizePalette": "ツールパレットのサイズを変更",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "კავშირის წაშლა",
       "removeNode": "კვანძის წაშლა",
       "resizePanel": "პანელის ზომის შეცვლა",
+      "maximizePanel": "პანელის სრულად გაშლა",
+      "restorePanelSize": "წინა ზომის აღდგენა",
       "minimizePanel": "პანელის ჩაკეცვა",
       "restorePanel": "პანელის აღდგენა",
       "resizePalette": "ხელსაწყოთა პალიტრის ზომის შეცვლა",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -4149,6 +4149,8 @@
       "removeConnection": "연결 제거",
       "removeNode": "노드 제거",
       "resizePanel": "패널 크기 조정",
+      "maximizePanel": "패널 최대화",
+      "restorePanelSize": "이전 크기로 복원",
       "minimizePanel": "패널 최소화",
       "restorePanel": "패널 복원",
       "resizePalette": "도구 팔레트 크기 조정",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Verbinding verwijderen",
       "removeNode": "Knooppunt verwijderen",
       "resizePanel": "Paneelgrootte wijzigen",
+      "maximizePanel": "Paneel maximaliseren",
+      "restorePanelSize": "Vorige grootte herstellen",
       "minimizePanel": "Paneel minimaliseren",
       "restorePanel": "Paneel herstellen",
       "resizePalette": "Grootte van het gereedschapspalet wijzigen",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Remover ligação",
       "removeNode": "Remover nó",
       "resizePanel": "Redimensionar painel",
+      "maximizePanel": "Maximizar painel",
+      "restorePanelSize": "Restaurar tamanho anterior",
       "minimizePanel": "Minimizar painel",
       "restorePanel": "Restaurar painel",
       "resizePalette": "Redimensionar a paleta de ferramentas",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -4353,7 +4353,7 @@
       "removeConnection": "Удалить связь",
       "removeNode": "Удалить узел",
       "resizePanel": "Изменить размер панели",
-      "maximizePanel": "Развернуть панель",
+      "maximizePanel": "Развернуть панель на весь экран",
       "restorePanelSize": "Восстановить прежний размер",
       "minimizePanel": "Свернуть панель",
       "restorePanel": "Развернуть панель",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -4353,6 +4353,8 @@
       "removeConnection": "Удалить связь",
       "removeNode": "Удалить узел",
       "resizePanel": "Изменить размер панели",
+      "maximizePanel": "Развернуть панель",
+      "restorePanelSize": "Восстановить прежний размер",
       "minimizePanel": "Свернуть панель",
       "restorePanel": "Развернуть панель",
       "resizePalette": "Изменить размер палитры инструментов",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -4149,6 +4149,8 @@
       "removeConnection": "ลบการเชื่อมต่อ",
       "removeNode": "ลบโหนด",
       "resizePanel": "ปรับขนาดแผง",
+      "maximizePanel": "ขยายแผงเต็มพื้นที่",
+      "restorePanelSize": "คืนค่าขนาดก่อนหน้า",
       "minimizePanel": "ย่อแผง",
       "restorePanel": "คืนขนาดแผง",
       "resizePalette": "ปรับขนาดแผงเครื่องมือ",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -4217,6 +4217,8 @@
       "removeConnection": "Bağlantıyı kaldır",
       "removeNode": "Düğümü kaldır",
       "resizePanel": "Paneli yeniden boyutlandır",
+      "maximizePanel": "Paneli büyüt",
+      "restorePanelSize": "Önceki boyutu geri yükle",
       "minimizePanel": "Paneli küçült",
       "restorePanel": "Paneli geri yükle",
       "resizePalette": "Araç paletini yeniden boyutlandır",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -4149,6 +4149,8 @@
       "removeConnection": "Xóa kết nối",
       "removeNode": "Xóa nút",
       "resizePanel": "Đổi kích thước bảng",
+      "maximizePanel": "Phóng to bảng",
+      "restorePanelSize": "Khôi phục kích thước trước đó",
       "minimizePanel": "Thu nhỏ bảng",
       "restorePanel": "Khôi phục bảng",
       "resizePalette": "Đổi kích thước bảng công cụ",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -4149,6 +4149,8 @@
       "removeConnection": "删除连接",
       "removeNode": "删除节点",
       "resizePanel": "调整面板大小",
+      "maximizePanel": "最大化面板",
+      "restorePanelSize": "恢复之前的大小",
       "minimizePanel": "最小化面板",
       "restorePanel": "还原面板",
       "resizePalette": "调整工具面板大小",


### PR DESCRIPTION
## Summary
- add a maximize and restore control to the Model Builder title bar
- fill the available map canvas while maximized and preserve the exact prior panel geometry
- localize the new accessible control labels across every shipped locale

## Test plan
- [x] Run the production build and scoped pre-commit checks
- [x] Run i18n catalog parity tests and confirm 100% locale coverage
- [x] Verify in a real browser that maximize fills the map canvas and restore returns the prior size and position

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added maximize and restore controls to the Model Builder panel.
  - Maximized mode fills the available container and disables dragging and resizing.
  - Restoring the panel returns it to its previous dimensions.
  - Maximizing automatically clears the minimized state.
  - Added accessible controls for maximizing and restoring the panel.

- **Localization**
  - Added translated maximize and restore actions across supported languages, including Arabic, Chinese, French, German, Japanese, Spanish, and others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->