### PR TITLE
fix: repair nested ArcGIS polygon rings

### DIFF
--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -1883,7 +1883,7 @@ function repairArcGISNestedPolygonRings(feature: Feature): Feature {
       }
       if (
         Math.abs(rings[candidate].area) < parentArea &&
-        pointInRing(rings[child].ring[0], rings[candidate].ring)
+        ringStrictlyContains(rings[candidate].ring, rings[child].ring)
       ) {
         rings[child].parent = candidate;
         parentArea = Math.abs(rings[candidate].area);
@@ -1940,6 +1940,54 @@ function pointInRing(point: Position, ring: Position[]): boolean {
     }
   }
   return inside;
+}
+
+function ringStrictlyContains(container: Position[], child: Position[]): boolean {
+  return (
+    child.slice(0, -1).every((point) => pointInRing(point, container)) &&
+    !ringsIntersect(container, child)
+  );
+}
+
+function ringsIntersect(first: Position[], second: Position[]): boolean {
+  for (let firstIndex = 0; firstIndex < first.length - 1; firstIndex += 1) {
+    for (let secondIndex = 0; secondIndex < second.length - 1; secondIndex += 1) {
+      if (
+        segmentsIntersect(
+          first[firstIndex],
+          first[firstIndex + 1],
+          second[secondIndex],
+          second[secondIndex + 1],
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function segmentsIntersect(a: Position, b: Position, c: Position, d: Position): boolean {
+  const cross = (start: Position, end: Position, point: Position): number =>
+    (end[0] - start[0]) * (point[1] - start[1]) - (end[1] - start[1]) * (point[0] - start[0]);
+  const abC = cross(a, b, c);
+  const abD = cross(a, b, d);
+  const cdA = cross(c, d, a);
+  const cdB = cross(c, d, b);
+  if (abC === 0 && pointOnSegment(c, a, b)) return true;
+  if (abD === 0 && pointOnSegment(d, a, b)) return true;
+  if (cdA === 0 && pointOnSegment(a, c, d)) return true;
+  if (cdB === 0 && pointOnSegment(b, c, d)) return true;
+  return abC > 0 !== abD > 0 && cdA > 0 !== cdB > 0;
+}
+
+function pointOnSegment(point: Position, start: Position, end: Position): boolean {
+  return (
+    point[0] >= Math.min(start[0], end[0]) &&
+    point[0] <= Math.max(start[0], end[0]) &&
+    point[1] >= Math.min(start[1], end[1]) &&
+    point[1] <= Math.max(start[1], end[1])
+  );
 }
 
 async function resolveFeatureLayerUrl(

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -2,7 +2,7 @@
 
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import type { HostedLayer, VectorTileLayer } from "@esri/maplibre-arcgis";
-import type { Feature, FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection, MultiPolygon, Position } from "geojson";
 import type * as maplibregl from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
@@ -1832,6 +1832,7 @@ async function fetchArcGISGeoJson(
   if (json.type !== "FeatureCollection" || !Array.isArray(json.features)) {
     throw new Error("The ArcGIS feature layer did not return GeoJSON features.");
   }
+  const features = json.features.map(repairArcGISNestedPolygonRings);
   // ArcGIS caps a single query at the service's maxRecordCount and flags the
   // shortfall with `exceededTransferLimit`. In `f=geojson` output that flag is
   // not always where the `f=json` output puts it — some servers only nest it
@@ -1840,10 +1841,105 @@ async function fetchArcGISGeoJson(
   // genuinely last one.
   return {
     ...json,
+    features,
     exceededTransferLimit: Boolean(
       json.exceededTransferLimit || json.properties?.exceededTransferLimit,
     ),
   };
+}
+
+/**
+ * Reassemble rings that ArcGIS exported as separate one-ring polygons.
+ *
+ * ArcGIS determines shell/hole membership from its own winding convention. If
+ * a service contains rings wound the other way around, `f=geojson` can emit a
+ * MultiPolygon whose nested rings are all independent polygons. MapLibre then
+ * fills the intended holes. Only that unmistakable shape is repaired here:
+ * ordinary polygons and multipolygons that already contain hole rings pass
+ * through unchanged.
+ */
+function repairArcGISNestedPolygonRings(feature: Feature): Feature {
+  const geometry = feature.geometry;
+  if (
+    geometry?.type !== "MultiPolygon" ||
+    geometry.coordinates.length < 2 ||
+    geometry.coordinates.some((polygon) => polygon.length !== 1)
+  ) {
+    return feature;
+  }
+
+  const rings = geometry.coordinates.map(([ring]) => ({
+    area: signedRingArea(ring),
+    depth: 0,
+    parent: -1,
+    ring,
+  }));
+
+  for (let child = 0; child < rings.length; child += 1) {
+    let parentArea = Number.POSITIVE_INFINITY;
+    for (let candidate = 0; candidate < rings.length; candidate += 1) {
+      if (candidate === child || Math.abs(rings[candidate].area) <= Math.abs(rings[child].area)) {
+        continue;
+      }
+      if (
+        Math.abs(rings[candidate].area) < parentArea &&
+        pointInRing(rings[child].ring[0], rings[candidate].ring)
+      ) {
+        rings[child].parent = candidate;
+        parentArea = Math.abs(rings[candidate].area);
+      }
+    }
+  }
+
+  if (!rings.some((ring) => ring.parent !== -1)) return feature;
+  const depthOf = (index: number): number => {
+    const parent = rings[index].parent;
+    return parent === -1 ? 0 : depthOf(parent) + 1;
+  };
+  rings.forEach((ring, index) => {
+    ring.depth = depthOf(index);
+  });
+
+  const coordinates: MultiPolygon["coordinates"] = [];
+  rings.forEach((entry, index) => {
+    if (entry.depth % 2 !== 0) return;
+    const polygon: Position[][] = [orientRing(entry.ring, true)];
+    rings.forEach((candidate, candidateIndex) => {
+      if (candidate.parent === index && candidate.depth % 2 === 1) {
+        polygon.push(orientRing(rings[candidateIndex].ring, false));
+      }
+    });
+    coordinates.push(polygon);
+  });
+
+  return { ...feature, geometry: { ...geometry, coordinates } };
+}
+
+function signedRingArea(ring: Position[]): number {
+  let twiceArea = 0;
+  for (let index = 0; index < ring.length - 1; index += 1) {
+    twiceArea += ring[index][0] * ring[index + 1][1] - ring[index + 1][0] * ring[index][1];
+  }
+  return twiceArea / 2;
+}
+
+function orientRing(ring: Position[], counterClockwise: boolean): Position[] {
+  return signedRingArea(ring) > 0 === counterClockwise ? ring : [...ring].reverse();
+}
+
+function pointInRing(point: Position, ring: Position[]): boolean {
+  let inside = false;
+  for (let current = 0, previous = ring.length - 1; current < ring.length; previous = current++) {
+    const [x1, y1] = ring[current];
+    const [x2, y2] = ring[previous];
+    if (
+      y1 > point[1] !== y2 > point[1] &&
+      point[0] < ((x2 - x1) * (point[1] - y1)) / (y2 - y1) + x1
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
 }
 
 async function resolveFeatureLayerUrl(

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -1858,7 +1858,8 @@ async function fetchArcGISGeoJson(
  * MultiPolygon whose nested rings are all independent polygons. MapLibre then
  * fills the intended holes. This guarded containment heuristic is limited to
  * small all-one-ring exports; ordinary polygons, structured multipolygons,
- * and large multipart features pass through unchanged.
+ * large multipart features, and boundary-touching rings pass through
+ * unchanged rather than risk destructive reclassification.
  */
 function repairArcGISNestedPolygonRings(feature: Feature): Feature {
   const geometry = feature.geometry;
@@ -1873,6 +1874,7 @@ function repairArcGISNestedPolygonRings(feature: Feature): Feature {
 
   const rings = geometry.coordinates.map(([ring]) => ({
     area: signedRingArea(ring),
+    bounds: ringBounds(ring),
     depth: 0,
     parent: -1,
     ring,
@@ -1889,6 +1891,7 @@ function repairArcGISNestedPolygonRings(feature: Feature): Feature {
         continue;
       }
       if (
+        boundsContain(rings[candidate].bounds, rings[child].bounds) &&
         Math.abs(rings[candidate].area) < parentArea &&
         ringStrictlyContains(rings[candidate].ring, rings[child].ring)
       ) {
@@ -1928,6 +1931,29 @@ function signedRingArea(ring: Position[]): number {
     twiceArea += ring[index][0] * ring[index + 1][1] - ring[index + 1][0] * ring[index][1];
   }
   return twiceArea / 2;
+}
+
+type RingBounds = [west: number, south: number, east: number, north: number];
+
+function ringBounds(ring: Position[]): RingBounds {
+  return ring.reduce<RingBounds>(
+    (bounds, position) => [
+      Math.min(bounds[0], position[0]),
+      Math.min(bounds[1], position[1]),
+      Math.max(bounds[2], position[0]),
+      Math.max(bounds[3], position[1]),
+    ],
+    [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY, -Infinity, -Infinity],
+  );
+}
+
+function boundsContain(container: RingBounds, child: RingBounds): boolean {
+  return (
+    container[0] <= child[0] &&
+    container[1] <= child[1] &&
+    container[2] >= child[2] &&
+    container[3] >= child[3]
+  );
 }
 
 function ringCrossesAntimeridian(ring: Position[]): boolean {

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -9,6 +9,8 @@ import type { GeoLibreAppAPI } from "../types";
 export type ArcGISLayerType = "feature" | "vector-tile" | "map-service" | "image-service";
 export type ArcGISSourceType = "url" | "portal-item";
 
+const MAX_ARCGIS_RING_REPAIR_PARTS = 64;
+
 /**
  * Every {@link ArcGISLayerType}, as a runtime list so a stored value (a saved
  * service-library entry, a hand-edited project) can be validated against it
@@ -1854,15 +1856,16 @@ async function fetchArcGISGeoJson(
  * ArcGIS determines shell/hole membership from its own winding convention. If
  * a service contains rings wound the other way around, `f=geojson` can emit a
  * MultiPolygon whose nested rings are all independent polygons. MapLibre then
- * fills the intended holes. Only that unmistakable shape is repaired here:
- * ordinary polygons and multipolygons that already contain hole rings pass
- * through unchanged.
+ * fills the intended holes. This guarded containment heuristic is limited to
+ * small all-one-ring exports; ordinary polygons, structured multipolygons,
+ * and large multipart features pass through unchanged.
  */
 function repairArcGISNestedPolygonRings(feature: Feature): Feature {
   const geometry = feature.geometry;
   if (
     geometry?.type !== "MultiPolygon" ||
     geometry.coordinates.length < 2 ||
+    geometry.coordinates.length > MAX_ARCGIS_RING_REPAIR_PARTS ||
     geometry.coordinates.some((polygon) => polygon.length !== 1)
   ) {
     return feature;

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -1874,6 +1874,10 @@ function repairArcGISNestedPolygonRings(feature: Feature): Feature {
     parent: -1,
     ring,
   }));
+  // Planar containment is ambiguous across the antimeridian. Leave those
+  // geometries untouched rather than risk turning a separate polygon into a
+  // hole; MapLibre already handles their original GeoJSON representation.
+  if (rings.some(({ ring }) => ringCrossesAntimeridian(ring))) return feature;
 
   for (let child = 0; child < rings.length; child += 1) {
     let parentArea = Number.POSITIVE_INFINITY;
@@ -1904,9 +1908,9 @@ function repairArcGISNestedPolygonRings(feature: Feature): Feature {
   rings.forEach((entry, index) => {
     if (entry.depth % 2 !== 0) return;
     const polygon: Position[][] = [orientRing(entry.ring, true)];
-    rings.forEach((candidate, candidateIndex) => {
+    rings.forEach((candidate) => {
       if (candidate.parent === index && candidate.depth % 2 === 1) {
-        polygon.push(orientRing(rings[candidateIndex].ring, false));
+        polygon.push(orientRing(candidate.ring, false));
       }
     });
     coordinates.push(polygon);
@@ -1921,6 +1925,12 @@ function signedRingArea(ring: Position[]): number {
     twiceArea += ring[index][0] * ring[index + 1][1] - ring[index + 1][0] * ring[index][1];
   }
   return twiceArea / 2;
+}
+
+function ringCrossesAntimeridian(ring: Position[]): boolean {
+  return ring
+    .slice(0, -1)
+    .some((position, index) => Math.abs(position[0] - ring[index + 1][0]) > 180);
 }
 
 function orientRing(ring: Position[], counterClockwise: boolean): Position[] {

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -316,6 +316,15 @@ describe("addArcGISLayer (feature layer)", () => {
                   [4, 4],
                 ],
               ],
+              [
+                [
+                  [9, 1],
+                  [12, 1],
+                  [12, 4],
+                  [9, 4],
+                  [9, 1],
+                ],
+              ],
             ],
           },
         },
@@ -336,7 +345,11 @@ describe("addArcGISLayer (feature layer)", () => {
 
     assert.equal(geometry?.type, "MultiPolygon");
     if (geometry?.type !== "MultiPolygon") return;
-    assert.equal(geometry.coordinates.length, 2, "the nested island remains a separate polygon");
+    assert.equal(
+      geometry.coordinates.length,
+      3,
+      "the nested island and overlapping polygon remain separate polygons",
+    );
     assert.equal(geometry.coordinates[0].length, 2, "the contained ring becomes a hole");
     assert.deepEqual(geometry.coordinates[1][0][0], [4, 4]);
   });

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -354,6 +354,51 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual(geometry.coordinates[1][0][0], [4, 4]);
   });
 
+  it("leaves disjoint one-ring ArcGIS polygons unchanged", async () => {
+    const disjointGeometry = {
+      type: "MultiPolygon" as const,
+      coordinates: [
+        [
+          [
+            [0, 0],
+            [0, 2],
+            [2, 2],
+            [2, 0],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [10, 12],
+            [12, 12],
+            [12, 10],
+            [10, 10],
+          ],
+        ],
+      ],
+    };
+    const response = {
+      type: "FeatureCollection",
+      features: [{ type: "Feature", properties: {}, geometry: disjointGeometry }],
+    };
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return jsonResponse(url.includes("/query") ? response : LAYER_INFO);
+    }) as typeof fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+
+    assert.deepEqual(
+      useAppStore.getState().layers.find((layer) => layer.id === id)?.geojson?.features[0].geometry,
+      disjointGeometry,
+    );
+  });
+
   it("adds an interactive layer immediately and queries the current viewport", async () => {
     const requests: URL[] = [];
     // Only the first page of each viewport query is deferred, so the test can

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -279,6 +279,68 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.deepEqual(fitBoundsCalls, [[-160, 18, -154, 23]]);
   });
 
+  it("reassembles nested rings exported as separate ArcGIS polygons", async () => {
+    const malformedMask = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: { NAME: "Mask" },
+          geometry: {
+            type: "MultiPolygon",
+            coordinates: [
+              [
+                [
+                  [0, 0],
+                  [0, 10],
+                  [10, 10],
+                  [10, 0],
+                  [0, 0],
+                ],
+              ],
+              [
+                [
+                  [2, 2],
+                  [8, 2],
+                  [8, 8],
+                  [2, 8],
+                  [2, 2],
+                ],
+              ],
+              [
+                [
+                  [4, 4],
+                  [4, 6],
+                  [6, 6],
+                  [6, 4],
+                  [4, 4],
+                ],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return jsonResponse(url.includes("/query") ? malformedMask : LAYER_INFO);
+    }) as typeof fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: SERVICE_URL,
+    });
+    const geometry = useAppStore.getState().layers.find((layer) => layer.id === id)?.geojson
+      ?.features[0].geometry;
+
+    assert.equal(geometry?.type, "MultiPolygon");
+    if (geometry?.type !== "MultiPolygon") return;
+    assert.equal(geometry.coordinates.length, 2, "the nested island remains a separate polygon");
+    assert.equal(geometry.coordinates[0].length, 2, "the contained ring becomes a hole");
+    assert.deepEqual(geometry.coordinates[1][0][0], [4, 4]);
+  });
+
   it("adds an interactive layer immediately and queries the current viewport", async () => {
     const requests: URL[] = [];
     // Only the first page of each viewport query is deferred, so the test can


### PR DESCRIPTION
## Summary
- reconstruct nested ArcGIS rings that are exported as separate one-ring polygons
- preserve ordinary polygon and multipolygon responses unchanged
- add regression coverage for a mask with a hole and nested island

## Test plan
- [x] Load the Mask_HHSK FeatureServer layer in the real app
- [x] Verify the layer in light and dark themes with zero diagnostics
- [x] Run the frontend test suite
- [x] Run the production build
- [x] Run pre-commit on the changed files

Fixes #2068

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ArcGIS polygon handling by correctly preserving outer boundaries, holes, and nested islands in GeoJSON responses.
  * Preserved existing structures for overlapping, disjoint, oversized, invalid, and antimeridian-crossing geometries.
  * Unaffected geometries continue to be returned unchanged.

* **Tests**
  * Added regression coverage for nested polygon rings, hole reconstruction, nested islands, overlapping polygons, and disjoint shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->