### PR TITLE
fix: support assets on static STAC collections

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -21,7 +21,6 @@ import {
   openPMTilesLayerPanel,
   openRasterLayerPanel,
   openSplattingLayerPanel,
-  openStacSearchLayerPanel,
   openZarrLayerPanel,
   openThreeDTilesLayerPanel,
   openVectorLayerPanel,
@@ -46,6 +45,7 @@ import {
   setSourceCoopLabels,
   setReverseGeocodeLabels,
   setStacLabels,
+  STAC_PLUGIN_ID,
   setTimelapseLabels,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
@@ -1175,7 +1175,10 @@ export function TopToolbar({
   const addLayer: AddLayerHandlers = {
     vector: () => openVectorLayerPanel(appApi),
     raster: () => openRasterLayerPanel(appApi),
-    stac: () => openStacSearchLayerPanel(appApi),
+    stac: () => {
+      if (isActive(STAC_PLUGIN_ID)) openRightPanel(STAC_PLUGIN_ID);
+      else toggle(STAC_PLUGIN_ID, appApi);
+    },
     flatGeobuf: () => openFlatGeobufAddVectorLayerPanel(appApi),
     pmtiles: () => openPMTilesLayerPanel(appApi),
     zarr: () => openZarrLayerPanel(appApi),

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -817,7 +817,7 @@ async function visualizeAsset(
   }
 }
 
-/** A catalog's descriptive title when available, otherwise its stable item identifier. */
+/** An item's descriptive title when available, otherwise its stable identifier. */
 function itemTitle(item: StacItem): string {
   const title = item.properties.title;
   return typeof title === "string" && title.trim() ? title : item.id;

--- a/packages/plugins/src/plugins/maplibre-stac.ts
+++ b/packages/plugins/src/plugins/maplibre-stac.ts
@@ -719,7 +719,7 @@ async function visualizeAsset(
   signal?: AbortSignal,
   target?: string,
 ): Promise<void> {
-  const name = `${item.id} — ${assetLabel(key, asset)}`;
+  const name = `${itemTitle(item)} — ${assetLabel(key, asset)}`;
   const format = assetFormat(asset);
   switch (format) {
     case "pmtiles": {
@@ -815,6 +815,12 @@ async function visualizeAsset(
       throw new Error(`Unhandled asset format: ${String(unhandled)}`);
     }
   }
+}
+
+/** A catalog's descriptive title when available, otherwise its stable item identifier. */
+function itemTitle(item: StacItem): string {
+  const title = item.properties.title;
+  return typeof title === "string" && title.trim() ? title : item.id;
 }
 
 function buildPanel(container: HTMLElement): () => void {
@@ -1174,7 +1180,7 @@ function buildPanel(container: HTMLElement): () => void {
         if (target.closest("button, select")) return;
         selectItem(item.id, false);
       });
-      const title = el("div", item.id);
+      const title = el("div", itemTitle(item));
       title.style.cssText = "font-weight:600;word-break:break-word;";
       const date = String(item.properties.datetime ?? item.properties.start_datetime ?? "");
       const subtitle = el("div", [item.collection, date.slice(0, 10)].filter(Boolean).join(" · "));

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -372,7 +372,8 @@ function collectionAssetItem(document: Record<string, unknown>, url: string): St
     const horizontal = horizontalBbox(bbox);
     return horizontal ? [horizontal] : [];
   });
-  const interval = extent?.temporal?.interval?.[0];
+  const temporalIntervals = extent?.temporal?.interval ?? [];
+  const interval = temporalIntervals[0];
   const start = interval?.[0] ?? undefined;
   const end = interval?.[1] ?? undefined;
   return normalizeItem(
@@ -386,6 +387,7 @@ function collectionAssetItem(document: Record<string, unknown>, url: string): St
         ...(typeof document.title === "string" ? { title: document.title } : {}),
         ...(typeof document.description === "string" ? { description: document.description } : {}),
         "geolibre:spatial_bboxes": spatialBboxes,
+        "geolibre:temporal_intervals": temporalIntervals,
         ...(start && start === end ? { datetime: start } : {}),
         ...(start && start !== end ? { start_datetime: start } : {}),
         ...(end && start !== end ? { end_datetime: end } : {}),
@@ -551,17 +553,25 @@ function inTime(item: StacItem, interval?: string): boolean {
   const [rawStart, rawEnd = rawStart] = interval.split("/");
   const queryStart = rawStart === ".." ? undefined : Date.parse(rawStart);
   const queryEnd = rawEnd === ".." ? undefined : Date.parse(rawEnd);
-  const itemStart = Date.parse(
-    String(item.properties.datetime ?? item.properties.start_datetime ?? ""),
-  );
-  const itemEnd = Date.parse(
-    String(item.properties.datetime ?? item.properties.end_datetime ?? ""),
-  );
-  if (!Number.isFinite(itemStart) && !Number.isFinite(itemEnd)) return true;
-  return (
-    (queryEnd === undefined || !Number.isFinite(itemStart) || itemStart <= queryEnd) &&
-    (queryStart === undefined || !Number.isFinite(itemEnd) || itemEnd >= queryStart)
-  );
+  const advertised = item.properties["geolibre:temporal_intervals"];
+  const intervals = Array.isArray(advertised)
+    ? advertised
+    : [
+        [
+          item.properties.datetime ?? item.properties.start_datetime ?? null,
+          item.properties.datetime ?? item.properties.end_datetime ?? null,
+        ],
+      ];
+  return intervals.some((candidate) => {
+    if (!Array.isArray(candidate)) return false;
+    const itemStart = candidate[0] === null ? undefined : Date.parse(String(candidate[0] ?? ""));
+    const itemEnd = candidate[1] === null ? undefined : Date.parse(String(candidate[1] ?? ""));
+    if (!Number.isFinite(itemStart) && !Number.isFinite(itemEnd)) return true;
+    return (
+      (queryEnd === undefined || itemStart === undefined || itemStart <= queryEnd) &&
+      (queryStart === undefined || itemEnd === undefined || itemEnd >= queryStart)
+    );
+  });
 }
 
 /** Searches a static catalog by following child/item links, with a hard safety cap. */

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -360,6 +360,35 @@ function collectionBbox(
   return horizontalBbox(Array.isArray(boxes) ? boxes[0] : undefined);
 }
 
+/** Presents a Collection's own assets as one item so the existing asset browser can render it. */
+function collectionAssetItem(document: Record<string, unknown>, url: string): StacItem | undefined {
+  if (document.type !== "Collection" || typeof document.id !== "string") return undefined;
+  if (typeof document.assets !== "object" || document.assets === null) return undefined;
+  const assets = document.assets as Record<string, StacAsset>;
+  if (!Object.keys(assets).length) return undefined;
+  const extent = document.extent as StacCollection["extent"] | undefined;
+  const interval = extent?.temporal?.interval?.[0];
+  const start = interval?.[0] ?? undefined;
+  const end = interval?.[1] ?? undefined;
+  return normalizeItem(
+    {
+      type: "Feature",
+      id: document.id,
+      collection: document.id,
+      geometry: null,
+      bbox: collectionBbox(document),
+      properties: {
+        ...(start && start === end ? { datetime: start } : {}),
+        ...(start && start !== end ? { start_datetime: start } : {}),
+        ...(end && start !== end ? { end_datetime: end } : {}),
+      },
+      assets,
+      links: linksOf(document.links, url),
+    },
+    url,
+  );
+}
+
 export async function openCatalogNode(
   href: string,
   fetcher: FetchLike = fetch,
@@ -609,6 +638,8 @@ export async function searchStaticStac(
 
   const collect = (document: Record<string, unknown>, url: string): void => {
     if (document.type !== "Feature") {
+      const collectionItem = collectionAssetItem(document, url);
+      if (collectionItem && accepts(collectionItem)) found.push(collectionItem);
       for (const link of linksOf(document.links, url)) {
         if (link.rel === "item") walk.items.push({ url: link.href });
         else if (link.rel === "child") walk.folders.push({ url: link.href });

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -60,6 +60,7 @@ export interface StacItem extends Feature<Geometry | null> {
   properties: Record<string, unknown> & {
     datetime?: string;
     start_datetime?: string;
+    end_datetime?: string;
     "table:storage_options"?: StorageOptions;
     "xarray:open_kwargs"?: XarrayOpenKwargs;
     "icechunk:branch"?: string;
@@ -367,23 +368,30 @@ function collectionAssetItem(document: Record<string, unknown>, url: string): St
   const assets = document.assets as Record<string, StacAsset>;
   if (!Object.keys(assets).length) return undefined;
   const extent = document.extent as StacCollection["extent"] | undefined;
+  const spatialBboxes = (extent?.spatial?.bbox ?? []).flatMap((bbox) => {
+    const horizontal = horizontalBbox(bbox);
+    return horizontal ? [horizontal] : [];
+  });
   const interval = extent?.temporal?.interval?.[0];
   const start = interval?.[0] ?? undefined;
   const end = interval?.[1] ?? undefined;
   return normalizeItem(
     {
       type: "Feature",
-      id: document.id,
+      id: `${document.id}::collection-assets`,
       collection: document.id,
       geometry: null,
       bbox: collectionBbox(document),
       properties: {
+        ...(typeof document.title === "string" ? { title: document.title } : {}),
+        ...(typeof document.description === "string" ? { description: document.description } : {}),
+        "geolibre:spatial_bboxes": spatialBboxes,
         ...(start && start === end ? { datetime: start } : {}),
         ...(start && start !== end ? { start_datetime: start } : {}),
         ...(end && start !== end ? { end_datetime: end } : {}),
       },
       assets,
-      links: linksOf(document.links, url),
+      links: document.links as StacLink[] | undefined,
     },
     url,
   );
@@ -541,15 +549,18 @@ function intersects(a: number[], b: [number, number, number, number]): boolean {
 function inTime(item: StacItem, interval?: string): boolean {
   if (!interval) return true;
   const [rawStart, rawEnd = rawStart] = interval.split("/");
-  const start = rawStart === ".." ? undefined : rawStart;
-  const end = rawEnd === ".." ? undefined : rawEnd;
-  const value = item.properties.datetime ?? item.properties.start_datetime;
-  if (!value) return true;
-  const time = Date.parse(String(value));
+  const queryStart = rawStart === ".." ? undefined : Date.parse(rawStart);
+  const queryEnd = rawEnd === ".." ? undefined : Date.parse(rawEnd);
+  const itemStart = Date.parse(
+    String(item.properties.datetime ?? item.properties.start_datetime ?? ""),
+  );
+  const itemEnd = Date.parse(
+    String(item.properties.datetime ?? item.properties.end_datetime ?? ""),
+  );
+  if (!Number.isFinite(itemStart) && !Number.isFinite(itemEnd)) return true;
   return (
-    Number.isFinite(time) &&
-    (!start || time >= Date.parse(start)) &&
-    (!end || time <= Date.parse(end))
+    (queryEnd === undefined || !Number.isFinite(itemStart) || itemStart <= queryEnd) &&
+    (queryStart === undefined || !Number.isFinite(itemEnd) || itemEnd >= queryStart)
   );
 }
 
@@ -592,7 +603,11 @@ export async function searchStaticStac(
     if (filters.collections?.length && !filters.collections.includes(item.collection ?? "")) {
       return false;
     }
-    if (filters.bbox && !(bbox && intersects(bbox, filters.bbox))) return false;
+    const collectionBboxes = item.properties["geolibre:spatial_bboxes"];
+    const bboxes = Array.isArray(collectionBboxes) ? collectionBboxes : bbox ? [bbox] : [];
+    if (filters.bbox && !bboxes.some((candidate) => intersects(candidate, filters.bbox!))) {
+      return false;
+    }
     return inTime(item, filters.datetime);
   };
 

--- a/packages/plugins/src/plugins/stac-api.ts
+++ b/packages/plugins/src/plugins/stac-api.ts
@@ -368,7 +368,8 @@ function collectionAssetItem(document: Record<string, unknown>, url: string): St
   const assets = document.assets as Record<string, StacAsset>;
   if (!Object.keys(assets).length) return undefined;
   const extent = document.extent as StacCollection["extent"] | undefined;
-  const spatialBboxes = (extent?.spatial?.bbox ?? []).flatMap((bbox) => {
+  const spatialBoxes = extent?.spatial?.bbox;
+  const spatialBboxes = (Array.isArray(spatialBoxes) ? spatialBoxes : []).flatMap((bbox) => {
     const horizontal = horizontalBbox(bbox);
     return horizontal ? [horizontal] : [];
   });
@@ -554,14 +555,15 @@ function inTime(item: StacItem, interval?: string): boolean {
   const queryStart = rawStart === ".." ? undefined : Date.parse(rawStart);
   const queryEnd = rawEnd === ".." ? undefined : Date.parse(rawEnd);
   const advertised = item.properties["geolibre:temporal_intervals"];
-  const intervals = Array.isArray(advertised)
-    ? advertised
-    : [
-        [
-          item.properties.datetime ?? item.properties.start_datetime ?? null,
-          item.properties.datetime ?? item.properties.end_datetime ?? null,
-        ],
-      ];
+  const intervals =
+    Array.isArray(advertised) && advertised.length
+      ? advertised
+      : [
+          [
+            item.properties.datetime ?? item.properties.start_datetime ?? null,
+            item.properties.datetime ?? item.properties.end_datetime ?? null,
+          ],
+        ];
   return intervals.some((candidate) => {
     if (!Array.isArray(candidate)) return false;
     const itemStart = candidate[0] === null ? undefined : Date.parse(String(candidate[0] ?? ""));

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -1074,6 +1074,34 @@ test("searchStaticStac traverses child and item links and applies filters", asyn
   );
 });
 
+test("searchStaticStac exposes assets attached directly to a Collection", async () => {
+  const url = "https://example.com/data/collection.json";
+  const root = {
+    type: "Collection",
+    id: "collection-assets",
+    extent: {
+      spatial: { bbox: [[4.8, 52, 5.2, 52.2]] },
+      temporal: { interval: [["2020-02-05T00:00:00Z", null]] },
+    },
+    assets: {
+      geoparquet: { href: "data.parquet", type: "application/vnd.apache.parquet" },
+      pmtiles: { href: "tiles.pmtiles", type: "application/vnd.pmtiles" },
+    },
+    links: [],
+  };
+
+  const result = await searchStaticStac(
+    { url, title: "Static collection", isApi: false, collections: [], root },
+    { limit: 20 },
+  );
+
+  assert.equal(result.matched, 1);
+  assert.equal(result.items[0].id, "collection-assets");
+  assert.deepEqual(result.items[0].bbox, [4.8, 52, 5.2, 52.2]);
+  assert.equal(result.items[0].assets.geoparquet.href, "https://example.com/data/data.parquet");
+  assert.equal(result.items[0].assets.pmtiles.href, "https://example.com/data/tiles.pmtiles");
+});
+
 test("searchStaticStac pages through a catalog holding more items than one page fits", async () => {
   const total = 25;
   const docs: Record<string, unknown> = {

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -1080,8 +1080,13 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
     type: "Collection",
     id: "collection-assets",
     extent: {
-      spatial: { bbox: [[4.8, 52, 5.2, 52.2]] },
-      temporal: { interval: [["2020-02-05T00:00:00Z", null]] },
+      spatial: {
+        bbox: [
+          [4.8, 52, 5.2, 52.2],
+          [10, 60, 11, 61],
+        ],
+      },
+      temporal: { interval: [["2020-01-01T00:00:00Z", "2020-12-31T23:59:59Z"]] },
     },
     assets: {
       geoparquet: { href: "data.parquet", type: "application/vnd.apache.parquet" },
@@ -1092,14 +1097,30 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
 
   const result = await searchStaticStac(
     { url, title: "Static collection", isApi: false, collections: [], root },
-    { limit: 20 },
+    { bbox: [10.5, 60.5, 10.6, 60.6], datetime: "2020-06-01", limit: 20 },
   );
 
   assert.equal(result.matched, 1);
-  assert.equal(result.items[0].id, "collection-assets");
+  assert.equal(result.items[0].id, "collection-assets::collection-assets");
   assert.deepEqual(result.items[0].bbox, [4.8, 52, 5.2, 52.2]);
   assert.equal(result.items[0].assets.geoparquet.href, "https://example.com/data/data.parquet");
   assert.equal(result.items[0].assets.pmtiles.href, "https://example.com/data/tiles.pmtiles");
+
+  const outsideTime = await searchStaticStac(
+    { url, title: "Static collection", isApi: false, collections: [], root },
+    { datetime: "2021-01-01", limit: 20 },
+  );
+  assert.equal(outsideTime.matched, 0);
+
+  const openEnded = {
+    ...root,
+    extent: { ...root.extent, temporal: { interval: [[null, "2020-12-31T23:59:59Z"]] } },
+  };
+  const beforeOpenEnd = await searchStaticStac(
+    { url, title: "Static collection", isApi: false, collections: [], root: openEnded },
+    { datetime: "1900-01-01", limit: 20 },
+  );
+  assert.equal(beforeOpenEnd.matched, 1);
 });
 
 test("searchStaticStac pages through a catalog holding more items than one page fits", async () => {

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -1079,6 +1079,7 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
   const root = {
     type: "Collection",
     id: "collection-assets",
+    title: "Collection assets",
     extent: {
       spatial: {
         bbox: [
@@ -1107,6 +1108,7 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
 
   assert.equal(result.matched, 1);
   assert.equal(result.items[0].id, "collection-assets::collection-assets");
+  assert.equal(result.items[0].properties.title, "Collection assets");
   assert.deepEqual(result.items[0].bbox, [4.8, 52, 5.2, 52.2]);
   assert.equal(result.items[0].assets.geoparquet.href, "https://example.com/data/data.parquet");
   assert.equal(result.items[0].assets.pmtiles.href, "https://example.com/data/tiles.pmtiles");
@@ -1132,6 +1134,17 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
     { datetime: "1900-01-01", limit: 20 },
   );
   assert.equal(beforeOpenEnd.matched, 1);
+
+  const unknownExtents = {
+    ...root,
+    extent: { spatial: { bbox: {} as unknown as number[][] } },
+  };
+  const unknownTime = await searchStaticStac(
+    { url, title: "Static collection", isApi: false, collections: [], root: unknownExtents },
+    { datetime: "2024-01-01", limit: 20 },
+  );
+  assert.equal(unknownTime.matched, 1);
+  assert.equal(unknownTime.items[0].bbox, undefined);
 });
 
 test("searchStaticStac pages through a catalog holding more items than one page fits", async () => {

--- a/tests/stac-api.test.ts
+++ b/tests/stac-api.test.ts
@@ -1086,7 +1086,12 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
           [10, 60, 11, 61],
         ],
       },
-      temporal: { interval: [["2020-01-01T00:00:00Z", "2020-12-31T23:59:59Z"]] },
+      temporal: {
+        interval: [
+          ["2020-01-01T00:00:00Z", "2020-12-31T23:59:59Z"],
+          ["2022-01-01T00:00:00Z", "2022-12-31T23:59:59Z"],
+        ],
+      },
     },
     assets: {
       geoparquet: { href: "data.parquet", type: "application/vnd.apache.parquet" },
@@ -1111,6 +1116,12 @@ test("searchStaticStac exposes assets attached directly to a Collection", async 
     { datetime: "2021-01-01", limit: 20 },
   );
   assert.equal(outsideTime.matched, 0);
+
+  const laterInterval = await searchStaticStac(
+    { url, title: "Static collection", isApi: false, collections: [], root },
+    { datetime: "2022-06-01", limit: 20 },
+  );
+  assert.equal(laterInterval.matched, 1);
 
   const openEnded = {
     ...root,


### PR DESCRIPTION
## Summary
- route Add Data > STAC Layer to the full STAC Catalogs browser
- expose assets attached directly to static STAC Collection documents as searchable results
- preserve collection extents, temporal metadata, and relative asset URL resolution

## Test plan
- [x] Run the focused STAC API test suite
- [x] Run the repository pre-commit gate and production build
- [x] Connect to the Utrecht static catalog and verify GeoParquet and PMTiles assets in light and dark themes

Fixes #2064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * STAC searches now include matching collections that contain assets, alongside standard items.
  * Collection metadata, spatial and temporal extents, and asset links are preserved, including relative URLs.
  * Temporal searches support open-ended and overlapping time ranges.
  * STAC results and displayed assets use descriptive titles when available.
  * Adding a STAC layer now opens the existing STAC panel or activates it automatically when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->