### PR TITLE
Add configurable startup map view

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -378,7 +378,7 @@ function cloneDesktopSettings(settings: DesktopSettings): DraftDesktopSettings {
       hiddenMenuItems: [...settings.uiProfile.hiddenMenuItems],
     },
     updates: { ...settings.updates },
-    startup: { ...settings.startup },
+    startup: { ...settings.startup, center: [...settings.startup.center] },
   };
 }
 
@@ -1113,6 +1113,23 @@ export function SettingsDialog({
       startup: { ...current.startup, ...patch },
     }));
     setError(null);
+  };
+
+  // Ignore a cleared field (valueAsNumber is NaN) so it does not silently fall
+  // back to the hardcoded default on save; the last valid value is kept.
+  const updateStartupCenterValue = (index: 0 | 1, value: number) => {
+    if (!Number.isFinite(value)) return;
+    setDraftDesktopSettings((current) => {
+      const center: StartupSettings["center"] = [...current.startup.center];
+      center[index] = value;
+      return { ...current, startup: { ...current.startup, center } };
+    });
+    setError(null);
+  };
+
+  const updateStartupZoom = (value: number) => {
+    if (!Number.isFinite(value)) return;
+    updateDraftStartupSettings({ zoom: value });
   };
 
   const chooseStartupProject = async () => {
@@ -3015,12 +3032,7 @@ export function SettingsDialog({
                           step="0.000001"
                           value={draftDesktopSettings.startup.center[0]}
                           onChange={(event) =>
-                            updateDraftStartupSettings({
-                              center: [
-                                event.target.valueAsNumber,
-                                draftDesktopSettings.startup.center[1],
-                              ],
-                            })
+                            updateStartupCenterValue(0, event.target.valueAsNumber)
                           }
                         />
                       </div>
@@ -3036,12 +3048,7 @@ export function SettingsDialog({
                           step="0.000001"
                           value={draftDesktopSettings.startup.center[1]}
                           onChange={(event) =>
-                            updateDraftStartupSettings({
-                              center: [
-                                draftDesktopSettings.startup.center[0],
-                                event.target.valueAsNumber,
-                              ],
-                            })
+                            updateStartupCenterValue(1, event.target.valueAsNumber)
                           }
                         />
                       </div>
@@ -3054,9 +3061,7 @@ export function SettingsDialog({
                           max={24}
                           step={0.25}
                           value={draftDesktopSettings.startup.zoom}
-                          onChange={(event) =>
-                            updateDraftStartupSettings({ zoom: event.target.valueAsNumber })
-                          }
+                          onChange={(event) => updateStartupZoom(event.target.valueAsNumber)}
                         />
                       </div>
                     </div>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1130,6 +1130,18 @@ export function SettingsDialog({
     }
   };
 
+  const applyCurrentStartupView = () => {
+    const view = mapControllerRef.current?.readView();
+    if (!view) {
+      setError(t("settings.startup.viewUnavailable"));
+      return;
+    }
+    updateDraftStartupSettings({
+      center: [roundCoordinate(view.center[0]), roundCoordinate(view.center[1])],
+      zoom: Number(view.zoom.toFixed(2)),
+    });
+  };
+
   // Live updates from the Settings dropdown's Interface submenu (not the draft,
   // which only the dialog commits on Save). Reads the latest state so rapid
   // toggles do not clobber each other.
@@ -2972,6 +2984,83 @@ export function SettingsDialog({
                       </span>
                     </span>
                   </label>
+                  <div className="space-y-3 rounded-md border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <p className="text-sm">{t("settings.startup.defaultView")}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {t("settings.startup.defaultViewHint")}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={applyCurrentStartupView}
+                      >
+                        <Crosshair className="h-3.5 w-3.5" />
+                        {t("settings.startup.useCurrentView")}
+                      </Button>
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="settings-startup-longitude">
+                          {t("settings.startup.longitude")}
+                        </Label>
+                        <Input
+                          id="settings-startup-longitude"
+                          type="number"
+                          min={-180}
+                          max={180}
+                          step="0.000001"
+                          value={draftDesktopSettings.startup.center[0]}
+                          onChange={(event) =>
+                            updateDraftStartupSettings({
+                              center: [
+                                event.target.valueAsNumber,
+                                draftDesktopSettings.startup.center[1],
+                              ],
+                            })
+                          }
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="settings-startup-latitude">
+                          {t("settings.startup.latitude")}
+                        </Label>
+                        <Input
+                          id="settings-startup-latitude"
+                          type="number"
+                          min={-90}
+                          max={90}
+                          step="0.000001"
+                          value={draftDesktopSettings.startup.center[1]}
+                          onChange={(event) =>
+                            updateDraftStartupSettings({
+                              center: [
+                                draftDesktopSettings.startup.center[0],
+                                event.target.valueAsNumber,
+                              ],
+                            })
+                          }
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="settings-startup-zoom">{t("settings.startup.zoom")}</Label>
+                        <Input
+                          id="settings-startup-zoom"
+                          type="number"
+                          min={0}
+                          max={24}
+                          step={0.25}
+                          value={draftDesktopSettings.startup.zoom}
+                          onChange={(event) =>
+                            updateDraftStartupSettings({ zoom: event.target.valueAsNumber })
+                          }
+                        />
+                      </div>
+                    </div>
+                  </div>
                 </div>
               ) : null}
               {effectiveSection === "updates" ? (

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -1,4 +1,8 @@
-import { isAllowedPluginManifestUrl } from "@geolibre/core";
+import {
+  createDefaultMapView,
+  isAllowedPluginManifestUrl,
+  normalizeMapViewState,
+} from "@geolibre/core";
 import { useEffect } from "react";
 import { create } from "zustand";
 import { normalizeStringList } from "../lib/string-lists";
@@ -95,6 +99,10 @@ export interface StartupSettings {
   projectName: string | null;
   /** Projection used when startup does not restore or receive a project. */
   globeByDefault: boolean;
+  /** Center used for the untitled workspace when no project is provided. */
+  center: [number, number];
+  /** Zoom used for the untitled workspace when no project is provided. */
+  zoom: number;
 }
 
 export interface ThemeSettings {
@@ -205,6 +213,8 @@ export const DEFAULT_STARTUP_SETTINGS: StartupSettings = {
   projectPath: null,
   projectName: null,
   globeByDefault: true,
+  center: [...createDefaultMapView().center],
+  zoom: createDefaultMapView().zoom,
 };
 
 export const DEFAULT_THEME_SETTINGS: ThemeSettings = {
@@ -270,6 +280,12 @@ export function normalizeDesktopSettings(settings: unknown): DesktopSettings {
 function normalizeStartupSettings(startup: unknown): StartupSettings {
   if (!startup || typeof startup !== "object") return DEFAULT_STARTUP_SETTINGS;
   const candidate = startup as Partial<StartupSettings>;
+  const view = normalizeMapViewState({
+    center: candidate.center,
+    zoom: candidate.zoom,
+    bearing: 0,
+    pitch: 0,
+  });
   const mode: StartupProjectMode =
     candidate.mode === "last" || candidate.mode === "specific" ? candidate.mode : "default";
   const projectPath =
@@ -285,6 +301,8 @@ function normalizeStartupSettings(startup: unknown): StartupSettings {
     projectPath,
     projectName,
     globeByDefault: typeof candidate.globeByDefault === "boolean" ? candidate.globeByDefault : true,
+    center: view.center,
+    zoom: view.zoom,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useStartupProject.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupProject.ts
@@ -1,10 +1,10 @@
-import { useAppStore, type MapProjection } from "@geolibre/core";
+import { useAppStore, type MapProjection, type MapViewState } from "@geolibre/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { dataUrlParameters, serviceUrlParameter } from "../lib/data-url";
 import { isTauri } from "../lib/is-tauri";
 import { projectUrlFromLocation } from "../lib/project-url";
-import { planStartup, startupDefaultProjection, type StartupPlan } from "../lib/startup-project";
+import { planStartup, startupDefaultWorkspace, type StartupPlan } from "../lib/startup-project";
 import { openRecentProjectFile, RecentProjectGoneError } from "../lib/tauri-io";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 import { DEFAULT_STARTUP_SETTINGS, useDesktopSettingsStore } from "./useDesktopSettings";
@@ -63,12 +63,19 @@ function currentStartupPlan(): StartupPlan {
   });
 }
 
-/** Seed the empty workspace's projection, without marking the project dirty. */
-function applyDefaultProjection(projection: MapProjection): void {
+/** Seed the empty workspace's camera and projection without marking the project dirty. */
+function applyDefaultWorkspace(
+  workspace: Pick<MapViewState, "center" | "zoom"> & { projection: MapProjection },
+): void {
   useAppStore.setState((state) => ({
+    mapView: {
+      ...state.mapView,
+      center: [...workspace.center],
+      zoom: workspace.zoom,
+    },
     preferences: {
       ...state.preferences,
-      map: { ...state.preferences.map, projection },
+      map: { ...state.preferences.map, projection: workspace.projection },
     },
   }));
 }
@@ -97,7 +104,7 @@ export function useStartupProject(): {
   // rendered, and re-running the initializer would set the same value.
   const [restoring, setRestoring] = useState(() => {
     const plan = currentStartupPlan();
-    if (plan.kind === "default") applyDefaultProjection(plan.projection);
+    if (plan.kind === "default") applyDefaultWorkspace(plan);
     return plan.kind === "restore";
   });
 
@@ -108,7 +115,7 @@ export function useStartupProject(): {
     const path = plan.path;
     const settings = useDesktopSettingsStore.getState().desktopSettings.startup;
     const openDefaultWorkspace = () => {
-      applyDefaultProjection(startupDefaultProjection(settings));
+      applyDefaultWorkspace(startupDefaultWorkspace(settings));
       setRestoring(false);
     };
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1987,6 +1987,13 @@
       "noProjectSelected": "No project selected",
       "globeByDefault": "Enable 3D globe by default",
       "globeByDefaultHint": "Used for the untitled workspace when no startup project or project link is provided.",
+      "defaultView": "Default map view",
+      "defaultViewHint": "Set the center and zoom for the untitled workspace.",
+      "longitude": "Center longitude",
+      "latitude": "Center latitude",
+      "zoom": "Zoom level",
+      "useCurrentView": "Use Current View",
+      "viewUnavailable": "The current map view is unavailable.",
       "selectError": "The selected project could not be read.",
       "restoring": "Opening your startup project…",
       "loadWarning": "The startup project is unavailable. GeoLibre opened the default workspace instead."

--- a/apps/geolibre-desktop/src/lib/startup-project.ts
+++ b/apps/geolibre-desktop/src/lib/startup-project.ts
@@ -1,4 +1,4 @@
-import type { MapProjection } from "@geolibre/core";
+import type { MapProjection, MapViewState } from "@geolibre/core";
 import type { StartupSettings } from "../hooks/useDesktopSettings";
 
 /**
@@ -45,6 +45,17 @@ export function startupDefaultProjection(settings: StartupSettings): MapProjecti
   return settings.globeByDefault ? "globe" : "mercator";
 }
 
+/** Camera and projection for the empty workspace shown when no project is provided. */
+export function startupDefaultWorkspace(
+  settings: StartupSettings,
+): Pick<MapViewState, "center" | "zoom"> & { projection: MapProjection } {
+  return {
+    projection: startupDefaultProjection(settings),
+    center: [...settings.center],
+    zoom: settings.zoom,
+  };
+}
+
 /**
  * What a launch has to settle before the shell may mount.
  *
@@ -59,7 +70,7 @@ export function startupDefaultProjection(settings: StartupSettings): MapProjecti
 export type StartupPlan =
   | { kind: "payload" }
   | { kind: "restore"; path: string }
-  | { kind: "default"; projection: MapProjection };
+  | ({ kind: "default" } & ReturnType<typeof startupDefaultWorkspace>);
 
 /**
  * Decide a launch's startup plan.
@@ -85,7 +96,7 @@ export function planStartup(options: {
     ? startupProjectPath(options.settings, options.recentProjects)
     : null;
   if (path) return { kind: "restore", path };
-  return { kind: "default", projection: startupDefaultProjection(options.settings) };
+  return { kind: "default", ...startupDefaultWorkspace(options.settings) };
 }
 
 /**

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -78,7 +78,7 @@ The project name is edited in place on the right of the toolbar, and it is saved
 | **Reopen the last project** | Open the most recently used *local* project. |
 | **Open a specific project** | Always open one chosen project. Use **Choose Project** to pick the file; the mode stays unavailable until you have. |
 
-**Enable 3D globe by default** controls the projection of the new, untitled workspace shown when no project is provided. Turn it off to start that workspace in Mercator. A restored project or project link always uses the projection saved in that project instead.
+**Enable 3D globe by default** controls the projection of the new, untitled workspace shown when no project is provided. Turn it off to start that workspace in Mercator. **Default map view** sets the center longitude, center latitude, and zoom level for the same workspace. Choose **Use Current View** to copy the center and zoom from the map canvas. A restored project or project link always uses the projection and camera saved in that project instead.
 
 If the startup project has been moved or deleted, GeoLibre opens the default workspace instead, says so in a banner, and drops the missing file from the recent-projects list.
 

--- a/tests/startup-project-settings.test.ts
+++ b/tests/startup-project-settings.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   planStartup,
   startupDefaultProjection,
+  startupDefaultWorkspace,
   startupProjectPath,
   startupSettingsAfterForcedSaveAs,
 } from "../apps/geolibre-desktop/src/lib/startup-project";
@@ -18,6 +19,8 @@ describe("startup project settings", () => {
       projectPath: null,
       projectName: null,
       globeByDefault: true,
+      center: [-100, 40],
+      zoom: 2,
     });
   });
 
@@ -29,6 +32,8 @@ describe("startup project settings", () => {
           projectPath: " /tmp/field.geolibre.json ",
           projectName: " Field ",
           globeByDefault: false,
+          center: [-84.388, 33.749],
+          zoom: 10.25,
         },
       }).startup,
       {
@@ -36,6 +41,8 @@ describe("startup project settings", () => {
         projectPath: "/tmp/field.geolibre.json",
         projectName: "Field",
         globeByDefault: false,
+        center: [-84.388, 33.749],
+        zoom: 10.25,
       },
     );
   });
@@ -45,6 +52,19 @@ describe("startup project settings", () => {
     assert.equal(
       normalizeDesktopSettings({ startup: { globeByDefault: "no" } }).startup.globeByDefault,
       true,
+    );
+  });
+
+  it("normalizes the empty-workspace camera", () => {
+    assert.deepEqual(normalizeDesktopSettings({ startup: {} }).startup.center, [-100, 40]);
+    assert.equal(normalizeDesktopSettings({ startup: {} }).startup.zoom, 2);
+    assert.deepEqual(
+      normalizeDesktopSettings({ startup: { center: [-240, 120], zoom: 30 } }).startup.center,
+      [-180, 90],
+    );
+    assert.equal(
+      normalizeDesktopSettings({ startup: { center: [-84, 34], zoom: -4 } }).startup.zoom,
+      0,
     );
   });
 
@@ -66,6 +86,20 @@ describe("startupDefaultProjection", () => {
     assert.equal(
       startupDefaultProjection({ ...DEFAULT_STARTUP_SETTINGS, globeByDefault: false }),
       "mercator",
+    );
+  });
+});
+
+describe("startupDefaultWorkspace", () => {
+  it("uses the configured empty-workspace camera", () => {
+    assert.deepEqual(
+      startupDefaultWorkspace({
+        ...DEFAULT_STARTUP_SETTINGS,
+        globeByDefault: false,
+        center: [-84.388, 33.749],
+        zoom: 11.5,
+      }),
+      { projection: "mercator", center: [-84.388, 33.749], zoom: 11.5 },
     );
   });
 });
@@ -114,7 +148,12 @@ describe("planStartup", () => {
           settings: { ...pinned, globeByDefault },
           recentProjects: recent(PINNED),
         }),
-        { kind: "default", projection: globeByDefault ? "globe" : "mercator" },
+        {
+          kind: "default",
+          projection: globeByDefault ? "globe" : "mercator",
+          center: [-100, 40],
+          zoom: 2,
+        },
       );
     }
   });
@@ -128,7 +167,7 @@ describe("planStartup", () => {
         settings: { ...DEFAULT_STARTUP_SETTINGS, mode: "last" },
         recentProjects: [],
       }),
-      { kind: "default", projection: "globe" },
+      { kind: "default", projection: "globe", center: [-100, 40], zoom: 2 },
     );
     assert.deepEqual(
       planStartup({
@@ -137,7 +176,7 @@ describe("planStartup", () => {
         settings: { ...DEFAULT_STARTUP_SETTINGS, globeByDefault: false },
         recentProjects: recent(PINNED),
       }),
-      { kind: "default", projection: "mercator" },
+      { kind: "default", projection: "mercator", center: [-100, 40], zoom: 2 },
     );
   });
 });
@@ -157,6 +196,7 @@ describe("startupProjectPath", () => {
     assert.equal(
       startupProjectPath(
         {
+          ...DEFAULT_STARTUP_SETTINGS,
           mode: "specific",
           projectPath: "/tmp/pinned.geolibre.json",
           projectName: "Pinned",
@@ -171,7 +211,7 @@ describe("startupProjectPath", () => {
   it("reopens the most recent project in last mode", () => {
     assert.equal(
       startupProjectPath(
-        { mode: "last", projectPath: null, projectName: null, globeByDefault: true },
+        { ...DEFAULT_STARTUP_SETTINGS, mode: "last" },
         recent("/tmp/newest.geolibre.json", "/tmp/older.geolibre.json"),
       ),
       "/tmp/newest.geolibre.json",
@@ -184,7 +224,7 @@ describe("startupProjectPath", () => {
     // setting's own copy ("most recently used local project") does not promise.
     assert.equal(
       startupProjectPath(
-        { mode: "last", projectPath: null, projectName: null, globeByDefault: true },
+        { ...DEFAULT_STARTUP_SETTINGS, mode: "last" },
         recent("https://share.geolibre.app/p/abc", "/tmp/local.geolibre.json"),
       ),
       "/tmp/local.geolibre.json",
@@ -199,10 +239,7 @@ describe("startupProjectPath", () => {
     const uri =
       "content://com.android.externalstorage.documents/document/primary%3ADocuments%2Fjson%2FGeneral_Project.geolibre.json";
     assert.equal(
-      startupProjectPath(
-        { mode: "last", projectPath: null, projectName: null, globeByDefault: true },
-        recent(uri),
-      ),
+      startupProjectPath({ ...DEFAULT_STARTUP_SETTINGS, mode: "last" }, recent(uri)),
       uri,
     );
   });
@@ -210,7 +247,7 @@ describe("startupProjectPath", () => {
   it("restores nothing when every recent project is remote", () => {
     assert.equal(
       startupProjectPath(
-        { mode: "last", projectPath: null, projectName: null, globeByDefault: true },
+        { ...DEFAULT_STARTUP_SETTINGS, mode: "last" },
         recent("https://share.geolibre.app/p/abc"),
       ),
       null,
@@ -218,13 +255,7 @@ describe("startupProjectPath", () => {
   });
 
   it("restores nothing in last mode with no history", () => {
-    assert.equal(
-      startupProjectPath(
-        { mode: "last", projectPath: null, projectName: null, globeByDefault: true },
-        [],
-      ),
-      null,
-    );
+    assert.equal(startupProjectPath({ ...DEFAULT_STARTUP_SETTINGS, mode: "last" }, []), null);
   });
 });
 
@@ -240,11 +271,21 @@ describe("startupSettingsAfterForcedSaveAs", () => {
   it("follows a pinned project to the document the save actually created", () => {
     assert.deepEqual(
       startupSettingsAfterForcedSaveAs(
-        { mode: "specific", projectPath: PICKED, projectName: "General", globeByDefault: true },
+        {
+          ...DEFAULT_STARTUP_SETTINGS,
+          mode: "specific",
+          projectPath: PICKED,
+          projectName: "General",
+        },
         PICKED,
         CREATED,
       ),
-      { mode: "specific", projectPath: CREATED, projectName: "General", globeByDefault: true },
+      {
+        ...DEFAULT_STARTUP_SETTINGS,
+        mode: "specific",
+        projectPath: CREATED,
+        projectName: "General",
+      },
     );
   });
 
@@ -252,6 +293,7 @@ describe("startupSettingsAfterForcedSaveAs", () => {
     assert.equal(
       startupSettingsAfterForcedSaveAs(
         {
+          ...DEFAULT_STARTUP_SETTINGS,
           mode: "specific",
           projectPath: "/tmp/pinned.geolibre.json",
           projectName: "Pinned",
@@ -267,7 +309,7 @@ describe("startupSettingsAfterForcedSaveAs", () => {
   it("does nothing for the modes that resolve a path of their own", () => {
     assert.equal(
       startupSettingsAfterForcedSaveAs(
-        { mode: "last", projectPath: null, projectName: null, globeByDefault: true },
+        { ...DEFAULT_STARTUP_SETTINGS, mode: "last" },
         PICKED,
         CREATED,
       ),
@@ -280,7 +322,12 @@ describe("startupSettingsAfterForcedSaveAs", () => {
     // The desktop case: a plain Save writes the file it opened, every time.
     assert.equal(
       startupSettingsAfterForcedSaveAs(
-        { mode: "specific", projectPath: PICKED, projectName: "General", globeByDefault: true },
+        {
+          ...DEFAULT_STARTUP_SETTINGS,
+          mode: "specific",
+          projectPath: PICKED,
+          projectName: "General",
+        },
         PICKED,
         PICKED,
       ),
@@ -288,7 +335,12 @@ describe("startupSettingsAfterForcedSaveAs", () => {
     );
     assert.equal(
       startupSettingsAfterForcedSaveAs(
-        { mode: "specific", projectPath: PICKED, projectName: "General", globeByDefault: true },
+        {
+          ...DEFAULT_STARTUP_SETTINGS,
+          mode: "specific",
+          projectPath: PICKED,
+          projectName: "General",
+        },
         null,
         CREATED,
       ),

--- a/tests/startup-project-snapshot.test.ts
+++ b/tests/startup-project-snapshot.test.ts
@@ -30,6 +30,8 @@ function settings(patch: Partial<StartupSettings> = {}): StartupSettings {
     projectPath: null,
     projectName: null,
     globeByDefault: true,
+    center: [-100, 40],
+    zoom: 2,
     ...patch,
   };
 }


### PR DESCRIPTION
## Summary

- add persisted center and zoom settings for the untitled startup workspace
- add a Use Current View button that captures the live map canvas camera
- apply the saved camera together with the startup projection without overriding restored projects or project links
- document the new controls and cover normalization and startup planning with tests

## Testing

- `npm run test:frontend`
- `npm run build`
- `pre-commit run --all-files`
- verified the settings and reload flow in a real browser with no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable default map views for new untitled workspaces.
  * Users can set longitude, latitude, and zoom or apply the current map view.
  * Saved projects now restore their complete map view, including camera position and zoom.

* **Bug Fixes**
  * Invalid map coordinates and zoom values are safely ignored or constrained to valid ranges.
  * Added handling when the current map view is unavailable.

* **Documentation**
  * Updated the settings guide with information about configuring default map views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->