### PR TITLE
Preserve KML folder structure on import

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -716,6 +716,8 @@ export function DesktopShell({
   const addImageOverlayLayer = useAppStore((s) => s.addImageOverlayLayer);
   const addTileLayer = useAppStore((s) => s.addTileLayer);
   const addLayerGroup = useAppStore((s) => s.addLayerGroup);
+  const moveLayerGroupToGroup = useAppStore((s) => s.moveLayerGroupToGroup);
+  const moveLayerToGroup = useAppStore((s) => s.moveLayerToGroup);
   const { isActive: isPluginActive, toggle: togglePlugin } = usePluginRegistry();
   const addLayer = useAppStore((s) => s.addLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
@@ -1347,6 +1349,10 @@ export function DesktopShell({
       // Frame ids for each time-animated overlay sequence (keyed by the loader's
       // group marker), so they can be gathered into one layer group afterward.
       const frameGroups = new Map<string, string[]>();
+      // KML Folder ancestry becomes nested GeoLibre groups. Prefix keys with
+      // the source path so identically named folders from separate files do not
+      // get combined when several files are imported in one batch.
+      const kmlGroups = new Map<string, string>();
       for (const layer of importedLayers) {
         if (isLoadedKmlSuperOverlay(layer)) {
           lastLayerId = addTileLayer(layer.name || layerNameFromPath(layer.path), {
@@ -1404,17 +1410,37 @@ export function DesktopShell({
           nonGeographic.push(layerName);
           console.warn(
             `[GeoLibre] "${layerName}" declares geographic coordinates but its values are out of range ` +
-              `(max |x| ${Math.round(offRange.maxAbsX).toLocaleString()}, max |y| ${Math.round(offRange.maxAbsY).toLocaleString()} ` +
+              `(max |x| ${Math.round(offRange.maxAbsX).toLocaleString()}, max |y| ${Math.round(
+                offRange.maxAbsY,
+              ).toLocaleString()} ` +
               `over ${offRange.sampled.toLocaleString()} sampled coordinates). The file's CRS is almost certainly ` +
               `mislabelled — reproject it, or correct its .prj/crs, and load it again.`,
           );
         }
         lastLayerId = addGeoJsonLayer(layerName, layer.data, layer.path);
+        if (layer.groupPath?.length) {
+          let parentId: string | null = null;
+          const pathParts: string[] = [];
+          for (const folderName of layer.groupPath) {
+            pathParts.push(folderName);
+            const key = `${layer.path}\0${pathParts.join("\0")}`;
+            let groupId = kmlGroups.get(key);
+            if (!groupId) {
+              groupId = addLayerGroup(folderName);
+              if (parentId) moveLayerGroupToGroup(groupId, parentId);
+              kmlGroups.set(key, groupId);
+            }
+            parentId = groupId;
+          }
+          if (parentId) moveLayerToGroup(lastLayerId, parentId);
+        }
       }
 
       setCrsWarning(
         nonGeographic.length > 0
-          ? t("addData.nonGeographicCoordinates", { names: nonGeographic.join(", ") })
+          ? t("addData.nonGeographicCoordinates", {
+              names: nonGeographic.join(", "),
+            })
           : null,
       );
 
@@ -1464,6 +1490,8 @@ export function DesktopShell({
       addTileLayer,
       addLayer,
       addLayerGroup,
+      moveLayerGroupToGroup,
+      moveLayerToGroup,
       isPluginActive,
       togglePlugin,
       t,
@@ -1486,7 +1514,9 @@ export function DesktopShell({
         // pyramid, which a path-less browser File cannot support.
         const layers =
           paths.length === imports.length
-            ? await loadDroppedVectorPaths(paths, { onLargeDataset: confirmLargeVectorDataset })
+            ? await loadDroppedVectorPaths(paths, {
+                onLargeDataset: confirmLargeVectorDataset,
+              })
             : await loadDroppedVectorFiles(
                 imports.map(({ file }) => file),
                 {
@@ -1720,7 +1750,9 @@ export function DesktopShell({
                   setDropError(
                     err instanceof OsmPbfTooLargeError
                       ? t("toolbar.error.osmPbfTooLarge")
-                      : `Could not parse ${name}: ${err instanceof Error ? err.message : String(err)}`,
+                      : `Could not parse ${name}: ${
+                          err instanceof Error ? err.message : String(err)
+                        }`,
                   );
                 }
               }
@@ -1865,7 +1897,9 @@ export function DesktopShell({
             setDropError(
               err instanceof OsmPbfTooLargeError
                 ? t("toolbar.error.osmPbfTooLarge")
-                : `Could not parse ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
+                : `Could not parse ${file.name}: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
             );
             continue;
           }
@@ -2482,7 +2516,9 @@ export function DesktopShell({
                   const file = new File([bytes as BlobPart], fileName ?? `${name}.tif`, {
                     type: "image/tiff",
                   });
-                  await addRasterToMap(createAppAPI(mapControllerRef), file, { name });
+                  await addRasterToMap(createAppAPI(mapControllerRef), file, {
+                    name,
+                  });
                 }}
               />
             </Suspense>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1357,8 +1357,12 @@ export function DesktopShell({
       // splits into one layer per placemark, so the final fit needs every id
       // from that file to frame the whole import rather than one placemark.
       const layerIdsBySource = new Map<string, string[]>();
+      // Tracked across every record kind (not just the GeoJSON ones) so a file
+      // whose placemarks are followed by an overlay or model is still
+      // recognized as the last source imported.
       let lastSourcePath: string | null = null;
       for (const layer of importedLayers) {
+        if (layer.path) lastSourcePath = layer.path;
         if (isLoadedKmlSuperOverlay(layer)) {
           lastLayerId = addTileLayer(layer.name || layerNameFromPath(layer.path), {
             tiles: [layer.url],
@@ -1424,7 +1428,6 @@ export function DesktopShell({
         }
         lastLayerId = addGeoJsonLayer(layerName, layer.data, layer.path);
         if (layer.path) {
-          lastSourcePath = layer.path;
           const sourceIds = layerIdsBySource.get(layer.path) ?? [];
           sourceIds.push(lastLayerId);
           layerIdsBySource.set(layer.path, sourceIds);
@@ -1476,9 +1479,9 @@ export function DesktopShell({
 
       // A folder-aware KML becomes one layer per placemark, so framing the last
       // layer alone would open on a single point. Combine the extents of every
-      // layer that file contributed and fit that instead.
+      // layer the last source contributed and fit that instead.
       const sourceLayerIds = lastSourcePath ? (layerIdsBySource.get(lastSourcePath) ?? []) : [];
-      if (sourceLayerIds.length > 1 && sourceLayerIds.at(-1) === lastLayerId) {
+      if (sourceLayerIds.length > 1) {
         const sourceLayerIdSet = new Set(sourceLayerIds);
         const bounds = useAppStore
           .getState()

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1479,9 +1479,10 @@ export function DesktopShell({
       // layer that file contributed and fit that instead.
       const sourceLayerIds = lastSourcePath ? (layerIdsBySource.get(lastSourcePath) ?? []) : [];
       if (sourceLayerIds.length > 1 && sourceLayerIds.at(-1) === lastLayerId) {
+        const sourceLayerIdSet = new Set(sourceLayerIds);
         const bounds = useAppStore
           .getState()
-          .layers.filter((layer) => sourceLayerIds.includes(layer.id))
+          .layers.filter((layer) => sourceLayerIdSet.has(layer.id))
           .map(getLayerBounds)
           .filter((value): value is [number, number, number, number] => value !== null);
         if (bounds.length) {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1353,6 +1353,11 @@ export function DesktopShell({
       // the source path so identically named folders from separate files do not
       // get combined when several files are imported in one batch.
       const kmlGroups = new Map<string, string>();
+      // GeoJSON layer ids contributed by each source file. A folder-aware KML
+      // splits into one layer per placemark, so the final fit needs every id
+      // from that file to frame the whole import rather than one placemark.
+      const layerIdsBySource = new Map<string, string[]>();
+      let lastSourcePath: string | null = null;
       for (const layer of importedLayers) {
         if (isLoadedKmlSuperOverlay(layer)) {
           lastLayerId = addTileLayer(layer.name || layerNameFromPath(layer.path), {
@@ -1418,6 +1423,12 @@ export function DesktopShell({
           );
         }
         lastLayerId = addGeoJsonLayer(layerName, layer.data, layer.path);
+        if (layer.path) {
+          lastSourcePath = layer.path;
+          const sourceIds = layerIdsBySource.get(layer.path) ?? [];
+          sourceIds.push(lastLayerId);
+          layerIdsBySource.set(layer.path, sourceIds);
+        }
         if (layer.groupPath?.length) {
           let parentId: string | null = null;
           const pathParts: string[] = [];
@@ -1461,6 +1472,27 @@ export function DesktopShell({
       // stepped through immediately, without the user hunting for the plugin.
       if (hasTimeAnimation && !isPluginActive(TIME_SLIDER_PLUGIN_ID)) {
         togglePlugin(TIME_SLIDER_PLUGIN_ID, createAppAPI(mapControllerRef));
+      }
+
+      // A folder-aware KML becomes one layer per placemark, so framing the last
+      // layer alone would open on a single point. Combine the extents of every
+      // layer that file contributed and fit that instead.
+      const sourceLayerIds = lastSourcePath ? (layerIdsBySource.get(lastSourcePath) ?? []) : [];
+      if (sourceLayerIds.length > 1 && sourceLayerIds.at(-1) === lastLayerId) {
+        const bounds = useAppStore
+          .getState()
+          .layers.filter((layer) => sourceLayerIds.includes(layer.id))
+          .map(getLayerBounds)
+          .filter((value): value is [number, number, number, number] => value !== null);
+        if (bounds.length) {
+          mapControllerRef.current?.fitBounds([
+            Math.min(...bounds.map((value) => value[0])),
+            Math.min(...bounds.map((value) => value[1])),
+            Math.max(...bounds.map((value) => value[2])),
+            Math.max(...bounds.map((value) => value[3])),
+          ]);
+          return;
+        }
       }
 
       const importedLayer = useAppStore.getState().layers.find((layer) => layer.id === lastLayerId);

--- a/apps/geolibre-desktop/src/lib/kml.ts
+++ b/apps/geolibre-desktop/src/lib/kml.ts
@@ -31,6 +31,9 @@ interface KmlStyle {
   __geolibre_kml_icon_href?: string;
 }
 
+/** Internal import metadata used to reconstruct KML Folder groups. */
+export const KML_FOLDER_PATH_PROPERTY = "__geolibre_kml_folder_path";
+
 /**
  * Parse a KML document into a styled GeoJSON FeatureCollection.
  *
@@ -58,10 +61,14 @@ export function parseKmlText(text: string): FeatureCollection {
   for (const placemark of descendants(root, "Placemark")) {
     const geometry = geometryFromPlacemark(placemark);
     if (!geometry) continue;
+    const folders = folderPath(placemark);
     features.push({
       type: "Feature",
       geometry,
-      properties: placemarkProperties(placemark, styles, styleMaps),
+      properties: {
+        ...placemarkProperties(placemark, styles, styleMaps),
+        ...(folders.length > 0 ? { [KML_FOLDER_PATH_PROPERTY]: folders } : {}),
+      },
     });
   }
 
@@ -70,6 +77,17 @@ export function parseKmlText(text: string): FeatureCollection {
   }
 
   return { type: "FeatureCollection", features };
+}
+
+/** Names of the enclosing KML Folder elements, from outermost to innermost. */
+function folderPath(element: Element): string[] {
+  const path: string[] = [];
+  for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+    if (parent.localName.toLowerCase() !== "folder") continue;
+    const name = childText(parent, "name");
+    if (name) path.unshift(name);
+  }
+  return path;
 }
 
 /**
@@ -662,9 +680,15 @@ function extendedData(placemark: Element): Record<string, string> {
 
 function descendants(parent: Element, localName: string): Element[] {
   const target = localName.toLowerCase();
-  return Array.from(parent.getElementsByTagName("*")).filter(
-    (element) => element.localName.toLowerCase() === target,
-  );
+  const matches: Element[] = [];
+  const visit = (element: Element): void => {
+    for (const child of Array.from(element.children)) {
+      if (child.localName.toLowerCase() === target) matches.push(child);
+      visit(child);
+    }
+  };
+  visit(parent);
+  return matches;
 }
 
 function directChildren(parent: Element, localName: string): Element[] {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1719,7 +1719,9 @@ async function loadKmzLayers(
             entries,
             options,
           );
-          if (features.features.length > 0) layers.push({ data: features, path });
+          if (features.features.length > 0) {
+            layers.push(...splitKmlFolderLayers(features, path));
+          }
         } catch (error) {
           // Declining the oversized-vector prompt must not throw away the
           // pyramid, which is already registered and loads on its own.
@@ -3648,7 +3650,9 @@ export async function loadDroppedVectorPaths(
           // Only add a vector layer when it actually has features (an overlay-only
           // KML's DuckDB fallback can return an empty collection).
           const vector = await loadTauriVectorFile(path, options);
-          if (vector.data.features.length > 0) layers.push(vector);
+          if (vector.data.features.length > 0) {
+            layers.push(...splitKmlFolderLayers(vector.data, vector.path));
+          }
         } catch (error) {
           // Declining the oversized-vector prompt, or a genuine parse failure,
           // still leaves any ground overlays/models already added above (a real

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -20,7 +20,7 @@ import {
 } from "@tauri-apps/plugin-fs";
 import type { StartupSettings } from "../hooks/useDesktopSettings";
 import { unzip } from "fflate";
-import type { FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection } from "geojson";
 import i18next from "i18next";
 import { combine, parseDbf, parseShp } from "shpjs";
 import {
@@ -479,7 +479,15 @@ function mergeFeatureCollections(collections: FeatureCollection[]): FeatureColle
   };
 }
 
-/** Split folder-aware KML placemarks into layers that can occupy distinct groups. */
+/**
+ * Split folder-aware KML placemarks into layers that can occupy distinct groups.
+ *
+ * Only placemarks that actually sit inside a `<Folder>` become their own layer;
+ * everything else stays merged into a single layer, as it was before folder
+ * support. A real-world export is often a handful of foldered placemarks among
+ * hundreds of flat ones, and splitting those too would turn one cheap layer add
+ * into hundreds of store mutations and layer-panel rows.
+ */
 export function splitKmlFolderLayers(
   collection: FeatureCollection,
   path: string,
@@ -489,31 +497,41 @@ export function splitKmlFolderLayers(
   );
   if (!hasFolderMetadata) return [{ data: collection, path }];
 
+  const layers: LoadedVectorLayer[] = [];
+  // Placemarks outside any Folder, gathered into the one merged layer below.
+  const ungrouped: Feature[] = [];
+  collection.features.forEach((feature, index) => {
+    const properties = { ...(feature.properties ?? {}) };
+    const rawPath = properties[KML_FOLDER_PATH_PROPERTY];
+    delete properties[KML_FOLDER_PATH_PROPERTY];
+    const groupPath = Array.isArray(rawPath)
+      ? rawPath.filter((part): part is string => typeof part === "string" && part.trim() !== "")
+      : [];
+    const stripped: Feature = { ...feature, properties };
+    if (groupPath.length === 0) {
+      ungrouped.push(stripped);
+      return;
+    }
+    const name =
+      typeof properties.name === "string" && properties.name.trim() !== ""
+        ? properties.name
+        : `Placemark ${index + 1}`;
+    layers.push({
+      data: { type: "FeatureCollection", features: [stripped] },
+      name,
+      path,
+      groupPath,
+    });
+  });
+
   // Store insertion is top-first, so feed placemarks in reverse document order
-  // to keep their visible layer/group order aligned with Google Earth.
-  return collection.features
-    .map<LoadedVectorLayer>((feature, index) => {
-      const properties = { ...(feature.properties ?? {}) };
-      const rawPath = properties[KML_FOLDER_PATH_PROPERTY];
-      delete properties[KML_FOLDER_PATH_PROPERTY];
-      const groupPath = Array.isArray(rawPath)
-        ? rawPath.filter((part): part is string => typeof part === "string" && part.trim() !== "")
-        : [];
-      const name =
-        typeof properties.name === "string" && properties.name.trim() !== ""
-          ? properties.name
-          : `Placemark ${index + 1}`;
-      return {
-        data: {
-          type: "FeatureCollection",
-          features: [{ ...feature, properties }],
-        },
-        name,
-        path,
-        ...(groupPath.length > 0 ? { groupPath } : {}),
-      };
-    })
-    .reverse();
+  // to keep their visible layer/group order aligned with Google Earth. The
+  // merged ungrouped layer is added first so it settles below the folders.
+  layers.reverse();
+  if (ungrouped.length > 0) {
+    layers.unshift({ data: { type: "FeatureCollection", features: ungrouped }, path });
+  }
+  return layers;
 }
 
 function normalizeShapefileResult(value: unknown): FeatureCollection {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -59,6 +59,7 @@ import { parseGpxLayer } from "./gpx";
 import { isTauri } from "./is-tauri";
 import { SHAPEFILE_COMPANION_EXTENSIONS, shapefileCompanionPathsFromSelection } from "./mas-build";
 import {
+  KML_FOLDER_PATH_PROPERTY,
   parseKmlGroundOverlays,
   parseKmlModels,
   parseKmlText,
@@ -273,6 +274,8 @@ export interface LoadedVectorLayer {
   data: FeatureCollection;
   name?: string;
   path: string;
+  /** Enclosing KML Folder names, reconstructed as nested layer groups. */
+  groupPath?: string[];
 }
 
 /**
@@ -474,6 +477,43 @@ function mergeFeatureCollections(collections: FeatureCollection[]): FeatureColle
     type: "FeatureCollection",
     features: collections.flatMap((collection) => collection.features),
   };
+}
+
+/** Split folder-aware KML placemarks into layers that can occupy distinct groups. */
+export function splitKmlFolderLayers(
+  collection: FeatureCollection,
+  path: string,
+): LoadedVectorLayer[] {
+  const hasFolderMetadata = collection.features.some((feature) =>
+    Array.isArray(feature.properties?.[KML_FOLDER_PATH_PROPERTY]),
+  );
+  if (!hasFolderMetadata) return [{ data: collection, path }];
+
+  // Store insertion is top-first, so feed placemarks in reverse document order
+  // to keep their visible layer/group order aligned with Google Earth.
+  return collection.features
+    .map<LoadedVectorLayer>((feature, index) => {
+      const properties = { ...(feature.properties ?? {}) };
+      const rawPath = properties[KML_FOLDER_PATH_PROPERTY];
+      delete properties[KML_FOLDER_PATH_PROPERTY];
+      const groupPath = Array.isArray(rawPath)
+        ? rawPath.filter((part): part is string => typeof part === "string" && part.trim() !== "")
+        : [];
+      const name =
+        typeof properties.name === "string" && properties.name.trim() !== ""
+          ? properties.name
+          : `Placemark ${index + 1}`;
+      return {
+        data: {
+          type: "FeatureCollection",
+          features: [{ ...feature, properties }],
+        },
+        name,
+        path,
+        ...(groupPath.length > 0 ? { groupPath } : {}),
+      };
+    })
+    .reverse();
 }
 
 function normalizeShapefileResult(value: unknown): FeatureCollection {
@@ -973,7 +1013,9 @@ async function loadShapefileZip(
   }
   if (shouldRouteToDuckDb(unzipped.file.data.byteLength)) {
     console.info(
-      `[GeoLibre] "${unzipped.file.name}" is ${Math.round(unzipped.file.data.byteLength / (1024 * 1024))} MB uncompressed; reading it with DuckDB instead of shpjs to keep the parse off the main thread.`,
+      `[GeoLibre] "${unzipped.file.name}" is ${Math.round(
+        unzipped.file.data.byteLength / (1024 * 1024),
+      )} MB uncompressed; reading it with DuckDB instead of shpjs to keep the parse off the main thread.`,
     );
     return loadDuckDbVector(unzipped.file, options);
   }
@@ -1476,9 +1518,9 @@ async function fetchDaeAsGlbDataUrl(href: string): Promise<{
     const daeBytes = new Blob([daeText]).size;
     if (daeBytes > MAX_DAE_SOURCE_BYTES) {
       console.warn(
-        `Skipping a KML model: "${href}" is ${Math.round(daeBytes / (1024 * 1024))} MB, over the ${Math.round(
-          MAX_DAE_SOURCE_BYTES / (1024 * 1024),
-        )} MB limit.`,
+        `Skipping a KML model: "${href}" is ${Math.round(
+          daeBytes / (1024 * 1024),
+        )} MB, over the ${Math.round(MAX_DAE_SOURCE_BYTES / (1024 * 1024))} MB limit.`,
       );
       return null;
     }
@@ -1713,7 +1755,7 @@ async function loadKmzLayers(
   let cancellation: unknown;
   try {
     const features = await kmzVectorFeatures(kmlFiles, entries, options);
-    if (features.features.length > 0) layers.push({ data: features, path });
+    if (features.features.length > 0) layers.push(...splitKmlFolderLayers(features, path));
   } catch (error) {
     if (!isVectorLoadCancelled(error)) throw error;
     cancellation = error;
@@ -2027,7 +2069,9 @@ async function loadBrowserVectorFile(
   // route here would be misleading for a container near the threshold.
   if (streamViaDuckDb && ROUTABLE_TEXT_EXTENSIONS.has(extension)) {
     console.info(
-      `[GeoLibre] "${file.name}" is ${Math.round(file.size / (1024 * 1024))} MB; streaming it through DuckDB instead of the in-memory reader.`,
+      `[GeoLibre] "${file.name}" is ${Math.round(
+        file.size / (1024 * 1024),
+      )} MB; streaming it through DuckDB instead of the in-memory reader.`,
     );
   }
 
@@ -2322,7 +2366,9 @@ async function loadTauriVectorFile(
   // See `loadBrowserVectorFile`: containers decide their own routing later.
   if (streamViaDuckDb && ROUTABLE_TEXT_EXTENSIONS.has(extension)) {
     console.info(
-      `[GeoLibre] "${browserSafeFileName(path)}" is ${Math.round((sizeBytes ?? 0) / (1024 * 1024))} MB; streaming it through DuckDB instead of the in-memory reader.`,
+      `[GeoLibre] "${browserSafeFileName(path)}" is ${Math.round(
+        (sizeBytes ?? 0) / (1024 * 1024),
+      )} MB; streaming it through DuckDB instead of the in-memory reader.`,
     );
   }
 
@@ -2733,7 +2779,10 @@ export async function openLocalDataFilesWithFallback(
     });
     const paths = Array.isArray(selected) ? selected : selected ? [selected] : [];
     return Promise.all(
-      paths.map(async (path) => ({ data: toArrayBuffer(await readFile(path)), path })),
+      paths.map(async (path) => ({
+        data: toArrayBuffer(await readFile(path)),
+        path,
+      })),
     );
   }
 
@@ -2747,7 +2796,10 @@ export async function openLocalDataFilesWithFallback(
         const files = Array.from(input.files ?? []);
         resolve(
           await Promise.all(
-            files.map(async (file) => ({ data: await file.arrayBuffer(), path: file.name })),
+            files.map(async (file) => ({
+              data: await file.arrayBuffer(),
+              path: file.name,
+            })),
           ),
         );
       } catch (error) {
@@ -2931,13 +2983,18 @@ export class RecentProjectGoneError extends Error {
  */
 const startupSnapshotIo: StartupSnapshotIo = {
   write: async (file, content) => {
-    await mkdir(STARTUP_SNAPSHOT_DIR, { baseDir: BaseDirectory.AppLocalData, recursive: true });
+    await mkdir(STARTUP_SNAPSHOT_DIR, {
+      baseDir: BaseDirectory.AppLocalData,
+      recursive: true,
+    });
     await writeTextFile(`${STARTUP_SNAPSHOT_DIR}/${file}`, content, {
       baseDir: BaseDirectory.AppLocalData,
     });
   },
   read: (file) =>
-    readTextFile(`${STARTUP_SNAPSHOT_DIR}/${file}`, { baseDir: BaseDirectory.AppLocalData }),
+    readTextFile(`${STARTUP_SNAPSHOT_DIR}/${file}`, {
+      baseDir: BaseDirectory.AppLocalData,
+    }),
 };
 
 /**
@@ -3301,7 +3358,9 @@ export async function loadDroppedVectorFiles(
           // fallback for an overlay-only KML can return an empty collection, and
           // an empty vector layer alongside the overlay is just clutter.
           const vector = await loadBrowserVectorFile(file, [], options);
-          if (vector.data.features.length > 0) layers.push(vector);
+          if (vector.data.features.length > 0) {
+            layers.push(...splitKmlFolderLayers(vector.data, vector.path));
+          }
         } catch (error) {
           // Declining the oversized-vector prompt, or a genuine parse failure,
           // still leaves any ground overlays/models already added above (a real

--- a/tests/kml-folder-layers.test.ts
+++ b/tests/kml-folder-layers.test.ts
@@ -7,19 +7,14 @@ import { KML_FOLDER_PATH_PROPERTY } from "../apps/geolibre-desktop/src/lib/kml";
 // global at module-eval time; shim it before the dynamic import.
 (globalThis as { self?: unknown }).self ??= globalThis;
 
-type LoadedVectorLayer = {
-  data: FeatureCollection;
-  path: string;
-  name?: string;
-  groupPath?: string[];
-};
-type SplitKmlFolderLayers = (collection: FeatureCollection, path: string) => LoadedVectorLayer[];
+type SplitKmlFolderLayers =
+  typeof import("../apps/geolibre-desktop/src/lib/tauri-io").splitKmlFolderLayers;
 
 let splitKmlFolderLayers: SplitKmlFolderLayers;
 
 before(async () => {
   const mod = await import("../apps/geolibre-desktop/src/lib/tauri-io");
-  splitKmlFolderLayers = mod.splitKmlFolderLayers as unknown as SplitKmlFolderLayers;
+  splitKmlFolderLayers = mod.splitKmlFolderLayers;
 });
 
 /** A point placemark, optionally inside the given KML Folder ancestry. */

--- a/tests/kml-folder-layers.test.ts
+++ b/tests/kml-folder-layers.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import type { Feature, FeatureCollection } from "geojson";
+import { KML_FOLDER_PATH_PROPERTY } from "../apps/geolibre-desktop/src/lib/kml";
+
+// tauri-io statically pulls in shpjs, whose bundle reads the browser `self`
+// global at module-eval time; shim it before the dynamic import.
+(globalThis as { self?: unknown }).self ??= globalThis;
+
+type LoadedVectorLayer = {
+  data: FeatureCollection;
+  path: string;
+  name?: string;
+  groupPath?: string[];
+};
+type SplitKmlFolderLayers = (collection: FeatureCollection, path: string) => LoadedVectorLayer[];
+
+let splitKmlFolderLayers: SplitKmlFolderLayers;
+
+before(async () => {
+  const mod = await import("../apps/geolibre-desktop/src/lib/tauri-io");
+  splitKmlFolderLayers = mod.splitKmlFolderLayers as unknown as SplitKmlFolderLayers;
+});
+
+/** A point placemark, optionally inside the given KML Folder ancestry. */
+function placemark(name: string | undefined, folders?: string[]): Feature {
+  return {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: {
+      ...(name === undefined ? {} : { name }),
+      ...(folders ? { [KML_FOLDER_PATH_PROPERTY]: folders } : {}),
+    },
+  };
+}
+
+function collection(features: Feature[]): FeatureCollection {
+  return { type: "FeatureCollection", features };
+}
+
+describe("splitKmlFolderLayers", () => {
+  it("leaves a folderless collection as one layer", () => {
+    const input = collection([placemark("A"), placemark("B")]);
+    const layers = splitKmlFolderLayers(input, "tour.kml");
+
+    assert.equal(layers.length, 1);
+    assert.equal(layers[0]?.data, input);
+    assert.equal(layers[0]?.path, "tour.kml");
+    assert.equal(layers[0]?.groupPath, undefined);
+    assert.equal(layers[0]?.name, undefined);
+  });
+
+  it("gives each foldered placemark its own named layer and group path", () => {
+    const layers = splitKmlFolderLayers(
+      collection([
+        placemark("Point A", ["Project X", "Subfolder A"]),
+        placemark("Point A-1", ["Project X", "Subfolder A", "Subfolder A-1"]),
+      ]),
+      "tour.kml",
+    );
+
+    assert.equal(layers.length, 2);
+    // Store insertion is top-first, so the layers come back in reverse document
+    // order and the first placemark ends up on top.
+    assert.deepEqual(
+      layers.map((layer) => layer.name),
+      ["Point A-1", "Point A"],
+    );
+    assert.deepEqual(layers[0]?.groupPath, ["Project X", "Subfolder A", "Subfolder A-1"]);
+    assert.deepEqual(layers[1]?.groupPath, ["Project X", "Subfolder A"]);
+    assert.equal(layers[0]?.data.features.length, 1);
+    assert.equal(layers[1]?.path, "tour.kml");
+  });
+
+  it("names an unnamed placemark by its position in the document", () => {
+    const layers = splitKmlFolderLayers(
+      collection([placemark(undefined, ["Folder"]), placemark("  ", ["Folder"])]),
+      "tour.kml",
+    );
+
+    assert.deepEqual(
+      layers.map((layer) => layer.name),
+      ["Placemark 2", "Placemark 1"],
+    );
+  });
+
+  it("strips the internal folder property from the split features", () => {
+    const layers = splitKmlFolderLayers(collection([placemark("A", ["Folder"])]), "tour.kml");
+
+    assert.equal(layers[0]?.data.features[0]?.properties?.[KML_FOLDER_PATH_PROPERTY], undefined);
+    assert.equal(layers[0]?.data.features[0]?.properties?.name, "A");
+  });
+
+  it("keeps placemarks outside any folder merged into a single layer", () => {
+    const layers = splitKmlFolderLayers(
+      collection([
+        placemark("Flat 1"),
+        placemark("Foldered", ["Folder"]),
+        placemark("Flat 2"),
+        placemark("Flat 3"),
+      ]),
+      "tour.kml",
+    );
+
+    assert.equal(layers.length, 2);
+    // The merged layer is added first so the folders settle above it, and it
+    // carries no name so the import falls back to the file name.
+    assert.equal(layers[0]?.name, undefined);
+    assert.equal(layers[0]?.groupPath, undefined);
+    assert.deepEqual(
+      layers[0]?.data.features.map((feature) => feature.properties?.name),
+      ["Flat 1", "Flat 2", "Flat 3"],
+    );
+    assert.equal(layers[1]?.name, "Foldered");
+    assert.deepEqual(layers[1]?.groupPath, ["Folder"]);
+  });
+
+  it("ignores blank folder names", () => {
+    const layers = splitKmlFolderLayers(
+      collection([placemark("A", ["", "  "]), placemark("B", ["Folder"])]),
+      "tour.kml",
+    );
+
+    // "A" has no usable ancestry left, so it stays in the merged layer.
+    assert.equal(layers.length, 2);
+    assert.deepEqual(
+      layers[0]?.data.features.map((feature) => feature.properties?.name),
+      ["A"],
+    );
+    assert.deepEqual(layers[1]?.groupPath, ["Folder"]);
+  });
+});

--- a/tests/kml-folders.test.ts
+++ b/tests/kml-folders.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DOMParser } from "linkedom";
+import { KML_FOLDER_PATH_PROPERTY, parseKmlText } from "../apps/geolibre-desktop/src/lib/kml";
+
+globalThis.DOMParser = DOMParser as unknown as typeof globalThis.DOMParser;
+
+describe("KML folder metadata", () => {
+  it("records enclosing folders from outermost to innermost", () => {
+    const collection = parseKmlText(`
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Folder>
+            <name>Project X</name>
+            <Folder>
+              <name>Subfolder A</name>
+              <Placemark>
+                <name>Point A</name>
+                <Point><coordinates>2,47,0</coordinates></Point>
+              </Placemark>
+              <Folder>
+                <name>Subfolder A-1</name>
+                <Placemark>
+                  <name>Point A-1</name>
+                  <Point><coordinates>10,48,0</coordinates></Point>
+                </Placemark>
+              </Folder>
+            </Folder>
+          </Folder>
+        </Document>
+      </kml>
+    `);
+
+    assert.deepEqual(collection.features[0]?.properties?.[KML_FOLDER_PATH_PROPERTY], [
+      "Project X",
+      "Subfolder A",
+    ]);
+    assert.deepEqual(collection.features[1]?.properties?.[KML_FOLDER_PATH_PROPERTY], [
+      "Project X",
+      "Subfolder A",
+      "Subfolder A-1",
+    ]);
+  });
+
+  it("does not add internal metadata to a top-level placemark", () => {
+    const collection = parseKmlText(`
+      <kml xmlns="http://www.opengis.net/kml/2.2">
+        <Document>
+          <Placemark>
+            <name>Standalone</name>
+            <Point><coordinates>2,47</coordinates></Point>
+          </Placemark>
+        </Document>
+      </kml>
+    `);
+
+    assert.equal(collection.features[0]?.properties?.[KML_FOLDER_PATH_PROPERTY], undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve enclosing KML Folder ancestry while parsing placemarks
- create nested GeoLibre layer groups for KML and KMZ imports
- retain placemark and folder ordering from the source document
- add regression coverage for nested and top-level placemarks

Addresses discussion #2072.

## Verification

- imported the discussion's `Project X.kmz` in the real app
- confirmed `Project X`, `Subfolder A`, `Subfolder A-1`, and `Subfolder B` nesting in light and dark themes
- confirmed all three placemarks render with zero browser console errors
- `node --import tsx --test tests/kml-folders.test.ts`
- `npm run build`
- pre-commit hooks for all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imported KML and KMZ files now preserve nested folder structure, placemark order, and original names.
  * Maps automatically fit all layers imported from the same file.
  * Same-named folders from different files remain separate instead of merging.

* **Bug Fixes**
  * Corrected folder ancestry handling for nested imports.
  * Top-level placemarks no longer receive incorrect folder metadata.

* **Tests**
  * Added coverage for nested, top-level, folderless, and unnamed KML placemarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->