### PR TITLE
fix: read the GA measurement ID from a secret as well as a variable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,7 +62,14 @@ jobs:
         # variable fails here instead: see MEASUREMENT_ID_PATTERN in
         # apps/geolibre-desktop/src/lib/analytics.ts.
         env:
-          RAW_MEASUREMENT_ID: ${{ vars.GEOLIBRE_GA_MEASUREMENT_ID }}
+          # Accepted as either a repository variable or a secret, the way
+          # VITE_MAPILLARY_ACCESS_TOKEN is below: a GA4 measurement ID is public
+          # by construction (it ships in the page source), so a variable is the
+          # natural home, but it is a reasonable thing to have typed into the
+          # secrets page and there is no reason to reject it there. Supplied as
+          # a secret it is masked in this job's log, so the step reports "***"
+          # rather than the ID.
+          RAW_MEASUREMENT_ID: ${{ secrets.GEOLIBRE_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
           EVENT_NAME: ${{ github.event_name }}
         shell: bash
         run: |

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -68,7 +68,12 @@ jobs:
         # stream as geolibre.app. Empty is the normal case and ships no tracker
         # at all (as do the desktop, Docker, and Jupyter wheel builds).
         env:
-          RAW_MEASUREMENT_ID: ${{ vars.GEOLIBRE_WEB_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
+          # Either name works as a repository variable or a secret (see the
+          # matching step in pages.yml). Supplied as a secret it is masked in
+          # this job's log, so the step reports "***" rather than the ID.
+          RAW_MEASUREMENT_ID: >-
+            ${{ secrets.GEOLIBRE_WEB_GA_MEASUREMENT_ID || vars.GEOLIBRE_WEB_GA_MEASUREMENT_ID
+            || secrets.GEOLIBRE_GA_MEASUREMENT_ID || vars.GEOLIBRE_GA_MEASUREMENT_ID }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- `GEOLIBRE_GA_MEASUREMENT_ID` and `GEOLIBRE_WEB_GA_MEASUREMENT_ID` are configured as repository **secrets**, but both deploy workflows read only `vars.*`. Every build since #2076 therefore resolved an empty ID and published no tag, which is why no Google tag is detectable on either site.
- Both resolve steps now accept either source, in the same `secrets.X || vars.X` order `VITE_MAPILLARY_ACCESS_TOKEN` already uses in these workflows. A measurement ID is public by construction, so a variable remains the natural home; there is just no reason to reject one typed into the secrets page.
- Supplied as a secret the value is masked in the job log, so the step reports `Analytics enabled for ***.` rather than the ID. Validation still runs against the real value.

## Test plan

- [ ] Merge, then confirm the resolve step in the Deploy Website and Deploy web.geolibre.app runs prints `Analytics enabled` instead of `Analytics disabled`.
- [ ] `curl -s https://geolibre.app/ | grep -c googletagmanager` returns a non-zero count.
- [ ] Load https://web.geolibre.app/ and confirm the request to `googletagmanager.com/gtag/js?id=G-...`, and that GA4 Realtime records the visit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Analytics configuration can now be provided through repository secrets or variables.
  * Secrets take precedence when both values are available.
  * Analytics settings are consistently applied across website deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->