### PR TITLE
fix: install MapLibre transform compat on the headless entry

### DIFF
--- a/packages/map/src/headless.ts
+++ b/packages/map/src/headless.ts
@@ -10,6 +10,10 @@
 import type { GeoLibreLayer } from "@geolibre/core";
 import type * as maplibregl from "maplibre-gl";
 import { removeLayerFromMap, syncLayer } from "./layer-sync";
+import { installMapTransformCompat } from "./map-transform-compat";
+
+installMapTransformCompat();
+export { installMapTransformCompat };
 
 export interface LayerSync {
   /** Diff-sync the full layer list (bottom-to-top stacking order). */

--- a/packages/map/src/headless.ts
+++ b/packages/map/src/headless.ts
@@ -10,10 +10,12 @@
 import type { GeoLibreLayer } from "@geolibre/core";
 import type * as maplibregl from "maplibre-gl";
 import { removeLayerFromMap, syncLayer } from "./layer-sync";
-import { installMapTransformCompat } from "./map-transform-compat";
+import { installMapTransformCompat as _installMapTransformCompat } from "./map-transform-compat";
+export { installMapTransformCompat } from "./map-transform-compat";
 
-installMapTransformCompat();
-export { installMapTransformCompat };
+// Before any `Map` is constructed: re-expose `map.transform` for third-party
+// code (notably @deck.gl/mapbox) that still reads it.
+_installMapTransformCompat();
 
 export interface LayerSync {
   /** Diff-sync the full layer list (bottom-to-top stacking order). */


### PR DESCRIPTION
## Summary

`installMapTransformCompat()` already runs from `map-controller.ts` for the desktop app. `@geolibre/map/headless` did not call it.

After MapLibre 6, `map.transform` moved to `map._camera.transform`. `@deck.gl/mapbox` still reads `map.transform.height` on every frame. Independent apps that only import the headless entry therefore throw `Cannot read properties of undefined (reading 'height')` and COG / `maplibre-gl-raster` overlays draw nothing.

This installs the existing shim when the headless module loads, and re-exports it for apps that construct `Map` first.

## Test plan

- [ ] `import { createLayerSync } from "@geolibre/map/headless"` then `new Map(...)` — `map.transform.height` is defined
- [ ] Add a COG via `maplibre-gl-raster` — overlay draws, no per-frame `height` error
- [ ] Desktop app still starts (idempotent; no-op if `Map#transform` already exists)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility support for map transformations when the headless map module loads.
  * Exposed the map transformation compatibility installer for advanced integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->