### PR TITLE
fix: preserve attribute rows on portrait phones

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1534,7 +1534,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           role="separator"
           aria-orientation="horizontal"
           aria-label={t("attributeTable.resize")}
-          className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+          className="geolibre-attribute-table-resize-handle absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
           onMouseDown={startTableResize}
         />
       ) : null}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1534,7 +1534,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           role="separator"
           aria-orientation="horizontal"
           aria-label={t("attributeTable.resize")}
-          className="geolibre-attribute-table-resize-handle absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+          className="geolibre-attribute-table-resize-handle absolute -top-1 start-0 end-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
           onMouseDown={startTableResize}
         />
       ) : null}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1525,7 +1525,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     <section
       ref={tableSectionRef}
       aria-label={t("attributeTable.title")}
-      className="relative flex shrink-0 flex-col border-t bg-card"
+      data-collapsed={collapsed || undefined}
+      className="geolibre-attribute-table-panel relative flex shrink-0 flex-col border-t bg-card"
       style={{ height: collapsed ? undefined : tableHeight }}
     >
       {!collapsed ? (

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2137,6 +2137,18 @@ body,
   scrollbar-width: thin;
 }
 
+/* The attribute-table toolbar wraps into several rows on portrait phones. Its
+   desktop default is only 192px tall, which can leave the flexing row viewport
+   with no usable height after the toolbar and status bar are laid out. Give the
+   open panel a viewport-relative height on narrow portrait screens so the rows
+   remain scrollable. The desktop inline height and resize handle still govern
+   every other layout. */
+@media (max-width: 639px) and (orientation: portrait) {
+  .geolibre-attribute-table-panel:not([data-collapsed]) {
+    height: clamp(22rem, 60dvh, 32rem) !important;
+  }
+}
+
 .geolibre-kml-description table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2147,6 +2147,10 @@ body,
   .geolibre-attribute-table-panel:not([data-collapsed]) {
     height: clamp(22rem, 60dvh, 32rem) !important;
   }
+
+  .geolibre-attribute-table-resize-handle {
+    display: none;
+  }
 }
 
 .geolibre-kml-description table {


### PR DESCRIPTION
## Summary
- give the open attribute table a responsive height on narrow portrait screens
- preserve the compact collapsed state and existing desktop resize behavior
- keep the row viewport vertically scrollable below wrapped controls

Fixes #2067

## Test plan
- [x] Load `us_cities.geojson` and open its attribute table at a 412 x 915 viewport
- [x] Confirm rows and vertical scrolling remain usable in light and dark themes
- [x] Confirm collapsing the table restores a compact toolbar-only panel
- [x] Run the production build and pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the attribute table panel layout on portrait mobile screens.
  * Expanded panels now use responsive viewport-based sizing, keeping toolbar and content rows usable and scrollable.
  * Resize handles are hidden on portrait mobile screens where manual resizing is impractical.
  * Preserved existing sizing and resize behavior across other layouts.
  * Improved panel state handling for more consistent responsive presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->