### PR TITLE
feat: add Earth Engine layers to Python API

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -57,23 +57,28 @@ m.add_tile_layer(
     attribution="(c) OpenStreetMap contributors",
 )
 m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
-
-# Earth Engine layers need `pip install earthengine-api` and credentials
-# (run `ee.Authenticate()` once, if you have not already).
-import ee
-ee.Authenticate()
-ee.Initialize(project="your-google-cloud-project")
-m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
-
 m.add_basemap("dark")
 m.set_center(-120, 47, zoom=8)
 ```
 
+Google Earth Engine layers are optional and need `pip install earthengine-api`
+plus credentials (`ee.Authenticate()` once, then a Google Cloud project):
+
+```python
+import ee
+
+ee.Authenticate()  # once per machine
+ee.Initialize(project="your-google-cloud-project")
+m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
+```
+
 `add_ee_layer` evaluates the Earth Engine object in the kernel and adds the
 resulting tile URL as a raster layer (ImageCollections are mosaicked, vector
-objects are styled into raster tiles with `vis_params`). That URL is tied to an
-Earth Engine map id that expires, so a saved project may need the Earth Engine
-layer regenerated when it is reopened.
+objects are styled into raster tiles — for those, `vis_params` takes
+`ee.FeatureCollection.style()` keys such as `color`, `fillColor`, `width`, and
+`pointSize`, not image keys). That URL is tied to an Earth Engine map id that
+expires, so a saved project may need the Earth Engine layer regenerated when it
+is reopened.
 
 `add_raster` / `add_cog` also accept a **local** GeoTIFF path on the kernel host:
 the file is served by the bundled localhost server so the app can read it. This

--- a/docs/python.md
+++ b/docs/python.md
@@ -78,7 +78,8 @@ objects are styled into raster tiles — for those, `vis_params` takes
 `ee.FeatureCollection.style()` keys such as `color`, `fillColor`, `width`, and
 `pointSize`, not image keys). That URL is tied to an Earth Engine map id that
 expires, so a saved project may need the Earth Engine layer regenerated when it
-is reopened.
+is reopened. The result is a plain raster tile layer, not one of the live layers
+the app's own Earth Engine panel manages.
 
 `add_raster` / `add_cog` also accept a **local** GeoTIFF path on the kernel host:
 the file is served by the bundled localhost server so the app can read it. This

--- a/docs/python.md
+++ b/docs/python.md
@@ -57,9 +57,23 @@ m.add_tile_layer(
     attribution="(c) OpenStreetMap contributors",
 )
 m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
+
+# Earth Engine layers need `pip install earthengine-api` and credentials
+# (run `ee.Authenticate()` once, if you have not already).
+import ee
+ee.Authenticate()
+ee.Initialize(project="your-google-cloud-project")
+m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
+
 m.add_basemap("dark")
 m.set_center(-120, 47, zoom=8)
 ```
+
+`add_ee_layer` evaluates the Earth Engine object in the kernel and adds the
+resulting tile URL as a raster layer (ImageCollections are mosaicked, vector
+objects are styled into raster tiles with `vis_params`). That URL is tied to an
+Earth Engine map id that expires, so a saved project may need the Earth Engine
+layer regenerated when it is reopened.
 
 `add_raster` / `add_cog` also accept a **local** GeoTIFF path on the kernel host:
 the file is served by the bundled localhost server so the app can read it. This
@@ -240,6 +254,7 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add a vector tile layer from a TileJSON endpoint. |
 | `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
+| `add_ee_layer(ee_object, vis_params=, name=, shown=, opacity=)` | Add an authenticated Google Earth Engine object as raster tiles (needs `earthengine-api`). |
 | `add_wms(endpoint, layers, name=, styles=, image_format=, transparent=, tile_size=, **style)` | Add a WMS layer (GetMap, tiled raster). |
 | `add_wmts(url, name=, tile_size=, **style)` | Add a WMTS layer from a tile URL template. |
 | `add_wfs(endpoint, type_name, name=, version=, output_format=, srs_name=, max_features=, **style)` | Add a WFS layer (GetFeature GeoJSON, fetched and inlined). |

--- a/python/README.md
+++ b/python/README.md
@@ -44,6 +44,10 @@ m.add_tile_layer(
     attribution="(c) OpenStreetMap contributors",
 )
 m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
+
+import ee
+ee.Initialize(project="your-google-cloud-project")
+m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
 m.add_basemap("dark")
 m.set_center(-120, 47, zoom=8)
 ```
@@ -74,6 +78,7 @@ m.to_project()["mapView"]["center"]
 | `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add vector tiles from a TileJSON endpoint. |
 | `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
+| `add_ee_layer(ee_object, vis_params=, name=, shown=, opacity=)` | Add an authenticated Google Earth Engine object as raster tiles. |
 | `add_wms(endpoint, layers, name=, styles=, image_format=, transparent=, tile_size=, **style)` | Add a WMS (GetMap) tiled raster layer. |
 | `add_wmts(url, name=, tile_size=, **style)` | Add a WMTS tile URL template. |
 | `add_wfs(endpoint, type_name, name=, version=, output_format=, srs_name=, max_features=, **style)` | Add a WFS layer (GeoJSON, fetched and inlined). |

--- a/python/README.md
+++ b/python/README.md
@@ -45,7 +45,10 @@ m.add_tile_layer(
 )
 m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
 
+# Earth Engine layers need `pip install earthengine-api` and credentials
+# (run `ee.Authenticate()` once, if you have not already).
 import ee
+ee.Authenticate()
 ee.Initialize(project="your-google-cloud-project")
 m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
 m.add_basemap("dark")
@@ -188,6 +191,11 @@ anywhere untrusted, or use `Map.save_project`, which redacts by default.
   (works in the running server with no restart where it is installed). On other
   remote servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)` to
   use that same remote path; `Map(server_proxy=False)` forces the direct path.
+- `add_ee_layer` needs the Earth Engine Python API, which is **not** a
+  dependency of this package: `pip install earthengine-api`. Authenticate once
+  with `ee.Authenticate()` and initialize with `ee.Initialize(project=...)`
+  before adding a layer. The generated tile URL is tied to an Earth Engine map
+  id that expires, so a saved project may need the layer regenerated later.
 - Optional extras: `pip install "geolibre[all]"` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)` and for reading **local** vector files
   (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`/`add_kml`/`add_gpkg`),

--- a/python/README.md
+++ b/python/README.md
@@ -44,15 +44,19 @@ m.add_tile_layer(
     attribution="(c) OpenStreetMap contributors",
 )
 m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
-
-# Earth Engine layers need `pip install earthengine-api` and credentials
-# (run `ee.Authenticate()` once, if you have not already).
-import ee
-ee.Authenticate()
-ee.Initialize(project="your-google-cloud-project")
-m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
 m.add_basemap("dark")
 m.set_center(-120, 47, zoom=8)
+```
+
+Google Earth Engine layers are optional and need `pip install earthengine-api`
+plus credentials (`ee.Authenticate()` once, then a Google Cloud project):
+
+```python
+import ee
+
+ee.Authenticate()  # once per machine
+ee.Initialize(project="your-google-cloud-project")
+m.add_ee_layer(ee.Image("USGS/SRTMGL1_003"), {"min": 0, "max": 3000}, name="SRTM")
 ```
 
 Round-trip the project:

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1632,6 +1632,117 @@ class Map(anywidget.AnyWidget):
             )
         )
 
+    def add_ee_layer(
+        self,
+        ee_object: Any,
+        vis_params: dict[str, Any] | None = None,
+        name: str = "Earth Engine",
+        shown: bool = True,
+        opacity: float = 1.0,
+    ) -> str:
+        """Add a Google Earth Engine object as a raster tile layer.
+
+        This follows the ``geemap``/``leafmap`` convention: Earth Engine is
+        evaluated in the Python kernel to obtain a map tile URL, while the
+        GeoLibre app renders that URL as a normal raster layer. Earth Engine
+        must already be authenticated and initialized (usually with
+        ``ee.Authenticate()`` and ``ee.Initialize(project=...)``).
+
+        Args:
+            ee_object: An ``ee.Image``, ``ee.ImageCollection``,
+                ``ee.FeatureCollection``, ``ee.Feature``, or ``ee.Geometry``.
+                A compatible object exposing ``getMapId`` is also accepted.
+            vis_params: Earth Engine visualization parameters, such as
+                ``bands``, ``min``, ``max``, and ``palette``.
+            name: Layer display name.
+            shown: Whether the layer is initially visible.
+            opacity: Initial opacity between 0 and 1.
+
+        Returns:
+            The id of the added layer.
+
+        Raises:
+            ImportError: If conversion requires the optional Earth Engine
+                Python package and it is not installed.
+            TypeError: If ``ee_object`` is not a supported Earth Engine object.
+            ValueError: If Earth Engine returns no usable tile URL or opacity
+                is outside the range 0--1.
+
+        Note:
+            The generated tile URL is tied to the Earth Engine map ID. A saved
+            project may need the layer to be regenerated after that map ID
+            expires.
+        """
+        try:
+            opacity_value = float(opacity)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("opacity must be a finite number between 0 and 1") from exc
+        if not math.isfinite(opacity_value) or not 0 <= opacity_value <= 1:
+            raise ValueError("opacity must be a finite number between 0 and 1")
+
+        params = dict(vis_params or {})
+        map_object = ee_object
+        map_params = params
+
+        if not callable(getattr(map_object, "getMapId", None)):
+            try:
+                import ee
+            except ImportError as exc:
+                raise ImportError(
+                    "Adding this Earth Engine object requires the `earthengine-api` "
+                    "package. Install it with `pip install earthengine-api`."
+                ) from exc
+
+            if isinstance(map_object, ee.ImageCollection):
+                map_object = map_object.mosaic()
+            elif isinstance(map_object, (ee.FeatureCollection, ee.Feature, ee.Geometry)):
+                if isinstance(map_object, ee.Geometry):
+                    map_object = ee.Feature(map_object)
+                if isinstance(map_object, ee.Feature):
+                    map_object = ee.FeatureCollection([map_object])
+                vector_style = {
+                    "color": "000000",
+                    "fillColor": "00000000",
+                    "width": 2,
+                    "pointSize": 3,
+                    "pointShape": "circle",
+                    **params,
+                }
+                map_object = map_object.style(**vector_style)
+                map_params = {}
+            elif not isinstance(map_object, ee.Image):
+                raise TypeError(
+                    "ee_object must be an Earth Engine Image, ImageCollection, "
+                    "FeatureCollection, Feature, or Geometry"
+                )
+
+        try:
+            map_id = map_object.getMapId(map_params)
+        except Exception as exc:
+            raise RuntimeError(
+                "Earth Engine could not create map tiles. Authenticate and initialize "
+                "Earth Engine before calling add_ee_layer()."
+            ) from exc
+
+        tile_fetcher = map_id.get("tile_fetcher") if isinstance(map_id, dict) else None
+        tile_url = getattr(tile_fetcher, "url_format", None)
+        if not tile_url and isinstance(map_id, dict):
+            tile_url = map_id.get("tile_url") or map_id.get("url_format")
+        if not isinstance(tile_url, str) or not tile_url:
+            raise ValueError("Earth Engine returned a map ID without a tile URL")
+
+        layer = _project.tile_layer(
+            name,
+            tile_url,
+            attribution="Google Earth Engine",
+        )
+        layer["visible"] = bool(shown)
+        layer["opacity"] = opacity_value
+        layer["metadata"]["provider"] = "earth-engine"
+        if isinstance(map_id, dict) and map_id.get("mapid"):
+            layer["metadata"]["earthEngineMapId"] = map_id["mapid"]
+        return self._add_layer(layer)
+
     @staticmethod
     def _resolve_raster_source(source: Any) -> str:
         """Resolve a raster source to a URL the in-iframe app can fetch.

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -16,7 +16,7 @@ import time
 import urllib.parse
 import uuid
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 from urllib.error import URLError
 
@@ -1686,7 +1686,8 @@ class Map(anywidget.AnyWidget):
         Raises:
             ImportError: If conversion requires the optional Earth Engine
                 Python package and it is not installed.
-            TypeError: If ``ee_object`` is not a supported Earth Engine object.
+            TypeError: If ``ee_object`` is not a supported Earth Engine object,
+                or ``vis_params`` is not a mapping.
             ValueError: If Earth Engine returns no usable tile URL, opacity is
                 outside the range 0--1, or ``vis_params`` carries a key
                 ``ee.FeatureCollection.style()`` does not accept.
@@ -1698,6 +1699,11 @@ class Map(anywidget.AnyWidget):
             The generated tile URL is tied to the Earth Engine map ID. A saved
             project may need the layer to be regenerated after that map ID
             expires.
+
+            The layer is a plain raster tile layer, not one of the live layers
+            the app's own Earth Engine panel manages, so it is listed and
+            styled like any other tile layer rather than appearing in that
+            panel.
         """
         try:
             opacity_value = float(opacity)
@@ -1706,6 +1712,8 @@ class Map(anywidget.AnyWidget):
         if not math.isfinite(opacity_value) or not 0 <= opacity_value <= 1:
             raise ValueError("opacity must be a finite number between 0 and 1")
 
+        if vis_params is not None and not isinstance(vis_params, Mapping):
+            raise TypeError("vis_params must be a mapping of Earth Engine visualization keys")
         params = dict(vis_params or {})
         map_object = ee_object
         map_params = params

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -41,6 +41,24 @@ _VALID_THEMES = frozenset({"light", "dark"})
 # same 50 MB ceiling applies to a fetched response or a local file.
 _MAX_TABULAR_BYTES = _project._MAX_GEOJSON_BYTES
 
+# ``ee.FeatureCollection.style()`` is declared with explicit keyword parameters,
+# not ``**kwargs``, so an image-shaped ``vis_params`` (``min``/``max``/``palette``)
+# would reach it as ``TypeError: style() got an unexpected keyword argument`` --
+# indistinguishable, to the caller, from the ``TypeError`` add_ee_layer raises for
+# an unsupported object. Validate against the accepted keys instead.
+_EE_VECTOR_STYLE_KEYS = frozenset(
+    {
+        "color",
+        "pointSize",
+        "pointShape",
+        "width",
+        "fillColor",
+        "styleProperty",
+        "neighborhood",
+        "lineType",
+    }
+)
+
 # Column name for CSV fields beyond the header row. csv.DictReader's default
 # restkey is ``None``, which would put a non-string key in the feature
 # properties and break JSON serialization on the way to the widget.
@@ -1653,7 +1671,11 @@ class Map(anywidget.AnyWidget):
                 ``ee.FeatureCollection``, ``ee.Feature``, or ``ee.Geometry``.
                 A compatible object exposing ``getMapId`` is also accepted.
             vis_params: Earth Engine visualization parameters, such as
-                ``bands``, ``min``, ``max``, and ``palette``.
+                ``bands``, ``min``, ``max``, and ``palette``. For vector
+                objects these are ``ee.FeatureCollection.style()`` keys
+                instead (``color``, ``fillColor``, ``width``, ``pointSize``,
+                ``pointShape``, ``lineType``, ``styleProperty``,
+                ``neighborhood``).
             name: Layer display name.
             shown: Whether the layer is initially visible.
             opacity: Initial opacity between 0 and 1.
@@ -1665,11 +1687,12 @@ class Map(anywidget.AnyWidget):
             ImportError: If conversion requires the optional Earth Engine
                 Python package and it is not installed.
             TypeError: If ``ee_object`` is not a supported Earth Engine object.
-            ValueError: If Earth Engine returns no usable tile URL or opacity
-                is outside the range 0--1.
-            RuntimeError: If Earth Engine fails to create map tiles (for
-                example when it is not initialized, or the request is
-                rejected).
+            ValueError: If Earth Engine returns no usable tile URL, opacity is
+                outside the range 0--1, or ``vis_params`` carries a key
+                ``ee.FeatureCollection.style()`` does not accept.
+            RuntimeError: If Earth Engine fails to prepare the object or to
+                create map tiles (for example when it is not initialized, or
+                the request is rejected).
 
         Note:
             The generated tile URL is tied to the Earth Engine map ID. A saved
@@ -1703,23 +1726,37 @@ class Map(anywidget.AnyWidget):
             else ()
         )
         if ee is not None and isinstance(map_object, ee_types):
-            if isinstance(map_object, ee.ImageCollection):
-                map_object = map_object.mosaic()
-            elif isinstance(map_object, (ee.FeatureCollection, ee.Feature, ee.Geometry)):
-                if isinstance(map_object, ee.Geometry):
-                    map_object = ee.Feature(map_object)
-                if isinstance(map_object, ee.Feature):
-                    map_object = ee.FeatureCollection([map_object])
-                vector_style = {
-                    "color": "000000",
-                    "fillColor": "00000000",
-                    "width": 2,
-                    "pointSize": 3,
-                    "pointShape": "circle",
-                    **params,
-                }
-                map_object = map_object.style(**vector_style)
-                map_params = {}
+            is_vector = isinstance(map_object, (ee.FeatureCollection, ee.Feature, ee.Geometry))
+            if is_vector:
+                unsupported = sorted(set(params) - _EE_VECTOR_STYLE_KEYS)
+                if unsupported:
+                    raise ValueError(
+                        "vis_params for an Earth Engine FeatureCollection, Feature, or "
+                        f"Geometry may only contain {sorted(_EE_VECTOR_STYLE_KEYS)}; got "
+                        f"{unsupported}"
+                    )
+            try:
+                if isinstance(map_object, ee.ImageCollection):
+                    map_object = map_object.mosaic()
+                elif is_vector:
+                    if isinstance(map_object, ee.Geometry):
+                        map_object = ee.Feature(map_object)
+                    if isinstance(map_object, ee.Feature):
+                        map_object = ee.FeatureCollection([map_object])
+                    vector_style = {
+                        "color": "000000",
+                        "fillColor": "00000000",
+                        "width": 2,
+                        "pointSize": 3,
+                        "pointShape": "circle",
+                        **params,
+                    }
+                    map_object = map_object.style(**vector_style)
+                    map_params = {}
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Earth Engine could not prepare this object for display: {exc}"
+                ) from exc
         elif not callable(getattr(map_object, "getMapId", None)):
             if ee is None:
                 raise ImportError(

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1667,6 +1667,9 @@ class Map(anywidget.AnyWidget):
             TypeError: If ``ee_object`` is not a supported Earth Engine object.
             ValueError: If Earth Engine returns no usable tile URL or opacity
                 is outside the range 0--1.
+            RuntimeError: If Earth Engine fails to create map tiles (for
+                example when it is not initialized, or the request is
+                rejected).
 
         Note:
             The generated tile URL is tied to the Earth Engine map ID. A saved
@@ -1684,15 +1687,22 @@ class Map(anywidget.AnyWidget):
         map_object = ee_object
         map_params = params
 
-        if not callable(getattr(map_object, "getMapId", None)):
-            try:
-                import ee
-            except ImportError as exc:
-                raise ImportError(
-                    "Adding this Earth Engine object requires the `earthengine-api` "
-                    "package. Install it with `pip install earthengine-api`."
-                ) from exc
+        try:
+            import ee
+        except ImportError:
+            ee = None
 
+        # Earth Engine types are classified *before* the duck-typed
+        # ``getMapId`` fallback: ``ee.ImageCollection``, ``ee.FeatureCollection``
+        # and ``ee.Feature`` all expose ``getMapId`` themselves, so a
+        # ``getMapId``-first check would silently skip the mosaic/style step and
+        # drop every vector option except ``color``.
+        ee_types = (
+            (ee.Image, ee.ImageCollection, ee.FeatureCollection, ee.Feature, ee.Geometry)
+            if ee is not None
+            else ()
+        )
+        if ee is not None and isinstance(map_object, ee_types):
             if isinstance(map_object, ee.ImageCollection):
                 map_object = map_object.mosaic()
             elif isinstance(map_object, (ee.FeatureCollection, ee.Feature, ee.Geometry)):
@@ -1710,18 +1720,24 @@ class Map(anywidget.AnyWidget):
                 }
                 map_object = map_object.style(**vector_style)
                 map_params = {}
-            elif not isinstance(map_object, ee.Image):
-                raise TypeError(
-                    "ee_object must be an Earth Engine Image, ImageCollection, "
-                    "FeatureCollection, Feature, or Geometry"
+        elif not callable(getattr(map_object, "getMapId", None)):
+            if ee is None:
+                raise ImportError(
+                    "Adding this Earth Engine object requires the `earthengine-api` "
+                    "package. Install it with `pip install earthengine-api`."
                 )
+            raise TypeError(
+                "ee_object must be an Earth Engine Image, ImageCollection, "
+                "FeatureCollection, Feature, or Geometry"
+            )
 
         try:
             map_id = map_object.getMapId(map_params)
         except Exception as exc:
             raise RuntimeError(
-                "Earth Engine could not create map tiles. Authenticate and initialize "
-                "Earth Engine before calling add_ee_layer()."
+                f"Earth Engine could not create map tiles: {exc}. Authenticate and "
+                "initialize Earth Engine before calling add_ee_layer(), and check "
+                "that vis_params are valid for this object."
             ) from exc
 
         tile_fetcher = map_id.get("tile_fetcher") if isinstance(map_id, dict) else None

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -70,6 +70,115 @@ def test_add_wmts(m):
     assert _last_layer(m)["type"] == "wmts"
 
 
+def test_add_ee_layer_from_map_id(m):
+    class TileFetcher:
+        url_format = "https://earthengine.googleapis.com/maps/test/tiles/{z}/{x}/{y}"
+
+    class Image:
+        def getMapId(self, vis_params):
+            assert vis_params == {"min": 0, "max": 3000, "palette": ["blue", "green"]}
+            return {"mapid": "test-map", "tile_fetcher": TileFetcher()}
+
+    layer_id = m.add_ee_layer(
+        Image(),
+        {"min": 0, "max": 3000, "palette": ["blue", "green"]},
+        name="Elevation",
+        shown=False,
+        opacity=0.4,
+    )
+    layer = _last_layer(m)
+    assert layer["id"] == layer_id
+    assert layer["name"] == "Elevation"
+    assert layer["type"] == "xyz"
+    assert layer["visible"] is False
+    assert layer["opacity"] == 0.4
+    assert layer["source"]["tiles"] == [TileFetcher.url_format]
+    assert layer["source"]["attribution"] == "Google Earth Engine"
+    assert layer["metadata"]["sourceKind"] == "xyz-url"
+    assert layer["metadata"]["provider"] == "earth-engine"
+    assert layer["metadata"]["earthEngineMapId"] == "test-map"
+
+
+@pytest.mark.parametrize("opacity", [-0.1, 1.1, float("nan"), "bad"])
+def test_add_ee_layer_rejects_invalid_opacity(m, opacity):
+    with pytest.raises(ValueError, match="opacity must"):
+        m.add_ee_layer(object(), opacity=opacity)
+
+
+def test_add_ee_layer_requires_tile_url(m):
+    class Image:
+        def getMapId(self, _vis_params):
+            return {"mapid": "missing-fetcher"}
+
+    with pytest.raises(ValueError, match="without a tile URL"):
+        m.add_ee_layer(Image())
+
+
+def test_add_ee_layer_wraps_earth_engine_errors(m):
+    class Image:
+        def getMapId(self, _vis_params):
+            raise RuntimeError("not initialized")
+
+    with pytest.raises(RuntimeError, match="Authenticate and initialize"):
+        m.add_ee_layer(Image())
+
+
+def test_add_ee_layer_mosaics_image_collection(monkeypatch, m):
+    class TileFetcher:
+        url_format = "https://earthengine.googleapis.com/maps/collection/tiles/{z}/{x}/{y}"
+
+    class Image:
+        def getMapId(self, vis_params):
+            assert vis_params == {"bands": ["B4", "B3", "B2"]}
+            return {"tile_fetcher": TileFetcher()}
+
+    class ImageCollection:
+        def mosaic(self):
+            return Image()
+
+    fake_ee = types.SimpleNamespace(
+        Image=Image,
+        ImageCollection=ImageCollection,
+        FeatureCollection=type("FeatureCollection", (), {}),
+        Feature=type("Feature", (), {}),
+        Geometry=type("Geometry", (), {}),
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+    m.add_ee_layer(ImageCollection(), {"bands": ["B4", "B3", "B2"]})
+    assert _last_layer(m)["source"]["tiles"] == [TileFetcher.url_format]
+
+
+def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
+    captured = {}
+
+    class TileFetcher:
+        url_format = "https://earthengine.googleapis.com/maps/features/tiles/{z}/{x}/{y}"
+
+    class Image:
+        def getMapId(self, vis_params):
+            captured["map_params"] = vis_params
+            return {"tile_fetcher": TileFetcher()}
+
+    class FeatureCollection:
+        def style(self, **style):
+            captured["style"] = style
+            return Image()
+
+    fake_ee = types.SimpleNamespace(
+        Image=Image,
+        ImageCollection=type("ImageCollection", (), {}),
+        FeatureCollection=FeatureCollection,
+        Feature=type("Feature", (), {}),
+        Geometry=type("Geometry", (), {}),
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+    m.add_ee_layer(FeatureCollection(), {"color": "ff0000", "width": 4})
+    assert captured["style"]["color"] == "ff0000"
+    assert captured["style"]["width"] == 4
+    assert captured["style"]["fillColor"] == "00000000"
+    assert captured["map_params"] == {}
+
+
 def test_add_raster_is_cog(m):
     m.add_raster("https://e/dem.tif", bands=[1, 2, 3])
     layer = _last_layer(m)

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -133,6 +133,11 @@ def test_add_ee_layer_mosaics_image_collection(monkeypatch, m):
             return {"tile_fetcher": TileFetcher()}
 
     class ImageCollection:
+        # The real ee.ImageCollection exposes getMapId, so dispatch must not
+        # take a duck-typed shortcut past mosaic().
+        def getMapId(self, _vis_params):  # pragma: no cover - must not be called
+            raise AssertionError("ImageCollection.getMapId must not be called")
+
         def mosaic(self):
             return Image()
 
@@ -148,6 +153,19 @@ def test_add_ee_layer_mosaics_image_collection(monkeypatch, m):
     assert _last_layer(m)["source"]["tiles"] == [TileFetcher.url_format]
 
 
+def test_add_ee_layer_rejects_unsupported_object(monkeypatch, m):
+    fake_ee = types.SimpleNamespace(
+        Image=type("Image", (), {}),
+        ImageCollection=type("ImageCollection", (), {}),
+        FeatureCollection=type("FeatureCollection", (), {}),
+        Feature=type("Feature", (), {}),
+        Geometry=type("Geometry", (), {}),
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+    with pytest.raises(TypeError, match="ee_object must be"):
+        m.add_ee_layer(object())
+
+
 def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
     captured = {}
 
@@ -160,6 +178,11 @@ def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
             return {"tile_fetcher": TileFetcher()}
 
     class FeatureCollection:
+        # The real ee.FeatureCollection exposes getMapId, but it honours only
+        # `color`; styling must run so width/fillColor/pointSize survive.
+        def getMapId(self, _vis_params):  # pragma: no cover - must not be called
+            raise AssertionError("FeatureCollection.getMapId must not be called")
+
         def style(self, **style):
             captured["style"] = style
             return Image()

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -202,9 +202,10 @@ def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
     assert captured["map_params"] == {}
 
 
-def test_add_ee_layer_rejects_non_mapping_vis_params(m):
+@pytest.mark.parametrize("vis_params", [["min", "max"], "min", 3])
+def test_add_ee_layer_rejects_non_mapping_vis_params(m, vis_params):
     with pytest.raises(TypeError, match="vis_params must be a mapping"):
-        m.add_ee_layer(object(), ["min", "max"])
+        m.add_ee_layer(object(), vis_params)
 
 
 def _fake_vector_ee(captured):

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -202,6 +202,40 @@ def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
     assert captured["map_params"] == {}
 
 
+def test_add_ee_layer_rejects_image_vis_params_on_vector(monkeypatch, m):
+    class FeatureCollection:
+        def style(self, **_style):  # pragma: no cover - must not be reached
+            raise AssertionError("style() must not be called with bad vis_params")
+
+    fake_ee = types.SimpleNamespace(
+        Image=type("Image", (), {}),
+        ImageCollection=type("ImageCollection", (), {}),
+        FeatureCollection=FeatureCollection,
+        Feature=type("Feature", (), {}),
+        Geometry=type("Geometry", (), {}),
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+    with pytest.raises(ValueError, match="may only contain"):
+        m.add_ee_layer(FeatureCollection(), {"min": 0, "max": 3000})
+
+
+def test_add_ee_layer_wraps_preparation_errors(monkeypatch, m):
+    class ImageCollection:
+        def mosaic(self):
+            raise RuntimeError("collection is empty")
+
+    fake_ee = types.SimpleNamespace(
+        Image=type("Image", (), {}),
+        ImageCollection=ImageCollection,
+        FeatureCollection=type("FeatureCollection", (), {}),
+        Feature=type("Feature", (), {}),
+        Geometry=type("Geometry", (), {}),
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+    with pytest.raises(RuntimeError, match="could not prepare this object"):
+        m.add_ee_layer(ImageCollection())
+
+
 def test_add_raster_is_cog(m):
     m.add_raster("https://e/dem.tif", bands=[1, 2, 3])
     layer = _last_layer(m)

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -202,6 +202,73 @@ def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
     assert captured["map_params"] == {}
 
 
+def _fake_vector_ee(captured):
+    """Fake `ee` module whose vector types record the conversion chain."""
+
+    class TileFetcher:
+        url_format = "https://earthengine.googleapis.com/maps/vector/tiles/{z}/{x}/{y}"
+
+    class Image:
+        def getMapId(self, vis_params):
+            captured["map_params"] = vis_params
+            return {"tile_fetcher": TileFetcher()}
+
+    class Geometry:
+        pass
+
+    class Feature:
+        def __init__(self, geometry=None):
+            captured["feature_from"] = geometry
+
+    class FeatureCollection:
+        def __init__(self, features=None):
+            captured["collection_from"] = features
+
+        def style(self, **style):
+            captured["style"] = style
+            return Image()
+
+    fake_ee = types.SimpleNamespace(
+        Image=Image,
+        ImageCollection=type("ImageCollection", (), {}),
+        FeatureCollection=FeatureCollection,
+        Feature=Feature,
+        Geometry=Geometry,
+    )
+    return fake_ee, TileFetcher.url_format
+
+
+def test_add_ee_layer_wraps_feature_in_collection(monkeypatch, m):
+    captured = {}
+    fake_ee, url = _fake_vector_ee(captured)
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+
+    feature = fake_ee.Feature()
+    m.add_ee_layer(feature, {"color": "00ff00"})
+
+    assert captured["collection_from"] == [feature]
+    assert captured["style"]["color"] == "00ff00"
+    assert captured["style"]["pointSize"] == 3
+    assert captured["map_params"] == {}
+    assert _last_layer(m)["source"]["tiles"] == [url]
+
+
+def test_add_ee_layer_wraps_geometry_in_feature_and_collection(monkeypatch, m):
+    captured = {}
+    fake_ee, url = _fake_vector_ee(captured)
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+
+    geometry = fake_ee.Geometry()
+    m.add_ee_layer(geometry, {"width": 5})
+
+    assert captured["feature_from"] is geometry
+    assert isinstance(captured["collection_from"][0], fake_ee.Feature)
+    assert captured["style"]["width"] == 5
+    assert captured["style"]["fillColor"] == "00000000"
+    assert captured["map_params"] == {}
+    assert _last_layer(m)["source"]["tiles"] == [url]
+
+
 def test_add_ee_layer_rejects_image_vis_params_on_vector(monkeypatch, m):
     class FeatureCollection:
         def style(self, **_style):  # pragma: no cover - must not be reached

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -202,6 +202,11 @@ def test_add_ee_layer_styles_feature_collection(monkeypatch, m):
     assert captured["map_params"] == {}
 
 
+def test_add_ee_layer_rejects_non_mapping_vis_params(m):
+    with pytest.raises(TypeError, match="vis_params must be a mapping"):
+        m.add_ee_layer(object(), ["min", "max"])
+
+
 def _fake_vector_ee(captured):
     """Fake `ee` module whose vector types record the conversion chain."""
 

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -48,6 +48,8 @@ m.add_csv(data, x="longitude", y="latitude", name="CSV")
 m.add_cog(url, name="COG", bands=None, colormap=None, rescale=None)
 m.add_raster(...)                                     # same, incl. a local GeoTIFF
 m.add_tile_layer(url, name, tile_size=256, attribution=None)
+m.add_ee_layer(ee_object, vis_params=None, name="Earth Engine", shown=True,
+               opacity=1.0)
 m.add_pmtiles(url, name, tile_type="vector", source_layers=None)
 m.add_vector_tiles(url, name, source_layers=None)
 m.add_wms(endpoint, layers, name, version="1.1.1")
@@ -60,6 +62,11 @@ m.add_video(...)
 Every `add_*` returns the new layer's **id** and accepts style keyword
 arguments inline (`m.add_geojson(url, name="Roads", strokeColor="#ef4444",
 strokeWidth=3)`).
+
+`add_ee_layer` accepts an authenticated Earth Engine Image, ImageCollection,
+FeatureCollection, Feature, or Geometry. Initialize the Earth Engine Python API
+before calling it; ImageCollections are mosaicked and vector objects are styled
+into raster tiles using `vis_params`.
 
 ### Symbology without precomputing
 

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -66,9 +66,12 @@ strokeWidth=3)`).
 `add_ee_layer` accepts an authenticated Earth Engine Image, ImageCollection,
 FeatureCollection, Feature, or Geometry. Initialize the Earth Engine Python API
 before calling it; ImageCollections are mosaicked and vector objects are styled
-into raster tiles using `vis_params`. The stored tile URL is tied to an Earth
-Engine map id that expires, so a project loaded later may need the Earth Engine
-layer regenerated.
+into raster tiles — for a FeatureCollection/Feature/Geometry, `vis_params` takes
+`ee.FeatureCollection.style()` keys (`color`, `fillColor`, `width`, `pointSize`,
+`pointShape`, `lineType`, `styleProperty`, `neighborhood`), not image keys like
+`min`/`max`/`palette`. The stored tile URL is tied to an Earth Engine map id
+that expires, so a project loaded later may need the Earth Engine layer
+regenerated.
 
 ### Symbology without precomputing
 

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -66,7 +66,9 @@ strokeWidth=3)`).
 `add_ee_layer` accepts an authenticated Earth Engine Image, ImageCollection,
 FeatureCollection, Feature, or Geometry. Initialize the Earth Engine Python API
 before calling it; ImageCollections are mosaicked and vector objects are styled
-into raster tiles using `vis_params`.
+into raster tiles using `vis_params`. The stored tile URL is tied to an Earth
+Engine map id that expires, so a project loaded later may need the Earth Engine
+layer regenerated.
 
 ### Symbology without precomputing
 

--- a/skills/geolibre/references/python-api.md
+++ b/skills/geolibre/references/python-api.md
@@ -71,7 +71,8 @@ into raster tiles — for a FeatureCollection/Feature/Geometry, `vis_params` tak
 `pointShape`, `lineType`, `styleProperty`, `neighborhood`), not image keys like
 `min`/`max`/`palette`. The stored tile URL is tied to an Earth Engine map id
 that expires, so a project loaded later may need the Earth Engine layer
-regenerated.
+regenerated. The result is a plain raster tile layer, not one of the live
+layers the app's own Earth Engine panel manages.
 
 ### Symbology without precomputing
 


### PR DESCRIPTION
## Summary
- add a geemap-style `Map.add_ee_layer` method for Earth Engine raster and vector objects
- preserve visualization, visibility, opacity, attribution, and map metadata in GeoLibre projects
- document the API and cover supported object conversion and error paths

## Test plan
- [x] Run the complete Python test suite
- [x] Run scoped pre-commit hooks, including Ruff and the application build
- [x] Restore a generated project in the real GeoLibre app and verify the layer renders with the configured opacity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying authenticated Google Earth Engine images, image collections, features, and geometries as map layers.
  * Added visualization, naming, visibility, and opacity options.
  * Image collections are automatically mosaicked, while vector data is styled and rasterized.
  * Added validation and clear error reporting for unsupported data, invalid visualization settings, and tile-generation issues.

* **Documentation**
  * Updated quickstarts and API references with Earth Engine authentication, setup requirements, layer behavior, dependency details, and expiring map tile guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->