### PR TITLE
Fix raster calculator values and discrete styling

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -10,7 +10,7 @@ import {
   runRasterTool,
   readRasterData,
   runRasterToolClient,
-  convertGeoTiffToCog,
+  convertRasterDataToCog,
   exceedsBrowserCogConversionLimit,
   buildSpectralIndexExpression,
   type AlgorithmParameter,
@@ -579,7 +579,10 @@ export function RasterToolsDialog({ mapControllerRef }: RasterToolsDialogProps):
       }
       const app = createAppAPI(mapControllerRef);
       try {
-        const cogBytes = await convertGeoTiffToCog(new Uint8Array(bytes));
+        // Encode the computed Float32 samples directly. Passing the temporary
+        // geotiff.js file through the WASM reader can reinterpret its byte
+        // order and corrupt otherwise-correct calculated values.
+        const cogBytes = await convertRasterDataToCog(result);
         await addRasterToMap(
           app,
           // TypeScript widens wasm byte buffers to ArrayBufferLike, which is

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -86,6 +86,15 @@ function readRasterReversed(layer: GeoLibreLayer): boolean {
   );
 }
 
+/** Reads the persisted raster render mode, defaulting like the control. */
+function readRasterMode(layer: GeoLibreLayer): string {
+  const raw = layer.metadata.rasterState;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return "rgb";
+  return typeof (raw as Record<string, unknown>).mode === "string"
+    ? String((raw as Record<string, unknown>).mode)
+    : "rgb";
+}
+
 // Per-layer classification state and built GPU textures. Module-global to
 // match the single mounted raster control (see maplibre-raster.ts).
 const entries = new Map<string, ClassificationEntry>();
@@ -266,6 +275,7 @@ function reconcile(control: unknown): void {
     // map still draws a continuous ramp. Move to the renderer that can honor
     // the requested symbology; the control's engine picker updates with it.
     if (
+      readRasterMode(layer) === "single" &&
       rasterControl.getEngine?.() !== "maplibre-gl-raster" &&
       typeof rasterControl.setEngine === "function"
     ) {

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -43,6 +43,8 @@ type RasterLayerManager = {
 type ControlWithManager = {
   _layerManager?: RasterLayerManager;
   getRaster?: (id: string) => RasterInfoLike | undefined;
+  getEngine?: () => string;
+  setEngine?: (engine: "maplibre-gl-raster") => void;
 };
 type RasterInfoLike = {
   source?: { kind: "url"; url: string } | { kind: "file"; fileName: string; objectUrl: string };
@@ -232,7 +234,8 @@ function ensureTexture(manager: RasterLayerManager, entry: ClassificationEntry):
  * @param control - The mounted raster control (for `_rebuild`).
  */
 function reconcile(control: unknown): void {
-  const manager = (control as ControlWithManager)._layerManager;
+  const rasterControl = control as ControlWithManager;
+  const manager = rasterControl._layerManager;
   if (!manager) return;
 
   const layers = useAppStore.getState().layers;
@@ -255,6 +258,18 @@ function reconcile(control: unknown): void {
         changed = true;
       }
       continue;
+    }
+
+    // Discrete and custom colormaps are injected into the deck.gl GPU
+    // pipeline. The alternate WASM and TiTiler engines bypass that pipeline,
+    // so leaving either selected makes the UI report classification while the
+    // map still draws a continuous ramp. Move to the renderer that can honor
+    // the requested symbology; the control's engine picker updates with it.
+    if (
+      rasterControl.getEngine?.() !== "maplibre-gl-raster" &&
+      typeof rasterControl.setEngine === "function"
+    ) {
+      rasterControl.setEngine("maplibre-gl-raster");
     }
 
     // Reverse lives on rasterState (the control renders it for built-in ramps;

--- a/packages/processing/src/cog-convert.ts
+++ b/packages/processing/src/cog-convert.ts
@@ -10,6 +10,7 @@
 // result instead. It runs entirely client-side, so it works in the browser
 // build with no Python sidecar. See opengeos/GeoLibre#789.
 import init, { CogBuilder, GeoTiffReader, geotiff_info } from "geolibre-wasm";
+import type { RasterData } from "./raster-client";
 
 /** Header-only metadata for a GeoTIFF, parsed from {@link geotiff_info}. Cheap:
  * reads only the TIFF header, never the pixel data, so it is safe on large
@@ -196,5 +197,55 @@ export async function convertGeoTiffToCog(
     }
   } finally {
     reader.free();
+  }
+}
+
+/** Encode an in-memory client-processing result directly as a Float32 COG. */
+export async function convertRasterDataToCog(raster: RasterData): Promise<Uint8Array> {
+  await initCogWasm();
+  const samples = geoTiffSampleCount({
+    width: raster.width,
+    height: raster.height,
+    bands: raster.bands.length,
+  });
+  if (exceedsBrowserCogConversionLimit(samples)) {
+    throw new Error(
+      `Raster has ${samples.toLocaleString()} decoded samples, exceeding the safe browser conversion limit.`,
+    );
+  }
+
+  const builder = new CogBuilder(raster.width, raster.height, raster.bands.length);
+  try {
+    const epsg = Number(
+      raster.geoKeys.ProjectedCSTypeGeoKey ?? raster.geoKeys.GeographicTypeGeoKey,
+    );
+    if (Number.isFinite(epsg) && epsg > 0) builder.set_epsg(epsg);
+    builder.set_geo_transform(
+      Float64Array.from([
+        raster.originX,
+        raster.flipX ? -raster.resX : raster.resX,
+        0,
+        raster.originY,
+        0,
+        raster.flipY ? raster.resY : -raster.resY,
+      ]),
+    );
+    if (raster.nodata != null && Number.isFinite(raster.nodata)) {
+      builder.set_nodata(raster.nodata);
+    }
+    builder.set_tile_size(COG_TILE_SIZE);
+    builder.set_compression("deflate");
+    builder.set_overview_levels(overviewLevels(raster.width, raster.height));
+
+    const pixels = raster.width * raster.height;
+    const values = new Float32Array(samples);
+    for (let pixel = 0; pixel < pixels; pixel += 1) {
+      for (let band = 0; band < raster.bands.length; band += 1) {
+        values[pixel * raster.bands.length + band] = raster.bands[band][pixel];
+      }
+    }
+    return builder.write_f32(values);
+  } finally {
+    builder.free();
   }
 }

--- a/packages/processing/src/cog-convert.ts
+++ b/packages/processing/src/cog-convert.ts
@@ -219,6 +219,11 @@ export async function convertRasterDataToCog(raster: RasterData): Promise<Uint8A
     const epsg = Number(
       raster.geoKeys.ProjectedCSTypeGeoKey ?? raster.geoKeys.GeographicTypeGeoKey,
     );
+    if (Number.isFinite(epsg) && epsg >= 32767 && epsg <= 65535) {
+      throw new Error(
+        `Client raster output cannot preserve user-defined or private CRS code ${epsg}. Use the sidecar engine instead.`,
+      );
+    }
     if (Number.isFinite(epsg) && epsg > 0) builder.set_epsg(epsg);
     builder.set_geo_transform(
       Float64Array.from([

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -275,6 +275,7 @@ export {
   readGeoTiffInfo,
   isTiledGeoTiff,
   convertGeoTiffToCog,
+  convertRasterDataToCog,
   COG_WASM_COMPRESSIONS,
   exceedsBrowserCogConversionLimit,
   geoTiffSampleCount,

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -94,22 +94,24 @@ describe("convertGeoTiffToCog", () => {
     }
   });
 
-  it("rejects a user-defined CRS code that cannot be preserved by the COG writer", async () => {
-    await assert.rejects(
-      convertRasterDataToCog({
-        bands: [Float32Array.from([1])],
-        width: 1,
-        height: 1,
-        originX: 0,
-        originY: 1,
-        resX: 1,
-        resY: 1,
-        nodata: null,
-        geoKeys: { GTModelTypeGeoKey: 1, ProjectedCSTypeGeoKey: 32767 },
-      }),
-      /cannot preserve user-defined or private CRS code 32767/,
-    );
-  });
+  for (const crsCode of [32767, 32768, 65535]) {
+    it(`rejects user-defined or private CRS code ${crsCode}`, async () => {
+      await assert.rejects(
+        convertRasterDataToCog({
+          bands: [Float32Array.from([1])],
+          width: 1,
+          height: 1,
+          originX: 0,
+          originY: 1,
+          resX: 1,
+          resY: 1,
+          nodata: null,
+          geoKeys: { GTModelTypeGeoKey: 1, ProjectedCSTypeGeoKey: crsCode },
+        }),
+        new RegExp(`cannot preserve user-defined or private CRS code ${crsCode}`),
+      );
+    });
+  }
 
   // Raster to COG lets the user pick a codec on the web, so every advertised
   // choice has to survive an Int16 source — webp/jpeg/jpegxl do not (they reject

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -6,6 +6,7 @@ import { GeoTiffReader } from "geolibre-wasm";
 import {
   COG_WASM_COMPRESSIONS,
   convertGeoTiffToCog,
+  convertRasterDataToCog,
   initCogWasm,
   isTiledGeoTiff,
   readGeoTiffInfo,
@@ -65,6 +66,29 @@ describe("convertGeoTiffToCog", () => {
       assert.equal(band.length, 32 * 32);
       assert.equal(band[0], -11);
       assert.equal(band[20], 9);
+    } finally {
+      reader.free();
+    }
+  });
+
+  it("encodes in-memory Float32 processing results without corrupting sample bytes", async () => {
+    const expected = Float32Array.from([0, 250.25, 282.2, 322.89]);
+    const cog = await convertRasterDataToCog({
+      bands: [expected],
+      width: 4,
+      height: 1,
+      originX: 2.8,
+      originY: 47.35,
+      resX: 0.001,
+      resY: 0.001,
+      nodata: -99999,
+      geoKeys: { GTModelTypeGeoKey: 2, GeographicTypeGeoKey: 4326 },
+    });
+    const reader = new GeoTiffReader(cog);
+    try {
+      assert.deepEqual(Array.from(reader.read_band_f32(0)), Array.from(expected));
+      assert.equal(reader.epsg, 4326);
+      assert.deepEqual(Array.from(reader.geo_transform()), [2.8, 0.001, 0, 47.35, 0, -0.001]);
     } finally {
       reader.free();
     }

--- a/tests/cog-convert.test.ts
+++ b/tests/cog-convert.test.ts
@@ -94,6 +94,23 @@ describe("convertGeoTiffToCog", () => {
     }
   });
 
+  it("rejects a user-defined CRS code that cannot be preserved by the COG writer", async () => {
+    await assert.rejects(
+      convertRasterDataToCog({
+        bands: [Float32Array.from([1])],
+        width: 1,
+        height: 1,
+        originX: 0,
+        originY: 1,
+        resX: 1,
+        resY: 1,
+        nodata: null,
+        geoKeys: { GTModelTypeGeoKey: 1, ProjectedCSTypeGeoKey: 32767 },
+      }),
+      /cannot preserve user-defined or private CRS code 32767/,
+    );
+  });
+
   // Raster to COG lets the user pick a codec on the web, so every advertised
   // choice has to survive an Int16 source — webp/jpeg/jpegxl do not (they reject
   // anything but 8-bit samples) and zstd/raw are not implemented at all, which

--- a/tests/raster-symbology-texture.test.ts
+++ b/tests/raster-symbology-texture.test.ts
@@ -74,7 +74,11 @@ function renderColormapProps(
 
 function rasterLayer(
   id: string,
-  opts: { rasterSymbology?: Record<string, unknown>; reversed?: boolean } = {},
+  opts: {
+    rasterSymbology?: Record<string, unknown>;
+    reversed?: boolean;
+    mode?: "single" | "rgb";
+  } = {},
 ): GeoLibreLayer {
   return {
     id,
@@ -91,7 +95,7 @@ function rasterLayer(
       // Reverse lives on rasterState now (the control renders it for built-in
       // colormaps; the injected texture reads it for classified / custom).
       rasterState: {
-        mode: "single",
+        mode: opts.mode ?? "single",
         colormap: "viridis",
         reversed: opts.reversed ?? false,
       },
@@ -184,5 +188,26 @@ describe("raster symbology render injection", () => {
     activateRasterClassification(control);
 
     assert.equal(control.getEngine(), "maplibre-gl-raster");
+  });
+
+  it("does not switch renderers for stale classification metadata in RGB mode", () => {
+    useAppStore.getState().addLayer(
+      rasterLayer("r1", {
+        mode: "rgb",
+        rasterSymbology: {
+          classified: true,
+          ramp: "autumn",
+          method: "manual",
+          classCount: 2,
+          breaks: [0, 200, 300],
+        },
+      }),
+    );
+    const control = fakeControl();
+    control.setEngine("cog-tiler-wasm");
+
+    activateRasterClassification(control);
+
+    assert.equal(control.getEngine(), "cog-tiler-wasm");
   });
 });

--- a/tests/raster-symbology-texture.test.ts
+++ b/tests/raster-symbology-texture.test.ts
@@ -29,6 +29,7 @@ type PipelineModule = { module?: { name?: string }; props?: Record<string, unkno
  * (`reversed: false`, a named-colormap texture/index).
  */
 function fakeControl() {
+  let engine = "maplibre-gl-raster";
   const manager: Record<string, unknown> = {
     _device: {},
     _deps: {},
@@ -45,7 +46,17 @@ function fakeControl() {
         ],
       }),
   };
-  return { _layerManager: manager } as { _layerManager: Record<string, unknown> };
+  return {
+    _layerManager: manager,
+    getEngine: () => engine,
+    setEngine: (next: string) => {
+      engine = next;
+    },
+  } as {
+    _layerManager: Record<string, unknown>;
+    getEngine: () => string;
+    setEngine: (next: string) => void;
+  };
 }
 
 /** Renders a single-band tile through the patched manager and returns the
@@ -153,5 +164,25 @@ describe("raster symbology render injection", () => {
     assert.ok(props?.colormapTexture, "expected an injected colormap texture");
     assert.equal(created.length >= 1, true);
     assert.equal(created[0]?.opts.width, 256);
+  });
+
+  it("switches from the WASM renderer when discrete classes need the GPU pipeline", () => {
+    useAppStore.getState().addLayer(
+      rasterLayer("r1", {
+        rasterSymbology: {
+          classified: true,
+          ramp: "autumn",
+          method: "manual",
+          classCount: 2,
+          breaks: [144.86, 200, 322.84],
+        },
+      }),
+    );
+    const control = fakeControl();
+    control.setEngine("cog-tiler-wasm");
+
+    activateRasterClassification(control);
+
+    assert.equal(control.getEngine(), "maplibre-gl-raster");
   });
 });


### PR DESCRIPTION
## Summary

- encode browser raster results directly as Float32 COGs so calculated values survive the output pipeline
- switch discrete and custom raster symbology to the compatible GPU renderer
- add regression coverage for Float32 values, georeferencing, and renderer selection

Related to https://github.com/opengeos/GeoLibre/discussions/2032#discussioncomment-18114701

## Verification

- checked every output sample from `where(A > 250, A, 0)` against `Sancerre_RGEALTI_5M_4326_COG.tif`: 932,116 samples, 0 mismatches
- verified manual two-class styling in the real app in light and dark themes
- `node --import tsx --test tests/cog-convert.test.ts tests/raster-client.test.ts tests/raster-symbology.test.ts tests/raster-symbology-texture.test.ts`
- `npm run build`
- `pre-commit run --files apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx packages/plugins/src/plugins/raster-symbology-texture.ts packages/processing/src/cog-convert.ts packages/processing/src/index.ts tests/cog-convert.test.ts tests/raster-symbology-texture.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct conversion of computed raster results to Cloud Optimized GeoTIFF files while preserving values and spatial metadata.
  * Raster classification and custom symbology now automatically select the compatible rendering engine.

* **Bug Fixes**
  * Prevented calculated raster values from being corrupted during GeoTIFF conversion.

* **Tests**
  * Added coverage for raster value preservation, spatial metadata, and automatic renderer switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->