### PR TITLE
feat: add optional Google Analytics to the hosted sites

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -75,9 +75,27 @@ jobs:
           # up live collaboration; requires the workers/collab relay to be
           # deployed (see docs/collaboration.md).
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
+          # Google Analytics measurement ID for the demo app served under
+          # geolibre.app/demo/, so it reports to the same stream as the
+          # documentation pages around it. Only on the deploying push: a
+          # pull_request run builds the same site for a check, and analytics
+          # from an unpublished build would be noise. Unset (the default,
+          # including on every fork) ships no tracker. See analytics.ts.
+          VITE_GEOLIBRE_GA_MEASUREMENT_ID: >-
+            ${{ github.event_name != 'pull_request' && vars.GEOLIBRE_GA_MEASUREMENT_ID || '' }}
 
       - name: Build documentation
         run: zensical build --strict
+        env:
+          # Same measurement ID for the documentation itself. `provider` is a
+          # separate variable the theme keys its analytics partial off; it is
+          # derived here rather than configured, so setting the one repository
+          # variable GEOLIBRE_GA_MEASUREMENT_ID turns the whole site on. See the
+          # extra.analytics block in mkdocs.yml.
+          GEOLIBRE_ANALYTICS_PROVIDER: >-
+            ${{ github.event_name != 'pull_request' && vars.GEOLIBRE_GA_MEASUREMENT_ID != '' && 'google' || '' }}
+          GEOLIBRE_GA_MEASUREMENT_ID: >-
+            ${{ github.event_name != 'pull_request' && vars.GEOLIBRE_GA_MEASUREMENT_ID || '' }}
 
       - name: Add web demo to site
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,6 +52,42 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Resolve the analytics measurement ID
+        id: analytics
+        # One validated value for both builds below. A bare `!= ''` test would
+        # hand the documentation `provider: google` for anything non-empty,
+        # including a value the app's own resolveAnalyticsId rejects (a GTM
+        # container id, a stray quote), leaving the site loading a tag that
+        # reports nowhere. Same shape the app enforces, so a mistyped repository
+        # variable fails here instead: see MEASUREMENT_ID_PATTERN in
+        # apps/geolibre-desktop/src/lib/analytics.ts.
+        env:
+          RAW_MEASUREMENT_ID: ${{ vars.GEOLIBRE_GA_MEASUREMENT_ID }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          id=$(printf '%s' "${RAW_MEASUREMENT_ID:-}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+          if [ -n "$id" ] && ! printf '%s' "$id" | grep -Eq '^G-[A-Z0-9]{4,24}$'; then
+            echo "::error::GEOLIBRE_GA_MEASUREMENT_ID is not a GA4 measurement ID (G-...)."
+            exit 1
+          fi
+          # A pull_request run builds the same site as a check but publishes
+          # nothing, and analytics from an unpublished build would be noise.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            id=""
+          fi
+          if [ -n "$id" ]; then
+            echo "Analytics enabled for $id."
+            provider=google
+          else
+            echo "Analytics disabled (no measurement ID for this run)."
+            provider=""
+          fi
+          {
+            echo "measurement_id=$id"
+            echo "provider=$provider"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build web demo
         run: npm run build -w geolibre-desktop
         env:
@@ -77,25 +113,21 @@ jobs:
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
           # Google Analytics measurement ID for the demo app served under
           # geolibre.app/demo/, so it reports to the same stream as the
-          # documentation pages around it. Only on the deploying push: a
-          # pull_request run builds the same site for a check, and analytics
-          # from an unpublished build would be noise. Unset (the default,
-          # including on every fork) ships no tracker. See analytics.ts.
-          VITE_GEOLIBRE_GA_MEASUREMENT_ID: >-
-            ${{ github.event_name != 'pull_request' && vars.GEOLIBRE_GA_MEASUREMENT_ID || '' }}
+          # documentation pages around it. Empty (the default, including on
+          # every fork and on pull_request runs) ships no tracker; see the
+          # resolve step above and analytics.ts.
+          VITE_GEOLIBRE_GA_MEASUREMENT_ID: ${{ steps.analytics.outputs.measurement_id }}
 
       - name: Build documentation
         run: zensical build --strict
         env:
           # Same measurement ID for the documentation itself. `provider` is a
           # separate variable the theme keys its analytics partial off; it is
-          # derived here rather than configured, so setting the one repository
-          # variable GEOLIBRE_GA_MEASUREMENT_ID turns the whole site on. See the
-          # extra.analytics block in mkdocs.yml.
-          GEOLIBRE_ANALYTICS_PROVIDER: >-
-            ${{ github.event_name != 'pull_request' && vars.GEOLIBRE_GA_MEASUREMENT_ID != '' && 'google' || '' }}
-          GEOLIBRE_GA_MEASUREMENT_ID: >-
-            ${{ github.event_name != 'pull_request' && vars.GEOLIBRE_GA_MEASUREMENT_ID || '' }}
+          # derived by the resolve step rather than configured, so setting the
+          # one repository variable GEOLIBRE_GA_MEASUREMENT_ID turns the whole
+          # site on. See the extra.analytics block in mkdocs.yml.
+          GEOLIBRE_ANALYTICS_PROVIDER: ${{ steps.analytics.outputs.provider }}
+          GEOLIBRE_GA_MEASUREMENT_ID: ${{ steps.analytics.outputs.measurement_id }}
 
       - name: Add web demo to site
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -64,10 +64,16 @@ jobs:
         env:
           RAW_MEASUREMENT_ID: ${{ vars.GEOLIBRE_GA_MEASUREMENT_ID }}
           EVENT_NAME: ${{ github.event_name }}
+        shell: bash
         run: |
           set -euo pipefail
-          id=$(printf '%s' "${RAW_MEASUREMENT_ID:-}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
-          if [ -n "$id" ] && ! printf '%s' "$id" | grep -Eq '^G-[A-Z0-9]{4,24}$'; then
+          # Trim the ends only, the way the app's own resolveAnalyticsId does.
+          # Deleting *all* whitespace would quietly repair "G-AB CD1234" into a
+          # value that passes, which is the paste error this step exists to
+          # catch. The bash regex matches the whole string, so an embedded
+          # newline fails it rather than matching one line of several.
+          id=$(printf '%s' "${RAW_MEASUREMENT_ID:-}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:lower:]' '[:upper:]')
+          if [ -n "$id" ] && [[ ! $id =~ ^G-[A-Z0-9]{4,24}$ ]]; then
             echo "::error::GEOLIBRE_GA_MEASUREMENT_ID is not a GA4 measurement ID (G-...)."
             exit 1
           fi

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -57,6 +57,32 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Resolve the analytics measurement ID
+        id: analytics
+        # Validated against the same shape the app enforces, so a mistyped
+        # repository variable fails the deploy instead of publishing a tag that
+        # reports nowhere (MEASUREMENT_ID_PATTERN in
+        # apps/geolibre-desktop/src/lib/analytics.ts). This site is its own
+        # domain, so GEOLIBRE_WEB_GA_MEASUREMENT_ID can point it at a separate
+        # GA4 data stream; without it web.geolibre.app reports to the same
+        # stream as geolibre.app. Empty is the normal case and ships no tracker
+        # at all (as do the desktop, Docker, and Jupyter wheel builds).
+        env:
+          RAW_MEASUREMENT_ID: ${{ vars.GEOLIBRE_WEB_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
+        run: |
+          set -euo pipefail
+          id=$(printf '%s' "${RAW_MEASUREMENT_ID:-}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+          if [ -n "$id" ] && ! printf '%s' "$id" | grep -Eq '^G-[A-Z0-9]{4,24}$'; then
+            echo "::error::The GA measurement ID variable is not a GA4 measurement ID (G-...)."
+            exit 1
+          fi
+          if [ -n "$id" ]; then
+            echo "Analytics enabled for $id."
+          else
+            echo "Analytics disabled (no measurement ID configured)."
+          fi
+          echo "measurement_id=$id" >> "$GITHUB_OUTPUT"
+
       - name: Build the web app
         # geolibre-desktop's prebuild hook builds the embed package and runs
         # build-jupyterlite.mjs before Vite, so the published app includes the
@@ -71,14 +97,9 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           VITE_MAPILLARY_ACCESS_TOKEN: ${{ secrets.VITE_MAPILLARY_ACCESS_TOKEN || vars.VITE_MAPILLARY_ACCESS_TOKEN }}
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
-          # Google Analytics measurement ID, baked into the client bundle. Unset
-          # is the normal case and ships no tracker at all (desktop, Docker, the
-          # Jupyter wheel, and every fork build). See analytics.ts. This site is
-          # its own domain, so GEOLIBRE_WEB_GA_MEASUREMENT_ID can point it at a
-          # separate GA4 data stream; without it web.geolibre.app reports to the
-          # same stream as geolibre.app.
-          VITE_GEOLIBRE_GA_MEASUREMENT_ID: >-
-            ${{ vars.GEOLIBRE_WEB_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
+          # Google Analytics measurement ID, baked into the client bundle by the
+          # resolve step above. See analytics.ts.
+          VITE_GEOLIBRE_GA_MEASUREMENT_ID: ${{ steps.analytics.outputs.measurement_id }}
 
       - name: Prepare the site for GitHub Pages
         working-directory: apps/geolibre-desktop/dist

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -71,6 +71,14 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
           VITE_MAPILLARY_ACCESS_TOKEN: ${{ secrets.VITE_MAPILLARY_ACCESS_TOKEN || vars.VITE_MAPILLARY_ACCESS_TOKEN }}
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
+          # Google Analytics measurement ID, baked into the client bundle. Unset
+          # is the normal case and ships no tracker at all (desktop, Docker, the
+          # Jupyter wheel, and every fork build). See analytics.ts. This site is
+          # its own domain, so GEOLIBRE_WEB_GA_MEASUREMENT_ID can point it at a
+          # separate GA4 data stream; without it web.geolibre.app reports to the
+          # same stream as geolibre.app.
+          VITE_GEOLIBRE_GA_MEASUREMENT_ID: >-
+            ${{ vars.GEOLIBRE_WEB_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
 
       - name: Prepare the site for GitHub Pages
         working-directory: apps/geolibre-desktop/dist

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -69,10 +69,16 @@ jobs:
         # at all (as do the desktop, Docker, and Jupyter wheel builds).
         env:
           RAW_MEASUREMENT_ID: ${{ vars.GEOLIBRE_WEB_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
+        shell: bash
         run: |
           set -euo pipefail
-          id=$(printf '%s' "${RAW_MEASUREMENT_ID:-}" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
-          if [ -n "$id" ] && ! printf '%s' "$id" | grep -Eq '^G-[A-Z0-9]{4,24}$'; then
+          # Trim the ends only, the way the app's own resolveAnalyticsId does.
+          # Deleting *all* whitespace would quietly repair "G-AB CD1234" into a
+          # value that passes, which is the paste error this step exists to
+          # catch. The bash regex matches the whole string, so an embedded
+          # newline fails it rather than matching one line of several.
+          id=$(printf '%s' "${RAW_MEASUREMENT_ID:-}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr '[:lower:]' '[:upper:]')
+          if [ -n "$id" ] && [[ ! $id =~ ^G-[A-Z0-9]{4,24}$ ]]; then
             echo "::error::The GA measurement ID variable is not a GA4 measurement ID (G-...)."
             exit 1
           fi

--- a/apps/geolibre-desktop/src/lib/analytics.ts
+++ b/apps/geolibre-desktop/src/lib/analytics.ts
@@ -1,0 +1,119 @@
+// Optional Google Analytics (GA4) for the *hosted web builds* only.
+//
+// The tracker is off unless a measurement ID is configured at build time, so
+// the desktop app, the Jupyter embed wheel, the Docker image, and every local
+// or fork build ship without it. See resolveAnalyticsId for why that gate is
+// a build fact rather than a runtime one. Only opengeos' own Pages deploys
+// (geolibre.app/demo/ and web.geolibre.app) pass the variable, and the privacy
+// policy documents that (docs/privacy.md).
+//
+// Deliberately not wired into `docker/entrypoint.sh`: the container serves a
+// CSP whose script-src does not allow googletagmanager.com, so a runtime value
+// would be published into geolibre-runtime-config.js and then silently blocked
+// by the browser. Reading through readDeploymentEnvValue keeps the usual
+// precedence if that ever changes.
+
+import { readDeploymentEnvValue, type EnvRecord } from "./deployment-env";
+
+export const GA_MEASUREMENT_ID_ENV = "VITE_GEOLIBRE_GA_MEASUREMENT_ID";
+
+/** id of the injected <script>, used to keep installation idempotent. */
+const GA_SCRIPT_ID = "geolibre-google-analytics";
+
+// GA4 measurement IDs are "G-" plus an uppercase alphanumeric stream token
+// (10 characters today, but the length is not contractual). Validated because
+// the value is interpolated into a script URL: anything that is not this shape
+// is a paste error, and refusing it beats loading a tag that reports nowhere.
+const MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]{4,24}$/;
+
+/** The globals gtag.js expects to find already present. */
+interface AnalyticsWindow {
+  dataLayer?: unknown[];
+}
+
+/**
+ * Resolve the Google Analytics measurement ID for a hosted web deployment.
+ *
+ * A missing or malformed ID leaves analytics completely disabled.
+ *
+ * @param webApp - Whether this is the hosted web build. Must be derived from
+ *   the build target alone, exactly as `resolveAuthGate` requires: a runtime
+ *   signal the visitor controls (`?embed=1`) must not decide whether a
+ *   deployment's analytics run, and the desktop/embed builds must never load a
+ *   tracker even if a stray variable was present when they were compiled.
+ * @param deploymentEnv - Runtime env; defaults to the value on `window`.
+ * @param buildEnv - Build-time env; defaults to `import.meta.env`.
+ * @returns The normalized `G-…` measurement ID, or undefined when unset.
+ */
+export function resolveAnalyticsId(
+  webApp: boolean,
+  deploymentEnv?: EnvRecord,
+  buildEnv?: EnvRecord,
+): string | undefined {
+  if (!webApp) return undefined;
+  const value = readDeploymentEnvValue(GA_MEASUREMENT_ID_ENV, deploymentEnv, buildEnv)?.trim();
+  if (!value) return undefined;
+  // Measurement IDs are issued uppercase; accept a lowercased paste rather than
+  // rejecting a value that is otherwise exactly right.
+  const id = value.toUpperCase();
+  if (!MEASUREMENT_ID_PATTERN.test(id)) {
+    console.error(
+      `[GeoLibre] Ignoring ${GA_MEASUREMENT_ID_ENV}: ${value} is not a GA4 measurement ID (G-…).`,
+    );
+    return undefined;
+  }
+  return id;
+}
+
+/**
+ * Load gtag.js and configure it for one measurement ID.
+ *
+ * This is the standard Google tag snippet, written out so the bundle carries no
+ * analytics dependency: seed `dataLayer`, queue the `js`/`config` calls, then
+ * append the remote script, which drains the queue once it loads. Safe to call
+ * more than once: a second call with the tag already present is a no-op, so
+ * React StrictMode's double-invoke and dev HMR do not stack tags.
+ *
+ * @param id - A validated measurement ID from {@link resolveAnalyticsId}.
+ * @param doc - Document to install into; defaults to the ambient one.
+ */
+export function installAnalytics(id: string, doc: Document = document): void {
+  if (doc.getElementById(GA_SCRIPT_ID)) return;
+  const view = (doc.defaultView ?? globalThis) as AnalyticsWindow;
+  const dataLayer = (view.dataLayer ??= []);
+  // gtag.js replays each queued entry as an `arguments` object rather than an
+  // array, so this stays a function declaration (an arrow function has none)
+  // and pushes `arguments` instead of its rest parameters.
+  function gtag(_command: string, ..._args: unknown[]): void {
+    // eslint-disable-next-line prefer-rest-params
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+  gtag("config", id);
+
+  const script = doc.createElement("script");
+  script.id = GA_SCRIPT_ID;
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(id)}`;
+  (doc.head ?? doc.documentElement).appendChild(script);
+}
+
+/**
+ * Install analytics when this deployment has configured a measurement ID.
+ *
+ * The single entry point called at startup; arguments carry the same meaning as
+ * in {@link resolveAnalyticsId}.
+ *
+ * @returns The measurement ID that was installed, or undefined when analytics
+ *   are off, which is the normal case for every build but the hosted ones.
+ */
+export function startAnalytics(
+  webApp: boolean,
+  deploymentEnv?: EnvRecord,
+  buildEnv?: EnvRecord,
+): string | undefined {
+  const id = resolveAnalyticsId(webApp, deploymentEnv, buildEnv);
+  if (!id) return undefined;
+  installAnalytics(id);
+  return id;
+}

--- a/apps/geolibre-desktop/src/lib/analytics.ts
+++ b/apps/geolibre-desktop/src/lib/analytics.ts
@@ -1,11 +1,18 @@
 // Optional Google Analytics (GA4) for the *hosted web builds* only.
 //
-// The tracker is off unless a measurement ID is configured at build time, so
-// the desktop app, the Jupyter embed wheel, the Docker image, and every local
-// or fork build ship without it. See resolveAnalyticsId for why that gate is
-// a build fact rather than a runtime one. Only opengeos' own Pages deploys
-// (geolibre.app/demo/ and web.geolibre.app) pass the variable, and the privacy
-// policy documents that (docs/privacy.md).
+// The tracker is off unless a measurement ID is configured at build time, and
+// only opengeos' own Pages deploys (geolibre.app/demo/ and web.geolibre.app)
+// pass one, so the desktop app, the Jupyter embed wheel, the Docker image, and
+// every local or fork build have no ID compiled in and load nothing. Note the
+// desktop installers bundle the very same Vite output as the web app, so this
+// module is *present* in them (a few hundred bytes of inert code); what keeps
+// it dark there is the missing ID plus the webApp gate below, not tree shaking.
+// See resolveAnalyticsId for why that gate is a build fact rather than a
+// runtime one, and docs/privacy.md for what the hosted sites report.
+//
+// The two deploy workflows validate the measurement ID against the same shape
+// this module enforces, so a mistyped repository variable fails the deploy
+// instead of publishing a tag that reports nowhere.
 //
 // Deliberately not wired into `docker/entrypoint.sh`: the container serves a
 // CSP whose script-src does not allow googletagmanager.com, so a runtime value
@@ -29,6 +36,7 @@ const MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]{4,24}$/;
 /** The globals gtag.js expects to find already present. */
 interface AnalyticsWindow {
   dataLayer?: unknown[];
+  location?: { origin: string; pathname: string };
 }
 
 /**
@@ -88,8 +96,26 @@ export function installAnalytics(id: string, doc: Document = document): void {
     // eslint-disable-next-line prefer-rest-params
     dataLayer.push(arguments);
   }
+  // What gets reported as the page: origin + path, never the query string. A
+  // GeoLibre URL carries the visitor's work in its parameters (`?url=` a project,
+  // `?data=` an inline dataset, a collaboration session id, a shared-settings
+  // URL), and gtag would otherwise send the whole address as `page_location`.
+  // The privacy policy promises analytics never see the data you load, so the
+  // query is dropped here rather than trusted to a property-side setting.
+  //
+  // `set` applies to every later event as well, which covers the page_view that
+  // GA4's enhanced measurement fires on a history change: the app rewrites its
+  // own URL (a collaboration session, a sign-in return), and this is a
+  // single-page app whose path never changes, so pinning the value is right.
+  const location = view.location;
+  const pageLocation = location ? `${location.origin}${location.pathname}` : undefined;
+  const pageView = pageLocation ? { page_location: pageLocation } : {};
+  gtag("set", pageView);
   gtag("js", new Date());
-  gtag("config", id);
+  // send_page_view: false suppresses the automatic view, which would carry the
+  // raw URL; the explicit event below replaces it with the trimmed one.
+  gtag("config", id, { ...pageView, send_page_view: false });
+  gtag("event", "page_view", pageView);
 
   const script = doc.createElement("script");
   script.id = GA_SCRIPT_ID;

--- a/apps/geolibre-desktop/src/lib/analytics.ts
+++ b/apps/geolibre-desktop/src/lib/analytics.ts
@@ -40,6 +40,20 @@ interface AnalyticsWindow {
 }
 
 /**
+ * Strip the query and fragment from an absolute URL.
+ *
+ * @returns `origin` + `pathname`, or undefined when the value does not parse.
+ */
+function pageOf(url: string): string | undefined {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Resolve the Google Analytics measurement ID for a hosted web deployment.
  *
  * A missing or malformed ID leaves analytics completely disabled.
@@ -107,9 +121,19 @@ export function installAnalytics(id: string, doc: Document = document): void {
   // GA4's enhanced measurement fires on a history change: the app rewrites its
   // own URL (a collaboration session, a sign-in return), and this is a
   // single-page app whose path never changes, so pinning the value is right.
+  //
+  // The referrer needs the same treatment. Left alone, gtag.js reads
+  // `document.referrer`, and a link followed inside the site (the docs page or
+  // the demo that sent the visitor here) carries that page's own query. Setting
+  // it explicitly overrides what gtag would have derived; omitted when there is
+  // no referrer, which is what gtag would report anyway.
   const location = view.location;
   const pageLocation = location ? `${location.origin}${location.pathname}` : undefined;
-  const pageView = pageLocation ? { page_location: pageLocation } : {};
+  const referrer = doc.referrer ? pageOf(doc.referrer) : undefined;
+  const pageView = {
+    ...(pageLocation ? { page_location: pageLocation } : {}),
+    ...(referrer ? { page_referrer: referrer } : {}),
+  };
   gtag("set", pageView);
   gtag("js", new Date());
   // send_page_view: false suppresses the automatic view, which would carry the

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -62,6 +62,7 @@ import "./lib/auth-return-url-boot";
 // lazily imported, so `i18nReady` resolves once the initial locale's catalog has
 // loaded and init has run — the render below awaits it.
 import i18n, { AVAILABLE_LANGUAGES, i18nReady, setActiveLanguage } from "./i18n";
+import { startAnalytics } from "./lib/analytics";
 import { installDiagnosticsCapture } from "./lib/diagnostics";
 import { isTauri } from "./lib/is-tauri";
 import { installStaleChunkReload } from "./lib/stale-chunk-reload";
@@ -119,6 +120,10 @@ installStaleChunkReload();
 // `isEmbedded()` — that returns true for a plain `?embed=1` query parameter, so
 // any visitor could disable a configured sign-in wall by typing a URL.
 const isHostedWebApp = !isTauri() && !__GEOLIBRE_EMBED_BUILD__;
+// Google Analytics, if this deployment was built with a measurement ID (only
+// the geolibre.app and web.geolibre.app Pages deploys are, see analytics.ts).
+// A no-op in every other build, so nothing is loaded and nothing is sent.
+startAnalytics(isHostedWebApp);
 // Clerk or Auth0, whichever this deployment configured (neither, normally).
 const authGate = resolveAuthGate(isHostedWebApp);
 if (authGate) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -596,6 +596,7 @@ Where to find the output:
 | `GEOLIBRE_STORE_BUILD` | unset | Set `1` for Microsoft Store MSIX builds (removes in-app updater). |
 | `GEOLIBRE_MAS_BUILD` | unset | Set `1` for Mac App Store builds (removes sidecar/server features). |
 | `GEOLIBRE_EMBED` | unset | Set `1` for the Jupyter embed wheel build. |
+| `VITE_GEOLIBRE_GA_MEASUREMENT_ID` | unset | Set a GA4 measurement ID (`G-…`) to load Google Analytics in the **web** build. Unset ships no analytics code at all, which is the default for every build; the desktop and Jupyter embed builds ignore it entirely. Used only by the hosted geolibre.app and web.geolibre.app deploys; see [Privacy Policy](privacy.md#website-analytics). |
 
 Example — build with no external CDN dependencies:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,7 +133,7 @@ New to GeoLibre? Start with the [User Guide](user-guide/interface.md) for a feat
 GeoLibre Web is the full browser version of the GeoLibre app, ready to use with nothing to install. It is great for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, adding URL-based layers, styling layers, and testing plugins. Desktop-only file dialogs, local MBTiles, local raster reads, and filesystem save/open operations still require the installed Tauri app.
 
 !!! note "Hosted on GitHub Pages, private by design"
-    GeoLibre Web is a static site deployed on GitHub Pages and runs entirely in your browser. It has no analytics and no server account, and the data you load is processed client-side in your browser session. Data leaves your browser only when you choose to add a remote URL or explicitly share a project.
+    GeoLibre Web is a static site deployed on GitHub Pages and runs entirely in your browser. There is no server account, and the data you load is processed client-side in your browser session. Data leaves your browser only when you choose to add a remote URL or explicitly share a project. The hosted site measures page visits with Google Analytics, which never sees the data you load (see the [Privacy Policy](privacy.md#website-analytics)). A build you host yourself has no analytics at all.
 
     If your data cannot be public at all, run the same web build on your own server next to your data. See [Self-Hosting & Private Data](self-hosting.md).
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -64,15 +64,19 @@ your browser. It is governed by [Google's privacy policy](https://policies.googl
 
 What analytics never sees is the geospatial data you work with: layers, files,
 project contents, queries, and coordinates are processed in your browser and are
-not sent to Google.
+not sent to Google. The page address we report is trimmed to the site and path
+(for example `https://web.geolibre.app/`), with the query string removed, because
+a GeoLibre link can carry a project URL, an inline dataset, or a collaboration
+session identifier in its parameters.
 
 You can opt out by blocking `www.googletagmanager.com` with a content blocker or
 your browser's tracking protection; GeoLibre Web works normally with analytics
 blocked.
 
 Analytics run only on the sites we host. The desktop app, the Jupyter widget, the
-Docker image, and any build you host yourself contain no analytics code: the
-measurement ID is supplied at build time and is absent from those builds (see
+Docker image, and any build you host yourself never load or run them: the
+measurement ID is supplied at build time and is absent from those builds, so
+nothing is requested from Google and nothing is reported (see
 [Self-Hosting](self-hosting.md)).
 
 ## Personal information

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -73,11 +73,12 @@ You can opt out by blocking `www.googletagmanager.com` with a content blocker or
 your browser's tracking protection; GeoLibre Web works normally with analytics
 blocked.
 
-Analytics run only on the sites we host. The desktop app, the Jupyter widget, the
-Docker image, and any build you host yourself never load or run them: the
-measurement ID is supplied at build time and is absent from those builds, so
-nothing is requested from Google and nothing is reported (see
-[Self-Hosting](self-hosting.md)).
+Analytics run only on the sites we host. The desktop app, the Jupyter widget, and
+the Docker image never load or run them: the measurement ID is supplied at build
+time and is absent from those builds, so nothing is requested from Google and
+nothing is reported. A copy you build and host yourself is the same unless you
+deliberately supply a measurement ID of your own at build time, in which case the
+analytics are yours, not ours (see [Self-Hosting](self-hosting.md)).
 
 ## Personal information
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,16 +1,21 @@
 # Privacy Policy
 
-_Last updated: June 21, 2026_
+_Last updated: August 23, 2026_
 
 GeoLibre Desktop ("GeoLibre", "the app") is an open-source desktop GIS
 application developed by the OpenGeos community. This policy explains how the app
-handles your data.
+handles your data, and how our websites (geolibre.app and web.geolibre.app)
+handle yours.
 
 ## Summary
 
-GeoLibre runs locally on your device. It does not require an account, and it does
-not collect analytics, telemetry, or usage data. Your geospatial data and
-projects stay on your device unless you choose to share or export them.
+GeoLibre runs locally on your device. It does not require an account, and the
+app itself does not collect analytics, telemetry, or usage data. Your geospatial
+data and projects stay on your device unless you choose to share or export them.
+
+Our websites are separate from the app: geolibre.app and web.geolibre.app measure
+page visits with Google Analytics, as described under
+[Website analytics](#website-analytics) below.
 
 Your use of the app is also governed by our [Terms of Service](terms.md).
 
@@ -45,6 +50,30 @@ the request you make, and are governed by their own privacy policies:
 
 GeoLibre does not control these third-party services; please review their privacy
 policies for how they handle data.
+
+## Website analytics
+
+This section covers our websites, not the installed app.
+
+The documentation site (<https://geolibre.app>) and the hosted browser app
+(<https://web.geolibre.app>, and the demo at <https://geolibre.app/demo/>) use
+Google Analytics 4 to count page visits and see which pages are used. Google
+receives your IP address, the page you are on, the referring page, and general
+device/browser information, and sets its own cookies or similar identifiers in
+your browser. It is governed by [Google's privacy policy](https://policies.google.com/privacy).
+
+What analytics never sees is the geospatial data you work with: layers, files,
+project contents, queries, and coordinates are processed in your browser and are
+not sent to Google.
+
+You can opt out by blocking `www.googletagmanager.com` with a content blocker or
+your browser's tracking protection; GeoLibre Web works normally with analytics
+blocked.
+
+Analytics run only on the sites we host. The desktop app, the Jupyter widget, the
+Docker image, and any build you host yourself contain no analytics code: the
+measurement ID is supplied at build time and is absent from those builds (see
+[Self-Hosting](self-hosting.md)).
 
 ## Personal information
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -377,7 +377,7 @@ the public internet:
 | AI assistant | Off unless configured | Leave `GEOLIBRE_AI_URL` unset, or route it through your own proxy. |
 | Project sharing | `share.geolibre.app` | `GEOLIBRE_SHARE_URL=off`, or your own [projects server](server-api.md). |
 | Collaboration | Off unless configured | Leave `GEOLIBRE_COLLAB_URL` unset, or run `workers/collab-node` yourself. |
-| Telemetry | None | GeoLibre collects no analytics or usage data. The hosted sites (geolibre.app, web.geolibre.app) run Google Analytics, but that is a build-time option the Docker image and every build from source leave off: it is enabled only by setting `VITE_GEOLIBRE_GA_MEASUREMENT_ID` when running `npm run build`, and there is no runtime variable that turns it on. See [Privacy Policy](privacy.md). |
+| Telemetry | None | GeoLibre collects no analytics or usage data. The hosted sites (geolibre.app, web.geolibre.app) run Google Analytics, but nothing you deploy does. The Docker image **cannot** turn it on: the `Dockerfile` declares no build argument for it, and the container's CSP does not allow `googletagmanager.com`. A build from source can, by setting `VITE_GEOLIBRE_GA_MEASUREMENT_ID` for `npm run build` with your own measurement ID; there is no runtime variable that enables it. See [Privacy Policy](privacy.md). |
 
 ## Deployment checklist
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -377,7 +377,7 @@ the public internet:
 | AI assistant | Off unless configured | Leave `GEOLIBRE_AI_URL` unset, or route it through your own proxy. |
 | Project sharing | `share.geolibre.app` | `GEOLIBRE_SHARE_URL=off`, or your own [projects server](server-api.md). |
 | Collaboration | Off unless configured | Leave `GEOLIBRE_COLLAB_URL` unset, or run `workers/collab-node` yourself. |
-| Telemetry | None | GeoLibre collects no analytics or usage data. See [Privacy Policy](privacy.md). |
+| Telemetry | None | GeoLibre collects no analytics or usage data. The hosted sites (geolibre.app, web.geolibre.app) run Google Analytics, but that is a build-time option the Docker image and every build from source leave off: it is enabled only by setting `VITE_GEOLIBRE_GA_MEASUREMENT_ID` when running `npm run build`, and there is no runtime variable that turns it on. See [Privacy Policy](privacy.md). |
 
 ## Deployment checklist
 

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -4,7 +4,7 @@ GeoLibre's browser build can be embedded in any web page and configured through 
 
 ## The live viewer
 
-The browser build is hosted at `https://web.geolibre.app/`. It is a static site deployed on GitHub Pages that runs entirely in your browser: it has no analytics and no server account, and the data you load is processed client-side. Data leaves your browser only when you add a remote URL or explicitly share a project.
+The browser build is hosted at `https://web.geolibre.app/`. It is a static site deployed on GitHub Pages that runs entirely in your browser: there is no server account, and the data you load is processed client-side. The hosted site counts page visits with Google Analytics, which never sees the data you load (see the [Privacy Policy](../privacy.md#website-analytics)); a copy you host yourself has no analytics at all. Data leaves your browser only when you add a remote URL or explicitly share a project.
 
 Open a public project by passing its `.geolibre.json` URL with the `url` parameter:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,18 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
+  # Google Analytics for geolibre.app, configured entirely from the environment
+  # so the tracker only loads where a measurement ID is set: the production
+  # Pages deploy. A local `zensical build`, a fork, and a PR preview leave these
+  # unset and ship no tracker, which is also why the ID is not hard-coded here.
+  #
+  # `provider` is a second variable because the theme keys the whole integration
+  # off it: with a provider and a blank property it would still load gtag.js,
+  # pointed at nothing. .github/workflows/pages.yml derives it from
+  # GEOLIBRE_GA_MEASUREMENT_ID, so an operator only ever sets that one value.
+  analytics:
+    provider: !ENV [GEOLIBRE_ANALYTICS_PROVIDER, ""]
+    property: !ENV [GEOLIBRE_GA_MEASUREMENT_ID, ""]
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/opengeos/GeoLibre

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -10,10 +10,29 @@ import {
 
 const ID = "G-ABC1234567";
 
+/** A hosted URL carrying the kind of query GeoLibre puts in its own links. */
+const SENSITIVE_URL = {
+  origin: "https://web.geolibre.app",
+  pathname: "/",
+  search: "?url=https://example.com/secret-project.geolibre.json&session=abc123",
+};
+
 /** A document with the globals gtag.js seeds, as a browser page would have. */
 function makeDocument() {
   const { document } = parseHTML("<!doctype html><html><head></head><body></body></html>");
+  // linkedom leaves `location` undefined; analytics reads origin and pathname
+  // from it to build the page it reports.
+  Object.defineProperty(document.defaultView, "location", {
+    value: SENSITIVE_URL,
+    configurable: true,
+  });
   return document as unknown as Document;
+}
+
+/** The queued gtag calls, each as a plain array. */
+function queue(doc: Document): unknown[][] {
+  const { dataLayer } = doc.defaultView as unknown as { dataLayer: IArguments[] };
+  return dataLayer.map((entry) => Array.from(entry));
 }
 
 /** The GA script tag installed into `doc`, if any. */
@@ -67,19 +86,46 @@ describe("analytics installation", () => {
     assert.equal(script.src, `https://www.googletagmanager.com/gtag/js?id=${ID}`);
     assert.equal(script.async, true);
 
-    const { dataLayer } = doc.defaultView as unknown as { dataLayer: IArguments[] };
-    // The queue gtag.js drains on load: the `js` timestamp, then `config`.
+    // The queue gtag.js drains on load: the page default, the `js` timestamp,
+    // the configuration, then the one page view we send ourselves.
+    const calls = queue(doc);
     assert.deepEqual(
-      dataLayer.map((entry) => Array.from(entry)[0]),
-      ["js", "config"],
+      calls.map((call) => call[0]),
+      ["set", "js", "config", "event"],
     );
-    assert.deepEqual(Array.from(dataLayer[1]), ["config", ID]);
+    assert.deepEqual(calls[2], [
+      "config",
+      ID,
+      { page_location: "https://web.geolibre.app/", send_page_view: false },
+    ]);
+    assert.deepEqual(calls[3], [
+      "event",
+      "page_view",
+      { page_location: "https://web.geolibre.app/" },
+    ]);
 
     // A second call (StrictMode's double-invoke, or dev HMR) must not stack a
     // second tag or re-queue the configuration.
     installAnalytics(ID, doc);
     assert.equal(doc.querySelectorAll("script[src*='googletagmanager']").length, 1);
-    assert.equal(dataLayer.length, 2);
+    assert.equal(queue(doc).length, 4);
+  });
+
+  it("never reports the query string", () => {
+    // A GeoLibre link carries the visitor's work in its parameters (a project
+    // URL, an inline dataset, a collaboration session), so nothing queued for
+    // Google may contain the query, including the automatic page view that
+    // `send_page_view: false` suppresses.
+    const doc = makeDocument();
+    installAnalytics(ID, doc);
+    const queued = JSON.stringify(queue(doc));
+    assert.ok(!queued.includes("secret-project"), queued);
+    assert.ok(!queued.includes("session=abc123"), queued);
+    assert.ok(!queued.includes("?"), queued);
+    for (const call of queue(doc)) {
+      if (call[0] === "config")
+        assert.equal((call[2] as Record<string, unknown>).send_page_view, false);
+    }
   });
 });
 

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it, mock } from "node:test";
+import { parseHTML } from "linkedom";
+import {
+  GA_MEASUREMENT_ID_ENV,
+  installAnalytics,
+  resolveAnalyticsId,
+  startAnalytics,
+} from "../apps/geolibre-desktop/src/lib/analytics";
+
+const ID = "G-ABC1234567";
+
+/** A document with the globals gtag.js seeds, as a browser page would have. */
+function makeDocument() {
+  const { document } = parseHTML("<!doctype html><html><head></head><body></body></html>");
+  return document as unknown as Document;
+}
+
+/** The GA script tag installed into `doc`, if any. */
+function tag(doc: Document): HTMLScriptElement | null {
+  return doc.querySelector("script[src*='googletagmanager']");
+}
+
+describe("analytics configuration", () => {
+  it("stays off when no measurement ID is configured", () => {
+    assert.equal(resolveAnalyticsId(true, {}, {}), undefined);
+    assert.equal(resolveAnalyticsId(true, { [GA_MEASUREMENT_ID_ENV]: "  " }, {}), undefined);
+  });
+
+  it("reads the measurement ID from either env tier", () => {
+    assert.equal(resolveAnalyticsId(true, { [GA_MEASUREMENT_ID_ENV]: ID }, {}), ID);
+    assert.equal(resolveAnalyticsId(true, {}, { [GA_MEASUREMENT_ID_ENV]: ID }), ID);
+  });
+
+  it("normalizes a lowercased measurement ID", () => {
+    assert.equal(resolveAnalyticsId(true, { [GA_MEASUREMENT_ID_ENV]: ID.toLowerCase() }, {}), ID);
+  });
+
+  it("refuses a value that is not a GA4 measurement ID", () => {
+    const error = mock.method(console, "error", () => {});
+    try {
+      // A Universal Analytics property, a tag manager container, and a value
+      // that would smuggle a query parameter into the script URL.
+      for (const value of ["UA-12345-1", "GTM-ABCD123", "G-ABC1234567&x=1"]) {
+        assert.equal(resolveAnalyticsId(true, { [GA_MEASUREMENT_ID_ENV]: value }, {}), undefined);
+      }
+      assert.equal(error.mock.callCount(), 3);
+    } finally {
+      error.mock.restore();
+    }
+  });
+
+  it("stays off outside the hosted web build even when configured", () => {
+    // The desktop shell and the Jupyter embed wheel pass webApp: false, so a
+    // measurement ID left in the build environment must not load a tracker.
+    assert.equal(resolveAnalyticsId(false, { [GA_MEASUREMENT_ID_ENV]: ID }, {}), undefined);
+  });
+});
+
+describe("analytics installation", () => {
+  it("seeds dataLayer and appends the tag once", () => {
+    const doc = makeDocument();
+    installAnalytics(ID, doc);
+
+    const script = tag(doc);
+    assert.ok(script, "gtag.js was not appended");
+    assert.equal(script.src, `https://www.googletagmanager.com/gtag/js?id=${ID}`);
+    assert.equal(script.async, true);
+
+    const { dataLayer } = doc.defaultView as unknown as { dataLayer: IArguments[] };
+    // The queue gtag.js drains on load: the `js` timestamp, then `config`.
+    assert.deepEqual(
+      dataLayer.map((entry) => Array.from(entry)[0]),
+      ["js", "config"],
+    );
+    assert.deepEqual(Array.from(dataLayer[1]), ["config", ID]);
+
+    // A second call (StrictMode's double-invoke, or dev HMR) must not stack a
+    // second tag or re-queue the configuration.
+    installAnalytics(ID, doc);
+    assert.equal(doc.querySelectorAll("script[src*='googletagmanager']").length, 1);
+    assert.equal(dataLayer.length, 2);
+  });
+});
+
+describe("analytics startup", () => {
+  /** Run `body` with a document in scope, as the browser entry point has. */
+  function withDocument(body: (doc: Document) => void) {
+    const doc = makeDocument();
+    const globals = globalThis as { document?: Document };
+    const previous = globals.document;
+    globals.document = doc;
+    try {
+      body(doc);
+    } finally {
+      if (previous) globals.document = previous;
+      else delete globals.document;
+    }
+  }
+
+  it("installs the tag for a configured hosted web build", () => {
+    withDocument((doc) => {
+      assert.equal(startAnalytics(true, { [GA_MEASUREMENT_ID_ENV]: ID }, {}), ID);
+      assert.ok(tag(doc));
+    });
+  });
+
+  it("installs nothing when analytics are not configured", () => {
+    withDocument((doc) => {
+      assert.equal(startAnalytics(true, {}, {}), undefined);
+      assert.equal(tag(doc), null);
+    });
+  });
+});

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -17,6 +17,10 @@ const SENSITIVE_URL = {
   search: "?url=https://example.com/secret-project.geolibre.json&session=abc123",
 };
 
+/** The page that linked here, itself carrying a project in its query. */
+const SENSITIVE_REFERRER =
+  "https://geolibre.app/demo/?url=https://example.com/private.geolibre.json";
+
 /** A document with the globals gtag.js seeds, as a browser page would have. */
 function makeDocument() {
   const { document } = parseHTML("<!doctype html><html><head></head><body></body></html>");
@@ -24,6 +28,10 @@ function makeDocument() {
   // from it to build the page it reports.
   Object.defineProperty(document.defaultView, "location", {
     value: SENSITIVE_URL,
+    configurable: true,
+  });
+  Object.defineProperty(document, "referrer", {
+    value: SENSITIVE_REFERRER,
     configurable: true,
   });
   return document as unknown as Document;
@@ -93,16 +101,12 @@ describe("analytics installation", () => {
       calls.map((call) => call[0]),
       ["set", "js", "config", "event"],
     );
-    assert.deepEqual(calls[2], [
-      "config",
-      ID,
-      { page_location: "https://web.geolibre.app/", send_page_view: false },
-    ]);
-    assert.deepEqual(calls[3], [
-      "event",
-      "page_view",
-      { page_location: "https://web.geolibre.app/" },
-    ]);
+    const page = {
+      page_location: "https://web.geolibre.app/",
+      page_referrer: "https://geolibre.app/demo/",
+    };
+    assert.deepEqual(calls[2], ["config", ID, { ...page, send_page_view: false }]);
+    assert.deepEqual(calls[3], ["event", "page_view", page]);
 
     // A second call (StrictMode's double-invoke, or dev HMR) must not stack a
     // second tag or re-queue the configuration.
@@ -111,16 +115,18 @@ describe("analytics installation", () => {
     assert.equal(queue(doc).length, 4);
   });
 
-  it("never reports the query string", () => {
+  it("never reports the query string, of this page or the referring one", () => {
     // A GeoLibre link carries the visitor's work in its parameters (a project
     // URL, an inline dataset, a collaboration session), so nothing queued for
     // Google may contain the query, including the automatic page view that
-    // `send_page_view: false` suppresses.
+    // `send_page_view: false` suppresses and the referrer gtag would otherwise
+    // read from the document itself.
     const doc = makeDocument();
     installAnalytics(ID, doc);
     const queued = JSON.stringify(queue(doc));
     assert.ok(!queued.includes("secret-project"), queued);
     assert.ok(!queued.includes("session=abc123"), queued);
+    assert.ok(!queued.includes("private.geolibre.json"), queued);
     assert.ok(!queued.includes("?"), queued);
     for (const call of queue(doc)) {
       if (call[0] === "config")


### PR DESCRIPTION
## Summary

- Adds Google Analytics 4 to geolibre.app (Zensical `extra.analytics`, configured entirely from the environment) and to the browser app at web.geolibre.app (new `apps/geolibre-desktop/src/lib/analytics.ts`, gated on `VITE_GEOLIBRE_GA_MEASUREMENT_ID`).
- The tracker loads only where a measurement ID is set. The desktop app, the Jupyter embed wheel, the Docker image, PR preview builds, and every local or fork build ship no analytics code path at all; the app-side gate is the existing build-time `isHostedWebApp` flag, never a runtime signal a visitor controls.
- Updates the privacy policy (new "Website analytics" section separating the app from the hosted sites) and the three other pages that stated the hosted sites carry no analytics.

To enable: set the repository variable `GEOLIBRE_GA_MEASUREMENT_ID`. Optionally set `GEOLIBRE_WEB_GA_MEASUREMENT_ID` to point web.geolibre.app at its own GA4 data stream; without it that site reports to the same stream as geolibre.app.

## Test plan

- [x] `tests/analytics.test.ts`: resolution across both env tiers, rejection of non-GA4 values, off outside the hosted web build, idempotent installation, startup wiring.
- [x] `npm run test:frontend:coverage` passes the coverage gate; the new module reports 100% lines and functions.
- [x] Real browser check against a production build served by `vite preview`: with the ID set, `googletagmanager.com/gtag/js?id=...` is requested and `dataLayer` holds the `js` and `config` entries; rebuilt without the ID, no request is made and `dataLayer` stays empty.
- [x] `zensical build --strict` with and without the variables: the tag is emitted only when they are set.
- [x] `npm run typecheck` (full build) and `pre-commit run --files ...` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Google Analytics tracking for hosted web and documentation builds.
  * Analytics can be enabled through build-time configuration and remains disabled for desktop, self-hosted, pull-request, and unconfigured builds.
  * Tracking excludes loaded geospatial data and query parameters from reported page locations.
  * Added validation for analytics configuration to prevent invalid measurement IDs.

* **Documentation**
  * Updated privacy, self-hosting, embedding, and setup documentation to explain analytics behavior, data handling, and opt-out options.

* **Tests**
  * Added coverage for analytics configuration, validation, installation, and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->