### PR TITLE
fix(add-data): gate PostgreSQL on the desktop runtime, not just Tauri

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -5,7 +5,7 @@ import {
   type PostgisTableInfo,
 } from "@geolibre/processing";
 import { Button, Input, Label, Select } from "@geolibre/ui";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ensureMartinBinary,
@@ -19,7 +19,7 @@ import { postgisFeatureKeys, registerPostgisConnection } from "../../../../lib/p
 import { postgisTableKey, postgisTableLabel } from "../../../../lib/postgis-table-selection";
 import { IS_MAS_BUILD } from "../../../../lib/build-flags";
 import { startGeoLibreSidecar } from "../../../../lib/sidecar";
-import { isTauri } from "../../../../lib/tauri-io";
+import { isDesktopRuntime } from "../../../../lib/is-mobile";
 import {
   createBaseLayer,
   errorMessage,
@@ -42,6 +42,12 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.postgres.defaultName"));
   const { martin } = source.shell;
+  // Both load modes need a local helper process the desktop shell alone can
+  // start: the Martin tile server for vector tiles, the Python sidecar for the
+  // editable mode. `isTauri()` is true in the packaged Android/iOS apps too, so
+  // gating on it let a tablet run straight into a raw sidecar connection error
+  // (GeoLibre#2091). The user agent is stable for the session, so evaluate once.
+  const desktopRuntime = useMemo(() => isDesktopRuntime(), []);
   const [postgresConnectionString, setPostgresConnectionString] = useState(
     () => initialPostgres?.connection ?? readSavedPostgresConnections()[0] ?? "",
   );
@@ -130,7 +136,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
     setSelectedGeometryColumn("");
 
     try {
-      if (!isTauri()) {
+      if (!desktopRuntime) {
         throw new Error(t("addData.postgres.errorDesktopOnly"));
       }
       // Defensive: the source is hidden from the Add Data menu in the Mac App
@@ -215,7 +221,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
     martin.setSelectedSourceId("");
 
     try {
-      if (!isTauri()) {
+      if (!desktopRuntime) {
         throw new Error(t("addData.postgres.errorDesktopOnly"));
       }
       // Defensive, mirroring handleConnectEditable: no martin server in the
@@ -448,7 +454,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
       }
     >
       <div className="space-y-3">
-        {!isTauri() ? (
+        {!desktopRuntime ? (
           <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
             {t("addData.postgres.desktopOnlyNotice")}
           </p>
@@ -555,7 +561,7 @@ export function PostgresSource({ initialPostgres }: PostgresSourceProps) {
                 type="button"
                 variant="outline"
                 onClick={loadMode === "editable" ? handleConnectEditable : handleConnectPostgres}
-                disabled={source.isSubmitting || !isTauri()}
+                disabled={source.isSubmitting || !desktopRuntime}
               >
                 {t("addData.postgres.connect")}
               </Button>

--- a/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BrowserPanel.tsx
@@ -13,10 +13,10 @@ import { Input, ScrollArea } from "@geolibre/ui";
 import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState, type KeyboardEvent, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
+import { isDesktopRuntime } from "../../lib/is-mobile";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
 import {
   isLoadableFilePath,
-  isTauri,
   listDirectory,
   openLocalDataFileWithFallback,
   pickLocalDirectory,
@@ -156,11 +156,14 @@ export function BrowserPanel({
     (connectionString: string) => {
       if (connFetchedRef.current.has(connectionString)) return;
       connFetchedRef.current.add(connectionString);
-      // PostGIS browsing needs the desktop sidecar/Martin; off-Tauri, show the
-      // same localized "requires GeoLibre Desktop" message the Add Data dialog
-      // gives rather than letting startGeoLibreSidecar/fetch fail with a raw
-      // network error. Dropped from the fetched set so it can retry on desktop.
-      if (!isTauri()) {
+      // PostGIS browsing needs the desktop sidecar/Martin, so outside the
+      // desktop shell show the same localized "requires GeoLibre Desktop"
+      // message the Add Data dialog gives rather than letting
+      // startGeoLibreSidecar/fetch fail with a raw network error. The gate is
+      // isDesktopRuntime(), not isTauri(): the packaged mobile apps are Tauri
+      // too and have no sidecar to reach (GeoLibre#2091). Dropped from the
+      // fetched set so it can retry on desktop.
+      if (!isDesktopRuntime()) {
         connFetchedRef.current.delete(connectionString);
         setConnLoads((prev) => ({
           ...prev,

--- a/apps/geolibre-desktop/src/i18n/locales/ar.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ar.json
@@ -759,7 +759,7 @@
       "errorConnectFirst": "اتصل بـ PostgreSQL أولًا.",
       "errorNoVectorLayers": "مصدر Martin المحدد لا يحتوي على طبقات متجهة.",
       "errorSelectSource": "حدد مصدر Martin لإضافته.",
-      "desktopOnlyNotice": "طبقات PostgreSQL متاحة فقط في GeoLibre Desktop. تشغّل هذه الميزة خادم بلاطات Martin محليًا، وهو ما لا يستطيع تطبيق الويب تشغيله.",
+      "desktopOnlyNotice": "طبقات PostgreSQL متاحة فقط في GeoLibre Desktop. تشغّل هذه الميزة خادم بلاطات Martin محليًا، وهو ما لا تستطيع تطبيقات الويب والهاتف تشغيله.",
       "savedConnection": "اتصال محفوظ",
       "selectSavedConnection": "اختيار اتصال محفوظ",
       "connectionString": "سلسلة اتصال PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Stellen Sie zuerst eine Verbindung zu PostgreSQL her.",
       "errorNoVectorLayers": "Die ausgewählte Martin-Quelle hat keine Vektorebenen.",
       "errorSelectSource": "Wählen Sie eine Martin-Quelle zum Hinzufügen aus.",
-      "desktopOnlyNotice": "PostgreSQL-Ebenen sind nur in GeoLibre Desktop verfügbar. Diese Funktion startet einen lokalen Martin-Kachelserver, den die Web-App nicht starten kann.",
+      "desktopOnlyNotice": "PostgreSQL-Ebenen sind nur in GeoLibre Desktop verfügbar. Diese Funktion startet einen lokalen Martin-Kachelserver, den die Web- und Mobil-Apps nicht starten können.",
       "savedConnection": "Gespeicherte Verbindung",
       "selectSavedConnection": "Gespeicherte Verbindung auswählen",
       "connectionString": "PostgreSQL-Verbindungszeichenfolge",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Connect to PostgreSQL first.",
       "errorNoVectorLayers": "The selected Martin source has no vector layers.",
       "errorSelectSource": "Select a Martin source to add.",
-      "desktopOnlyNotice": "PostgreSQL layers are only available in GeoLibre Desktop. This feature runs a local Martin tile server, which the web app cannot launch.",
+      "desktopOnlyNotice": "PostgreSQL layers are only available in GeoLibre Desktop. This feature runs a local Martin tile server, which the web and mobile apps cannot launch.",
       "savedConnection": "Saved connection",
       "selectSavedConnection": "Select saved connection",
       "connectionString": "PostgreSQL connection string",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Conéctese primero a PostgreSQL.",
       "errorNoVectorLayers": "La fuente Martin seleccionada no tiene capas vectoriales.",
       "errorSelectSource": "Seleccione una fuente Martin para añadir.",
-      "desktopOnlyNotice": "Las capas de PostgreSQL solo están disponibles en GeoLibre Desktop. Esta función ejecuta un servidor de teselas Martin local, que las aplicaciones web y móvil no pueden iniciar.",
+      "desktopOnlyNotice": "Las capas de PostgreSQL solo están disponibles en GeoLibre Desktop. Esta función ejecuta un servidor de teselas Martin local, que las aplicaciones web y móviles no pueden iniciar.",
       "savedConnection": "Conexión guardada",
       "selectSavedConnection": "Seleccionar conexión guardada",
       "connectionString": "Cadena de conexión de PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Conéctese primero a PostgreSQL.",
       "errorNoVectorLayers": "La fuente Martin seleccionada no tiene capas vectoriales.",
       "errorSelectSource": "Seleccione una fuente Martin para añadir.",
-      "desktopOnlyNotice": "Las capas de PostgreSQL solo están disponibles en GeoLibre Desktop. Esta función ejecuta un servidor de teselas Martin local, que la aplicación web no puede iniciar.",
+      "desktopOnlyNotice": "Las capas de PostgreSQL solo están disponibles en GeoLibre Desktop. Esta función ejecuta un servidor de teselas Martin local, que las aplicaciones web y móvil no pueden iniciar.",
       "savedConnection": "Conexión guardada",
       "selectSavedConnection": "Seleccionar conexión guardada",
       "connectionString": "Cadena de conexión de PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/fa.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fa.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "نخست به PostgreSQL متصل شوید.",
       "errorNoVectorLayers": "منبع Martin انتخاب‌شده هیچ لایهٔ برداری ندارد.",
       "errorSelectSource": "یک منبع Martin را برای افزودن برگزینید.",
-      "desktopOnlyNotice": "لایه‌های PostgreSQL تنها در GeoLibre Desktop در دسترس‌اند. این قابلیت یک سرور کاشی محلی Martin را اجرا می‌کند که برنامهٔ وب توان راه‌اندازی‌اش را ندارد.",
+      "desktopOnlyNotice": "لایه‌های PostgreSQL تنها در GeoLibre Desktop در دسترس‌اند. این قابلیت یک سرور کاشی محلی Martin را اجرا می‌کند که برنامه‌های وب و موبایل توان راه‌اندازی‌اش را ندارند.",
       "savedConnection": "اتصال ذخیره‌شده",
       "selectSavedConnection": "انتخاب اتصال ذخیره‌شده",
       "connectionString": "رشتهٔ اتصال PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Connectez-vous d'abord à PostgreSQL.",
       "errorNoVectorLayers": "La source Martin sélectionnée n'a pas de couches vectorielles.",
       "errorSelectSource": "Sélectionnez une source Martin à ajouter.",
-      "desktopOnlyNotice": "Les couches PostgreSQL ne sont disponibles que dans GeoLibre Desktop. Cette fonctionnalité exécute un serveur de tuiles Martin local, que les applications web et mobile ne peuvent pas lancer.",
+      "desktopOnlyNotice": "Les couches PostgreSQL ne sont disponibles que dans GeoLibre Desktop. Cette fonctionnalité exécute un serveur de tuiles Martin local, que les applications web et mobiles ne peuvent pas lancer.",
       "savedConnection": "Connexion enregistrée",
       "selectSavedConnection": "Sélectionner une connexion enregistrée",
       "connectionString": "Chaîne de connexion PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Connectez-vous d'abord à PostgreSQL.",
       "errorNoVectorLayers": "La source Martin sélectionnée n'a pas de couches vectorielles.",
       "errorSelectSource": "Sélectionnez une source Martin à ajouter.",
-      "desktopOnlyNotice": "Les couches PostgreSQL ne sont disponibles que dans GeoLibre Desktop. Cette fonctionnalité exécute un serveur de tuiles Martin local, que l'application web ne peut pas lancer.",
+      "desktopOnlyNotice": "Les couches PostgreSQL ne sont disponibles que dans GeoLibre Desktop. Cette fonctionnalité exécute un serveur de tuiles Martin local, que les applications web et mobile ne peuvent pas lancer.",
       "savedConnection": "Connexion enregistrée",
       "selectSavedConnection": "Sélectionner une connexion enregistrée",
       "connectionString": "Chaîne de connexion PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "पहले PostgreSQL से कनेक्ट करें।",
       "errorNoVectorLayers": "चयनित Martin स्रोत में कोई वेक्टर लेयर नहीं है।",
       "errorSelectSource": "जोड़ने के लिए एक Martin स्रोत चुनें।",
-      "desktopOnlyNotice": "PostgreSQL लेयर केवल GeoLibre Desktop में उपलब्ध हैं। यह सुविधा एक स्थानीय Martin टाइल सर्वर चलाती है, जिसे वेब ऐप शुरू नहीं कर सकता।",
+      "desktopOnlyNotice": "PostgreSQL लेयर केवल GeoLibre Desktop में उपलब्ध हैं। यह सुविधा एक स्थानीय Martin टाइल सर्वर चलाती है, जिसे वेब और मोबाइल ऐप शुरू नहीं कर सकते।",
       "savedConnection": "सहेजा गया कनेक्शन",
       "selectSavedConnection": "सहेजा गया कनेक्शन चुनें",
       "connectionString": "PostgreSQL कनेक्शन स्ट्रिंग",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -684,7 +684,7 @@
       "errorConnectFirst": "Hubungkan ke PostgreSQL terlebih dahulu.",
       "errorNoVectorLayers": "Sumber Martin yang dipilih tidak memiliki layer vektor.",
       "errorSelectSource": "Pilih sumber Martin untuk ditambahkan.",
-      "desktopOnlyNotice": "Layer PostgreSQL hanya tersedia di GeoLibre Desktop. Fitur ini menjalankan server ubin Martin lokal, yang tidak dapat diluncurkan oleh aplikasi web.",
+      "desktopOnlyNotice": "Layer PostgreSQL hanya tersedia di GeoLibre Desktop. Fitur ini menjalankan server ubin Martin lokal, yang tidak dapat diluncurkan oleh aplikasi web dan seluler.",
       "savedConnection": "Koneksi tersimpan",
       "selectSavedConnection": "Pilih koneksi tersimpan",
       "connectionString": "String koneksi PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Connettiti prima a PostgreSQL.",
       "errorNoVectorLayers": "La sorgente Martin selezionata non ha livelli vettoriali.",
       "errorSelectSource": "Seleziona una sorgente Martin da aggiungere.",
-      "desktopOnlyNotice": "I livelli PostgreSQL sono disponibili solo in GeoLibre Desktop. Questa funzione avvia un server di tile Martin locale, che l'app web non può eseguire.",
+      "desktopOnlyNotice": "I livelli PostgreSQL sono disponibili solo in GeoLibre Desktop. Questa funzione avvia un server di tile Martin locale, che le app web e mobile non possono eseguire.",
       "savedConnection": "Connessione salvata",
       "selectSavedConnection": "Seleziona connessione salvata",
       "connectionString": "Stringa di connessione PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -684,7 +684,7 @@
       "errorConnectFirst": "先にPostgreSQLに接続してください。",
       "errorNoVectorLayers": "選択したMartinソースにはベクターレイヤーがありません。",
       "errorSelectSource": "追加するMartinソースを選択してください。",
-      "desktopOnlyNotice": "PostgreSQLレイヤーはGeoLibre Desktopでのみ利用できます。この機能はローカルのMartinタイルサーバーを実行しますが、Webアプリでは起動できません。",
+      "desktopOnlyNotice": "PostgreSQLレイヤーはGeoLibre Desktopでのみ利用できます。この機能はローカルのMartinタイルサーバーを実行しますが、Webアプリやモバイルアプリでは起動できません。",
       "savedConnection": "保存済み接続",
       "selectSavedConnection": "保存済み接続を選択",
       "connectionString": "PostgreSQL接続文字列",

--- a/apps/geolibre-desktop/src/i18n/locales/ka.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ka.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "ჯერ დაუკავშირდით PostgreSQL-ს.",
       "errorNoVectorLayers": "არჩეულ Martin წყაროს ვექტორული შრეები არ აქვს.",
       "errorSelectSource": "აირჩიეთ დასამატებელი Martin წყარო.",
-      "desktopOnlyNotice": "PostgreSQL შრეები ხელმისაწვდომია მხოლოდ GeoLibre Desktop-ში. ეს ფუნქცია უშვებს ლოკალურ Martin ფილების სერვერს, რომლის გაშვებაც ვებ-აპლიკაციას არ შეუძლია.",
+      "desktopOnlyNotice": "PostgreSQL შრეები ხელმისაწვდომია მხოლოდ GeoLibre Desktop-ში. ეს ფუნქცია უშვებს ლოკალურ Martin ფილების სერვერს, რომლის გაშვებაც ვებ- და მობილურ აპლიკაციებს არ შეუძლიათ.",
       "savedConnection": "შენახული კავშირი",
       "selectSavedConnection": "აირჩიეთ შენახული კავშირი",
       "connectionString": "PostgreSQL-ის კავშირის სტრიქონი",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -684,7 +684,7 @@
       "errorConnectFirst": "먼저 PostgreSQL에 연결하세요.",
       "errorNoVectorLayers": "선택한 Martin 소스에 벡터 레이어가 없습니다.",
       "errorSelectSource": "추가할 Martin 소스를 선택하세요.",
-      "desktopOnlyNotice": "PostgreSQL 레이어는 GeoLibre Desktop에서만 사용할 수 있습니다. 이 기능은 로컬 Martin 타일 서버를 실행하는데, 웹 앱에서는 이를 실행할 수 없습니다.",
+      "desktopOnlyNotice": "PostgreSQL 레이어는 GeoLibre Desktop에서만 사용할 수 있습니다. 이 기능은 로컬 Martin 타일 서버를 실행하는데, 웹 앱과 모바일 앱에서는 이를 실행할 수 없습니다.",
       "savedConnection": "저장된 연결",
       "selectSavedConnection": "저장된 연결 선택",
       "connectionString": "PostgreSQL 연결 문자열",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Maak eerst verbinding met PostgreSQL.",
       "errorNoVectorLayers": "De geselecteerde Martin-bron heeft geen vectorlagen.",
       "errorSelectSource": "Selecteer een Martin-bron om toe te voegen.",
-      "desktopOnlyNotice": "PostgreSQL-lagen zijn alleen beschikbaar in GeoLibre Desktop. Deze functie start een lokale Martin-tegelserver, die de webapp niet kan starten.",
+      "desktopOnlyNotice": "PostgreSQL-lagen zijn alleen beschikbaar in GeoLibre Desktop. Deze functie start een lokale Martin-tegelserver, die de web- en mobiele apps niet kunnen starten.",
       "savedConnection": "Opgeslagen verbinding",
       "selectSavedConnection": "Opgeslagen verbinding selecteren",
       "connectionString": "PostgreSQL-verbindingsreeks",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Conecte-se ao PostgreSQL primeiro.",
       "errorNoVectorLayers": "A fonte Martin selecionada não tem camadas vetoriais.",
       "errorSelectSource": "Selecione uma fonte Martin para adicionar.",
-      "desktopOnlyNotice": "As camadas PostgreSQL estão disponíveis apenas no GeoLibre Desktop. Este recurso executa um servidor de tiles Martin local, que o aplicativo web não pode iniciar.",
+      "desktopOnlyNotice": "As camadas PostgreSQL estão disponíveis apenas no GeoLibre Desktop. Este recurso executa um servidor de tiles Martin local, que os aplicativos web e móvel não podem iniciar.",
       "savedConnection": "Conexão salva",
       "selectSavedConnection": "Selecionar conexão salva",
       "connectionString": "String de conexão PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Conecte-se ao PostgreSQL primeiro.",
       "errorNoVectorLayers": "A fonte Martin selecionada não tem camadas vetoriais.",
       "errorSelectSource": "Selecione uma fonte Martin para adicionar.",
-      "desktopOnlyNotice": "As camadas PostgreSQL estão disponíveis apenas no GeoLibre Desktop. Este recurso executa um servidor de tiles Martin local, que os aplicativos web e móvel não podem iniciar.",
+      "desktopOnlyNotice": "As camadas PostgreSQL estão disponíveis apenas no GeoLibre Desktop. Este recurso executa um servidor de tiles Martin local, que os aplicativos web e móveis não podem iniciar.",
       "savedConnection": "Conexão salva",
       "selectSavedConnection": "Selecionar conexão salva",
       "connectionString": "String de conexão PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -729,7 +729,7 @@
       "errorConnectFirst": "Сначала подключитесь к PostgreSQL.",
       "errorNoVectorLayers": "У выбранного источника Martin нет векторных слоёв.",
       "errorSelectSource": "Выберите источник Martin для добавления.",
-      "desktopOnlyNotice": "Слои PostgreSQL доступны только в GeoLibre Desktop. Эта функция запускает локальный тайловый сервер Martin, который веб-приложение запустить не может.",
+      "desktopOnlyNotice": "Слои PostgreSQL доступны только в GeoLibre Desktop. Эта функция запускает локальный тайловый сервер Martin, который веб- и мобильные приложения запустить не могут.",
       "savedConnection": "Сохранённое подключение",
       "selectSavedConnection": "Выбрать сохранённое подключение",
       "connectionString": "Строка подключения PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/th.json
+++ b/apps/geolibre-desktop/src/i18n/locales/th.json
@@ -684,7 +684,7 @@
       "errorConnectFirst": "เชื่อมต่อ PostgreSQL ก่อน",
       "errorNoVectorLayers": "แหล่งข้อมูล Martin ที่เลือกไม่มีเลเยอร์เวกเตอร์",
       "errorSelectSource": "เลือกแหล่งข้อมูล Martin ที่ต้องการเพิ่ม",
-      "desktopOnlyNotice": "เลเยอร์ PostgreSQL ใช้ได้เฉพาะใน GeoLibre Desktop เท่านั้น เนื่องจากฟีเจอร์นี้เรียกใช้เซิร์ฟเวอร์ไทล์ Martin ในเครื่อง ซึ่งเว็บแอปไม่สามารถเปิดใช้ได้",
+      "desktopOnlyNotice": "เลเยอร์ PostgreSQL ใช้ได้เฉพาะใน GeoLibre Desktop เท่านั้น เนื่องจากฟีเจอร์นี้เรียกใช้เซิร์ฟเวอร์ไทล์ Martin ในเครื่อง ซึ่งเว็บแอปและแอปบนมือถือไม่สามารถเปิดใช้ได้",
       "savedConnection": "การเชื่อมต่อที่บันทึกไว้",
       "selectSavedConnection": "เลือกการเชื่อมต่อที่บันทึกไว้",
       "connectionString": "สตริงการเชื่อมต่อ PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -699,7 +699,7 @@
       "errorConnectFirst": "Önce PostgreSQL'e bağlanın.",
       "errorNoVectorLayers": "Seçilen Martin kaynağının vektör katmanı yok.",
       "errorSelectSource": "Eklenecek bir Martin kaynağı seçin.",
-      "desktopOnlyNotice": "PostgreSQL katmanları yalnızca GeoLibre Masaüstü'nde kullanılabilir. Bu özellik, web uygulamasının başlatamadığı yerel bir Martin döşeme sunucusu çalıştırır.",
+      "desktopOnlyNotice": "PostgreSQL katmanları yalnızca GeoLibre Masaüstü'nde kullanılabilir. Bu özellik, web ve mobil uygulamaların başlatamadığı yerel bir Martin döşeme sunucusu çalıştırır.",
       "savedConnection": "Kayıtlı bağlantı",
       "selectSavedConnection": "Kayıtlı bağlantı seç",
       "connectionString": "PostgreSQL bağlantı dizesi",

--- a/apps/geolibre-desktop/src/i18n/locales/vi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/vi.json
@@ -684,7 +684,7 @@
       "errorConnectFirst": "Trước tiên hãy kết nối với PostgreSQL.",
       "errorNoVectorLayers": "Nguồn Martin đã chọn không có lớp vectơ.",
       "errorSelectSource": "Đọc danh mục Martin...",
-      "desktopOnlyNotice": "Các lớp PostgreSQL chỉ có sẵn trong GeoLibre Desktop. Tính năng này chạy một máy chủ ô Martin cục bộ mà ứng dụng web không thể khởi chạy.",
+      "desktopOnlyNotice": "Các lớp PostgreSQL chỉ có sẵn trong GeoLibre Desktop. Tính năng này chạy một máy chủ ô Martin cục bộ mà ứng dụng web và di động không thể khởi chạy.",
       "savedConnection": "Kết nối đã lưu",
       "selectSavedConnection": "Chọn kết nối đã lưu",
       "connectionString": "Chuỗi kết nối PostgreSQL",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -684,7 +684,7 @@
       "errorConnectFirst": "请先连接到 PostgreSQL。",
       "errorNoVectorLayers": "所选的 Martin 数据源没有矢量图层。",
       "errorSelectSource": "请选择要添加的 Martin 数据源。",
-      "desktopOnlyNotice": "PostgreSQL 图层仅在 GeoLibre 桌面版中可用。此功能需要运行本地 Martin 瓦片服务器，而网页应用无法启动它。",
+      "desktopOnlyNotice": "PostgreSQL 图层仅在 GeoLibre 桌面版中可用。此功能需要运行本地 Martin 瓦片服务器，而网页版和移动版应用无法启动它。",
       "savedConnection": "已保存的连接",
       "selectSavedConnection": "选择已保存的连接",
       "connectionString": "PostgreSQL 连接字符串",

--- a/apps/geolibre-desktop/src/lib/is-mobile.ts
+++ b/apps/geolibre-desktop/src/lib/is-mobile.ts
@@ -1,4 +1,5 @@
 import { isIpadDesktopUserAgent } from "@geolibre/core";
+import { isTauri } from "./is-tauri";
 
 /**
  * Whether the app is running on a mobile operating system (Android or iOS).
@@ -49,4 +50,22 @@ export function isMobile(
   // with @geolibre/plugins' Earth Engine availability check so a future
   // correction to the heuristic lands in both.
   return isIpadDesktopUserAgent(userAgent, maxTouchPoints);
+}
+
+/**
+ * Whether the app runs in the *desktop* Tauri shell — the Tauri webview on a
+ * desktop OS, excluding the packaged Android/iOS apps.
+ *
+ * {@link isTauri} alone is true in the mobile apps too, so a feature that needs
+ * a local helper process (the Python sidecar, the Martin tile server) must gate
+ * on this instead. Gating on `isTauri()` lets the flow run on a phone or tablet
+ * and fail with a raw "could not connect to the sidecar at 127.0.0.1:8765"
+ * error, which is what GeoLibre#2091 reported on iPadOS.
+ *
+ * @param userAgent - Override for testing; defaults to `navigator.userAgent`.
+ * @param maxTouchPoints - Override for testing; see {@link isMobile}.
+ * @returns True only inside the Tauri shell on a desktop operating system.
+ */
+export function isDesktopRuntime(userAgent?: string, maxTouchPoints?: number): boolean {
+  return isTauri() && !isMobile(userAgent, maxTouchPoints);
 }

--- a/apps/geolibre-desktop/src/lib/martin.ts
+++ b/apps/geolibre-desktop/src/lib/martin.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import i18next from "i18next";
 import { IS_MAS_BUILD } from "./build-flags";
-import { isTauri } from "./tauri-io";
+import { isDesktopRuntime } from "./is-mobile";
 
 export interface MartinBinaryInfo {
   path: string;
@@ -111,8 +111,11 @@ function assertMartinAllowed(): void {
   if (IS_MAS_BUILD) {
     throw new Error(i18next.t("masBuild.unavailable"));
   }
-  if (!isTauri()) {
-    throw new Error("PostgreSQL layers require GeoLibre Desktop.");
+  // Not just "outside Tauri": the packaged Android/iOS apps are Tauri too, and
+  // martin has no mobile build, so they are as unable to spawn it as the web
+  // app is (GeoLibre#2091).
+  if (!isDesktopRuntime()) {
+    throw new Error(i18next.t("addData.postgres.errorDesktopOnly"));
   }
 }
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -32,15 +32,15 @@ Android has no Python sidecar or local helper binaries:
   (all need the Python sidecar)
 - Add Data → **PostgreSQL** (served by the local Martin tile server)
 
-These are gated by a user-agent `isMobile()` check so they never appear and then
-fail. Everything else runs client-side.
+These are gated by a user-agent `isMobile()` check, so the Add Data menu and the
+Layer panel's add-data group never offer them. Everything else runs client-side.
 
-The Browser panel keeps its **Databases** section on every platform for
-discovery, so the PostgreSQL dialog is still reachable there. It gates on
-`isDesktopRuntime()` — `isTauri() && !isMobile()` — rather than on `isTauri()`
-alone, so on Android it shows the "requires GeoLibre Desktop" notice and
-disables Connect instead of calling a sidecar that cannot exist
-(GeoLibre#2091).
+PostgreSQL has one entry point that check does not cover: the Browser panel
+keeps its **Databases** section on every platform for discovery, so its ＋ still
+opens the PostgreSQL dialog. The dialog gates on `isDesktopRuntime()`
+(`isTauri() && !isMobile()`) rather than on `isTauri()` alone, so on Android it
+shows the "requires GeoLibre Desktop" notice and disables Connect instead of
+calling a sidecar that cannot exist (GeoLibre#2091).
 
 ## Toolchain setup (one time)
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -35,6 +35,13 @@ Android has no Python sidecar or local helper binaries:
 These are gated by a user-agent `isMobile()` check so they never appear and then
 fail. Everything else runs client-side.
 
+The Browser panel keeps its **Databases** section on every platform for
+discovery, so the PostgreSQL dialog is still reachable there. It gates on
+`isDesktopRuntime()` — `isTauri() && !isMobile()` — rather than on `isTauri()`
+alone, so on Android it shows the "requires GeoLibre Desktop" notice and
+disables Connect instead of calling a sidecar that cannot exist
+(GeoLibre#2091).
+
 ## Toolchain setup (one time)
 
 You need the Android SDK + NDK, a JDK (17 or 21 — newer JDKs can break the

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -51,14 +51,15 @@ spawning subprocesses:
 - Add Data → **PostgreSQL** (served by the local Martin tile server)
 
 These are gated by a user-agent `isMobile()` check (which already matches
-iPhone/iPad) so they never appear and then fail. Everything else runs
-client-side.
+iPhone/iPad), so the Add Data menu and the Layer panel's add-data group never
+offer them. Everything else runs client-side.
 
-The Browser panel keeps its **Databases** section on every platform for
-discovery, so the PostgreSQL dialog is still reachable there. It gates on
-`isDesktopRuntime()` — `isTauri() && !isMobile()` — rather than on `isTauri()`
-alone, so on iOS it shows the "requires GeoLibre Desktop" notice and disables
-Connect instead of calling a sidecar that cannot exist (GeoLibre#2091).
+PostgreSQL has one entry point that check does not cover: the Browser panel
+keeps its **Databases** section on every platform for discovery, so its ＋ still
+opens the PostgreSQL dialog. The dialog gates on `isDesktopRuntime()`
+(`isTauri() && !isMobile()`) rather than on `isTauri()` alone, so on iOS it
+shows the "requires GeoLibre Desktop" notice and disables Connect instead of
+calling a sidecar that cannot exist (GeoLibre#2091).
 
 ## Location permission (required)
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -54,6 +54,12 @@ These are gated by a user-agent `isMobile()` check (which already matches
 iPhone/iPad) so they never appear and then fail. Everything else runs
 client-side.
 
+The Browser panel keeps its **Databases** section on every platform for
+discovery, so the PostgreSQL dialog is still reachable there. It gates on
+`isDesktopRuntime()` — `isTauri() && !isMobile()` — rather than on `isTauri()`
+alone, so on iOS it shows the "requires GeoLibre Desktop" notice and disables
+Connect instead of calling a sidecar that cannot exist (GeoLibre#2091).
+
 ## Location permission (required)
 
 This is the one place iOS differs sharply from Android. Android's geolocation

--- a/tests/is-mobile.test.ts
+++ b/tests/is-mobile.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { isAndroid, isMobile } from "../apps/geolibre-desktop/src/lib/is-mobile";
+import { isAndroid, isDesktopRuntime, isMobile } from "../apps/geolibre-desktop/src/lib/is-mobile";
 
 describe("isMobile", () => {
   it("detects Android (incl. the Tauri webview UA)", () => {
@@ -59,5 +59,56 @@ describe("isAndroid", () => {
   it("does not classify iOS or desktop user agents as Android", () => {
     assert.equal(isAndroid("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)"), false);
     assert.equal(isAndroid("Mozilla/5.0 (X11; Linux x86_64) Chrome/138 Safari/537.36"), false);
+  });
+});
+
+describe("isDesktopRuntime", () => {
+  const DESKTOP_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/138 Safari/537.36";
+  const IPAD_UA =
+    "Mozilla/5.0 (iPad; CPU OS 26_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148";
+  const IPAD_DESKTOP_UA =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15";
+
+  /** Runs `body` with a stubbed `window`, with or without the Tauri marker. */
+  function withWindow(tauri: boolean, body: () => void) {
+    const globals = globalThis as { window?: unknown };
+    const had = "window" in globals;
+    const previous = globals.window;
+    globals.window = tauri ? { __TAURI_INTERNALS__: {} } : {};
+    try {
+      body();
+    } finally {
+      if (had) globals.window = previous;
+      else delete globals.window;
+    }
+  }
+
+  it("is true only inside the Tauri shell on a desktop OS", () => {
+    withWindow(true, () => {
+      assert.equal(isDesktopRuntime(DESKTOP_UA, 0), true);
+    });
+  });
+
+  it("is false in the packaged mobile apps, which are Tauri too", () => {
+    withWindow(true, () => {
+      // The iPad case from GeoLibre#2091, both the mobile and the desktop-class
+      // user agent iPadOS can report.
+      assert.equal(isDesktopRuntime(IPAD_UA, 5), false);
+      assert.equal(isDesktopRuntime(IPAD_DESKTOP_UA, 5), false);
+      assert.equal(
+        isDesktopRuntime(
+          "Mozilla/5.0 (Linux; Android 16; Pixel 8) Chrome/138 Mobile Safari/537.36 wv",
+          5,
+        ),
+        false,
+      );
+    });
+  });
+
+  it("is false in a browser, mobile or not", () => {
+    withWindow(false, () => {
+      assert.equal(isDesktopRuntime(DESKTOP_UA, 0), false);
+      assert.equal(isDesktopRuntime(IPAD_UA, 5), false);
+    });
   });
 });


### PR DESCRIPTION
Fixes #2091

## The bug

On iPadOS, opening **Add PostgreSQL Layer** and pressing Connect fails with a raw, untranslated error in an otherwise French UI:

> Could not connect to the GeoLibre sidecar at http://127.0.0.1:8765. Start the sidecar to run processing tools.

## Root cause

The Add Data menu and the Layer panel already hide the PostgreSQL source on mobile, but the Browser panel deliberately keeps its **Databases** section on every platform for discovery, so its ＋ still opens the dialog there. The design intent is that the dialog itself reports the requirement, which is what the web build does.

`PostgresSource` gated its "requires GeoLibre Desktop" notice, its Connect button and both connect handlers on `isTauri()` alone. `isTauri()` is true in the packaged Android/iOS apps too, so on a tablet the guard passed, `handleConnectEditable` called the Python sidecar (which cannot run on iOS), and the sidecar client's own English connection error surfaced in the dialog. `martin.ts`'s `assertMartinAllowed` had the same `!isTauri()` check, plus a hardcoded English string instead of the existing translated key.

## The fix

- New `isDesktopRuntime()` (`isTauri() && !isMobile()`) in `lib/is-mobile.ts`.
- `PostgresSource` and `assertMartinAllowed` gate on it, so the mobile apps now behave exactly like the web build: the amber notice, a disabled Connect, and no sidecar call at all.
- `assertMartinAllowed` throws `addData.postgres.errorDesktopOnly` instead of a hardcoded English sentence.
- The notice said the local Martin tile server is something "the web app cannot launch"; it now reads "the web and mobile apps", updated across all 19 locale catalogs.
- `docs/ios.md` / `docs/android.md` said these sources "never appear and then fail", which was not true of the Browser panel route; they now describe the actual gate.

The Databases section stays visible on mobile so web and mobile stay consistent, and so the user gets an explanation rather than a silently missing feature.

## Verification

Driven in the real app with Playwright against the dev server, simulating the packaged iPad shell (iPad Pro 11 landscape UA + `window.__TAURI_INTERNALS__`) in French, and confirmed in **both dark and light themes**:

| runtime | before | after |
| --- | --- | --- |
| iPad + Tauri | English sidecar error, Connect enabled, no notice | translated notice, Connect disabled, no sidecar call |
| desktop + Tauri | unchanged | unchanged (Connect enabled, reaches the sidecar) |
| browser | unchanged | unchanged (notice, Connect disabled) |

Also run: full frontend suite (6889 tests), `npm run build`, and pre-commit on the changed files. `tests/is-mobile.test.ts` gains coverage for `isDesktopRuntime`, including both user agents iPadOS can report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - PostgreSQL connections, table browsing, and local tile-server features are now limited to GeoLibre Desktop.
  - Web, Android, and iOS apps show a clear desktop-only notice and disable Connect instead of attempting unavailable connections.
  - Runtime detection now reliably distinguishes desktop installations from packaged mobile apps.

- **Documentation**
  - Updated Android and iOS documentation to clarify PostgreSQL availability.

- **Localization**
  - Updated PostgreSQL notices across supported languages to mention web and mobile limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->